### PR TITLE
(PUP-7158) pkg_spec.rb failure on individual execution starting c5d97e

### DIFF
--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -9,6 +9,8 @@ describe Puppet::Type.type(:package).provider(:pkg) do
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})
+  else
+    Puppet::Util::Execution.execute('exit 0', {:failonfail => false})
   end
 
   before :each do


### PR DESCRIPTION
Before this change attempts to execute only pkg_spec would fail while
mocking CHILD_STATUS. When executed with other specs that initialize
CHILD_STATUS in some way execution is successful