### PR TITLE
(PUP-7042) Mark strings in application

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -228,7 +228,7 @@ class Application
       begin
         require @loader.expand(application_name.to_s.downcase)
       rescue LoadError => e
-        Puppet.log_and_raise(e, "Unable to find application '#{application_name}'. #{e}")
+        Puppet.log_and_raise(e, _("Unable to find application '#{application_name}'. #{e}"))
       end
 
       class_name = Puppet::Util::ConstantInflector.file2constant(application_name.to_s)
@@ -249,7 +249,7 @@ class Application
       ################################################################
 
       if clazz.nil?
-        raise Puppet::Error.new("Unable to load application class '#{class_name}' from file 'puppet/application/#{application_name}.rb'")
+        raise Puppet::Error.new(_("Unable to load application class '#{class_name}' from file 'puppet/application/#{application_name}.rb'"))
       end
 
       return clazz
@@ -339,7 +339,7 @@ class Application
     # I don't really like the names of these lifecycle phases.  It would be nice to change them to some more meaningful
     # names, and make deprecated aliases.  --cprice 2012-03-16
 
-    exit_on_fail("get application-specific default settings") do
+    exit_on_fail(_("get application-specific default settings")) do
       initialize_app_defaults
     end
 
@@ -359,7 +359,7 @@ class Application
   end
 
   def main
-    raise NotImplementedError, "No valid command or main"
+    raise NotImplementedError, _("No valid command or main")
   end
 
   def run_command
@@ -472,7 +472,7 @@ class Application
   end
 
   def help
-    "No help available for puppet #{name}"
+    _("No help available for puppet #{name}")
   end
 end
 end

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -228,7 +228,7 @@ class Application
       begin
         require @loader.expand(application_name.to_s.downcase)
       rescue LoadError => e
-        Puppet.log_and_raise(e, _("Unable to find application '#{application_name}'. #{e}"))
+        Puppet.log_and_raise(e, _("Unable to find application '%{application_name}'. %{error}") % { application_name: application_name, error: e })
       end
 
       class_name = Puppet::Util::ConstantInflector.file2constant(application_name.to_s)
@@ -249,7 +249,7 @@ class Application
       ################################################################
 
       if clazz.nil?
-        raise Puppet::Error.new(_("Unable to load application class '#{class_name}' from file 'puppet/application/#{application_name}.rb'"))
+        raise Puppet::Error.new(_("Unable to load application class '%{class_name}' from file 'puppet/application/%{application_name}.rb'") % { class_name: class_name, application_name: application_name })
       end
 
       return clazz
@@ -345,17 +345,17 @@ class Application
 
     Puppet::ApplicationSupport.push_application_context(self.class.run_mode)
 
-    exit_on_fail("initialize")                                   { preinit }
-    exit_on_fail("parse application options")                    { parse_options }
-    exit_on_fail("prepare for execution")                        { setup }
+    exit_on_fail(_("initialize"))                                   { preinit }
+    exit_on_fail(_("parse application options"))                    { parse_options }
+    exit_on_fail(_("prepare for execution"))                        { setup }
 
     if deprecated?
       Puppet.deprecation_warning(_("`puppet %{name}` is deprecated and will be removed in a future release.") % { name: name })
     end
 
-    exit_on_fail("configure routes from #{Puppet[:route_file]}") { configure_indirector_routes }
-    exit_on_fail("log runtime debug info")                       { log_runtime_environment }
-    exit_on_fail("run")                                          { run_command }
+    exit_on_fail(_("configure routes from %{route_file}") % { route_file: Puppet[:route_file] }) { configure_indirector_routes }
+    exit_on_fail(_("log runtime debug info"))                       { log_runtime_environment }
+    exit_on_fail(_("run"))                                          { run_command }
   end
 
   def main
@@ -472,7 +472,7 @@ class Application
   end
 
   def help
-    _("No help available for puppet #{name}")
+    _("No help available for puppet %{app_name}") % { app_name: name }
   end
 end
 end

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -343,7 +343,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       return
     end
     unless digest = cert.digest(options[:digest].to_s)
-      raise ArgumentError, _("Could not get fingerprint for digest '#{options[:digest]}'")
+      raise ArgumentError, _("Could not get fingerprint for digest '%{digest}'") % { digest: options[:digest] }
     end
     puts digest.to_s
   end
@@ -367,7 +367,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def main(daemon)
-    Puppet.notice _("Starting Puppet client version #{Puppet.version}")
+    Puppet.notice _("Starting Puppet client version %{version}") % { version: Puppet.version }
     daemon.start
   end
 

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -21,7 +21,7 @@ class Puppet::Application::Agent < Puppet::Application
   def preinit
     # Do an initial trap, so that cancels don't get a stack trace.
     Signal.trap(:INT) do
-      $stderr.puts "Cancelling startup"
+      $stderr.puts _("Cancelling startup")
       exit(0)
     end
 
@@ -338,12 +338,12 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def fingerprint
     host = Puppet::SSL::Host.new
     unless cert = host.certificate || host.certificate_request
-      $stderr.puts "Fingerprint asked but no certificate nor certificate request have yet been issued"
+      $stderr.puts _("Fingerprint asked but no certificate nor certificate request have yet been issued")
       exit(1)
       return
     end
     unless digest = cert.digest(options[:digest].to_s)
-      raise ArgumentError, "Could not get fingerprint for digest '#{options[:digest]}'"
+      raise ArgumentError, _("Could not get fingerprint for digest '#{options[:digest]}'")
     end
     puts digest.to_s
   end
@@ -367,7 +367,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def main(daemon)
-    Puppet.notice "Starting Puppet client version #{Puppet.version}"
+    Puppet.notice _("Starting Puppet client version #{Puppet.version}")
     daemon.start
   end
 
@@ -384,7 +384,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
-    raise ArgumentError, "The puppet agent command does not take parameters" unless command_line.args.empty?
+    raise ArgumentError, _("The puppet agent command does not take parameters") unless command_line.args.empty?
 
     setup_test if options[:test]
 

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -190,8 +190,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet[:code] = options[:code] || STDIN.read
     else
       manifest = command_line.args.shift
-      raise _("Could not find file #{manifest}") unless Puppet::FileSystem.exist?(manifest)
-      Puppet.warning(_("Only one file can be applied per run.  Skipping #{command_line.args.join(', ')}")) if command_line.args.size > 0
+      raise _("Could not find file %{manifest}") % { manifest: manifest } unless Puppet::FileSystem.exist?(manifest)
+      Puppet.warning(_("Only one file can be applied per run.  Skipping %{files}") % { files: command_line.args.join(', ') }) if command_line.args.size > 0
     end
 
     # splay if needed
@@ -200,7 +200,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     unless Puppet[:node_name_fact].empty?
       # Collect our facts.
       unless facts = Puppet::Node::Facts.indirection.find(Puppet[:node_name_value])
-        raise _("Could not find facts for #{Puppet[:node_name_value]}")
+        raise _("Could not find facts for %{node}") % { node: Puppet[:node_name_value] }
       end
 
       Puppet[:node_name_value] = facts.values[Puppet[:node_name_fact]]
@@ -209,7 +209,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     # Find our Node
     unless node = Puppet::Node.indirection.find(Puppet[:node_name_value])
-      raise _("Could not find node #{Puppet[:node_name_value]}")
+      raise _("Could not find node %{node}") % { node: Puppet[:node_name_value] }
     end
 
     configured_environment = node.environment || Puppet.lookup(:current_environment)
@@ -225,6 +225,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # the :manifest setting of the apply_environment.
     node.environment = apply_environment
 
+    #TRANSLATORS "puppet apply" is a program command and should not be translated
     Puppet.override({:current_environment => apply_environment}, _("For puppet apply")) do
       # Merge in the facts.
       node.merge(facts.values) if facts
@@ -237,7 +238,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         file = Puppet[:classfile]
         if Puppet::FileSystem.exist?(file)
           unless FileTest.readable?(file)
-            $stderr.puts _("#{file} is not readable")
+            $stderr.puts _("%{file} is not readable") % { file: file }
             exit(63)
           end
           node.classes = Puppet::FileSystem.read(file, :encoding => 'utf-8').split(/[\s\n]+/)

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -190,8 +190,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       Puppet[:code] = options[:code] || STDIN.read
     else
       manifest = command_line.args.shift
-      raise "Could not find file #{manifest}" unless Puppet::FileSystem.exist?(manifest)
-      Puppet.warning("Only one file can be applied per run.  Skipping #{command_line.args.join(', ')}") if command_line.args.size > 0
+      raise _("Could not find file #{manifest}") unless Puppet::FileSystem.exist?(manifest)
+      Puppet.warning(_("Only one file can be applied per run.  Skipping #{command_line.args.join(', ')}")) if command_line.args.size > 0
     end
 
     # splay if needed
@@ -200,7 +200,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     unless Puppet[:node_name_fact].empty?
       # Collect our facts.
       unless facts = Puppet::Node::Facts.indirection.find(Puppet[:node_name_value])
-        raise "Could not find facts for #{Puppet[:node_name_value]}"
+        raise _("Could not find facts for #{Puppet[:node_name_value]}")
       end
 
       Puppet[:node_name_value] = facts.values[Puppet[:node_name_fact]]
@@ -209,7 +209,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     # Find our Node
     unless node = Puppet::Node.indirection.find(Puppet[:node_name_value])
-      raise "Could not find node #{Puppet[:node_name_value]}"
+      raise _("Could not find node #{Puppet[:node_name_value]}")
     end
 
     configured_environment = node.environment || Puppet.lookup(:current_environment)
@@ -225,7 +225,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # the :manifest setting of the apply_environment.
     node.environment = apply_environment
 
-    Puppet.override({:current_environment => apply_environment}, "For puppet apply") do
+    Puppet.override({:current_environment => apply_environment}, _("For puppet apply")) do
       # Merge in the facts.
       node.merge(facts.values) if facts
 
@@ -237,7 +237,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         file = Puppet[:classfile]
         if Puppet::FileSystem.exist?(file)
           unless FileTest.readable?(file)
-            $stderr.puts "#{file} is not readable"
+            $stderr.puts _("#{file} is not readable")
             exit(63)
           end
           node.classes = Puppet::FileSystem.read(file, :encoding => 'utf-8').split(/[\s\n]+/)
@@ -310,7 +310,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     Puppet::Util::Log.newdestination(:console) unless options[:setdest]
 
     Signal.trap(:INT) do
-      $stderr.puts "Exiting"
+      $stderr.puts _("Exiting")
       exit(1)
     end
 

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -322,7 +322,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   # Create and run an applicator.  I wanted to build an interface where you could do
   # something like 'ca.apply(:generate).to(:all) but I don't think it's really possible.
   def apply(ca, method, options)
-    raise ArgumentError, "You must specify the hosts to apply to; valid values are an array or the symbol :all" unless options[:to]
+    raise ArgumentError, _("You must specify the hosts to apply to; valid values are an array or the symbol :all") unless options[:to]
     applier = Puppet::SSL::CertificateAuthority::Interface.new(method, options)
     applier.apply(ca)
   end

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -19,7 +19,7 @@ class Puppet::Application::Device < Puppet::Application
   def preinit
     # Do an initial trap, so that cancels don't get a stack trace.
     Signal.trap(:INT) do
-      $stderr.puts "Cancelling startup"
+      $stderr.puts _("Cancelling startup")
       exit(0)
     end
 

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -25,7 +25,7 @@ class Puppet::Application::Doc < Puppet::Application
     if Puppet::Util::Reference.method_defined?(method)
       options[:format] = method
     else
-      raise "Invalid output format #{arg}"
+      raise _("Invalid output format #{arg}")
     end
   end
 
@@ -34,7 +34,7 @@ class Puppet::Application::Doc < Puppet::Application
     if Puppet::Util::Reference.modes.include?(arg) or arg.intern==:rdoc
       options[:mode] = arg.intern
     else
-      raise "Invalid output mode #{arg}"
+      raise _("Invalid output mode #{arg}")
     end
   end
 
@@ -127,7 +127,7 @@ HELP
       files << ::File.dirname(env.manifest) if env.manifest != Puppet::Node::Environment::NO_MANIFEST
     end
     files += command_line.args
-    Puppet.info "scanning: #{files.inspect}"
+    Puppet.info _("scanning: #{files.inspect}")
 
     Puppet.settings[:document_all] = options[:all] || false
     begin
@@ -139,7 +139,7 @@ HELP
         Puppet::Util::RDoc.rdoc(options[:outputdir], files, options[:charset])
       end
     rescue => detail
-      Puppet.log_exception(detail, "Could not generate documentation: #{detail}")
+      Puppet.log_exception(detail, _("Could not generate documentation: #{detail}"))
       exit_code = 1
     end
     exit exit_code
@@ -151,13 +151,13 @@ HELP
     exit_code = 0
     require 'puppet/util/reference'
     options[:references].sort { |a,b| a.to_s <=> b.to_s }.each do |name|
-      raise "Could not find reference #{name}" unless section = Puppet::Util::Reference.reference(name)
+      raise _("Could not find reference #{name}") unless section = Puppet::Util::Reference.reference(name)
 
       begin
         # Add the per-section text, but with no ToC
         text += section.send(options[:format], with_contents)
       rescue => detail
-        Puppet.log_exception(detail, "Could not generate reference #{name}: #{detail}")
+        Puppet.log_exception(detail, _("Could not generate reference #{name}: #{detail}"))
         exit_code = 1
         next
       end

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -25,7 +25,7 @@ class Puppet::Application::Doc < Puppet::Application
     if Puppet::Util::Reference.method_defined?(method)
       options[:format] = method
     else
-      raise _("Invalid output format #{arg}")
+      raise _("Invalid output format %{arg}") % { arg: arg }
     end
   end
 
@@ -34,7 +34,7 @@ class Puppet::Application::Doc < Puppet::Application
     if Puppet::Util::Reference.modes.include?(arg) or arg.intern==:rdoc
       options[:mode] = arg.intern
     else
-      raise _("Invalid output mode #{arg}")
+      raise _("Invalid output mode %{arg}") % { arg: arg }
     end
   end
 
@@ -127,7 +127,7 @@ HELP
       files << ::File.dirname(env.manifest) if env.manifest != Puppet::Node::Environment::NO_MANIFEST
     end
     files += command_line.args
-    Puppet.info _("scanning: #{files.inspect}")
+    Puppet.info _("scanning: %{files}") % { files: files.inspect }
 
     Puppet.settings[:document_all] = options[:all] || false
     begin
@@ -139,7 +139,7 @@ HELP
         Puppet::Util::RDoc.rdoc(options[:outputdir], files, options[:charset])
       end
     rescue => detail
-      Puppet.log_exception(detail, _("Could not generate documentation: #{detail}"))
+      Puppet.log_exception(detail, _("Could not generate documentation: %{detail}") % { detail: detail })
       exit_code = 1
     end
     exit exit_code
@@ -151,13 +151,13 @@ HELP
     exit_code = 0
     require 'puppet/util/reference'
     options[:references].sort { |a,b| a.to_s <=> b.to_s }.each do |name|
-      raise _("Could not find reference #{name}") unless section = Puppet::Util::Reference.reference(name)
+      raise _("Could not find reference %{name}") % { name: name } unless section = Puppet::Util::Reference.reference(name)
 
       begin
         # Add the per-section text, but with no ToC
         text += section.send(options[:format], with_contents)
       rescue => detail
-        Puppet.log_exception(detail, _("Could not generate reference #{name}: #{detail}"))
+        Puppet.log_exception(detail, _("Could not generate reference %{name}: %{detail}") % { name: name, detail: detail })
         exit_code = 1
         next
       end

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -35,7 +35,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     else
       @render_as = Puppet::Network::FormatHandler.format(format)
     end
-    @render_as or raise ArgumentError, "I don't know how to render '#{format}'"
+    @render_as or raise ArgumentError, _("I don't know how to render '#{format}'")
   end
 
   def render(result, args_and_options)
@@ -57,7 +57,7 @@ class Puppet::Application::FaceBase < Puppet::Application
   def preinit
     super
     Signal.trap(:INT) do
-      $stderr.puts "Cancelling Face"
+      $stderr.puts _("Cancelling Face")
       exit(0)
     end
   end
@@ -129,7 +129,7 @@ class Puppet::Application::FaceBase < Puppet::Application
 
         face   = @face.name
         action = action_name.nil? ? 'default' : "'#{action_name}'"
-        msg = "'#{face}' has no #{action} action.  See `puppet help #{face}`."
+        msg = _("'#{face}' has no #{action} action.  See `puppet help #{face}`.")
 
         Puppet.err(msg)
         Puppet::Util::Log.force_flushqueue()
@@ -207,7 +207,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     # Call the method associated with the provided action (e.g., 'find').
     unless @action
       puts Puppet::Face[:help, :current].help(@face.name)
-      raise "#{face} does not respond to action #{arguments.first}"
+      raise _("#{face} does not respond to action #{arguments.first}")
     end
 
     # We need to do arity checking here because this is generic code
@@ -240,13 +240,13 @@ class Puppet::Application::FaceBase < Puppet::Application
     # --daniel 2011-04-27
     if (arity = @action.positional_arg_count) > 0
       unless (count = arguments.length) == arity then
-        s = arity == 2 ? '' : 's'
-        raise ArgumentError, "puppet #{@face.name} #{@action.name} takes #{arity-1} argument#{s}, but you gave #{count-1}"
+        s = arity == 2 ? '' : _('s')
+        raise ArgumentError, _("puppet #{@face.name} #{@action.name} takes #{arity-1} argument#{s}, but you gave #{count-1}")
       end
     end
 
     if @face.deprecated?
-      Puppet.deprecation_warning("'puppet #{@face.name}' is deprecated and will be removed in a future release")
+      Puppet.deprecation_warning(_("'puppet #{@face.name}' is deprecated and will be removed in a future release"))
     end
 
     result = @face.send(@action.name, *arguments)
@@ -265,7 +265,7 @@ class Puppet::Application::FaceBase < Puppet::Application
 
   rescue => detail
     Puppet.log_exception(detail)
-    Puppet.err "Try 'puppet help #{@face.name} #{@action.name}' for usage"
+    Puppet.err _("Try 'puppet help #{@face.name} #{@action.name}' for usage")
 
   ensure
     exit status

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -35,7 +35,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     else
       @render_as = Puppet::Network::FormatHandler.format(format)
     end
-    @render_as or raise ArgumentError, _("I don't know how to render '#{format}'")
+    @render_as or raise ArgumentError, _("I don't know how to render '%{format}'") % { format: format }
   end
 
   def render(result, args_and_options)
@@ -129,7 +129,7 @@ class Puppet::Application::FaceBase < Puppet::Application
 
         face   = @face.name
         action = action_name.nil? ? 'default' : "'#{action_name}'"
-        msg = _("'#{face}' has no #{action} action.  See `puppet help #{face}`.")
+        msg = _("'%{face}' has no %{action} action.  See `puppet help %{face}`.") % { face: face, action: action }
 
         Puppet.err(msg)
         Puppet::Util::Log.force_flushqueue()
@@ -207,7 +207,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     # Call the method associated with the provided action (e.g., 'find').
     unless @action
       puts Puppet::Face[:help, :current].help(@face.name)
-      raise _("#{face} does not respond to action #{arguments.first}")
+      raise _("%{face} does not respond to action %{arg}") % { face: face, arg: arguments.first }
     end
 
     # We need to do arity checking here because this is generic code
@@ -240,13 +240,12 @@ class Puppet::Application::FaceBase < Puppet::Application
     # --daniel 2011-04-27
     if (arity = @action.positional_arg_count) > 0
       unless (count = arguments.length) == arity then
-        s = arity == 2 ? '' : _('s')
-        raise ArgumentError, _("puppet #{@face.name} #{@action.name} takes #{arity-1} argument#{s}, but you gave #{count-1}")
+        raise ArgumentError, n_("puppet %{face} %{action} takes %{arg_count} argument, but you gave %{given_count}", "puppet %{face} %{action} takes %{arg_count} arguments, but you gave %{given_count}", arity - 1) % { face: @face.name, action: @action.name, arg_count: arity-1, s: s, given_count: count-1 }
       end
     end
 
     if @face.deprecated?
-      Puppet.deprecation_warning(_("'puppet #{@face.name}' is deprecated and will be removed in a future release"))
+      Puppet.deprecation_warning(_("'puppet %{face}' is deprecated and will be removed in a future release") % { face: @face.name })
     end
 
     result = @face.send(@action.name, *arguments)
@@ -265,7 +264,7 @@ class Puppet::Application::FaceBase < Puppet::Application
 
   rescue => detail
     Puppet.log_exception(detail)
-    Puppet.err _("Try 'puppet help #{@face.name} #{@action.name}' for usage")
+    Puppet.err _("Try 'puppet help %{face} %{action}' for usage") % { face: @face.name, action: @action.name }
 
   ensure
     exit status

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -170,11 +170,11 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     args.each do |file|
       unless Puppet::FileSystem.exist?(file)
-        $stderr.puts _("#{file}: no such file")
+        $stderr.puts _("%{file}: no such file") % { file: file }
         next
       end
       unless FileTest.readable?(file)
-        $stderr.puts _("#{file}: cannot read file")
+        $stderr.puts _("%{file}: cannot read file") % { file: file }
         next
       end
       md5 = @client.backup(file)
@@ -216,7 +216,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       checksum_b = right
     end
     if (checksum_a || file_a) && (checksum_b || file_b)
-      Puppet.info(_("Comparing #{checksum_a} #{checksum_b} #{file_a} #{file_b}"))
+      Puppet.info(_("Comparing %{checksum_a} %{checksum_b} %{file_a} %{file_b}") % { checksum_a: checksum_a, checksum_b: checksum_b, file_a: file_a, file_b: file_b })
       print @client.diff(checksum_a, checksum_b, file_a, file_b)
     else
       raise Puppet::Error, _("Need exactly two arguments: filebucket diff <file_a> <file_b>")

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -166,15 +166,15 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def backup
-    raise "You must specify a file to back up" unless args.length > 0
+    raise _("You must specify a file to back up") unless args.length > 0
 
     args.each do |file|
       unless Puppet::FileSystem.exist?(file)
-        $stderr.puts "#{file}: no such file"
+        $stderr.puts _("#{file}: no such file")
         next
       end
       unless FileTest.readable?(file)
-        $stderr.puts "#{file}: cannot read file"
+        $stderr.puts _("#{file}: cannot read file")
         next
       end
       md5 = @client.backup(file)
@@ -196,7 +196,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def diff
-    raise Puppet::Error, "Need exactly two arguments: filebucket diff <file_a> <file_b>" unless args.count == 2
+    raise Puppet::Error, _("Need exactly two arguments: filebucket diff <file_a> <file_b>") unless args.count == 2
     left = args.shift
     right = args.shift
     if Puppet::FileSystem.exist?(left)
@@ -216,10 +216,10 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       checksum_b = right
     end
     if (checksum_a || file_a) && (checksum_b || file_b)
-      Puppet.info("Comparing #{checksum_a} #{checksum_b} #{file_a} #{file_b}")
+      Puppet.info(_("Comparing #{checksum_a} #{checksum_b} #{file_a} #{file_b}"))
       print @client.diff(checksum_a, checksum_b, file_a, file_b)
     else
-      raise Puppet::Error, "Need exactly two arguments: filebucket diff <file_a> <file_b>"
+      raise Puppet::Error, _("Need exactly two arguments: filebucket diff <file_a> <file_b>")
     end
   end
 
@@ -230,7 +230,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     @server = nil
 
     Signal.trap(:INT) do
-      $stderr.puts "Cancelling"
+      $stderr.puts _("Cancelling")
       exit(1)
     end
 

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -107,7 +107,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       retrieval_starttime = Time.now
 
       unless catalog = Puppet::Resource::Catalog.indirection.find(Puppet[:certname])
-        raise _("Could not find catalog for #{Puppet[:certname]}")
+        raise _("Could not find catalog for %{certname}") % { certname: Puppet[:certname] }
       end
 
       @report.configuration_version = catalog.version
@@ -129,13 +129,13 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         begin
           audited_resource = ral_resource.to_resource
         rescue StandardError => detail
-          ral_resource.log_exception(detail, _("Could not inspect #{ral_resource}; skipping: #{detail}"))
+          ral_resource.log_exception(detail, _("Could not inspect %{ral_resource}; skipping: %{detail}") % { ral_resource: ral_resource, detail: detail })
           audited_attributes.each do |name|
             event = ral_resource.event(
                                        :property => name,
                                        :status   => "failure",
                                        :audited  => true,
-                                       :message  => _("failed to inspect #{name}")
+                                       :message  => _("failed to inspect %{name}") % { name: name }
                                        )
             status.add_event(event)
           end
@@ -149,7 +149,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
                                          :property       => name,
                                          :status         => "audit",
                                          :audited        => true,
-                                         :message        => _("inspected value is #{audited_resource[name].inspect}")
+                                         :message        => _("inspected value is %{resource}") % { resource: audited_resource[name].inspect }
                                          )
               status.add_event(event)
             end
@@ -175,7 +175,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       begin
         Puppet::Transaction::Report.indirection.save(@report)
       rescue => detail
-        Puppet.log_exception(detail, _("Could not send report: #{detail}"))
+        Puppet.log_exception(detail, _("Could not send report: %{detail}") % { detail: detail })
       end
     end
   end

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -79,7 +79,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
-    raise "Inspect requires reporting to be enabled. Set report=true in puppet.conf to enable reporting." unless Puppet[:report]
+    raise _("Inspect requires reporting to be enabled. Set report=true in puppet.conf to enable reporting.") unless Puppet[:report]
 
     @report = Puppet::Transaction::Report.new("inspect")
 
@@ -87,7 +87,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     Puppet::Util::Log.newdestination(:console) unless options[:setdest]
 
     Signal.trap(:INT) do
-      $stderr.puts "Exiting"
+      $stderr.puts _("Exiting")
       exit(1)
     end
 
@@ -103,11 +103,11 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def run_command
-    benchmark(:notice, "Finished inspection") do
+    benchmark(:notice, _("Finished inspection")) do
       retrieval_starttime = Time.now
 
       unless catalog = Puppet::Resource::Catalog.indirection.find(Puppet[:certname])
-        raise "Could not find catalog for #{Puppet[:certname]}"
+        raise _("Could not find catalog for #{Puppet[:certname]}")
       end
 
       @report.configuration_version = catalog.version
@@ -129,13 +129,13 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
         begin
           audited_resource = ral_resource.to_resource
         rescue StandardError => detail
-          ral_resource.log_exception(detail, "Could not inspect #{ral_resource}; skipping: #{detail}")
+          ral_resource.log_exception(detail, _("Could not inspect #{ral_resource}; skipping: #{detail}"))
           audited_attributes.each do |name|
             event = ral_resource.event(
                                        :property => name,
                                        :status   => "failure",
                                        :audited  => true,
-                                       :message  => "failed to inspect #{name}"
+                                       :message  => _("failed to inspect #{name}")
                                        )
             status.add_event(event)
           end
@@ -149,7 +149,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
                                          :property       => name,
                                          :status         => "audit",
                                          :audited        => true,
-                                         :message        => "inspected value is #{audited_resource[name].inspect}"
+                                         :message        => _("inspected value is #{audited_resource[name].inspect}")
                                          )
               status.add_event(event)
             end
@@ -175,7 +175,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       begin
         Puppet::Transaction::Report.indirection.save(@report)
       rescue => detail
-        Puppet.log_exception(detail, "Could not send report: #{detail}")
+        Puppet.log_exception(detail, _("Could not send report: #{detail}"))
       end
     end
   end

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -5,7 +5,7 @@ require 'puppet/parser/compiler'
 
 class Puppet::Application::Lookup < Puppet::Application
 
-  RUN_HELP = "Run 'puppet lookup --help' for more details".freeze
+  RUN_HELP = _("Run 'puppet lookup --help' for more details").freeze
   DEEP_MERGE_OPTIONS = '--knock-out-prefix, --sort-merged-arrays, and --merge-hash-arrays'.freeze
 
   run_mode :master
@@ -57,7 +57,7 @@ class Puppet::Application::Lookup < Puppet::Application
     if %w{.yaml .yml .json}.include?(arg.match(/\.[^.]*$/)[0])
       options[:fact_file] = arg
     else
-      raise "The --fact file only accepts yaml and json files.\n#{RUN_HELP}"
+      raise _("The --fact file only accepts yaml and json files.\n#{RUN_HELP}")
     end
   end
 
@@ -266,7 +266,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     #end
 
     if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix]) && options[:merge] != 'deep'
-      raise "The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUN_HELP}"
+      raise _("The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUN_HELP}")
     end
 
     use_default_value = !options[:default_value].nil?
@@ -277,7 +277,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
       strategies = Puppet::Pops::MergeStrategy.strategy_keys
       unless strategies.include?(merge.to_sym)
         strategies = strategies.map {|k| "'#{k}'"}
-        raise "The --merge option only accepts #{strategies[0...-1].join(', ')}, or #{strategies.last}\n#{RUN_HELP}"
+        raise _("The --merge option only accepts #{strategies[0...-1].join(', ')}, or #{strategies.last}\n#{RUN_HELP}")
       end
 
       if merge == 'deep'
@@ -302,7 +302,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
         # Explain lookup_options for lookup of an unqualified value.
         keys = Puppet::Pops::Lookup::GLOBAL
       else
-        raise 'No keys were given to lookup.'
+        raise _('No keys were given to lookup.')
       end
     end
     explain = explain_data || explain_options
@@ -310,7 +310,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # Format defaults to text (:s) when producing an explanation and :yaml when producing the value
     format = options[:render_as] || (explain ? :s : :yaml)
     renderer = Puppet::Network::FormatHandler.format(format == :json ? :pson : format)
-    raise "Unknown rendering format '#{format}'" if renderer.nil?
+    raise _("Unknown rendering format '#{format}'") if renderer.nil?
 
 
     generate_scope do |scope|
@@ -353,7 +353,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
       end
 
       unless given_facts.instance_of?(Hash)
-        raise "Incorrect formatted data in #{fact_file} given via the --facts flag"
+        raise _("Incorrect formatted data in #{fact_file} given via the --facts flag")
       end
 
       node.parameters = original_facts.merge(given_facts)

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -57,7 +57,7 @@ class Puppet::Application::Lookup < Puppet::Application
     if %w{.yaml .yml .json}.include?(arg.match(/\.[^.]*$/)[0])
       options[:fact_file] = arg
     else
-      raise _("The --fact file only accepts yaml and json files.\n#{RUN_HELP}")
+      raise _("The --fact file only accepts yaml and json files.\n%{run_help}") % { run_help: RUN_HELP }
     end
   end
 
@@ -266,7 +266,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     #end
 
     if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix]) && options[:merge] != 'deep'
-      raise _("The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUN_HELP}")
+      raise _("The options %{deep_merge_opts} are only available with '--merge deep'\n%{run_help}") % { deep_merge_opts: DEEP_MERGE_OPTIONS, run_help: RUN_HELP }
     end
 
     use_default_value = !options[:default_value].nil?
@@ -277,7 +277,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
       strategies = Puppet::Pops::MergeStrategy.strategy_keys
       unless strategies.include?(merge.to_sym)
         strategies = strategies.map {|k| "'#{k}'"}
-        raise _("The --merge option only accepts #{strategies[0...-1].join(', ')}, or #{strategies.last}\n#{RUN_HELP}")
+        raise _("The --merge option only accepts %{strategies}, or %{last_strategy}\n%{run_help}") % { strategies: strategies[0...-1].join(', '), last_strategy: strategies.last, run_help: RUN_HELP }
       end
 
       if merge == 'deep'
@@ -310,7 +310,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # Format defaults to text (:s) when producing an explanation and :yaml when producing the value
     format = options[:render_as] || (explain ? :s : :yaml)
     renderer = Puppet::Network::FormatHandler.format(format == :json ? :pson : format)
-    raise _("Unknown rendering format '#{format}'") if renderer.nil?
+    raise _("Unknown rendering format '%{format}'") % { format: format } if renderer.nil?
 
 
     generate_scope do |scope|
@@ -353,7 +353,7 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
       end
 
       unless given_facts.instance_of?(Hash)
-        raise _("Incorrect formatted data in #{fact_file} given via the --facts flag")
+        raise _("Incorrect formatted data in %{fact_file} given via the --facts flag") % { fact_file: fact_file }
       end
 
       node.parameters = original_facts.merge(given_facts)

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -169,12 +169,12 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def compile
     begin
       unless catalog = Puppet::Resource::Catalog.indirection.find(options[:node])
-        raise _("Could not compile catalog for #{options[:node]}")
+        raise _("Could not compile catalog for %{node}") % { node: options[:node] }
       end
 
       puts PSON::pretty_generate(catalog.to_resource, :allow_nan => true, :max_nesting => false)
     rescue => detail
-      Puppet.log_exception(detail, _("Failed to compile catalog for node #{options[:node]}: #{detail}"))
+      Puppet.log_exception(detail, _("Failed to compile catalog for node %{node}: %{detail}") % { node: options[:node], detail: detail })
       exit(30)
     end
     exit(0)
@@ -194,11 +194,11 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
         begin
           Puppet::Util.chuser
         rescue => detail
-          Puppet.log_exception(detail, _("Could not change user to #{Puppet[:user]}: #{detail}"))
+          Puppet.log_exception(detail, _("Could not change user to %{user}: %{detail}") % { user: Puppet[:user], detail: detail })
           exit(39)
         end
       else
-        Puppet.err(_("Could not change user to #{Puppet[:user]}. User does not exist and is required to continue."))
+        Puppet.err(_("Could not change user to %{user}. User does not exist and is required to continue.") % { user: Puppet[:user] })
         exit(74)
       end
     end
@@ -316,6 +316,6 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def announce_start_of_master
-    Puppet.notice _("Starting Puppet master version #{Puppet.version}")
+    Puppet.notice _("Starting Puppet master version %{version}") % { version: Puppet.version }
   end
 end

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -150,7 +150,7 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def preinit
     Signal.trap(:INT) do
-      $stderr.puts "Canceling startup"
+      $stderr.puts _("Canceling startup")
       exit(0)
     end
 
@@ -169,12 +169,12 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def compile
     begin
       unless catalog = Puppet::Resource::Catalog.indirection.find(options[:node])
-        raise "Could not compile catalog for #{options[:node]}"
+        raise _("Could not compile catalog for #{options[:node]}")
       end
 
       puts PSON::pretty_generate(catalog.to_resource, :allow_nan => true, :max_nesting => false)
     rescue => detail
-      Puppet.log_exception(detail, "Failed to compile catalog for node #{options[:node]}: #{detail}")
+      Puppet.log_exception(detail, _("Failed to compile catalog for node #{options[:node]}: #{detail}"))
       exit(30)
     end
     exit(0)
@@ -194,20 +194,20 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
         begin
           Puppet::Util.chuser
         rescue => detail
-          Puppet.log_exception(detail, "Could not change user to #{Puppet[:user]}: #{detail}")
+          Puppet.log_exception(detail, _("Could not change user to #{Puppet[:user]}: #{detail}"))
           exit(39)
         end
       else
-        Puppet.err("Could not change user to #{Puppet[:user]}. User does not exist and is required to continue.")
+        Puppet.err(_("Could not change user to #{Puppet[:user]}. User does not exist and is required to continue."))
         exit(74)
       end
     end
 
     if options[:rack]
-      Puppet.deprecation_warning("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
+      Puppet.deprecation_warning(_("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information."))
       start_rack_master
     else
-      Puppet.deprecation_warning("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
+      Puppet.deprecation_warning(_("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information."))
       start_webrick_master
     end
   end
@@ -267,7 +267,7 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
-    raise Puppet::Error.new("Puppet master is not supported on Microsoft Windows") if Puppet.features.microsoft_windows?
+    raise Puppet::Error.new(_("Puppet master is not supported on Microsoft Windows")) if Puppet.features.microsoft_windows?
 
     setup_logs
 
@@ -316,6 +316,6 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def announce_start_of_master
-    Puppet.notice "Starting Puppet master version #{Puppet.version}"
+    Puppet.notice _("Starting Puppet master version #{Puppet.version}")
   end
 end

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -190,14 +190,14 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
   def parse_args(args)
     type = args.shift or raise _("You must specify the type to display")
-    Puppet::Type.type(type) or raise _("Could not find type #{type}")
+    Puppet::Type.type(type) or raise _("Could not find type %{type}") % { type: type }
     name = args.shift
     params = {}
     args.each do |setting|
       if setting =~ /^(\w+)=(.+)$/
         params[$1] = $2
       else
-        raise _("Invalid parameter setting #{setting}")
+        raise _("Invalid parameter setting %{setting}") % { setting: setting }
       end
     end
 

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -133,7 +133,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     Puppet.override(:current_environment => env, :loaders => Puppet::Pops::Loaders.new(env)) do
       type, name, params = parse_args(command_line.args)
 
-      raise "Editing with Yaml output is not supported" if options[:edit] and options[:to_yaml]
+      raise _("Editing with Yaml output is not supported") if options[:edit] and options[:to_yaml]
 
       resources = find_or_save_resources(type, name, params)
 
@@ -189,15 +189,15 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def parse_args(args)
-    type = args.shift or raise "You must specify the type to display"
-    Puppet::Type.type(type) or raise "Could not find type #{type}"
+    type = args.shift or raise _("You must specify the type to display")
+    Puppet::Type.type(type) or raise _("Could not find type #{type}")
     name = args.shift
     params = {}
     args.each do |setting|
       if setting =~ /^(\w+)=(.+)$/
         params[$1] = $2
       else
-        raise "Invalid parameter setting #{setting}"
+        raise _("Invalid parameter setting #{setting}")
       end
     end
 
@@ -219,7 +219,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       end
     else
       if type == "file"
-        raise "Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc"
+        raise _("Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc")
       end
       Puppet::Resource.indirection.search( key, {} )
     end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/application.rb` and `lib/puppet/application/*` for
translation.