### PR TITLE
(PUP-7042) Mark strings in graph

### DIFF
--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -61,7 +61,7 @@ class Puppet::Graph::SimpleGraph
     source = base || event.resource
 
     unless vertex?(source)
-      Puppet.warning _("Got an event from invalid vertex #{source.ref}")
+      Puppet.warning _("Got an event from invalid vertex %{source}") % { source: source.ref }
       return []
     end
     # Get all of the edges that this vertex should forward events
@@ -146,7 +146,7 @@ class Puppet::Graph::SimpleGraph
         frame[:step] = :children
 
       else
-        fail _("#{frame[:step]} is an unknown step")
+        fail "#{frame[:step]} is an unknown step"
       end
     end
   end
@@ -193,6 +193,7 @@ class Puppet::Graph::SimpleGraph
   # through the graph first, which are more likely to be interesting to the
   # user.  I think; it would be interesting to verify that. --daniel 2011-01-23
   def paths_in_cycle(cycle, max_paths = 1)
+    #TRANSLATORS "negative or zero" refers to the count of paths
     raise ArgumentError, _("negative or zero max_paths") if max_paths < 1
 
     # Calculate our filtered outbound vertex lists...
@@ -225,7 +226,7 @@ class Puppet::Graph::SimpleGraph
     return if n == 0
     s = n == 1 ? '' : 's'
 
-    message = _("Found #{n} dependency cycle#{s}:\n")
+    message = n_("Found %{num} dependency cycle:\n", "Found %{num} dependency cycles:\n", n) % { num: n }
     cycles.each do |cycle|
       paths = paths_in_cycle(cycle)
       message += paths.map{ |path| '(' + path.join(" => ") + ')'}.join("\n") + "\n"
@@ -233,10 +234,11 @@ class Puppet::Graph::SimpleGraph
 
     if Puppet[:graph] then
       filename = write_cycles_to_graph(cycles)
-      message += _("Cycle graph written to #{filename}.")
+      message += _("Cycle graph written to %{filename}.") % { filename: filename }
     else
-      message += _("Try the '--graph' option and opening the ")
-      message += _("resulting '.dot' file in OmniGraffle or GraphViz")
+      #TRANSLATORS "graph" refers to a command line option and should not be translated
+      #TRANSLATORS OmniGraffle and GraphViz and program names and should not be translated
+      message += _("Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz")
     end
 
     raise Puppet::Error, message

--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -61,7 +61,7 @@ class Puppet::Graph::SimpleGraph
     source = base || event.resource
 
     unless vertex?(source)
-      Puppet.warning "Got an event from invalid vertex #{source.ref}"
+      Puppet.warning _("Got an event from invalid vertex #{source.ref}")
       return []
     end
     # Get all of the edges that this vertex should forward events
@@ -146,7 +146,7 @@ class Puppet::Graph::SimpleGraph
         frame[:step] = :children
 
       else
-        fail "#{frame[:step]} is an unknown step"
+        fail _("#{frame[:step]} is an unknown step")
       end
     end
   end
@@ -193,7 +193,7 @@ class Puppet::Graph::SimpleGraph
   # through the graph first, which are more likely to be interesting to the
   # user.  I think; it would be interesting to verify that. --daniel 2011-01-23
   def paths_in_cycle(cycle, max_paths = 1)
-    raise ArgumentError, "negative or zero max_paths" if max_paths < 1
+    raise ArgumentError, _("negative or zero max_paths") if max_paths < 1
 
     # Calculate our filtered outbound vertex lists...
     adj = {}
@@ -225,7 +225,7 @@ class Puppet::Graph::SimpleGraph
     return if n == 0
     s = n == 1 ? '' : 's'
 
-    message = "Found #{n} dependency cycle#{s}:\n"
+    message = _("Found #{n} dependency cycle#{s}:\n")
     cycles.each do |cycle|
       paths = paths_in_cycle(cycle)
       message += paths.map{ |path| '(' + path.join(" => ") + ')'}.join("\n") + "\n"
@@ -233,10 +233,10 @@ class Puppet::Graph::SimpleGraph
 
     if Puppet[:graph] then
       filename = write_cycles_to_graph(cycles)
-      message += "Cycle graph written to #{filename}."
+      message += _("Cycle graph written to #{filename}.")
     else
-      message += "Try the '--graph' option and opening the "
-      message += "resulting '.dot' file in OmniGraffle or GraphViz"
+      message += _("Try the '--graph' option and opening the ")
+      message += _("resulting '.dot' file in OmniGraffle or GraphViz")
     end
 
     raise Puppet::Error, message


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/graph/*` for translation.