### PR TITLE
(PUP-7042) Mark strings in settings

### DIFF
--- a/lib/puppet/settings/array_setting.rb
+++ b/lib/puppet/settings/array_setting.rb
@@ -11,7 +11,7 @@ class Puppet::Settings::ArraySetting < Puppet::Settings::BaseSetting
     when Array
       value
     else
-      raise ArgumentError, "Expected an Array or String, got a #{value.class}"
+      raise ArgumentError, _("Expected an Array or String, got a #{value.class}")
     end
   end
 end

--- a/lib/puppet/settings/array_setting.rb
+++ b/lib/puppet/settings/array_setting.rb
@@ -11,7 +11,7 @@ class Puppet::Settings::ArraySetting < Puppet::Settings::BaseSetting
     when Array
       value
     else
-      raise ArgumentError, _("Expected an Array or String, got a #{value.class}")
+      raise ArgumentError, _("Expected an Array or String, got a %{klass}") % { klass: value.class }
     end
   end
 end

--- a/lib/puppet/settings/autosign_setting.rb
+++ b/lib/puppet/settings/autosign_setting.rb
@@ -16,7 +16,7 @@ class Puppet::Settings::AutosignSetting < Puppet::Settings::FileSetting
     elsif Puppet::Util.absolute_path?(value)
       value
     else
-      raise Puppet::Settings::ValidationError, "Invalid autosign value #{value}: must be 'true'/'false' or an absolute path"
+      raise Puppet::Settings::ValidationError, _("Invalid autosign value #{value}: must be 'true'/'false' or an absolute path")
     end
   end
 end

--- a/lib/puppet/settings/autosign_setting.rb
+++ b/lib/puppet/settings/autosign_setting.rb
@@ -16,7 +16,7 @@ class Puppet::Settings::AutosignSetting < Puppet::Settings::FileSetting
     elsif Puppet::Util.absolute_path?(value)
       value
     else
-      raise Puppet::Settings::ValidationError, _("Invalid autosign value #{value}: must be 'true'/'false' or an absolute path")
+      raise Puppet::Settings::ValidationError, _("Invalid autosign value %{value}: must be 'true'/'false' or an absolute path") % { value: value }
     end
   end
 end

--- a/lib/puppet/settings/boolean_setting.rb
+++ b/lib/puppet/settings/boolean_setting.rb
@@ -22,7 +22,7 @@ class Puppet::Settings::BooleanSetting < Puppet::Settings::BaseSetting
     when true, "true"; return true
     when false, "false"; return false
     else
-      raise Puppet::Settings::ValidationError, "Invalid value '#{value.inspect}' for boolean parameter: #{@name}"
+      raise Puppet::Settings::ValidationError, _("Invalid value '#{value.inspect}' for boolean parameter: #{@name}")
     end
   end
 

--- a/lib/puppet/settings/boolean_setting.rb
+++ b/lib/puppet/settings/boolean_setting.rb
@@ -22,7 +22,7 @@ class Puppet::Settings::BooleanSetting < Puppet::Settings::BaseSetting
     when true, "true"; return true
     when false, "false"; return false
     else
-      raise Puppet::Settings::ValidationError, _("Invalid value '#{value.inspect}' for boolean parameter: #{@name}")
+      raise Puppet::Settings::ValidationError, _("Invalid value '%{value}' for boolean parameter: %{name}") % { value: value.inspect, name: @name }
     end
   end
 

--- a/lib/puppet/settings/config_file.rb
+++ b/lib/puppet/settings/config_file.rb
@@ -35,7 +35,7 @@ class Puppet::Settings::ConfigFile
         if line.is_a?(Puppet::Settings::IniFile::SettingLine)
           parse_setting(line, section)
         elsif line.text !~ /^\s*#|^\s*$/
-          raise Puppet::Settings::ParseError.new(_("Could not match line #{line.text}"), file, line.line_number)
+          raise Puppet::Settings::ParseError.new(_("Could not match line %{text}") % { text: line.text }, file, line.line_number)
         end
       end
     end
@@ -83,7 +83,7 @@ private
   def unique_sections_in(ini, file, allowed_section_names)
     ini.section_lines.collect do |section|
       if !allowed_section_names.empty? && !allowed_section_names.include?(section.name)
-        raise(Puppet::Error, _("Illegal section '#{section.name}' in config file #{file} at line #{section.line_number}. The only valid puppet.conf sections are: [#{allowed_section_names.join(", ")}]. Please use the directory environments feature to specify environments. (See https://docs.puppet.com/puppet/latest/reference/environments.html)"))
+        raise(Puppet::Error, _("Illegal section '%{name}' in config file %{file} at line %{line}. The only valid puppet.conf sections are: [%{allowed_sections}]. Please use the directory environments feature to specify environments. (See https://docs.puppet.com/puppet/latest/reference/environments.html)") % { name: section.name, file: file, line: section.line_number, allowed_sections: allowed_section_names.join(", ") })
       end
       section.name
     end.uniq

--- a/lib/puppet/settings/config_file.rb
+++ b/lib/puppet/settings/config_file.rb
@@ -35,7 +35,7 @@ class Puppet::Settings::ConfigFile
         if line.is_a?(Puppet::Settings::IniFile::SettingLine)
           parse_setting(line, section)
         elsif line.text !~ /^\s*#|^\s*$/
-          raise Puppet::Settings::ParseError.new("Could not match line #{line.text}", file, line.line_number)
+          raise Puppet::Settings::ParseError.new(_("Could not match line #{line.text}"), file, line.line_number)
         end
       end
     end
@@ -83,7 +83,7 @@ private
   def unique_sections_in(ini, file, allowed_section_names)
     ini.section_lines.collect do |section|
       if !allowed_section_names.empty? && !allowed_section_names.include?(section.name)
-        raise(Puppet::Error, "Illegal section '#{section.name}' in config file #{file} at line #{section.line_number}. The only valid puppet.conf sections are: [#{allowed_section_names.join(", ")}]. Please use the directory environments feature to specify environments. (See https://docs.puppet.com/puppet/latest/reference/environments.html)")
+        raise(Puppet::Error, _("Illegal section '#{section.name}' in config file #{file} at line #{section.line_number}. The only valid puppet.conf sections are: [#{allowed_section_names.join(", ")}]. Please use the directory environments feature to specify environments. (See https://docs.puppet.com/puppet/latest/reference/environments.html)"))
       end
       section.name
     end.uniq

--- a/lib/puppet/settings/duration_setting.rb
+++ b/lib/puppet/settings/duration_setting.rb
@@ -26,7 +26,7 @@ class Puppet::Settings::DurationSetting < Puppet::Settings::BaseSetting
     when (value.is_a?(String) and value =~ FORMAT)
       $1.to_i * UNITMAP[$2 || 's']
     else
-      raise Puppet::Settings::ValidationError, "Invalid duration format '#{value.inspect}' for parameter: #{@name}"
+      raise Puppet::Settings::ValidationError, _("Invalid duration format '#{value.inspect}' for parameter: #{@name}")
     end
   end
 end

--- a/lib/puppet/settings/duration_setting.rb
+++ b/lib/puppet/settings/duration_setting.rb
@@ -26,7 +26,7 @@ class Puppet::Settings::DurationSetting < Puppet::Settings::BaseSetting
     when (value.is_a?(String) and value =~ FORMAT)
       $1.to_i * UNITMAP[$2 || 's']
     else
-      raise Puppet::Settings::ValidationError, _("Invalid duration format '#{value.inspect}' for parameter: #{@name}")
+      raise Puppet::Settings::ValidationError, _("Invalid duration format '%{value}' for parameter: %{name}") % { value: value.inspect, name: @name }
     end
   end
 end

--- a/lib/puppet/settings/enum_setting.rb
+++ b/lib/puppet/settings/enum_setting.rb
@@ -10,7 +10,7 @@ class Puppet::Settings::EnumSetting < Puppet::Settings::BaseSetting
       value
     else
       raise Puppet::Settings::ValidationError,
-        "Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'"
+        _("Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'")
     end
   end
 end

--- a/lib/puppet/settings/enum_setting.rb
+++ b/lib/puppet/settings/enum_setting.rb
@@ -10,7 +10,7 @@ class Puppet::Settings::EnumSetting < Puppet::Settings::BaseSetting
       value
     else
       raise Puppet::Settings::ValidationError,
-        _("Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'")
+        _("Invalid value '%{value}' for parameter %{name}. Allowed values are '%{allowed_values}'") % { value: value, name: @name, allowed_values: values.join("', '") }
     end
   end
 end

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -138,13 +138,13 @@ class Puppet::Settings::EnvironmentConf
     section_keys = config.sections.keys
     main = config.sections[:main]
     if section_keys.size > 1
-      Puppet.warning("Invalid sections in environment.conf at '#{path_to_conf_file}'. Environment conf may not have sections. The following sections are being ignored: '#{(section_keys - [:main]).join(',')}'")
+      Puppet.warning(_("Invalid sections in environment.conf at '#{path_to_conf_file}'. Environment conf may not have sections. The following sections are being ignored: '#{(section_keys - [:main]).join(',')}'"))
       valid = false
     end
 
     extraneous_settings = main.settings.map(&:name) - VALID_SETTINGS
     if !extraneous_settings.empty?
-      Puppet.warning("Invalid settings in environment.conf at '#{path_to_conf_file}'. The following unknown setting(s) are being ignored: #{extraneous_settings.join(', ')}")
+      Puppet.warning(_("Invalid settings in environment.conf at '#{path_to_conf_file}'. The following unknown setting(s) are being ignored: #{extraneous_settings.join(', ')}"))
       valid = false
     end
 

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -138,13 +138,13 @@ class Puppet::Settings::EnvironmentConf
     section_keys = config.sections.keys
     main = config.sections[:main]
     if section_keys.size > 1
-      Puppet.warning(_("Invalid sections in environment.conf at '#{path_to_conf_file}'. Environment conf may not have sections. The following sections are being ignored: '#{(section_keys - [:main]).join(',')}'"))
+      Puppet.warning(_("Invalid sections in environment.conf at '%{path_to_conf_file}'. Environment conf may not have sections. The following sections are being ignored: '%{sections}'") % { path_to_conf_file: path_to_conf_file, sections: (section_keys - [:main]).join(',') })
       valid = false
     end
 
     extraneous_settings = main.settings.map(&:name) - VALID_SETTINGS
     if !extraneous_settings.empty?
-      Puppet.warning(_("Invalid settings in environment.conf at '#{path_to_conf_file}'. The following unknown setting(s) are being ignored: #{extraneous_settings.join(', ')}"))
+      Puppet.warning(_("Invalid settings in environment.conf at '%{path_to_conf_file}'. The following unknown setting(s) are being ignored: %{ignored_settings}") % { path_to_conf_file: path_to_conf_file, ignored_settings: extraneous_settings.join(', ') })
       valid = false
     end
 

--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -179,7 +179,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
       name = $1
       unless @settings.include?(name)
         raise ArgumentError,
-          _("Settings parameter '#{name}' is undefined")
+          _("Settings parameter '%{name}' is undefined") % { name: name }
       end
     }
   end
@@ -215,7 +215,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   end
 
   def unknown_value(parameter, value)
-    raise SettingError, _("The #{parameter} parameter for the setting '#{name}' must be either 'root' or 'service', not '#{value}'")
+    raise SettingError, _("The %{parameter} parameter for the setting '%{name}' must be either 'root' or 'service', not '%{value}'") % { parameter: parameter, name: name, value: value }
   end
 
   def controlled_access(&block)

--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -179,7 +179,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
       name = $1
       unless @settings.include?(name)
         raise ArgumentError,
-          "Settings parameter '#{name}' is undefined"
+          _("Settings parameter '#{name}' is undefined")
       end
     }
   end
@@ -215,7 +215,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   end
 
   def unknown_value(parameter, value)
-    raise SettingError, "The #{parameter} parameter for the setting '#{name}' must be either 'root' or 'service', not '#{value}'"
+    raise SettingError, _("The #{parameter} parameter for the setting '#{name}' must be either 'root' or 'service', not '#{value}'")
   end
 
   def controlled_access(&block)

--- a/lib/puppet/settings/priority_setting.rb
+++ b/lib/puppet/settings/priority_setting.rb
@@ -36,7 +36,7 @@ class Puppet::Settings::PrioritySetting < Puppet::Settings::BaseSetting
     when (value.is_a?(String) and PRIORITY_MAP[value.to_sym])
       PRIORITY_MAP[value.to_sym]
     else
-      raise Puppet::Settings::ValidationError, "Invalid priority format '#{value.inspect}' for parameter: #{@name}"
+      raise Puppet::Settings::ValidationError, _("Invalid priority format '#{value.inspect}' for parameter: #{@name}")
     end
   end
 end

--- a/lib/puppet/settings/priority_setting.rb
+++ b/lib/puppet/settings/priority_setting.rb
@@ -36,7 +36,7 @@ class Puppet::Settings::PrioritySetting < Puppet::Settings::BaseSetting
     when (value.is_a?(String) and PRIORITY_MAP[value.to_sym])
       PRIORITY_MAP[value.to_sym]
     else
-      raise Puppet::Settings::ValidationError, _("Invalid priority format '#{value.inspect}' for parameter: #{@name}")
+      raise Puppet::Settings::ValidationError, _("Invalid priority format '%{value}' for parameter: %{name}") % { value: value.inspect, name: @name }
     end
   end
 end

--- a/lib/puppet/settings/server_list_setting.rb
+++ b/lib/puppet/settings/server_list_setting.rb
@@ -13,7 +13,7 @@ class Puppet::Settings::ServerListSetting < Puppet::Settings::ArraySetting
       when Array
         server
       else
-        raise ArgumentError, _("Expected an Array of String, got a #{value.class}")
+        raise ArgumentError, _("Expected an Array of String, got a %{klass}") % { klass: value.class }
       end
     }
   end

--- a/lib/puppet/settings/server_list_setting.rb
+++ b/lib/puppet/settings/server_list_setting.rb
@@ -13,7 +13,7 @@ class Puppet::Settings::ServerListSetting < Puppet::Settings::ArraySetting
       when Array
         server
       else
-        raise ArgumentError, "Expected an Array of String, got a #{value.class}"
+        raise ArgumentError, _("Expected an Array of String, got a #{value.class}")
       end
     }
   end

--- a/lib/puppet/settings/symbolic_enum_setting.rb
+++ b/lib/puppet/settings/symbolic_enum_setting.rb
@@ -11,7 +11,7 @@ class Puppet::Settings::SymbolicEnumSetting < Puppet::Settings::BaseSetting
       sym
     else
       raise Puppet::Settings::ValidationError,
-        "Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'"
+        _("Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'")
     end
   end
 end

--- a/lib/puppet/settings/symbolic_enum_setting.rb
+++ b/lib/puppet/settings/symbolic_enum_setting.rb
@@ -11,7 +11,7 @@ class Puppet::Settings::SymbolicEnumSetting < Puppet::Settings::BaseSetting
       sym
     else
       raise Puppet::Settings::ValidationError,
-        _("Invalid value '#{value}' for parameter #{@name}. Allowed values are '#{values.join("', '")}'")
+        _("Invalid value '%{value}' for parameter %{name}. Allowed values are '%{allowed_values}'") % { value: value, name: @name, allowed_values: values.join("', '") }
     end
   end
 end

--- a/lib/puppet/settings/terminus_setting.rb
+++ b/lib/puppet/settings/terminus_setting.rb
@@ -8,7 +8,7 @@ class Puppet::Settings::TerminusSetting < Puppet::Settings::BaseSetting
     when Symbol
       value
     else
-      raise Puppet::Settings::ValidationError, _("Invalid terminus setting: #{value}")
+      raise Puppet::Settings::ValidationError, _("Invalid terminus setting: %{value}") % { value: value }
     end
   end
 end

--- a/lib/puppet/settings/terminus_setting.rb
+++ b/lib/puppet/settings/terminus_setting.rb
@@ -8,7 +8,7 @@ class Puppet::Settings::TerminusSetting < Puppet::Settings::BaseSetting
     when Symbol
       value
     else
-      raise Puppet::Settings::ValidationError, "Invalid terminus setting: #{value}"
+      raise Puppet::Settings::ValidationError, _("Invalid terminus setting: #{value}")
     end
   end
 end

--- a/lib/puppet/settings/ttl_setting.rb
+++ b/lib/puppet/settings/ttl_setting.rb
@@ -30,7 +30,7 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
     case
     when value.is_a?(Numeric)
       if value < 0
-        raise Puppet::Settings::ValidationError, _("Invalid negative 'time to live' #{value.inspect} - did you mean 'unlimited'?")
+        raise Puppet::Settings::ValidationError, _("Invalid negative 'time to live' %{value} - did you mean 'unlimited'?") % { value: value.inspect }
       end
       value
 
@@ -40,7 +40,7 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
     when (value.is_a?(String) and value =~ FORMAT)
       $1.to_i * UNITMAP[$2 || 's']
     else
-      raise Puppet::Settings::ValidationError, _("Invalid 'time to live' format '#{value.inspect}' for parameter: #{param_name}")
+      raise Puppet::Settings::ValidationError, _("Invalid 'time to live' format '%{value}' for parameter: %{param_name}") % { value: value.inspect, param_name: param_name }
     end
   end
 end

--- a/lib/puppet/settings/ttl_setting.rb
+++ b/lib/puppet/settings/ttl_setting.rb
@@ -30,7 +30,7 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
     case
     when value.is_a?(Numeric)
       if value < 0
-        raise Puppet::Settings::ValidationError, "Invalid negative 'time to live' #{value.inspect} - did you mean 'unlimited'?"
+        raise Puppet::Settings::ValidationError, _("Invalid negative 'time to live' #{value.inspect} - did you mean 'unlimited'?")
       end
       value
 
@@ -40,7 +40,7 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
     when (value.is_a?(String) and value =~ FORMAT)
       $1.to_i * UNITMAP[$2 || 's']
     else
-      raise Puppet::Settings::ValidationError, "Invalid 'time to live' format '#{value.inspect}' for parameter: #{param_name}"
+      raise Puppet::Settings::ValidationError, _("Invalid 'time to live' format '#{value.inspect}' for parameter: #{param_name}")
     end
   end
 end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/settings/*` for translation.