### PR TITLE
(PUP-7142) Autoload Pcore types from TypeSet.

### DIFF
--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -138,6 +138,21 @@ module ModuleLoaders
         when :resource_type
         when :resource_type_pp
         when :type
+          if !global?
+            # Global name can only be the module typeset
+            return nil unless name_parts[0] == module_name
+
+            origin, smart_path = find_existing_path(init_typeset_name)
+            return nil unless smart_path
+
+            value = smart_path.instantiator.create(self, typed_name, origin, get_contents(origin))
+            if value.is_a?(Types::PTypeSetType)
+              # cache the entry and return it
+              return set_entry(typed_name, value, origin)
+            end
+
+            raise ArgumentError,"The code loaded from #{origin} does not define the TypeSet '#{module_name.capitalize}'"
+          end
         else
           # anything else cannot possibly be in this module
           # TODO: should not be allowed anyway... may have to revisit this decision
@@ -148,17 +163,31 @@ module ModuleLoaders
       # Get the paths that actually exist in this module (they are lazily processed once and cached).
       # The result is an array (that may be empty).
       # Find the file to instantiate, and instantiate the entity if file is found
-      origin = nil
-      if (smart_path = smart_paths.effective_paths(typed_name.type).find do |sp|
-          origin = sp.effective_path(typed_name, global? ? 0 : 1)
-          existing_path(origin)
-        end)
+      origin, smart_path = find_existing_path(typed_name)
+      if smart_path
         value = smart_path.instantiator.create(self, typed_name, origin, get_contents(origin))
         # cache the entry and return it
-        set_entry(typed_name, value, origin)
-      else
-        nil
+        return set_entry(typed_name, value, origin)
       end
+
+      return nil unless typed_name.type == :type && typed_name.qualified?
+
+      # Search for TypeSet using parent name
+      ts_name = typed_name.parent
+      while ts_name
+        # Do not traverse parents here. This search must be confined to this loader
+        tse = get_entry(ts_name)
+        tse = find(ts_name) if tse.nil? || tse.value.nil?
+        if tse && (ts = tse.value).is_a?(Types::PTypeSetType)
+          # The TypeSet might be unresolved at this point. If so, it must be resolved using
+          # this loader. That in turn, adds all contained types to this loader.
+          ts.resolve(Types::TypeParser.singleton, self)
+          te = get_entry(typed_name)
+          return te unless te.nil?
+        end
+        ts_name = ts_name.parent
+      end
+      nil
     end
 
     # Abstract method that subclasses override that checks if it is meaningful to search using a generic smart path.
@@ -220,6 +249,28 @@ module ModuleLoaders
       # The system loader has a nil module_name and it does not have a private_loader as there are no functions
       # that can only by called by puppet runtime - if so, it acts as the private loader directly.
       @private_loader ||= (global? ? self : @loaders.private_loader_for_module(module_name))
+    end
+
+    private
+
+    # @return [TypedName] the fake typed name that maps to the init_typeset path for this module
+    def init_typeset_name
+      @init_typeset_name ||= TypedName.new(:type, "#{module_name}::init_typeset")
+    end
+
+    # Find an existing path for the given `typed_name`. Return `nil` if no such path is found
+    # @param typed_name [TypedName] the `typed_name` to find a path for
+    # @return [Array,nil] `nil`or a two element array an effective path `String` and the `SmartPath` that produced the effective path.
+    def find_existing_path(typed_name)
+      is_global = global?
+      smart_paths.effective_paths(typed_name.type).each do |sp|
+        origin = sp.effective_path(typed_name, is_global ? 0 : 1)
+        unless origin.nil?
+          existing = existing_path(origin)
+          return [origin, sp] unless existing.nil?
+        end
+      end
+      nil
     end
   end
 

--- a/lib/puppet/pops/loader/typed_name.rb
+++ b/lib/puppet/pops/loader/typed_name.rb
@@ -36,6 +36,11 @@ class TypedName
 
   alias eql? ==
 
+  # @return the parent of this instance, or nil if this instance is not qualified
+  def parent
+    @name_parts.size > 1 ? self.class.new(@type, @name_parts[0...-1].join(DOUBLE_COLON), @name_authority) : nil
+  end
+
   def qualified?
     @name_parts.size > 1
   end

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -47,7 +47,7 @@ class PTypeSetType < PMetaType
     Pcore::KEY_PCORE_VERSION => TYPE_STRING_OR_VERSION,
     TypeFactory.optional(KEY_NAME_AUTHORITY) => Pcore::TYPE_URI,
     TypeFactory.optional(KEY_NAME) => Pcore::TYPE_QUALIFIED_REFERENCE,
-    KEY_VERSION => TYPE_STRING_OR_VERSION,
+    TypeFactory.optional(KEY_VERSION) => TYPE_STRING_OR_VERSION,
     TypeFactory.optional(KEY_TYPES) => TypeFactory.hash_kv(Pcore::TYPE_SIMPLE_TYPE_NAME, PType::DEFAULT, PCollectionType::NOT_EMPTY_SIZE),
     TypeFactory.optional(KEY_REFERENCES) => TypeFactory.hash_kv(Pcore::TYPE_SIMPLE_TYPE_NAME, TYPE_TYPE_REFERENCE_I12N, PCollectionType::NOT_EMPTY_SIZE),
     TypeFactory.optional(KEY_ANNOTATIONS) => TYPE_ANNOTATIONS,
@@ -168,7 +168,7 @@ class PTypeSetType < PMetaType
     result[Pcore::KEY_PCORE_VERSION] =  @pcore_version.to_s
     result[KEY_NAME_AUTHORITY] = @name_authority unless @name_authority.nil?
     result[KEY_NAME] = @name
-    result[KEY_VERSION] = @version.to_s
+    result[KEY_VERSION] = @version.to_s unless @version.nil?
     result[KEY_TYPES] = @types unless @types.empty?
     result[KEY_REFERENCES] = Hash[@references.map { |ref_alias, ref| [ref_alias, ref.i12n_hash] }] unless @references.empty?
     result
@@ -178,11 +178,16 @@ class PTypeSetType < PMetaType
   # or a type defined in a type set that is referenced by this type set (nesting may occur to any level).
   # The name resolution is case insensitive.
   #
-  # @param qname [String] the qualified name of the type to resolve
+  # @param qname [String,Loader::TypedName] the qualified name of the type to resolve
   # @return [PAnyType,nil] the resolved type, or `nil` in case no type could be found
   #
   # @api public
   def [](qname)
+    if qname.is_a?(Loader::TypedName)
+      return nil unless qname.type == :type && qname.name_authority == @name_authority
+      qname = qname.name
+    end
+
     type = @types[qname] || @types[@dc_to_cc_map[qname.downcase]]
     if type.nil? && !@references.empty?
       segments = qname.split(TypeFormatter::NAME_SEGMENT_SEPARATOR)

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -409,6 +409,9 @@ describe 'loaders' do
 
     let(:env_dir_files) do
       {
+        'types' => {
+          'c.pp' => 'type C = Integer'
+        },
         'modules' => {
           'a' => {
             'manifests' => {
@@ -429,7 +432,27 @@ describe 'loaders' do
           },
           'c' => {
             'types' => {
-              'c.pp' => 'type C::C = Integer'
+              'init_typeset.pp' => <<-PUPPET.unindent,
+                type C = TypeSet[{
+                  pcore_version => '1.0.0',
+                  types => {
+                    C => Integer,
+                    D => Float
+                  }
+                }]
+                PUPPET
+              'd.pp' => <<-PUPPET.unindent,
+                type C::D = TypeSet[{
+                  pcore_version => '1.0.0',
+                  types => {
+                    X => String,
+                    Y => Float
+                  }
+                }]
+                PUPPET
+              'd' => {
+                'y.pp' => 'type C::D::Y = Integer'
+              }
             },
             'metadata.json' => sprintf(metadata_json, 'c', '')
           },
@@ -483,6 +506,51 @@ describe 'loaders' do
       type = type.resolved_type
       expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
       expect(type.type_string).to eql('A::A')
+    end
+
+    it 'does not resolve init_typeset when more qualified type is found in typeset' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('C::D::X', Puppet::Pops::Loaders.find_loader('c'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.resolved_type).to be_a(Puppet::Pops::Types::PStringType)
+    end
+
+    it 'defined TypeSet type shadows type defined inside of TypeSet' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('C::D', Puppet::Pops::Loaders.find_loader('c'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeSetType)
+    end
+
+    it 'parent name search does not traverse parent loaders' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('C::C', Puppet::Pops::Loaders.find_loader('c'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.resolved_type).to be_a(Puppet::Pops::Types::PIntegerType)
+    end
+
+    it 'global type defined in environment trumps modules init_typeset type' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('C', Puppet::Pops::Loaders.find_loader('c'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.resolved_type).to be_a(Puppet::Pops::Types::PIntegerType)
+    end
+
+    it 'hit on qualified name trumps hit on typeset using parent name + traversal' do
+      type = Puppet::Pops::Types::TypeParser.singleton.parse('C::D::Y', Puppet::Pops::Loaders.find_loader('c'))
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.resolved_type).to be_a(Puppet::Pops::Types::PIntegerType)
+    end
+
+    it 'hit on qualified name and subsequent hit in typeset when searching for other name causes collision' do
+      l = Puppet::Pops::Loaders.find_loader('c')
+      p = Puppet::Pops::Types::TypeParser.singleton
+      p.parse('C::D::Y', l)
+      expect { p.parse('C::D::X', l) }.to raise_error(/Attempt to redefine entity 'http:\/\/puppet.com\/2016.1\/runtime\/type\/c::d::y'/)
+    end
+
+    it 'hit in typeset using parent name and subsequent search that would cause hit on fqn does not cause collision (fqn already loaded from typeset)' do
+      l = Puppet::Pops::Loaders.find_loader('c')
+      p = Puppet::Pops::Types::TypeParser.singleton
+      p.parse('C::D::X', l)
+      type = p.parse('C::D::Y', l)
+      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+      expect(type.resolved_type).to be_a(Puppet::Pops::Types::PFloatType)
     end
   end
 

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -110,14 +110,6 @@ module Puppet::Pops
               /expects a value for key 'pcore_version'/)
           end
 
-          it 'version is missing' do
-            ts = <<-OBJECT
-            pcore_version => '1.0.0',
-            OBJECT
-            expect { parse_type_set('MySet', ts) }.to raise_error(TypeAssertionError,
-              /expects a value for key 'version'/)
-          end
-
           it 'the version is an invalid semantic version' do
             ts = <<-OBJECT
             version => '1.x',


### PR DESCRIPTION
This commit adds a search algorithm to the module loader so that it
is capable of finding types that are embedded in TypeSets.

A `TypeSet` is a type and therefore autoloaded just like any other type.
That the file "types/x.pp" in module 'a' will contain the type `A::X`
still holds true. What is different is that if `A::X` is a `TypeSet`
which in turn contains the type `Z`, then the autoloader will find the
type `A::X::Z` by loading the `A::X` TypeSet and resolve it.

A special TypeSet that represents the module root can be added in the
file "types/init_typeset.pp". This file must define a `TypeSet` that
has an unqualified name that equals the capitalized name of the module
where it is defined.