### PR TITLE
(PUP-7042) Mark strings in node

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -24,7 +24,7 @@ class Puppet::Node
   ENVIRONMENT = 'environment'.freeze
 
   def initialize_from_hash(data)
-    @name       = data['name']       || (raise ArgumentError, "No name provided in serialized data")
+    @name       = data['name']       || (raise ArgumentError, _("No name provided in serialized data"))
     @classes    = data['classes']    || []
     @parameters = data['parameters'] || {}
     @environment_name = data['environment']
@@ -86,7 +86,7 @@ class Puppet::Node
   end
 
   def initialize(name, options = {})
-    raise ArgumentError, "Node names cannot be nil" unless name
+    raise ArgumentError, _("Node names cannot be nil") unless name
     @name = name
 
     if classes = options[:classes]
@@ -119,7 +119,7 @@ class Puppet::Node
       merge(@facts.values)
     end
   rescue => detail
-    error = Puppet::Error.new("Could not retrieve facts for #{name}: #{detail}")
+    error = Puppet::Error.new(_("Could not retrieve facts for #{name}: #{detail}"))
     error.set_backtrace(detail.backtrace)
     raise error
   end
@@ -128,7 +128,7 @@ class Puppet::Node
   def merge(params)
     params.each do |name, value|
       if @parameters.include?(name)
-        Puppet::Util::Warnings.warnonce("The node parameter '#{name}' for node '#{@name}' was already set to '#{@parameters[name]}'. It could not be set to '#{value}'")
+        Puppet::Util::Warnings.warnonce(_("The node parameter '#{name}' for node '#{@name}' was already set to '#{@parameters[name]}'. It could not be set to '#{value}'"))
       else
         @parameters[name] = value
       end
@@ -159,7 +159,7 @@ class Puppet::Node
       if parameters["hostname"] and parameters["domain"]
         fqdn = parameters["hostname"] + "." + parameters["domain"]
       else
-        Puppet.warning "Host is missing hostname and/or domain: #{name}"
+        Puppet.warning _("Host is missing hostname and/or domain: #{name}")
       end
     end
 
@@ -191,7 +191,7 @@ class Puppet::Node
   # Ensures the data is frozen
   #
   def trusted_data=(data)
-    Puppet.warning("Trusted node data modified for node #{name}") unless @trusted_data.nil?
+    Puppet.warning(_("Trusted node data modified for node #{name}")) unless @trusted_data.nil?
     @trusted_data = data.freeze
   end
 end

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -119,7 +119,7 @@ class Puppet::Node
       merge(@facts.values)
     end
   rescue => detail
-    error = Puppet::Error.new(_("Could not retrieve facts for #{name}: #{detail}"))
+    error = Puppet::Error.new(_("Could not retrieve facts for %{name}: %{detail}") % { name: name, detail: detail })
     error.set_backtrace(detail.backtrace)
     raise error
   end
@@ -128,7 +128,7 @@ class Puppet::Node
   def merge(params)
     params.each do |name, value|
       if @parameters.include?(name)
-        Puppet::Util::Warnings.warnonce(_("The node parameter '#{name}' for node '#{@name}' was already set to '#{@parameters[name]}'. It could not be set to '#{value}'"))
+        Puppet::Util::Warnings.warnonce(_("The node parameter '%{param_name}' for node '%{node_name}' was already set to '%{value}'. It could not be set to '%{desired_value}'") % { param_name: name, node_name: @name, value: @parameters[name], desired_value: value })
       else
         @parameters[name] = value
       end
@@ -159,7 +159,7 @@ class Puppet::Node
       if parameters["hostname"] and parameters["domain"]
         fqdn = parameters["hostname"] + "." + parameters["domain"]
       else
-        Puppet.warning _("Host is missing hostname and/or domain: #{name}")
+        Puppet.warning _("Host is missing hostname and/or domain: %{name}") % { name: name }
       end
     end
 
@@ -191,7 +191,7 @@ class Puppet::Node
   # Ensures the data is frozen
   #
   def trusted_data=(data)
-    Puppet.warning(_("Trusted node data modified for node #{name}")) unless @trusted_data.nil?
+    Puppet.warning(_("Trusted node data modified for node %{name}") % { name: name }) unless @trusted_data.nil?
     @trusted_data = data.freeze
   end
 end

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -213,7 +213,7 @@ class Puppet::Node::Environment
   def validation_errors
     errors = []
     if conflicting_manifest_settings?
-      errors << _("The 'disable_per_environment_manifest' setting is true, and the '#{name}' environment has an environment.conf manifest that conflicts with the 'default_manifest' setting.")
+      errors << _("The 'disable_per_environment_manifest' setting is true, and the '%{env_name}' environment has an environment.conf manifest that conflicts with the 'default_manifest' setting.") % { env_name: name }
     end
     errors
   end
@@ -530,7 +530,7 @@ class Puppet::Node::Environment
   rescue => detail
     @known_resource_types.parse_failed = true
 
-    msg = _("Could not parse for environment #{self}: #{detail}")
+    msg = _("Could not parse for environment %{env}: %{detail}") % { env: self, detail: detail }
     error = Puppet::Error.new(msg)
     error.set_backtrace(detail.backtrace)
     raise error

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -213,7 +213,7 @@ class Puppet::Node::Environment
   def validation_errors
     errors = []
     if conflicting_manifest_settings?
-      errors << "The 'disable_per_environment_manifest' setting is true, and the '#{name}' environment has an environment.conf manifest that conflicts with the 'default_manifest' setting."
+      errors << _("The 'disable_per_environment_manifest' setting is true, and the '#{name}' environment has an environment.conf manifest that conflicts with the 'default_manifest' setting.")
     end
     errors
   end
@@ -530,7 +530,7 @@ class Puppet::Node::Environment
   rescue => detail
     @known_resource_types.parse_failed = true
 
-    msg = "Could not parse for environment #{self}: #{detail}"
+    msg = _("Could not parse for environment #{self}: #{detail}")
     error = Puppet::Error.new(msg)
     error.set_backtrace(detail.backtrace)
     raise error

--- a/lib/puppet/parameter/package_options.rb
+++ b/lib/puppet/parameter/package_options.rb
@@ -19,7 +19,7 @@ class Puppet::Parameter::PackageOptions < Puppet::Parameter
       when String
         quote(val)
       else
-        fail("Expected either a string or hash of options")
+        fail(_("Expected either a string or hash of options"))
       end
     end
   end

--- a/lib/puppet/parameter/path.rb
+++ b/lib/puppet/parameter/path.rb
@@ -24,10 +24,10 @@ class Puppet::Parameter::Path < Puppet::Parameter
   #
   def validate_path(paths)
     if paths.is_a?(Array) and ! self.class.arrays? then
-      fail "#{name} only accepts a single path, not an array of paths"
+      fail _("#{name} only accepts a single path, not an array of paths")
     end
 
-    fail("#{name} must be a fully qualified path") unless Array(paths).all? {|path| absolute_path?(path)}
+    fail(_("#{name} must be a fully qualified path")) unless Array(paths).all? {|path| absolute_path?(path)}
 
     paths
   end
@@ -50,7 +50,7 @@ class Puppet::Parameter::Path < Puppet::Parameter
   # @raise [Puppet::Error] if the given paths does not comply with the on/many paths rule.
   def unsafe_munge(paths)
     if paths.is_a?(Array) and ! self.class.arrays? then
-      fail "#{name} only accepts a single path, not an array of paths"
+      fail _("#{name} only accepts a single path, not an array of paths")
     end
     paths
   end

--- a/lib/puppet/parameter/path.rb
+++ b/lib/puppet/parameter/path.rb
@@ -24,10 +24,10 @@ class Puppet::Parameter::Path < Puppet::Parameter
   #
   def validate_path(paths)
     if paths.is_a?(Array) and ! self.class.arrays? then
-      fail _("#{name} only accepts a single path, not an array of paths")
+      fail _("%{name} only accepts a single path, not an array of paths") % { name: name }
     end
 
-    fail(_("#{name} must be a fully qualified path")) unless Array(paths).all? {|path| absolute_path?(path)}
+    fail(_("%{name} must be a fully qualified path") % { name: name }) unless Array(paths).all? {|path| absolute_path?(path)}
 
     paths
   end
@@ -50,7 +50,7 @@ class Puppet::Parameter::Path < Puppet::Parameter
   # @raise [Puppet::Error] if the given paths does not comply with the on/many paths rule.
   def unsafe_munge(paths)
     if paths.is_a?(Array) and ! self.class.arrays? then
-      fail _("#{name} only accepts a single path, not an array of paths")
+      fail _("%{name} only accepts a single path, not an array of paths") % { name: name }
     end
     paths
   end

--- a/lib/puppet/parameter/value_collection.rb
+++ b/lib/puppet/parameter/value_collection.rb
@@ -181,11 +181,11 @@ class Puppet::Parameter::ValueCollection
     return if empty?
 
     unless @values.detect { |name, v| v.match?(value) }
-      str = _("Invalid value #{value.inspect}. ")
+      str = _("Invalid value %{value}. ") % { value: value.inspect }
 
-      str += _("Valid values are #{values.join(", ")}. ") unless values.empty?
+      str += _("Valid values are %{value_list}. ") % { value_list: values.join(", ") } unless values.empty?
 
-      str += _("Valid values match #{regexes.join(", ")}.") unless regexes.empty?
+      str += _("Valid values match %{pattern}.") % { pattern: regexes.join(", ") } unless regexes.empty?
 
       raise ArgumentError, str
     end

--- a/lib/puppet/parameter/value_collection.rb
+++ b/lib/puppet/parameter/value_collection.rb
@@ -133,7 +133,7 @@ class Puppet::Parameter::ValueCollection
     call_opt = options[:call]
     unless call_opt.nil?
       devfail "Cannot use obsolete :call value '#{call_opt}' for property '#{self.class.name}'" unless call_opt == :none || call_opt == :instead
-      Puppet.deprecation_warning("Property option :call is deprecated and no longer used. Please remove it.")
+      Puppet.deprecation_warning(_("Property option :call is deprecated and no longer used. Please remove it."))
       options = options.reject { |k,v| k == :call }
     end
 
@@ -181,11 +181,11 @@ class Puppet::Parameter::ValueCollection
     return if empty?
 
     unless @values.detect { |name, v| v.match?(value) }
-      str = "Invalid value #{value.inspect}. "
+      str = _("Invalid value #{value.inspect}. ")
 
-      str += "Valid values are #{values.join(", ")}. " unless values.empty?
+      str += _("Valid values are #{values.join(", ")}. ") unless values.empty?
 
-      str += "Valid values match #{regexes.join(", ")}." unless regexes.empty?
+      str += _("Valid values match #{regexes.join(", ")}.") unless regexes.empty?
 
       raise ArgumentError, str
     end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/node.rb` and `lib/puppet/node/*` for translation.