### PR TITLE
(PUP-7171) Fix problem with dotted keys hiera.yaml interpolations

### DIFF
--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -97,7 +97,7 @@ module Interpolation
           catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
           value = found;
         end
-        lookup_invocation.remember_scope_lookup(key, value)
+        lookup_invocation.remember_scope_lookup(key, root_key, segments, value)
         value
       end
 

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -93,7 +93,7 @@ class Invocation
   # values that the configuration was based on
   #
   # @api private
-  def remember_scope_lookup(key, value)
+  def remember_scope_lookup(*lookup_result)
     # Does nothing by default
   end
 


### PR DESCRIPTION
The check if hiera.yaml was stable with respect to changing scope
between lookups, didn't take into account that the interpolated keys
could use dot notation. As a result, dotted keys were used for lookups
in the provided scope. When used with `strict_variables = true`, this
resulted in an error. When set to `false`, it degraded performance.