### PR TITLE
Revert "Merge pull request #5276 from DavidS/notify-everywhere"

### DIFF
--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -6,8 +6,6 @@ module Puppet
   Type.newtype(:notify) do
     @doc = "Sends an arbitrary message to the agent run-time log."
 
-    apply_to_all
-
     newproperty(:message, :idempotent => false) do
       desc "The message to be sent to the log."
       def sync


### PR DESCRIPTION
This reverts commit 9fccfc7374e25795171bdaf6f34f3b207ad582e8, reversing
changes made to 89205d63a831deb732276d9b1bc412d45e7a6567.

This change was originally intended for a feature release, but due to
merge-hijinx ended up in position to be released in an up-coming 'z' release. On merge-up to master, this change should be negated, i.e., we want the original change-set to stay in master.