### PR TITLE
(PUP-7042) Mark strings in info_service

### DIFF
--- a/lib/puppet/info_service/class_information_service.rb
+++ b/lib/puppet/info_service/class_information_service.rb
@@ -15,7 +15,7 @@ class Puppet::InfoService::ClassInformationService
     # feature flags in effect.
 
     unless env_file_hash.is_a?(Hash)
-      raise ArgumentError, 'Given argument must be a Hash'
+      raise ArgumentError, _('Given argument must be a Hash')
     end
 
     result = {}
@@ -52,7 +52,7 @@ class Puppet::InfoService::ClassInformationService
   end
 
   def parse_file(f)
-    return {:error => "The file #{f} does not exist"} unless Puppet::FileSystem.exist?(f)
+    return {:error => _("The file #{f} does not exist")} unless Puppet::FileSystem.exist?(f)
 
     begin
       parse_result = @parser.parse_file(f)

--- a/lib/puppet/info_service/class_information_service.rb
+++ b/lib/puppet/info_service/class_information_service.rb
@@ -52,7 +52,7 @@ class Puppet::InfoService::ClassInformationService
   end
 
   def parse_file(f)
-    return {:error => _("The file #{f} does not exist")} unless Puppet::FileSystem.exist?(f)
+    return {:error => _("The file %{f} does not exist") % { f: f }} unless Puppet::FileSystem.exist?(f)
 
     begin
       parse_result = @parser.parse_file(f)


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/info_service/*` for translation.