### PR TITLE
(PUP-7042) Mark strings in resource

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -41,7 +41,7 @@ class Puppet::Resource
     end
 
     if ext_params = data['ext_parameters']
-      raise Puppet::Error, 'Unable to deserialize non-Data type parameters unless a deserializer is provided' unless json_deserializer
+      raise Puppet::Error, _('Unable to deserialize non-Data type parameters unless a deserializer is provided') unless json_deserializer
       reader = json_deserializer.reader
       ext_params.each do |param, value|
         reader.re_initialize(value)
@@ -88,7 +88,7 @@ class Puppet::Resource
         if is_json_type?(value)
           params[param] = value
         elsif json_serializer.nil?
-          Puppet.warning("Resource '#{to_s}' contains a #{value.class.name} value. It will be converted to the String '#{value}'")
+          Puppet.warning(_("Resource '#{to_s}' contains a #{value.class.name} value. It will be converted to the String '#{value}'"))
           params[param] = value
         else
           ext_params[param] = value
@@ -506,12 +506,12 @@ class Puppet::Resource
   # @deprecated Not used by Puppet
   # @api private
   def set_default_parameters(scope)
-    Puppet.deprecation_warning('The method Puppet::Resource.set_default_parameters is deprecated and will be removed in the next major release of Puppet.')
+    Puppet.deprecation_warning(_('The method Puppet::Resource.set_default_parameters is deprecated and will be removed in the next major release of Puppet.'))
 
     return [] unless resource_type and resource_type.respond_to?(:arguments)
 
     unless is_a?(Puppet::Parser::Resource)
-      fail Puppet::DevError, "Cannot evaluate default parameters for #{self} - not a parser resource"
+      fail Puppet::DevError, _("Cannot evaluate default parameters for #{self} - not a parser resource")
     end
 
     missing_arguments.collect do |param, default|
@@ -519,7 +519,7 @@ class Puppet::Resource
       if rtype.type == :hostclass
         using_bound_value = false
         catch(:no_such_key) do
-          bound_value = Puppet::Pops::Lookup.search_and_merge("#{rtype.name}::#{param}", Puppet::Pops::Lookup::Invocation.new(scope), nil)
+          bound_value = Puppet::Pops::Lookup.search_and_merge(_("#{rtype.name}::#{param}"), Puppet::Pops::Lookup::Invocation.new(scope), nil)
           # Assign bound value but don't let an undef trump a default expression
           unless bound_value.nil? && !default.nil?
             self[param.to_sym] = bound_value
@@ -551,13 +551,13 @@ class Puppet::Resource
   # @deprecated Not used by Puppet
   # @api private
   def validate_complete
-    Puppet.deprecation_warning('The method Puppet::Resource.validate_complete is deprecated and will be removed in the next major release of Puppet.')
+    Puppet.deprecation_warning(_('The method Puppet::Resource.validate_complete is deprecated and will be removed in the next major release of Puppet.'))
 
     return unless resource_type and resource_type.respond_to?(:arguments)
 
     resource_type.arguments.each do |param, default|
       param = param.to_sym
-      fail Puppet::ParseError, "Must pass #{param} to #{self}" unless parameters.include?(param)
+      fail Puppet::ParseError, _("Must pass #{param} to #{self}") unless parameters.include?(param)
     end
 
     # Perform optional type checking
@@ -568,13 +568,13 @@ class Puppet::Resource
       unless Puppet::Pops::Types::TypeCalculator.instance?(t, value.value)
         inferred_type = Puppet::Pops::Types::TypeCalculator.infer_set(value.value)
         actual = inferred_type.generalize()
-        fail Puppet::ParseError, "Expected parameter '#{name}' of '#{self}' to have type #{t.to_s}, got #{actual.to_s}"
+        fail Puppet::ParseError, _("Expected parameter '#{name}' of '#{self}' to have type #{t.to_s}, got #{actual.to_s}")
       end
     end
   end
 
   def validate_parameter(name)
-    raise Puppet::ParseError.new("no parameter named '#{name}'", file, line) unless valid_parameter?(name)
+    raise Puppet::ParseError.new(_("no parameter named '#{name}'"), file, line) unless valid_parameter?(name)
   end
 
   def prune_parameters(options = {})
@@ -678,7 +678,7 @@ class Puppet::Resource
       # If we've gotten this far, then none of the provided title patterns
       # matched. Since there's no way to determine the title then the
       # resource should fail here.
-      raise Puppet::Error, "No set of title patterns matched the title \"#{title}\"."
+      raise Puppet::Error, _("No set of title patterns matched the title \"#{title}\".")
     else
       return { :name => title.to_s }
     end

--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -74,7 +74,7 @@ module Puppet::Resource::CapabilityFinder
             ['=', 'code_id', code_id]]]]
     end
 
-    Puppet.notice _("Looking up capability #{cap} in PuppetDB: #{query_terms}")
+    Puppet.notice _("Looking up capability %{cap} in PuppetDB: %{query_terms}") % { cap: cap, query_terms: query_terms }
 
     query_puppetdb(query_terms)
   end

--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -74,7 +74,7 @@ module Puppet::Resource::CapabilityFinder
             ['=', 'code_id', code_id]]]]
     end
 
-    Puppet.notice "Looking up capability #{cap} in PuppetDB: #{query_terms}"
+    Puppet.notice _("Looking up capability #{cap} in PuppetDB: #{query_terms}")
 
     query_puppetdb(query_terms)
   end

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -186,7 +186,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       return if existing == resource
       resource_declaration = " at #{resource.file}:#{resource.line}" if resource.file and resource.line
       existing_declaration = " at #{existing.file}:#{existing.line}" if existing.file and existing.line
-      msg = "Cannot alias #{ref} to #{key.inspect}#{resource_declaration}; resource #{newref.inspect} already declared#{existing_declaration}"
+      msg = _("Cannot alias #{ref} to #{key.inspect}#{resource_declaration}; resource #{newref.inspect} already declared#{existing_declaration}")
       raise ArgumentError, msg
     end
     @resource_table[newref] = resource
@@ -547,7 +547,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       f.puts classes.join("\n")
     end
   rescue => detail
-    Puppet.err "Could not create class file #{Puppet[:classfile]}: #{detail}"
+    Puppet.err _("Could not create class file #{Puppet[:classfile]}: #{detail}")
   end
 
   # Store the list of resources we manage
@@ -567,7 +567,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       f.puts to_print.join("\n")
     end
   rescue => detail
-    Puppet.err "Could not create resource file #{Puppet[:resourcefile]}: #{detail}"
+    Puppet.err _("Could not create resource file #{Puppet[:resourcefile]}: #{detail}")
   end
 
   # Produce the graph files if requested.

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -186,7 +186,8 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       return if existing == resource
       resource_declaration = " at #{resource.file}:#{resource.line}" if resource.file and resource.line
       existing_declaration = " at #{existing.file}:#{existing.line}" if existing.file and existing.line
-      msg = _("Cannot alias #{ref} to #{key.inspect}#{resource_declaration}; resource #{newref.inspect} already declared#{existing_declaration}")
+      #TRANSLATORS "resource" here is a Puppet type and should not be translated
+      msg = _("Cannot alias %{ref} to %{key}%{resource_declaration}; resource %{newref} already declared%{existing_declaration}") % { ref: ref, key: key.inspect, resource_declaration: resource_declaration, newref: newref.inspect, existing_declaration: existing_declaration }
       raise ArgumentError, msg
     end
     @resource_table[newref] = resource
@@ -547,7 +548,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       f.puts classes.join("\n")
     end
   rescue => detail
-    Puppet.err _("Could not create class file #{Puppet[:classfile]}: #{detail}")
+    Puppet.err _("Could not create class file %{file}: %{detail}") % { file: Puppet[:classfile], detail: detail }
   end
 
   # Store the list of resources we manage
@@ -567,7 +568,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       f.puts to_print.join("\n")
     end
   rescue => detail
-    Puppet.err _("Could not create resource file #{Puppet[:resourcefile]}: #{detail}")
+    Puppet.err _("Could not create resource file %{file}: %{detail}") % { file: Puppet[:resourcefile], detail: detail }
   end
 
   # Produce the graph files if requested.

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -140,7 +140,7 @@ module Puppet
       end
 
       def failed_because(detail)
-        @real_resource.log_exception(detail, "Could not evaluate: #{detail}")
+        @real_resource.log_exception(detail, _("Could not evaluate: #{detail}"))
         failed = true
         # There's a contract (implicit unfortunately) that a status of failed
         # will always be accompanied by an event with some explanatory power.  This

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -140,7 +140,7 @@ module Puppet
       end
 
       def failed_because(detail)
-        @real_resource.log_exception(detail, _("Could not evaluate: #{detail}"))
+        @real_resource.log_exception(detail, _("Could not evaluate: %{detail}") % { detail: detail })
         failed = true
         # There's a contract (implicit unfortunately) that a status of failed
         # will always be accompanied by an event with some explanatory power.  This

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -123,12 +123,12 @@ class Puppet::Resource::Type
 
     resource.export.map do |ex|
       # Assert that the ref really is a resource reference
-      raise Puppet::Error, "Invalid export in #{resource.ref}: #{ex} is not a resource" unless ex.is_a?(Puppet::Resource)
-      raise Puppet::Error, "Invalid export in #{resource.ref}: #{ex} is not a capability resource" if ex.resource_type.nil? || !ex.resource_type.is_capability?
+      raise Puppet::Error, _("Invalid export in #{resource.ref}: #{ex} is not a resource") unless ex.is_a?(Puppet::Resource)
+      raise Puppet::Error, _("Invalid export in #{resource.ref}: #{ex} is not a capability resource") if ex.resource_type.nil? || !ex.resource_type.is_capability?
 
       blueprint = produces.find { |pr| pr[:capability] == ex.type }
       if blueprint.nil?
-        raise Puppet::ParseError, "Resource type #{resource.type} does not produce #{ex.type}"
+        raise Puppet::ParseError, _("Resource type #{resource.type} does not produce #{ex.type}")
       end
       t = ex.type
       t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
@@ -235,12 +235,12 @@ class Puppet::Resource::Type
 
   # Add code from a new instance to our code.
   def merge(other)
-    fail "#{name} is not a class; cannot add code to it" unless type == :hostclass
-    fail "#{other.name} is not a class; cannot add code from it" unless other.type == :hostclass
-    fail "Cannot have code outside of a class/node/define because 'freeze_main' is enabled" if name == "" and Puppet.settings[:freeze_main]
+    fail _("#{name} is not a class; cannot add code to it") unless type == :hostclass
+    fail _("#{other.name} is not a class; cannot add code from it") unless other.type == :hostclass
+    fail _("Cannot have code outside of a class/node/define because 'freeze_main' is enabled") if name == "" and Puppet.settings[:freeze_main]
 
     if parent and other.parent and parent != other.parent
-      fail "Cannot merge classes with different parent classes (#{name} => #{parent} vs. #{other.name} => #{other.parent})"
+      fail _("Cannot merge classes with different parent classes (#{name} => #{parent} vs. #{other.name} => #{other.parent})")
     end
 
     # We know they're either equal or only one is set, so keep whichever parent is specified.
@@ -325,7 +325,7 @@ class Puppet::Resource::Type
   # @deprecated Not used by Puppet
   # @api private
   def assign_parameter_values(parameters, resource)
-    Puppet.deprecation_warning('The method Puppet::Resource::Type.assign_parameter_values is deprecated and will be removed in the next major release of Puppet.')
+    Puppet.deprecation_warning(_('The method Puppet::Resource::Type.assign_parameter_values is deprecated and will be removed in the next major release of Puppet.'))
 
     return unless parameters
 
@@ -341,7 +341,7 @@ class Puppet::Resource::Type
     return nil unless parent
 
     @parent_type ||= scope.environment.known_resource_types.send("find_#{type}", parent) ||
-      fail(Puppet::ParseError, "Could not find parent resource type '#{parent}' of type #{type} in #{scope.environment}")
+      fail(Puppet::ParseError, _("Could not find parent resource type '#{parent}' of type #{type} in #{scope.environment}"))
   end
 
   # Validate and set any arguments passed by the resource as variables in the scope.
@@ -398,7 +398,7 @@ class Puppet::Resource::Type
       param = parameters[sym_name]
       next unless param.nil? || param.value.nil?
       catch(:no_such_key) do
-        bound_value = Puppet::Pops::Lookup.search_and_merge("#{name}::#{param_name}", Puppet::Pops::Lookup::Invocation.new(scope), nil)
+        bound_value = Puppet::Pops::Lookup.search_and_merge(_("#{name}::#{param_name}"), Puppet::Pops::Lookup::Invocation.new(scope), nil)
         # Assign bound value but don't let an undef trump a default expression
         resource[sym_name] = bound_value unless bound_value.nil? && !default.nil?
       end
@@ -532,9 +532,9 @@ class Puppet::Resource::Type
     return unless Puppet::Type.metaparamclass(param)
 
     if default
-      warnonce "#{param} is a metaparam; this value will inherit to all contained resources in the #{self.name} definition"
+      warnonce _("#{param} is a metaparam; this value will inherit to all contained resources in the #{self.name} definition")
     else
-      raise Puppet::ParseError, "#{param} is a metaparameter; please choose another parameter name in the #{self.name} definition"
+      raise Puppet::ParseError, _("#{param} is a metaparameter; please choose another parameter name in the #{self.name} definition")
     end
   end
 

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -67,9 +67,9 @@ class Puppet::Resource::TypeCollection
 
   def add_hostclass(instance)
     handle_hostclass_merge(instance)
-    dupe_check(instance, @hostclasses) { |dupe| "Class '#{instance.name}' is already defined#{dupe.error_context}; cannot redefine" }
-    dupe_check(instance, @definitions) { |dupe| "Definition '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined as a class" }
-    dupe_check(instance, @applications) { |dupe| "Application '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined as a class" }
+    dupe_check(instance, @hostclasses) { |dupe| _("Class '#{instance.name}' is already defined#{dupe.error_context}; cannot redefine") }
+    dupe_check(instance, @definitions) { |dupe| _("Definition '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined as a class") }
+    dupe_check(instance, @applications) { |dupe| _("Application '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined as a class") }
 
     @hostclasses[instance.name] = instance
     instance
@@ -100,7 +100,7 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_node(instance)
-    dupe_check(instance, @nodes) { |dupe| "Node '#{instance.name}' is already defined#{dupe.error_context}; cannot redefine" }
+    dupe_check(instance, @nodes) { |dupe| _("Node '#{instance.name}' is already defined#{dupe.error_context}; cannot redefine") }
 
     @node_list << instance
     @nodes[instance.name] = instance
@@ -108,7 +108,7 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_site(instance)
-    dupe_check_singleton(instance, @sites) { |dupe| "Site is already defined#{dupe.error_context}; cannot redefine" }
+    dupe_check_singleton(instance, @sites) { |dupe| _("Site is already defined#{dupe.error_context}; cannot redefine") }
     @sites << instance
     instance
   end
@@ -144,14 +144,14 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_definition(instance)
-    dupe_check(instance, @hostclasses) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a definition" }
-    dupe_check(instance, @definitions) { |dupe| "Definition '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined" }
-    dupe_check(instance, @applications) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as an application; cannot be redefined" }
+    dupe_check(instance, @hostclasses) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a definition") }
+    dupe_check(instance, @definitions) { |dupe| _("Definition '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined") }
+    dupe_check(instance, @applications) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as an application; cannot be redefined") }
     @definitions[instance.name] = instance
   end
 
   def add_capability_mapping(instance)
-    dupe_check(instance, @capability_mappings) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a mapping" }
+    dupe_check(instance, @capability_mappings) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a mapping") }
     @capability_mappings[instance.name] = instance
   end
 
@@ -160,9 +160,9 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_application(instance)
-    dupe_check(instance, @hostclasses) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as an application" }
-    dupe_check(instance, @definitions) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as a definition; cannot redefine as an application" }
-    dupe_check(instance, @applications) { |dupe| "'#{instance.name}' is already defined#{dupe.error_context} as an application; cannot be redefined" }
+    dupe_check(instance, @hostclasses) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as an application") }
+    dupe_check(instance, @definitions) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a definition; cannot redefine as an application") }
+    dupe_check(instance, @applications) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as an application; cannot be redefined") }
     @applications[instance.name] = instance
   end
 
@@ -214,7 +214,7 @@ class Puppet::Resource::TypeCollection
 
     @version
   rescue Puppet::ExecutionFailure => e
-    raise Puppet::ParseError, "Execution of config_version command `#{environment.config_version}` failed: #{e.message}", e.backtrace
+    raise Puppet::ParseError, _("Execution of config_version command `#{environment.config_version}` failed: #{e.message}"), e.backtrace
   end
 
   private
@@ -234,7 +234,7 @@ class Puppet::Resource::TypeCollection
         # as this is a time consuming operation. Warn the user.
         # Check first if debugging is on since the call to debug_once is expensive
         if Puppet[:debug]
-          debug_once "Not attempting to load #{type} #{fqname} as this object was missing during a prior compilation"
+          debug_once _("Not attempting to load #{type} #{fqname} as this object was missing during a prior compilation")
         end
       else
         result = loader.try_load_fqname(type, fqname)

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -67,9 +67,9 @@ class Puppet::Resource::TypeCollection
 
   def add_hostclass(instance)
     handle_hostclass_merge(instance)
-    dupe_check(instance, @hostclasses) { |dupe| _("Class '#{instance.name}' is already defined#{dupe.error_context}; cannot redefine") }
-    dupe_check(instance, @definitions) { |dupe| _("Definition '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined as a class") }
-    dupe_check(instance, @applications) { |dupe| _("Application '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined as a class") }
+    dupe_check(instance, @hostclasses) { |dupe| _("Class '%{klass}' is already defined%{error}; cannot redefine") % { klass: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @definitions) { |dupe| _("Definition '%{klass}' is already defined%{error}; cannot be redefined as a class") % { klass: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @applications) { |dupe| _("Application '%{klass}' is already defined%{error}; cannot be redefined as a class") % { klass: instance.name, error: dupe.error_context } }
 
     @hostclasses[instance.name] = instance
     instance
@@ -100,7 +100,7 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_node(instance)
-    dupe_check(instance, @nodes) { |dupe| _("Node '#{instance.name}' is already defined#{dupe.error_context}; cannot redefine") }
+    dupe_check(instance, @nodes) { |dupe| _("Node '%{name}' is already defined%{error}; cannot redefine") % { name: instance.name, error: dupe.error_context } }
 
     @node_list << instance
     @nodes[instance.name] = instance
@@ -108,7 +108,7 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_site(instance)
-    dupe_check_singleton(instance, @sites) { |dupe| _("Site is already defined#{dupe.error_context}; cannot redefine") }
+    dupe_check_singleton(instance, @sites) { |dupe| _("Site is already defined%{error}; cannot redefine") % { error: dupe.error_context } }
     @sites << instance
     instance
   end
@@ -144,14 +144,14 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_definition(instance)
-    dupe_check(instance, @hostclasses) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a definition") }
-    dupe_check(instance, @definitions) { |dupe| _("Definition '#{instance.name}' is already defined#{dupe.error_context}; cannot be redefined") }
-    dupe_check(instance, @applications) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as an application; cannot be redefined") }
+    dupe_check(instance, @hostclasses) { |dupe| _("'%{name}' is already defined%{error} as a class; cannot redefine as a definition") % { name: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @definitions) { |dupe| _("Definition '%{name}' is already defined%{error}; cannot be redefined") % { name: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @applications) { |dupe| _("'%{name}' is already defined%{error} as an application; cannot be redefined") % { name: instance.name, error: dupe.error_context } }
     @definitions[instance.name] = instance
   end
 
   def add_capability_mapping(instance)
-    dupe_check(instance, @capability_mappings) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as a mapping") }
+    dupe_check(instance, @capability_mappings) { |dupe| _("'%{name}' is already defined%{error} as a class; cannot redefine as a mapping") % { name: instance.name, error: dupe.error_context } }
     @capability_mappings[instance.name] = instance
   end
 
@@ -160,9 +160,9 @@ class Puppet::Resource::TypeCollection
   end
 
   def add_application(instance)
-    dupe_check(instance, @hostclasses) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a class; cannot redefine as an application") }
-    dupe_check(instance, @definitions) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as a definition; cannot redefine as an application") }
-    dupe_check(instance, @applications) { |dupe| _("'#{instance.name}' is already defined#{dupe.error_context} as an application; cannot be redefined") }
+    dupe_check(instance, @hostclasses) { |dupe| _("'%{name}' is already defined%{error} as a class; cannot redefine as an application") % { name: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @definitions) { |dupe| _("'%{name}' is already defined%{error} as a definition; cannot redefine as an application") % { name: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @applications) { |dupe| _("'%{name}' is already defined%{error} as an application; cannot be redefined") % { name: instance.name, error: dupe.error_context } }
     @applications[instance.name] = instance
   end
 
@@ -214,7 +214,7 @@ class Puppet::Resource::TypeCollection
 
     @version
   rescue Puppet::ExecutionFailure => e
-    raise Puppet::ParseError, _("Execution of config_version command `#{environment.config_version}` failed: #{e.message}"), e.backtrace
+    raise Puppet::ParseError, _("Execution of config_version command `%{cmd}` failed: %{message}") % { cmd: environment.config_version, message: e.message }, e.backtrace
   end
 
   private
@@ -234,7 +234,7 @@ class Puppet::Resource::TypeCollection
         # as this is a time consuming operation. Warn the user.
         # Check first if debugging is on since the call to debug_once is expensive
         if Puppet[:debug]
-          debug_once _("Not attempting to load #{type} #{fqname} as this object was missing during a prior compilation")
+          debug_once _("Not attempting to load %{type} %{fqname} as this object was missing during a prior compilation") % { type: type, fqname: fqname }
         end
       else
         result = loader.try_load_fqname(type, fqname)


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/resource.rb` and `lib/puppet/resource/*` for translation.