### PR TITLE
(PUP-7235) Fix bug causing crash when using hiera.yaml glob pattern

### DIFF
--- a/lib/puppet/pops/lookup/location_resolver.rb
+++ b/lib/puppet/pops/lookup/location_resolver.rb
@@ -35,8 +35,8 @@ module Lookup
 
     def expand_globs(datadir, declared_globs, lookup_invocation)
       declared_globs.map do |declared_glob|
-        glob = interpolate(declared_glob, lookup_invocation, false)
-        Pathname.glob(datadir, glob).reject { |path| path.directory? }.map { |path| ResolvedLocation.new(glob, path, true) }
+        glob = datadir + interpolate(declared_glob, lookup_invocation, false)
+        Pathname.glob(glob).reject { |path| path.directory? }.map { |path| ResolvedLocation.new(glob.to_s, path, true) }
       end.flatten
     end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -50,7 +50,7 @@ describe "The lookup function" do
             hash_c:
               merge: hash
           YAML
-        }
+      }
     end
 
     let(:environment_files) do
@@ -675,6 +675,71 @@ describe "The lookup function" do
 
       it 'raises an error' do
         expect { lookup('a') }.to raise_error(Puppet::Error, /hiera configuration version 4 cannot be used in the global layer/)
+      end
+    end
+
+    context 'and an environment Hiera v5 configuration using globs' do
+      let(:env_hiera_yaml) do
+        <<-YAML.unindent
+        ---
+        version: 5
+        hierarchy:
+          - name: Globs
+            globs:
+              - "globs/*.yaml"
+              - "globs_%{domain}/*.yaml"
+        YAML
+      end
+
+      let(:env_data) do
+        {
+          'globs' => {
+            'a.yaml' => <<-YAML.unindent,
+              glob_a: value glob_a
+              YAML
+            'b.yaml' => <<-YAML.unindent
+              glob_b:
+                a: value glob_b.a
+                b: value glob_b.b
+            YAML
+          },
+          'globs_example.com' => {
+            'a.yaml' => <<-YAML.unindent,
+              glob_c: value glob_a
+              YAML
+            'b.yaml' => <<-YAML.unindent
+              glob_b:
+                c: value glob_b.c
+                d: value glob_b.d
+            YAML
+
+          }
+        }
+      end
+
+      let(:environment_files) do
+        {
+          env_name => {
+            'hiera.yaml' => env_hiera_yaml,
+            'data' => env_data
+          }
+        }
+      end
+
+      it 'finds environment data using globs' do
+        expect(lookup('glob_a')).to eql('value glob_a')
+        expect(warnings).to be_empty
+      end
+
+      it 'performs merges between interpolated and globbed paths' do
+        expect(lookup('glob_b', 'merge' => 'hash')).to eql(
+          {
+            'a' => 'value glob_b.a',
+            'b' => 'value glob_b.b',
+            'c' => 'value glob_b.c',
+            'd' => 'value glob_b.d'
+          })
+        expect(warnings).to be_empty
       end
     end
 


### PR DESCRIPTION
This commit repairs the broken glob/globs implementation that was
introduced in hiera.yaml, version 5. Apparently there were no tests for
it, which of course was an oversight that had consequences. Tests are
also added in this commit.