### PR TITLE
(PUP-7042) Mark strings in agent

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -31,7 +31,7 @@ class Puppet::Agent
   # Perform a run with our client.
   def run(client_options = {})
     if disabled?
-      Puppet.notice _("Skipping run of #{client_class}; administratively disabled (Reason: '#{disable_message}');\nUse 'puppet agent --enable' to re-enable.")
+      Puppet.notice _("Skipping run of %{client_class}; administratively disabled (Reason: '%{disable_message}');\nUse 'puppet agent --enable' to re-enable.") % { client_class: client_class, disable_message: disable_message }
       return
     end
 
@@ -44,16 +44,16 @@ class Puppet::Agent
             client_args = client_options.merge(:pluginsync => Puppet::Configurer.should_pluginsync?)
             lock { client.run(client_args) }
           rescue Puppet::LockError
-            Puppet.notice _("Run of #{client_class} already in progress; skipping  (#{lockfile_path} exists)")
+            Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
             return
           rescue StandardError => detail
-            Puppet.log_exception(detail, _("Could not run #{client_class}: #{detail}"))
+            Puppet.log_exception(detail, _("Could not run %{client_class}: %{detail}") % { client_class: client_class, detail: detail })
           end
         end
       end
       true
     end
-    Puppet.notice _("Shutdown/restart in progress (#{Puppet::Application.run_status.inspect}); skipping run") unless block_run
+    Puppet.notice _("Shutdown/restart in progress (%{status}); skipping run") % { status: Puppet::Application.run_status.inspect } unless block_run
     result
   end
 
@@ -92,7 +92,7 @@ class Puppet::Agent
     begin
       @client = client_class.new(Puppet::Configurer::DownloaderFactory.new, transaction_uuid)
     rescue StandardError => detail
-      Puppet.log_exception(detail, _("Could not create instance of #{client_class}: #{detail}"))
+      Puppet.log_exception(detail, _("Could not create instance of %{client_class}: %{detail}") % { client_class: client_class, detail: detail })
       return
     end
     yield @client

--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -31,7 +31,7 @@ class Puppet::Agent
   # Perform a run with our client.
   def run(client_options = {})
     if disabled?
-      Puppet.notice "Skipping run of #{client_class}; administratively disabled (Reason: '#{disable_message}');\nUse 'puppet agent --enable' to re-enable."
+      Puppet.notice _("Skipping run of #{client_class}; administratively disabled (Reason: '#{disable_message}');\nUse 'puppet agent --enable' to re-enable.")
       return
     end
 
@@ -44,16 +44,16 @@ class Puppet::Agent
             client_args = client_options.merge(:pluginsync => Puppet::Configurer.should_pluginsync?)
             lock { client.run(client_args) }
           rescue Puppet::LockError
-            Puppet.notice "Run of #{client_class} already in progress; skipping  (#{lockfile_path} exists)"
+            Puppet.notice _("Run of #{client_class} already in progress; skipping  (#{lockfile_path} exists)")
             return
           rescue StandardError => detail
-            Puppet.log_exception(detail, "Could not run #{client_class}: #{detail}")
+            Puppet.log_exception(detail, _("Could not run #{client_class}: #{detail}"))
           end
         end
       end
       true
     end
-    Puppet.notice "Shutdown/restart in progress (#{Puppet::Application.run_status.inspect}); skipping run" unless block_run
+    Puppet.notice _("Shutdown/restart in progress (#{Puppet::Application.run_status.inspect}); skipping run") unless block_run
     result
   end
 
@@ -65,7 +65,7 @@ class Puppet::Agent
     return yield unless forking or Puppet.features.windows?
 
     child_pid = Kernel.fork do
-      $0 = "puppet agent: applying configuration"
+      $0 = _("puppet agent: applying configuration")
       begin
         exit(yield)
       rescue SystemExit
@@ -92,7 +92,7 @@ class Puppet::Agent
     begin
       @client = client_class.new(Puppet::Configurer::DownloaderFactory.new, transaction_uuid)
     rescue StandardError => detail
-      Puppet.log_exception(detail, "Could not create instance of #{client_class}: #{detail}")
+      Puppet.log_exception(detail, _("Could not create instance of #{client_class}: #{detail}"))
       return
     end
     yield @client

--- a/lib/puppet/agent/disabler.rb
+++ b/lib/puppet/agent/disabler.rb
@@ -16,14 +16,14 @@ module Puppet::Agent::Disabler
 
   # Let the daemon run again, freely in the filesystem.
   def enable
-    Puppet.notice "Enabling Puppet."
+    Puppet.notice _("Enabling Puppet.")
     disable_lockfile.unlock
   end
 
   # Stop the daemon from making any catalog runs.
   def disable(msg=nil)
     data = {}
-    Puppet.notice "Disabling Puppet."
+    Puppet.notice _("Disabling Puppet.")
     if (! msg.nil?)
       data[DISABLED_MESSAGE_JSON_KEY] = msg
     end

--- a/lib/puppet/agent/locker.rb
+++ b/lib/puppet/agent/locker.rb
@@ -23,13 +23,13 @@ module Puppet::Agent::Locker
         lockfile.unlock
       end
     else
-      fail Puppet::LockError, 'Failed to acquire lock'
+      fail Puppet::LockError, _('Failed to acquire lock')
     end
   end
 
   # @deprecated
   def running?
-    Puppet.deprecation_warning <<-ENDHEREDOC
+    Puppet.deprecation_warning _(<<-ENDHEREDOC)
 Puppet::Agent::Locker.running? is deprecated as it is inherently unsafe.
 The only safe way to know if the lock is locked is to try lock and perform some
 action and then handle the LockError that may result.


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/agent.rb` and `lib/puppet/agent/*` for translation.