### PR TITLE
(maint) fix minor spec regex warning

### DIFF
--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -596,7 +596,7 @@ describe Puppet::Util::Execution do
 
         expect {
           subject.execute('fail command', :failonfail => true, :sensitive => true)
-        }.to raise_error(Puppet::ExecutionFailure, /Execution of '\[redacted]' returned 1/)
+        }.to raise_error(Puppet::ExecutionFailure, /Execution of '\[redacted\]' returned 1/)
       end
 
       it "should not raise an error if failonfail is false and the child failed" do


### PR DESCRIPTION
 - This removes a warning from rspec about an unescaped ] used in a
   regular expression:

warning: regular expression has ']' without escape: /Execution of '\[redacted]' returned 1/