### PR TITLE
(pup-7021) establish central string encoding conversion

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -10,6 +10,7 @@ require 'puppet/util/platform'
 require 'puppet/util/symbolic_file_mode'
 require 'puppet/file_system/uniquefile'
 require 'securerandom'
+require 'puppet/util/character_encoding'
 
 module Puppet
 module Util

--- a/lib/puppet/util/character_encoding.rb
+++ b/lib/puppet/util/character_encoding.rb
@@ -1,0 +1,96 @@
+# A module to centralize heuristics/practices for managing character encoding in Puppet
+require 'puppet/util'
+
+module Puppet::Util::CharacterEncoding
+  class << self
+    #TODO make encoding warnings a category/silenceable#.
+
+    # @api public
+    # @param [String] string a string to transcode / force_encode to utf-8
+    # @return [String] string if already utf-8, OR
+    #   a copy of string with external encoding set to utf-8 if bytes are valid utf-8 OR
+    #   a copy of string transcoded to utf-8
+    # @raise [Puppet::Error] a failure to legitimately set external encoding or
+    #   transcode string
+    def convert_to_utf_8(string)
+      return string if string.encoding == Encoding::UTF_8
+
+      value_to_encode = string.dup
+
+      begin
+        if valid_utf_8?(value_to_encode)
+          # Before we try to transcode the string, check if it is valid UTF-8 as
+          # currently constitued (in its non-UTF-8 encoding), and if it is, limit
+          # ourselves to setting the external encoding of the string to UTF-8
+          # rather than actually transcoding it. We do this to handle
+          # a couple scenarios:
+
+          # The first scenario is that the string was originally valid UTF-8 but
+          # the current puppet run is not in a UTF-8 environment. In this case,
+          # the string will likely have invalid byte sequences (i.e.,
+          # string.valid_encoding? == false), and attempting to transcode will
+          # fail with Encoding::InvalidByteSequenceError, referencing the
+          # invalid byte sequence in the original, pre-transcode, string. We
+          # might have gotten here, for example, if puppet is run first in a
+          # user context with UTF-8 encoding (setting the "is" value to UTF-8)
+          # and then later run via cron without UTF-8 specified, resulting in in
+          # EN_US (ISO-8859-1) on many systems. In this scenario we're
+          # effectively best-guessing this string originated as UTF-8 and only
+          # set external encoding to UTF-8 - transcoding would have failed
+          # anyway.
+
+          # The second scenario (more rare, I expect) is that this string does
+          # NOT have invalid byte sequences (string.valid_encoding? == true),
+          # but is *ALSO valid unicode*.
+          # Our example case is "\u16A0" - "RUNIC LETTER FEHU FEOH FE"
+          # http://www.fileformat.info/info/unicode/char/16A0/index.htm
+          # 0xE1 0x9A 0xA0 / 225 154 160
+          # These bytes are valid in ISO-8859-1 but the character they represent
+          # transcodes cleanly in ruby to *different* characters in UTF-8.
+          # That's not what we want if the user intended the original string as
+          # UTF-8. We can only guess, so if the string is valid UTF-8 as
+          # currently constituted, we default to assuming the string originated
+          # in UTF-8 and do not transcode it - we only set external encoding.
+          value_to_encode.force_encoding(Encoding::UTF_8)
+        elsif transcodable?(value_to_encode)
+          # If the string is not currently valid UTF-8 but it can be transcoded,
+          # we can guess this string was not originally unicode. We need it to
+          # be now, so transcode it to UTF-8. For strings with original
+          # encodings like SHIFT_JIS, this should be the final result.
+          value_to_encode.encode!(Encoding::UTF_8)
+        else
+          # If the string is neither valid UTF-8 as-is nor is transcodable, fail
+          # at this point. It requires user remediation.
+          raise EncodingError
+        end
+      rescue EncodingError => detail
+        # catch both our own self-determined failure to transcode as well as any
+        # error on ruby's part, ie Encoding::InvalidByteSequenceError or
+        # Encoding::UndefinedConversionError.
+        raise Puppet::Error, "#{detail.inspect}: #{value_to_encode.dump} is not valid UTF-8 and cannot be transcoded by Puppet."
+      end
+
+      return value_to_encode
+    end
+
+    private
+
+    # Do our best to determine if a string is valid
+    # UTF-8 via String#valid_encoding?
+    # @api private
+    # @param [String] string a string to test
+    # @return [Boolean] whether we think the string is UTF-8 or not
+    def valid_utf_8?(string)
+      string.dup.force_encoding(Encoding::UTF_8).valid_encoding?
+    end
+
+    # Trying to encode! a string with existing invalid byte sequences raises
+    # Encoding::InvalidByteSequenceError, so we don't consider it transcodable
+    # @api private
+    # @param [String] string a string to test
+    # @return [Boolean] whether we think the string can be transcoded
+    def transcodable?(string)
+      string.valid_encoding?
+    end
+  end
+end

--- a/lib/puppet/util/character_encoding.rb
+++ b/lib/puppet/util/character_encoding.rb
@@ -67,7 +67,7 @@ module Puppet::Util::CharacterEncoding
         # catch both our own self-determined failure to transcode as well as any
         # error on ruby's part, ie Encoding::InvalidByteSequenceError or
         # Encoding::UndefinedConversionError.
-        raise Puppet::Error, "#{detail.inspect}: #{value_to_encode.dump} is not valid UTF-8 and cannot be transcoded by Puppet."
+        raise Puppet::Error, _("#{detail.inspect}: #{value_to_encode.dump} is not valid UTF-8 and cannot be transcoded by Puppet.")
       end
 
       return value_to_encode

--- a/spec/unit/util/character_encoding_spec.rb
+++ b/spec/unit/util/character_encoding_spec.rb
@@ -1,0 +1,66 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/character_encoding'
+
+describe Puppet::Util::CharacterEncoding do
+  describe "::convert_to_utf_8" do
+    context "when passed a UTF-8 string" do
+      it "should return the string unaltered" do
+        utf8_string = "\u06FF\u2603"
+        expect(Puppet::Util::CharacterEncoding.convert_to_utf_8(utf8_string)).to eq(utf8_string)
+      end
+    end
+
+    context "when passed a string not in UTF-8 encoding" do
+      context "the bytes of which represent valid UTF-8" do
+        # I think this effectively what the ruby Etc module is doing when it
+        # returns strings read in from /etc/passwd and /etc/group
+        let(:iso_8859_1_string) { [225, 154, 160].pack('C*').force_encoding(Encoding::ISO_8859_1) }
+        let(:result) { Puppet::Util::CharacterEncoding.convert_to_utf_8(iso_8859_1_string) }
+
+        it "should set external encoding to UTF-8" do
+          expect(result.encoding).to eq(Encoding::UTF_8)
+        end
+
+        it "should not modify the bytes (transcode) the string" do
+          expect(result.bytes.to_a).to eq([225, 154, 160])
+        end
+      end
+
+      context "the bytes of which do not represent valid UTF-8" do
+        it "should transcode the string to UTF-8 if it is transcodable" do
+          # http://www.fileformat.info/info/unicode/char/3050/index.htm
+          # ぐ - HIRAGANA LETTER GU
+          # In Shift_JIS: \x82 \xae - 130 174
+          # In Unicode: \u3050 - \xe3 \x81 \x90 - 227 129 144
+          # if we were only ruby > 2.3.0, we could do String.new("\x82\xae", :encoding => Encoding::Shift_JIS)
+          as_shift_jis = [130, 174].pack('C*').force_encoding(Encoding::Shift_JIS)
+          as_utf8 = "\u3050"
+
+          # this is not valid UTF-8
+          expect(as_shift_jis.dup.force_encoding(Encoding::UTF_8).valid_encoding?).to be_falsey
+
+          result = Puppet::Util::CharacterEncoding.convert_to_utf_8(as_shift_jis)
+          expect(result).to eq(as_utf8)
+          # largely redundant but reinforces the point - this was transcoded:
+          expect(result.bytes.to_a).to eq([227, 129, 144])
+        end
+
+        it "should raise an exception if not transcodable" do
+          # An admittedly contrived case, but perhaps not so improbable
+          # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
+          # 希 Han Character 'rare; hope, expect, strive for'
+          # In EUC_KR: \xfd \xf1 - 253 241
+          # In Unicode: \u5e0c - \xe5 \xb8 \x8c - 229 184 140
+
+          # If the original system value is in EUC_KR, and puppet (ruby) is run
+          # in ISO_8859_1, this value will be read in as ASCII, with invalid
+          # escape sequences in that encoding. It is also not valid unicode
+          # as-is. This scenario is one we can't recover from, so fail.
+          as_ascii = [254, 241].pack('C*').force_encoding(Encoding::ASCII)
+          expect { Puppet::Util::CharacterEncoding.convert_to_utf_8(as_ascii) }.to raise_error(Puppet::Error, /not valid UTF-8/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit creates puppet/util/character_encoding, a single location to house
logic related to the management character encoding conversion logic in puppet.
Prior to this commit, conversion logic was just beginning to fan out and
duplicate throughout puppet - with all the associated risk and maintenance
burden. We will leverage this code in a separate effort adding a
character-encoding-aware wrapper for ruby's Etc module and rewiring our
providers to use that instead.

This commit actually only adds a single public method -
'Puppet::Util::CharacterEncoding::convert_to_utf8'.

This method applies a standard heuristic to attempt to convert a (copy of a)
passed in string to UTF-8. That heuristic is summarized and justified as
follows (much of this is left as code-comments in the commit as well):

Given a supplied string:
- If the string has UTF-8 encoding, return it as-is. We have no need to do
  anything.

otherwise, if the string is not UTF-8 already:
- Check if its bytes represent valid UTF-8 as currently constitued (in its
  non-UTF-8 encoding) and if so, limit ourselves to setting the external
  encoding of the string to UTF-8 rather than actually transcoding it. We do
  this to handle a couple scenarios:

The first scenario is that the string was originally valid UTF-8 but the
current puppet run is not in a UTF-8 environment. In this case, the string will
likely have invalid byte sequences (i.e., string.valid_encoding? == false), and
attempting to transcode will fail with Encoding::InvalidByteSequenceError,
referencing the invalid byte sequence in the original, pre-transcode, string.
We might have gotten here, for example, if puppet is run first in a user
context with UTF-8 encoding (setting the "is" value to UTF-8) and then later
run via cron without UTF-8 specified, resulting in running in POSIX or some
other default encoding on many systems. In this scenario we're effectively
best-guessing this string originated as UTF-8 and only set external encoding to
UTF-8 - transcoding would have failed anyway.

The second scenario (more rare/unlikely, I expect) is that this string does NOT
have invalid byte sequences (string.valid_encoding? == true), but would
transcode cleanly into different, also valid unicode.

Our example case is "\u16A0" - "RUNIC LETTER FEHU FEOH FE"
http://www.fileformat.info/info/unicode/char/16A0/index.htm
0xE1 0x9A 0xA0 / 225 154 160

These bytes are valid in ISO-8859-1 but the character they represent transcodes
(incorrectly, but cleanly) in ruby to *different* characters in UTF-8. That's
not what we want if the user intended the original string as UTF-8.  Since
we're effectively moving towards a universal UTF-8 standard, if the string is
valid UTF-8 as currently constituted, we default to assuming the string
originated in UTF-8 and do not transcode it - we only set external encoding.

Otherwise, if the string is neither currently considered UTF-8 nor would be
valid UTF-8 bytes:
- Check if the string is even transcodable, as best we can. We know at least
  one way to determine it is _not_ transcodable, which is if
  string.valid_encoding == false, which will always result in
  InvalidByteSequenceError. We may augment this check in the future if we have
  better ways. If it is transcodable, go ahead and attempt to transcode (byte
  changing conversion) to UTF-8.

If none of our conditions have been met thus far:
- the string has been confirmed to not be UTF-8, nor would be valid UTF-8 with
  its current bytes, nor can be transcoded to UTF-8. In this scenario, we fail,
  as this string cannot be converted to UTF-8.
