### PR TITLE
(PUP-7042) Mark strings in property

### DIFF
--- a/lib/puppet/property/ensure.rb
+++ b/lib/puppet/property/ensure.rb
@@ -54,7 +54,7 @@ class Puppet::Property::Ensure < Puppet::Property
       elsif newvalue == :absent
         return _("removed")
       else
-        return _("#{self.name} changed '#{self.is_to_s(currentvalue)}' to '#{self.should_to_s(newvalue)}'")
+        return _("%{value0} changed '%{value1}' to '%{value2}'") % { value0: self.name, value1: self.is_to_s(currentvalue), value2: self.should_to_s(newvalue) }
       end
     rescue Puppet::Error, Puppet::DevError
       raise

--- a/lib/puppet/property/ensure.rb
+++ b/lib/puppet/property/ensure.rb
@@ -50,11 +50,11 @@ class Puppet::Property::Ensure < Puppet::Property
   def change_to_s(currentvalue, newvalue)
     begin
       if currentvalue == :absent || currentvalue.nil?
-        return "created"
+        return _("created")
       elsif newvalue == :absent
-        return "removed"
+        return _("removed")
       else
-        return "#{self.name} changed '#{self.is_to_s(currentvalue)}' to '#{self.should_to_s(newvalue)}'"
+        return _("#{self.name} changed '#{self.is_to_s(currentvalue)}' to '#{self.should_to_s(newvalue)}'")
       end
     rescue Puppet::Error, Puppet::DevError
       raise

--- a/lib/puppet/property/list.rb
+++ b/lib/puppet/property/list.rb
@@ -14,7 +14,7 @@ module Puppet
 
       def is_to_s(currentvalue)
         if currentvalue == :absent
-          return "absent"
+          return _("absent")
         else
           return currentvalue.join(delimiter)
         end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/property/*` for translation.