### PR TITLE
(PUP-7214) PUP-6663 causes a regression of PUP-535

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
   # eventually become this Puppet::Type::Package::ProviderRpm class.
   # The query format by which we identify installed packages
   self::NEVRA_FORMAT = %Q{%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\\n}
-  self::NEVRA_REGEX  = %r{^(\S+) (\S+) (\S+) (\S+) (\S+)$}
+  self::NEVRA_REGEX  = %r{^'?(\S+) (\S+) (\S+) (\S+) (\S+)$}
   self::NEVRA_FIELDS = [:name, :epoch, :version, :release, :arch]
 
   ARCH_LIST = [

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -7,12 +7,13 @@ describe provider_class do
 
   let (:packages) do
     <<-RPM_OUTPUT
-    cracklib-dicts 0 2.8.9 3.3 x86_64
+    'cracklib-dicts 0 2.8.9 3.3 x86_64
     basesystem 0 8.0 5.1.1.el5.centos noarch
     chkconfig 0 1.3.30.2 2.el5 x86_64
     myresource 0 1.2.3.4 5.el4 noarch
     mysummaryless 0 1.2.3.4 5.el4 noarch
     tomcat 1 1.2.3.4 5.el4 x86_64
+    '
     RPM_OUTPUT
   end
 


### PR DESCRIPTION
This fixes a regression introduced in PUP-6663 where
the package name contains a leading ' in some conditions

Strip out all uses of ' before applying the regex, as
according to most rpm guidelines ' is not a valid character.

See
https://fedoraproject.org/wiki/Packaging:Naming?rd=Packaging:NamingGuidelines