### PR TITLE
(PUP-7285) Add metric_id http option to http report processor

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -62,9 +62,13 @@ module Puppet::Network::HTTP
     end
 
     # @!macro [new] common_options
-    #   @param options [Hash] options influencing the request made
+    #   @param options [Hash] options influencing the request made. Any
+    #   options not recognized by this class will be ignored - no error will
+    #   be thrown.
     #   @option options [Hash{Symbol => String}] :basic_auth The basic auth
-    #     :username and :password to use for the request
+    #     :username and :password to use for the request, :metric_id Ignored
+    #     by this class - used by Puppet Server only. The metric id by which
+    #     to track metrics on requests.
 
     # @param path [String]
     # @param headers [Hash{String => String}]

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -14,7 +14,11 @@ Puppet::Reports.register_report(:http) do
   def process
     url = URI.parse(Puppet[:reporturl])
     headers = { "Content-Type" => "application/x-yaml" }
-    options = {}
+    # This metric_id option is silently ignored by Puppet's http client
+    # (Puppet::Network::HTTP) but is used by Puppet Server's http client
+    # (Puppet::Server::HttpClient) to track metrics on the request made to the
+    # `reporturl` to store a report.
+    options = { :metric_id => [:puppet, :report, :http] }
     if url.user && url.password
       options[:basic_auth] = {
         :user => url.user,

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -39,6 +39,7 @@ describe processor do
   describe "when making a request" do
     let(:connection) { stub_everything "connection" }
     let(:httpok) { Net::HTTPOK.new('1.1', 200, '') }
+    let(:options) { {:metric_id => [:puppet, :report, :http]} }
 
     before :each do
       Puppet::Network::HttpPool.expects(:http_instance).returns(connection)
@@ -46,7 +47,7 @@ describe processor do
 
     it "should use the path specified by the 'reporturl' setting" do
       report_path = URI.parse(Puppet[:reporturl]).path
-      connection.expects(:post).with(report_path, anything, anything, {}).returns(httpok)
+      connection.expects(:post).with(report_path, anything, anything, options).returns(httpok)
 
       subject.process
     end
@@ -54,22 +55,24 @@ describe processor do
     it "should use the username and password specified by the 'reporturl' setting" do
       Puppet[:reporturl] = "https://user:pass@myhost.mydomain:1234/report/upload"
 
-      connection.expects(:post).with(anything, anything, anything, :basic_auth => {
-        :user => 'user',
-        :password => 'pass'
-      }).returns(httpok)
+      connection.expects(:post).with(anything, anything, anything,
+                                     {:metric_id => [:puppet, :report, :http],
+                                      :basic_auth => {
+                                        :user => 'user',
+                                        :password => 'pass'
+                                      }}).returns(httpok)
 
       subject.process
     end
 
     it "should give the body as the report as YAML" do
-      connection.expects(:post).with(anything, subject.to_yaml, anything, {}).returns(httpok)
+      connection.expects(:post).with(anything, subject.to_yaml, anything, options).returns(httpok)
 
       subject.process
     end
 
     it "should set content-type to 'application/x-yaml'" do
-      connection.expects(:post).with(anything, anything, has_entry("Content-Type" => "application/x-yaml"), {}).returns(httpok)
+      connection.expects(:post).with(anything, anything, has_entry("Content-Type" => "application/x-yaml"), options).returns(httpok)
 
       subject.process
     end


### PR DESCRIPTION
Add a `metric_id` http option to the http request made by the http report
processor to report urls. This will allow Puppet Server to track the amount of
time it spends making these requests. The value for this metric id is
`[:puppet :report :http]`.