### PR TITLE
(PUP-7042) Mark strings in indirector

### DIFF
--- a/lib/puppet/indirector.rb
+++ b/lib/puppet/indirector.rb
@@ -22,7 +22,7 @@ module Puppet::Indirector
       Puppet::Indirector::Terminus.terminus_class(indirection_name, terminus_name || cache_name)
 
       indirection = Puppet::Indirector::Indirection.instance(indirection_name)
-      raise "Indirection #{indirection_name} does not exist" unless indirection
+      raise _("Indirection #{indirection_name} does not exist") unless indirection
 
       indirection.terminus_class = terminus_name if terminus_name
       indirection.cache_class = cache_name if cache_name
@@ -35,7 +35,7 @@ module Puppet::Indirector
   # evaluated at parse time, which is before the user has had a chance
   # to override it.
   def indirects(indirection, options = {})
-    raise(ArgumentError, "Already handling indirection for #{@indirection.name}; cannot also handle #{indirection}") if @indirection
+    raise(ArgumentError, _("Already handling indirection for #{@indirection.name}; cannot also handle #{indirection}")) if @indirection
     # populate this class with the various new methods
     extend ClassMethods
     include Puppet::Indirector::Envelope

--- a/lib/puppet/indirector.rb
+++ b/lib/puppet/indirector.rb
@@ -22,7 +22,7 @@ module Puppet::Indirector
       Puppet::Indirector::Terminus.terminus_class(indirection_name, terminus_name || cache_name)
 
       indirection = Puppet::Indirector::Indirection.instance(indirection_name)
-      raise _("Indirection #{indirection_name} does not exist") unless indirection
+      raise _("Indirection %{indirection_name} does not exist") % { indirection_name: indirection_name } unless indirection
 
       indirection.terminus_class = terminus_name if terminus_name
       indirection.cache_class = cache_name if cache_name
@@ -35,7 +35,7 @@ module Puppet::Indirector
   # evaluated at parse time, which is before the user has had a chance
   # to override it.
   def indirects(indirection, options = {})
-    raise(ArgumentError, _("Already handling indirection for #{@indirection.name}; cannot also handle #{indirection}")) if @indirection
+    raise(ArgumentError, _("Already handling indirection for %{current}; cannot also handle %{next}") % { current: @indirection.name, next: indirection }) if @indirection
     # populate this class with the various new methods
     extend ClassMethods
     include Puppet::Indirector::Envelope

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -17,10 +17,10 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   def extract_facts_from_request(request)
     return unless text_facts = request.options[:facts]
     unless format = request.options[:facts_format]
-      raise ArgumentError, "Facts but no fact format provided for #{request.key}"
+      raise ArgumentError, _("Facts but no fact format provided for #{request.key}")
     end
 
-    Puppet::Util::Profiler.profile("Found facts", [:compiler, :find_facts]) do
+    Puppet::Util::Profiler.profile(_("Found facts"), [:compiler, :find_facts]) do
       # If the facts were encoded as yaml, then the param reconstitution system
       # in Network::HTTP::Handler will automagically deserialize the value.
       if text_facts.is_a?(Puppet::Node::Facts)
@@ -31,7 +31,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       end
 
       unless facts.name == request.key
-        raise Puppet::Error, "Catalog for #{request.key.inspect} was requested with fact definition for the wrong node (#{facts.name.inspect})."
+        raise Puppet::Error, _("Catalog for #{request.key.inspect} was requested with fact definition for the wrong node (#{facts.name.inspect}).")
       end
 
       options = {
@@ -66,7 +66,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   end
 
   def initialize
-    Puppet::Util::Profiler.profile("Setup server facts for compiling", [:compiler, :init_server_facts]) do
+    Puppet::Util::Profiler.profile(_("Setup server facts for compiling"), [:compiler, :init_server_facts]) do
       set_server_facts
     end
   end
@@ -114,11 +114,11 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   def inlineable?(resource, sources)
     case
       when resource[:ensure] == 'absent'
-        return Puppet::Util::Profiler.profile("Not inlining absent resource", [:compiler, :static_compile_inlining, :skipped_file_metadata, :absent]) { false }
+        return Puppet::Util::Profiler.profile(_("Not inlining absent resource"), [:compiler, :static_compile_inlining, :skipped_file_metadata, :absent]) { false }
       when sources.empty?
-        return Puppet::Util::Profiler.profile("Not inlining resource without sources", [:compiler, :static_compile_inlining, :skipped_file_metadata, :no_sources]) { false }
+        return Puppet::Util::Profiler.profile(_("Not inlining resource without sources"), [:compiler, :static_compile_inlining, :skipped_file_metadata, :no_sources]) { false }
       when (not (sources.all? {|source| source =~ /^puppet:/}))
-        return Puppet::Util::Profiler.profile("Not inlining unsupported source scheme", [:compiler, :static_compile_inlining, :skipped_file_metadata, :unsupported_scheme]) { false }
+        return Puppet::Util::Profiler.profile(_("Not inlining unsupported source scheme"), [:compiler, :static_compile_inlining, :skipped_file_metadata, :unsupported_scheme]) { false }
       else
         return true
     end
@@ -138,12 +138,12 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   # Helper method to log file resources that could not be inlined because they
   # fall outside of an environment.
   def log_file_outside_environment
-    Puppet::Util::Profiler.profile("Not inlining file outside environment", [:compiler, :static_compile_inlining, :skipped_file_metadata, :file_outside_environment]) { true }
+    Puppet::Util::Profiler.profile(_("Not inlining file outside environment"), [:compiler, :static_compile_inlining, :skipped_file_metadata, :file_outside_environment]) { true }
   end
 
   # Helper method to log file resources that were successfully inlined.
   def log_metadata_inlining
-    Puppet::Util::Profiler.profile("Inlining file metadata", [:compiler, :static_compile_inlining, :inlined_file_metadata]) { true }
+    Puppet::Util::Profiler.profile(_("Inlining file metadata"), [:compiler, :static_compile_inlining, :inlined_file_metadata]) { true }
   end
 
   # Inline file metadata for static catalogs
@@ -230,7 +230,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
           end
         end
 
-        raise "Could not get metadata for #{resource[:source]}" unless metadata
+        raise _("Could not get metadata for #{resource[:source]}") unless metadata
 
         if inlineable_metadata?(metadata, metadata.source,  environment_path)
           metadata.content_uri = get_content_uri(metadata, metadata.source, environment_path)
@@ -251,12 +251,12 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     if node.environment && node.environment.static_catalogs? && options[:static_catalog] && options[:code_id]
       # Check for errors before compiling the catalog
       checksum_type = common_checksum_type(options[:checksum_type])
-      raise Puppet::Error, "Unable to find a common checksum type between agent '#{options[:checksum_type]}' and master '#{known_checksum_types}'." unless checksum_type
+      raise Puppet::Error, _("Unable to find a common checksum type between agent '#{options[:checksum_type]}' and master '#{known_checksum_types}'.") unless checksum_type
     end
 
-    str = "Compiled %s for " % [checksum_type ? 'static catalog' : 'catalog']
+    str = _("Compiled %s for ") % [checksum_type ? _('static catalog') : _('catalog')]
     str += node.name
-    str += " in environment #{node.environment}" if node.environment
+    str += _(" in environment #{node.environment}") if node.environment
     config = nil
 
     benchmark(:notice, str) do
@@ -272,8 +272,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
         end
 
         if checksum_type && config.is_a?(model)
-          str = "Inlined resource metadata into static catalog for #{node.name}"
-          str += " in environment #{node.environment}" if node.environment
+          str = _("Inlined resource metadata into static catalog for #{node.name}")
+          str += _(" in environment #{node.environment}") if node.environment
           benchmark(:notice, str) do
             Puppet::Util::Profiler.profile(str, [:compiler, :static_compile_postprocessing, node.environment, node.name]) do
               inline_metadata(config, checksum_type)
@@ -289,14 +289,14 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
   # Turn our host name into a node object.
   def find_node(name, environment, transaction_uuid, configured_environment)
-    Puppet::Util::Profiler.profile("Found node information", [:compiler, :find_node]) do
+    Puppet::Util::Profiler.profile(_("Found node information"), [:compiler, :find_node]) do
       node = nil
       begin
         node = Puppet::Node.indirection.find(name, :environment => environment,
                                              :transaction_uuid => transaction_uuid,
                                              :configured_environment => configured_environment)
       rescue => detail
-        message = "Failed when searching for node #{name}: #{detail}"
+        message = _("Failed when searching for node #{name}: #{detail}")
         Puppet.log_exception(detail, message)
         raise Puppet::Error, message, detail.backtrace
       end
@@ -315,7 +315,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   def node_from_request(request)
     if node = request.options[:use_node]
       if request.remote?
-        raise Puppet::Error, "Invalid option use_node for a remote request"
+        raise Puppet::Error, _("Invalid option use_node for a remote request")
       else
         return node
       end
@@ -333,7 +333,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       return node
     end
 
-    raise ArgumentError, "Could not find node '#{name}'; cannot compile"
+    raise ArgumentError, _("Could not find node '#{name}'; cannot compile")
   end
 
   # Initialize our server fact hash; we add these to each client, and they
@@ -351,7 +351,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       if value = Facter.value(fact)
         @server_facts[var] = value
       else
-        Puppet.warning "Could not retrieve fact #{fact}"
+        Puppet.warning _("Could not retrieve fact #{fact}")
       end
     end
 

--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -38,7 +38,7 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
   def find(request)
     return nil unless catalog = super
 
-    raise "Did not get catalog back" unless catalog.is_a?(model)
+    raise _("Did not get catalog back") unless catalog.is_a?(model)
 
     catalog.resources.find_all { |res| res.type == "File" }.each do |resource|
       next if resource[:ensure] == 'absent'
@@ -77,7 +77,7 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     newsource = file[:source][0].sub("puppet:///", "")
     file[:source][0] = newsource
 
-    raise "Could not get metadata for #{resource[:source]}" unless metadata = file.parameter(:source).metadata
+    raise _("Could not get metadata for #{resource[:source]}") unless metadata = file.parameter(:source).metadata
 
     replace_metadata(request, resource, metadata)
   end
@@ -109,7 +109,7 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     end
 
     old_source = resource.delete(:source)
-    Puppet.info "Metadata for #{resource} in catalog for '#{request.key}' added from '#{old_source}'"
+    Puppet.info _("Metadata for #{resource} in catalog for '#{request.key}' added from '#{old_source}'")
   end
 
   # Generate children resources for a recursive file and add them to the catalog.
@@ -221,9 +221,9 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     sum = @summer.sumdata(resource[:content])
 
     if Puppet::FileBucket::File.indirection.find("#{type}/#{sum}")
-      Puppet.info "Content for '#{resource[:source]}' already exists"
+      Puppet.info _("Content for '#{resource[:source]}' already exists")
     else
-      Puppet.info "Storing content for source '#{resource[:source]}'"
+      Puppet.info _("Storing content for source '#{resource[:source]}'")
       content = Puppet::FileServing::Content.indirection.find(resource[:source], {:environment => request.environment})
       file = Puppet::FileBucket::File.new(content.content)
       Puppet::FileBucket::File.indirection.save(file)

--- a/lib/puppet/indirector/catalog/static_compiler.rb
+++ b/lib/puppet/indirector/catalog/static_compiler.rb
@@ -77,7 +77,7 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     newsource = file[:source][0].sub("puppet:///", "")
     file[:source][0] = newsource
 
-    raise _("Could not get metadata for #{resource[:source]}") unless metadata = file.parameter(:source).metadata
+    raise _("Could not get metadata for %{resource}") % { resource: resource[:source] } unless metadata = file.parameter(:source).metadata
 
     replace_metadata(request, resource, metadata)
   end
@@ -109,7 +109,7 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     end
 
     old_source = resource.delete(:source)
-    Puppet.info _("Metadata for #{resource} in catalog for '#{request.key}' added from '#{old_source}'")
+    Puppet.info _("Metadata for %{resource} in catalog for '%{request}' added from '%{old_source}'") % { resource: resource, request: request.key, old_source: old_source }
   end
 
   # Generate children resources for a recursive file and add them to the catalog.
@@ -221,9 +221,9 @@ class Puppet::Resource::Catalog::StaticCompiler < Puppet::Resource::Catalog::Com
     sum = @summer.sumdata(resource[:content])
 
     if Puppet::FileBucket::File.indirection.find("#{type}/#{sum}")
-      Puppet.info _("Content for '#{resource[:source]}' already exists")
+      Puppet.info _("Content for '%{resource}' already exists") % { resource: resource[:source] }
     else
-      Puppet.info _("Storing content for source '#{resource[:source]}'")
+      Puppet.info _("Storing content for source '%{resource}'") % { resource: resource[:source] }
       content = Puppet::FileServing::Content.indirection.find(resource[:source], {:environment => request.environment})
       file = Puppet::FileBucket::File.new(content.content)
       Puppet::FileBucket::File.indirection.save(file)

--- a/lib/puppet/indirector/certificate/disabled_ca.rb
+++ b/lib/puppet/indirector/certificate/disabled_ca.rb
@@ -13,7 +13,7 @@ CA to prevent clients getting confusing 'success' behaviour."
   [:find, :head, :search, :save, :destroy].each do |name|
     define_method(name) do |request|
       if request.remote?
-        raise Puppet::Error, "this master is not a CA"
+        raise Puppet::Error, _("this master is not a CA")
       else
         @file.send(name, request)
       end

--- a/lib/puppet/indirector/certificate_request/ca.rb
+++ b/lib/puppet/indirector/certificate_request/ca.rb
@@ -9,14 +9,14 @@ class Puppet::SSL::CertificateRequest::Ca < Puppet::Indirector::SslFile
   def save(request)
     if host = Puppet::SSL::Host.indirection.find(request.key)
       if Puppet[:allow_duplicate_certs]
-        Puppet.notice "#{request.key} already has a #{host.state} certificate; new certificate will overwrite it"
+        Puppet.notice _("#{request.key} already has a #{host.state} certificate; new certificate will overwrite it")
       else
-        raise "#{request.key} already has a #{host.state} certificate; ignoring certificate request"
+        raise _("#{request.key} already has a #{host.state} certificate; ignoring certificate request")
       end
     end
 
     result = super
-    Puppet.notice "#{request.key} has a waiting certificate request"
+    Puppet.notice _("#{request.key} has a waiting certificate request")
     result
   end
 end

--- a/lib/puppet/indirector/certificate_request/ca.rb
+++ b/lib/puppet/indirector/certificate_request/ca.rb
@@ -9,14 +9,14 @@ class Puppet::SSL::CertificateRequest::Ca < Puppet::Indirector::SslFile
   def save(request)
     if host = Puppet::SSL::Host.indirection.find(request.key)
       if Puppet[:allow_duplicate_certs]
-        Puppet.notice _("#{request.key} already has a #{host.state} certificate; new certificate will overwrite it")
+        Puppet.notice _("%{request} already has a %{host} certificate; new certificate will overwrite it") % { request: request.key, host: host.state }
       else
-        raise _("#{request.key} already has a #{host.state} certificate; ignoring certificate request")
+        raise _("%{request} already has a %{host} certificate; ignoring certificate request") % { request: request.key, host: host.state }
       end
     end
 
     result = super
-    Puppet.notice _("#{request.key} has a waiting certificate request")
+    Puppet.notice _("%{request} has a waiting certificate request") % { request: request.key }
     result
   end
 end

--- a/lib/puppet/indirector/certificate_request/disabled_ca.rb
+++ b/lib/puppet/indirector/certificate_request/disabled_ca.rb
@@ -13,7 +13,7 @@ prevent clients getting confusing 'success' behaviour."
   [:find, :head, :search, :save, :destroy].each do |name|
     define_method(name) do |request|
       if request.remote?
-        raise Puppet::Error, "this master is not a CA"
+        raise Puppet::Error, _("this master is not a CA")
       else
         @file.send(name, request)
       end

--- a/lib/puppet/indirector/certificate_revocation_list/disabled_ca.rb
+++ b/lib/puppet/indirector/certificate_revocation_list/disabled_ca.rb
@@ -13,7 +13,7 @@ prevent clients getting confusing 'success' behaviour."
   [:find, :head, :search, :save, :destroy].each do |name|
     define_method(name) do |request|
       if request.remote?
-        raise Puppet::Error, "this master is not a CA"
+        raise Puppet::Error, _("this master is not a CA")
       else
         @file.send(name, request)
       end

--- a/lib/puppet/indirector/certificate_status/file.rb
+++ b/lib/puppet/indirector/certificate_status/file.rb
@@ -12,7 +12,7 @@ class Puppet::Indirector::CertificateStatus::File < Puppet::Indirector::Code
     on the CA."
 
   def ca
-    raise ArgumentError, "This process is not configured as a certificate authority" unless Puppet::SSL::CertificateAuthority.ca?
+    raise ArgumentError, _("This process is not configured as a certificate authority") unless Puppet::SSL::CertificateAuthority.ca?
     Puppet::SSL::CertificateAuthority.new
   end
 
@@ -24,25 +24,25 @@ class Puppet::Indirector::CertificateStatus::File < Puppet::Indirector::Code
       Puppet::SSL::Key,
     ].collect do |part|
       if part.indirection.destroy(request.key)
-        deleted << "#{part}"
+        deleted << _("#{part}")
       end
     end
 
-    return "Nothing was deleted" if deleted.empty?
-    "Deleted for #{request.key}: #{deleted.join(", ")}"
+    return _("Nothing was deleted") if deleted.empty?
+    _("Deleted for #{request.key}: #{deleted.join(", ")}")
   end
 
   def save(request)
     if request.instance.desired_state == "signed"
       certificate_request = Puppet::SSL::CertificateRequest.indirection.find(request.key)
-      raise Puppet::Error, "Cannot sign for host #{request.key} without a certificate request" unless certificate_request
+      raise Puppet::Error, _("Cannot sign for host #{request.key} without a certificate request") unless certificate_request
       ca.sign(request.key)
     elsif request.instance.desired_state == "revoked"
       certificate = Puppet::SSL::Certificate.indirection.find(request.key)
-      raise Puppet::Error, "Cannot revoke host #{request.key} because has it doesn't have a signed certificate" unless certificate
+      raise Puppet::Error, _("Cannot revoke host #{request.key} because has it doesn't have a signed certificate") unless certificate
       ca.revoke(request.key)
     else
-      raise Puppet::Error, "State #{request.instance.desired_state} invalid; Must specify desired state of 'signed' or 'revoked' for host #{request.key}"
+      raise Puppet::Error, _("State #{request.instance.desired_state} invalid; Must specify desired state of 'signed' or 'revoked' for host #{request.key}")
     end
 
   end

--- a/lib/puppet/indirector/certificate_status/file.rb
+++ b/lib/puppet/indirector/certificate_status/file.rb
@@ -24,25 +24,25 @@ class Puppet::Indirector::CertificateStatus::File < Puppet::Indirector::Code
       Puppet::SSL::Key,
     ].collect do |part|
       if part.indirection.destroy(request.key)
-        deleted << _("#{part}")
+        deleted << "#{part}"
       end
     end
 
     return _("Nothing was deleted") if deleted.empty?
-    _("Deleted for #{request.key}: #{deleted.join(", ")}")
+    _("Deleted for %{request}: %{deleted}") % { request: request.key, deleted: deleted.join(", ") }
   end
 
   def save(request)
     if request.instance.desired_state == "signed"
       certificate_request = Puppet::SSL::CertificateRequest.indirection.find(request.key)
-      raise Puppet::Error, _("Cannot sign for host #{request.key} without a certificate request") unless certificate_request
+      raise Puppet::Error, _("Cannot sign for host %{request} without a certificate request") % { request: request.key } unless certificate_request
       ca.sign(request.key)
     elsif request.instance.desired_state == "revoked"
       certificate = Puppet::SSL::Certificate.indirection.find(request.key)
-      raise Puppet::Error, _("Cannot revoke host #{request.key} because has it doesn't have a signed certificate") unless certificate
+      raise Puppet::Error, _("Cannot revoke host %{request} because has it doesn't have a signed certificate") % { request: request.key } unless certificate
       ca.revoke(request.key)
     else
-      raise Puppet::Error, _("State #{request.instance.desired_state} invalid; Must specify desired state of 'signed' or 'revoked' for host #{request.key}")
+      raise Puppet::Error, _("State %{state} invalid; Must specify desired state of 'signed' or 'revoked' for host %{request}") % { state: request.instance.desired_state, request: request.key }
     end
 
   end

--- a/lib/puppet/indirector/exec.rb
+++ b/lib/puppet/indirector/exec.rb
@@ -11,14 +11,14 @@ class Puppet::Indirector::Exec < Puppet::Indirector::Terminus
     raise Puppet::DevError, "Exec commands must be an array" unless external_command.is_a?(Array)
 
     # Make sure it's fully qualified.
-    raise ArgumentError, "You must set the exec parameter to a fully qualified command" unless Puppet::Util.absolute_path?(external_command[0])
+    raise ArgumentError, _("You must set the exec parameter to a fully qualified command") unless Puppet::Util.absolute_path?(external_command[0])
 
     # Add our name to it.
     external_command << name
     begin
       output = execute(external_command, :failonfail => true, :combine => false)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Failed to find #{name} via exec: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Failed to find #{name} via exec: #{detail}"), detail.backtrace
     end
 
     if output =~ /\A\s*\Z/ # all whitespace

--- a/lib/puppet/indirector/exec.rb
+++ b/lib/puppet/indirector/exec.rb
@@ -18,7 +18,7 @@ class Puppet::Indirector::Exec < Puppet::Indirector::Terminus
     begin
       output = execute(external_command, :failonfail => true, :combine => false)
     rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, _("Failed to find #{name} via exec: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Failed to find %{name} via exec: %{detail}") % { name: name, detail: detail }, detail.backtrace
     end
 
     if output =~ /\A\s*\Z/ # all whitespace

--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -46,7 +46,7 @@ class Puppet::Indirector::Face < Puppet::Face
         result = indirection.__send__(method, key, options)
       end
     rescue => detail
-      message = _("Could not call '#{method}' on '#{indirection_name}': #{detail}")
+      message = _("Could not call '%{method}' on '%{indirection}': %{detail}") % { method: method, indirection: indirection_name, detail: detail }
       Puppet.log_exception(detail, message)
       raise RuntimeError, message, detail.backtrace
     end
@@ -113,9 +113,9 @@ class Puppet::Indirector::Face < Puppet::Face
 
     when_invoked do |options|
       if t = indirection.terminus_class
-        _("Run mode '#{Puppet.run_mode.name}': #{t}")
+        _("Run mode '%{mode}': %{terminus}") % { mode: Puppet.run_mode.name, terminus: t }
       else
-        _("No default terminus class for run mode '#{Puppet.run_mode.name}'")
+        _("No default terminus class for run mode '%{mode}'") % { mode: Puppet.run_mode.name }
       end
     end
   end
@@ -137,7 +137,7 @@ class Puppet::Indirector::Face < Puppet::Face
   def indirection
     unless @indirection
       @indirection = Puppet::Indirector::Indirection.instance(indirection_name)
-      @indirection or raise _("Could not find terminus for #{indirection_name}")
+      @indirection or raise _("Could not find terminus for %{indirection}") % { indirection: indirection_name }
     end
     @indirection
   end
@@ -146,7 +146,7 @@ class Puppet::Indirector::Face < Puppet::Face
     begin
       indirection.terminus_class = from
     rescue => detail
-      msg = _("Could not set '#{indirection.name}' terminus to '#{from}' (#{detail}); valid terminus types are #{self.class.terminus_classes(indirection.name).join(", ") }")
+      msg = _("Could not set '%{indirection}' terminus to '%{from}' (%{detail}); valid terminus types are %{types}") % { indirection: indirection.name, from: from, detail: detail, types: self.class.terminus_classes(indirection.name).join(", ") }
       raise detail, msg, detail.backtrace
     end
   end

--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -1,8 +1,8 @@
 require 'puppet/face'
 
 class Puppet::Indirector::Face < Puppet::Face
-  option "--terminus TERMINUS" do
-    summary "The indirector terminus to use."
+  option "--terminus _" + _("TERMINUS") do
+    summary _("The indirector terminus to use.")
     description <<-EOT
       Indirector faces expose indirected subsystems of Puppet. These
       subsystems are each able to retrieve and alter a specific type of data
@@ -46,7 +46,7 @@ class Puppet::Indirector::Face < Puppet::Face
         result = indirection.__send__(method, key, options)
       end
     rescue => detail
-      message = "Could not call '#{method}' on '#{indirection_name}': #{detail}"
+      message = _("Could not call '#{method}' on '#{indirection_name}': #{detail}")
       Puppet.log_exception(detail, message)
       raise RuntimeError, message, detail.backtrace
     end
@@ -54,8 +54,8 @@ class Puppet::Indirector::Face < Puppet::Face
     return result
   end
 
-  option "--extra HASH" do
-    summary "Extra arguments to pass to the indirection request"
+  option "--extra " + _("HASH") do
+    summary _("Extra arguments to pass to the indirection request")
     description <<-EOT
       A terminus can take additional arguments to refine the operation, which
       are passed as an arbitrary hash to the back-end.  Anything passed as
@@ -65,14 +65,14 @@ class Puppet::Indirector::Face < Puppet::Face
   end
 
   action :destroy do
-    summary "Delete an object."
-    arguments "<key>"
+    summary _("Delete an object.")
+    arguments _("<key>")
     when_invoked {|key, options| call_indirection_method :destroy, key, options[:extra] }
   end
 
   action :find do
-    summary "Retrieve an object by name."
-    arguments "[<key>]"
+    summary _("Retrieve an object by name.")
+    arguments _("[<key>]")
     when_invoked do |*args|
       # Default the key to Puppet[:certname] if none is supplied
       if args.length == 1
@@ -86,8 +86,8 @@ class Puppet::Indirector::Face < Puppet::Face
   end
 
   action :save do
-    summary "API only: create or overwrite an object."
-    arguments "<key>"
+    summary _("API only: create or overwrite an object.")
+    arguments _("<key>")
     description <<-EOT
       API only: create or overwrite an object. As the Faces framework does not
       currently accept data from STDIN, save actions cannot currently be invoked
@@ -97,14 +97,14 @@ class Puppet::Indirector::Face < Puppet::Face
   end
 
   action :search do
-    summary "Search for an object or retrieve multiple objects."
-    arguments "<query>"
+    summary _("Search for an object or retrieve multiple objects.")
+    arguments _("<query>")
     when_invoked {|key, options| call_indirection_method :search, key, options[:extra] }
   end
 
   # Print the configuration for the current terminus class
   action :info do
-    summary "Print the default terminus class for this face."
+    summary _("Print the default terminus class for this face.")
     description <<-EOT
       Prints the default terminus class for this subcommand. Note that different
       run modes may have different default termini; when in doubt, specify the
@@ -113,9 +113,9 @@ class Puppet::Indirector::Face < Puppet::Face
 
     when_invoked do |options|
       if t = indirection.terminus_class
-        "Run mode '#{Puppet.run_mode.name}': #{t}"
+        _("Run mode '#{Puppet.run_mode.name}': #{t}")
       else
-        "No default terminus class for run mode '#{Puppet.run_mode.name}'"
+        _("No default terminus class for run mode '#{Puppet.run_mode.name}'")
       end
     end
   end
@@ -137,7 +137,7 @@ class Puppet::Indirector::Face < Puppet::Face
   def indirection
     unless @indirection
       @indirection = Puppet::Indirector::Indirection.instance(indirection_name)
-      @indirection or raise "Could not find terminus for #{indirection_name}"
+      @indirection or raise _("Could not find terminus for #{indirection_name}")
     end
     @indirection
   end
@@ -146,7 +146,7 @@ class Puppet::Indirector::Face < Puppet::Face
     begin
       indirection.terminus_class = from
     rescue => detail
-      msg = "Could not set '#{indirection.name}' terminus to '#{from}' (#{detail}); valid terminus types are #{self.class.terminus_classes(indirection.name).join(", ") }"
+      msg = _("Could not set '#{indirection.name}' terminus to '#{from}' (#{detail}); valid terminus types are #{self.class.terminus_classes(indirection.name).join(", ") }")
       raise detail, msg, detail.backtrace
     end
   end

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -25,11 +25,11 @@ module Puppet::FileBucketFile
       if Puppet::FileSystem.exist?(contents_file) && matches(paths_file, files_original_path)
         if request.options[:diff_with]
           other_contents_file = path_for(request.options[:bucket_path], request.options[:diff_with], 'contents')
-          raise _("could not find diff_with #{request.options[:diff_with]}") unless Puppet::FileSystem.exist?(other_contents_file)
+          raise _("could not find diff_with %{diff}") % { diff: request.options[:diff_with] } unless Puppet::FileSystem.exist?(other_contents_file)
           raise _("Unable to diff on this platform") unless Puppet[:diff] != ""
           return diff(Puppet::FileSystem.path_string(contents_file), Puppet::FileSystem.path_string(other_contents_file))
         else
-          Puppet.info _("FileBucket read #{checksum}")
+          Puppet.info _("FileBucket read %{checksum}") % { checksum: checksum }
           model.new(Puppet::FileSystem.binread(contents_file))
         end
       else
@@ -193,9 +193,9 @@ module Puppet::FileBucketFile
       if path == '' # Treat "md5/<checksum>/" like "md5/<checksum>"
         path = nil
       end
-      raise ArgumentError, _("Unsupported checksum type #{checksum_type.inspect}") if checksum_type != Puppet[:digest_algorithm]
+      raise ArgumentError, _("Unsupported checksum type %{checksum_type}") % { checksum_type: checksum_type.inspect } if checksum_type != Puppet[:digest_algorithm]
       expected = method(checksum_type + "_hex_length").call
-      raise _("Invalid checksum #{checksum.inspect}") if checksum !~ /^[0-9a-f]{#{expected}}$/
+      raise _("Invalid checksum %{checksum}") % { checksum: checksum.inspect } if checksum !~ /^[0-9a-f]{#{expected}}$/
       [checksum, path]
     end
 

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -25,11 +25,11 @@ module Puppet::FileBucketFile
       if Puppet::FileSystem.exist?(contents_file) && matches(paths_file, files_original_path)
         if request.options[:diff_with]
           other_contents_file = path_for(request.options[:bucket_path], request.options[:diff_with], 'contents')
-          raise "could not find diff_with #{request.options[:diff_with]}" unless Puppet::FileSystem.exist?(other_contents_file)
-          raise "Unable to diff on this platform" unless Puppet[:diff] != ""
+          raise _("could not find diff_with #{request.options[:diff_with]}") unless Puppet::FileSystem.exist?(other_contents_file)
+          raise _("Unable to diff on this platform") unless Puppet[:diff] != ""
           return diff(Puppet::FileSystem.path_string(contents_file), Puppet::FileSystem.path_string(other_contents_file))
         else
-          Puppet.info "FileBucket read #{checksum}"
+          Puppet.info _("FileBucket read #{checksum}")
           model.new(Puppet::FileSystem.binread(contents_file))
         end
       else
@@ -39,7 +39,7 @@ module Puppet::FileBucketFile
 
     def list(request)
       if request.remote?
-        raise Puppet::Error, "Listing remote file buckets is not allowed"
+        raise Puppet::Error, _("Listing remote file buckets is not allowed")
       end
 
       fromdate = request.options[:fromdate] || "0:0:0 1-1-1970"
@@ -47,12 +47,12 @@ module Puppet::FileBucketFile
       begin
         to = Time.parse(todate)
       rescue ArgumentError
-        raise Puppet::Error, "Error while parsing 'todate'"
+        raise Puppet::Error, _("Error while parsing 'todate'")
       end
       begin
         from = Time.parse(fromdate)
       rescue ArgumentError
-        raise Puppet::Error, "Error while parsing 'fromdate'"
+        raise Puppet::Error, _("Error while parsing 'fromdate'")
       end
       # Setting hash's default value to [], needed by the following loop
       bucket = Hash.new {[]}
@@ -193,9 +193,9 @@ module Puppet::FileBucketFile
       if path == '' # Treat "md5/<checksum>/" like "md5/<checksum>"
         path = nil
       end
-      raise ArgumentError, "Unsupported checksum type #{checksum_type.inspect}" if checksum_type != Puppet[:digest_algorithm]
+      raise ArgumentError, _("Unsupported checksum type #{checksum_type.inspect}") if checksum_type != Puppet[:digest_algorithm]
       expected = method(checksum_type + "_hex_length").call
-      raise "Invalid checksum #{checksum.inspect}" if checksum !~ /^[0-9a-f]{#{expected}}$/
+      raise _("Invalid checksum #{checksum.inspect}") if checksum !~ /^[0-9a-f]{#{expected}}$/
       [checksum, path]
     end
 

--- a/lib/puppet/indirector/file_metadata/http.rb
+++ b/lib/puppet/indirector/file_metadata/http.rb
@@ -22,6 +22,6 @@ class Puppet::Indirector::FileMetadata::Http < Puppet::Indirector::GenericHttp
   end
 
   def search(request)
-    raise Puppet::Error, "cannot lookup multiple files"
+    raise Puppet::Error, _("cannot lookup multiple files")
   end
 end

--- a/lib/puppet/indirector/file_server.rb
+++ b/lib/puppet/indirector/file_server.rb
@@ -36,7 +36,7 @@ class Puppet::Indirector::FileServer < Puppet::Indirector::Terminus
     mount, relative_path = configuration.split_path(request)
 
     unless mount and paths = mount.search(relative_path, request)
-      Puppet.info _("Could not find filesystem info for file '#{request.key}' in environment #{request.environment}")
+      Puppet.info _("Could not find filesystem info for file '%{request}' in environment %{env}") % { request: request.key, env: request.environment }
       return nil
     end
     path2instances(request, *paths)

--- a/lib/puppet/indirector/file_server.rb
+++ b/lib/puppet/indirector/file_server.rb
@@ -36,7 +36,7 @@ class Puppet::Indirector::FileServer < Puppet::Indirector::Terminus
     mount, relative_path = configuration.split_path(request)
 
     unless mount and paths = mount.search(relative_path, request)
-      Puppet.info "Could not find filesystem info for file '#{request.key}' in environment #{request.environment}"
+      Puppet.info _("Could not find filesystem info for file '#{request.key}' in environment #{request.environment}")
       return nil
     end
     path2instances(request, *paths)

--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -4,7 +4,7 @@ require 'hiera/scope'
 class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
   def initialize(*args)
     if ! Puppet.features.hiera?
-      raise "Hiera terminus not supported without hiera library"
+      raise _("Hiera terminus not supported without hiera library")
     end
     super
   end
@@ -63,7 +63,7 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
         convert_merge(strategy)
       end
     else
-      raise Puppet::DataBinding::LookupError, "Unrecognized value for request 'merge' parameter: '#{merge}'"
+      raise Puppet::DataBinding::LookupError, _("Unrecognized value for request 'merge' parameter: '#{merge}'")
     end
   end
 
@@ -74,7 +74,7 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
     if Puppet::FileSystem.exist?(hiera_config)
       config = Hiera::Config.load(hiera_config)
     else
-      Puppet.warning "Config file #{hiera_config} not found, using Hiera defaults"
+      Puppet.warning _("Config file #{hiera_config} not found, using Hiera defaults")
     end
 
     config[:logger] = 'puppet'

--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -4,6 +4,7 @@ require 'hiera/scope'
 class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
   def initialize(*args)
     if ! Puppet.features.hiera?
+      #TRANSLATORS "Hiera" is the name of a code library and should not be translated
       raise _("Hiera terminus not supported without hiera library")
     end
     super
@@ -63,7 +64,8 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
         convert_merge(strategy)
       end
     else
-      raise Puppet::DataBinding::LookupError, _("Unrecognized value for request 'merge' parameter: '#{merge}'")
+      #TRANSLATORS "merge" is a parameter name and should not be translated
+      raise Puppet::DataBinding::LookupError, _("Unrecognized value for request 'merge' parameter: '%{merge}'") % { merge: merge }
     end
   end
 
@@ -74,7 +76,7 @@ class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
     if Puppet::FileSystem.exist?(hiera_config)
       config = Hiera::Config.load(hiera_config)
     else
-      Puppet.warning _("Config file #{hiera_config} not found, using Hiera defaults")
+      Puppet.warning _("Config file %{hiera_config} not found, using Hiera defaults") % { hiera_config: hiera_config }
     end
 
     config[:logger] = 'puppet'

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -60,6 +60,7 @@ class Puppet::Indirector::Indirection
 
   # Set the time-to-live for instances created through this indirection.
   def ttl=(value)
+    #TRANSLATORS "TTL" stands for "time to live" and refers to a duration of time
     raise ArgumentError, _("Indirection TTL must be an integer") unless value.is_a?(Integer)
     @ttl = value
   end
@@ -165,7 +166,7 @@ class Puppet::Indirector::Indirection
 
     return nil unless instance = cache.find(request(:find, key, nil, options))
 
-    Puppet.info _("Expiring the #{self.name} cache of #{instance.name}")
+    Puppet.info _("Expiring the %{cache} cache of %{instance}") % { cache: self.name, instance: instance.name }
 
     # Set an expiration date in the past
     instance.expiration = Time.now - 60
@@ -195,7 +196,7 @@ class Puppet::Indirector::Indirection
       if not result.nil?
         result.expiration ||= self.expiration if result.respond_to?(:expiration)
         if cache?
-          Puppet.info _("Caching #{self.name} for #{request.key}")
+          Puppet.info _("Caching %{indirection} for %{request}") % { indirection: self.name, request: request.key }
           begin
             cache.save request(:save, key, result, options)
           rescue => detail
@@ -206,7 +207,7 @@ class Puppet::Indirector::Indirection
 
         filtered = result
         if terminus.respond_to?(:filter)
-          Puppet::Util::Profiler.profile(_("Filtered result for #{self.name} #{request.key}"), [:indirector, :filter, self.name, request.key]) do
+          Puppet::Util::Profiler.profile(_("Filtered result for %{indirection} %{request}") % { indirection: self.name, request: request.key }, [:indirector, :filter, self.name, request.key]) do
             begin
               filtered = terminus.filter(result)
             rescue Puppet::Error => detail
@@ -235,14 +236,14 @@ class Puppet::Indirector::Indirection
     # See if our instance is in the cache and up to date.
     return nil unless cache? and ! request.ignore_cache? and cached = cache.find(request)
     if cached.expired?
-      Puppet.info _("Not using expired #{self.name} for #{request.key} from cache; expired at #{cached.expiration}")
+      Puppet.info _("Not using expired %{indirection} for %{request} from cache; expired at %{expiration}") % { indirection: self.name, request: request.key, expiration: cached.expiration }
       return nil
     end
 
     Puppet.debug "Using cached #{self.name} for #{request.key}"
     cached
   rescue => detail
-    Puppet.log_exception(detail, _("Cached #{self.name} for #{request.key} failed: #{detail}"))
+    Puppet.log_exception(detail, _("Cached %{indirection} for %{request} failed: %{detail}") % { indirection: self.name, request: request.key, detail: detail })
     nil
   end
 
@@ -314,7 +315,7 @@ class Puppet::Indirector::Indirection
     # Pick our terminus.
     if respond_to?(:select_terminus)
       unless terminus_name = select_terminus(request)
-        raise ArgumentError, _("Could not determine appropriate terminus for #{request.description}")
+        raise ArgumentError, _("Could not determine appropriate terminus for %{request}") % { request: request.description }
       end
     else
       terminus_name = terminus_class
@@ -331,7 +332,7 @@ class Puppet::Indirector::Indirection
   def make_terminus(terminus_class)
     # Load our terminus class.
     unless klass = Puppet::Indirector::Terminus.terminus_class(self.name, terminus_class)
-      raise ArgumentError, _("Could not find terminus #{terminus_class} for indirection #{self.name}")
+      raise ArgumentError, _("Could not find terminus %{terminus_class} for indirection %{indirection}") % { terminus_class: terminus_class, indirection: self.name }
     end
     klass.new
   end

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -60,7 +60,7 @@ class Puppet::Indirector::Indirection
 
   # Set the time-to-live for instances created through this indirection.
   def ttl=(value)
-    raise ArgumentError, "Indirection TTL must be an integer" unless value.is_a?(Integer)
+    raise ArgumentError, _("Indirection TTL must be an integer") unless value.is_a?(Integer)
     @ttl = value
   end
 
@@ -165,7 +165,7 @@ class Puppet::Indirector::Indirection
 
     return nil unless instance = cache.find(request(:find, key, nil, options))
 
-    Puppet.info "Expiring the #{self.name} cache of #{instance.name}"
+    Puppet.info _("Expiring the #{self.name} cache of #{instance.name}")
 
     # Set an expiration date in the past
     instance.expiration = Time.now - 60
@@ -195,7 +195,7 @@ class Puppet::Indirector::Indirection
       if not result.nil?
         result.expiration ||= self.expiration if result.respond_to?(:expiration)
         if cache?
-          Puppet.info "Caching #{self.name} for #{request.key}"
+          Puppet.info _("Caching #{self.name} for #{request.key}")
           begin
             cache.save request(:save, key, result, options)
           rescue => detail
@@ -206,7 +206,7 @@ class Puppet::Indirector::Indirection
 
         filtered = result
         if terminus.respond_to?(:filter)
-          Puppet::Util::Profiler.profile("Filtered result for #{self.name} #{request.key}", [:indirector, :filter, self.name, request.key]) do
+          Puppet::Util::Profiler.profile(_("Filtered result for #{self.name} #{request.key}"), [:indirector, :filter, self.name, request.key]) do
             begin
               filtered = terminus.filter(result)
             rescue Puppet::Error => detail
@@ -235,14 +235,14 @@ class Puppet::Indirector::Indirection
     # See if our instance is in the cache and up to date.
     return nil unless cache? and ! request.ignore_cache? and cached = cache.find(request)
     if cached.expired?
-      Puppet.info "Not using expired #{self.name} for #{request.key} from cache; expired at #{cached.expiration}"
+      Puppet.info _("Not using expired #{self.name} for #{request.key} from cache; expired at #{cached.expiration}")
       return nil
     end
 
     Puppet.debug "Using cached #{self.name} for #{request.key}"
     cached
   rescue => detail
-    Puppet.log_exception(detail, "Cached #{self.name} for #{request.key} failed: #{detail}")
+    Puppet.log_exception(detail, _("Cached #{self.name} for #{request.key} failed: #{detail}"))
     nil
   end
 
@@ -314,7 +314,7 @@ class Puppet::Indirector::Indirection
     # Pick our terminus.
     if respond_to?(:select_terminus)
       unless terminus_name = select_terminus(request)
-        raise ArgumentError, "Could not determine appropriate terminus for #{request.description}"
+        raise ArgumentError, _("Could not determine appropriate terminus for #{request.description}")
       end
     else
       terminus_name = terminus_class
@@ -331,7 +331,7 @@ class Puppet::Indirector::Indirection
   def make_terminus(terminus_class)
     # Load our terminus class.
     unless klass = Puppet::Indirector::Terminus.terminus_class(self.name, terminus_class)
-      raise ArgumentError, "Could not find terminus #{terminus_class} for indirection #{self.name}"
+      raise ArgumentError, _("Could not find terminus #{terminus_class} for indirection #{self.name}")
     end
     klass.new
   end

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -17,14 +17,14 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
 
     Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::ASCII_8BIT) }
   rescue TypeError => detail
-    Puppet.log_exception(detail, "Could not save #{self.name} #{request.key}: #{detail}")
+    Puppet.log_exception(detail, _("Could not save #{self.name} #{request.key}: #{detail}"))
   end
 
   def destroy(request)
     Puppet::FileSystem.unlink(path(request.key))
   rescue => detail
     unless detail.is_a? Errno::ENOENT
-      raise Puppet::Error, "Could not destroy #{self.name} #{request.key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not destroy #{self.name} #{request.key}: #{detail}"), detail.backtrace
     end
     1                           # emulate success...
   end
@@ -38,8 +38,8 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
   # Return the path to a given node's file.
   def path(name, ext = '.json')
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit("directory traversal detected in #{self.class}: #{name.inspect}")
-      raise ArgumentError, "invalid key"
+      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      raise ArgumentError, _("invalid key")
     end
 
     base = Puppet.run_mode.master? ? Puppet[:server_datadir] : Puppet[:client_datadir]
@@ -56,13 +56,13 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     rescue Errno::ENOENT
       return nil
     rescue => detail
-      raise Puppet::Error, "Could not read JSON data for #{indirection.name} #{key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not read JSON data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
     end
 
     begin
       return from_json(json)
     rescue => detail
-      raise Puppet::Error, "Could not parse JSON data for #{indirection.name} #{key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not parse JSON data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
     end
   end
 

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -17,14 +17,14 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
 
     Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::ASCII_8BIT) }
   rescue TypeError => detail
-    Puppet.log_exception(detail, _("Could not save #{self.name} #{request.key}: #{detail}"))
+    Puppet.log_exception(detail, _("Could not save %{json} %{request}: %{detail}") % { json: self.name, request: request.key, detail: detail })
   end
 
   def destroy(request)
     Puppet::FileSystem.unlink(path(request.key))
   rescue => detail
     unless detail.is_a? Errno::ENOENT
-      raise Puppet::Error, _("Could not destroy #{self.name} #{request.key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not destroy %{json} %{request}: %{detail}") % { json: self.name, request: request.key, detail: detail }, detail.backtrace
     end
     1                           # emulate success...
   end
@@ -38,7 +38,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
   # Return the path to a given node's file.
   def path(name, ext = '.json')
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      Puppet.crit(_("directory traversal detected in %{json}: %{name}") % { json: self.class, name: name.inspect })
       raise ArgumentError, _("invalid key")
     end
 
@@ -56,13 +56,13 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     rescue Errno::ENOENT
       return nil
     rescue => detail
-      raise Puppet::Error, _("Could not read JSON data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not read JSON data for %{name} %{key}: %{detail}") % { name: indirection.name, key: key, detail: detail }, detail.backtrace
     end
 
     begin
       return from_json(json)
     rescue => detail
-      raise Puppet::Error, _("Could not parse JSON data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not parse JSON data for %{name} %{key}: %{detail}") % { name: indirection.name, key: key, detail: detail }, detail.backtrace
     end
   end
 

--- a/lib/puppet/indirector/key/disabled_ca.rb
+++ b/lib/puppet/indirector/key/disabled_ca.rb
@@ -13,7 +13,7 @@ prevent clients getting confusing 'success' behaviour."
   [:find, :head, :search, :save, :destroy].each do |name|
     define_method(name) do |request|
       if request.remote?
-        raise Puppet::Error, "this master is not a CA"
+        raise Puppet::Error, _("this master is not a CA")
       else
         @file.send(name, request)
       end

--- a/lib/puppet/indirector/key/file.rb
+++ b/lib/puppet/indirector/key/file.rb
@@ -30,7 +30,7 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
     begin
       Puppet::FileSystem.unlink(key_path)
     rescue => detail
-      raise Puppet::Error, "Could not remove #{request.key} public key: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not remove #{request.key} public key: #{detail}"), detail.backtrace
     end
   end
 
@@ -44,7 +44,7 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
         f.print request.instance.content.public_key.to_pem
       end
     rescue => detail
-      raise Puppet::Error, "Could not write #{request.key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not write #{request.key}: #{detail}"), detail.backtrace
     end
   end
 end

--- a/lib/puppet/indirector/key/file.rb
+++ b/lib/puppet/indirector/key/file.rb
@@ -30,7 +30,7 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
     begin
       Puppet::FileSystem.unlink(key_path)
     rescue => detail
-      raise Puppet::Error, _("Could not remove #{request.key} public key: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not remove %{request} public key: %{detail}") % { request: request.key, detail: detail }, detail.backtrace
     end
   end
 
@@ -44,7 +44,7 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
         f.print request.instance.content.public_key.to_pem
       end
     rescue => detail
-      raise Puppet::Error, _("Could not write #{request.key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not write %{request}: %{detail}") % { request: request.key, detail: detail }, detail.backtrace
     end
   end
 end

--- a/lib/puppet/indirector/ldap.rb
+++ b/lib/puppet/indirector/ldap.rb
@@ -62,13 +62,14 @@ class Puppet::Indirector::Ldap < Puppet::Indirector::Terminus
   # Create an ldap connection.
   def connection
     unless @connection
+      #TRANSLATORS "ruby/ldap libraries" are code dependencies
       raise Puppet::Error, _("Could not set up LDAP Connection: Missing ruby/ldap libraries") unless Puppet.features.ldap?
       begin
         conn = Puppet::Util::Ldap::Connection.instance
         conn.start
         @connection = conn.connection
       rescue => detail
-        message = _("Could not connect to LDAP: #{detail}")
+        message = _("Could not connect to LDAP: %{detail}") % { detail: detail }
         Puppet.log_exception(detail, message)
         raise Puppet::Error, message, detail.backtrace
       end

--- a/lib/puppet/indirector/ldap.rb
+++ b/lib/puppet/indirector/ldap.rb
@@ -30,7 +30,7 @@ class Puppet::Indirector::Ldap < Puppet::Indirector::Terminus
   # Find the ldap node, return the class list and parent node specially,
   # and everything else in a parameter hash.
   def ldapsearch(filter)
-    raise ArgumentError.new("You must pass a block to ldapsearch") unless block_given?
+    raise ArgumentError.new(_("You must pass a block to ldapsearch")) unless block_given?
 
     found = false
     count = 0
@@ -47,10 +47,10 @@ class Puppet::Indirector::Ldap < Puppet::Indirector::Terminus
         # Try reconnecting to ldap if we get an exception and we haven't yet retried.
         count += 1
         @connection = nil
-        Puppet.warning "Retrying LDAP connection"
+        Puppet.warning _("Retrying LDAP connection")
         retry
       else
-        error = Puppet::Error.new("LDAP Search failed")
+        error = Puppet::Error.new(_("LDAP Search failed"))
         error.set_backtrace(detail.backtrace)
         raise error
       end
@@ -62,13 +62,13 @@ class Puppet::Indirector::Ldap < Puppet::Indirector::Terminus
   # Create an ldap connection.
   def connection
     unless @connection
-      raise Puppet::Error, "Could not set up LDAP Connection: Missing ruby/ldap libraries" unless Puppet.features.ldap?
+      raise Puppet::Error, _("Could not set up LDAP Connection: Missing ruby/ldap libraries") unless Puppet.features.ldap?
       begin
         conn = Puppet::Util::Ldap::Connection.instance
         conn.start
         @connection = conn.connection
       rescue => detail
-        message = "Could not connect to LDAP: #{detail}"
+        message = _("Could not connect to LDAP: #{detail}")
         Puppet.log_exception(detail, message)
         raise Puppet::Error, message, detail.backtrace
       end

--- a/lib/puppet/indirector/memory.rb
+++ b/lib/puppet/indirector/memory.rb
@@ -11,7 +11,7 @@ class Puppet::Indirector::Memory < Puppet::Indirector::Terminus
   end
 
   def destroy(request)
-    raise ArgumentError.new(_("Could not find #{request.key} to destroy")) unless @instances.include?(request.key)
+    raise ArgumentError.new(_("Could not find %{request} to destroy") % { request: request.key }) unless @instances.include?(request.key)
     @instances.delete(request.key)
   end
 

--- a/lib/puppet/indirector/memory.rb
+++ b/lib/puppet/indirector/memory.rb
@@ -11,7 +11,7 @@ class Puppet::Indirector::Memory < Puppet::Indirector::Terminus
   end
 
   def destroy(request)
-    raise ArgumentError.new("Could not find #{request.key} to destroy") unless @instances.include?(request.key)
+    raise ArgumentError.new(_("Could not find #{request.key} to destroy")) unless @instances.include?(request.key)
     @instances.delete(request.key)
   end
 

--- a/lib/puppet/indirector/msgpack.rb
+++ b/lib/puppet/indirector/msgpack.rb
@@ -8,7 +8,7 @@ require 'puppet/util'
 class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
   def initialize(*args)
     if ! Puppet.features.msgpack?
-      raise "MessagePack terminus not supported without msgpack library"
+      raise _("MessagePack terminus not supported without msgpack library")
     end
     super
   end
@@ -23,14 +23,14 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
 
     Puppet::Util.replace_file(filename, 0660) {|f| f.print to_msgpack(request.instance) }
   rescue TypeError => detail
-    Puppet.log_exception(detail, "Could not save #{self.name} #{request.key}: #{detail}")
+    Puppet.log_exception(detail, _("Could not save #{self.name} #{request.key}: #{detail}"))
   end
 
   def destroy(request)
     Puppet::FileSystem.unlink(path(request.key))
   rescue => detail
     unless detail.is_a? Errno::ENOENT
-      raise Puppet::Error, "Could not destroy #{self.name} #{request.key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not destroy #{self.name} #{request.key}: #{detail}"), detail.backtrace
     end
     1                           # emulate success...
   end
@@ -44,8 +44,8 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
   # Return the path to a given node's file.
   def path(name, ext = '.msgpack')
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit("directory traversal detected in #{self.class}: #{name.inspect}")
-      raise ArgumentError, "invalid key"
+      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      raise ArgumentError, _("invalid key")
     end
 
     base = Puppet.run_mode.master? ? Puppet[:server_datadir] : Puppet[:client_datadir]
@@ -62,13 +62,13 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
     rescue Errno::ENOENT
       return nil
     rescue => detail
-      raise Puppet::Error, "Could not read MessagePack data for #{indirection.name} #{key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not read MessagePack data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
     end
 
     begin
       return from_msgpack(msgpack)
     rescue => detail
-      raise Puppet::Error, "Could not parse MessagePack data for #{indirection.name} #{key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not parse MessagePack data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
     end
   end
 

--- a/lib/puppet/indirector/msgpack.rb
+++ b/lib/puppet/indirector/msgpack.rb
@@ -23,14 +23,14 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
 
     Puppet::Util.replace_file(filename, 0660) {|f| f.print to_msgpack(request.instance) }
   rescue TypeError => detail
-    Puppet.log_exception(detail, _("Could not save #{self.name} #{request.key}: #{detail}"))
+    Puppet.log_exception(detail, _("Could not save %{name} %{request}: %{detail}") % { name: self.name, request: request.key, detail: detail })
   end
 
   def destroy(request)
     Puppet::FileSystem.unlink(path(request.key))
   rescue => detail
     unless detail.is_a? Errno::ENOENT
-      raise Puppet::Error, _("Could not destroy #{self.name} #{request.key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not destroy %{name} %{request}: %{detail}") % { name: self.name, request: request.key, detail: detail }, detail.backtrace
     end
     1                           # emulate success...
   end
@@ -44,7 +44,7 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
   # Return the path to a given node's file.
   def path(name, ext = '.msgpack')
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      Puppet.crit(_("directory traversal detected in %{indirection}: %{name}") % { indirection: self.class, name: name.inspect })
       raise ArgumentError, _("invalid key")
     end
 
@@ -62,13 +62,14 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
     rescue Errno::ENOENT
       return nil
     rescue => detail
-      raise Puppet::Error, _("Could not read MessagePack data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
+      #TRANSLATORS "MessagePack" is a program name and should not be translated
+      raise Puppet::Error, _("Could not read MessagePack data for %{indirection} %{key}: %{detail}") % { indirection: indirection.name, key: key, detail: detail }, detail.backtrace
     end
 
     begin
       return from_msgpack(msgpack)
     rescue => detail
-      raise Puppet::Error, _("Could not parse MessagePack data for #{indirection.name} #{key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not parse MessagePack data for %{indirection} %{key}: %{detail}") % { indirection: indirection.name, key: key, detail: detail }, detail.backtrace
     end
   end
 

--- a/lib/puppet/indirector/node/exec.rb
+++ b/lib/puppet/indirector/node/exec.rb
@@ -57,13 +57,13 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
       when Symbol
         hash[data[0]] = data[1]
       else
-        raise Puppet::Error, _("key is a #{data[0].class}, not a string or symbol")
+        raise Puppet::Error, _("key is a %{klass}, not a string or symbol") % { klass: data[0].class }
       end
 
       hash
     end
 
   rescue => detail
-      raise Puppet::Error, _("Could not load external node results for #{name}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not load external node results for %{name}: %{detail}") % { name: name, detail: detail }, detail.backtrace
   end
 end

--- a/lib/puppet/indirector/node/exec.rb
+++ b/lib/puppet/indirector/node/exec.rb
@@ -8,7 +8,7 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
 
   def command
     command = Puppet[:external_nodes]
-    raise ArgumentError, "You must set the 'external_nodes' parameter to use the external node terminus" unless command != "none"
+    raise ArgumentError, _("You must set the 'external_nodes' parameter to use the external node terminus") unless command != _("none")
     command.split
   end
 
@@ -57,13 +57,13 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
       when Symbol
         hash[data[0]] = data[1]
       else
-        raise Puppet::Error, "key is a #{data[0].class}, not a string or symbol"
+        raise Puppet::Error, _("key is a #{data[0].class}, not a string or symbol")
       end
 
       hash
     end
 
   rescue => detail
-      raise Puppet::Error, "Could not load external node results for #{name}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not load external node results for #{name}: #{detail}"), detail.backtrace
   end
 end

--- a/lib/puppet/indirector/node/ldap.rb
+++ b/lib/puppet/indirector/node/ldap.rb
@@ -175,7 +175,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
 
   # Find information for our parent and merge it into the current info.
   def find_and_merge_parent(parent, information)
-    parent_info = name2hash(parent) || raise(Puppet::Error.new("Could not find parent node '#{parent}'"))
+    parent_info = name2hash(parent) || raise(Puppet::Error.new(_("Could not find parent node '#{parent}'")))
     information[:classes] += parent_info[:classes]
     parent_info[:parameters].each do |param, value|
       # Specifically test for whether it's set, so false values are handled correctly.
@@ -202,7 +202,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
     # Preload the parent array with the node name.
     parents = [info[:name]]
     while parent
-      raise ArgumentError, "Found loop in LDAP node parents; #{parent} appears twice" if parents.include?(parent)
+      raise ArgumentError, _("Found loop in LDAP node parents; #{parent} appears twice") if parents.include?(parent)
       parents << parent
       parent = find_and_merge_parent(parent, info)
     end
@@ -241,7 +241,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
 
     if values.length > 1
       raise Puppet::Error,
-        "Node entry #{entry.dn} specifies more than one parent: #{values.inspect}"
+        _("Node entry #{entry.dn} specifies more than one parent: #{values.inspect}")
     end
     return(values.empty? ? nil : values.shift)
   end

--- a/lib/puppet/indirector/node/ldap.rb
+++ b/lib/puppet/indirector/node/ldap.rb
@@ -175,7 +175,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
 
   # Find information for our parent and merge it into the current info.
   def find_and_merge_parent(parent, information)
-    parent_info = name2hash(parent) || raise(Puppet::Error.new(_("Could not find parent node '#{parent}'")))
+    parent_info = name2hash(parent) || raise(Puppet::Error.new(_("Could not find parent node '%{parent}'") % { parent: parent }))
     information[:classes] += parent_info[:classes]
     parent_info[:parameters].each do |param, value|
       # Specifically test for whether it's set, so false values are handled correctly.
@@ -202,7 +202,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
     # Preload the parent array with the node name.
     parents = [info[:name]]
     while parent
-      raise ArgumentError, _("Found loop in LDAP node parents; #{parent} appears twice") if parents.include?(parent)
+      raise ArgumentError, _("Found loop in LDAP node parents; %{parent} appears twice") % { parent: parent } if parents.include?(parent)
       parents << parent
       parent = find_and_merge_parent(parent, info)
     end
@@ -241,7 +241,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
 
     if values.length > 1
       raise Puppet::Error,
-        _("Node entry #{entry.dn} specifies more than one parent: #{values.inspect}")
+        _("Node entry %{entry} specifies more than one parent: %{parents}") % { entry: entry.dn, parents: values.inspect }
     end
     return(values.empty? ? nil : values.shift)
   end

--- a/lib/puppet/indirector/report/processor.rb
+++ b/lib/puppet/indirector/report/processor.rb
@@ -36,7 +36,7 @@ class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
         newrep.extend(mod)
         newrep.process
       rescue => detail
-        Puppet.log_exception(detail, _("Report #{name} failed: #{detail}"))
+        Puppet.log_exception(detail, _("Report %{report} failed: %{detail}") % { report: name, detail: detail })
       end
     end
   end
@@ -52,7 +52,7 @@ class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
       if mod = Puppet::Reports.report(name)
         yield(mod)
       else
-        Puppet.warning _("No report named '#{name}'")
+        Puppet.warning _("No report named '%{name}'") % { name: name }
       end
     end
   end

--- a/lib/puppet/indirector/report/processor.rb
+++ b/lib/puppet/indirector/report/processor.rb
@@ -36,7 +36,7 @@ class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
         newrep.extend(mod)
         newrep.process
       rescue => detail
-        Puppet.log_exception(detail, "Report #{name} failed: #{detail}")
+        Puppet.log_exception(detail, _("Report #{name} failed: #{detail}"))
       end
     end
   end
@@ -52,7 +52,7 @@ class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
       if mod = Puppet::Reports.report(name)
         yield(mod)
       else
-        Puppet.warning "No report named '#{name}'"
+        Puppet.warning _("No report named '#{name}'")
       end
     end
   end

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -97,7 +97,7 @@ class Puppet::Indirector::Request
   end
 
   def model
-    raise ArgumentError, _("Could not find indirection '#{indirection_name}'") unless i = indirection
+    raise ArgumentError, _("Could not find indirection '%{indirection}'") % { indirection: indirection_name } unless i = indirection
     i.model
   end
 
@@ -136,7 +136,7 @@ class Puppet::Indirector::Request
       when true, false, String, Symbol, Integer, Float
         params << [key, value]
       else
-        raise ArgumentError, _("HTTP REST queries cannot handle values of type '#{value.class}'")
+        raise ArgumentError, _("HTTP REST queries cannot handle values of type '%{klass}'") % { klass: value.class }
       end
     end
   end
@@ -191,7 +191,7 @@ class Puppet::Indirector::Request
           self.port   = srv_port
           return yield(self)
         rescue SystemCallError => e
-          Puppet.warning _("Error connecting to #{srv_server}:#{srv_port}: #{e.message}")
+          Puppet.warning _("Error connecting to %{srv_server}:%{srv_port}: %{message}") % { srv_server: srv_server, srv_port: srv_port, message: e.message }
         end
       end
     end
@@ -247,7 +247,7 @@ class Puppet::Indirector::Request
       # and the resulting string components of the URI are now ASCII
       uri = URI.parse(URI.escape(key))
     rescue => detail
-      raise ArgumentError, _("Could not understand URL #{key}: #{detail}"), detail.backtrace
+      raise ArgumentError, _("Could not understand URL %{key}: %{detail}") % { key: key, detail: detail }, detail.backtrace
     end
 
     # Just short-circuit these to full paths

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -97,7 +97,7 @@ class Puppet::Indirector::Request
   end
 
   def model
-    raise ArgumentError, "Could not find indirection '#{indirection_name}'" unless i = indirection
+    raise ArgumentError, _("Could not find indirection '#{indirection_name}'") unless i = indirection
     i.model
   end
 
@@ -136,7 +136,7 @@ class Puppet::Indirector::Request
       when true, false, String, Symbol, Integer, Float
         params << [key, value]
       else
-        raise ArgumentError, "HTTP REST queries cannot handle values of type '#{value.class}'"
+        raise ArgumentError, _("HTTP REST queries cannot handle values of type '#{value.class}'")
       end
     end
   end
@@ -191,7 +191,7 @@ class Puppet::Indirector::Request
           self.port   = srv_port
           return yield(self)
         rescue SystemCallError => e
-          Puppet.warning "Error connecting to #{srv_server}:#{srv_port}: #{e.message}"
+          Puppet.warning _("Error connecting to #{srv_server}:#{srv_port}: #{e.message}")
         end
       end
     end
@@ -247,7 +247,7 @@ class Puppet::Indirector::Request
       # and the resulting string components of the URI are now ASCII
       uri = URI.parse(URI.escape(key))
     rescue => detail
-      raise ArgumentError, "Could not understand URL #{key}: #{detail}", detail.backtrace
+      raise ArgumentError, _("Could not understand URL #{key}: #{detail}"), detail.backtrace
     end
 
     # Just short-circuit these to full paths

--- a/lib/puppet/indirector/resource/ral.rb
+++ b/lib/puppet/indirector/resource/ral.rb
@@ -58,6 +58,6 @@ class Puppet::Resource::Ral < Puppet::Indirector::Code
   end
 
   def type( request )
-    Puppet::Type.type(type_name(request)) or raise Puppet::Error, _("Could not find type #{type_name(request)}")
+    Puppet::Type.type(type_name(request)) or raise Puppet::Error, _("Could not find type %{request_type}") % { request_type: type_name(request) }
   end
 end

--- a/lib/puppet/indirector/resource/ral.rb
+++ b/lib/puppet/indirector/resource/ral.rb
@@ -58,6 +58,6 @@ class Puppet::Resource::Ral < Puppet::Indirector::Code
   end
 
   def type( request )
-    Puppet::Type.type(type_name(request)) or raise Puppet::Error, "Could not find type #{type_name(request)}"
+    Puppet::Type.type(type_name(request)) or raise Puppet::Error, _("Could not find type #{type_name(request)}")
   end
 end

--- a/lib/puppet/indirector/resource/validator.rb
+++ b/lib/puppet/indirector/resource/validator.rb
@@ -2,7 +2,7 @@ module Puppet::Resource::Validator
   def validate_key(request)
     type, title = request.key.split('/', 2)
     unless type.downcase == request.instance.type.downcase and title == request.instance.title
-      raise Puppet::Indirector::ValidationError, "Resource instance does not match request key"
+      raise Puppet::Indirector::ValidationError, _("Resource instance does not match request key")
     end
   end
 end

--- a/lib/puppet/indirector/resource_type/parser.rb
+++ b/lib/puppet/indirector/resource_type/parser.rb
@@ -73,9 +73,8 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
           when nil
             result_candidates = [krt.hostclasses.values, krt.definitions.values, krt.applications.values, krt.nodes.values]
           else
-            raise ArgumentError, "Unrecognized kind filter: " +
-                      "'#{request.options[:kind]}', expected one " +
-                      " of 'class', 'defined_type', 'application', or 'node'."
+            #TRANSLATORS the kinds in quotes should not be translated
+            raise ArgumentError, _("Unrecognized kind filter: '#{request.options[:kind]}', expected one of 'class', 'defined_type', 'application', or 'node'.")
         end
 
       result = result_candidates.flatten.reject { |t| t.name == "" }
@@ -87,7 +86,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
       begin
         regex = Regexp.new(key)
       rescue => detail
-        raise ArgumentError, "Invalid regex '#{request.key}': #{detail}", detail.backtrace
+        raise ArgumentError, _("Invalid regex '#{request.key}': #{detail}"), detail.backtrace
       end
 
       result.reject! { |t| t.name.to_s !~ regex }
@@ -102,7 +101,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
   end
 
   def allow_remote_requests?
-    Puppet.deprecation_warning("The resource_type endpoint is deprecated in favor of the environment_classes endpoint. See https://docs.puppet.com/puppetserver/latest/puppet-api/v3/environment_classes.html")
+    Puppet.deprecation_warning(_("The resource_type endpoint is deprecated in favor of the environment_classes endpoint. See https://docs.puppet.com/puppetserver/latest/puppet-api/v3/environment_classes.html"))
     super
   end
 end

--- a/lib/puppet/indirector/resource_type/parser.rb
+++ b/lib/puppet/indirector/resource_type/parser.rb
@@ -74,7 +74,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
             result_candidates = [krt.hostclasses.values, krt.definitions.values, krt.applications.values, krt.nodes.values]
           else
             #TRANSLATORS the kinds in quotes should not be translated
-            raise ArgumentError, _("Unrecognized kind filter: '#{request.options[:kind]}', expected one of 'class', 'defined_type', 'application', or 'node'.")
+            raise ArgumentError, _("Unrecognized kind filter: '%{filter}', expected one of 'class', 'defined_type', 'application', or 'node'.") % { filter: request.options[:kind] }
         end
 
       result = result_candidates.flatten.reject { |t| t.name == "" }
@@ -86,7 +86,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
       begin
         regex = Regexp.new(key)
       rescue => detail
-        raise ArgumentError, _("Invalid regex '#{request.key}': #{detail}"), detail.backtrace
+        raise ArgumentError, _("Invalid regex '%{regex}': %{detail}") % { regex: request.key, detail: detail }, detail.backtrace
       end
 
       result.reject! { |t| t.name.to_s !~ regex }

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -180,7 +180,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       # that makes a user aware of the reason for the failure.
       #
       content_type, body = parse_response(response)
-      msg = _("Find #{elide(uri_with_query_string, 100)} resulted in 404 with the message: #{body}")
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(uri_with_query_string, 100), body: body }
       raise Puppet::Error, msg
     else
       nil
@@ -288,7 +288,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       returned_message = uncompress_body(response)
     end
 
-    message = _("Error #{response.code} on SERVER: #{returned_message}")
+    message = _("Error %{code} on SERVER: %{returned_message}") % { code: response.code, returned_message: returned_message }
     Net::HTTPError.new(message, response)
   end
 

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -180,7 +180,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       # that makes a user aware of the reason for the failure.
       #
       content_type, body = parse_response(response)
-      msg = "Find #{elide(uri_with_query_string, 100)} resulted in 404 with the message: #{body}"
+      msg = _("Find #{elide(uri_with_query_string, 100)} resulted in 404 with the message: #{body}")
       raise Puppet::Error, msg
     else
       nil
@@ -213,7 +213,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   end
 
   def destroy(request)
-    raise ArgumentError, "DELETE does not accept options" unless request.options.empty?
+    raise ArgumentError, _("DELETE does not accept options") unless request.options.empty?
 
     response = do_request(request) do |req|
       http_delete(req, IndirectedRoutes.request_to_uri(req), headers)
@@ -228,7 +228,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   end
 
   def save(request)
-    raise ArgumentError, "PUT does not accept options" unless request.options.empty?
+    raise ArgumentError, _("PUT does not accept options") unless request.options.empty?
 
     response = do_request(request) do |req|
       http_put(req, IndirectedRoutes.request_to_uri(req), req.instance.render, headers.merge({ "Content-Type" => req.instance.mime }))
@@ -288,7 +288,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       returned_message = uncompress_body(response)
     end
 
-    message = "Error #{response.code} on SERVER: #{returned_message}"
+    message = _("Error #{response.code} on SERVER: #{returned_message}")
     Net::HTTPError.new(message, response)
   end
 
@@ -300,7 +300,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       [ response['content-type'].gsub(/\s*;.*$/,''),
         body = uncompress_body(response) ]
     else
-      raise "No content type in http response; cannot parse"
+      raise _("No content type in http response; cannot parse")
     end
   end
 

--- a/lib/puppet/indirector/ssl_file.rb
+++ b/lib/puppet/indirector/ssl_file.rb
@@ -54,8 +54,8 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
 
   def path(name)
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit("directory traversal detected in #{self.class}: #{name.inspect}")
-      raise ArgumentError, "invalid key"
+      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      raise ArgumentError, _("invalid key")
     end
 
     if ca?(name) and ca_location
@@ -72,11 +72,11 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
     path = Puppet::FileSystem.pathname(path(request.key))
     return false unless Puppet::FileSystem.exist?(path)
 
-    Puppet.notice "Removing file #{model} #{request.key} at '#{path}'"
+    Puppet.notice _("Removing file #{model} #{request.key} at '#{path}'")
     begin
       Puppet::FileSystem.unlink(path)
     rescue => detail
-      raise Puppet::Error, "Could not remove #{request.key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not remove #{request.key}: #{detail}"), detail.backtrace
     end
   end
 
@@ -92,8 +92,8 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
     path = path(request.key)
     dir = File.dirname(path)
 
-    raise Puppet::Error.new("Cannot save #{request.key}; parent directory #{dir} does not exist") unless FileTest.directory?(dir)
-    raise Puppet::Error.new("Cannot save #{request.key}; parent directory #{dir} is not writable") unless FileTest.writable?(dir)
+    raise Puppet::Error.new(_("Cannot save #{request.key}; parent directory #{dir} does not exist")) unless FileTest.directory?(dir)
+    raise Puppet::Error.new(_("Cannot save #{request.key}; parent directory #{dir} is not writable")) unless FileTest.writable?(dir)
 
     write(request.key, path) { |f| f.print request.instance.to_s }
   end
@@ -142,7 +142,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
     dir, short = File.split(file)
     return nil unless Puppet::FileSystem.exist?(dir)
 
-    raise ArgumentError, "Tried to fix SSL files to a file containing uppercase" unless short.downcase == short
+    raise ArgumentError, _("Tried to fix SSL files to a file containing uppercase") unless short.downcase == short
     real_file = Dir.entries(dir).reject { |f| f =~ /^\./ }.find do |other|
       other.downcase == short
     end
@@ -151,7 +151,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
 
     full_file = File.join(dir, real_file)
 
-    Puppet.deprecation_warning "Automatic downcasing and renaming of ssl files is deprecated; please request the file using its correct case: #{full_file}"
+    Puppet.deprecation_warning _("Automatic downcasing and renaming of ssl files is deprecated; please request the file using its correct case: #{full_file}")
     File.rename(full_file, file)
 
     file
@@ -187,7 +187,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
       begin
         Puppet.settings.setting(setting).open_file(path, 'w:ASCII') { |f| yield f }
       rescue => detail
-        raise Puppet::Error, "Could not write #{path} to #{setting}: #{detail}", detail.backtrace
+        raise Puppet::Error, _("Could not write #{path} to #{setting}: #{detail}"), detail.backtrace
       end
     else
       raise Puppet::DevError, "You must provide a setting to determine where the files are stored"

--- a/lib/puppet/indirector/ssl_file.rb
+++ b/lib/puppet/indirector/ssl_file.rb
@@ -54,7 +54,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
 
   def path(name)
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      Puppet.crit(_("directory traversal detected in %{indirection}: %{name}") % { indirection: self.class, name: name.inspect })
       raise ArgumentError, _("invalid key")
     end
 
@@ -72,11 +72,11 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
     path = Puppet::FileSystem.pathname(path(request.key))
     return false unless Puppet::FileSystem.exist?(path)
 
-    Puppet.notice _("Removing file #{model} #{request.key} at '#{path}'")
+    Puppet.notice _("Removing file %{model} %{request} at '%{path}'") % { model: model, request: request.key, path: path }
     begin
       Puppet::FileSystem.unlink(path)
     rescue => detail
-      raise Puppet::Error, _("Could not remove #{request.key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not remove %{request}: %{detail}") % { request: request.key, detail: detail }, detail.backtrace
     end
   end
 
@@ -92,8 +92,8 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
     path = path(request.key)
     dir = File.dirname(path)
 
-    raise Puppet::Error.new(_("Cannot save #{request.key}; parent directory #{dir} does not exist")) unless FileTest.directory?(dir)
-    raise Puppet::Error.new(_("Cannot save #{request.key}; parent directory #{dir} is not writable")) unless FileTest.writable?(dir)
+    raise Puppet::Error.new(_("Cannot save %{request}; parent directory %{dir} does not exist") % { request: request.key, dir: dir }) unless FileTest.directory?(dir)
+    raise Puppet::Error.new(_("Cannot save %{request}; parent directory %{dir} is not writable") % { request: request.key, dir: dir }) unless FileTest.writable?(dir)
 
     write(request.key, path) { |f| f.print request.instance.to_s }
   end
@@ -151,7 +151,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
 
     full_file = File.join(dir, real_file)
 
-    Puppet.deprecation_warning _("Automatic downcasing and renaming of ssl files is deprecated; please request the file using its correct case: #{full_file}")
+    Puppet.deprecation_warning _("Automatic downcasing and renaming of ssl files is deprecated; please request the file using its correct case: %{full_file}") % { full_file: full_file }
     File.rename(full_file, file)
 
     file
@@ -187,7 +187,7 @@ class Puppet::Indirector::SslFile < Puppet::Indirector::Terminus
       begin
         Puppet.settings.setting(setting).open_file(path, 'w:ASCII') { |f| yield f }
       rescue => detail
-        raise Puppet::Error, _("Could not write #{path} to #{setting}: #{detail}"), detail.backtrace
+        raise Puppet::Error, _("Could not write %{path} to %{setting}: %{detail}") % { path: path, setting: setting, detail: detail }, detail.backtrace
       end
     else
       raise Puppet::DevError, "You must provide a setting to determine where the files are stored"

--- a/lib/puppet/indirector/terminus.rb
+++ b/lib/puppet/indirector/terminus.rb
@@ -32,7 +32,7 @@ class Puppet::Indirector::Terminus
       elsif ind = Puppet::Indirector::Indirection.instance(name)
         @indirection = ind
       else
-        raise ArgumentError, "Could not find indirection instance #{name} for #{self.name}"
+        raise ArgumentError, _("Could not find indirection instance #{name} for #{self.name}")
       end
     end
 
@@ -157,13 +157,13 @@ class Puppet::Indirector::Terminus
 
   def validate_key(request)
     unless request.key == request.instance.name
-      raise Puppet::Indirector::ValidationError, "Instance name #{request.instance.name.inspect} does not match requested key #{request.key.inspect}"
+      raise Puppet::Indirector::ValidationError, _("Instance name #{request.instance.name.inspect} does not match requested key #{request.key.inspect}")
     end
   end
 
   def validate_model(request)
     unless model === request.instance
-      raise Puppet::Indirector::ValidationError, "Invalid instance type #{request.instance.class.inspect}, expected #{model.inspect}"
+      raise Puppet::Indirector::ValidationError, _("Invalid instance type #{request.instance.class.inspect}, expected #{model.inspect}")
     end
   end
 end

--- a/lib/puppet/indirector/terminus.rb
+++ b/lib/puppet/indirector/terminus.rb
@@ -32,7 +32,7 @@ class Puppet::Indirector::Terminus
       elsif ind = Puppet::Indirector::Indirection.instance(name)
         @indirection = ind
       else
-        raise ArgumentError, _("Could not find indirection instance #{name} for #{self.name}")
+        raise ArgumentError, _("Could not find indirection instance %{name} for %{terminus}") % { name: name, terminus: self.name }
       end
     end
 
@@ -157,13 +157,13 @@ class Puppet::Indirector::Terminus
 
   def validate_key(request)
     unless request.key == request.instance.name
-      raise Puppet::Indirector::ValidationError, _("Instance name #{request.instance.name.inspect} does not match requested key #{request.key.inspect}")
+      raise Puppet::Indirector::ValidationError, _("Instance name %{name} does not match requested key %{key}") % { name: request.instance.name.inspect, key: request.key.inspect }
     end
   end
 
   def validate_model(request)
     unless model === request.instance
-      raise Puppet::Indirector::ValidationError, _("Invalid instance type #{request.instance.class.inspect}, expected #{model.inspect}")
+      raise Puppet::Indirector::ValidationError, _("Invalid instance type %{klass}, expected %{model_type}") % { klass: request.instance.class.inspect, model_type: model.inspect }
     end
   end
 end

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -11,13 +11,13 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
     begin
       return fix(Puppet::Util::Yaml.load_file(file))
     rescue Puppet::Util::Yaml::YamlLoadError => detail
-      raise Puppet::Error, "Could not parse YAML data for #{indirection.name} #{request.key}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not parse YAML data for #{indirection.name} #{request.key}: #{detail}"), detail.backtrace
     end
   end
 
   # Convert our object to YAML and store it to the disk.
   def save(request)
-    raise ArgumentError.new("You can only save objects that respond to :name") unless request.instance.respond_to?(:name)
+    raise ArgumentError.new(_("You can only save objects that respond to :name")) unless request.instance.respond_to?(:name)
 
     file = path(request.key)
 
@@ -29,15 +29,15 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
     begin
       Puppet::Util::Yaml.dump(request.instance, file)
     rescue TypeError => detail
-      Puppet.err "Could not save #{self.name} #{request.key}: #{detail}"
+      Puppet.err _("Could not save #{self.name} #{request.key}: #{detail}")
     end
   end
 
   # Return the path to a given node's file.
   def path(name,ext='.yaml')
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit("directory traversal detected in #{self.class}: #{name.inspect}")
-      raise ArgumentError, "invalid key"
+      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      raise ArgumentError, _("invalid key")
     end
 
     base = Puppet.run_mode.master? ? Puppet[:yamldir] : Puppet[:clientyamldir]

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -11,7 +11,7 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
     begin
       return fix(Puppet::Util::Yaml.load_file(file))
     rescue Puppet::Util::Yaml::YamlLoadError => detail
-      raise Puppet::Error, _("Could not parse YAML data for #{indirection.name} #{request.key}: #{detail}"), detail.backtrace
+      raise Puppet::Error, _("Could not parse YAML data for %{indirection} %{request}: %{detail}") % { indirection: indirection.name, request: request.key, detail: detail }, detail.backtrace
     end
   end
 
@@ -29,14 +29,14 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
     begin
       Puppet::Util::Yaml.dump(request.instance, file)
     rescue TypeError => detail
-      Puppet.err _("Could not save #{self.name} #{request.key}: #{detail}")
+      Puppet.err _("Could not save %{indirection} %{request}: %{detail}") % { indirection: self.name, request: request.key, detail: detail }
     end
   end
 
   # Return the path to a given node's file.
   def path(name,ext='.yaml')
     if name =~ Puppet::Indirector::BadNameRegexp then
-      Puppet.crit(_("directory traversal detected in #{self.class}: #{name.inspect}"))
+      Puppet.crit(_("directory traversal detected in %{indirection}: %{name}") % { indirection: self.class, name: name.inspect })
       raise ArgumentError, _("invalid key")
     end
 


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/indirector.rb` and `lib/puppet/indirector/*` for
translation.