### PR TITLE
(PUP-7042) Mark strings in context

### DIFF
--- a/lib/puppet/context.rb
+++ b/lib/puppet/context.rb
@@ -52,7 +52,7 @@ class Puppet::Context
     elsif block
       block.call
     else
-      raise UndefinedBindingError, _("no '#{name}' in #{@table.inspect} at top of #{@stack.inspect}")
+      raise UndefinedBindingError, _("no '%{name}' in %{table} at top of %{stack}") % { name: name, table: @table.inspect, stack: @stack.inspect }
     end
   end
 
@@ -77,7 +77,7 @@ class Puppet::Context
     if @ignores.include?(name)
       @ignores.delete(name)
     else
-      raise UndefinedBindingError, _("no '#{name}' in ignores #{@ignores.inspect} at top of #{@stack.inspect}")
+      raise UndefinedBindingError, _("no '%{name}' in ignores %{ignores} at top of %{stack}") % { name: name, ignores: @ignores.inspect, stack: @stack.inspect }
     end
   end
 
@@ -90,7 +90,7 @@ class Puppet::Context
     if @rollbacks[name].nil?
       @rollbacks[name] = @stack[-1][0]
     else
-      raise DuplicateRollbackMarkError, _("Mark for '#{name}' already exists")
+      raise DuplicateRollbackMarkError, _("Mark for '%{name}' already exists") % { name: name }
     end
   end
 
@@ -104,7 +104,7 @@ class Puppet::Context
   # @api private
   def rollback(name)
     if @rollbacks[name].nil?
-      raise UnknownRollbackMarkError, _("Unknown mark '#{name}'")
+      raise UnknownRollbackMarkError, _("Unknown mark '%{name}'") % { name: name }
     end
 
     while @stack[-1][0] != @rollbacks[name]

--- a/lib/puppet/context.rb
+++ b/lib/puppet/context.rb
@@ -38,7 +38,7 @@ class Puppet::Context
   # @api private
   def pop
     if @stack[-1][0] == 0
-      raise(StackUnderflow, "Attempted to pop, but already at root of the context stack.")
+      raise(StackUnderflow, _("Attempted to pop, but already at root of the context stack."))
     else
       (_, @table, @description) = @stack.pop
     end
@@ -52,7 +52,7 @@ class Puppet::Context
     elsif block
       block.call
     else
-      raise UndefinedBindingError, "no '#{name}' in #{@table.inspect} at top of #{@stack.inspect}"
+      raise UndefinedBindingError, _("no '#{name}' in #{@table.inspect} at top of #{@stack.inspect}")
     end
   end
 
@@ -77,7 +77,7 @@ class Puppet::Context
     if @ignores.include?(name)
       @ignores.delete(name)
     else
-      raise UndefinedBindingError, "no '#{name}' in ignores #{@ignores.inspect} at top of #{@stack.inspect}"
+      raise UndefinedBindingError, _("no '#{name}' in ignores #{@ignores.inspect} at top of #{@stack.inspect}")
     end
   end
 
@@ -90,7 +90,7 @@ class Puppet::Context
     if @rollbacks[name].nil?
       @rollbacks[name] = @stack[-1][0]
     else
-      raise DuplicateRollbackMarkError, "Mark for '#{name}' already exists"
+      raise DuplicateRollbackMarkError, _("Mark for '#{name}' already exists")
     end
   end
 
@@ -104,7 +104,7 @@ class Puppet::Context
   # @api private
   def rollback(name)
     if @rollbacks[name].nil?
-      raise UnknownRollbackMarkError, "Unknown mark '#{name}'"
+      raise UnknownRollbackMarkError, _("Unknown mark '#{name}'")
     end
 
     while @stack[-1][0] != @rollbacks[name]

--- a/lib/puppet/context/trusted_information.rb
+++ b/lib/puppet/context/trusted_information.rb
@@ -45,7 +45,7 @@ class Puppet::Context::TrustedInformation
     if authenticated
       extensions = {}
       if certificate.nil?
-        Puppet.info('TrustedInformation expected a certificate, but none was given.')
+        Puppet.info(_('TrustedInformation expected a certificate, but none was given.'))
       else
         extensions = Hash[certificate.custom_extensions.collect do |ext|
           [ext['oid'].freeze, ext['value'].freeze]


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/context.rb` and `lib/puppet/context/*` for translation.