### PR TITLE
(PUP-7176) Handle merge of scalar or mixed types as unique

### DIFF
--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -380,7 +380,7 @@ module Puppet::Pops
     end
 
     def value_t
-      @value_t ||= Types::TypeParser.singleton.parse('Variant[Array[Data],Hash[String,Data]]')
+      @value_t ||= Types::PAnyType::DEFAULT
     end
 
     MergeStrategy.add_strategy(self)


### PR DESCRIPTION
This commit ensures that a 'deep' merge that encounters a mixed set of
types or non mergable types defaults to a 'first found' strategy. This
is done by simply trusting the logic in the DeepMerge gem.