### PR TITLE
(pe-19366) Gather resource (package) inventory

### DIFF
--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -165,6 +165,18 @@
         "corrective_change": {
             "description": "True if a change or noop event in this report was caused by an unexpected change to the system between Puppet runs.",
             "type":        "boolean"
+        },
+
+        "resource_inventory": {
+            "description": "Object with one property per resource-type collected for inventory.",
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "object",
+                    "$ref": "#/definitions/inventory"
+                }
+            },
+            "additionalProperties": false
         }
     },
 
@@ -647,6 +659,30 @@
             ],
 
             "additionalProperties": false
+        },
+        "inventory": {
+            "description": "An inventory entry for a resource-type in a report.",
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "$ref": "#/definitions/inventory_item"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "inventory_item": {
+            "description": "An inventory item for a resource inventory entry.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                }
+            },
+            "required": ["title"]
         }
     }
 }

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -226,6 +226,23 @@ class Puppet::Configurer
     end
   end
 
+  def gather_resource_inventory(resource_types)
+    resource_inventory = {}
+
+    resource_types.each do |resource_type|
+      resources = Puppet::Resource.indirection.search(resource_type, {})
+      resource_inventory[resource_type.to_sym] = resources.map do |resource|
+        resource_details = {:title => resource.title}
+        resource.keys.each do |k|
+          resource_details[k] = resource[k]
+        end
+        resource_details
+      end
+    end
+
+    return resource_inventory
+  end
+
   def run_internal(options)
     report = options[:report]
 
@@ -341,6 +358,10 @@ class Puppet::Configurer
       options[:report].catalog_uuid = catalog.catalog_uuid
       options[:report].cached_catalog_status = @cached_catalog_status
       apply_catalog(catalog, options)
+      if Puppet[:pe_enable_resource_inventory]
+        Puppet.info "Gathering resource inventory"
+        report.add_resource_inventory(gather_resource_inventory(["package"]))
+      end
       report.exit_status
     rescue => detail
       Puppet.log_exception(detail, "Failed to apply catalog: #{detail}")

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1402,6 +1402,11 @@ EOT
         apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
         or read them online at https://docs.puppetlabs.com/puppet/latest/reference/man/."
     },
+    :pe_enable_resource_inventory => {
+      :default => false,
+      :type => :boolean,
+      :desc => "Enables resource inventory gathering on the puppet agent"
+    },
     :server => {
       :default => "puppet",
       :desc => "The puppet master server to which the puppet agent should connect.",

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -132,6 +132,10 @@ class Puppet::Transaction::Report
   #
   attr_accessor :resources_failed_to_generate
 
+  # Resource inventory
+  #   @return  [Symbol => [Hash{Symbol => String}]] Resource type to an array of resource parameters
+  attr_reader :resource_inventory
+
   def self.from_data_hash(data)
     obj = self.allocate
     obj.initialize_from_hash(data)
@@ -146,6 +150,11 @@ class Puppet::Transaction::Report
   def <<(msg)
     @logs << msg
     self
+  end
+
+  # @api private
+  def add_resource_inventory(resource_inventory)
+    @resource_inventory = resource_inventory
   end
 
   # @api private
@@ -227,6 +236,7 @@ class Puppet::Transaction::Report
     @noop = Puppet[:noop]
     @noop_pending = false
     @corrective_change = false
+    @resource_inventory = {}
   end
 
   # @api private
@@ -242,6 +252,7 @@ class Puppet::Transaction::Report
     @host = data['host']
     @time = data['time']
     @corrective_change = data['corrective_change']
+    @resource_inventory = data['resource_inventory']
 
     if master_used = data['master_used']
       @master_used = master_used
@@ -305,6 +316,7 @@ class Puppet::Transaction::Report
       'metrics' => @metrics,
       'resource_statuses' => @resource_statuses,
       'corrective_change' => @corrective_change,
+      'resource_inventory' => @resource_inventory,
     }
   end
 

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -127,6 +127,12 @@ describe Puppet::Transaction::Report do
     expect(report.metrics['time'].values.any? {|metric| metric.first =~ /whit/i}).to be_falsey
   end
 
+  it "should be able to set resource inventory" do
+    report = Puppet::Transaction::Report.new("apply")
+    report.add_resource_inventory("some resource_inventory")
+    expect(report.resource_inventory).to eq("some resource_inventory")
+  end
+
   describe "when accepting logs" do
     before do
       @report = Puppet::Transaction::Report.new("apply")


### PR DESCRIPTION
Here we add the ability to gather package inventory information and add
it to the report.

This functionality defaults to being disabled, and can be enabled by
setting the `pe_enable_resource_inventory` configuration option to `true`.
When enabled Puppet::Indirector.search will be used to gather a list of
all package resources and add it to a new "resource_inventory" field in
the report.

While resource gathering is currently limited to pacakges, the intent is
to add more resources in the future.