### PR TITLE
(pup-7156) add shim for semantic

### DIFF
--- a/lib/puppet/vendor/load_semantic.rb
+++ b/lib/puppet/vendor/load_semantic.rb
@@ -1,0 +1,1 @@
+$: << File.join([File.dirname(__FILE__), "semantic/lib"])

--- a/lib/puppet/vendor/semantic/lib/semantic.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic.rb
@@ -1,0 +1,5 @@
+require 'puppet/vendor/semantic_puppet/lib/semantic_puppet'
+
+$stderr.puts "Warning: Puppet's internal vendored libraries are Private APIs and can change without warning. The 'semantic' library has been replaced with 'semantic_puppet'."
+
+Semantic = SemanticPuppet


### PR DESCRIPTION
In c111fb7, puppet switched to using the 'semantic_puppet' library instead of
'semantic'. Thus, the vendored libraries changed - 'semantic' was removed and
'semantic_puppet' added. Unexpectedly, this broke users of
garethr/puppet-module-skeleton, as this project at the time directly loaded the
'semantic' library via "require 'puppet/vendor/semantic/lib/semantic'".

This commit introduces a shim for puppet/vendor/semantic, so that users who
have required the library will not be broken. A warning is emitted as well,
noting that puppet's vendored libraries are private internal API and not
intended for external/public use.