### PR TITLE
(PUP-7159) Force destroy zfs / zpool

### DIFF
--- a/acceptance/lib/puppet/acceptance/solaris_util.rb
+++ b/acceptance/lib/puppet/acceptance/solaris_util.rb
@@ -20,7 +20,7 @@ module Puppet
         lst = on(agent, "zfs list").stdout.lines.each do |l|
           case l
           when /rpool.tstzones/
-            on agent,"zfs destroy -r rpool/tstzones"
+            on agent,"zfs destroy -f -r rpool/tstzones"
           end
         end
         on agent, "rm -rf /tstzones"
@@ -156,8 +156,8 @@ trap '' HUP
     module ZFSUtils
       def clean(agent, o={})
         o = {:fs=>'tstfs', :pool=>'tstpool', :poolpath => '/ztstpool'}.merge(o)
-        on agent, "zfs destroy -r %s/%s ||:" % [o[:pool], o[:fs]]
-        on agent, "zpool destroy %s ||:" %  o[:pool]
+        on agent, "zfs destroy -f -r %s/%s ||:" % [o[:pool], o[:fs]]
+        on agent, "zpool destroy -f %s ||:" %  o[:pool]
         on agent, "rm -rf %s ||:" % o[:poolpath]
       end
 
@@ -172,7 +172,7 @@ trap '' HUP
     module ZPoolUtils
       def clean(agent, o={})
         o = {:pool=>'tstpool', :poolpath => '/ztstpool'}.merge(o)
-        on agent, "zpool destroy %s ||:" % o[:pool]
+        on agent, "zpool destroy -f %s ||:" % o[:pool]
         on agent, "rm -rf %s ||:" % o[:poolpath]
       end
 


### PR DESCRIPTION
 - There have been intermittent test failures resulting from the
   inability (under certain circumstances) to properly tear down
   resources on Solaris 11 hosts.  Logs will typically show something
   like:

   rm -rf /ztstpool ||:
         rm: Unable to remove directory /ztstpool/mnt: Device busy
         rm: Unable to remove directory /ztstpool: Directory not empty

 - According to Oracle docs for ZFS file system:
   https://docs.oracle.com/cd/E19253-01/819-5461/gammq/index.html

   And Oracle docs for ZFS storage pools:
   https://docs.oracle.com/cd/E19253-01/819-5461/gammr/index.html

   Both the zfs and zpool commands have -f switches available to force
   removal when a device is busy.