### PR TITLE
(PUP-7212) Add a Pcore Annotation type and an annotate function

### DIFF
--- a/lib/puppet/functions/annotate.rb
+++ b/lib/puppet/functions/annotate.rb
@@ -1,0 +1,105 @@
+# Handles annotations on objects. The function can be used in four different ways.
+#
+# With two arguments, an `Annotation` type and an object, the function returns the annotation
+# for the object of the given type, or `undef` if no such annotation exists.
+#
+# @example Using `annotate` with two arguments
+#
+# ~~~ puppet
+# $annotation = Mod::NickNameAdapter.annotate(o)
+#
+# $annotation = annotate(Mod::NickNameAdapter.annotate, o)
+# ~~~
+#
+# With two arguments, an `Annotation` type and an object, and a block, the function returns the
+# annotation for the object of the given type, or annotates it with a new annotation initialized
+# from the hash returned by the given block when no such annotation exists. The block will not
+# be called when an annotation of the given type is already present.
+#
+# @example Using `annotate` with two arguments and a block
+#
+# ~~~ puppet
+# $annotation = Mod::NickNameAdapter.annotate(o) || { { 'nick_name' => 'Buddy' } }
+#
+# $annotation = annotate(Mod::NickNameAdapter.annotate, o) || { { 'nick_name' => 'Buddy' } }
+# ~~~
+#
+# With three arguments, an `Annotation` type, an object, and an `Hash`, the function will annotate
+# the given object with a new annotation of the given type that is initialized from the given hash.
+# An existing annotation of the given type is discarded.
+#
+# @example Using `annotate` with three arguments where third argument is a Hash
+#
+# ~~~ puppet
+# $annotation = Mod::NickNameAdapter.annotate(o, { 'nick_name' => 'Buddy' })
+#
+# $annotation = annotate(Mod::NickNameAdapter.annotate, o, { 'nick_name' => 'Buddy' })
+# ~~~
+#
+# With three arguments, an `Annotation` type, an object, and an the string `clear`, the function will
+# clear the annotatation of the given type in the given object. The old annotation is returned if
+# it existed.
+#
+# @example Using `annotate` with three arguments where third argument is the string 'clear'
+#
+# ~~~ puppet
+# $annotation = Mod::NickNameAdapter.annotate(o, clear)
+#
+# $annotation = annotate(Mod::NickNameAdapter.annotate, o, clear)
+# ~~~
+#
+# With three arguments, the type `Pcore`, an object, and a Hash of hashes keyed by `Annotation` types,
+# the function will annotate the given object with all types used as keys in the given hash. Each annotation
+# is initialized with the nested hash for the respective type. The annotated object is returned.
+#
+# @example Add multiple annotations to a new instance of `Mod::Person` using the `Pcore` type.
+#
+# ~~~ puppet
+#   $person = Pcore.annotate(Mod::Person({'name' => 'William'}), {
+#     Mod::NickNameAdapter >= { 'nick_name' => 'Bill' },
+#     Mod::HobbiesAdapter => { 'hobbies' => ['Ham Radio', 'Philatelist'] }
+#   })
+# ~~~
+#
+# @since 5.0.0
+#
+Puppet::Functions.create_function(:annotate) do
+  dispatch :annotate do
+    param 'Type[Annotation]', :type
+    param 'Any', :value
+    optional_block_param 'Callable[0, 0]', :block
+  end
+
+  dispatch :annotate_new do
+    param 'Type[Annotation]', :type
+    param 'Any', :value
+    param 'Variant[Enum[clear],Hash[Pcore::MemberName,Any]]', :i12n_hash
+  end
+
+  dispatch :annotate_multi do
+    param 'Type[Pcore]', :type
+    param 'Any', :value
+    param 'Hash[Type[Annotation], Hash[Pcore::MemberName,Any]]', :annotations
+  end
+
+  # @param type [Type] the type the value must be an instance of
+  # @param value [Object] the value to assert
+  #
+  def annotate(type, value, &block)
+    type.implementation_class.annotate(value, &block)
+  end
+
+  # @param type [Type] the type the value must be an instance of
+  # @param value [Object] the value to assert
+  #
+  def annotate_new(type, value, i12n_hash)
+    type.implementation_class.annotate_new(value, i12n_hash)
+  end
+
+  # @param type [Type] the type the value must be an instance of
+  # @param value [Object] the value to assert
+  #
+  def annotate_multi(type, value, annotations)
+    type.implementation_class.annotate(value, annotations)
+  end
+end

--- a/lib/puppet/pops/adaptable.rb
+++ b/lib/puppet/pops/adaptable.rb
@@ -171,8 +171,7 @@ module Adaptable
     # @return [adapter] the given adapter
     #
     def self.associate_adapter(adapter, o)
-      attr_name = :"@#{instance_var_name(adapter.class.name)}"
-      o.instance_variable_set(attr_name, adapter)
+      o.instance_variable_set(self_attr_name, adapter)
       adapter
     end
 
@@ -187,13 +186,19 @@ module Adaptable
       name.split(DOUBLE_COLON).join(USCORE)
     end
 
+    # Returns the name of the class, or the name of the type if the class represents an Object type
+    # @return [String] the name of the class or type
+    def self.type_name
+      self.name
+    end
+
     # Returns a suitable instance variable name for the _name_ of this instance. The name is created by calling
     # Adapter#instance_var_name and then cached.
     # @return [String] the instance variable name for _name_
     # @api private
     #
     def self.self_attr_name
-      @attr_name_sym ||= :"@#{instance_var_name(self.name)}"
+      @attr_name_sym ||= :"@#{instance_var_name(type_name)}"
     end
   end
 end

--- a/lib/puppet/pops/parser/locator.rb
+++ b/lib/puppet/pops/parser/locator.rb
@@ -282,7 +282,7 @@ class Locator
     # TODO: LocatorForChars is never added. It looks like it could be removed (remnant from Ruby 1.8 compatibility?)
     # @api private
     def self.register_ptype(loader, ir)
-      @type = Pcore::create_object_type(loader, ir, self, 'Puppet::AST::Locator', 'Any',
+      @type = Pcore::create_object_type(loader, ir, self, 'Puppet::AST::Locator', nil,
         'string' => Types::PStringType::DEFAULT,
         'file' => Types::PStringType::DEFAULT,
         'line_index' => {

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -24,6 +24,13 @@ module Pcore
     @type
   end
 
+  def self.annotate(instance, annotations_hash)
+    annotations_hash.each_pair do |type, i12n_hash|
+      type.implementation_class.annotate(instance) { i12n_hash }
+    end
+    instance
+  end
+
   def self.init(loader, ir, for_agent)
     add_alias('Pcore::URI_RX', TYPE_URI_RX, loader)
     add_type(TYPE_URI_ALIAS, loader)

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -2,11 +2,14 @@ require 'uri'
 
 module Puppet::Pops
 module Pcore
+  include Types::PuppetObject
+
   TYPE_URI_RX = Types::TypeFactory.regexp(URI.regexp)
   TYPE_URI = Types::TypeFactory.pattern(TYPE_URI_RX)
   TYPE_URI_ALIAS = Types::PTypeAliasType.new('Pcore::URI', nil, TYPE_URI)
   TYPE_SIMPLE_TYPE_NAME = Types::TypeFactory.pattern(/\A[A-Z]\w*\z/)
   TYPE_QUALIFIED_REFERENCE = Types::TypeFactory.pattern(/\A[A-Z][\w]*(?:::[A-Z][\w]*)*\z/)
+  TYPE_MEMBER_NAME = Types::PPatternType.new([Types::PRegexpType.new(Patterns::PARAM_NAME)])
 
   KEY_PCORE_URI = 'pcore_uri'.freeze
   KEY_PCORE_VERSION = 'pcore_version'.freeze
@@ -17,17 +20,20 @@ module Pcore
 
   RUNTIME_NAME_AUTHORITY = 'http://puppet.com/2016.1/runtime'
 
+  def self._ptype
+    @type
+  end
+
   def self.init(loader, ir, for_agent)
     add_alias('Pcore::URI_RX', TYPE_URI_RX, loader)
     add_type(TYPE_URI_ALIAS, loader)
     add_alias('Pcore::SimpleTypeName', TYPE_SIMPLE_TYPE_NAME, loader)
+    add_alias('Pcore::MemberName', TYPE_MEMBER_NAME, loader)
     add_alias('Pcore::TypeName', TYPE_QUALIFIED_REFERENCE, loader)
     add_alias('Pcore::QRef', TYPE_QUALIFIED_REFERENCE, loader)
-    begin
     Types::TypedModelObject.register_ptypes(loader, ir)
-    rescue Exception => e
-      puts e.message
-    end
+
+    @type = create_object_type(loader, ir, Pcore, 'Pcore', nil)
 
     ir.register_implementation_namespace('Pcore', 'Puppet::Pops::Pcore', loader)
     unless for_agent

--- a/lib/puppet/pops/types/annotatable.rb
+++ b/lib/puppet/pops/types/annotatable.rb
@@ -7,9 +7,7 @@ KEY_ANNOTATIONS = 'annotations'.freeze
 #
 # @api public
 module Annotatable
-  TYPE_ANNOTATION_KEY_TYPE = PType::DEFAULT # TBD
-  TYPE_ANNOTATION_VALUE_TYPE = PStructType::DEFAULT #TBD
-  TYPE_ANNOTATIONS = PHashType.new(TYPE_ANNOTATION_KEY_TYPE, TYPE_ANNOTATION_VALUE_TYPE)
+  TYPE_ANNOTATIONS = PHashType.new(PType.new(PTypeReferenceType.new('Annotation')), PHashType::DEFAULT)
 
   # @return [{PType => PStructType}] the map of annotations
   # @api public

--- a/lib/puppet/pops/types/annotation.rb
+++ b/lib/puppet/pops/types/annotation.rb
@@ -1,0 +1,71 @@
+module Puppet::Pops
+module Types
+  # Pcore variant of the Adaptable::Adapter. Uses a Pcore Object type instead of a Class
+  class Annotation < Adaptable::Adapter
+    include Types::PuppetObject
+
+    CLEAR = 'clear'.freeze
+
+    # Register the Annotation type. This is the type that all custom Annotations will inherit from.
+    def self.register_ptype(loader, ir)
+      @type = Pcore::create_object_type(loader, ir, self, 'Annotation', nil, EMPTY_HASH)
+    end
+
+    def self._ptype
+      @type
+    end
+
+    # Finds an existing annotation for the given object and returns it.
+    # If no annotation was found, and a block is given, a new annotation is created from the
+    # initializer hash that must be returned from the block.
+    # If no annotation was found and no block is given, this method returns `nil`
+    #
+    # @param o [Object] object to annotate
+    # @param block [Proc] optional, evaluated when a new annotation must be created. Should return the i12n hash
+    # @return [Annotation<self>] an annotation of the same class as the receiver of the call
+    #
+    def self.annotate(o)
+      adapter = get(o)
+      if adapter.nil?
+        if o.is_a?(PObjectType)
+          i12n = o.annotations[_ptype]
+          i12n = yield if i12n.nil? && block_given?
+        else
+          i12n = yield if block_given?
+        end
+        adapter = associate_adapter(_ptype.from_hash(i12n), o) unless i12n.nil?
+      end
+      adapter
+    end
+
+    # Forces the creation or removal of an annotation of this type.
+    # If `i21n` is a hash, a new annotation is created and returned
+    # If `i12n` is `nil`, then the annotation is cleared and the previous annotation is returned.
+    #
+    # @param o [Object] object to annotate
+    # @param i12n [Hash{String,Object},nil] the initializer for the annotation or `nil` to clear the annotation
+    # @return [Annotation<self>] an annotation of the same class as the receiver of the call
+    #
+    def self.annotate_new(o, i12n_hash)
+      if o.is_a?(PObjectType) && o.annotations.include?(_ptype)
+        # Prevent clear or redefine of annotations declared on type
+        action = i12n_hash == CLEAR ? 'clear' : 'redefine'
+        raise ArgumentError, "attempt to #{action} #{type_name} annotation declared on type #{o.name}"
+      end
+
+      if i12n_hash == CLEAR
+        clear(o)
+      else
+        associate_adapter(_ptype.from_hash(i12n_hash), o)
+      end
+    end
+
+    # Uses name of type instead of name of the class (the class is likely dynamically generated and as such,
+    # has no name)
+    # @return [String] the name of the type
+    def self.type_name
+      _ptype.name
+    end
+  end
+end
+end

--- a/lib/puppet/pops/types/class_loader.rb
+++ b/lib/puppet/pops/types/class_loader.rb
@@ -86,24 +86,24 @@ class ClassLoader
     # If class is already loaded, try this first
     result = find_class(name_path)
 
-    unless result.is_a?(Class)
+    unless result.is_a?(Module)
       # Attempt to load it using the auto loader
       loaded_path = nil
       if paths_for_name(name_path).find {|path| loaded_path = path; @autoloader.load(path, Puppet.lookup(:current_environment)) }
         result = find_class(name_path)
-        unless result.is_a?(Class)
+        unless result.is_a?(Module)
           raise RuntimeError, "Loading of #{name} using relative path: '#{loaded_path}' did not create expected class"
         end
       end
     end
-    return nil unless result.is_a?(Class)
+    return nil unless result.is_a?(Module)
     result
   end
 
   def self.find_class(name_path)
     name_path.reduce(Object) do |ns, name|
       begin
-        ns.const_get(name)
+        ns.const_get(name, false) # don't search ancestors
       rescue NameError
         return nil
       end

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -25,11 +25,11 @@ class PObjectType < PMetaType
 
   TYPE_ATTRIBUTE = TypeFactory.struct({
     KEY_TYPE => PType::DEFAULT,
-    KEY_ANNOTATIONS => TypeFactory.optional(TYPE_ANNOTATIONS),
-    KEY_FINAL => TypeFactory.optional(PBooleanType::DEFAULT),
-    KEY_OVERRIDE => TypeFactory.optional(PBooleanType::DEFAULT),
-    KEY_KIND => TypeFactory.optional(TYPE_ATTRIBUTE_KIND),
-    KEY_VALUE => PAnyType::DEFAULT
+    TypeFactory.optional(KEY_FINAL) => PBooleanType::DEFAULT,
+    TypeFactory.optional(KEY_OVERRIDE) => PBooleanType::DEFAULT,
+    TypeFactory.optional(KEY_KIND) => TYPE_ATTRIBUTE_KIND,
+    KEY_VALUE => PAnyType::DEFAULT,
+    TypeFactory.optional(KEY_ANNOTATIONS) => TYPE_ANNOTATIONS
   })
   TYPE_ATTRIBUTES = TypeFactory.hash_kv(Pcore::TYPE_MEMBER_NAME, TypeFactory.not_undef)
   TYPE_ATTRIBUTE_CALLABLE = TypeFactory.callable(0,0)
@@ -38,9 +38,9 @@ class PObjectType < PMetaType
 
   TYPE_FUNCTION = TypeFactory.struct({
     KEY_TYPE => TYPE_FUNCTION_TYPE,
-    KEY_ANNOTATIONS => TypeFactory.optional(TYPE_ANNOTATIONS),
-    KEY_FINAL => TypeFactory.optional(PBooleanType::DEFAULT),
-    KEY_OVERRIDE => TypeFactory.optional(PBooleanType::DEFAULT)
+    TypeFactory.optional(KEY_FINAL) => PBooleanType::DEFAULT,
+    TypeFactory.optional(KEY_OVERRIDE) => PBooleanType::DEFAULT,
+    TypeFactory.optional(KEY_ANNOTATIONS) => TYPE_ANNOTATIONS
   })
   TYPE_FUNCTIONS = TypeFactory.hash_kv(Pcore::TYPE_MEMBER_NAME, TypeFactory.not_undef)
 
@@ -49,18 +49,27 @@ class PObjectType < PMetaType
   TYPE_CHECKS = PAnyType::DEFAULT # TBD
 
   TYPE_OBJECT_I12N = TypeFactory.struct({
-    KEY_NAME => TypeFactory.optional(TYPE_OBJECT_NAME),
-    KEY_PARENT => TypeFactory.optional(PType::DEFAULT),
-    KEY_ATTRIBUTES => TypeFactory.optional(TYPE_ATTRIBUTES),
-    KEY_FUNCTIONS => TypeFactory.optional(TYPE_FUNCTIONS),
-    KEY_EQUALITY => TypeFactory.optional(TYPE_EQUALITY),
-    KEY_EQUALITY_INCLUDE_TYPE => TypeFactory.optional(PBooleanType::DEFAULT),
-    KEY_CHECKS =>  TypeFactory.optional(TYPE_CHECKS),
-    KEY_ANNOTATIONS =>  TypeFactory.optional(TYPE_ANNOTATIONS)
+    TypeFactory.optional(KEY_NAME) => TYPE_OBJECT_NAME,
+    TypeFactory.optional(KEY_PARENT) => PType::DEFAULT,
+    TypeFactory.optional(KEY_ATTRIBUTES) => TYPE_ATTRIBUTES,
+    TypeFactory.optional(KEY_FUNCTIONS) => TYPE_FUNCTIONS,
+    TypeFactory.optional(KEY_EQUALITY) => TYPE_EQUALITY,
+    TypeFactory.optional(KEY_EQUALITY_INCLUDE_TYPE) => PBooleanType::DEFAULT,
+    TypeFactory.optional(KEY_CHECKS) =>  TYPE_CHECKS,
+    TypeFactory.optional(KEY_ANNOTATIONS) => TYPE_ANNOTATIONS
   })
 
   def self.register_ptype(loader, ir)
-    create_ptype(loader, ir, 'AnyType', 'i12n_hash' => TYPE_OBJECT_I12N)
+    type = create_ptype(loader, ir, 'AnyType', 'i12n_hash' => TYPE_OBJECT_I12N)
+
+    # Now, when the Object type exists, add annotations with keys derived from Annotation and freeze the types.
+    annotations = TypeFactory.optional(PHashType.new(PType.new(Annotation._ptype), TypeFactory.hash_kv(Pcore::TYPE_MEMBER_NAME, PAnyType::DEFAULT)))
+    TYPE_ATTRIBUTE.hashed_elements[KEY_ANNOTATIONS].replace_value_type(annotations)
+    TYPE_FUNCTION.hashed_elements[KEY_ANNOTATIONS].replace_value_type(annotations)
+    TYPE_OBJECT_I12N.hashed_elements[KEY_ANNOTATIONS].replace_value_type(annotations)
+    PTypeSetType::TYPE_TYPESET_I12N.hashed_elements[KEY_ANNOTATIONS].replace_value_type(annotations)
+    PTypeSetType::TYPE_TYPE_REFERENCE_I12N.hashed_elements[KEY_ANNOTATIONS].replace_value_type(annotations)
+    type
   end
 
   # @abstract Encapsulates behavior common to {PAttribute} and {PFunction}

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -22,7 +22,6 @@ class PObjectType < PMetaType
   TYPE_ATTRIBUTE_KIND = TypeFactory.enum(ATTRIBUTE_KIND_CONSTANT, ATTRIBUTE_KIND_DERIVED, ATTRIBUTE_KIND_GIVEN_OR_DERIVED)
 
   TYPE_OBJECT_NAME = Pcore::TYPE_QUALIFIED_REFERENCE
-  TYPE_MEMBER_NAME = PPatternType.new([PRegexpType.new(Patterns::PARAM_NAME)])
 
   TYPE_ATTRIBUTE = TypeFactory.struct({
     KEY_TYPE => PType::DEFAULT,
@@ -32,7 +31,7 @@ class PObjectType < PMetaType
     KEY_KIND => TypeFactory.optional(TYPE_ATTRIBUTE_KIND),
     KEY_VALUE => PAnyType::DEFAULT
   })
-  TYPE_ATTRIBUTES = TypeFactory.hash_kv(TYPE_MEMBER_NAME, TypeFactory.not_undef)
+  TYPE_ATTRIBUTES = TypeFactory.hash_kv(Pcore::TYPE_MEMBER_NAME, TypeFactory.not_undef)
   TYPE_ATTRIBUTE_CALLABLE = TypeFactory.callable(0,0)
 
   TYPE_FUNCTION_TYPE = PType.new(PCallableType::DEFAULT)
@@ -43,9 +42,9 @@ class PObjectType < PMetaType
     KEY_FINAL => TypeFactory.optional(PBooleanType::DEFAULT),
     KEY_OVERRIDE => TypeFactory.optional(PBooleanType::DEFAULT)
   })
-  TYPE_FUNCTIONS = TypeFactory.hash_kv(TYPE_MEMBER_NAME, TypeFactory.not_undef)
+  TYPE_FUNCTIONS = TypeFactory.hash_kv(Pcore::TYPE_MEMBER_NAME, TypeFactory.not_undef)
 
-  TYPE_EQUALITY = TypeFactory.variant(TYPE_MEMBER_NAME, TypeFactory.array_of(TYPE_MEMBER_NAME))
+  TYPE_EQUALITY = TypeFactory.variant(Pcore::TYPE_MEMBER_NAME, TypeFactory.array_of(Pcore::TYPE_MEMBER_NAME))
 
   TYPE_CHECKS = PAnyType::DEFAULT # TBD
 

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -457,9 +457,10 @@ class PObjectType < PMetaType
   end
 
   # @api private
-  def implementation_class
-    if @implementation_class.nil?
-      impl_name = Loaders.implementation_registry.module_name_for_type(self)
+  def implementation_class(create = true)
+    if @implementation_class.nil? && create
+      ir = Loaders.implementation_registry
+      impl_name = ir.nil? ? nil : ir.module_name_for_type(self)
       if impl_name.nil?
         # Use generator to create a default implementation
         @implementation_class = RubyGenerator.new.create_class(self)
@@ -475,6 +476,12 @@ class PObjectType < PMetaType
       end
     end
     @implementation_class
+  end
+
+  # @api private
+  def implementation_class=(cls)
+    raise ArgumentError, "attempt to redefine implementation class for #{label}" unless @implementation_class.nil?
+    @implementation_class = cls
   end
 
   # @api private

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -53,6 +53,9 @@ class PTypeSetType < PMetaType
     TypeFactory.optional(KEY_ANNOTATIONS) => TYPE_ANNOTATIONS,
   })
 
+  def self.register_ptype(loader, ir)
+    create_ptype(loader, ir, 'AnyType', 'i12n_hash' => TYPE_TYPESET_I12N.resolve(TypeParser.singleton, loader))
+  end
 
   attr_reader :pcore_uri
   attr_reader :pcore_version

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -59,7 +59,7 @@ class TypedModelObject < Object
   end
 
   def self.register_ptypes(loader, ir)
-    types = []
+    types = [Annotation.register_ptype(loader, ir)]
     Types.constants.each do |c|
       cls = Types.const_get(c)
       next unless cls.is_a?(Class) && cls < self
@@ -1746,6 +1746,14 @@ class PStructElement < TypedModelObject
   def ==(o)
     self.class == o.class && value_type == o.value_type && key_type == o.key_type
   end
+
+  # Special boostrap method to overcome the hen and egg problem with the Object initializer that contains
+  # types that are derived from Object (such as Annotation)
+  #
+  # @api private
+  def replace_value_type(new_type)
+    @value_type = new_type
+  end
 end
 
 # @api public
@@ -3344,6 +3352,7 @@ require 'puppet/pops/pcore'
 require_relative 'annotatable'
 require_relative 'p_meta_type'
 require_relative 'p_object_type'
+require_relative 'annotation'
 require_relative 'p_runtime_type'
 require_relative 'p_sem_ver_type'
 require_relative 'p_sem_ver_range_type'

--- a/spec/unit/functions/annotate_spec.rb
+++ b/spec/unit/functions/annotate_spec.rb
@@ -1,0 +1,175 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+describe 'the annotate function' do
+  include PuppetSpec::Compiler
+
+  let(:annotation) { <<-PUPPET }
+    type MyAdapter = Object[{
+      parent => Annotation,
+      attributes => {
+        id => Integer,
+        value => String[1]
+      }
+    }]
+  PUPPET
+
+  let(:annotation2) { <<-PUPPET }
+    type MyAdapter2 = Object[{
+      parent => Annotation,
+      attributes => {
+        id => Integer,
+        value => String[1]
+      }
+    }]
+  PUPPET
+
+  context 'with object and hash arguments' do
+    it 'creates new annotation on object' do
+      code = <<-PUPPET
+        #{annotation}
+        type MyObject = Object[{
+        }]
+        $my_object = MyObject({})
+        MyAdapter.annotate($my_object, { 'id' => 2, 'value' => 'annotation value' })
+        notice(MyAdapter.annotate($my_object).value)
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(['annotation value'])
+    end
+
+    it 'forces creation of new annotation' do
+      code = <<-PUPPET
+      #{annotation}
+      type MyObject = Object[{
+      }]
+      $my_object = MyObject({})
+      MyAdapter.annotate($my_object, { 'id' => 2, 'value' => 'annotation value' })
+      notice(MyAdapter.annotate($my_object).value)
+      MyAdapter.annotate($my_object, { 'id' => 2, 'value' => 'annotation value 2' })
+      notice(MyAdapter.annotate($my_object).value)
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(['annotation value', 'annotation value 2'])
+    end
+  end
+
+  context 'with object and block arguments' do
+    it 'creates new annotation on object' do
+      code = <<-PUPPET
+        #{annotation}
+        type MyObject = Object[{
+        }]
+        $my_object = MyObject({})
+        MyAdapter.annotate($my_object) || { { 'id' => 2, 'value' => 'annotation value' } }
+        notice(MyAdapter.annotate($my_object).value)
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(['annotation value'])
+    end
+
+    it 'does not recreate annotation' do
+      code = <<-PUPPET
+      #{annotation}
+      type MyObject = Object[{
+      }]
+      $my_object = MyObject({})
+      MyAdapter.annotate($my_object) || {
+        notice('should call this');
+        { 'id' => 2, 'value' => 'annotation value' }
+      }
+      MyAdapter.annotate($my_object) || {
+        notice('should not call this');
+        { 'id' => 2, 'value' => 'annotation value 2' }
+      }
+      notice(MyAdapter.annotate($my_object).value)
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(['should call this', 'annotation value'])
+    end
+  end
+
+  it "with object and 'clear' arguments, clears and returns annotation" do
+    code = <<-PUPPET
+      #{annotation}
+      type MyObject = Object[{
+      }]
+      $my_object = MyObject({})
+      MyAdapter.annotate($my_object, { 'id' => 2, 'value' => 'annotation value' })
+      notice(MyAdapter.annotate($my_object, clear).value)
+      notice(MyAdapter.annotate($my_object) == undef)
+    PUPPET
+    expect(eval_and_collect_notices(code)).to eql(['annotation value', 'true'])
+  end
+
+  context 'when object is an annotated Type' do
+    it 'finds annotation declared in the type' do
+      code = <<-PUPPET
+        #{annotation}
+        type MyObject = Object[{
+          annotations => {
+            MyAdapter => { 'id' => 2, 'value' => 'annotation value' }
+          }
+        }]
+        notice(MyAdapter.annotate(MyObject).value)
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(['annotation value'])
+    end
+
+    it 'fails attempts to clear a declared annotation' do
+      code = <<-PUPPET
+        #{annotation}
+        type MyObject = Object[{
+          annotations => {
+            MyAdapter => { 'id' => 2, 'value' => 'annotation value' }
+          }
+        }]
+        notice(MyAdapter.annotate(MyObject).value)
+        notice(MyAdapter.annotate(MyObject, clear).value)
+      PUPPET
+      expect { eval_and_collect_notices(code) }.to raise_error(/attempt to clear MyAdapter annotation declared on type MyObject/)
+    end
+
+    it 'fails attempts to redefine a declared annotation' do
+      code = <<-PUPPET
+        #{annotation}
+        type MyObject = Object[{
+          annotations => {
+            MyAdapter => { 'id' => 2, 'value' => 'annotation value' }
+          }
+        }]
+        notice(MyAdapter.annotate(MyObject).value)
+        notice(MyAdapter.annotate(MyObject, { 'id' => 3, 'value' => 'some other value' }).value)
+      PUPPET
+      expect { eval_and_collect_notices(code) }.to raise_error(/attempt to redefine MyAdapter annotation declared on type MyObject/)
+    end
+
+    it 'allows annotation that are not declared in the type' do
+      code = <<-PUPPET
+        #{annotation}
+        #{annotation2}
+        type MyObject = Object[{
+          annotations => {
+            MyAdapter => { 'id' => 2, 'value' => 'annotation value' }
+          }
+        }]
+        notice(MyAdapter.annotate(MyObject).value)
+        notice(MyAdapter2.annotate(MyObject, { 'id' => 3, 'value' => 'some other value' }).value)
+      PUPPET
+      expect(eval_and_collect_notices(code)).to eql(['annotation value', 'some other value'])
+    end
+  end
+
+  it 'used on Pcore, can add multiple annotations an object' do
+    code = <<-PUPPET
+      #{annotation}
+      #{annotation2}
+      type MyObject = Object[{
+      }]
+      $my_object = Pcore.annotate(MyObject({}), {
+        MyAdapter => { 'id' => 2, 'value' => 'annotation value' },
+        MyAdapter2 => { 'id' => 3, 'value' => 'second annotation value' }
+      })
+      notice(MyAdapter.annotate($my_object).value)
+      notice(MyAdapter2.annotate($my_object).value)
+    PUPPET
+    expect(eval_and_collect_notices(code)).to eql(['annotation value', 'second annotation value'])
+  end
+end


### PR DESCRIPTION
This PR adds the `Annotation` type as an `Object`. The actual implementation class is a subclass of `Puppet::Pops::Adaptable::Adapter` and may be extended from the Puppet Language as an `Object` type that uses `Annotation` as its parent.

The commit also adds the function `annotate` that can be used in several different ways (see documentation in ruby source for the function).
