### PR TITLE
(PUP-7042) Mark strings in parser

### DIFF
--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -180,7 +180,7 @@ class Puppet::Parser::AST::PopsBridge
         # when running tests that run a partial setup.
         # This is bad if the logic is trying to compile, but a warning can not be issues since it is a normal
         # use case that there is no scope when requesting the type in order to just get the parameters.
-        Puppet.debug {"Instantiating Resource with type checked parameters - scope is missing, skipping type checking."}
+        Puppet.debug {_("Instantiating Resource with type checked parameters - scope is missing, skipping type checking.")}
         nil
       end
       scope

--- a/lib/puppet/parser/ast/resource.rb
+++ b/lib/puppet/parser/ast/resource.rb
@@ -6,7 +6,7 @@ class Puppet::Parser::AST::Resource < Puppet::Parser::AST::Branch
   attr_accessor :type, :instances, :exported, :virtual
 
   def initialize(argshash)
-    Puppet.warn_once('deprecation', 'AST::Resource', 'Use of Puppet::Parser::AST::Resource is deprecated and not fully functional')
+    Puppet.warn_once('deprecation', 'AST::Resource', _('Use of Puppet::Parser::AST::Resource is deprecated and not fully functional'))
     super(argshash)
   end
 

--- a/lib/puppet/parser/ast/resource_instance.rb
+++ b/lib/puppet/parser/ast/resource_instance.rb
@@ -4,7 +4,7 @@
 class Puppet::Parser::AST::ResourceInstance < Puppet::Parser::AST::Branch
   attr_accessor :title, :parameters
   def initialize(argshash)
-    Puppet.warn_once('deprecation', 'AST::ResourceInstance', 'Use of Puppet::Parser::AST::ResourceInstance is deprecated')
+    Puppet.warn_once('deprecation', 'AST::ResourceInstance', _('Use of Puppet::Parser::AST::ResourceInstance is deprecated'))
     super(argshash)
   end
 end

--- a/lib/puppet/parser/ast/resourceparam.rb
+++ b/lib/puppet/parser/ast/resourceparam.rb
@@ -4,7 +4,7 @@ class Puppet::Parser::AST::ResourceParam < Puppet::Parser::AST::Branch
   attr_accessor :value, :param, :add
 
   def initialize(argshash)
-    Puppet.warn_once('deprecation', 'AST::ResourceParam', 'Use of Puppet::Parser::AST::ResourceParam is deprecated and not fully functional')
+    Puppet.warn_once('deprecation', 'AST::ResourceParam', _('Use of Puppet::Parser::AST::ResourceParam is deprecated and not fully functional'))
     super(argshash)
   end
 

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -36,7 +36,7 @@ class Puppet::Parser::Compiler
     Puppet.log_exception(detail)
     raise
   rescue => detail
-    message = "#{detail} on node #{node.name}"
+    message = _("#{detail} on node #{node.name}")
     Puppet.log_exception(detail, message)
     raise Puppet::Error, message, detail.backtrace
  end
@@ -79,7 +79,7 @@ class Puppet::Parser::Compiler
     if @current_app
       # We are in the process of pulling application components out that
       # apply to this node
-      Puppet.notice "Check #{resource}"
+      Puppet.notice _("Check #{resource}")
       return unless @current_components.any? do |comp|
         comp.type == resource.type && comp.title == resource.title
       end
@@ -91,7 +91,7 @@ class Puppet::Parser::Compiler
     @catalog.add_resource(resource)
 
     if not resource.class? and resource[:stage]
-      raise ArgumentError, "Only classes can set 'stage'; normal resources like #{resource} cannot change run stage"
+      raise ArgumentError, _("Only classes can set 'stage'; normal resources like #{resource} cannot change run stage")
     end
 
     # Stages should not be inside of classes.  They are always a
@@ -117,7 +117,7 @@ class Puppet::Parser::Compiler
           return if upstream.keys.map(&:type).include?('Site')
         end
       end
-      raise ArgumentError, "Application instances like '#{resource}' can only be contained within a Site"
+      raise ArgumentError, _("Application instances like '#{resource}' can only be contained within a Site")
     end
   end
 
@@ -143,42 +143,42 @@ class Puppet::Parser::Compiler
   # Compiler our catalog.  This mostly revolves around finding and evaluating classes.
   # This is the main entry into our catalog.
   def compile
-    Puppet.override( @context_overrides , "For compiling #{node.name}") do
+    Puppet.override( @context_overrides , _("For compiling #{node.name}")) do
       @catalog.environment_instance = environment
 
       # Set the client's parameters into the top scope.
-      Puppet::Util::Profiler.profile("Compile: Set node parameters", [:compiler, :set_node_params]) { set_node_parameters }
+      Puppet::Util::Profiler.profile(_("Compile: Set node parameters"), [:compiler, :set_node_params]) { set_node_parameters }
 
-      Puppet::Util::Profiler.profile("Compile: Created settings scope", [:compiler, :create_settings_scope]) { create_settings_scope }
+      Puppet::Util::Profiler.profile(_("Compile: Created settings scope"), [:compiler, :create_settings_scope]) { create_settings_scope }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated capability mappings", [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated capability mappings"), [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated main", [:compiler, :evaluate_main]) { evaluate_main }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated main"), [:compiler, :evaluate_main]) { evaluate_main }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated site", [:compiler, :evaluate_site]) { evaluate_site }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated site"), [:compiler, :evaluate_site]) { evaluate_site }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated AST node", [:compiler, :evaluate_ast_node]) { evaluate_ast_node }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated AST node"), [:compiler, :evaluate_ast_node]) { evaluate_ast_node }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated node classes", [:compiler, :evaluate_node_classes]) { evaluate_node_classes }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated node classes"), [:compiler, :evaluate_node_classes]) { evaluate_node_classes }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated application instances", [:compiler, :evaluate_applications]) { evaluate_applications }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated application instances"), [:compiler, :evaluate_applications]) { evaluate_applications }
 
       # New capability mappings may have been defined when the site was evaluated
-      Puppet::Util::Profiler.profile("Compile: Evaluated site capability mappings", [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated site capability mappings"), [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
 
-      Puppet::Util::Profiler.profile("Compile: Evaluated generators", [:compiler, :evaluate_generators]) { evaluate_generators }
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated generators"), [:compiler, :evaluate_generators]) { evaluate_generators }
 
-      Puppet::Util::Profiler.profile("Compile: Validate Catalog pre-finish", [:compiler, :validate_pre_finish]) do
+      Puppet::Util::Profiler.profile(_("Compile: Validate Catalog pre-finish"), [:compiler, :validate_pre_finish]) do
         validate_catalog(CatalogValidator::PRE_FINISH)
       end
 
-      Puppet::Util::Profiler.profile("Compile: Finished catalog", [:compiler, :finish_catalog]) { finish }
+      Puppet::Util::Profiler.profile(_("Compile: Finished catalog"), [:compiler, :finish_catalog]) { finish }
 
-      Puppet::Util::Profiler.profile("Compile: Prune", [:compiler, :prune_catalog]) { prune_catalog }
+      Puppet::Util::Profiler.profile(_("Compile: Prune"), [:compiler, :prune_catalog]) { prune_catalog }
 
       fail_on_unevaluated
 
-      Puppet::Util::Profiler.profile("Compile: Validate Catalog final", [:compiler, :validate_final]) do
+      Puppet::Util::Profiler.profile(_("Compile: Validate Catalog final"), [:compiler, :validate_final]) do
         validate_catalog(CatalogValidator::FINAL)
       end
 
@@ -308,14 +308,14 @@ class Puppet::Parser::Compiler
     @applications.each do |app|
       components = []
       mapping = app.parameters[:nodes] ? app.parameters[:nodes].value : {}
-      raise Puppet::Error, "Invalid node mapping in #{app.ref}: Mapping must be a hash" unless mapping.is_a?(Hash)
+      raise Puppet::Error, _("Invalid node mapping in #{app.ref}: Mapping must be a hash") unless mapping.is_a?(Hash)
       all_mapped = Set.new
       mapping.each do |k,v|
-        raise Puppet::Error, "Invalid node mapping in #{app.ref}: Key #{k} is not a Node" unless k.is_a?(Puppet::Resource) && k.type == 'Node'
+        raise Puppet::Error, _("Invalid node mapping in #{app.ref}: Key #{k} is not a Node") unless k.is_a?(Puppet::Resource) && k.type == _('Node')
         v = [v] unless v.is_a?(Array)
         v.each do |res|
-          raise Puppet::Error, "Invalid node mapping in #{app.ref}: Value #{res} is not a resource" unless res.is_a?(Puppet::Resource)
-          raise Puppet::Error, "Application #{app.ref} maps component #{res} to multiple nodes" if all_mapped.add?(res.ref).nil?
+          raise Puppet::Error, _("Invalid node mapping in #{app.ref}: Value #{res} is not a resource") unless res.is_a?(Puppet::Resource)
+          raise Puppet::Error, _("Application #{app.ref} maps component #{res} to multiple nodes") if all_mapped.add?(res.ref).nil?
           components << res if k.title == node.name
         end
       end
@@ -360,7 +360,7 @@ class Puppet::Parser::Compiler
     end
 
     hostclasses = classes.collect do |name|
-      environment.known_resource_types.find_hostclass(name) or raise Puppet::Error, "Could not find class #{name} for #{node.name}"
+      environment.known_resource_types.find_hostclass(name) or raise Puppet::Error, _("Could not find class #{name} for #{node.name}")
     end
 
     if class_parameters
@@ -485,7 +485,7 @@ class Puppet::Parser::Compiler
     end
 
     unless (astnode ||= krt.node("default"))
-      raise Puppet::ParseError, "Could not find node statement with name 'default' or '#{node.names.join(", ")}'"
+      raise Puppet::ParseError, _("Could not find node statement with name 'default' or '#{node.names.join(", ")}'")
     end
 
     # Create a resource to model this node, and then add it to the list
@@ -506,7 +506,7 @@ class Puppet::Parser::Compiler
       # We have to iterate over a dup of the array because
       # collections can delete themselves from the list, which
       # changes its length and causes some collections to get missed.
-      Puppet::Util::Profiler.profile("Evaluated collections", [:compiler, :evaluate_collections]) do
+      Puppet::Util::Profiler.profile(_("Evaluated collections"), [:compiler, :evaluate_collections]) do
         found_something = false
         @collections.dup.each do |collection|
           found_something = true if collection.evaluate
@@ -521,7 +521,7 @@ class Puppet::Parser::Compiler
   # evaluate_generators loop.
   def evaluate_definitions
     exceptwrap do
-      Puppet::Util::Profiler.profile("Evaluated definitions", [:compiler, :evaluate_definitions]) do
+      Puppet::Util::Profiler.profile(_("Evaluated definitions"), [:compiler, :evaluate_definitions]) do
         urs = unevaluated_resources.each do |resource|
          begin
             resource.evaluate
@@ -550,7 +550,7 @@ class Puppet::Parser::Compiler
     loop do
       done = true
 
-      Puppet::Util::Profiler.profile("Iterated (#{count + 1}) on generators", [:compiler, :iterate_on_generators]) do
+      Puppet::Util::Profiler.profile(_("Iterated (#{count + 1}) on generators"), [:compiler, :iterate_on_generators]) do
         # Call collections first, then definitions.
         done = false if evaluate_collections
         done = false if evaluate_definitions
@@ -561,7 +561,7 @@ class Puppet::Parser::Compiler
       count += 1
 
       if count > 1000
-        raise Puppet::ParseError, "Somehow looped more than 1000 times while evaluating host catalog"
+        raise Puppet::ParseError, _("Somehow looped more than 1000 times while evaluating host catalog")
       end
     end
   end
@@ -592,7 +592,7 @@ class Puppet::Parser::Compiler
     remaining = @resource_overrides.values.flatten.collect(&:ref)
 
     if !remaining.empty?
-      raise Puppet::ParseError, "Could not find resource(s) #{remaining.join(', ')} for overriding"
+      raise Puppet::ParseError, _("Could not find resource(s) #{remaining.join(', ')} for overriding")
     end
   end
 
@@ -603,7 +603,7 @@ class Puppet::Parser::Compiler
   def fail_on_unevaluated_resource_collections
     remaining = @collections.collect(&:unresolved_resources).flatten.compact
     if !remaining.empty?
-      raise Puppet::ParseError, "Failed to realize virtual resources #{remaining.join(', ')}"
+      raise Puppet::ParseError, _("Failed to realize virtual resources #{remaining.join(', ')}")
     end
   end
 
@@ -632,7 +632,7 @@ class Puppet::Parser::Compiler
 
   def add_resource_metaparams
     unless main = catalog.resource(:class, :main)
-      raise "Couldn't find main"
+      raise _("Couldn't find main")
     end
 
     names = Puppet::Type.metaparams.select do |name|
@@ -704,7 +704,7 @@ class Puppet::Parser::Compiler
     # It cannot survive the initvars method, and is later reinstated
     # as part of compiling...
     #
-    Puppet.override( @context_overrides , "For initializing compiler") do
+    Puppet.override( @context_overrides , _("For initializing compiler")) do
       # THE MAGIC STARTS HERE ! This triggers parsing, loading etc.
       @catalog.version = environment.known_resource_types.version
     end

--- a/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
@@ -14,7 +14,7 @@ class Puppet::Parser::Compiler
         end
       end
       assumed_exports.each_pair do |key, (param, cap)|
-        raise CatalogValidationError.new("Capability '#{cap}' referenced by '#{param.name}' is never exported", param.file, param.line) unless exported.include?(key)
+        raise CatalogValidationError.new(_("Capability '#{cap}' referenced by '#{param.name}' is never exported"), param.file, param.line) unless exported.include?(key)
       end
       nil
     end
@@ -53,7 +53,7 @@ class Puppet::Parser::Compiler
         unless rt.nil? || !rt.is_capability?
           title_key = catalog.title_key_for_ref(value.ref)
           if hash.include?(title_key)
-            raise CatalogValidationError.new("'#{value}' is exported by both '#{hash[title_key]}' and '#{resource}'", param.file, param.line)
+            raise CatalogValidationError.new(_("'#{value}' is exported by both '#{hash[title_key]}' and '#{resource}'"), param.file, param.line)
           else
             hash[title_key] = resource
           end

--- a/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
@@ -14,7 +14,7 @@ class Puppet::Parser::Compiler
         end
       end
       assumed_exports.each_pair do |key, (param, cap)|
-        raise CatalogValidationError.new(_("Capability '#{cap}' referenced by '#{param.name}' is never exported"), param.file, param.line) unless exported.include?(key)
+        raise CatalogValidationError.new(_("Capability '%{cap}' referenced by '%{param}' is never exported") % { cap: cap, param: param.name }, param.file, param.line) unless exported.include?(key)
       end
       nil
     end
@@ -53,7 +53,7 @@ class Puppet::Parser::Compiler
         unless rt.nil? || !rt.is_capability?
           title_key = catalog.title_key_for_ref(value.ref)
           if hash.include?(title_key)
-            raise CatalogValidationError.new(_("'#{value}' is exported by both '#{hash[title_key]}' and '#{resource}'"), param.file, param.line)
+            raise CatalogValidationError.new(_("'%{value}' is exported by both '%{hash}' and '%{resource}'") % { value: value, hash: hash[title_key], resource: resource }, param.file, param.line)
           else
             hash[title_key] = resource
           end

--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -23,7 +23,7 @@ class Puppet::Parser::Compiler
       if has_capability?(param.value)
         unless CAPABILITY_ACCEPTED_METAPARAMS[param.name]
           raise CatalogValidationError.new(
-            _("'#{param.name}' is not a valid relationship to a capability"),
+            _("'%{param}' is not a valid relationship to a capability") % { param: param.name },
               param.file, param.line)
         end
       else
@@ -32,7 +32,7 @@ class Puppet::Parser::Compiler
         refs.each do |r|
           next if r.nil? || r == :undef
           unless catalog.resource(r.to_s)
-            msg = _("Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'")
+            msg = _("Could not find resource '%{res}' in parameter '%{param}'") % { res: r.to_s, param: param.name.to_s }
             raise CatalogValidationError.new(msg, param.file, param.line)
           end
         end

--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -23,7 +23,7 @@ class Puppet::Parser::Compiler
       if has_capability?(param.value)
         unless CAPABILITY_ACCEPTED_METAPARAMS[param.name]
           raise CatalogValidationError.new(
-            "'#{param.name}' is not a valid relationship to a capability", 
+            _("'#{param.name}' is not a valid relationship to a capability"),
               param.file, param.line)
         end
       else
@@ -32,7 +32,7 @@ class Puppet::Parser::Compiler
         refs.each do |r|
           next if r.nil? || r == :undef
           unless catalog.resource(r.to_s)
-            msg = "Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'"
+            msg = _("Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'")
             raise CatalogValidationError.new(msg, param.file, param.line)
           end
         end

--- a/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
@@ -11,7 +11,7 @@ class Puppet::Parser::Compiler
 
       catalog.downstream_from_vertex(the_site_resource).keys.each do |r|
         unless r.is_application_component? || r.resource_type.application?
-          raise CatalogValidationError.new(_("Only application components can appear inside a site - #{r} is not allowed"), r.file, r.line)
+          raise CatalogValidationError.new(_("Only application components can appear inside a site - %{res} is not allowed") % { res: r }, r.file, r.line)
         end
       end
     end

--- a/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
@@ -11,7 +11,7 @@ class Puppet::Parser::Compiler
 
       catalog.downstream_from_vertex(the_site_resource).keys.each do |r|
         unless r.is_application_component? || r.resource_type.application?
-          raise CatalogValidationError.new("Only application components can appear inside a site - #{r} is not allowed", r.file, r.line)
+          raise CatalogValidationError.new(_("Only application components can appear inside a site - #{r} is not allowed"), r.file, r.line)
         end
       end
     end

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -9,7 +9,7 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
       node.environment = env
       new(node, :code_id => code_id).compile
     rescue => detail
-      message = _("#{detail} in environment #{env.name}")
+      message = _("%{detail} in environment %{env}") % { detail: detail, env: env.name }
       Puppet.log_exception(detail, message)
       raise Puppet::Error, message, detail.backtrace
     end
@@ -56,7 +56,7 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   def compile
     add_function_overrides
     begin
-      Puppet.override(@context_overrides, _("For compiling environment catalog #{environment.name}")) do
+      Puppet.override(@context_overrides, _("For compiling environment catalog %{env}") % { env: environment.name }) do
         @catalog.environment_instance = environment
 
         Puppet::Util::Profiler.profile(_("Env Compile: Created settings scope"), [:compiler, :create_settings_scope]) { create_settings_scope }
@@ -131,7 +131,7 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
     @catalog.add_resource(resource)
 
     if !resource.class? && resource[:stage]
-      raise ArgumentError, _("Only classes can set 'stage'; normal resources like #{resource} cannot change run stage")
+      raise ArgumentError, _("Only classes can set 'stage'; normal resources like %{resource} cannot change run stage") % { resource: resource }
     end
 
     # Stages should not be inside of classes.  They are always a
@@ -159,7 +159,7 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   def evaluate_applications
     exceptwrap do
       resources.select { |resource| type = resource.resource_type; type.is_a?(Puppet::Resource::Type) && type.application? }.each do |resource|
-        Puppet::Util::Profiler.profile(_("Evaluated application #{resource}"), [:compiler, :evaluate_resource, resource]) do
+        Puppet::Util::Profiler.profile(_("Evaluated application %{resource}") % { resource: resource }, [:compiler, :evaluate_resource, resource]) do
           resource.evaluate
         end
       end

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -9,7 +9,7 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
       node.environment = env
       new(node, :code_id => code_id).compile
     rescue => detail
-      message = "#{detail} in environment #{env.name}"
+      message = _("#{detail} in environment #{env.name}")
       Puppet.log_exception(detail, message)
       raise Puppet::Error, message, detail.backtrace
     end
@@ -56,28 +56,28 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   def compile
     add_function_overrides
     begin
-      Puppet.override(@context_overrides, "For compiling environment catalog #{environment.name}") do
+      Puppet.override(@context_overrides, _("For compiling environment catalog #{environment.name}")) do
         @catalog.environment_instance = environment
 
-        Puppet::Util::Profiler.profile("Env Compile: Created settings scope", [:compiler, :create_settings_scope]) { create_settings_scope }
+        Puppet::Util::Profiler.profile(_("Env Compile: Created settings scope"), [:compiler, :create_settings_scope]) { create_settings_scope }
 
-        Puppet::Util::Profiler.profile("Env Compile: Evaluated main", [:compiler, :evaluate_main]) { evaluate_main }
+        Puppet::Util::Profiler.profile(_("Env Compile: Evaluated main"), [:compiler, :evaluate_main]) { evaluate_main }
 
-        Puppet::Util::Profiler.profile("Env Compile: Evaluated site", [:compiler, :evaluate_site]) { evaluate_site }
+        Puppet::Util::Profiler.profile(_("Env Compile: Evaluated site"), [:compiler, :evaluate_site]) { evaluate_site }
 
-        Puppet::Util::Profiler.profile("Env Compile: Evaluated application instances", [:compiler, :evaluate_applications]) { evaluate_applications }
+        Puppet::Util::Profiler.profile(_("Env Compile: Evaluated application instances"), [:compiler, :evaluate_applications]) { evaluate_applications }
 
-        Puppet::Util::Profiler.profile("Env Compile: Prune", [:compiler, :prune_catalog]) { prune_catalog }
+        Puppet::Util::Profiler.profile(_("Env Compile: Prune"), [:compiler, :prune_catalog]) { prune_catalog }
 
-        Puppet::Util::Profiler.profile("Env Compile: Validate Catalog pre-finish", [:compiler, :validate_pre_finish]) do
+        Puppet::Util::Profiler.profile(_("Env Compile: Validate Catalog pre-finish"), [:compiler, :validate_pre_finish]) do
           validate_catalog(CatalogValidator::PRE_FINISH)
         end
 
-        Puppet::Util::Profiler.profile("Env Compile: Finished catalog", [:compiler, :finish_catalog]) { finish }
+        Puppet::Util::Profiler.profile(_("Env Compile: Finished catalog"), [:compiler, :finish_catalog]) { finish }
 
         fail_on_unevaluated
 
-        Puppet::Util::Profiler.profile("Env Compile: Validate Catalog final", [:compiler, :validate_final]) do
+        Puppet::Util::Profiler.profile(_("Env Compile: Validate Catalog final"), [:compiler, :validate_final]) do
           validate_catalog(CatalogValidator::FINAL)
         end
 
@@ -131,7 +131,7 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
     @catalog.add_resource(resource)
 
     if !resource.class? && resource[:stage]
-      raise ArgumentError, "Only classes can set 'stage'; normal resources like #{resource} cannot change run stage"
+      raise ArgumentError, _("Only classes can set 'stage'; normal resources like #{resource} cannot change run stage")
     end
 
     # Stages should not be inside of classes.  They are always a
@@ -153,13 +153,13 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   end
 
   def on_empty_site
-    Puppet.warning("Environment Compiler: Could not find a site definition to evaluate")
+    Puppet.warning(_("Environment Compiler: Could not find a site definition to evaluate"))
   end
 
   def evaluate_applications
     exceptwrap do
       resources.select { |resource| type = resource.resource_type; type.is_a?(Puppet::Resource::Type) && type.application? }.each do |resource|
-        Puppet::Util::Profiler.profile("Evaluated application #{resource}", [:compiler, :evaluate_resource, resource]) do
+        Puppet::Util::Profiler.profile(_("Evaluated application #{resource}"), [:compiler, :evaluate_resource, resource]) do
           resource.evaluate
         end
       end

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -146,7 +146,7 @@ module Puppet::Parser::Functions
     name = name.intern
     environment = options[:environment] || Puppet.lookup(:current_environment)
 
-    Puppet.warning "Overwriting previous definition for function #{name}" if get_function(name, environment)
+    Puppet.warning _("Overwriting previous definition for function #{name}") if get_function(name, environment)
 
     arity = options[:arity] || -1
     ftype = options[:type] || :statement
@@ -164,16 +164,16 @@ module Puppet::Parser::Functions
     env_module = environment_module(environment)
 
     env_module.send(:define_method, fname) do |*args|
-      Puppet::Util::Profiler.profile("Called #{name}", [:functions, name]) do
+      Puppet::Util::Profiler.profile(_("Called #{name}"), [:functions, name]) do
         if args[0].is_a? Array
           if arity >= 0 and args[0].size != arity
-            raise ArgumentError, "#{name}(): Wrong number of arguments given (#{args[0].size} for #{arity})"
+            raise ArgumentError, _("#{name}(): Wrong number of arguments given (#{args[0].size} for #{arity})")
           elsif arity < 0 and args[0].size < (arity+1).abs
-            raise ArgumentError, "#{name}(): Wrong number of arguments given (#{args[0].size} for minimum #{(arity+1).abs})"
+            raise ArgumentError, _("#{name}(): Wrong number of arguments given (#{args[0].size} for minimum #{(arity+1).abs})")
           end
           self.send(real_fname, args[0])
         else
-          raise ArgumentError, "custom functions must be called with a single array that contains the arguments. For example, function_example([1]) instead of function_example(1)"
+          raise ArgumentError, _("custom functions must be called with a single array that contains the arguments. For example, function_example([1]) instead of function_example(1)")
         end
       end
     end
@@ -272,7 +272,7 @@ module Puppet::Parser::Functions
 
   class Error
     def self.is4x(name)
-      raise Puppet::ParseError, "#{name}() can only be called using the 4.x function API. See Scope#call_function"
+      raise Puppet::ParseError, _("#{name}() can only be called using the 4.x function API. See Scope#call_function")
     end
   end
 end

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -146,7 +146,7 @@ module Puppet::Parser::Functions
     name = name.intern
     environment = options[:environment] || Puppet.lookup(:current_environment)
 
-    Puppet.warning _("Overwriting previous definition for function #{name}") if get_function(name, environment)
+    Puppet.warning _("Overwriting previous definition for function %{name}") % { name: name } if get_function(name, environment)
 
     arity = options[:arity] || -1
     ftype = options[:type] || :statement
@@ -164,12 +164,12 @@ module Puppet::Parser::Functions
     env_module = environment_module(environment)
 
     env_module.send(:define_method, fname) do |*args|
-      Puppet::Util::Profiler.profile(_("Called #{name}"), [:functions, name]) do
+      Puppet::Util::Profiler.profile(_("Called %{name}") % { name: name }, [:functions, name]) do
         if args[0].is_a? Array
           if arity >= 0 and args[0].size != arity
-            raise ArgumentError, _("#{name}(): Wrong number of arguments given (#{args[0].size} for #{arity})")
+            raise ArgumentError, _("%{name}(): Wrong number of arguments given (%{arg_count} for %{arity})") % { name: name, arg_count: args[0].size, arity: arity }
           elsif arity < 0 and args[0].size < (arity+1).abs
-            raise ArgumentError, _("#{name}(): Wrong number of arguments given (#{args[0].size} for minimum #{(arity+1).abs})")
+            raise ArgumentError, _("%{name}(): Wrong number of arguments given (%{arg_count} for minimum %{min_arg_count})") % { name: name, arg_count: args[0].size, min_arg_count: (arity+1).abs }
           end
           self.send(real_fname, args[0])
         else
@@ -272,7 +272,7 @@ module Puppet::Parser::Functions
 
   class Error
     def self.is4x(name)
-      raise Puppet::ParseError, _("#{name}() can only be called using the 4.x function API. See Scope#call_function")
+      raise Puppet::ParseError, _("%{name}() can only be called using the 4.x function API. See Scope#call_function") % { name: name }
     end
   end
 end

--- a/lib/puppet/parser/functions/contain.rb
+++ b/lib/puppet/parser/functions/contain.rb
@@ -25,6 +25,6 @@ allowing the function call to `contain` to directly continue.
 "
 ) do |classes|
   # Call the 4.x version of this function in case 3.x ruby code uses this function
-  Puppet.warn_once(:deprecation, '3xfunction#contain', "Calling function_contain via the Scope class is deprecated. Use Scope#call_function instead")
+  Puppet.warn_once(:deprecation, '3xfunction#contain', _("Calling function_contain via the Scope class is deprecated. Use Scope#call_function instead"))
   call_function('contain', classes)
 end

--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -47,7 +47,7 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
     final value of a parameter (just as when setting a parameter to `undef` in a puppet language
     resource declaration).
   ENDHEREDOC
-  raise ArgumentError, (_("create_resources(): wrong number of arguments (#{args.length}; must be 2 or 3)")) if args.length > 3
+  raise ArgumentError, (_("create_resources(): wrong number of arguments (%{count}; must be 2 or 3)") % { count: args.length }) if args.length > 3
   raise ArgumentError, (_('create_resources(): second argument must be a hash')) unless args[1].is_a?(Hash)
   if args.length == 3
     raise ArgumentError, (_('create_resources(): third argument, if provided, must be a hash')) unless args[2].is_a?(Hash)

--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -47,10 +47,10 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
     final value of a parameter (just as when setting a parameter to `undef` in a puppet language
     resource declaration).
   ENDHEREDOC
-  raise ArgumentError, ("create_resources(): wrong number of arguments (#{args.length}; must be 2 or 3)") if args.length > 3
-  raise ArgumentError, ('create_resources(): second argument must be a hash') unless args[1].is_a?(Hash)
+  raise ArgumentError, (_("create_resources(): wrong number of arguments (#{args.length}; must be 2 or 3)")) if args.length > 3
+  raise ArgumentError, (_('create_resources(): second argument must be a hash')) unless args[1].is_a?(Hash)
   if args.length == 3
-    raise ArgumentError, ('create_resources(): third argument, if provided, must be a hash') unless args[2].is_a?(Hash)
+    raise ArgumentError, (_('create_resources(): third argument, if provided, must be a hash')) unless args[2].is_a?(Hash)
   end
 
   type, instances, defaults = args

--- a/lib/puppet/parser/functions/file.rb
+++ b/lib/puppet/parser/functions/file.rb
@@ -28,6 +28,6 @@ Puppet::Parser::Functions::newfunction(
     if path
       Puppet::FileSystem.read_preserve_line_endings(path)
     else
-      raise Puppet::ParseError, _("Could not find any files from #{vals.join(", ")}")
+      raise Puppet::ParseError, _("Could not find any files from %{values}") % { values: vals.join(", ") }
     end
 end

--- a/lib/puppet/parser/functions/file.rb
+++ b/lib/puppet/parser/functions/file.rb
@@ -28,6 +28,6 @@ Puppet::Parser::Functions::newfunction(
     if path
       Puppet::FileSystem.read_preserve_line_endings(path)
     else
-      raise Puppet::ParseError, "Could not find any files from #{vals.join(", ")}"
+      raise Puppet::ParseError, _("Could not find any files from #{vals.join(", ")}")
     end
 end

--- a/lib/puppet/parser/functions/generate.rb
+++ b/lib/puppet/parser/functions/generate.rb
@@ -11,6 +11,7 @@ Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue
     generators, so all shell metacharacters are passed directly to
     the generator.") do |args|
 
+      #TRANSLATORS "fully qualified" refers to a fully qualified file system path
       raise Puppet::ParseError, _("Generators must be fully qualified") unless Puppet::Util.absolute_path?(args[0])
 
       if Puppet.features.microsoft_windows?
@@ -32,6 +33,6 @@ Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue
       begin
         Dir.chdir(File.dirname(args[0])) { Puppet::Util::Execution.execute(args).to_str }
       rescue Puppet::ExecutionFailure => detail
-        raise Puppet::ParseError, _("Failed to execute generator #{args[0]}: #{detail}"), detail.backtrace
+        raise Puppet::ParseError, _("Failed to execute generator %{generator}: %{detail}") % { generator: args[0], detail: detail }, detail.backtrace
       end
 end

--- a/lib/puppet/parser/functions/generate.rb
+++ b/lib/puppet/parser/functions/generate.rb
@@ -11,7 +11,7 @@ Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue
     generators, so all shell metacharacters are passed directly to
     the generator.") do |args|
 
-      raise Puppet::ParseError, "Generators must be fully qualified" unless Puppet::Util.absolute_path?(args[0])
+      raise Puppet::ParseError, _("Generators must be fully qualified") unless Puppet::Util.absolute_path?(args[0])
 
       if Puppet.features.microsoft_windows?
         valid = args[0] =~ /^[a-z]:(?:[\/\\][-.~\w]+)+$/i
@@ -21,17 +21,17 @@ Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue
 
       unless valid
         raise Puppet::ParseError,
-          "Generators can only contain alphanumerics, file separators, and dashes"
+          _("Generators can only contain alphanumerics, file separators, and dashes")
       end
 
       if args[0] =~ /\.\./
         raise Puppet::ParseError,
-          "Can not use generators with '..' in them."
+          _("Can not use generators with '..' in them.")
       end
 
       begin
         Dir.chdir(File.dirname(args[0])) { Puppet::Util::Execution.execute(args).to_str }
       rescue Puppet::ExecutionFailure => detail
-        raise Puppet::ParseError, "Failed to execute generator #{args[0]}: #{detail}", detail.backtrace
+        raise Puppet::ParseError, _("Failed to execute generator #{args[0]}: #{detail}"), detail.backtrace
       end
 end

--- a/lib/puppet/parser/functions/include.rb
+++ b/lib/puppet/parser/functions/include.rb
@@ -28,6 +28,6 @@ the future parser's resource and relationship expressions.
 - Since 4.0.0 support for class and resource type values, absolute names
 - Since 4.7.0 returns an Array[Type[Class]] of all included classes 
 ") do |classes|
-  Puppet.warn_once(:deprecation, '3xfunction#include', "Calling function_include via the Scope class is deprecated. Use Scope#call_function instead")
   call_function('include', classes)
+  Puppet.warn_once(:deprecation, '3xfunction#include', _("Calling function_include via the Scope class is deprecated. Use Scope#call_function instead"))
 end

--- a/lib/puppet/parser/functions/include.rb
+++ b/lib/puppet/parser/functions/include.rb
@@ -29,5 +29,6 @@ the future parser's resource and relationship expressions.
 - Since 4.7.0 returns an Array[Type[Class]] of all included classes 
 ") do |classes|
   call_function('include', classes)
+  #TRANSLATORS "function_include", "Scope", and "Scope#call_function" refer to Puppet internals and should not be translated
   Puppet.warn_once(:deprecation, '3xfunction#include', _("Calling function_include via the Scope class is deprecated. Use Scope#call_function instead"))
 end

--- a/lib/puppet/parser/functions/inline_template.rb
+++ b/lib/puppet/parser/functions/inline_template.rb
@@ -15,7 +15,7 @@ Puppet::Parser::Functions::newfunction(:inline_template, :type => :rvalue, :arit
         wrapper.result(string)
       rescue => detail
         raise Puppet::ParseError,
-          "Failed to parse inline template: #{detail}", detail.backtrace
+          _("Failed to parse inline template: #{detail}"), detail.backtrace
       end
     end.join("")
 end

--- a/lib/puppet/parser/functions/inline_template.rb
+++ b/lib/puppet/parser/functions/inline_template.rb
@@ -15,7 +15,7 @@ Puppet::Parser::Functions::newfunction(:inline_template, :type => :rvalue, :arit
         wrapper.result(string)
       rescue => detail
         raise Puppet::ParseError,
-          _("Failed to parse inline template: #{detail}"), detail.backtrace
+          _("Failed to parse inline template: %{detail}") % { detail: detail }, detail.backtrace
       end
     end.join("")
 end

--- a/lib/puppet/parser/functions/require.rb
+++ b/lib/puppet/parser/functions/require.rb
@@ -35,6 +35,6 @@ resource and relationship expressions.
 - Since 4.0.0 Class and Resource types, absolute names
 - Since 4.7.0 Returns an Array[Type[Class]] with references to the required classes
 ") do |classes|
-  Puppet.warn_once(:deprecation, '3xfunction#require', "Calling function_require via the Scope class is deprecated. Use Scope#call_function instead")
   call_function('require', classes)
+  Puppet.warn_once(:deprecation, '3xfunction#require', _("Calling function_require via the Scope class is deprecated. Use Scope#call_function instead"))
 end

--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -27,23 +27,23 @@ class Puppet::Parser::Relationship
   end
 
   def param_name
-    PARAM_MAP[type] || raise(ArgumentError, "Invalid relationship type #{type}")
+    PARAM_MAP[type] || raise(ArgumentError, _("Invalid relationship type #{type}"))
   end
 
   def mk_relationship(source, target, catalog)
     # There was once an assumption that this could be an array. These raise
     # assertions are here as a sanity check for 4.0 and can be removed after
     # a release or two
-    raise ArgumentError, "source shouldn't be an array" if source.is_a?(Array)
-    raise ArgumentError, "target shouldn't be an array" if target.is_a?(Array)
+    raise ArgumentError, _("source shouldn't be an array") if source.is_a?(Array)
+    raise ArgumentError, _("target shouldn't be an array") if target.is_a?(Array)
     source = source.to_s
     target = target.to_s
 
     unless source_resource = catalog.resource(source)
-      raise ArgumentError, "Could not find resource '#{source}' for relationship on '#{target}'"
+      raise ArgumentError, _("Could not find resource '#{source}' for relationship on '#{target}'")
     end
     unless catalog.resource(target)
-      raise ArgumentError, "Could not find resource '#{target}' for relationship from '#{source}'"
+      raise ArgumentError, _("Could not find resource '#{target}' for relationship from '#{source}'")
     end
     Puppet.debug {"Adding relationship from #{source} to #{target} with '#{param_name}'"}
     if source_resource[param_name].class != Array

--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -27,23 +27,25 @@ class Puppet::Parser::Relationship
   end
 
   def param_name
-    PARAM_MAP[type] || raise(ArgumentError, _("Invalid relationship type #{type}"))
+    PARAM_MAP[type] || raise(ArgumentError, _("Invalid relationship type %{relationship_type}") % { relationship_type: type })
   end
 
   def mk_relationship(source, target, catalog)
     # There was once an assumption that this could be an array. These raise
     # assertions are here as a sanity check for 4.0 and can be removed after
     # a release or two
+    #TRANSLATORS "source" is a keyword and should not be translated
     raise ArgumentError, _("source shouldn't be an array") if source.is_a?(Array)
+    #TRANSLATORS "target" is a keyword and should not be translated
     raise ArgumentError, _("target shouldn't be an array") if target.is_a?(Array)
     source = source.to_s
     target = target.to_s
 
     unless source_resource = catalog.resource(source)
-      raise ArgumentError, _("Could not find resource '#{source}' for relationship on '#{target}'")
+      raise ArgumentError, _("Could not find resource '%{source}' for relationship on '%{target}'") % { source: source, target: target }
     end
     unless catalog.resource(target)
-      raise ArgumentError, _("Could not find resource '#{target}' for relationship from '#{source}'")
+      raise ArgumentError, _("Could not find resource '%{target}' for relationship from '%{source}'") % { target: target, source: source }
     end
     Puppet.debug {"Adding relationship from #{source} to #{target} with '#{param_name}'"}
     if source_resource[param_name].class != Array

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -60,7 +60,7 @@ class Puppet::Parser::Resource < Puppet::Resource
     return unless self.class?
 
     unless stage = catalog.resource(:stage, self[:stage] || (scope && scope.resource && scope.resource[:stage]) || :main)
-      raise ArgumentError, _("Could not find stage #{self[:stage] || :main} specified by #{self}")
+      raise ArgumentError, _("Could not find stage %{stage} specified by %{resource}") % { stage: self[:stage] || :main, resource: self }
     end
 
     self[:stage] ||= stage.title unless stage.title == :main
@@ -70,7 +70,7 @@ class Puppet::Parser::Resource < Puppet::Resource
   # Retrieve the associated definition and evaluate it.
   def evaluate
     return if evaluated?
-    Puppet::Util::Profiler.profile(_("Evaluated resource #{self}"), [:compiler, :evaluate_resource, self]) do
+    Puppet::Util::Profiler.profile(_("Evaluated resource %{res}") % { res: self }, [:compiler, :evaluate_resource, self]) do
       @evaluated = true
       if builtin_type?
         devfail "Cannot evaluate a builtin type (#{type})"
@@ -242,18 +242,18 @@ class Puppet::Parser::Resource < Puppet::Resource
     map = {}
     [ self[:consume] ].flatten.map do |ref|
       # Assert that the ref really is a resource reference
-      raise Puppet::Error, _("Invalid consume in #{self.ref}: #{ref} is not a resource") unless ref.is_a?(Puppet::Resource)
+      raise Puppet::Error, _("Invalid consume in %{value0}: %{ref} is not a resource") % { value0: self.ref, ref: ref } unless ref.is_a?(Puppet::Resource)
 
       # Resolve references
       t = ref.type
       t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
       cap = catalog.resource(t, ref.title)
       if cap.nil?
-        raise _("Resource #{ref} could not be found; it might not have been produced yet")
+        raise _("Resource %{ref} could not be found; it might not have been produced yet") % { ref: ref }
       end
 
       # Ensure that the found resource is a capability resource
-      raise Puppet::Error, _("Invalid consume in #{ref}: #{cap} is not a capability resource") unless cap.resource_type.is_capability?
+      raise Puppet::Error, _("Invalid consume in %{ref}: %{cap} is not a capability resource") % { ref: ref, cap: cap } unless cap.resource_type.is_capability?
       cap
     end.each do |cns|
       # Establish mappings
@@ -262,7 +262,7 @@ class Puppet::Parser::Resource < Puppet::Resource
       end
       # @todo lutter 2015-08-03: catch this earlier, can we do this during
       # static analysis ?
-      raise _("Resource #{self} tries to consume #{cns} but no 'consumes' mapping exists for #{self.resource_type} and #{cns.type}") unless blueprint
+      raise _("Resource %{res} tries to consume %{cns} but no 'consumes' mapping exists for %{resource_type} and %{cns_type}") % { res: self, cns: cns, resource_type: self.resource_type, cns_type: cns.type } unless blueprint
 
       # setup scope that has, for each attr of cns, a binding to cns[attr]
       scope.with_global_scope do |global_scope|
@@ -281,7 +281,7 @@ class Puppet::Parser::Resource < Puppet::Resource
             # @todo lutter 2015-07-01: this should be caught by the checker
             # much earlier. We consume several capres, at least two of which
             # want to map to the same parameter (PUP-5080)
-            raise _("Attempt to reassign attribute '#{name}' in '#{self}' caused by multiple consumed mappings to the same attribute") if map[name]
+            raise _("Attempt to reassign attribute '%{name}' in '%{resource}' caused by multiple consumed mappings to the same attribute") % { name: name, resource: self } if map[name]
             map[name] = value
           end
         end
@@ -380,7 +380,7 @@ class Puppet::Parser::Resource < Puppet::Resource
   def extract_parameters(params)
     params.each do |param|
       # Don't set the same parameter twice
-      self.fail Puppet::ParseError, _("Duplicate parameter '#{param.name}' for on #{self}") if @parameters[param.name]
+      self.fail Puppet::ParseError, _("Duplicate parameter '%{param}' for on %{resource}") % { param: param.name, resource: self } if @parameters[param.name]
 
       set_parameter(param)
     end

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -60,7 +60,7 @@ class Puppet::Parser::Resource < Puppet::Resource
     return unless self.class?
 
     unless stage = catalog.resource(:stage, self[:stage] || (scope && scope.resource && scope.resource[:stage]) || :main)
-      raise ArgumentError, "Could not find stage #{self[:stage] || :main} specified by #{self}"
+      raise ArgumentError, _("Could not find stage #{self[:stage] || :main} specified by #{self}")
     end
 
     self[:stage] ||= stage.title unless stage.title == :main
@@ -70,7 +70,7 @@ class Puppet::Parser::Resource < Puppet::Resource
   # Retrieve the associated definition and evaluate it.
   def evaluate
     return if evaluated?
-    Puppet::Util::Profiler.profile("Evaluated resource #{self}", [:compiler, :evaluate_resource, self]) do
+    Puppet::Util::Profiler.profile(_("Evaluated resource #{self}"), [:compiler, :evaluate_resource, self]) do
       @evaluated = true
       if builtin_type?
         devfail "Cannot evaluate a builtin type (#{type})"
@@ -125,8 +125,8 @@ class Puppet::Parser::Resource < Puppet::Resource
   end
 
   def initialize(type, title, attributes)
-    raise ArgumentError, 'Resources require a hash as last argument' unless attributes.is_a? Hash
-    raise ArgumentError, 'Resources require a scope' unless attributes[:scope]
+    raise ArgumentError, _('Resources require a hash as last argument') unless attributes.is_a? Hash
+    raise ArgumentError, _('Resources require a scope') unless attributes[:scope]
     super
 
     @source ||= scope.source
@@ -156,7 +156,7 @@ class Puppet::Parser::Resource < Puppet::Resource
     # Test the resource scope, to make sure the resource is even allowed
     # to override.
     unless self.source.object_id == resource.source.object_id || resource.source.child_of?(self.source)
-      raise Puppet::ParseError.new("Only subclasses can override parameters", resource.file, resource.line)
+      raise Puppet::ParseError.new(_("Only subclasses can override parameters"), resource.file, resource.line)
     end
     # Some of these might fail, but they'll fail in the way we want.
     resource.parameters.each do |name, param|
@@ -242,18 +242,18 @@ class Puppet::Parser::Resource < Puppet::Resource
     map = {}
     [ self[:consume] ].flatten.map do |ref|
       # Assert that the ref really is a resource reference
-      raise Puppet::Error, "Invalid consume in #{self.ref}: #{ref} is not a resource" unless ref.is_a?(Puppet::Resource)
+      raise Puppet::Error, _("Invalid consume in #{self.ref}: #{ref} is not a resource") unless ref.is_a?(Puppet::Resource)
 
       # Resolve references
       t = ref.type
       t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t) unless t == 'class' || t == 'node'
       cap = catalog.resource(t, ref.title)
       if cap.nil?
-        raise "Resource #{ref} could not be found; it might not have been produced yet"
+        raise _("Resource #{ref} could not be found; it might not have been produced yet")
       end
 
       # Ensure that the found resource is a capability resource
-      raise Puppet::Error, "Invalid consume in #{ref}: #{cap} is not a capability resource" unless cap.resource_type.is_capability?
+      raise Puppet::Error, _("Invalid consume in #{ref}: #{cap} is not a capability resource") unless cap.resource_type.is_capability?
       cap
     end.each do |cns|
       # Establish mappings
@@ -262,7 +262,7 @@ class Puppet::Parser::Resource < Puppet::Resource
       end
       # @todo lutter 2015-08-03: catch this earlier, can we do this during
       # static analysis ?
-      raise "Resource #{self} tries to consume #{cns} but no 'consumes' mapping exists for #{self.resource_type} and #{cns.type}" unless blueprint
+      raise _("Resource #{self} tries to consume #{cns} but no 'consumes' mapping exists for #{self.resource_type} and #{cns.type}") unless blueprint
 
       # setup scope that has, for each attr of cns, a binding to cns[attr]
       scope.with_global_scope do |global_scope|
@@ -281,7 +281,7 @@ class Puppet::Parser::Resource < Puppet::Resource
             # @todo lutter 2015-07-01: this should be caught by the checker
             # much earlier. We consume several capres, at least two of which
             # want to map to the same parameter (PUP-5080)
-            raise "Attempt to reassign attribute '#{name}' in '#{self}' caused by multiple consumed mappings to the same attribute" if map[name]
+            raise _("Attempt to reassign attribute '#{name}' in '#{self}' caused by multiple consumed mappings to the same attribute") if map[name]
             map[name] = value
           end
         end
@@ -380,7 +380,7 @@ class Puppet::Parser::Resource < Puppet::Resource
   def extract_parameters(params)
     params.each do |param|
       # Don't set the same parameter twice
-      self.fail Puppet::ParseError, "Duplicate parameter '#{param.name}' for on #{self}" if @parameters[param.name]
+      self.fail Puppet::ParseError, _("Duplicate parameter '#{param.name}' for on #{self}") if @parameters[param.name]
 
       set_parameter(param)
     end

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -155,12 +155,12 @@ class Puppet::Parser::Scope
 
     def []=(name, value)
       # TODO: Bad choice of exception
-      raise Puppet::ParseError, "Numerical variables cannot be changed. Attempt to set $#{name}"
+      raise Puppet::ParseError, _("Numerical variables cannot be changed. Attempt to set $#{name}")
     end
 
     def delete(name)
       # TODO: Bad choice of exception
-      raise Puppet::ParseError, "Numerical variables cannot be deleted: Attempt to delete: $#{name}"
+      raise Puppet::ParseError, _("Numerical variables cannot be deleted: Attempt to delete: $#{name}")
     end
 
     def add_entries_to(target = {})
@@ -214,8 +214,8 @@ class Puppet::Parser::Scope
     def parameter_reference_failure(from, to)
       # Parameters are evaluated in the order they have in the @params hash.
       keys = @params.keys
-      raise Puppet::Error, "#{@callee_name}: expects a value for parameter $#{to}" if keys.index(to) < keys.index(from)
-      raise Puppet::Error, "#{@callee_name}: default expression for $#{from} tries to illegally access not yet evaluated $#{to}"
+      raise Puppet::Error, _("#{@callee_name}: expects a value for parameter $#{to}") if keys.index(to) < keys.index(from)
+      raise Puppet::Error, _("#{@callee_name}: default expression for $#{from} tries to illegally access not yet evaluated $#{to}")
     end
     private :parameter_reference_failure
 
@@ -234,7 +234,7 @@ class Puppet::Parser::Scope
     end
 
     def []=(name, value)
-      raise Puppet::Error, "Attempt to assign variable #{name} when evaluating parameters" if @read_only
+      raise Puppet::Error, _("Attempt to assign variable #{name} when evaluating parameters") if @read_only
       @params[name] ||= Access.new
       @params[name].value = value
     end
@@ -486,7 +486,7 @@ class Puppet::Parser::Scope
   # @api public
   def lookupvar(name, options = EMPTY_HASH)
     unless name.is_a? String
-      raise Puppet::ParseError, "Scope variable name #{name.inspect} is a #{name.class}, not a string"
+      raise Puppet::ParseError, _("Scope variable name #{name.inspect} is a #{name.class}, not a string")
     end
 
     if name =~ /^(.*)::(.+)$/
@@ -525,10 +525,10 @@ class Puppet::Parser::Scope
       when :off
         # do nothing
       when :warning
-        Puppet.warn_once(UNDEFINED_VARIABLES_KIND, "Variable: #{name}",
-        "Undefined variable '#{name}'; #{reason}" )
+        Puppet.warn_once(UNDEFINED_VARIABLES_KIND, _("Variable: #{name}"),
+        _("Undefined variable '#{name}'; #{reason}") )
       when :error
-        raise ArgumentError, "Undefined variable '#{name}'; #{reason}"
+        raise ArgumentError, _("Undefined variable '#{name}'; #{reason}")
       end
     end
     nil
@@ -653,8 +653,8 @@ class Puppet::Parser::Scope
   private :has_enclosing_scope?
 
   def qualified_scope(classname)
-    raise "class #{classname} could not be found"     unless klass = find_hostclass(classname)
-    raise "class #{classname} has not been evaluated" unless kscope = class_scope(klass)
+    raise _("class #{classname} could not be found")     unless klass = find_hostclass(classname)
+    raise _("class #{classname} has not been evaluated") unless kscope = class_scope(klass)
     kscope
   end
   private :qualified_scope
@@ -704,7 +704,7 @@ class Puppet::Parser::Scope
 
     params.each { |param|
       if table.include?(param.name)
-        raise Puppet::ParseError.new("Default already defined for #{type} { #{param.name} }; cannot redefine", param.file, param.line)
+        raise Puppet::ParseError.new(_("Default already defined for #{type} { #{param.name} }; cannot redefine"), param.file, param.line)
       end
       table[param.name] = param
     }
@@ -750,28 +750,28 @@ class Puppet::Parser::Scope
   # when you need to set options.
   def setvar(name, value, options = EMPTY_HASH)
     if name =~ /^[0-9]+$/
-      raise Puppet::ParseError.new("Cannot assign to a numeric match result variable '$#{name}'") # unless options[:ephemeral]
+      raise Puppet::ParseError.new(_("Cannot assign to a numeric match result variable '$#{name}'")) # unless options[:ephemeral]
     end
     unless name.is_a? String
-      raise Puppet::ParseError, "Scope variable name #{name.inspect} is a #{name.class}, not a string"
+      raise Puppet::ParseError, _("Scope variable name #{name.inspect} is a #{name.class}, not a string")
     end
 
     # Check for reserved variable names
     if (name == VARNAME_TRUSTED || name == VARNAME_FACTS) && !options[:privileged]
-      raise Puppet::ParseError, "Attempt to assign to a reserved variable name: '#{name}'"
+      raise Puppet::ParseError, _("Attempt to assign to a reserved variable name: '#{name}'")
     end
 
     # Check for server_facts reserved variable name if the trusted_sever_facts setting is true
     if name == VARNAME_SERVER_FACTS && !options[:privileged] && Puppet[:trusted_server_facts]
-      raise Puppet::ParseError, "Attempt to assign to a reserved variable name: '#{name}'"
+      raise Puppet::ParseError, _("Attempt to assign to a reserved variable name: '#{name}'")
     end
 
     table = effective_symtable(options[:ephemeral])
     if table.bound?(name)
       if options[:append]
-        error = Puppet::ParseError.new("Cannot append, variable '$#{name}' is defined in this scope")
+        error = Puppet::ParseError.new(_("Cannot append, variable '$#{name}' is defined in this scope"))
       else
-        error = Puppet::ParseError.new("Cannot reassign variable '$#{name}'")
+        error = Puppet::ParseError.new(_("Cannot reassign variable '$#{name}'"))
       end
       error.file = options[:file] if options[:file]
       error.line = options[:line] if options[:line]
@@ -816,7 +816,7 @@ class Puppet::Parser::Scope
     when String
       object.freeze
     else
-      raise Puppet::Error, "Unsupported data type: '#{object.class}'"
+      raise Puppet::Error, _("Unsupported data type: '#{object.class}'")
     end
     object
   end
@@ -861,7 +861,7 @@ class Puppet::Parser::Scope
       bound_value.merge(new_value)
     else
       if bound_value.is_a?(Hash)
-        raise ArgumentError, "Trying to append to a hash with something which is not a hash is unsupported"
+        raise ArgumentError, _("Trying to append to a hash with something which is not a hash is unsupported")
       end
       bound_value + new_value
     end
@@ -883,7 +883,7 @@ class Puppet::Parser::Scope
   # @deprecated use #pop_epehemeral
   # @api private
   def unset_ephemeral_var(level=:all)
-    Puppet.deprecation_warning('Method Parser::Scope#unset_ephemeral_var() is deprecated')
+    Puppet.deprecation_warning(_('Method Parser::Scope#unset_ephemeral_var() is deprecated'))
     if level == :all
       @ephemeral = [ MatchScope.new(@symtable, nil)]
     else
@@ -1005,7 +1005,7 @@ class Puppet::Parser::Scope
       # (TODO: Fix that problem)
       new_ephemeral(false)
     else
-      raise(ArgumentError,"Invalid regex match data. Got a #{match.class}") unless match.is_a?(MatchData)
+      raise(ArgumentError,_("Invalid regex match data. Got a #{match.class}")) unless match.is_a?(MatchData)
       # Create a match ephemeral and set values from match data
       new_match_scope(match)
     end
@@ -1094,7 +1094,7 @@ class Puppet::Parser::Scope
         name.title.sub(/^([^:]{1,2})/, '::\1')
 
       when Puppet::Pops::Types::PHostClassType
-        raise ArgumentError, "Cannot use an unspecific Class[] Type" unless name.class_name
+        raise ArgumentError, _("Cannot use an unspecific Class[] Type") unless name.class_name
         name.class_name.sub(/^([^:]{1,2})/, '::\1')
 
       when Puppet::Pops::Types::PResourceType
@@ -1120,13 +1120,13 @@ class Puppet::Parser::Scope
 
   def assert_class_and_title(type_name, title)
     if type_name.nil? || type_name == ''
-      raise ArgumentError, "Cannot use an unspecific Resource[] where a Resource['class', name] is expected"
+      raise ArgumentError, _("Cannot use an unspecific Resource[] where a Resource['class', name] is expected")
     end
     unless type_name =~ /^[Cc]lass$/
-      raise ArgumentError, "Cannot use a Resource[#{type_name}] where a Resource['class', name] is expected"
+      raise ArgumentError, _("Cannot use a Resource[#{type_name}] where a Resource['class', name] is expected")
     end
     if title.nil?
-      raise ArgumentError, "Cannot use an unspecific Resource['class'] where a Resource['class', name] is expected"
+      raise ArgumentError, _("Cannot use an unspecific Resource['class'] where a Resource['class', name] is expected")
     end
   end
 

--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -78,7 +78,7 @@ class Puppet::Parser::TemplateWrapper
     # Expose all the variables in our scope as instance variables of the
     # current object, making it possible to access them without conflict
     # to the regular methods.
-    benchmark(:debug, "Bound template variables for #{template_source}") do
+    benchmark(:debug, _("Bound template variables for #{template_source}")) do
       scope.to_hash.each do |name, value|
         realname = name.gsub(/[^\w]/, "_")
         instance_variable_set("@#{realname}", value)
@@ -86,7 +86,7 @@ class Puppet::Parser::TemplateWrapper
     end
 
     result = nil
-    benchmark(:debug, "Interpolated template #{template_source}") do
+    benchmark(:debug, _("Interpolated template #{template_source}")) do
       template = ERB.new(string, 0, "-")
       template.filename = @__file__
       result = template.result(binding)

--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -78,7 +78,7 @@ class Puppet::Parser::TemplateWrapper
     # Expose all the variables in our scope as instance variables of the
     # current object, making it possible to access them without conflict
     # to the regular methods.
-    benchmark(:debug, _("Bound template variables for #{template_source}")) do
+    benchmark(:debug, _("Bound template variables for %{template_source}") % { template_source: template_source }) do
       scope.to_hash.each do |name, value|
         realname = name.gsub(/[^\w]/, "_")
         instance_variable_set("@#{realname}", value)
@@ -86,7 +86,7 @@ class Puppet::Parser::TemplateWrapper
     end
 
     result = nil
-    benchmark(:debug, _("Interpolated template #{template_source}")) do
+    benchmark(:debug, _("Interpolated template %{template_source}") % { template_source: template_source }) do
       template = ERB.new(string, 0, "-")
       template.filename = @__file__
       result = template.result(binding)

--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -98,7 +98,7 @@ class Puppet::Parser::TypeLoader
   end
 
   def raise_no_files_found(pattern)
-    raise TypeLoaderError, _("No file(s) found for import of '#{pattern}'")
+    raise TypeLoaderError, _("No file(s) found for import of '%{pattern}'") % { pattern: pattern }
   end
 
   def load_files(modname, files)

--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -98,7 +98,7 @@ class Puppet::Parser::TypeLoader
   end
 
   def raise_no_files_found(pattern)
-    raise TypeLoaderError, "No file(s) found for import of '#{pattern}'"
+    raise TypeLoaderError, _("No file(s) found for import of '#{pattern}'")
   end
 
   def load_files(modname, files)


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/parser/*` for translation.