### PR TITLE
(PUP-7289) Ensure that Hiera datadir gets interpolations resolved

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -518,6 +518,7 @@ class HieraConfigV5 < HieraConfig
       end
 
       entry_datadir = @config_root + (he[KEY_DATADIR] || datadir)
+      entry_datadir = Pathname(interpolate(entry_datadir.to_s, lookup_invocation, false))
       location_key = LOCATION_KEYS.find { |key| he.include?(key) }
       locations = case location_key
       when KEY_PATHS

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -166,6 +166,7 @@ describe "The lookup function" do
         scope = compiler.topscope
         scope['environment'] = env_name
         scope['domain'] = 'example.com'
+        scope['ipl_datadir'] = 'hieradata'
         scope['scope_scalar'] = 'scope scalar value'
         scope['scope_hash'] = { 'a' => 'scope hash a', 'b' => 'scope hash b' }
         if explain
@@ -1260,7 +1261,7 @@ describe "The lookup function" do
           ---
           version: 5
           defaults:
-            datadir: hieradata
+            datadir: "%{ipl_datadir}"
 
           hierarchy:
             - name: Yaml


### PR DESCRIPTION
Prior to this commit, the datadir in a Hiera version 5 config was not
subject to interpolation evaluation. This commit ensures that the
evaluation takes place.