### PR TITLE
(PUP-7042) Mark strings in functions

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -176,7 +176,7 @@ module Puppet::Functions
   # @api public
   def self.create_loaded_function(func_name, loader, function_base = Function, &block)
     if function_base.ancestors.none? { |s| s == Puppet::Pops::Functions::Function }
-      raise ArgumentError, "Functions must be based on Puppet::Pops::Functions::Function. Got #{function_base}"
+      raise ArgumentError, _("Functions must be based on Puppet::Pops::Functions::Function. Got #{function_base}")
     end
 
     func_name = func_name.to_s
@@ -236,7 +236,7 @@ module Puppet::Functions
   # @api private
   def self.default_dispatcher(the_class, func_name)
     unless the_class.method_defined?(func_name)
-      raise ArgumentError, "Function Creation Error, cannot create a default dispatcher for function '#{func_name}', no method with this name found"
+      raise ArgumentError, _("Function Creation Error, cannot create a default dispatcher for function '#{func_name}', no method with this name found")
     end
     any_signature(*min_max_param(the_class.instance_method(func_name)))
   end
@@ -299,7 +299,7 @@ module Puppet::Functions
     #
     def self.local_types(&block)
       if loader.nil?
-        raise ArgumentError, "No loader present. Call create_loaded_function(:myname, loader,...), instead of 'create_function' if running tests"
+        raise ArgumentError, _("No loader present. Call create_loaded_function(:myname, loader,...), instead of 'create_function' if running tests")
       end
       aliases = LocalTypeAliasesBuilder.new(loader, name)
       aliases.instance_eval(&block)
@@ -363,7 +363,7 @@ module Puppet::Functions
     # @api public
     def param(type, name)
       internal_param(type, name)
-      raise ArgumentError, 'A required parameter cannot be added after an optional parameter' if @min != @max
+      raise ArgumentError, _('A required parameter cannot be added after an optional parameter') if @min != @max
       @min += 1
       @max += 1
     end
@@ -412,7 +412,7 @@ module Puppet::Functions
     # @api public
     def required_repeated_param(type, name)
       internal_param(type, name, true)
-      raise ArgumentError, 'A required repeated parameter cannot be added after an optional parameter' if @min != @max
+      raise ArgumentError, _('A required repeated parameter cannot be added after an optional parameter') if @min != @max
       @min += 1
       @max = :default
     end
@@ -434,22 +434,22 @@ module Puppet::Functions
         type_string, name = type_and_name
         type = @type_parser.parse(type_string, loader)
       else
-        raise ArgumentError, "block_param accepts max 2 arguments (type, name), got #{type_and_name.size}."
+        raise ArgumentError, _("block_param accepts max 2 arguments (type, name), got #{type_and_name.size}.")
       end
 
       unless Puppet::Pops::Types::TypeCalculator.is_kind_of_callable?(type, false)
-        raise ArgumentError, "Expected PCallableType or PVariantType thereof, got #{type.class}"
+        raise ArgumentError, _("Expected PCallableType or PVariantType thereof, got #{type.class}")
       end
 
       unless name.is_a?(Symbol)
-        raise ArgumentError, "Expected block_param name to be a Symbol, got #{name.class}"
+        raise ArgumentError, _("Expected block_param name to be a Symbol, got #{name.class}")
       end
 
       if @block_type.nil?
         @block_type = type
         @block_name = name
       else
-        raise ArgumentError, 'Attempt to redefine block'
+        raise ArgumentError, _('Attempt to redefine block')
       end
     end
     alias required_block_param block_param
@@ -470,7 +470,7 @@ module Puppet::Functions
     #
     # @api public
     def return_type(type)
-      raise ArgumentError, "Argument to 'return_type' must be a String reference to a Puppet Data Type. Got #{type.class}" unless type.is_a?(String)
+      raise ArgumentError, _("Argument to 'return_type' must be a String reference to a Puppet Data Type. Got #{type.class}") unless type.is_a?(String)
       @return_type = type
     end
 
@@ -478,11 +478,11 @@ module Puppet::Functions
 
     # @api private
     def internal_param(type, name, repeat = false)
-      raise ArgumentError, 'Parameters cannot be added after a block parameter' unless @block_type.nil?
-      raise ArgumentError, 'Parameters cannot be added after a repeated parameter' if @max == :default
+      raise ArgumentError, _('Parameters cannot be added after a block parameter') unless @block_type.nil?
+      raise ArgumentError, _('Parameters cannot be added after a repeated parameter') if @max == :default
 
       if name.is_a?(String)
-        raise ArgumentError, "Parameter name argument must be a Symbol. Got #{name.class}"
+        raise ArgumentError, _("Parameter name argument must be a Symbol. Got #{name.class}")
       end
 
       if type.is_a?(String)
@@ -495,7 +495,7 @@ module Puppet::Functions
           @weaving << @names.size()-1
         end
       else
-        raise ArgumentError, "Parameter 'type' must be a String reference to a Puppet Data Type. Got #{type.class}"
+        raise ArgumentError, _("Parameter 'type' must be a String reference to a Puppet Data Type. Got #{type.class}")
       end
     end
 
@@ -559,7 +559,7 @@ module Puppet::Functions
     def type(assignment_string)
       result = parser.parse_string("type #{assignment_string}", nil) # no file source :-(
       unless result.body.kind_of?(Puppet::Pops::Model::TypeAlias)
-        raise ArgumentError, "Expected a type alias assignment on the form 'AliasType = T', got '#{assignment_string}'"
+        raise ArgumentError, _("Expected a type alias assignment on the form 'AliasType = T', got '#{assignment_string}'")
       end
       @local_types << result.body
     end

--- a/lib/puppet/functions/binary_file.rb
+++ b/lib/puppet/functions/binary_file.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:binary_file, Puppet::Functions::InternalFunct
   def binary_file(scope, unresolved_path)
     path = Puppet::Parser::Files.find_file(unresolved_path, scope.compiler.environment)
     unless path && Puppet::FileSystem.exist?(path)
-      raise Puppet::ParseError, "binary_file(): The given file '#{unresolved_path}' does not exist"
+      raise Puppet::ParseError, _("binary_file(): The given file '#{unresolved_path}' does not exist")
     end
     Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(Puppet::FileSystem.binread(path))
   end

--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -129,12 +129,12 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
         scope.compiler.findresource(val.resource_type, val.title)
 
       when Puppet::Pops::Types::PResourceType
-        raise ArgumentError, 'The given resource type is a reference to all kind of types' if val.type_name.nil?
+        raise ArgumentError, _('The given resource type is a reference to all kind of types') if val.type_name.nil?
         type = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, val.type_name)
         val.title.nil? ? type : scope.compiler.findresource(type, val.title)
 
       when Puppet::Pops::Types::PHostClassType
-        raise  ArgumentError, 'The given class type is a reference to all classes' if val.class_name.nil?
+        raise  ArgumentError, _('The given class type is a reference to all classes') if val.class_name.nil?
         scope.compiler.findresource(:class, val.class_name)
 
       when Puppet::Pops::Types::PType
@@ -148,12 +148,12 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
           # Interpreted as asking if a class (and nothing else) is defined without having to be included in the catalog
           # (this is the same as asking for just the class' name, but with the added certainty that it cannot be a defined type.
           #
-          raise  ArgumentError, 'The given class type is a reference to all classes' if val.type.class_name.nil?
+          raise  ArgumentError, _('The given class type is a reference to all classes') if val.type.class_name.nil?
           Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_hostclass(scope, val.type.class_name)
           #scope.environment.known_resource_types.find_hostclass(val.type.class_name)
         end
       else
-        raise ArgumentError, "Invalid argument of type '#{val.class}' to 'defined'"
+        raise ArgumentError, _("Invalid argument of type '#{val.class}' to 'defined'")
       end
     end
   end

--- a/lib/puppet/functions/dig.rb
+++ b/lib/puppet/functions/dig.rb
@@ -14,7 +14,7 @@ Puppet::Functions.create_function(:dig) do
     args.reduce(data) do | d, k |
       return nil if d.nil? || k.nil?
       if !(d.is_a?(Array) || d.is_a?(Hash))
-        raise ArgumentError, "The given data does not contain a Collection at #{walked_path}, got '#{d.class}'"
+        raise ArgumentError, _("The given data does not contain a Collection at #{walked_path}, got '#{d.class}'")
       end
       walked_path << k
       d[k]

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -84,7 +84,7 @@ Puppet::Functions.create_function(:hiera_include, Hiera::PuppetFunction) do
   end
 
   def post_lookup(scope, key, value)
-    raise Puppet::ParseError, "Could not find data item #{key}" if value.nil?
+    raise Puppet::ParseError, _("Could not find data item #{key}") if value.nil?
     call_function_with_scope(scope, 'include', value) unless value.empty?
   end
 end

--- a/lib/puppet/functions/hocon_data.rb
+++ b/lib/puppet/functions/hocon_data.rb
@@ -2,7 +2,7 @@
 #
 Puppet::Functions.create_function(:hocon_data) do
   unless Puppet.features.hocon?
-    raise Puppet::DataBinding::LookupError, 'Lookup using Hocon data_hash function is not supported without hocon library'
+    raise Puppet::DataBinding::LookupError, _('Lookup using Hocon data_hash function is not supported without hocon library')
   end
 
   require 'hocon'
@@ -18,7 +18,7 @@ Puppet::Functions.create_function(:hocon_data) do
     begin
       Hocon.parse(Puppet::FileSystem.read(path, :encoding => 'utf-8'))
     rescue Hocon::ConfigError => ex
-      raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+      raise Puppet::DataBinding::LookupError, _("Unable to parse (#{path}): #{ex.message}")
     end
   end
 end

--- a/lib/puppet/functions/json_data.rb
+++ b/lib/puppet/functions/json_data.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:json_data) do
       JSON.parse(Puppet::FileSystem.read(path, :encoding => 'utf-8'))
     rescue JSON::ParserError => ex
       # Filename not included in message, so we add it here.
-      raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+      raise Puppet::DataBinding::LookupError, _("Unable to parse (#{path}): #{ex.message}")
     end
   end
 end

--- a/lib/puppet/functions/match.rb
+++ b/lib/puppet/functions/match.rb
@@ -78,7 +78,7 @@ Puppet::Functions.create_function(:match) do
   protected
 
   def match_Object(obj, s)
-    msg = "match() expects pattern of T, where T is String, Regexp, Regexp[r], Pattern[p], or Array[T]. Got #{obj.class}"
+    msg = _("match() expects pattern of T, where T is String, Regexp, Regexp[r], Pattern[p], or Array[T]. Got #{obj.class}")
     raise ArgumentError, msg
   end
 
@@ -91,7 +91,7 @@ Puppet::Functions.create_function(:match) do
   end
 
   def match_PRegexpType(regexp_t, s)
-    raise ArgumentError, "Given Regexp Type has no regular expression" unless regexp_t.pattern
+    raise ArgumentError, _("Given Regexp Type has no regular expression") unless regexp_t.pattern
     do_match(s, regexp_t.regexp)
   end
 

--- a/lib/puppet/functions/require.rb
+++ b/lib/puppet/functions/require.rb
@@ -27,7 +27,7 @@ Puppet::Functions.create_function(:require, Puppet::Functions::InternalFunction)
     classes.each do |klass|
       # lookup the class in the scopes
       klass = (classobj = krt.find_hostclass(klass)) ? classobj.name : nil
-      raise Puppet::ParseError.new("Could not find class #{klass}") unless klass
+      raise Puppet::ParseError.new(_("Could not find class #{klass}")) unless klass
       ref = Puppet::Resource.new(:class, klass)
       resource = scope.resource
       resource.set_parameter(:require, [resource[:require]].flatten.compact << ref)

--- a/lib/puppet/functions/slice.rb
+++ b/lib/puppet/functions/slice.rb
@@ -99,11 +99,11 @@ Puppet::Functions.create_function(:slice) do
       serving_size = 1
     end
     if serving_size == 0
-      raise ArgumentError, "slice(): block must define at least one parameter. Block has 0."
+      raise ArgumentError, _("slice(): block must define at least one parameter. Block has 0.")
     end
     unless serving_size == 1 || serving_size == slice_size
-      raise ArgumentError, "slice(): block must define one parameter, or " +
-        "the same number of parameters as the given size of the slice (#{slice_size}). Block has #{serving_size}; "+
+      raise ArgumentError, _("slice(): block must define one parameter, or ") +
+        _("the same number of parameters as the given size of the slice (#{slice_size}). Block has #{serving_size}; ")+
       pblock.parameter_names.join(', ')
     end
     serving_size

--- a/lib/puppet/functions/strftime.rb
+++ b/lib/puppet/functions/strftime.rb
@@ -29,7 +29,7 @@ Puppet::Functions.create_function(:strftime) do
 
   def legacy_strftime(format, timezone = nil)
     Puppet.warn_once('deprecation', 'legacy#strftime',
-      'The argument signature (String format, [String timezone]) is deprecated for #strfime. See #strftime documentation and Timespan type for more info')
+      _('The argument signature (String format, [String timezone]) is deprecated for #strfime. See #strftime documentation and Timespan type for more info'))
     Puppet::Pops::Time::Timestamp.format_time(format, Time.now.utc, timezone)
   end
 end

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -20,7 +20,7 @@ Puppet::Functions.create_function(:yaml_data) do
     rescue YAML::SyntaxError => ex
       # Psych errors includes the absolute path to the file, so no need to add that
       # to the message
-      raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
+      raise Puppet::DataBinding::LookupError, _("Unable to parse #{ex.message}")
     end
   end
 end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/functions.rb` and `lib/puppet/functions/*` for translation.