### PR TITLE
(PUP-7240) Prevent invocation inheritance when lookup adapters differs

### DIFF
--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -237,7 +237,7 @@ class LookupAdapter < DataAdapter
     meta_invocation.lookup(LookupKey::LOOKUP_OPTIONS, lookup_invocation.module_name) do
       meta_invocation.with(:meta, LOOKUP_OPTIONS) do
         if meta_invocation.global_only?
-          global_lookup_options(meta_invocation, merge_strategy)
+          compile_patterns(global_lookup_options(meta_invocation, merge_strategy))
         else
           opts = env_lookup_options(meta_invocation, merge_strategy)
           catch(:no_such_key) do

--- a/spec/unit/pops/lookup/lookup_spec.rb
+++ b/spec/unit/pops/lookup/lookup_spec.rb
@@ -142,12 +142,30 @@ describe 'The lookup API' do
         {
           'hiera.yaml' => <<-YAML.unindent,
             version: 5
+            hierarchy:
+              - name: Common
+                path: common.yaml
+              - name: More
+                path: more.yaml
             YAML
           'data' => {
-            'common.yaml' => <<-YAML.unindent
+            'common.yaml' => <<-YAML.unindent,
               a: a (from other global)
               d: d (from other global)
+              mixed_adapter_hash:
+                a:
+                  ab: value a.ab (from other common global)
+                  ad: value a.ad (from other common global)
               mod::e: mod::e (from other global)
+              lookup_options:
+                mixed_adapter_hash:
+                  merge: deep
+              YAML
+            'more.yaml' => <<-YAML.unindent
+              mixed_adapter_hash:
+                a:
+                  aa: value a.aa (from other more global)
+                  ac: value a.ac (from other more global)
               YAML
           }
         }
@@ -189,6 +207,19 @@ describe 'The lookup API' do
       it 'does not find data in module layer' do
         expect(Lookup.lookup('mod::c', nil, 'not found', true, nil, other_invocation)).to eql('not found')
         expect(Lookup.lookup('mod::c', nil, 'not found', true, nil, invocation)).to eql('mod::c (from module)')
+      end
+
+      it 'resolves lookup options using the custom adapter' do
+        expect(Lookup.lookup('mixed_adapter_hash', nil, 'not found', true, nil, other_invocation)).to eql(
+          {
+            'a' => {
+              'aa' => 'value a.aa (from other more global)',
+              'ab' => 'value a.ab (from other common global)',
+              'ac' => 'value a.ac (from other more global)',
+              'ad' => 'value a.ad (from other common global)'
+            }
+          }
+        )
       end
     end
   end


### PR DESCRIPTION
The logic that controls how a lookup invocation is inherited did not
take into account that a completely different lookup instance could
execute a lookup in a nested fashion. This made a lookup for the special
`lookup_options` key fail for custom adapters.

This commit ensures that the inheritance of adapter class is assigned
to the class of the parent when no explicit class is given. It also
ensures that no inheritance takes place when the adapter classes differ.