### PR TITLE
(PUP-7251) decompress gzip as binary

### DIFF
--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -20,7 +20,8 @@ module Puppet::Network::HTTP::Compression
     def uncompress_body(response)
       case response['content-encoding']
       when 'gzip'
-        return Zlib::GzipReader.new(StringIO.new(response.body)).read
+        # ZLib::GzipReader has an associated encoding, by default Encoding.default_external
+        return Zlib::GzipReader.new(StringIO.new(response.body), :encoding => Encoding::BINARY).read
       when 'deflate'
         return Zlib::Inflate.new.inflate(response.body)
       when nil, 'identity'


### PR DESCRIPTION
When puppet server recently correctly started sending gzip compressed content
(TK-429) we saw regressions in puppet's handling of UTF-8 characters in the
catalog, specificaly the test ticket_6448_file_with_utf8_source.rb. It turned
out that after decompression in Puppet::Network::Http::Compression, the catalog
had mangled UTF-8 bytes. This is because Zlib::GzipReader will decompress
content as whatever Encoding.default_external is. PSON (currently default
catalog content type) is BINARY encoded per specification
https://docs.puppet.com/puppet/latest/http_api/pson.html#differences-from-json.
Zlib::GzipReader will accept an encoding option just like an IO object, and
thus this commit updates the decompression to Encoding::BINARY.

This is confirmed by analyzing the body returned when puppet server's webserver
is run with decompression disabled. In this case we fall through to the final
statement in the compression determination, here: which simply returns
response.body. With compression disabled, the encoding of response.body is
binary.

Note that a more complete fix will actually specify the charset parameter of
the Content-Type header, i.e.:

Content-Type: text/json; charset=utf-8

That fix is tracked via PUP-7261.

Signed-off-by: Moses Mendoza <moses@puppet.com>