### PR TITLE
(PUP-7042) Mark strings in ssl

### DIFF
--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -29,7 +29,7 @@ class Puppet::SSL::Base
   end
 
   def self.validate_certname(name)
-    raise "Certname #{name.inspect} must not contain unprintable or non-ASCII characters" unless name =~ VALID_CERTNAME
+    raise _("Certname #{name.inspect} must not contain unprintable or non-ASCII characters") unless name =~ VALID_CERTNAME
   end
 
   attr_accessor :name, :content
@@ -141,7 +141,7 @@ class Puppet::SSL::Base
     if match = digest_re.match(ln)
       match[0].downcase
     else
-      raise Puppet::Error, "Unknown signature algorithm '#{ln}'"
+      raise Puppet::Error, _("Unknown signature algorithm '#{ln}'")
     end
   end
 

--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -29,7 +29,7 @@ class Puppet::SSL::Base
   end
 
   def self.validate_certname(name)
-    raise _("Certname #{name.inspect} must not contain unprintable or non-ASCII characters") unless name =~ VALID_CERTNAME
+    raise _("Certname %{name} must not contain unprintable or non-ASCII characters") % { name: name.inspect } unless name =~ VALID_CERTNAME
   end
 
   attr_accessor :name, :content
@@ -141,7 +141,7 @@ class Puppet::SSL::Base
     if match = digest_re.match(ln)
       match[0].downcase
     else
-      raise Puppet::Error, _("Unknown signature algorithm '#{ln}'")
+      raise Puppet::Error, _("Unknown signature algorithm '%{ln}'") % { ln: ln }
     end
   end
 

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -66,7 +66,7 @@ class Puppet::SSL::CertificateAuthority
   # @api private
   def autosign(csr)
     if autosign?(csr)
-      Puppet.info "Autosigning #{csr.name}"
+      Puppet.info _("Autosigning #{csr.name}")
       sign(csr.name)
     end
   end
@@ -118,7 +118,7 @@ class Puppet::SSL::CertificateAuthority
   # Generates a new certificate.
   # @return Puppet::SSL::Certificate
   def generate(name, options = {})
-    raise ArgumentError, "A Certificate already exists for #{name}" if Puppet::SSL::Certificate.indirection.find(name)
+    raise ArgumentError, _("A Certificate already exists for #{name}") if Puppet::SSL::Certificate.indirection.find(name)
 
     # Pass on any requested subjectAltName field.
     san = options[:dns_alt_names]
@@ -176,7 +176,7 @@ class Puppet::SSL::CertificateAuthority
       # random password is limited to ASCII characters 48 ('0') through 122 ('z')
       Puppet.settings.setting(:capass).open('w:ASCII') { |f| f.print pass }
     rescue Errno::EACCES => detail
-      raise Puppet::Error, "Could not write CA password: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not write CA password: #{detail}"), detail.backtrace
     end
 
     @password = pass
@@ -209,7 +209,7 @@ class Puppet::SSL::CertificateAuthority
   #
   # @deprecated Use Puppet::SSL::CertificateAuthority#list or Puppet Server Certificate status API
   def list_certificates(name='*')
-    Puppet.deprecation_warning("Puppet::SSL::CertificateAuthority#list_certificates is deprecated. Please use Puppet::SSL::CertificateAuthority#list or the certificate status API to query certificate information. See https://docs.puppet.com/puppet/latest/http_api/http_certificate_status.html")
+    Puppet.deprecation_warning(_("Puppet::SSL::CertificateAuthority#list_certificates is deprecated. Please use Puppet::SSL::CertificateAuthority#list or the certificate status API to query certificate information. See https://docs.puppet.com/puppet/latest/http_api/http_certificate_status.html"))
     Puppet::SSL::Certificate.indirection.search(name)
   end
 
@@ -247,7 +247,7 @@ class Puppet::SSL::CertificateAuthority
 
   # Revoke a given certificate.
   def revoke(name)
-    raise ArgumentError, "Cannot revoke certificates when the CRL is disabled" unless crl
+    raise ArgumentError, _("Cannot revoke certificates when the CRL is disabled") unless crl
 
     cert = Puppet::SSL::Certificate.indirection.find(name)
 
@@ -260,7 +260,7 @@ class Puppet::SSL::CertificateAuthority
               end
 
     if serials.empty?
-      raise ArgumentError, "Could not find a serial number for #{name}"
+      raise ArgumentError, _("Could not find a serial number for #{name}")
     end
 
     serials.each do |s|
@@ -294,7 +294,7 @@ class Puppet::SSL::CertificateAuthority
       issuer = csr.content
     else
       unless csr = Puppet::SSL::CertificateRequest.indirection.find(hostname)
-        raise ArgumentError, "Could not find certificate request for #{hostname}"
+        raise ArgumentError, _("Could not find certificate request for #{hostname}")
       end
 
       cert_type = :server
@@ -303,7 +303,7 @@ class Puppet::SSL::CertificateAuthority
       # Make sure that the CSR conforms to our internal signing policies.
       # This will raise if the CSR doesn't conform, but just in case...
       check_internal_signing_policies(hostname, csr, options) or
-        raise CertificateSigningError.new(hostname), "CSR had an unknown failure checking internal signing policies, will not sign!"
+        raise CertificateSigningError.new(hostname), _("CSR had an unknown failure checking internal signing policies, will not sign!")
     end
 
     cert = Puppet::SSL::Certificate.new(hostname)
@@ -313,7 +313,7 @@ class Puppet::SSL::CertificateAuthority
     signer = Puppet::SSL::CertificateSigner.new
     signer.sign(cert.content, host.key.content)
 
-    Puppet.notice "Signed certificate request for #{hostname}"
+    Puppet.notice _("Signed certificate request for #{hostname}")
 
     # Add the cert to the inventory before we save it, since
     # otherwise we could end up with it being duplicated, if
@@ -346,17 +346,17 @@ class Puppet::SSL::CertificateAuthority
 
     if unknown_req and not unknown_req.empty?
       names = unknown_req.map {|x| x["oid"] }.sort.uniq.join(", ")
-      raise CertificateSigningError.new(hostname), "CSR has request extensions that are not permitted: #{names}"
+      raise CertificateSigningError.new(hostname), _("CSR has request extensions that are not permitted: #{names}")
     end
 
     # Do not sign misleading CSRs
     cn = csr.content.subject.to_a.assoc("CN")[1]
     if hostname != cn
-      raise CertificateSigningError.new(hostname), "CSR subject common name #{cn.inspect} does not match expected certname #{hostname.inspect}"
+      raise CertificateSigningError.new(hostname), _("CSR subject common name #{cn.inspect} does not match expected certname #{hostname.inspect}")
     end
 
     if hostname !~ Puppet::SSL::Base::VALID_CERTNAME
-      raise CertificateSigningError.new(hostname), "CSR #{hostname.inspect} subject contains unprintable or non-ASCII characters"
+      raise CertificateSigningError.new(hostname), _("CSR #{hostname.inspect} subject contains unprintable or non-ASCII characters")
     end
 
     # Wildcards: we don't allow 'em at any point.
@@ -365,11 +365,11 @@ class Puppet::SSL::CertificateAuthority
     # to scrobble through the content of the CSR subject field to make sure it
     # is what we expect where we expect it.
     if csr.content.subject.to_s.include? '*'
-      raise CertificateSigningError.new(hostname), "CSR subject contains a wildcard, which is not allowed: #{csr.content.subject.to_s}"
+      raise CertificateSigningError.new(hostname), _("CSR subject contains a wildcard, which is not allowed: #{csr.content.subject.to_s}")
     end
 
     unless csr.content.verify(csr.content.public_key)
-      raise CertificateSigningError.new(hostname), "CSR contains a public key that does not correspond to the signing key"
+      raise CertificateSigningError.new(hostname), _("CSR contains a public key that does not correspond to the signing key")
     end
 
     auth_extensions = csr.request_extensions.select do |extension|
@@ -381,25 +381,25 @@ class Puppet::SSL::CertificateAuthority
         extension['oid']
       end
 
-      raise CertificateSigningError.new(hostname), "CSR '#{csr.name}' contains authorization extensions (#{ext_names.join(', ')}), which are disallowed by default. Use `puppet cert --allow-authorization-extensions sign #{csr.name}` to sign this request."
+      raise CertificateSigningError.new(hostname), _("CSR '#{csr.name}' contains authorization extensions (#{ext_names.join(', ')}), which are disallowed by default. Use `puppet cert --allow-authorization-extensions sign #{csr.name}` to sign this request.")
     end
 
     unless csr.subject_alt_names.empty?
       # If you alt names are allowed, they are required. Otherwise they are
       # disallowed. Self-signed certs are implicitly trusted, however.
       unless options[:allow_dns_alt_names]
-        raise CertificateSigningError.new(hostname), "CSR '#{csr.name}' contains subject alternative names (#{csr.subject_alt_names.join(', ')}), which are disallowed. Use `puppet cert --allow-dns-alt-names sign #{csr.name}` to sign this request."
+        raise CertificateSigningError.new(hostname), _("CSR '#{csr.name}' contains subject alternative names (#{csr.subject_alt_names.join(', ')}), which are disallowed. Use `puppet cert --allow-dns-alt-names sign #{csr.name}` to sign this request.")
       end
 
       # If subjectAltNames are present, validate that they are only for DNS
       # labels, not any other kind.
       unless csr.subject_alt_names.all? {|x| x =~ /^DNS:/ }
-        raise CertificateSigningError.new(hostname), "CSR '#{csr.name}' contains a subjectAltName outside the DNS label space: #{csr.subject_alt_names.join(', ')}.  To continue, this CSR needs to be cleaned."
+        raise CertificateSigningError.new(hostname), _("CSR '#{csr.name}' contains a subjectAltName outside the DNS label space: #{csr.subject_alt_names.join(', ')}.  To continue, this CSR needs to be cleaned.")
       end
 
       # Check for wildcards in the subjectAltName fields too.
       if csr.subject_alt_names.any? {|x| x.include? '*' }
-        raise CertificateSigningError.new(hostname), "CSR '#{csr.name}' subjectAltName contains a wildcard, which is not allowed: #{csr.subject_alt_names.join(', ')}  To continue, this CSR needs to be cleaned."
+        raise CertificateSigningError.new(hostname), _("CSR '#{csr.name}' subjectAltName contains a wildcard, which is not allowed: #{csr.subject_alt_names.join(', ')}  To continue, this CSR needs to be cleaned.")
       end
     end
 
@@ -477,7 +477,7 @@ class Puppet::SSL::CertificateAuthority
   #
   # @deprecated use Puppet::SSL::CertificateAuthority#verify or Puppet Server certificate status API
   def certificate_is_alive?(cert)
-    Puppet.deprecation_warning("Puppet::SSL::CertificateAuthority#certificate_is_alive? is deprecated. Please use Puppet::SSL::CertificateAuthority#verify or the certificate status API to query certificate information. See https://docs.puppet.com/puppet/latest/http_api/http_certificate_status.html")
+    Puppet.deprecation_warning(_("Puppet::SSL::CertificateAuthority#certificate_is_alive? is deprecated. Please use Puppet::SSL::CertificateAuthority#verify or the certificate status API to query certificate information. See https://docs.puppet.com/puppet/latest/http_api/http_certificate_status.html"))
     x509_store(:cache => true).verify(cert.content)
   end
 
@@ -494,7 +494,7 @@ class Puppet::SSL::CertificateAuthority
   # @return [Boolean] true if signed, there are no cases where false is returned
   def verify(name)
     unless cert = Puppet::SSL::Certificate.indirection.find(name)
-      raise ArgumentError, "Could not find a certificate for #{name}"
+      raise ArgumentError, _("Could not find a certificate for #{name}")
     end
     store = create_x509_store
 
@@ -503,7 +503,7 @@ class Puppet::SSL::CertificateAuthority
 
   def fingerprint(name, md = :SHA256)
     unless cert = Puppet::SSL::Certificate.indirection.find(name) || Puppet::SSL::CertificateRequest.indirection.find(name)
-      raise ArgumentError, "Could not find a certificate or csr for #{name}"
+      raise ArgumentError, _("Could not find a certificate or csr for #{name}")
     end
     cert.fingerprint(md)
   end

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -18,13 +18,13 @@ module Puppet
         # Actually perform the work.
         def apply(ca)
           unless subjects || SUBJECTLESS_METHODS.include?(method)
-            raise ArgumentError, "You must provide hosts or --all when using #{method}"
+            raise ArgumentError, _("You must provide hosts or --all when using #{method}")
           end
 
           destructive_subjects = [:signed, :all].include?(subjects)
           if DESTRUCTIVE_METHODS.include?(method) && destructive_subjects
-            subject_text = (subjects == :all ? subjects : "all signed")
-            raise ArgumentError, "Refusing to #{method} #{subject_text} certs, provide an explicit list of certs to #{method}"
+            subject_text = (subjects == :all ? subjects : _("all signed"))
+            raise ArgumentError, _("Refusing to #{method} #{subject_text} certs, provide an explicit list of certs to #{method}")
           end
 
           # if the interface implements the method, use it instead of the ca's method
@@ -38,7 +38,7 @@ module Puppet
         end
 
         def generate(ca)
-          raise InterfaceError, "It makes no sense to generate all hosts; you must specify a list" if subjects == :all
+          raise InterfaceError, _("It makes no sense to generate all hosts; you must specify a list") if subjects == :all
 
           subjects.each do |host|
             ca.generate(host, options)
@@ -250,7 +250,7 @@ module Puppet
             if value = ca.print(host)
               puts value
             else
-              raise ArgumentError, "Could not find certificate for #{host}"
+              raise ArgumentError, _("Could not find certificate for #{host}")
             end
           end
         end
@@ -261,7 +261,7 @@ module Puppet
             if cert = (Puppet::SSL::Certificate.indirection.find(host) || Puppet::SSL::CertificateRequest.indirection.find(host))
               puts "#{host} #{cert.digest(@digest)}"
             else
-	      raise ArgumentError, "Could not find certificate for #{host}"
+	      raise ArgumentError, _("Could not find certificate for #{host}")
             end
           end
         end
@@ -269,7 +269,7 @@ module Puppet
         # Signs given certificates or all waiting if subjects == :all
         def sign(ca)
           list = subjects == :all ? ca.waiting? : subjects
-          raise InterfaceError, "No waiting certificate requests to sign" if list.empty?
+          raise InterfaceError, _("No waiting certificate requests to sign") if list.empty?
 
           signing_options = options.select { |k,_|
             [:allow_authorization_extensions, :allow_dns_alt_names].include?(k)
@@ -278,7 +278,7 @@ module Puppet
           list.each do |host|
             cert = Puppet::SSL::CertificateRequest.indirection.find(host)
 
-            raise InterfaceError, "Could not find CSR for: #{host.inspect}." unless cert
+            raise InterfaceError, _("Could not find CSR for: #{host.inspect}.") unless cert
 
             # ca.sign will also do this - and it should if it is called
             # elsewhere - but we want to reject an attempt to sign a
@@ -288,16 +288,16 @@ module Puppet
             name_width = host.inspect.length
             info = {:type => :request, :cert => cert}
             host_string = format_host(host, info, name_width, options[:format])
-            puts "Signing Certificate Request for:\n#{host_string}"
+            puts _("Signing Certificate Request for:\n#{host_string}")
 
             if options[:interactive]
-              STDOUT.print "Sign Certificate Request? [y/N] "
+              STDOUT.print _("Sign Certificate Request? [y/N] ")
 
               if !options[:yes]
                 input = STDIN.gets.chomp
-                raise InterfaceError, "NOT Signing Certificate Request" unless VALID_CONFIRMATION_VALUES.include?(input)
+                raise InterfaceError, _("NOT Signing Certificate Request") unless VALID_CONFIRMATION_VALUES.include?(input)
               else
-                puts "Assuming YES from `-y' or `--assume-yes' flag"
+                puts _("Assuming YES from `-y' or `--assume-yes' flag")
               end
             end
 
@@ -312,7 +312,7 @@ module Puppet
         # Set the list of hosts we're operating on.  Also supports keywords.
         def subjects=(value)
           unless value == :all || value == :signed || value.is_a?(Array)
-            raise ArgumentError, "Subjects must be an array or :all; not #{value}"
+            raise ArgumentError, _("Subjects must be an array or :all; not #{value}")
           end
 
           @subjects = (value == []) ? nil : value

--- a/lib/puppet/ssl/certificate_authority/interface.rb
+++ b/lib/puppet/ssl/certificate_authority/interface.rb
@@ -18,13 +18,13 @@ module Puppet
         # Actually perform the work.
         def apply(ca)
           unless subjects || SUBJECTLESS_METHODS.include?(method)
-            raise ArgumentError, _("You must provide hosts or --all when using #{method}")
+            raise ArgumentError, _("You must provide hosts or --all when using %{method}") % { method: method }
           end
 
           destructive_subjects = [:signed, :all].include?(subjects)
           if DESTRUCTIVE_METHODS.include?(method) && destructive_subjects
             subject_text = (subjects == :all ? subjects : _("all signed"))
-            raise ArgumentError, _("Refusing to #{method} #{subject_text} certs, provide an explicit list of certs to #{method}")
+            raise ArgumentError, _("Refusing to %{method} %{subject_text} certs, provide an explicit list of certs to %{method}") % { method: method, subject_text: subject_text }
           end
 
           # if the interface implements the method, use it instead of the ca's method
@@ -250,7 +250,7 @@ module Puppet
             if value = ca.print(host)
               puts value
             else
-              raise ArgumentError, _("Could not find certificate for #{host}")
+              raise ArgumentError, _("Could not find certificate for %{host}") % { host: host }
             end
           end
         end
@@ -261,7 +261,7 @@ module Puppet
             if cert = (Puppet::SSL::Certificate.indirection.find(host) || Puppet::SSL::CertificateRequest.indirection.find(host))
               puts "#{host} #{cert.digest(@digest)}"
             else
-	      raise ArgumentError, _("Could not find certificate for #{host}")
+	      raise ArgumentError, _("Could not find certificate for %{host}") % { host: host }
             end
           end
         end
@@ -278,7 +278,7 @@ module Puppet
           list.each do |host|
             cert = Puppet::SSL::CertificateRequest.indirection.find(host)
 
-            raise InterfaceError, _("Could not find CSR for: #{host.inspect}.") unless cert
+            raise InterfaceError, _("Could not find CSR for: %{host}.") % { host: host.inspect } unless cert
 
             # ca.sign will also do this - and it should if it is called
             # elsewhere - but we want to reject an attempt to sign a
@@ -288,7 +288,7 @@ module Puppet
             name_width = host.inspect.length
             info = {:type => :request, :cert => cert}
             host_string = format_host(host, info, name_width, options[:format])
-            puts _("Signing Certificate Request for:\n#{host_string}")
+            puts _("Signing Certificate Request for:\n%{host_string}") % { host_string: host_string }
 
             if options[:interactive]
               STDOUT.print _("Sign Certificate Request? [y/N] ")
@@ -312,7 +312,7 @@ module Puppet
         # Set the list of hosts we're operating on.  Also supports keywords.
         def subjects=(value)
           unless value == :all || value == :signed || value.is_a?(Array)
-            raise ArgumentError, _("Subjects must be an array or :all; not #{value}")
+            raise ArgumentError, _("Subjects must be an array or :all; not %{value}") % { value: value }
           end
 
           @subjects = (value == []) ? nil : value

--- a/lib/puppet/ssl/certificate_factory.rb
+++ b/lib/puppet/ssl/certificate_factory.rb
@@ -28,9 +28,9 @@ module Puppet::SSL::CertificateFactory
     # Work out if we can even build the requested type of certificate.
     build_extensions = "build_#{cert_type.to_s}_extensions"
     respond_to?(build_extensions) or
-      raise ArgumentError, "#{cert_type.to_s} is an invalid certificate type!"
+      raise ArgumentError, _("#{cert_type.to_s} is an invalid certificate type!")
 
-    raise ArgumentError, "Certificate TTL must be an integer" unless ttl.nil? || ttl.is_a?(Integer)
+    raise ArgumentError, _("Certificate TTL must be an integer") unless ttl.nil? || ttl.is_a?(Integer)
 
     # set up the certificate, and start building the content.
     cert = OpenSSL::X509::Certificate.new

--- a/lib/puppet/ssl/certificate_factory.rb
+++ b/lib/puppet/ssl/certificate_factory.rb
@@ -28,7 +28,7 @@ module Puppet::SSL::CertificateFactory
     # Work out if we can even build the requested type of certificate.
     build_extensions = "build_#{cert_type.to_s}_extensions"
     respond_to?(build_extensions) or
-      raise ArgumentError, _("#{cert_type.to_s} is an invalid certificate type!")
+      raise ArgumentError, _("%{cert_type} is an invalid certificate type!") % { cert_type: cert_type.to_s }
 
     raise ArgumentError, _("Certificate TTL must be an integer") unless ttl.nil? || ttl.is_a?(Integer)
 

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -74,7 +74,7 @@ DOC
   #
   # @return [OpenSSL::X509::Request] The generated CSR
   def generate(key, options = {})
-    Puppet.info "Creating a new SSL certificate request for #{name}"
+    Puppet.info _("Creating a new SSL certificate request for #{name}")
 
     # Support either an actual SSL key, or a Puppet key.
     key = key.content if key.is_a?(Puppet::SSL::Key)
@@ -100,10 +100,10 @@ DOC
     signer = Puppet::SSL::CertificateSigner.new
     signer.sign(csr, key)
 
-    raise Puppet::Error, "CSR sign verification failed; you need to clean the certificate request for #{name} on the server" unless csr.verify(key.public_key)
+    raise Puppet::Error, _("CSR sign verification failed; you need to clean the certificate request for #{name} on the server") unless csr.verify(key.public_key)
 
     @content = csr
-    Puppet.info "Certificate Request fingerprint (#{digest.name}): #{digest.to_hex}"
+    Puppet.info _("Certificate Request fingerprint (#{digest.name}): #{digest.to_hex}")
     @content
   end
 
@@ -146,7 +146,7 @@ DOC
   # hashes, with key/value pairs for the extension's oid, its value, and
   # optionally its critical state.
   def request_extensions
-    raise Puppet::Error, "CSR needs content to extract fields" unless @content
+    raise Puppet::Error, _("CSR needs content to extract fields") unless @content
 
     # Prefer the standard extReq, but accept the Microsoft specific version as
     # a fallback, if the standard version isn't found.
@@ -173,7 +173,7 @@ DOC
       when 3
         {"oid" => ext_values[0].value, "value" => value, "critical" => ext_values[1].value}
       else
-        raise Puppet::Error, "In #{attribute.oid}, expected extension record #{index} to have two or three items, but found #{ext_values.length}"
+        raise Puppet::Error, _("In #{attribute.oid}, expected extension record #{index} to have two or three items, but found #{ext_values.length}")
       end
     end
   end
@@ -224,7 +224,7 @@ DOC
     csr_attributes.each do |oid, value|
       begin
         if PRIVATE_CSR_ATTRIBUTES.include? oid
-          raise ArgumentError, "Cannot specify CSR attribute #{oid}: conflicts with internally used CSR attribute"
+          raise ArgumentError, _("Cannot specify CSR attribute #{oid}: conflicts with internally used CSR attribute")
         end
 
         encoded = OpenSSL::ASN1::PrintableString.new(value.to_s)
@@ -233,7 +233,7 @@ DOC
         csr.add_attribute(OpenSSL::X509::Attribute.new(oid, attr_set))
         Puppet.debug("Added csr attribute: #{oid} => #{attr_set.inspect}")
       rescue OpenSSL::X509::AttributeError => e
-        raise Puppet::Error, "Cannot create CSR with attribute #{oid}: #{e.message}", e.backtrace
+        raise Puppet::Error, _("Cannot create CSR with attribute #{oid}: #{e.message}"), e.backtrace
       end
     end
   end
@@ -252,13 +252,13 @@ DOC
       options[:extension_requests].each_pair do |oid, value|
         begin
           if PRIVATE_EXTENSIONS.include? oid
-            raise Puppet::Error, "Cannot specify CSR extension request #{oid}: conflicts with internally used extension request"
+            raise Puppet::Error, _("Cannot specify CSR extension request #{oid}: conflicts with internally used extension request")
           end
 
           ext = OpenSSL::X509::Extension.new(oid, OpenSSL::ASN1::UTF8String.new(value.to_s).to_der, false)
           extensions << ext
         rescue OpenSSL::X509::ExtensionError => e
-          raise Puppet::Error, "Cannot create CSR with extension request #{oid}: #{e.message}", e.backtrace
+          raise Puppet::Error, _("Cannot create CSR with extension request #{oid}: #{e.message}"), e.backtrace
         end
       end
     end
@@ -301,23 +301,23 @@ DOC
   def unpack_extension_request(attribute)
 
     unless attribute.value.is_a? OpenSSL::ASN1::Set
-      raise Puppet::Error, "In #{attribute.oid}, expected Set but found #{attribute.value.class}"
+      raise Puppet::Error, _("In #{attribute.oid}, expected Set but found #{attribute.value.class}")
     end
 
     unless attribute.value.value.is_a? Array
-      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array] but found #{attribute.value.value.class}"
+      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array] but found #{attribute.value.value.class}")
     end
 
     unless attribute.value.value.size == 1
-      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array] with one value but found #{attribute.value.value.size} elements"
+      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array] with one value but found #{attribute.value.value.size} elements")
     end
 
     unless attribute.value.value.first.is_a? OpenSSL::ASN1::Sequence
-      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array[Sequence[...]]], but found #{extension.class}"
+      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array[Sequence[...]]], but found #{extension.class}")
     end
 
     unless attribute.value.value.first.value.is_a? Array
-      raise Puppet::Error, "In #{attribute.oid}, expected Set[Array[Sequence[Array[...]]]], but found #{extension.value.class}"
+      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array[Sequence[Array[...]]]], but found #{extension.value.class}")
     end
 
     extensions = attribute.value.value.first.value

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -74,7 +74,7 @@ DOC
   #
   # @return [OpenSSL::X509::Request] The generated CSR
   def generate(key, options = {})
-    Puppet.info _("Creating a new SSL certificate request for #{name}")
+    Puppet.info _("Creating a new SSL certificate request for %{name}") % { name: name }
 
     # Support either an actual SSL key, or a Puppet key.
     key = key.content if key.is_a?(Puppet::SSL::Key)
@@ -100,10 +100,10 @@ DOC
     signer = Puppet::SSL::CertificateSigner.new
     signer.sign(csr, key)
 
-    raise Puppet::Error, _("CSR sign verification failed; you need to clean the certificate request for #{name} on the server") unless csr.verify(key.public_key)
+    raise Puppet::Error, _("CSR sign verification failed; you need to clean the certificate request for %{name} on the server") % { name: name } unless csr.verify(key.public_key)
 
     @content = csr
-    Puppet.info _("Certificate Request fingerprint (#{digest.name}): #{digest.to_hex}")
+    Puppet.info _("Certificate Request fingerprint (%{digest}): %{hex_digest}") % { digest: digest.name, hex_digest: digest.to_hex }
     @content
   end
 
@@ -173,7 +173,7 @@ DOC
       when 3
         {"oid" => ext_values[0].value, "value" => value, "critical" => ext_values[1].value}
       else
-        raise Puppet::Error, _("In #{attribute.oid}, expected extension record #{index} to have two or three items, but found #{ext_values.length}")
+        raise Puppet::Error, _("In %{attr}, expected extension record %{index} to have two or three items, but found %{count}") % { attr: attribute.oid, index: index, count: ext_values.length }
       end
     end
   end
@@ -224,7 +224,7 @@ DOC
     csr_attributes.each do |oid, value|
       begin
         if PRIVATE_CSR_ATTRIBUTES.include? oid
-          raise ArgumentError, _("Cannot specify CSR attribute #{oid}: conflicts with internally used CSR attribute")
+          raise ArgumentError, _("Cannot specify CSR attribute %{oid}: conflicts with internally used CSR attribute") % { oid: oid }
         end
 
         encoded = OpenSSL::ASN1::PrintableString.new(value.to_s)
@@ -233,7 +233,7 @@ DOC
         csr.add_attribute(OpenSSL::X509::Attribute.new(oid, attr_set))
         Puppet.debug("Added csr attribute: #{oid} => #{attr_set.inspect}")
       rescue OpenSSL::X509::AttributeError => e
-        raise Puppet::Error, _("Cannot create CSR with attribute #{oid}: #{e.message}"), e.backtrace
+        raise Puppet::Error, _("Cannot create CSR with attribute %{oid}: %{message}") % { oid: oid, message: e.message }, e.backtrace
       end
     end
   end
@@ -252,13 +252,13 @@ DOC
       options[:extension_requests].each_pair do |oid, value|
         begin
           if PRIVATE_EXTENSIONS.include? oid
-            raise Puppet::Error, _("Cannot specify CSR extension request #{oid}: conflicts with internally used extension request")
+            raise Puppet::Error, _("Cannot specify CSR extension request %{oid}: conflicts with internally used extension request") % { oid: oid }
           end
 
           ext = OpenSSL::X509::Extension.new(oid, OpenSSL::ASN1::UTF8String.new(value.to_s).to_der, false)
           extensions << ext
         rescue OpenSSL::X509::ExtensionError => e
-          raise Puppet::Error, _("Cannot create CSR with extension request #{oid}: #{e.message}"), e.backtrace
+          raise Puppet::Error, _("Cannot create CSR with extension request %{oid}: %{message}") % { oid: oid, message: e.message }, e.backtrace
         end
       end
     end
@@ -301,23 +301,23 @@ DOC
   def unpack_extension_request(attribute)
 
     unless attribute.value.is_a? OpenSSL::ASN1::Set
-      raise Puppet::Error, _("In #{attribute.oid}, expected Set but found #{attribute.value.class}")
+      raise Puppet::Error, _("In %{attr}, expected Set but found %{klass}") % { attr: attribute.oid, klass: attribute.value.class }
     end
 
     unless attribute.value.value.is_a? Array
-      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array] but found #{attribute.value.value.class}")
+      raise Puppet::Error, _("In %{attr}, expected Set[Array] but found %{klass}") % { attr: attribute.oid, klass: attribute.value.value.class }
     end
 
     unless attribute.value.value.size == 1
-      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array] with one value but found #{attribute.value.value.size} elements")
+      raise Puppet::Error, _("In %{attr}, expected Set[Array] with one value but found %{count} elements") % { attr: attribute.oid, count: attribute.value.value.size }
     end
 
     unless attribute.value.value.first.is_a? OpenSSL::ASN1::Sequence
-      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array[Sequence[...]]], but found #{extension.class}")
+      raise Puppet::Error, _("In %{attr}, expected Set[Array[Sequence[...]]], but found %{klass}") % { attr: attribute.oid, klass: extension.class }
     end
 
     unless attribute.value.value.first.value.is_a? Array
-      raise Puppet::Error, _("In #{attribute.oid}, expected Set[Array[Sequence[Array[...]]]], but found #{extension.value.class}")
+      raise Puppet::Error, _("In %{attr}, expected Set[Array[Sequence[Array[...]]]], but found %{klass}") % { attr: attribute.oid, klass: extension.value.class }
     end
 
     extensions = attribute.value.value.first.value

--- a/lib/puppet/ssl/certificate_request_attributes.rb
+++ b/lib/puppet/ssl/certificate_request_attributes.rb
@@ -19,16 +19,16 @@ class Puppet::SSL::CertificateRequestAttributes
   # @return true if we are able to load the file, false otherwise
   # @raise [Puppet::Error] if there are unexpected attribute keys
   def load
-    Puppet.info("csr_attributes file loading from #{path}")
+    Puppet.info(_("csr_attributes file loading from #{path}"))
     if Puppet::FileSystem.exist?(path)
       hash = Puppet::Util::Yaml.load_file(path, {})
       if ! hash.is_a?(Hash)
-        raise Puppet::Error, "invalid CSR attributes, expected instance of Hash, received instance of #{hash.class}"
+        raise Puppet::Error, _("invalid CSR attributes, expected instance of Hash, received instance of #{hash.class}")
       end
       @custom_attributes = hash.delete('custom_attributes') || {}
       @extension_requests = hash.delete('extension_requests') || {}
       if not hash.keys.empty?
-        raise Puppet::Error, "unexpected attributes #{hash.keys.inspect} in #{@path.inspect}"
+        raise Puppet::Error, _("unexpected attributes #{hash.keys.inspect} in #{@path.inspect}")
       end
       return true
     end

--- a/lib/puppet/ssl/certificate_request_attributes.rb
+++ b/lib/puppet/ssl/certificate_request_attributes.rb
@@ -19,16 +19,16 @@ class Puppet::SSL::CertificateRequestAttributes
   # @return true if we are able to load the file, false otherwise
   # @raise [Puppet::Error] if there are unexpected attribute keys
   def load
-    Puppet.info(_("csr_attributes file loading from #{path}"))
+    Puppet.info(_("csr_attributes file loading from %{path}") % { path: path })
     if Puppet::FileSystem.exist?(path)
       hash = Puppet::Util::Yaml.load_file(path, {})
       if ! hash.is_a?(Hash)
-        raise Puppet::Error, _("invalid CSR attributes, expected instance of Hash, received instance of #{hash.class}")
+        raise Puppet::Error, _("invalid CSR attributes, expected instance of Hash, received instance of %{klass}") % { klass: hash.class }
       end
       @custom_attributes = hash.delete('custom_attributes') || {}
       @extension_requests = hash.delete('extension_requests') || {}
       if not hash.keys.empty?
-        raise Puppet::Error, _("unexpected attributes #{hash.keys.inspect} in #{@path.inspect}")
+        raise Puppet::Error, _("unexpected attributes %{keys} in %{path}") % { keys: hash.keys.inspect, path: @path.inspect }
       end
       return true
     end

--- a/lib/puppet/ssl/certificate_revocation_list.rb
+++ b/lib/puppet/ssl/certificate_revocation_list.rb
@@ -26,7 +26,7 @@ DOC
 
   # Knows how to create a CRL with our system defaults.
   def generate(cert, cakey)
-    Puppet.info "Creating a new certificate revocation list"
+    Puppet.info _("Creating a new certificate revocation list")
 
     create_crl_issued_by(cert)
     start_at_initial_crl_number
@@ -39,14 +39,14 @@ DOC
   # The name doesn't actually matter; there's only one CRL.
   # We just need the name so our Indirector stuff all works more easily.
   def initialize(fakename)
-    @name = "crl"
+    @name = _("crl")
   end
 
   # Revoke the certificate with serial number SERIAL issued by this
   # CA, then write the CRL back to disk. The REASON must be one of the
   # OpenSSL::OCSP::REVOKED_* reasons
   def revoke(serial, cakey, reason = OpenSSL::OCSP::REVOKED_STATUS_KEYCOMPROMISE)
-    Puppet.notice "Revoked certificate with serial #{serial}"
+    Puppet.notice _("Revoked certificate with serial #{serial}")
     time = Time.now
 
     add_certificate_revocation_for(serial, reason, time)

--- a/lib/puppet/ssl/certificate_revocation_list.rb
+++ b/lib/puppet/ssl/certificate_revocation_list.rb
@@ -46,7 +46,7 @@ DOC
   # CA, then write the CRL back to disk. The REASON must be one of the
   # OpenSSL::OCSP::REVOKED_* reasons
   def revoke(serial, cakey, reason = OpenSSL::OCSP::REVOKED_STATUS_KEYCOMPROMISE)
-    Puppet.notice _("Revoked certificate with serial #{serial}")
+    Puppet.notice _("Revoked certificate with serial %{serial}") % { serial: serial }
     time = Time.now
 
     add_certificate_revocation_for(serial, reason, time)

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -104,7 +104,7 @@ DOC
   # Specify how we expect to interact with our certificate authority.
   def self.ca_location=(mode)
     modes = CA_MODES.collect { |m, vals| m.to_s }.join(", ")
-    raise ArgumentError, _("CA Mode can only be one of: #{modes}") unless CA_MODES.include?(mode)
+    raise ArgumentError, _("CA Mode can only be one of: %{modes}") % { modes: modes } unless CA_MODES.include?(mode)
 
     @ca_location = mode
 
@@ -208,17 +208,17 @@ DOC
 
   def validate_certificate_with_key
     raise Puppet::Error, _("No certificate to validate.") unless certificate
-    raise Puppet::Error, _("No private key with which to validate certificate with fingerprint: #{certificate.fingerprint}") unless key
+    raise Puppet::Error, _("No private key with which to validate certificate with fingerprint: %{fingerprint}") % { fingerprint: certificate.fingerprint } unless key
     unless certificate.content.check_private_key(key.content)
-      raise Puppet::Error, _(<<ERROR_STRING)
+      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: certificate.fingerprint, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
 The certificate retrieved from the master does not match the agent's private key.
-Certificate fingerprint: #{certificate.fingerprint}
+Certificate fingerprint: %{fingerprint}
 To fix this, remove the certificate from both the master and the agent and then start a puppet run, which will automatically regenerate a certificate.
 On the master:
-  puppet cert clean #{Puppet[:certname]}
+  puppet cert clean %{cert_name}
 On the agent:
-  1a. On most platforms: find #{Puppet[:ssldir]} -name #{Puppet[:certname]}.pem -delete
-  1b. On Windows: del "#{Puppet[:certdir].gsub('/', '\\')}\\#{Puppet[:certname]}.pem" /f
+  1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
+  1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f
   2. puppet agent -t
 ERROR_STRING
     end
@@ -235,17 +235,17 @@ ERROR_STRING
     if !existing_request.nil? &&
       (key.content.public_key.to_s != existing_request.content.public_key.to_s)
 
-      raise Puppet::Error, _(<<ERROR_STRING)
+      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: existing_request.fingerprint, csr_public_key: existing_request.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
 The CSR retrieved from the master does not match the agent's public key.
-CSR fingerprint: #{existing_request.fingerprint}
-CSR public key: #{existing_request.content.public_key.to_text}
-Agent public key: #{key.content.public_key.to_text}
+CSR fingerprint: %{fingerprint}
+CSR public key: %{csr_public_key}
+Agent public key: %{agent_public_key}
 To fix this, remove the CSR from both the master and the agent and then start a puppet run, which will automatically regenerate a CSR.
 On the master:
-  puppet cert clean #{Puppet[:certname]}
+  puppet cert clean %{cert_name}
 On the agent:
-  1a. On most platforms: find #{Puppet[:ssldir]} -name #{Puppet[:certname]}.pem -delete
-  1b. On Windows: del "#{Puppet[:certdir].gsub('/', '\\')}\\#{Puppet[:certname]}.pem" /f
+  1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
+  1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f
   2. puppet agent -t
 ERROR_STRING
     end
@@ -344,7 +344,7 @@ ERROR_STRING
       generate
       return if certificate
     rescue StandardError => detail
-      Puppet.log_exception(detail, _("Could not request certificate: #{detail.message}"))
+      Puppet.log_exception(detail, _("Could not request certificate: %{message}") % { message: detail.message })
       if time < 1
         puts _("Exiting; failed to retrieve certificate and waitforcert is disabled")
         exit(1)
@@ -365,7 +365,7 @@ ERROR_STRING
         break if certificate
         Puppet.notice _("Did not receive certificate")
       rescue StandardError => detail
-        Puppet.log_exception(detail, _("Could not request certificate: #{detail.message}"))
+        Puppet.log_exception(detail, _("Could not request certificate: %{message}") % { message: detail.message })
       end
     end
   end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -104,7 +104,7 @@ DOC
   # Specify how we expect to interact with our certificate authority.
   def self.ca_location=(mode)
     modes = CA_MODES.collect { |m, vals| m.to_s }.join(", ")
-    raise ArgumentError, "CA Mode can only be one of: #{modes}" unless CA_MODES.include?(mode)
+    raise ArgumentError, _("CA Mode can only be one of: #{modes}") unless CA_MODES.include?(mode)
 
     @ca_location = mode
 
@@ -207,10 +207,10 @@ DOC
   end
 
   def validate_certificate_with_key
-    raise Puppet::Error, "No certificate to validate." unless certificate
-    raise Puppet::Error, "No private key with which to validate certificate with fingerprint: #{certificate.fingerprint}" unless key
+    raise Puppet::Error, _("No certificate to validate.") unless certificate
+    raise Puppet::Error, _("No private key with which to validate certificate with fingerprint: #{certificate.fingerprint}") unless key
     unless certificate.content.check_private_key(key.content)
-      raise Puppet::Error, <<ERROR_STRING
+      raise Puppet::Error, _(<<ERROR_STRING)
 The certificate retrieved from the master does not match the agent's private key.
 Certificate fingerprint: #{certificate.fingerprint}
 To fix this, remove the certificate from both the master and the agent and then start a puppet run, which will automatically regenerate a certificate.
@@ -235,7 +235,7 @@ ERROR_STRING
     if !existing_request.nil? &&
       (key.content.public_key.to_s != existing_request.content.public_key.to_s)
 
-      raise Puppet::Error, <<ERROR_STRING
+      raise Puppet::Error, _(<<ERROR_STRING)
 The CSR retrieved from the master does not match the agent's public key.
 CSR fingerprint: #{existing_request.fingerprint}
 CSR public key: #{existing_request.content.public_key.to_text}
@@ -344,9 +344,9 @@ ERROR_STRING
       generate
       return if certificate
     rescue StandardError => detail
-      Puppet.log_exception(detail, "Could not request certificate: #{detail.message}")
+      Puppet.log_exception(detail, _("Could not request certificate: #{detail.message}"))
       if time < 1
-        puts "Exiting; failed to retrieve certificate and waitforcert is disabled"
+        puts _("Exiting; failed to retrieve certificate and waitforcert is disabled")
         exit(1)
       else
         sleep(time)
@@ -355,7 +355,7 @@ ERROR_STRING
     end
 
     if time < 1
-      puts "Exiting; no certificate found and waitforcert is disabled"
+      puts _("Exiting; no certificate found and waitforcert is disabled")
       exit(1)
     end
 
@@ -363,9 +363,9 @@ ERROR_STRING
       sleep time
       begin
         break if certificate
-        Puppet.notice "Did not receive certificate"
+        Puppet.notice _("Did not receive certificate")
       rescue StandardError => detail
-        Puppet.log_exception(detail, "Could not request certificate: #{detail.message}")
+        Puppet.log_exception(detail, _("Could not request certificate: #{detail.message}"))
       end
     end
   end

--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -29,7 +29,7 @@ class Puppet::SSL::Inventory
   # Rebuild the inventory from scratch.  This should happen if
   # the file is entirely missing or if it's somehow corrupted.
   def rebuild
-    Puppet.notice "Rebuilding inventory file"
+    Puppet.notice _("Rebuilding inventory file")
 
     # RFC 5280 says the cert subject may contain UTF8 - https://www.ietf.org/rfc/rfc5280.txt
     Puppet.settings.setting(:cert_inventory).open('w:UTF-8') do |f|

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -21,7 +21,7 @@ DOC
 
   # Knows how to create keys with our system defaults.
   def generate
-    Puppet.info _("Creating a new SSL key for #{name}")
+    Puppet.info _("Creating a new SSL key for %{name}") % { name: name }
     @content = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
   end
 

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -21,7 +21,7 @@ DOC
 
   # Knows how to create keys with our system defaults.
   def generate
-    Puppet.info "Creating a new SSL key for #{name}"
+    Puppet.info _("Creating a new SSL key for #{name}")
     @content = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
   end
 

--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -100,22 +100,22 @@ module Puppet::SSL::Oids
       begin
         mapping = YAML.load_file(custom_oid_file)
       rescue => err
-        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': #{err}"), err.backtrace
+        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '%{custom_oid_file}': %{err}") % { custom_oid_file: custom_oid_file, err: err }, err.backtrace
       end
 
       unless mapping.has_key?(map_key)
-        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': no such index '#{map_key}'")
+        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '%{custom_oid_file}': no such index '%{map_key}'") % { custom_oid_file: custom_oid_file, map_key: map_key }
       end
 
       unless mapping[map_key].is_a?(Hash)
-        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': data under index '#{map_key}' must be a Hash")
+        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '%{custom_oid_file}': data under index '%{map_key}' must be a Hash") % { custom_oid_file: custom_oid_file, map_key: map_key }
       end
 
       oid_defns = []
       mapping[map_key].keys.each do |oid|
         shortname, longname = mapping[map_key][oid].values_at("shortname","longname")
         if shortname.nil? || longname.nil?
-          raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': incomplete definition of oid '#{oid}'")
+          raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '%{custom_oid_file}': incomplete definition of oid '%{oid}'") % { custom_oid_file: custom_oid_file, oid: oid }
         end
         oid_defns << [oid, shortname, longname]
       end
@@ -147,7 +147,7 @@ module Puppet::SSL::Oids
           OpenSSL::ASN1::ObjectId.register(*oid_defn)
         end
       rescue => err
-        raise ArgumentError, _("Error registering ssl custom OIDs mapping from file '#{custom_oid_file}': #{err}"), err.backtrace
+        raise ArgumentError, _("Error registering ssl custom OIDs mapping from file '%{custom_oid_file}': %{err}") % { custom_oid_file: custom_oid_file, err: err }, err.backtrace
       end
     end
   end

--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -100,22 +100,22 @@ module Puppet::SSL::Oids
       begin
         mapping = YAML.load_file(custom_oid_file)
       rescue => err
-        raise Puppet::Error, "Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': #{err}", err.backtrace
+        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': #{err}"), err.backtrace
       end
 
       unless mapping.has_key?(map_key)
-        raise Puppet::Error, "Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': no such index '#{map_key}'"
+        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': no such index '#{map_key}'")
       end
 
       unless mapping[map_key].is_a?(Hash)
-        raise Puppet::Error, "Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': data under index '#{map_key}' must be a Hash"
+        raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': data under index '#{map_key}' must be a Hash")
       end
 
       oid_defns = []
       mapping[map_key].keys.each do |oid|
         shortname, longname = mapping[map_key][oid].values_at("shortname","longname")
         if shortname.nil? || longname.nil?
-          raise Puppet::Error, "Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': incomplete definition of oid '#{oid}'"
+          raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '#{custom_oid_file}': incomplete definition of oid '#{oid}'")
         end
         oid_defns << [oid, shortname, longname]
       end
@@ -147,7 +147,7 @@ module Puppet::SSL::Oids
           OpenSSL::ASN1::ObjectId.register(*oid_defn)
         end
       rescue => err
-        raise ArgumentError, "Error registering ssl custom OIDs mapping from file '#{custom_oid_file}': #{err}", err.backtrace
+        raise ArgumentError, _("Error registering ssl custom OIDs mapping from file '#{custom_oid_file}': #{err}"), err.backtrace
       end
     end
   end


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/ssl/*` for translation.