### PR TITLE
(PUP-6588) Fix --module-repository to use full remote URL

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -45,7 +45,7 @@ class Puppet::Forge
     # Return a Net::HTTPResponse read for this +path+.
     def make_http_request(path, io = nil)
       Puppet.debug "HTTP GET #{@host}#{path}"
-      request = get_request_object(path)
+      request = get_request_object(@uri.path.chomp('/')+path)
       return read_response(request, io)
     end
 

--- a/spec/unit/face/module/search_spec.rb
+++ b/spec/unit/face/module/search_spec.rb
@@ -171,7 +171,7 @@ describe "puppet module search" do
       end
     end
 
-    it "should accept the --module-repository option" do
+    it "should accept the --module_repository option" do
       forge = mock("Puppet::Forge")
       searcher = mock("Searcher")
       options[:module_repository] = "http://forge.example.com"

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -48,6 +48,28 @@ describe Puppet::Forge::Repository do
       expect(repository.make_http_request("the_path")).to eq(result)
     end
 
+    it "merges forge URI and path specified" do
+      result = "#{Object.new}"
+
+      performs_an_http_request result do |http|
+        http.expects(:request).with(responds_with(:path, "/test/the_path/"))
+      end
+
+      repository = Puppet::Forge::Repository.new('http://fake.com/test', agent)
+      expect(repository.make_http_request("/the_path/")).to eq(result)
+    end
+
+    it "handles trailing slashes when merging URI and path" do
+      result = "#{Object.new}"
+
+      performs_an_http_request result do |http|
+        http.expects(:request).with(responds_with(:path, "/test/the_path"))
+      end
+
+      repository = Puppet::Forge::Repository.new('http://fake.com/test/', agent)
+      expect(repository.make_http_request("/the_path")).to eq(result)
+    end
+
     it 'returns the result object from a request with ssl' do
       result = "#{Object.new}"
       performs_an_https_request result do |http|


### PR DESCRIPTION
Fixes the `--module-repository` argument when a remote URL includes a
path, as in `http://forge:8080/modules`. This allows the module tool to
work with repositories that use paths to separate different types of
artifacts.

I'd like to retarget this at stable after releases are cleaned up.