### PR TITLE
(maint) bump version.rb to 4.9.2

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.9.1'
+  PUPPETVERSION = '4.9.2'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
Bump PUPPETVERSION to 4.9.2 in anticipation of a pending bug-fix release.

Signed-off-by: Moses Mendoza <moses@puppet.com>