### PR TITLE
(PUP-7042) Mark strings in util

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -62,7 +62,7 @@ module Util
       when :windows
         Puppet::Util::Windows::Process.get_environment_strings
       else
-        raise "Unable to retrieve the environment for mode #{mode}"
+        raise _("Unable to retrieve the environment for mode #{mode}")
     end
   end
   module_function :get_environment
@@ -79,7 +79,7 @@ module Util
           Puppet::Util::Windows::Process.set_environment_variable(key, nil)
         end
       else
-        raise "Unable to clear the environment for mode #{mode}"
+        raise _("Unable to clear the environment for mode #{mode}")
     end
   end
   module_function :clear_environment
@@ -95,7 +95,7 @@ module Util
       when :windows
         Puppet::Util::Windows::Process.set_environment_variable(name,value)
       else
-        raise "Unable to set the environment variable #{name} for mode #{mode}"
+        raise _("Unable to set the environment variable #{name} for mode #{mode}")
     end
   end
   module_function :set_env
@@ -112,7 +112,7 @@ module Util
           Puppet::Util::Windows::Process.set_environment_variable(name.to_s, val)
         end
       else
-        raise "Unable to merge given values into the current environment for mode #{mode}"
+        raise _("Unable to merge given values into the current environment for mode #{mode}")
     end
   end
   module_function :merge_environment
@@ -153,8 +153,8 @@ module Util
       begin
         Puppet::Util::SUIDManager.change_group(group, true)
       rescue => detail
-        Puppet.warning "could not change to group #{group.inspect}: #{detail}"
-        $stderr.puts "could not change to group #{group.inspect}"
+        Puppet.warning _("could not change to group #{group.inspect}: #{detail}")
+        $stderr.puts _("could not change to group #{group.inspect}")
 
         # Don't exit on failed group changes, since it's
         # not fatal
@@ -166,7 +166,7 @@ module Util
       begin
         Puppet::Util::SUIDManager.change_user(user, true)
       rescue => detail
-        $stderr.puts "Could not change to user #{user}: #{detail}"
+        $stderr.puts _("Could not change to user #{user}: #{detail}")
         exit(74)
       end
     end
@@ -223,7 +223,9 @@ module Util
       seconds = Benchmark.realtime {
         yield
       }
-      object.send(level, msg + (" in %0.2f seconds" % seconds))
+      #TRANSLATORS forms the end of a string indicating how long a
+      # given operation took
+      object.send(level, msg + (_(" in %0.2f seconds") % seconds))
       return seconds
     else
       yield
@@ -254,10 +256,10 @@ module Util
           if e.to_s =~ /HOME/ and (Puppet::Util.get_env('HOME').nil? || Puppet::Util.get_env('HOME') == "")
             # if we get here they have a tilde in their PATH.  We'll issue a single warning about this and then
             # ignore this path element and carry on with our lives.
-            Puppet::Util::Warnings.warnonce("PATH contains a ~ character, and HOME is not set; ignoring PATH element '#{dir}'.")
+            Puppet::Util::Warnings.warnonce(_("PATH contains a ~ character, and HOME is not set; ignoring PATH element '#{dir}'."))
           elsif e.to_s =~ /doesn't exist|can't find user/
             # ...otherwise, we just skip the non-existent entry, and do nothing.
-            Puppet::Util::Warnings.warnonce("Couldn't expand PATH containing a ~ character; ignoring PATH element '#{dir}'.")
+            Puppet::Util::Warnings.warnonce(_("Couldn't expand PATH containing a ~ character; ignoring PATH element '#{dir}'."))
           else
             raise
           end
@@ -326,7 +328,7 @@ module Util
     begin
       URI::Generic.build(params)
     rescue => detail
-      raise Puppet::Error, "Failed to convert '#{path}' to URI: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Failed to convert '#{path}' to URI: #{detail}"), detail.backtrace
     end
   end
   module_function :path_to_uri
@@ -551,7 +553,7 @@ module Util
     ## NOTE: when debugging spec failures, these two lines can be very useful
     #puts err.inspect
     #puts Puppet::Util.pretty_backtrace(err.backtrace)
-    Puppet.log_exception(err, "Could not #{message}: #{err}")
+    Puppet.log_exception(err, _("Could not #{message}: #{err}"))
     Puppet::Util::Log.force_flushqueue()
     exit(code)
   end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -62,7 +62,7 @@ module Util
       when :windows
         Puppet::Util::Windows::Process.get_environment_strings
       else
-        raise _("Unable to retrieve the environment for mode #{mode}")
+        raise _("Unable to retrieve the environment for mode %{mode}") % { mode: mode }
     end
   end
   module_function :get_environment
@@ -79,7 +79,7 @@ module Util
           Puppet::Util::Windows::Process.set_environment_variable(key, nil)
         end
       else
-        raise _("Unable to clear the environment for mode #{mode}")
+        raise _("Unable to clear the environment for mode %{mode}") % { mode: mode }
     end
   end
   module_function :clear_environment
@@ -95,7 +95,7 @@ module Util
       when :windows
         Puppet::Util::Windows::Process.set_environment_variable(name,value)
       else
-        raise _("Unable to set the environment variable #{name} for mode #{mode}")
+        raise _("Unable to set the environment variable %{name} for mode %{mode}") % { name: name, mode: mode }
     end
   end
   module_function :set_env
@@ -112,7 +112,7 @@ module Util
           Puppet::Util::Windows::Process.set_environment_variable(name.to_s, val)
         end
       else
-        raise _("Unable to merge given values into the current environment for mode #{mode}")
+        raise _("Unable to merge given values into the current environment for mode %{mode}") % { mode: mode }
     end
   end
   module_function :merge_environment
@@ -153,8 +153,8 @@ module Util
       begin
         Puppet::Util::SUIDManager.change_group(group, true)
       rescue => detail
-        Puppet.warning _("could not change to group #{group.inspect}: #{detail}")
-        $stderr.puts _("could not change to group #{group.inspect}")
+        Puppet.warning _("could not change to group %{group}: %{detail}") % { group: group.inspect, detail: detail }
+        $stderr.puts _("could not change to group %{group}") % { group: group.inspect }
 
         # Don't exit on failed group changes, since it's
         # not fatal
@@ -166,7 +166,7 @@ module Util
       begin
         Puppet::Util::SUIDManager.change_user(user, true)
       rescue => detail
-        $stderr.puts _("Could not change to user #{user}: #{detail}")
+        $stderr.puts _("Could not change to user %{user}: %{detail}") % { user: user, detail: detail }
         exit(74)
       end
     end
@@ -256,10 +256,12 @@ module Util
           if e.to_s =~ /HOME/ and (Puppet::Util.get_env('HOME').nil? || Puppet::Util.get_env('HOME') == "")
             # if we get here they have a tilde in their PATH.  We'll issue a single warning about this and then
             # ignore this path element and carry on with our lives.
-            Puppet::Util::Warnings.warnonce(_("PATH contains a ~ character, and HOME is not set; ignoring PATH element '#{dir}'."))
+            #TRANSLATORS PATH and HOME are environment variables and should not be translated
+            Puppet::Util::Warnings.warnonce(_("PATH contains a ~ character, and HOME is not set; ignoring PATH element '%{dir}'.") % { dir: dir })
           elsif e.to_s =~ /doesn't exist|can't find user/
             # ...otherwise, we just skip the non-existent entry, and do nothing.
-            Puppet::Util::Warnings.warnonce(_("Couldn't expand PATH containing a ~ character; ignoring PATH element '#{dir}'."))
+            #TRANSLATORS PATH is an environment variable and should not be translated
+            Puppet::Util::Warnings.warnonce(_("Couldn't expand PATH containing a ~ character; ignoring PATH element '%{dir}'.") % { dir: dir })
           else
             raise
           end
@@ -328,7 +330,7 @@ module Util
     begin
       URI::Generic.build(params)
     rescue => detail
-      raise Puppet::Error, _("Failed to convert '#{path}' to URI: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Failed to convert '%{path}' to URI: %{detail}") % { path: path, detail: detail }, detail.backtrace
     end
   end
   module_function :path_to_uri
@@ -553,7 +555,7 @@ module Util
     ## NOTE: when debugging spec failures, these two lines can be very useful
     #puts err.inspect
     #puts Puppet::Util.pretty_backtrace(err.backtrace)
-    Puppet.log_exception(err, _("Could not #{message}: #{err}"))
+    Puppet.log_exception(err, _("Could not %{message}: %{err}") % { message: message, err: err })
     Puppet::Util::Log.force_flushqueue()
     exit(code)
   end

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -70,7 +70,7 @@ class Puppet::Util::Autoload
       rescue SystemExit,NoMemoryError
         raise
       rescue Exception => detail
-        message = _("Could not autoload #{name}: #{detail}")
+        message = _("Could not autoload %{name}: %{detail}") % { name: name, detail: detail }
         Puppet.log_exception(detail, message)
         raise Puppet::Error, message, detail.backtrace
       end

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -70,7 +70,7 @@ class Puppet::Util::Autoload
       rescue SystemExit,NoMemoryError
         raise
       rescue Exception => detail
-        message = "Could not autoload #{name}: #{detail}"
+        message = _("Could not autoload #{name}: #{detail}")
         Puppet.log_exception(detail, message)
         raise Puppet::Error, message, detail.backtrace
       end
@@ -184,7 +184,7 @@ class Puppet::Util::Autoload
 
   def initialize(obj, path, options = {})
     @path = path.to_s
-    raise ArgumentError, "Autoload paths cannot be fully qualified" if Puppet::Util.absolute_path?(@path)
+    raise ArgumentError, _("Autoload paths cannot be fully qualified") if Puppet::Util.absolute_path?(@path)
     @object = obj
 
     set_options(options)

--- a/lib/puppet/util/backups.rb
+++ b/lib/puppet/util/backups.rb
@@ -46,7 +46,7 @@ module Puppet::Util::Backups
     rescue => detail
       # since they said they want a backup, let's error out
       # if we couldn't make one
-      self.fail Puppet::Error, _("Could not back #{file} up: #{detail.message}"), detail
+      self.fail Puppet::Error, _("Could not back %{file} up: %{message}") % { file: file, message: detail.message }, detail
     end
   end
 
@@ -64,15 +64,15 @@ module Puppet::Util::Backups
     end
 
     if stat.ftype == "directory"
-      raise Puppet::Error, _("Will not remove directory backup #{newfile}; use a filebucket")
+      raise Puppet::Error, _("Will not remove directory backup %{newfile}; use a filebucket") % { newfile: newfile }
     end
 
-    info _("Removing old backup of type #{stat.ftype}")
+    info _("Removing old backup of type %{file_type}") % { file_type: stat.ftype }
 
     begin
       Puppet::FileSystem.unlink(newfile)
     rescue => detail
-      message = _("Could not remove old backup: #{detail}")
+      message = _("Could not remove old backup: %{detail}") % { detail: detail }
       self.log_exception(detail, message)
       self.fail Puppet::Error, message, detail
     end
@@ -80,7 +80,7 @@ module Puppet::Util::Backups
 
   def backup_file_with_filebucket(f)
     sum = self.bucket.backup(f)
-    self.info _("Filebucketed #{f} to #{self.bucket.name} with sum #{sum}")
+    self.info _("Filebucketed %{f} to %{filebucket} with sum %{sum}") % { f: f, filebucket: self.bucket.name, sum: sum }
     return sum
     end
 end

--- a/lib/puppet/util/backups.rb
+++ b/lib/puppet/util/backups.rb
@@ -23,7 +23,7 @@ module Puppet::Util::Backups
     when "directory"
       # we don't need to backup directories when recurse is on
       return true if self[:recurse]
-      info "Recursively backing up to filebucket"
+      info _("Recursively backing up to filebucket")
       Find.find(self[:path]) { |f| backup_file_with_filebucket(f) if File.file?(f) }
     when "file"; backup_file_with_filebucket(file)
     when "link";
@@ -46,7 +46,7 @@ module Puppet::Util::Backups
     rescue => detail
       # since they said they want a backup, let's error out
       # if we couldn't make one
-      self.fail Puppet::Error, "Could not back #{file} up: #{detail.message}", detail
+      self.fail Puppet::Error, _("Could not back #{file} up: #{detail.message}"), detail
     end
   end
 
@@ -64,15 +64,15 @@ module Puppet::Util::Backups
     end
 
     if stat.ftype == "directory"
-      raise Puppet::Error, "Will not remove directory backup #{newfile}; use a filebucket"
+      raise Puppet::Error, _("Will not remove directory backup #{newfile}; use a filebucket")
     end
 
-    info "Removing old backup of type #{stat.ftype}"
+    info _("Removing old backup of type #{stat.ftype}")
 
     begin
       Puppet::FileSystem.unlink(newfile)
     rescue => detail
-      message = "Could not remove old backup: #{detail}"
+      message = _("Could not remove old backup: #{detail}")
       self.log_exception(detail, message)
       self.fail Puppet::Error, message, detail
     end
@@ -80,7 +80,7 @@ module Puppet::Util::Backups
 
   def backup_file_with_filebucket(f)
     sum = self.bucket.backup(f)
-    self.info "Filebucketed #{f} to #{self.bucket.name} with sum #{sum}"
+    self.info _("Filebucketed #{f} to #{self.bucket.name} with sum #{sum}")
     return sum
     end
 end

--- a/lib/puppet/util/classgen.rb
+++ b/lib/puppet/util/classgen.rb
@@ -157,11 +157,11 @@ module Puppet::Util::ClassGen
 
     if is_constant_defined?(const)
       if options[:overwrite]
-        Puppet.info _("Redefining #{name} in #{self}")
+        Puppet.info _("Redefining %{name} in %{klass}") % { name: name, klass: self }
         remove_const(const)
       else
         raise Puppet::ConstantAlreadyDefined,
-          _("Class #{const} is already defined in #{self}")
+          _("Class %{const} is already defined in %{klass}") % { const: const, klass: self }
       end
     end
     const_set(const, klass)
@@ -206,7 +206,7 @@ module Puppet::Util::ClassGen
     if hash = options[:hash]
       if hash.include? klassname and ! options[:overwrite]
         raise Puppet::SubclassAlreadyDefined,
-          _("Already a generated class named #{klassname}")
+          _("Already a generated class named %{klassname}") % { klassname: klassname }
       end
 
       hash[klassname] = klass
@@ -218,7 +218,7 @@ module Puppet::Util::ClassGen
               array.find { |c| c.name == klassname } and
               ! options[:overwrite])
         raise Puppet::SubclassAlreadyDefined,
-          _("Already a generated class named #{klassname}")
+          _("Already a generated class named %{klassname}") % { klassname: klassname }
       end
 
       array << klass

--- a/lib/puppet/util/classgen.rb
+++ b/lib/puppet/util/classgen.rb
@@ -157,11 +157,11 @@ module Puppet::Util::ClassGen
 
     if is_constant_defined?(const)
       if options[:overwrite]
-        Puppet.info "Redefining #{name} in #{self}"
+        Puppet.info _("Redefining #{name} in #{self}")
         remove_const(const)
       else
         raise Puppet::ConstantAlreadyDefined,
-          "Class #{const} is already defined in #{self}"
+          _("Class #{const} is already defined in #{self}")
       end
     end
     const_set(const, klass)
@@ -206,7 +206,7 @@ module Puppet::Util::ClassGen
     if hash = options[:hash]
       if hash.include? klassname and ! options[:overwrite]
         raise Puppet::SubclassAlreadyDefined,
-          "Already a generated class named #{klassname}"
+          _("Already a generated class named #{klassname}")
       end
 
       hash[klassname] = klass
@@ -218,7 +218,7 @@ module Puppet::Util::ClassGen
               array.find { |c| c.name == klassname } and
               ! options[:overwrite])
         raise Puppet::SubclassAlreadyDefined,
-          "Already a generated class named #{klassname}"
+          _("Already a generated class named #{klassname}")
       end
 
       array << klass

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -63,7 +63,7 @@ module Puppet
       #
       # @return [void]
       def execute
-        Puppet::Util.exit_on_fail("initialize global default settings") do
+        Puppet::Util.exit_on_fail(_("initialize global default settings")) do
           Puppet.initialize_settings(args)
         end
 
@@ -159,10 +159,10 @@ module Puppet
             puts Puppet.version
           elsif @command_line.subcommand_name.nil? && args.count > 0
             # If the subcommand is truly nil and there is an arg, it's an option; print out the invalid option message
-            puts colorize(:hred, "Error: Could not parse application options: invalid option: #{args[0]}")
+            puts colorize(:hred, _("Error: Could not parse application options: invalid option: #{args[0]}"))
             exit 1
           else
-            puts "See 'puppet help' for help on available puppet subcommands"
+            puts _("See 'puppet help' for help on available puppet subcommands")
           end
         end
       end
@@ -175,7 +175,7 @@ module Puppet
         end
 
         def run
-          puts colorize(:hred, "Error: Unknown Puppet subcommand '#{@subcommand_name}'")
+          puts colorize(:hred, _("Error: Unknown Puppet subcommand '#{@subcommand_name}'"))
           super
           exit 1
         end

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -159,7 +159,7 @@ module Puppet
             puts Puppet.version
           elsif @command_line.subcommand_name.nil? && args.count > 0
             # If the subcommand is truly nil and there is an arg, it's an option; print out the invalid option message
-            puts colorize(:hred, _("Error: Could not parse application options: invalid option: #{args[0]}"))
+            puts colorize(:hred, _("Error: Could not parse application options: invalid option: %{opt}") % { opt: args[0] })
             exit 1
           else
             puts _("See 'puppet help' for help on available puppet subcommands")
@@ -175,7 +175,7 @@ module Puppet
         end
 
         def run
-          puts colorize(:hred, _("Error: Unknown Puppet subcommand '#{@subcommand_name}'"))
+          puts colorize(:hred, _("Error: Unknown Puppet subcommand '%{cmd}'") % { cmd: @subcommand_name })
           super
           exit 1
         end

--- a/lib/puppet/util/command_line/puppet_option_parser.rb
+++ b/lib/puppet/util/command_line/puppet_option_parser.rb
@@ -44,7 +44,7 @@ module Puppet
           elsif args.length == 4
             long, short, desc, type = args
           else
-            raise ArgumentError, _("this method only takes 3 or 4 arguments. Given: #{args.inspect}")
+            raise ArgumentError, _("this method only takes 3 or 4 arguments. Given: %{args}") % { value0: args.inspect }
           end
 
           options = {
@@ -61,7 +61,7 @@ module Puppet
             when :NONE
               options[:type] = :flag
             else
-              raise PuppetOptionError.new(_("Unsupported type: '#{type}'"))
+              raise PuppetOptionError.new(_("Unsupported type: '%{type}'") % { type: type })
           end
 
           @parser.opt long.sub("^--", "").intern, desc, options

--- a/lib/puppet/util/command_line/puppet_option_parser.rb
+++ b/lib/puppet/util/command_line/puppet_option_parser.rb
@@ -44,7 +44,7 @@ module Puppet
           elsif args.length == 4
             long, short, desc, type = args
           else
-            raise ArgumentError, "this method only takes 3 or 4 arguments. Given: #{args.inspect}"
+            raise ArgumentError, _("this method only takes 3 or 4 arguments. Given: #{args.inspect}")
           end
 
           options = {
@@ -61,7 +61,7 @@ module Puppet
             when :NONE
               options[:type] = :flag
             else
-              raise PuppetOptionError.new("Unsupported type: '#{type}'")
+              raise PuppetOptionError.new(_("Unsupported type: '#{type}'"))
           end
 
           @parser.opt long.sub("^--", "").intern, desc, options
@@ -73,7 +73,7 @@ module Puppet
           begin
             @parser.parse args_copy
           rescue Puppet::Util::CommandLine::Trollop::CommandlineError => err
-            raise PuppetOptionError.new("Error parsing arguments", err)
+            raise PuppetOptionError.new(_("Error parsing arguments"), err)
           end
         end
 

--- a/lib/puppet/util/command_line/trollop.rb
+++ b/lib/puppet/util/command_line/trollop.rb
@@ -146,7 +146,7 @@ class Parser
   ## value, you must specify +:type+ as well.
 
   def opt name, desc="", opts={}
-    raise ArgumentError, _("you already have an argument named '#{name}'") if @specs.member? name
+    raise ArgumentError, _("you already have an argument named '%{name}'") % { name: name } if @specs.member? name
 
     ## fill in :type
     opts[:type] = # normalize
@@ -194,7 +194,7 @@ class Parser
       when Date; :date
       when Array
         if opts[:default].empty?
-          raise ArgumentError, _("multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'")
+          raise ArgumentError, _("multiple argument type cannot be deduced from an empty array for '%{value0}'") % { value0: opts[:default][0].class.name }
         end
         case opts[:default][0]    # the first element determines the types
         when Integer; :ints
@@ -203,14 +203,14 @@ class Parser
         when IO; :ios
         when Date; :dates
         else
-          raise ArgumentError, _("unsupported multiple argument type '#{opts[:default][0].class.name}'")
+          raise ArgumentError, _("unsupported multiple argument type '%{value0}'") % { value0: opts[:default][0].class.name }
         end
       when nil; nil
       else
-        raise ArgumentError, _("unsupported argument type '#{opts[:default].class.name}'")
+        raise ArgumentError, _("unsupported argument type '%{value0}'") % { value0: opts[:default].class.name }
       end
 
-    raise ArgumentError, _(":type specification and default type don't match (default type is #{type_from_default})") if opts[:type] && type_from_default && opts[:type] != type_from_default
+    raise ArgumentError, _(":type specification and default type don't match (default type is %{type_from_default})") % { type_from_default: type_from_default } if opts[:type] && type_from_default && opts[:type] != type_from_default
 
     opts[:type] = opts[:type] || type_from_default || :flag
 
@@ -225,7 +225,7 @@ class Parser
       else
         raise ArgumentError, "invalid long option name #{opts[:long].inspect}"
       end
-    raise ArgumentError, _("long option name #{opts[:long].inspect} is already taken; please specify a (different) :long") if @long[opts[:long]]
+    raise ArgumentError, _("long option name %{value0} is already taken; please specify a (different) :long") % { value0: opts[:long].inspect } if @long[opts[:long]]
 
     ## fill in :short
     opts[:short] = opts[:short].to_s if opts[:short] unless opts[:short] == :none
@@ -236,7 +236,7 @@ class Parser
     end
 
     if opts[:short]
-      raise ArgumentError, _("short option name #{opts[:short].inspect} is already taken; please specify a (different) :short") if @short[opts[:short]]
+      raise ArgumentError, _("short option name %{value0} is already taken; please specify a (different) :short") % { value0: opts[:short].inspect } if @short[opts[:short]]
       raise ArgumentError, _("a short option name can't be a number or a dash") if opts[:short] =~ INVALID_SHORT_ARG_REGEX
     end
 
@@ -270,13 +270,13 @@ class Parser
   ## undirected (i.e., mutual) dependencies. Directed dependencies are
   ## better modeled with Trollop::die.
   def depends *syms
-    syms.each { |sym| raise ArgumentError, _("unknown option '#{sym}'") unless @specs[sym] }
+    syms.each { |sym| raise ArgumentError, _("unknown option '%{sym}'") % { sym: sym } unless @specs[sym] }
     @constraints << [:depends, syms]
   end
 
   ## Marks two (or more!) options as conflicting.
   def conflicts *syms
-    syms.each { |sym| raise ArgumentError, _("unknown option '#{sym}'") unless @specs[sym] }
+    syms.each { |sym| raise ArgumentError, _("unknown option '%{sym}'") % { sym: sym } unless @specs[sym] }
     @constraints << [:conflicts, syms]
   end
 
@@ -333,16 +333,16 @@ class Parser
       when /^--([^-]\S*)$/
         @long[$1] ? @long[$1] : @long["[no-]#{$1}"]
       else
-        raise CommandlineError, _("invalid argument syntax: '#{arg}'")
+        raise CommandlineError, _("invalid argument syntax: '%{arg}'") % { arg: arg }
       end
 
       unless sym
         next 0 if ignore_invalid_options
-        raise CommandlineError, _("unknown argument '#{arg}'") unless sym
+        raise CommandlineError, _("unknown argument '%{arg}'") % { arg: arg } unless sym
       end
 
       if given_args.include?(sym) && !@specs[sym][:multi]
-        raise CommandlineError, _("option '#{arg}' specified multiple times")
+        raise CommandlineError, _("option '%{arg}' specified multiple times") % { arg: arg }
       end
 
       given_args[sym] ||= {}
@@ -379,14 +379,14 @@ class Parser
 
       case type
       when :depends
-        syms.each { |sym| raise CommandlineError, _("--#{@specs[constraint_sym][:long]} requires --#{@specs[sym][:long]}") unless given_args.include? sym }
+        syms.each { |sym| raise CommandlineError, _("--%{value0} requires --%{value1}") % { value0: @specs[constraint_sym][:long], value1: @specs[sym][:long] } unless given_args.include? sym }
       when :conflicts
-        syms.each { |sym| raise CommandlineError, _("--#{@specs[constraint_sym][:long]} conflicts with --#{@specs[sym][:long]}") if given_args.include?(sym) && (sym != constraint_sym) }
+        syms.each { |sym| raise CommandlineError, _("--%{value0} conflicts with --%{value1}") % { value0: @specs[constraint_sym][:long], value1: @specs[sym][:long] } if given_args.include?(sym) && (sym != constraint_sym) }
       end
     end
 
     required.each do |sym, val|
-      raise CommandlineError, _("option --#{@specs[sym][:long]} must be specified") unless given_args.include? sym
+      raise CommandlineError, _("option --%{opt} must be specified") % { opt: @specs[sym][:long] } unless given_args.include? sym
     end
 
     ## parse parameters
@@ -395,7 +395,7 @@ class Parser
       params = given_data[:params]
 
       opts = @specs[sym]
-      raise CommandlineError, _("option '#{arg}' needs a parameter") if params.empty? && opts[:type] != :flag
+      raise CommandlineError, _("option '%{arg}' needs a parameter") % { arg: arg } if params.empty? && opts[:type] != :flag
 
       vals["#{sym}_given".intern] = true # mark argument as specified on the commandline
 
@@ -455,7 +455,7 @@ class Parser
       end
       time ? Date.new(time.year, time.month, time.day) : Date.parse(param)
     rescue ArgumentError
-      raise CommandlineError, _("option '#{arg}' needs a date"), $!.backtrace
+      raise CommandlineError, _("option '%{arg}' needs a date") % { arg: arg }, $!.backtrace
     end
   end
 
@@ -512,9 +512,9 @@ class Parser
 
         if spec[:default]
           if spec[:desc] =~ /\.$/
-            _(" (Default: #{default_s})")
+            _(" (Default: %{default_s})") % { default_s: default_s }
           else
-            _(" (default: #{default_s})")
+            _(" (default: %{default_s})") % { default_s: default_s }
           end
         else
           ""
@@ -551,9 +551,9 @@ class Parser
   ## The per-parser version of Trollop::die (see that for documentation).
   def die arg, msg
     if msg
-      $stderr.puts _("Error: argument --#{@specs[arg][:long]} #{msg}.")
+      $stderr.puts _("Error: argument --%{value0} %{msg}.") % { value0: @specs[arg][:long], msg: msg }
     else
-      $stderr.puts _("Error: #{arg}.")
+      $stderr.puts _("Error: %{arg}.") % { arg: arg }
     end
     $stderr.puts _("Try --help for help.")
     exit(-1)
@@ -634,12 +634,12 @@ private
   end
 
   def parse_integer_parameter param, arg
-    raise CommandlineError, _("option '#{arg}' needs an integer") unless param =~ /^\d+$/
+    raise CommandlineError, _("option '%{arg}' needs an integer") % { arg: arg } unless param =~ /^\d+$/
     param.to_i
   end
 
   def parse_float_parameter param, arg
-    raise CommandlineError, _("option '#{arg}' needs a floating-point number") unless param =~ FLOAT_RE
+    raise CommandlineError, _("option '%{arg}' needs a floating-point number") % { arg: arg } unless param =~ FLOAT_RE
     param.to_f
   end
 
@@ -651,7 +651,7 @@ private
       begin
         open param
       rescue SystemCallError => e
-        raise CommandlineError, _("file or url for option '#{arg}' cannot be opened: #{e.message}"), e.backtrace
+        raise CommandlineError, _("file or url for option '%{arg}' cannot be opened: %{value0}") % { arg: arg, value0: e.message }, e.backtrace
       end
     end
   end
@@ -778,7 +778,7 @@ def with_standard_exception_handling parser
   begin
     yield
   rescue CommandlineError => e
-    $stderr.puts _("Error: #{e.message}.")
+    $stderr.puts _("Error: %{value0}.") % { value0: e.message }
     $stderr.puts _("Try --help for help.")
     exit(-1)
   rescue HelpNeeded

--- a/lib/puppet/util/command_line/trollop.rb
+++ b/lib/puppet/util/command_line/trollop.rb
@@ -146,7 +146,7 @@ class Parser
   ## value, you must specify +:type+ as well.
 
   def opt name, desc="", opts={}
-    raise ArgumentError, "you already have an argument named '#{name}'" if @specs.member? name
+    raise ArgumentError, _("you already have an argument named '#{name}'") if @specs.member? name
 
     ## fill in :type
     opts[:type] = # normalize
@@ -194,7 +194,7 @@ class Parser
       when Date; :date
       when Array
         if opts[:default].empty?
-          raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
+          raise ArgumentError, _("multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'")
         end
         case opts[:default][0]    # the first element determines the types
         when Integer; :ints
@@ -203,14 +203,14 @@ class Parser
         when IO; :ios
         when Date; :dates
         else
-          raise ArgumentError, "unsupported multiple argument type '#{opts[:default][0].class.name}'"
+          raise ArgumentError, _("unsupported multiple argument type '#{opts[:default][0].class.name}'")
         end
       when nil; nil
       else
-        raise ArgumentError, "unsupported argument type '#{opts[:default].class.name}'"
+        raise ArgumentError, _("unsupported argument type '#{opts[:default].class.name}'")
       end
 
-    raise ArgumentError, ":type specification and default type don't match (default type is #{type_from_default})" if opts[:type] && type_from_default && opts[:type] != type_from_default
+    raise ArgumentError, _(":type specification and default type don't match (default type is #{type_from_default})") if opts[:type] && type_from_default && opts[:type] != type_from_default
 
     opts[:type] = opts[:type] || type_from_default || :flag
 
@@ -225,7 +225,7 @@ class Parser
       else
         raise ArgumentError, "invalid long option name #{opts[:long].inspect}"
       end
-    raise ArgumentError, "long option name #{opts[:long].inspect} is already taken; please specify a (different) :long" if @long[opts[:long]]
+    raise ArgumentError, _("long option name #{opts[:long].inspect} is already taken; please specify a (different) :long") if @long[opts[:long]]
 
     ## fill in :short
     opts[:short] = opts[:short].to_s if opts[:short] unless opts[:short] == :none
@@ -236,8 +236,8 @@ class Parser
     end
 
     if opts[:short]
-      raise ArgumentError, "short option name #{opts[:short].inspect} is already taken; please specify a (different) :short" if @short[opts[:short]]
-      raise ArgumentError, "a short option name can't be a number or a dash" if opts[:short] =~ INVALID_SHORT_ARG_REGEX
+      raise ArgumentError, _("short option name #{opts[:short].inspect} is already taken; please specify a (different) :short") if @short[opts[:short]]
+      raise ArgumentError, _("a short option name can't be a number or a dash") if opts[:short] =~ INVALID_SHORT_ARG_REGEX
     end
 
     ## fill in :default for flags
@@ -270,13 +270,13 @@ class Parser
   ## undirected (i.e., mutual) dependencies. Directed dependencies are
   ## better modeled with Trollop::die.
   def depends *syms
-    syms.each { |sym| raise ArgumentError, "unknown option '#{sym}'" unless @specs[sym] }
+    syms.each { |sym| raise ArgumentError, _("unknown option '#{sym}'") unless @specs[sym] }
     @constraints << [:depends, syms]
   end
 
   ## Marks two (or more!) options as conflicting.
   def conflicts *syms
-    syms.each { |sym| raise ArgumentError, "unknown option '#{sym}'" unless @specs[sym] }
+    syms.each { |sym| raise ArgumentError, _("unknown option '#{sym}'") unless @specs[sym] }
     @constraints << [:conflicts, syms]
   end
 
@@ -310,8 +310,8 @@ class Parser
     required = {}
 
     if handle_help_and_version
-      opt :version, "Print version and exit" if @version unless @specs[:version] || @long["version"]
-      opt :help, "Show this message" unless @specs[:help] || @long["help"]
+      opt :version, _("Print version and exit") if @version unless @specs[:version] || @long["version"]
+      opt :help, _("Show this message") unless @specs[:help] || @long["help"]
     end
 
     @specs.each do |sym, opts|
@@ -333,16 +333,16 @@ class Parser
       when /^--([^-]\S*)$/
         @long[$1] ? @long[$1] : @long["[no-]#{$1}"]
       else
-        raise CommandlineError, "invalid argument syntax: '#{arg}'"
+        raise CommandlineError, _("invalid argument syntax: '#{arg}'")
       end
 
       unless sym
         next 0 if ignore_invalid_options
-        raise CommandlineError, "unknown argument '#{arg}'" unless sym
+        raise CommandlineError, _("unknown argument '#{arg}'") unless sym
       end
 
       if given_args.include?(sym) && !@specs[sym][:multi]
-        raise CommandlineError, "option '#{arg}' specified multiple times"
+        raise CommandlineError, _("option '#{arg}' specified multiple times")
       end
 
       given_args[sym] ||= {}
@@ -379,14 +379,14 @@ class Parser
 
       case type
       when :depends
-        syms.each { |sym| raise CommandlineError, "--#{@specs[constraint_sym][:long]} requires --#{@specs[sym][:long]}" unless given_args.include? sym }
+        syms.each { |sym| raise CommandlineError, _("--#{@specs[constraint_sym][:long]} requires --#{@specs[sym][:long]}") unless given_args.include? sym }
       when :conflicts
-        syms.each { |sym| raise CommandlineError, "--#{@specs[constraint_sym][:long]} conflicts with --#{@specs[sym][:long]}" if given_args.include?(sym) && (sym != constraint_sym) }
+        syms.each { |sym| raise CommandlineError, _("--#{@specs[constraint_sym][:long]} conflicts with --#{@specs[sym][:long]}") if given_args.include?(sym) && (sym != constraint_sym) }
       end
     end
 
     required.each do |sym, val|
-      raise CommandlineError, "option --#{@specs[sym][:long]} must be specified" unless given_args.include? sym
+      raise CommandlineError, _("option --#{@specs[sym][:long]} must be specified") unless given_args.include? sym
     end
 
     ## parse parameters
@@ -395,7 +395,7 @@ class Parser
       params = given_data[:params]
 
       opts = @specs[sym]
-      raise CommandlineError, "option '#{arg}' needs a parameter" if params.empty? && opts[:type] != :flag
+      raise CommandlineError, _("option '#{arg}' needs a parameter") if params.empty? && opts[:type] != :flag
 
       vals["#{sym}_given".intern] = true # mark argument as specified on the commandline
 
@@ -455,7 +455,7 @@ class Parser
       end
       time ? Date.new(time.year, time.month, time.day) : Date.parse(param)
     rescue ArgumentError
-      raise CommandlineError, "option '#{arg}' needs a date", $!.backtrace
+      raise CommandlineError, _("option '#{arg}' needs a date"), $!.backtrace
     end
   end
 
@@ -488,7 +488,7 @@ class Parser
 
     unless @order.size > 0 && @order.first.first == :text
       stream.puts "#@version\n" if @version
-      stream.puts "Options:"
+      stream.puts _("Options:")
     end
 
     @order.each do |what, opt|
@@ -512,9 +512,9 @@ class Parser
 
         if spec[:default]
           if spec[:desc] =~ /\.$/
-            " (Default: #{default_s})"
+            _(" (Default: #{default_s})")
           else
-            " (default: #{default_s})"
+            _(" (default: #{default_s})")
           end
         else
           ""
@@ -551,11 +551,11 @@ class Parser
   ## The per-parser version of Trollop::die (see that for documentation).
   def die arg, msg
     if msg
-      $stderr.puts "Error: argument --#{@specs[arg][:long]} #{msg}."
+      $stderr.puts _("Error: argument --#{@specs[arg][:long]} #{msg}.")
     else
-      $stderr.puts "Error: #{arg}."
+      $stderr.puts _("Error: #{arg}.")
     end
-    $stderr.puts "Try --help for help."
+    $stderr.puts _("Try --help for help.")
     exit(-1)
   end
 
@@ -634,12 +634,12 @@ private
   end
 
   def parse_integer_parameter param, arg
-    raise CommandlineError, "option '#{arg}' needs an integer" unless param =~ /^\d+$/
+    raise CommandlineError, _("option '#{arg}' needs an integer") unless param =~ /^\d+$/
     param.to_i
   end
 
   def parse_float_parameter param, arg
-    raise CommandlineError, "option '#{arg}' needs a floating-point number" unless param =~ FLOAT_RE
+    raise CommandlineError, _("option '#{arg}' needs a floating-point number") unless param =~ FLOAT_RE
     param.to_f
   end
 
@@ -651,7 +651,7 @@ private
       begin
         open param
       rescue SystemCallError => e
-        raise CommandlineError, "file or url for option '#{arg}' cannot be opened: #{e.message}", e.backtrace
+        raise CommandlineError, _("file or url for option '#{arg}' cannot be opened: #{e.message}"), e.backtrace
       end
     end
   end
@@ -778,8 +778,8 @@ def with_standard_exception_handling parser
   begin
     yield
   rescue CommandlineError => e
-    $stderr.puts "Error: #{e.message}."
-    $stderr.puts "Try --help for help."
+    $stderr.puts _("Error: #{e.message}.")
+    $stderr.puts _("Try --help for help.")
     exit(-1)
   rescue HelpNeeded
     parser.educate

--- a/lib/puppet/util/diff.rb
+++ b/lib/puppet/util/diff.rb
@@ -25,7 +25,7 @@ module Puppet::Util::Diff
   # context defaults to 3 lines
   def lcs_diff(data_old, data_new, format=:unified, context_lines=3)
     unless Puppet.features.diff?
-      Puppet.warning "Cannot provide diff without the diff/lcs Ruby library"
+      Puppet.warning _("Cannot provide diff without the diff/lcs Ruby library")
       return ""
     end
     data_old = data_old.split(/\n/).map! { |e| e.chomp }

--- a/lib/puppet/util/errors.rb
+++ b/lib/puppet/util/errors.rb
@@ -37,11 +37,11 @@ module Puppet::Util::Errors
   # @return [String] description of file and line
   def error_context
     if file and line
-      _(" at #{file}:#{line}")
+      _(" at %{file}:%{line}") % { file: file, line: line }
     elsif line
-      _(" at line #{line}")
+      _(" at line %{line}") % { line: line }
     elsif file
-      _(" in #{file}")
+      _(" in %{file}") % { file: file }
     else
       ""
     end
@@ -65,7 +65,7 @@ module Puppet::Util::Errors
     rescue Puppet::Error => detail
       raise adderrorcontext(detail)
     rescue => detail
-      message = options[:message] || _("#{self.class} failed with error #{detail.class}: #{detail}")
+      message = options[:message] || _("%{klass} failed with error %{error_type}: %{detail}") % { klass: self.class, error_type: detail.class, detail: detail }
 
       error = options[:type].new(message)
       # We can't use self.fail here because it always expects strings,

--- a/lib/puppet/util/errors.rb
+++ b/lib/puppet/util/errors.rb
@@ -37,11 +37,11 @@ module Puppet::Util::Errors
   # @return [String] description of file and line
   def error_context
     if file and line
-      " at #{file}:#{line}"
+      _(" at #{file}:#{line}")
     elsif line
-      " at line #{line}"
+      _(" at line #{line}")
     elsif file
-      " in #{file}"
+      _(" in #{file}")
     else
       ""
     end
@@ -65,7 +65,7 @@ module Puppet::Util::Errors
     rescue Puppet::Error => detail
       raise adderrorcontext(detail)
     rescue => detail
-      message = options[:message] || "#{self.class} failed with error #{detail.class}: #{detail}"
+      message = options[:message] || _("#{self.class} failed with error #{detail.class}: #{detail}")
 
       error = options[:type].new(message)
       # We can't use self.fail here because it always expects strings,

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -228,11 +228,11 @@ module Puppet::Util::Execution
       # read output in if required
       unless options[:squelch]
         output = wait_for_output(stdout)
-        Puppet.warning "Could not get output" unless output
+        Puppet.warning _("Could not get output") unless output
       end
 
       if options[:failonfail] and exit_status != 0
-        raise Puppet::ExecutionFailure, "Execution of '#{command_str}' returned #{exit_status}: #{output.strip}"
+        raise Puppet::ExecutionFailure, _("Execution of '#{command_str}' returned #{exit_status}: #{output.strip}")
       end
     ensure
       if !options[:squelch] && stdout
@@ -301,7 +301,7 @@ module Puppet::Util::Execution
           Kernel.exec(*command)
         end
       rescue => detail
-        Puppet.log_exception(detail, "Could not execute posix command: #{detail}")
+        Puppet.log_exception(detail, _("Could not execute posix command: #{detail}"))
         exit!(1)
       end
     end
@@ -349,7 +349,7 @@ module Puppet::Util::Execution
         end
       else
         time_to_sleep = try / 2.0
-        Puppet.warning "Waiting for output; will sleep #{time_to_sleep} seconds"
+        Puppet.warning _("Waiting for output; will sleep #{time_to_sleep} seconds")
         sleep(time_to_sleep)
       end
     end

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -232,7 +232,7 @@ module Puppet::Util::Execution
       end
 
       if options[:failonfail] and exit_status != 0
-        raise Puppet::ExecutionFailure, _("Execution of '#{command_str}' returned #{exit_status}: #{output.strip}")
+        raise Puppet::ExecutionFailure, _("Execution of '%{str}' returned %{exit_status}: %{output}") % { str: command_str, exit_status: exit_status, output: output.strip }
       end
     ensure
       if !options[:squelch] && stdout
@@ -301,7 +301,7 @@ module Puppet::Util::Execution
           Kernel.exec(*command)
         end
       rescue => detail
-        Puppet.log_exception(detail, _("Could not execute posix command: #{detail}"))
+        Puppet.log_exception(detail, _("Could not execute posix command: %{detail}") % { detail: detail })
         exit!(1)
       end
     end
@@ -349,7 +349,7 @@ module Puppet::Util::Execution
         end
       else
         time_to_sleep = try / 2.0
-        Puppet.warning _("Waiting for output; will sleep #{time_to_sleep} seconds")
+        Puppet.warning _("Waiting for output; will sleep %{time_to_sleep} seconds") % { time_to_sleep: time_to_sleep }
         sleep(time_to_sleep)
       end
     end

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -18,7 +18,7 @@ class Puppet::Util::Feature
       begin
         result = yield
       rescue StandardError,ScriptError => detail
-        warn _("Failed to load feature test for #{name}: #{detail}")
+        warn _("Failed to load feature test for %{name}: %{detail}") % { name: name, detail: detail }
         result = false
       end
       @results[name] = result
@@ -79,7 +79,7 @@ class Puppet::Util::Feature
   private
 
   def load_library(lib, name)
-    raise ArgumentError, _("Libraries must be passed as strings not #{lib.class}") unless lib.is_a?(String)
+    raise ArgumentError, _("Libraries must be passed as strings not %{klass}") % { klass: lib.class } unless lib.is_a?(String)
 
     @rubygems ||= Puppet::Util::RubyGems::Source.new
     @rubygems.clear_paths

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -18,7 +18,7 @@ class Puppet::Util::Feature
       begin
         result = yield
       rescue StandardError,ScriptError => detail
-        warn "Failed to load feature test for #{name}: #{detail}"
+        warn _("Failed to load feature test for #{name}: #{detail}")
         result = false
       end
       @results[name] = result
@@ -79,7 +79,7 @@ class Puppet::Util::Feature
   private
 
   def load_library(lib, name)
-    raise ArgumentError, "Libraries must be passed as strings not #{lib.class}" unless lib.is_a?(String)
+    raise ArgumentError, _("Libraries must be passed as strings not #{lib.class}") unless lib.is_a?(String)
 
     @rubygems ||= Puppet::Util::RubyGems::Source.new
     @rubygems.clear_paths

--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -43,14 +43,14 @@ module Puppet::Util::FileParsing
     def fields=(fields)
       @fields = fields.collect do |field|
         r = field.intern
-        raise ArgumentError.new("Cannot have fields named #{r}") if INVALID_FIELDS.include?(r)
+        raise ArgumentError.new(_("Cannot have fields named #{r}")) if INVALID_FIELDS.include?(r)
         r
       end
     end
 
     def initialize(type, options = {}, &block)
       @type = type.intern
-      raise ArgumentError, "Invalid record type #{@type}" unless [:record, :text].include?(@type)
+      raise ArgumentError, _("Invalid record type #{@type}") unless [:record, :text].include?(@type)
 
       set_options(options)
 
@@ -86,7 +86,7 @@ module Puppet::Util::FileParsing
           if self.optional.include?(field)
             self.absent
           else
-            raise ArgumentError, "Field '#{field}' is required"
+            raise ArgumentError, _("Field '#{field}' is required")
           end
         else
           details[field].to_s
@@ -227,7 +227,7 @@ module Puppet::Util::FileParsing
       if val = parse_line(line)
         val
       else
-        error = Puppet::ResourceError.new("Could not parse line #{line.inspect}")
+        error = Puppet::ResourceError.new(_("Could not parse line #{line.inspect}"))
         error.line = count
         raise error
       end
@@ -270,7 +270,7 @@ module Puppet::Util::FileParsing
   #   the regex will be removed.
   # * <tt>:separator</tt>: The record separator.  Defaults to /\s+/.
   def record_line(name, options, &block)
-    raise ArgumentError, "Must include a list of fields" unless options.include?(:fields)
+    raise ArgumentError, _("Must include a list of fields") unless options.include?(:fields)
 
     record = FileRecord.new(:record, options, &block)
     record.name = name.intern
@@ -285,7 +285,7 @@ module Puppet::Util::FileParsing
 
   # Define a new type of text record.
   def text_line(name, options, &block)
-    raise ArgumentError, "You must provide a :match regex for text lines" unless options.include?(:match)
+    raise ArgumentError, _("You must provide a :match regex for text lines") unless options.include?(:match)
 
     record = FileRecord.new(:text, options, &block)
     record.name = name.intern
@@ -305,7 +305,7 @@ module Puppet::Util::FileParsing
   # Convert our parsed record into a text record.
   def to_line(details)
     unless record = record_type(details[:record_type])
-      raise ArgumentError, "Invalid record type #{details[:record_type].inspect}"
+      raise ArgumentError, _("Invalid record type #{details[:record_type].inspect}")
     end
 
     if record.respond_to?(:pre_gen)
@@ -361,7 +361,7 @@ module Puppet::Util::FileParsing
     @record_types ||= {}
     @record_order ||= []
 
-    raise ArgumentError, "Line type #{record.name} is already defined" if @record_types.include?(record.name)
+    raise ArgumentError, _("Line type #{record.name} is already defined") if @record_types.include?(record.name)
 
     @record_types[record.name] = record
     @record_order << record

--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -43,14 +43,14 @@ module Puppet::Util::FileParsing
     def fields=(fields)
       @fields = fields.collect do |field|
         r = field.intern
-        raise ArgumentError.new(_("Cannot have fields named #{r}")) if INVALID_FIELDS.include?(r)
+        raise ArgumentError.new(_("Cannot have fields named %{name}") % { name: r }) if INVALID_FIELDS.include?(r)
         r
       end
     end
 
     def initialize(type, options = {}, &block)
       @type = type.intern
-      raise ArgumentError, _("Invalid record type #{@type}") unless [:record, :text].include?(@type)
+      raise ArgumentError, _("Invalid record type %{record_type}") % { record_type: @type } unless [:record, :text].include?(@type)
 
       set_options(options)
 
@@ -86,7 +86,7 @@ module Puppet::Util::FileParsing
           if self.optional.include?(field)
             self.absent
           else
-            raise ArgumentError, _("Field '#{field}' is required")
+            raise ArgumentError, _("Field '%{field}' is required") % { field: field }
           end
         else
           details[field].to_s
@@ -227,7 +227,7 @@ module Puppet::Util::FileParsing
       if val = parse_line(line)
         val
       else
-        error = Puppet::ResourceError.new(_("Could not parse line #{line.inspect}"))
+        error = Puppet::ResourceError.new(_("Could not parse line %{line}") % { line: line.inspect })
         error.line = count
         raise error
       end
@@ -305,7 +305,7 @@ module Puppet::Util::FileParsing
   # Convert our parsed record into a text record.
   def to_line(details)
     unless record = record_type(details[:record_type])
-      raise ArgumentError, _("Invalid record type #{details[:record_type].inspect}")
+      raise ArgumentError, _("Invalid record type %{record_type}") % { record_type: details[:record_type].inspect }
     end
 
     if record.respond_to?(:pre_gen)
@@ -361,7 +361,7 @@ module Puppet::Util::FileParsing
     @record_types ||= {}
     @record_order ||= []
 
-    raise ArgumentError, _("Line type #{record.name} is already defined") if @record_types.include?(record.name)
+    raise ArgumentError, _("Line type %{name} is already defined") % { name: record.name } if @record_types.include?(record.name)
 
     @record_types[record.name] = record
     @record_order << record

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -45,7 +45,7 @@ class Puppet::Util::FileType
         rescue Puppet::Error => detail
           raise
         rescue => detail
-          message = "#{self.class} could not read #{@path}: #{detail}"
+          message = _("#{self.class} could not read #{@path}: #{detail}")
           Puppet.log_exception(detail, message)
           raise Puppet::Error, message, detail.backtrace
         end
@@ -61,7 +61,7 @@ class Puppet::Util::FileType
         rescue Puppet::Error => detail
           raise
         rescue => detail
-          message = "#{self.class} could not write #{@path}: #{detail}"
+          message = _("#{self.class} could not write #{@path}: #{detail}")
           Puppet.log_exception(detail, message)
           raise Puppet::Error, message, detail.backtrace
         end
@@ -79,7 +79,7 @@ class Puppet::Util::FileType
   end
 
   def initialize(path, default_mode = nil)
-    raise ArgumentError.new("Path is nil") if path.nil?
+    raise ArgumentError.new(_("Path is nil")) if path.nil?
     @path = path
     @default_mode = default_mode
   end
@@ -148,19 +148,19 @@ class Puppet::Util::FileType
 
     # Read the file.
     def read
-      Puppet.info "Reading #{@path} from RAM"
+      Puppet.info _("Reading #{@path} from RAM")
       @@tabs[@path]
     end
 
     # Remove the file.
     def remove
-      Puppet.info "Removing #{@path} from RAM"
+      Puppet.info _("Removing #{@path} from RAM")
       @@tabs[@path] = ""
     end
 
     # Overwrite the file.
     def write(text)
-      Puppet.info "Writing #{@path} to RAM"
+      Puppet.info _("Writing #{@path} to RAM")
       @@tabs[@path] = text
     end
   end
@@ -175,7 +175,7 @@ class Puppet::Util::FileType
       begin
         @uid = Puppet::Util.uid(user)
       rescue Puppet::Error => detail
-        raise FileReadError, "Could not retrieve user #{user}: #{detail}", detail.backtrace
+        raise FileReadError, _("Could not retrieve user #{user}: #{detail}"), detail.backtrace
       end
 
       # XXX We have to have the user name, not the uid, because some
@@ -230,9 +230,9 @@ class Puppet::Util::FileType
       when /can't open your crontab/
         return ""
       when /you are not authorized to use cron/
-        raise FileReadError, "User #{@path} not authorized to use cron", detail.backtrace
+        raise FileReadError, _("User #{@path} not authorized to use cron"), detail.backtrace
       else
-        raise FileReadError, "Could not read crontab for #{@path}: #{detail}", detail.backtrace
+        raise FileReadError, _("Could not read crontab for #{@path}: #{detail}"), detail.backtrace
       end
     end
 
@@ -240,7 +240,7 @@ class Puppet::Util::FileType
     def remove
       Puppet::Util::Execution.execute(%w{crontab -r}, cronargs)
     rescue => detail
-      raise FileReadError, "Could not remove crontab for #{@path}: #{detail}", detail.backtrace
+      raise FileReadError, _("Could not remove crontab for #{@path}: #{detail}"), detail.backtrace
     end
 
     # Overwrite a specific @path's cron tab; must be passed the @path name
@@ -255,7 +255,7 @@ class Puppet::Util::FileType
         File.chown(Puppet::Util.uid(@path), nil, output_file.path)
         Puppet::Util::Execution.execute(["crontab", output_file.path], cronargs)
       rescue => detail
-        raise FileReadError, "Could not write crontab for #{@path}: #{detail}", detail.backtrace
+        raise FileReadError, _("Could not write crontab for #{@path}: #{detail}"), detail.backtrace
       ensure
         output_file.close
         output_file.unlink
@@ -273,9 +273,9 @@ class Puppet::Util::FileType
       when /Cannot open a file in the .* directory/
         return ""
       when /You are not authorized to use the cron command/
-        raise FileReadError, "User #{@path} not authorized to use cron", detail.backtrace
+        raise FileReadError, _("User #{@path} not authorized to use cron"), detail.backtrace
       else
-        raise FileReadError, "Could not read crontab for #{@path}: #{detail}", detail.backtrace
+        raise FileReadError, _("Could not read crontab for #{@path}: #{detail}"), detail.backtrace
       end
     end
 
@@ -283,7 +283,7 @@ class Puppet::Util::FileType
     def remove
       Puppet::Util::Execution.execute(%w{crontab -r}, cronargs)
     rescue => detail
-      raise FileReadError, "Could not remove crontab for #{@path}: #{detail}", detail.backtrace
+      raise FileReadError, _("Could not remove crontab for #{@path}: #{detail}"), detail.backtrace
     end
 
     # Overwrite a specific @path's cron tab; must be passed the @path name
@@ -299,7 +299,7 @@ class Puppet::Util::FileType
         File.chown(Puppet::Util.uid(@path), nil, output_file.path)
         Puppet::Util::Execution.execute(["crontab", output_file.path], cronargs)
       rescue => detail
-        raise FileReadError, "Could not write crontab for #{@path}: #{detail}", detail.backtrace
+        raise FileReadError, _("Could not write crontab for #{@path}: #{detail}"), detail.backtrace
       ensure
         output_file.close
         output_file.unlink

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -45,7 +45,7 @@ class Puppet::Util::FileType
         rescue Puppet::Error => detail
           raise
         rescue => detail
-          message = _("#{self.class} could not read #{@path}: #{detail}")
+          message = _("%{klass} could not read %{path}: %{detail}") % { klass: self.class, path: @path, detail: detail }
           Puppet.log_exception(detail, message)
           raise Puppet::Error, message, detail.backtrace
         end
@@ -61,7 +61,7 @@ class Puppet::Util::FileType
         rescue Puppet::Error => detail
           raise
         rescue => detail
-          message = _("#{self.class} could not write #{@path}: #{detail}")
+          message = _("%{klass} could not write %{path}: %{detail}") % { klass: self.class, path: @path, detail: detail }
           Puppet.log_exception(detail, message)
           raise Puppet::Error, message, detail.backtrace
         end
@@ -148,19 +148,19 @@ class Puppet::Util::FileType
 
     # Read the file.
     def read
-      Puppet.info _("Reading #{@path} from RAM")
+      Puppet.info _("Reading %{path} from RAM") % { path: @path }
       @@tabs[@path]
     end
 
     # Remove the file.
     def remove
-      Puppet.info _("Removing #{@path} from RAM")
+      Puppet.info _("Removing %{path} from RAM") % { path: @path }
       @@tabs[@path] = ""
     end
 
     # Overwrite the file.
     def write(text)
-      Puppet.info _("Writing #{@path} to RAM")
+      Puppet.info _("Writing %{path} to RAM") % { path: @path }
       @@tabs[@path] = text
     end
   end
@@ -175,7 +175,7 @@ class Puppet::Util::FileType
       begin
         @uid = Puppet::Util.uid(user)
       rescue Puppet::Error => detail
-        raise FileReadError, _("Could not retrieve user #{user}: #{detail}"), detail.backtrace
+        raise FileReadError, _("Could not retrieve user %{user}: %{detail}") % { user: user, detail: detail }, detail.backtrace
       end
 
       # XXX We have to have the user name, not the uid, because some
@@ -230,9 +230,9 @@ class Puppet::Util::FileType
       when /can't open your crontab/
         return ""
       when /you are not authorized to use cron/
-        raise FileReadError, _("User #{@path} not authorized to use cron"), detail.backtrace
+        raise FileReadError, _("User %{path} not authorized to use cron") % { path: @path }, detail.backtrace
       else
-        raise FileReadError, _("Could not read crontab for #{@path}: #{detail}"), detail.backtrace
+        raise FileReadError, _("Could not read crontab for %{path}: %{detail}") % { path: @path, detail: detail }, detail.backtrace
       end
     end
 
@@ -240,7 +240,7 @@ class Puppet::Util::FileType
     def remove
       Puppet::Util::Execution.execute(%w{crontab -r}, cronargs)
     rescue => detail
-      raise FileReadError, _("Could not remove crontab for #{@path}: #{detail}"), detail.backtrace
+      raise FileReadError, _("Could not remove crontab for %{path}: %{detail}") % { path: @path, detail: detail }, detail.backtrace
     end
 
     # Overwrite a specific @path's cron tab; must be passed the @path name
@@ -255,7 +255,7 @@ class Puppet::Util::FileType
         File.chown(Puppet::Util.uid(@path), nil, output_file.path)
         Puppet::Util::Execution.execute(["crontab", output_file.path], cronargs)
       rescue => detail
-        raise FileReadError, _("Could not write crontab for #{@path}: #{detail}"), detail.backtrace
+        raise FileReadError, _("Could not write crontab for %{path}: %{detail}") % { path: @path, detail: detail }, detail.backtrace
       ensure
         output_file.close
         output_file.unlink
@@ -273,9 +273,9 @@ class Puppet::Util::FileType
       when /Cannot open a file in the .* directory/
         return ""
       when /You are not authorized to use the cron command/
-        raise FileReadError, _("User #{@path} not authorized to use cron"), detail.backtrace
+        raise FileReadError, _("User %{path} not authorized to use cron") % { path: @path }, detail.backtrace
       else
-        raise FileReadError, _("Could not read crontab for #{@path}: #{detail}"), detail.backtrace
+        raise FileReadError, _("Could not read crontab for %{path}: %{detail}") % { path: @path, detail: detail }, detail.backtrace
       end
     end
 
@@ -283,7 +283,7 @@ class Puppet::Util::FileType
     def remove
       Puppet::Util::Execution.execute(%w{crontab -r}, cronargs)
     rescue => detail
-      raise FileReadError, _("Could not remove crontab for #{@path}: #{detail}"), detail.backtrace
+      raise FileReadError, _("Could not remove crontab for %{path}: %{detail}") % { path: @path, detail: detail }, detail.backtrace
     end
 
     # Overwrite a specific @path's cron tab; must be passed the @path name
@@ -299,7 +299,7 @@ class Puppet::Util::FileType
         File.chown(Puppet::Util.uid(@path), nil, output_file.path)
         Puppet::Util::Execution.execute(["crontab", output_file.path], cronargs)
       rescue => detail
-        raise FileReadError, _("Could not write crontab for #{@path}: #{detail}"), detail.backtrace
+        raise FileReadError, _("Could not write crontab for %{path}: %{detail}") % { path: @path, detail: detail }, detail.backtrace
       ensure
         output_file.close
         output_file.unlink

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -192,6 +192,6 @@ module Puppet::Util::HttpProxy
       return response
     end
 
-    raise RedirectionLimitExceededException, _("Too many HTTP redirections for #{uri}")
+    raise RedirectionLimitExceededException, _("Too many HTTP redirections for %{uri}") % { uri: uri }
   end
 end

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -192,6 +192,6 @@ module Puppet::Util::HttpProxy
       return response
     end
 
-    raise RedirectionLimitExceededException, "Too many HTTP redirections for #{uri}"
+    raise RedirectionLimitExceededException, _("Too many HTTP redirections for #{uri}")
   end
 end

--- a/lib/puppet/util/inifile.rb
+++ b/lib/puppet/util/inifile.rb
@@ -136,7 +136,7 @@ module Puppet::Util::IniConfig
     def read
       text = @filetype.read
       if text.nil?
-        raise IniParseError, _("Cannot read nonexistent file #{@file.inspect}")
+        raise IniParseError, _("Cannot read nonexistent file %{file}") % { file: @file.inspect }
       end
       parse(text)
     end
@@ -183,13 +183,13 @@ module Puppet::Util::IniConfig
           val = match[2]
 
           if section.nil?
-            raise IniParseError.new(_("Property with key #{key.inspect} outside of a section"))
+            raise IniParseError.new(_("Property with key %{key} outside of a section") % { key: key.inspect })
           end
 
           section[key] = val
           optname = key
         else
-          raise IniParseError.new(_("Can't parse line '#{l.chomp}'"), @file, line_num)
+          raise IniParseError.new(_("Can't parse line '%{line}'") % { line: l.chomp }, @file, line_num)
         end
       end
       section.mark_clean unless section.nil?
@@ -238,7 +238,7 @@ module Puppet::Util::IniConfig
     # @return [Puppet::Util::IniConfig::Section]
     def add_section(name)
       if section_exists?(name)
-        raise IniParseError.new(_("Section #{name.inspect} is already defined, cannot redefine"), @file)
+        raise IniParseError.new(_("Section %{name} is already defined, cannot redefine") % { name: name.inspect }, @file)
       end
 
       section = Section.new(name, @file)

--- a/lib/puppet/util/inifile.rb
+++ b/lib/puppet/util/inifile.rb
@@ -136,7 +136,7 @@ module Puppet::Util::IniConfig
     def read
       text = @filetype.read
       if text.nil?
-        raise IniParseError, "Cannot read nonexistent file #{@file.inspect}"
+        raise IniParseError, _("Cannot read nonexistent file #{@file.inspect}")
       end
       parse(text)
     end
@@ -183,13 +183,13 @@ module Puppet::Util::IniConfig
           val = match[2]
 
           if section.nil?
-            raise IniParseError.new("Property with key #{key.inspect} outside of a section")
+            raise IniParseError.new(_("Property with key #{key.inspect} outside of a section"))
           end
 
           section[key] = val
           optname = key
         else
-          raise IniParseError.new("Can't parse line '#{l.chomp}'", @file, line_num)
+          raise IniParseError.new(_("Can't parse line '#{l.chomp}'"), @file, line_num)
         end
       end
       section.mark_clean unless section.nil?
@@ -238,7 +238,7 @@ module Puppet::Util::IniConfig
     # @return [Puppet::Util::IniConfig::Section]
     def add_section(name)
       if section_exists?(name)
-        raise IniParseError.new("Section #{name.inspect} is already defined, cannot redefine", @file)
+        raise IniParseError.new(_("Section #{name.inspect} is already defined, cannot redefine"), @file)
       end
 
       section = Section.new(name, @file)

--- a/lib/puppet/util/instance_loader.rb
+++ b/lib/puppet/util/instance_loader.rb
@@ -68,7 +68,7 @@ module Puppet::Util::InstanceLoader
       if instance_loader(type).load(name)
         unless instances.include? name
           Puppet.warning(
-            _("Loaded #{type} file for #{name} but #{type} was not defined")
+            _("Loaded %{type} file for %{name} but %{type} was not defined") % { type: type, name: name }
           )
           return nil
         end

--- a/lib/puppet/util/instance_loader.rb
+++ b/lib/puppet/util/instance_loader.rb
@@ -68,7 +68,7 @@ module Puppet::Util::InstanceLoader
       if instance_loader(type).load(name)
         unless instances.include? name
           Puppet.warning(
-            "Loaded #{type} file for #{name} but #{type} was not defined"
+            _("Loaded #{type} file for #{name} but #{type} was not defined")
           )
           return nil
         end

--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -37,7 +37,7 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
     return nil if file_contents.nil? or file_contents.empty?
     PSON.parse(file_contents)
   rescue PSON::ParserError => e
-    Puppet.warning "Unable to read lockfile data from #{@file_path}: not in PSON"
+    Puppet.warning _("Unable to read lockfile data from #{@file_path}: not in PSON")
     nil
   end
 

--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -37,7 +37,7 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
     return nil if file_contents.nil? or file_contents.empty?
     PSON.parse(file_contents)
   rescue PSON::ParserError => e
-    Puppet.warning _("Unable to read lockfile data from #{@file_path}: not in PSON")
+    Puppet.warning _("Unable to read lockfile data from %{path}: not in PSON") % { path: @file_path }
     nil
   end
 

--- a/lib/puppet/util/ldap/connection.rb
+++ b/lib/puppet/util/ldap/connection.rb
@@ -66,6 +66,6 @@ class Puppet::Util::Ldap::Connection
       @connection.set_option(LDAP::LDAP_OPT_REFERRALS, LDAP::LDAP_OPT_ON)
       @connection.simple_bind(user, password)
   rescue => detail
-      raise Puppet::Error, _("Could not connect to LDAP: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not connect to LDAP: %{detail}") % { detail: detail }, detail.backtrace
   end
 end

--- a/lib/puppet/util/ldap/connection.rb
+++ b/lib/puppet/util/ldap/connection.rb
@@ -35,7 +35,7 @@ class Puppet::Util::Ldap::Connection
   end
 
   def initialize(host, port, options = {})
-    raise Puppet::Error, "Could not set up LDAP Connection: Missing ruby/ldap libraries" unless Puppet.features.ldap?
+    raise Puppet::Error, _("Could not set up LDAP Connection: Missing ruby/ldap libraries") unless Puppet.features.ldap?
 
     @host, @port = host, port
 
@@ -66,6 +66,6 @@ class Puppet::Util::Ldap::Connection
       @connection.set_option(LDAP::LDAP_OPT_REFERRALS, LDAP::LDAP_OPT_ON)
       @connection.simple_bind(user, password)
   rescue => detail
-      raise Puppet::Error, "Could not connect to LDAP: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not connect to LDAP: #{detail}"), detail.backtrace
   end
 end

--- a/lib/puppet/util/ldap/manager.rb
+++ b/lib/puppet/util/ldap/manager.rb
@@ -213,14 +213,14 @@ class Puppet::Util::Ldap::Manager
   # Update the ldap entry with the desired state.
   def update(name, is, should)
     if should[:ensure] == :absent
-      Puppet.info _("Removing #{dn(name)} from ldap")
+      Puppet.info _("Removing %{name} from ldap") % { name: dn(name) }
       delete(name)
       return
     end
 
     # We're creating a new entry
     if is.empty? or is[:ensure] == :absent
-      Puppet.info _("Creating #{dn(name)} in ldap")
+      Puppet.info _("Creating %{name} in ldap") % { name: dn(name) }
       # Remove any :absent params and :ensure, then convert the names to ldap names.
       attrs = ldap_convert(should)
       create(name, attrs)

--- a/lib/puppet/util/ldap/manager.rb
+++ b/lib/puppet/util/ldap/manager.rb
@@ -213,14 +213,14 @@ class Puppet::Util::Ldap::Manager
   # Update the ldap entry with the desired state.
   def update(name, is, should)
     if should[:ensure] == :absent
-      Puppet.info "Removing #{dn(name)} from ldap"
+      Puppet.info _("Removing #{dn(name)} from ldap")
       delete(name)
       return
     end
 
     # We're creating a new entry
     if is.empty? or is[:ensure] == :absent
-      Puppet.info "Creating #{dn(name)} in ldap"
+      Puppet.info _("Creating #{dn(name)} in ldap")
       # Remove any :absent params and :ensure, then convert the names to ldap names.
       attrs = ldap_convert(should)
       create(name, attrs)

--- a/lib/puppet/util/limits.rb
+++ b/lib/puppet/util/limits.rb
@@ -7,6 +7,6 @@ module Puppet::Util::Limits
 
     Process.setpriority(0, Process.pid, priority)
   rescue Errno::EACCES, NotImplementedError
-    Puppet.warning(_("Failed to set process priority to '#{priority}'"))
+    Puppet.warning(_("Failed to set process priority to '%{priority}'") % { priority: priority })
   end
 end

--- a/lib/puppet/util/limits.rb
+++ b/lib/puppet/util/limits.rb
@@ -7,6 +7,6 @@ module Puppet::Util::Limits
 
     Process.setpriority(0, Process.pid, priority)
   rescue Errno::EACCES, NotImplementedError
-    Puppet.warning("Failed to set process priority to '#{priority}'")
+    Puppet.warning(_("Failed to set process priority to '#{priority}'"))
   end
 end

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -382,19 +382,19 @@ class Puppet::Util::Log
     # Issue based messages do not have details in the message. It
     # must be appended here
     unless issue_code.nil?
-      msg = _("Could not parse for environment #{environment}: #{msg}") unless environment.nil?
+      msg = _("Could not parse for environment %{env}: %{msg}") % { env: environment, msg: msg } unless environment.nil?
       if file && line && pos
-        msg = _("#{msg} at #{file}:#{line}:#{pos}")
+        msg = _("%{msg} at %{file}:%{line}:%{pos}") % { msg: msg, file: file, line: line, pos: pos }
       elsif file and line
-        msg = _("#{msg}  at #{file}:#{line}")
+        msg = _("%{msg}  at %{file}:%{line}") % { msg: msg, file: file, line: line }
       elsif line && pos
-        msg = _("#{msg}  at line #{line}:#{pos}")
+        msg = _("%{msg}  at line %{line}:%{pos}") % { msg: msg, line: line, pos: pos }
       elsif line
-        msg = _("#{msg}  at line #{line}")
+        msg = _("%{msg}  at line %{line}") % { msg: msg, line: line }
       elsif file
-        msg = _("#{msg}  in #{file}")
+        msg = _("%{msg}  in %{file}") % { msg: msg, file: file }
       end
-      msg = _("#{msg} on node #{node}") unless node.nil?
+      msg = _("%{msg} on node %{node}") % { msg: msg, node: node } unless node.nil?
       if @backtrace.is_a?(Array)
         msg += "\n"
         msg += @backtrace.join("\n")

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -209,7 +209,7 @@ class Puppet::Util::Log
 
   # Reopen all of our logs.
   def Log.reopen
-    Puppet.notice "Reopening log files"
+    Puppet.notice _("Reopening log files")
     types = @destinations.keys
     @destinations.each { |type, dest|
       dest.close if dest.respond_to?(:close)
@@ -382,19 +382,19 @@ class Puppet::Util::Log
     # Issue based messages do not have details in the message. It
     # must be appended here
     unless issue_code.nil?
-      msg = "Could not parse for environment #{environment}: #{msg}" unless environment.nil?
+      msg = _("Could not parse for environment #{environment}: #{msg}") unless environment.nil?
       if file && line && pos
-        msg = "#{msg} at #{file}:#{line}:#{pos}"
+        msg = _("#{msg} at #{file}:#{line}:#{pos}")
       elsif file and line
-        msg = "#{msg}  at #{file}:#{line}"
+        msg = _("#{msg}  at #{file}:#{line}")
       elsif line && pos
-        msg = "#{msg}  at line #{line}:#{pos}"
+        msg = _("#{msg}  at line #{line}:#{pos}")
       elsif line
-        msg = "#{msg}  at line #{line}"
+        msg = _("#{msg}  at line #{line}")
       elsif file
-        msg = "#{msg}  in #{file}"
+        msg = _("#{msg}  in #{file}")
       end
-      msg = "#{msg} on node #{node}" unless node.nil?
+      msg = _("#{msg} on node #{node}") unless node.nil?
       if @backtrace.is_a?(Array)
         msg += "\n"
         msg += @backtrace.join("\n")

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -18,7 +18,7 @@ Puppet::Util::Log.newdesttype :syslog do
     begin
       facility = Syslog.const_get("LOG_#{str.upcase}")
     rescue NameError
-      raise Puppet::Error, _("Invalid syslog facility #{str}"), $!.backtrace
+      raise Puppet::Error, _("Invalid syslog facility %{str}") % { str: str }, $!.backtrace
     end
 
     @syslog = Syslog.open(name, options, facility)
@@ -72,7 +72,7 @@ Puppet::Util::Log.newdesttype :file do
     # specified a "special" destination.
     unless Puppet::FileSystem.exist?(Puppet::FileSystem.dir(path))
       FileUtils.mkdir_p(File.dirname(path), :mode => 0755)
-      Puppet.info _("Creating log directory #{File.dirname(path)}")
+      Puppet.info _("Creating log directory %{dir}") % { dir: File.dirname(path) }
     end
 
     # create the log file, if it doesn't already exist
@@ -97,7 +97,7 @@ Puppet::Util::Log.newdesttype :file do
       begin
         FileUtils.chown(Puppet[:user], Puppet[:group], path)
       rescue ArgumentError, Errno::EPERM
-        Puppet.err _("Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{path}")
+        Puppet.err _("Unable to set ownership to %{user}:%{group} for log file: %{path}") % { user: Puppet[:user], group: Puppet[:group], path: path }
       end
     end
 

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -18,7 +18,7 @@ Puppet::Util::Log.newdesttype :syslog do
     begin
       facility = Syslog.const_get("LOG_#{str.upcase}")
     rescue NameError
-      raise Puppet::Error, "Invalid syslog facility #{str}", $!.backtrace
+      raise Puppet::Error, _("Invalid syslog facility #{str}"), $!.backtrace
     end
 
     @syslog = Syslog.open(name, options, facility)
@@ -72,7 +72,7 @@ Puppet::Util::Log.newdesttype :file do
     # specified a "special" destination.
     unless Puppet::FileSystem.exist?(Puppet::FileSystem.dir(path))
       FileUtils.mkdir_p(File.dirname(path), :mode => 0755)
-      Puppet.info "Creating log directory #{File.dirname(path)}"
+      Puppet.info _("Creating log directory #{File.dirname(path)}")
     end
 
     # create the log file, if it doesn't already exist
@@ -97,7 +97,7 @@ Puppet::Util::Log.newdesttype :file do
       begin
         FileUtils.chown(Puppet[:user], Puppet[:group], path)
       rescue ArgumentError, Errno::EPERM
-        Puppet.err "Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{path}"
+        Puppet.err _("Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{path}")
       end
     end
 

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -176,11 +176,11 @@ module Logging
         call_trace =
         case MM.new(file, line)
         when FILE_AND_LINE
-          _("\n   (at #{file}:#{line})")
+          _("\n   (at %{file}:%{line})") % { file: file, line: line }
         when FILE_NO_LINE
-          _("\n   (in #{file})")
+          _("\n   (in %{file})") % { file: file }
         when NO_FILE_LINE
-          _("\n   (in unknown file, line #{line})")
+          _("\n   (in unknown file, line %{line})") % { line: line }
         else
           _("\n   (file & line not available)")
         end
@@ -279,10 +279,13 @@ module Logging
       key ||= (offender = get_deprecation_offender)
       if (! $deprecation_warnings.has_key?(key)) then
         $deprecation_warnings[key] = message
+        # split out to allow translation
+        unknown = _('unknown')
         call_trace = use_caller ?
           (offender || get_deprecation_offender).join('; ') :
-          "#{file || _('unknown')}:#{line || _('unknown')}"
-        warning(_("#{message}\n   (at #{call_trace})"))
+          "#{file || unknown}:#{line || unknown}"
+        #TRANSLATORS error message with origin location
+        warning(_("%{message}\n   (at %{call_trace})") % { message: message, call_trace: call_trace })
       end
     end
   end

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -80,7 +80,7 @@ module Logging
     if exception.respond_to?(:original)
       original =  exception.original
       unless original.nil?
-        arr << 'Wrapped exception:'
+        arr << _('Wrapped exception:')
         arr << original.message
         build_exception_trace(arr, original, trace)
       end
@@ -103,7 +103,7 @@ module Logging
       arr << Puppet::Util.pretty_backtrace(exception.backtrace)
     end
     if exception.respond_to?(:original) and exception.original
-      arr << "Wrapped exception:"
+      arr << _("Wrapped exception:")
       arr << format_exception(exception.original, :default, trace)
     end
     arr.flatten.join("\n")
@@ -176,13 +176,13 @@ module Logging
         call_trace =
         case MM.new(file, line)
         when FILE_AND_LINE
-          "\n   (at #{file}:#{line})"
+          _("\n   (at #{file}:#{line})")
         when FILE_NO_LINE
-          "\n   (in #{file})"
+          _("\n   (in #{file})")
         when NO_FILE_LINE
-          "\n   (in unknown file, line #{line})"
+          _("\n   (in unknown file, line #{line})")
         else
-          "\n   (file & line not available)"
+          _("\n   (file & line not available)")
         end
         warning("#{message}#{call_trace}")
       end
@@ -281,8 +281,8 @@ module Logging
         $deprecation_warnings[key] = message
         call_trace = use_caller ?
           (offender || get_deprecation_offender).join('; ') :
-          "#{file || 'unknown'}:#{line || 'unknown'}"
-        warning("#{message}\n   (at #{call_trace})")
+          "#{file || _('unknown')}:#{line || _('unknown')}"
+        warning(_("#{message}\n   (at #{call_trace})"))
       end
     end
   end

--- a/lib/puppet/util/network_device.rb
+++ b/lib/puppet/util/network_device.rb
@@ -7,7 +7,7 @@ class Puppet::Util::NetworkDevice
     require "puppet/util/network_device/#{device.provider}/device"
     @current = Puppet::Util::NetworkDevice.const_get(device.provider.capitalize).const_get(:Device).new(device.url, device.options)
   rescue => detail
-    raise detail, "Can't load #{device.provider} for #{device.name}: #{detail}", detail.backtrace
+    raise detail, _("Can't load #{device.provider} for #{device.name}: #{detail}"), detail.backtrace
   end
 
   # Should only be used in tests

--- a/lib/puppet/util/network_device.rb
+++ b/lib/puppet/util/network_device.rb
@@ -7,7 +7,7 @@ class Puppet::Util::NetworkDevice
     require "puppet/util/network_device/#{device.provider}/device"
     @current = Puppet::Util::NetworkDevice.const_get(device.provider.capitalize).const_get(:Device).new(device.url, device.options)
   rescue => detail
-    raise detail, _("Can't load #{device.provider} for #{device.name}: #{detail}"), detail.backtrace
+    raise detail, _("Can't load %{provider} for %{device}: %{detail}") % { provider: device.provider, device: device.name, detail: detail }, detail.backtrace
   end
 
   # Should only be used in tests

--- a/lib/puppet/util/network_device/cisco/device.rb
+++ b/lib/puppet/util/network_device/cisco/device.rb
@@ -51,7 +51,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
       if out =~ /^%/mo or out =~ /^Command rejected:/mo
         # strip off the command just sent
         error = out.sub(cmd,'')
-        Puppet.err "Error while executing '#{cmd}', device returned: #{error}"
+        Puppet.err _("Error while executing '#{cmd}', device returned: #{error}")
       end
     end
   end
@@ -67,7 +67,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
   end
 
   def enable
-    raise "Can't issue \"enable\" to enter privileged, no enable password set" unless enable_password
+    raise _("Can't issue \"enable\" to enter privileged, no enable password set") unless enable_password
     transport.command("enable", :prompt => /^Password:/)
     transport.command(enable_password)
   end
@@ -196,7 +196,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
         end
         vlans[vlan[:name]] = vlan
       when /^\s+([a-zA-Z0-9,\/. ]+)\s*$/
-        raise "invalid sh vlan summary output" unless vlan
+        raise _("invalid sh vlan summary output") unless vlan
         if $1.strip.length > 0
           vlan[:interfaces] += $1.strip.split(/\s*,\s*/).map{ |ifn| canonalize_ifname(ifn) }
         end
@@ -208,7 +208,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
 
   def update_vlan(id, is = {}, should = {})
     if should[:ensure] == :absent
-      Puppet.info "Removing #{id} from device vlan"
+      Puppet.info _("Removing #{id} from device vlan")
       execute("conf t")
       execute("no vlan #{id}")
       execute("exit")
@@ -217,7 +217,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
 
     # Cisco VLANs are supposed to be alphanumeric only
     if should[:description] =~ /[^\w]/
-      Puppet.err "Invalid VLAN name '#{should[:description]}' for Cisco device.\nVLAN name must be alphanumeric, no spaces or special characters."
+      Puppet.err _("Invalid VLAN name '#{should[:description]}' for Cisco device.\nVLAN name must be alphanumeric, no spaces or special characters.")
       return
     end
     
@@ -251,7 +251,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
         when "dynamic desirable"
           trunking[:mode] = 'dynamic desirable'
         else
-          raise "Unknown switchport mode: #{$1} for #{interface}"
+          raise _("Unknown switchport mode: #{$1} for #{interface}")
         end
       when /^Administrative Trunking Encapsulation:\s+(.*)$/
         case $1
@@ -260,7 +260,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
         when "negotiate"
           trunking[:encapsulation] = :negotiate
         else
-          raise "Unknown switchport encapsulation: #{$1} for #{interface}"
+          raise _("Unknown switchport encapsulation: #{$1} for #{interface}")
         end
       when /^Access Mode VLAN:\s+(.*) \((.*)\)$/
         trunking[:access_vlan] = $1 if $2 != '(Inactive)'

--- a/lib/puppet/util/network_device/cisco/device.rb
+++ b/lib/puppet/util/network_device/cisco/device.rb
@@ -51,7 +51,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
       if out =~ /^%/mo or out =~ /^Command rejected:/mo
         # strip off the command just sent
         error = out.sub(cmd,'')
-        Puppet.err _("Error while executing '#{cmd}', device returned: #{error}")
+        Puppet.err _("Error while executing '%{cmd}', device returned: %{error}") % { cmd: cmd, error: error }
       end
     end
   end
@@ -208,7 +208,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
 
   def update_vlan(id, is = {}, should = {})
     if should[:ensure] == :absent
-      Puppet.info _("Removing #{id} from device vlan")
+      Puppet.info _("Removing %{id} from device vlan") % { id: id }
       execute("conf t")
       execute("no vlan #{id}")
       execute("exit")
@@ -217,7 +217,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
 
     # Cisco VLANs are supposed to be alphanumeric only
     if should[:description] =~ /[^\w]/
-      Puppet.err _("Invalid VLAN name '#{should[:description]}' for Cisco device.\nVLAN name must be alphanumeric, no spaces or special characters.")
+      Puppet.err _("Invalid VLAN name '%{name}' for Cisco device.\nVLAN name must be alphanumeric, no spaces or special characters.") % { name: should[:description] }
       return
     end
     
@@ -251,7 +251,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
         when "dynamic desirable"
           trunking[:mode] = 'dynamic desirable'
         else
-          raise _("Unknown switchport mode: #{$1} for #{interface}")
+          raise _("Unknown switchport mode: %{mode} for %{interface}") % { mode: $1, interface: interface }
         end
       when /^Administrative Trunking Encapsulation:\s+(.*)$/
         case $1
@@ -260,7 +260,7 @@ class Puppet::Util::NetworkDevice::Cisco::Device < Puppet::Util::NetworkDevice::
         when "negotiate"
           trunking[:encapsulation] = :negotiate
         else
-          raise _("Unknown switchport encapsulation: #{$1} for #{interface}")
+          raise _("Unknown switchport encapsulation: %{value} for %{interface}") % { value: $1, interface: interface }
         end
       when /^Access Mode VLAN:\s+(.*) \((.*)\)$/
         trunking[:access_vlan] = $1 if $2 != '(Inactive)'

--- a/lib/puppet/util/network_device/cisco/interface.rb
+++ b/lib/puppet/util/network_device/cisco/interface.rb
@@ -87,7 +87,7 @@ class Puppet::Util::NetworkDevice::Cisco::Interface
       if out =~ /^%/mo or out =~ /^Command rejected:/mo
         # strip off the command just sent
         error = out.sub(command,'')
-        Puppet.err "Error while executing '#{command}', device returned: #{error}"
+        Puppet.err _("Error while executing '#{command}', device returned: #{error}")
       end
     end
   end

--- a/lib/puppet/util/network_device/cisco/interface.rb
+++ b/lib/puppet/util/network_device/cisco/interface.rb
@@ -87,7 +87,7 @@ class Puppet::Util::NetworkDevice::Cisco::Interface
       if out =~ /^%/mo or out =~ /^Command rejected:/mo
         # strip off the command just sent
         error = out.sub(command,'')
-        Puppet.err _("Error while executing '#{command}', device returned: #{error}")
+        Puppet.err _("Error while executing '%{command}', device returned: %{error}") % { command: command, error: error }
       end
     end
   end

--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -52,7 +52,7 @@ class Puppet::Util::NetworkDevice::Config
           when /^\[([\w.-]+)\]\s*$/ # [device.fqdn]
             name = $1
             name.chomp!
-            raise Puppet::Error, "Duplicate device found at line #{count}, already found at #{device.line}" if devices.include?(name)
+            raise Puppet::Error, _("Duplicate device found at line #{count}, already found at #{device.line}") if devices.include?(name)
             device = OpenStruct.new
             device.name = name
             device.line = count
@@ -62,16 +62,16 @@ class Puppet::Util::NetworkDevice::Config
           when /^\s*(type|url|debug)(\s+(.+)\s*)*$/
             parse_directive(device, $1, $3, count)
           else
-            raise Puppet::Error, "Invalid line #{count}: #{line}"
+            raise Puppet::Error, _("Invalid line #{count}: #{line}")
           end
           count += 1
         }
       }
     rescue Errno::EACCES => detail
-      Puppet.err "Configuration error: Cannot read #{@file}; cannot serve"
+      Puppet.err _("Configuration error: Cannot read #{@file}; cannot serve")
       #raise Puppet::Error, "Cannot read #{@config}"
     rescue Errno::ENOENT => detail
-      Puppet.err "Configuration error: '#{@file}' does not exit; cannot serve"
+      Puppet.err _("Configuration error: '#{@file}' does not exit; cannot serve")
     end
 
     @devices = devices
@@ -85,13 +85,13 @@ class Puppet::Util::NetworkDevice::Config
       begin
         URI.parse(value)
       rescue URI::InvalidURIError
-        raise Puppet::Error, "#{value} is an invalid url"
+        raise Puppet::Error, _("#{value} is an invalid url")
       end
       device.url = value
     when "debug"
       device.options[:debug] = true
     else
-      raise Puppet::Error, "Invalid argument '#{var}' at line #{count}"
+      raise Puppet::Error, _("Invalid argument '#{var}' at line #{count}")
     end
   end
 

--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -52,7 +52,7 @@ class Puppet::Util::NetworkDevice::Config
           when /^\[([\w.-]+)\]\s*$/ # [device.fqdn]
             name = $1
             name.chomp!
-            raise Puppet::Error, _("Duplicate device found at line #{count}, already found at #{device.line}") if devices.include?(name)
+            raise Puppet::Error, _("Duplicate device found at line %{count}, already found at %{line}") % { count: count, line: device.line } if devices.include?(name)
             device = OpenStruct.new
             device.name = name
             device.line = count
@@ -62,16 +62,16 @@ class Puppet::Util::NetworkDevice::Config
           when /^\s*(type|url|debug)(\s+(.+)\s*)*$/
             parse_directive(device, $1, $3, count)
           else
-            raise Puppet::Error, _("Invalid line #{count}: #{line}")
+            raise Puppet::Error, _("Invalid line %{count}: %{line}") % { count: count, line: line }
           end
           count += 1
         }
       }
     rescue Errno::EACCES => detail
-      Puppet.err _("Configuration error: Cannot read #{@file}; cannot serve")
+      Puppet.err _("Configuration error: Cannot read %{file}; cannot serve") % { file: @file }
       #raise Puppet::Error, "Cannot read #{@config}"
     rescue Errno::ENOENT => detail
-      Puppet.err _("Configuration error: '#{@file}' does not exit; cannot serve")
+      Puppet.err _("Configuration error: '%{file}' does not exit; cannot serve") % { file: @file }
     end
 
     @devices = devices
@@ -85,13 +85,13 @@ class Puppet::Util::NetworkDevice::Config
       begin
         URI.parse(value)
       rescue URI::InvalidURIError
-        raise Puppet::Error, _("#{value} is an invalid url")
+        raise Puppet::Error, _("%{value} is an invalid url") % { value: value }
       end
       device.url = value
     when "debug"
       device.options[:debug] = true
     else
-      raise Puppet::Error, _("Invalid argument '#{var}' at line #{count}")
+      raise Puppet::Error, _("Invalid argument '%{var}' at line %{count}") % { var: var, count: count }
     end
   end
 

--- a/lib/puppet/util/network_device/transport/ssh.rb
+++ b/lib/puppet/util/network_device/transport/ssh.rb
@@ -13,7 +13,7 @@ class Puppet::Util::NetworkDevice::Transport::Ssh < Puppet::Util::NetworkDevice:
     super()
     @verbose = verbose
     unless Puppet.features.ssh?
-      raise 'Connecting with ssh to a network device requires the \'net/ssh\' ruby library'
+      raise _('Connecting with ssh to a network device requires the \'net/ssh\' ruby library')
     end
   end
 
@@ -33,21 +33,21 @@ class Puppet::Util::NetworkDevice::Transport::Ssh < Puppet::Util::NetworkDevice:
       Puppet.debug("connecting to #{host} as #{user}")
       @ssh = Net::SSH.start(host, user, :port => port, :password => password, :timeout => timeout)
     rescue TimeoutError
-      raise TimeoutError, "timed out while opening an ssh connection to the host", $!.backtrace
+      raise TimeoutError, _("timed out while opening an ssh connection to the host"), $!.backtrace
     rescue Net::SSH::AuthenticationFailed
-      raise Puppet::Error, "SSH authentication failure connecting to #{host} as #{user}", $!.backtrace
+      raise Puppet::Error, _("SSH authentication failure connecting to #{host} as #{user}"), $!.backtrace
     rescue Net::SSH::Exception
-      raise Puppet::Error, "SSH connection failure to #{host}", $!.backtrace
+      raise Puppet::Error, _("SSH connection failure to #{host}"), $!.backtrace
     end
 
     @buf = ""
     @eof = false
     @channel = nil
     @ssh.open_channel do |channel|
-      channel.request_pty { |ch,success| raise "failed to open pty" unless success }
+      channel.request_pty { |ch,success| raise _("failed to open pty") unless success }
 
       channel.send_channel_request("shell") do |ch, success|
-        raise "failed to open ssh shell channel" unless success
+        raise _("failed to open ssh shell channel") unless success
 
         ch.on_data { |_,data| @buf << data }
         ch.on_extended_data { |_,type,data|  @buf << data if type == 1 }

--- a/lib/puppet/util/network_device/transport/ssh.rb
+++ b/lib/puppet/util/network_device/transport/ssh.rb
@@ -35,9 +35,9 @@ class Puppet::Util::NetworkDevice::Transport::Ssh < Puppet::Util::NetworkDevice:
     rescue TimeoutError
       raise TimeoutError, _("timed out while opening an ssh connection to the host"), $!.backtrace
     rescue Net::SSH::AuthenticationFailed
-      raise Puppet::Error, _("SSH authentication failure connecting to #{host} as #{user}"), $!.backtrace
+      raise Puppet::Error, _("SSH authentication failure connecting to %{host} as %{user}") % { host: host, user: user }, $!.backtrace
     rescue Net::SSH::Exception
-      raise Puppet::Error, _("SSH connection failure to #{host}"), $!.backtrace
+      raise Puppet::Error, _("SSH connection failure to %{host}") % { host: host }, $!.backtrace
     end
 
     @buf = ""

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -45,7 +45,7 @@ module Puppet::Util::Plist
                                                   {:failonfail => true, :combine => true})
           return parse_plist(plist)
         rescue Puppet::ExecutionFailure => detail
-          Puppet.warning(_("Cannot read file #{file_path}; Puppet is skipping it.\n") + _("Details: #{detail}"))
+          Puppet.warning(_("Cannot read file %{file_path}; Puppet is skipping it.\n") % { file_path: file_path } + _("Details: %{detail}") % { detail: detail })
         end
       end
       return nil
@@ -138,7 +138,7 @@ module Puppet::Util::Plist
         plist_to_save.value = CFPropertyList.guess(plist)
         plist_to_save.save(file_path, to_format(format), :formatted => true)
       rescue IOError => e
-        Puppet.err(_("Unable to write the file #{file_path}. #{e.inspect}"))
+        Puppet.err(_("Unable to write the file %{file_path}. %{error}") % { file_path: file_path, error: e.inspect })
       end
     end
 

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -45,7 +45,7 @@ module Puppet::Util::Plist
                                                   {:failonfail => true, :combine => true})
           return parse_plist(plist)
         rescue Puppet::ExecutionFailure => detail
-          Puppet.warning("Cannot read file #{file_path}; Puppet is skipping it.\n" + "Details: #{detail}")
+          Puppet.warning(_("Cannot read file #{file_path}; Puppet is skipping it.\n") + _("Details: #{detail}"))
         end
       end
       return nil
@@ -138,7 +138,7 @@ module Puppet::Util::Plist
         plist_to_save.value = CFPropertyList.guess(plist)
         plist_to_save.save(file_path, to_format(format), :formatted => true)
       rescue IOError => e
-        Puppet.err("Unable to write the file #{file_path}. #{e.inspect}")
+        Puppet.err(_("Unable to write the file #{file_path}. #{e.inspect}"))
       end
     end
 

--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -21,7 +21,7 @@ module Puppet::Util::POSIX
 
     if id.is_a?(Integer)
       if id > Puppet[:maximum_uid].to_i
-        Puppet.err _("Tried to get #{field} field for silly id #{id}")
+        Puppet.err _("Tried to get %{field} field for silly id %{id}") % { field: field, id: id }
         return nil
       end
       method = methodbyid(space)
@@ -46,7 +46,7 @@ module Puppet::Util::POSIX
     if id.is_a?(Integer)
       integer = true
       if id > Puppet[:maximum_uid].to_i
-        Puppet.err _("Tried to get #{field} field for silly id #{id}")
+        Puppet.err _("Tried to get %{field} field for silly id %{id}") % { field: field, id: id }
         return nil
       end
     end

--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -21,7 +21,7 @@ module Puppet::Util::POSIX
 
     if id.is_a?(Integer)
       if id > Puppet[:maximum_uid].to_i
-        Puppet.err "Tried to get #{field} field for silly id #{id}"
+        Puppet.err _("Tried to get #{field} field for silly id #{id}")
         return nil
       end
       method = methodbyid(space)
@@ -46,7 +46,7 @@ module Puppet::Util::POSIX
     if id.is_a?(Integer)
       integer = true
       if id > Puppet[:maximum_uid].to_i
-        Puppet.err "Tried to get #{field} field for silly id #{id}"
+        Puppet.err _("Tried to get #{field} field for silly id #{id}")
         return nil
       end
     end
@@ -74,7 +74,7 @@ module Puppet::Util::POSIX
     when :gr, :group; return :gid
     when :pw, :user, :passwd; return :uid
     else
-      raise ArgumentError.new("Can only handle users and groups")
+      raise ArgumentError.new(_("Can only handle users and groups"))
     end
   end
 
@@ -84,7 +84,7 @@ module Puppet::Util::POSIX
     when :gr, :group; return :getgrgid
     when :pw, :user, :passwd; return :getpwuid
     else
-      raise ArgumentError.new("Can only handle users and groups")
+      raise ArgumentError.new(_("Can only handle users and groups"))
     end
   end
 
@@ -94,7 +94,7 @@ module Puppet::Util::POSIX
     when :gr, :group; return :getgrnam
     when :pw, :user, :passwd; return :getpwnam
     else
-      raise ArgumentError.new("Can only handle users and groups")
+      raise ArgumentError.new(_("Can only handle users and groups"))
     end
   end
 

--- a/lib/puppet/util/profiler/wall_clock.rb
+++ b/lib/puppet/util/profiler/wall_clock.rb
@@ -12,7 +12,7 @@ class Puppet::Util::Profiler::WallClock < Puppet::Util::Profiler::Logging
 
   def do_finish(context, description, metric_id)
     {:time => context.stop,
-     :msg => "took #{context} seconds"}
+     :msg => _("took #{context} seconds")}
   end
 
   class Timer

--- a/lib/puppet/util/profiler/wall_clock.rb
+++ b/lib/puppet/util/profiler/wall_clock.rb
@@ -12,7 +12,7 @@ class Puppet::Util::Profiler::WallClock < Puppet::Util::Profiler::Logging
 
   def do_finish(context, description, metric_id)
     {:time => context.stop,
-     :msg => _("took #{context} seconds")}
+     :msg => _("took %{context} seconds") % { context: context }}
   end
 
   class Timer

--- a/lib/puppet/util/provider_features.rb
+++ b/lib/puppet/util/provider_features.rb
@@ -69,7 +69,7 @@ module Puppet::Util::ProviderFeatures
       @features[obj.name] = obj
     rescue ArgumentError => detail
       error = ArgumentError.new(
-        "Could not create feature #{name}: #{detail}"
+        _("Could not create feature #{name}: #{detail}")
       )
       error.set_backtrace(detail.backtrace)
       raise error

--- a/lib/puppet/util/provider_features.rb
+++ b/lib/puppet/util/provider_features.rb
@@ -69,7 +69,7 @@ module Puppet::Util::ProviderFeatures
       @features[obj.name] = obj
     rescue ArgumentError => detail
       error = ArgumentError.new(
-        _("Could not create feature #{name}: #{detail}")
+        _("Could not create feature %{name}: %{detail}") % { name: name, detail: detail }
       )
       error.set_backtrace(detail.backtrace)
       raise error

--- a/lib/puppet/util/rdoc.rb
+++ b/lib/puppet/util/rdoc.rb
@@ -41,20 +41,20 @@ module Puppet::Util::RDoc
 
   # launch an output to console manifest doc
   def manifestdoc(files)
-    raise "RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638"
+    raise _("RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638")
   end
 
   # Outputs to the console the documentation
   # of a manifest
   def output(file, ast)
-    raise "RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638"
+    raise _("RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638")
   end
 
   def output_astnode_doc(ast)
-    raise "RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638"
+    raise _("RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638")
   end
 
   def output_resource_doc(code)
-    raise "RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638"
+    raise _("RDOC SUPPORT FOR MANIFEST HAS BEEN REMOVED - See PUP-3638")
   end
 end

--- a/lib/puppet/util/reference.rb
+++ b/lib/puppet/util/reference.rb
@@ -32,15 +32,15 @@ class Puppet::Util::Reference
     depth = 4
     # Use the minimum depth
     sections.each do |name|
-      section = reference(name) or raise "Could not find section #{name}"
+      section = reference(name) or raise _("Could not find section #{name}")
       depth = section.depth if section.depth < depth
     end
   end
 
   def self.pdf(text)
-    puts "creating pdf"
+    puts _("creating pdf")
     rst2latex = which('rst2latex') || which('rst2latex.py') ||
-      raise("Could not find rst2latex")
+      raise(_("Could not find rst2latex"))
 
     cmd = %{#{rst2latex} /tmp/puppetdoc.txt > /tmp/puppetdoc.tex}
     Puppet::Util.replace_file("/tmp/puppetdoc.txt") {|f| f.puts text }
@@ -50,7 +50,7 @@ class Puppet::Util::Reference
     Puppet::FileSystem.unlink('/tmp/puppetdoc.tex') rescue nil
     output = %x{#{cmd}}
     unless $CHILD_STATUS == 0
-      $stderr.puts "rst2latex failed"
+      $stderr.puts _("rst2latex failed")
       $stderr.puts output
       exit(1)
     end
@@ -90,7 +90,7 @@ class Puppet::Util::Reference
     meta_def(:generate, &block)
 
     # Now handle the defaults
-    @title ||= "#{@name.to_s.capitalize} Reference"
+    @title ||= _("#{@name.to_s.capitalize} Reference")
     @page ||= @title.gsub(/\s+/, '')
     @depth ||= 2
     @header ||= ""

--- a/lib/puppet/util/reference.rb
+++ b/lib/puppet/util/reference.rb
@@ -32,7 +32,7 @@ class Puppet::Util::Reference
     depth = 4
     # Use the minimum depth
     sections.each do |name|
-      section = reference(name) or raise _("Could not find section #{name}")
+      section = reference(name) or raise _("Could not find section %{name}") % { name: name }
       depth = section.depth if section.depth < depth
     end
   end
@@ -90,7 +90,7 @@ class Puppet::Util::Reference
     meta_def(:generate, &block)
 
     # Now handle the defaults
-    @title ||= _("#{@name.to_s.capitalize} Reference")
+    @title ||= _("%{name} Reference") % { name: @name.to_s.capitalize }
     @page ||= @title.gsub(/\s+/, '')
     @depth ||= 2
     @header ||= ""

--- a/lib/puppet/util/resource_template.rb
+++ b/lib/puppet/util/resource_template.rb
@@ -44,7 +44,7 @@ class Puppet::Util::ResourceTemplate
   end
 
   def initialize(file, resource)
-    raise ArgumentError, "Template #{file} does not exist" unless Puppet::FileSystem.exist?(file)
+    raise ArgumentError, _("Template #{file} does not exist") unless Puppet::FileSystem.exist?(file)
     @file = file
     @resource = resource
   end

--- a/lib/puppet/util/resource_template.rb
+++ b/lib/puppet/util/resource_template.rb
@@ -44,7 +44,7 @@ class Puppet::Util::ResourceTemplate
   end
 
   def initialize(file, resource)
-    raise ArgumentError, _("Template #{file} does not exist") unless Puppet::FileSystem.exist?(file)
+    raise ArgumentError, _("Template %{file} does not exist") % { file: file } unless Puppet::FileSystem.exist?(file)
     @file = file
     @resource = resource
   end

--- a/lib/puppet/util/retry_action.rb
+++ b/lib/puppet/util/retry_action.rb
@@ -28,10 +28,10 @@ module Puppet::Util::RetryAction
       yield
     rescue *retry_exceptions => e
       if failures >= retries
-        raise RetryException::RetriesExceeded, "#{retries} exceeded", e.backtrace
+        raise RetryException::RetriesExceeded, _("#{retries} exceeded"), e.backtrace
       end
 
-      Puppet.info("Caught exception #{e.class}:#{e} retrying")
+      Puppet.info(_("Caught exception #{e.class}:#{e} retrying"))
 
       failures += 1
 

--- a/lib/puppet/util/retry_action.rb
+++ b/lib/puppet/util/retry_action.rb
@@ -28,10 +28,10 @@ module Puppet::Util::RetryAction
       yield
     rescue *retry_exceptions => e
       if failures >= retries
-        raise RetryException::RetriesExceeded, _("#{retries} exceeded"), e.backtrace
+        raise RetryException::RetriesExceeded, _("%{retries} exceeded") % { retries: retries }, e.backtrace
       end
 
-      Puppet.info(_("Caught exception #{e.class}:#{e} retrying"))
+      Puppet.info(_("Caught exception %{klass}:%{error} retrying") % { klass: e.class, error: e })
 
       failures += 1
 

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -63,7 +63,7 @@ module Puppet::Util::SELinux
       return nil
     end
     unless context =~ /^([^\s:]+):([^\s:]+):([^\s:]+)(?::([\sa-zA-Z0-9:,._-]+))?$/
-      raise Puppet::Error, _("Invalid context to parse: #{context}")
+      raise Puppet::Error, _("Invalid context to parse: %{context}") % { context: context }
     end
     ret = {
       :seluser => $1,
@@ -116,7 +116,7 @@ module Puppet::Util::SELinux
     if retval == 0
       return true
     else
-      Puppet.warning _("Failed to set SELinux context #{context} on #{file}")
+      Puppet.warning _("Failed to set SELinux context %{context} on %{file}") % { context: context, file: file }
       return false
     end
   end

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -63,7 +63,7 @@ module Puppet::Util::SELinux
       return nil
     end
     unless context =~ /^([^\s:]+):([^\s:]+):([^\s:]+)(?::([\sa-zA-Z0-9:,._-]+))?$/
-      raise Puppet::Error, "Invalid context to parse: #{context}"
+      raise Puppet::Error, _("Invalid context to parse: #{context}")
     end
     ret = {
       :seluser => $1,
@@ -91,7 +91,7 @@ module Puppet::Util::SELinux
         # We can't set partial context components when no context exists
         # unless/until we can find a way to make Puppet call this method
         # once for all selinux file label attributes.
-        Puppet.warning "Can't set SELinux context on file unless the file already has some kind of context"
+        Puppet.warning _("Can't set SELinux context on file unless the file already has some kind of context")
         return nil
       end
       context = context.split(':')
@@ -105,7 +105,7 @@ module Puppet::Util::SELinux
         when :selrange
           context[3] = value
         else
-          raise ArgumentError, "set_selinux_context component must be one of :seluser, :selrole, :seltype, or :selrange"
+          raise ArgumentError, _("set_selinux_context component must be one of :seluser, :selrole, :seltype, or :selrange")
       end
       context = context.join(':')
     else
@@ -116,7 +116,7 @@ module Puppet::Util::SELinux
     if retval == 0
       return true
     else
-      Puppet.warning "Failed to set SELinux context #{context} on #{file}"
+      Puppet.warning _("Failed to set SELinux context #{context} on #{file}")
       return false
     end
   end

--- a/lib/puppet/util/splayer.rb
+++ b/lib/puppet/util/splayer.rb
@@ -11,7 +11,7 @@ module Puppet::Util::Splayer
     return if splayed?
 
     time = rand(Puppet[:splaylimit] + 1)
-    Puppet.info _("Sleeping for #{time} seconds (splay is enabled)")
+    Puppet.info _("Sleeping for %{time} seconds (splay is enabled)") % { time: time }
     sleep(time)
     @splayed = true
   end

--- a/lib/puppet/util/splayer.rb
+++ b/lib/puppet/util/splayer.rb
@@ -11,7 +11,7 @@ module Puppet::Util::Splayer
     return if splayed?
 
     time = rand(Puppet[:splaylimit] + 1)
-    Puppet.info "Sleeping for #{time} seconds (splay is enabled)"
+    Puppet.info _("Sleeping for #{time} seconds (splay is enabled)")
     sleep(time)
     @splayed = true
   end

--- a/lib/puppet/util/storage.rb
+++ b/lib/puppet/util/storage.rb
@@ -50,25 +50,25 @@ class Puppet::Util::Storage
       return
     end
     unless File.file?(filename)
-      Puppet.warning("Checksumfile #{filename} is not a file, ignoring")
+      Puppet.warning(_("Checksumfile #{filename} is not a file, ignoring"))
       return
     end
     Puppet::Util.benchmark(:debug, "Loaded state") do
       begin
         @@state = Puppet::Util::Yaml.load_file(filename)
       rescue Puppet::Util::Yaml::YamlLoadError => detail
-        Puppet.err "Checksumfile #{filename} is corrupt (#{detail}); replacing"
+        Puppet.err _("Checksumfile #{filename} is corrupt (#{detail}); replacing")
 
         begin
           File.rename(filename, filename + ".bad")
         rescue
-          raise Puppet::Error, "Could not rename corrupt #{filename}; remove manually", detail.backtrace
+          raise Puppet::Error, _("Could not rename corrupt #{filename}; remove manually"), detail.backtrace
         end
       end
     end
 
     unless @@state.is_a?(Hash)
-      Puppet.err "State got corrupted"
+      Puppet.err _("State got corrupted")
       self.init
     end
   end
@@ -80,7 +80,7 @@ class Puppet::Util::Storage
   def self.store
     Puppet.debug "Storing state"
 
-    Puppet.info "Creating state file #{Puppet[:statefile]}" unless Puppet::FileSystem.exist?(Puppet[:statefile])
+    Puppet.info _("Creating state file #{Puppet[:statefile]}") unless Puppet::FileSystem.exist?(Puppet[:statefile])
 
     Puppet::Util.benchmark(:debug, "Stored state") do
       Puppet::Util::Yaml.dump(@@state, Puppet[:statefile])

--- a/lib/puppet/util/storage.rb
+++ b/lib/puppet/util/storage.rb
@@ -50,19 +50,19 @@ class Puppet::Util::Storage
       return
     end
     unless File.file?(filename)
-      Puppet.warning(_("Checksumfile #{filename} is not a file, ignoring"))
+      Puppet.warning(_("Checksumfile %{filename} is not a file, ignoring") % { filename: filename })
       return
     end
     Puppet::Util.benchmark(:debug, "Loaded state") do
       begin
         @@state = Puppet::Util::Yaml.load_file(filename)
       rescue Puppet::Util::Yaml::YamlLoadError => detail
-        Puppet.err _("Checksumfile #{filename} is corrupt (#{detail}); replacing")
+        Puppet.err _("Checksumfile %{filename} is corrupt (%{detail}); replacing") % { filename: filename, detail: detail }
 
         begin
           File.rename(filename, filename + ".bad")
         rescue
-          raise Puppet::Error, _("Could not rename corrupt #{filename}; remove manually"), detail.backtrace
+          raise Puppet::Error, _("Could not rename corrupt %{filename}; remove manually") % { filename: filename }, detail.backtrace
         end
       end
     end
@@ -80,7 +80,7 @@ class Puppet::Util::Storage
   def self.store
     Puppet.debug "Storing state"
 
-    Puppet.info _("Creating state file #{Puppet[:statefile]}") unless Puppet::FileSystem.exist?(Puppet[:statefile])
+    Puppet.info _("Creating state file %{file}") % { file: Puppet[:statefile] } unless Puppet::FileSystem.exist?(Puppet[:statefile])
 
     Puppet::Util.benchmark(:debug, "Stored state") do
       Puppet::Util::Yaml.dump(@@state, Puppet[:statefile])

--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -99,7 +99,7 @@ module Puppet::Util::SUIDManager
   # change to a different gid without root.
   def change_group(group, permanently=false)
     gid = convert_xid(:gid, group)
-    raise Puppet::Error, _("No such group #{group}") unless gid
+    raise Puppet::Error, _("No such group %{group}") % { group: group } unless gid
 
     return if Process.egid == gid
 
@@ -115,7 +115,7 @@ module Puppet::Util::SUIDManager
   # supplementary groups will be set the to default groups for the new uid.
   def change_user(user, permanently=false)
     uid = convert_xid(:uid, user)
-    raise Puppet::Error, _("No such user #{user}") unless uid
+    raise Puppet::Error, _("No such user %{user}") % { user: user } unless uid
 
     return if Process.euid == uid
 
@@ -142,10 +142,10 @@ module Puppet::Util::SUIDManager
   # Make sure the passed argument is a number.
   def convert_xid(type, id)
     map = {:gid => :group, :uid => :user}
-    raise ArgumentError, _("Invalid id type #{type}") unless map.include?(type)
+    raise ArgumentError, _("Invalid id type %{type}") % { type: type } unless map.include?(type)
     ret = Puppet::Util.send(type, id)
     if ret == nil
-      raise Puppet::Error, _("Invalid #{map[type]}: #{id}")
+      raise Puppet::Error, _("Invalid %{klass}: %{id}") % { klass: map[type], id: id }
     end
     ret
   end

--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -99,7 +99,7 @@ module Puppet::Util::SUIDManager
   # change to a different gid without root.
   def change_group(group, permanently=false)
     gid = convert_xid(:gid, group)
-    raise Puppet::Error, "No such group #{group}" unless gid
+    raise Puppet::Error, _("No such group #{group}") unless gid
 
     return if Process.egid == gid
 
@@ -115,7 +115,7 @@ module Puppet::Util::SUIDManager
   # supplementary groups will be set the to default groups for the new uid.
   def change_user(user, permanently=false)
     uid = convert_xid(:uid, user)
-    raise Puppet::Error, "No such user #{user}" unless uid
+    raise Puppet::Error, _("No such user #{user}") unless uid
 
     return if Process.euid == uid
 
@@ -142,10 +142,10 @@ module Puppet::Util::SUIDManager
   # Make sure the passed argument is a number.
   def convert_xid(type, id)
     map = {:gid => :group, :uid => :user}
-    raise ArgumentError, "Invalid id type #{type}" unless map.include?(type)
+    raise ArgumentError, _("Invalid id type #{type}") unless map.include?(type)
     ret = Puppet::Util.send(type, id)
     if ret == nil
-      raise Puppet::Error, "Invalid #{map[type]}: #{id}"
+      raise Puppet::Error, _("Invalid #{map[type]}: #{id}")
     end
     ret
   end

--- a/lib/puppet/util/symbolic_file_mode.rb
+++ b/lib/puppet/util/symbolic_file_mode.rb
@@ -34,14 +34,14 @@ module SymbolicFileMode
 
   def symbolic_mode_to_int(modification, to_mode = 0, is_a_directory = false)
     if modification.nil? or modification == '' then
-      raise Puppet::Error, "An empty mode string is illegal"
+      raise Puppet::Error, _("An empty mode string is illegal")
     end
     if modification =~ /^[0-7]+$/ then return modification.to_i(8) end
     if modification =~ /^\d+$/ then
-      raise Puppet::Error, "Numeric modes must be in octal, not decimal!"
+      raise Puppet::Error, _("Numeric modes must be in octal, not decimal!")
     end
 
-    fail "non-numeric current mode (#{to_mode.inspect})" unless to_mode.is_a?(Numeric)
+    fail _("non-numeric current mode (#{to_mode.inspect})") unless to_mode.is_a?(Numeric)
 
     original_mode = {
       's' => (to_mode & 07000) >> 9,
@@ -61,7 +61,7 @@ module SymbolicFileMode
     modification.split(/\s*,\s*/).each do |part|
       begin
         _, to, dsl = /^([ugoa]*)([-+=].*)$/.match(part).to_a
-        if dsl.nil? then raise Puppet::Error, 'Missing action' end
+        if dsl.nil? then raise Puppet::Error, _('Missing action') end
         to = "a" unless to and to.length > 0
 
         # We want a snapshot of the mode before we start messing with it to
@@ -76,7 +76,7 @@ module SymbolicFileMode
 
           action = '!'
           actions = {
-            '!' => lambda {|_,_| raise Puppet::Error, 'Missing operation (-, =, or +)' },
+            '!' => lambda {|_,_| raise Puppet::Error, _('Missing operation (-, =, or +)') },
             '=' => lambda {|m,v| m | v },
             '+' => lambda {|m,v| m | v },
             '-' => lambda {|m,v| m & ~v },
@@ -98,7 +98,7 @@ module SymbolicFileMode
             when 'X' then
               # Only meaningful in combination with "set" actions.
               if action != '+' then
-                raise Puppet::Error, "X only works with the '+' operator"
+                raise Puppet::Error, _("X only works with the '+' operator")
               end
 
               # As per the BSD manual page, set if this is a directory, or if
@@ -109,11 +109,11 @@ module SymbolicFileMode
               end
 
             when /[st]/ then
-              bit = SymbolicSpecialToBit[op][who] or fail "internal error"
+              bit = SymbolicSpecialToBit[op][who] or fail _("internal error")
               final_mode['s'] = actions[action].call(final_mode['s'], bit)
 
             else
-              raise Puppet::Error, 'Unknown operation'
+              raise Puppet::Error, _('Unknown operation')
             end
           end
 
@@ -128,7 +128,7 @@ module SymbolicFileMode
           rest = ''
         end
 
-        raise Puppet::Error, "#{e}#{rest} in symbolic mode #{modification.inspect}", e.backtrace
+        raise Puppet::Error, _("#{e}#{rest} in symbolic mode #{modification.inspect}"), e.backtrace
       end
     end
 

--- a/lib/puppet/util/symbolic_file_mode.rb
+++ b/lib/puppet/util/symbolic_file_mode.rb
@@ -41,7 +41,7 @@ module SymbolicFileMode
       raise Puppet::Error, _("Numeric modes must be in octal, not decimal!")
     end
 
-    fail _("non-numeric current mode (#{to_mode.inspect})") unless to_mode.is_a?(Numeric)
+    fail _("non-numeric current mode (%{mode})") % { mode: to_mode.inspect } unless to_mode.is_a?(Numeric)
 
     original_mode = {
       's' => (to_mode & 07000) >> 9,
@@ -128,7 +128,7 @@ module SymbolicFileMode
           rest = ''
         end
 
-        raise Puppet::Error, _("#{e}#{rest} in symbolic mode #{modification.inspect}"), e.backtrace
+        raise Puppet::Error, _("%{error}%{rest} in symbolic mode %{modification}") % { error: e, rest: rest, modification: modification.inspect }, e.backtrace
       end
     end
 

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -24,7 +24,7 @@ module Puppet::Util::Tagging
           end
         else
           @tags.delete(name)
-          fail(Puppet::ParseError, _("Invalid tag '#{name}'"))
+          fail(Puppet::ParseError, _("Invalid tag '%{name}'") % { name: name })
         end
       end
     end

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -24,7 +24,7 @@ module Puppet::Util::Tagging
           end
         else
           @tags.delete(name)
-          fail(Puppet::ParseError, "Invalid tag '#{name}'")
+          fail(Puppet::ParseError, _("Invalid tag '#{name}'"))
         end
       end
     end

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -16,7 +16,7 @@ module Puppet::Util::Windows::ADSI
       begin
         WIN32OLE.connect(uri)
       rescue WIN32OLERuntimeError => e
-        raise Puppet::Error.new( "ADSI connection error: #{e}", e )
+        raise Puppet::Error.new( _("ADSI connection error: #{e}"), e )
       end
     end
 
@@ -39,7 +39,7 @@ module Puppet::Util::Windows::ADSI
             buffer_size.write_dword(max_length) # length in TCHARs
 
             if GetComputerNameW(buffer, buffer_size) == FFI::WIN32_FALSE
-              raise Puppet::Util::Windows::Error.new("Failed to get computer name")
+              raise Puppet::Util::Windows::Error.new(_("Failed to get computer name"))
             end
             @computer_name = buffer.read_wide_string(buffer_size.read_dword)
           end
@@ -77,7 +77,7 @@ module Puppet::Util::Windows::ADSI
     # used for IAdsGroup::Add / IAdsGroup::Remove.  These URIs are not useable
     # to resolve an account with WIN32OLE.connect
     def sid_uri(sid)
-      raise Puppet::Error.new( "Must use a valid SID::Principal" ) if !sid.kind_of?(Puppet::Util::Windows::SID::Principal)
+      raise Puppet::Error.new( _("Must use a valid SID::Principal") ) if !sid.kind_of?(Puppet::Util::Windows::SID::Principal)
 
       "WinNT://#{sid.sid}"
     end
@@ -129,7 +129,7 @@ module Puppet::Util::Windows::ADSI
 
     def parse_name(name)
       if name =~ /\//
-        raise Puppet::Error.new( "Value must be in DOMAIN\\user style syntax" )
+        raise Puppet::Error.new( _("Value must be in DOMAIN\\user style syntax") )
       end
 
       matches = name.scan(/((.*)\\)?(.*)/)
@@ -153,7 +153,7 @@ module Puppet::Util::Windows::ADSI
 
       sids = names.map do |name|
         sid = Puppet::Util::Windows::SID.name_to_sid_object(name)
-        raise Puppet::Error.new( "Could not resolve name: #{name}" ) if !sid
+        raise Puppet::Error.new( _("Could not resolve name: #{name}") ) if !sid
         [sid.sid, sid]
       end
 
@@ -211,12 +211,12 @@ module Puppet::Util::Windows::ADSI
         # ERROR_BAD_USERNAME 2202L from winerror.h
         if e.message =~ /8007089A/m
           raise Puppet::Error.new(
-           "Puppet is not able to create/delete domain users with the user resource.",
+           _("Puppet is not able to create/delete domain users with the user resource."),
            e
           )
         end
 
-        raise Puppet::Error.new( "User update failed: #{e}", e )
+        raise Puppet::Error.new( _("User update failed: #{e}"), e )
       end
       self
     end
@@ -311,7 +311,7 @@ module Puppet::Util::Windows::ADSI
 
     def self.create(name)
       # Windows error 1379: The specified local group already exists.
-      raise Puppet::Error.new( "Cannot create user if group '#{name}' exists." ) if Puppet::Util::Windows::ADSI::Group.exists? name
+      raise Puppet::Error.new(_("Cannot create user if group '#{name}' exists.")) if Puppet::Util::Windows::ADSI::Group.exists? name
       new(name, Puppet::Util::Windows::ADSI.create(name, 'user'))
     end
 
@@ -325,7 +325,7 @@ module Puppet::Util::Windows::ADSI
           buffer_size.write_dword(max_length) # length in TCHARs
 
           if GetUserNameW(buffer, buffer_size) == FFI::WIN32_FALSE
-            raise Puppet::Util::Windows::Error.new("Failed to get user name")
+            raise Puppet::Util::Windows::Error.new(_("Failed to get user name"))
           end
           # buffer_size includes trailing NULL
           user_name = buffer.read_wide_string(buffer_size.read_dword - 1)
@@ -403,7 +403,7 @@ module Puppet::Util::Windows::ADSI
         # but warn if we fail
         raise e unless e.message.include?('80041010')
 
-        Puppet.warning "Cannot delete user profile for '#{sid}' prior to Vista SP1"
+        Puppet.warning _("Cannot delete user profile for '#{sid}' prior to Vista SP1")
       end
     end
   end
@@ -441,12 +441,12 @@ module Puppet::Util::Windows::ADSI
         # ERROR_BAD_USERNAME 2202L from winerror.h
         if e.message =~ /8007089A/m
           raise Puppet::Error.new(
-            "Puppet is not able to create/delete domain groups with the group resource.",
+            _("Puppet is not able to create/delete domain groups with the group resource."),
             e
           )
         end
 
-        raise Puppet::Error.new( "Group update failed: #{e}", e )
+        raise Puppet::Error.new( _("Group update failed: #{e}"), e )
       end
       self
     end
@@ -502,7 +502,7 @@ module Puppet::Util::Windows::ADSI
 
     def self.create(name)
       # Windows error 2224: The account already exists.
-      raise Puppet::Error.new( "Cannot create group if user '#{name}' exists." ) if Puppet::Util::Windows::ADSI::User.exists? name
+      raise Puppet::Error.new( _("Cannot create group if user '#{name}' exists.") ) if Puppet::Util::Windows::ADSI::User.exists? name
       new(name, Puppet::Util::Windows::ADSI.create(name, 'group'))
     end
 
@@ -533,7 +533,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def self.each(&block)
-      wql = Puppet::Util::Windows::ADSI.execquery( 'select name from win32_group where localaccount = "TRUE"' )
+      wql = Puppet::Util::Windows::ADSI.execquery('select name from win32_group where localaccount = "TRUE"')
 
       groups = []
       wql.each do |g|

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -16,7 +16,7 @@ module Puppet::Util::Windows::ADSI
       begin
         WIN32OLE.connect(uri)
       rescue WIN32OLERuntimeError => e
-        raise Puppet::Error.new( _("ADSI connection error: #{e}"), e )
+        raise Puppet::Error.new( _("ADSI connection error: %{e}") % { e: e }, e )
       end
     end
 
@@ -153,7 +153,7 @@ module Puppet::Util::Windows::ADSI
 
       sids = names.map do |name|
         sid = Puppet::Util::Windows::SID.name_to_sid_object(name)
-        raise Puppet::Error.new( _("Could not resolve name: #{name}") ) if !sid
+        raise Puppet::Error.new( _("Could not resolve name: %{name}") % { name: name } ) if !sid
         [sid.sid, sid]
       end
 
@@ -216,7 +216,7 @@ module Puppet::Util::Windows::ADSI
           )
         end
 
-        raise Puppet::Error.new( _("User update failed: #{e}"), e )
+        raise Puppet::Error.new( _("User update failed: %{e}") % { e: e }, e )
       end
       self
     end
@@ -311,7 +311,7 @@ module Puppet::Util::Windows::ADSI
 
     def self.create(name)
       # Windows error 1379: The specified local group already exists.
-      raise Puppet::Error.new(_("Cannot create user if group '#{name}' exists.")) if Puppet::Util::Windows::ADSI::Group.exists? name
+      raise Puppet::Error.new(_("Cannot create user if group '%{name}' exists.") % { name: name }) if Puppet::Util::Windows::ADSI::Group.exists? name
       new(name, Puppet::Util::Windows::ADSI.create(name, 'user'))
     end
 
@@ -403,7 +403,7 @@ module Puppet::Util::Windows::ADSI
         # but warn if we fail
         raise e unless e.message.include?('80041010')
 
-        Puppet.warning _("Cannot delete user profile for '#{sid}' prior to Vista SP1")
+        Puppet.warning _("Cannot delete user profile for '%{sid}' prior to Vista SP1") % { sid: sid }
       end
     end
   end
@@ -446,7 +446,7 @@ module Puppet::Util::Windows::ADSI
           )
         end
 
-        raise Puppet::Error.new( _("Group update failed: #{e}"), e )
+        raise Puppet::Error.new( _("Group update failed: %{error}") % { error: e }, e )
       end
       self
     end
@@ -502,7 +502,7 @@ module Puppet::Util::Windows::ADSI
 
     def self.create(name)
       # Windows error 2224: The account already exists.
-      raise Puppet::Error.new( _("Cannot create group if user '#{name}' exists.") ) if Puppet::Util::Windows::ADSI::User.exists? name
+      raise Puppet::Error.new( _("Cannot create group if user '%{name}' exists.") % { name: name } ) if Puppet::Util::Windows::ADSI::User.exists? name
       new(name, Puppet::Util::Windows::ADSI.create(name, 'group'))
     end
 

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -65,7 +65,7 @@ module Puppet::Util::Windows::APITypes
     #   null_terminator = :double_null, then the terminating sequence is four bytes of zero.  This is UNIT32 = 0
     def read_arbitrary_wide_string_up_to(max_char_length = 512, null_terminator = :single_null)
       if null_terminator != :single_null && null_terminator != :double_null
-        raise _("Unable to read wide strings with #{null_terminator} terminal nulls")
+        raise _("Unable to read wide strings with %{null_terminator} terminal nulls") % { null_terminator: null_terminator }
       end
 
       terminator_width = null_terminator == :single_null ? 1 : 2

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -65,7 +65,7 @@ module Puppet::Util::Windows::APITypes
     #   null_terminator = :double_null, then the terminating sequence is four bytes of zero.  This is UNIT32 = 0
     def read_arbitrary_wide_string_up_to(max_char_length = 512, null_terminator = :single_null)
       if null_terminator != :single_null && null_terminator != :double_null
-        raise "Unable to read wide strings with #{null_terminator} terminal nulls"
+        raise _("Unable to read wide strings with #{null_terminator} terminal nulls")
       end
 
       terminator_width = null_terminator == :single_null ? 1 : 2
@@ -193,7 +193,7 @@ module Puppet::Util::Windows::APITypes
              :Data4, [:byte, 8]
 
       def self.[](s)
-        raise 'Bad GUID format.' unless s =~ /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i
+        raise _('Bad GUID format.') unless s =~ /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i
 
         new.tap do |guid|
           guid[:Data1] = s[0, 8].to_i(16)

--- a/lib/puppet/util/windows/com.rb
+++ b/lib/puppet/util/windows/com.rb
@@ -14,7 +14,7 @@ module Puppet::Util::Windows::COM
   module_function :SUCCEEDED, :FAILED
 
   def raise_if_hresult_failed(name, *args)
-    failed = FAILED(result = send(name, *args)) and raise "#{name} failed (hresult #{format('%#08x', result)})."
+    failed = FAILED(result = send(name, *args)) and raise _("#{name} failed (hresult #{format('%#08x', result)}).")
 
     result
   ensure
@@ -139,7 +139,7 @@ module Puppet::Util::Windows::COM
         self::VTBL.members.each do |name|
           define_method(name) do |*args|
             if Puppet::Util::Windows::COM.FAILED(result = @vtbl[name].call(self, *args))
-              raise Puppet::Util::Windows::Error.new("Failed to call #{self}::#{name} with HRESULT: #{result}.", result)
+              raise Puppet::Util::Windows::Error.new(_("Failed to call #{self}::#{name} with HRESULT: #{result}."), result)
             end
             result
           end
@@ -166,7 +166,7 @@ module Puppet::Util::Windows::COM
           FFI::MemoryPointer.new(:pointer) do |ppv|
             hr = Puppet::Util::Windows::COM.CoCreateInstance(self.class::CLSID, FFI::Pointer::NULL, @opts[:clsctx], self.class::IID, ppv)
             if Puppet::Util::Windows::COM.FAILED(hr)
-              raise "CoCreateInstance failed (#{self.class})."
+              raise _("CoCreateInstance failed (#{self.class}).")
             end
 
             self.pointer = ppv.read_pointer
@@ -180,7 +180,7 @@ module Puppet::Util::Windows::COM
         self::VTBL.members.each do |name|
           define_method(name) do |*args|
             if Puppet::Util::Windows::COM.FAILED(result = @vtbl[name].call(self, *args))
-              raise Puppet::Util::Windows::Error.new("Failed to call #{self}::#{name} with HRESULT: #{result}.", result)
+              raise Puppet::Util::Windows::Error.new(_("Failed to call #{self}::#{name} with HRESULT: #{result}."), result)
             end
             result
           end

--- a/lib/puppet/util/windows/com.rb
+++ b/lib/puppet/util/windows/com.rb
@@ -14,7 +14,7 @@ module Puppet::Util::Windows::COM
   module_function :SUCCEEDED, :FAILED
 
   def raise_if_hresult_failed(name, *args)
-    failed = FAILED(result = send(name, *args)) and raise _("#{name} failed (hresult #{format('%#08x', result)}).")
+    failed = FAILED(result = send(name, *args)) and raise _("%{name} failed (hresult %{result}).") % { name: name, result: format('%#08x', result) }
 
     result
   ensure
@@ -139,7 +139,7 @@ module Puppet::Util::Windows::COM
         self::VTBL.members.each do |name|
           define_method(name) do |*args|
             if Puppet::Util::Windows::COM.FAILED(result = @vtbl[name].call(self, *args))
-              raise Puppet::Util::Windows::Error.new(_("Failed to call #{self}::#{name} with HRESULT: #{result}."), result)
+              raise Puppet::Util::Windows::Error.new(_("Failed to call %{klass}::%{name} with HRESULT: %{result}.") % { klass: self, name: name, result: result }, result)
             end
             result
           end
@@ -166,7 +166,7 @@ module Puppet::Util::Windows::COM
           FFI::MemoryPointer.new(:pointer) do |ppv|
             hr = Puppet::Util::Windows::COM.CoCreateInstance(self.class::CLSID, FFI::Pointer::NULL, @opts[:clsctx], self.class::IID, ppv)
             if Puppet::Util::Windows::COM.FAILED(hr)
-              raise _("CoCreateInstance failed (#{self.class}).")
+              raise _("CoCreateInstance failed (%{klass}).") % { klass: self.class }
             end
 
             self.pointer = ppv.read_pointer
@@ -180,7 +180,7 @@ module Puppet::Util::Windows::COM
         self::VTBL.members.each do |name|
           define_method(name) do |*args|
             if Puppet::Util::Windows::COM.FAILED(result = @vtbl[name].call(self, *args))
-              raise Puppet::Util::Windows::Error.new(_("Failed to call #{self}::#{name} with HRESULT: #{result}."), result)
+              raise Puppet::Util::Windows::Error.new(_("Failed to call %{klass}::%{name} with HRESULT: %{result}.") % { klass: self, name: name, result: result }, result)
             end
             result
           end

--- a/lib/puppet/util/windows/error.rb
+++ b/lib/puppet/util/windows/error.rb
@@ -39,13 +39,13 @@ class Puppet::Util::Windows::Error < Puppet::Error
 
       if length == FFI::WIN32_FALSE
         # can't raise same error type here or potentially recurse infinitely
-        raise Puppet::Error.new("FormatMessageW could not format code #{code}")
+        raise Puppet::Error.new(_("FormatMessageW could not format code #{code}"))
       end
 
       # returns an FFI::Pointer with autorelease set to false, which is what we want
       buffer_ptr.read_win32_local_pointer do |wide_string_ptr|
         if wide_string_ptr.null?
-          raise Puppet::Error.new("FormatMessageW failed to allocate buffer for code #{code}")
+          raise Puppet::Error.new(_("FormatMessageW failed to allocate buffer for code #{code}"))
         end
 
         error_string = wide_string_ptr.read_wide_string(length)

--- a/lib/puppet/util/windows/error.rb
+++ b/lib/puppet/util/windows/error.rb
@@ -39,13 +39,13 @@ class Puppet::Util::Windows::Error < Puppet::Error
 
       if length == FFI::WIN32_FALSE
         # can't raise same error type here or potentially recurse infinitely
-        raise Puppet::Error.new(_("FormatMessageW could not format code #{code}"))
+        raise Puppet::Error.new(_("FormatMessageW could not format code %{code}") % { code: code })
       end
 
       # returns an FFI::Pointer with autorelease set to false, which is what we want
       buffer_ptr.read_win32_local_pointer do |wide_string_ptr|
         if wide_string_ptr.null?
-          raise Puppet::Error.new(_("FormatMessageW failed to allocate buffer for code #{code}"))
+          raise Puppet::Error.new(_("FormatMessageW failed to allocate buffer for code %{code}") % { code: code })
         end
 
         error_string = wide_string_ptr.read_wide_string(length)

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -151,7 +151,7 @@ module Puppet::Util::Windows::File
 
   def set_attributes(path, flags)
     success = SetFileAttributesW(wide_string(path), flags) != FFI::WIN32_FALSE
-    raise Puppet::Util::Windows::Error.new("Failed to set file attributes") if !success
+    raise Puppet::Util::Windows::Error.new(_("Failed to set file attributes")) if !success
 
     success
   end
@@ -186,7 +186,7 @@ module Puppet::Util::Windows::File
 
   def self.device_io_control(handle, io_control_code, in_buffer = nil, out_buffer = nil)
     if out_buffer.nil?
-      raise Puppet::Util::Windows::Error.new("out_buffer is required")
+      raise Puppet::Util::Windows::Error.new(_("out_buffer is required"))
     end
 
     FFI::MemoryPointer.new(:dword, 1) do |bytes_returned_ptr|
@@ -267,7 +267,7 @@ module Puppet::Util::Windows::File
       buffer_size = GetLongPathNameW(path_ptr, FFI::Pointer::NULL, 0)
       FFI::MemoryPointer.new(:wchar, buffer_size) do |converted_ptr|
         if GetLongPathNameW(path_ptr, converted_ptr, buffer_size) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to call GetLongPathName")
+          raise Puppet::Util::Windows::Error.new(_("Failed to call GetLongPathName"))
         end
 
         converted = converted_ptr.read_wide_string(buffer_size - 1)

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -93,6 +93,7 @@ module Puppet::Util::Windows::SID
     def self.lookup_account_sid(system_name = nil, sid_bytes)
       system_name_ptr = FFI::Pointer::NULL
       if (sid_bytes.nil? || (!sid_bytes.is_a? Array) || (sid_bytes.length == 0))
+        #TRANSLATORS `lookup_account_sid` is a variable name and should not be translated
         raise Puppet::Util::Windows::Error.new(_('Byte array for lookup_account_sid must not be nil and must be at least 1 byte long'))
       end
 

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -64,14 +64,14 @@ module Puppet::Util::Windows::SID
                 last_error = FFI.errno
 
                 if (success == FFI::WIN32_FALSE && last_error != ERROR_INSUFFICIENT_BUFFER)
-                  raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountNameW', last_error)
+                  raise Puppet::Util::Windows::Error.new(_('Failed to call LookupAccountNameW'), last_error)
                 end
 
                 FFI::MemoryPointer.new(:lpwstr, domain_length_ptr.read_dword) do |domain_ptr|
                   if LookupAccountNameW(system_name_ptr, account_name_ptr,
                       sid_ptr, sid_length_ptr,
                       domain_ptr, domain_length_ptr, name_use_enum_ptr) == FFI::WIN32_FALSE
-                   raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountNameW')
+                   raise Puppet::Util::Windows::Error.new(_('Failed to call LookupAccountNameW'))
                   end
 
                   # with a SID returned, loop back through lookup_account_sid to retrieve official name
@@ -93,7 +93,7 @@ module Puppet::Util::Windows::SID
     def self.lookup_account_sid(system_name = nil, sid_bytes)
       system_name_ptr = FFI::Pointer::NULL
       if (sid_bytes.nil? || (!sid_bytes.is_a? Array) || (sid_bytes.length == 0))
-        raise Puppet::Util::Windows::Error.new('Byte array for lookup_account_sid must not be nil and must be at least 1 byte long')
+        raise Puppet::Util::Windows::Error.new(_('Byte array for lookup_account_sid must not be nil and must be at least 1 byte long'))
       end
 
       begin
@@ -115,14 +115,14 @@ module Puppet::Util::Windows::SID
                 last_error = FFI.errno
 
                 if (success == FFI::WIN32_FALSE && last_error != ERROR_INSUFFICIENT_BUFFER)
-                  raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountSidW', last_error)
+                  raise Puppet::Util::Windows::Error.new(_('Failed to call LookupAccountSidW'), last_error)
                 end
 
                 FFI::MemoryPointer.new(:lpwstr, name_length_ptr.read_dword) do |name_ptr|
                   FFI::MemoryPointer.new(:lpwstr, domain_length_ptr.read_dword) do |domain_ptr|
                     if LookupAccountSidW(system_name_ptr, sid_ptr, name_ptr, name_length_ptr,
                         domain_ptr, domain_length_ptr, name_use_enum_ptr) == FFI::WIN32_FALSE
-                     raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountSidW')
+                     raise Puppet::Util::Windows::Error.new(_('Failed to call LookupAccountSidW'))
                     end
 
                     return new(

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -21,7 +21,7 @@ module Puppet::Util::Windows::Process
     exit_status = -1
     FFI::MemoryPointer.new(:dword, 1) do |exit_status_ptr|
       if GetExitCodeProcess(handle, exit_status_ptr) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Failed to get child process exit code")
+        raise Puppet::Util::Windows::Error.new(_("Failed to get child process exit code"))
       end
       exit_status = exit_status_ptr.read_dword
 
@@ -214,7 +214,7 @@ module Puppet::Util::Windows::Process
       result = GetVersionExW(os_version_ptr)
 
       if result == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("GetVersionEx failed")
+        raise Puppet::Util::Windows::Error.new(_("GetVersionEx failed"))
       end
 
       ver = os_version[:dwMajorVersion]
@@ -251,17 +251,17 @@ module Puppet::Util::Windows::Process
   module_function :get_environment_strings
 
   def set_environment_variable(name, val)
-    raise Puppet::Util::Windows::Error('environment variable name must not be nil or empty') if ! name || name.empty?
+    raise Puppet::Util::Windows::Error(_('environment variable name must not be nil or empty')) if ! name || name.empty?
 
     FFI::MemoryPointer.from_string_to_wide_string(name) do |name_ptr|
       if (val.nil?)
         if SetEnvironmentVariableW(name_ptr, FFI::MemoryPointer::NULL) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to remove environment variable: #{name}")
+          raise Puppet::Util::Windows::Error.new(_("Failed to remove environment variable: #{name}"))
         end
       else
         FFI::MemoryPointer.from_string_to_wide_string(val) do |val_ptr|
           if SetEnvironmentVariableW(name_ptr, val_ptr) == FFI::WIN32_FALSE
-            raise Puppet::Util::Windows::Error.new("Failed to set environment variable: #{name}")
+            raise Puppet::Util::Windows::Error.new(_("Failed to set environment variable: #{name}"))
           end
         end
       end

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -256,12 +256,12 @@ module Puppet::Util::Windows::Process
     FFI::MemoryPointer.from_string_to_wide_string(name) do |name_ptr|
       if (val.nil?)
         if SetEnvironmentVariableW(name_ptr, FFI::MemoryPointer::NULL) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new(_("Failed to remove environment variable: #{name}"))
+          raise Puppet::Util::Windows::Error.new(_("Failed to remove environment variable: %{name}") % { name: name })
         end
       else
         FFI::MemoryPointer.from_string_to_wide_string(val) do |val_ptr|
           if SetEnvironmentVariableW(name_ptr, val_ptr) == FFI::WIN32_FALSE
-            raise Puppet::Util::Windows::Error.new(_("Failed to set environment variable: #{name}"))
+            raise Puppet::Util::Windows::Error.new(_("Failed to set environment variable: %{name}") % { name: name })
           end
         end
       end

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -18,7 +18,7 @@ module Puppet::Util::Windows
     def root(name)
       Win32::Registry.const_get(name)
     rescue NameError
-      raise Puppet::Error, _("Invalid registry key '#{name}'"), $!.backtrace
+      raise Puppet::Error, _("Invalid registry key '%{name}'") % { name: name }, $!.backtrace
     end
 
     def open(name, path, mode = KEY_READ | KEY64, &block)
@@ -28,7 +28,7 @@ module Puppet::Util::Windows
           return yield subkey
         end
       rescue Win32::Registry::Error => error
-        raise Puppet::Util::Windows::Error.new(_("Failed to open registry key '#{hkey.keyname}\\#{path}'"), error.code, error)
+        raise Puppet::Util::Windows::Error.new(_("Failed to open registry key '%{key}\\%{path}'") % { key: hkey.keyname, path: path }, error.code, error)
       end
     end
 
@@ -103,7 +103,7 @@ module Puppet::Util::Windows
             break if result == ERROR_NO_MORE_ITEMS
 
             if result != FFI::ERROR_SUCCESS
-              msg = _("Failed to enumerate #{key.keyname} registry keys at index #{index}")
+              msg = _("Failed to enumerate %{key} registry keys at index %{index}") % { key: key.keyname, index: index }
               raise Puppet::Util::Windows::Error.new(msg)
             end
 
@@ -134,7 +134,7 @@ module Puppet::Util::Windows
           break if result == ERROR_NO_MORE_ITEMS
 
           if result != FFI::ERROR_SUCCESS
-            msg = _("Failed to enumerate #{key.keyname} registry values at index #{index}")
+            msg = _("Failed to enumerate %{key} registry values at index %{index}") % { key: key.keyname, index: index }
             raise Puppet::Util::Windows::Error.new(msg)
           end
 
@@ -164,7 +164,7 @@ module Puppet::Util::Windows
           )
 
           if status != FFI::ERROR_SUCCESS
-            msg = _("Failed to query registry #{key.keyname} for sizes")
+            msg = _("Failed to query registry %{key} for sizes") % { key: key.keyname }
             raise Puppet::Util::Windows::Error.new(msg)
           end
 
@@ -200,7 +200,7 @@ module Puppet::Util::Windows
 
       query_value_ex(key, name_ptr) do |type, data_ptr, byte_length|
         unless rtype.empty? or rtype.include?(type)
-          raise TypeError, _("Type mismatch (expect #{rtype.inspect} but #{type} present)")
+          raise TypeError, _("Type mismatch (expect %{rtype} but %{type} present)") % { rtype: rtype.inspect, type: type }
         end
 
         string_length = 0
@@ -222,12 +222,12 @@ module Puppet::Util::Windows
             when Win32::Registry::REG_QWORD
               result = [ type, data_ptr.read_qword ]
             else
-              raise TypeError, _("Type #{type} is not supported.")
+              raise TypeError, _("Type %{type} is not supported.") % { type: type }
           end
         rescue IndexError => ex
           raise if (ex.message !~ /^Memory access .* is out of bounds$/i)
           parent_key_name = key.parent ? "#{key.parent.keyname}\\" : ""
-          Puppet.warning _("A value in the registry key #{parent_key_name}#{key.keyname} is corrupt or invalid")
+          Puppet.warning _("A value in the registry key %{parent_key_name}%{key} is corrupt or invalid") % { parent_key_name: parent_key_name, key: key.keyname }
         end
       end
 
@@ -247,7 +247,7 @@ module Puppet::Util::Windows
               buffer_ptr, length_ptr)
 
             if result != FFI::ERROR_SUCCESS
-              msg = _("Failed to read registry value #{name_ptr.read_wide_string} at #{key.keyname}")
+              msg = _("Failed to read registry value %{value} at %{key}") % { value: name_ptr.read_wide_string, key: key.keyname }
               raise Puppet::Util::Windows::Error.new(msg)
             end
 
@@ -265,7 +265,7 @@ module Puppet::Util::Windows
         result = RegDeleteValueW(key.hkey, name_ptr)
 
         if result != FFI::ERROR_SUCCESS
-          msg = _("Failed to delete registry value #{name} at #{key.keyname}")
+          msg = _("Failed to delete registry value %{name} at %{key}") % { name: name, key: key.keyname }
           raise Puppet::Util::Windows::Error.new(msg, result)
         end
       end
@@ -280,7 +280,7 @@ module Puppet::Util::Windows
         result = RegDeleteKeyExW(key.hkey, name_ptr, regsam, 0)
 
         if result != FFI::ERROR_SUCCESS
-          msg = _("Failed to delete registry key #{name} at #{key.keyname}")
+          msg = _("Failed to delete registry key %{name} at %{key}") % { name: name, key: key.keyname }
           raise Puppet::Util::Windows::Error.new(msg, result)
         end
       end

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -18,7 +18,7 @@ module Puppet::Util::Windows
     def root(name)
       Win32::Registry.const_get(name)
     rescue NameError
-      raise Puppet::Error, "Invalid registry key '#{name}'", $!.backtrace
+      raise Puppet::Error, _("Invalid registry key '#{name}'"), $!.backtrace
     end
 
     def open(name, path, mode = KEY_READ | KEY64, &block)
@@ -28,7 +28,7 @@ module Puppet::Util::Windows
           return yield subkey
         end
       rescue Win32::Registry::Error => error
-        raise Puppet::Util::Windows::Error.new("Failed to open registry key '#{hkey.keyname}\\#{path}'", error.code, error)
+        raise Puppet::Util::Windows::Error.new(_("Failed to open registry key '#{hkey.keyname}\\#{path}'"), error.code, error)
       end
     end
 
@@ -103,7 +103,7 @@ module Puppet::Util::Windows
             break if result == ERROR_NO_MORE_ITEMS
 
             if result != FFI::ERROR_SUCCESS
-              msg = "Failed to enumerate #{key.keyname} registry keys at index #{index}"
+              msg = _("Failed to enumerate #{key.keyname} registry keys at index #{index}")
               raise Puppet::Util::Windows::Error.new(msg)
             end
 
@@ -134,7 +134,7 @@ module Puppet::Util::Windows
           break if result == ERROR_NO_MORE_ITEMS
 
           if result != FFI::ERROR_SUCCESS
-            msg = "Failed to enumerate #{key.keyname} registry values at index #{index}"
+            msg = _("Failed to enumerate #{key.keyname} registry values at index #{index}")
             raise Puppet::Util::Windows::Error.new(msg)
           end
 
@@ -164,7 +164,7 @@ module Puppet::Util::Windows
           )
 
           if status != FFI::ERROR_SUCCESS
-            msg = "Failed to query registry #{key.keyname} for sizes"
+            msg = _("Failed to query registry #{key.keyname} for sizes")
             raise Puppet::Util::Windows::Error.new(msg)
           end
 
@@ -200,7 +200,7 @@ module Puppet::Util::Windows
 
       query_value_ex(key, name_ptr) do |type, data_ptr, byte_length|
         unless rtype.empty? or rtype.include?(type)
-          raise TypeError, "Type mismatch (expect #{rtype.inspect} but #{type} present)"
+          raise TypeError, _("Type mismatch (expect #{rtype.inspect} but #{type} present)")
         end
 
         string_length = 0
@@ -222,12 +222,12 @@ module Puppet::Util::Windows
             when Win32::Registry::REG_QWORD
               result = [ type, data_ptr.read_qword ]
             else
-              raise TypeError, "Type #{type} is not supported."
+              raise TypeError, _("Type #{type} is not supported.")
           end
         rescue IndexError => ex
           raise if (ex.message !~ /^Memory access .* is out of bounds$/i)
           parent_key_name = key.parent ? "#{key.parent.keyname}\\" : ""
-          Puppet.warning "A value in the registry key #{parent_key_name}#{key.keyname} is corrupt or invalid"
+          Puppet.warning _("A value in the registry key #{parent_key_name}#{key.keyname} is corrupt or invalid")
         end
       end
 
@@ -247,7 +247,7 @@ module Puppet::Util::Windows
               buffer_ptr, length_ptr)
 
             if result != FFI::ERROR_SUCCESS
-              msg = "Failed to read registry value #{name_ptr.read_wide_string} at #{key.keyname}"
+              msg = _("Failed to read registry value #{name_ptr.read_wide_string} at #{key.keyname}")
               raise Puppet::Util::Windows::Error.new(msg)
             end
 
@@ -265,7 +265,7 @@ module Puppet::Util::Windows
         result = RegDeleteValueW(key.hkey, name_ptr)
 
         if result != FFI::ERROR_SUCCESS
-          msg = "Failed to delete registry value #{name} at #{key.keyname}"
+          msg = _("Failed to delete registry value #{name} at #{key.keyname}")
           raise Puppet::Util::Windows::Error.new(msg, result)
         end
       end
@@ -280,7 +280,7 @@ module Puppet::Util::Windows
         result = RegDeleteKeyExW(key.hkey, name_ptr, regsam, 0)
 
         if result != FFI::ERROR_SUCCESS
-          msg = "Failed to delete registry key #{name} at #{key.keyname}"
+          msg = _("Failed to delete registry key #{name} at #{key.keyname}")
           raise Puppet::Util::Windows::Error.new(msg, result)
         end
       end

--- a/lib/puppet/util/windows/root_certs.rb
+++ b/lib/puppet/util/windows/root_certs.rb
@@ -44,7 +44,7 @@ class Puppet::Util::Windows::RootCerts
         begin
           certs << OpenSSL::X509::Certificate.new(cert_buf)
         rescue => detail
-          Puppet.warning("Failed to import root certificate: #{detail.inspect}")
+          Puppet.warning(_("Failed to import root certificate: #{detail.inspect}"))
         end
       end
     ensure

--- a/lib/puppet/util/windows/root_certs.rb
+++ b/lib/puppet/util/windows/root_certs.rb
@@ -44,7 +44,7 @@ class Puppet::Util::Windows::RootCerts
         begin
           certs << OpenSSL::X509::Certificate.new(cert_buf)
         rescue => detail
-          Puppet.warning(_("Failed to import root certificate: #{detail.inspect}"))
+          Puppet.warning(_("Failed to import root certificate: %{detail}") % { detail: detail.inspect })
         end
       end
     ensure

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -435,7 +435,7 @@ module Puppet::Util::Windows::Security
         ace_type = ace[:Header][:AceType]
         if ace_type != Puppet::Util::Windows::AccessControlEntry::ACCESS_ALLOWED_ACE_TYPE &&
           ace_type != Puppet::Util::Windows::AccessControlEntry::ACCESS_DENIED_ACE_TYPE
-          Puppet.warning _("Unsupported access control entry type: 0x#{ace_type.to_s(16)}")
+          Puppet.warning _("Unsupported access control entry type: 0x%{type}") % { type: ace_type.to_s(16) }
           next
         end
 
@@ -469,7 +469,7 @@ module Puppet::Util::Windows::Security
              FFI::Pointer::NULL_HANDLE) # template
 
     if handle == Puppet::Util::Windows::File::INVALID_HANDLE_VALUE
-      raise Puppet::Util::Windows::Error.new(_("Failed to open '#{path}'"))
+      raise Puppet::Util::Windows::Error.new(_("Failed to open '%{path}'") % { path: path })
     end
 
     begin

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -170,7 +170,7 @@ module Puppet::Util::Windows::Security
       if GetVolumeInformationW(wide_string(root), FFI::Pointer::NULL, 0,
           FFI::Pointer::NULL, FFI::Pointer::NULL,
           flags_ptr, FFI::Pointer::NULL, 0) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Failed to get volume information")
+        raise Puppet::Util::Windows::Error.new(_("Failed to get volume information"))
       end
       supported = flags_ptr.read_dword & FILE_PERSISTENT_ACLS == FILE_PERSISTENT_ACLS
     end
@@ -380,11 +380,11 @@ module Puppet::Util::Windows::Security
 
     Puppet::Util::Windows::SID.string_to_sid_ptr(sid) do |sid_ptr|
       if Puppet::Util::Windows::SID.IsValidSid(sid_ptr) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Invalid SID")
+        raise Puppet::Util::Windows::Error.new(_("Invalid SID"))
       end
 
       if AddAccessAllowedAceEx(acl, ACL_REVISION, inherit, mask, sid_ptr) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Failed to add access control entry")
+        raise Puppet::Util::Windows::Error.new(_("Failed to add access control entry"))
       end
     end
 
@@ -397,11 +397,11 @@ module Puppet::Util::Windows::Security
 
     Puppet::Util::Windows::SID.string_to_sid_ptr(sid) do |sid_ptr|
       if Puppet::Util::Windows::SID.IsValidSid(sid_ptr) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Invalid SID")
+        raise Puppet::Util::Windows::Error.new(_("Invalid SID"))
       end
 
       if AddAccessDeniedAceEx(acl, ACL_REVISION, inherit, mask, sid_ptr) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Failed to add access control entry")
+        raise Puppet::Util::Windows::Error.new(_("Failed to add access control entry"))
       end
     end
 
@@ -412,7 +412,7 @@ module Puppet::Util::Windows::Security
   def parse_dacl(dacl_ptr)
     # REMIND: need to handle NULL DACL
     if IsValidAcl(dacl_ptr) == FFI::WIN32_FALSE
-      raise Puppet::Util::Windows::Error.new("Invalid DACL")
+      raise Puppet::Util::Windows::Error.new(_("Invalid DACL"))
     end
 
     dacl_struct = ACL.new(dacl_ptr)
@@ -435,7 +435,7 @@ module Puppet::Util::Windows::Security
         ace_type = ace[:Header][:AceType]
         if ace_type != Puppet::Util::Windows::AccessControlEntry::ACCESS_ALLOWED_ACE_TYPE &&
           ace_type != Puppet::Util::Windows::AccessControlEntry::ACCESS_DENIED_ACE_TYPE
-          Puppet.warning "Unsupported access control entry type: 0x#{ace_type.to_s(16)}"
+          Puppet.warning _("Unsupported access control entry type: 0x#{ace_type.to_s(16)}")
           next
         end
 
@@ -469,7 +469,7 @@ module Puppet::Util::Windows::Security
              FFI::Pointer::NULL_HANDLE) # template
 
     if handle == Puppet::Util::Windows::File::INVALID_HANDLE_VALUE
-      raise Puppet::Util::Windows::Error.new("Failed to open '#{path}'")
+      raise Puppet::Util::Windows::Error.new(_("Failed to open '#{path}'"))
     end
 
     begin
@@ -516,7 +516,7 @@ module Puppet::Util::Windows::Security
             if AdjustTokenPrivileges(token, FFI::WIN32_FALSE,
                 token_privileges, token_privileges.size,
                 FFI::MemoryPointer::NULL, FFI::MemoryPointer::NULL) == FFI::WIN32_FALSE
-              raise Puppet::Util::Windows::Error.new("Failed to adjust process privileges")
+              raise Puppet::Util::Windows::Error.new(_("Failed to adjust process privileges"))
             end
           end
         end
@@ -546,7 +546,7 @@ module Puppet::Util::Windows::Security
                   dacl_ptr_ptr,
                   FFI::Pointer::NULL, #sacl
                   sd_ptr_ptr) #sec desc
-                raise Puppet::Util::Windows::Error.new("Failed to get security information") if rv != FFI::ERROR_SUCCESS
+                raise Puppet::Util::Windows::Error.new(_("Failed to get security information")) if rv != FFI::ERROR_SUCCESS
 
                 # these 2 convenience params are not freed since they point inside sd_ptr
                 owner = Puppet::Util::Windows::SID.sid_ptr_to_string(owner_sid_ptr_ptr.get_pointer(0))
@@ -557,7 +557,7 @@ module Puppet::Util::Windows::Security
                     sd_ptr_ptr.read_win32_local_pointer do |sd_ptr|
 
                       if GetSecurityDescriptorControl(sd_ptr, control, revision) == FFI::WIN32_FALSE
-                        raise Puppet::Util::Windows::Error.new("Failed to get security descriptor control")
+                        raise Puppet::Util::Windows::Error.new(_("Failed to get security descriptor control"))
                       end
 
                       protect = (control.read_word & SE_DACL_PROTECTED) == SE_DACL_PROTECTED
@@ -590,11 +590,11 @@ module Puppet::Util::Windows::Security
   def set_security_descriptor(path, sd)
     FFI::MemoryPointer.new(:byte, get_max_generic_acl_size(sd.dacl.count)) do |acl_ptr|
       if InitializeAcl(acl_ptr, acl_ptr.size, ACL_REVISION) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Failed to initialize ACL")
+        raise Puppet::Util::Windows::Error.new(_("Failed to initialize ACL"))
       end
 
       if IsValidAcl(acl_ptr) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Invalid DACL")
+        raise Puppet::Util::Windows::Error.new(_("Invalid DACL"))
       end
 
       with_privilege(SE_BACKUP_NAME) do
@@ -629,7 +629,7 @@ module Puppet::Util::Windows::Security
                                      FFI::MemoryPointer::NULL)
 
                 if rv != FFI::ERROR_SUCCESS
-                  raise Puppet::Util::Windows::Error.new("Failed to set security information")
+                  raise Puppet::Util::Windows::Error.new(_("Failed to set security information"))
                 end
               end
             end

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -155,7 +155,7 @@ module Puppet::Util::Windows
         FFI::MemoryPointer.new(:pointer, 1) do |sid_ptr_ptr|
 
           if ConvertStringSidToSidW(lpcwstr, sid_ptr_ptr) == FFI::WIN32_FALSE
-            raise Puppet::Util::Windows::Error.new(_("Failed to convert string SID: #{string_sid}"))
+            raise Puppet::Util::Windows::Error.new(_("Failed to convert string SID: %{string_sid}") % { string_sid: string_sid })
           end
 
           sid_ptr_ptr.read_win32_local_pointer do |sid_ptr|

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -90,7 +90,7 @@ module Puppet::Util::Windows
     # This method returns a SID::Principal with the account, domain, SID, etc
     def octet_string_to_sid_object(bytes)
       if !bytes || !bytes.respond_to?('pack') || bytes.empty?
-        raise Puppet::Util::Windows::Error.new("Octet string must be an array of bytes")
+        raise Puppet::Util::Windows::Error.new(_("Octet string must be an array of bytes"))
       end
 
       Principal.lookup_account_sid(bytes)
@@ -124,18 +124,18 @@ module Puppet::Util::Windows
     # Convert a SID pointer to a SID string, e.g. "S-1-5-32-544".
     def sid_ptr_to_string(psid)
       if ! psid.kind_of?(FFI::Pointer) || IsValidSid(psid) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Invalid SID")
+        raise Puppet::Util::Windows::Error.new(_("Invalid SID"))
       end
 
       sid_string = nil
       FFI::MemoryPointer.new(:pointer, 1) do |buffer_ptr|
         if ConvertSidToStringSidW(psid, buffer_ptr) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to convert binary SID")
+          raise Puppet::Util::Windows::Error.new(_("Failed to convert binary SID"))
         end
 
         buffer_ptr.read_win32_local_pointer do |wide_string_ptr|
           if wide_string_ptr.null?
-            raise Puppet::Error.new("ConvertSidToStringSidW failed to allocate buffer for sid")
+            raise Puppet::Error.new(_("ConvertSidToStringSidW failed to allocate buffer for sid"))
           end
 
           sid_string = wide_string_ptr.read_arbitrary_wide_string_up_to(MAXIMUM_SID_STRING_LENGTH)
@@ -155,7 +155,7 @@ module Puppet::Util::Windows
         FFI::MemoryPointer.new(:pointer, 1) do |sid_ptr_ptr|
 
           if ConvertStringSidToSidW(lpcwstr, sid_ptr_ptr) == FFI::WIN32_FALSE
-            raise Puppet::Util::Windows::Error.new("Failed to convert string SID: #{string_sid}")
+            raise Puppet::Util::Windows::Error.new(_("Failed to convert string SID: #{string_sid}"))
           end
 
           sid_ptr_ptr.read_win32_local_pointer do |sid_ptr|
@@ -186,7 +186,7 @@ module Puppet::Util::Windows
     def get_length_sid(sid_ptr)
       # MSDN states IsValidSid should be called on pointer first
       if ! sid_ptr.kind_of?(FFI::Pointer) || IsValidSid(sid_ptr) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Invalid SID")
+        raise Puppet::Util::Windows::Error.new(_("Invalid SID"))
       end
 
       GetLengthSid(sid_ptr)

--- a/lib/puppet/util/windows/taskscheduler.rb
+++ b/lib/puppet/util/windows/taskscheduler.rb
@@ -210,7 +210,7 @@ module Win32
     # Returns an array of scheduled task names.
     #
     def enum
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
       array = []
 
       @pITS.UseInstance(COM::EnumWorkItems, :Enum) do |pIEnum|
@@ -243,7 +243,7 @@ module Win32
     # Activate the specified task.
     #
     def activate(task)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
       raise TypeError unless task.is_a?(String)
 
       FFI::MemoryPointer.new(:pointer) do |ptr|
@@ -259,7 +259,7 @@ module Win32
     # Delete the specified task name.
     #
     def delete(task)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
       raise TypeError unless task.is_a?(String)
 
       @pITS.Delete(wide_string(task))
@@ -270,7 +270,7 @@ module Win32
     # Execute the current task.
     #
     def run
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       @pITask.Run
     end
@@ -282,8 +282,8 @@ module Win32
     # file instead. A '.job' extension is recommended but not enforced.
     #
     def save(file = nil)
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
-      raise Error.new('Account information must be set on the current task to save it properly.') if !@account_information_set
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
+      raise Error.new(_('Account information must be set on the current task to save it properly.')) if !@account_information_set
 
       reset = true
 
@@ -303,7 +303,7 @@ module Win32
     # Terminate the current task.
     #
     def terminate
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       @pITask.Terminate
     end
@@ -311,7 +311,7 @@ module Win32
     # Set the host on which the various TaskScheduler methods will execute.
     #
     def machine=(host)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
       raise TypeError unless host.is_a?(String)
 
       @pITS.SetTargetComputer(wide_string(host))
@@ -338,8 +338,8 @@ module Win32
     # properly registered and visible through the MMC snap-in / schtasks.exe
     #
     def set_account_information(user, password)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       bool = false
 
@@ -348,7 +348,7 @@ module Win32
           @pITask.SetAccountInformation(wide_string(""), FFI::Pointer::NULL)
         else
           if user.length > MAX_ACCOUNT_LENGTH
-            raise Error.new("User has exceeded maximum allowed length #{MAX_ACCOUNT_LENGTH}")
+            raise Error.new(_("User has exceeded maximum allowed length #{MAX_ACCOUNT_LENGTH}"))
           end
           user = wide_string(user)
           password = wide_string(password)
@@ -360,7 +360,7 @@ module Win32
       rescue Puppet::Util::Windows::Error => e
         raise e unless e.code == SCHED_E_ACCOUNT_INFORMATION_NOT_SET
 
-        warn 'job created, but password was invalid'
+        warn _('job created, but password was invalid')
       end
 
       bool
@@ -370,8 +370,8 @@ module Win32
     # been associated with the task.
     #
     def account_information
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       # default under certain failures
       user = nil
@@ -395,8 +395,8 @@ module Win32
     # Returns the name of the application associated with the task.
     #
     def application_name
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       app = nil
 
@@ -414,13 +414,13 @@ module Win32
     # Sets the application name associated with the task.
     #
     def application_name=(app)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless app.is_a?(String)
 
       # the application name is written to a .job file on disk, so is subject to path limitations
       if app.length > MAX_PATH
-        raise Error.new("Application name has exceeded maximum allowed length #{MAX_PATH}")
+        raise Error.new(_("Application name has exceeded maximum allowed length #{MAX_PATH}"))
       end
       @pITask.SetApplicationName(wide_string(app))
 
@@ -430,8 +430,8 @@ module Win32
     # Returns the command line parameters for the task.
     #
     def parameters
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       param = nil
 
@@ -451,12 +451,12 @@ module Win32
     # line parameters set it to an empty string.
     #
     def parameters=(param)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless param.is_a?(String)
 
       if param.length > MAX_PARAMETERS_LENGTH
-        raise Error.new("Parameters has exceeded maximum allowed length #{MAX_PARAMETERS_LENGTH}")
+        raise Error.new(_("Parameters has exceeded maximum allowed length #{MAX_PARAMETERS_LENGTH}"))
       end
 
       @pITask.SetParameters(wide_string(param))
@@ -467,8 +467,8 @@ module Win32
     # Returns the working directory for the task.
     #
     def working_directory
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       dir = nil
 
@@ -486,12 +486,12 @@ module Win32
     # Sets the working directory for the task.
     #
     def working_directory=(dir)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless dir.is_a?(String)
 
       if dir.length > MAX_PATH
-        raise Error.new("Working directory has exceeded maximum allowed length #{MAX_PATH}")
+        raise Error.new(_("Working directory has exceeded maximum allowed length #{MAX_PATH}"))
       end
 
       @pITask.SetWorkingDirectory(wide_string(dir))
@@ -504,8 +504,8 @@ module Win32
     # and 'unknown'.
     #
     def priority
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       priority_name = ''
 
@@ -537,8 +537,8 @@ module Win32
     # priority constant value.
     #
     def priority=(priority)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless priority.is_a?(Numeric)
 
       @pITask.SetPriority(priority)
@@ -552,12 +552,12 @@ module Win32
     #
     def new_work_item(task, trigger)
       raise TypeError unless trigger.is_a?(Hash)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
 
       # I'm working around github issue #1 here.
       enum.each{ |name|
         if name.downcase == task.downcase + '.job'
-          raise Error.new("task '#{task}' already exists")
+          raise Error.new(_("task '#{task}' already exists"))
         end
       }
 
@@ -593,8 +593,8 @@ module Win32
     # Returns the number of triggers associated with the active task.
     #
     def trigger_count
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       count = 0
 
@@ -609,8 +609,8 @@ module Win32
     # Deletes the trigger at the specified index.
     #
     def delete_trigger(index)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       @pITask.DeleteTrigger(index)
       index
@@ -620,8 +620,8 @@ module Win32
     # current task.
     #
     def trigger(index)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       trigger = {}
 
@@ -638,8 +638,8 @@ module Win32
     # Sets the trigger for the currently active task.
     #
     def trigger=(trigger)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless trigger.is_a?(Hash)
 
       FFI::MemoryPointer.new(:word, 1) do |trigger_index_ptr|
@@ -658,8 +658,8 @@ module Win32
     # Adds a trigger at the specified index.
     #
     def add_trigger(index, trigger)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless trigger.is_a?(Hash)
 
       @pITask.UseInstance(COM::TaskTrigger, :GetTrigger, index) do |pITaskTrigger|
@@ -671,7 +671,7 @@ module Win32
     # must OR the return value to determine the flags yourself.
     #
     def flags
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       flags = 0
 
@@ -686,8 +686,8 @@ module Win32
     # Sets an OR'd value of flags that modify the behavior of the work item.
     #
     def flags=(flags)
-      raise Error.new('No current task scheduler. ITaskScheduler is NULL.') if @pITS.nil?
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No current task scheduler. ITaskScheduler is NULL.')) if @pITS.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       @pITask.SetFlags(flags)
       flags
@@ -697,7 +697,7 @@ module Win32
     # 'ready', 'running', 'not scheduled' or 'unknown'.
     #
     def status
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       st = nil
 
@@ -723,7 +723,7 @@ module Win32
     # Returns the exit code from the last scheduled run.
     #
     def exit_code
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       status = 0
 
@@ -742,7 +742,7 @@ module Win32
     # Returns the comment associated with the task, if any.
     #
     def comment
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       comment = nil
 
@@ -760,11 +760,11 @@ module Win32
     # Sets the comment for the task.
     #
     def comment=(comment)
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless comment.is_a?(String)
 
       if comment.length > MAX_COMMENT_LENGTH
-        raise Error.new("Comment has exceeded maximum allowed length #{MAX_COMMENT_LENGTH}")
+        raise Error.new(_("Comment has exceeded maximum allowed length #{MAX_COMMENT_LENGTH}"))
       end
 
       @pITask.SetComment(wide_string(comment))
@@ -774,7 +774,7 @@ module Win32
     # Returns the name of the user who created the task.
     #
     def creator
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       creator = nil
 
@@ -792,11 +792,11 @@ module Win32
     # Sets the creator for the task.
     #
     def creator=(creator)
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless creator.is_a?(String)
 
       if creator.length > MAX_ACCOUNT_LENGTH
-        raise Error.new("Creator has exceeded maximum allowed length #{MAX_ACCOUNT_LENGTH}")
+        raise Error.new(_("Creator has exceeded maximum allowed length #{MAX_ACCOUNT_LENGTH}"))
       end
 
 
@@ -807,7 +807,7 @@ module Win32
     # Returns a Time object that indicates the next time the task will run.
     #
     def next_run_time
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       time = nil
 
@@ -823,7 +823,7 @@ module Win32
     # nil if the task has never run.
     #
     def most_recent_run_time
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       time = nil
 
@@ -843,7 +843,7 @@ module Win32
     # will run before terminating.
     #
     def max_run_time
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
 
       max_run_time = nil
 
@@ -859,7 +859,7 @@ module Win32
     # before terminating. Returns the value you specified if successful.
     #
     def max_run_time=(max_run_time)
-      raise Error.new('No currently active task. ITask is NULL.') if @pITask.nil?
+      raise Error.new(_('No currently active task. ITask is NULL.')) if @pITask.nil?
       raise TypeError unless max_run_time.is_a?(Numeric)
 
       @pITask.SetMaxRunTime(max_run_time)
@@ -977,7 +977,7 @@ module Win32
             when :TASK_TIME_TRIGGER_ONCE
               # Do nothing. The Type member of the TASK_TRIGGER struct is ignored.
             else
-              raise Error.new("Unknown trigger type #{trigger['trigger_type']}")
+              raise Error.new(_("Unknown trigger type #{trigger['trigger_type']}"))
           end
 
           trigger_struct = COM::TASK_TRIGGER.new(trigger_ptr)
@@ -1044,7 +1044,7 @@ module Win32
         when :TASK_TIME_TRIGGER_ONCE
           trigger['type'] = { 'once' => nil }
         else
-          raise Error.new("Unknown trigger type #{task_trigger[:TriggerType]}")
+          raise Error.new(_("Unknown trigger type #{task_trigger[:TriggerType]}"))
       end
 
       trigger

--- a/lib/puppet/util/windows/taskscheduler.rb
+++ b/lib/puppet/util/windows/taskscheduler.rb
@@ -348,7 +348,7 @@ module Win32
           @pITask.SetAccountInformation(wide_string(""), FFI::Pointer::NULL)
         else
           if user.length > MAX_ACCOUNT_LENGTH
-            raise Error.new(_("User has exceeded maximum allowed length #{MAX_ACCOUNT_LENGTH}"))
+            raise Error.new(_("User has exceeded maximum allowed length %{max}") % { max: MAX_ACCOUNT_LENGTH })
           end
           user = wide_string(user)
           password = wide_string(password)
@@ -420,7 +420,7 @@ module Win32
 
       # the application name is written to a .job file on disk, so is subject to path limitations
       if app.length > MAX_PATH
-        raise Error.new(_("Application name has exceeded maximum allowed length #{MAX_PATH}"))
+        raise Error.new(_("Application name has exceeded maximum allowed length %{max}") % { max: MAX_PATH })
       end
       @pITask.SetApplicationName(wide_string(app))
 
@@ -456,7 +456,7 @@ module Win32
       raise TypeError unless param.is_a?(String)
 
       if param.length > MAX_PARAMETERS_LENGTH
-        raise Error.new(_("Parameters has exceeded maximum allowed length #{MAX_PARAMETERS_LENGTH}"))
+        raise Error.new(_("Parameters has exceeded maximum allowed length %{max}") % { max: MAX_PARAMETERS_LENGTH })
       end
 
       @pITask.SetParameters(wide_string(param))
@@ -491,7 +491,7 @@ module Win32
       raise TypeError unless dir.is_a?(String)
 
       if dir.length > MAX_PATH
-        raise Error.new(_("Working directory has exceeded maximum allowed length #{MAX_PATH}"))
+        raise Error.new(_("Working directory has exceeded maximum allowed length %{max}") % { max: MAX_PATH })
       end
 
       @pITask.SetWorkingDirectory(wide_string(dir))
@@ -557,7 +557,7 @@ module Win32
       # I'm working around github issue #1 here.
       enum.each{ |name|
         if name.downcase == task.downcase + '.job'
-          raise Error.new(_("task '#{task}' already exists"))
+          raise Error.new(_("task '%{task}' already exists") % { task: task })
         end
       }
 
@@ -764,7 +764,7 @@ module Win32
       raise TypeError unless comment.is_a?(String)
 
       if comment.length > MAX_COMMENT_LENGTH
-        raise Error.new(_("Comment has exceeded maximum allowed length #{MAX_COMMENT_LENGTH}"))
+        raise Error.new(_("Comment has exceeded maximum allowed length %{max}") % { max: MAX_COMMENT_LENGTH })
       end
 
       @pITask.SetComment(wide_string(comment))
@@ -796,7 +796,7 @@ module Win32
       raise TypeError unless creator.is_a?(String)
 
       if creator.length > MAX_ACCOUNT_LENGTH
-        raise Error.new(_("Creator has exceeded maximum allowed length #{MAX_ACCOUNT_LENGTH}"))
+        raise Error.new(_("Creator has exceeded maximum allowed length %{max}") % { max: MAX_ACCOUNT_LENGTH })
       end
 
 
@@ -977,7 +977,7 @@ module Win32
             when :TASK_TIME_TRIGGER_ONCE
               # Do nothing. The Type member of the TASK_TRIGGER struct is ignored.
             else
-              raise Error.new(_("Unknown trigger type #{trigger['trigger_type']}"))
+              raise Error.new(_("Unknown trigger type %{type}") % { type: trigger['trigger_type'] })
           end
 
           trigger_struct = COM::TASK_TRIGGER.new(trigger_ptr)
@@ -1044,7 +1044,7 @@ module Win32
         when :TASK_TIME_TRIGGER_ONCE
           trigger['type'] = { 'once' => nil }
         else
-          raise Error.new(_("Unknown trigger type #{task_trigger[:TriggerType]}"))
+          raise Error.new(_("Unknown trigger type %{type}") % { type: task_trigger[:TriggerType] })
       end
 
       trigger

--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -37,17 +37,17 @@ module Puppet::Util::Windows::User
         size_pointer.write_uint32(SECURITY_MAX_SID_SIZE)
 
         if CreateWellKnownSid(:WinBuiltinAdministratorsSid, FFI::Pointer::NULL, sid_pointer, size_pointer) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to create administrators SID")
+          raise Puppet::Util::Windows::Error.new(_("Failed to create administrators SID"))
         end
       end
 
       if IsValidSid(sid_pointer) == FFI::WIN32_FALSE
-        raise Puppet::Util::Windows::Error.new("Invalid SID")
+        raise Puppet::Util::Windows::Error.new(_("Invalid SID"))
       end
 
       FFI::MemoryPointer.new(:win32_bool, 1) do |ismember_pointer|
         if CheckTokenMembership(FFI::Pointer::NULL_HANDLE, sid_pointer, ismember_pointer) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to check membership")
+          raise Puppet::Util::Windows::Error.new(_("Failed to check membership"))
         end
 
         # Is administrators SID enabled in calling thread's access token?
@@ -85,7 +85,7 @@ module Puppet::Util::Windows::User
       FFI::MemoryPointer.new(:handle, 1) do |token_pointer|
         if LogonUserW(wide_string(name), wide_string('.'), password.nil? ? FFI::Pointer::NULL : wide_string(password),
             fLOGON32_LOGON_NETWORK, fLOGON32_PROVIDER_DEFAULT, token_pointer) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to logon user #{name.inspect}")
+          raise Puppet::Util::Windows::Error.new(_("Failed to logon user #{name.inspect}"))
         end
 
         yield token = token_pointer.read_handle
@@ -109,13 +109,13 @@ module Puppet::Util::Windows::User
 
         # Load the profile. Since it doesn't exist, it will be created
         if LoadUserProfileW(token, pi.pointer) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to load user profile #{user.inspect}")
+          raise Puppet::Util::Windows::Error.new(_("Failed to load user profile #{user.inspect}"))
         end
 
         Puppet.debug("Loaded profile for #{user}")
 
         if UnloadUserProfile(token, pi[:hProfile]) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new("Failed to unload user profile #{user.inspect}")
+          raise Puppet::Util::Windows::Error.new(_("Failed to unload user profile #{user.inspect}"))
         end
       end
     end

--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -85,7 +85,7 @@ module Puppet::Util::Windows::User
       FFI::MemoryPointer.new(:handle, 1) do |token_pointer|
         if LogonUserW(wide_string(name), wide_string('.'), password.nil? ? FFI::Pointer::NULL : wide_string(password),
             fLOGON32_LOGON_NETWORK, fLOGON32_PROVIDER_DEFAULT, token_pointer) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new(_("Failed to logon user #{name.inspect}"))
+          raise Puppet::Util::Windows::Error.new(_("Failed to logon user %{name}") % { name: name.inspect })
         end
 
         yield token = token_pointer.read_handle
@@ -109,13 +109,13 @@ module Puppet::Util::Windows::User
 
         # Load the profile. Since it doesn't exist, it will be created
         if LoadUserProfileW(token, pi.pointer) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new(_("Failed to load user profile #{user.inspect}"))
+          raise Puppet::Util::Windows::Error.new(_("Failed to load user profile %{user}") % { user: user.inspect })
         end
 
         Puppet.debug("Loaded profile for #{user}")
 
         if UnloadUserProfile(token, pi[:hProfile]) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error.new(_("Failed to unload user profile #{user.inspect}"))
+          raise Puppet::Util::Windows::Error.new(_("Failed to unload user profile %{user}") % { user: user.inspect })
         end
       end
     end


### PR DESCRIPTION
This commit marks user-facing error and info level strings in
`lib/puppet/util.rb` and `lib/puppet/util/*` for translation.