### PR TITLE
(PUP-7167) Make Hiera interpolate keys in hash values

### DIFF
--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -20,7 +20,9 @@ module Interpolation
     when Array
       value.map { |element| interpolate(element, context, allow_methods) }
     when Hash
-      Hash[value.map { |k, v| [k, interpolate(v, context, allow_methods)] }]
+      result = {}
+      value.each_pair { |k, v| result[interpolate(k, context, allow_methods)] = interpolate(v, context, allow_methods) }
+      result
     else
       value
     end


### PR DESCRIPTION
This commit ensures that when Hiera finds a hash, it resolves interpolated
expressions in both keys and values. Prior to this commit, only values
were resolved.