### PR TITLE
(PUP-7042) Mark strings in syntax_checker

### DIFF
--- a/lib/puppet/syntax_checkers/base64.rb
+++ b/lib/puppet/syntax_checkers/base64.rb
@@ -17,7 +17,7 @@ class Puppet::SyntaxCheckers::Base64 < Puppet::Plugins::SyntaxCheckers::SyntaxCh
   def check(text, syntax, acceptor, source_pos)
     raise ArgumentError.new(_("Base64 syntax checker: the text to check must be a String.")) unless text.is_a?(String)
     raise ArgumentError.new(_("Base64 syntax checker: the syntax identifier must be a String, e.g. json, data+json")) unless syntax.is_a?(String)
-    raise ArgumentError.new(_("Base64 syntax checker: invalid Acceptor, got: '#{acceptor.class.name}'.")) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
+    raise ArgumentError.new(_("Base64 syntax checker: invalid Acceptor, got: '%{klass}'.") % { klass: acceptor.class.name }) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
     cleaned_text = text.gsub(/[\r?\n[:blank:]]/, '')
     begin
       # Do a strict decode64 on text with all whitespace stripped since the non strict version
@@ -29,7 +29,7 @@ class Puppet::SyntaxCheckers::Base64 < Puppet::Plugins::SyntaxCheckers::SyntaxCh
       else
         msg2 = _("contains letters outside strict base 64 range (or whitespace)")
       end
-      msg = _("Base64 syntax checker: Cannot parse invalid Base64 string - #{msg2}")
+      msg = _("Base64 syntax checker: Cannot parse invalid Base64 string - %{msg2}") % { msg2: msg2 }
 
       # TODO: improve the pops API to allow simpler diagnostic creation while still maintaining capabilities
       # and the issue code. (In this case especially, where there is only a single error message being issued).

--- a/lib/puppet/syntax_checkers/base64.rb
+++ b/lib/puppet/syntax_checkers/base64.rb
@@ -15,9 +15,9 @@ class Puppet::SyntaxCheckers::Base64 < Puppet::Plugins::SyntaxCheckers::SyntaxCh
   # @api public
   #
   def check(text, syntax, acceptor, source_pos)
-    raise ArgumentError.new("Base64 syntax checker: the text to check must be a String.") unless text.is_a?(String)
-    raise ArgumentError.new("Base64 syntax checker: the syntax identifier must be a String, e.g. json, data+json") unless syntax.is_a?(String)
-    raise ArgumentError.new("Base64 syntax checker: invalid Acceptor, got: '#{acceptor.class.name}'.") unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
+    raise ArgumentError.new(_("Base64 syntax checker: the text to check must be a String.")) unless text.is_a?(String)
+    raise ArgumentError.new(_("Base64 syntax checker: the syntax identifier must be a String, e.g. json, data+json")) unless syntax.is_a?(String)
+    raise ArgumentError.new(_("Base64 syntax checker: invalid Acceptor, got: '#{acceptor.class.name}'.")) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
     cleaned_text = text.gsub(/[\r?\n[:blank:]]/, '')
     begin
       # Do a strict decode64 on text with all whitespace stripped since the non strict version
@@ -25,11 +25,11 @@ class Puppet::SyntaxCheckers::Base64 < Puppet::Plugins::SyntaxCheckers::SyntaxCh
       Base64.strict_decode64(cleaned_text)
     rescue => e
       if (cleaned_text.bytes.to_a.size * 8) % 6 != 0
-        msg2 = "padding is not correct"
+        msg2 = _("padding is not correct")
       else
-        msg2 = "contains letters outside strict base 64 range (or whitespace)"
+        msg2 = _("contains letters outside strict base 64 range (or whitespace)")
       end
-      msg = "Base64 syntax checker: Cannot parse invalid Base64 string - #{msg2}"
+      msg = _("Base64 syntax checker: Cannot parse invalid Base64 string - #{msg2}")
 
       # TODO: improve the pops API to allow simpler diagnostic creation while still maintaining capabilities
       # and the issue code. (In this case especially, where there is only a single error message being issued).

--- a/lib/puppet/syntax_checkers/json.rb
+++ b/lib/puppet/syntax_checkers/json.rb
@@ -16,14 +16,14 @@ class Puppet::SyntaxCheckers::Json < Puppet::Plugins::SyntaxCheckers::SyntaxChec
   def check(text, syntax, acceptor, source_pos)
     raise ArgumentError.new(_("Json syntax checker: the text to check must be a String.")) unless text.is_a?(String)
     raise ArgumentError.new(_("Json syntax checker: the syntax identifier must be a String, e.g. json, data+json")) unless syntax.is_a?(String)
-    raise ArgumentError.new(_("Json syntax checker: invalid Acceptor, got: '#{acceptor.class.name}'.")) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
+    raise ArgumentError.new(_("Json syntax checker: invalid Acceptor, got: '%{klass}'.") % { klass: acceptor.class.name }) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
     #raise ArgumentError.new("Json syntax checker: location_info must be a Hash") unless location_info.is_a?(Hash)
 
     begin
       JSON.parse(text)
     rescue => e
       # Cap the message to 100 chars and replace newlines
-      msg = _("JSON syntax checker: Cannot parse invalid JSON string. \"#{e.message().slice(0,100).gsub(/\r?\n/, "\\n")}\"")
+      msg = _("JSON syntax checker: Cannot parse invalid JSON string. \"%{message}\"") % { message: e.message().slice(0,100).gsub(/\r?\n/, "\\n") }
 
       # TODO: improve the pops API to allow simpler diagnostic creation while still maintaining capabilities
       # and the issue code. (In this case especially, where there is only a single error message being issued).

--- a/lib/puppet/syntax_checkers/json.rb
+++ b/lib/puppet/syntax_checkers/json.rb
@@ -14,16 +14,16 @@ class Puppet::SyntaxCheckers::Json < Puppet::Plugins::SyntaxCheckers::SyntaxChec
   # @api public
   #
   def check(text, syntax, acceptor, source_pos)
-    raise ArgumentError.new("Json syntax checker: the text to check must be a String.") unless text.is_a?(String)
-    raise ArgumentError.new("Json syntax checker: the syntax identifier must be a String, e.g. json, data+json") unless syntax.is_a?(String)
-    raise ArgumentError.new("Json syntax checker: invalid Acceptor, got: '#{acceptor.class.name}'.") unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
+    raise ArgumentError.new(_("Json syntax checker: the text to check must be a String.")) unless text.is_a?(String)
+    raise ArgumentError.new(_("Json syntax checker: the syntax identifier must be a String, e.g. json, data+json")) unless syntax.is_a?(String)
+    raise ArgumentError.new(_("Json syntax checker: invalid Acceptor, got: '#{acceptor.class.name}'.")) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
     #raise ArgumentError.new("Json syntax checker: location_info must be a Hash") unless location_info.is_a?(Hash)
 
     begin
       JSON.parse(text)
     rescue => e
       # Cap the message to 100 chars and replace newlines
-      msg = "JSON syntax checker: Cannot parse invalid JSON string. \"#{e.message().slice(0,100).gsub(/\r?\n/, "\\n")}\""
+      msg = _("JSON syntax checker: Cannot parse invalid JSON string. \"#{e.message().slice(0,100).gsub(/\r?\n/, "\\n")}\"")
 
       # TODO: improve the pops API to allow simpler diagnostic creation while still maintaining capabilities
       # and the issue code. (In this case especially, where there is only a single error message being issued).


### PR DESCRIPTION
This commit marks user-facing error and info strings in
`lib/puppet/syntax_checker/*` for translation.