### PR TITLE
(PUP-7042) Mark strings in configurer

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -19,7 +19,7 @@ class Puppet::Configurer
 
   # Provide more helpful strings to the logging that the Agent does
   def self.to_s
-    "Puppet configuration client"
+    _("Puppet configuration client")
   end
 
   def self.should_pluginsync?
@@ -47,12 +47,12 @@ class Puppet::Configurer
       Puppet::Util::Storage.load
       @compile_time ||= Puppet::Util::Storage.cache(:configuration)[:compile_time]
   rescue => detail
-    Puppet.log_exception(detail, "Removing corrupt state file #{Puppet[:statefile]}: #{detail}")
+    Puppet.log_exception(detail, _("Removing corrupt state file #{Puppet[:statefile]}: #{detail}"))
     begin
       Puppet::FileSystem.unlink(Puppet[:statefile])
       retry
     rescue => detail
-      raise Puppet::Error.new("Cannot remove #{Puppet[:statefile]}: #{detail}", detail)
+      raise Puppet::Error.new(_("Cannot remove #{Puppet[:statefile]}: #{detail}"), detail)
     end
   end
 
@@ -73,13 +73,13 @@ class Puppet::Configurer
     if (Puppet[:use_cached_catalog] && result = retrieve_catalog_from_cache(query_options))
       @cached_catalog_status = 'explicitly_requested'
 
-      Puppet.info "Using cached catalog from environment '#{result.environment}'"
+      Puppet.info _("Using cached catalog from environment '#{result.environment}'")
     else
       result = retrieve_new_catalog(query_options)
 
       if !result
         if !Puppet[:usecacheonfailure]
-          Puppet.warning "Not using cache on failed catalog"
+          Puppet.warning _("Not using cache on failed catalog")
           return nil
         end
 
@@ -88,12 +88,12 @@ class Puppet::Configurer
         if result
           # don't use use cached catalog if it doesn't match server specified environment
           if @node_environment && result.environment != @environment
-            Puppet.err "Not using cached catalog because its environment '#{result.environment}' does not match '#{@environment}'"
+            Puppet.err _("Not using cached catalog because its environment '#{result.environment}' does not match '#{@environment}'")
             return nil
           end
 
           @cached_catalog_status = 'on_failure'
-          Puppet.info "Using cached catalog from environment '#{result.environment}'"
+          Puppet.info _("Using cached catalog from environment '#{result.environment}'")
         end
       end
     end
@@ -147,14 +147,14 @@ class Puppet::Configurer
     catalog = retrieve_catalog(query_options)
     return convert_catalog(catalog, @duration) if catalog
 
-    Puppet.err "Could not retrieve catalog; skipping run"
+    Puppet.err _("Could not retrieve catalog; skipping run")
     nil
   end
 
   def prepare_and_retrieve_catalog_from_cache
     result = retrieve_catalog_from_cache({:transaction_uuid => @transaction_uuid, :static_catalog => @static_catalog})
     if result
-      Puppet.info "Using cached catalog from environment '#{result.environment}'"
+      Puppet.info _("Using cached catalog from environment '#{result.environment}'")
       return convert_catalog(result, @duration)
     end
     nil
@@ -167,7 +167,7 @@ class Puppet::Configurer
     begin
       report.configuration_version = catalog.version
 
-      benchmark(:notice, "Applied catalog") do
+      benchmark(:notice, _("Applied catalog")) do
         catalog.apply(options)
       end
     ensure
@@ -206,7 +206,7 @@ class Puppet::Configurer
           found = find_functional_server()
           server = found[:server]
           if server.nil?
-            Puppet.warning "Could not select a functional puppet master"
+            Puppet.warning _("Could not select a functional puppet master")
             server = [nil, nil]
           end
           Puppet.override(:server => server[0], :serverport => server[1]) do
@@ -237,7 +237,7 @@ class Puppet::Configurer
         @cached_catalog_status = 'explicitly_requested'
 
         if @environment != catalog.environment && !Puppet[:strict_environment_mode]
-          Puppet.notice "Local environment: '#{@environment}' doesn't match the environment of the cached catalog '#{catalog.environment}', switching agent to '#{catalog.environment}'."
+          Puppet.notice _("Local environment: '#{@environment}' doesn't match the environment of the cached catalog '#{catalog.environment}', switching agent to '#{catalog.environment}'.")
           @environment = catalog.environment
         end
 
@@ -277,16 +277,16 @@ class Puppet::Configurer
             @node_environment = node.environment.to_s
 
             if node.environment.to_s != @environment
-              Puppet.notice "Local environment: '#{@environment}' doesn't match server specified node environment '#{node.environment}', switching agent to '#{node.environment}'."
+              Puppet.notice _("Local environment: '#{@environment}' doesn't match server specified node environment '#{node.environment}', switching agent to '#{node.environment}'.")
               @environment = node.environment.to_s
               report.environment = @environment
               query_options = nil
             else
-              Puppet.info "Using configured environment '#{@environment}'"
+              Puppet.info _("Using configured environment '#{@environment}'")
             end
           end
         rescue StandardError => detail
-          Puppet.warning("Unable to fetch my node definition, but the agent run will continue:")
+          Puppet.warning(_("Unable to fetch my node definition, but the agent run will continue:"))
           Puppet.warning(detail)
         end
       end
@@ -311,7 +311,7 @@ class Puppet::Configurer
       end
 
       if Puppet[:strict_environment_mode] && catalog.environment != @environment
-        Puppet.err "Not using catalog because its environment '#{catalog.environment}' does not match agent specified environment '#{@environment}' and strict_environment_mode is set"
+        Puppet.err _("Not using catalog because its environment '#{catalog.environment}' does not match agent specified environment '#{@environment}' and strict_environment_mode is set")
         return nil
       end
 
@@ -322,9 +322,9 @@ class Puppet::Configurer
       tries = 0
       while catalog.environment and not catalog.environment.empty? and catalog.environment != @environment
         if tries > 3
-          raise Puppet::Error, "Catalog environment didn't stabilize after #{tries} fetches, aborting run"
+          raise Puppet::Error, _("Catalog environment didn't stabilize after #{tries} fetches, aborting run")
         end
-        Puppet.notice "Local environment: '#{@environment}' doesn't match server specified environment '#{catalog.environment}', restarting agent run with environment '#{catalog.environment}'"
+        Puppet.notice _("Local environment: '#{@environment}' doesn't match server specified environment '#{catalog.environment}', restarting agent run with environment '#{catalog.environment}'")
         @environment = catalog.environment
         report.environment = @environment
 
@@ -343,7 +343,7 @@ class Puppet::Configurer
       apply_catalog(catalog, options)
       report.exit_status
     rescue => detail
-      Puppet.log_exception(detail, "Failed to apply catalog: #{detail}")
+      Puppet.log_exception(detail, _("Failed to apply catalog: #{detail}"))
       return nil
     ensure
       execute_postrun_command or return nil
@@ -390,7 +390,7 @@ class Puppet::Configurer
     save_last_run_summary(report)
     Puppet::Transaction::Report.indirection.save(report, nil, :environment => Puppet::Node::Environment.remote(@environment)) if Puppet[:report]
   rescue => detail
-    Puppet.log_exception(detail, "Could not send report: #{detail}")
+    Puppet.log_exception(detail, _("Could not send report: #{detail}"))
   end
 
   def save_last_run_summary(report)
@@ -399,7 +399,7 @@ class Puppet::Configurer
       fh.print YAML.dump(report.raw_summary)
     end
   rescue => detail
-    Puppet.log_exception(detail, "Could not save last run local report: #{detail}")
+    Puppet.log_exception(detail, _("Could not save last run local report: #{detail}"))
   end
 
   private
@@ -411,7 +411,7 @@ class Puppet::Configurer
       Puppet::Util::Execution.execute([command])
       true
     rescue => detail
-      Puppet.log_exception(detail, "Could not run command from #{setting}: #{detail}")
+      Puppet.log_exception(detail, _("Could not run command from #{setting}: #{detail}"))
       false
     end
   end
@@ -424,7 +424,7 @@ class Puppet::Configurer
     end
     result
   rescue => detail
-    Puppet.log_exception(detail, "Could not retrieve catalog from cache: #{detail}")
+    Puppet.log_exception(detail, _("Could not retrieve catalog from cache: #{detail}"))
     return nil
   end
 
@@ -436,7 +436,7 @@ class Puppet::Configurer
     end
     result
   rescue StandardError => detail
-    Puppet.log_exception(detail, "Could not retrieve catalog from remote server: #{detail}")
+    Puppet.log_exception(detail, _("Could not retrieve catalog from remote server: #{detail}"))
     return nil
   end
 

--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -6,7 +6,7 @@ class Puppet::Configurer::Downloader
 
   # Evaluate our download, returning the list of changed values.
   def evaluate
-    Puppet.info _("Retrieving #{name}")
+    Puppet.info _("Retrieving %{name}") % { name: name }
 
     files = []
     begin
@@ -17,7 +17,7 @@ class Puppet::Configurer::Downloader
         end
       end
     rescue Puppet::Error => detail
-      Puppet.log_exception(detail, _("Could not retrieve #{name}: #{detail}"))
+      Puppet.log_exception(detail, _("Could not retrieve %{name}: %{detail}") % { name: name, detail: detail })
     end
     files
   end

--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -6,7 +6,7 @@ class Puppet::Configurer::Downloader
 
   # Evaluate our download, returning the list of changed values.
   def evaluate
-    Puppet.info "Retrieving #{name}"
+    Puppet.info _("Retrieving #{name}")
 
     files = []
     begin
@@ -17,7 +17,7 @@ class Puppet::Configurer::Downloader
         end
       end
     rescue Puppet::Error => detail
-      Puppet.log_exception(detail, "Could not retrieve #{name}: #{detail}")
+      Puppet.log_exception(detail, _("Could not retrieve #{name}: #{detail}"))
     end
     files
   end

--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -21,7 +21,7 @@ module Puppet::Configurer::FactHandler
     rescue SystemExit,NoMemoryError
       raise
     rescue Exception => detail
-      message = "Could not retrieve local facts: #{detail}"
+      message = _("Could not retrieve local facts: #{detail}")
       Puppet.log_exception(detail, message)
       raise Puppet::Error, message, detail.backtrace
     end

--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -21,7 +21,7 @@ module Puppet::Configurer::FactHandler
     rescue SystemExit,NoMemoryError
       raise
     rescue Exception => detail
-      message = _("Could not retrieve local facts: #{detail}")
+      message = _("Could not retrieve local facts: %{detail}") % { detail: detail }
       Puppet.log_exception(detail, message)
       raise Puppet::Error, message, detail.backtrace
     end


### PR DESCRIPTION
This commit marks error and info strings in `lib/puppet/configurer.rb`
and `lib/puppet/configurer/*` for translation.