### PR TITLE
(docs) exec's environment takes an array

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -252,10 +252,11 @@ module Puppet
     end
 
     newparam(:environment) do
-      desc "Any additional environment variables you want to set for a
-        command.  Note that if you use this to set PATH, it will override
-        the `path` attribute.  Multiple environment variables should be
-        specified as an array."
+      desc "An array of any additional environment variables you want to set for a
+        command. e.g.: `[ 'HOME=/root', 'MAIL=root@example.com']`
+        Note that if you use this to set PATH, it will override the `path`
+        attribute. Multiple environment variables should be specified as an
+        array."
 
       validate do |values|
         values = [values] unless values.is_a? Array


### PR DESCRIPTION
Intuitively, one may think that `exec`'s environment parameter takes a
Hash, however, it expects an Array, which was not documented anywhere.