### PR TITLE
(PUP-7042) Mark strings in file_serving

### DIFF
--- a/lib/puppet/file_serving/base.rb
+++ b/lib/puppet/file_serving/base.rb
@@ -53,7 +53,7 @@ class Puppet::FileServing::Base
   # Set our base path.
   attr_reader :path
   def path=(path)
-    raise ArgumentError.new("Paths must be fully qualified") unless Puppet::FileServing::Base.absolute?(path)
+    raise ArgumentError.new(_("Paths must be fully qualified")) unless Puppet::FileServing::Base.absolute?(path)
     @path = path
   end
 
@@ -61,7 +61,7 @@ class Puppet::FileServing::Base
   # the file's path relative to the initial recursion point.
   attr_reader :relative_path
   def relative_path=(path)
-    raise ArgumentError.new("Relative paths must not be fully qualified") if Puppet::FileServing::Base.absolute?(path)
+    raise ArgumentError.new(_("Relative paths must not be fully qualified")) if Puppet::FileServing::Base.absolute?(path)
     @relative_path = path
   end
 

--- a/lib/puppet/file_serving/configuration.rb
+++ b/lib/puppet/file_serving/configuration.rb
@@ -50,8 +50,8 @@ class Puppet::FileServing::Configuration
 
     mount_name, path = request.key.split(File::Separator, 2)
 
-    raise(ArgumentError, "Cannot find file: Invalid mount '#{mount_name}'") unless mount_name =~ %r{^[-\w]+$}
-    raise(ArgumentError, "Cannot find file: Invalid relative path '#{path}'") if path and path.split('/').include?('..')
+    raise(ArgumentError, _("Cannot find file: Invalid mount '#{mount_name}'")) unless mount_name =~ %r{^[-\w]+$}
+    raise(ArgumentError, _("Cannot find file: Invalid relative path '#{path}'")) if path and path.split('/').include?('..')
 
     return nil unless mount = find_mount(mount_name, request.environment)
     if mount.name == "modules" and mount_name != "modules"
@@ -99,7 +99,7 @@ class Puppet::FileServing::Configuration
       newmounts = @parser.parse
       @mounts = newmounts
     rescue => detail
-      Puppet.log_exception(detail, "Error parsing fileserver configuration: #{detail}; using old configuration")
+      Puppet.log_exception(detail, _("Error parsing fileserver configuration: #{detail}; using old configuration"))
     end
 
   ensure

--- a/lib/puppet/file_serving/configuration.rb
+++ b/lib/puppet/file_serving/configuration.rb
@@ -50,8 +50,8 @@ class Puppet::FileServing::Configuration
 
     mount_name, path = request.key.split(File::Separator, 2)
 
-    raise(ArgumentError, _("Cannot find file: Invalid mount '#{mount_name}'")) unless mount_name =~ %r{^[-\w]+$}
-    raise(ArgumentError, _("Cannot find file: Invalid relative path '#{path}'")) if path and path.split('/').include?('..')
+    raise(ArgumentError, _("Cannot find file: Invalid mount '%{mount_name}'") % { mount_name: mount_name }) unless mount_name =~ %r{^[-\w]+$}
+    raise(ArgumentError, _("Cannot find file: Invalid relative path '%{path}'") % { path: path }) if path and path.split('/').include?('..')
 
     return nil unless mount = find_mount(mount_name, request.environment)
     if mount.name == "modules" and mount_name != "modules"
@@ -99,7 +99,7 @@ class Puppet::FileServing::Configuration
       newmounts = @parser.parse
       @mounts = newmounts
     rescue => detail
-      Puppet.log_exception(detail, _("Error parsing fileserver configuration: #{detail}; using old configuration"))
+      Puppet.log_exception(detail, _("Error parsing fileserver configuration: %{detail}; using old configuration") % { detail: detail })
     end
 
   ensure

--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -7,8 +7,8 @@ class Puppet::FileServing::Configuration::Parser
 
   # Parse our configuration file.
   def parse
-    raise(_("File server configuration #{@file} does not exist")) unless Puppet::FileSystem.exist?(@file)
-    raise(_("Cannot read file server configuration #{@file}")) unless FileTest.readable?(@file)
+    raise(_("File server configuration %{config_file} does not exist") % { config_file: @file }) unless Puppet::FileSystem.exist?(@file)
+    raise(_("Cannot read file server configuration %{config_file}") % { config_file: @file }) unless FileTest.readable?(@file)
 
     @mounts = {}
     @count = 0
@@ -37,10 +37,10 @@ class Puppet::FileServing::Configuration::Parser
           when "deny"
             deny(mount, value)
           else
-            raise ArgumentError.new(_("Invalid argument '#{var}' in #{@file.filename}, line #{@count}"))
+            raise ArgumentError.new(_("Invalid argument '%{var}' in %{file}, line %{line_num}") % { var: var, file: @file.filename, line_num: @count })
           end
         else
-          raise ArgumentError.new(_("Invalid line '#{line.chomp}' at #{@file.filename}, line #{@count}"))
+          raise ArgumentError.new(_("Invalid line '%{line}' at %{file}, line %{line_num}") % { line: line.chomp, file: @file.filename, line_num: @count })
         end
       }
     }
@@ -64,10 +64,10 @@ class Puppet::FileServing::Configuration::Parser
   def allow(mount, value)
     value.split(/\s*,\s*/).each { |val|
       begin
-        mount.info _("allowing #{val} access")
+        mount.info _("allowing %{val} access") % { val: val }
         mount.allow(val)
       rescue Puppet::AuthStoreError => detail
-        raise ArgumentError.new(_("#{detail.to_s} in #{@file}, line #{@count}"))
+        raise ArgumentError.new(_("%{detail} in %{file}, line %{line_num}") % { detail: detail.to_s, file: @file, line_num: @count })
       end
     }
   end
@@ -76,17 +76,17 @@ class Puppet::FileServing::Configuration::Parser
   def deny(mount, value)
     value.split(/\s*,\s*/).each { |val|
       begin
-        mount.info _("denying #{val} access")
+        mount.info _("denying %{val} access") % { val: val }
         mount.deny(val)
       rescue Puppet::AuthStoreError => detail
-        raise ArgumentError.new(_("#{detail.to_s} in #{@file}, line #{@count}"))
+        raise ArgumentError.new(_("%{detail} in %{file}, line %{line_num}") % { detail: detail.to_s, file: @file, line_num: @count })
       end
     }
   end
 
   # Create a new mount.
   def newmount(name)
-    raise ArgumentError.new(_("#{@mounts[name]} is already mounted at #{name} in #{@file}, line #{@count}")) if @mounts.include?(name)
+    raise ArgumentError.new(_("%{mount} is already mounted at %{name} in %{file}, line %{line_num}") % { mount: @mounts[name], name: name, file: @file, line_num: @count }) if @mounts.include?(name)
     case name
     when "modules"
       mount = Mount::Modules.new(name)
@@ -105,11 +105,11 @@ class Puppet::FileServing::Configuration::Parser
       begin
         mount.path = value
       rescue ArgumentError => detail
-        Puppet.log_exception(detail, _("Removing mount \"#{mount.name}\": #{detail}"))
+        Puppet.log_exception(detail, _("Removing mount \"%{mount}\": %{detail}") % { mount: mount.name, detail: detail })
         @mounts.delete(mount.name)
       end
     else
-      Puppet.warning _("The '#{mount.name}' module can not have a path. Ignoring attempt to set it")
+      Puppet.warning _("The '%{mount}' module can not have a path. Ignoring attempt to set it") % { mount: mount.name }
     end
   end
 

--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -7,8 +7,8 @@ class Puppet::FileServing::Configuration::Parser
 
   # Parse our configuration file.
   def parse
-    raise("File server configuration #{@file} does not exist") unless Puppet::FileSystem.exist?(@file)
-    raise("Cannot read file server configuration #{@file}") unless FileTest.readable?(@file)
+    raise(_("File server configuration #{@file} does not exist")) unless Puppet::FileSystem.exist?(@file)
+    raise(_("Cannot read file server configuration #{@file}")) unless FileTest.readable?(@file)
 
     @mounts = {}
     @count = 0
@@ -28,7 +28,7 @@ class Puppet::FileServing::Configuration::Parser
           var = $1
           value = $2
           value.strip!
-          raise(ArgumentError, "Fileserver configuration file does not use '=' as a separator") if value =~ /^=/
+          raise(ArgumentError, _("Fileserver configuration file does not use '=' as a separator")) if value =~ /^=/
           case var
           when "path"
             path(mount, value)
@@ -37,10 +37,10 @@ class Puppet::FileServing::Configuration::Parser
           when "deny"
             deny(mount, value)
           else
-            raise ArgumentError.new("Invalid argument '#{var}' in #{@file.filename}, line #{@count}")
+            raise ArgumentError.new(_("Invalid argument '#{var}' in #{@file.filename}, line #{@count}"))
           end
         else
-          raise ArgumentError.new("Invalid line '#{line.chomp}' at #{@file.filename}, line #{@count}")
+          raise ArgumentError.new(_("Invalid line '#{line.chomp}' at #{@file.filename}, line #{@count}"))
         end
       }
     }
@@ -64,10 +64,10 @@ class Puppet::FileServing::Configuration::Parser
   def allow(mount, value)
     value.split(/\s*,\s*/).each { |val|
       begin
-        mount.info "allowing #{val} access"
+        mount.info _("allowing #{val} access")
         mount.allow(val)
       rescue Puppet::AuthStoreError => detail
-        raise ArgumentError.new("#{detail.to_s} in #{@file}, line #{@count}")
+        raise ArgumentError.new(_("#{detail.to_s} in #{@file}, line #{@count}"))
       end
     }
   end
@@ -76,17 +76,17 @@ class Puppet::FileServing::Configuration::Parser
   def deny(mount, value)
     value.split(/\s*,\s*/).each { |val|
       begin
-        mount.info "denying #{val} access"
+        mount.info _("denying #{val} access")
         mount.deny(val)
       rescue Puppet::AuthStoreError => detail
-        raise ArgumentError.new("#{detail.to_s} in #{@file}, line #{@count}")
+        raise ArgumentError.new(_("#{detail.to_s} in #{@file}, line #{@count}"))
       end
     }
   end
 
   # Create a new mount.
   def newmount(name)
-    raise ArgumentError.new("#{@mounts[name]} is already mounted at #{name} in #{@file}, line #{@count}") if @mounts.include?(name)
+    raise ArgumentError.new(_("#{@mounts[name]} is already mounted at #{name} in #{@file}, line #{@count}")) if @mounts.include?(name)
     case name
     when "modules"
       mount = Mount::Modules.new(name)
@@ -105,11 +105,11 @@ class Puppet::FileServing::Configuration::Parser
       begin
         mount.path = value
       rescue ArgumentError => detail
-        Puppet.log_exception(detail, "Removing mount \"#{mount.name}\": #{detail}")
+        Puppet.log_exception(detail, _("Removing mount \"#{mount.name}\": #{detail}"))
         @mounts.delete(mount.name)
       end
     else
-      Puppet.warning "The '#{mount.name}' module can not have a path. Ignoring attempt to set it"
+      Puppet.warning _("The '#{mount.name}' module can not have a path. Ignoring attempt to set it")
     end
   end
 

--- a/lib/puppet/file_serving/content.rb
+++ b/lib/puppet/file_serving/content.rb
@@ -30,7 +30,7 @@ class Puppet::FileServing::Content < Puppet::FileServing::Base
   def content
     unless @content
       # This stat can raise an exception, too.
-      raise(ArgumentError, "Cannot read the contents of links unless following links") if stat.ftype == "symlink"
+      raise(ArgumentError, _("Cannot read the contents of links unless following links")) if stat.ftype == _("symlink")
 
       @content = Puppet::FileSystem.binread(full_path)
     end

--- a/lib/puppet/file_serving/content.rb
+++ b/lib/puppet/file_serving/content.rb
@@ -30,7 +30,7 @@ class Puppet::FileServing::Content < Puppet::FileServing::Base
   def content
     unless @content
       # This stat can raise an exception, too.
-      raise(ArgumentError, _("Cannot read the contents of links unless following links")) if stat.ftype == _("symlink")
+      raise(ArgumentError, _("Cannot read the contents of links unless following links")) if stat.ftype == "symlink"
 
       @content = Puppet::FileSystem.binread(full_path)
     end

--- a/lib/puppet/file_serving/fileset.rb
+++ b/lib/puppet/file_serving/fileset.rb
@@ -31,7 +31,7 @@ class Puppet::FileServing::Fileset
     else
       path = path.chomp(File::SEPARATOR) unless path == File::SEPARATOR
     end
-    raise ArgumentError.new(_("Fileset paths must be fully qualified: #{path}")) unless Puppet::Util.absolute_path?(path)
+    raise ArgumentError.new(_("Fileset paths must be fully qualified: %{path}") % { path: path }) unless Puppet::Util.absolute_path?(path)
 
     @path = path
 
@@ -48,6 +48,7 @@ class Puppet::FileServing::Fileset
     end
 
     raise ArgumentError.new(_("Fileset paths must exist")) unless valid?(path)
+    #TRANSLATORS "recurse" and "recurselimit" are parameter names and should not be translated
     raise ArgumentError.new(_("Fileset recurse parameter must not be a number anymore, please use recurselimit")) if @recurse.is_a?(Integer)
   end
 
@@ -75,7 +76,8 @@ class Puppet::FileServing::Fileset
 
   def links=(links)
     links = links.to_sym
-    raise(ArgumentError, _("Invalid :links value '#{links}'")) unless [:manage, :follow].include?(links)
+    #TRANSLATORS ":links" is a parameter name and should not be translated
+    raise(ArgumentError, _("Invalid :links value '%{links}'") % { links: links }) unless [:manage, :follow].include?(links)
     @links = links
     @stat_method = @links == :manage ? :lstat : :stat
   end
@@ -88,7 +90,7 @@ class Puppet::FileServing::Fileset
       begin
         send(method, value)
       rescue NoMethodError
-        raise ArgumentError, _("Invalid option '#{option}'"), $!.backtrace
+        raise ArgumentError, _("Invalid option '%{option}'") % { option: option }, $!.backtrace
       end
     end
   end

--- a/lib/puppet/file_serving/fileset.rb
+++ b/lib/puppet/file_serving/fileset.rb
@@ -31,7 +31,7 @@ class Puppet::FileServing::Fileset
     else
       path = path.chomp(File::SEPARATOR) unless path == File::SEPARATOR
     end
-    raise ArgumentError.new("Fileset paths must be fully qualified: #{path}") unless Puppet::Util.absolute_path?(path)
+    raise ArgumentError.new(_("Fileset paths must be fully qualified: #{path}")) unless Puppet::Util.absolute_path?(path)
 
     @path = path
 
@@ -47,8 +47,8 @@ class Puppet::FileServing::Fileset
       initialize_from_hash(options)
     end
 
-    raise ArgumentError.new("Fileset paths must exist") unless valid?(path)
-    raise ArgumentError.new("Fileset recurse parameter must not be a number anymore, please use recurselimit") if @recurse.is_a?(Integer)
+    raise ArgumentError.new(_("Fileset paths must exist")) unless valid?(path)
+    raise ArgumentError.new(_("Fileset recurse parameter must not be a number anymore, please use recurselimit")) if @recurse.is_a?(Integer)
   end
 
   # Return a list of all files in our fileset.  This is different from the
@@ -75,7 +75,7 @@ class Puppet::FileServing::Fileset
 
   def links=(links)
     links = links.to_sym
-    raise(ArgumentError, "Invalid :links value '#{links}'") unless [:manage, :follow].include?(links)
+    raise(ArgumentError, _("Invalid :links value '#{links}'")) unless [:manage, :follow].include?(links)
     @links = links
     @stat_method = @links == :manage ? :lstat : :stat
   end
@@ -88,7 +88,7 @@ class Puppet::FileServing::Fileset
       begin
         send(method, value)
       rescue NoMethodError
-        raise ArgumentError, "Invalid option '#{option}'", $!.backtrace
+        raise ArgumentError, _("Invalid option '#{option}'"), $!.backtrace
       end
     end
   end

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -18,13 +18,13 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
   PARAM_ORDER = [:mode, :ftype, :owner, :group]
 
   def checksum_type=(type)
-    raise(ArgumentError, "Unsupported checksum type #{type}") unless Puppet::Util::Checksums.respond_to?("#{type}_file")
+    raise(ArgumentError, _("Unsupported checksum type #{type}")) unless Puppet::Util::Checksums.respond_to?("#{type}_file")
 
     @checksum_type = type
   end
 
   def source_permissions=(source_permissions)
-    raise(ArgumentError, "Unsupported source_permission #{source_permissions}") unless [:use, :use_when_creating, :ignore].include?(source_permissions.intern)
+    raise(ArgumentError, _("Unsupported source_permission #{source_permissions}")) unless [:use, :use_when_creating, :ignore].include?(source_permissions.intern)
 
     @source_permissions = source_permissions.intern
   end
@@ -33,10 +33,10 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     begin
       uri = URI.parse(URI.escape(path))
     rescue URI::InvalidURIError => detail
-      raise(ArgumentError, "Could not understand URI #{path}: #{detail}")
+      raise(ArgumentError, _("Could not understand URI #{path}: #{detail}"))
     end
-    raise(ArgumentError, "Cannot use opaque URLs '#{path}'") unless uri.hierarchical?
-    raise(ArgumentError, "Must use URLs of type puppet as content URI") if uri.scheme != "puppet"
+    raise(ArgumentError, _("Cannot use opaque URLs '#{path}'")) unless uri.hierarchical?
+    raise(ArgumentError, _("Must use URLs of type puppet as content URI")) if uri.scheme != "puppet"
 
     @content_uri = path
   end
@@ -72,7 +72,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     def initialize(stat, path, source_permissions)
       super(stat, source_permissions)
       @path = path
-      raise(ArgumentError, "Unsupported Windows source permissions option #{source_permissions}") unless @source_permissions_ignore
+      raise(ArgumentError, _("Unsupported Windows source permissions option #{source_permissions}")) unless @source_permissions_ignore
     end
 
     { :owner => 'S-1-5-32-544',
@@ -119,7 +119,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
       @destination = Puppet::FileSystem.readlink(real_path)
       @checksum = ("{#{@checksum_type}}") + send("#{@checksum_type}_file", real_path).to_s rescue nil
     else
-      raise ArgumentError, "Cannot manage files of type #{stat.ftype}"
+      raise ArgumentError, _("Cannot manage files of type #{stat.ftype}")
     end
   end
 

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -18,13 +18,13 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
   PARAM_ORDER = [:mode, :ftype, :owner, :group]
 
   def checksum_type=(type)
-    raise(ArgumentError, _("Unsupported checksum type #{type}")) unless Puppet::Util::Checksums.respond_to?("#{type}_file")
+    raise(ArgumentError, _("Unsupported checksum type %{type}") % { type: type }) unless Puppet::Util::Checksums.respond_to?("#{type}_file")
 
     @checksum_type = type
   end
 
   def source_permissions=(source_permissions)
-    raise(ArgumentError, _("Unsupported source_permission #{source_permissions}")) unless [:use, :use_when_creating, :ignore].include?(source_permissions.intern)
+    raise(ArgumentError, _("Unsupported source_permission %{source_permissions}") % { source_permissions: source_permissions }) unless [:use, :use_when_creating, :ignore].include?(source_permissions.intern)
 
     @source_permissions = source_permissions.intern
   end
@@ -33,9 +33,9 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     begin
       uri = URI.parse(URI.escape(path))
     rescue URI::InvalidURIError => detail
-      raise(ArgumentError, _("Could not understand URI #{path}: #{detail}"))
+      raise(ArgumentError, _("Could not understand URI %{path}: %{detail}") % { path: path, detail: detail })
     end
-    raise(ArgumentError, _("Cannot use opaque URLs '#{path}'")) unless uri.hierarchical?
+    raise(ArgumentError, _("Cannot use opaque URLs '%{path}'") % { path: path }) unless uri.hierarchical?
     raise(ArgumentError, _("Must use URLs of type puppet as content URI")) if uri.scheme != "puppet"
 
     @content_uri = path
@@ -72,7 +72,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     def initialize(stat, path, source_permissions)
       super(stat, source_permissions)
       @path = path
-      raise(ArgumentError, _("Unsupported Windows source permissions option #{source_permissions}")) unless @source_permissions_ignore
+      raise(ArgumentError, _("Unsupported Windows source permissions option %{source_permissions}") % { source_permissions: source_permissions }) unless @source_permissions_ignore
     end
 
     { :owner => 'S-1-5-32-544',
@@ -119,7 +119,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
       @destination = Puppet::FileSystem.readlink(real_path)
       @checksum = ("{#{@checksum_type}}") + send("#{@checksum_type}_file", real_path).to_s rescue nil
     else
-      raise ArgumentError, _("Cannot manage files of type #{stat.ftype}")
+      raise ArgumentError, _("Cannot manage files of type %{file_type}") % { file_type: stat.ftype }
     end
   end
 

--- a/lib/puppet/file_serving/mount.rb
+++ b/lib/puppet/file_serving/mount.rb
@@ -18,7 +18,7 @@ class Puppet::FileServing::Mount < Puppet::Network::AuthStore
   # Create our object.  It must have a name.
   def initialize(name)
     unless name =~ %r{^[-\w]+$}
-      raise ArgumentError, _("Invalid mount name format '#{name}'")
+      raise ArgumentError, _("Invalid mount name format '%{name}'") % { name: name }
     end
     @name = name
 

--- a/lib/puppet/file_serving/mount.rb
+++ b/lib/puppet/file_serving/mount.rb
@@ -18,7 +18,7 @@ class Puppet::FileServing::Mount < Puppet::Network::AuthStore
   # Create our object.  It must have a name.
   def initialize(name)
     unless name =~ %r{^[-\w]+$}
-      raise ArgumentError, "Invalid mount name format '#{name}'"
+      raise ArgumentError, _("Invalid mount name format '#{name}'")
     end
     @name = name
 

--- a/lib/puppet/file_serving/mount/file.rb
+++ b/lib/puppet/file_serving/mount/file.rb
@@ -15,7 +15,7 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
   def complete_path(relative_path, node)
     full_path = path(node)
 
-    raise ArgumentError.new("Mounts without paths are not usable") unless full_path
+    raise ArgumentError.new(_("Mounts without paths are not usable")) unless full_path
 
     # If there's no relative path name, then we're serving the mount itself.
     return full_path unless relative_path
@@ -23,7 +23,7 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
     file = ::File.join(full_path, relative_path)
 
     if !(Puppet::FileSystem.exist?(file) or Puppet::FileSystem.symlink?(file))
-      Puppet.info("File does not exist or is not accessible: #{file}")
+      Puppet.info(_("File does not exist or is not accessible: #{file}"))
       return nil
     end
 
@@ -52,8 +52,8 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
       # Mark that we're expandable.
       @expandable = true
     else
-      raise ArgumentError, "#{path} does not exist or is not a directory" unless FileTest.directory?(path)
-      raise ArgumentError, "#{path} is not readable" unless FileTest.readable?(path)
+      raise ArgumentError, _("#{path} does not exist or is not a directory") unless FileTest.directory?(path)
+      raise ArgumentError, _("#{path} is not readable") unless FileTest.readable?(path)
       @expandable = false
     end
     @path = path
@@ -67,7 +67,7 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
   # Verify our configuration is valid.  This should really check to
   # make sure at least someone will be allowed, but, eh.
   def validate
-    raise ArgumentError.new("Mounts without paths are not usable") if @path.nil?
+    raise ArgumentError.new(_("Mounts without paths are not usable")) if @path.nil?
   end
 
   private
@@ -89,7 +89,7 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
     if node
       map = clientmap(node)
     else
-      Puppet.notice "No client; expanding '#{path}' with local host"
+      Puppet.notice _("No client; expanding '#{path}' with local host")
       # Else, use the local information
       map = localmap
     end

--- a/lib/puppet/file_serving/mount/file.rb
+++ b/lib/puppet/file_serving/mount/file.rb
@@ -23,7 +23,7 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
     file = ::File.join(full_path, relative_path)
 
     if !(Puppet::FileSystem.exist?(file) or Puppet::FileSystem.symlink?(file))
-      Puppet.info(_("File does not exist or is not accessible: #{file}"))
+      Puppet.info(_("File does not exist or is not accessible: %{file}") % { file: file })
       return nil
     end
 
@@ -52,8 +52,8 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
       # Mark that we're expandable.
       @expandable = true
     else
-      raise ArgumentError, _("#{path} does not exist or is not a directory") unless FileTest.directory?(path)
-      raise ArgumentError, _("#{path} is not readable") unless FileTest.readable?(path)
+      raise ArgumentError, _("%{path} does not exist or is not a directory") % { path: path } unless FileTest.directory?(path)
+      raise ArgumentError, _("%{path} is not readable") % { path: path } unless FileTest.readable?(path)
       @expandable = false
     end
     @path = path
@@ -89,7 +89,7 @@ class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
     if node
       map = clientmap(node)
     else
-      Puppet.notice _("No client; expanding '#{path}' with local host")
+      Puppet.notice _("No client; expanding '%{path}' with local host") % { path: path }
       # Else, use the local information
       map = localmap
     end

--- a/lib/puppet/file_serving/mount/modules.rb
+++ b/lib/puppet/file_serving/mount/modules.rb
@@ -5,7 +5,7 @@ require 'puppet/file_serving/mount'
 class Puppet::FileServing::Mount::Modules < Puppet::FileServing::Mount
   # Return an instance of the appropriate class.
   def find(path, request)
-    raise "No module specified" if path.to_s.empty?
+    raise _("No module specified") if path.to_s.empty?
     module_name, relative_path = path.split("/", 2)
     return nil unless mod = request.environment.module(module_name)
 

--- a/lib/puppet/file_serving/terminus_selector.rb
+++ b/lib/puppet/file_serving/terminus_selector.rb
@@ -26,7 +26,7 @@ module Puppet::FileServing::TerminusSelector
     when nil
       :file_server
     else
-      raise ArgumentError, _("URI protocol '#{request.protocol}' is not currently supported for file serving")
+      raise ArgumentError, _("URI protocol '%{protocol}' is not currently supported for file serving") % { protocol: request.protocol }
     end
   end
 end

--- a/lib/puppet/file_serving/terminus_selector.rb
+++ b/lib/puppet/file_serving/terminus_selector.rb
@@ -26,7 +26,7 @@ module Puppet::FileServing::TerminusSelector
     when nil
       :file_server
     else
-      raise ArgumentError, "URI protocol '#{request.protocol}' is not currently supported for file serving"
+      raise ArgumentError, _("URI protocol '#{request.protocol}' is not currently supported for file serving")
     end
   end
 end

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -14,7 +14,7 @@ class Puppet::FileSystem::FileImpl
     if path.respond_to?(:to_str)
       Pathname.new(path)
     else
-      raise ArgumentError, _("FileSystem implementation expected Pathname, got: '#{path.class}'")
+      raise ArgumentError, _("FileSystem implementation expected Pathname, got: '%{klass}'") % { klass: path.class }
     end
   end
 
@@ -61,7 +61,7 @@ class Puppet::FileSystem::FileImpl
           timeout -= wait
           wait *= 2
           if timeout < 0
-            raise Timeout::Error, _("Timeout waiting for exclusive lock on #{@path}")
+            raise Timeout::Error, _("Timeout waiting for exclusive lock on %{path}") % { path: @path }
           end
         end
       end

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -14,7 +14,7 @@ class Puppet::FileSystem::FileImpl
     if path.respond_to?(:to_str)
       Pathname.new(path)
     else
-      raise ArgumentError, "FileSystem implementation expected Pathname, got: '#{path.class}'"
+      raise ArgumentError, _("FileSystem implementation expected Pathname, got: '#{path.class}'")
     end
   end
 
@@ -61,7 +61,7 @@ class Puppet::FileSystem::FileImpl
           timeout -= wait
           wait *= 2
           if timeout < 0
-            raise Timeout::Error, "Timeout waiting for exclusive lock on #{@path}"
+            raise Timeout::Error, _("Timeout waiting for exclusive lock on #{@path}")
           end
         end
       end

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -65,7 +65,7 @@ class Puppet::FileSystem::MemoryImpl
     if path.is_a?(Puppet::FileSystem::MemoryFile)
       path
     else
-      find(path) or raise ArgumentError, _("Unable to find registered object for #{path.inspect}")
+      find(path) or raise ArgumentError, _("Unable to find registered object for %{path}") % { path: path.inspect }
     end
   end
 

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -65,7 +65,7 @@ class Puppet::FileSystem::MemoryImpl
     if path.is_a?(Puppet::FileSystem::MemoryFile)
       path
     else
-      find(path) or raise ArgumentError, "Unable to find registered object for #{path.inspect}"
+      find(path) or raise ArgumentError, _("Unable to find registered object for #{path.inspect}")
     end
   end
 

--- a/lib/puppet/file_system/path_pattern.rb
+++ b/lib/puppet/file_system/path_pattern.rb
@@ -48,12 +48,12 @@ module Puppet::FileSystem
     def validate
       @pathname.each_filename do |e|
         if e =~ TRAVERSAL
-          raise(InvalidPattern, "PathPatterns cannot be created with directory traversals.")
+          raise(InvalidPattern, _("PathPatterns cannot be created with directory traversals."))
         end
       end
       case @pathname.to_s
       when CURRENT_DRIVE_RELATIVE_WINDOWS
-        raise(InvalidPattern, "A PathPattern cannot be a Windows current drive relative path.")
+        raise(InvalidPattern, _("A PathPattern cannot be a Windows current drive relative path."))
       end
     end
 
@@ -61,7 +61,7 @@ module Puppet::FileSystem
       begin
         @pathname = Pathname.new(pattern.strip)
       rescue ArgumentError => error
-        raise InvalidPattern.new("PathPatterns cannot be created with a zero byte.", error)
+        raise InvalidPattern.new(_("PathPatterns cannot be created with a zero byte."), error)
       end
       validate
     end
@@ -76,9 +76,9 @@ module Puppet::FileSystem
       super
       case @pathname.to_s
       when ABSOLUTE_WINDOWS
-        raise(InvalidPattern, "A relative PathPattern cannot be prefixed with a drive.")
+        raise(InvalidPattern, _("A relative PathPattern cannot be prefixed with a drive."))
       when ABSOLUTE_UNIX
-        raise(InvalidPattern, "A relative PathPattern cannot be an absolute path.")
+        raise(InvalidPattern, _("A relative PathPattern cannot be an absolute path."))
       end
     end
   end
@@ -91,7 +91,7 @@ module Puppet::FileSystem
     def validate
       super
       if @pathname.to_s !~ ABSOLUTE_UNIX and @pathname.to_s !~ ABSOLUTE_WINDOWS
-        raise(InvalidPattern, "An absolute PathPattern cannot be a relative path.")
+        raise(InvalidPattern, _("An absolute PathPattern cannot be a relative path."))
       end
     end
   end

--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -106,7 +106,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
         prefix = prefix_suffix[0]
         suffix = prefix_suffix[1]
       else
-        raise ArgumentError, _("unexpected prefix_suffix: #{prefix_suffix.inspect}")
+        raise ArgumentError, _("unexpected prefix_suffix: %{value}") % { value: prefix_suffix.inspect }
     end
     t = Time.now.strftime("%Y%m%d")
     path = "#{prefix}#{t}-#{$$}-#{rand(0x100000000).to_s(36)}"
@@ -136,7 +136,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
       n ||= 0
       n += 1
       retry if !max_try or n < max_try
-      raise _("cannot generate temporary name using `#{basename}' under `#{tmpdir}'")
+      raise _("cannot generate temporary name using `%{basename}' under `%{tmpdir}'") % { basename: basename, tmpdir: tmpdir }
     end
     path
   end

--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -106,7 +106,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
         prefix = prefix_suffix[0]
         suffix = prefix_suffix[1]
       else
-        raise ArgumentError, "unexpected prefix_suffix: #{prefix_suffix.inspect}"
+        raise ArgumentError, _("unexpected prefix_suffix: #{prefix_suffix.inspect}")
     end
     t = Time.now.strftime("%Y%m%d")
     path = "#{prefix}#{t}-#{$$}-#{rand(0x100000000).to_s(36)}"
@@ -136,7 +136,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
       n ||= 0
       n += 1
       retry if !max_try or n < max_try
-      raise "cannot generate temporary name using `#{basename}' under `#{tmpdir}'"
+      raise _("cannot generate temporary name using `#{basename}' under `#{tmpdir}'")
     end
     path
   end

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -44,7 +44,7 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
     return 0 if dest_exists && dest_stat.ftype == 'directory'
 
     if dest_exists && dest_stat.ftype == 'file' && options[:force] != true
-      raise(Errno::EEXIST, _("#{dest} already exists and the :force option was not specified"))
+      raise(Errno::EEXIST, _("%{dest} already exists and the :force option was not specified") % { dest: dest })
     end
 
     if options[:noop] != true

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -44,7 +44,7 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
     return 0 if dest_exists && dest_stat.ftype == 'directory'
 
     if dest_exists && dest_stat.ftype == 'file' && options[:force] != true
-      raise(Errno::EEXIST, "#{dest} already exists and the :force option was not specified")
+      raise(Errno::EEXIST, _("#{dest} already exists and the :force option was not specified"))
     end
 
     if options[:noop] != true
@@ -118,12 +118,12 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
 
   def raise_if_symlinks_unsupported
     if ! Puppet.features.manages_symlinks?
-      msg = "This version of Windows does not support symlinks.  Windows Vista / 2008 or higher is required."
+      msg = _("This version of Windows does not support symlinks.  Windows Vista / 2008 or higher is required.")
       raise Puppet::Util::Windows::Error.new(msg)
     end
 
     if ! Puppet::Util::Windows::Process.process_privilege_symlink?
-      Puppet.warning "The current user does not have the necessary permission to manage symlinks."
+      Puppet.warning _("The current user does not have the necessary permission to manage symlinks.")
     end
   end
 


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/file_server/*` for translation.