### PR TITLE
(PUP-7186) Switch AIX nim test to a simpler test fixture

### DIFF
--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -6,7 +6,7 @@ confine :to, :platform => "aix"
 
 teardown do
     test_apply('cdrecord', 'absent', '')
-    test_apply('bos.atm.atmle', 'absent', '')
+    test_apply('puppet.test.rte', 'absent', '')
 end
 
 def assert_package_version(package, expected_version)
@@ -48,6 +48,9 @@ def test_apply(package_name, ensure_value, expected_version)
   end
 end
 
+# These two packages live in an LPP source on the NIM master. Details
+# on our nim masters are available at
+# https://confluence.puppetlabs.com/display/OPS/IBM+Power+LPARs
 package_types = {
     "RPM" => {
         :package_name    => "cdrecord",
@@ -55,14 +58,14 @@ package_types = {
         :new_version     => '1.9-9'
     },
     "BFF" => {
-        :package_name    => "bos.atm.atmle",
-        :old_version     => '6.1.7.0',
-        :new_version     => '7.1.2.0'
+        :package_name    => "puppet.test.rte",
+        :old_version     => '1.0.0.0',
+        :new_version     => '2.0.0.0'
     }
 }
 
 step "Setup: ensure test packages are not installed" do
-  pkgs = ['cdrecord', 'bos.atm.atmle']
+  pkgs = ['cdrecord', 'puppet.test.rte']
   pkgs.each do |pkg|
     on hosts, puppet_apply(["--detailed-exitcodes", "--verbose"]),
        {:stdin => get_manifest(pkg, 'absent'), :acceptable_exit_codes => [0,2]}


### PR DESCRIPTION
The AIX nim provider tests previously relied on a real package. This package did not install cleanly on AIX 7.2. This updates the nim test to use a new test fixture created internally, which allows the test to function on all AIX versions.