### PR TITLE
(PUP-7205) Backport hiera_eyaml v5 lookup function to 4.9.z

### DIFF
--- a/lib/puppet/feature/hiera_eyaml.rb
+++ b/lib/puppet/feature/hiera_eyaml.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:hiera_eyaml, :libs => ['hiera/backend/eyaml/parser/parser'])

--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -1,0 +1,73 @@
+# @since 5.0.0
+#
+Puppet::Functions.create_function(:eyaml_lookup_key) do
+  unless Puppet.features.hiera_eyaml?
+    raise Puppet::DataBinding::LookupError, 'Lookup using eyaml lookup_key function is only supported when the hiera_eyaml library is present'
+  end
+
+  require 'hiera/backend/eyaml/encryptor'
+  require 'hiera/backend/eyaml/utils'
+  require 'hiera/backend/eyaml/options'
+  require 'hiera/backend/eyaml/parser/parser'
+
+  dispatch :eyaml_lookup_key do
+    param 'String[1]', :key
+    param 'Hash[String[1],Any]', :options
+    param 'Puppet::LookupContext', :context
+  end
+
+  def eyaml_lookup_key(key, options, context)
+    return context.cached_value(key) if context.cache_has_key(key)
+
+    # nil key is used to indicate that the cache contains the raw content of the eyaml file
+    raw_data = context.cached_value(nil)
+    if raw_data.nil?
+      options.each_pair do |k, v|
+        unless k == 'path'
+          Hiera::Backend::Eyaml::Options[k.to_sym] = v
+          context.explain { "Setting Eyaml option '#{k}' to '#{v}'" }
+        end
+      end
+      raw_data = load_data_hash(options)
+      context.cache(nil, raw_data)
+    end
+    context.not_found unless raw_data.include?(key)
+    context.cache(key, decrypt_value(raw_data[key]))
+  end
+
+  def load_data_hash(options)
+    begin
+      data = YAML.load_file(options['path'])
+      Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data.is_a?(Hash) ? data : {})
+    rescue YAML::SyntaxError => ex
+      # Psych errors includes the absolute path to the file, so no need to add that
+      # to the message
+      raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
+    end
+  end
+
+  def decrypt_value(value)
+    case value
+    when String
+      decrypt(value)
+    when Hash
+      result = {}
+      value.each_pair { |k, v| result[k] = decrypt_value(v) }
+      result
+    when Array
+      value.map { |v| decrypt_value(v) }
+    else
+      value
+    end
+  end
+
+  def decrypt(data)
+    return data unless encrypted?(data)
+    tokens = Hiera::Backend::Eyaml::Parser::ParserFactory.hiera_backend_parser.parse(data)
+    tokens.map(&:to_plain_text).join.chomp
+  end
+
+  def encrypted?(data)
+    /.*ENC\[.*?\]/ =~ data ? true : false
+  end
+end

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -44,6 +44,7 @@ class HieraConfig
   KEY_LOOKUP_KEY = LookupKeyFunctionProvider::TAG
   KEY_DATA_DIG = DataDigFunctionProvider::TAG
   KEY_V3_DATA_HASH = V3DataHashFunctionProvider::TAG
+  KEY_V3_LOOKUP_KEY = V3LookupKeyFunctionProvider::TAG
   KEY_V3_BACKEND = V3BackendFunctionProvider::TAG
   KEY_V4_DATA_HASH = V4DataHashFunctionProvider::TAG
   KEY_BACKEND = 'backend'.freeze
@@ -57,6 +58,7 @@ class HieraConfig
     KEY_LOOKUP_KEY => LookupKeyFunctionProvider,
     KEY_V3_DATA_HASH => V3DataHashFunctionProvider,
     KEY_V3_BACKEND => V3BackendFunctionProvider,
+    KEY_V3_LOOKUP_KEY => V3LookupKeyFunctionProvider,
     KEY_V4_DATA_HASH => V4DataHashFunctionProvider
   }
 
@@ -294,7 +296,7 @@ class HieraConfigV3 < HieraConfig
 
     [@config[KEY_BACKENDS]].flatten.each do |backend|
       raise Puppet::DataBinding::LookupError, "#{@config_path}: Backend '#{backend}' defined more than once" if data_providers.include?(backend)
-      original_paths = @config[KEY_HIERARCHY]
+      original_paths = [@config[KEY_HIERARCHY]].flatten
       backend_config = @config[backend] || EMPTY_HASH
       datadir = Pathname(interpolate(backend_config[KEY_DATADIR] || default_datadir, lookup_invocation, false))
       ext = backend == 'hocon' ? '.conf' : ".#{backend}"
@@ -304,6 +306,8 @@ class HieraConfigV3 < HieraConfig
         create_data_provider(backend, parent_data_provider, KEY_V3_DATA_HASH, "#{backend}_data", { KEY_DATADIR => datadir }, paths)
       when backend == 'hocon' && Puppet.features.hocon?
         create_data_provider(backend, parent_data_provider, KEY_V3_DATA_HASH, 'hocon_data', { KEY_DATADIR => datadir }, paths)
+      when backend == 'eyaml' && Puppet.features.hiera_eyaml?
+        create_data_provider(backend, parent_data_provider, KEY_V3_LOOKUP_KEY, 'eyaml_lookup_key', backend_config.merge(KEY_DATADIR => datadir), paths)
       else
         create_hiera3_backend_provider(backend, backend, parent_data_provider, datadir, paths, @loaded_config)
       end

--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -14,17 +14,22 @@ class LookupKeyFunctionProvider < FunctionProvider
   # @return [Object] the found object
   # @throw :no_such_key when the object is not found
   def unchecked_key_lookup(key, lookup_invocation, merge)
+    root_key = key.root_key
     lookup_invocation.with(:data_provider, self) do
       MergeStrategy.strategy(merge).lookup(locations, lookup_invocation) do |location|
-        if location.nil?
-          value = lookup_key(key.root_key, lookup_invocation, nil, merge)
-          lookup_invocation.report_found(key.root_key, validate_data_value(self, value))
-        else
-          lookup_invocation.with(:location, location) do
-            value = lookup_key(key.root_key, lookup_invocation, location.location, merge)
-            lookup_invocation.report_found(key.root_key, validate_data_value(self, value))
-          end
-        end
+        invoke_with_location(lookup_invocation, location, root_key, merge)
+      end
+    end
+  end
+
+  def invoke_with_location(lookup_invocation, location, root_key, merge)
+    if location.nil?
+      value = lookup_key(root_key, lookup_invocation, nil, merge)
+      lookup_invocation.report_found(root_key, validate_data_value(self, value))
+    else
+      lookup_invocation.with(:location, location) do
+        value = lookup_key(root_key, lookup_invocation, location.location, merge)
+        lookup_invocation.report_found(root_key, validate_data_value(self, value))
       end
     end
   end
@@ -49,6 +54,33 @@ class LookupKeyFunctionProvider < FunctionProvider
     end
     lookup_invocation.report_not_found(key)
     throw :no_such_key
+  end
+end
+
+# @api private
+class V3LookupKeyFunctionProvider < LookupKeyFunctionProvider
+  TAG = 'v3_lookup_key'.freeze
+
+  def initialize(name, parent_data_provider, function_name, options, locations)
+    @datadir = options.delete(HieraConfig::KEY_DATADIR)
+    super
+  end
+
+  def unchecked_key_lookup(key, lookup_invocation, merge)
+    extra_paths = lookup_invocation.hiera_v3_location_overrides
+    if extra_paths.nil? || extra_paths.empty?
+      super
+    else
+      # Extra paths provided. Must be resolved and placed in front of known paths
+      paths = parent_data_provider.config(lookup_invocation).resolve_paths(@datadir, extra_paths, lookup_invocation, false, ".#{@name}")
+      all_locations = paths + locations
+      root_key = key.root_key
+      lookup_invocation.with(:data_provider, self) do
+        MergeStrategy.strategy(merge).lookup(all_locations, lookup_invocation) do |location|
+          invoke_with_location(lookup_invocation, location, root_key, merge)
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This PR contains all the commits that went in with PUP-7100 rebased to stable.
