### PR TITLE
(PUP-7021) Add UTF-8-aware Etc wrapper

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -48,6 +48,7 @@ end
 # @api public
 module Puppet
   require 'puppet/file_system'
+  require 'puppet/etc'
   require 'puppet/context'
   require 'puppet/environments'
 

--- a/lib/puppet/etc.rb
+++ b/lib/puppet/etc.rb
@@ -1,0 +1,148 @@
+require 'puppet/util/character_encoding'
+# Wrapper around Ruby Etc module allowing us to manage encoding in a single
+# place.
+# This represents a subset of Ruby's Etc module, only the methods required by Puppet.
+# Etc returns strings in variable encoding depending on
+# environment. For Puppet we specifically want UTF-8 as our input from the Etc
+# module - which is our input for many resource instance 'is' values. The
+# associated 'should' value will basically always be coming from Puppet in
+# UTF-8. Etc is defined for Windows but calls to it return nil.
+#
+# We only use Etc for retrieving existing property values from the system. For
+# setting property values, providers leverage system tools (i.e., `useradd`)
+#
+# @api private
+module Puppet::Etc
+  class << self
+    # Etc::getgrent returns an Etc::Group struct object
+    # On first call opens /etc/group and returns parse of first entry. Each subsquent call
+    # returns new struct the next entry or nil if EOF. Call ::endgrent to close file.
+    def getgrent
+      if group_entry = ::Etc.getgrent
+        convert_field_values_to_utf8!(group_entry)
+      end
+      group_entry
+    end
+
+    # closes handle to /etc/group file
+    def endgrent
+      ::Etc.endgrent
+    end
+
+    # effectively equivalent to IO#rewind of /etc/group
+    def setgrent
+      ::Etc.setgrent
+    end
+
+    # Etc::getpwent returns an Etc::Passwd struct object
+    # On first call opens /etc/passwd and returns parse of first entry. Each subsquent call
+    # returns new struct for the next entry or nil if EOF. Call ::endgrent to close file.
+    def getpwent
+      if user_entry = ::Etc.getpwent
+        convert_field_values_to_utf8!(user_entry)
+      end
+      user_entry
+    end
+
+    # closes handle to /etc/passwd file
+    def endpwent
+      ::Etc.endpwent
+    end
+
+    #effectively equivalent to IO#rewind of /etc/passwd
+    def setpwent
+      ::Etc.setpwent
+    end
+
+    # Etc::getpwnam searches /etc/passwd file for an entry corresponding to
+    # username.
+    # returns an Etc::Passwd struct corresponding to the entry or raises
+    # ArgumentError if none
+    def getpwnam(username)
+      if user_entry = ::Etc.getpwnam(username)
+        convert_field_values_to_utf8!(user_entry)
+      end
+      user_entry
+    end
+
+    # Etc::getgrnam searches /etc/group file for an entry corresponding to groupname.
+    # returns an Etc::Group struct corresponding to the entry or raises
+    # ArgumentError if none
+    def getgrnam(groupname)
+      if group_entry = ::Etc.getgrnam(groupname)
+        convert_field_values_to_utf8!(group_entry)
+      end
+      group_entry
+    end
+
+    # Etc::getgrid searches /etc/group file for an entry corresponding to id.
+    # returns an Etc::Group struct corresponding to the entry or raises
+    # ArgumentError if none
+    def getgrgid(id)
+      if group_entry = ::Etc.getgrgid(id)
+        convert_field_values_to_utf8!(group_entry)
+      end
+      group_entry
+    end
+
+    # Etc::getpwuid searches /etc/passwd file for an entry corresponding to id.
+    # returns an Etc::Passwd struct corresponding to the entry or raises
+    # ArgumentError if none
+    def getpwuid(id)
+      if user_entry = ::Etc.getpwuid(id)
+        convert_field_values_to_utf8!(user_entry)
+      end
+      user_entry
+    end
+
+    private
+    # Utility method for converting the String values of a struct returned by
+    # the Etc module to UTF-8. Structs returned by the ruby Etc module contain
+    # members with fields of type String, Integer, or Array of Strings, so we
+    # handle these types. Otherwise ignore fields.
+    #
+    # NOTE: If a string cannot be converted to UTF-8, this leaves the original
+    # string string intact in the Struct.
+    #
+    # Warning! This is a destructive method - the struct passed is modified!
+    #
+    # @api private
+    # @param [Etc::Passwd or Etc::Group struct]
+    # @return [Etc::Passwd or Etc::Group struct] the original struct with values
+    #   converted to UTF-8 if possible, or the original value intact if not
+    def convert_field_values_to_utf8!(struct)
+      struct.each_with_index do |value, index|
+        if value.is_a?(String)
+          begin
+            struct[index] = Puppet::Util::CharacterEncoding.convert_to_utf_8(value)
+          rescue Puppet::Error
+            # struct[index] unmodified
+          end
+        elsif value.is_a?(Array) && value.all? { |elem| elem.is_a?(String) }
+          struct[index] = convert_array_values_to_utf8!(value)
+        end
+      end
+    end
+
+    # Helper method for ::convert_field_values_to_utf8!
+    #
+    # Warning! This is a destructive method - the array passed is modified!
+    #
+    # @api private
+    # @param [Array] object containing String values to convert to UTF-8
+    # @return [Array] original Array with String values converted to UTF-8 if
+    #   convertible, or original, unmodified values if not.
+    def convert_array_values_to_utf8!(string_array)
+      string_array.map! do |elem|
+        begin
+          Puppet::Util::CharacterEncoding.convert_to_utf_8(elem)
+        rescue Puppet::Error
+          elem # individual array element unmodified
+        end
+      end
+    end
+  end
+end
+
+
+

--- a/lib/puppet/etc.rb
+++ b/lib/puppet/etc.rb
@@ -18,10 +18,7 @@ module Puppet::Etc
     # On first call opens /etc/group and returns parse of first entry. Each subsquent call
     # returns new struct the next entry or nil if EOF. Call ::endgrent to close file.
     def getgrent
-      if group_entry = ::Etc.getgrent
-        convert_field_values_to_utf8!(group_entry)
-      end
-      group_entry
+      convert_field_values_to_utf8!(::Etc.getgrent)
     end
 
     # closes handle to /etc/group file
@@ -38,10 +35,7 @@ module Puppet::Etc
     # On first call opens /etc/passwd and returns parse of first entry. Each subsquent call
     # returns new struct for the next entry or nil if EOF. Call ::endgrent to close file.
     def getpwent
-      if user_entry = ::Etc.getpwent
-        convert_field_values_to_utf8!(user_entry)
-      end
-      user_entry
+      convert_field_values_to_utf8!(::Etc.getpwent)
     end
 
     # closes handle to /etc/passwd file
@@ -59,40 +53,28 @@ module Puppet::Etc
     # returns an Etc::Passwd struct corresponding to the entry or raises
     # ArgumentError if none
     def getpwnam(username)
-      if user_entry = ::Etc.getpwnam(username)
-        convert_field_values_to_utf8!(user_entry)
-      end
-      user_entry
+      convert_field_values_to_utf8!(::Etc.getpwnam(username))
     end
 
     # Etc::getgrnam searches /etc/group file for an entry corresponding to groupname.
     # returns an Etc::Group struct corresponding to the entry or raises
     # ArgumentError if none
     def getgrnam(groupname)
-      if group_entry = ::Etc.getgrnam(groupname)
-        convert_field_values_to_utf8!(group_entry)
-      end
-      group_entry
+      convert_field_values_to_utf8!(::Etc.getgrnam(groupname))
     end
 
     # Etc::getgrid searches /etc/group file for an entry corresponding to id.
     # returns an Etc::Group struct corresponding to the entry or raises
     # ArgumentError if none
     def getgrgid(id)
-      if group_entry = ::Etc.getgrgid(id)
-        convert_field_values_to_utf8!(group_entry)
-      end
-      group_entry
+      convert_field_values_to_utf8!(::Etc.getgrgid(id))
     end
 
     # Etc::getpwuid searches /etc/passwd file for an entry corresponding to id.
     # returns an Etc::Passwd struct corresponding to the entry or raises
     # ArgumentError if none
     def getpwuid(id)
-      if user_entry = ::Etc.getpwuid(id)
-        convert_field_values_to_utf8!(user_entry)
-      end
-      user_entry
+      convert_field_values_to_utf8!(::Etc.getpwuid(id))
     end
 
     private
@@ -111,14 +93,12 @@ module Puppet::Etc
     # @return [Etc::Passwd or Etc::Group struct] the original struct with values
     #   converted to UTF-8 if possible, or the original value intact if not
     def convert_field_values_to_utf8!(struct)
+      return nil if struct.nil?
       struct.each_with_index do |value, index|
         if value.is_a?(String)
-          begin
-            struct[index] = Puppet::Util::CharacterEncoding.convert_to_utf_8(value)
-          rescue Puppet::Error
-            # struct[index] unmodified
-          end
-        elsif value.is_a?(Array) && value.all? { |elem| elem.is_a?(String) }
+            converted = Puppet::Util::CharacterEncoding.convert_to_utf_8!(value)
+            struct[index] = converted if !converted.nil?
+        elsif value.is_a?(Array)
           struct[index] = convert_array_values_to_utf8!(value)
         end
       end
@@ -134,11 +114,8 @@ module Puppet::Etc
     #   convertible, or original, unmodified values if not.
     def convert_array_values_to_utf8!(string_array)
       string_array.map! do |elem|
-        begin
-          Puppet::Util::CharacterEncoding.convert_to_utf_8(elem)
-        rescue Puppet::Error
-          elem # individual array element unmodified
-        end
+        converted = Puppet::Util::CharacterEncoding.convert_to_utf_8!(elem)
+        converted.nil? ? elem : converted
       end
     end
   end

--- a/lib/puppet/util/character_encoding.rb
+++ b/lib/puppet/util/character_encoding.rb
@@ -1,24 +1,29 @@
 # A module to centralize heuristics/practices for managing character encoding in Puppet
-require 'puppet/util'
 
 module Puppet::Util::CharacterEncoding
   class << self
-    #TODO make encoding warnings a category/silenceable#.
-
+    # Warning! This is a destructive method - the string supplied is modified!
     # @api public
     # @param [String] string a string to transcode / force_encode to utf-8
     # @return [String] string if already utf-8, OR
-    #   a copy of string with external encoding set to utf-8 if bytes are valid utf-8 OR
-    #   a copy of string transcoded to utf-8
-    # @raise [Puppet::Error] a failure to legitimately set external encoding or
-    #   transcode string
-    def convert_to_utf_8(string)
-      return string if string.encoding == Encoding::UTF_8
-
-      value_to_encode = string.dup
+    #   the same string with external encoding set to utf-8 if bytes are valid utf-8 OR
+    #   the same string transcoded to utf-8 OR
+    #   nil upon a failure to legitimately set external encoding or transcode string
+    def convert_to_utf_8!(string)
+      currently_valid = string.valid_encoding?
 
       begin
-        if valid_utf_8?(value_to_encode)
+        if string.encoding == Encoding::UTF_8
+          if currently_valid
+            return string
+          else
+            # If a string is currently believed to be UTF-8, but is also not
+            # valid_encoding?, we have no recourse but to fail because we have no
+            # idea what encoding this string originally came from where it *was*
+            # valid - all we know is it's not currently valid UTF-8.
+            raise EncodingError
+          end
+        elsif valid_utf_8_bytes?(string)
           # Before we try to transcode the string, check if it is valid UTF-8 as
           # currently constitued (in its non-UTF-8 encoding), and if it is, limit
           # ourselves to setting the external encoding of the string to UTF-8
@@ -51,46 +56,40 @@ module Puppet::Util::CharacterEncoding
           # UTF-8. We can only guess, so if the string is valid UTF-8 as
           # currently constituted, we default to assuming the string originated
           # in UTF-8 and do not transcode it - we only set external encoding.
-          value_to_encode.force_encoding(Encoding::UTF_8)
-        elsif transcodable?(value_to_encode)
-          # If the string is not currently valid UTF-8 but it can be transcoded,
-          # we can guess this string was not originally unicode. We need it to
-          # be now, so transcode it to UTF-8. For strings with original
-          # encodings like SHIFT_JIS, this should be the final result.
-          value_to_encode.encode!(Encoding::UTF_8)
+          return string.force_encoding(Encoding::UTF_8)
+        elsif currently_valid
+          # If the string is not currently valid UTF-8 but it can be transcoded
+          # (it is valid in its current encoding), we can guess this string was
+          # not originally unicode. Transcode it to UTF-8. For strings with
+          # original encodings like SHIFT_JIS, this should be the final result.
+          return string.encode!(Encoding::UTF_8)
         else
-          # If the string is neither valid UTF-8 as-is nor is transcodable, fail
-          # at this point. It requires user remediation.
+          # If the string is neither valid UTF-8 as-is nor valid in its current
+          # encoding, fail. It requires user remediation.
           raise EncodingError
         end
       rescue EncodingError => detail
-        # catch both our own self-determined failure to transcode as well as any
-        # error on ruby's part, ie Encoding::InvalidByteSequenceError or
-        # Encoding::UndefinedConversionError.
-        raise Puppet::Error, _("#{detail.inspect}: #{value_to_encode.dump} is not valid UTF-8 and cannot be transcoded by Puppet.")
+        # Catch both our own self-determined failure to transcode as well as any
+        # error on ruby's part, ie Encoding::UndefinedConversionError on a
+        # failure to encode!.
+        Puppet.debug(_("%{error}: %{value} is not valid UTF-8 and cannot be transcoded by Puppet.") %
+          { error: detail.inspect, value: string.dump })
+        return nil
       end
-
-      return value_to_encode
     end
 
     private
 
-    # Do our best to determine if a string is valid
-    # UTF-8 via String#valid_encoding?
+    # Do our best to determine if a string is valid UTF-8 via String#valid_encoding? without permanently
+    # modifying or duplicating the string due to performance concerns
     # @api private
     # @param [String] string a string to test
     # @return [Boolean] whether we think the string is UTF-8 or not
-    def valid_utf_8?(string)
-      string.dup.force_encoding(Encoding::UTF_8).valid_encoding?
-    end
-
-    # Trying to encode! a string with existing invalid byte sequences raises
-    # Encoding::InvalidByteSequenceError, so we don't consider it transcodable
-    # @api private
-    # @param [String] string a string to test
-    # @return [Boolean] whether we think the string can be transcoded
-    def transcodable?(string)
-      string.valid_encoding?
+    def valid_utf_8_bytes?(string)
+      original_encoding = string.encoding
+      valid = string.force_encoding(Encoding::UTF_8).valid_encoding?
+      string.force_encoding(original_encoding)
+      valid
     end
   end
 end

--- a/spec/unit/etc_spec.rb
+++ b/spec/unit/etc_spec.rb
@@ -1,4 +1,4 @@
-require 'puppet/etc'
+require 'puppet'
 require 'spec_helper'
 
 # The Ruby::Etc module is largely non-functional on Windows - many methods

--- a/spec/unit/etc_spec.rb
+++ b/spec/unit/etc_spec.rb
@@ -1,0 +1,234 @@
+require 'puppet/etc'
+require 'spec_helper'
+
+# The Ruby::Etc module is largely non-functional on Windows - many methods
+# simply return nil regardless of input, the Etc::Group struct is not defined,
+# and Etc::Passwd is missing fields
+describe Puppet::Etc, :if => !Puppet.features.microsoft_windows? do
+  let(:bin) { 'bin'.force_encoding(Encoding::ISO_8859_1) }
+  let(:root) { 'root'.force_encoding(Encoding::ISO_8859_1) }
+  let(:x) { 'x'.force_encoding(Encoding::ISO_8859_1) }
+  let(:daemon) { 'daemon'.force_encoding(Encoding::ISO_8859_1) }
+  let(:root_comment) { 'i am the root user'.force_encoding(Encoding::ISO_8859_1) }
+  let(:user_struct_iso_8859_1) { Etc::Passwd.new(root, x, 0, 0, root_comment) }
+  let(:group_struct_iso_8859_1) { Etc::Group.new(bin, x, 1, [root, bin, daemon]) }
+
+  # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
+  # 希 Han Character 'rare; hope, expect, strive for'
+  # In EUC_KR: \xfd \xf1 - 253 241
+  # Not convertible to UTF-8, likely to be read in as BINARY by Ruby unless system is in EUC_KR
+  let(:not_convertible) { [254, 241].pack('C*') }
+
+  # characters representing different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  #
+  # Should all convert cleanly to UTF-8
+  # Unless the system is in UTF-8, these will likely be read in as BINARY by Ruby
+  let(:convertible_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ𠜎
+  let(:convertible_binary) { "A\u06FF\u16A0\u{2070E}".force_encoding(Encoding::BINARY) }
+
+  # For the methods described which actually expect an encoding conversion, we
+  # only superficially test via #force_encoding - the deeper level testing is in
+  # character_encoding_spec.rb which handles testing transcoding etc.
+
+  describe "getgrent" do
+    context "given an original system Etc Group struct with ISO-8850-1 string values" do
+      before { Etc.expects(:getgrent).returns(group_struct_iso_8859_1) }
+      let(:converted) { Puppet::Etc.getgrent }
+
+      it "should return a struct with :name and :passwd field values converted to UTF-8" do
+        [converted.name, converted.passwd].each do |value|
+          expect(value.encoding).to eq(Encoding::UTF_8)
+        end
+      end
+
+      it "should return a struct with a :mem array with all field values converted to UTF-8" do
+        converted.mem.each { |elem| expect(elem.encoding).to eq(Encoding::UTF_8) }
+      end
+    end
+
+    context "given an original Etc::Group struct with field values that cannot be converted to UTF-8" do
+      let(:group) { Etc::Group.new }
+      before do
+        # group membership contains valid and invalid UTF-8
+        group.mem = [convertible_binary, not_convertible]
+        # group name contains a value that is invalid UTF-8
+        group.name = not_convertible
+        # group passwd field is valid UTF-8
+        group.passwd = convertible_binary
+
+        Etc.expects(:getgrent).returns(group)
+      end
+
+      let(:converted) { Puppet::Etc.getgrent }
+
+      it "should convert convertible values in arrays to UTF-8" do
+        expect(converted.mem[0]).to eq("A\u06FF\u16A0\u{2070E}")
+        expect(converted.mem[0].encoding).to eq(Encoding::UTF_8) # just being explicit
+      end
+
+      it "should leave the unconvertible values unmodified" do
+        expect(converted.name).to eq([254, 241].pack('C*'))
+        expect(converted.name.encoding).to eq(Encoding::BINARY) # just being explicit
+      end
+
+      it "should leave unconvertible values in arrays unmodifed" do
+        expect(converted.mem[1]).to eq([254, 241].pack('C*'))
+        expect(converted.mem[1].encoding).to eq(Encoding::BINARY) # just being explicit
+      end
+
+      it "should convert values that can be converted to UTf-8" do
+        expect(converted.passwd).to eq("A\u06FF\u16A0\u{2070E}")
+        expect(converted.passwd.encoding).to eq(Encoding::UTF_8) # just being explicit
+      end
+    end
+  end
+
+  describe "endgrent" do
+    it "should call Etc.getgrent" do
+      Etc.expects(:getgrent)
+      Puppet::Etc.getgrent
+    end
+  end
+
+  describe "setgrent" do
+    it "should call Etc.setgrent" do
+      Etc.expects(:setgrent)
+      Puppet::Etc.setgrent
+    end
+  end
+
+  describe "getpwent" do
+    context "given an original system Etc Passwd struct with ISO-8859-1 string values" do
+      before { Etc.expects(:getpwent).returns(user_struct_iso_8859_1) }
+      let(:converted) { Puppet::Etc.getpwent }
+
+      it "should return an Etc Passwd struct with field values converted to UTF-8" do
+        [converted.name, converted.passwd, converted.gecos].each do |value|
+          expect(value.encoding).to eq(Encoding::UTF_8)
+        end
+      end
+    end
+
+    context "given an original Etc::Passwd struct with field values that cannot be converted to UTF-8" do
+      let(:user) { Etc::Passwd.new }
+      before do
+        # user comment field cannot be converted to UTF-8
+        user.gecos =  not_convertible
+        # user passwd field is valid UTF-8
+        user.passwd = convertible_binary
+
+        Etc.expects(:getpwent).returns(user)
+      end
+
+      let(:converted) { Puppet::Etc.getpwent }
+
+      it "should leave the unconvertible values unmodified" do
+        expect(converted.gecos).to eq([254, 241].pack('C*'))
+        expect(converted.gecos.encoding).to eq(Encoding::BINARY) # just being explicit
+      end
+
+      it "should convert values that can be converted to UTf-8" do
+        expect(converted.passwd).to eq("A\u06FF\u16A0\u{2070E}")
+        expect(converted.passwd.encoding).to eq(Encoding::UTF_8) # just being explicit
+      end
+    end
+  end
+
+  describe "endpwent" do
+    it "should call Etc.endpwent" do
+      Etc.expects(:endpwent)
+      Puppet::Etc.endpwent
+    end
+  end
+
+  describe "setpwent" do
+    it "should call Etc.setpwent" do
+      Etc.expects(:setpwent)
+      Puppet::Etc.setpwent
+    end
+  end
+
+  describe "getpwnam" do
+    context "given a username to query" do
+      it "should call Etc.getpwnam with that username" do
+        Etc.expects(:getpwnam).with('foo')
+        Puppet::Etc.getpwnam('foo')
+      end
+    end
+
+    context "given an original system Etc Passwd struct with ISO-8859-1 string values" do
+      it "should return an Etc Passwd struct with field values converted to UTF-8" do
+        Etc.expects(:getpwnam).with('root').returns(user_struct_iso_8859_1)
+        converted = Puppet::Etc.getpwnam('root')
+        [converted.name, converted.passwd, converted.gecos].each do |value|
+          expect(value.encoding).to eq(Encoding::UTF_8)
+        end
+      end
+    end
+  end
+
+  describe "getgrnam" do
+    context "given a group name to query" do
+      it "should call Etc.getgrnam with that group name" do
+        Etc.expects(:getgrnam).with('foo')
+        Puppet::Etc.getgrnam('foo')
+      end
+    end
+
+    context "given an original system Etc Group struct with ISO-8859-1 string values" do
+      it "should return an Etc Group struct with field values converted to UTF-8" do
+        Etc.expects(:getgrnam).with('bin').returns(group_struct_iso_8859_1)
+        converted = Puppet::Etc.getgrnam('bin')
+        [converted.name, converted.passwd].each do |value|
+          expect(value.encoding).to eq(Encoding::UTF_8)
+        end
+        converted.mem.each { |elem| expect(elem.encoding).to eq(Encoding::UTF_8) }
+      end
+    end
+  end
+
+  describe "getgrgid" do
+    context "given a group ID to query" do
+      it "should call Etc.getgrgid with the id" do
+        Etc.expects(:getgrgid).with(0)
+        Puppet::Etc.getgrgid(0)
+      end
+    end
+
+    context "given an original Etc Group struct with field values in ISO-8859-1" do
+      it "should return an Etc Group struct with field values converted to UTF-8" do
+        Etc.expects(:getgrgid).with(1).returns(group_struct_iso_8859_1)
+        converted = Puppet::Etc.getgrgid(1)
+        [converted.name, converted.passwd].each do |value|
+          expect(value.encoding).to eq(Encoding::UTF_8)
+        end
+        converted.mem.each { |elem| expect(elem.encoding).to eq(Encoding::UTF_8) }
+      end
+    end
+  end
+
+  describe "getpwid" do
+    context "given a UID to query" do
+      it "should call Etc.getpwuid with the id" do
+        Etc.expects(:getpwuid).with(2)
+        Puppet::Etc.getpwuid(2)
+      end
+    end
+  end
+
+  context "given an orginal Etc Passwd struct with field values in ISO-8859-1" do
+    it "should return an Etc Passwd struct with field values converted to UTF-8" do
+      Etc.expects(:getpwuid).with(0).returns(user_struct_iso_8859_1)
+      converted = Puppet::Etc.getpwuid(0)
+      [converted.name, converted.passwd, converted.gecos].each do |value|
+        expect(value.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
This PR includes the content of https://github.com/puppetlabs/puppet/pull/5633, and is separated out for ease of review. This PR content is the content of commit '(pup-7021) Add UTF-8-aware Etc wrapper'.

The Ruby Etc module will return various Struct objects containing strings in
the system's locale, or if they are invalid in the current locale, as
ASCII-8BIT (Binary). This leads to inconsistent and problematic behavior when
Puppet uses the Etc module in its providers, particularly when trying to
concatenate or compare strings which now may have different, and often
incompatible, encodings. The nameservice provider in particular makes heavy use
of Etc, which has resulted in numerous bugs reported regarding UTF-8.

Initial attempts to resolve the issues focused on the locations where string
comparison or concatenation was happening, but it became quickly clear that
there are too many places to do this, and the better solution would likely be
to control the problem where the strings first enter the system - at the Etc
module.

This commit adds a Puppet wrapper around ruby's Etc module that leverages
puppet/util/character_encoding to convert the values returned by Etc to UTF-8.
In order to avoid ever letting the original Etc values get into the system (and
with a side benefit of avoiding extraneous object creation) the Structs are
modified in-place.

It is true that this commit may introduce different failure scenarios, as
unavoidable failure will now likely be located in the string conversion process
(ie if we have truly UTF-8 incompatible strings), rather than higher in the
stack at comparison or concatenation for display, but it seems these were going
to fail anyway.