### PR TITLE
Bump minitar to 0.6+

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -45,7 +45,7 @@ gem_platform_dependencies:
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'
-      minitar: '~> 0.5.4'
+      minitar: '~> 0.6'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.6'
@@ -56,7 +56,7 @@ gem_platform_dependencies:
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'
-      minitar: '~> 0.5.4'
+      minitar: '~> 0.6'
 bundle_platforms:
   universal-darwin: all
   x86-mingw32: mingw


### PR DESCRIPTION
Note that this should not be merged until this is properly vetted.  I believe that this requires a synchronized version bump between agent and master because code manager / r10k runs under JRuby.  While the version only went from `0.5.4` to `0.6.1`, there was also nearly 5 years between releases, and it looks like there might be API changes based on the commit log (despite best efforts of the author to minimize incompatibility / churn)

This PR is an initial spike to see if anything fails in AppVeyor (specs run locally on 2008R2, there were no problems)

Left to validate:

- [ ] - Identify any breaking API changes that may not be adequately tested 
- [ ] - verify PMT related impact on platforms that use Minitar (AIX / Solaris / Windows)
- [ ] - verify if `puppet-server` must sync a gem bump
- [ ] - verify the gameplan for r10k with @jessereynolds (it looks like CI already blew up as a result of the new gem as they weren't pinned like 
- [ ] - `puppet-agent` repo will need corresponding changes to choose the right gem to package - see https://github.com/puppetlabs/puppet-agent/blob/master/configs/components/rubygem-minitar.rb