### PR TITLE
(PUP-7286) Fix regression in Hiera version 3 merge behavior

### DIFF
--- a/lib/puppet/pops/lookup/lookup_key_function_provider.rb
+++ b/lib/puppet/pops/lookup/lookup_key_function_provider.rb
@@ -91,8 +91,9 @@ class V3BackendFunctionProvider < LookupKeyFunctionProvider
     @backend ||= instantiate_backend(lookup_invocation)
     config = parent_data_provider.config(lookup_invocation)
 
-    # Never pass hiera.yaml defined merge_behavior down to the backend. It will pick it up from the config
-    resolution_type = lookup_invocation.hiera_v3_merge_behavior? ? nil : convert_merge(merge)
+    # A merge_behavior retrieved from hiera.yaml must not be converted here. Instead, passing the symbol :hash
+    # tells the V3 backend to pick it up from the config.
+    resolution_type = lookup_invocation.hiera_v3_merge_behavior? ? :hash : convert_merge(merge)
     @backend.lookup(key, lookup_invocation.scope, lookup_invocation.hiera_v3_location_overrides, resolution_type, context = {:recurse_guard => nil})
   end
 


### PR DESCRIPTION
An oversight caused the a merge behavior specified in the hiera.yaml
file to be applied to all hiera_xxx functions. The hiera_hash is the
only function that should use that definition.

This commit ensures that no other functions are affected by the
merge_behavior or merge_options in hiera.yaml.