### PR TITLE
(PUP-7117) Updated acceptance test for utf-8 characters in file resource

### DIFF
--- a/acceptance/tests/utf8/utf8-in-file-resource.rb
+++ b/acceptance/tests/utf8/utf8-in-file-resource.rb
@@ -5,15 +5,21 @@ test_name 'utf-8 characters in resource title and param values' do
     'eos-4',      # PUP-7146
     'cumulus',    # PUP-7147
     'cisco_ios',  # PUP-7150
+    'aix',        # PUP-7194
+    'huawei',     # PUP-7195
   ]   
 
   # utf8chars = "€‰ㄘ万竹ÜÖ"
   utf8chars = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
   agents.each do |agent|
+    puts "agent name: #{agent.node_name}, platform: #{agent.platform}"
     agent_file = agent.tmpfile("file" + utf8chars) 
+    teardown do
+      on(agent, "rm -rf #{agent_file}")
+    end
     # remove this file, so puppet can create it and not merely correct
     # its drift.
-    on(agent, "rm -rf #{agent_file}", :enviornment => {:LANG => "en_US.UTF-8"})
+    on(agent, "rm -rf #{agent_file}", :environment => {:LANG => "en_US.UTF-8"})
 
     manifest =
 <<PP
@@ -28,57 +34,52 @@ file { "#{agent_file}" :
 PP
 
     step "Apply manifest" do
-      result = apply_manifest_on(
+      apply_manifest_on(
         agent,
         manifest,
         {
-          :acceptable_exit_codes => (0..2),
+          :acceptable_exit_codes => [2],
           :catch_failures => true, 
           :environment => {:LANG => "en_US.UTF-8"}
         }
       )
-      result = on(
-        agent, "cat #{agent_file}", :enviornment => {:LANG => "en_US.UTF-8"}
-      )
-      assert_equal(result.exit_code, 0)
-      assert_match(
-        /#{utf8chars}/,
-        result.stdout,
-        "result stdout did not contain"
-      )
+      on(
+        agent, "cat #{agent_file}", :environment => {:LANG => "en_US.UTF-8"}
+      ) do
+        assert_match(
+          /#{utf8chars}/,
+          stdout,
+          "result stdout did not contain \"#{utf8chars}\"",
+        )
+      end
     end
 
     step "Drift correction" do
       on(
         agent,
         "echo '' > #{agent_file}",
-        :enviornment => {:LANG => "en_US.UTF-8"}
+        :environment => {:LANG => "en_US.UTF-8"}
       )
-      result = on(
-        agent,
-        "cat #{agent_file}",
-        :enviornment => {:LANG => "en_US.UTF-8"}
-      )
-      assert_equal(result.stdout.chomp, "", "expected empty file")
-      result = apply_manifest_on(
+      apply_manifest_on(
         agent,
         manifest,
         {
-          :acceptable_exit_codes => (0..255),
+          :acceptable_exit_codes => [2],
           :catch_failures => true, 
           :environment => {:LANG => "en_US.UTF-8"}
         }
       )
-      result = on(
+      on(
         agent,
         "cat #{agent_file}",
         :environment => {:LANG => "en_US.UTF-8"}
-      )
-      assert_match(
-        /#{utf8chars}/,
-        result.stdout,
-        "result stdout did not contain"
-      )
+      ) do
+        assert_match(
+          /#{utf8chars}/,
+          stdout,
+          "result stdout did not contain \"#{utf8chars}\""
+        )
+      end
     end
   end
 end

--- a/acceptance/tests/utf8/utf8-in-file-resource.rb
+++ b/acceptance/tests/utf8/utf8-in-file-resource.rb
@@ -1,0 +1,85 @@
+test_name 'utf-8 characters in resource title and param values' do
+
+  confine :except, :platform => [
+    'windows',    # PUP-6983
+    'eos-4',      # PUP-7146
+    'cumulus',    # PUP-7147
+    'cisco_ios',  # PUP-7150
+  ]   
+
+  # utf8chars = "€‰ㄘ万竹ÜÖ"
+  utf8chars = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
+  agents.each do |agent|
+    agent_file = agent.tmpfile("file" + utf8chars) 
+    # remove this file, so puppet can create it and not merely correct
+    # its drift.
+    on(agent, "rm -rf #{agent_file}", :enviornment => {:LANG => "en_US.UTF-8"})
+
+    manifest =
+<<PP
+
+file { "#{agent_file}" :
+  ensure => file,
+  mode => "0644",
+  content => "This is the file content. file #{utf8chars} 
+",
+}
+
+PP
+
+    step "Apply manifest" do
+      result = apply_manifest_on(
+        agent,
+        manifest,
+        {
+          :acceptable_exit_codes => (0..2),
+          :catch_failures => true, 
+          :environment => {:LANG => "en_US.UTF-8"}
+        }
+      )
+      result = on(
+        agent, "cat #{agent_file}", :enviornment => {:LANG => "en_US.UTF-8"}
+      )
+      assert_equal(result.exit_code, 0)
+      assert_match(
+        /#{utf8chars}/,
+        result.stdout,
+        "result stdout did not contain"
+      )
+    end
+
+    step "Drift correction" do
+      on(
+        agent,
+        "echo '' > #{agent_file}",
+        :enviornment => {:LANG => "en_US.UTF-8"}
+      )
+      result = on(
+        agent,
+        "cat #{agent_file}",
+        :enviornment => {:LANG => "en_US.UTF-8"}
+      )
+      assert_equal(result.stdout.chomp, "", "expected empty file")
+      result = apply_manifest_on(
+        agent,
+        manifest,
+        {
+          :acceptable_exit_codes => (0..255),
+          :catch_failures => true, 
+          :environment => {:LANG => "en_US.UTF-8"}
+        }
+      )
+      result = on(
+        agent,
+        "cat #{agent_file}",
+        :environment => {:LANG => "en_US.UTF-8"}
+      )
+      assert_match(
+        /#{utf8chars}/,
+        result.stdout,
+        "result stdout did not contain"
+      )
+    end
+  end
+end
+


### PR DESCRIPTION
The original version of this test was modified to set the environment
variable LANG to "en_US.UTF-8" on each call to on() and apply_manifest_on().
There are some VM pooler templates that do not set this by default.