### PR TITLE
(PUP-7169) Ensure propagation of Hiera 3 merge options to custom backend

### DIFF
--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -97,13 +97,17 @@ class V3BackendFunctionProvider < LookupKeyFunctionProvider
       # Equivalent to Hiera :hash with default :native merge behavior. A Hash must be passed here
       # to override possible Hiera deep merge config settings.
       { :behavior => :native }
-    when 'deep'
+    when 'deep', 'unconstrained_deep'
       # Equivalent to Hiera :hash with :deeper merge behavior.
       { :behavior => :deeper }
+    when 'reverse_deep'
+      # Equivalent to Hiera :hash with :deep merge behavior.
+      { :behavior => :deep }
     when Hash
       strategy = merge['strategy']
-      if strategy == 'deep'
-        result = { :behavior => :deeper }
+      case strategy
+      when 'deep', 'unconstrained_deep', 'reverse_deep'
+        result = { :behavior => strategy == 'reverse_deep' ? :deep : :deeper }
         # Remaining entries must have symbolic keys
         merge.each_pair { |k,v| result[k.to_sym] = v unless k == 'strategy' }
         result


### PR DESCRIPTION
This commit fixes an oversight in the logic that converts merge strategy
and options from Hiera 5 to Hiera 3. The special internal strategies
'unconstrained_deep' and 'reverse_deep' was not considered. Now they
are.