### PR TITLE
(PUP-7042) Mark strings in network

### DIFF
--- a/lib/puppet/network/auth_config_parser.rb
+++ b/lib/puppet/network/auth_config_parser.rb
@@ -28,11 +28,12 @@ class AuthConfigParser
         right = rights.newright(name, count, @file)
       when /^\s*(allow(?:_ip)?|deny(?:_ip)?|method|environment|auth(?:enticated)?)\s+(.+?)(\s*#.*)?$/
         if right.nil?
-          raise Puppet::ConfigurationError, _("Missing or invalid 'path' before right directive at line #{count} of #{@file}")
+          #TRANSLATORS "path" is a configuration file entry and should not be translated
+          raise Puppet::ConfigurationError, _("Missing or invalid 'path' before right directive at line %{count} of %{file}") % { count: count, file: @file }
         end
         parse_right_directive(right, $1, $2, count)
       else
-        raise Puppet::ConfigurationError, _("Invalid line #{count}: #{line}")
+        raise Puppet::ConfigurationError, _("Invalid line %{count}: %{line}") % { count: count, line: line }
       end
       count += 1
     }
@@ -65,7 +66,7 @@ class AuthConfigParser
       modify_right(right, :restrict_authenticated, value, _("adding authentication %s"), count)
     else
       raise Puppet::ConfigurationError,
-        _("Invalid argument '#{var}' at line #{count}")
+        _("Invalid argument '%{var}' at line %{count}") % { var: var, count: count }
     end
   end
 
@@ -76,7 +77,7 @@ class AuthConfigParser
         right.info msg % val
         right.send(method, val)
       rescue Puppet::AuthStoreError => detail
-        raise Puppet::ConfigurationError, _("#{detail} at line #{count} of #{@file}"), detail.backtrace
+        raise Puppet::ConfigurationError, _("%{detail} at line %{count} of %{file}") % { detail: detail, count: count, file: @file }, detail.backtrace
       end
     end
   end

--- a/lib/puppet/network/auth_config_parser.rb
+++ b/lib/puppet/network/auth_config_parser.rb
@@ -28,11 +28,11 @@ class AuthConfigParser
         right = rights.newright(name, count, @file)
       when /^\s*(allow(?:_ip)?|deny(?:_ip)?|method|environment|auth(?:enticated)?)\s+(.+?)(\s*#.*)?$/
         if right.nil?
-          raise Puppet::ConfigurationError, "Missing or invalid 'path' before right directive at line #{count} of #{@file}"
+          raise Puppet::ConfigurationError, _("Missing or invalid 'path' before right directive at line #{count} of #{@file}")
         end
         parse_right_directive(right, $1, $2, count)
       else
-        raise Puppet::ConfigurationError, "Invalid line #{count}: #{line}"
+        raise Puppet::ConfigurationError, _("Invalid line #{count}: #{line}")
       end
       count += 1
     }
@@ -50,22 +50,22 @@ class AuthConfigParser
     value.strip!
     case var
     when "allow"
-      modify_right(right, :allow, value, "allowing %s access", count)
+      modify_right(right, :allow, value, _("allowing %s access"), count)
     when "deny"
-      modify_right(right, :deny, value, "denying %s access", count)
+      modify_right(right, :deny, value, _("denying %s access"), count)
     when "allow_ip"
-      modify_right(right, :allow_ip, value, "allowing IP %s access", count)
+      modify_right(right, :allow_ip, value, _("allowing IP %s access"), count)
     when "deny_ip"
-      modify_right(right, :deny_ip, value, "denying IP %s access", count)
+      modify_right(right, :deny_ip, value, _("denying IP %s access"), count)
     when "method"
-      modify_right(right, :restrict_method, value, "allowing 'method' %s", count)
+      modify_right(right, :restrict_method, value, _("allowing 'method' %s"), count)
     when "environment"
-      modify_right(right, :restrict_environment, value, "adding environment %s", count)
+      modify_right(right, :restrict_environment, value, _("adding environment %s"), count)
     when /auth(?:enticated)?/
-      modify_right(right, :restrict_authenticated, value, "adding authentication %s", count)
+      modify_right(right, :restrict_authenticated, value, _("adding authentication %s"), count)
     else
       raise Puppet::ConfigurationError,
-        "Invalid argument '#{var}' at line #{count}"
+        _("Invalid argument '#{var}' at line #{count}")
     end
   end
 
@@ -76,7 +76,7 @@ class AuthConfigParser
         right.info msg % val
         right.send(method, val)
       rescue Puppet::AuthStoreError => detail
-        raise Puppet::ConfigurationError, "#{detail} at line #{count} of #{@file}", detail.backtrace
+        raise Puppet::ConfigurationError, _("#{detail} at line #{count} of #{@file}"), detail.backtrace
       end
     end
   end

--- a/lib/puppet/network/authconfig.rb
+++ b/lib/puppet/network/authconfig.rb
@@ -51,7 +51,7 @@ module Puppet
     def insert_default_acl
       self.class.default_acl.each do |acl|
         unless rights[acl[:acl]]
-          Puppet.info _("Inserting default '#{acl[:acl]}' (auth #{acl[:authenticated]}) ACL")
+          Puppet.info _("Inserting default '%{acl}' (auth %{auth}) ACL") % { acl: acl[:acl], auth: acl[:authenticated] }
           mk_acl(acl)
         end
       end
@@ -79,7 +79,7 @@ module Puppet
     # is denied.
     def check_authorization(method, path, params)
       if authorization_failure_exception = @rights.is_request_forbidden_and_why?(method, path, params)
-        Puppet.warning(_("Denying access: #{authorization_failure_exception}"))
+        Puppet.warning(_("Denying access: %{authorization_failure_exception}") % { authorization_failure_exception: authorization_failure_exception })
         raise authorization_failure_exception
       end
     end

--- a/lib/puppet/network/authconfig.rb
+++ b/lib/puppet/network/authconfig.rb
@@ -51,7 +51,7 @@ module Puppet
     def insert_default_acl
       self.class.default_acl.each do |acl|
         unless rights[acl[:acl]]
-          Puppet.info "Inserting default '#{acl[:acl]}' (auth #{acl[:authenticated]}) ACL"
+          Puppet.info _("Inserting default '#{acl[:acl]}' (auth #{acl[:authenticated]}) ACL")
           mk_acl(acl)
         end
       end
@@ -79,7 +79,7 @@ module Puppet
     # is denied.
     def check_authorization(method, path, params)
       if authorization_failure_exception = @rights.is_request_forbidden_and_why?(method, path, params)
-        Puppet.warning("Denying access: #{authorization_failure_exception}")
+        Puppet.warning(_("Denying access: #{authorization_failure_exception}"))
         raise authorization_failure_exception
       end
     end

--- a/lib/puppet/network/authstore.rb
+++ b/lib/puppet/network/authstore.rb
@@ -33,7 +33,7 @@ module Puppet
         return decl.result
       end
 
-      info "defaulting to no access for #{name}"
+      info _("defaulting to no access for #{name}")
       false
     end
 
@@ -254,7 +254,7 @@ module Puppet
           bits = 8*segments.length
           [:inexact, bits, IPAddr.new((segments+[0,0,0])[0,4].join(".") + "/#{bits}")]
         else
-          raise AuthStoreError, "Invalid IP pattern #{value}"
+          raise AuthStoreError, _("Invalid IP pattern #{value}")
         end
       end
 

--- a/lib/puppet/network/authstore.rb
+++ b/lib/puppet/network/authstore.rb
@@ -33,7 +33,7 @@ module Puppet
         return decl.result
       end
 
-      info _("defaulting to no access for #{name}")
+      info _("defaulting to no access for %{name}") % { name: name }
       false
     end
 
@@ -254,7 +254,7 @@ module Puppet
           bits = 8*segments.length
           [:inexact, bits, IPAddr.new((segments+[0,0,0])[0,4].join(".") + "/#{bits}")]
         else
-          raise AuthStoreError, _("Invalid IP pattern #{value}")
+          raise AuthStoreError, _("Invalid IP pattern %{value}") % { value: value }
         end
       end
 

--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -11,19 +11,19 @@ module Puppet::Network::FormatSupport
     def convert_from(format, data)
       get_format(format).intern(self, data)
     rescue => err
-      raise Puppet::Network::FormatHandler::FormatError, "Could not intern from #{format}: #{err}", err.backtrace
+      raise Puppet::Network::FormatHandler::FormatError, _("Could not intern from #{format}: #{err}"), err.backtrace
     end
 
     def convert_from_multiple(format, data)
       get_format(format).intern_multiple(self, data)
     rescue => err
-      raise Puppet::Network::FormatHandler::FormatError, "Could not intern_multiple from #{format}: #{err}", err.backtrace
+      raise Puppet::Network::FormatHandler::FormatError, _("Could not intern_multiple from #{format}: #{err}"), err.backtrace
     end
 
     def render_multiple(format, instances)
       get_format(format).render_multiple(instances)
     rescue => err
-      raise Puppet::Network::FormatHandler::FormatError, "Could not render_multiple to #{format}: #{err}", err.backtrace
+      raise Puppet::Network::FormatHandler::FormatError, _("Could not render_multiple to #{format}: #{err}"), err.backtrace
     end
 
     def default_format
@@ -101,7 +101,7 @@ module Puppet::Network::FormatSupport
 
     self.class.get_format(format).render(self)
   rescue => err
-    raise Puppet::Network::FormatHandler::FormatError, "Could not render to #{format}: #{err}", err.backtrace
+    raise Puppet::Network::FormatHandler::FormatError, _("Could not render to #{format}: #{err}"), err.backtrace
   end
 
   def mime(format = nil)
@@ -109,7 +109,7 @@ module Puppet::Network::FormatSupport
 
     self.class.get_format(format).mime
   rescue => err
-    raise Puppet::Network::FormatHandler::FormatError, "Could not mime to #{format}: #{err}", err.backtrace
+    raise Puppet::Network::FormatHandler::FormatError, _("Could not mime to #{format}: #{err}"), err.backtrace
   end
 
   def support_format?(name)

--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -11,19 +11,22 @@ module Puppet::Network::FormatSupport
     def convert_from(format, data)
       get_format(format).intern(self, data)
     rescue => err
-      raise Puppet::Network::FormatHandler::FormatError, _("Could not intern from #{format}: #{err}"), err.backtrace
+      #TRANSLATORS "intern" is a function name and should not be translated
+      raise Puppet::Network::FormatHandler::FormatError, _("Could not intern from %{format}: %{err}") % { format: format, err: err }, err.backtrace
     end
 
     def convert_from_multiple(format, data)
       get_format(format).intern_multiple(self, data)
     rescue => err
-      raise Puppet::Network::FormatHandler::FormatError, _("Could not intern_multiple from #{format}: #{err}"), err.backtrace
+      #TRANSLATORS "intern_multiple" is a function name and should not be translated
+      raise Puppet::Network::FormatHandler::FormatError, _("Could not intern_multiple from %{format}: %{err}") % { format: format, err: err }, err.backtrace
     end
 
     def render_multiple(format, instances)
       get_format(format).render_multiple(instances)
     rescue => err
-      raise Puppet::Network::FormatHandler::FormatError, _("Could not render_multiple to #{format}: #{err}"), err.backtrace
+      #TRANSLATORS "render_multiple" is a function name and should not be translated
+      raise Puppet::Network::FormatHandler::FormatError, _("Could not render_multiple to %{format}: %{err}") % { format: format, err: err }, err.backtrace
     end
 
     def default_format
@@ -101,7 +104,8 @@ module Puppet::Network::FormatSupport
 
     self.class.get_format(format).render(self)
   rescue => err
-    raise Puppet::Network::FormatHandler::FormatError, _("Could not render to #{format}: #{err}"), err.backtrace
+    #TRANSLATORS "render" is a function name and should not be translated
+    raise Puppet::Network::FormatHandler::FormatError, _("Could not render to %{format}: %{err}") % { format: format, err: err }, err.backtrace
   end
 
   def mime(format = nil)
@@ -109,7 +113,8 @@ module Puppet::Network::FormatSupport
 
     self.class.get_format(format).mime
   rescue => err
-    raise Puppet::Network::FormatHandler::FormatError, _("Could not mime to #{format}: #{err}"), err.backtrace
+    #TRANSLATORS "mime" is a function name and should not be translated
+    raise Puppet::Network::FormatHandler::FormatError, _("Could not mime to %{format}: %{err}") % { format: format, err: err }, err.backtrace
   end
 
   def support_format?(name)

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -42,7 +42,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
     return data if data.is_a?(klass)
 
     unless data.is_a? Hash
-      raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a valid instance of #{klass}")
+      raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a valid instance of %{klass}") % { klass: klass }
     end
 
     klass.from_data_hash(data)

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -30,7 +30,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
   def intern_multiple(klass, text)
     data = YAML.load(text)
     unless data.respond_to?(:collect)
-      raise Puppet::Network::FormatHandler::FormatError, "Serialized YAML did not contain a collection of instances when calling intern_multiple"
+      raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a collection of instances when calling intern_multiple")
     end
 
     data.collect do |datum|
@@ -42,7 +42,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
     return data if data.is_a?(klass)
 
     unless data.is_a? Hash
-      raise Puppet::Network::FormatHandler::FormatError, "Serialized YAML did not contain a valid instance of #{klass}"
+      raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a valid instance of #{klass}")
     end
 
     klass.from_data_hash(data)

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -40,7 +40,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       # TODO: should we tell the user we found an indirection but it doesn't
       # allow remote requests, or just pretend there's no handler at all? what
       # are the security implications for the former?
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No handler for #{indirection.name}", :NO_INDIRECTION_REMOTE_REQUESTS)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("No handler for #{indirection.name}"), :NO_INDIRECTION_REMOTE_REQUESTS)
     end
 
     trusted = Puppet::Context::TrustedInformation.remote(params[:authenticated], params[:node], certificate)
@@ -57,7 +57,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
 
     if indirection_name !~ /^\w+$/
       raise Puppet::Network::HTTP::Error::HTTPBadRequestError.new(
-        "The indirection name must be purely alphanumeric, not '#{indirection_name}'")
+        _("The indirection name must be purely alphanumeric, not '#{indirection_name}'"))
     end
 
     # this also depluralizes the indirection_name if it is a search
@@ -67,24 +67,24 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     # request
     if url_prefix != IndirectionType.url_prefix_for(indirection_name)
       raise Puppet::Network::HTTP::Error::HTTPBadRequestError.new(
-        "Indirection '#{indirection_name}' does not match url prefix '#{url_prefix}'")
+        _("Indirection '#{indirection_name}' does not match url prefix '#{url_prefix}'"))
     end
 
     indirection = Puppet::Indirector::Indirection.instance(indirection_name.to_sym)
     if !indirection
       raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(
-        "Could not find indirection '#{indirection_name}'",
+        _("Could not find indirection '#{indirection_name}'"),
         Puppet::Network::HTTP::Issues::HANDLER_NOT_FOUND)
     end
 
     if !environment
       raise Puppet::Network::HTTP::Error::HTTPBadRequestError.new(
-        "An environment parameter must be specified")
+        _("An environment parameter must be specified"))
     end
 
     if ! Puppet::Node::Environment.valid_name?(environment)
       raise Puppet::Network::HTTP::Error::HTTPBadRequestError.new(
-        "The environment must be purely alphanumeric, not '#{environment}'")
+        _("The environment must be purely alphanumeric, not '#{environment}'"))
     end
 
     configured_environment = Puppet.lookup(:environments).get(environment)
@@ -101,14 +101,14 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
 
     if configured_environment.nil?
       raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(
-        "Could not find environment '#{environment}'")
+        _("Could not find environment '#{environment}'"))
     end
 
     params.delete(:bucket_path)
 
     if key == "" or key.nil?
       raise Puppet::Network::HTTP::Error::HTTPBadRequestError.new(
-        "No request key specified in #{uri}")
+        _("No request key specified in #{uri}"))
     end
 
     [indirection, method, key, params]
@@ -119,19 +119,19 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   # Execute our find.
   def do_find(indirection, key, params, request, response)
     unless result = indirection.find(key, params)
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("Could not find #{indirection.name} #{key}", Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("Could not find #{indirection.name} #{key}"), Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
     end
 
     format = accepted_response_formatter_for(indirection.model, request)
 
     rendered_result = result
     if result.respond_to?(:render)
-      Puppet::Util::Profiler.profile("Rendered result in #{format}", [:http, :v3_render, format]) do
+      Puppet::Util::Profiler.profile(_("Rendered result in #{format}"), [:http, :v3_render, format]) do
         rendered_result = result.render(format)
       end
     end
 
-    Puppet::Util::Profiler.profile("Sent response", [:http, :v3_response]) do
+    Puppet::Util::Profiler.profile(_("Sent response"), [:http, :v3_response]) do
       response.respond_with(200, format, rendered_result)
     end
   end
@@ -139,7 +139,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   # Execute our head.
   def do_head(indirection, key, params, request, response)
     unless indirection.head(key, params)
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("Could not find #{indirection.name} #{key}", Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("Could not find #{indirection.name} #{key}"), Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
     end
 
     # No need to set a response because no response is expected from a
@@ -151,7 +151,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     result = indirection.search(key, params)
 
     if result.nil?
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("Could not find instances in #{indirection.name} with '#{key}'", Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("Could not find instances in #{indirection.name} with '#{key}'"), Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
     end
 
     format = accepted_response_formatter_for(indirection.model, request)
@@ -179,7 +179,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   end
 
   def accepted_response_formatter_for(model_class, request)
-    accepted_formats = request.headers['accept'] or raise Puppet::Network::HTTP::Error::HTTPNotAcceptableError.new("Missing required Accept header", Puppet::Network::HTTP::Issues::MISSING_HEADER_FIELD)
+    accepted_formats = request.headers['accept'] or raise Puppet::Network::HTTP::Error::HTTPNotAcceptableError.new(_("Missing required Accept header"), Puppet::Network::HTTP::Issues::MISSING_HEADER_FIELD)
     request.response_formatter_for(model_class.supported_formats, accepted_formats)
   end
 
@@ -197,11 +197,11 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
 
   def indirection_method(http_method, indirection)
     raise Puppet::Network::HTTP::Error::HTTPMethodNotAllowedError.new(
-      "No support for http method #{http_method}") unless METHOD_MAP[http_method]
+      _("No support for http method #{http_method}")) unless METHOD_MAP[http_method]
 
     unless method = METHOD_MAP[http_method][plurality(indirection)]
       raise Puppet::Network::HTTP::Error::HTTPBadRequestError.new(
-        "No support for plurality #{plurality(indirection)} for #{http_method} operations")
+        _("No support for plurality #{plurality(indirection)} for #{http_method} operations"))
     end
 
     method

--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -8,7 +8,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
     code_id = request.params[:code_id]
 
     if env.nil?
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("#{env_name} is not a known environment"), Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("%{env_name} is not a known environment") % { env_name: env_name }, Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
     end
 
     catalog = Puppet::Parser::EnvironmentCompiler.compile(env, code_id).to_resource
@@ -49,7 +49,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
       nodes.each do |node, comps|
         comps = [comps] unless comps.is_a?(Array)
         comps.each do |comp|
-          raise Puppet::ParseError.new(_("Application #{app} assigns multiple nodes to component #{comp}"), file, line) if node_mapping.include?(comp.ref)
+          raise Puppet::ParseError.new(_("Application %{app} assigns multiple nodes to component %{comp}") % { app: app, comp: comp }, file, line) if node_mapping.include?(comp.ref)
           node_mapping[comp.ref] = node.title
         end
       end

--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -8,7 +8,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
     code_id = request.params[:code_id]
 
     if env.nil?
-      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("#{env_name} is not a known environment", Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("#{env_name} is not a known environment"), Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
     end
 
     catalog = Puppet::Parser::EnvironmentCompiler.compile(env, code_id).to_resource
@@ -49,7 +49,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
       nodes.each do |node, comps|
         comps = [comps] unless comps.is_a?(Array)
         comps.each do |comp|
-          raise Puppet::ParseError.new("Application #{app} assigns multiple nodes to component #{comp}", file, line) if node_mapping.include?(comp.ref)
+          raise Puppet::ParseError.new(_("Application #{app} assigns multiple nodes to component #{comp}"), file, line) if node_mapping.include?(comp.ref)
           node_mapping[comp.ref] = node.title
         end
       end

--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -27,7 +27,7 @@ module Puppet::Network::HTTP::Compression
       when nil, 'identity'
         return response.body
       else
-        raise Net::HTTPError.new(_("Unknown content encoding - #{response['content-encoding']}"), response)
+        raise Net::HTTPError.new(_("Unknown content encoding - %{encoding}") % { encoding: response['content-encoding'] }, response)
       end
     end
 
@@ -40,7 +40,7 @@ module Puppet::Network::HTTP::Compression
       when nil, 'identity'
         uncompressor = IdentityAdapter.new
       else
-        raise Net::HTTPError.new(_("Unknown content encoding - #{response['content-encoding']}"), response)
+        raise Net::HTTPError.new(_("Unknown content encoding - %{encoding}") % { encoding: response['content-encoding'] }, response)
       end
 
       yield uncompressor

--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -27,7 +27,7 @@ module Puppet::Network::HTTP::Compression
       when nil, 'identity'
         return response.body
       else
-        raise Net::HTTPError.new("Unknown content encoding - #{response['content-encoding']}", response)
+        raise Net::HTTPError.new(_("Unknown content encoding - #{response['content-encoding']}"), response)
       end
     end
 
@@ -40,7 +40,7 @@ module Puppet::Network::HTTP::Compression
       when nil, 'identity'
         uncompressor = IdentityAdapter.new
       else
-        raise Net::HTTPError.new("Unknown content encoding - #{response['content-encoding']}", response)
+        raise Net::HTTPError.new(_("Unknown content encoding - #{response['content-encoding']}"), response)
       end
 
       yield uncompressor

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -51,7 +51,7 @@ module Puppet::Network::HTTP
       @port = port
 
       unknown_options = options.keys - OPTION_DEFAULTS.keys
-      raise Puppet::Error, _("Unrecognized option(s): #{unknown_options.map(&:inspect).sort.join(', ')}") unless unknown_options.empty?
+      raise Puppet::Error, _("Unrecognized option(s): %{opts}") % { opts: unknown_options.map(&:inspect).sort.join(', ') } unless unknown_options.empty?
 
       options = OPTION_DEFAULTS.merge(options)
       @use_ssl = options[:use_ssl]
@@ -197,7 +197,7 @@ module Puppet::Network::HTTP
         # and try again...
       end
 
-      raise RedirectionLimitExceededException, _("Too many HTTP redirections for #{@host}:#{@port}")
+      raise RedirectionLimitExceededException, _("Too many HTTP redirections for %{host}:%{port}") % { host: @host, port: @port }
     end
 
     def apply_options_to(request, options)
@@ -227,8 +227,8 @@ module Puppet::Network::HTTP
         leaf_ssl_cert = @verify.peer_certs.last
 
         valid_certnames = [leaf_ssl_cert.name, *leaf_ssl_cert.subject_alt_names].uniq
-        msg = valid_certnames.length > 1 ? _("one of #{valid_certnames.join(', ')}") : valid_certnames.first
-        msg = _("Server hostname '#{site.host}' did not match server certificate; expected #{msg}")
+        msg = valid_certnames.length > 1 ? _("one of %{certnames}") % { certnames: valid_certnames.join(', ') } : valid_certnames.first
+        msg = _("Server hostname '%{host}' did not match server certificate; expected %{msg}") % { host: site.host, msg: msg }
 
         raise Puppet::Error, msg, error.backtrace
       else

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -51,7 +51,7 @@ module Puppet::Network::HTTP
       @port = port
 
       unknown_options = options.keys - OPTION_DEFAULTS.keys
-      raise Puppet::Error, "Unrecognized option(s): #{unknown_options.map(&:inspect).sort.join(', ')}" unless unknown_options.empty?
+      raise Puppet::Error, _("Unrecognized option(s): #{unknown_options.map(&:inspect).sort.join(', ')}") unless unknown_options.empty?
 
       options = OPTION_DEFAULTS.merge(options)
       @use_ssl = options[:use_ssl]
@@ -197,7 +197,7 @@ module Puppet::Network::HTTP
         # and try again...
       end
 
-      raise RedirectionLimitExceededException, "Too many HTTP redirections for #{@host}:#{@port}"
+      raise RedirectionLimitExceededException, _("Too many HTTP redirections for #{@host}:#{@port}")
     end
 
     def apply_options_to(request, options)
@@ -219,7 +219,7 @@ module Puppet::Network::HTTP
       end
       response
     rescue OpenSSL::SSL::SSLError => error
-      if error.message.include? "certificate verify failed"
+      if error.message.include? _("certificate verify failed")
         msg = error.message
         msg << ": [" + @verify.verify_errors.join('; ') + "]"
         raise Puppet::Error, msg, error.backtrace
@@ -227,8 +227,8 @@ module Puppet::Network::HTTP
         leaf_ssl_cert = @verify.peer_certs.last
 
         valid_certnames = [leaf_ssl_cert.name, *leaf_ssl_cert.subject_alt_names].uniq
-        msg = valid_certnames.length > 1 ? "one of #{valid_certnames.join(', ')}" : valid_certnames.first
-        msg = "Server hostname '#{site.host}' did not match server certificate; expected #{msg}"
+        msg = valid_certnames.length > 1 ? _("one of #{valid_certnames.join(', ')}") : valid_certnames.first
+        msg = _("Server hostname '#{site.host}' did not match server certificate; expected #{msg}")
 
         raise Puppet::Error, msg, error.backtrace
       else

--- a/lib/puppet/network/http/error.rb
+++ b/lib/puppet/network/http/error.rb
@@ -20,35 +20,35 @@ module Puppet::Network::HTTP::Error
   class HTTPNotAcceptableError < HTTPError
     CODE = 406
     def initialize(message, issue_kind = Issues::RUNTIME_ERROR)
-      super("Not Acceptable: " + message, CODE, issue_kind)
+      super(_("Not Acceptable: ") + message, CODE, issue_kind)
     end
   end
 
   class HTTPNotFoundError < HTTPError
     CODE = 404
     def initialize(message, issue_kind = Issues::RUNTIME_ERROR)
-      super("Not Found: " + message, CODE, issue_kind)
+      super(_("Not Found: ") + message, CODE, issue_kind)
     end
   end
 
   class HTTPNotAuthorizedError < HTTPError
     CODE = 403
     def initialize(message, issue_kind = Issues::RUNTIME_ERROR)
-      super("Not Authorized: " + message, CODE, issue_kind)
+      super(_("Not Authorized: ") + message, CODE, issue_kind)
     end
   end
 
   class HTTPBadRequestError < HTTPError
     CODE = 400
     def initialize(message, issue_kind = Issues::RUNTIME_ERROR)
-      super("Bad Request: " + message, CODE, issue_kind)
+      super(_("Bad Request: ") + message, CODE, issue_kind)
     end
   end
 
   class HTTPMethodNotAllowedError < HTTPError
     CODE = 405
     def initialize(message, issue_kind = Issues::RUNTIME_ERROR)
-      super("Method Not Allowed: " + message, CODE, issue_kind)
+      super(_("Method Not Allowed: ") + message, CODE, issue_kind)
     end
   end
 
@@ -58,7 +58,7 @@ module Puppet::Network::HTTP::Error
     attr_reader :backtrace
 
     def initialize(original_error, issue_kind = Issues::RUNTIME_ERROR)
-      super("Server Error: " + original_error.message, CODE, issue_kind)
+      super(_("Server Error: ") + original_error.message, CODE, issue_kind)
       @backtrace = ["Warning: The 'stacktrace' property is deprecated and will be removed in a future version of Puppet. For security reasons, stacktraces are not returned with Puppet HTTP Error responses."]
     end
 

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -20,7 +20,7 @@ module Puppet::Network::HTTP::Handler
     routes.each { |r| dupes[r.path_matcher] = (dupes[r.path_matcher] || 0) + 1 }
     dupes = dupes.collect { |pm, count| pm if count > 1 }.compact
     if dupes.count > 0
-      raise ArgumentError, _("Given multiple routes with identical path regexes: #{dupes.map{ |rgx| rgx.inspect }.join(', ')}")
+      raise ArgumentError, _("Given multiple routes with identical path regexes: %{regexes}") % { regexes: dupes.map{ |rgx| rgx.inspect }.join(', ') }
     end
 
     @routes = routes
@@ -55,11 +55,11 @@ module Puppet::Network::HTTP::Handler
 
     profiler = configure_profiler(request_headers, request_params)
 
-    Puppet::Util::Profiler.profile(_("Processed request #{request_method} #{request_path}"), [:http, request_method, request_path]) do
+    Puppet::Util::Profiler.profile(_("Processed request %{request_method} %{request_path}") % { request_method: request_method, request_path: request_path }, [:http, request_method, request_path]) do
       if route = @routes.find { |r| r.matches?(new_request) }
         route.process(new_request, new_response)
       else
-        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("No route for #{new_request.method} #{new_request.path}"), HANDLER_NOT_FOUND)
+        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("No route for %{request} %{path}") % { request: new_request.method, path: new_request.path }, HANDLER_NOT_FOUND)
       end
     end
 
@@ -94,7 +94,7 @@ module Puppet::Network::HTTP::Handler
     begin
       return Resolv.getname(result[:ip])
     rescue => detail
-      Puppet.err _("Could not resolve #{result[:ip]}: #{detail}")
+      Puppet.err _("Could not resolve %{ip}: %{detail}") % { ip: result[:ip], detail: detail }
     end
     result[:ip]
   end

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -20,7 +20,7 @@ module Puppet::Network::HTTP::Handler
     routes.each { |r| dupes[r.path_matcher] = (dupes[r.path_matcher] || 0) + 1 }
     dupes = dupes.collect { |pm, count| pm if count > 1 }.compact
     if dupes.count > 0
-      raise ArgumentError, "Given multiple routes with identical path regexes: #{dupes.map{ |rgx| rgx.inspect }.join(', ')}"
+      raise ArgumentError, _("Given multiple routes with identical path regexes: #{dupes.map{ |rgx| rgx.inspect }.join(', ')}")
     end
 
     @routes = routes
@@ -55,11 +55,11 @@ module Puppet::Network::HTTP::Handler
 
     profiler = configure_profiler(request_headers, request_params)
 
-    Puppet::Util::Profiler.profile("Processed request #{request_method} #{request_path}", [:http, request_method, request_path]) do
+    Puppet::Util::Profiler.profile(_("Processed request #{request_method} #{request_path}"), [:http, request_method, request_path]) do
       if route = @routes.find { |r| r.matches?(new_request) }
         route.process(new_request, new_response)
       else
-        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("No route for #{new_request.method} #{new_request.path}", HANDLER_NOT_FOUND)
+        raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("No route for #{new_request.method} #{new_request.path}"), HANDLER_NOT_FOUND)
       end
     end
 
@@ -94,7 +94,7 @@ module Puppet::Network::HTTP::Handler
     begin
       return Resolv.getname(result[:ip])
     rescue => detail
-      Puppet.err "Could not resolve #{result[:ip]}: #{detail}"
+      Puppet.err _("Could not resolve #{result[:ip]}: #{detail}")
     end
     result[:ip]
   end

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -62,7 +62,7 @@ class Puppet::Network::HTTP::Pool
     Puppet.debug("Closing connection for #{site}")
     http.finish
   rescue => detail
-    Puppet.log_exception(detail, _("Failed to close connection for #{site}: #{detail}"))
+    Puppet.log_exception(detail, _("Failed to close connection for %{site}: %{detail}") % { site: site, detail: detail })
   end
 
   # Borrow and take ownership of a persistent connection. If a new

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -62,7 +62,7 @@ class Puppet::Network::HTTP::Pool
     Puppet.debug("Closing connection for #{site}")
     http.finish
   rescue => detail
-    Puppet.log_exception(detail, "Failed to close connection for #{site}: #{detail}")
+    Puppet.log_exception(detail, _("Failed to close connection for #{site}: #{detail}"))
   end
 
   # Borrow and take ownership of a persistent connection. If a new

--- a/lib/puppet/network/http/rack.rb
+++ b/lib/puppet/network/http/rack.rb
@@ -23,9 +23,9 @@ class Puppet::Network::HTTP::Rack
       # Send a Status 500 Error on unhandled exceptions.
       response.status = 500
       response['Content-Type'] = 'text/plain'
-      response.write 'Internal Server Error: "%s"' % detail.message
+      response.write _('Internal Server Error: "%s"') % detail.message
       # log what happened
-      Puppet.log_exception(detail, "Puppet Server (Rack): Internal Server Error: Unhandled Exception: \"%s\"" % detail.message)
+      Puppet.log_exception(detail, _("Puppet Server (Rack): Internal Server Error: Unhandled Exception: \"%s\"") % detail.message)
     end
     response.finish
   end

--- a/lib/puppet/network/http/request.rb
+++ b/lib/puppet/network/http/request.rb
@@ -11,7 +11,7 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
           hash[:client_cert],
           hash[:body])
     else
-      raise ArgumentError, "Unknown arguments: #{unknown.collect(&:inspect).join(', ')}"
+      raise ArgumentError, _("Unknown arguments: #{unknown.collect(&:inspect).join(', ')}")
     end
   end
 
@@ -24,14 +24,14 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
       header.gsub!(/\s*;.*$/,'') # strip any charset
       format = Puppet::Network::FormatHandler.mime(header)
       if format.nil?
-        raise "Client sent a mime-type (#{header}) that doesn't correspond to a format we support"
+        raise _("Client sent a mime-type (#{header}) that doesn't correspond to a format we support")
       else
         assert_supported_format(format)
         return format.name.to_s if format.suitable?
       end
     end
 
-    raise "No Content-Type header was received, it isn't possible to unserialize the request"
+    raise _("No Content-Type header was received, it isn't possible to unserialize the request")
   end
 
   def response_formatter_for(supported_formats, accepted_formats = headers['accept'])
@@ -40,7 +40,7 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
       supported_formats)
 
       if formatter.nil?
-        raise Puppet::Network::HTTP::Error::HTTPNotAcceptableError.new("No supported formats are acceptable (Accept: #{accepted_formats})", Puppet::Network::HTTP::Issues::UNSUPPORTED_FORMAT)
+        raise Puppet::Network::HTTP::Error::HTTPNotAcceptableError.new(_("No supported formats are acceptable (Accept: #{accepted_formats})"), Puppet::Network::HTTP::Issues::UNSUPPORTED_FORMAT)
       end
 
       assert_supported_format(formatter)
@@ -50,7 +50,7 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
 
   def assert_supported_format(format)
     if format.name == :yaml || format.name == :b64_zlib_yaml
-      raise Puppet::Error, "YAML in network requests is not supported. See http://links.puppetlabs.com/deprecate_yaml_on_network"
+      raise Puppet::Error, _("YAML in network requests is not supported. See http://links.puppetlabs.com/deprecate_yaml_on_network")
     end
   end
 end

--- a/lib/puppet/network/http/request.rb
+++ b/lib/puppet/network/http/request.rb
@@ -11,7 +11,7 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
           hash[:client_cert],
           hash[:body])
     else
-      raise ArgumentError, _("Unknown arguments: #{unknown.collect(&:inspect).join(', ')}")
+      raise ArgumentError, _("Unknown arguments: %{args}") % { args: unknown.collect(&:inspect).join(', ') }
     end
   end
 
@@ -24,7 +24,8 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
       header.gsub!(/\s*;.*$/,'') # strip any charset
       format = Puppet::Network::FormatHandler.mime(header)
       if format.nil?
-        raise _("Client sent a mime-type (#{header}) that doesn't correspond to a format we support")
+        #TRANSLATORS "mime-type" is a keyword and should not be translated
+        raise _("Client sent a mime-type (%{header}) that doesn't correspond to a format we support") % { header: header }
       else
         assert_supported_format(format)
         return format.name.to_s if format.suitable?
@@ -40,7 +41,7 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
       supported_formats)
 
       if formatter.nil?
-        raise Puppet::Network::HTTP::Error::HTTPNotAcceptableError.new(_("No supported formats are acceptable (Accept: #{accepted_formats})"), Puppet::Network::HTTP::Issues::UNSUPPORTED_FORMAT)
+        raise Puppet::Network::HTTP::Error::HTTPNotAcceptableError.new(_("No supported formats are acceptable (Accept: %{accepted_formats})") % { accepted_formats: accepted_formats }, Puppet::Network::HTTP::Issues::UNSUPPORTED_FORMAT)
       end
 
       assert_supported_format(formatter)

--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -97,7 +97,7 @@ class Puppet::Network::HTTP::WEBrick
     # Get the cached copy.  We know it's been generated, too.
     host = Puppet::SSL::Host.localhost
 
-    raise Puppet::Error, _("Could not retrieve certificate for #{host.name} and not running on a valid certificate authority") unless host.certificate
+    raise Puppet::Error, _("Could not retrieve certificate for %{host} and not running on a valid certificate authority") % { value0: host.name } unless host.certificate
 
     results[:SSLPrivateKey] = host.key.content
     results[:SSLCertificate] = host.certificate.content

--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -21,13 +21,13 @@ class Puppet::Network::HTTP::WEBrick
 
     @server.mount('/', Puppet::Network::HTTP::WEBrickREST)
 
-    raise "WEBrick server is already listening" if @listening
+    raise _("WEBrick server is already listening") if @listening
     @listening = true
     @thread = Thread.new do
       @server.start do |sock|
         timeout = 10.0
         if ! IO.select([sock],nil,nil,timeout)
-          raise "Client did not send data within %.1f seconds of connecting" % timeout
+          raise _("Client did not send data within %.1f seconds of connecting") % timeout
         end
         sock.accept
         @server.run(sock)
@@ -37,7 +37,7 @@ class Puppet::Network::HTTP::WEBrick
   end
 
   def unlisten
-    raise "WEBrick server is not listening" unless @listening
+    raise _("WEBrick server is not listening") unless @listening
     @server.shutdown
     wait_for_shutdown
     @server = nil
@@ -97,7 +97,7 @@ class Puppet::Network::HTTP::WEBrick
     # Get the cached copy.  We know it's been generated, too.
     host = Puppet::SSL::Host.localhost
 
-    raise Puppet::Error, "Could not retrieve certificate for #{host.name} and not running on a valid certificate authority" unless host.certificate
+    raise Puppet::Error, _("Could not retrieve certificate for #{host.name} and not running on a valid certificate authority") unless host.certificate
 
     results[:SSLPrivateKey] = host.key.content
     results[:SSLCertificate] = host.certificate.content
@@ -105,7 +105,7 @@ class Puppet::Network::HTTP::WEBrick
     results[:SSLEnable] = true
     results[:SSLOptions] = OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3
 
-    raise Puppet::Error, "Could not find CA certificate" unless Puppet::SSL::Certificate.indirection.find(Puppet::SSL::CA_NAME)
+    raise Puppet::Error, _("Could not find CA certificate") unless Puppet::SSL::Certificate.indirection.find(Puppet::SSL::CA_NAME)
 
     results[:SSLCACertificateFile] = ssl_configuration.ca_auth_file
     results[:SSLVerifyClient] = OpenSSL::SSL::VERIFY_PEER

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -13,7 +13,7 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
   end
 
   def initialize(server)
-    raise ArgumentError, "server is required" unless server
+    raise ArgumentError, _("server is required") unless server
     register([Puppet::Network::HTTP::API.master_routes,
               Puppet::Network::HTTP::API.ca_routes,
               Puppet::Network::HTTP::API.not_found_upgrade])

--- a/lib/puppet/network/rights.rb
+++ b/lib/puppet/network/rights.rb
@@ -55,7 +55,7 @@ class Rights
     # case will return an error to the outside world
     msg = "#{name} [#{args[:method]}]"
 
-    AuthorizationError.new("Forbidden request: #{msg}")
+    AuthorizationError.new(_("Forbidden request: #{msg}"))
   end
 
   def initialize
@@ -123,7 +123,7 @@ class Rights
         @name = name.gsub(/^~\s+/,'')
         @key = Regexp.new(@name)
       else
-        raise ArgumentError, "Unknown right type '#{name}'"
+        raise ArgumentError, _("Unknown right type '#{name}'")
       end
 
       super()
@@ -165,21 +165,21 @@ class Rights
     def restrict_method(m)
       m = m.intern if m.is_a?(String)
 
-      raise ArgumentError, "'#{m}' is not an allowed value for method directive" unless ALL.include?(m)
+      raise ArgumentError, _("'#{m}' is not an allowed value for method directive") unless ALL.include?(m)
 
       # if we were allowing all methods, then starts from scratch
       if @methods === ALL
         @methods = []
       end
 
-      raise ArgumentError, "'#{m}' is already in the '#{name}' ACL" if @methods.include?(m)
+      raise ArgumentError, _("'#{m}' is already in the '#{name}' ACL") if @methods.include?(m)
 
       @methods << m
     end
 
     def restrict_environment(environment)
       env = Puppet.lookup(:environments).get(environment)
-      raise ArgumentError, "'#{env}' is already in the '#{name}' ACL" if @environment.include?(env)
+      raise ArgumentError, _("'#{env}' is already in the '#{name}' ACL") if @environment.include?(env)
 
       @environment << env
     end
@@ -191,7 +191,7 @@ class Rights
       when "no", "off", "false", false, "all" ,"any", :all, :any
         authentication = false
       else
-        raise ArgumentError, "'#{name}' incorrect authenticated value: #{authentication}"
+        raise ArgumentError, _("'#{name}' incorrect authenticated value: #{authentication}")
       end
       @authentication = authentication
     end

--- a/lib/puppet/network/rights.rb
+++ b/lib/puppet/network/rights.rb
@@ -55,7 +55,7 @@ class Rights
     # case will return an error to the outside world
     msg = "#{name} [#{args[:method]}]"
 
-    AuthorizationError.new(_("Forbidden request: #{msg}"))
+    AuthorizationError.new(_("Forbidden request: %{msg}") % { msg: msg })
   end
 
   def initialize
@@ -123,7 +123,7 @@ class Rights
         @name = name.gsub(/^~\s+/,'')
         @key = Regexp.new(@name)
       else
-        raise ArgumentError, _("Unknown right type '#{name}'")
+        raise ArgumentError, _("Unknown right type '%{name}'") % { name: name }
       end
 
       super()
@@ -165,21 +165,21 @@ class Rights
     def restrict_method(m)
       m = m.intern if m.is_a?(String)
 
-      raise ArgumentError, _("'#{m}' is not an allowed value for method directive") unless ALL.include?(m)
+      raise ArgumentError, _("'%{m}' is not an allowed value for method directive") % { m: m } unless ALL.include?(m)
 
       # if we were allowing all methods, then starts from scratch
       if @methods === ALL
         @methods = []
       end
 
-      raise ArgumentError, _("'#{m}' is already in the '#{name}' ACL") if @methods.include?(m)
+      raise ArgumentError, _("'%{m}' is already in the '%{name}' ACL") % { m: m, name: name } if @methods.include?(m)
 
       @methods << m
     end
 
     def restrict_environment(environment)
       env = Puppet.lookup(:environments).get(environment)
-      raise ArgumentError, _("'#{env}' is already in the '#{name}' ACL") if @environment.include?(env)
+      raise ArgumentError, _("'%{env}' is already in the '%{name}' ACL") % { env: env, name: name } if @environment.include?(env)
 
       @environment << env
     end
@@ -191,7 +191,7 @@ class Rights
       when "no", "off", "false", false, "all" ,"any", :all, :any
         authentication = false
       else
-        raise ArgumentError, _("'#{name}' incorrect authenticated value: #{authentication}")
+        raise ArgumentError, _("'%{name}' incorrect authenticated value: %{authentication}") % { name: name, authentication: authentication }
       end
       @authentication = authentication
     end

--- a/lib/puppet/network/server.rb
+++ b/lib/puppet/network/server.rb
@@ -22,13 +22,13 @@ class Puppet::Network::Server
   end
 
   def start
-    raise "Cannot listen -- already listening." if listening?
+    raise _("Cannot listen -- already listening.") if listening?
     @listening = true
     @http_server.listen(address, port)
   end
 
   def stop
-    raise "Cannot unlisten -- not currently listening." unless listening?
+    raise _("Cannot unlisten -- not currently listening.") unless listening?
     @http_server.unlisten
     @listening = false
   end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/network/*` for translation.