### PR TITLE
(PUP-7179) Resolve Pcore types using the same loader that loaded the type

### DIFF
--- a/lib/puppet/functions/assert_type.rb
+++ b/lib/puppet/functions/assert_type.rb
@@ -50,7 +50,7 @@
 #
 # @since 4.0.0
 #
-Puppet::Functions.create_function(:assert_type, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:assert_type) do
   dispatch :assert_type do
     param 'Type', :type
     param 'Any', :value
@@ -58,7 +58,6 @@ Puppet::Functions.create_function(:assert_type, Puppet::Functions::InternalFunct
   end
 
   dispatch :assert_type_s do
-    scope_param
     param 'String', :type_string
     param 'Any', :value
     optional_block_param 'Callable[Type, Type]', :block
@@ -84,12 +83,11 @@ Puppet::Functions.create_function(:assert_type, Puppet::Functions::InternalFunct
     value
   end
 
-  # @param scope [Puppet::Parser::Scope] scope used when obtaining loader for defined types
   # @param type_string [String] the type the value must be an instance of given in String form
   # @param value [Object] the value to assert
   #
-  def assert_type_s(scope, type_string, value, &proc)
-    t = Puppet::Pops::Types::TypeParser.singleton.parse(type_string, scope)
+  def assert_type_s(type_string, value, &proc)
+    t = Puppet::Pops::Types::TypeParser.singleton.parse(type_string)
     block_given? ? assert_type(t, value, &proc) : assert_type(t, value)
   end
 end

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -118,19 +118,18 @@ module Adapters
 
     # Finds the loader to use when loading originates from the source position of the given argument.
     #
-    # @param [Model::PopsObject] instance The model object
-    # @param [Puppet::Parser::Scope] scope The scope to use
-    # @param [String] file the file from where the model was parsed
-    # @return [Loader,nil] the found loader or `nil` if it could not be found
+    # @param instance [Model::PopsObject] The model object
+    # @param file [String] the file from where the model was parsed
+    # @param default_loader [Loader] the loader to return if no loader is found for the model
+    # @return [Loader] the found loader or default_loader if it could not be found
     #
-    def self.loader_for_model_object(model, scope, file = nil)
-      if scope.nil?
-        loaders = Puppet.lookup(:loaders) { nil }
-        loaders.nil? ? nil : loaders.private_environment_loader
+    def self.loader_for_model_object(model, file = nil, default_loader = nil)
+      loaders = Puppet.lookup(:loaders) { nil }
+      if loaders.nil?
+        default_loader
       else
-        loaders = scope.compiler.loaders
-        loader_name = loader_name_by_source(scope.environment, model, file)
-        loader_name.nil? ? loaders.private_environment_loader : loaders[loader_name]
+        loader_name = loader_name_by_source(loaders.environment, model, file)
+        loader_name.nil? ? default_loader || loaders.find_loader(nil) : loaders[loader_name]
       end
     end
 

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -309,7 +309,7 @@ class EvaluatorImpl
   # A QualifiedReference (i.e. a  capitalized qualified name such as Foo, or Foo::Bar) evaluates to a PType
   #
   def eval_QualifiedReference(o, scope)
-    type = Types::TypeParser.singleton.interpret(o, scope)
+    type = Types::TypeParser.singleton.interpret(o)
     fail(Issues::UNKNOWN_RESOURCE_TYPE, o, {:type_name => type.type_string }) if type.is_a?(Types::PTypeReferenceType)
     type
   end
@@ -473,7 +473,7 @@ class EvaluatorImpl
     keys = o.keys || []
     if left.is_a?(Types::PHostClassType)
       # Evaluate qualified references without errors no undefined types
-      keys = keys.map {|key| key.is_a?(Model::QualifiedReference) ? Types::TypeParser.singleton.interpret(key, scope) : evaluate(key, scope) }
+      keys = keys.map {|key| key.is_a?(Model::QualifiedReference) ? Types::TypeParser.singleton.interpret(key) : evaluate(key, scope) }
     else
       keys = keys.map {|key| evaluate(key, scope) }
       # Resource[File] becomes File

--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -56,7 +56,7 @@ class RelationshipOperator
   # A string must be a type reference in string format
   # @api private
   def transform_String(o, scope)
-    assert_catalog_type(Types::TypeParser.singleton.parse(o, scope), scope)
+    assert_catalog_type(Types::TypeParser.singleton.parse(o), scope)
   end
 
   # A qualified name is short hand for a class with this name

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -277,7 +277,7 @@ module Runtime3Support
 
   def call_function(name, args, o, scope, &block)
     file, line = extract_file_line(o)
-    loader = Adapters::LoaderAdapter.loader_for_model_object(o, scope, file)
+    loader = Adapters::LoaderAdapter.loader_for_model_object(o, file)
     if loader && func = loader.load(:function, name)
       Puppet::Util::Profiler.profile(name, [:functions, name]) do
         # Add stack frame when calling. See Puppet::Pops::PuppetStack

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -110,7 +110,10 @@ module Puppet::Pops::Loader::LoaderPaths
       # Puppet name to path always skips the name-space as that is part of the generic path
       # i.e. <module>/mymodule/functions/foo.pp is the function mymodule::foo
       parts = typed_name.name_parts
-      parts = parts[start_index_in_name..-1] if parts.size > 1
+      if start_index_in_name > 0
+        return nil if start_index_in_name >= parts.size
+        parts = parts[start_index_in_name..-1]
+      end
       "#{File.join(generic_path, parts)}.pp"
     end
   end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -16,6 +16,7 @@ class Loaders
   attr_reader :public_environment_loader
   attr_reader :private_environment_loader
   attr_reader :implementation_registry
+  attr_reader :environment
 
   def self.new(environment, for_agent = false)
     obj = environment.loaders
@@ -30,6 +31,7 @@ class Loaders
     # Protect against environment havoc
     raise ArgumentError.new("Attempt to redefine already initialized loaders for environment") unless environment.loaders.nil?
     environment.loaders = self
+    @environment = environment
     @loaders_by_name = {}
 
     add_loader_by_name(self.class.static_loader)

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -25,9 +25,9 @@ class TypeParser
   #     parser.parse('Array[String]')
   #     parser.parse('Hash[Integer, Array[String]]')
   #
-  # @param string [String] a string with the type expressed in stringified form as produced by the 
+  # @param string [String] a string with the type expressed in stringified form as produced by the
   #   types {"#to_s} method.
-  # @param context [Puppet::Parser::Scope,Loader::Loader] scope or loader to use when loading type aliases
+  # @param context [Loader::Loader] optional loader used as no adapted loader is found
   # @return [PAnyType] a specialization of the PAnyType representing the type.
   #
   # @api public
@@ -44,11 +44,11 @@ class TypeParser
   end
 
   # @param ast [Puppet::Pops::Model::PopsObject] the ast to interpret
-  # @param context [Puppet::Parser::Scope,Loader::Loader, nil] scope or loader to use when loading type aliases
+  # @param context [Loader::Loader] optional loader used when no adapted loader is found
   # @return [PAnyType] a specialization of the PAnyType representing the type.
   #
   # @api public
-  def interpret(ast, context)
+  def interpret(ast, context = nil)
     result = @type_transformer.visit_this_1(self, ast, context)
     raise_invalid_type_specification_error(ast) unless result.is_a?(PAnyType)
     result
@@ -200,13 +200,7 @@ class TypeParser
 
   # @api private
   def loader_from_context(ast, context)
-    if context.nil?
-      nil
-    elsif context.is_a?(Puppet::Pops::Loader::Loader)
-      context
-    else
-      Puppet::Pops::Adapters::LoaderAdapter.loader_for_model_object(ast, context)
-    end
+    Adapters::LoaderAdapter.loader_for_model_object(ast, nil, context)
   end
 
   # @api private

--- a/spec/lib/puppet_spec/language.rb
+++ b/spec/lib/puppet_spec/language.rb
@@ -21,7 +21,9 @@ module PuppetSpec::Language
 
           compiler.send(:instance_variable_set, :@catalog, catalog)
 
-          expect(evaluator.evaluate_string(compiler.topscope, resources)).to eq(true)
+          Puppet.override(:loaders => compiler.loaders) do
+            expect(evaluator.evaluate_string(compiler.topscope, resources)).to eq(true)
+          end
         when Array
           catalog = PuppetSpec::Compiler.compile_to_catalog(manifest)
 

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -29,6 +29,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     @scope = Puppet::Parser::Scope.new(@compiler)
     @scope.source = Puppet::Resource::Type.new(:node, 'node.example.com')
     @scope.parent = @compiler.topscope
+    Puppet.push_context(:loaders => @compiler.loaders)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   let(:environment) { Puppet::Node::Environment.create(:testing, []) }

--- a/spec/unit/pops/evaluator/evaluator_rspec_helper.rb
+++ b/spec/unit/pops/evaluator/evaluator_rspec_helper.rb
@@ -23,18 +23,20 @@ module EvaluatorRspecHelper
     # top_scope = Puppet::Parser::Scope.new(compiler)
 
     evaluator = Puppet::Pops::Evaluator::EvaluatorImpl.new
-    result = evaluator.evaluate(in_top_scope.current, top_scope)
-    if in_named_scope
-      other_scope = Puppet::Parser::Scope.new(compiler, :namespace => scopename)
-      result = evaluator.evaluate(in_named_scope.current, other_scope)
+    Puppet.override(:loaders => compiler.loaders) do
+      result = evaluator.evaluate(in_top_scope.current, top_scope)
+      if in_named_scope
+        other_scope = Puppet::Parser::Scope.new(compiler, :namespace => scopename)
+        result = evaluator.evaluate(in_named_scope.current, other_scope)
+      end
+      if in_top_scope_again
+        result = evaluator.evaluate(in_top_scope_again.current, top_scope)
+      end
+      if block_given?
+        block.call(top_scope)
+      end
+      result
     end
-    if in_top_scope_again
-      result = evaluator.evaluate(in_top_scope_again.current, top_scope)
-    end
-    if block_given?
-      block.call(top_scope)
-    end
-    result
   end
 
   # Evaluate a Factory wrapper round a model object in top scope + local scope
@@ -52,20 +54,22 @@ module EvaluatorRspecHelper
     top_scope = compiler.topscope()
 
     evaluator = Puppet::Pops::Evaluator::EvaluatorImpl.new
-    result = evaluator.evaluate(in_top_scope.current, top_scope)
-    if in_local_scope
-      # This is really bad in 3.x scope
-      top_scope.with_guarded_scope do
-        top_scope.new_ephemeral(true)
-        result = evaluator.evaluate(in_local_scope.current, top_scope)
+    Puppet.override(:loaders => compiler.loaders) do
+      result = evaluator.evaluate(in_top_scope.current, top_scope)
+      if in_local_scope
+        # This is really bad in 3.x scope
+        top_scope.with_guarded_scope do
+          top_scope.new_ephemeral(true)
+          result = evaluator.evaluate(in_local_scope.current, top_scope)
+        end
       end
+      if in_top_scope_again
+        result = evaluator.evaluate(in_top_scope_again.current, top_scope)
+      end
+      if block_given?
+        block.call(top_scope)
+      end
+      result
     end
-    if in_top_scope_again
-      result = evaluator.evaluate(in_top_scope_again.current, top_scope)
-    end
-    if block_given?
-      block.call(top_scope)
-    end
-    result
   end
 end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -335,41 +335,136 @@ describe 'loaders' do
 
   context 'when calling' do
     let(:env) { environment_for(mix_4x_and_3x_functions) }
-    let(:scope) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)).newscope(nil) }
-    let(:loader) { Puppet::Pops::Loaders.new(env).private_loader_for_module('user') }
+    let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
+    let(:scope) { compiler.topscope }
+    let(:loader) { compiler.loaders.private_loader_for_module('user') }
+
+    around(:each) do |example|
+      Puppet.override(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders) do
+        example.run
+      end
+    end
 
     it 'a 3x function in dependent module can be called from a 4x function' do
-      Puppet.override({ :current_environment => scope.environment, :global_scope => scope }) do
-        function = loader.load_typed(typed_name(:function, 'user::caller')).value
-        expect(function.call(scope)).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
-      end
+      function = loader.load_typed(typed_name(:function, 'user::caller')).value
+      expect(function.call(scope)).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
     end
 
     it 'a 3x function in dependent module can be called from a puppet function' do
-      Puppet.override({ :current_environment => scope.environment, :global_scope => scope }) do
-        function = loader.load_typed(typed_name(:function, 'user::puppetcaller')).value
-        expect(function.call(scope)).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
-      end
+      function = loader.load_typed(typed_name(:function, 'user::puppetcaller')).value
+      expect(function.call(scope)).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
     end
 
     it 'a 4x function can be called from a puppet function' do
-      Puppet.override({ :current_environment => scope.environment, :global_scope => scope }) do
-        function = loader.load_typed(typed_name(:function, 'user::puppetcaller4')).value
-        expect(function.call(scope)).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
-      end
+      function = loader.load_typed(typed_name(:function, 'user::puppetcaller4')).value
+      expect(function.call(scope)).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
     end
+
     it 'a puppet function can be called from a 4x function' do
-      Puppet.override({ :current_environment => scope.environment, :global_scope => scope }) do
-        function = loader.load_typed(typed_name(:function, 'user::callingpuppet')).value
-        expect(function.call(scope)).to eql("Did you call to say you love me?")
-      end
+      function = loader.load_typed(typed_name(:function, 'user::callingpuppet')).value
+      expect(function.call(scope)).to eql("Did you call to say you love me?")
     end
 
     it 'a 3x function can be called with caller scope propagated from a 4x function' do
-      Puppet.override({ :current_environment => scope.environment, :global_scope => scope }) do
-        function = loader.load_typed(typed_name(:function, 'user::caller_ws')).value
-        expect(function.call(scope, 'passed in scope')).to eql("usee::callee_ws() got 'passed in scope'")
-      end
+      function = loader.load_typed(typed_name(:function, 'user::caller_ws')).value
+      expect(function.call(scope, 'passed in scope')).to eql("usee::callee_ws() got 'passed in scope'")
+    end
+  end
+
+  context 'loading types' do
+    let(:env_name) { 'testenv' }
+    let(:environments_dir) { Puppet[:environmentpath] }
+    let(:env_dir) { File.join(environments_dir, env_name) }
+    let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, 'modules')]) }
+    let(:metadata_json) {
+      <<-JSON
+      {
+        "name": "example/%1$s",
+        "version": "0.0.2",
+        "source": "git@github.com/example/example-%1$s.git",
+        "dependencies": [],
+        "author": "Bob the Builder",
+        "license": "Apache-2.0"%2$s
+      }
+      JSON
+    }
+
+    let(:env_dir_files) do
+      {
+        'modules' => {
+          'a' => {
+            'manifests' => {
+              'init.pp' => 'class a { notice(A::A) }'
+            },
+            'types' => {
+              'a.pp' => 'type A::A = Variant[B::B, String]',
+              'n.pp' => 'type A::N = C::C'
+            },
+            'metadata.json' => sprintf(metadata_json, 'a', ', "dependencies": [{ "name": "example/b" }]')
+          },
+          'b' => {
+            'types' => {
+              'b.pp' => 'type B::B = Variant[C::C, Float]',
+              'x.pp' => 'type B::X = A::A'
+            },
+            'metadata.json' => sprintf(metadata_json, 'b', ', "dependencies": [{ "name": "example/c" }]')
+          },
+          'c' => {
+            'types' => {
+              'c.pp' => 'type C::C = Integer'
+            },
+            'metadata.json' => sprintf(metadata_json, 'c', '')
+          },
+        }
+      }
+    end
+
+    let(:populated_env_dir) do
+      dir_contained_in(environments_dir, env_name => env_dir_files)
+      PuppetSpec::Files.record_tmp(env_dir)
+      env_dir
+    end
+
+    before(:each) do
+      Puppet.push_context(:loaders => Puppet::Pops::Loaders.new(env))
+    end
+
+    after(:each) do
+      Puppet.pop_context
+    end
+
+    it 'resolves types using the loader that loaded the type a -> b -> c' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('A::A', Puppet::Pops::Loaders.find_loader('a'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.name).to eql('A::A')
+      type = type.resolved_type
+      expect(type).to be_a(Puppet::Pops::Types::PVariantType)
+      type = type.types[0]
+      expect(type.name).to eql('B::B')
+      type = type.resolved_type
+      expect(type).to be_a(Puppet::Pops::Types::PVariantType)
+      type = type.types[0]
+      expect(type.name).to eql('C::C')
+      type = type.resolved_type
+      expect(type).to be_a(Puppet::Pops::Types::PIntegerType)
+    end
+
+    it 'will not resolve implicit transitive dependencies, a -> c' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('A::N', Puppet::Pops::Loaders.find_loader('a'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.name).to eql('A::N')
+      type = type.resolved_type
+      expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
+      expect(type.type_string).to eql('C::C')
+    end
+
+    it 'will not resolve reverse dependencies, b -> a' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('B::X', Puppet::Pops::Loaders.find_loader('b'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.name).to eql('B::X')
+      type = type.resolved_type
+      expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
+      expect(type.type_string).to eql('A::A')
     end
   end
 

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -40,16 +40,16 @@ describe 'Puppet Ruby Generator' do
 
     context 'when generating anonymous classes' do
 
-      scope = nil
+      loader = nil
 
-      let(:first_type) { parser.parse('MyModule::FirstGenerated', scope) }
-      let(:second_type) { parser.parse('MyModule::SecondGenerated', scope) }
+      let(:first_type) { parser.parse('MyModule::FirstGenerated', loader) }
+      let(:second_type) { parser.parse('MyModule::SecondGenerated', loader) }
       let(:first) { generator.create_class(first_type) }
       let(:second) { generator.create_class(second_type) }
 
       before(:each) do
-        eval_and_collect_notices(source) do |topscope, catalog|
-          scope = topscope
+        eval_and_collect_notices(source) do |topscope|
+          loader = topscope.compiler.loaders.find_loader(nil)
         end
       end
 
@@ -149,9 +149,9 @@ describe 'Puppet Ruby Generator' do
         if module_def.nil?
           first_type = nil
           second_type = nil
-          eval_and_collect_notices(source) do |scope, catalog|
-            first_type = parser.parse('MyModule::FirstGenerated', scope)
-            second_type = parser.parse('MyModule::SecondGenerated', scope)
+          eval_and_collect_notices(source) do
+            first_type = parser.parse('MyModule::FirstGenerated')
+            second_type = parser.parse('MyModule::SecondGenerated')
 
             loader = Loaders.find_loader(nil)
             Loaders.implementation_registry.register_type_mapping(
@@ -327,8 +327,8 @@ describe 'Puppet Ruby Generator' do
       let(:fourth) { generator.create_class(fourth_type) }
 
       before(:each) do
-        eval_and_collect_notices(source) do |scope, catalog|
-          typeset = parser.parse('OtherModule', scope)
+        eval_and_collect_notices(source) do
+          typeset = parser.parse('OtherModule')
         end
       end
 
@@ -457,9 +457,9 @@ describe 'Puppet Ruby Generator' do
         # environment specific settings are configured by the spec_helper in before(:each)
         if module_def.nil?
           typeset = nil
-          eval_and_collect_notices(source) do |scope, catalog|
-            typeset1 = parser.parse('MyModule', scope)
-            typeset2 = parser.parse('OtherModule', scope)
+          eval_and_collect_notices(source) do
+            typeset1 = parser.parse('MyModule')
+            typeset2 = parser.parse('OtherModule')
 
             loader = Loaders.find_loader(nil)
             Loaders.implementation_registry.register_type_mapping(

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1480,7 +1480,7 @@ describe 'The type calculator' do
         loader = Object.new
         loader.expects(:load).with(:type, 'tree').returns t
 
-        Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Model::QualifiedReference), scope).at_most_once.returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
         t.resolve(parser, scope)
         expect(calculator.assignable?(t, parser.parse('Hash[String,Variant[String,Hash[String,Variant[String,String]]]]'))).to be_truthy
@@ -1496,7 +1496,7 @@ describe 'The type calculator' do
         loader.expects(:load).with(:type, 'tree1').returns t1
         loader.expects(:load).with(:type, 'tree2').returns t2
 
-        Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Model::QualifiedReference), scope).at_least_once.returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
         t1.resolve(parser, scope)
         t2.resolve(parser, scope)
@@ -1504,19 +1504,16 @@ describe 'The type calculator' do
       end
 
       it 'crossing recursive aliases are assignable' do
-        scope = Object.new
-
         t1 = type_alias_t('Tree1', 'Hash[String,Variant[String,Tree2]]')
         t2 = type_alias_t('Tree2', 'Hash[String,Variant[String,Tree1]]')
         loader = Object.new
         loader.expects(:load).with(:type, 'tree1').returns t1
         loader.expects(:load).with(:type, 'tree2').returns t2
-        loader.expects(:is_a?).with(Loader::Loader).returns true
 
-        Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Model::QualifiedReference), scope).at_least_once.returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
-        t1.resolve(parser, scope)
-        t2.resolve(parser, scope)
+        t1.resolve(parser, loader)
+        t2.resolve(parser, loader)
         expect(calculator.assignable?(t1, t2)).to be_truthy
       end
 
@@ -1526,8 +1523,7 @@ describe 'The type calculator' do
         ta = type_alias_t('PositiveInteger', 'Integer[0,default]')
         loader = Object.new
         loader.expects(:load).with(:type, 'positiveinteger').returns ta
-        Adapters::LoaderAdapter.expects(:loader_for_model_object)
-          .with(instance_of(Model::QualifiedReference), scope).returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
         t1 = type_t(range_t(0, :default))
         t2 = parser.parse('Type[PositiveInteger]', scope)
@@ -1540,8 +1536,7 @@ describe 'The type calculator' do
         ta = type_alias_t('PositiveIntegerType', 'Type[Integer[0,default]]')
         loader = Object.new
         loader.expects(:load).with(:type, 'positiveintegertype').returns ta
-        Adapters::LoaderAdapter.expects(:loader_for_model_object)
-          .with(instance_of(Model::QualifiedReference), scope).returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
         t1 = type_t(range_t(0, :default))
         t2 = parser.parse('PositiveIntegerType', scope)
@@ -1554,8 +1549,7 @@ describe 'The type calculator' do
         ta = type_alias_t('PositiveInteger', 'Integer[0,default]')
         loader = Object.new
         loader.expects(:load).with(:type, 'positiveinteger').returns ta
-        Adapters::LoaderAdapter.expects(:loader_for_model_object)
-          .with(instance_of(Model::QualifiedReference), scope).returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
         t1 = type_t(type_t(range_t(0, :default)))
         t2 = parser.parse('Type[Type[PositiveInteger]]', scope)
@@ -1568,8 +1562,7 @@ describe 'The type calculator' do
         ta = type_alias_t('PositiveIntegerType', 'Type[Integer[0,default]]')
         loader = Object.new
         loader.expects(:load).with(:type, 'positiveintegertype').returns ta
-        Adapters::LoaderAdapter.expects(:loader_for_model_object)
-          .with(instance_of(Model::QualifiedReference), scope).returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
         t1 = type_t(type_t(range_t(0, :default)))
         t2 = parser.parse('Type[PositiveIntegerType]', scope)
@@ -1866,31 +1859,26 @@ describe 'The type calculator' do
       end
 
       it 'should consider x an instance of the aliased type that uses self recursion' do
-        scope = Object.new
-
         t = type_alias_t('Tree', 'Hash[String,Variant[String,Tree]]')
         loader = Object.new
         loader.expects(:load).with(:type, 'tree').returns t
 
-        Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Model::QualifiedReference), scope).at_most_once.returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
-        t.resolve(parser, scope)
+        t.resolve(parser, loader)
         expect(calculator.instance?(t, {'a'=>{'aa'=>{'aaa'=>'aaaa'}}, 'b'=>'bb'})).to be_truthy
       end
 
       it 'should consider x an instance of the aliased type that uses contains an alias that causes self recursion' do
-        scope = Object.new
-
         t1 = type_alias_t('Tree', 'Hash[String,Variant[String,OtherTree]]')
         t2 = type_alias_t('OtherTree', 'Hash[String,Tree]')
         loader = Object.new
         loader.expects(:load).with(:type, 'tree').returns t1
         loader.expects(:load).with(:type, 'othertree').returns t2
-        loader.expects(:is_a?).with(Loader::Loader).returns true
 
-        Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Model::QualifiedReference), scope).at_least_once.returns loader
+        Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns loader
 
-        t1.resolve(parser, scope)
+        t1.resolve(parser, loader)
         expect(calculator.instance?(t1, {'a'=>{'aa'=>{'aaa'=>'aaaa'}}, 'b'=>'bb'})).to be_truthy
       end
     end

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -158,7 +158,7 @@ describe TypeParser do
     let(:loader) { Object.new }
 
     before :each do
-      Adapters::LoaderAdapter.expects(:loader_for_model_object).with(instance_of(Model::QualifiedReference), scope).at_most_once.returns loader
+      Adapters::LoaderAdapter.expects(:loader_for_model_object).returns loader
     end
 
     it 'interprets anything that is not found by the loader to be a type reference' do
@@ -194,9 +194,6 @@ describe TypeParser do
 
   context 'with loader context' do
     let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "type_parser_unit_test_loader") }
-    before :each do
-      Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).never
-    end
 
     it 'interprets anything that is not found by the loader to be a type reference' do
       loader.expects(:load).with(:type, 'nonesuch').returns nil

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -262,11 +262,17 @@ describe Puppet::Resource::Type do
       wrap3x(Puppet::Pops::Model::Factory.NUMBER(number).var())
     end
 
-    before do
-      @scope = Puppet::Parser::Scope.new(Puppet::Parser::Compiler.new(Puppet::Node.new("foo")), :source => stub("source"))
+    before(:each) do
+      compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("foo"))
+      @scope = Puppet::Parser::Scope.new(compiler, :source => stub("source"))
       @resource = Puppet::Parser::Resource.new(:foo, "bar", :scope => @scope)
       @type = Puppet::Resource::Type.new(:definition, "foo")
       @resource.environment.known_resource_types.add @type
+      Puppet.push_context(:loaders => compiler.loaders)
+    end
+
+    after(:each) do
+      Puppet.pop_context
     end
 
     ['module_name', 'name', 'title'].each do |variable|


### PR DESCRIPTION
When resolving a type (Object, Alias, or TypeSet), it is essential that
the loader that initially loaded the type is used. This means that
if a type `A::X` in module `a` references type `B::Y` i module `b`, which
in in turn references a type `C::Z` in module `c`, then the loader for
module `a` must be used when resolving `A::X`, the loader for module `b`
must resovle `B::Y` and finally, the loader for module `c` resolves
`C::Z`.

In essence, this means that all loaders must be found by the loader names
adapted to the source of the AST that represents the type.

Fixing this resulted in cleaner code. It is now never necessary to pass
a `scope` to the TypeParser and only tests that lacks a fully configured
`Loaders` instance needs to pass a loader.