### PR TITLE
(PUP-7191) consider non-existent services on AIX to be stopped/disabled rather than failing

### DIFF
--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -55,6 +55,36 @@ end
 agents.each do |agent|
 
   ## Setup
+  step "Verify a non-existent service is considered stopped and disabled" do
+    on(agent, puppet_resource('service', 'sloth_daemon'), :catch_failures => true, :catch_changes => true) do |result|
+      assert_match(/ensure[[:space:]]+=>[[:space:]]+'stopped'/, result.stdout, "non-existent service service should be stopped, but received #{result.stdout}")
+      assert_match(/enable[[:space:]]+=>[[:space:]]+'false'/, result.stdout, "non-existent service should be disabled, but received #{result.stdout}")
+    end
+  end
+
+  step "Verify stopping and disabling a non-existent service is a no-op" do
+    manifest = <<-PP
+      service { 'sloth_daemon' : ensure => stopped, enable => false }
+    PP
+    apply_manifest_on(agent, manifest, :catch_changes => true)
+  end
+  
+  step "Verify starting a non-existent service prints an error message but does not fail the run without detailed exit codes" do
+    manifest = <<-PP
+      service { 'sloth_daemon' : ensure => running }
+    PP
+    apply_manifest_on(agent, manifest) do |result|
+      assert_match(/Error:.*The sloth_daemon Subsystem is not on file/, result.stderr, "non-existent service should error when started, but received #{result.stderr}")
+    end
+  end
+
+  step "Verify starting a non-existent service with detailed exit codes correctly returns an error code" do
+    manifest = <<-PP
+      service { 'sloth_daemon' : ensure => running }
+    PP
+    apply_manifest_on(agent, manifest, :acceptable_exit_codes => [4])
+  end
+
   step "Setup on #{agent}"
   sloth_daemon_path = agent.tmpfile("sloth_daemon.sh")
   create_remote_file(agent, sloth_daemon_path, sloth_daemon_script)

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -138,7 +138,6 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
       Puppet.debug("Service #{@resource[:name]} is #{args[-1]}")
       return state
     end
-    self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
     self.debug(detail.message)
     return :stopped

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -91,56 +91,56 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
   end
 
   def restart
-      execute([command(:lssrc), "-Ss", @resource[:name]]).each_line do |line|
-        args = line.split(":")
+    execute([command(:lssrc), "-Ss", @resource[:name]]).each_line do |line|
+      args = line.split(":")
 
-        next unless args[0] == @resource[:name]
+      next unless args[0] == @resource[:name]
 
-        # Subsystems with the -K flag can get refreshed (HUPed)
-        # While subsystems with -S (signals) must be stopped/started
-        method = args[11]
-        do_refresh = case method
-          when "-K" then :true
-          when "-S" then :false
-          else self.fail("Unknown service communication method #{method}")
-        end
-
-        begin
-          if do_refresh == :true
-            execute([command(:refresh), "-s", @resource[:name]])
-          else
-            self.stop
-            self.start
-          end
-          return :true
-        rescue Puppet::ExecutionFailure => detail
-          raise Puppet::Error.new("Unable to restart service #{@resource[:name]}, error was: #{detail}", detail )
-        end
+      # Subsystems with the -K flag can get refreshed (HUPed)
+      # While subsystems with -S (signals) must be stopped/started
+      method = args[11]
+      do_refresh = case method
+        when "-K" then :true
+        when "-S" then :false
+        else self.fail("Unknown service communication method #{method}")
       end
-      self.fail("No such service found")
+
+      begin
+        if do_refresh == :true
+          execute([command(:refresh), "-s", @resource[:name]])
+        else
+          self.stop
+          self.start
+        end
+        return :true
+      rescue Puppet::ExecutionFailure => detail
+        raise Puppet::Error.new("Unable to restart service #{@resource[:name]}, error was: #{detail}", detail )
+      end
+    end
+    self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
+    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def status
-      execute([command(:lssrc), "-s", @resource[:name]]).each_line do |line|
-        args = line.split
+    execute([command(:lssrc), "-s", @resource[:name]]).each_line do |line|
+      args = line.split
 
-        # This is the header line
-        next unless args[0] == @resource[:name]
+      # This is the header line
+      next unless args[0] == @resource[:name]
 
-        # PID is the 3rd field, but inoperative subsystems
-        # skip this so split doesn't work right
-        state = case args[-1]
-          when "active" then :running
-          when "inoperative" then :stopped
-        end
-        Puppet.debug("Service #{@resource[:name]} is #{args[-1]}")
-        return state
+      # PID is the 3rd field, but inoperative subsystems
+      # skip this so split doesn't work right
+      state = case args[-1]
+        when "active" then :running
+        when "inoperative" then :stopped
       end
-      self.fail("No such service found")
+      Puppet.debug("Service #{@resource[:name]} is #{args[-1]}")
+      return state
+    end
+    self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
+    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
 end

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -140,7 +140,8 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
     end
     self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
+    self.debug(detail.message)
+    return :stopped
   end
 
 end

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -167,6 +167,11 @@ _EOF_
       @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
       expect(@provider.status).to eq(nil)
     end
+
+    it "should consider a non-existing service to be have a status of :stopped" do
+      @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', 'myservice']).raises(Puppet::ExecutionFailure, "fail")
+      expect(@provider.status).to eq(:stopped)
+    end
   end
 
   describe "when restarting a service" do


### PR DESCRIPTION
Prior to this PR, attempting to manage a non-existent service would result in an error even when ensuring the service is stopped, ie:
```
$ puppet resource service foo ensure=stopped
Error: /Service[foo]: Could not evaluate: Cannot get status of foo, error was: Execution of '/usr/bin/lssrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
Wrapped exception:
Execution of '/usr/bin/lssrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
Error: Could not run: Cannot get status of foo, error was: Execution of '/usr/bin/lssrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
Wrapped exception:
Execution of '/usr/bin/lssrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
$ echo $?
1
```

This is in contrast to current and long-standing behavior on RHEL and Ubuntu
systems, where doing something like ensure => stopped on a non-existent service
is a no-op, and from the ral's perspective a non-existent service is considered
to be in the 'stopped' state. That said, this behavior is not necessarily
"standard" though it probably should be. For example, the launchd provider both
prints an error *and* considers the service stopped.

This commit updates the AIX behavior so that a non-existent service is
considered stopped rather than failing with an error and/or failing the puppet
run if ensuring the service stopped. Ral attempts to ensure=running on a
non-existent service still provide an error, but return correct puppet now
instead of just erroring.

With this PR, output when stopping a non-existent service is effectively a no-op:
```
$ puppet resource service foo ensure=stopped
service { 'foo':
  ensure => 'stopped',
}
$ echo $?
0
$ puppet apply -e " service { 'foo' : ensure => stopped } "
Notice: Compiled catalog for pe-aix-71-agent.delivery.puppetlabs.net in environment production in 1.12 seconds
Notice: Applied catalog in 0.19 seconds
$ echo $?
0
```

And attempting to start a non-existent service errors, but exits according to puppet's detailed exit codes policy:
```
$ puppet apply -e " service { 'foo' : ensure => running } "
Notice: Compiled catalog for pe-aix-71-agent.delivery.puppetlabs.net in environment production in 0.57 seconds
Error: Could not start Service[foo]: Execution of '/usr/bin/startsrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
Error: /Stage[main]/Main/Service[foo]/ensure: change from stopped to running failed: Could not start Service[foo]: Execution of '/usr/bin/startsrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
Notice: Applied catalog in 0.17 seconds
$ echo $?
0
$ puppet apply -e " service { 'foo' : ensure => running } " --detailed-exitcodes
Notice: Compiled catalog for pe-aix-71-agent.delivery.puppetlabs.net in environment production in 0.58 seconds
Error: Could not start Service[foo]: Execution of '/usr/bin/startsrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
Error: /Stage[main]/Main/Service[foo]/ensure: change from stopped to running failed: Could not start Service[foo]: Execution of '/usr/bin/startsrc -s foo' returned 1: 0513-085 The foo Subsystem is not on file.
Notice: Applied catalog in 0.17 seconds
$ echo $?
4
```

There's a whitespace commit in this PR that makes this change appear large than it is. Diff suppressing whitespace change: https://github.com/puppetlabs/puppet/pull/5632/files?w=1