### PR TITLE
(PUP-7190) confine utf-8 test against aix and huawei

### DIFF
--- a/acceptance/tests/utf8/utf8-in-function-args.rb
+++ b/acceptance/tests/utf8/utf8-in-function-args.rb
@@ -5,6 +5,9 @@ test_name 'utf-8 characters in function parameters' do
     'cumulus',      # PUP-7147
     'cisco',        # PUP-7150
   ]
+  confine :except, :platform => /^aix/           # PUP-7190
+  confine :except, :platform => /^huawei/
+
   # utf8chars = "€‰ㄘ万竹ÜÖ"
   utf8chars = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
   master_lookup_test_dir = master.tmpdir("lookup_test_dir")


### PR DESCRIPTION
Our acceptance hosts are not configured with UTF-8 locale files, resulting in a
failure of these tests. Eventually we may reconfigure the hosts to support this
but for now confine this test to resume passing.

Signed-off-by: Moses Mendoza <moses@puppet.com>