### PR TITLE
(PUP-7291) Enable APL explain output for log-level debug

### DIFF
--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -73,7 +73,9 @@ module Lookup
 
   # @api private
   def self.search_and_merge(name, lookup_invocation, merge)
-    lookup_invocation.lookup_adapter.lookup(name, lookup_invocation, merge)
+    answer = lookup_invocation.lookup_adapter.lookup(name, lookup_invocation, merge)
+    lookup_invocation.emit_debug_info("Automatic Parameter Lookup of '#{name}") if Puppet[:debug]
+    answer
   end
 
   def self.assert_type(subject, type, value)


### PR DESCRIPTION
Setting log-level to debug triggers full explainer output for calls
to lookup but not for automatic parameter lookups. This commit ensures
that the APLs are explained too.