### PR TITLE
(PUP-7164) Handle empty hiera yaml data file gracefully

### DIFF
--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -10,7 +10,12 @@ Puppet::Functions.create_function(:yaml_data) do
 
   def yaml_data(options, context)
     begin
-      data = YAML.load_file(options['path'])
+      path = options['path']
+      data = YAML.load_file(path)
+      unless data.is_a?(Hash)
+        Puppet.warning("#{path}: file does not contain a valid yaml hash")
+        data = {}
+      end
       Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data.nil? ? {} : data)
     rescue YAML::SyntaxError => ex
       # Psych errors includes the absolute path to the file, so no need to add that

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -74,7 +74,7 @@ class Invocation
     rescue Puppet::DataBinding::LookupError
       raise
     rescue Puppet::Error => detail
-      raise Puppet::DataBinding::LookupError.new(detail.message, detail)
+      raise Puppet::DataBinding::LookupError.new(detail.message, nil, nil, nil, detail)
     ensure
       @name_stack.pop
     end


### PR DESCRIPTION
This commit ensures that a hiera yaml file that parses correctly but
returns something other than a hash is accepted (as an empty hash) but
with a warning.

The commit also contains a fix that made type mismatch messages repeated
twice when the exception was logged.