### PR TITLE
(PUP-7042) Mark strings in module_tool

### DIFF
--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -34,7 +34,7 @@ module Puppet
       if matcher = full_module_name.match(FULL_MODULE_NAME_PATTERN)
         return matcher.captures
       else
-        raise ArgumentError, "Not a valid full name: #{full_module_name}"
+        raise ArgumentError, _("Not a valid full name: #{full_module_name}")
       end
     end
 

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -34,7 +34,7 @@ module Puppet
       if matcher = full_module_name.match(FULL_MODULE_NAME_PATTERN)
         return matcher.captures
       else
-        raise ArgumentError, _("Not a valid full name: #{full_module_name}")
+        raise ArgumentError, _("Not a valid full name: %{full_module_name}") % { full_module_name: full_module_name }
       end
     end
 

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -37,11 +37,11 @@ module Puppet::ModuleTool
         @metadata = Puppet::ModuleTool::Metadata.new
 
         unless @path
-          raise ArgumentError, "Could not determine module path"
+          raise ArgumentError, _("Could not determine module path")
         end
 
         if require_metadata && !Puppet::ModuleTool.is_module_root?(@path)
-          raise ArgumentError, "Unable to find metadata.json in module root at #{@path} See https://docs.puppet.com/puppet/latest/reference/modules_publishing.html for required file format."
+          raise ArgumentError, _("Unable to find metadata.json in module root at #{@path} See https://docs.puppet.com/puppet/latest/reference/modules_publishing.html for required file format.")
         end
 
         metadata_path   = File.join(@path, 'metadata.json')
@@ -51,13 +51,13 @@ module Puppet::ModuleTool
             begin
               @metadata.update(JSON.load(f))
             rescue JSON::ParserError => ex
-              raise ArgumentError, "Could not parse JSON #{metadata_path}", ex.backtrace
+              raise ArgumentError, _("Could not parse JSON #{metadata_path}"), ex.backtrace
             end
           end
         end
 
         if File.file?(File.join(@path, 'Modulefile'))
-          Puppet.warning "A Modulefile was found in the root directory of the module. This file will be ignored and can safely be removed."
+          Puppet.warning _("A Modulefile was found in the root directory of the module. This file will be ignored and can safely be removed.")
         end
 
         return @metadata
@@ -69,14 +69,14 @@ module Puppet::ModuleTool
       end
 
       def parse_filename(filename)
-        if match = /^((.*?)-(.*?))-(\d+\.\d+\.\d+.*?)$/.match(File.basename(filename,'.tar.gz'))
+        if match = /^((.*?)-(.*?))-(\d+\.\d+\.\d+.*?)$/.match(File.basename(filename, '.tar.gz'))
           module_name, author, shortname, version = match.captures
         else
-          raise ArgumentError, "Could not parse filename to obtain the username, module name and version.  (#{@release_name})"
+          raise ArgumentError, _("Could not parse filename to obtain the username, module name and version.  (#{@release_name})")
         end
 
         unless SemanticPuppet::Version.valid?(version)
-          raise ArgumentError, "Invalid version format: #{version} (Semantic Versions are acceptable: http://semver.org)"
+          raise ArgumentError, _("Invalid version format: %{version} (Semantic Versions are acceptable: http://semver.org)") % { version: version }
         end
 
         return {

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -41,7 +41,7 @@ module Puppet::ModuleTool
         end
 
         if require_metadata && !Puppet::ModuleTool.is_module_root?(@path)
-          raise ArgumentError, _("Unable to find metadata.json in module root at #{@path} See https://docs.puppet.com/puppet/latest/reference/modules_publishing.html for required file format.")
+          raise ArgumentError, _("Unable to find metadata.json in module root at %{path} See https://docs.puppet.com/puppet/latest/reference/modules_publishing.html for required file format.") % { path: @path }
         end
 
         metadata_path   = File.join(@path, 'metadata.json')
@@ -51,7 +51,7 @@ module Puppet::ModuleTool
             begin
               @metadata.update(JSON.load(f))
             rescue JSON::ParserError => ex
-              raise ArgumentError, _("Could not parse JSON #{metadata_path}"), ex.backtrace
+              raise ArgumentError, _("Could not parse JSON %{metadata_path}") % { metadata_path: metadata_path }, ex.backtrace
             end
           end
         end
@@ -72,7 +72,7 @@ module Puppet::ModuleTool
         if match = /^((.*?)-(.*?))-(\d+\.\d+\.\d+.*?)$/.match(File.basename(filename, '.tar.gz'))
           module_name, author, shortname, version = match.captures
         else
-          raise ArgumentError, _("Could not parse filename to obtain the username, module name and version.  (#{@release_name})")
+          raise ArgumentError, _("Could not parse filename to obtain the username, module name and version.  (%{release_name})") % { release_name: @release_name }
         end
 
         unless SemanticPuppet::Version.valid?(version)

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -18,7 +18,7 @@ module Puppet::ModuleTool
         create_directory
         copy_contents
         write_json
-        Puppet.notice _("Building #{@path} for release")
+        Puppet.notice _("Building %{path} for release") % { path: @path }
         pack
         relative = Pathname.new(archive_file).relative_path_from(Pathname.new(File.expand_path(Dir.pwd)))
 
@@ -114,7 +114,7 @@ module Puppet::ModuleTool
           symlinks.each do |s|
             s = Pathname.new s
             mpath = Pathname.new @path
-            Puppet.warning _("Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from mpath} -> #{s.realpath.relative_path_from mpath}.")
+            Puppet.warning _("Symlinks in modules are unsupported. Please investigate symlink %{from} -> %{to}.") % { from: s.relative_path_from(mpath), to: s.realpath.relative_path_from(mpath) }
           end
 
           raise Puppet::ModuleTool::Errors::ModuleToolError, _("Found symlinks. Symlinks in modules are not allowed, please remove them.")

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -18,7 +18,7 @@ module Puppet::ModuleTool
         create_directory
         copy_contents
         write_json
-        Puppet.notice "Building #{@path} for release"
+        Puppet.notice _("Building #{@path} for release")
         pack
         relative = Pathname.new(archive_file).relative_path_from(Pathname.new(File.expand_path(Dir.pwd)))
 
@@ -114,10 +114,10 @@ module Puppet::ModuleTool
           symlinks.each do |s|
             s = Pathname.new s
             mpath = Pathname.new @path
-            Puppet.warning "Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from mpath} -> #{s.realpath.relative_path_from mpath}."
+            Puppet.warning _("Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from mpath} -> #{s.realpath.relative_path_from mpath}.")
           end
 
-          raise Puppet::ModuleTool::Errors::ModuleToolError, "Found symlinks. Symlinks in modules are not allowed, please remove them."
+          raise Puppet::ModuleTool::Errors::ModuleToolError, _("Found symlinks. Symlinks in modules are not allowed, please remove them.")
         end
       end
 
@@ -125,7 +125,7 @@ module Puppet::ModuleTool
         metadata_path = File.join(build_path, 'metadata.json')
 
         if metadata.to_hash.include? 'checksums'
-          Puppet.warning "A 'checksums' field was found in metadata.json. This field will be ignored and can safely be removed."
+          Puppet.warning _("A 'checksums' field was found in metadata.json. This field will be ignored and can safely be removed.")
         end
 
         # TODO: This may necessarily change the order in which the metadata.json

--- a/lib/puppet/module_tool/applications/checksummer.rb
+++ b/lib/puppet/module_tool/applications/checksummer.rb
@@ -44,9 +44,9 @@ module Puppet::ModuleTool
         elsif metadata_file.exist?
           # Check metadata.json too; legacy modules store their checksums there.
           JSON.parse(metadata_file.read)['checksums'] or
-          raise ArgumentError, "No file containing checksums found."
+          raise ArgumentError, _("No file containing checksums found.")
         else
-          raise ArgumentError, "No file containing checksums found."
+          raise ArgumentError, _("No file containing checksums found.")
         end
       end
 

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -78,7 +78,7 @@ module Puppet::ModuleTool
           results[:install_dir] = @install_dir.target
 
           unless @local_tarball && @ignore_dependencies
-            Puppet.notice _("Downloading from #{module_repository.host} ...")
+            Puppet.notice _("Downloading from %{host} ...") % { host: module_repository.host }
           end
 
           if @ignore_dependencies

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -78,7 +78,7 @@ module Puppet::ModuleTool
           results[:install_dir] = @install_dir.target
 
           unless @local_tarball && @ignore_dependencies
-            Puppet.notice "Downloading from #{module_repository.host} ..."
+            Puppet.notice _("Downloading from #{module_repository.host} ...")
           end
 
           if @ignore_dependencies
@@ -124,7 +124,7 @@ module Puppet::ModuleTool
           end
 
           begin
-            Puppet.info "Resolving dependencies ..."
+            Puppet.info _("Resolving dependencies ...")
             releases = SemanticPuppet::Dependency.resolve(graph)
           rescue SemanticPuppet::Dependency::UnsatisfiableGraph
             raise NoVersionsSatisfyError, results.merge(:requested_name => name)
@@ -153,10 +153,10 @@ module Puppet::ModuleTool
             end
           end
 
-          Puppet.info "Preparing to install ..."
+          Puppet.info _("Preparing to install ...")
           releases.each { |release| release.prepare }
 
-          Puppet.notice 'Installing -- do not interrupt ...'
+          Puppet.notice _('Installing -- do not interrupt ...')
           releases.each do |release|
             installed = installed_modules[release.name]
             if forced? || installed.nil?

--- a/lib/puppet/module_tool/applications/searcher.rb
+++ b/lib/puppet/module_tool/applications/searcher.rb
@@ -12,7 +12,7 @@ module Puppet::ModuleTool
       def run
         results = {}
         begin
-          Puppet.notice _("Searching #{@forge.host} ...")
+          Puppet.notice _("Searching %{host} ...") % { host: @forge.host }
           results[:answers] = @forge.search(@term)
           results[:result] = :success
         rescue ForgeError => e

--- a/lib/puppet/module_tool/applications/searcher.rb
+++ b/lib/puppet/module_tool/applications/searcher.rb
@@ -12,7 +12,7 @@ module Puppet::ModuleTool
       def run
         results = {}
         begin
-          Puppet.notice "Searching #{@forge.host} ..."
+          Puppet.notice _("Searching #{@forge.host} ...")
           results[:answers] = @forge.search(@term)
           results[:result] = :success
         rescue ForgeError => e

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -46,7 +46,7 @@ module Puppet::ModuleTool
         tmpdirpath = Pathname.new tmpdir
 
         symlinks.each do |s|
-          Puppet.warning _("Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from tmpdirpath}->#{Puppet::FileSystem.readlink(s)}.")
+          Puppet.warning _("Symlinks in modules are unsupported. Please investigate symlink %{from}->%{to}.") % { from: s.relative_path_from(tmpdirpath), to: Puppet::FileSystem.readlink(s) }
         end
       end
 
@@ -55,7 +55,7 @@ module Puppet::ModuleTool
         begin
           Puppet::ModuleTool::Tar.instance.unpack(@filename.to_s, tmpdir, [@module_path.stat.uid, @module_path.stat.gid].join(':'))
         rescue Puppet::ExecutionFailure => e
-          raise RuntimeError, _("Could not extract contents of module archive: #{e.message}")
+          raise RuntimeError, _("Could not extract contents of module archive: %{message}") % { message: e.message }
         end
       end
 

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -46,7 +46,7 @@ module Puppet::ModuleTool
         tmpdirpath = Pathname.new tmpdir
 
         symlinks.each do |s|
-          Puppet.warning "Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from tmpdirpath}->#{Puppet::FileSystem.readlink(s)}."
+          Puppet.warning _("Symlinks in modules are unsupported. Please investigate symlink #{s.relative_path_from tmpdirpath}->#{Puppet::FileSystem.readlink(s)}.")
         end
       end
 
@@ -55,7 +55,7 @@ module Puppet::ModuleTool
         begin
           Puppet::ModuleTool::Tar.instance.unpack(@filename.to_s, tmpdir, [@module_path.stat.uid, @module_path.stat.gid].join(':'))
         rescue Puppet::ExecutionFailure => e
-          raise RuntimeError, "Could not extract contents of module archive: #{e.message}"
+          raise RuntimeError, _("Could not extract contents of module archive: #{e.message}")
         end
       end
 
@@ -69,7 +69,7 @@ module Puppet::ModuleTool
         if metadata_file
           @root_dir = Pathname.new(metadata_file).dirname
         else
-          raise "No valid metadata.json found!"
+          raise _("No valid metadata.json found!")
         end
       end
 

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -70,7 +70,7 @@ module Puppet::ModuleTool
           dir = Pathname.new(mod.modulepath)
 
           vstring = mod.version ? "v#{mod.version}" : '???'
-          Puppet.notice "Found '#{name}' (#{colorize(:cyan, vstring)}) in #{dir} ..."
+          Puppet.notice _("Found '#{name}' (#{colorize(:cyan, vstring)}) in #{dir} ...")
           unless @ignore_changes
             changes = Checksummer.run(mod.path) rescue []
             if mod.has_metadata? && !changes.empty?
@@ -96,7 +96,7 @@ module Puppet::ModuleTool
             end
           end
 
-          Puppet.notice "Downloading from #{module_repository.host} ..."
+          Puppet.notice _("Downloading from #{module_repository.host} ...")
           if @ignore_dependencies
             graph = build_single_module_graph(name, version)
           else
@@ -134,7 +134,7 @@ module Puppet::ModuleTool
           end
 
           begin
-            Puppet.info "Resolving dependencies ..."
+            Puppet.info _("Resolving dependencies ...")
             releases = SemanticPuppet::Dependency.resolve(graph)
           rescue SemanticPuppet::Dependency::UnsatisfiableGraph
             raise NoVersionsSatisfyError, results.merge(:requested_name => name)
@@ -181,10 +181,10 @@ module Puppet::ModuleTool
             end
           end
 
-          Puppet.info "Preparing to upgrade ..."
+          Puppet.info _("Preparing to upgrade ...")
           releases.each { |release| release.prepare }
 
-          Puppet.notice 'Upgrading -- do not interrupt ...'
+          Puppet.notice _('Upgrading -- do not interrupt ...')
           releases.each do |release|
             if installed = installed_modules[release.name]
               release.install(Pathname.new(installed.mod.modulepath))

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -70,7 +70,7 @@ module Puppet::ModuleTool
           dir = Pathname.new(mod.modulepath)
 
           vstring = mod.version ? "v#{mod.version}" : '???'
-          Puppet.notice _("Found '#{name}' (#{colorize(:cyan, vstring)}) in #{dir} ...")
+          Puppet.notice _("Found '%{name}' (%{version}) in %{dir} ...") % { name: name, version: colorize(:cyan, vstring), dir: dir }
           unless @ignore_changes
             changes = Checksummer.run(mod.path) rescue []
             if mod.has_metadata? && !changes.empty?
@@ -96,7 +96,7 @@ module Puppet::ModuleTool
             end
           end
 
-          Puppet.notice _("Downloading from #{module_repository.host} ...")
+          Puppet.notice _("Downloading from %{host} ...") % { host: module_repository.host }
           if @ignore_dependencies
             graph = build_single_module_graph(name, version)
           else

--- a/lib/puppet/module_tool/contents_description.rb
+++ b/lib/puppet/module_tool/contents_description.rb
@@ -52,7 +52,7 @@ module Puppet::ModuleTool
             end
             @data << type_hash
           else
-            Puppet.warning _("Could not find/load type: #{name}")
+            Puppet.warning _("Could not find/load type: %{name}") % { name: name }
           end
         end
       end

--- a/lib/puppet/module_tool/contents_description.rb
+++ b/lib/puppet/module_tool/contents_description.rb
@@ -52,7 +52,7 @@ module Puppet::ModuleTool
             end
             @data << type_hash
           else
-            Puppet.warning "Could not find/load type: #{name}"
+            Puppet.warning _("Could not find/load type: #{name}")
           end
         end
       end

--- a/lib/puppet/module_tool/errors/installer.rb
+++ b/lib/puppet/module_tool/errors/installer.rb
@@ -8,16 +8,16 @@ module Puppet::ModuleTool::Errors
       @installed_version = v(options[:installed_version])
       @requested_version = v(options[:requested_version])
       @local_changes     = options[:local_changes]
-      super "'#{@module_name}' (#{@requested_version}) requested; '#{@module_name}' (#{@installed_version}) already installed"
+      super _("'#{@module_name}' (#{@requested_version}) requested; '#{@module_name}' (#{@installed_version}) already installed")
     end
 
     def multiline
       message = []
-      message << "Could not install module '#{@module_name}' (#{@requested_version})"
-      message << "  Module '#{@module_name}' (#{@installed_version}) is already installed"
-      message << "    Installed module has had changes made locally" unless @local_changes.empty?
-      message << "    Use `puppet module upgrade` to install a different version"
-      message << "    Use `puppet module install --force` to re-install only this module"
+      message << _("Could not install module '#{@module_name}' (#{@requested_version})")
+      message << _("  Module '#{@module_name}' (#{@installed_version}) is already installed")
+      message << _("    Installed module has had changes made locally") unless @local_changes.empty?
+      message << _("    Use `puppet module upgrade` to install a different version")
+      message << _("    Use `puppet module install --force` to re-install only this module")
       message.join("\n")
     end
   end
@@ -27,15 +27,15 @@ module Puppet::ModuleTool::Errors
       @requested_package = options[:requested_package]
       @source = options[:source]
 
-      super "Could not install '#{@requested_package}'; no releases are available from #{@source}"
+      super _("Could not install '#{@requested_package}'; no releases are available from #{@source}")
     end
 
     def multiline
       message = []
-      message << "Could not install '#{@requested_package}'"
+      message << _("Could not install '#{@requested_package}'")
 
-      message << "  No releases are available from #{@source}"
-      message << "    Does '#{@requested_package}' have at least one published release?"
+      message << _("  No releases are available from #{@source}")
+      message << _("    Does '#{@requested_package}' have at least one published release?")
 
       message.join("\n")
     end
@@ -46,11 +46,11 @@ module Puppet::ModuleTool::Errors
       @requested_module  = options[:requested_module]
       @requested_version = options[:requested_version]
       @directory         = options[:directory]
-      super("'#{@requested_module}' (#{@requested_version}) requested; Path #{@directory} is not a directory.", original)
+      super(_("'#{@requested_module}' (#{@requested_version}) requested; Path #{@directory} is not a directory."), original)
     end
 
     def multiline
-      <<-MSG.strip
+      _(<<-MSG).strip
 Could not install module '#{@requested_module}' (#{@requested_version})
   Path '#{@directory}' exists but is not a directory.
   A potential solution is to rename the path and then
@@ -64,11 +64,11 @@ Could not install module '#{@requested_module}' (#{@requested_version})
       @requested_module  = options[:requested_module]
       @requested_version = options[:requested_version]
       @directory         = options[:directory]
-      super("'#{@requested_module}' (#{@requested_version}) requested; Permission is denied to create #{@directory}.", original)
+      super(_("'#{@requested_module}' (#{@requested_version}) requested; Permission is denied to create #{@directory}."), original)
     end
 
     def multiline
-      <<-MSG.strip
+      _(<<-MSG).strip
 Could not install module '#{@requested_module}' (#{@requested_version})
   Permission is denied when trying to create directory '#{@directory}'.
   A potential solution is to check the ownership and permissions of
@@ -81,11 +81,11 @@ Could not install module '#{@requested_module}' (#{@requested_version})
     def initialize(options)
       @entry_path = options[:entry_path]
       @directory  = options[:directory]
-      super "Attempt to install file with an invalid path into #{@entry_path.inspect} under #{@directory.inspect}"
+      super _("Attempt to install file with an invalid path into #{@entry_path.inspect} under #{@directory.inspect}")
     end
 
     def multiline
-      <<-MSG.strip
+      _(<<-MSG).strip
 Could not install package with an invalid path.
   Package attempted to install file into
   #{@entry_path.inspect} under #{@directory.inspect}.

--- a/lib/puppet/module_tool/errors/installer.rb
+++ b/lib/puppet/module_tool/errors/installer.rb
@@ -8,13 +8,13 @@ module Puppet::ModuleTool::Errors
       @installed_version = v(options[:installed_version])
       @requested_version = v(options[:requested_version])
       @local_changes     = options[:local_changes]
-      super _("'#{@module_name}' (#{@requested_version}) requested; '#{@module_name}' (#{@installed_version}) already installed")
+      super _("'%{module_name}' (%{version}) requested; '%{module_name}' (%{installed_version}) already installed") % { module_name: @module_name, version: @requested_version, installed_version: @installed_version }
     end
 
     def multiline
       message = []
-      message << _("Could not install module '#{@module_name}' (#{@requested_version})")
-      message << _("  Module '#{@module_name}' (#{@installed_version}) is already installed")
+      message << _("Could not install module '%{module_name}' (%{version})") % { module_name: @module_name, version: @requested_version }
+      message << _("  Module '%{module_name}' (%{version}) is already installed") % { module_name: @module_name, version: @installed_version }
       message << _("    Installed module has had changes made locally") unless @local_changes.empty?
       message << _("    Use `puppet module upgrade` to install a different version")
       message << _("    Use `puppet module install --force` to re-install only this module")
@@ -27,15 +27,15 @@ module Puppet::ModuleTool::Errors
       @requested_package = options[:requested_package]
       @source = options[:source]
 
-      super _("Could not install '#{@requested_package}'; no releases are available from #{@source}")
+      super _("Could not install '%{requested_package}'; no releases are available from %{source}") % { requested_package: @requested_package, source: @source }
     end
 
     def multiline
       message = []
-      message << _("Could not install '#{@requested_package}'")
+      message << _("Could not install '%{requested_package}'") % { requested_package: @requested_package }
 
-      message << _("  No releases are available from #{@source}")
-      message << _("    Does '#{@requested_package}' have at least one published release?")
+      message << _("  No releases are available from %{source}") % { source: @source }
+      message << _("    Does '%{requested_package}' have at least one published release?") % { requested_package: @requested_package }
 
       message.join("\n")
     end
@@ -46,15 +46,15 @@ module Puppet::ModuleTool::Errors
       @requested_module  = options[:requested_module]
       @requested_version = options[:requested_version]
       @directory         = options[:directory]
-      super(_("'#{@requested_module}' (#{@requested_version}) requested; Path #{@directory} is not a directory."), original)
+      super(_("'%{module_name}' (%{version}) requested; Path %{dir} is not a directory.") % { module_name: @requested_module, version: @requested_version, dir: @directory }, original)
     end
 
     def multiline
-      _(<<-MSG).strip
-Could not install module '#{@requested_module}' (#{@requested_version})
-  Path '#{@directory}' exists but is not a directory.
+      _(<<-MSG).strip % { module_name: @requested_module, version: @requested_version, dir: @directory }
+Could not install module '%{module_name}' (%{version})
+  Path '%{dir}' exists but is not a directory.
   A potential solution is to rename the path and then
-  mkdir -p '#{@directory}'
+  mkdir -p '%{dir}'
       MSG
     end
   end
@@ -64,13 +64,13 @@ Could not install module '#{@requested_module}' (#{@requested_version})
       @requested_module  = options[:requested_module]
       @requested_version = options[:requested_version]
       @directory         = options[:directory]
-      super(_("'#{@requested_module}' (#{@requested_version}) requested; Permission is denied to create #{@directory}."), original)
+      super(_("'%{module_name}' (%{version}) requested; Permission is denied to create %{dir}.") % { module_name: @requested_module, version: @requested_version, dir: @directory }, original)
     end
 
     def multiline
-      _(<<-MSG).strip
-Could not install module '#{@requested_module}' (#{@requested_version})
-  Permission is denied when trying to create directory '#{@directory}'.
+      _(<<-MSG).strip % { module_name: @requested_module, version: @requested_version, dir: @directory }
+Could not install module '%{module_name}' (%{version})
+  Permission is denied when trying to create directory '%{dir}'.
   A potential solution is to check the ownership and permissions of
   parent directories.
       MSG
@@ -81,14 +81,14 @@ Could not install module '#{@requested_module}' (#{@requested_version})
     def initialize(options)
       @entry_path = options[:entry_path]
       @directory  = options[:directory]
-      super _("Attempt to install file with an invalid path into #{@entry_path.inspect} under #{@directory.inspect}")
+      super _("Attempt to install file with an invalid path into %{path} under %{dir}") % { path: @entry_path.inspect, dir: @directory.inspect }
     end
 
     def multiline
-      _(<<-MSG).strip
+      _(<<-MSG).strip % { path: @entry_path.inspect, dir: @directory.inspect }
 Could not install package with an invalid path.
   Package attempted to install file into
-  #{@entry_path.inspect} under #{@directory.inspect}.
+  %{path} under %{dir}.
       MSG
     end
   end

--- a/lib/puppet/module_tool/errors/shared.rb
+++ b/lib/puppet/module_tool/errors/shared.rb
@@ -8,14 +8,14 @@ module Puppet::ModuleTool::Errors
       @conditions        = options[:conditions]
       @action            = options[:action]
 
-      super "Could not #{@action} '#{@requested_name}' (#{vstring}); no version satisfies all dependencies"
+      super _("Could not #{@action} '#{@requested_name}' (#{vstring}); no version satisfies all dependencies")
     end
 
     def multiline
       message = []
-      message << "Could not #{@action} module '#{@requested_name}' (#{vstring})"
-      message << "  No version of '#{@requested_name}' can satisfy all dependencies"
-      message << "    Use `puppet module #{@action} --ignore-dependencies` to #{@action} only this module"
+      message << _("Could not #{@action} module '#{@requested_name}' (#{vstring})")
+      message << _("  No version of '#{@requested_name}' can satisfy all dependencies")
+      message << _("    Use `puppet module #{@action} --ignore-dependencies` to #{@action} only this module")
 
       message.join("\n")
     end
@@ -30,21 +30,21 @@ module Puppet::ModuleTool::Errors
       @action            = options[:action]
 
       if @requested_version == :latest
-        super "Could not #{@action} '#{@module_name}'; no releases are available from #{@source}"
+        super _("Could not #{@action} '#{@module_name}'; no releases are available from #{@source}")
       else
-        super "Could not #{@action} '#{@module_name}'; no releases matching '#{@requested_version}' are available from #{@source}"
+        super _("Could not #{@action} '#{@module_name}'; no releases matching '#{@requested_version}' are available from #{@source}")
       end
     end
 
     def multiline
       message = []
-      message << "Could not #{@action} '#{@module_name}' (#{vstring})"
+      message << _("Could not #{@action} '#{@module_name}' (#{vstring})")
 
       if @requested_version == :latest
-        message << "  No releases are available from #{@source}"
-        message << "    Does '#{@module_name}' have at least one published release?"
+        message << _("  No releases are available from #{@source}")
+        message << _("    Does '#{@module_name}' have at least one published release?")
       else
-        message << "  No releases matching '#{@requested_version}' are available from #{@source}"
+        message << _("  No releases matching '#{@requested_version}' are available from #{@source}")
       end
 
       message.join("\n")
@@ -58,27 +58,27 @@ module Puppet::ModuleTool::Errors
       @dependency        = options[:dependency]
       @directory         = options[:directory]
       @metadata          = options[:metadata]
-      super "'#{@requested_module}' (#{@requested_version}) requested; installation conflict"
+      super _("'#{@requested_module}' (#{@requested_version}) requested; installation conflict")
     end
 
     def multiline
       message = []
-      message << "Could not install module '#{@requested_module}' (#{@requested_version})"
+      message << _("Could not install module '#{@requested_module}' (#{@requested_version})")
 
       if @dependency
-        message << "  Dependency '#{@dependency[:name]}' (#{v(@dependency[:version])}) would overwrite #{@directory}"
+        message << _("  Dependency '#{@dependency[:name]}' (#{v(@dependency[:version])}) would overwrite #{@directory}")
       else
-        message << "  Installation would overwrite #{@directory}"
+        message << _("  Installation would overwrite #{@directory}")
       end
 
       if @metadata
-        message << "    Currently, '#{@metadata["name"]}' (#{v(@metadata["version"])}) is installed to that directory"
+        message << _("    Currently, '#{@metadata["name"]}' (#{v(@metadata["version"])}) is installed to that directory")
       end
 
       if @dependency
-        message << "    Use `puppet module install --ignore-dependencies` to install only this module"
+        message << _("    Use `puppet module install --ignore-dependencies` to install only this module")
       else
-        message << "    Use `puppet module install --force` to install this module anyway"
+        message << _("    Use `puppet module install --force` to install this module anyway")
       end
 
       message.join("\n")
@@ -93,19 +93,20 @@ module Puppet::ModuleTool::Errors
       @conditions        = options[:conditions]
       @source            = options[:source][1..-1]
 
-      super "'#{@requested_module}' (#{v(@requested_version)}) requested; Invalid dependency cycle"
+      super _("'#{@requested_module}' (#{v(@requested_version)}) requested; Invalid dependency cycle")
     end
 
     def multiline
       trace = []
-      trace << "You specified '#{@source.first[:name]}' (#{v(@requested_version)})"
-      trace += @source[1..-1].map { |m| "which depends on '#{m[:name]}' (#{v(m[:version])})" }
+      trace << _("You specified '#{@source.first[:name]}' (#{v(@requested_version)})")
+      #TRANSLATORS Second half of "You specified a module..."
+      trace += @source[1..-1].map { |m| _("which depends on '#{m[:name]}' (#{v(m[:version])})") }
 
       message = []
-      message << "Could not install module '#{@requested_module}' (#{v(@requested_version)})"
-      message << "  No version of '#{@module_name}' will satisfy dependencies"
-      message << trace.map { |s| "    #{s}" }.join(",\n")
-      message << "    Use `puppet module install --force` to install this module anyway"
+      message << _("Could not install module '#{@requested_module}' (#{v(@requested_version)})")
+      message << _("  No version of '#{@module_name}' will satisfy dependencies")
+      message << trace.map { |s| _("    #{s}") }.join(",\n")
+      message << _("    Use `puppet module install --force` to install this module anyway")
 
       message.join("\n")
     end
@@ -116,17 +117,17 @@ module Puppet::ModuleTool::Errors
       @module_name = options[:module_name]
       @suggestions = options[:suggestions] || []
       @action      = options[:action]
-      super "Could not #{@action} '#{@module_name}'; module is not installed"
+      super _("Could not #{@action} '#{@module_name}'; module is not installed")
     end
 
     def multiline
       message = []
-      message << "Could not #{@action} module '#{@module_name}'"
-      message << "  Module '#{@module_name}' is not installed"
+      message << _("Could not #{@action} module '#{@module_name}'")
+      message << _("  Module '#{@module_name}' is not installed")
       message += @suggestions.map do |suggestion|
-        "    You may have meant `puppet module #{@action} #{suggestion}`"
+        _("    You may have meant `puppet module #{@action} #{suggestion}`")
       end
-      message << "    Use `puppet module install` to install this module" if @action == :upgrade
+      message << _("    Use `puppet module install` to install this module") if @action == :upgrade
       message.join("\n")
     end
   end
@@ -136,17 +137,17 @@ module Puppet::ModuleTool::Errors
       @module_name = options[:module_name]
       @modules     = options[:installed_modules]
       @action      = options[:action]
-      super "Could not #{@action} '#{@module_name}'; module appears in multiple places in the module path"
+      super _("Could not #{@action} '#{@module_name}'; module appears in multiple places in the module path")
     end
 
     def multiline
       message = []
-      message << "Could not #{@action} module '#{@module_name}'"
-      message << "  Module '#{@module_name}' appears multiple places in the module path"
+      message << _("Could not #{@action} module '#{@module_name}'")
+      message << _("  Module '#{@module_name}' appears multiple places in the module path")
       message += @modules.map do |mod|
-        "    '#{@module_name}' (#{v(mod.version)}) was found in #{mod.modulepath}"
+        _("    '#{@module_name}' (#{v(mod.version)}) was found in #{mod.modulepath}")
       end
-      message << "    Use the `--modulepath` option to limit the search to specific directories"
+      message << _("    Use the `--modulepath` option to limit the search to specific directories")
       message.join("\n")
     end
   end
@@ -157,14 +158,14 @@ module Puppet::ModuleTool::Errors
       @requested_version = options[:requested_version]
       @installed_version = options[:installed_version]
       @action            = options[:action]
-      super "Could not #{@action} '#{@module_name}'; module has had changes made locally"
+      super _("Could not #{@action} '#{@module_name}'; module has had changes made locally")
     end
 
     def multiline
       message = []
-      message << "Could not #{@action} module '#{@module_name}' (#{vstring})"
-      message << "  Installed module has had changes made locally"
-      message << "    Use `puppet module #{@action} --ignore-changes` to #{@action} this module anyway"
+      message << _("Could not #{@action} module '#{@module_name}' (#{vstring})")
+      message << _("  Installed module has had changes made locally")
+      message << _("    Use `puppet module #{@action} --ignore-changes` to #{@action} this module anyway")
       message.join("\n")
     end
   end
@@ -174,14 +175,14 @@ module Puppet::ModuleTool::Errors
       @name   = name
       @action = options[:action]
       @error  = options[:error]
-      super "Could not #{@action} '#{@name}'; #{@error.message}"
+      super _("Could not #{@action} '#{@name}'; #{@error.message}")
     end
 
     def multiline
       message = []
-      message << "Could not #{@action} module '#{@name}'"
-      message << "  Failure trying to parse metadata"
-      message << "    Original message was: #{@error.message}"
+      message << _("Could not #{@action} module '#{@name}'")
+      message << _("  Failure trying to parse metadata")
+      message << _("    Original message was: #{@error.message}")
       message.join("\n")
     end
   end

--- a/lib/puppet/module_tool/errors/shared.rb
+++ b/lib/puppet/module_tool/errors/shared.rb
@@ -8,14 +8,14 @@ module Puppet::ModuleTool::Errors
       @conditions        = options[:conditions]
       @action            = options[:action]
 
-      super _("Could not #{@action} '#{@requested_name}' (#{vstring}); no version satisfies all dependencies")
+      super _("Could not %{action} '%{module_name}' (%{version}); no version satisfies all dependencies") % { action: @action, module_name: @requested_name, version: vstring }
     end
 
     def multiline
       message = []
-      message << _("Could not #{@action} module '#{@requested_name}' (#{vstring})")
-      message << _("  No version of '#{@requested_name}' can satisfy all dependencies")
-      message << _("    Use `puppet module #{@action} --ignore-dependencies` to #{@action} only this module")
+      message << _("Could not %{action} module '%{module_name}' (%{version})") % { action: @action, module_name: @requested_name, version: vstring }
+      message << _("  No version of '%{module_name}' can satisfy all dependencies") % { module_name: @requested_name }
+      message << _("    Use `puppet module %{action} --ignore-dependencies` to %{action} only this module") % { action: @action }
 
       message.join("\n")
     end
@@ -30,21 +30,21 @@ module Puppet::ModuleTool::Errors
       @action            = options[:action]
 
       if @requested_version == :latest
-        super _("Could not #{@action} '#{@module_name}'; no releases are available from #{@source}")
+        super _("Could not %{action} '%{module_name}'; no releases are available from %{source}") % { action: @action, module_name: @module_name, source: @source }
       else
-        super _("Could not #{@action} '#{@module_name}'; no releases matching '#{@requested_version}' are available from #{@source}")
+        super _("Could not %{action} '%{module_name}'; no releases matching '%{version}' are available from %{source}") % { action: @action, module_name: @module_name, version: @requested_version, source: @source }
       end
     end
 
     def multiline
       message = []
-      message << _("Could not #{@action} '#{@module_name}' (#{vstring})")
+      message << _("Could not %{action} '%{module_name}' (%{version})") % { action: @action, module_name: @module_name, version: vstring }
 
       if @requested_version == :latest
-        message << _("  No releases are available from #{@source}")
-        message << _("    Does '#{@module_name}' have at least one published release?")
+        message << _("  No releases are available from %{source}") % { source: @source }
+        message << _("    Does '%{module_name}' have at least one published release?") % { module_name: @module_name }
       else
-        message << _("  No releases matching '#{@requested_version}' are available from #{@source}")
+        message << _("  No releases matching '%{version}' are available from %{source}") % { version: @requested_version, source: @source }
       end
 
       message.join("\n")
@@ -58,21 +58,21 @@ module Puppet::ModuleTool::Errors
       @dependency        = options[:dependency]
       @directory         = options[:directory]
       @metadata          = options[:metadata]
-      super _("'#{@requested_module}' (#{@requested_version}) requested; installation conflict")
+      super _("'%{module_name}' (%{version}) requested; installation conflict") % { module_name: @requested_module, version: @requested_version }
     end
 
     def multiline
       message = []
-      message << _("Could not install module '#{@requested_module}' (#{@requested_version})")
+      message << _("Could not install module '%{module_name}' (%{version})") % { module_name: @requested_module, version: @requested_version }
 
       if @dependency
-        message << _("  Dependency '#{@dependency[:name]}' (#{v(@dependency[:version])}) would overwrite #{@directory}")
+        message << _("  Dependency '%{name}' (%{version}) would overwrite %{dir}") % { name: @dependency[:name], version: v(@dependency[:version]), dir: @directory }
       else
-        message << _("  Installation would overwrite #{@directory}")
+        message << _("  Installation would overwrite %{dir}") % { dir: @directory }
       end
 
       if @metadata
-        message << _("    Currently, '#{@metadata["name"]}' (#{v(@metadata["version"])}) is installed to that directory")
+        message << _("    Currently, '%{name}' (%{version}) is installed to that directory") % { name: @metadata["name"], version: v(@metadata["version"]) }
       end
 
       if @dependency
@@ -93,19 +93,19 @@ module Puppet::ModuleTool::Errors
       @conditions        = options[:conditions]
       @source            = options[:source][1..-1]
 
-      super _("'#{@requested_module}' (#{v(@requested_version)}) requested; Invalid dependency cycle")
+      super _("'%{module_name}' (%{version}) requested; Invalid dependency cycle") % { module_name: @requested_module, version: v(@requested_version) }
     end
 
     def multiline
       trace = []
-      trace << _("You specified '#{@source.first[:name]}' (#{v(@requested_version)})")
+      trace << _("You specified '%{name}' (%{version})") % { name: @source.first[:name], version: v(@requested_version) }
       #TRANSLATORS Second half of "You specified a module..."
-      trace += @source[1..-1].map { |m| _("which depends on '#{m[:name]}' (#{v(m[:version])})") }
+      trace += @source[1..-1].map { |m| _("which depends on '%{name}' (%{version})") % { name: m[:name], version: v(m[:version]) } }
 
       message = []
-      message << _("Could not install module '#{@requested_module}' (#{v(@requested_version)})")
-      message << _("  No version of '#{@module_name}' will satisfy dependencies")
-      message << trace.map { |s| _("    #{s}") }.join(",\n")
+      message << _("Could not install module '%{module_name}' (%{version})") % { module_name: @requested_module, version: v(@requested_version) }
+      message << _("  No version of '%{module_name}' will satisfy dependencies") % { module_name: @module_name }
+      message << trace.map { |s| "    #{s}".join(",\n") }
       message << _("    Use `puppet module install --force` to install this module anyway")
 
       message.join("\n")
@@ -117,15 +117,15 @@ module Puppet::ModuleTool::Errors
       @module_name = options[:module_name]
       @suggestions = options[:suggestions] || []
       @action      = options[:action]
-      super _("Could not #{@action} '#{@module_name}'; module is not installed")
+      super _("Could not %{action} '%{module_name}'; module is not installed") % { action: @action, module_name: @module_name }
     end
 
     def multiline
       message = []
-      message << _("Could not #{@action} module '#{@module_name}'")
-      message << _("  Module '#{@module_name}' is not installed")
+      message << _("Could not %{action} module '%{module_name}'") % { action: @action, module_name: @module_name }
+      message << _("  Module '%{module_name}' is not installed") % { module_name: @module_name }
       message += @suggestions.map do |suggestion|
-        _("    You may have meant `puppet module #{@action} #{suggestion}`")
+        _("    You may have meant `puppet module %{action} %{suggestion}`") % { action: @action, suggestion: suggestion }
       end
       message << _("    Use `puppet module install` to install this module") if @action == :upgrade
       message.join("\n")
@@ -137,15 +137,16 @@ module Puppet::ModuleTool::Errors
       @module_name = options[:module_name]
       @modules     = options[:installed_modules]
       @action      = options[:action]
-      super _("Could not #{@action} '#{@module_name}'; module appears in multiple places in the module path")
+      #TRANSLATORS "module path" refers to a set of directories where modules may be installed
+      super _("Could not %{action} '%{module_name}'; module appears in multiple places in the module path") % { action: @action, module_name: @module_name }
     end
 
     def multiline
       message = []
-      message << _("Could not #{@action} module '#{@module_name}'")
-      message << _("  Module '#{@module_name}' appears multiple places in the module path")
+      message << _("Could not %{action} module '%{module_name}'") % { action: @action, module_name: @module_name }
+      message << _("  Module '%{module_name}' appears multiple places in the module path") % { module_name: @module_name }
       message += @modules.map do |mod|
-        _("    '#{@module_name}' (#{v(mod.version)}) was found in #{mod.modulepath}")
+        _("    '%{module_name}' (%{version}) was found in %{path}") % { module_name: @module_name, version: v(mod.version), path: mod.modulepath }
       end
       message << _("    Use the `--modulepath` option to limit the search to specific directories")
       message.join("\n")
@@ -158,14 +159,14 @@ module Puppet::ModuleTool::Errors
       @requested_version = options[:requested_version]
       @installed_version = options[:installed_version]
       @action            = options[:action]
-      super _("Could not #{@action} '#{@module_name}'; module has had changes made locally")
+      super _("Could not %{action} '%{module_name}'; module has had changes made locally") % { action: @action, module_name: @module_name }
     end
 
     def multiline
       message = []
-      message << _("Could not #{@action} module '#{@module_name}' (#{vstring})")
+      message << _("Could not %{action} module '%{module_name}' (%{version})") % { action: @action, module_name: @module_name, version: vstring }
       message << _("  Installed module has had changes made locally")
-      message << _("    Use `puppet module #{@action} --ignore-changes` to #{@action} this module anyway")
+      message << _("    Use `puppet module %{action} --ignore-changes` to %{action} this module anyway") % { action: @action }
       message.join("\n")
     end
   end
@@ -175,14 +176,14 @@ module Puppet::ModuleTool::Errors
       @name   = name
       @action = options[:action]
       @error  = options[:error]
-      super _("Could not #{@action} '#{@name}'; #{@error.message}")
+      super _("Could not %{action} '%{module_name}'; %{error}") % { action: @action, module_name: @name, error: @error.message }
     end
 
     def multiline
       message = []
-      message << _("Could not #{@action} module '#{@name}'")
+      message << _("Could not %{action} module '%{module_name}'") % { action: @action, module_name: @name }
       message << _("  Failure trying to parse metadata")
-      message << _("    Original message was: #{@error.message}")
+      message << _("    Original message was: %{message}") % { message: @error.message }
       message.join("\n")
     end
   end

--- a/lib/puppet/module_tool/errors/uninstaller.rb
+++ b/lib/puppet/module_tool/errors/uninstaller.rb
@@ -7,15 +7,15 @@ module Puppet::ModuleTool::Errors
       @module_name = options[:module_name]
       @modules     = options[:installed_modules]
       @version     = options[:version_range]
-      super _("Could not uninstall '#{@module_name}'; no installed version matches")
+      super _("Could not uninstall '%{module_name}'; no installed version matches") % { module_name: @module_name }
     end
 
     def multiline
       message = []
-      message << _("Could not uninstall module '#{@module_name}' (#{v(@version)})")
-      message << _("  No installed version of '#{@module_name}' matches (#{v(@version)})")
+      message << _("Could not uninstall module '%{module_name}' (%{version})") % { module_name: @module_name, version: v(@version) }
+      message << _("  No installed version of '%{module_name}' matches (%{version})") % { module_name: @module_name, version: v(@version) }
       message += @modules.map do |mod|
-        _("    '#{mod[:name]}' (#{v(mod[:version])}) is installed in #{mod[:path]}")
+        _("    '%{module_name}' (%{version}) is installed in %{path}") % { module_name: mod[:name], version: v(mod[:version]), path: mod[:path] }
       end
       message.join("\n")
     end
@@ -28,15 +28,15 @@ module Puppet::ModuleTool::Errors
       @requested_version = options[:requested_version]
       @installed_version = options[:installed_version]
 
-      super _("Could not uninstall '#{@module_name}'; installed modules still depend upon it")
+      super _("Could not uninstall '%{module_name}'; installed modules still depend upon it") % { module_name: @module_name }
     end
 
     def multiline
       message = []
-      message << (_("Could not uninstall module '#{@module_name}'") << (@requested_version ? _(" (#{v(@requested_version)})") : ''))
-      message << _("  Other installed modules have dependencies on '#{@module_name}' (#{v(@installed_version)})")
+      message << (_("Could not uninstall module '%{module_name}'") % { module_name: @module_name } << (@requested_version ? "  (#v(@requested_version)})" : ''))
+      message << _("  Other installed modules have dependencies on '%{module_name}' (%{version})") % { module_name: @module_name, version: v(@installed_version) }
       message += @required_by.map do |mod|
-        _("    '#{mod['name']}' (#{v(mod['version'])}) requires '#{@module_name}' (#{v(mod['version_requirement'])})")
+        _("    '%{module_name}' (%{version}) requires '%{module_dep}' (%{dep_version})") % { module_name: mod['name'], version: v(mod['version']), module_dep: @module_name, dep_version: v(mod['version_requirement']) }
       end
       message << _("    Use `puppet module uninstall --force` to uninstall this module anyway")
       message.join("\n")

--- a/lib/puppet/module_tool/errors/uninstaller.rb
+++ b/lib/puppet/module_tool/errors/uninstaller.rb
@@ -7,15 +7,15 @@ module Puppet::ModuleTool::Errors
       @module_name = options[:module_name]
       @modules     = options[:installed_modules]
       @version     = options[:version_range]
-      super "Could not uninstall '#{@module_name}'; no installed version matches"
+      super _("Could not uninstall '#{@module_name}'; no installed version matches")
     end
 
     def multiline
       message = []
-      message << "Could not uninstall module '#{@module_name}' (#{v(@version)})"
-      message << "  No installed version of '#{@module_name}' matches (#{v(@version)})"
+      message << _("Could not uninstall module '#{@module_name}' (#{v(@version)})")
+      message << _("  No installed version of '#{@module_name}' matches (#{v(@version)})")
       message += @modules.map do |mod|
-        "    '#{mod[:name]}' (#{v(mod[:version])}) is installed in #{mod[:path]}"
+        _("    '#{mod[:name]}' (#{v(mod[:version])}) is installed in #{mod[:path]}")
       end
       message.join("\n")
     end
@@ -28,17 +28,17 @@ module Puppet::ModuleTool::Errors
       @requested_version = options[:requested_version]
       @installed_version = options[:installed_version]
 
-      super "Could not uninstall '#{@module_name}'; installed modules still depend upon it"
+      super _("Could not uninstall '#{@module_name}'; installed modules still depend upon it")
     end
 
     def multiline
       message = []
-      message << ("Could not uninstall module '#{@module_name}'" << (@requested_version ? " (#{v(@requested_version)})" : ''))
-      message << "  Other installed modules have dependencies on '#{@module_name}' (#{v(@installed_version)})"
+      message << (_("Could not uninstall module '#{@module_name}'") << (@requested_version ? _(" (#{v(@requested_version)})") : ''))
+      message << _("  Other installed modules have dependencies on '#{@module_name}' (#{v(@installed_version)})")
       message += @required_by.map do |mod|
-        "    '#{mod['name']}' (#{v(mod['version'])}) requires '#{@module_name}' (#{v(mod['version_requirement'])})"
+        _("    '#{mod['name']}' (#{v(mod['version'])}) requires '#{@module_name}' (#{v(mod['version_requirement'])})")
       end
-      message << "    Use `puppet module uninstall --force` to uninstall this module anyway"
+      message << _("    Use `puppet module uninstall --force` to uninstall this module anyway")
       message.join("\n")
     end
   end

--- a/lib/puppet/module_tool/errors/upgrader.rb
+++ b/lib/puppet/module_tool/errors/upgrader.rb
@@ -17,16 +17,16 @@ module Puppet::ModuleTool::Errors
       @dependency_name   = options[:dependency_name]
       @newer_versions    = options[:newer_versions]
       @possible_culprits = options[:possible_culprits]
-      super _("Could not upgrade '#{@module_name}'; more recent versions not found")
+      super _("Could not upgrade '%{module_name}'; more recent versions not found") % { module_name: @module_name }
     end
 
     def multiline
       message = []
-      message << _("Could not upgrade module '#{@module_name}' (#{vstring})")
+      message << _("Could not upgrade module '%{module_name}' (%{version})") % { module_name: @module_name, version: vstring }
       if @newer_versions.empty?
-        message << _("  The installed version is already the latest version matching #{vstring}")
+        message << _("  The installed version is already the latest version matching %{version}") % { version: vstring }
       else
-        message << _("  There are #{@newer_versions.length} newer versions")
+        message << _("  There are %{count} newer versions") % { count: @newer_versions.length }
         message << _("    No combination of dependency upgrades would satisfy all dependencies")
         unless @possible_culprits.empty?
           message << _("    Dependencies will not be automatically upgraded across major versions")
@@ -49,12 +49,12 @@ module Puppet::ModuleTool::Errors
       @conditions        = options[:conditions]
       @action            = options[:action]
 
-      super _("Could not #{@action} '#{@module_name}' (#{vstring}); downgrades are not allowed")
+      super _("Could not %{action} '%{module_name}' (%{version}); downgrades are not allowed") % { action: @action, module_name: @module_name, version: vstring }
     end
 
     def multiline
       message = []
-      message << _("Could not #{@action} module '#{@module_name}' (#{vstring})")
+      message << _("Could not %{action} module '%{module_name}' (%{version})") % { action: @action, module_name: @module_name, version: vstring }
       message << _("  Downgrading is not allowed.")
 
       message.join("\n")

--- a/lib/puppet/module_tool/errors/upgrader.rb
+++ b/lib/puppet/module_tool/errors/upgrader.rb
@@ -17,26 +17,26 @@ module Puppet::ModuleTool::Errors
       @dependency_name   = options[:dependency_name]
       @newer_versions    = options[:newer_versions]
       @possible_culprits = options[:possible_culprits]
-      super "Could not upgrade '#{@module_name}'; more recent versions not found"
+      super _("Could not upgrade '#{@module_name}'; more recent versions not found")
     end
 
     def multiline
       message = []
-      message << "Could not upgrade module '#{@module_name}' (#{vstring})"
+      message << _("Could not upgrade module '#{@module_name}' (#{vstring})")
       if @newer_versions.empty?
-        message << "  The installed version is already the latest version matching #{vstring}"
+        message << _("  The installed version is already the latest version matching #{vstring}")
       else
-        message << "  There are #{@newer_versions.length} newer versions"
-        message << "    No combination of dependency upgrades would satisfy all dependencies"
+        message << _("  There are #{@newer_versions.length} newer versions")
+        message << _("    No combination of dependency upgrades would satisfy all dependencies")
         unless @possible_culprits.empty?
-          message << "    Dependencies will not be automatically upgraded across major versions"
-          message << "    Upgrading one or more of these modules may permit the upgrade to succeed:"
+          message << _("    Dependencies will not be automatically upgraded across major versions")
+          message << _("    Upgrading one or more of these modules may permit the upgrade to succeed:")
           @possible_culprits.each do |name|
             message << "    - #{name}"
           end
         end
       end
-      message << "    Use `puppet module upgrade --force` to upgrade only this module"
+      message << _("    Use `puppet module upgrade --force` to upgrade only this module")
       message.join("\n")
     end
   end
@@ -49,13 +49,13 @@ module Puppet::ModuleTool::Errors
       @conditions        = options[:conditions]
       @action            = options[:action]
 
-      super "Could not #{@action} '#{@module_name}' (#{vstring}); downgrades are not allowed"
+      super _("Could not #{@action} '#{@module_name}' (#{vstring}); downgrades are not allowed")
     end
 
     def multiline
       message = []
-      message << "Could not #{@action} module '#{@module_name}' (#{vstring})"
-      message << "  Downgrading is not allowed."
+      message << _("Could not #{@action} module '#{@module_name}' (#{vstring})")
+      message << _("  Downgrading is not allowed.")
 
       message.join("\n")
     end

--- a/lib/puppet/module_tool/install_directory.rb
+++ b/lib/puppet/module_tool/install_directory.rb
@@ -19,7 +19,7 @@ module Puppet
 
         begin
           @target.mkpath
-          Puppet.notice _("Created target directory #{@target}")
+          Puppet.notice _("Created target directory %{dir}") % { dir: @target }
         rescue SystemCallError => orig_error
           raise converted_to_friendly_error(module_name, version, orig_error)
         end

--- a/lib/puppet/module_tool/install_directory.rb
+++ b/lib/puppet/module_tool/install_directory.rb
@@ -19,7 +19,7 @@ module Puppet
 
         begin
           @target.mkpath
-          Puppet.notice "Created target directory #{@target}"
+          Puppet.notice _("Created target directory #{@target}")
         rescue SystemCallError => orig_error
           raise converted_to_friendly_error(module_name, version, orig_error)
         end

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -61,7 +61,7 @@ module Puppet::ModuleTool
         begin
           version = SemanticPuppet::Version.parse(mod.version)
         rescue SemanticPuppet::Version::ValidationFailure => e
-          Puppet.warning "#{mod.name} (#{mod.path}) has an invalid version number (#{mod.version}). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org)."
+          Puppet.warning _("#{mod.name} (#{mod.path}) has an invalid version number (#{mod.version}). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).")
           version = SemanticPuppet::Version.parse("0.0.0")
         end
         release = "#{name}@#{version}"

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -61,7 +61,7 @@ module Puppet::ModuleTool
         begin
           version = SemanticPuppet::Version.parse(mod.version)
         rescue SemanticPuppet::Version::ValidationFailure => e
-          Puppet.warning _("#{mod.name} (#{mod.path}) has an invalid version number (#{mod.version}). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).")
+          Puppet.warning _("%{module_name} (%{path}) has an invalid version number (%{version}). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).") % { module_name: mod.name, path: mod.path, version: mod.version }
           version = SemanticPuppet::Version.parse("0.0.0")
         end
         release = "#{name}@#{version}"

--- a/lib/puppet/module_tool/local_tarball.rb
+++ b/lib/puppet/module_tool/local_tarball.rb
@@ -83,7 +83,7 @@ module Puppet::ModuleTool
       begin
         Puppet::ModuleTool::Applications::Unpacker.unpack(file, destination)
       rescue Puppet::ExecutionFailure => e
-        raise RuntimeError, "Could not extract contents of module archive: #{e.message}"
+        raise RuntimeError, _("Could not extract contents of module archive: #{e.message}")
       end
     end
   end

--- a/lib/puppet/module_tool/local_tarball.rb
+++ b/lib/puppet/module_tool/local_tarball.rb
@@ -83,7 +83,7 @@ module Puppet::ModuleTool
       begin
         Puppet::ModuleTool::Applications::Unpacker.unpack(file, destination)
       rescue Puppet::ExecutionFailure => e
-        raise RuntimeError, _("Could not extract contents of module archive: #{e.message}")
+        raise RuntimeError, _("Could not extract contents of module archive: %{message}") % { message: e.message }
       end
     end
   end

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -68,7 +68,7 @@ module Puppet::ModuleTool
       validate_version_range(version_requirement) if version_requirement
 
       if dup = @data['dependencies'].find { |d| d.full_module_name == name && d.version_requirement != version_requirement }
-        raise ArgumentError, "Dependency conflict for #{full_module_name}: Dependency #{name} was given conflicting version requirements #{version_requirement} and #{dup.version_requirement}. Verify that there are no duplicates in the metadata.json."
+        raise ArgumentError, _("Dependency conflict for #{full_module_name}: Dependency #{name} was given conflicting version requirements #{version_requirement} and #{dup.version_requirement}. Verify that there are no duplicates in the metadata.json.")
       end
 
       dep = Dependency.new(name, version_requirement, repository)
@@ -174,24 +174,24 @@ module Puppet::ModuleTool
 
       err = case modname
       when nil, '', :namespace_missing
-        "the field must be a namespaced module name"
+        _("the field must be a namespaced module name")
       when /[^a-z0-9_]/i
-        "the module name contains non-alphanumeric (or underscore) characters"
+        _("the module name contains non-alphanumeric (or underscore) characters")
       when /^[^a-z]/i
-        "the module name must begin with a letter"
+        _("the module name must begin with a letter")
       else
-        "the namespace contains non-alphanumeric characters"
+        _("the namespace contains non-alphanumeric characters")
       end
 
-      raise ArgumentError, "Invalid 'name' field in metadata.json: #{err}"
+      raise ArgumentError, _("Invalid 'name' field in metadata.json: #{err}")
     end
 
     # Validates that the version string can be parsed as per SemVer.
     def validate_version(version)
       return if SemanticPuppet::Version.valid?(version)
 
-      err = "version string cannot be parsed as a valid Semantic Version"
-      raise ArgumentError, "Invalid 'version' field in metadata.json: #{err}"
+      err = _("version string cannot be parsed as a valid Semantic Version")
+      raise ArgumentError, _("Invalid 'version' field in metadata.json: #{err}")
     end
 
     # Validates that the given _value_ is a symbolic name that starts with a letter
@@ -203,19 +203,19 @@ module Puppet::ModuleTool
       err = nil
       if value.is_a?(String)
         unless value =~ /^[a-zA-Z][a-zA-Z0-9_]*$/
-          err = value =~ /^[a-zA-Z]/ ? 'contains non-alphanumeric characters' : 'must begin with a letter'
+          err = value =~ /^[a-zA-Z]/ ? _('contains non-alphanumeric characters') : _('must begin with a letter')
         end
       else
-        err = 'must be a string'
+        err = _('must be a string')
       end
-      raise ArgumentError, "field 'data_provider' #{err}" if err
+      raise ArgumentError, _("field 'data_provider' #{err}") if err
     end
 
     # Validates that the version range can be parsed by Semantic.
     def validate_version_range(version_range)
       SemanticPuppet::VersionRange.parse(version_range)
     rescue ArgumentError => e
-      raise ArgumentError, "Invalid 'version_range' field in metadata.json: #{e}"
+      raise ArgumentError, _("Invalid 'version_range' field in metadata.json: #{e}")
     end
   end
 end

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -68,7 +68,7 @@ module Puppet::ModuleTool
       validate_version_range(version_requirement) if version_requirement
 
       if dup = @data['dependencies'].find { |d| d.full_module_name == name && d.version_requirement != version_requirement }
-        raise ArgumentError, _("Dependency conflict for #{full_module_name}: Dependency #{name} was given conflicting version requirements #{version_requirement} and #{dup.version_requirement}. Verify that there are no duplicates in the metadata.json.")
+        raise ArgumentError, _("Dependency conflict for %{module_name}: Dependency %{name} was given conflicting version requirements %{version_requirement} and %{dup_version}. Verify that there are no duplicates in the metadata.json.") % { module_name: full_module_name, name: name, version_requirement: version_requirement, dup_version: dup.version_requirement }
       end
 
       dep = Dependency.new(name, version_requirement, repository)
@@ -183,7 +183,7 @@ module Puppet::ModuleTool
         _("the namespace contains non-alphanumeric characters")
       end
 
-      raise ArgumentError, _("Invalid 'name' field in metadata.json: #{err}")
+      raise ArgumentError, _("Invalid 'name' field in metadata.json: %{err}") % { err: err }
     end
 
     # Validates that the version string can be parsed as per SemVer.
@@ -191,7 +191,7 @@ module Puppet::ModuleTool
       return if SemanticPuppet::Version.valid?(version)
 
       err = _("version string cannot be parsed as a valid Semantic Version")
-      raise ArgumentError, _("Invalid 'version' field in metadata.json: #{err}")
+      raise ArgumentError, _("Invalid 'version' field in metadata.json: %{err}") % { err: err }
     end
 
     # Validates that the given _value_ is a symbolic name that starts with a letter
@@ -203,19 +203,22 @@ module Puppet::ModuleTool
       err = nil
       if value.is_a?(String)
         unless value =~ /^[a-zA-Z][a-zA-Z0-9_]*$/
-          err = value =~ /^[a-zA-Z]/ ? _('contains non-alphanumeric characters') : _('must begin with a letter')
+          if value =~ /^[a-zA-Z]/
+            raise ArgumentError, _("field 'data_provider' contains non-alphanumeric characters")
+          else
+            raise ArgumentError, _("field 'data_provider' must begin with a letter")
+          end
         end
       else
-        err = _('must be a string')
+        raise ArgumentError, _("field 'data_provider' must be a string")
       end
-      raise ArgumentError, _("field 'data_provider' #{err}") if err
     end
 
     # Validates that the version range can be parsed by Semantic.
     def validate_version_range(version_range)
       SemanticPuppet::VersionRange.parse(version_range)
     rescue ArgumentError => e
-      raise ArgumentError, _("Invalid 'version_range' field in metadata.json: #{e}")
+      raise ArgumentError, _("Invalid 'version_range' field in metadata.json: %{err}") % { err: e }
     end
   end
 end

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -29,7 +29,7 @@ module Puppet::ModuleTool::Shared
     @urls     = {}
     @versions = Hash.new { |h,k| h[k] = [] }
 
-    Puppet.notice _("Downloading from #{forge.uri} ...")
+    Puppet.notice _("Downloading from %{uri} ...") % { uri: forge.uri }
     author, modname = Puppet::ModuleTool.username_and_modname_from(@module_name)
     info = forge.remote_dependency_info(author, modname, @options[:version])
     info.each do |pair|
@@ -151,7 +151,7 @@ module Puppet::ModuleTool::Shared
           cache_path = forge.retrieve(release[:file])
         end
       rescue OpenURI::HTTPError => e
-        raise RuntimeError, _("Could not download module: #{e.message}"), e.backtrace
+        raise RuntimeError, _("Could not download module: %{message}") % { message: e.message }, e.backtrace
       end
 
       [

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -29,7 +29,7 @@ module Puppet::ModuleTool::Shared
     @urls     = {}
     @versions = Hash.new { |h,k| h[k] = [] }
 
-    Puppet.notice "Downloading from #{forge.uri} ..."
+    Puppet.notice _("Downloading from #{forge.uri} ...")
     author, modname = Puppet::ModuleTool.username_and_modname_from(@module_name)
     info = forge.remote_dependency_info(author, modname, @options[:version])
     info.each do |pair|
@@ -151,7 +151,7 @@ module Puppet::ModuleTool::Shared
           cache_path = forge.retrieve(release[:file])
         end
       rescue OpenURI::HTTPError => e
-        raise RuntimeError, "Could not download module: #{e.message}", e.backtrace
+        raise RuntimeError, _("Could not download module: #{e.message}"), e.backtrace
       end
 
       [

--- a/lib/puppet/module_tool/tar.rb
+++ b/lib/puppet/module_tool/tar.rb
@@ -11,6 +11,7 @@ module Puppet::ModuleTool::Tar
     elsif Puppet.features.minitar? && Puppet.features.zlib?
       Mini.new
     else
+      #TRANSLATORS "tar" is a program name and should not be translated
       raise RuntimeError, _('No suitable tar implementation found')
     end
   end

--- a/lib/puppet/module_tool/tar.rb
+++ b/lib/puppet/module_tool/tar.rb
@@ -11,7 +11,7 @@ module Puppet::ModuleTool::Tar
     elsif Puppet.features.minitar? && Puppet.features.zlib?
       Mini.new
     else
-      raise RuntimeError, 'No suitable tar implementation found'
+      raise RuntimeError, _('No suitable tar implementation found')
     end
   end
 end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/module_tool.rb` and `lib/puppet/module_tool/*` for translation.