### PR TITLE
(PUP-7227) Add "reference" as a valid Pcore Object attribute kind

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -19,7 +19,8 @@ class PObjectType < PMetaType
   ATTRIBUTE_KIND_CONSTANT = 'constant'.freeze
   ATTRIBUTE_KIND_DERIVED = 'derived'.freeze
   ATTRIBUTE_KIND_GIVEN_OR_DERIVED = 'given_or_derived'.freeze
-  TYPE_ATTRIBUTE_KIND = TypeFactory.enum(ATTRIBUTE_KIND_CONSTANT, ATTRIBUTE_KIND_DERIVED, ATTRIBUTE_KIND_GIVEN_OR_DERIVED)
+  ATTRIBUTE_KIND_REFERENCE = 'reference'.freeze
+  TYPE_ATTRIBUTE_KIND = TypeFactory.enum(ATTRIBUTE_KIND_CONSTANT, ATTRIBUTE_KIND_DERIVED, ATTRIBUTE_KIND_GIVEN_OR_DERIVED, ATTRIBUTE_KIND_REFERENCE)
 
   TYPE_OBJECT_NAME = Pcore::TYPE_QUALIFIED_REFERENCE
 
@@ -242,8 +243,7 @@ class PObjectType < PMetaType
   # @api public
   class PAttribute < PAnnotatedMember
 
-    # @return [String,nil] The attribute kind as defined by #TYPE_ATTRIBUTE_KIND, or `nil` to
-    #   indicate that
+    # @return [String,nil] The attribute kind as defined by #TYPE_ATTRIBUTE_KIND, or `nil`
     attr_reader :kind
 
     # @param name [String] The name of the attribute

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -359,7 +359,7 @@ class RubyGenerator < TypeFormatter
   end
 
   def content_participant?(a)
-    obj_type?(a.type)
+    a.kind != PObjectType::ATTRIBUTE_KIND_REFERENCE && obj_type?(a.type)
   end
 
   def obj_type?(t)

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -67,7 +67,7 @@ describe 'The Object Type' do
         }
       OBJECT
       expect { parse_object('MyObject', obj) }.to raise_error(TypeAssertionError,
-        /expects a match for Enum\['constant', 'derived', 'given_or_derived'\], got 'derivd'/)
+        /expects a match for Enum\['constant', 'derived', 'given_or_derived', 'reference'\], got 'derivd'/)
     end
 
     it 'stores value in attribute' do

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -57,7 +57,8 @@ describe 'Puppet Ruby Generator' do
             zipcode => String,
             email => String,
             another => { type => Optional[MyModule::FirstGenerated], value => undef },
-            number => Integer
+            number => Integer,
+            aref => { type => Optional[MyModule::FirstGenerated], value => undef, kind => reference }
           }
         }]
       CODE
@@ -176,6 +177,14 @@ describe 'Puppet Ruby Generator' do
       context 'creates an instance' do
         it 'that the TypeCalculator infers to the Object type' do
           expect(TypeCalculator.infer(first.from_hash('name' => 'Bob Builder'))).to eq(first_type)
+        end
+
+        it "where attributes of kind 'reference' are not considered part of #_pall_contents" do
+          inst = first.from_hash('name' => 'Bob Builder')
+          wrinst = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23, 40, inst, inst)
+          results = []
+          wrinst._pall_contents([]) { |v| results << v }
+          expect(results).to eq([inst])
         end
       end
     end


### PR DESCRIPTION
This commit adds the 'reference' as a valid _kind_ on a Pcore
Object attribute. Attributes that are of this kind will not participate
when iterating over contained objects using the generated `#_pcontents`
or `#_pall_contents` methods.