### PR TITLE
(PUP-7042) Mark strings in reports

### DIFF
--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -29,7 +29,7 @@ Puppet::Reports.register_report(:http) do
     conn = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl)
     response = conn.post(url.path, self.to_yaml, headers, options)
     unless response.kind_of?(Net::HTTPSuccess)
-      Puppet.err _("Unable to submit report to #{Puppet[:reporturl].to_s} [#{response.code}] #{response.msg}")
+      Puppet.err _("Unable to submit report to %{url} [%{code}] %{message}") % { url: Puppet[:reporturl].to_s, code: response.code, message: response.msg }
     end
   end
 end

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -29,7 +29,7 @@ Puppet::Reports.register_report(:http) do
     conn = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl)
     response = conn.post(url.path, self.to_yaml, headers, options)
     unless response.kind_of?(Net::HTTPSuccess)
-      Puppet.err "Unable to submit report to #{Puppet[:reporturl].to_s} [#{response.code}] #{response.msg}"
+      Puppet.err _("Unable to submit report to #{Puppet[:reporturl].to_s} [#{response.code}] #{response.msg}")
     end
   end
 end

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -3,7 +3,7 @@
 # fast_gettext for your project.
 gettext:
   # This is used for the name of the .pot and .po files; they will be
-  # called <project_name>.pot?
+  # called <project_name>.pot
   project_name: 'puppet'
   # This is used in comments in the .pot and .po files to indicate what
   # project the files belong to and should be a little more descriptive than


### PR DESCRIPTION
This commit marks user-facing error strings in `lib/puppet/reports/*`
for translation.