### PR TITLE
(PUP-7204) Add support for mapped paths to hiera.yaml

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -901,6 +901,19 @@ class Puppet::Parser::Scope
     find_global_scope.without_ephemeral_scopes(&block)
   end
 
+  # Execute given block with a ephemeral scope containing the given variables
+  # @api private
+  def with_local_scope(scope_variables)
+    local = LocalScope.new(@ephemeral.last)
+    scope_variables.each_pair { |k, v| local[k] = v }
+    @ephemeral.push(local)
+    begin
+      yield(self)
+    ensure
+      @ephemeral.pop
+    end
+  end
+
   # Execute given block with all ephemeral popped from the ephemeral stack
   #
   # @api private

--- a/lib/puppet/pops/lookup/location_resolver.rb
+++ b/lib/puppet/pops/lookup/location_resolver.rb
@@ -67,6 +67,28 @@ module Lookup
         ResolvedLocation.new(declared_uri, uri, true)
       end
     end
+
+    def expand_mapped_paths(datadir, mapped_path_triplet, lookup_invocation)
+      # The scope interpolation method is used directly to avoid unnecessary parsing of the string that otherwise
+      # would need to be generated
+      mapped_vars = interpolate_method(:scope).call(mapped_path_triplet[0], lookup_invocation, 'mapped_path[0]')
+
+      # No paths here unless the scope lookup returned something
+      return EMPTY_ARRAY if mapped_vars.empty?
+
+      mapped_vars = [mapped_vars] if mapped_vars.is_a?(String)
+      var_key = mapped_path_triplet[1]
+      template = mapped_path_triplet[2]
+      scope = lookup_invocation.scope
+      lookup_invocation.with_local_memory_eluding(var_key) do
+        mapped_vars.map do |var|
+          # Need to use parent lookup invocation to avoid adding 'var' to the set of variables to track for changes. The
+          # variable that 'var' stems from is added above.
+          path = scope.with_local_scope(var_key => var) {  datadir + interpolate(template, lookup_invocation, false) }
+          ResolvedLocation.new(template, path, path.exist?)
+        end
+      end
+    end
   end
 end
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -805,6 +805,14 @@ describe "The lookup function" do
           expect(warnings).to be_empty
         end
 
+        it 'includes mapped path in explain output' do
+          explanation = explain('path_h', 'merge' => 'deep')
+          ['a', 'b', 'c'].each do |var|
+            expect(explanation).to match(/^\s+Path "#{env_dir}\/spec\/data\/paths\/#{var}\.yaml"\n\s+Original path: "paths\/%\{var\}\.yaml"/)
+          end
+          expect(warnings).to be_empty
+        end
+
         it 'performs merges between mapped paths and global path interpolated using same key' do
           expect(lookup('path_h', 'merge' => 'hash')).to eql(
             {
@@ -899,6 +907,14 @@ describe "The lookup function" do
           expect(warnings).to be_empty
         end
 
+        it 'includes mapped path in explain output' do
+          explanation = explain('path_h', 'merge' => 'deep')
+          ['x\.a', 'y\.b', 'z\.c'].each do |var|
+            expect(explanation).to match(/^\s+Path "#{env_dir}\/spec\/data\/paths\/#{var}\.yaml"\n\s+Original path: "paths\/%\{var\.0\}\.%\{var\.1\}\.yaml"/)
+          end
+          expect(warnings).to be_empty
+        end
+
         it 'performs merges between mapped paths' do
           expect(lookup('path_m', 'merge' => 'hash')).to eql(
             {
@@ -923,6 +939,11 @@ describe "The lookup function" do
                 YAML
             }
           }
+        end
+
+        it 'includes mapped path in explain output' do
+          expect(explain('path_s')).to match(/^\s+Path "#{env_dir}\/spec\/data\/paths\/s\.yaml"\n\s+Original path: "paths\/%\{var\}\.yaml"/)
+          expect(warnings).to be_empty
         end
 
         it 'finds environment data using mapped_paths' do


### PR DESCRIPTION
This commit adds support for a new hierarchy entry named `mapped_paths`.
It must be a three element array of strings where the first string
denotes a scope variable that should point to a collection of strings,
the second string is the variable name that will be mapped to each
element of the collection, and the third string is a template where that
variable can be used in interpolation expressions.

Paths are produced by iterating over the collection, mapping each entry
to the variable name in a local scope, and then resolve the template
using the local scope.