### PR TITLE
(PUP-7042) Mark strings in reference

### DIFF
--- a/lib/puppet/reference/indirection.rb
+++ b/lib/puppet/reference/indirection.rb
@@ -19,7 +19,7 @@ reference = Puppet::Util::Reference.newreference :indirection, :doc => "Indirect
         terminus_doc = Puppet::Util::Docs.scrub(term_class.doc)
         text << markdown_header("`#{terminus_name}` terminus", 3) << terminus_doc << "\n\n"
       else
-        Puppet.warning "Could not build docs for indirector #{name.inspect}, terminus #{terminus_name.inspect}: could not locate terminus."
+        Puppet.warning _("Could not build docs for indirector #{name.inspect}, terminus #{terminus_name.inspect}: could not locate terminus.")
       end
     end
   end

--- a/lib/puppet/reference/indirection.rb
+++ b/lib/puppet/reference/indirection.rb
@@ -19,7 +19,7 @@ reference = Puppet::Util::Reference.newreference :indirection, :doc => "Indirect
         terminus_doc = Puppet::Util::Docs.scrub(term_class.doc)
         text << markdown_header("`#{terminus_name}` terminus", 3) << terminus_doc << "\n\n"
       else
-        Puppet.warning _("Could not build docs for indirector #{name.inspect}, terminus #{terminus_name.inspect}: could not locate terminus.")
+        Puppet.warning _("Could not build docs for indirector %{name}, terminus %{terminus}: could not locate terminus.") % { name: name.inspect, terminus: terminus_name.inspect }
       end
     end
   end

--- a/lib/puppet/reference/metaparameter.rb
+++ b/lib/puppet/reference/metaparameter.rb
@@ -27,7 +27,7 @@ etc.), prevent Puppet from making changes (`noop`), and change logging verbosity
       str << "\n\n"
     }
   rescue => detail
-    Puppet.log_exception(detail, "incorrect metaparams: #{detail}")
+    Puppet.log_exception(detail, _("incorrect metaparams: #{detail}"))
     exit(1)
   end
 

--- a/lib/puppet/reference/metaparameter.rb
+++ b/lib/puppet/reference/metaparameter.rb
@@ -27,7 +27,7 @@ etc.), prevent Puppet from making changes (`noop`), and change logging verbosity
       str << "\n\n"
     }
   rescue => detail
-    Puppet.log_exception(detail, _("incorrect metaparams: #{detail}"))
+    Puppet.log_exception(detail, _("incorrect metaparams: %{detail}") % { detail: detail })
     exit(1)
   end
 

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -56,21 +56,21 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
         missing.each do |test, values|
           case test
           when :exists
-            details << _("  - Missing files #{values.join(", ")}\n")
+            details << _("  - Missing files %{files}\n") % { files: values.join(", ") }
           when :variable
             values.each do |name, facts|
               if Puppet.settings.valid?(name)
-                details << _("  - Setting #{name} (currently #{Puppet.settings.value(name).inspect}) not in list #{facts.join(", ")}\n")
+                details << _("  - Setting %{name} (currently %{value}) not in list %{facts}\n") % { name: name, value: Puppet.settings.value(name).inspect, facts: facts.join(", ") }
               else
-                details << _("  - Fact #{name} (currently #{Facter.value(name).inspect}) not in list #{facts.join(", ")}\n")
+                details << _("  - Fact %{name} (currently %{value}) not in list %{facts}\n") % { name: name, value: Facter.value(name).inspect, facts: facts.join(", ") }
               end
             end
           when :true
-            details << _("  - Got #{values} true tests that should have been false\n")
+            details << _("  - Got %{values} true tests that should have been false\n") % { values: values }
           when :false
-            details << _("  - Got #{values} false tests that should have been true\n")
+            details << _("  - Got %{values} false tests that should have been true\n") % { values: values }
           when :feature
-            details << _("  - Missing features #{values.collect { |f| f.to_s }.join(",")}\n")
+            details << _("  - Missing features %{values}\n") % { values: values.collect { |f| f.to_s }.join(",") }
           end
         end
         notes << details

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -56,21 +56,21 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
         missing.each do |test, values|
           case test
           when :exists
-            details << "  - Missing files #{values.join(", ")}\n"
+            details << _("  - Missing files #{values.join(", ")}\n")
           when :variable
             values.each do |name, facts|
               if Puppet.settings.valid?(name)
-                details << "  - Setting #{name} (currently #{Puppet.settings.value(name).inspect}) not in list #{facts.join(", ")}\n"
+                details << _("  - Setting #{name} (currently #{Puppet.settings.value(name).inspect}) not in list #{facts.join(", ")}\n")
               else
-                details << "  - Fact #{name} (currently #{Facter.value(name).inspect}) not in list #{facts.join(", ")}\n"
+                details << _("  - Fact #{name} (currently #{Facter.value(name).inspect}) not in list #{facts.join(", ")}\n")
               end
             end
           when :true
-            details << "  - Got #{values} true tests that should have been false\n"
+            details << _("  - Got #{values} true tests that should have been false\n")
           when :false
-            details << "  - Got #{values} false tests that should have been true\n"
+            details << _("  - Got #{values} false tests that should have been true\n")
           when :feature
-            details << "  - Missing features #{values.collect { |f| f.to_s }.join(",")}\n"
+            details << _("  - Missing features #{values.collect { |f| f.to_s }.join(",")}\n")
           end
         end
         notes << details

--- a/lib/puppet/reference/type.rb
+++ b/lib/puppet/reference/type.rb
@@ -77,11 +77,11 @@ Puppet::Util::Reference.newreference :type, :doc => "All Puppet resource types a
     }.each { |sname|
       property = type.propertybyname(sname)
 
-      raise "Could not retrieve property #{sname} on type #{type.name}" unless property
+      raise _("Could not retrieve property #{sname} on type #{type.name}") unless property
 
       doc = nil
       unless doc = property.doc
-        $stderr.puts "No docs for #{type}[#{sname}]"
+        $stderr.puts _("No docs for #{type}[#{sname}]")
         next
       end
       doc = doc.dup

--- a/lib/puppet/reference/type.rb
+++ b/lib/puppet/reference/type.rb
@@ -77,11 +77,11 @@ Puppet::Util::Reference.newreference :type, :doc => "All Puppet resource types a
     }.each { |sname|
       property = type.propertybyname(sname)
 
-      raise _("Could not retrieve property #{sname} on type #{type.name}") unless property
+      raise _("Could not retrieve property %{sname} on type %{type_name}") % { sname: sname, type_name: type.name } unless property
 
       doc = nil
       unless doc = property.doc
-        $stderr.puts _("No docs for #{type}[#{sname}]")
+        $stderr.puts _("No docs for %{type}[%{sname}]") % { type: type, sname: sname }
         next
       end
       doc = doc.dup


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/reference/*` for translation.