### PR TITLE
(PUP-7042) Mark strings in feature

### DIFF
--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -32,11 +32,11 @@ Puppet.features.add(:microsoft_windows) do
     require 'win32/service'
     true
   rescue LoadError => err
-    warn "Cannot run on Microsoft Windows without the win32-process, win32-dir and win32-service gems: #{err}" unless Puppet.features.posix?
+    warn _("Cannot run on Microsoft Windows without the win32-process, win32-dir and win32-service gems: #{err}") unless Puppet.features.posix?
   end
 end
 
-raise Puppet::Error,"Cannot determine basic system flavour" unless Puppet.features.posix? or Puppet.features.microsoft_windows?
+raise Puppet::Error,_("Cannot determine basic system flavour") unless Puppet.features.posix? or Puppet.features.microsoft_windows?
 
 # We've got LDAP available.
 Puppet.features.add(:ldap, :libs => ["ldap"])

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -32,7 +32,8 @@ Puppet.features.add(:microsoft_windows) do
     require 'win32/service'
     true
   rescue LoadError => err
-    warn _("Cannot run on Microsoft Windows without the win32-process, win32-dir and win32-service gems: #{err}") unless Puppet.features.posix?
+    #TRANSLATORS "win32-process", "win32-dir", and "win32-service" are program names and should not be translated
+    warn _("Cannot run on Microsoft Windows without the win32-process, win32-dir and win32-service gems: %{err}") % { err: err } unless Puppet.features.posix?
   end
 end
 


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/feature/*` for translation.