### PR TITLE
(PUP-6656) Reorder install_options for package resource

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -39,17 +39,17 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   #
   # @api private
   # @param package [String] The name of the package to query
-  # @param enablerepo [Array<String>] A list of repositories to enable for this query
   # @param disablerepo [Array<String>] A list of repositories to disable for this query
+  # @param enablerepo [Array<String>] A list of repositories to enable for this query
   # @param disableexcludes [Array<String>] A list of repository excludes to disable for this query
   # @return [Hash<Symbol, String>]
-  def self.latest_package_version(package, enablerepo, disablerepo, disableexcludes)
+  def self.latest_package_version(package, disablerepo, enablerepo, disableexcludes)
 
-    key = [enablerepo, disablerepo, disableexcludes]
+    key = [disablerepo, enablerepo, disableexcludes]
 
     @latest_versions ||= {}
     if @latest_versions[key].nil?
-      @latest_versions[key] = check_updates(enablerepo, disablerepo, disableexcludes)
+      @latest_versions[key] = check_updates(disablerepo, enablerepo, disableexcludes)
     end
 
     if @latest_versions[key][package]
@@ -61,15 +61,15 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   # combination of repositories to enable and disable.
   #
   # @api private
-  # @param enablerepo [Array<String>] A list of repositories to enable for this query
   # @param disablerepo [Array<String>] A list of repositories to disable for this query
+  # @param enablerepo [Array<String>] A list of repositories to enable for this query
   # @param disableexcludes [Array<String>] A list of repository excludes to disable for this query
   # @return [Hash<String, Array<Hash<String, String>>>] All packages that were
   #   found with a list of found versions for each package.
-  def self.check_updates(enablerepo, disablerepo, disableexcludes)
+  def self.check_updates(disablerepo, enablerepo, disableexcludes)
     args = [command(:cmd), 'check-update']
-    args.concat(enablerepo.map { |repo| ["--enablerepo=#{repo}"] }.flatten)
     args.concat(disablerepo.map { |repo| ["--disablerepo=#{repo}"] }.flatten)
+    args.concat(enablerepo.map { |repo| ["--enablerepo=#{repo}"] }.flatten)
     args.concat(disableexcludes.map { |repo| ["--disableexcludes=#{repo}"] }.flatten)
 
     output = Puppet::Util::Execution.execute(args, :failonfail => false, :combine => false)
@@ -213,7 +213,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
   # What's the latest package version available?
   def latest
-    upd = self.class.latest_package_version(@resource[:name], enablerepo, disablerepo, disableexcludes)
+    upd = self.class.latest_package_version(@resource[:name], disablerepo, enablerepo, disableexcludes)
     unless upd.nil?
       # FIXME: there could be more than one update for a package
       # because of multiarch


### PR DESCRIPTION
In some versions of CentOS/RHEL, yum check-update fails when `--enablerepo` preceeds` --disablerepo` This patch changes the order of install_options to prevent that failure.