### PR TITLE
(PUP-7042) Mark strings in transaction

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -79,7 +79,7 @@ class Puppet::Transaction
       prerun_errors.each do |res, detail|
         res.log_exception(detail)
       end
-      raise Puppet::Error, "Some pre-run checks failed"
+      raise Puppet::Error, _("Some pre-run checks failed")
     end
   end
 
@@ -95,7 +95,7 @@ class Puppet::Transaction
 
     persistence.load if catalog.host_config?
 
-    Puppet.info "Applying configuration version '#{catalog.version}'" if catalog.version
+    Puppet.info _("Applying configuration version '#{catalog.version}'") if catalog.version
 
     continue_while = lambda { !stop_processing? }
 
@@ -118,7 +118,7 @@ class Puppet::Transaction
       # is one, it must have been selected by the user.
       return if missing_tags?(resource)
       if resource.provider
-        resource.err "Provider #{resource.provider.class.name} is not functional on this host"
+        resource.err _("Provider #{resource.provider.class.name} is not functional on this host")
       else
         providerless_types << resource.type
       end
@@ -134,14 +134,14 @@ class Puppet::Transaction
     teardown = lambda do
       # Just once per type. No need to punish the user.
       providerless_types.uniq.each do |type|
-        Puppet.err "Could not find a suitable provider for #{type}"
+        Puppet.err _("Could not find a suitable provider for #{type}")
       end
 
       post_evalable_providers.each do |provider|
         begin
           provider.post_resource_eval
         rescue => detail
-          Puppet.log_exception(detail, "post_resource_eval failed for provider #{provider}")
+          Puppet.log_exception(detail, _("post_resource_eval failed for provider #{provider}"))
         end
       end
 
@@ -157,11 +157,11 @@ class Puppet::Transaction
                                 :canceled_resource_handler => canceled_resource_handler,
                                 :teardown => teardown) do |resource|
       if resource.is_a?(Puppet::Type::Component)
-        Puppet.warning "Somehow left a component in the relationship graph"
+        Puppet.warning _("Somehow left a component in the relationship graph")
       else
-        resource.info "Starting to evaluate the resource" if Puppet[:evaltrace] and @catalog.host_config?
+        resource.info _("Starting to evaluate the resource") if Puppet[:evaltrace] and @catalog.host_config?
         seconds = thinmark { block.call(resource) }
-        resource.info "Evaluated in %0.2f seconds" % seconds if Puppet[:evaltrace] and @catalog.host_config?
+        resource.info _("Evaluated in %0.2f seconds") % seconds if Puppet[:evaltrace] and @catalog.host_config?
       end
     end
 
@@ -231,7 +231,7 @@ class Puppet::Transaction
     add_resource_status(status)
     event_manager.queue_events(ancestor || resource, status.events) unless status.failed?
   rescue => detail
-    resource.err "Could not evaluate: #{detail}"
+    resource.err _("Could not evaluate: #{detail}")
   end
 
   # Evaluate a single resource.
@@ -261,7 +261,7 @@ class Puppet::Transaction
       # See above. --daniel 2011-06-06
       unless suppress_report then
         s.failed_dependencies.each do |dep|
-          resource.notice "Dependency #{dep} has failures: #{resource_status(dep).failed}"
+          resource.notice _("Dependency #{dep} has failures: #{resource_status(dep).failed}")
         end
       end
     end
@@ -318,7 +318,8 @@ class Puppet::Transaction
     begin
       provider_class.prefetch(resources)
     rescue LoadError, Puppet::MissingCommand => detail
-      Puppet.log_exception(detail, "Could not prefetch #{type_name} provider '#{provider_class.name}': #{detail}")
+      #TRANSLATORS `prefetch` is a function name and should not be translated
+      Puppet.log_exception(detail, _("Could not prefetch #{type_name} provider '#{provider_class.name}': #{detail}"))
     end
     @prefetched_providers[type_name][provider_class.name] = true
   end
@@ -346,7 +347,7 @@ class Puppet::Transaction
       # like class and stage.  This is undesirable; while just skipping the
       # output isn't perfect, it is RC-safe. --daniel 2011-06-07
       unless resource.class == Puppet::Type.type(:whit) then
-        resource.warning "Skipping because of failed dependencies"
+        resource.warning _("Skipping because of failed dependencies")
       end
     elsif resource.virtual?
       resource.debug "Skipping because virtual"

--- a/lib/puppet/transaction/additional_resource_generator.rb
+++ b/lib/puppet/transaction/additional_resource_generator.rb
@@ -22,7 +22,7 @@ class Puppet::Transaction::AdditionalResourceGenerator
       generated = resource.generate
     rescue => detail
       @resources_failed_to_generate = true
-      resource.log_exception(detail, _("Failed to generate additional resources using 'generate': #{detail}"))
+      resource.log_exception(detail, _("Failed to generate additional resources using 'generate': %{detail}") % { detail: detail })
     end
     return unless generated
     generated = [generated] unless generated.is_a?(Array)

--- a/lib/puppet/transaction/additional_resource_generator.rb
+++ b/lib/puppet/transaction/additional_resource_generator.rb
@@ -22,7 +22,7 @@ class Puppet::Transaction::AdditionalResourceGenerator
       generated = resource.generate
     rescue => detail
       @resources_failed_to_generate = true
-      resource.log_exception(detail, "Failed to generate additional resources using 'generate': #{detail}")
+      resource.log_exception(detail, _("Failed to generate additional resources using 'generate': #{detail}"))
     end
     return unless generated
     generated = [generated] unless generated.is_a?(Array)
@@ -51,13 +51,14 @@ class Puppet::Transaction::AdditionalResourceGenerator
 
   def eval_generate(resource)
     return false unless resource.respond_to?(:eval_generate)
-    raise Puppet::DevError,"Depthfirst resources are not supported by eval_generate" if resource.depthfirst?
+    raise Puppet::DevError, _("Depthfirst resources are not supported by eval_generate") if resource.depthfirst?
     begin
       generated = replace_duplicates_with_catalog_resources(resource.eval_generate)
       return false if generated.empty?
     rescue => detail
       @resources_failed_to_generate = true
-      resource.log_exception(detail, "Failed to generate additional resources using 'eval_generate': #{detail}")
+      #TRANSLATORS eval_generate is a method name and should be left untranslated
+      resource.log_exception(detail, _("Failed to generate additional resources using 'eval_generate': %{detail}") % { detail: detail })
       return false
     end
     add_resources(generated, resource)

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -82,7 +82,7 @@ class Puppet::Transaction::Event
   end
 
   def status=(value)
-    raise ArgumentError, "Event status can only be #{EVENT_STATUSES.join(', ')}" unless EVENT_STATUSES.include?(value)
+    raise ArgumentError, _("Event status can only be #{EVENT_STATUSES.join(', ')}") unless EVENT_STATUSES.include?(value)
     @status = value
   end
 

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -82,7 +82,7 @@ class Puppet::Transaction::Event
   end
 
   def status=(value)
-    raise ArgumentError, _("Event status can only be #{EVENT_STATUSES.join(', ')}") unless EVENT_STATUSES.include?(value)
+    raise ArgumentError, _("Event status can only be %{statuses}") % { statuses: EVENT_STATUSES.join(', ') } unless EVENT_STATUSES.include?(value)
     @status = value
   end
 

--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -84,13 +84,13 @@ class Puppet::Transaction::EventManager
   def dequeue_all_events_for_resource(target)
     callbacks = @event_queues[target]
     if callbacks && !callbacks.empty?
-      target.info "Unscheduling all events on #{target}"
+      target.info _("Unscheduling all events on #{target}")
       @event_queues[target] = {}
     end
   end
 
   def dequeue_events_for_resource(target, callback)
-    target.info "Unscheduling #{callback} on #{target}"
+    target.info _("Unscheduling #{callback} on #{target}")
     @event_queues[target][callback] = [] if @event_queues[target]
   end
 
@@ -105,7 +105,7 @@ class Puppet::Transaction::EventManager
     if refreshing_c_whit
       source.debug "The container #{target} will propagate my #{callback} event"
     else
-      source.info "Scheduling #{callback} of #{target}"
+      source.info _("Scheduling #{callback} of #{target}")
     end
 
     @event_queues[target] ||= {}
@@ -147,11 +147,11 @@ class Puppet::Transaction::EventManager
     resource.send(callback)
 
     if not resource.is_a?(Puppet::Type.type(:whit))
-      resource.notice "Triggered '#{callback}' from #{events.length} events"
+      resource.notice n_("Triggered '#{callback}' from %{count} event", "Triggered '#{callback}' from %{count} events", events.length) % { :count => events.length }
     end
     return true
   rescue => detail
-    resource.err "Failed to call #{callback}: #{detail}"
+    resource.err _("Failed to call #{callback}: #{detail}")
 
     transaction.resource_status(resource).failed_to_restart = true
     resource.log_exception(detail)
@@ -159,7 +159,7 @@ class Puppet::Transaction::EventManager
   end
 
   def process_noop_events(resource, callback, events)
-    resource.notice "Would have triggered '#{callback}' from #{events.length} events"
+    resource.notice _("Would have triggered '#{callback}' from #{events.length} events")
 
     # And then add an event for it.
     queue_events(resource, [resource.event(:status => "noop", :name => :noop_restart)])

--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -84,13 +84,13 @@ class Puppet::Transaction::EventManager
   def dequeue_all_events_for_resource(target)
     callbacks = @event_queues[target]
     if callbacks && !callbacks.empty?
-      target.info _("Unscheduling all events on #{target}")
+      target.info _("Unscheduling all events on %{target}") % { target: target }
       @event_queues[target] = {}
     end
   end
 
   def dequeue_events_for_resource(target, callback)
-    target.info _("Unscheduling #{callback} on #{target}")
+    target.info _("Unscheduling %{callback} on %{target}") % { callback: callback, target: target }
     @event_queues[target][callback] = [] if @event_queues[target]
   end
 
@@ -105,7 +105,7 @@ class Puppet::Transaction::EventManager
     if refreshing_c_whit
       source.debug "The container #{target} will propagate my #{callback} event"
     else
-      source.info _("Scheduling #{callback} of #{target}")
+      source.info _("Scheduling %{callback} of %{target}") % { callback: callback, target: target }
     end
 
     @event_queues[target] ||= {}
@@ -147,11 +147,11 @@ class Puppet::Transaction::EventManager
     resource.send(callback)
 
     if not resource.is_a?(Puppet::Type.type(:whit))
-      resource.notice n_("Triggered '#{callback}' from %{count} event", "Triggered '#{callback}' from %{count} events", events.length) % { :count => events.length }
+      resource.notice n_("Triggered '%{callback}' from %{count} event", "Triggered '%{callback}' from %{count} events", events.length) % { count: events.length, callback: callback }
     end
     return true
   rescue => detail
-    resource.err _("Failed to call #{callback}: #{detail}")
+    resource.err _("Failed to call %{callback}: %{detail}") % { callback: callback, detail: detail }
 
     transaction.resource_status(resource).failed_to_restart = true
     resource.log_exception(detail)
@@ -159,7 +159,7 @@ class Puppet::Transaction::EventManager
   end
 
   def process_noop_events(resource, callback, events)
-    resource.notice _("Would have triggered '#{callback}' from #{events.length} events")
+    resource.notice n_("Would have triggered '%{callback}' from %{count} event", "Would have triggered '%{callback}' from %{count} events", events.length) % { count: events.length, callback: callback }
 
     # And then add an event for it.
     queue_events(resource, [resource.event(:status => "noop", :name => :noop_restart)])

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -47,7 +47,7 @@ class Puppet::Transaction::Persistence
       return
     end
     unless File.file?(filename)
-      Puppet.warning(_("Transaction store file #{filename} is not a file, ignoring"))
+      Puppet.warning(_("Transaction store file %{filename} is not a file, ignoring") % { filename: filename })
       return
     end
 
@@ -56,13 +56,13 @@ class Puppet::Transaction::Persistence
       begin
         result = Puppet::Util::Yaml.load_file(filename, false, true)
       rescue Puppet::Util::Yaml::YamlLoadError => detail
-        Puppet.log_exception(detail, _("Transaction store file #{filename} is corrupt (#{detail}); replacing"), { :level => :warning })
+        Puppet.log_exception(detail, _("Transaction store file %{filename} is corrupt (%{detail}); replacing") % { filename: filename, detail: detail }, { :level => :warning })
 
         begin
           File.rename(filename, filename + ".bad")
         rescue => detail
-          Puppet.log_exception(detail, _("Unable to rename corrupt transaction store file: #{detail}"))
-          raise Puppet::Error, _("Could not rename corrupt transaction store file #{filename}; remove manually"), detail.backtrace
+          Puppet.log_exception(detail, _("Unable to rename corrupt transaction store file: %{detail}") % { detail: detail })
+          raise Puppet::Error, _("Could not rename corrupt transaction store file %{filename}; remove manually") % { filename: filename }, detail.backtrace
         end
 
         result = {}
@@ -70,7 +70,7 @@ class Puppet::Transaction::Persistence
     end
 
     unless result.is_a?(Hash)
-      Puppet.err _("Transaction store file #{filename} is valid YAML but not returning a hash. Check the file for corruption, or remove it before continuing.")
+      Puppet.err _("Transaction store file %{filename} is valid YAML but not returning a hash. Check the file for corruption, or remove it before continuing.") % { filename: filename }
       return
     end
 

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -47,22 +47,22 @@ class Puppet::Transaction::Persistence
       return
     end
     unless File.file?(filename)
-      Puppet.warning("Transaction store file #{filename} is not a file, ignoring")
+      Puppet.warning(_("Transaction store file #{filename} is not a file, ignoring"))
       return
     end
 
     result = nil
-    Puppet::Util.benchmark(:debug, "Loaded transaction store file") do
+    Puppet::Util.benchmark(:debug, _("Loaded transaction store file")) do
       begin
         result = Puppet::Util::Yaml.load_file(filename, false, true)
       rescue Puppet::Util::Yaml::YamlLoadError => detail
-        Puppet.log_exception(detail, "Transaction store file #{filename} is corrupt (#{detail}); replacing", { :level => :warning })
+        Puppet.log_exception(detail, _("Transaction store file #{filename} is corrupt (#{detail}); replacing"), { :level => :warning })
 
         begin
           File.rename(filename, filename + ".bad")
         rescue => detail
-          Puppet.log_exception(detail, "Unable to rename corrupt transaction store file: #{detail}")
-          raise Puppet::Error, "Could not rename corrupt transaction store file #{filename}; remove manually", detail.backtrace
+          Puppet.log_exception(detail, _("Unable to rename corrupt transaction store file: #{detail}"))
+          raise Puppet::Error, _("Could not rename corrupt transaction store file #{filename}; remove manually"), detail.backtrace
         end
 
         result = {}
@@ -70,7 +70,7 @@ class Puppet::Transaction::Persistence
     end
 
     unless result.is_a?(Hash)
-      Puppet.err "Transaction store file #{filename} is valid YAML but not returning a hash. Check the file for corruption, or remove it before continuing."
+      Puppet.err _("Transaction store file #{filename} is valid YAML but not returning a hash. Check the file for corruption, or remove it before continuing.")
       return
     end
 

--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -47,12 +47,12 @@ class Puppet::Transaction::ResourceHarness
 
   def schedule(resource)
     unless resource.catalog
-      resource.warning "Cannot schedule without a schedule-containing catalog"
+      resource.warning _("Cannot schedule without a schedule-containing catalog")
       return nil
     end
 
     return nil unless name = resource[:schedule]
-    resource.catalog.resource(:schedule, name) || resource.fail("Could not find schedule #{name}")
+    resource.catalog.resource(:schedule, name) || resource.fail(_("Could not find schedule #{name}"))
   end
 
   # Used mostly for scheduling and auditing at this point.
@@ -144,7 +144,7 @@ class Puppet::Transaction::ResourceHarness
 
       event = create_change_event(param, current_value, historical_value)
       event.status = "failure"
-      event.message = param.format("change from %s to %s failed: #{detail}",
+      event.message = param.format(_("change from %s to %s failed: #{detail}"),
                                    param.is_to_s(current_value),
                                    param.should_to_s(param.should))
       event
@@ -152,7 +152,7 @@ class Puppet::Transaction::ResourceHarness
       # Execution will halt on Exceptions, they get raised to the application
       event = create_change_event(param, current_value, historical_value)
       event.status = "failure"
-      event.message = param.format("change from %s to %s failed: #{detail}",
+      event.message = param.format(_("change from %s to %s failed: #{detail}"),
                                    param.is_to_s(current_value),
                                    param.should_to_s(param.should))
       raise
@@ -209,7 +209,7 @@ class Puppet::Transaction::ResourceHarness
     # The event we've been provided might have been redacted so we need to use the state stored within
     # the resource application context to see if an event was actually generated.
     if !are_audited_values_equal(context.historical_values[property.name], context.current_values[property.name])
-      event.message = property.format("audit change: previously recorded value %s has been changed to %s",
+      event.message = property.format(_("audit change: previously recorded value %s has been changed to %s"),
                  property.is_to_s(event.historical_value),
                  property.is_to_s(event.previous_value))
     end
@@ -219,14 +219,14 @@ class Puppet::Transaction::ResourceHarness
 
   def audit_message(param, do_audit, historical_value, current_value)
     if do_audit && historical_value && !are_audited_values_equal(historical_value, current_value)
-      param.format(" (previously recorded value was %s)", param.is_to_s(historical_value))
+      param.format(_(" (previously recorded value was %s)"), param.is_to_s(historical_value))
     else
       ""
     end
   end
 
   def noop(event, param, current_value, audit_message)
-    event.message = param.format("current_value %s, should be %s (noop)#{audit_message}",
+    event.message = param.format(_("current_value %s, should be %s (noop)#{audit_message}"),
                                  param.is_to_s(current_value),
                                  param.should_to_s(param.should))
     event.status = "noop"
@@ -235,7 +235,7 @@ class Puppet::Transaction::ResourceHarness
   def sync(event, param, current_value, audit_message)
     param.sync
     if param.sensitive
-      event.message = param.format("changed %s to %s#{audit_message}", param.is_to_s(current_value), param.should_to_s(param.should))
+      event.message = param.format(_("changed %s to %s#{audit_message}"), param.is_to_s(current_value), param.should_to_s(param.should))
     else
       event.message = "#{param.change_to_s(current_value, param.should)}#{audit_message}"
     end
@@ -256,7 +256,7 @@ class Puppet::Transaction::ResourceHarness
         end
       else
         property = resource.property(param_name)
-        property.notice(property.format("audit change: newly-recorded value %s", context.current_values[param_name]))
+        property.notice(property.format(_("audit change: newly-recorded value %s"), context.current_values[param_name]))
       end
     end
   end


### PR DESCRIPTION
This commit marks user-facing error and info level strings in
`lib/puppet/transaction.rb` and `lib/puppet/transaction/*` for
translation.