### PR TITLE
PUP-7287) Ensure that explain is muted in check for stable config

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -170,14 +170,16 @@ class HieraConfig
 
   def scope_interpolations_stable?(lookup_invocation)
     scope = lookup_invocation.scope
-    @scope_interpolations.all? do |key, root_key, segments, old_value|
-      value = scope[root_key]
-      unless value.nil? || segments.empty?
-        found = '';
-        catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
-        value = found;
+    lookup_invocation.without_explain do
+      @scope_interpolations.all? do |key, root_key, segments, old_value|
+        value = scope[root_key]
+        unless value.nil? || segments.empty?
+          found = '';
+          catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
+          value = found;
+        end
+        old_value.eql?(value)
       end
-      old_value.eql?(value)
     end
   end
 

--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -122,6 +122,20 @@ class Invocation
     end
   end
 
+  def without_explain
+    if explainer.nil?
+      yield
+    else
+      save_explainer = @explainer
+      begin
+        @explainer = nil
+        yield
+      ensure
+        @explainer = save_explainer
+      end
+    end
+  end
+
   def only_explain_options?
     @explainer.nil? ? false : @explainer.only_explain_options?
   end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -338,6 +338,20 @@ describe "The lookup function" do
         expect(notices).to eql(['success'])
         expect(debugs.any? { |m| m =~ /Hiera configuration recreated due to change of scope variables used in interpolation expressions/ }).to be_truthy
       end
+
+      it 'does not include the lookups performed during stability check in explain output' do
+        Puppet[:log_level] = 'debug'
+        collect_notices("notice('success')") do |scope|
+          var = { 'sub' => '_d' }
+          scope['var'] = var
+          expect(lookup_func.call(scope, 'y')).to eql('value y from x_d')
+
+          # Second call triggers the check
+          expect(lookup_func.call(scope, 'y')).to eql('value y from x_d')
+        end
+        expect(notices).to eql(['success'])
+        expect(debugs.any? { |m| m =~ /Sub key: "sub"/ }).to be_falsey
+      end
     end
 
     context 'that uses reserved option' do


### PR DESCRIPTION
Some unwanted explain output was generated during the check for changes of variables used in interpolation expressions in the hiera config. This PR ensures that this output is muted.