### PR TITLE
(packaging) Bump puppet version to 4.9.2

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.9.1'
+  PUPPETVERSION = '4.9.2'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
puppet 4.9.2 will be included in puppet-agent 1.9.1.