### PR TITLE
(PUP-7042) Mark strings in type

### DIFF
--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:augeas) do
   validate do
     has_lens = !self[:lens].nil?
     has_incl = !self[:incl].nil?
-    self.fail "You must specify both the lens and incl parameters, or neither." if has_lens != has_incl
+    self.fail _("You must specify both the lens and incl parameters, or neither.") if has_lens != has_incl
   end
 
   newparam(:show_diff, :boolean => true, :parent => Puppet::Parameter::Boolean) do
@@ -188,7 +188,7 @@ Puppet::Type.newtype(:augeas) do
 
     # Make output a bit prettier
     def change_to_s(currentvalue, newvalue)
-      "executed successfully"
+      _("executed successfully")
     end
 
     # if the onlyif resource is provided, then the value is parsed.

--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -195,7 +195,7 @@ Puppet::Type.newtype(:cron) do
       if retval
         return retval.to_s
       else
-        self.fail _("#{value} is not a valid #{self.class.name}")
+        self.fail _("%{value} is not a valid %{name}") % { value: value, name: self.class.name }
       end
     end
   end
@@ -253,7 +253,7 @@ Puppet::Type.newtype(:cron) do
     end
 
     validate do |value|
-      raise ArgumentError, _("Invalid special schedule #{value.inspect}") unless specials.include?(value)
+      raise ArgumentError, _("Invalid special schedule %{value}") % { value: value.inspect } unless specials.include?(value)
     end
 
     def munge(value)
@@ -326,7 +326,7 @@ Puppet::Type.newtype(:cron) do
 
     validate do |value|
       unless value =~ /^\s*(\w+)\s*=\s*(.*)\s*$/ or value == :absent or value == "absent"
-        raise ArgumentError, _("Invalid environment setting #{value.inspect}")
+        raise ArgumentError, _("Invalid environment setting %{value}") % { value: value.inspect }
       end
     end
 
@@ -433,7 +433,7 @@ Puppet::Type.newtype(:cron) do
     [ :minute, :hour, :weekday, :monthday, :month ].each do |field|
       next unless self[field]
       next if self[field] == :absent
-      raise ArgumentError, _("#{self.ref} cannot specify both a special schedule and a value for #{field}")
+      raise ArgumentError, _("%{cron} cannot specify both a special schedule and a value for %{field}") % { cron: self.ref, field: field }
     end
   end
 

--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -195,7 +195,7 @@ Puppet::Type.newtype(:cron) do
       if retval
         return retval.to_s
       else
-        self.fail "#{value} is not a valid #{self.class.name}"
+        self.fail _("#{value} is not a valid #{self.class.name}")
       end
     end
   end
@@ -253,7 +253,7 @@ Puppet::Type.newtype(:cron) do
     end
 
     validate do |value|
-      raise ArgumentError, "Invalid special schedule #{value.inspect}" unless specials.include?(value)
+      raise ArgumentError, _("Invalid special schedule #{value.inspect}") unless specials.include?(value)
     end
 
     def munge(value)
@@ -326,7 +326,7 @@ Puppet::Type.newtype(:cron) do
 
     validate do |value|
       unless value =~ /^\s*(\w+)\s*=\s*(.*)\s*$/ or value == :absent or value == "absent"
-        raise ArgumentError, "Invalid environment setting #{value.inspect}"
+        raise ArgumentError, _("Invalid environment setting #{value.inspect}")
       end
     end
 
@@ -433,7 +433,7 @@ Puppet::Type.newtype(:cron) do
     [ :minute, :hour, :weekday, :monthday, :month ].each do |field|
       next unless self[field]
       next if self[field] == :absent
-      raise ArgumentError, "#{self.ref} cannot specify both a special schedule and a value for #{field}"
+      raise ArgumentError, _("#{self.ref} cannot specify both a special schedule and a value for #{field}")
     end
   end
 

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -159,9 +159,9 @@ module Puppet
         unless self.should.include?(@status.exitstatus.to_s)
           if @resource.parameter(:command).sensitive
             # Don't print sensitive commands in the clear
-            self.fail(_("[command redacted] returned #{@status.exitstatus} instead of one of [#{self.should.join(",")}]"))
+            self.fail(_("[command redacted] returned %{status} instead of one of [%{expected}]") % { status: @status.exitstatus, expected: self.should.join(",") })
           else
-            self.fail(_("'#{self.resource[:command]}' returned #{@status.exitstatus} instead of one of [#{self.should.join(",")}]"))
+            self.fail(_("'%{cmd}' returned %{status} instead of one of [%{expected}]") % { cmd: self.resource[:command], status: @status.exitstatus, expected: self.should.join(",") })
           end
         end
 
@@ -179,7 +179,7 @@ module Puppet
         any output is logged at the `err` log level."
 
       validate do |command|
-        raise ArgumentError, _("Command must be a String, got value of class #{command.class}") unless command.is_a? String
+        raise ArgumentError, _("Command must be a String, got value of class %{klass}") % { klass: command.class } unless command.is_a? String
       end
     end
 
@@ -261,7 +261,7 @@ module Puppet
         values = [values] unless values.is_a? Array
         values.each do |value|
           unless value =~ /\w+=/
-            raise ArgumentError, _("Invalid environment setting '#{value}'")
+            raise ArgumentError, _("Invalid environment setting '%{value}'") % { value: value }
           end
         end
       end
@@ -274,7 +274,7 @@ module Puppet
         if value =~ /^0?[0-7]{1,4}$/
           return value.to_i(8)
         else
-          raise Puppet::Error, _("The umask specification is invalid: #{value.inspect}")
+          raise Puppet::Error, _("The umask specification is invalid: %{value}") % { value: value.inspect }
         end
       end
     end
@@ -443,7 +443,7 @@ module Puppet
         begin
           output, status = provider.run(value, true)
         rescue Timeout::Error
-          err _("Check #{value.inspect} exceeded timeout")
+          err _("Check %{value} exceeded timeout") % { value: value.inspect }
           return false
         end
 
@@ -494,7 +494,7 @@ module Puppet
         begin
           output, status = provider.run(value, true)
         rescue Timeout::Error
-          err _("Check #{value.inspect} exceeded timeout")
+          err _("Check %{value} exceeded timeout") % { value: value.inspect }
           return false
         end
 

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -101,7 +101,7 @@ module Puppet
 
       # Make output a bit prettier
       def change_to_s(currentvalue, newvalue)
-        "executed successfully"
+        _("executed successfully")
       end
 
       # First verify that all of our checks pass.
@@ -135,7 +135,7 @@ module Puppet
             end
           end
         rescue Timeout::Error
-          self.fail Puppet::Error, "Command exceeded timeout", $!
+          self.fail Puppet::Error, _("Command exceeded timeout"), $!
         end
 
         if log = @resource[:logoutput]
@@ -159,9 +159,9 @@ module Puppet
         unless self.should.include?(@status.exitstatus.to_s)
           if @resource.parameter(:command).sensitive
             # Don't print sensitive commands in the clear
-            self.fail("[command redacted] returned #{@status.exitstatus} instead of one of [#{self.should.join(",")}]")
+            self.fail(_("[command redacted] returned #{@status.exitstatus} instead of one of [#{self.should.join(",")}]"))
           else
-            self.fail("'#{self.resource[:command]}' returned #{@status.exitstatus} instead of one of [#{self.should.join(",")}]")
+            self.fail(_("'#{self.resource[:command]}' returned #{@status.exitstatus} instead of one of [#{self.should.join(",")}]"))
           end
         end
 
@@ -179,7 +179,7 @@ module Puppet
         any output is logged at the `err` log level."
 
       validate do |command|
-        raise ArgumentError, "Command must be a String, got value of class #{command.class}" unless command.is_a? String
+        raise ArgumentError, _("Command must be a String, got value of class #{command.class}") unless command.is_a? String
       end
     end
 
@@ -208,9 +208,9 @@ module Puppet
 
       validate do |user|
         if Puppet.features.microsoft_windows?
-          self.fail "Unable to execute commands as other users on Windows"
+          self.fail _("Unable to execute commands as other users on Windows")
         elsif !Puppet.features.root? && resource.current_username() != user
-          self.fail "Only root can execute commands as other users"
+          self.fail _("Only root can execute commands as other users")
         end
       end
     end
@@ -261,7 +261,7 @@ module Puppet
         values = [values] unless values.is_a? Array
         values.each do |value|
           unless value =~ /\w+=/
-            raise ArgumentError, "Invalid environment setting '#{value}'"
+            raise ArgumentError, _("Invalid environment setting '#{value}'")
           end
         end
       end
@@ -274,7 +274,7 @@ module Puppet
         if value =~ /^0?[0-7]{1,4}$/
           return value.to_i(8)
         else
-          raise Puppet::Error, "The umask specification is invalid: #{value.inspect}"
+          raise Puppet::Error, _("The umask specification is invalid: #{value.inspect}")
         end
       end
     end
@@ -290,7 +290,7 @@ module Puppet
         begin
           value = Float(value)
         rescue ArgumentError
-          raise ArgumentError, "The timeout must be a number.", $!.backtrace
+          raise ArgumentError, _("The timeout must be a number."), $!.backtrace
         end
         [value, 0.0].max
       end
@@ -308,11 +308,11 @@ module Puppet
       munge do |value|
         if value.is_a?(String)
           unless value =~ /^[\d]+$/
-            raise ArgumentError, "Tries must be an integer"
+            raise ArgumentError, _("Tries must be an integer")
           end
           value = Integer(value)
         end
-        raise ArgumentError, "Tries must be an integer >= 1" if value < 1
+        raise ArgumentError, _("Tries must be an integer >= 1") if value < 1
         value
       end
 
@@ -325,11 +325,11 @@ module Puppet
       munge do |value|
         if value.is_a?(String)
           unless value =~ /^[-\d.]+$/
-            raise ArgumentError, "try_sleep must be a number"
+            raise ArgumentError, _("try_sleep must be a number")
           end
           value = Float(value)
         end
-        raise ArgumentError, "try_sleep cannot be a negative number" if value < 0
+        raise ArgumentError, _("try_sleep cannot be a negative number") if value < 0
         value
       end
 
@@ -443,7 +443,7 @@ module Puppet
         begin
           output, status = provider.run(value, true)
         rescue Timeout::Error
-          err "Check #{value.inspect} exceeded timeout"
+          err _("Check #{value.inspect} exceeded timeout")
           return false
         end
 
@@ -494,7 +494,7 @@ module Puppet
         begin
           output, status = provider.run(value, true)
         rescue Timeout::Error
-          err "Check #{value.inspect} exceeded timeout"
+          err _("Check #{value.inspect} exceeded timeout")
           return false
         end
 

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:file) do
 
     validate do |value|
       unless Puppet::Util.absolute_path?(value)
-        fail Puppet::Error, "File paths must be fully qualified, not '#{value}'"
+        fail Puppet::Error, _("File paths must be fully qualified, not '#{value}'")
       end
     end
 
@@ -121,7 +121,7 @@ Puppet::Type.newtype(:file) do
       when String
         value
       else
-        self.fail "Invalid backup type #{value.inspect}"
+        self.fail _("Invalid backup type #{value.inspect}")
       end
     end
   end
@@ -165,7 +165,7 @@ Puppet::Type.newtype(:file) do
       when :false; false
       when :remote; :remote
       else
-        self.fail "Invalid recurse value #{value.inspect}"
+        self.fail _("Invalid recurse value #{value.inspect}")
       end
     end
   end
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:file) do
       when Integer; value
       when /^\d+$/; Integer(value)
       else
-        self.fail "Invalid recurselimit value #{value.inspect}"
+        self.fail _("Invalid recurselimit value #{value.inspect}")
       end
     end
   end
@@ -368,17 +368,17 @@ Puppet::Type.newtype(:file) do
     end
     creator_count += 1 if @parameters.include?(:source)
 
-    self.fail "You cannot specify more than one of #{CREATORS.collect { |p| p.to_s}.join(", ")}" if creator_count > 1
+    self.fail _("You cannot specify more than one of #{CREATORS.collect { |p| p.to_s}.join(", ")}") if creator_count > 1
 
-    self.fail "You cannot specify a remote recursion without a source" if !self[:source] && self[:recurse] == :remote
+    self.fail _("You cannot specify a remote recursion without a source") if !self[:source] && self[:recurse] == :remote
 
-    self.fail "You cannot specify source when using checksum 'none'" if self[:checksum] == :none && !self[:source].nil?
+    self.fail _("You cannot specify source when using checksum 'none'") if self[:checksum] == :none && !self[:source].nil?
 
     SOURCE_ONLY_CHECKSUMS.each do |checksum_type|
-      self.fail "You cannot specify content when using checksum '#{checksum_type}'" if self[:checksum] == checksum_type && !self[:content].nil?
+      self.fail _("You cannot specify content when using checksum '#{checksum_type}'") if self[:checksum] == checksum_type && !self[:content].nil?
     end
 
-    self.warning "Possible error: recurselimit is set but not recurse, no recursion will happen" if !self[:recurse] && self[:recurselimit]
+    self.warning _("Possible error: recurselimit is set but not recurse, no recursion will happen") if !self[:recurse] && self[:recurselimit]
 
     if @parameters[:content] && @parameters[:content].actual_content
       # Now that we know the checksum, update content (in case it was created before checksum was known).
@@ -386,10 +386,10 @@ Puppet::Type.newtype(:file) do
     end
 
     if self[:checksum] && self[:checksum_value] && !send("#{self[:checksum]}?", self[:checksum_value])
-      self.fail "Checksum value '#{self[:checksum_value]}' is not a valid checksum type #{self[:checksum]}"
+      self.fail _("Checksum value '#{self[:checksum_value]}' is not a valid checksum type #{self[:checksum]}")
     end
 
-    self.warning "Checksum value is ignored unless content or source are specified" if self[:checksum_value] && !self[:content] && !self[:source]
+    self.warning _("Checksum value is ignored unless content or source are specified") if self[:checksum_value] && !self[:content] && !self[:source]
 
     provider.validate if provider.respond_to?(:validate)
   end
@@ -427,11 +427,11 @@ Puppet::Type.newtype(:file) do
     return nil if backup =~ /^\./
 
     unless catalog or backup == "puppet"
-      fail "Can not find filebucket for backups without a catalog"
+      fail _("Can not find filebucket for backups without a catalog")
     end
 
     unless catalog and filebucket = catalog.resource(:filebucket, backup) or backup == "puppet"
-      fail "Could not find filebucket #{backup} specified in backup"
+      fail _("Could not find filebucket #{backup} specified in backup")
     end
 
     return default_bucket unless filebucket
@@ -737,7 +737,7 @@ Puppet::Type.newtype(:file) do
     when "link", "file"
       return remove_file(current_type, wanted_type)
     else
-      self.fail "Could not back up files of type #{current_type}"
+      self.fail _("Could not back up files of type #{current_type}")
     end
   end
 
@@ -747,9 +747,7 @@ Puppet::Type.newtype(:file) do
     # catalog validation (because that would be a breaking change from Puppet 4).
     if Puppet.features.microsoft_windows? && parameter(:source) &&
       [:use, :use_when_creating].include?(self[:source_permissions])
-      err_msg = "Copying owner/mode/group from the source file on Windows" <<
-      " is not supported; use source_permissions => ignore."
-
+      err_msg = _("Copying owner/mode/group from the source file on Windows is not supported; use source_permissions => ignore.")
       if self[:owner] == nil || self[:group] == nil || self[:mode] == nil
         # Fail on Windows if source permissions are being used and the file resource
         # does not have mode owner, group, and mode all set (which would take precedence).
@@ -830,7 +828,7 @@ Puppet::Type.newtype(:file) do
     rescue Errno::ENOTDIR => error
       nil
     rescue Errno::EACCES => error
-      warning "Could not stat; permission denied"
+      warning _("Could not stat; permission denied")
       nil
     end
   end
@@ -952,7 +950,7 @@ Puppet::Type.newtype(:file) do
       stat_needed
       true
     else
-      notice "Not removing directory; use 'force' to override"
+      notice _("Not removing directory; use 'force' to override")
       false
     end
   end
@@ -976,7 +974,8 @@ Puppet::Type.newtype(:file) do
   # @return [void]
   def backup_existing
     unless perform_backup
-      raise Puppet::Error, "Could not back up; will not replace"
+      #TRANSLATORS refers to a file which could not be backed up
+      raise Puppet::Error, _("Could not back up; will not replace")
     end
   end
 
@@ -990,7 +989,7 @@ Puppet::Type.newtype(:file) do
     newsum = parameter(:checksum).sum_file(path)
     return if [:absent, nil, content_checksum].include?(newsum)
 
-    self.fail "File written to disk did not match checksum; discarding changes (#{content_checksum} vs #{newsum})"
+    self.fail _("File written to disk did not match checksum; discarding changes (#{content_checksum} vs #{newsum})")
   end
 
   def write_temporary_file?

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:file) do
 
     validate do |value|
       unless Puppet::Util.absolute_path?(value)
-        fail Puppet::Error, _("File paths must be fully qualified, not '#{value}'")
+        fail Puppet::Error, _("File paths must be fully qualified, not '%{path}'") % { path: value }
       end
     end
 
@@ -121,7 +121,7 @@ Puppet::Type.newtype(:file) do
       when String
         value
       else
-        self.fail _("Invalid backup type #{value.inspect}")
+        self.fail _("Invalid backup type %{value}") % { value: value.inspect }
       end
     end
   end
@@ -165,7 +165,7 @@ Puppet::Type.newtype(:file) do
       when :false; false
       when :remote; :remote
       else
-        self.fail _("Invalid recurse value #{value.inspect}")
+        self.fail _("Invalid recurse value %{value}") % { value: value.inspect }
       end
     end
   end
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:file) do
       when Integer; value
       when /^\d+$/; Integer(value)
       else
-        self.fail _("Invalid recurselimit value #{value.inspect}")
+        self.fail _("Invalid recurselimit value %{value}") % { value: value.inspect }
       end
     end
   end
@@ -368,14 +368,14 @@ Puppet::Type.newtype(:file) do
     end
     creator_count += 1 if @parameters.include?(:source)
 
-    self.fail _("You cannot specify more than one of #{CREATORS.collect { |p| p.to_s}.join(", ")}") if creator_count > 1
+    self.fail _("You cannot specify more than one of %{creators}") % { creators: CREATORS.collect { |p| p.to_s}.join(", ") } if creator_count > 1
 
     self.fail _("You cannot specify a remote recursion without a source") if !self[:source] && self[:recurse] == :remote
 
     self.fail _("You cannot specify source when using checksum 'none'") if self[:checksum] == :none && !self[:source].nil?
 
     SOURCE_ONLY_CHECKSUMS.each do |checksum_type|
-      self.fail _("You cannot specify content when using checksum '#{checksum_type}'") if self[:checksum] == checksum_type && !self[:content].nil?
+      self.fail _("You cannot specify content when using checksum '%{checksum_type}'") % { checksum_type: checksum_type } if self[:checksum] == checksum_type && !self[:content].nil?
     end
 
     self.warning _("Possible error: recurselimit is set but not recurse, no recursion will happen") if !self[:recurse] && self[:recurselimit]
@@ -386,7 +386,7 @@ Puppet::Type.newtype(:file) do
     end
 
     if self[:checksum] && self[:checksum_value] && !send("#{self[:checksum]}?", self[:checksum_value])
-      self.fail _("Checksum value '#{self[:checksum_value]}' is not a valid checksum type #{self[:checksum]}")
+      self.fail _("Checksum value '%{value}' is not a valid checksum type %{checksum}") % { value: self[:checksum_value], checksum: self[:checksum] }
     end
 
     self.warning _("Checksum value is ignored unless content or source are specified") if self[:checksum_value] && !self[:content] && !self[:source]
@@ -431,7 +431,7 @@ Puppet::Type.newtype(:file) do
     end
 
     unless catalog and filebucket = catalog.resource(:filebucket, backup) or backup == "puppet"
-      fail _("Could not find filebucket #{backup} specified in backup")
+      fail _("Could not find filebucket %{backup} specified in backup") % { backup: backup }
     end
 
     return default_bucket unless filebucket
@@ -737,7 +737,7 @@ Puppet::Type.newtype(:file) do
     when "link", "file"
       return remove_file(current_type, wanted_type)
     else
-      self.fail _("Could not back up files of type #{current_type}")
+      self.fail _("Could not back up files of type %{current_type}") % { current_type: current_type }
     end
   end
 
@@ -989,7 +989,7 @@ Puppet::Type.newtype(:file) do
     newsum = parameter(:checksum).sum_file(path)
     return if [:absent, nil, content_checksum].include?(newsum)
 
-    self.fail _("File written to disk did not match checksum; discarding changes (#{content_checksum} vs #{newsum})")
+    self.fail _("File written to disk did not match checksum; discarding changes (%{content_checksum} vs %{newsum})") % { content_checksum: content_checksum, newsum: newsum }
   end
 
   def write_temporary_file?

--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -111,7 +111,7 @@ module Puppet
       begin
         @bucket = Puppet::FileBucket::Dipper.new(args)
       rescue => detail
-        message = _("Could not create #{type} filebucket: #{detail}")
+        message = _("Could not create %{type} filebucket: %{detail}") % { type: type, detail: detail }
         self.log_exception(detail, message)
         self.fail(message)
       end

--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -71,11 +71,11 @@ module Puppet
 
       validate do |value|
         if value.is_a? Array
-          raise ArgumentError, "You can only have one filebucket path"
+          raise ArgumentError, _("You can only have one filebucket path")
         end
 
         if value.is_a? String and not Puppet::Util.absolute_path?(value)
-          raise ArgumentError, "Filebucket paths must be absolute"
+          raise ArgumentError, _("Filebucket paths must be absolute")
         end
 
         true
@@ -111,7 +111,7 @@ module Puppet
       begin
         @bucket = Puppet::FileBucket::Dipper.new(args)
       rescue => detail
-        message = "Could not create #{type} filebucket: #{detail}"
+        message = _("Could not create #{type} filebucket: #{detail}")
         self.log_exception(detail, message)
         self.fail(message)
       end

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -66,7 +66,7 @@ module Puppet
           if gid =~ /^[-0-9]+$/
             gid = Integer(gid)
           else
-            self.fail "Invalid GID #{gid}"
+            self.fail _("Invalid GID #{gid}")
           end
         when Symbol
           unless gid == :absent
@@ -157,7 +157,7 @@ module Puppet
       end
 
       validate do |value|
-        raise ArgumentError, "Attributes value pairs must be separated by an =" unless value.include?("=")
+        raise ArgumentError, _("Attributes value pairs must be separated by an =") unless value.include?("=")
       end
     end
 

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -66,7 +66,7 @@ module Puppet
           if gid =~ /^[-0-9]+$/
             gid = Integer(gid)
           else
-            self.fail _("Invalid GID #{gid}")
+            self.fail _("Invalid GID %{gid}") % { gid: gid }
           end
         when Symbol
           unless gid == :absent

--- a/lib/puppet/type/host.rb
+++ b/lib/puppet/type/host.rb
@@ -29,7 +29,7 @@ module Puppet
 
       validate do |value|
         return true if ((valid_v4?(value) || valid_v6?(value)) && (valid_newline?(value)))
-        raise Puppet::Error, _("Invalid IP address #{value.inspect}")
+        raise Puppet::Error, _("Invalid IP address %{value}") % { value: value.inspect }
       end
     end
 

--- a/lib/puppet/type/host.rb
+++ b/lib/puppet/type/host.rb
@@ -29,7 +29,7 @@ module Puppet
 
       validate do |value|
         return true if ((valid_v4?(value) || valid_v6?(value)) && (valid_newline?(value)))
-        raise Puppet::Error, "Invalid IP address #{value.inspect}"
+        raise Puppet::Error, _("Invalid IP address #{value.inspect}")
       end
     end
 
@@ -48,8 +48,8 @@ module Puppet
 
       validate do |value|
         # This regex already includes newline check.
-        raise Puppet::Error, "Host aliases cannot include whitespace" if value =~ /\s/
-        raise Puppet::Error, "Host aliases cannot be an empty string. Use an empty array to delete all host_aliases " if value =~ /^\s*$/
+        raise Puppet::Error, _("Host aliases cannot include whitespace") if value =~ /\s/
+        raise Puppet::Error, _("Host aliases cannot be an empty string. Use an empty array to delete all host_aliases ") if value =~ /^\s*$/
       end
 
     end
@@ -57,7 +57,7 @@ module Puppet
     newproperty(:comment) do
       desc "A comment that will be attached to the line with a # character."
       validate do |value|
-        raise Puppet::Error, "Comment cannot include newline" if (value =~ /\n/ || value =~ /\r/)
+        raise Puppet::Error, _("Comment cannot include newline") if (value =~ /\n/ || value =~ /\r/)
       end
     end
 
@@ -81,10 +81,10 @@ module Puppet
       validate do |value|
         value.split('.').each do |hostpart|
           unless hostpart =~ /^([\d\w]+|[\d\w][\d\w\-]+[\d\w])$/
-            raise Puppet::Error, "Invalid host name"
+            raise Puppet::Error, _("Invalid host name")
           end
         end
-        raise Puppet::Error, "Hostname cannot include newline" if (value =~ /\n/ || value =~ /\r/)
+        raise Puppet::Error, _("Hostname cannot include newline") if (value =~ /\n/ || value =~ /\r/)
       end
     end
 

--- a/lib/puppet/type/interface.rb
+++ b/lib/puppet/type/interface.rb
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:interface) do
       validate do |values|
         values = [values] unless values.is_a?(Array)
         values.each do |value|
-          self.fail "Invalid interface ip address" unless parse(value.gsub(/\s*(eui-64|link-local)\s*$/,''))
+          self.fail _("Invalid interface ip address") unless parse(value.gsub(/\s*(eui-64|link-local)\s*$/,''))
         end
       end
 

--- a/lib/puppet/type/k5login.rb
+++ b/lib/puppet/type/k5login.rb
@@ -20,7 +20,7 @@ Puppet::Type.newtype(:k5login) do
 
     validate do |value|
       unless absolute_path?(value)
-        raise Puppet::Error, "File paths must be fully qualified."
+        raise Puppet::Error, _("File paths must be fully qualified.")
       end
     end
   end

--- a/lib/puppet/type/macauthorization.rb
+++ b/lib/puppet/type/macauthorization.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:macauthorization) do
   def munge_integer(value)
       Integer(value)
   rescue ArgumentError
-      fail "munge_integer only takes integers")
+      fail _("munge_integer only takes integers")
   end
 
   newparam(:name) do

--- a/lib/puppet/type/macauthorization.rb
+++ b/lib/puppet/type/macauthorization.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:macauthorization) do
   def munge_integer(value)
       Integer(value)
   rescue ArgumentError
-      fail("munge_integer only takes integers")
+      fail "munge_integer only takes integers")
   end
 
   newparam(:name) do

--- a/lib/puppet/type/mailalias.rb
+++ b/lib/puppet/type/mailalias.rb
@@ -36,7 +36,7 @@ module Puppet
 
       validate do |value|
 	unless Puppet::Util.absolute_path?(value)
-	  fail Puppet::Error, "File paths must be fully qualified, not '#{value}'"
+	  fail Puppet::Error, _("File paths must be fully qualified, not '#{value}'")
 	end
       end
     end
@@ -55,7 +55,7 @@ module Puppet
 
     validate do
       if self[:recipient] && self[:file]
-	self.fail "You cannot specify both a recipient and a file"
+	self.fail _("You cannot specify both a recipient and a file")
       end
     end
   end

--- a/lib/puppet/type/mailalias.rb
+++ b/lib/puppet/type/mailalias.rb
@@ -36,7 +36,7 @@ module Puppet
 
       validate do |value|
 	unless Puppet::Util.absolute_path?(value)
-	  fail Puppet::Error, _("File paths must be fully qualified, not '#{value}'")
+	  fail Puppet::Error, _("File paths must be fully qualified, not '%{value}'") % { value: value }
 	end
       end
     end

--- a/lib/puppet/type/maillist.rb
+++ b/lib/puppet/type/maillist.rb
@@ -11,7 +11,7 @@ module Puppet
       end
 
       def change_to_s(current_value, newvalue)
-        return "Purged #{resource}" if newvalue == :purged
+        return _("Purged #{resource}") if newvalue == :purged
         super
       end
 

--- a/lib/puppet/type/maillist.rb
+++ b/lib/puppet/type/maillist.rb
@@ -11,7 +11,7 @@ module Puppet
       end
 
       def change_to_s(current_value, newvalue)
-        return _("Purged #{resource}") if newvalue == :purged
+        return _("Purged %{resource}") % { resource: resource } if newvalue == :purged
         super
       end
 

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -65,7 +65,7 @@ module Puppet
                      # the wrong attributes so I sync AFTER the umount
           return :mount_unmounted
         else
-          raise Puppet::Error, "Unexpected change from #{current_value} to unmounted}"
+          raise Puppet::Error, _("Unexpected change from #{current_value} to unmounted}")
         end
       end
 
@@ -131,7 +131,7 @@ module Puppet
         path, depending on the operating system."
 
       validate do |value|
-        raise Puppet::Error, "device must not contain whitespace: #{value}" if value =~ /\s/
+        raise Puppet::Error, _("device must not contain whitespace: #{value}") if value =~ /\s/
       end
     end
 
@@ -157,7 +157,7 @@ module Puppet
       end
 
       validate do |value|
-        raise Puppet::Error, "blockdevice must not contain whitespace: #{value}" if value =~ /\s/
+        raise Puppet::Error, _("blockdevice must not contain whitespace: #{value}") if value =~ /\s/
       end
     end
 
@@ -166,8 +166,8 @@ module Puppet
         operating system.  This is a required option."
 
       validate do |value|
-        raise Puppet::Error, "fstype must not contain whitespace: #{value}" if value =~ /\s/
-        raise Puppet::Error, "fstype must not be an empty string" if value.empty?
+        raise Puppet::Error, _("fstype must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("fstype must not be an empty string") if value.empty?
       end
     end
 
@@ -177,8 +177,8 @@ module Puppet
         Consult the fstab(5) man page for system-specific details."
 
       validate do |value|
-        raise Puppet::Error, "options must not contain whitespace: #{value}" if value =~ /\s/
-        raise Puppet::Error, "options must not be an empty string" if value.empty?
+        raise Puppet::Error, _("options must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("options must not be an empty string") if value.empty?
       end
     end
 
@@ -243,7 +243,7 @@ module Puppet
       isnamevar
 
       validate do |value|
-        raise Puppet::Error, "name must not contain whitespace: #{value}" if value =~ /\s/
+        raise Puppet::Error, _("name must not contain whitespace: #{value}") if value =~ /\s/
       end
 
       munge do |value|

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -65,7 +65,7 @@ module Puppet
                      # the wrong attributes so I sync AFTER the umount
           return :mount_unmounted
         else
-          raise Puppet::Error, _("Unexpected change from #{current_value} to unmounted}")
+          raise Puppet::Error, _("Unexpected change from %{current} to unmounted}") % { current: current_value }
         end
       end
 
@@ -131,7 +131,7 @@ module Puppet
         path, depending on the operating system."
 
       validate do |value|
-        raise Puppet::Error, _("device must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("device must not contain whitespace: %{value}") % { value: value } if value =~ /\s/
       end
     end
 
@@ -157,7 +157,7 @@ module Puppet
       end
 
       validate do |value|
-        raise Puppet::Error, _("blockdevice must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("blockdevice must not contain whitespace: %{value}") % { value: value } if value =~ /\s/
       end
     end
 
@@ -166,7 +166,7 @@ module Puppet
         operating system.  This is a required option."
 
       validate do |value|
-        raise Puppet::Error, _("fstype must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("fstype must not contain whitespace: %{value}") % { value: value } if value =~ /\s/
         raise Puppet::Error, _("fstype must not be an empty string") if value.empty?
       end
     end
@@ -177,7 +177,7 @@ module Puppet
         Consult the fstab(5) man page for system-specific details."
 
       validate do |value|
-        raise Puppet::Error, _("options must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("options must not contain whitespace: %{value}") % { value: value } if value =~ /\s/
         raise Puppet::Error, _("options must not be an empty string") if value.empty?
       end
     end
@@ -243,7 +243,7 @@ module Puppet
       isnamevar
 
       validate do |value|
-        raise Puppet::Error, _("name must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("name must not contain whitespace: %{value}") % { value: value } if value =~ /\s/
       end
 
       munge do |value|

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -111,7 +111,7 @@ module Puppet
         begin
           provider.update
         rescue => detail
-          self.fail Puppet::Error, _("Could not update: #{detail}"), detail
+          self.fail Puppet::Error, _("Could not update: %{detail}") % { detail: detail }, detail
         end
 
         if current == :absent
@@ -125,7 +125,7 @@ module Puppet
         begin
           provider.install
         rescue => detail
-          self.fail Puppet::Error, _("Could not update: #{detail}"), detail
+          self.fail Puppet::Error, _("Could not update: %{detail}") % { detail: detail }, detail
         end
 
         if self.retrieve == :absent
@@ -160,7 +160,7 @@ module Puppet
                 @latest = provider.latest
                 @lateststamp = Time.now.to_i
               rescue => detail
-                error = Puppet::Error.new(_("Could not get latest version: #{detail}"))
+                error = Puppet::Error.new(_("Could not get latest version: %{detail}") % { detail: detail })
                 error.set_backtrace(detail.backtrace)
                 raise error
               end
@@ -260,7 +260,7 @@ module Puppet
 
       validate do |value|
         if !value.is_a?(String)
-          raise ArgumentError, _("Name must be a String not #{value.class}")
+          raise ArgumentError, _("Name must be a String not %{klass}") % { klass: value.class }
         end
       end
     end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -111,7 +111,7 @@ module Puppet
         begin
           provider.update
         rescue => detail
-          self.fail Puppet::Error, "Could not update: #{detail}", detail
+          self.fail Puppet::Error, _("Could not update: #{detail}"), detail
         end
 
         if current == :absent
@@ -125,7 +125,7 @@ module Puppet
         begin
           provider.install
         rescue => detail
-          self.fail Puppet::Error, "Could not update: #{detail}", detail
+          self.fail Puppet::Error, _("Could not update: #{detail}"), detail
         end
 
         if self.retrieve == :absent
@@ -160,7 +160,7 @@ module Puppet
                 @latest = provider.latest
                 @lateststamp = Time.now.to_i
               rescue => detail
-                error = Puppet::Error.new("Could not get latest version: #{detail}")
+                error = Puppet::Error.new(_("Could not get latest version: #{detail}"))
                 error.set_backtrace(detail.backtrace)
                 raise error
               end
@@ -260,7 +260,7 @@ module Puppet
 
       validate do |value|
         if !value.is_a?(String)
-          raise ArgumentError, "Name must be a String not #{value.class}"
+          raise ArgumentError, _("Name must be a String not #{value.class}")
         end
       end
     end

--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -12,7 +12,7 @@ Puppet::Type.newtype(:resources) do
     desc "The name of the type to be managed."
 
     validate do |name|
-      raise ArgumentError, "Could not find resource type '#{name}'" unless Puppet::Type.type(name)
+      raise ArgumentError, _("Could not find resource type '#{name}'") unless Puppet::Type.type(name)
     end
 
     munge { |v| v.to_s }
@@ -30,9 +30,9 @@ Puppet::Type.newtype(:resources) do
     validate do |value|
       if munge(value)
         unless @resource.resource_type.respond_to?(:instances)
-          raise ArgumentError, "Purging resources of type #{@resource[:name]} is not supported, since they cannot be queried from the system"
+          raise ArgumentError, _("Purging resources of type #{@resource[:name]} is not supported, since they cannot be queried from the system")
         end
-        raise ArgumentError, "Purging is only supported on types that accept 'ensure'" unless @resource.resource_type.validproperty?(:ensure)
+        raise ArgumentError, _("Purging is only supported on types that accept 'ensure'") unless @resource.resource_type.validproperty?(:ensure)
       end
     end
   end
@@ -54,7 +54,7 @@ Puppet::Type.newtype(:resources) do
         false
       when Integer; value
       else
-        raise ArgumentError, "Invalid value #{value.inspect}"
+        raise ArgumentError, _("Invalid value #{value.inspect}")
       end
     end
 
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:resources) do
           when String
             Integer(v)
           else
-            raise ArgumentError, "Invalid value #{v.inspect}."
+            raise ArgumentError, _("Invalid value #{v.inspect}.")
         end
       end
     end
@@ -100,7 +100,7 @@ Puppet::Type.newtype(:resources) do
   def able_to_ensure_absent?(resource)
       resource[:ensure] = :absent
   rescue ArgumentError, Puppet::Error
-      err "The 'ensure' attribute on #{self[:name]} resources does not accept 'absent' as a value"
+      err _("The 'ensure' attribute on #{self[:name]} resources does not accept 'absent' as a value")
       false
   end
 

--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -12,7 +12,7 @@ Puppet::Type.newtype(:resources) do
     desc "The name of the type to be managed."
 
     validate do |name|
-      raise ArgumentError, _("Could not find resource type '#{name}'") unless Puppet::Type.type(name)
+      raise ArgumentError, _("Could not find resource type '%{name}'") % { name: name } unless Puppet::Type.type(name)
     end
 
     munge { |v| v.to_s }
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:resources) do
     validate do |value|
       if munge(value)
         unless @resource.resource_type.respond_to?(:instances)
-          raise ArgumentError, _("Purging resources of type #{@resource[:name]} is not supported, since they cannot be queried from the system")
+          raise ArgumentError, _("Purging resources of type %{res_type} is not supported, since they cannot be queried from the system") % { res_type: @resource[:name] }
         end
         raise ArgumentError, _("Purging is only supported on types that accept 'ensure'") unless @resource.resource_type.validproperty?(:ensure)
       end
@@ -54,7 +54,7 @@ Puppet::Type.newtype(:resources) do
         false
       when Integer; value
       else
-        raise ArgumentError, _("Invalid value #{value.inspect}")
+        raise ArgumentError, _("Invalid value %{value}") % { value: value.inspect }
       end
     end
 
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:resources) do
           when String
             Integer(v)
           else
-            raise ArgumentError, _("Invalid value #{v.inspect}.")
+            raise ArgumentError, _("Invalid value %{value}.") % { value: v.inspect }
         end
       end
     end
@@ -100,7 +100,7 @@ Puppet::Type.newtype(:resources) do
   def able_to_ensure_absent?(resource)
       resource[:ensure] = :absent
   rescue ArgumentError, Puppet::Error
-      err _("The 'ensure' attribute on #{self[:name]} resources does not accept 'absent' as a value")
+      err _("The 'ensure' attribute on %{name} resources does not accept 'absent' as a value") % { name: self[:name] }
       false
   end
 

--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -93,7 +93,7 @@ module Puppet
         values.each { |value|
           unless  value.is_a?(String) and
               value =~ /\d+(:\d+){0,2}\s*-\s*\d+(:\d+){0,2}/
-            self.fail _("Invalid range value '#{value}'")
+            self.fail _("Invalid range value '%{value}'") % { value: value }
           end
         }
       end
@@ -110,15 +110,15 @@ module Puppet
             range << val.split(":").collect { |n| n.to_i }
           }
 
-          self.fail _("Invalid range #{value}") if range.length != 2
+          self.fail _("Invalid range %{value}") % { value: value } if range.length != 2
 
           # Make sure the hours are valid
           [range[0][0], range[1][0]].each do |n|
-            raise ArgumentError, _("Invalid hour '#{n}'") if n < 0 or n > 23
+            raise ArgumentError, _("Invalid hour '%{n}'") % { n: n } if n < 0 or n > 23
           end
 
           [range[0][1], range[1][1]].each do |n|
-            raise ArgumentError, _("Invalid minute '#{n}'") if n and (n < 0 or n > 59)
+            raise ArgumentError, _("Invalid minute '%{n}'") % { n: n } if n and (n < 0 or n > 59)
           end
           ret << range
         }
@@ -152,7 +152,7 @@ module Puppet
 
             unless time.hour == range[0]
               self.devfail(
-                _("Incorrectly converted time: #{time}: #{time.hour} vs #{range[0]}")
+                _("Incorrectly converted time: %{time}: %{hour} vs %{value}") % { time: time, hour: time.hour, value: range[0] }
               )
             end
 
@@ -328,7 +328,7 @@ module Puppet
 
         if value != 1 and @resource[:periodmatch] != :distance
           raise Puppet::Error,
-            _("Repeat must be 1 unless periodmatch is 'distance', not '#{@resource[:periodmatch]}'")
+            _("Repeat must be 1 unless periodmatch is 'distance', not '%{period}'") % { period: @resource[:periodmatch] }
         end
       end
 

--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -93,7 +93,7 @@ module Puppet
         values.each { |value|
           unless  value.is_a?(String) and
               value =~ /\d+(:\d+){0,2}\s*-\s*\d+(:\d+){0,2}/
-            self.fail "Invalid range value '#{value}'"
+            self.fail _("Invalid range value '#{value}'")
           end
         }
       end
@@ -110,15 +110,15 @@ module Puppet
             range << val.split(":").collect { |n| n.to_i }
           }
 
-          self.fail "Invalid range #{value}" if range.length != 2
+          self.fail _("Invalid range #{value}") if range.length != 2
 
           # Make sure the hours are valid
           [range[0][0], range[1][0]].each do |n|
-            raise ArgumentError, "Invalid hour '#{n}'" if n < 0 or n > 23
+            raise ArgumentError, _("Invalid hour '#{n}'") if n < 0 or n > 23
           end
 
           [range[0][1], range[1][1]].each do |n|
-            raise ArgumentError, "Invalid minute '#{n}'" if n and (n < 0 or n > 59)
+            raise ArgumentError, _("Invalid minute '#{n}'") if n and (n < 0 or n > 59)
           end
           ret << range
         }
@@ -152,7 +152,7 @@ module Puppet
 
             unless time.hour == range[0]
               self.devfail(
-                "Incorrectly converted time: #{time}: #{time.hour} vs #{range[0]}"
+                _("Incorrectly converted time: #{time}: #{time.hour} vs #{range[0]}")
               )
             end
 
@@ -161,7 +161,7 @@ module Puppet
 
           unless limits[0] < limits[1]
             self.info(
-            "Assuming upper limit should be that time the next day"
+            _("Assuming upper limit should be that time the next day")
             )
 
             # Find midnight between the two days. Adding one second
@@ -319,7 +319,7 @@ module Puppet
       validate do |value|
         unless value.is_a?(Integer) or value =~ /^\d+$/
           raise Puppet::Error,
-            "Repeat must be a number"
+            _("Repeat must be a number")
         end
 
         # This implicitly assumes that 'periodmatch' is distance -- that
@@ -328,7 +328,7 @@ module Puppet
 
         if value != 1 and @resource[:periodmatch] != :distance
           raise Puppet::Error,
-            "Repeat must be 1 unless periodmatch is 'distance', not '#{@resource[:periodmatch]}'"
+            _("Repeat must be 1 unless periodmatch is 'distance', not '#{@resource[:periodmatch]}'")
         end
       end
 
@@ -371,7 +371,7 @@ module Puppet
         values.each { |value|
           unless value.is_a?(String) and
               (value =~ /^[0-6]$/ or value =~ /^(Mon|Tues?|Wed(?:nes)?|Thu(?:rs)?|Fri|Sat(?:ur)?|Sun)(day)?$/i)
-            raise ArgumentError, "%s is not a valid day of the week" % value
+            raise ArgumentError, _("%s is not a valid day of the week") % value
           end
         }
       end

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:scheduled_task) do
     desc "The full path to the application to run, without any arguments."
 
     validate do |value|
-      raise Puppet::Error.new('Must be specified using an absolute path.') unless absolute_path?(value)
+      raise Puppet::Error.new(_('Must be specified using an absolute path.')) unless absolute_path?(value)
     end
     munge do |value|
       # windows converts slashes to backslashes, so the *is* value
@@ -45,7 +45,7 @@ Puppet::Type.newtype(:scheduled_task) do
     desc "The full path of the directory in which to start the command."
 
     validate do |value|
-      raise Puppet::Error.new('Must be specified using an absolute path.') unless absolute_path?(value)
+      raise Puppet::Error.new(_('Must be specified using an absolute path.')) unless absolute_path?(value)
     end
   end
 

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -86,7 +86,7 @@ module Puppet
 
       validate do |value|
         if value == :manual and !Puppet.features.microsoft_windows?
-          raise Puppet::Error.new("Setting enable to manual is only supported on Microsoft Windows.")
+          raise Puppet::Error.new(_("Setting enable to manual is only supported on Microsoft Windows."))
         end
       end
     end

--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -71,7 +71,7 @@ module Puppet
           the `name` attribute/resource title."
 
       validate do |value|
-        raise Puppet::Error, "Key must not contain whitespace: #{value}" if value =~ /\s/
+        raise Puppet::Error, _("Key must not contain whitespace: #{value}") if value =~ /\s/
       end
     end
 
@@ -130,7 +130,7 @@ module Puppet
 
       validate do |value|
         unless value == :absent or value =~ /^[-a-z0-9A-Z_]+(?:=\".*?\")?$/
-          raise Puppet::Error, "Option #{value} is not valid. A single option must either be of the form 'option' or 'option=\"value\". Multiple options must be provided as an array"
+          raise Puppet::Error, _("Option #{value} is not valid. A single option must either be of the form 'option' or 'option=\"value\". Multiple options must be provided as an array")
         end
       end
     end
@@ -147,7 +147,7 @@ module Puppet
       return if @parameters.include?(:user)
 
       # If neither target nor user is defined, this is an error
-      raise Puppet::Error, "Attribute 'user' or 'target' is mandatory"
+      raise Puppet::Error, _("Attribute 'user' or 'target' is mandatory")
     end
 
     # regular expression suitable for use by a ParsedFile based provider

--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -71,7 +71,7 @@ module Puppet
           the `name` attribute/resource title."
 
       validate do |value|
-        raise Puppet::Error, _("Key must not contain whitespace: #{value}") if value =~ /\s/
+        raise Puppet::Error, _("Key must not contain whitespace: %{value}") % { value: value } if value =~ /\s/
       end
     end
 
@@ -130,7 +130,7 @@ module Puppet
 
       validate do |value|
         unless value == :absent or value =~ /^[-a-z0-9A-Z_]+(?:=\".*?\")?$/
-          raise Puppet::Error, _("Option #{value} is not valid. A single option must either be of the form 'option' or 'option=\"value\". Multiple options must be provided as an array")
+          raise Puppet::Error, _("Option %{value} is not valid. A single option must either be of the form 'option' or 'option=\"value\". Multiple options must be provided as an array") % { value: value }
         end
       end
     end

--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -41,10 +41,10 @@ module Puppet
 
       validate do |value|
         if value =~ /\s/
-          raise Puppet::Error, "Aliases cannot include whitespace"
+          raise Puppet::Error, _("Aliases cannot include whitespace")
         end
         if value =~ /,/
-          raise Puppet::Error, "Aliases must be provided as an array, not a comma-separated list"
+          raise Puppet::Error, _("Aliases must be provided as an array, not a comma-separated list")
         end
       end
     end
@@ -55,8 +55,8 @@ module Puppet
       isnamevar
 
       validate do |value|
-        raise Puppet::Error, "Resourcename cannot include whitespaces" if value =~ /\s/
-        raise Puppet::Error, "No comma in resourcename allowed. If you want to specify aliases use the host_aliases property" if value.include?(',')
+        raise Puppet::Error, _("Resourcename cannot include whitespaces") if value =~ /\s/
+        raise Puppet::Error, _("No comma in resourcename allowed. If you want to specify aliases use the host_aliases property") if value.include?(',')
       end
     end
 

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -45,7 +45,7 @@ Puppet::Type.newtype(:tidy) do
       when Integer; value
       when /^\d+$/; Integer(value)
       else
-        raise ArgumentError, _("Invalid recurse value #{value.inspect}")
+        raise ArgumentError, _("Invalid recurse value %{value}") % { value: value.inspect }
       end
     end
   end
@@ -121,7 +121,7 @@ Puppet::Type.newtype(:tidy) do
       if num = AgeConvertors[unit]
         return num * multi
       else
-        self.fail _("Invalid age unit '#{unit}'")
+        self.fail _("Invalid age unit '%{unit}'") % { unit: unit }
       end
     end
 
@@ -141,7 +141,7 @@ Puppet::Type.newtype(:tidy) do
         unit = :d
       else
         #TRANSLATORS tidy is the name of a program and should not be translated
-        self.fail _("Invalid tidy age #{age}")
+        self.fail _("Invalid tidy age %{age}") % { age: age }
       end
 
       convert(unit, multi)
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:tidy) do
         num.times do result *= 1024 end
         return result
       else
-        self.fail _("Invalid size unit '#{unit}'")
+        self.fail _("Invalid size unit '%{unit}'") % { unit: unit }
       end
     end
 
@@ -180,7 +180,7 @@ Puppet::Type.newtype(:tidy) do
         unit = :k
       else
         #TRANSLATORS tidy is the name of a program and should not be translated
-        self.fail _("Invalid tidy size #{age}")
+        self.fail _("Invalid tidy size %{age}") % { age: age }
       end
 
       convert(unit, multi)
@@ -260,7 +260,8 @@ Puppet::Type.newtype(:tidy) do
     end
     found_files = files.find_all { |path| tidy?(path) }.collect { |path| mkfile(path) }
     result = found_files.each { |file| debug "Tidying #{file.ref}" }.sort { |a,b| b[:path] <=> a[:path] }
-    notice _("Tidying #{found_files.size} files")
+    #TRANSLATORS "Tidy" is a program name and should not be translated
+    notice _("Tidying %{count} files") % { count: found_files.size }
 
     # No need to worry about relationships if we don't have rmdirs; there won't be
     # any directories.
@@ -327,6 +328,7 @@ Puppet::Type.newtype(:tidy) do
       info _("File does not exist")
       return nil
     rescue Errno::EACCES => error
+      #TRANSLATORS "stat" is a program name and should not be translated
       warning _("Could not stat; permission denied")
       return nil
     end

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -45,7 +45,7 @@ Puppet::Type.newtype(:tidy) do
       when Integer; value
       when /^\d+$/; Integer(value)
       else
-        raise ArgumentError, "Invalid recurse value #{value.inspect}"
+        raise ArgumentError, _("Invalid recurse value #{value.inspect}")
       end
     end
   end
@@ -82,7 +82,7 @@ Puppet::Type.newtype(:tidy) do
 
     # Make sure we convert to an array.
     munge do |value|
-      fail "Tidy can't use matches with recurse 0, false, or undef" if "#{@resource[:recurse]}" =~ /^(0|false|)$/
+      fail _("Tidy can't use matches with recurse 0, false, or undef") if "#{@resource[:recurse]}" =~ /^(0|false|)$/
       [value].flatten
     end
 
@@ -121,7 +121,7 @@ Puppet::Type.newtype(:tidy) do
       if num = AgeConvertors[unit]
         return num * multi
       else
-        self.fail "Invalid age unit '#{unit}'"
+        self.fail _("Invalid age unit '#{unit}'")
       end
     end
 
@@ -140,7 +140,8 @@ Puppet::Type.newtype(:tidy) do
         multi = Integer($1)
         unit = :d
       else
-        self.fail "Invalid tidy age #{age}"
+        #TRANSLATORS tidy is the name of a program and should not be translated
+        self.fail _("Invalid tidy age #{age}")
       end
 
       convert(unit, multi)
@@ -161,7 +162,7 @@ Puppet::Type.newtype(:tidy) do
         num.times do result *= 1024 end
         return result
       else
-        self.fail "Invalid size unit '#{unit}'"
+        self.fail _("Invalid size unit '#{unit}'")
       end
     end
 
@@ -178,7 +179,8 @@ Puppet::Type.newtype(:tidy) do
         multi = Integer($1)
         unit = :k
       else
-        self.fail "Invalid tidy size #{age}"
+        #TRANSLATORS tidy is the name of a program and should not be translated
+        self.fail _("Invalid tidy size #{age}")
       end
 
       convert(unit, multi)
@@ -258,7 +260,7 @@ Puppet::Type.newtype(:tidy) do
     end
     found_files = files.find_all { |path| tidy?(path) }.collect { |path| mkfile(path) }
     result = found_files.each { |file| debug "Tidying #{file.ref}" }.sort { |a,b| b[:path] <=> a[:path] }
-    notice "Tidying #{found_files.size} files"
+    notice _("Tidying #{found_files.size} files")
 
     # No need to worry about relationships if we don't have rmdirs; there won't be
     # any directories.
@@ -322,10 +324,10 @@ Puppet::Type.newtype(:tidy) do
     begin
       Puppet::FileSystem.lstat(path)
     rescue Errno::ENOENT => error
-      info "File does not exist"
+      info _("File does not exist")
       return nil
     rescue Errno::EACCES => error
-      warning "Could not stat; permission denied"
+      warning _("Could not stat; permission denied")
       return nil
     end
   end

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -163,7 +163,7 @@ module Puppet
           end
         end
 
-        fail "Could not find group(s) #{@should.join(",")}" unless found
+        fail _("Could not find group(s) #{@should.join(",")}") unless found
 
         # Use the default event.
       end
@@ -221,22 +221,22 @@ module Puppet
         accidental variable interpolation.}
 
       validate do |value|
-        raise ArgumentError, "Passwords cannot include ':'" if value.is_a?(String) and value.include?(":")
+        raise ArgumentError, _("Passwords cannot include ':'") if value.is_a?(String) and value.include?(":")
       end
 
       def change_to_s(currentvalue, newvalue)
         if currentvalue == :absent
-          return "created password"
+          return _("created password")
         else
-          return "changed password"
+          return _("changed password")
         end
       end
 
       def is_to_s( currentvalue )
-        return '[old password hash redacted]'
+        return _('[old password hash redacted]')
       end
       def should_to_s( newvalue )
-        return '[new password hash redacted]'
+        return _('[new password hash redacted]')
       end
 
     end
@@ -255,7 +255,7 @@ module Puppet
 
       validate do |value|
         if value.to_s !~ /^-?\d+$/
-          raise ArgumentError, "Password minimum age must be provided as a number."
+          raise ArgumentError, _("Password minimum age must be provided as a number.")
         end
       end
     end
@@ -274,7 +274,7 @@ module Puppet
 
       validate do |value|
         if value.to_s !~ /^-?\d+$/
-          raise ArgumentError, "Password maximum age must be provided as a number."
+          raise ArgumentError, _("Password maximum age must be provided as a number.")
         end
       end
     end
@@ -286,10 +286,10 @@ module Puppet
 
       validate do |value|
         if value =~ /^\d+$/
-          raise ArgumentError, "Group names must be provided, not GID numbers."
+          raise ArgumentError, _("Group names must be provided, not GID numbers.")
         end
-        raise ArgumentError, "Group names must be provided as an array, not a comma-separated list." if value.include?(",")
-        raise ArgumentError, "Group names must not be empty. If you want to specify \"no groups\" pass an empty array" if value.empty?
+        raise ArgumentError, _("Group names must be provided as an array, not a comma-separated list.") if value.include?(",")
+        raise ArgumentError, _("Group names must not be empty. If you want to specify \"no groups\" pass an empty array") if value.empty?
       end
 
       def change_to_s(currentvalue, newvalue)
@@ -375,7 +375,7 @@ module Puppet
 
       validate do |val|
         if munge(val)
-          raise ArgumentError, "User provider #{provider.class.name} can not manage home directories" if provider and not provider.class.manages_homedir?
+          raise ArgumentError, _("User provider #{provider.class.name} can not manage home directories") if provider and not provider.class.manages_homedir?
         end
       end
     end
@@ -391,7 +391,7 @@ module Puppet
 
       validate do |value|
         if value.intern != :absent and value !~ /^\d{4}-\d{2}-\d{2}$/
-          raise ArgumentError, "Expiry dates must be YYYY-MM-DD or the string \"absent\""
+          raise ArgumentError, _("Expiry dates must be YYYY-MM-DD or the string \"absent\"")
         end
       end
     end
@@ -468,9 +468,9 @@ module Puppet
 
       validate do |value|
         if value =~ /^\d+$/
-          raise ArgumentError, "Role names must be provided, not numbers"
+          raise ArgumentError, _("Role names must be provided, not numbers")
         end
-        raise ArgumentError, "Role names must be provided as an array, not a comma-separated list" if value.include?(",")
+        raise ArgumentError, _("Role names must be provided as an array, not a comma-separated list") if value.include?(",")
       end
     end
 
@@ -505,9 +505,9 @@ module Puppet
 
       validate do |value|
         if value =~ /^\d+$/
-          raise ArgumentError, "Auth names must be provided, not numbers"
+          raise ArgumentError, _("Auth names must be provided, not numbers")
         end
-        raise ArgumentError, "Auth names must be provided as an array, not a comma-separated list" if value.include?(",")
+        raise ArgumentError, _("Auth names must be provided as an array, not a comma-separated list") if value.include?(",")
       end
     end
 
@@ -531,9 +531,9 @@ module Puppet
 
       validate do |value|
         if value =~ /^\d+$/
-          raise ArgumentError, "Profile names must be provided, not numbers"
+          raise ArgumentError, _("Profile names must be provided, not numbers")
         end
-        raise ArgumentError, "Profile names must be provided as an array, not a comma-separated list" if value.include?(",")
+        raise ArgumentError, _("Profile names must be provided as an array, not a comma-separated list") if value.include?(",")
       end
     end
 
@@ -555,7 +555,7 @@ module Puppet
       end
 
       validate do |value|
-        raise ArgumentError, "Key/value pairs must be separated by an =" unless value.include?("=")
+        raise ArgumentError, _("Key/value pairs must be separated by an =") unless value.include?("=")
       end
     end
 
@@ -589,7 +589,7 @@ module Puppet
       end
 
       validate do |value|
-        raise ArgumentError, "Attributes value pairs must be separated by an =" unless value.include?("=")
+        raise ArgumentError, _("Attributes value pairs must be separated by an =") unless value.include?("=")
       end
     end
 
@@ -662,14 +662,14 @@ module Puppet
         if value.is_a?(Array)
           value.each do |entry|
 
-            raise ArgumentError, "Each entry for purge_ssh_keys must be a string, not a #{entry.class}" unless entry.is_a?(String)
+            raise ArgumentError, _("Each entry for purge_ssh_keys must be a string, not a #{entry.class}") unless entry.is_a?(String)
 
             valid_home = Puppet::Util.absolute_path?(entry) || entry =~ %r{^~/|^%h/}
-            raise ArgumentError, "Paths to keyfiles must be absolute, not #{entry}" unless valid_home
+            raise ArgumentError, _("Paths to keyfiles must be absolute, not #{entry}") unless valid_home
           end
           return
         end
-        raise ArgumentError, "purge_ssh_keys must be true, false, or an array of file names, not #{value.inspect}"
+        raise ArgumentError, _("purge_ssh_keys must be true, false, or an array of file names, not #{value.inspect}")
       end
 
       munge do |value|
@@ -681,14 +681,14 @@ module Puppet
         return [] if value == :false
         home = resource[:home]
         if value == :true and not home
-          raise ArgumentError, "purge_ssh_keys can only be true for users with a defined home directory"
+          raise ArgumentError, _("purge_ssh_keys can only be true for users with a defined home directory")
         end
 
         return [ "#{home}/.ssh/authorized_keys" ] if value == :true
         # value is an array - munge each value
         [ value ].flatten.map do |entry|
           if entry =~ /^~|^%h/ and not home
-            raise ArgumentError, "purge_ssh_keys value '#{value}' meta character ~ or %h only allowed for users with a defined home directory"
+            raise ArgumentError, _("purge_ssh_keys value '#{value}' meta character ~ or %h only allowed for users with a defined home directory")
           end
           entry.gsub!(/^~\//, "#{home}/")
           entry.gsub!(/^%h\//, "#{home}/")
@@ -702,7 +702,7 @@ module Puppet
 
       validate do |value|
         if value =~ /^\d+$/
-          raise ArgumentError, "Class name must be provided."
+          raise ArgumentError, _("Class name must be provided.")
         end
       end
     end

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -163,7 +163,7 @@ module Puppet
           end
         end
 
-        fail _("Could not find group(s) #{@should.join(",")}") unless found
+        fail _("Could not find group(s) %{groups}") % { groups: @should.join(",") } unless found
 
         # Use the default event.
       end
@@ -375,7 +375,7 @@ module Puppet
 
       validate do |val|
         if munge(val)
-          raise ArgumentError, _("User provider #{provider.class.name} can not manage home directories") if provider and not provider.class.manages_homedir?
+          raise ArgumentError, _("User provider %{name} can not manage home directories") % { name: provider.class.name } if provider and not provider.class.manages_homedir?
         end
       end
     end
@@ -391,6 +391,8 @@ module Puppet
 
       validate do |value|
         if value.intern != :absent and value !~ /^\d{4}-\d{2}-\d{2}$/
+          #TRANSLATORS YYYY-MM-DD represents a date with a four-digit year, a two-digit month, and a two-digit day,
+          #TRANSLATORS separated by dashes.
           raise ArgumentError, _("Expiry dates must be YYYY-MM-DD or the string \"absent\"")
         end
       end
@@ -662,14 +664,14 @@ module Puppet
         if value.is_a?(Array)
           value.each do |entry|
 
-            raise ArgumentError, _("Each entry for purge_ssh_keys must be a string, not a #{entry.class}") unless entry.is_a?(String)
+            raise ArgumentError, _("Each entry for purge_ssh_keys must be a string, not a %{klass}") % { klass: entry.class } unless entry.is_a?(String)
 
             valid_home = Puppet::Util.absolute_path?(entry) || entry =~ %r{^~/|^%h/}
-            raise ArgumentError, _("Paths to keyfiles must be absolute, not #{entry}") unless valid_home
+            raise ArgumentError, _("Paths to keyfiles must be absolute, not %{entry}") % { entry: entry } unless valid_home
           end
           return
         end
-        raise ArgumentError, _("purge_ssh_keys must be true, false, or an array of file names, not #{value.inspect}")
+        raise ArgumentError, _("purge_ssh_keys must be true, false, or an array of file names, not %{value}") % { value: value.inspect }
       end
 
       munge do |value|
@@ -688,7 +690,7 @@ module Puppet
         # value is an array - munge each value
         [ value ].flatten.map do |entry|
           if entry =~ /^~|^%h/ and not home
-            raise ArgumentError, _("purge_ssh_keys value '#{value}' meta character ~ or %h only allowed for users with a defined home directory")
+            raise ArgumentError, _("purge_ssh_keys value '%{value}' meta character ~ or %{home_placeholder} only allowed for users with a defined home directory") % { value: value, home_placeholder: '%h' }
           end
           entry.gsub!(/^~\//, "#{home}/")
           entry.gsub!(/^%h\//, "#{home}/")

--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -62,7 +62,7 @@ Puppet::Type.newtype(:yumrepo) do
       parsed = URI.parse(value)
 
       unless VALID_SCHEMES.include?(parsed.scheme)
-        raise "Must be a valid URL"
+        raise _("Must be a valid URL")
       end
     end
   end
@@ -79,7 +79,7 @@ Puppet::Type.newtype(:yumrepo) do
         parsed = URI.parse(uri)
 
         unless VALID_SCHEMES.include?(parsed.scheme)
-          raise "Must be a valid URL"
+          raise _("Must be a valid URL")
         end
       end
     end
@@ -126,7 +126,7 @@ Puppet::Type.newtype(:yumrepo) do
         parsed = URI.parse(uri)
 
         unless VALID_SCHEMES.include?(parsed.scheme)
-          raise "Must be a valid URL"
+          raise _("Must be a valid URL")
         end
       end
     end
@@ -150,7 +150,7 @@ Puppet::Type.newtype(:yumrepo) do
       parsed = URI.parse(value)
 
       unless VALID_SCHEMES.include?(parsed.scheme)
-        raise "Must be a valid URL"
+        raise _("Must be a valid URL")
       end
     end
   end
@@ -172,7 +172,7 @@ Puppet::Type.newtype(:yumrepo) do
       parsed = URI.parse(value)
 
       unless VALID_SCHEMES.include?(parsed.scheme)
-        raise "Must be a valid URL"
+        raise _("Must be a valid URL")
       end
     end
   end
@@ -258,7 +258,7 @@ Puppet::Type.newtype(:yumrepo) do
     validate do |value|
       next if value.to_s == 'absent'
       unless (1..99).include?(value.to_i)
-        fail("Must be within range 1-99")
+        fail(_("Must be within range 1-99"))
       end
     end
   end
@@ -300,7 +300,7 @@ Puppet::Type.newtype(:yumrepo) do
       parsed = URI.parse(value)
 
       unless VALID_SCHEMES.include?(parsed.scheme)
-        raise "Must be a valid URL"
+        raise _("Must be a valid URL")
       end
     end
   end
@@ -366,7 +366,7 @@ Puppet::Type.newtype(:yumrepo) do
       parsed = URI.parse(value)
 
       unless VALID_SCHEMES.include?(parsed.scheme)
-        raise "Must be a valid URL"
+        raise _("Must be a valid URL")
       end
     end
   end

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -99,7 +99,7 @@ end
       warned = false
       while provider.processing?
         next if warned
-        info "Waiting for zone to finish processing"
+        info _("Waiting for zone to finish processing")
         warned = true
         sleep 1
       end
@@ -196,7 +196,7 @@ end
       Puppet to move a zone. Consequently this is a readonly property."
 
     validate do |value|
-      raise ArgumentError, "The zone base must be fully qualified" unless value =~ /^\//
+      raise ArgumentError, _("The zone base must be fully qualified") unless value =~ /^\//
     end
 
     munge do |value|
@@ -233,7 +233,7 @@ end
 
     validate do |value|
       unless value !~ /^\//
-        raise ArgumentError, "Datasets must be the name of a zfs filesystem"
+        raise ArgumentError, _("Datasets must be the name of a zfs filesystem")
       end
     end
   end
@@ -254,7 +254,7 @@ end
 
     validate do |value|
       unless value =~ /^\//
-        raise ArgumentError, "Inherited filesystems must be fully qualified"
+        raise ArgumentError, _("Inherited filesystems must be fully qualified")
       end
     end
   end
@@ -327,15 +327,15 @@ end
   def validate_ip(ip, name)
     IPAddr.new(ip) if ip
   rescue ArgumentError
-    self.fail Puppet::Error, "'#{ip}' is an invalid #{name}", $!
+    self.fail Puppet::Error, _("'#{ip}' is an invalid #{name}"), $!
   end
 
   def validate_exclusive(interface, address, router)
     return if !interface.nil? and address.nil?
-    self.fail "only interface may be specified when using exclusive IP stack: #{interface}:#{address}"
+    self.fail _("only interface may be specified when using exclusive IP stack: #{interface}:#{address}")
   end
   def validate_shared(interface, address, router)
-    self.fail "ip must contain interface name and ip address separated by a \":\"" if interface.nil? or address.nil?
+    self.fail _("ip must contain interface name and ip address separated by a \":\"") if interface.nil? or address.nil?
     [address, router].each do |ip|
       validate_ip(address, "IP address") unless ip.nil?
     end

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -327,12 +327,12 @@ end
   def validate_ip(ip, name)
     IPAddr.new(ip) if ip
   rescue ArgumentError
-    self.fail Puppet::Error, _("'#{ip}' is an invalid #{name}"), $!
+    self.fail Puppet::Error, _("'%{ip}' is an invalid %{name}") % { ip: ip, name: name }, $!
   end
 
   def validate_exclusive(interface, address, router)
     return if !interface.nil? and address.nil?
-    self.fail _("only interface may be specified when using exclusive IP stack: #{interface}:#{address}")
+    self.fail _("only interface may be specified when using exclusive IP stack: %{interface}:%{address}") % { interface: interface, address: address }
   end
   def validate_shared(interface, address, router)
     self.fail _("ip must contain interface name and ip address separated by a \":\"") if interface.nil? or address.nil?


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/type/*` for translation.