### PR TITLE
(maint) Explicitly specify encodings where missed

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -435,6 +435,7 @@ end
 # (e.g., bin/rdoc becomes rdoc); the shebang line handles running it. Under
 # windows, we add an '.rb' extension and let file associations do their stuff.
 def install_binfile(from, op_file, target)
+  # encoding not important here
   tmp_file = Tempfile.new('puppet-binfile')
 
   if not InstallOptions.ruby.nil?
@@ -443,8 +444,8 @@ def install_binfile(from, op_file, target)
     ruby = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
   end
 
-  File.open(from) do |ip|
-    File.open(tmp_file.path, "w") do |op|
+  File.open(from, 'r:UTF-8') do |ip|
+    File.open(tmp_file.path, "w:UTF-8") do |op|
       op.puts "#!#{ruby}" unless $operatingsystem == "windows"
       contents = ip.readlines
       contents.shift if contents[0] =~ /^#!/
@@ -467,7 +468,7 @@ def install_binfile(from, op_file, target)
       end
 
       if not installed_wrapper
-        tmp_file2 = Tempfile.new('puppet-wrapper')
+        tmp_file2 = Tempfile.new('puppet-wrapper', :encoding => Encoding::UTF_8)
         cwv = <<-EOS
 @echo off
 SETLOCAL
@@ -478,7 +479,7 @@ if exist "%~dp0environment.bat" (
 )
 ruby.exe -S -- puppet %*
 EOS
-        File.open(tmp_file2.path, "w") { |cw| cw.puts cwv }
+        File.open(tmp_file2.path, "w:UTF-8") { |cw| cw.puts cwv }
         FileUtils.install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
 
         tmp_file2.unlink

--- a/lib/puppet/external/pson/common.rb
+++ b/lib/puppet/external/pson/common.rb
@@ -289,6 +289,7 @@ module PSON
   # Marshal and YAML.
   def dump(obj, anIO = nil, limit = nil)
     if anIO and limit.nil?
+      # FIXME: shouldn't anIO be validated to have Encoding::BINARY given this is PSON?
       anIO = anIO.to_io if anIO.respond_to?(:to_io)
       unless anIO.respond_to?(:write)
         limit = anIO

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -153,7 +153,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       # Print to a buffer since the face needs to return the resulting string
       # and the face API is "all or nothing"
       #
-      buffer = StringIO.new
+      buffer = StringIO.new('', 'r+:UTF-8')
 
       if options[:e]
         buffer.print dump_parse(options[:e], 'command-line-string', options, false)
@@ -320,7 +320,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       # Print to a buffer since the face needs to return the resulting string
       # and the face API is "all or nothing"
       #
-      buffer = StringIO.new
+      buffer = StringIO.new('', 'r+:UTF-8')
       status = true
       if options[:e]
         buffer.print render_inline(options[:e], compiler, options)

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -122,7 +122,7 @@ MSG
 
   def erb(name)
     template = (Pathname(__FILE__).dirname + "help" + name)
-    erb = ERB.new(template.read, nil, '-')
+    erb = ERB.new(template.read(:encoding => Encoding::UTF_8), nil, '-')
     erb.filename = template.to_s
     return erb
   end

--- a/lib/puppet/face/man.rb
+++ b/lib/puppet/face/man.rb
@@ -46,7 +46,7 @@ Puppet::Face.define(:man, '0.0.1') do
       face = Puppet::Face[name.to_sym, :current]
 
       file = (Pathname(__FILE__).dirname + "help" + 'man.erb')
-      erb = ERB.new(file.read, nil, '-')
+      erb = ERB.new(file.read(:encoding => Encoding::UTF_8), nil, '-')
       erb.filename = file.to_s
 
       # Run the ERB template in our current binding, including all the local

--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -134,8 +134,7 @@ class Puppet::FileBucket::Dipper
           changed = Puppet::FileSystem.stat(file_handle).mode
           ::File.chmod(changed | 0200, file)
         end
-        ::File.open(file, ::File::WRONLY|::File::TRUNC|::File::CREAT) { |of|
-          of.binmode
+        Puppet::FileSystem.open(file, nil, 'wb') { |of|
           newcontents.stream do |source_stream|
             FileUtils.copy_stream(source_stream, of)
           end

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -95,7 +95,7 @@ class Puppet::FileBucket::File
     end
 
     def stream(&block)
-      s = StringIO.new(@contents)
+      s = StringIO.new(@contents, 'r+b')
       begin
         block.call(s)
       ensure

--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -6,14 +6,14 @@ class Puppet::FileServing::Configuration::Parser
   MODULES = 'modules'
 
   # Parse our configuration file.
-  def parse
+  def parse(encoding = Encoding.default_external)
     raise("File server configuration #{@file} does not exist") unless Puppet::FileSystem.exist?(@file)
     raise("Cannot read file server configuration #{@file}") unless FileTest.readable?(@file)
 
     @mounts = {}
     @count = 0
 
-    File.open(@file) { |f|
+    Puppet::FileSystem.open(@file, nil, "r:#{encoding.name}") { |f|
       mount = nil
       f.each_line { |line|
         # Have the count increment at the top, in case we throw exceptions.

--- a/lib/puppet/file_serving/content.rb
+++ b/lib/puppet/file_serving/content.rb
@@ -38,6 +38,7 @@ class Puppet::FileServing::Content < Puppet::FileServing::Base
   end
 
   def to_binary
+    # FIXME
     File.new(full_path, "rb")
   end
 end

--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -377,6 +377,7 @@ module Puppet::FileSystem
   end
 
   # Create and open a file for write only if it doesn't exist.
+  # Note: Does not currently support specifying an Encoding, use sparingly.
   #
   # @see Puppet::FileSystem::open
   #

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -68,6 +68,8 @@ class Puppet::FileSystem::FileImpl
     end
   end
 
+  # FIXME encoding
+  # must add a new parameter to each_line method in a backward compatible way
   def each_line(path, &block)
     ::File.open(path) do |f|
       f.each_line do |line|

--- a/lib/puppet/file_system/memory_file.rb
+++ b/lib/puppet/file_system/memory_file.rb
@@ -41,7 +41,7 @@ class Puppet::FileSystem::MemoryFile
 
   def handle
     raise Errno::ENOENT unless exist?
-    StringIO.new(@properties[:content] || '')
+    StringIO.new(@properties[:content] || '', 'r+:UTF-8')
   end
 
   def duplicate_as(other_path)

--- a/lib/puppet/generate/type.rb
+++ b/lib/puppet/generate/type.rb
@@ -164,7 +164,7 @@ module Puppet
         templates = {}
         templates.default_proc = lambda { |hash, key|
           raise "template was not found at '#{key}'." unless Puppet::FileSystem.file?(key)
-          template = ERB.new(File.read(key), nil, '-')
+          template = ERB.new(Puppet::FileSystem.read(key, :encoding => Encoding::UTF_8), nil, '-')
           template.filename = key
           template
         }

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -47,7 +47,7 @@ module Puppet::ModuleTool
         metadata_path   = File.join(@path, 'metadata.json')
 
         if File.file?(metadata_path)
-          File.open(metadata_path) do |f|
+          Puppet::FileSystem.open(metadata_path, nil, 'r:UTF-8') do |f|
             begin
               @metadata.update(JSON.load(f))
             rescue JSON::ParserError => ex

--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -18,9 +18,10 @@ module Puppet::Network::HTTP::Compression
     # return an uncompressed body if the response has been
     # compressed
     def uncompress_body(response)
+      # TODO: is response.body already a BINARY string?
       case response['content-encoding']
       when 'gzip'
-        return Zlib::GzipReader.new(StringIO.new(response.body)).read
+        return Zlib::GzipReader.new(StringIO.new(response.body, 'r+b')).read
       when 'deflate'
         return Zlib::Inflate.new.inflate(response.body)
       when nil, 'identity'

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -31,7 +31,8 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     group_file = "/etc/group"
     group_keys = ['group_name', 'password', 'gid', 'user_list']
     index = group_keys.index(key)
-    File.open(group_file) do |f|
+    # TODO: should this be UTF-8 given its /etc/group  .... or BINARY??
+    Puppet::FileSystem.open(group_file, nil, "r:#{Encoding.default_external.name}") do |f|
       f.each_line do |line|
          group = line.split(":")
          if group[index] == value

--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
 
   def checkforcdrom
     have_cdrom = begin
-                   !!(File.read("/etc/apt/sources.list") =~ /^[^#]*cdrom:/)
+                   !!(Puppet::FileSystem.read("/etc/apt/sources.list", :encoding => Encoding.default_external) =~ /^[^#]*cdrom:/)
                  rescue
                    # This is basically pathological...
                    false

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -119,7 +119,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
   def parse_pkgconf
     unless @resource[:source]
       if Puppet::FileSystem.exist?("/etc/pkg.conf")
-        File.open("/etc/pkg.conf", "rb").readlines.each do |line|
+        Puppet::FileSystem.open("/etc/pkg.conf", nil, "rb").readlines.each do |line|
           if matchdata = line.match(/^installpath\s*=\s*(.+)\s*$/i)
             @resource[:source] = matchdata[1]
           elsif matchdata = line.match(/^installpath\s*\+=\s*(.+)\s*$/i)

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -21,7 +21,10 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
 
     correct_wgetopts = false
     [ "/opt/csw/etc/pkgutil.conf", "/etc/opt/csw/pkgutil.conf" ].each do |confpath|
-      File.open(confpath) do |conf|
+      # http://pkgutil.wikidot.com/get-install-and-configure#toc8 doesn't specify
+      # an Encoding for pkgutil.conf - so presume the default
+      # Solaris should be defaulting to UTF-8 already
+      Puppet::FileSystem.open(confpath, nil, "r:#{Encoding.default_external.name}") do |conf|
         conf.each_line {|line| correct_wgetopts = true if line =~ /^\s*wgetopts\s*=.*(-nv|-q|--no-verbose|--quiet)/ }
       end
     end

--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -33,7 +33,9 @@ Puppet::Type.type(:service).provide :base, :parent => :service do
     regex = Regexp.new(@resource[:pattern])
     ps = getps
     self.debug "Executing '#{ps}'"
-    IO.popen(ps) { |table|
+    # TODO: this is tricky - probably want Encoding.default_external
+    # except that regex should be UTF-8
+    IO.popen(ps, :encoding => Encoding.default_external) { |table|
       table.each_line { |line|
         if regex.match(line)
           self.debug "Process matched: #{line}"

--- a/lib/puppet/provider/service/bsd.rb
+++ b/lib/puppet/provider/service/bsd.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:service).provide :bsd, :parent => :init do
   def enable
     Dir.mkdir(rcconf_dir) if not Puppet::FileSystem.exist?(rcconf_dir)
     rcfile = File.join(rcconf_dir, @resource[:name])
-    File.open(rcfile, File::WRONLY | File::APPEND | File::CREAT, 0644) { |f|
+    Puppet::FileSystem.open(rcfile, 0644, 'ab') { |f|
       f << "%s_enable=\"YES\"\n" % @resource[:name]
     }
   end

--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
       if Puppet::FileSystem.exist?(filename)
         s = File.read(filename)
         if s.gsub!(/^(#{rcvar}(_enable)?)=\"?(YES|NO)\"?/, "\\1=\"#{yesno}\"")
-          File.open(filename, File::WRONLY) { |f| f << s }
+          Puppet::FileSystem.open(filename, nil, 'w:UTF-8') { |f| f << s }
           self.debug("Replaced in #{filename}")
           success = true
         end
@@ -88,20 +88,20 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
     append = "\# Added by Puppet\n#{rcvar}_enable=\"#{yesno}\"\n"
     # First, try the one-file-per-service style
     if Puppet::FileSystem.exist?(rcconf_dir)
-      File.open(rcconf_dir + "/#{service}", File::WRONLY | File::APPEND | File::CREAT, 0644) {
+      Puppet::FileSystem.open(rcconf_dir + "/#{service}", 0644, 'a:UTF-8') {
         |f| f << append
         self.debug("Appended to #{f.path}")
       }
     else
       # Else, check the local rc file first, but don't create it
       if Puppet::FileSystem.exist?(rcconf_local)
-        File.open(rcconf_local, File::WRONLY | File::APPEND) {
+        Puppet::FileSystem.open(rcconf_local, 'a:UTF-8') {
           |f| f << append
           self.debug("Appended to #{f.path}")
         }
       else
         # At last use the standard rc.conf file
-        File.open(rcconf, File::WRONLY | File::APPEND | File::CREAT, 0644) {
+        Puppet::FileSystem.open(rcconf, 0644, 'a:UTF-8') {
           |f| f << append
           self.debug("Appended to #{f.path}")
         }

--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -72,7 +72,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
     # Replace in all files, not just in the first found with a match
     [rcconf, rcconf_local, rcconf_dir + "/#{service}"].each do |filename|
       if Puppet::FileSystem.exist?(filename)
-        s = File.read(filename)
+        s = Puppet::FileSystem.read(filename, :encoding => Encoding.default_external)
         if s.gsub!(/^(#{rcvar}(_enable)?)=\"?(YES|NO)\"?/, "\\1=\"#{yesno}\"")
           Puppet::FileSystem.open(filename, nil, 'w:UTF-8') { |f| f << s }
           self.debug("Replaced in #{filename}")

--- a/lib/puppet/provider/service/rcng.rb
+++ b/lib/puppet/provider/service/rcng.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:service).provide :rcng, :parent => :bsd do
   def enabled?
     rcfile = File.join(rcconf_dir, @resource[:name])
     if Puppet::FileSystem.exist?(rcfile)
-      File.open(rcfile).readlines.each do |line|
+      Puppet::FileSystem.open(rcfile, nil, "r:#{Encoding.default_external.name}").readlines.each do |line|
         # Now look for something that looks like "service=${service:=YES}" or "service=YES"
         if line.match(/^\s*#{@resource[:name]}=(?:YES|\${#{@resource[:name]}:=YES})/)
           return :true
@@ -33,7 +33,7 @@ Puppet::Type.type(:service).provide :rcng, :parent => :bsd do
     rcfile = File.join(rcconf_dir, @resource[:name])
     if Puppet::FileSystem.exist?(rcfile)
       newcontents = []
-      File.open(rcfile).readlines.each do |line|
+      Puppet::FileSystem.open(rcfile, nil, "r:#{Encoding.default_external.name}").readlines.each do |line|
         if line.match(/^\s*#{@resource[:name]}=(NO|\$\{#{@resource[:name]}:NO\})/)
           line = "#{@resource[:name]}=${#{@resource[:name]}:=YES}"
         end

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -348,7 +348,8 @@ private
   end
 
   def read_script_from(filename)
-    File.open(filename) do |file|
+    # TODO: upstart scripts should be UTF-8... or default encoding? ... or binary?
+    Puppet::FileSystem.open(filename, nil, 'r:UTF-8') do |file|
       file.read
     end
   end

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -224,6 +224,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     password_hash_file = "#{password_hash_dir}/#{guid}"
     if Puppet::FileSystem.exist?(password_hash_file) and File.file?(password_hash_file)
       raise Puppet::Error, "Could not read password hash file at #{password_hash_file}" if not File.readable?(password_hash_file)
+      # FIXME
       f = File.new(password_hash_file)
       password_hash = f.read
       f.close

--- a/lib/puppet/provider/user/hpux.rb
+++ b/lib/puppet/provider/user/hpux.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
       file_name="/tcb/files/auth/#{resource.name.chars.first}/#{resource.name}"
       if File.file?(file_name)
         # Found the tcb user for the specific user, now get passwd
-        File.open(file_name).each do |line|
+        Puppet::FileSystem.open(file_name, nil, "r:#{Encoding.default_external.name}}").each do |line|
           if ( line =~ /u_pwd/ )
             temp_passwd=line.split(":")[1].split("=")[1]
             ent.passwd = temp_passwd

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -58,7 +58,9 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     passwd_file = "/etc/passwd"
     passwd_keys = ['account', 'password', 'uid', 'gid', 'gecos', 'directory', 'shell']
     index = passwd_keys.index(key)
-    File.open(passwd_file) do |f|
+    # most distros want usernames to be in ASCII
+    # and may cause errors if they are not, but read the file as UTF-8
+    Puppet::FileSystem.open(passwd_file, nil, 'r:UTF-8') do |f|
       f.each_line do |line|
          user = line.split(":")
          if user[index] == value

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -541,6 +541,7 @@ class Puppet::SSL::CertificateAuthority
 
     def autosign_store
       auth = Puppet::Network::AuthStore.new
+      # FIXME encoding
       Puppet::FileSystem.each_line(@config) do |line|
         next if line =~ /^\s*#/
         next if line =~ /^\s*$/

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -878,7 +878,7 @@ Puppet::Type.newtype(:file) do
       end
     else
       umask = mode ? 000 : 022
-      Puppet::Util.withumask(umask) { ::File.open(self[:path], 'wb', mode_int ) { |f| property.write(f) if property } }
+      Puppet::Util.withumask(umask) { Puppet::FileSystem.open(self[:path], mode_int, 'wb' ) { |f| property.write(f) if property } }
     end
 
     # make sure all of the modes are actually correct

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -271,7 +271,7 @@ module Puppet
     end
 
     def chunk_file_from_disk
-      File.open(full_path, "rb") do |src|
+      Puppet::FileSystem.open(full_path, nil, "rb") do |src|
         while chunk = src.read(8192)
           yield chunk
         end

--- a/lib/puppet/type/k5login.rb
+++ b/lib/puppet/type/k5login.rb
@@ -57,7 +57,7 @@ Puppet::Type.newtype(:k5login) do
     # Return the principals
     def principals
       if Puppet::FileSystem.exist?(@resource[:name])
-        File.readlines(@resource[:name]).collect { |line| line.chomp }
+        File.readlines(@resource[:name], :encoding => Encoding.default_external).collect { |line| line.chomp }
       else
         :absent
       end

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -264,7 +264,7 @@ module Puppet::Util::Checksums
   # Perform an incremental checksum on a file.
   def checksum_file(digest, filename, lite = false)
     buffer = lite ? 512 : 4096
-    File.open(filename, 'rb') do |file|
+    Puppet::FileSystem.open(filename, nil, 'rb') do |file|
       while content = file.read(buffer)
         digest << content
         break if lite

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -89,7 +89,8 @@ Puppet::Util::Log.newdesttype :file do
       end
     end
 
-    file = File.open(path,  File::WRONLY|File::CREAT|File::APPEND)
+    # log files should always be written as UTF-8
+    file = Puppet::FileSystem.open(path, nil, 'w:UTF-8')
     file.puts('[') if need_array_start
 
     # Give ownership to the user and group puppet will run as

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -58,6 +58,7 @@ class IO
     # and doesn't actually carry over the mode.  It won't work to just use
     # open, either, because that doesn't like our system modes and the default
     # open bits don't do what we need, which is awesome. --daniel 2012-03-30
+    # FIXME: encoding
     IO.open(IO::sysopen(name, mode), mode) do |f|
       # ...seek to our desired offset, then write the bytes.  Don't try to
       # seek past the start of the file, eh, because who knows what platform

--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -39,7 +39,8 @@ class Puppet::Util::NetworkDevice::Config
     begin
       devices = {}
       device = nil
-      File.open(@file) { |f|
+      # TODO: what is the format for this file? UTF-8 or default external?
+      Puppet::FileSystem.open(@file, nil, 'r:UTF-8') { |f|
         count = 1
         f.each { |line|
           case line

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -117,7 +117,7 @@ module Puppet::Util::Plist
     #
     # @api private
     def read_file_with_offset(file_path, offset)
-      IO.read(file_path, offset)
+      IO.read(file_path, offset, 0, :encoding => Encoding::BINARY)
     end
 
     def to_format(format)

--- a/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
+++ b/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
@@ -105,7 +105,7 @@ module RDoc::PuppetParserCore
     %w{README README.rdoc}.each do |rfile|
       readme = File.join(File.dirname(File.dirname(@input_file_name)), rfile)
       # module README should be UTF-8, not default system encoding
-      comment = File.open(readme,"r:UTF-8") { |f| f.read } if FileTest.readable?(readme)
+      comment = Puppet::FileSystem.open(readme, nil, "r:UTF-8") { |f| f.read } if FileTest.readable?(readme)
     end
     look_for_directives_in(container, comment) unless comment.empty?
 
@@ -149,7 +149,8 @@ module RDoc::PuppetParserCore
     comments = ""
     current_fact = nil
     parsed_facts = []
-    File.open(@input_file_name) do |of|
+    # TODO: use external encoding or UTF-8 here?
+    Puppet::FileSystem.open(@input_file_name, nil, "r:#{Encoding.default_external.name}}") do |of|
       of.each do |line|
         # fetch comments
         if line =~ /^[ \t]*# ?(.*)$/
@@ -180,7 +181,8 @@ module RDoc::PuppetParserCore
     comments = ""
     current_plugin = nil
 
-    File.open(@input_file_name) do |of|
+    # TODO: use external encoding or UTF-8 here?
+    Puppet::FileSystem.open(@input_file_name, nil, "r:#{Encoding.default_external.name}}") do |of|
       of.each do |line|
         # fetch comments
         if line =~ /^[ \t]*# ?(.*)$/

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -163,6 +163,7 @@ module Puppet::Util::SELinux
         mounts += mountfh.read_nonblock(1024) while true
       else
         # Otherwise we shell out and let cat do it for us
+        # FIXME
         mountfh = IO.popen("/bin/cat /proc/mounts")
         mounts = mountfh.read
       end

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -159,7 +159,7 @@ module Puppet::Util::SELinux
       if File.method_defined? "read_nonblock"
         # If possible we use read_nonblock in a loop rather than read to work-
         # a linux kernel bug.  See ticket #1963 for details.
-        mountfh = File.open("/proc/mounts")
+        mountfh = Puppet::FileSystem.open("/proc/mounts", nil, 'rb')
         mounts += mountfh.read_nonblock(1024) while true
       else
         # Otherwise we shell out and let cat do it for us

--- a/lib/puppet/util/user_attr.rb
+++ b/lib/puppet/util/user_attr.rb
@@ -2,7 +2,7 @@ class UserAttr
   def self.get_attributes_by_name(name)
     attributes = nil
 
-    File.readlines('/etc/user_attr').each do |line|
+    File.readlines('/etc/user_attr', :encoding => Encoding.default_external).each do |line|
       next if line =~ /^#/
 
       token = line.split(':')

--- a/spec/unit/network/http/compression_spec.rb
+++ b/spec/unit/network/http/compression_spec.rb
@@ -90,7 +90,7 @@ describe "http compression" do
         @response.stubs(:[]).with('content-encoding').returns('gzip')
 
         io = stub 'io'
-        StringIO.expects(:new).with("mydata").returns io
+        StringIO.expects(:new).with("mydata", 'r+b').returns io
 
         reader = stub 'gzip reader'
         Zlib::GzipReader.expects(:new).with(io).returns(reader)

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -11,7 +11,7 @@ describe provider_class do
   def expect_read_from_pkgconf(lines)
     pkgconf = stub(:readlines => lines)
     Puppet::FileSystem.expects(:exist?).with('/etc/pkg.conf').returns(true)
-    File.expects(:open).with('/etc/pkg.conf', 'rb').returns(pkgconf)
+    Puppet::FileSystem.expects(:open).with('/etc/pkg.conf', nil, 'rb').returns(pkgconf)
   end
 
   def expect_pkgadd_with_source(source)
@@ -95,7 +95,7 @@ describe provider_class do
 
     it "should fail if /etc/pkg.conf exists, but is not readable" do
       Puppet::FileSystem.expects(:exist?).with('/etc/pkg.conf').returns(true)
-      File.expects(:open).with('/etc/pkg.conf', 'rb').raises(Errno::EACCES)
+      Puppet::FileSystem.expects(:open).with('/etc/pkg.conf', nil, 'rb').raises(Errno::EACCES)
 
       expect {
         provider.install

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -54,7 +54,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
       Dir.stubs(:mkdir).with('/etc/rc.conf.d')
       fh = stub 'fh'
-      File.stubs(:open).with('/etc/rc.conf.d/sshd', File::WRONLY | File::APPEND | File::CREAT, 0644).yields(fh)
+      Puppet::FileSystem.stubs(:open).with('/etc/rc.conf.d/sshd', 0644, 'ab').yields(fh)
       fh.expects(:<<).with("sshd_enable=\"YES\"\n")
       provider.enable
     end
@@ -64,7 +64,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
       Dir.stubs(:mkdir).with('/etc/rc.conf.d')
       File.stubs(:read).with('/etc/rc.conf.d/sshd').returns("sshd_enable=\"NO\"\n")
       fh = stub 'fh'
-      File.stubs(:open).with('/etc/rc.conf.d/sshd', File::WRONLY | File::APPEND | File::CREAT, 0644).yields(fh)
+      Puppet::FileSystem.stubs(:open).with('/etc/rc.conf.d/sshd', 0644, 'ab').yields(fh)
       fh.expects(:<<).with("sshd_enable=\"YES\"\n")
       provider.enable
     end

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -82,7 +82,7 @@ OUTPUT
     Puppet::FileSystem.stubs(:exist?).with('/etc/rc.conf').returns(true)
     File.stubs(:read).with('/etc/rc.conf').returns("openntpd_enable=\"NO\"\nntpd_enable=\"NO\"\n")
     fh = stub 'fh'
-    File.stubs(:open).with('/etc/rc.conf', File::WRONLY).yields(fh)
+    Puppet::FileSystem.stubs(:open).with('/etc/rc.conf', nil, 'w:UTF-8').yields(fh)
     fh.expects(:<<).with("openntpd_enable=\"NO\"\nntpd_enable=\"YES\"\n")
     Puppet::FileSystem.stubs(:exist?).with('/etc/rc.conf.local').returns(false)
     Puppet::FileSystem.stubs(:exist?).with('/etc/rc.conf.d/ntpd').returns(false)

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -80,7 +80,7 @@ OUTPUT
 
   it "should enable only the selected service" do
     Puppet::FileSystem.stubs(:exist?).with('/etc/rc.conf').returns(true)
-    File.stubs(:read).with('/etc/rc.conf').returns("openntpd_enable=\"NO\"\nntpd_enable=\"NO\"\n")
+    Puppet::FileSystem.stubs(:read).with('/etc/rc.conf', :encoding => Encoding::UTF_8).returns("openntpd_enable=\"NO\"\nntpd_enable=\"NO\"\n")
     fh = stub 'fh'
     Puppet::FileSystem.stubs(:open).with('/etc/rc.conf', nil, 'w:UTF-8').yields(fh)
     fh.expects(:<<).with("openntpd_enable=\"NO\"\nntpd_enable=\"YES\"\n")

--- a/spec/unit/provider/user/user_role_add_spec.rb
+++ b/spec/unit/provider/user/user_role_add_spec.rb
@@ -215,20 +215,20 @@ describe Puppet::Type.type(:user).provider(:user_role_add), :unless => Puppet.fe
     end
 
     it "should readlines of /etc/shadow" do
-      File.expects(:readlines).with("/etc/shadow").returns([])
+      File.expects(:readlines).with("/etc/shadow", :encoding => Encoding::UTF_8).returns([])
       provider.password
     end
 
     it "should reject anything that doesn't start with alpha numerics" do
       @array.expects(:reject).returns([])
-      File.stubs(:readlines).with("/etc/shadow").returns(@array)
+      File.stubs(:readlines).with("/etc/shadow", :encoding => Encoding::UTF_8).returns(@array)
       provider.password
     end
 
     it "should collect splitting on ':'" do
       @array.stubs(:reject).returns(@array)
       @array.expects(:collect).returns([])
-      File.stubs(:readlines).with("/etc/shadow").returns(@array)
+      File.stubs(:readlines).with("/etc/shadow", :encoding => Encoding::UTF_8).returns(@array)
       provider.password
     end
 
@@ -236,13 +236,13 @@ describe Puppet::Type.type(:user).provider(:user_role_add), :unless => Puppet.fe
       resource.stubs(:[]).with(:name).returns("username")
       @array.stubs(:reject).returns(@array)
       @array.stubs(:collect).returns([["username", "hashedpassword"], ["someoneelse", "theirpassword"]])
-      File.stubs(:readlines).with("/etc/shadow").returns(@array)
+      File.stubs(:readlines).with("/etc/shadow", :encoding => Encoding::UTF_8).returns(@array)
       expect(provider.password).to eq("hashedpassword")
     end
 
     it "should get the right password" do
       resource.stubs(:[]).with(:name).returns("username")
-      File.stubs(:readlines).with("/etc/shadow").returns(["#comment", "   nonsense", "  ", "username:hashedpassword:stuff:foo:bar:::", "other:pword:yay:::"])
+      File.stubs(:readlines).with("/etc/shadow", :encoding => Encoding::UTF_8).returns(["#comment", "   nonsense", "  ", "username:hashedpassword:stuff:foo:bar:::", "other:pword:yay:::"])
       expect(provider.password).to eq("hashedpassword")
     end
   end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1157,13 +1157,13 @@ describe Puppet::Type.type(:file) do
 
         it "should convert symbolic mode to int" do
           file[:mode] = 'oga=r'
-          File.expects(:open).with(file[:path], anything, 0444)
+          Puppet::FileSystem.expects(:open).with(file[:path], 0444, anything)
           file.write
         end
 
         it "should support int modes" do
           file[:mode] = '0444'
-          File.expects(:open).with(file[:path], anything, 0444)
+          Puppet::FileSystem.expects(:open).with(file[:path], 0444, anything)
           file.write
         end
       end

--- a/spec/unit/util/checksums_spec.rb
+++ b/spec/unit/util/checksums_spec.rb
@@ -41,7 +41,7 @@ describe Puppet::Util::Checksums do
     expect(@summer).to respond_to(:checksum?)
   end
 
-  %w{{md5}asdfasdf {sha1}asdfasdf {ctime}asdasdf {mtime}asdfasdf 
+  %w{{md5}asdfasdf {sha1}asdfasdf {ctime}asdasdf {mtime}asdfasdf
      {sha256}asdfasdf {sha256lite}asdfasdf}.each do |sum|
     it "should consider #{sum} to be a checksum" do
       expect(@summer).to be_checksum(sum)
@@ -82,7 +82,7 @@ describe Puppet::Util::Checksums do
         fh = mock 'filehandle'
         fh.expects(:read).with(4096).times(3).returns("firstline").then.returns("secondline").then.returns(nil)
 
-        File.expects(:open).with(file, "rb").yields(fh)
+        Puppet::FileSystem.expects(:open).with(file, nil, "rb").yields(fh)
 
         digest.expects(:<<).with "firstline"
         digest.expects(:<<).with "secondline"
@@ -123,7 +123,7 @@ describe Puppet::Util::Checksums do
         fh = mock 'filehandle'
         fh.expects(:read).with(512).returns('my content')
 
-        File.expects(:open).with(file, "rb").yields(fh)
+        Puppet::FileSystem.expects(:open).with(file, nil, "rb").yields(fh)
 
         digest.expects(:<<).with "my content"
         digest.expects(:hexdigest).returns :mydigest

--- a/spec/unit/util/lockfile_spec.rb
+++ b/spec/unit/util/lockfile_spec.rb
@@ -115,4 +115,17 @@ describe Puppet::Util::Lockfile do
     @lock.lock(data)
     expect(@lock.lock_data).to eq(data)
   end
+
+  it "should return UTF-8 lock data" do
+    # different UTF-8 widths
+    # 1-byte A
+    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+    # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+    mixed_utf8 = "A\u06FF\u16A0\u{2070E}"  # Aۿᚠ܎
+
+    @lock.lock(mixed_utf8)
+    # TODO: bytes match, but the strings encodings are now different
+    expect(@lock.lock_data.bytes).to eq(mixed_utf8.bytes)
+  end
 end

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Util::SELinux do
     end
 
     it "should return nil if /proc/mounts does not exist" do
-      File.stubs(:open).with("/proc/mounts").raises("No such file or directory - /proc/mounts")
+      Puppet::FileSystem.stubs(:open).with("/proc/mounts", nil, 'rb').raises("No such file or directory - /proc/mounts")
       expect(read_mounts).to eq(nil)
     end
   end
@@ -37,7 +37,7 @@ describe Puppet::Util::SELinux do
   describe "read_mounts" do
     before :each do
       fh = stub 'fh', :close => nil
-      File.stubs(:open).with("/proc/mounts").returns fh
+      Puppet::FileSystem.stubs(:open).with("/proc/mounts", nil, 'rb').returns fh
       fh.expects(:read_nonblock).times(2).returns("rootfs / rootfs rw 0 0\n/dev/root / ext3 rw,relatime,errors=continue,user_xattr,acl,data=ordered 0 0\n/dev /dev tmpfs rw,relatime,mode=755 0 0\n/proc /proc proc rw,relatime 0 0\n/sys /sys sysfs rw,relatime 0 0\n192.168.1.1:/var/export /mnt/nfs nfs rw,relatime,vers=3,rsize=32768,wsize=32768,namlen=255,hard,nointr,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=192.168.1.1,mountvers=3,mountproto=udp,addr=192.168.1.1 0 0\n").then.raises EOFError
     end
 
@@ -229,7 +229,7 @@ describe Puppet::Util::SELinux do
   describe "set_selinux_context" do
     before :each do
       fh = stub 'fh', :close => nil
-      File.stubs(:open).with("/proc/mounts").returns fh
+      Puppet::FileSystem.stubs(:open).with("/proc/mounts", nil, 'rb').returns fh
       fh.stubs(:read_nonblock).returns(
         "rootfs / rootfs rw 0 0\n/dev/root / ext3 rw,relatime,errors=continue,user_xattr,acl,data=ordered 0 0\n"+
         "/dev /dev tmpfs rw,relatime,mode=755 0 0\n/proc /proc proc rw,relatime 0 0\n"+


### PR DESCRIPTION
Intended to be merged after:
- [x] #5384 
- [ ] #5547 
- [x] #5593

This cleans up remaining locations where an encoding should be specified, but was not.


Important commit is just the last one - currently https://github.com/puppetlabs/puppet/pull/5636/commits/30a2ef7375a98d9eef6c0db643d289ff6873ff90 with +57 diffstat

As noted in #5660, https://github.com/puppetlabs/puppet/pull/5636/commits/5cf9f31c21e29a14fb87ea1d94613c43c7cdc3a2 should fix calls to `StringIO.new` to `.encode` files passed in, rather than specifying an `:encoding`, which `StringIO` ignores.