### PR TITLE
(PUP-6006) Change phrasing of multiple errors final error

### DIFF
--- a/lib/puppet/pops/issue_reporter.rb
+++ b/lib/puppet/pops/issue_reporter.rb
@@ -69,7 +69,7 @@ class IssueReporter
         break if emitted >= max_errors
       end
       warnings_message = (emit_warnings && warnings.size > 0) ? ", and #{warnings.size} warnings" : ""
-      giving_up_message = "Found #{errors.size} errors#{warnings_message}. Giving up"
+      giving_up_message = "Language validation logged #{errors.size} errors#{warnings_message}. Giving up"
       exception = emit_exception.new(giving_up_message)
       exception.file = errors[0].file
       raise exception


### PR DESCRIPTION
Before this, the error message for multiple errors simply said "multiple
errors. Giving up".
This commit changes this to say "Language valiation logged <n> errors.
Giving up". This tells the user that a) there is things in the log to
look at, and b) it was language validation (syntax errors and the like)
that caused the reported problems.