### PR TITLE
(PUP-7216) Prevent merge strategy from hiera_xxx to override hiera.yaml

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -65,6 +65,7 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
     end
     lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {})
     adapter = lookup_invocation.lookup_adapter
+    lookup_invocation.set_hiera_xxx_call
     lookup_invocation.set_global_only unless adapter.global_only? || adapter.has_environment_data_provider?(lookup_invocation)
     lookup_invocation.set_hiera_v3_location_overrides(override) unless override.nil? || override.is_a?(Array) && override.empty?
     Puppet::Pops::Lookup.lookup(key, nil, default, has_default, merge_type, lookup_invocation, &default_block)

--- a/lib/puppet/pops/lookup/global_data_provider.rb
+++ b/lib/puppet/pops/lookup/global_data_provider.rb
@@ -21,7 +21,18 @@ class GlobalDataProvider < ConfiguredDataProvider
           lookup_invocation.default_values,
           lookup_invocation.explainer)
       end
-      merge = config.merge_strategy if merge.is_a?(DefaultMergeStrategy)
+
+      unless config.merge_strategy.is_a?(DefaultMergeStrategy)
+        if lookup_invocation.hiera_xxx_call?
+          # Merge strategy of the hiera_xxx call should only be applied when no merge strategy is defined in the hiera config
+          merge = config.merge_strategy
+          lookup_invocation.set_hiera_v3_merge_behavior
+        elsif merge.is_a?(DefaultMergeStrategy)
+          # For all other calls, the strategy of the call overrides the strategy defined in the hiera config
+          merge = config.merge_strategy
+          lookup_invocation.set_hiera_v3_merge_behavior
+        end
+      end
     end
     super(key, lookup_invocation, merge)
   end

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -352,10 +352,8 @@ class HieraConfigV3 < HieraConfig
   def create_merge_strategy
     key = @config[KEY_MERGE_BEHAVIOR]
     case key
-    when nil
+    when nil, 'native'
       MergeStrategy.strategy(nil)
-    when 'native'
-      MergeStrategy.strategy(:first)
     when 'array'
       MergeStrategy.strategy(:unique)
     when 'deep', 'deeper'

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -38,6 +38,8 @@ class Invocation
     else
       @name_stack = parent_invocation.name_stack
       @adapter_class = parent_invocation.adapter_class
+      set_hiera_xxx_call if parent_invocation.hiera_xxx_call?
+      set_hiera_v3_merge_behavior if parent_invocation.hiera_v3_merge_behavior?
       set_global_only if parent_invocation.global_only?
       povr = parent_invocation.hiera_v3_location_overrides
       set_hiera_v3_location_overrides(povr) unless povr.empty?
@@ -191,6 +193,24 @@ class Invocation
   # @return [Pathname] the full path of the hiera.yaml config file
   def global_hiera_config_path
     lookup_adapter.global_hiera_config_path
+  end
+
+  # @return [Boolean] `true` if the invocation stems from the hiera_xxx function family
+  def hiera_xxx_call?
+    instance_variable_defined?(:@hiera_xxx_call)
+  end
+
+  def set_hiera_xxx_call
+    @hiera_xxx_call = true
+  end
+
+  # @return [Boolean] `true` if the invocation stems from the hiera_xxx function family
+  def hiera_v3_merge_behavior?
+    instance_variable_defined?(:@hiera_v3_merge_behavior)
+  end
+
+  def set_hiera_v3_merge_behavior
+    @hiera_v3_merge_behavior = true
   end
 
   # Overrides passed from hiera_xxx functions down to V3DataHashFunctionProvider

--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -57,7 +57,11 @@ class V3BackendFunctionProvider < LookupKeyFunctionProvider
 
   def lookup_key(key, lookup_invocation, location, merge)
     @backend ||= instantiate_backend(lookup_invocation)
-    @backend.lookup(key, lookup_invocation.scope, lookup_invocation.hiera_v3_location_overrides, convert_merge(merge), context = {:recurse_guard => nil})
+    config = parent_data_provider.config(lookup_invocation)
+
+    # Never pass hiera.yaml defined merge_behavior down to the backend. It will pick it up from the config
+    resolution_type = lookup_invocation.hiera_v3_merge_behavior? ? nil : convert_merge(merge)
+    @backend.lookup(key, lookup_invocation.scope, lookup_invocation.hiera_v3_location_overrides, resolution_type, context = {:recurse_guard => nil})
   end
 
   private


### PR DESCRIPTION
A merge strategy that are passed as a parameter in a call to lookup
should always override a merge strategy defined in hiera.yaml. This
works as intended. However, this mechanism was also used by the hiera_xxx
functions to pass a strategy. The `hiera_array` and `hiera_include` will
pass `unique` and `hiera_hash` will pass `hash`, and when called from a
`hiera_xxx` function, the synthesized parameter must *not* override
a merge strategy defined in hiera.yaml.

This commit adds a `#hiera_xxx_call?` method to the `LookupInvocation`,
ensures that it is set for all hiera_xxx calls, and then ensures that
any merge strategy that is passed down in combination with that setting,
has lower priority than the strategy defined in the `hiera.yaml` file.