### PR TITLE
(PUP-7165) Handle hiera.yaml v3 in environment root using --strict

### DIFF
--- a/lib/puppet/pops/lookup/environment_data_provider.rb
+++ b/lib/puppet/pops/lookup/environment_data_provider.rb
@@ -11,8 +11,16 @@ class EnvironmentDataProvider < ConfiguredDataProvider
   protected
 
   def assert_config_version(config)
-    raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in an environment" unless config.version > 3
-    config
+    if config.version > 3
+      config
+    else
+      if Puppet[:strict] == :error
+        raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in an environment"
+      else
+        Puppet.warn_once(:hiera_v3_at_env_root, config.config_path, 'hiera.yaml version 3 found at the environment root was ignored')
+      end
+      nil
+    end
   end
 
   # Return the root of the environment

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -318,7 +318,10 @@ class LookupAdapter < DataAdapter
     if mod.has_hiera_conf?
       mp = ModuleDataProvider.new(module_name)
       # A version 5 hiera.yaml trumps a data provider setting or binding in the module
-      if mp.config(lookup_invocation).version >= 5
+      mp_config = mp.config(lookup_invocation)
+      if mp_config.nil?
+        mp = nil
+      elsif mp_config.version >= 5
         unless provider_name.nil? || Puppet[:strict] == :off
           if binding
             Puppet.warn_once(:deprecation, "ModuleBinding#data_provider-#{module_name}",
@@ -388,7 +391,10 @@ class LookupAdapter < DataAdapter
     if config_path.exist?
       ep = EnvironmentDataProvider.new
       # A version 5 hiera.yaml trumps any data provider setting in the environment.conf
-      if ep.config(lookup_invocation).version >= 5
+      ep_config = ep.config(lookup_invocation)
+      if ep_config.nil?
+        ep = nil
+      elsif ep_config.version >= 5
         unless provider_name.nil? || Puppet[:strict] == :off
           Puppet.warn_once(:deprecation, 'environment.conf#data_provider',
             "Defining environment_data_provider='#{provider_name}' in environment.conf is deprecated", env_path + 'environment.conf')


### PR DESCRIPTION
This commit changes the behavior when the lookup logic encounters a
hiera.yaml of version 3 in an environment root. The behavior is now
under control of --strict.

When set to `error`, an error will be raised.
When set to `warning` or `off`, a warning will be logged and the
hiera.yaml file is then ignored by the environment data provider.