### PR TITLE
(PUP-7042) Mark strings in forge

### DIFF
--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -195,7 +195,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
 
     def validate_checksum(file, checksum)
       if Digest::MD5.file(file.path).hexdigest != checksum
-        raise RuntimeError, "Downloaded release for #{name} did not match expected checksum"
+        raise RuntimeError, _("Downloaded release for #{name} did not match expected checksum")
       end
     end
 
@@ -203,7 +203,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       begin
         Puppet::ModuleTool::Applications::Unpacker.unpack(file.path, destination)
       rescue Puppet::ExecutionFailure => e
-        raise RuntimeError, "Could not extract contents of module archive: #{e.message}"
+        raise RuntimeError, _("Could not extract contents of module archive: #{e.message}")
       end
     end
   end
@@ -216,7 +216,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       begin
         ModuleRelease.new(self, release)
       rescue ArgumentError => e
-        Puppet.warning "Cannot consider release #{metadata['name']}-#{metadata['version']}: #{e}"
+        Puppet.warning _("Cannot consider release #{metadata['name']}-#{metadata['version']}: #{e}")
         false
       end
     end

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -195,7 +195,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
 
     def validate_checksum(file, checksum)
       if Digest::MD5.file(file.path).hexdigest != checksum
-        raise RuntimeError, _("Downloaded release for #{name} did not match expected checksum")
+        raise RuntimeError, _("Downloaded release for %{name} did not match expected checksum") % { name: name }
       end
     end
 
@@ -203,7 +203,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       begin
         Puppet::ModuleTool::Applications::Unpacker.unpack(file.path, destination)
       rescue Puppet::ExecutionFailure => e
-        raise RuntimeError, _("Could not extract contents of module archive: #{e.message}")
+        raise RuntimeError, _("Could not extract contents of module archive: %{message}") % { message: e.message }
       end
     end
   end
@@ -216,7 +216,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       begin
         ModuleRelease.new(self, release)
       rescue ArgumentError => e
-        Puppet.warning _("Cannot consider release #{metadata['name']}-#{metadata['version']}: #{e}")
+        Puppet.warning _("Cannot consider release %{name}-%{version}: %{error}") % { name: metadata['name'], version: metadata['version'], error: e }
         false
       end
     end

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -25,14 +25,14 @@ module Puppet::Forge::Errors
       @uri     = options[:uri]
       original = options[:original]
 
-      super("Unable to verify the SSL certificate at #{@uri}", original)
+      super(_("Unable to verify the SSL certificate at #{@uri}"), original)
     end
 
     # Return a multiline version of the error message
     #
     # @return [String] the multiline version of the error message
     def multiline
-      <<-EOS.chomp
+      _(<<-EOS).chomp
 Could not connect via HTTPS to #{@uri}
   Unable to verify the SSL certificate
     The certificate may not be signed by a valid CA
@@ -51,7 +51,7 @@ Could not connect via HTTPS to #{@uri}
       original = options[:original]
       @detail  = original.message
 
-      message = "Unable to connect to the server at #{@uri}. Detail: #{@detail}."
+      message = _("Unable to connect to the server at #{@uri}. Detail: #{@detail}.")
       super(message, original)
     end
 
@@ -59,7 +59,7 @@ Could not connect via HTTPS to #{@uri}
     #
     # @return [String] the multiline version of the error message
     def multiline
-      <<-EOS.chomp
+      _(<<-EOS).chomp
 Could not connect to #{@uri}
   There was a network communications problem
     The error we caught said '#{@detail}'
@@ -79,7 +79,7 @@ Could not connect to #{@uri}
       @uri     = options[:uri]
       @message = options[:message]
       response = options[:response]
-      @response = "#{response.code} #{response.message.strip}"
+      @response = _("#{response.code} #{response.message.strip}")
 
       begin
         body = JSON.parse(response.body)
@@ -89,7 +89,7 @@ Could not connect to #{@uri}
       rescue JSON::ParserError
       end
 
-      message = "Request to Puppet Forge failed. Detail: "
+      message = _("Request to Puppet Forge failed. Detail: ")
       message << @message << " / " if @message
       message << @response << "."
       super(message, original)
@@ -99,12 +99,12 @@ Could not connect to #{@uri}
     #
     # @return [String] the multiline version of the error message
     def multiline
-      message = <<-EOS.chomp
+      message = _(<<-EOS).chomp
 Request to Puppet Forge failed.
   The server being queried was #{@uri}
   The HTTP response we received was '#{@response}'
       EOS
-      message << "\n  The message we received said '#{@message}'" if @message
+      message << _("\n  The message we received said '#{@message}'") if @message
       message
     end
   end

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -25,15 +25,15 @@ module Puppet::Forge::Errors
       @uri     = options[:uri]
       original = options[:original]
 
-      super(_("Unable to verify the SSL certificate at #{@uri}"), original)
+      super(_("Unable to verify the SSL certificate at %{uri}") % { uri: @uri }, original)
     end
 
     # Return a multiline version of the error message
     #
     # @return [String] the multiline version of the error message
     def multiline
-      _(<<-EOS).chomp
-Could not connect via HTTPS to #{@uri}
+      _(<<-EOS).chomp % { uri: @uri }
+Could not connect via HTTPS to %{uri}
   Unable to verify the SSL certificate
     The certificate may not be signed by a valid CA
     The CA bundle included with OpenSSL may not be valid or up to date
@@ -51,7 +51,7 @@ Could not connect via HTTPS to #{@uri}
       original = options[:original]
       @detail  = original.message
 
-      message = _("Unable to connect to the server at #{@uri}. Detail: #{@detail}.")
+      message = _("Unable to connect to the server at %{uri}. Detail: %{detail}.") % { uri: @uri, detail: @detail }
       super(message, original)
     end
 
@@ -59,10 +59,10 @@ Could not connect via HTTPS to #{@uri}
     #
     # @return [String] the multiline version of the error message
     def multiline
-      _(<<-EOS).chomp
-Could not connect to #{@uri}
+      _(<<-EOS).chomp % { uri: @uri, detail: @detail }
+Could not connect to %{uri}
   There was a network communications problem
-    The error we caught said '#{@detail}'
+    The error we caught said '%{detail}'
     Check your network connection and try again
       EOS
     end
@@ -79,7 +79,7 @@ Could not connect to #{@uri}
       @uri     = options[:uri]
       @message = options[:message]
       response = options[:response]
-      @response = _("#{response.code} #{response.message.strip}")
+      @response = "#{response.code} #{response.message.strip}"
 
       begin
         body = JSON.parse(response.body)
@@ -99,12 +99,12 @@ Could not connect to #{@uri}
     #
     # @return [String] the multiline version of the error message
     def multiline
-      message = _(<<-EOS).chomp
+      message = _(<<-EOS).chomp % { uri: @uri, response: @response }
 Request to Puppet Forge failed.
-  The server being queried was #{@uri}
-  The HTTP response we received was '#{@response}'
+  The server being queried was %{uri}
+  The HTTP response we received was '%{response}'
       EOS
-      message << _("\n  The message we received said '#{@message}'") if @message
+      message << _("\n  The message we received said '%{message}'") % { message: @message } if @message
       message
     end
   end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/forge.rb` and `lib/puppet/forge/*` for translation.