### PR TITLE
(PUP-3170) Cap integer size

### DIFF
--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -10,7 +10,7 @@ module Puppet
   #
   # @api public
   module Pops
-     EMPTY_HASH = {}.freeze
+    EMPTY_HASH = {}.freeze
     EMPTY_ARRAY = [].freeze
     EMPTY_STRING = ''.freeze
 

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -14,6 +14,9 @@ module Puppet
     EMPTY_ARRAY = [].freeze
     EMPTY_STRING = ''.freeze
 
+    MAX_INTEGER =  0x7fffffffffffffff
+    MIN_INTEGER = -0x8000000000000000
+
     DOUBLE_COLON = '::'.freeze
     USCORE = '_'.freeze
 

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -432,8 +432,15 @@ class EvaluatorImpl
       rescue ZeroDivisionError => e
         fail(Issues::DIV_BY_ZERO, right_o)
       end
-      if result == Float::INFINITY || result == -Float::INFINITY
-        fail(Issues::RESULT_IS_INFINITY, left_o, {:operator => operator})
+      case result
+      when Float
+        if result == Float::INFINITY || result == -Float::INFINITY
+          fail(Issues::RESULT_IS_INFINITY, left_o, {:operator => operator})
+        end
+      when Integer
+        if result < MIN_INTEGER || result > MAX_INTEGER
+          fail(Issues::NUMERIC_OVERFLOW, left_o.eContainer, {:value => result})
+        end
       end
       result
     end

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -7,8 +7,8 @@ module Puppet::Pops::Evaluator
 # Users should not create instances of this class. Instead the class methods {Runtime3Converter.convert},
 # {Runtime3Converter.map_args}, or {Runtime3Converter.instance} should be used
 class Runtime3Converter
-  MAX_INTEGER =  0x7fffffffffffffff
-  MIN_INTEGER = -0x8000000000000000
+  MAX_INTEGER =  Puppet::Pops::MAX_INTEGER
+  MIN_INTEGER = Puppet::Pops::MIN_INTEGER
 
   # Converts 4x supported values to a 3x values. Same as calling Runtime3Converter.instance.map_args(...)
   #

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -7,6 +7,9 @@ module Puppet::Pops::Evaluator
 # Users should not create instances of this class. Instead the class methods {Runtime3Converter.convert},
 # {Runtime3Converter.map_args}, or {Runtime3Converter.instance} should be used
 class Runtime3Converter
+  MAX_INTEGER =  0x7fffffffffffffff
+  MIN_INTEGER = -0x8000000000000000
+
   # Converts 4x supported values to a 3x values. Same as calling Runtime3Converter.instance.map_args(...)
   #
   # @param args [Array] Array of values to convert
@@ -59,6 +62,19 @@ class Runtime3Converter
 
   def convert_NilClass(o, scope, undef_value)
     @inner ? :undef : undef_value
+  end
+
+  def convert_Integer(o, scope, undef_value)
+    return o unless o < MIN_INTEGER || o > MAX_INTEGER
+    range_end = o > MAX_INTEGER ? 'max' : 'min'
+    raise Puppet::Error, "Use of a Ruby Integer outside of Puppet Integer #{range_end} range, got '#{"0x%x" % o}'"
+  end
+
+  def convert_BigDecimal(o, scope, undef_value)
+    # transform to same value float value if possible without any rounding error
+    f = o.to_f
+    return f unless f != o
+    raise Puppet::Error, "Use of a Ruby BigDecimal value outside Puppet Float range, got '#{o}'"
   end
 
   def convert_String(o, scope, undef_value)

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -738,5 +738,11 @@ module Issues
   ILLEGAL_BOM = hard_issue :ILLEGAL_BOM, :format_name, :bytes do
     "Illegal #{format_name} Byte Order mark at beginning of input: #{bytes} - remove these from the puppet source"
   end
+
+  NUMERIC_OVERFLOW = hard_issue :NUMERIC_OVERFLOW, :value do
+    range_end = value > 0 ? 'max' : 'min'
+    "#{label.a_an_uc(semantic)} resulted in a value outside of Puppet Integer #{range_end} range, got '#{"%#+x" % value}'"
+  end
+
 end
 end

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -967,7 +967,7 @@ class Factory
     x
   end
 
-  def build_Fixnum(o)
+  def build_Integer(o)
     x = LiteralInteger.new
     x.value = o;
     x

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -532,6 +532,13 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     o.values.each {|v| rvalue(v) }
   end
 
+  def check_LiteralInteger(o)
+    v = o.value
+    if v < MIN_INTEGER || v > MAX_INTEGER
+      acceptor.accept(Issues::NUMERIC_OVERFLOW, o, {:value => v})
+    end
+  end
+
   def check_LiteralHash(o)
     # the keys of a literal hash may be non-literal expressions. They cannot be checked.
     unique = Set.new

--- a/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
+++ b/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
@@ -28,6 +28,59 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       it "8 << -1 == 4"   do; expect(evaluate(literal(8) << literal(-1))).to eq(4); end
     end
 
+    # 64 bit signed integer max and min
+    MAX_INTEGER =  0x7fffffffffffffff
+    MIN_INTEGER = -0x8000000000000000
+
+    context "on integer values that cause 64 bit overflow" do
+      it "MAX + 1 => error" do
+        expect{
+          evaluate(literal(MAX_INTEGER) + literal(1))
+        }.to raise_error(/resulted in a value outside of Puppet Integer max range/)
+      end
+
+      it "MAX - -1 => error" do
+        expect{
+          evaluate(literal(MAX_INTEGER) - literal(-1))
+        }.to raise_error(/resulted in a value outside of Puppet Integer max range/)
+      end
+
+      it "MAX * 2 => error" do
+        expect{
+          evaluate(literal(MAX_INTEGER) * literal(2))
+        }.to raise_error(/resulted in a value outside of Puppet Integer max range/)
+      end
+
+      it "(MAX+1)*2 / 2 => error" do
+        expect{
+          evaluate(literal((MAX_INTEGER+1)*2) / literal(2))
+        }.to raise_error(/resulted in a value outside of Puppet Integer max range/)
+      end
+
+      it "MAX << 1 => error" do
+        expect{
+          evaluate(literal(MAX_INTEGER) << literal(1))
+        }.to raise_error(/resulted in a value outside of Puppet Integer max range/)
+      end
+
+      it "((MAX+1)*2)  << 1 => error" do
+        expect{
+          evaluate(literal((MAX_INTEGER+1)*2) >> literal(1))
+        }.to raise_error(/resulted in a value outside of Puppet Integer max range/)
+      end
+
+      it "MIN - 1 => error" do
+        expect{
+          evaluate(literal(MIN_INTEGER) - literal(1))
+        }.to raise_error(/resulted in a value outside of Puppet Integer min range/)
+      end
+
+      it "does not error on the border values" do
+          expect(evaluate(literal(MAX_INTEGER) + literal(MIN_INTEGER))).to eq(MAX_INTEGER+MIN_INTEGER)
+      end
+
+    end
+
     context "on Floats" do
       it "2.2 + 2.2  ==  4.4"   do; expect(evaluate(literal(2.2) + literal(2.2))).to eq(4.4)  ; end
       it "7.7 - 3.3  ==  4.4"   do; expect(evaluate(literal(7.7) - literal(3.3))).to eq(4.4)  ; end

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -129,5 +129,33 @@ describe 'when converting to 3.x' do
       v = Puppet::Pops::Types::PSensitiveType::Sensitive.new("don't reveal this")
       expect(converter.convert(v, {}, nil)).to equal(v)
     end
+
+    it 'errors if an Integer is too big' do
+      too_big = 0x7fffffffffffffff + 1
+      expect do
+        converter.convert(too_big, {}, nil)
+        end.to raise_error(/Use of a Ruby Integer outside of Puppet Integer max range, got/)
+    end
+
+    it 'errors if an Integer is too small' do
+      too_small = -0x8000000000000000-1
+      expect do
+        converter.convert(too_small, {}, nil)
+      end.to raise_error(/Use of a Ruby Integer outside of Puppet Integer min range, got/)
+    end
+
+    it 'errors if a BigDecimal is out of range for Float' do
+      big_dec = BigDecimal("123456789123456789.1415")
+      expect do
+        converter.convert(big_dec, {}, nil)
+      end.to raise_error(/Use of a Ruby BigDecimal value outside Puppet Float range, got/)
+    end
+
+    it 'BigDecimal values in Float range are converted' do
+      big_dec = BigDecimal("3.1415")
+      f = converter.convert(big_dec, {}, nil)
+      expect(f.class).to be(Float)
+    end
+
   end
 end

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -157,5 +157,12 @@ describe 'when converting to 3.x' do
       expect(f.class).to be(Float)
     end
 
+    it 'errors when Integer is out of range in a structure' do
+      structure = {'key' => [{ 'key' => [0x7fffffffffffffff + 1]}]}
+      expect do
+        converter.convert(structure, {}, nil)
+        end.to raise_error(/Use of a Ruby Integer outside of Puppet Integer max range, got/)
+    end
+
   end
 end

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -542,6 +542,16 @@ describe "validating 4x" do
     end
   end
 
+  context 'literal values' do
+    it 'rejects a literal integer outside of max signed 64 bit range' do
+      expect(validate(parse("0x8000000000000000"))).to have_issue(Puppet::Pops::Issues::NUMERIC_OVERFLOW)
+    end
+
+    it 'rejects a literal integer outside of min signed 64 bit range' do
+      expect(validate(parse("-0x8000000000000001"))).to have_issue(Puppet::Pops::Issues::NUMERIC_OVERFLOW)
+    end
+  end
+
   def parse(source)
     Puppet::Pops::Parser::Parser.new().parse_string(source)
   end


### PR DESCRIPTION
This modifies the runtime3_converter to raise errors when converting integer values out of 64 bit range, or BigDecimal values out of range for Float. 