### PR TITLE
(PUP-7042) Mark strings in provider

### DIFF
--- a/lib/puppet/provider/aixobject.rb
+++ b/lib/puppet/provider/aixobject.rb
@@ -317,7 +317,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
     begin
       execute(self.addcmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, _("Could not create #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not create %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
     end
   end
 
@@ -332,7 +332,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
     begin
       execute(self.deletecmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, _("Could not delete #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not delete %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
     end
   end
 
@@ -365,7 +365,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
 
     if getinfo().nil?
       # This is weird...
-      raise Puppet::Error, _("Trying to update parameter '#{param}' to '#{value}' for a resource that does not exists #{@resource.class.name} #{@resource.name}: #{detail}")
+      raise Puppet::Error, _("Trying to update parameter '%{param}' to '%{value}' for a resource that does not exists %{resource} %{name}: %{detail}") % { param: param, value: value, resource: @resource.class.name, name: @resource.name, detail: detail }
     end
     if value == getinfo()[param.to_sym]
       return
@@ -376,7 +376,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail
-        raise Puppet::Error, _("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"), detail.backtrace
+        raise Puppet::Error, _("Could not set %{param} on %{resource}[%{name}]: %{detail}") % { param: param, resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
       end
     end
 

--- a/lib/puppet/provider/aixobject.rb
+++ b/lib/puppet/provider/aixobject.rb
@@ -166,7 +166,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
         (key_str, val) = i.split('=')
         # Check the key
         if key_str.nil? or key_str.empty?
-          info "Empty key in string 'i'?"
+          info _("Empty key in string 'i'?")
           continue
         end
         key_str.strip!
@@ -309,7 +309,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
   # Create a new instance of the resource
   def create
     if exists?
-      info "already exists"
+      info _("already exists")
       # The object already exists
       return nil
     end
@@ -317,14 +317,14 @@ class Puppet::Provider::AixObject < Puppet::Provider
     begin
       execute(self.addcmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not create #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not create #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
     end
   end
 
   # Delete this instance of the resource
   def delete
     unless exists?
-      info "already absent"
+      info _("already absent")
       # the object already doesn't exist
       return nil
     end
@@ -332,7 +332,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
     begin
       execute(self.deletecmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not delete #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not delete #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
     end
   end
 
@@ -365,7 +365,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
 
     if getinfo().nil?
       # This is weird...
-      raise Puppet::Error, "Trying to update parameter '#{param}' to '#{value}' for a resource that does not exists #{@resource.class.name} #{@resource.name}: #{detail}"
+      raise Puppet::Error, _("Trying to update parameter '#{param}' to '#{value}' for a resource that does not exists #{@resource.class.name} #{@resource.name}: #{detail}")
     end
     if value == getinfo()[param.to_sym]
       return
@@ -376,7 +376,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail
-        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
+        raise Puppet::Error, _("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"), detail.backtrace
       end
     end
 

--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       sc = StringScanner.new(line)
       cmd = sc.scan(/\w+|==|!=/)
       formals = COMMANDS[cmd]
-      fail(_("Unknown command #{cmd}")) unless formals
+      fail(_("Unknown command %{cmd}") % { cmd: cmd }) unless formals
       argline << cmd
       narg = 0
       formals.each do |f|
@@ -107,7 +107,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             len = sc.pos - start
             len -= 1 unless sc.eos?
           unless p = sc.string[start, len]
-            fail(_("missing path argument #{narg} for #{cmd}"))
+            fail(_("missing path argument %{narg} for %{cmd}") % { narg: narg, cmd: cmd })
           end
           # Rip off any ticks if they are there.
           p = p[1, (p.size - 2)] if p[0,1] == "'" || p[0,1] == "\""
@@ -126,12 +126,12 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           else
             argline << sc.scan(/[^\s]+/)
           end
-          fail(_("missing string argument #{narg} for #{cmd}")) unless argline[-1]
+          fail(_("missing string argument %{narg} for %{cmd}") % { narg: narg, cmd: cmd }) unless argline[-1]
         elsif f == :comparator
           argline << sc.scan(/(==|!=|=~|<=|>=|<|>)/)
           unless argline[-1]
             puts sc.rest
-            fail(_("invalid comparator for command #{cmd}"))
+            fail(_("invalid comparator for command %{cmd}") % { cmd: cmd })
           end
         elsif f == :int
           argline << sc.scan(/\d+/).to_i
@@ -219,7 +219,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     return_value = false
 
     #validate and tear apart the command
-    fail (_("Invalid command: #{cmd_array.join(" ")}")) if cmd_array.length < 4
+    fail (_("Invalid command: %{cmd}") % { cmd: cmd_array.join(" ") }) if cmd_array.length < 4
     cmd = cmd_array.shift
     path = cmd_array.shift
     comparator = cmd_array.shift
@@ -250,7 +250,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     return_value = false
 
     #validate and tear apart the command
-    fail(_("Invalid command: #{cmd_array.join(" ")}")) if cmd_array.length < 3
+    fail(_("Invalid command: %{cmd}") % { cmd: cmd_array.join(" ") }) if cmd_array.length < 3
     cmd = cmd_array.shift
     path = cmd_array.shift
 
@@ -260,7 +260,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
     #Get the match paths from augeas
     result = @aug.match(path) || []
-    fail(_("Error trying to get path '#{path}'")) if (result == -1)
+    fail(_("Error trying to get path '%{path}'") % { path: path }) if (result == -1)
 
     #Get the values of the match paths from augeas
     values = result.collect{|r| @aug.get(r)}
@@ -278,7 +278,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (values == new_array)
       rescue
-        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
+        fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
       end
     when "!="
       begin
@@ -286,7 +286,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (values != new_array)
       rescue
-        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
+        fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
       end
     end
     !!return_value
@@ -298,7 +298,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     return_value = false
 
     #validate and tear apart the command
-    fail(_("Invalid command: #{cmd_array.join(" ")}")) if cmd_array.length < 3
+    fail(_("Invalid command: %{cmd}") % { cmd: cmd_array.join(" ") }) if cmd_array.length < 3
     cmd = cmd_array.shift
     path = cmd_array.shift
 
@@ -308,12 +308,12 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
     #Get the values from augeas
     result = @aug.match(path) || []
-    fail(_("Error trying to match path '#{path}'")) if (result == -1)
+    fail(_("Error trying to match path '%{path}'") % { path: path }) if (result == -1)
 
     # Now do the work
     case verb
     when "size"
-      fail(_("Invalid command: #{cmd_array.join(" ")}")) if clause_array.length != 2
+      fail(_("Invalid command: %{cmd}") % { cmd: cmd_array.join(" ") }) if clause_array.length != 2
       comparator = clause_array.shift
       arg = clause_array.shift
       case comparator
@@ -334,7 +334,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (result == new_array)
       rescue
-        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
+        fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
       end
     when "!="
       begin
@@ -342,7 +342,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (result != new_array)
       rescue
-        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
+        fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
       end
     end
     !!return_value
@@ -420,7 +420,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           when "match"; return_value = process_match(cmd_array)
           end
         rescue StandardError => e
-          fail(_("Error sending command '#{command}' with params #{cmd_array[1..-1].inspect}/#{e.message}"))
+          fail(_("Error sending command '%{command}' with params %{param}/%{message}") % { command: command, param: cmd_array[1..-1].inspect, message: e.message })
         end
       end
 
@@ -489,7 +489,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
   def do_execute_changes
     commands = parse_commands(resource[:changes])
     commands.each do |cmd_array|
-      fail(_("invalid command #{cmd_array.join[" "]}")) if cmd_array.length < 2
+      fail(_("invalid command %{cmd}") % { value0: cmd_array.join[" "] }) if cmd_array.length < 2
       command = cmd_array[0]
       cmd_array.shift
       begin
@@ -497,37 +497,37 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           when "set"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.set(cmd_array[0], cmd_array[1])
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (!rv)
           when "setm"
             if aug.respond_to?(command)
               debug("sending command '#{command}' with params #{cmd_array.inspect}")
               rv = aug.setm(cmd_array[0], cmd_array[1], cmd_array[2])
-              fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
+              fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (rv == -1)
             else
-              fail(_("command '#{command}' not supported in installed version of ruby-augeas"))
+              fail(_("command '%{command}' not supported in installed version of ruby-augeas") % { command: command })
             end
           when "rm", "remove"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.rm(cmd_array[0])
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (rv == -1)
           when "clear"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.clear(cmd_array[0])
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (!rv)
           when "clearm"
             # Check command exists ... doesn't currently in ruby-augeas 0.4.1
             if aug.respond_to?(command)
               debug("sending command '#{command}' with params #{cmd_array.inspect}")
               rv = aug.clearm(cmd_array[0], cmd_array[1])
-              fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
+              fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (!rv)
             else
-              fail(_("command '#{command}' not supported in installed version of ruby-augeas"))
+              fail(_("command '%{command}' not supported in installed version of ruby-augeas") % { command: command })
             end
           when "touch"
             debug("sending command '#{command}' (match, set) with params #{cmd_array.inspect}")
             if aug.match(cmd_array[0]).empty?
               rv = aug.clear(cmd_array[0])
-              fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
+              fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (!rv)
             end
           when "insert", "ins"
             label = cmd_array[0]
@@ -536,31 +536,31 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             case where
               when "before"; before = true
               when "after"; before = false
-              else fail(_("Invalid value '#{where}' for where param"))
+              else fail(_("Invalid value '%{where}' for where param") % { where: where })
             end
             debug("sending command '#{command}' with params #{[label, where, path].inspect}")
             rv = aug.insert(path, label, before)
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (rv == -1)
           when "defvar"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.defvar(cmd_array[0], cmd_array[1])
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (!rv)
           when "defnode"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.defnode(cmd_array[0], cmd_array[1], cmd_array[2])
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (!rv)
           when "mv", "move"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.mv(cmd_array[0], cmd_array[1])
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (rv == -1)
           when "rename"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.rename(cmd_array[0], cmd_array[1])
-            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
-          else fail(_("Command '#{command}' is not supported"))
+            fail(_("Error sending command '%{command}' with params %{params}") % { command: command, params: cmd_array.inspect }) if (rv == -1)
+          else fail(_("Command '%{command}' is not supported") % { command: command })
         end
       rescue StandardError => e
-        fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}/#{e.message}"))
+        fail(_("Error sending command '%{command}' with params %{params}/%{message}") % { command: command, params: cmd_array.inspect, message: e.message })
       end
     end
   end

--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       sc = StringScanner.new(line)
       cmd = sc.scan(/\w+|==|!=/)
       formals = COMMANDS[cmd]
-      fail("Unknown command #{cmd}") unless formals
+      fail(_("Unknown command #{cmd}")) unless formals
       argline << cmd
       narg = 0
       formals.each do |f|
@@ -102,12 +102,12 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             nbracket -= 1 if ch == "]"
             inSingleTick = !inSingleTick if ch == "'"
             inDoubleTick = !inDoubleTick if ch == "\""
-            fail("unmatched [") if nbracket < 0
+            fail(_("unmatched [")) if nbracket < 0
           end until ((nbracket == 0 && !inSingleTick && !inDoubleTick && (ch =~ /\s/)) || sc.eos?)
             len = sc.pos - start
             len -= 1 unless sc.eos?
           unless p = sc.string[start, len]
-            fail("missing path argument #{narg} for #{cmd}")
+            fail(_("missing path argument #{narg} for #{cmd}"))
           end
           # Rip off any ticks if they are there.
           p = p[1, (p.size - 2)] if p[0,1] == "'" || p[0,1] == "\""
@@ -126,12 +126,12 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           else
             argline << sc.scan(/[^\s]+/)
           end
-          fail("missing string argument #{narg} for #{cmd}") unless argline[-1]
+          fail(_("missing string argument #{narg} for #{cmd}")) unless argline[-1]
         elsif f == :comparator
           argline << sc.scan(/(==|!=|=~|<=|>=|<|>)/)
           unless argline[-1]
             puts sc.rest
-            fail("invalid comparator for command #{cmd}")
+            fail(_("invalid comparator for command #{cmd}"))
           end
         elsif f == :int
           argline << sc.scan(/\d+/).to_i
@@ -219,7 +219,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     return_value = false
 
     #validate and tear apart the command
-    fail ("Invalid command: #{cmd_array.join(" ")}") if cmd_array.length < 4
+    fail (_("Invalid command: #{cmd_array.join(" ")}")) if cmd_array.length < 4
     cmd = cmd_array.shift
     path = cmd_array.shift
     comparator = cmd_array.shift
@@ -250,7 +250,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     return_value = false
 
     #validate and tear apart the command
-    fail("Invalid command: #{cmd_array.join(" ")}") if cmd_array.length < 3
+    fail(_("Invalid command: #{cmd_array.join(" ")}")) if cmd_array.length < 3
     cmd = cmd_array.shift
     path = cmd_array.shift
 
@@ -260,7 +260,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
     #Get the match paths from augeas
     result = @aug.match(path) || []
-    fail("Error trying to get path '#{path}'") if (result == -1)
+    fail(_("Error trying to get path '#{path}'")) if (result == -1)
 
     #Get the values of the match paths from augeas
     values = result.collect{|r| @aug.get(r)}
@@ -278,7 +278,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (values == new_array)
       rescue
-        fail("Invalid array in command: #{cmd_array.join(" ")}")
+        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
       end
     when "!="
       begin
@@ -286,7 +286,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (values != new_array)
       rescue
-        fail("Invalid array in command: #{cmd_array.join(" ")}")
+        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
       end
     end
     !!return_value
@@ -298,7 +298,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     return_value = false
 
     #validate and tear apart the command
-    fail("Invalid command: #{cmd_array.join(" ")}") if cmd_array.length < 3
+    fail(_("Invalid command: #{cmd_array.join(" ")}")) if cmd_array.length < 3
     cmd = cmd_array.shift
     path = cmd_array.shift
 
@@ -308,12 +308,12 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
     #Get the values from augeas
     result = @aug.match(path) || []
-    fail("Error trying to match path '#{path}'") if (result == -1)
+    fail(_("Error trying to match path '#{path}'")) if (result == -1)
 
     # Now do the work
     case verb
     when "size"
-      fail("Invalid command: #{cmd_array.join(" ")}") if clause_array.length != 2
+      fail(_("Invalid command: #{cmd_array.join(" ")}")) if clause_array.length != 2
       comparator = clause_array.shift
       arg = clause_array.shift
       case comparator
@@ -334,7 +334,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (result == new_array)
       rescue
-        fail("Invalid array in command: #{cmd_array.join(" ")}")
+        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
       end
     when "!="
       begin
@@ -342,7 +342,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
         new_array = eval arg
         return_value = (result != new_array)
       rescue
-        fail("Invalid array in command: #{cmd_array.join(" ")}")
+        fail(_("Invalid array in command: #{cmd_array.join(" ")}"))
       end
     end
     !!return_value
@@ -378,7 +378,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     errors = @aug.match("/augeas//error")
     unless errors.empty?
       if path && !@aug.match(path).empty?
-        warning("Loading failed for one or more files, see debug for /augeas//error output")
+        warning(_("Loading failed for one or more files, see debug for /augeas//error output"))
       else
         debug("Loading failed for one or more files, output from /augeas//error:")
       end
@@ -420,7 +420,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           when "match"; return_value = process_match(cmd_array)
           end
         rescue StandardError => e
-          fail("Error sending command '#{command}' with params #{cmd_array[1..-1].inspect}/#{e.message}")
+          fail(_("Error sending command '#{command}' with params #{cmd_array[1..-1].inspect}/#{e.message}"))
         end
       end
 
@@ -435,7 +435,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           save_result = @aug.save
           unless save_result
             print_put_errors
-            fail("Saving failed, see debug")
+            fail(_("Saving failed, see debug"))
           end
 
           saved_files = @aug.match("/augeas/events/saved")
@@ -477,7 +477,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     do_execute_changes
     unless @aug.save
       print_put_errors
-      fail("Save failed, see debug")
+      fail(_("Save failed, see debug"))
     end
 
     :executed
@@ -489,7 +489,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
   def do_execute_changes
     commands = parse_commands(resource[:changes])
     commands.each do |cmd_array|
-      fail("invalid command #{cmd_array.join[" "]}") if cmd_array.length < 2
+      fail(_("invalid command #{cmd_array.join[" "]}")) if cmd_array.length < 2
       command = cmd_array[0]
       cmd_array.shift
       begin
@@ -497,37 +497,37 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           when "set"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.set(cmd_array[0], cmd_array[1])
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
           when "setm"
             if aug.respond_to?(command)
               debug("sending command '#{command}' with params #{cmd_array.inspect}")
               rv = aug.setm(cmd_array[0], cmd_array[1], cmd_array[2])
-              fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (rv == -1)
+              fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
             else
-              fail("command '#{command}' not supported in installed version of ruby-augeas")
+              fail(_("command '#{command}' not supported in installed version of ruby-augeas"))
             end
           when "rm", "remove"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.rm(cmd_array[0])
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (rv == -1)
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
           when "clear"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.clear(cmd_array[0])
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
           when "clearm"
             # Check command exists ... doesn't currently in ruby-augeas 0.4.1
             if aug.respond_to?(command)
               debug("sending command '#{command}' with params #{cmd_array.inspect}")
               rv = aug.clearm(cmd_array[0], cmd_array[1])
-              fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
+              fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
             else
-              fail("command '#{command}' not supported in installed version of ruby-augeas")
+              fail(_("command '#{command}' not supported in installed version of ruby-augeas"))
             end
           when "touch"
             debug("sending command '#{command}' (match, set) with params #{cmd_array.inspect}")
             if aug.match(cmd_array[0]).empty?
               rv = aug.clear(cmd_array[0])
-              fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
+              fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
             end
           when "insert", "ins"
             label = cmd_array[0]
@@ -536,31 +536,31 @@ Puppet::Type.type(:augeas).provide(:augeas) do
             case where
               when "before"; before = true
               when "after"; before = false
-              else fail("Invalid value '#{where}' for where param")
+              else fail(_("Invalid value '#{where}' for where param"))
             end
             debug("sending command '#{command}' with params #{[label, where, path].inspect}")
             rv = aug.insert(path, label, before)
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (rv == -1)
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
           when "defvar"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.defvar(cmd_array[0], cmd_array[1])
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
           when "defnode"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.defnode(cmd_array[0], cmd_array[1], cmd_array[2])
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (!rv)
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (!rv)
           when "mv", "move"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.mv(cmd_array[0], cmd_array[1])
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (rv == -1)
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
           when "rename"
             debug("sending command '#{command}' with params #{cmd_array.inspect}")
             rv = aug.rename(cmd_array[0], cmd_array[1])
-            fail("Error sending command '#{command}' with params #{cmd_array.inspect}") if (rv == -1)
-          else fail("Command '#{command}' is not supported")
+            fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}")) if (rv == -1)
+          else fail(_("Command '#{command}' is not supported"))
         end
       rescue StandardError => e
-        fail("Error sending command '#{command}' with params #{cmd_array.inspect}/#{e.message}")
+        fail(_("Error sending command '#{command}' with params #{cmd_array.inspect}/#{e.message}"))
       end
     end
   end

--- a/lib/puppet/provider/command.rb
+++ b/lib/puppet/provider/command.rb
@@ -19,7 +19,7 @@ class Puppet::Provider::Command
   # @param args [Array<String>] Any command line arguments to pass to the executable
   # @return The output from the command
   def execute(*args)
-    resolved_executable = @resolver.which(@executable) or raise Puppet::MissingCommand, "Command #{@name} is missing"
+    resolved_executable = @resolver.which(@executable) or raise Puppet::MissingCommand, _("Command #{@name} is missing")
     @executor.execute([resolved_executable] + args, @options)
   end
 end

--- a/lib/puppet/provider/command.rb
+++ b/lib/puppet/provider/command.rb
@@ -19,7 +19,7 @@ class Puppet::Provider::Command
   # @param args [Array<String>] Any command line arguments to pass to the executable
   # @return The output from the command
   def execute(*args)
-    resolved_executable = @resolver.which(@executable) or raise Puppet::MissingCommand, _("Command #{@name} is missing")
+    resolved_executable = @resolver.which(@executable) or raise Puppet::MissingCommand, _("Command %{name} is missing") % { name: @name }
     @executor.execute([resolved_executable] + args, @options)
   end
 end

--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -48,7 +48,7 @@ Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFi
           end
         end
       else
-        raise Puppet::Error, "Line got parsed as a crontab entry but cannot be handled. Please file a bug with the contents of your crontab"
+        raise Puppet::Error, _("Line got parsed as a crontab entry but cannot be handled. Please file a bug with the contents of your crontab")
       end
       record
     end
@@ -93,7 +93,7 @@ Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFi
     if resource.should(:command) then
       super
     else
-      resource.err "no command specified, cannot create"
+      resource.err _("no command specified, cannot create")
     end
   end
 

--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -17,7 +17,7 @@ class Puppet::Provider::Exec < Puppet::Provider
         if check
           dir = nil
         else
-          self.fail _("Working directory '#{dir}' does not exist")
+          self.fail _("Working directory '%{dir}' does not exist") % { dir: dir }
         end
       end
     end
@@ -39,11 +39,11 @@ class Puppet::Provider::Exec < Puppet::Provider
               env_name = $1
               value = $2
               if environment.include?(env_name) || environment.include?(env_name.to_sym)
-                warning _("Overriding environment setting '#{env_name}' with '#{value}'")
+                warning _("Overriding environment setting '%{env_name}' with '%{value}'") % { env_name: env_name, value: value }
               end
               environment[env_name] = value
             else
-              warning _("Cannot understand environment setting #{setting.inspect}")
+              warning _("Cannot understand environment setting %{setting}") % { setting: setting.inspect }
             end
           end
         end
@@ -93,6 +93,6 @@ class Puppet::Provider::Exec < Puppet::Provider
   def validatecmd(command)
     exe = extractexe(command)
     # if we're not fully qualified, require a path
-    self.fail _("'#{command}' is not qualified and no path was specified. Please qualify the command or specify a path.") if !absolute_path?(exe) and resource[:path].nil?
+    self.fail _("'%{command}' is not qualified and no path was specified. Please qualify the command or specify a path.") % { command: command } if !absolute_path?(exe) and resource[:path].nil?
   end
 end

--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -17,7 +17,7 @@ class Puppet::Provider::Exec < Puppet::Provider
         if check
           dir = nil
         else
-          self.fail "Working directory '#{dir}' does not exist"
+          self.fail _("Working directory '#{dir}' does not exist")
         end
       end
     end
@@ -39,11 +39,11 @@ class Puppet::Provider::Exec < Puppet::Provider
               env_name = $1
               value = $2
               if environment.include?(env_name) || environment.include?(env_name.to_sym)
-                warning "Overriding environment setting '#{env_name}' with '#{value}'"
+                warning _("Overriding environment setting '#{env_name}' with '#{value}'")
               end
               environment[env_name] = value
             else
-              warning "Cannot understand environment setting #{setting.inspect}"
+              warning _("Cannot understand environment setting #{setting.inspect}")
             end
           end
         end
@@ -93,6 +93,6 @@ class Puppet::Provider::Exec < Puppet::Provider
   def validatecmd(command)
     exe = extractexe(command)
     # if we're not fully qualified, require a path
-    self.fail "'#{command}' is not qualified and no path was specified. Please qualify the command or specify a path." if !absolute_path?(exe) and resource[:path].nil?
+    self.fail _("'#{command}' is not qualified and no path was specified. Please qualify the command or specify a path.") if !absolute_path?(exe) and resource[:path].nil?
   end
 end

--- a/lib/puppet/provider/exec/posix.rb
+++ b/lib/puppet/provider/exec/posix.rb
@@ -18,11 +18,11 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
 
     if File.expand_path(exe) == exe
       if !Puppet::FileSystem.exist?(exe)
-        raise ArgumentError, "Could not find command '#{exe}'"
+        raise ArgumentError, _("Could not find command '#{exe}'")
       elsif !File.file?(exe)
-        raise ArgumentError, "'#{exe}' is a #{File.ftype(exe)}, not a file"
+        raise ArgumentError, _("'#{exe}' is a #{File.ftype(exe)}, not a file")
       elsif !File.executable?(exe)
-        raise ArgumentError, "'#{exe}' is not executable"
+        raise ArgumentError, _("'#{exe}' is not executable")
       end
       return
     end
@@ -35,7 +35,7 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
 
     # 'which' will only return the command if it's executable, so we can't
     # distinguish not found from not executable
-    raise ArgumentError, "Could not find command '#{exe}'"
+    raise ArgumentError, _("Could not find command '#{exe}'")
   end
 
   def run(command, check = false)

--- a/lib/puppet/provider/exec/posix.rb
+++ b/lib/puppet/provider/exec/posix.rb
@@ -18,11 +18,11 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
 
     if File.expand_path(exe) == exe
       if !Puppet::FileSystem.exist?(exe)
-        raise ArgumentError, _("Could not find command '#{exe}'")
+        raise ArgumentError, _("Could not find command '%{exe}'") % { exe: exe }
       elsif !File.file?(exe)
-        raise ArgumentError, _("'#{exe}' is a #{File.ftype(exe)}, not a file")
+        raise ArgumentError, _("'%{exe}' is a %{klass}, not a file") % { exe: exe, klass: File.ftype(exe) }
       elsif !File.executable?(exe)
-        raise ArgumentError, _("'#{exe}' is not executable")
+        raise ArgumentError, _("'%{exe}' is not executable") % { exe: exe }
       end
       return
     end
@@ -35,7 +35,7 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
 
     # 'which' will only return the command if it's executable, so we can't
     # distinguish not found from not executable
-    raise ArgumentError, _("Could not find command '#{exe}'")
+    raise ArgumentError, _("Could not find command '%{exe}'") % { exe: exe }
   end
 
   def run(command, check = false)

--- a/lib/puppet/provider/exec/windows.rb
+++ b/lib/puppet/provider/exec/windows.rb
@@ -37,9 +37,9 @@ Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
 
     if absolute_path?(exe)
       if !Puppet::FileSystem.exist?(exe)
-        raise ArgumentError, _("Could not find command '#{exe}'")
+        raise ArgumentError, _("Could not find command '%{exe}'") % { exe: exe }
       elsif !File.file?(exe)
-        raise ArgumentError, _("'#{exe}' is a #{File.ftype(exe)}, not a file")
+        raise ArgumentError, _("'%{exe}' is a %{klass}, not a file") % { exe: exe, klass: File.ftype(exe) }
       end
       return
     end
@@ -50,6 +50,6 @@ Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
       end
     end
 
-    raise ArgumentError, _("Could not find command '#{exe}'")
+    raise ArgumentError, _("Could not find command '%{exe}'") % { exe: exe }
   end
 end

--- a/lib/puppet/provider/exec/windows.rb
+++ b/lib/puppet/provider/exec/windows.rb
@@ -37,9 +37,9 @@ Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
 
     if absolute_path?(exe)
       if !Puppet::FileSystem.exist?(exe)
-        raise ArgumentError, "Could not find command '#{exe}'"
+        raise ArgumentError, _("Could not find command '#{exe}'")
       elsif !File.file?(exe)
-        raise ArgumentError, "'#{exe}' is a #{File.ftype(exe)}, not a file"
+        raise ArgumentError, _("'#{exe}' is a #{File.ftype(exe)}, not a file")
       end
       return
     end
@@ -50,6 +50,6 @@ Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
       end
     end
 
-    raise ArgumentError, "Could not find command '#{exe}'"
+    raise ArgumentError, _("Could not find command '#{exe}'")
   end
 end

--- a/lib/puppet/provider/file/posix.rb
+++ b/lib/puppet/provider/file/posix.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:file).provide :posix do
     # large UIDs instead of negative ones.  This isn't a Ruby bug,
     # it's an OS X bug, since it shows up in perl, too.
     if currentvalue > Puppet[:maximum_uid].to_i
-      self.warning "Apparently using negative UID (#{currentvalue}) on a platform that does not consistently handle them"
+      self.warning _("Apparently using negative UID (#{currentvalue}) on a platform that does not consistently handle them")
       currentvalue = :silly
     end
 
@@ -81,7 +81,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.send(method, should, nil, resource[:path])
     rescue => detail
-      raise Puppet::Error, "Failed to set owner to '#{should}': #{detail}", detail.backtrace
+      raise Puppet::Error, _("Failed to set owner to '#{should}': #{detail}"), detail.backtrace
     end
   end
 
@@ -94,7 +94,7 @@ Puppet::Type.type(:file).provide :posix do
     # large GIDs instead of negative ones.  This isn't a Ruby bug,
     # it's an OS X bug, since it shows up in perl, too.
     if currentvalue > Puppet[:maximum_uid].to_i
-      self.warning "Apparently using negative GID (#{currentvalue}) on a platform that does not consistently handle them"
+      self.warning _("Apparently using negative GID (#{currentvalue}) on a platform that does not consistently handle them")
       currentvalue = :silly
     end
 
@@ -112,7 +112,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.send(method, nil, should, resource[:path])
     rescue => detail
-      raise Puppet::Error, "Failed to set group to '#{should}': #{detail}", detail.backtrace
+      raise Puppet::Error, _("Failed to set group to '#{should}': #{detail}"), detail.backtrace
     end
   end
 
@@ -128,7 +128,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.chmod(value.to_i(8), resource[:path])
     rescue => detail
-      error = Puppet::Error.new("failed to set mode #{mode} on #{resource[:path]}: #{detail.message}")
+      error = Puppet::Error.new(_("failed to set mode #{mode} on #{resource[:path]}: #{detail.message}"))
       error.set_backtrace detail.backtrace
       raise error
     end

--- a/lib/puppet/provider/file/posix.rb
+++ b/lib/puppet/provider/file/posix.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:file).provide :posix do
     # large UIDs instead of negative ones.  This isn't a Ruby bug,
     # it's an OS X bug, since it shows up in perl, too.
     if currentvalue > Puppet[:maximum_uid].to_i
-      self.warning _("Apparently using negative UID (#{currentvalue}) on a platform that does not consistently handle them")
+      self.warning _("Apparently using negative UID (%{currentvalue}) on a platform that does not consistently handle them") % { currentvalue: currentvalue }
       currentvalue = :silly
     end
 
@@ -81,7 +81,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.send(method, should, nil, resource[:path])
     rescue => detail
-      raise Puppet::Error, _("Failed to set owner to '#{should}': #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Failed to set owner to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
     end
   end
 
@@ -94,7 +94,7 @@ Puppet::Type.type(:file).provide :posix do
     # large GIDs instead of negative ones.  This isn't a Ruby bug,
     # it's an OS X bug, since it shows up in perl, too.
     if currentvalue > Puppet[:maximum_uid].to_i
-      self.warning _("Apparently using negative GID (#{currentvalue}) on a platform that does not consistently handle them")
+      self.warning _("Apparently using negative GID (%{currentvalue}) on a platform that does not consistently handle them") % { currentvalue: currentvalue }
       currentvalue = :silly
     end
 
@@ -112,7 +112,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.send(method, nil, should, resource[:path])
     rescue => detail
-      raise Puppet::Error, _("Failed to set group to '#{should}': #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Failed to set group to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
     end
   end
 
@@ -128,7 +128,7 @@ Puppet::Type.type(:file).provide :posix do
     begin
       File.chmod(value.to_i(8), resource[:path])
     rescue => detail
-      error = Puppet::Error.new(_("failed to set mode #{mode} on #{resource[:path]}: #{detail.message}"))
+      error = Puppet::Error.new(_("failed to set mode %{mode} on %{path}: %{message}") % { mode: mode, path: resource[:path], message: detail.message })
       error.set_backtrace detail.backtrace
       raise error
     end

--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_owner(should, resolved_path)
     rescue => detail
-      raise Puppet::Error, _("Failed to set owner to '#{should}': #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Failed to set owner to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
     end
   end
 
@@ -56,7 +56,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_group(should, resolved_path)
     rescue => detail
-      raise Puppet::Error, _("Failed to set group to '#{should}': #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Failed to set group to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
     end
   end
 
@@ -73,7 +73,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_mode(value.to_i(8), resource[:path])
     rescue => detail
-      error = Puppet::Error.new(_("failed to set mode #{mode} on #{resource[:path]}: #{detail.message}"))
+      error = Puppet::Error.new(_("failed to set mode %{mode} on %{path}: %{message}") % { mode: mode, path: resource[:path], message: detail.message })
       error.set_backtrace detail.backtrace
       raise error
     end

--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_owner(should, resolved_path)
     rescue => detail
-      raise Puppet::Error, "Failed to set owner to '#{should}': #{detail}", detail.backtrace
+      raise Puppet::Error, _("Failed to set owner to '#{should}': #{detail}"), detail.backtrace
     end
   end
 
@@ -56,7 +56,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_group(should, resolved_path)
     rescue => detail
-      raise Puppet::Error, "Failed to set group to '#{should}': #{detail}", detail.backtrace
+      raise Puppet::Error, _("Failed to set group to '#{should}': #{detail}"), detail.backtrace
     end
   end
 
@@ -73,7 +73,7 @@ Puppet::Type.type(:file).provide :windows do
     begin
       set_mode(value.to_i(8), resource[:path])
     rescue => detail
-      error = Puppet::Error.new("failed to set mode #{mode} on #{resource[:path]}: #{detail.message}")
+      error = Puppet::Error.new(_("failed to set mode #{mode} on #{resource[:path]}: #{detail.message}"))
       error.set_backtrace detail.backtrace
       raise error
     end
@@ -82,7 +82,7 @@ Puppet::Type.type(:file).provide :windows do
 
   def validate
     if [:owner, :group, :mode].any?{|p| resource[p]} and !supports_acl?(resource[:path])
-      resource.fail("Can only manage owner, group, and mode on filesystems that support Windows ACLs, such as NTFS")
+      resource.fail(_("Can only manage owner, group, and mode on filesystems that support Windows ACLs, such as NTFS"))
     end
   end
 

--- a/lib/puppet/provider/group/aix.rb
+++ b/lib/puppet/provider/group/aix.rb
@@ -98,7 +98,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
   def get_arguments(key, value, mapping, objectinfo)
     # In the case of attributes, return a list of key=value
     if key == :attributes
-      raise Puppet::Error, "Attributes must be a list of pairs key=value on #{@resource.class.name}[#{@resource.name}]" \
+      raise Puppet::Error, _("Attributes must be a list of pairs key=value on #{@resource.class.name}[#{@resource.name}]") \
         unless value and value.is_a? Hash
       return value.select { |k,v| true }.map { |pair| pair.join("=") }
     end
@@ -127,7 +127,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail
-        raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
+        raise Puppet::Error, _("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"), detail.backtrace
       end
     end
   end

--- a/lib/puppet/provider/group/aix.rb
+++ b/lib/puppet/provider/group/aix.rb
@@ -98,7 +98,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
   def get_arguments(key, value, mapping, objectinfo)
     # In the case of attributes, return a list of key=value
     if key == :attributes
-      raise Puppet::Error, _("Attributes must be a list of pairs key=value on #{@resource.class.name}[#{@resource.name}]") \
+      raise Puppet::Error, _("Attributes must be a list of pairs key=value on %{resource}[%{name}]") % { resource: @resource.class.name, name: @resource.name } \
         unless value and value.is_a? Hash
       return value.select { |k,v| true }.map { |pair| pair.join("=") }
     end
@@ -127,7 +127,7 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
       begin
         execute(cmd)
       rescue Puppet::ExecutionFailure  => detail
-        raise Puppet::Error, _("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"), detail.backtrace
+        raise Puppet::Error, _("Could not set %{param} on %{resource}[%{name}]: %{detail}") % { param: param, resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
       end
     end
   end

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
 
   has_feature :system_groups unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
 
-  verify :gid, "GID must be an integer" do |value|
+  verify :gid, _("GID must be an integer") do |value|
     value.is_a? Integer
   end
 
@@ -56,7 +56,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     # using both useradd and luseradd
     if not @resource.allowdupe? and @resource.forcelocal?
        if @resource.should(:gid) and findgroup('gid', @resource.should(:gid).to_s)
-           raise(Puppet::Error, "GID #{@resource.should(:gid).to_s} already exists, use allowdupe to force group creation")
+           raise(Puppet::Error, _("GID #{@resource.should(:gid).to_s} already exists, use allowdupe to force group creation"))
        end
     elsif @resource.allowdupe? and not @resource.forcelocal?
        return ["-o"]

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -56,7 +56,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     # using both useradd and luseradd
     if not @resource.allowdupe? and @resource.forcelocal?
        if @resource.should(:gid) and findgroup('gid', @resource.should(:gid).to_s)
-           raise(Puppet::Error, _("GID #{@resource.should(:gid).to_s} already exists, use allowdupe to force group creation"))
+           raise(Puppet::Error, _("GID %{resource} already exists, use allowdupe to force group creation") % { resource: @resource.should(:gid).to_s })
        end
     elsif @resource.allowdupe? and not @resource.forcelocal?
        return ["-o"]

--- a/lib/puppet/provider/group/pw.rb
+++ b/lib/puppet/provider/group/pw.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
 
   options :members, :flag => "-M", :method => :mem
 
-  verify :gid, "GID must be an integer" do |value|
+  verify :gid, _("GID must be an integer") do |value|
     value.is_a? Integer
   end
 

--- a/lib/puppet/provider/host/parsed.rb
+++ b/lib/puppet/provider/host/parsed.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:host).provide(:parsed,:parent => Puppet::Provider::ParsedFile
     },
     :to_line  => proc { |hash|
       [:ip, :name].each do |n|
-        raise ArgumentError, "#{n} is a required attribute for hosts" unless hash[n] and hash[n] != :absent
+        raise ArgumentError, _("#{n} is a required attribute for hosts") unless hash[n] and hash[n] != :absent
       end
       str = "#{hash[:ip]}\t#{hash[:name]}"
       if hash.include? :host_aliases and !hash[:host_aliases].nil? and hash[:host_aliases] != :absent

--- a/lib/puppet/provider/host/parsed.rb
+++ b/lib/puppet/provider/host/parsed.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:host).provide(:parsed,:parent => Puppet::Provider::ParsedFile
     },
     :to_line  => proc { |hash|
       [:ip, :name].each do |n|
-        raise ArgumentError, _("#{n} is a required attribute for hosts") unless hash[n] and hash[n] != :absent
+        raise ArgumentError, _("%{attr} is a required attribute for hosts") % { attr: n } unless hash[n] and hash[n] != :absent
       end
       str = "#{hash[:ip]}\t#{hash[:name]}"
       if hash.include? :host_aliases and !hash[:host_aliases].nil? and hash[:host_aliases] != :absent

--- a/lib/puppet/provider/macauthorization/macauthorization.rb
+++ b/lib/puppet/provider/macauthorization/macauthorization.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
 
     def populate_rules_rights
       auth_plist = Puppet::Util::Plist.parse_plist(AuthDB)
-      raise Puppet::Error.new("Cannot parse: #{AuthDB}") if not auth_plist
+      raise Puppet::Error.new(_("Cannot parse: #{AuthDB}")) if not auth_plist
       self.rights = auth_plist["rights"].dup
       self.rules = auth_plist["rules"].dup
       self.parsed_auth_db = self.rights.dup
@@ -93,7 +93,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
     when :rule
       destroy_rule
     else
-      raise Puppet::Error.new("Must specify auth_type when destroying.")
+      raise Puppet::Error.new(_("Must specify auth_type when destroying."))
     end
   end
 
@@ -111,7 +111,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
       when :rule
         flush_rule
       else
-        raise Puppet::Error.new("flush requested for unknown type.")
+        raise Puppet::Error.new(_("flush requested for unknown type."))
       end
       @property_hash.clear
     end
@@ -132,7 +132,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
         authdb["rules"].delete(resource[:name])
         Puppet::Util::Plist.write_plist_file(authdb, AuthDB)
       rescue Errno::EACCES => e
-        raise Puppet::Error.new("Error saving #{AuthDB}: #{e}", e)
+        raise Puppet::Error.new(_("Error saving #{AuthDB}: #{e}"), e)
       end
     end
   end
@@ -177,7 +177,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
       cmds << :security << "authorizationdb" << "write" << name
       execute(cmds, :failonfail => false, :combine => false, :stdinfile => tmp.path.to_s)
     rescue Errno::EACCES => e
-      raise Puppet::Error.new("Cannot save right to #{tmp.path}: #{e}", e)
+      raise Puppet::Error.new(_("Cannot save right to #{tmp.path}: #{e}"), e)
     ensure
       tmp.close
       tmp.unlink
@@ -196,7 +196,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
     begin
       Puppet::Util::Plist.write_plist_file(authdb, AuthDB)
     rescue
-      raise Puppet::Error.new("Error writing to: #{AuthDB}")
+      raise Puppet::Error.new(_("Error writing to: #{AuthDB}"))
     end
   end
 
@@ -229,7 +229,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
 
   def retrieve_value(resource_name, attribute)
     # We set boolean values to symbols when retrieving values
-    raise Puppet::Error.new("Cannot find #{resource_name} in auth db") if not self.class.parsed_auth_db.has_key?(resource_name)
+    raise Puppet::Error.new(_("Cannot find #{resource_name} in auth db")) if not self.class.parsed_auth_db.has_key?(resource_name)
 
     if PuppetToNativeAttributeMap.has_key?(attribute)
       native_attribute = PuppetToNativeAttributeMap[attribute]
@@ -284,10 +284,10 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
       elsif self.class.rules.has_key?(resource[:name])
         return :rule
       else
-        raise Puppet::Error.new("#{resource[:name]} is unknown type.")
+        raise Puppet::Error.new(_("#{resource[:name]} is unknown type."))
       end
     else
-      raise Puppet::Error.new("auth_type required for new resources.")
+      raise Puppet::Error.new(_("auth_type required for new resources."))
     end
   end
 

--- a/lib/puppet/provider/macauthorization/macauthorization.rb
+++ b/lib/puppet/provider/macauthorization/macauthorization.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
 
     def populate_rules_rights
       auth_plist = Puppet::Util::Plist.parse_plist(AuthDB)
-      raise Puppet::Error.new(_("Cannot parse: #{AuthDB}")) if not auth_plist
+      raise Puppet::Error.new(_("Cannot parse: %{auth}") % { auth: AuthDB }) if not auth_plist
       self.rights = auth_plist["rights"].dup
       self.rules = auth_plist["rules"].dup
       self.parsed_auth_db = self.rights.dup
@@ -132,7 +132,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
         authdb["rules"].delete(resource[:name])
         Puppet::Util::Plist.write_plist_file(authdb, AuthDB)
       rescue Errno::EACCES => e
-        raise Puppet::Error.new(_("Error saving #{AuthDB}: #{e}"), e)
+        raise Puppet::Error.new(_("Error saving %{auth}: %{error}") % { auth: AuthDB, error: e }, e)
       end
     end
   end
@@ -177,7 +177,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
       cmds << :security << "authorizationdb" << "write" << name
       execute(cmds, :failonfail => false, :combine => false, :stdinfile => tmp.path.to_s)
     rescue Errno::EACCES => e
-      raise Puppet::Error.new(_("Cannot save right to #{tmp.path}: #{e}"), e)
+      raise Puppet::Error.new(_("Cannot save right to %{path}: %{error}") % { path: tmp.path, error: e }, e)
     ensure
       tmp.close
       tmp.unlink
@@ -196,7 +196,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
     begin
       Puppet::Util::Plist.write_plist_file(authdb, AuthDB)
     rescue
-      raise Puppet::Error.new(_("Error writing to: #{AuthDB}"))
+      raise Puppet::Error.new(_("Error writing to: %{auth_db}") % { auth_db: AuthDB })
     end
   end
 
@@ -229,7 +229,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
 
   def retrieve_value(resource_name, attribute)
     # We set boolean values to symbols when retrieving values
-    raise Puppet::Error.new(_("Cannot find #{resource_name} in auth db")) if not self.class.parsed_auth_db.has_key?(resource_name)
+    raise Puppet::Error.new(_("Cannot find %{resource_name} in auth db") % { resource_name: resource_name }) if not self.class.parsed_auth_db.has_key?(resource_name)
 
     if PuppetToNativeAttributeMap.has_key?(attribute)
       native_attribute = PuppetToNativeAttributeMap[attribute]
@@ -284,7 +284,7 @@ Puppet::Type.type(:macauthorization).provide :macauthorization, :parent => Puppe
       elsif self.class.rules.has_key?(resource[:name])
         return :rule
       else
-        raise Puppet::Error.new(_("#{resource[:name]} is unknown type."))
+        raise Puppet::Error.new(_("%{resource} is unknown type.") % { resource: resource[:name] })
       end
     else
       raise Puppet::Error.new(_("auth_type required for new resources."))

--- a/lib/puppet/provider/maillist/mailman.rb
+++ b/lib/puppet/provider/maillist/mailman.rb
@@ -52,12 +52,12 @@ Puppet::Type.type(:maillist).provide(:mailman) do
     if val = @resource[:admin]
       args << val
     else
-      raise ArgumentError, "Mailman lists require an administrator email address"
+      raise ArgumentError, _("Mailman lists require an administrator email address")
     end
     if val = @resource[:password]
       args << val
     else
-      raise ArgumentError, "Mailman lists require an administrator password"
+      raise ArgumentError, _("Mailman lists require an administrator password")
     end
     newlist(*args)
   end

--- a/lib/puppet/provider/mcx/mcxcontent.rb
+++ b/lib/puppet/provider/mcx/mcxcontent.rb
@@ -134,13 +134,13 @@ Puppet::Type.type(:mcx).provide :mcxcontent, :parent => Puppet::Provider do
     ds_type = name.split('/')[1]
     unless ds_type
       raise MCXContentProviderException,
-      _("Could not parse ds_type from resource name '#{name}'.  Specify with ds_type parameter.")
+      _("Could not parse ds_type from resource name '%{name}'.  Specify with ds_type parameter.") % { name: name }
     end
     # De-pluralize and downcase.
     ds_type = ds_type.chop.downcase.to_sym
     unless TypeMap.key? ds_type
       raise MCXContentProviderException,
-      _("Could not parse ds_type from resource name '#{name}'.  Specify with ds_type parameter.")
+      _("Could not parse ds_type from resource name '%{name}'.  Specify with ds_type parameter.") % { name: name }
     end
     ds_type
   end
@@ -150,7 +150,7 @@ Puppet::Type.type(:mcx).provide :mcxcontent, :parent => Puppet::Provider do
     ds_name = name.split('/')[2]
     unless ds_name
       raise MCXContentProviderException,
-      _("Could not parse ds_name from resource name '#{name}'.  Specify with ds_name parameter.")
+      _("Could not parse ds_name from resource name '%{name}'.  Specify with ds_name parameter.") % { name: name }
     end
     ds_name
   end

--- a/lib/puppet/provider/mcx/mcxcontent.rb
+++ b/lib/puppet/provider/mcx/mcxcontent.rb
@@ -134,13 +134,13 @@ Puppet::Type.type(:mcx).provide :mcxcontent, :parent => Puppet::Provider do
     ds_type = name.split('/')[1]
     unless ds_type
       raise MCXContentProviderException,
-      "Could not parse ds_type from resource name '#{name}'.  Specify with ds_type parameter."
+      _("Could not parse ds_type from resource name '#{name}'.  Specify with ds_type parameter.")
     end
     # De-pluralize and downcase.
     ds_type = ds_type.chop.downcase.to_sym
     unless TypeMap.key? ds_type
       raise MCXContentProviderException,
-      "Could not parse ds_type from resource name '#{name}'.  Specify with ds_type parameter."
+      _("Could not parse ds_type from resource name '#{name}'.  Specify with ds_type parameter.")
     end
     ds_type
   end
@@ -150,7 +150,7 @@ Puppet::Type.type(:mcx).provide :mcxcontent, :parent => Puppet::Provider do
     ds_name = name.split('/')[2]
     unless ds_name
       raise MCXContentProviderException,
-      "Could not parse ds_name from resource name '#{name}'.  Specify with ds_name parameter."
+      _("Could not parse ds_name from resource name '#{name}'.  Specify with ds_name parameter.")
     end
     ds_name
   end

--- a/lib/puppet/provider/mount.rb
+++ b/lib/puppet/provider/mount.rb
@@ -24,7 +24,8 @@ module Puppet::Provider::Mount
   end
 
   def remount
-    info "Remounting"
+    #TRANSLATORS refers to remounting a file system
+    info _("Remounting")
     if resource[:remounts] == :true
       mountcmd "-o", "remount", resource[:name]
     elsif ["FreeBSD", "DragonFly", "OpenBSD"].include?(Facter.value(:operatingsystem))

--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -123,11 +123,13 @@ Puppet::Type.type(:mount).provide(
         result[:options] = [result[:options],special_options.sort].flatten.compact.join(',')
         if ! result[:device]
           result[:device] = :absent
-          Puppet.err _("Prefetch: Mount[#{result[:name]}]: Field 'device' is missing")
+          #TRANSLATORS "prefetch" is a program name and should not be translated
+          Puppet.err _("Prefetch: Mount[%{name}]: Field 'device' is missing") % { name: result[:name] }
         end
         if ! result[:fstype]
           result[:fstype] = :absent
-          Puppet.err _("Prefetch: Mount[#{result[:name]}]: Field 'fstype' is missing")
+          #TRANSLATORS "prefetch" is a program name and should not be translated
+          Puppet.err _("Prefetch: Mount[%{name}]: Field 'fstype' is missing") % { name: result[:name] }
         end
       end
       def to_line(result)
@@ -138,7 +140,7 @@ Puppet::Type.type(:mount).provide(
         elsif result[:device] and result[:device] != :absent
           if ! result[:device].match(%{^.+:/})
             # Just skip this entry; it was malformed to begin with
-            Puppet.err _("Mount[#{result[:name]}]: Field 'device' must be in the format of <absolute path> or <host>:<absolute path>")
+            Puppet.err _("Mount[%{name}]: Field 'device' must be in the format of <absolute path> or <host>:<absolute path>") % { name: result[:name] }
             return result[:line]
           end
           nodename, path = result[:device].split(":")
@@ -146,14 +148,14 @@ Puppet::Type.type(:mount).provide(
           output << "\tnodename\t= #{nodename}"
         else
           # Just skip this entry; it was malformed to begin with
-          Puppet.err _("Mount[#{result[:name]}]: Field 'device' is required")
+          Puppet.err _("Mount[%{name}]: Field 'device' is required") % { name: result[:name] }
           return result[:line]
         end
         if result[:fstype] and result[:fstype] != :absent
           output << "\tvfs\t\t= #{result[:fstype]}"
         else
           # Just skip this entry; it was malformed to begin with
-          Puppet.err _("Mount[#{result[:name]}]: Field 'device' is required")
+          Puppet.err _("Mount[%{name}]: Field 'device' is required") % { name: result[:name] }
           return result[:line]
         end
         if result[:options]
@@ -184,11 +186,11 @@ Puppet::Type.type(:mount).provide(
           if Facter.value(:kernel) == 'Linux'
             record[:options] = 'defaults'
           else
-            raise Puppet::Error, _("Mount[#{record[:name]}]: Field 'options' is required")
+            raise Puppet::Error, _("Mount[%{name}]: Field 'options' is required") % { name: record[:name] }
           end
         end
         if !record[:fstype] || record[:fstype].empty?
-          raise Puppet::Error, _("Mount[#{record[:name]}]: Field 'fstype' is required")
+          raise Puppet::Error, _("Mount[%{name}]: Field 'fstype' is required") % { name: record[:name] }
         end
         record
       end
@@ -266,7 +268,7 @@ Puppet::Type.type(:mount).provide(
       if match = regex.match(line) and name = match.captures.first
         instances << {:name => name, :mounted => :yes} # Only :name is important here
       else
-        raise Puppet::Error, _("Could not understand line #{line} from mount output")
+        raise Puppet::Error, _("Could not understand line %{line} from mount output") % { line: line }
       end
     end
     instances

--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -123,11 +123,11 @@ Puppet::Type.type(:mount).provide(
         result[:options] = [result[:options],special_options.sort].flatten.compact.join(',')
         if ! result[:device]
           result[:device] = :absent
-          Puppet.err "Prefetch: Mount[#{result[:name]}]: Field 'device' is missing"
+          Puppet.err _("Prefetch: Mount[#{result[:name]}]: Field 'device' is missing")
         end
         if ! result[:fstype]
           result[:fstype] = :absent
-          Puppet.err "Prefetch: Mount[#{result[:name]}]: Field 'fstype' is missing"
+          Puppet.err _("Prefetch: Mount[#{result[:name]}]: Field 'fstype' is missing")
         end
       end
       def to_line(result)
@@ -138,7 +138,7 @@ Puppet::Type.type(:mount).provide(
         elsif result[:device] and result[:device] != :absent
           if ! result[:device].match(%{^.+:/})
             # Just skip this entry; it was malformed to begin with
-            Puppet.err "Mount[#{result[:name]}]: Field 'device' must be in the format of <absolute path> or <host>:<absolute path>"
+            Puppet.err _("Mount[#{result[:name]}]: Field 'device' must be in the format of <absolute path> or <host>:<absolute path>")
             return result[:line]
           end
           nodename, path = result[:device].split(":")
@@ -146,14 +146,14 @@ Puppet::Type.type(:mount).provide(
           output << "\tnodename\t= #{nodename}"
         else
           # Just skip this entry; it was malformed to begin with
-          Puppet.err "Mount[#{result[:name]}]: Field 'device' is required"
+          Puppet.err _("Mount[#{result[:name]}]: Field 'device' is required")
           return result[:line]
         end
         if result[:fstype] and result[:fstype] != :absent
           output << "\tvfs\t\t= #{result[:fstype]}"
         else
           # Just skip this entry; it was malformed to begin with
-          Puppet.err "Mount[#{result[:name]}]: Field 'device' is required"
+          Puppet.err _("Mount[#{result[:name]}]: Field 'device' is required")
           return result[:line]
         end
         if result[:options]
@@ -184,11 +184,11 @@ Puppet::Type.type(:mount).provide(
           if Facter.value(:kernel) == 'Linux'
             record[:options] = 'defaults'
           else
-            raise Puppet::Error, "Mount[#{record[:name]}]: Field 'options' is required"
+            raise Puppet::Error, _("Mount[#{record[:name]}]: Field 'options' is required")
           end
         end
         if !record[:fstype] || record[:fstype].empty?
-          raise Puppet::Error, "Mount[#{record[:name]}]: Field 'fstype' is required"
+          raise Puppet::Error, _("Mount[#{record[:name]}]: Field 'fstype' is required")
         end
         record
       end
@@ -266,7 +266,7 @@ Puppet::Type.type(:mount).provide(
       if match = regex.match(line) and name = match.captures.first
         instances << {:name => name, :mounted => :yes} # Only :name is important here
       else
-        raise Puppet::Error, "Could not understand line #{line} from mount output"
+        raise Puppet::Error, _("Could not understand line #{line} from mount output")
       end
     end
     instances

--- a/lib/puppet/provider/naginator.rb
+++ b/lib/puppet/provider/naginator.rb
@@ -23,7 +23,7 @@ class Puppet::Provider::Naginator < Puppet::Provider::ParsedFile
   def self.parse(text)
       Nagios::Parser.new.parse(text.gsub(NAME_STRING, "_naginator_name"))
   rescue => detail
-      raise Puppet::Error, _("Could not parse configuration for #{resource_type.name}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not parse configuration for %{resource}: %{detail}") % { resource: resource_type.name, detail: detail }, detail.backtrace
   end
 
   def self.to_file(records)

--- a/lib/puppet/provider/naginator.rb
+++ b/lib/puppet/provider/naginator.rb
@@ -23,7 +23,7 @@ class Puppet::Provider::Naginator < Puppet::Provider::ParsedFile
   def self.parse(text)
       Nagios::Parser.new.parse(text.gsub(NAME_STRING, "_naginator_name"))
   rescue => detail
-      raise Puppet::Error, "Could not parse configuration for #{resource_type.name}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not parse configuration for #{resource_type.name}: #{detail}"), detail.backtrace
   end
 
   def self.to_file(records)

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -93,7 +93,7 @@ class Puppet::Provider::NameService < Puppet::Provider
       name = name.intern if name.is_a? String
       if @checks.include? name
         block = @checks[name][:block]
-        raise ArgumentError, _("Invalid value #{value}: #{@checks[name][:error]}") unless block.call(value)
+        raise ArgumentError, _("Invalid value %{value}: %{error}") % { value: value, error: @checks[name][:error] } unless block.call(value)
       end
     end
 
@@ -169,7 +169,7 @@ class Puppet::Provider::NameService < Puppet::Provider
         execute(cmd)
       end
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, _("Could not create #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not create %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
     end
   end
 
@@ -183,7 +183,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     begin
       execute(self.deletecmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, _("Could not delete #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not delete %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
     end
   end
 
@@ -285,7 +285,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     begin
       execute(cmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, _("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not set %{param} on %{resource}[%{name}]: %{detail}") % { param: param, resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
     end
   end
 

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -93,7 +93,7 @@ class Puppet::Provider::NameService < Puppet::Provider
       name = name.intern if name.is_a? String
       if @checks.include? name
         block = @checks[name][:block]
-        raise ArgumentError, "Invalid value #{value}: #{@checks[name][:error]}" unless block.call(value)
+        raise ArgumentError, _("Invalid value #{value}: #{@checks[name][:error]}") unless block.call(value)
       end
     end
 
@@ -158,7 +158,7 @@ class Puppet::Provider::NameService < Puppet::Provider
 
   def create
     if exists?
-      info "already exists"
+      info _("already exists")
       # The object already exists
       return nil
     end
@@ -169,13 +169,13 @@ class Puppet::Provider::NameService < Puppet::Provider
         execute(cmd)
       end
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not create #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not create #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
     end
   end
 
   def delete
     unless exists?
-      info "already absent"
+      info _("already absent")
       # the object already doesn't exist
       return nil
     end
@@ -183,7 +183,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     begin
       execute(self.deletecmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not delete #{@resource.class.name} #{@resource.name}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not delete #{@resource.class.name} #{@resource.name}: #{detail}"), detail.backtrace
     end
   end
 
@@ -285,7 +285,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     begin
       execute(cmd)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"), detail.backtrace
     end
   end
 

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -98,7 +98,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       begin
         dscl_output = execute(get_exec_preamble("-list"))
       rescue Puppet::ExecutionFailure
-        fail("Could not get #{@resource_type.name} list from DirectoryService")
+        fail(_("Could not get #{@resource_type.name} list from DirectoryService"))
       end
       dscl_output.split("\n")
     end
@@ -157,7 +157,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     begin
       dscl_output = execute(dscl_vector)
     rescue Puppet::ExecutionFailure
-      fail("Could not get report.  command execution failed.")
+      fail(_("Could not get report.  command execution failed."))
     end
 
     dscl_plist = self.parse_dscl_plist_data(dscl_output)
@@ -196,8 +196,8 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     # zeroes. If someone attempts to use a password hash that worked with
     # a previous version of OS X, we will fail early and warn them.
     if password_hash.length != 136
-      fail("OS X 10.7 requires a Salted SHA512 hash password of 136 characters. \
-           Please check your password and try again.")
+      fail(_("OS X 10.7 requires a Salted SHA512 hash password of 136 characters. \
+           Please check your password and try again."))
     end
 
     plist_file = "#{users_plist_dir}/#{resource_name}.plist"
@@ -284,7 +284,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     elsif id_type == 'gid'
       dscl_args << '/Groups' << 'gid'
     else
-      fail("Invalid id_type #{id_type}. Only 'uid' and 'gid' supported")
+      fail(_("Invalid id_type #{id_type}. Only 'uid' and 'gid' supported"))
     end
     dscl_out = dscl(dscl_args)
     # We're ok with throwing away negative uids here.
@@ -333,7 +333,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       guid = guid_plist["dsAttrTypeStandard:#{ns_to_ds_attribute_map[:guid]}"][0]
       self.class.set_password(@resource.name, guid, passphrase)
     rescue Puppet::ExecutionFailure => detail
-      fail("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}")
+      fail(_("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"))
     end
   end
 
@@ -362,7 +362,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       begin
         execute(exec_arg_vector)
       rescue Puppet::ExecutionFailure => detail
-        fail("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}")
+        fail(_("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"))
       end
     end
   end
@@ -389,7 +389,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     begin
       execute(exec_arg_vector)
     rescue Puppet::ExecutionFailure => detail
-      fail("Could not set GeneratedUID for #{@resource.class.name} #{@resource.name}: #{detail}")
+      fail(_("Could not set GeneratedUID for #{@resource.class.name} #{@resource.name}: #{detail}"))
     end
 
     if value = @resource.should(:password) and value != ""
@@ -417,7 +417,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
           begin
             execute(exec_arg_vector)
           rescue Puppet::ExecutionFailure => detail
-            fail("Could not create #{@resource.class.name} #{@resource.name}: #{detail}")
+            fail(_("Could not create #{@resource.class.name} #{@resource.name}: #{detail}"))
           end
         end
       end
@@ -437,7 +437,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
           begin
             execute(cmd)
           rescue Puppet::ExecutionFailure => detail
-            fail("Could not remove #{member} from group: #{@resource.name}, #{detail}")
+            fail(_("Could not remove #{member} from group: #{@resource.name}, #{detail}"))
           end
         end
       end
@@ -451,7 +451,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
         begin
           execute(cmd)
         rescue Puppet::ExecutionFailure => detail
-          fail("Could not add #{new_member} to group: #{@resource.name}, #{detail}")
+          fail(_("Could not add #{new_member} to group: #{@resource.name}, #{detail}"))
         end
       end
     end

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -98,7 +98,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       begin
         dscl_output = execute(get_exec_preamble("-list"))
       rescue Puppet::ExecutionFailure
-        fail(_("Could not get #{@resource_type.name} list from DirectoryService"))
+        fail(_("Could not get %{resource} list from DirectoryService") % { resource: @resource_type.name })
       end
       dscl_output.split("\n")
     end
@@ -284,7 +284,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     elsif id_type == 'gid'
       dscl_args << '/Groups' << 'gid'
     else
-      fail(_("Invalid id_type #{id_type}. Only 'uid' and 'gid' supported"))
+      fail(_("Invalid id_type %{id_type}. Only 'uid' and 'gid' supported") % { id_type: id_type })
     end
     dscl_out = dscl(dscl_args)
     # We're ok with throwing away negative uids here.
@@ -333,7 +333,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       guid = guid_plist["dsAttrTypeStandard:#{ns_to_ds_attribute_map[:guid]}"][0]
       self.class.set_password(@resource.name, guid, passphrase)
     rescue Puppet::ExecutionFailure => detail
-      fail(_("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"))
+      fail(_("Could not set %{param} on %{resource}[%{name}]: %{detail}") % { param: param, resource: @resource.class.name, name: @resource.name, detail: detail })
     end
   end
 
@@ -362,7 +362,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       begin
         execute(exec_arg_vector)
       rescue Puppet::ExecutionFailure => detail
-        fail(_("Could not set #{param} on #{@resource.class.name}[#{@resource.name}]: #{detail}"))
+        fail(_("Could not set %{param} on %{resource}[%{name}]: %{detail}") % { param: param, resource: @resource.class.name, name: @resource.name, detail: detail })
       end
     end
   end
@@ -389,7 +389,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
     begin
       execute(exec_arg_vector)
     rescue Puppet::ExecutionFailure => detail
-      fail(_("Could not set GeneratedUID for #{@resource.class.name} #{@resource.name}: #{detail}"))
+      fail(_("Could not set GeneratedUID for %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail })
     end
 
     if value = @resource.should(:password) and value != ""
@@ -417,7 +417,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
           begin
             execute(exec_arg_vector)
           rescue Puppet::ExecutionFailure => detail
-            fail(_("Could not create #{@resource.class.name} #{@resource.name}: #{detail}"))
+            fail(_("Could not create %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail })
           end
         end
       end
@@ -437,7 +437,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
           begin
             execute(cmd)
           rescue Puppet::ExecutionFailure => detail
-            fail(_("Could not remove #{member} from group: #{@resource.name}, #{detail}"))
+            fail(_("Could not remove %{member} from group: %{resource}, %{detail}") % { member: member, resource: @resource.name, detail: detail })
           end
         end
       end
@@ -451,7 +451,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
         begin
           execute(cmd)
         rescue Puppet::ExecutionFailure => detail
-          fail(_("Could not add #{new_member} to group: #{@resource.name}, #{detail}"))
+          fail(_("Could not add %{new_member} to group: %{name}, %{detail}") % { new_member: new_member, name: @resource.name, detail: detail })
         end
       end
     end

--- a/lib/puppet/provider/network_device.rb
+++ b/lib/puppet/provider/network_device.rb
@@ -22,7 +22,8 @@ class Puppet::Provider::NetworkDevice < Puppet::Provider
     end
   rescue => detail
     # Preserving behavior introduced in #6907
-    Puppet.log_exception(detail, _("Could not perform network device prefetch: #{detail}"))
+    #TRANSLATORS "prefetch" is a program name and should not be translated
+    Puppet.log_exception(detail, _("Could not perform network device prefetch: %{detail}") % { detail: detail })
   end
 
   def exists?

--- a/lib/puppet/provider/network_device.rb
+++ b/lib/puppet/provider/network_device.rb
@@ -22,7 +22,7 @@ class Puppet::Provider::NetworkDevice < Puppet::Provider
     end
   rescue => detail
     # Preserving behavior introduced in #6907
-    Puppet.log_exception(detail, "Could not perform network device prefetch: #{detail}")
+    Puppet.log_exception(detail, _("Could not perform network device prefetch: #{detail}"))
   end
 
   def exists?

--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -76,7 +76,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
     # installp will return an exit code of zero even if it didn't uninstall
     # anything... so let's make sure it worked.
     unless query().nil?
-      self.fail _("Failed to uninstall package '#{@resource[:name]}'")
+      self.fail _("Failed to uninstall package '%{name}'") % { name: @resource[:name] }
     end
   end
 
@@ -113,7 +113,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
       if hash[:pkgname]
         return nil
       else
-        raise Puppet::Error, _("Could not list installed Packages: #{detail}"), detail.backtrace
+        raise Puppet::Error, _("Could not list installed Packages: %{detail}") % { detail: detail }, detail.backtrace
       end
     end
 

--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
   end
 
   def self.prefetch(packages)
-    raise Puppet::Error, "The aix provider can only be used by root" if Process.euid != 0
+    raise Puppet::Error, _("The aix provider can only be used by root") if Process.euid != 0
 
     return unless packages.detect { |name, package| package.should(:ensure) == :latest }
 
@@ -76,13 +76,13 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
     # installp will return an exit code of zero even if it didn't uninstall
     # anything... so let's make sure it worked.
     unless query().nil?
-      self.fail "Failed to uninstall package '#{@resource[:name]}'"
+      self.fail _("Failed to uninstall package '#{@resource[:name]}'")
     end
   end
 
   def install(useversion = true)
     unless source = @resource[:source]
-      self.fail "A directory is required which will be used to find packages"
+      self.fail _("A directory is required which will be used to find packages")
     end
 
     pkg = @resource[:name]
@@ -94,7 +94,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
     # If the package is superseded, it means we're trying to downgrade and we
     # can't do that.
     if output =~ /^#{Regexp.escape(@resource[:name])}\s+.*\s+Already superseded by.*$/
-      self.fail "aix package provider is unable to downgrade packages"
+      self.fail _("aix package provider is unable to downgrade packages")
     end
   end
 
@@ -113,7 +113,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
       if hash[:pkgname]
         return nil
       else
-        raise Puppet::Error, "Could not list installed Packages: #{detail}", detail.backtrace
+        raise Puppet::Error, _("Could not list installed Packages: #{detail}"), detail.backtrace
       end
     end
 

--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -100,10 +100,10 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
   def install
     source = nil
     unless source = @resource[:source]
-      self.fail "Mac OS X PKG DMGs must specify a package source."
+      self.fail _("Mac OS X PKG DMGs must specify a package source.")
     end
     unless name = @resource[:name]
-      self.fail "Mac OS X PKG DMGs must specify a package name."
+      self.fail _("Mac OS X PKG DMGs must specify a package name.")
     end
     self.class.installpkgdmg(source,name)
   end

--- a/lib/puppet/provider/package/apple.rb
+++ b/lib/puppet/provider/package/apple.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:package).provide :apple, :parent => Puppet::Provider::Package
   def install
     source = nil
     unless source = @resource[:source]
-      self.fail "Mac OS X packages must specify a package source"
+      self.fail _("Mac OS X packages must specify a package source")
     end
 
     installer "-pkg", source, "-target", "/"

--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
 
     if have_cdrom and @resource[:allowcdrom] != :true
       raise Puppet::Error,
-        "/etc/apt/sources.list contains a cdrom source; not installing.  Use 'allowcdrom' to override this failure."
+        _("/etc/apt/sources.list contains a cdrom source; not installing.  Use 'allowcdrom' to override this failure.")
     end
   end
 
@@ -80,7 +80,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     if output =~ /Candidate:\s+(\S+)\s/
       return $1
     else
-      self.err "Could not find latest version"
+      self.err _("Could not find latest version")
       return nil
     end
   end
@@ -90,11 +90,11 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
   #
   def run_preseed
     if response = @resource[:responsefile] and Puppet::FileSystem.exist?(response)
-      self.info("Preseeding #{response} to debconf-set-selections")
+      self.info(_("Preseeding #{response} to debconf-set-selections"))
 
       preseed response
     else
-      self.info "No responsefile specified or non existent, not preseeding anything"
+      self.info _("No responsefile specified or non existent, not preseeding anything")
     end
   end
 

--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -90,7 +90,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
   #
   def run_preseed
     if response = @resource[:responsefile] and Puppet::FileSystem.exist?(response)
-      self.info(_("Preseeding #{response} to debconf-set-selections"))
+      self.info(_("Preseeding %{response} to debconf-set-selections") % { response: response })
 
       preseed response
     else

--- a/lib/puppet/provider/package/aptitude.rb
+++ b/lib/puppet/provider/package/aptitude.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:package).provide :aptitude, :parent => :apt, :source => :dpkg
     # Yay, stupid aptitude doesn't throw an error when the package is missing.
     if args.include?(:install) and output =~ /Couldn't find any package/
       raise Puppet::Error.new(
-        _("Could not find package #{self.name}")
+        _("Could not find package %{name}") % { name: self.name }
       )
     end
   end

--- a/lib/puppet/provider/package/aptitude.rb
+++ b/lib/puppet/provider/package/aptitude.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:package).provide :aptitude, :parent => :apt, :source => :dpkg
     # Yay, stupid aptitude doesn't throw an error when the package is missing.
     if args.include?(:install) and output =~ /Couldn't find any package/
       raise Puppet::Error.new(
-        "Could not find package #{self.name}"
+        _("Could not find package #{self.name}")
       )
     end
   end

--- a/lib/puppet/provider/package/aptrpm.rb
+++ b/lib/puppet/provider/package/aptrpm.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:package).provide :aptrpm, :parent => :rpm, :source => :rpm do
         if version =~ /^([^\(]+)\(/
           $1
         else
-          self.warning _("Could not match version '#{version}'")
+          self.warning _("Could not match version '%{version}'") % { version: version }
           nil
         end
       }.reject { |vers| vers.nil? }.sort { |a,b|

--- a/lib/puppet/provider/package/aptrpm.rb
+++ b/lib/puppet/provider/package/aptrpm.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:package).provide :aptrpm, :parent => :rpm, :source => :rpm do
         if version =~ /^([^\(]+)\(/
           $1
         else
-          self.warning "Could not match version '#{version}'"
+          self.warning _("Could not match version '#{version}'")
           nil
         end
       }.reject { |vers| vers.nil? }.sort { |a,b|
@@ -65,7 +65,7 @@ Puppet::Type.type(:package).provide :aptrpm, :parent => :rpm, :source => :rpm do
       # Get the latest and greatest version number
       return available_versions.pop
     else
-      self.err "Could not match string"
+      self.err _("Could not match string")
     end
   end
 

--- a/lib/puppet/provider/package/blastwave.rb
+++ b/lib/puppet/provider/package/blastwave.rb
@@ -15,12 +15,12 @@ Puppet::Type.type(:package).provide :blastwave, :parent => :sun, :source => :sun
   def self.extended(mod)
     unless command(:pkgget) != "pkg-get"
       raise Puppet::Error,
-        "The pkg-get command is missing; blastwave packaging unavailable"
+        _("The pkg-get command is missing; blastwave packaging unavailable")
     end
 
     unless Puppet::FileSystem.exist?("/var/pkg-get/admin")
-      Puppet.notice "It is highly recommended you create '/var/pkg-get/admin'."
-      Puppet.notice "See /var/pkg-get/admin-fullauto"
+      Puppet.notice _("It is highly recommended you create '/var/pkg-get/admin'.")
+      Puppet.notice _("See /var/pkg-get/admin-fullauto")
     end
   end
 
@@ -77,7 +77,7 @@ Puppet::Type.type(:package).provide :blastwave, :parent => :sun, :source => :sun
 
       return hash
     else
-      Puppet.warning "Cannot match #{line}"
+      Puppet.warning _("Cannot match #{line}")
       return nil
     end
   end

--- a/lib/puppet/provider/package/blastwave.rb
+++ b/lib/puppet/provider/package/blastwave.rb
@@ -77,7 +77,7 @@ Puppet::Type.type(:package).provide :blastwave, :parent => :sun, :source => :sun
 
       return hash
     else
-      Puppet.warning _("Cannot match #{line}")
+      Puppet.warning _("Cannot match %{line}") % { line: line }
       return nil
     end
   end

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
         hash[:ensure] = :absent
       end
       hash[:ensure] = :held if hash[:desired] == 'hold'
-    else 
+    else
       Puppet.debug("Failed to match dpkg-query line #{line.inspect}")
     end
 
@@ -79,7 +79,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
 
   def install
     unless file = @resource[:source]
-      raise ArgumentError, "You cannot install dpkg packages without a source"
+      raise ArgumentError, _("You cannot install dpkg packages without a source")
     end
 
     args = []
@@ -105,7 +105,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   def latest
     output = dpkg_deb "--show", @resource[:source]
     matches = /^(\S+)\t(\S+)$/.match(output).captures
-    warning "source doesn't contain named package, but #{matches[0]}" unless matches[0].match( Regexp.escape(@resource[:name]) )
+    warning _("source doesn't contain named package, but #{matches[0]}") unless matches[0].match( Regexp.escape(@resource[:name]) )
     matches[1]
   end
 

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -105,7 +105,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   def latest
     output = dpkg_deb "--show", @resource[:source]
     matches = /^(\S+)\t(\S+)$/.match(output).captures
-    warning _("source doesn't contain named package, but #{matches[0]}") unless matches[0].match( Regexp.escape(@resource[:name]) )
+    warning _("source doesn't contain named package, but %{name}") % { name: matches[0] } unless matches[0].match( Regexp.escape(@resource[:name]) )
     matches[1]
   end
 

--- a/lib/puppet/provider/package/fink.rb
+++ b/lib/puppet/provider/package/fink.rb
@@ -47,7 +47,7 @@ Puppet::Type.type(:package).provide :fink, :parent => :dpkg, :source => :dpkg do
     if output =~ /Candidate:\s+(\S+)\s/
       return $1
     else
-      self.err "Could not find latest version"
+      self.err _("Could not find latest version")
       return nil
     end
   end
@@ -57,11 +57,11 @@ Puppet::Type.type(:package).provide :fink, :parent => :dpkg, :source => :dpkg do
   #
   def run_preseed
     if response = @resource[:responsefile] and Puppet::FileSystem.exist?(response)
-      self.info("Preseeding #{response} to debconf-set-selections")
+      self.info(_("Preseeding #{response} to debconf-set-selections"))
 
       preseed response
     else
-      self.info "No responsefile specified or non existent, not preseeding anything"
+      self.info _("No responsefile specified or non existent, not preseeding anything")
     end
   end
 

--- a/lib/puppet/provider/package/fink.rb
+++ b/lib/puppet/provider/package/fink.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:package).provide :fink, :parent => :dpkg, :source => :dpkg do
   #
   def run_preseed
     if response = @resource[:responsefile] and Puppet::FileSystem.exist?(response)
-      self.info(_("Preseeding #{response} to debconf-set-selections"))
+      self.info(_("Preseeding %{response} to debconf-set-selections") % { response: response })
 
       preseed response
     else

--- a/lib/puppet/provider/package/freebsd.rb
+++ b/lib/puppet/provider/package/freebsd.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:package).provide :freebsd, :parent => :openbsd do
         end
       end
     else
-      Puppet.warning "source is defined but does not have trailing slash, ignoring #{@resource[:source]}" if @resource[:source]
+      Puppet.warning _("source is defined but does not have trailing slash, ignoring #{@resource[:source]}") if @resource[:source]
       pkgadd "-r", @resource[:name]
     end
   end

--- a/lib/puppet/provider/package/freebsd.rb
+++ b/lib/puppet/provider/package/freebsd.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:package).provide :freebsd, :parent => :openbsd do
         end
       end
     else
-      Puppet.warning _("source is defined but does not have trailing slash, ignoring #{@resource[:source]}") if @resource[:source]
+      Puppet.warning _("source is defined but does not have trailing slash, ignoring %{source}") % { source: @resource[:source] } if @resource[:source]
       pkgadd "-r", @resource[:name]
     end
   end

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -37,7 +37,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         map {|set| gemsplit(set) }.
         reject {|x| x.nil? }
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not list gems: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not list gems: #{detail}"), detail.backtrace
     end
 
     if options[:justme]
@@ -63,7 +63,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         :provider => name
       }
     else
-      Puppet.warning "Could not match #{desc}" unless desc.chomp.empty?
+      Puppet.warning _("Could not match #{desc}") unless desc.chomp.empty?
       nil
     end
   end
@@ -103,7 +103,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       begin
         uri = URI.parse(source)
       rescue => detail
-        self.fail Puppet::Error, "Invalid source '#{uri}': #{detail}", detail
+        self.fail Puppet::Error, _("Invalid source '#{uri}': #{detail}"), detail
       end
 
       case uri.scheme
@@ -114,7 +114,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         command << uri.path
       when 'puppet'
         # we don't support puppet:// URLs (yet)
-        raise Puppet::Error.new("puppet:// URLs are not supported as gem sources")
+        raise Puppet::Error.new(_("puppet:// URLs are not supported as gem sources"))
       else
         # check whether it's an absolute file path to help Windows out
         if Puppet::Util.absolute_path?(source)
@@ -132,7 +132,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     output = execute(command)
     # Apparently some stupid gem versions don't exit non-0 on failure
-    self.fail "Could not install: #{output.chomp}" if output.include?("ERROR")
+    self.fail _("Could not install: #{output.chomp}") if output.include?("ERROR")
   end
 
   def latest
@@ -157,7 +157,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     output = execute(command)
 
     # Apparently some stupid gem versions don't exit non-0 on failure
-    self.fail "Could not uninstall: #{output.chomp}" if output.include?("ERROR")
+    self.fail _("Could not uninstall: #{output.chomp}") if output.include?("ERROR")
   end
 
   def update

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -37,7 +37,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         map {|set| gemsplit(set) }.
         reject {|x| x.nil? }
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, _("Could not list gems: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not list gems: %{detail}") % { detail: detail }, detail.backtrace
     end
 
     if options[:justme]
@@ -63,7 +63,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
         :provider => name
       }
     else
-      Puppet.warning _("Could not match #{desc}") unless desc.chomp.empty?
+      Puppet.warning _("Could not match %{desc}") % { desc: desc } unless desc.chomp.empty?
       nil
     end
   end
@@ -103,7 +103,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       begin
         uri = URI.parse(source)
       rescue => detail
-        self.fail Puppet::Error, _("Invalid source '#{uri}': #{detail}"), detail
+        self.fail Puppet::Error, _("Invalid source '%{uri}': %{detail}") % { uri: uri, detail: detail }, detail
       end
 
       case uri.scheme
@@ -132,7 +132,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     output = execute(command)
     # Apparently some stupid gem versions don't exit non-0 on failure
-    self.fail _("Could not install: #{output.chomp}") if output.include?("ERROR")
+    self.fail _("Could not install: %{output}") % { output: output.chomp } if output.include?("ERROR")
   end
 
   def latest
@@ -157,7 +157,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     output = execute(command)
 
     # Apparently some stupid gem versions don't exit non-0 on failure
-    self.fail _("Could not uninstall: #{output.chomp}") if output.include?("ERROR")
+    self.fail _("Could not uninstall: %{output}") % { output: output.chomp } if output.include?("ERROR")
   end
 
   def update

--- a/lib/puppet/provider/package/hpux.rb
+++ b/lib/puppet/provider/package/hpux.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:package).provide :hpux, :parent => Puppet::Provider::Package 
 
   # source and name are required
   def install
-    raise ArgumentError, "source must be provided to install HP-UX packages" unless resource[:source]
+    raise ArgumentError, _("source must be provided to install HP-UX packages") unless resource[:source]
     args = standard_args + ["-s", resource[:source], resource[:name]]
     swinstall(*args)
   end

--- a/lib/puppet/provider/package/nim.rb
+++ b/lib/puppet/provider/package/nim.rb
@@ -44,13 +44,13 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     when "R"
       rpm "-e", @resource[:name]
     else
-      self.fail(_("Unrecognized AIX package type identifier: '#{pkg_type}'"))
+      self.fail(_("Unrecognized AIX package type identifier: '%{pkg_type}'") % { pkg_type: pkg_type })
     end
 
     # installp will return an exit code of zero even if it didn't uninstall
     # anything... so let's make sure it worked.
     unless query().nil?
-      self.fail _("Failed to uninstall package '#{@resource[:name]}'")
+      self.fail _("Failed to uninstall package '%{name}'") % { name: @resource[:name] }
     end
   end
 
@@ -98,10 +98,10 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
 
     if (package_type == nil)
       #TRANSLATORS Full message: "Unable to find package #{pkg} with version #{version} on lpp_source #{source}"
-      errmsg = _("Unable to find package '#{pkg}' ")
+      errmsg = _("Unable to find package '%{pkg}' ") % { pkg: pkg }
       if (version_specified)
         #TRANSLATORS Full message: "Unable to find package #{pkg} with version #{version} on lpp_source #{source}"
-        errmsg << _("with version '#{version}' ")
+        errmsg << _("with version '%{version}' ") % { version: version }
       end
       #TRANSLATORS Full message: "Unable to find package #{pkg} with version #{version} on lpp_source #{source}"
       errmsg << "on lpp_source '#{source}'"
@@ -209,13 +209,13 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     # looks sane, so we know we're dealing with the kind of output that we
     # are capable of handling.
     unless line.match(self.class::HEADER_LINE_REGEX)
-      self.fail _("Unable to parse output from nimclient showres: line does not match expected package header format:\n'#{line}'")
+      self.fail _("Unable to parse output from nimclient showres: line does not match expected package header format:\n'%{line}'") % { line: line }
     end
   end
 
   def parse_installp_package_string(package_string)
     unless match = package_string.match(self.class::INSTALLP_PACKAGE_REGEX)
-      self.fail _("Unable to parse output from nimclient showres: package string does not match expected installp package string format:\n'#{package_string}'")
+      self.fail _("Unable to parse output from nimclient showres: package string does not match expected installp package string format:\n'%{package_string}'") % { package_string: package_string }
     end
     package_name = match.captures[0]
     version = match.captures[1]
@@ -224,7 +224,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
 
   def parse_rpm_package_string(package_string)
     unless match = package_string.match(self.class::RPM_PACKAGE_REGEX)
-      self.fail _("Unable to parse output from nimclient showres: package string does not match expected rpm package string format:\n'#{package_string}'")
+      self.fail _("Unable to parse output from nimclient showres: package string does not match expected rpm package string format:\n'%{package_string}'") % { package_string: package_string }
     end
     package_name = match.captures[0]
     version = match.captures[1]
@@ -233,7 +233,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
 
   def parse_showres_package_line(line)
     unless match = line.match(self.class::PACKAGE_LINE_REGEX)
-      self.fail _("Unable to parse output from nimclient showres: line does not match expected package line format:\n'#{line}'")
+      self.fail _("Unable to parse output from nimclient showres: line does not match expected package line format:\n'%{line}'") % { line: line }
     end
 
     package_type_flag = match.captures[0]
@@ -245,7 +245,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
       when "R"
         parse_rpm_package_string(package_string)
       else
-        self.fail _("Unrecognized package type specifier: '#{package_type_flag}' in package line:\n'#{line}'")
+        self.fail _("Unrecognized package type specifier: '%{package_type_flag}' in package line:\n'%{line}'") % { package_type_flag: package_type_flag, line: line }
     end
   end
 

--- a/lib/puppet/provider/package/nim.rb
+++ b/lib/puppet/provider/package/nim.rb
@@ -44,19 +44,19 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     when "R"
       rpm "-e", @resource[:name]
     else
-      self.fail("Unrecognized AIX package type identifier: '#{pkg_type}'")
+      self.fail(_("Unrecognized AIX package type identifier: '#{pkg_type}'"))
     end
 
     # installp will return an exit code of zero even if it didn't uninstall
     # anything... so let's make sure it worked.
     unless query().nil?
-      self.fail "Failed to uninstall package '#{@resource[:name]}'"
+      self.fail _("Failed to uninstall package '#{@resource[:name]}'")
     end
   end
 
   def install(useversion = true)
     unless source = @resource[:source]
-      self.fail "An LPP source location is required in 'source'"
+      self.fail _("An LPP source location is required in 'source'")
     end
 
     pkg = @resource[:name]
@@ -97,10 +97,13 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     end
 
     if (package_type == nil)
-      errmsg = "Unable to find package '#{pkg}' "
+      #TRANSLATORS Full message: "Unable to find package #{pkg} with version #{version} on lpp_source #{source}"
+      errmsg = _("Unable to find package '#{pkg}' ")
       if (version_specified)
-        errmsg << "with version '#{version}' "
+        #TRANSLATORS Full message: "Unable to find package #{pkg} with version #{version} on lpp_source #{source}"
+        errmsg << _("with version '#{version}' ")
       end
+      #TRANSLATORS Full message: "Unable to find package #{pkg} with version #{version} on lpp_source #{source}"
       errmsg << "on lpp_source '#{source}'"
       self.fail errmsg
     end
@@ -133,11 +136,11 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     case package_type
     when :installp
       if output =~ /^#{Regexp.escape(@resource[:name])}\s+.*\s+Already superseded by.*$/
-        self.fail "NIM package provider is unable to downgrade packages"
+        self.fail _("NIM package provider is unable to downgrade packages")
       end
     when :rpm
       if output =~ /^#{Regexp.escape(@resource[:name])}.* is superseded by.*$/
-        self.fail "NIM package provider is unable to downgrade packages"
+        self.fail _("NIM package provider is unable to downgrade packages")
       end
     end
   end
@@ -206,13 +209,13 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     # looks sane, so we know we're dealing with the kind of output that we
     # are capable of handling.
     unless line.match(self.class::HEADER_LINE_REGEX)
-      self.fail "Unable to parse output from nimclient showres: line does not match expected package header format:\n'#{line}'"
+      self.fail _("Unable to parse output from nimclient showres: line does not match expected package header format:\n'#{line}'")
     end
   end
 
   def parse_installp_package_string(package_string)
     unless match = package_string.match(self.class::INSTALLP_PACKAGE_REGEX)
-      self.fail "Unable to parse output from nimclient showres: package string does not match expected installp package string format:\n'#{package_string}'"
+      self.fail _("Unable to parse output from nimclient showres: package string does not match expected installp package string format:\n'#{package_string}'")
     end
     package_name = match.captures[0]
     version = match.captures[1]
@@ -221,7 +224,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
 
   def parse_rpm_package_string(package_string)
     unless match = package_string.match(self.class::RPM_PACKAGE_REGEX)
-      self.fail "Unable to parse output from nimclient showres: package string does not match expected rpm package string format:\n'#{package_string}'"
+      self.fail _("Unable to parse output from nimclient showres: package string does not match expected rpm package string format:\n'#{package_string}'")
     end
     package_name = match.captures[0]
     version = match.captures[1]
@@ -230,7 +233,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
 
   def parse_showres_package_line(line)
     unless match = line.match(self.class::PACKAGE_LINE_REGEX)
-      self.fail "Unable to parse output from nimclient showres: line does not match expected package line format:\n'#{line}'"
+      self.fail _("Unable to parse output from nimclient showres: line does not match expected package line format:\n'#{line}'")
     end
 
     package_type_flag = match.captures[0]
@@ -242,7 +245,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
       when "R"
         parse_rpm_package_string(package_string)
       else
-        self.fail "Unrecognized package type specifier: '#{package_type_flag}' in package line:\n'#{line}'"
+        self.fail _("Unrecognized package type specifier: '#{package_type_flag}' in package line:\n'#{line}'")
     end
   end
 

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
             unless line =~ /Updating the pkgdb/
               # Print a warning on lines we can't match, but move
               # on, since it should be non-fatal
-              warning("Failed to match line #{line}")
+              warning(_("Failed to match line #{line}"))
             end
           end
         }
@@ -133,11 +133,11 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
 
         unless @resource[:source]
           raise Puppet::Error,
-          "No valid installpath found in /etc/pkg.conf and no source was set"
+          _("No valid installpath found in /etc/pkg.conf and no source was set")
         end
       else
         raise Puppet::Error,
-        "You must specify a package source or configure an installpath in /etc/pkg.conf"
+        _("You must specify a package source or configure an installpath in /etc/pkg.conf")
       end
     end
   end
@@ -209,7 +209,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
 
       return master_version unless master_version == 0
       return '' if version == -1
-      raise Puppet::Error, "#{version} is not available for this package"
+      raise Puppet::Error, _("#{version} is not available for this package")
     end
   rescue Puppet::ExecutionFailure
     return nil

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
             unless line =~ /Updating the pkgdb/
               # Print a warning on lines we can't match, but move
               # on, since it should be non-fatal
-              warning(_("Failed to match line #{line}"))
+              warning(_("Failed to match line %{line}") % { line: line })
             end
           end
         }
@@ -209,7 +209,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
 
       return master_version unless master_version == 0
       return '' if version == -1
-      raise Puppet::Error, _("#{version} is not available for this package")
+      raise Puppet::Error, _("%{version} is not available for this package") % { version: version }
     end
   rescue Puppet::ExecutionFailure
     return nil

--- a/lib/puppet/provider/package/opkg.rb
+++ b/lib/puppet/provider/package/opkg.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:package).provide :opkg, :source => :opkg, :parent => Puppet::
           packages << new(hash)
           hash = {}
         else
-          warning("Failed to match line %s" % line)
+          warning(_("Failed to match line %s" % line))
         end
       }
     end

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     end
 
     unless self.query
-      fail("Could not find package '#{@resource[:name]}'")
+      fail(_("Could not find package '#{@resource[:name]}'"))
     end
   end
 
@@ -82,13 +82,13 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
           if match = regex.match(line)
             packages[match.captures[0]] = match.captures[1]
           else
-            warning("Failed to match line '#{line}'")
+            warning(_("Failed to match line '#{line}'"))
           end
         end
       end
       packages
     rescue Puppet::ExecutionFailure
-      fail("Error getting installed packages")
+      fail(_("Error getting installed packages"))
     end
   end
 
@@ -173,7 +173,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
     if version
       unless @resource.allow_virtual?
-        warning("#{resource_name} is a group, but allow_virtual is false.")
+        warning(_("#{resource_name} is a group, but allow_virtual is false."))
         return nil
       end
     else
@@ -200,7 +200,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
     is_group = self.class.group?(resource_name)
 
-    fail("Refusing to uninstall package group #{resource_name}, because allow_virtual is false.") if is_group && !@resource.allow_virtual?
+    fail(_("Refusing to uninstall package group #{resource_name}, because allow_virtual is false.")) if is_group && !@resource.allow_virtual?
 
     cmd = %w{--noconfirm --noprogressbar}
     cmd += uninstall_options if @resource[:uninstall_options]
@@ -230,7 +230,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     begin
       source_uri = URI.parse source
     rescue => detail
-      self.fail Puppet::Error, "Invalid source '#{source}': #{detail}", detail
+      self.fail Puppet::Error, _("Invalid source '#{source}': #{detail}"), detail
     end
 
     source = case source_uri.scheme
@@ -239,9 +239,9 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     when /ftp/i then source
     when /file/i then source_uri.path
     when /puppet/i
-      fail "puppet:// URL is not supported by pacman"
+      fail _("puppet:// URL is not supported by pacman")
     else
-      fail "Source #{source} is not supported by pacman"
+      fail _("Source #{source} is not supported by pacman")
     end
     pacman "--noconfirm", "--noprogressbar", "-Sy"
     pacman "--noconfirm", "--noprogressbar", "-U", source
@@ -251,7 +251,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     resource_name = @resource[:name]
 
     # Refuse to install if not allowing virtual packages and the resource is a group
-    fail("Refusing to install package group #{resource_name}, because allow_virtual is false.") if self.class.group?(resource_name) && !@resource.allow_virtual?
+    fail(_("Refusing to install package group #{resource_name}, because allow_virtual is false.")) if self.class.group?(resource_name) && !@resource.allow_virtual?
 
     cmd = %w{--noconfirm --needed --noprogressbar}
     cmd += install_options if @resource[:install_options]

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     end
 
     unless self.query
-      fail(_("Could not find package '#{@resource[:name]}'"))
+      fail(_("Could not find package '%{name}'") % { name: @resource[:name] })
     end
   end
 
@@ -82,7 +82,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
           if match = regex.match(line)
             packages[match.captures[0]] = match.captures[1]
           else
-            warning(_("Failed to match line '#{line}'"))
+            warning(_("Failed to match line '%{line}'") % { line: line })
           end
         end
       end
@@ -173,7 +173,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
     if version
       unless @resource.allow_virtual?
-        warning(_("#{resource_name} is a group, but allow_virtual is false."))
+        warning(_("%{resource_name} is a group, but allow_virtual is false.") % { resource_name: resource_name })
         return nil
       end
     else
@@ -200,7 +200,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
     is_group = self.class.group?(resource_name)
 
-    fail(_("Refusing to uninstall package group #{resource_name}, because allow_virtual is false.")) if is_group && !@resource.allow_virtual?
+    fail(_("Refusing to uninstall package group %{resource_name}, because allow_virtual is false.") % { resource_name: resource_name }) if is_group && !@resource.allow_virtual?
 
     cmd = %w{--noconfirm --noprogressbar}
     cmd += uninstall_options if @resource[:uninstall_options]
@@ -230,7 +230,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     begin
       source_uri = URI.parse source
     rescue => detail
-      self.fail Puppet::Error, _("Invalid source '#{source}': #{detail}"), detail
+      self.fail Puppet::Error, _("Invalid source '%{source}': %{detail}") % { source: source, detail: detail }, detail
     end
 
     source = case source_uri.scheme
@@ -241,7 +241,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     when /puppet/i
       fail _("puppet:// URL is not supported by pacman")
     else
-      fail _("Source #{source} is not supported by pacman")
+      fail _("Source %{source} is not supported by pacman") % { source: source }
     end
     pacman "--noconfirm", "--noprogressbar", "-Sy"
     pacman "--noconfirm", "--noprogressbar", "-U", source
@@ -251,7 +251,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     resource_name = @resource[:name]
 
     # Refuse to install if not allowing virtual packages and the resource is a group
-    fail(_("Refusing to install package group #{resource_name}, because allow_virtual is false.")) if self.class.group?(resource_name) && !@resource.allow_virtual?
+    fail(_("Refusing to install package group %{resource_name}, because allow_virtual is false.") % { resource_name: resource_name }) if self.class.group?(resource_name) && !@resource.allow_virtual?
 
     cmd = %w{--noconfirm --needed --noprogressbar}
     cmd += install_options if @resource[:install_options]

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -111,7 +111,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
 
   def unhold
     r = exec_cmd(command(:pkg), 'unfreeze', @resource[:name])
-    raise Puppet::Error, _("Unable to unfreeze #{r[:out]}") unless [0,4].include? r[:exit]
+    raise Puppet::Error, _("Unable to unfreeze %{package}") % { package: r[:out] } unless [0,4].include? r[:exit]
   end
 
   def insync?(is)
@@ -146,7 +146,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       potential_matches = pkg(:list, '-Hvfa', "#{name}@#{should}").split("\n").map{|l|self.class.parse_line(l)}
       n = potential_matches.length
       if n > 1
-        warning(_("Implicit version #{should} has #{n} possible matches"))
+        warning(_("Implicit version %{should} has %{n} possible matches") % { should: should, n: n })
       end
       potential_matches.each{ |p|
         command = is == :absent ? 'install' : 'update'
@@ -156,7 +156,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
           # if the first installable match would cause no changes, we're in sync
           return true
         when 0
-          warning(_("Selecting version '#{p[:ensure]}' for implicit '#{should}'"))
+          warning(_("Selecting version '%{version}' for implicit '%{should}'") % { version: p[:ensure], should: should })
           @resource[:ensure] = p[:ensure]
           return false
         end
@@ -212,7 +212,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     end
     r = exec_cmd(command(:pkg), command, *args, name)
     return r if nofail
-    raise Puppet::Error, _("Unable to update #{r[:out]}") if r[:exit] != 0
+    raise Puppet::Error, _("Unable to update %{package}") % { package: r[:out] } if r[:exit] != 0
   end
 
   # uninstall the package. The complication comes from the -r_ecursive flag which is no longer
@@ -232,7 +232,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     r = install(true)
     # 4 == /No updates available for this image./
     return if [0,4].include? r[:exit]
-    raise Puppet::Error, _("Unable to update #{r[:out]}")
+    raise Puppet::Error, _("Unable to update %{package}") % { package: r[:out] }
   end
 
   # list a specific package

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       when '-'
         {:status => 'known'}
       else
-        raise ArgumentError, 'Unknown format %s: %s[%s]' % [self.name, flags, flags[0..0]]
+        raise ArgumentError, _('Unknown format %s: %s[%s]') % [self.name, flags, flags[0..0]]
       end
     ).merge(
       case flags[1..1]
@@ -52,7 +52,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       when '-'
         {}
       else
-        raise ArgumentError, 'Unknown format %s: %s[%s]' % [self.name, flags, flags[1..1]]
+        raise ArgumentError, _('Unknown format %s: %s[%s]') % [self.name, flags, flags[1..1]]
       end
     )
   end
@@ -82,7 +82,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     when /known/
       {:status => 'known'}
     else
-      raise ArgumentError, 'Unknown format %s: %s' % [self.name, state]
+      raise ArgumentError, _('Unknown format %s: %s') % [self.name, state]
     end
   end
 
@@ -101,7 +101,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       {:publisher => $1, :name => $2, :ensure => $3}.merge pkg_state($4).merge(ufoxi_flag($5))
 
     else
-      raise ArgumentError, 'Unknown line format %s: %s' % [self.name, line]
+      raise ArgumentError, _('Unknown line format %s: %s') % [self.name, line]
     end).merge({:provider => self.name})
   end
 
@@ -111,7 +111,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
 
   def unhold
     r = exec_cmd(command(:pkg), 'unfreeze', @resource[:name])
-    raise Puppet::Error, "Unable to unfreeze #{r[:out]}" unless [0,4].include? r[:exit]
+    raise Puppet::Error, _("Unable to unfreeze #{r[:out]}") unless [0,4].include? r[:exit]
   end
 
   def insync?(is)
@@ -146,7 +146,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       potential_matches = pkg(:list, '-Hvfa', "#{name}@#{should}").split("\n").map{|l|self.class.parse_line(l)}
       n = potential_matches.length
       if n > 1
-        warning("Implicit version #{should} has #{n} possible matches")
+        warning(_("Implicit version #{should} has #{n} possible matches"))
       end
       potential_matches.each{ |p|
         command = is == :absent ? 'install' : 'update'
@@ -156,7 +156,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
           # if the first installable match would cause no changes, we're in sync
           return true
         when 0
-          warning("Selecting version '#{p[:ensure]}' for implicit '#{should}'")
+          warning(_("Selecting version '#{p[:ensure]}' for implicit '#{should}'"))
           @resource[:ensure] = p[:ensure]
           return false
         end
@@ -212,7 +212,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     end
     r = exec_cmd(command(:pkg), command, *args, name)
     return r if nofail
-    raise Puppet::Error, "Unable to update #{r[:out]}" if r[:exit] != 0
+    raise Puppet::Error, _("Unable to update #{r[:out]}") if r[:exit] != 0
   end
 
   # uninstall the package. The complication comes from the -r_ecursive flag which is no longer
@@ -232,7 +232,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     r = install(true)
     # 4 == /No updates available for this image./
     return if [0,4].include? r[:exit]
-    raise Puppet::Error, "Unable to update #{r[:out]}"
+    raise Puppet::Error, _("Unable to update #{r[:out]}")
   end
 
   # list a specific package

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -104,7 +104,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
         File.open(cached_source) do |dmg|
           xml_str = hdiutil "mount", "-plist", "-nobrowse", "-readonly", "-noidme", "-mountrandom", "/tmp", dmg.path
           hdiutil_info = Puppet::Util::Plist.parse_plist(xml_str)
-          raise Puppet::Error.new(_("No disk entities returned by mount at #{dmg.path}")) unless hdiutil_info.has_key?("system-entities")
+          raise Puppet::Error.new(_("No disk entities returned by mount at %{path}") % { path: dmg.path }) unless hdiutil_info.has_key?("system-entities")
           mounts = hdiutil_info["system-entities"].collect { |entity|
             entity["mount-point"]
           }.compact

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
     end
 
     unless source =~ /\.dmg$/i || source =~ /\.pkg$/i
-      raise Puppet::Error.new("Mac OS X PKG DMGs must specify a source string ending in .dmg or flat .pkg file")
+      raise Puppet::Error.new(_("Mac OS X PKG DMGs must specify a source string ending in .dmg or flat .pkg file"))
     end
     require 'open-uri' # Dead code; this is never used. The File.open call 20-ish lines south of here used to be Kernel.open but changed in '09. -NF
     cached_source = source
@@ -104,7 +104,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
         File.open(cached_source) do |dmg|
           xml_str = hdiutil "mount", "-plist", "-nobrowse", "-readonly", "-noidme", "-mountrandom", "/tmp", dmg.path
           hdiutil_info = Puppet::Util::Plist.parse_plist(xml_str)
-          raise Puppet::Error.new("No disk entities returned by mount at #{dmg.path}") unless hdiutil_info.has_key?("system-entities")
+          raise Puppet::Error.new(_("No disk entities returned by mount at #{dmg.path}")) unless hdiutil_info.has_key?("system-entities")
           mounts = hdiutil_info["system-entities"].collect { |entity|
             entity["mount-point"]
           }.compact
@@ -142,10 +142,10 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
   def install
     source = nil
     unless source = @resource[:source]
-      raise Puppet::Error.new("Mac OS X PKG DMGs must specify a package source.")
+      raise Puppet::Error.new(_("Mac OS X PKG DMGs must specify a package source."))
     end
     unless name = @resource[:name]
-      raise Puppet::Error.new("Mac OS X PKG DMGs must specify a package name.")
+      raise Puppet::Error.new(_("Mac OS X PKG DMGs must specify a package name."))
     end
     self.class.installpkgdmg(source,name)
   end

--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -40,10 +40,10 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
 
     if packages.empty?
       if @resource[:ensure] == :absent
-        notice "declared as absent but unavailable #{@resource.file}:#{resource.line}"
+        notice _("declared as absent but unavailable #{@resource.file}:#{resource.line}")
         return false
       else
-        @resource.fail "No candidate to be installed"
+        @resource.fail _("No candidate to be installed")
       end
     end
 

--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
 
     if packages.empty?
       if @resource[:ensure] == :absent
-        notice _("declared as absent but unavailable #{@resource.file}:#{resource.line}")
+        notice _("declared as absent but unavailable %{file}:%{line}") % { file: @resource.file, line: resource.line }
         return false
       else
         @resource.fail _("No candidate to be installed")

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -15,8 +15,8 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
 
   def self.healthcheck()
     unless Puppet::FileSystem.exist?("/var/opt/csw/pkgutil/admin")
-      Puppet.notice "It is highly recommended you create '/var/opt/csw/pkgutil/admin'."
-      Puppet.notice "See /var/opt/csw/pkgutil"
+      Puppet.notice _("It is highly recommended you create '/var/opt/csw/pkgutil/admin'.")
+      Puppet.notice _("See /var/opt/csw/pkgutil")
     end
 
     correct_wgetopts = false
@@ -26,7 +26,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
       end
     end
     if ! correct_wgetopts
-      Puppet.notice "It is highly recommended that you set 'wgetopts=-nv' in your pkgutil.conf."
+      Puppet.notice _("It is highly recommended that you set 'wgetopts=-nv' in your pkgutil.conf.")
     end
   end
 
@@ -70,7 +70,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
       if line =~ /\s*(\S+)\s+(\S+)\s+(.*)/
         { :alias => $1, :name => $2, :avail => $3 }
       else
-        Puppet.warning "Cannot match %s" % line
+        Puppet.warning _("Cannot match %s") % line
       end
     end.reject { |h| h.nil? }
   end
@@ -88,7 +88,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     output = output.split("\n")
 
     if output[-1] == "Not in catalog"
-      Puppet.warning "Package not in pkgutil catalog: %s" % hash[:justme]
+      Puppet.warning _("Package not in pkgutil catalog: %s") % hash[:justme]
       return nil
     end
 
@@ -142,7 +142,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
 
       return hash
     else
-      Puppet.warning "Cannot match %s" % line
+      Puppet.warning _("Cannot match %s") % line
       return nil
     end
   end

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -213,11 +213,11 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
       case packages.size
         when 0
-          raise Puppet::Error.new(_("No package found with the specified name [#{@resource[:name]}]"))
+          raise Puppet::Error.new(_("No package found with the specified name [%{name}]") % { name: @resource[:name] })
         when 1
           @eix_result = packages[0]
         else
-          raise Puppet::Error.new(_("More than one package with the specified name [#{search_value}], please use the category parameter to disambiguate"))
+          raise Puppet::Error.new(_("More than one package with the specified name [%{search_value}], please use the category parameter to disambiguate") % { search_value: search_value })
       end
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error.new(detail)

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -213,11 +213,11 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
       case packages.size
         when 0
-          raise Puppet::Error.new("No package found with the specified name [#{@resource[:name]}]")
+          raise Puppet::Error.new(_("No package found with the specified name [#{@resource[:name]}]"))
         when 1
           @eix_result = packages[0]
         else
-          raise Puppet::Error.new("More than one package with the specified name [#{search_value}], please use the category parameter to disambiguate")
+          raise Puppet::Error.new(_("More than one package with the specified name [#{search_value}], please use the category parameter to disambiguate"))
       end
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error.new(detail)

--- a/lib/puppet/provider/package/ports.rb
+++ b/lib/puppet/provider/package/ports.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
 
     output = portupgrade(*cmd)
     if output =~ /\*\* No such /
-      raise Puppet::ExecutionFailure, "Could not find package #{@resource[:name]}"
+      raise Puppet::ExecutionFailure, _("Could not find package #{@resource[:name]}")
     end
   end
 
@@ -43,7 +43,7 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
 
     unless pkgstuff =~ /^\S+-([^-\s]+)$/
       raise Puppet::Error,
-        "Could not match package info '#{pkgstuff}'"
+        _("Could not match package info '#{pkgstuff}'")
     end
 
     version = $1
@@ -57,7 +57,7 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
 
     unless info =~ /\((\w+) has (.+)\)/
       raise Puppet::Error,
-        "Could not match version info '#{info}'"
+        _("Could not match version info '#{info}'")
     end
 
     source, newversion = $1, $2

--- a/lib/puppet/provider/package/ports.rb
+++ b/lib/puppet/provider/package/ports.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
 
     output = portupgrade(*cmd)
     if output =~ /\*\* No such /
-      raise Puppet::ExecutionFailure, _("Could not find package #{@resource[:name]}")
+      raise Puppet::ExecutionFailure, _("Could not find package %{name}") % { name: @resource[:name] }
     end
   end
 
@@ -43,7 +43,7 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
 
     unless pkgstuff =~ /^\S+-([^-\s]+)$/
       raise Puppet::Error,
-        _("Could not match package info '#{pkgstuff}'")
+        _("Could not match package info '%{pkgstuff}'") % { pkgstuff: pkgstuff }
     end
 
     version = $1
@@ -57,7 +57,7 @@ Puppet::Type.type(:package).provide :ports, :parent => :freebsd, :source => :fre
 
     unless info =~ /\((\w+) has (.+)\)/
       raise Puppet::Error,
-        _("Could not match version info '#{info}'")
+        _("Could not match version info '%{info}'") % { info: info }
     end
 
     source, newversion = $1, $2

--- a/lib/puppet/provider/package/portupgrade.rb
+++ b/lib/puppet/provider/package/portupgrade.rb
@@ -90,7 +90,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     end
 
     if output =~ /\*\* No such /
-      raise Puppet::ExecutionFailure, _("Could not find package #{@resource[:name]}")
+      raise Puppet::ExecutionFailure, _("Could not find package %{name}") % { name: @resource[:name] }
     end
 
     # No return code required, so do nil to be clean
@@ -148,10 +148,10 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
       # Seriously - this section should never be called in a perfect world.
       # as verification that the port is installed has already happened in query.
       if output =~ /^\*\* No matching package /
-        raise Puppet::ExecutionFailure, _("Could not find package #{@resource[:name]}")
+        raise Puppet::ExecutionFailure, _("Could not find package %{name}") % { name: @resource[:name] }
       else
         # Any other error (dump output to log)
-        raise Puppet::ExecutionFailure, _("Unexpected output from portversion: #{output}")
+        raise Puppet::ExecutionFailure, _("Unexpected output from portversion: %{output}") % { output: output }
       end
 
       # Just in case we still are running, return nil
@@ -160,7 +160,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
 
     # At this point normal operation has finished and we shouldn't have been called.
     # Error out and let the admin deal with it.
-    raise Puppet::Error, _("portversion.latest() - fatal error with portversion: #{output}")
+    raise Puppet::Error, _("portversion.latest() - fatal error with portversion: %{output}") % { output: output }
   end
 
   ###### Query subcommand - return a hash of details if exists, or nil if it doesn't.

--- a/lib/puppet/provider/package/portupgrade.rb
+++ b/lib/puppet/provider/package/portupgrade.rb
@@ -90,7 +90,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
     end
 
     if output =~ /\*\* No such /
-      raise Puppet::ExecutionFailure, "Could not find package #{@resource[:name]}"
+      raise Puppet::ExecutionFailure, _("Could not find package #{@resource[:name]}")
     end
 
     # No return code required, so do nil to be clean
@@ -148,10 +148,10 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
       # Seriously - this section should never be called in a perfect world.
       # as verification that the port is installed has already happened in query.
       if output =~ /^\*\* No matching package /
-        raise Puppet::ExecutionFailure, "Could not find package #{@resource[:name]}"
+        raise Puppet::ExecutionFailure, _("Could not find package #{@resource[:name]}")
       else
         # Any other error (dump output to log)
-        raise Puppet::ExecutionFailure, "Unexpected output from portversion: #{output}"
+        raise Puppet::ExecutionFailure, _("Unexpected output from portversion: #{output}")
       end
 
       # Just in case we still are running, return nil
@@ -160,7 +160,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
 
     # At this point normal operation has finished and we shouldn't have been called.
     # Error out and let the admin deal with it.
-    raise Puppet::Error, "portversion.latest() - fatal error with portversion: #{output}"
+    raise Puppet::Error, _("portversion.latest() - fatal error with portversion: #{output}")
   end
 
   ###### Query subcommand - return a hash of details if exists, or nil if it doesn't.

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -88,7 +88,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
         }
       }
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error, "Failed to list packages", $!.backtrace
+      raise Puppet::Error, _("Failed to list packages"), $!.backtrace
     end
 
     packages
@@ -128,7 +128,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
   # Here we just retrieve the version from the file specified in the source.
   def latest
     unless source = @resource[:source]
-      @resource.fail "RPMs must specify a package source"
+      @resource.fail _("RPMs must specify a package source")
     end
 
     cmd = [command(:rpm), "-q", "--qf", "'#{self.class::NEVRA_FORMAT}'", "-p", source]
@@ -138,7 +138,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
 
   def install
     unless source = @resource[:source]
-      @resource.fail "RPMs must specify a package source"
+      @resource.fail _("RPMs must specify a package source")
     end
 
     version =  @property_hash[:ensure]

--- a/lib/puppet/provider/package/rug.rb
+++ b/lib/puppet/provider/package/rug.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:package).provide :rug, :parent => :rpm do
 
     unless self.query
       raise Puppet::ExecutionFailure.new(
-        "Could not find package #{self.name}"
+        _("Could not find package #{self.name}")
       )
     end
   end

--- a/lib/puppet/provider/package/rug.rb
+++ b/lib/puppet/provider/package/rug.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:package).provide :rug, :parent => :rpm do
 
     unless self.query
       raise Puppet::ExecutionFailure.new(
-        _("Could not find package #{self.name}")
+        _("Could not find package %{name}") % { name: self.name }
       )
     end
   end

--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -76,7 +76,7 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
       return self.class.namemap(pkgs[0]) if errmsg.nil?
       # according to commit 41356a7 some errors do not raise an exception
       # so even though pkginfo passed, we have to check the actual output
-      raise Puppet::Error, "Unable to get information about package #{@resource[:name]} because of: #{errmsg}"
+      raise Puppet::Error, _("Unable to get information about package #{@resource[:name]} because of: #{errmsg}")
     rescue Puppet::ExecutionFailure
       return {:ensure => :absent}
     end
@@ -93,7 +93,8 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
 
   # only looking for -G now
   def install
-    raise Puppet::Error, "Sun packages must specify a package source" unless @resource[:source]
+    #TRANSLATORS Sun refers to the company name, do not translate
+    raise Puppet::Error, _("Sun packages must specify a package source") unless @resource[:source]
     options = {
       :adminfile    => @resource[:adminfile],
       :responsefile => @resource[:responsefile],

--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -76,7 +76,7 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
       return self.class.namemap(pkgs[0]) if errmsg.nil?
       # according to commit 41356a7 some errors do not raise an exception
       # so even though pkginfo passed, we have to check the actual output
-      raise Puppet::Error, _("Unable to get information about package #{@resource[:name]} because of: #{errmsg}")
+      raise Puppet::Error, _("Unable to get information about package %{name} because of: %{errmsg}") % { name: @resource[:name], errmsg: errmsg }
     rescue Puppet::ExecutionFailure
       return {:ensure => :absent}
     end

--- a/lib/puppet/provider/package/up2date.rb
+++ b/lib/puppet/provider/package/up2date.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:package).provide :up2date, :parent => :rpm, :source => :rpm d
 
     unless self.query
       raise Puppet::ExecutionFailure.new(
-        "Could not find package #{self.name}"
+        _("Could not find package #{self.name}")
       )
     end
   end

--- a/lib/puppet/provider/package/up2date.rb
+++ b/lib/puppet/provider/package/up2date.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:package).provide :up2date, :parent => :rpm, :source => :rpm d
 
     unless self.query
       raise Puppet::ExecutionFailure.new(
-        _("Could not find package #{self.name}")
+        _("Could not find package %{name}") % { name: self.name }
       )
     end
   end

--- a/lib/puppet/provider/package/urpmi.rb
+++ b/lib/puppet/provider/package/urpmi.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:package).provide :urpmi, :parent => :rpm, :source => :rpm do
     urpmi "--auto", wanted
 
     unless self.query
-      raise Puppet::Error, "Package #{self.name} was not present after trying to install it"
+      raise Puppet::Error, _("Package #{self.name} was not present after trying to install it")
     end
   end
 

--- a/lib/puppet/provider/package/urpmi.rb
+++ b/lib/puppet/provider/package/urpmi.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:package).provide :urpmi, :parent => :rpm, :source => :rpm do
     urpmi "--auto", wanted
 
     unless self.query
-      raise Puppet::Error, _("Package #{self.name} was not present after trying to install it")
+      raise Puppet::Error, _("Package %{name} was not present after trying to install it") % { name: self.name }
     end
   end
 

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -90,17 +90,17 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
     when self.class::ERROR_SUCCESS
       # yeah
     when self.class::ERROR_SUCCESS_REBOOT_INITIATED
-      warning("The package #{operation}ed successfully and the system is rebooting now.")
+      warning(_("The package #{operation}ed successfully and the system is rebooting now."))
     when self.class::ERROR_SUCCESS_REBOOT_REQUIRED
-      warning("The package #{operation}ed successfully, but the system must be rebooted.")
+      warning(_("The package #{operation}ed successfully, but the system must be rebooted."))
     else
-      raise Puppet::Util::Windows::Error.new("Failed to #{operation}", hr)
+      raise Puppet::Util::Windows::Error.new(_("Failed to #{operation}"), hr)
     end
   end
 
   # This only gets called if there is a value to validate, but not if it's absent
   def validate_source(value)
-    fail("The source parameter cannot be empty when using the Windows provider.") if value.empty?
+    fail(_("The source parameter cannot be empty when using the Windows provider.")) if value.empty?
   end
 
   def install_options

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -90,11 +90,11 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
     when self.class::ERROR_SUCCESS
       # yeah
     when self.class::ERROR_SUCCESS_REBOOT_INITIATED
-      warning(_("The package #{operation}ed successfully and the system is rebooting now."))
+      warning(_("The package %{operation}ed successfully and the system is rebooting now.") % { operation: operation })
     when self.class::ERROR_SUCCESS_REBOOT_REQUIRED
-      warning(_("The package #{operation}ed successfully, but the system must be rebooted."))
+      warning(_("The package %{operation}ed successfully, but the system must be rebooted.") % { operation: operation })
     else
-      raise Puppet::Util::Windows::Error.new(_("Failed to #{operation}"), hr)
+      raise Puppet::Util::Windows::Error.new(_("Failed to %{operation}") % { operation: operation }, hr)
     end
   end
 

--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -58,10 +58,10 @@ class Puppet::Provider::Package::Windows
         # REMIND: what about msp, etc
         MsiPackage
       when /\.exe"?\Z/i
-        fail(_("The source does not exist: '#{resource[:source]}'")) unless Puppet::FileSystem.exist?(resource[:source])
+        fail(_("The source does not exist: '%{source}'") % { source: resource[:source] }) unless Puppet::FileSystem.exist?(resource[:source])
         ExePackage
       else
-        fail(_("Don't know how to install '#{resource[:source]}'"))
+        fail(_("Don't know how to install '%{source}'") % { source: resource[:source] })
       end
     end
 

--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -50,7 +50,7 @@ class Puppet::Provider::Package::Windows
 
     # Get the class that knows how to install this resource
     def self.installer_class(resource)
-      fail("The source parameter is required when using the Windows provider.") unless resource[:source]
+      fail(_("The source parameter is required when using the Windows provider.")) unless resource[:source]
 
       case resource[:source]
       when /\.msi"?\Z/i
@@ -58,10 +58,10 @@ class Puppet::Provider::Package::Windows
         # REMIND: what about msp, etc
         MsiPackage
       when /\.exe"?\Z/i
-        fail("The source does not exist: '#{resource[:source]}'") unless Puppet::FileSystem.exist?(resource[:source])
+        fail(_("The source does not exist: '#{resource[:source]}'")) unless Puppet::FileSystem.exist?(resource[:source])
         ExePackage
       else
-        fail("Don't know how to install '#{resource[:source]}'")
+        fail(_("Don't know how to install '#{resource[:source]}'"))
       end
     end
 

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     elsif output.exitstatus == 0
       self.debug "#{command(:cmd)} check-update exited with 0; no package updates available."
     else
-      self.warning _("Could not check for updates, '#{command(:cmd)} check-update' exited with #{output.exitstatus}")
+      self.warning _("Could not check for updates, '%{cmd} check-update' exited with %{status}") % { cmd: command(:cmd), status: output.exitstatus }
     end
     updates
   end
@@ -196,18 +196,18 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     output = execute(command)
 
     if output =~ /^No package #{wanted} available\.$/
-      raise Puppet::Error, _("Could not find package #{wanted}")
+      raise Puppet::Error, _("Could not find package %{wanted}") % { wanted: wanted }
     end
 
     # If a version was specified, query again to see if it is a matching version
     if should
       is = self.query
-      raise Puppet::Error, _("Could not find package #{self.name}") unless is
+      raise Puppet::Error, _("Could not find package %{name}") % { name: self.name } unless is
 
       # FIXME: Should we raise an exception even if should == :latest
       # and yum updated us to a version other than @param_hash[:ensure] ?
       vercmp_result = rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(is[:ensure]))
-      raise Puppet::Error, _("Failed to update to version #{should}, got version #{is[:ensure]} instead") if vercmp_result != 0
+      raise Puppet::Error, _("Failed to update to version %{should}, got version %{version} instead") % { should: should, version: is[:ensure] } if vercmp_result != 0
     end
   end
 

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   defaultfor :osfamily => :redhat
 
   def self.prefetch(packages)
-    raise Puppet::Error, "The yum provider can only be used as root" if Process.euid != 0
+    raise Puppet::Error, _("The yum provider can only be used as root") if Process.euid != 0
     super
   end
 
@@ -80,7 +80,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     elsif output.exitstatus == 0
       self.debug "#{command(:cmd)} check-update exited with 0; no package updates available."
     else
-      self.warning "Could not check for updates, '#{command(:cmd)} check-update' exited with #{output.exitstatus}"
+      self.warning _("Could not check for updates, '#{command(:cmd)} check-update' exited with #{output.exitstatus}")
     end
     updates
   end
@@ -196,18 +196,18 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     output = execute(command)
 
     if output =~ /^No package #{wanted} available\.$/
-      raise Puppet::Error, "Could not find package #{wanted}"
+      raise Puppet::Error, _("Could not find package #{wanted}")
     end
 
     # If a version was specified, query again to see if it is a matching version
     if should
       is = self.query
-      raise Puppet::Error, "Could not find package #{self.name}" unless is
+      raise Puppet::Error, _("Could not find package #{self.name}") unless is
 
       # FIXME: Should we raise an exception even if should == :latest
       # and yum updated us to a version other than @param_hash[:ensure] ?
       vercmp_result = rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(is[:ensure]))
-      raise Puppet::Error, "Failed to update to version #{should}, got version #{is[:ensure]} instead" if vercmp_result != 0
+      raise Puppet::Error, _("Failed to update to version #{should}, got version #{is[:ensure]} instead") if vercmp_result != 0
     end
   end
 

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -106,7 +106,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
 
     unless self.query
       raise Puppet::ExecutionFailure.new(
-        "Could not find package #{self.name}"
+        _("Could not find package #{self.name}")
       )
     end
   end

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -106,7 +106,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
 
     unless self.query
       raise Puppet::ExecutionFailure.new(
-        _("Could not find package #{self.name}")
+        _("Could not find package %{name}") % { name: self.name }
       )
     end
   end

--- a/lib/puppet/provider/parsedfile.rb
+++ b/lib/puppet/provider/parsedfile.rb
@@ -265,7 +265,7 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
       target_records = retrieve(target)
     rescue Puppet::Util::FileType::FileReadError => detail
       puts detail.backtrace if Puppet[:trace]
-      Puppet.err "Could not prefetch #{self.resource_type.name} provider '#{self.name}' target '#{target}': #{detail}. Treating as empty"
+      Puppet.err _("Could not prefetch #{self.resource_type.name} provider '#{self.name}' target '#{target}': #{detail}. Treating as empty")
       target_records = []
     end
 

--- a/lib/puppet/provider/parsedfile.rb
+++ b/lib/puppet/provider/parsedfile.rb
@@ -265,7 +265,7 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
       target_records = retrieve(target)
     rescue Puppet::Util::FileType::FileReadError => detail
       puts detail.backtrace if Puppet[:trace]
-      Puppet.err _("Could not prefetch #{self.resource_type.name} provider '#{self.name}' target '#{target}': #{detail}. Treating as empty")
+      Puppet.err _("Could not prefetch %{resource} provider '%{name}' target '%{target}': %{detail}. Treating as empty") % { resource: self.resource_type.name, name: self.name, target: target, detail: detail }
       target_records = []
     end
 


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/provider.rb` and `lib/puppet/provider/*` for translation.