### PR TITLE
(PUP-7222) Add RubyMethod annotation and let RubyGenerator act on it

### DIFF
--- a/lib/puppet/pops/types/annotatable.rb
+++ b/lib/puppet/pops/types/annotatable.rb
@@ -11,7 +11,9 @@ module Annotatable
 
   # @return [{PType => PStructType}] the map of annotations
   # @api public
-  attr_reader :annotations
+  def annotations
+    @annotations.nil? ? EMPTY_HASH : @annotations
+  end
 
   # @api private
   def init_annotatable(i12n_hash)

--- a/lib/puppet/pops/types/annotation.rb
+++ b/lib/puppet/pops/types/annotation.rb
@@ -27,7 +27,7 @@ module Types
     def self.annotate(o)
       adapter = get(o)
       if adapter.nil?
-        if o.is_a?(PObjectType)
+        if o.is_a?(Annotatable)
           i12n = o.annotations[_ptype]
           i12n = yield if i12n.nil? && block_given?
         else
@@ -47,10 +47,10 @@ module Types
     # @return [Annotation<self>] an annotation of the same class as the receiver of the call
     #
     def self.annotate_new(o, i12n_hash)
-      if o.is_a?(PObjectType) && o.annotations.include?(_ptype)
+      if o.is_a?(Annotatable) && o.annotations.include?(_ptype)
         # Prevent clear or redefine of annotations declared on type
         action = i12n_hash == CLEAR ? 'clear' : 'redefine'
-        raise ArgumentError, "attempt to #{action} #{type_name} annotation declared on type #{o.name}"
+        raise ArgumentError, "attempt to #{action} #{type_name} annotation declared on #{o.label}"
       end
 
       if i12n_hash == CLEAR

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -156,121 +156,259 @@ class RubyGenerator < TypeFormatter
 
     init_params = others.reject { |a| a.kind == PObjectType::ATTRIBUTE_KIND_DERIVED }
     opt, non_opt = init_params.partition { |ip| ip.value? }
+    derived_attrs, obj_attrs = others.select { |a| a.container.equal?(obj) }.partition { |ip| ip.kind == PObjectType::ATTRIBUTE_KIND_DERIVED }
 
-    # Output type safe hash constructor
-    bld << "\n  def self.from_hash(i12n)\n"
-    bld << '    from_asserted_hash(' << namespace_relative(segments, TypeAsserter.name) << '.assert_instance_of('
-    bld << "'" << obj.label << " initializer', _ptype.i12n_type, i12n))\n  end\n\n  def self.from_asserted_hash(i12n)\n    new(\n"
-    non_opt.each { |ip| bld << "      i12n['" << ip.name << "'],\n" }
-    opt.each { |ip| bld << "      i12n.fetch('" << ip.name << "') { _ptype['" << ip.name << "'].value },\n" }
-    bld.chomp!(",\n")
-    bld << ")\n  end\n"
-
-    # Output type safe constructor
-    bld << "\n  def self.create"
-    if init_params.empty?
-      bld << "\n    new"
-    else
-      bld << '('
-      non_opt.each { |ip| bld << ip.name << ', ' }
-      opt.each { |ip| bld << ip.name << ' = ' << "_ptype['#{ip.name}'].value" << ', ' }
-      bld.chomp!(', ')
-      bld << ")\n"
-      bld << '    ta = ' << namespace_relative(segments, TypeAsserter.name) << "\n"
-      bld << "    attrs = _ptype.attributes(true)\n"
-      init_params.each do |a|
-        bld << "    ta.assert_instance_of('" << a.container.name << '[' << a.name << ']'
-        bld << "', attrs['" << a.name << "'].type, " << a.name << ")\n"
-      end
-      bld << '    new('
-      non_opt.each { |a| bld << a.name << ', ' }
-      opt.each { |a| bld << a.name << ', ' }
-      bld.chomp!(', ')
-      bld << ')'
-    end
-    bld << "\n  end\n"
-
-    # Output initializer
-    bld << "\n  def initialize"
-    unless init_params.empty?
-      bld << '('
-      non_opt.each { |ip| bld << ip.name << ', ' }
-      opt.each { |ip| bld << ip.name << ' = ' << "_ptype['#{ip.name}'].value" << ', ' }
-      bld.chomp!(', ')
-      bld << ')'
-      unless obj.parent.nil?
-        bld << "\n    super("
-        super_args = (non_opt + opt).select { |ip| !ip.container.equal?(obj) }
-        unless super_args.empty?
-          super_args.each { |ip| bld << ip.name << ', ' }
-          bld.chomp!(', ')
-        end
-        bld << ')'
-      end
-    end
-    bld << "\n"
-
-    init_params.each { |a| bld << '    @' << a.name << ' = ' << a.name << "\n" if a.container.equal?(obj) }
-    bld << "  end\n\n"
-
-    bld << "  def i12n_hash\n    result = "
-    bld << (obj.parent.nil? ? '{}' : 'super')
-    bld << "\n"
-    init_params.each { |a| bld << "    result['" << a.name << "'] = @" << a.name << "\n" if a.container.equal?(obj) }
-    bld << "    result\n  end\n\n"
-
-    bld << "  def to_s\n"
-    bld << "    " << namespace_relative(segments, TypeFormatter.name) << ".string(self)\n"
-    bld << "  end\n\n"
-
-    # Output attr_readers
-    others.each do |a|
-      next unless a.container.equal?(obj)
-      if a.kind == PObjectType::ATTRIBUTE_KIND_DERIVED || a.kind == PObjectType::ATTRIBUTE_KIND_GIVEN_OR_DERIVED
-        bld << '  def ' << a.name << "\n"
-        bld << "    raise Puppet::Error, \"no method is implemented for derived attribute #{a.label}\"\n"
-        bld << "  end\n"
-      else
-        bld << '  attr_reader :' << a.name << "\n"
-      end
-    end
-
-    # Output function placeholders
-    obj.functions(false).each_value do |func|
-      bld << "\n  def " << func.name << "(*args)\n"
-      bld << "    # Placeholder for #{func.type}\n"
-      bld << "    raise Puppet::Error, \"no method is implemented for #{func.label}\"\n"
-      bld << "  end\n"
-    end
-
-    # output hash and equality
-    include_class = obj.include_class_in_equality?
+    include_type = obj.equality_include_type? && !(obj.parent.is_a?(PObjectType) && obj.parent.equality_include_type?)
     if obj.equality.nil?
-      eq_names = obj.attributes(false).values.select { |a| a.kind != PObjectType::ATTRIBUTE_KIND_CONSTANT }.map(&:name)
+      eq_names = obj_attrs.reject { |a| a.kind == PObjectType::ATTRIBUTE_KIND_CONSTANT }.map(&:name)
     else
       eq_names = obj.equality
     end
 
-    unless eq_names.empty? && !include_class
-      bld << "\n  def hash\n    "
-      bld << 'super.hash ^ ' unless obj.parent.nil?
-      if eq_names.empty?
-        bld << "self.class.hash\n"
+    unless obj.parent.is_a?(PObjectType) && obj_attrs.empty?
+      # Output type safe hash constructor
+      bld << "\n  def self.from_hash(i12n)\n"
+      bld << '    from_asserted_hash(' << namespace_relative(segments, TypeAsserter.name) << '.assert_instance_of('
+      bld << "'" << obj.label << " initializer', _ptype.i12n_type, i12n))\n  end\n\n  def self.from_asserted_hash(i12n)\n    new"
+      unless non_opt.empty? && opt.empty?
+        bld << "(\n"
+        non_opt.each { |ip| bld << "      i12n['" << ip.name << "'],\n" }
+        opt.each do |ip|
+          if ip.value.nil?
+            bld << "      i12n['" << ip.name << "'],\n"
+          else
+            bld << "      i12n.fetch('" << ip.name << "') { "
+            default_string(bld, ip)
+            bld << " },\n"
+          end
+        end
+        bld.chomp!(",\n")
+        bld << ').freeze'
+      end
+      bld << "\n  end\n"
+
+      # Output type safe constructor
+      bld << "\n  def self.create"
+      if init_params.empty?
+        bld << "\n    new"
       else
-        bld << '['
-        bld << 'self.class, ' if include_class
-        eq_names.each { |eqn| bld << '@' << eqn << ', ' }
+        bld << '('
+        non_opt.each { |ip| bld << ip.name << ', ' }
+        opt.each do |ip|
+          bld << ip.name << ' = '
+          default_string(bld, ip)
+          bld << ', '
+        end
         bld.chomp!(', ')
-        bld << "].hash\n"
+        bld << ")\n"
+        bld << '    ta = ' << namespace_relative(segments, TypeAsserter.name) << "\n"
+        bld << "    attrs = _ptype.attributes(true)\n"
+        init_params.each do |a|
+          bld << "    ta.assert_instance_of('" << a.container.name << '[' << a.name << ']'
+          bld << "', attrs['" << a.name << "'].type, " << a.name << ")\n"
+        end
+        bld << '    new('
+        non_opt.each { |a| bld << a.name << ', ' }
+        opt.each { |a| bld << a.name << ', ' }
+        bld.chomp!(', ')
+        bld << ')'
+      end
+      bld << ".freeze\n  end\n"
+
+      # Output attr_readers
+      unless obj_attrs.empty?
+        bld << "\n"
+        obj_attrs.each { |a| bld << '  attr_reader :' << a.name << "\n" }
+      end
+
+      bld << "  attr_reader :hash\n" if obj.parent.nil?
+
+      derived_attrs.each do |a|
+        bld << "\n  def " << a.name << "\n"
+        code_annotation = RubyMethod.annotate(a)
+        ruby_body = code_annotation.nil? ? nil: code_annotation.body
+        if ruby_body.nil?
+          bld << "    raise Puppet::Error, \"no method is implemented for derived #{a.label}\"\n"
+        else
+          bld << '    ' << ruby_body << "\n"
+        end
+        bld << "  end\n"
+      end
+
+      if init_params.empty?
+        bld << "\n  def initialize\n    @hash = " << obj.hash.to_s << "\n  end" if obj.parent.nil?
+      else
+        # Output initializer
+        bld << "\n  def initialize"
+        bld << '('
+        non_opt.each { |ip| bld << ip.name << ', ' }
+        opt.each do |ip|
+          bld << ip.name << ' = '
+          default_string(bld, ip)
+          bld << ', '
+        end
+        bld.chomp!(', ')
+        bld << ')'
+
+        hash_participants = init_params.select { |ip| eq_names.include?(ip.name) }
+        if obj.parent.nil?
+          bld << "\n    @hash = "
+          bld << obj.hash.to_s << "\n" if hash_participants.empty?
+        else
+          bld << "\n    super("
+          super_args = (non_opt + opt).select { |ip| !ip.container.equal?(obj) }
+          unless super_args.empty?
+            super_args.each { |ip| bld << ip.name << ', ' }
+            bld.chomp!(', ')
+          end
+          bld << ")\n"
+          bld << '    @hash = @hash ^ ' unless hash_participants.empty?
+        end
+        unless hash_participants.empty?
+          hash_participants.each { |a| bld << a.name << '.hash ^ ' if a.container.equal?(obj) }
+          bld.chomp!(' ^ ')
+          bld << "\n"
+        end
+        init_params.each { |a| bld << '    @' << a.name << ' = ' << a.name << "\n" if a.container.equal?(obj) }
+        bld << "  end\n"
+      end
+    end
+
+    if obj_attrs.empty?
+      bld << "\n  def i12n_hash\n    {}\n  end\n" unless obj.parent.is_a?(PObjectType)
+    else
+      bld << "\n  def i12n_hash\n"
+      bld << '    result = '
+      bld << (obj.parent.nil? ? '{}' : 'super')
+      bld << "\n"
+      obj_attrs.each do |a|
+        bld << "    result['" << a.name << "'] = @" << a.name
+        if a.value?
+          bld << ' unless '
+          equals_default_string(bld, a)
+        end
+        bld << "\n"
+      end
+      bld << "    result\n  end\n"
+    end
+
+    content_participants = init_params.select { |a| content_participant?(a) }
+    if content_participants.empty?
+      unless obj.parent.is_a?(PObjectType)
+        bld << "\n  def _pcontents\n  end\n"
+        bld << "\n  def _pall_contents(path)\n  end\n"
+      end
+    else
+      bld << "\n  def _pcontents\n"
+      content_participants.each do |cp|
+        if array_type?(cp.type)
+          bld << '    @' << cp.name << ".each { |value| yield(value) }\n"
+        else
+          bld << '    yield(@' << cp.name << ') unless @' << cp.name  << ".nil?\n"
+        end
+      end
+      bld << "  end\n\n  def _pall_contents(path, &block)\n    path << self\n"
+      content_participants.each do |cp|
+        if array_type?(cp.type)
+          bld << '    @' << cp.name << ".each do |value|\n"
+          bld << "      block.call(value, path)\n"
+          bld << "      value._pall_contents(path, &block)\n"
+        else
+          bld << '    unless @' << cp.name << ".nil?\n"
+          bld << '      block.call(@' << cp.name << ", path)\n"
+          bld << '      @' << cp.name << "._pall_contents(path, &block)\n"
+        end
+        bld << "    end\n"
+      end
+      bld << "    path.pop\n  end\n"
+    end
+
+    unless obj.parent.is_a?(PObjectType)
+      bld << "\n  def to_s\n"
+      bld << '    ' << namespace_relative(segments, TypeFormatter.name) << ".string(self)\n"
+      bld << "  end\n"
+    end
+
+    # Output function placeholders
+    obj.functions(false).each_value do |func|
+      code_annotation = RubyMethod.annotate(func)
+      if code_annotation
+        body = code_annotation.body
+        params = code_annotation.parameters
+        bld << "\n  def " << func.name
+        unless params.nil? || params.empty?
+          bld << '(' << params << ')'
+        end
+        bld << "\n    " << body << "\n"
+      else
+        bld << "\n  def " << func.name << "(*args)\n"
+        bld << "    # Placeholder for #{func.type}\n"
+        bld << "    raise Puppet::Error, \"no method is implemented for #{func.label}\"\n"
       end
       bld << "  end\n"
+    end
 
+    unless eq_names.empty? && !include_type
       bld << "\n  def eql?(o)\n"
       bld << "    super &&\n" unless obj.parent.nil?
-      bld << "    self.class.eql?(o.class) &&\n" if include_class
+      bld << "    o.instance_of?(self.class) &&\n" if include_type
       eq_names.each { |eqn| bld << '    @' << eqn << '.eql?(o.' <<  eqn << ") &&\n" }
       bld.chomp!(" &&\n")
       bld << "\n  end\n  alias == eql?\n"
+    end
+  end
+
+  def content_participant?(a)
+    obj_type?(a.type)
+  end
+
+  def obj_type?(t)
+    case t
+    when PObjectType
+      true
+    when POptionalType
+      obj_type?(t.optional_type)
+    when PNotUndefType
+      obj_type?(t.type)
+    when PArrayType
+      obj_type?(t.element_type)
+    when PVariantType
+      t.types.all? { |v| obj_type?(v) }
+    else
+      false
+    end
+  end
+
+  def array_type?(t)
+    case t
+    when PArrayType
+      true
+    when POptionalType
+      array_type?(t.optional_type)
+    when PNotUndefType
+      array_type?(t.type)
+    when PVariantType
+      t.types.all? { |v| array_type?(v) }
+    else
+      false
+    end
+  end
+
+  def default_string(bld, a)
+    case a.value
+    when nil, true, false, Numeric, String
+      bld << a.value.inspect
+    else
+      bld << "_ptype['" << a.name << "'].value"
+    end
+  end
+
+  def equals_default_string(bld, a)
+    case a.value
+    when nil, true, false, Numeric, String
+      bld << '@' << a.name << ' == ' << a.value.inspect
+    else
+      bld << "_ptype['" << a.name << "'].default_value?(@" << a.name << ')'
     end
   end
 end

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -126,8 +126,8 @@ class RubyGenerator < TypeFormatter
 
     bld << "\n"
     bld << "  def self._ptype\n"
-    bld << '    @_ptype ||= ' << namespace_relative(segments, obj.class.name) << ".new('" << obj.name << "',\n"
-    bld << TypeFormatter.new.ruby_string('ref', 3, obj.i12n_hash(false)) << "    )\n"
+    bld << '    @_ptype ||= ' << namespace_relative(segments, obj.class.name) << ".new('" << obj.name << "', "
+    bld << TypeFormatter.singleton.ruby('ref').indented(2).string(obj.i12n_hash(false)) << ")\n"
     bld << "  end\n"
 
     class_body(obj, segments, bld)

--- a/lib/puppet/pops/types/ruby_method.rb
+++ b/lib/puppet/pops/types/ruby_method.rb
@@ -1,0 +1,31 @@
+module Puppet::Pops
+module Types
+  class RubyMethod < Annotation
+    # Register the Annotation type. This is the type that all custom Annotations will inherit from.
+    def self.register_ptype(loader, ir)
+      @type = Pcore::create_object_type(loader, ir, self, 'RubyMethod', 'Annotation',
+        'body' => PStringType::DEFAULT,
+        'parameters' => {
+          KEY_TYPE => POptionalType.new(PStringType::NON_EMPTY),
+          KEY_VALUE => nil
+        }
+      )
+    end
+
+    def self.from_hash(i12n)
+      from_asserted_hash(Types::TypeAsserter.assert_instance_of('RubyMethod initializer', _ptype.i12n_type, i12n))
+    end
+
+    def self.from_asserted_hash(i12n_hash)
+      new(i12n_hash['body'], i12n_hash['parameters'])
+    end
+
+    attr_reader :body, :parameters
+
+    def initialize(body, parameters = nil)
+      @body = body
+      @parameters = parameters
+    end
+  end
+end
+end

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -24,6 +24,26 @@ class TypeFormatter
     @singleton
   end
 
+  def expanded
+    tf = clone
+    tf.instance_variable_set(:@expanded, true)
+    tf
+  end
+
+  def indented(indent = 0, indent_width = 2)
+    tf = clone
+    tf.instance_variable_set(:@indent, indent)
+    tf.instance_variable_set(:@indent_width, indent_width)
+    tf
+  end
+
+  def ruby(ref_ctor)
+    tf = clone
+    tf.instance_variable_set(:@ruby, true)
+    tf.instance_variable_set(:@ref_ctor, ref_ctor)
+    tf
+  end
+
   # Produces a string representing the type
   # @api public
   #
@@ -84,9 +104,9 @@ class TypeFormatter
     if @ruby && t.is_a?(PAnyType)
       @ruby = false
       begin
-        @bld << @ref_ctor << "('"
-        @@string_visitor.visit_this_0(self, t)
-        @bld << "')"
+        @bld << @ref_ctor << '('
+        @@string_visitor.visit_this_0(self, TypeFormatter.new.string(t))
+        @bld << ')'
       ensure
         @ruby = true
       end
@@ -308,7 +328,6 @@ class TypeFormatter
     append_indented_string(t.i12n_hash, @indent || 0, @indent_width || 2, true)
     @bld.chomp!
     @bld << ')'
-    newline if @indent
   end
 
   # @api private
@@ -484,7 +503,17 @@ class TypeFormatter
 
   # @api private
   def string_Array(t)
-    append_array('') { append_strings(t) }
+    append_array('') do
+      if @indent && !is_short_array?(t)
+        @indent += 1
+        t.each { |elem| newline; append_string(elem); @bld << COMMA_SEP }
+        chomp_list
+        @indent -= 1
+        newline
+      else
+        append_strings(t)
+      end
+    end
   end
 
   # @api private
@@ -568,6 +597,21 @@ class TypeFormatter
   COMMA_SEP = ', '.freeze
 
   HASH_ENTRY_OP = ' => '.freeze
+
+  def is_short_array?(t)
+    t.empty? || 100 - @indent * @indent_width > t.inject(0) do |sum, elem|
+      case elem
+      when true, false, nil, Numeric, Symbol
+        sum + elem.inspect.length()
+      when String
+        sum + 2 + elem.length
+      when Hash, Array
+        sum + (elem.empty? ? 2 : 1000)
+      else
+        sum + 1000
+      end
+    end
+  end
 
   def range_array_part(t)
     t.nil? || t.unbounded? ? EMPTY_ARRAY : [t.from.nil? ? 'default' : t.from.to_s , t.to.nil? ? 'default' : t.to.to_s ]

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -59,7 +59,10 @@ class TypedModelObject < Object
   end
 
   def self.register_ptypes(loader, ir)
-    types = [Annotation.register_ptype(loader, ir)]
+    types = [
+      Annotation.register_ptype(loader, ir),
+      RubyMethod.register_ptype(loader, ir)
+    ]
     Types.constants.each do |c|
       cls = Types.const_get(c)
       next unless cls.is_a?(Class) && cls < self
@@ -3353,6 +3356,7 @@ require_relative 'annotatable'
 require_relative 'p_meta_type'
 require_relative 'p_object_type'
 require_relative 'annotation'
+require_relative 'ruby_method'
 require_relative 'p_runtime_type'
 require_relative 'p_sem_ver_type'
 require_relative 'p_sem_ver_range_type'

--- a/spec/unit/functions/annotate_spec.rb
+++ b/spec/unit/functions/annotate_spec.rb
@@ -124,7 +124,7 @@ describe 'the annotate function' do
         notice(MyAdapter.annotate(MyObject).value)
         notice(MyAdapter.annotate(MyObject, clear).value)
       PUPPET
-      expect { eval_and_collect_notices(code) }.to raise_error(/attempt to clear MyAdapter annotation declared on type MyObject/)
+      expect { eval_and_collect_notices(code) }.to raise_error(/attempt to clear MyAdapter annotation declared on MyObject/)
     end
 
     it 'fails attempts to redefine a declared annotation' do
@@ -138,7 +138,7 @@ describe 'the annotate function' do
         notice(MyAdapter.annotate(MyObject).value)
         notice(MyAdapter.annotate(MyObject, { 'id' => 3, 'value' => 'some other value' }).value)
       PUPPET
-      expect { eval_and_collect_notices(code) }.to raise_error(/attempt to redefine MyAdapter annotation declared on type MyObject/)
+      expect { eval_and_collect_notices(code) }.to raise_error(/attempt to redefine MyAdapter annotation declared on MyObject/)
     end
 
     it 'allows annotation that are not declared in the type' do

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -38,9 +38,13 @@ describe 'The type formatter' do
       expect(s.indented_string({'a' => 32,'b' => [1, 2, {'c' => 'd'}]})).to eq(<<-FORMATTED)
 {
   'a' => 32,
-  'b' => [1, 2, {
-    'c' => 'd'
-  }]
+  'b' => [
+    1,
+    2,
+    {
+      'c' => 'd'
+    }
+  ]
 }
 FORMATTED
     end
@@ -49,9 +53,13 @@ FORMATTED
       expect(s.indented_string({'a' => 32,'b' => [1, 2, {'c' => 'd'}]}, 3)).to eq(<<-FORMATTED)
       {
         'a' => 32,
-        'b' => [1, 2, {
-          'c' => 'd'
-        }]
+        'b' => [
+          1,
+          2,
+          {
+            'c' => 'd'
+          }
+        ]
       }
 FORMATTED
     end
@@ -60,13 +68,17 @@ FORMATTED
       expect(s.indented_string({'a' => 32,'b' => [1, 2, {'c' => 'd'}]}, 2, 4)).to eq(<<-FORMATTED)
         {
             'a' => 32,
-            'b' => [1, 2, {
-                'c' => 'd'
-            }]
+            'b' => [
+                1,
+                2,
+                {
+                    'c' => 'd'
+                }
+            ]
         }
-    FORMATTED
+FORMATTED
+    end
   end
-end
 
   context 'when representing the type as string' do
     include_context 'types_setup'


### PR DESCRIPTION
This PR adds the `Annotation` type `RubyMethod`. It can be used on derived `Object` attributes and on `Object` functions. The annotation has two attributes. `body` which is mandatory and `parameters` which is optional and only indended for function annotations (needed since we don't have a `Callable` that uses named parameters).