### PR TITLE
Revert "(PUP-7102) Fail with error on access problems with environment directory"

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -213,34 +213,9 @@ module Puppet::Environments
     end
 
     def valid_directory?(envdir)
-      return false unless Puppet::Node::Environment.valid_name?(Puppet::FileSystem.basename_string(envdir))
-
-      # Make an attempt to access the directory to determine if it's invalid
-      # due to permission problems or simply because it doesn't exist
-      begin
-        stat = Puppet::FileSystem.stat(envdir)
-        if stat && stat.directory?
-          raise Errno::EACCES, envdir.to_s unless stat.readable?
-          true
-        else
-          false
-        end
-      rescue Errno::ENOENT
-        false
-      rescue Errno::EACCES
-        # Report the directory where the actual access error occurs (traverse parents)
-        prev = envdir
-        current = Puppet::FileSystem.dir(prev)
-        while current
-          begin
-            break if Puppet::FileSystem.stat(current).readable?
-          rescue Errno::EACCES
-          end
-          prev = current
-          current = Puppet::FileSystem.dir(prev)
-        end
-        raise Errno::EACCES, prev.to_s
-      end
+      name = Puppet::FileSystem.basename_string(envdir)
+      Puppet::FileSystem.directory?(envdir) &&
+         Puppet::Node::Environment.valid_name?(name)
     end
 
     def valid_directories

--- a/lib/puppet/file_system/memory_file.rb
+++ b/lib/puppet/file_system/memory_file.rb
@@ -4,43 +4,29 @@ class Puppet::FileSystem::MemoryFile
   attr_reader :path, :children
 
   def self.a_missing_file(path)
-    new(path, :exist? => false, :executable? => false, :readable? => false)
+    new(path, :exist? => false, :executable? => false)
   end
 
   def self.a_regular_file_containing(path, content)
-    new(path, :exist? => true, :directory? => false, :executable? => false, :content => content, :readable? => true)
-  end
-
-  def self.an_unreadable_regular_file(path)
-    new(path, :exist? => true, :directory => false, :executable? => false, :readable? => false)
+    new(path, :exist? => true, :executable? => false, :content => content)
   end
 
   def self.an_executable(path)
-    new(path, :exist? => true, :directory => false, :executable? => true, :readable? => true)
+    new(path, :exist? => true, :executable? => true)
   end
 
   def self.a_directory(path, children = [])
     new(path,
-      :exist? => true,
-      :executable? => true,
-      :directory? => true,
-      :children => children,
-      :readable? => true)
-  end
-
-  def self.an_unreadable_directory(path, children = [])
-    new(path,
         :exist? => true,
-        :executable? => true,
+        :excutable? => true,
         :directory? => true,
-        :children => children,
-        :readable? => false)
+        :children => children)
   end
 
   def initialize(path, properties)
     @path = path
     @properties = properties
-    @children = (properties[:children] || []).map do |child|
+    @children = (properties[:children] || []).collect do |child|
       child.duplicate_as(File.join(@path, child.path))
     end
   end
@@ -48,7 +34,6 @@ class Puppet::FileSystem::MemoryFile
   def directory?; @properties[:directory?]; end
   def exist?; @properties[:exist?]; end
   def executable?; @properties[:executable?]; end
-  def readable?; @properties[:readable?]; end
 
   def each_line(&block)
     handle.each_line(&block)

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -19,10 +19,6 @@ class Puppet::FileSystem::MemoryImpl
     path.file?
   end
 
-  def readable?(path)
-    path.readable?
-  end
-
   def executable?(path)
     path.executable?
   end
@@ -37,11 +33,6 @@ class Puppet::FileSystem::MemoryImpl
 
   def pathname(path)
     find(path) || Puppet::FileSystem::MemoryFile.a_missing_file(path)
-  end
-
-  def dir(path)
-    dirname = File.dirname(path_string(path))
-    find(dirname) || Puppet::FileSystem::MemoryFile.a_directory(dirname, [path])
   end
 
   def basename(path)
@@ -68,36 +59,6 @@ class Puppet::FileSystem::MemoryImpl
     else
       return handle
     end
-  end
-
-  class MemoryStat
-    def initialize(path)
-      @path = path
-    end
-
-    def directory?
-      @path.directory?
-    end
-
-    def file?
-      @path.directory?
-    end
-
-    def executable?
-      @path.executable?
-    end
-
-    def readable?
-      @path.readable?
-    end
-
-    def writable?
-      @path.executable?
-    end
-  end
-
-  def stat(path)
-    MemoryStat.new(path)
   end
 
   def assert_path(path)

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -116,38 +116,6 @@ describe Puppet::Environments do
         ]
       end
 
-      context 'with access permission issues' do
-        let(:directory_tree) do
-          FS::MemoryFile.a_directory(File.expand_path('envdir'), [
-            FS::MemoryFile.a_directory('an_environment', [FS::MemoryFile.a_missing_file('environment.conf')]),
-            FS::MemoryFile.an_unreadable_directory('unreadable_environment', [])
-          ])
-        end
-
-        it 'raises error if a directory on the environment path is unreadable' do
-          loader_from(:filesystem => [directory_tree],
-            :directory => directory_tree) do |loader|
-            expect  { loader.list }.to raise_error(Errno::EACCES, /^Permission denied - .*\/envdir\/unreadable_environment$/)
-          end
-        end
-      end
-
-      context 'with access permission issues on parent' do
-        let(:directory_tree) do
-          FS::MemoryFile.an_unreadable_directory(File.expand_path('envdir'), [
-            FS::MemoryFile.an_unreadable_directory('an_environment', [FS::MemoryFile.a_missing_file('environment.conf')]),
-            FS::MemoryFile.an_unreadable_directory('unreadable_environment', [])
-          ])
-        end
-
-        it 'raises error if that reports the parent directory as the culprit' do
-          loader_from(:filesystem => [directory_tree],
-            :directory => directory_tree) do |loader|
-            expect  { loader.list }.to raise_error(Errno::EACCES, /^Permission denied - .*\/envdir$/)
-          end
-        end
-      end
-
       let(:content) do
         <<-EOF
 manifest=#{manifestdir}


### PR DESCRIPTION
Reverts puppetlabs/puppet#5650 which has the unintended side effect of causing puppetserver to fail to start.