### PR TITLE
(packaging) Bump version to 4.9.4

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -7,7 +7,7 @@
 
 
 module Puppet
-  PUPPETVERSION = '4.9.3'
+  PUPPETVERSION = '4.9.4'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This updates Puppet's version to 4.9.4 in preparation for the 1.9.3
release of puppet-agent.