### PR TITLE
(maint) manage hiera conf in lookup test

### DIFF
--- a/acceptance/tests/lookup/configuration_interpolation.rb
+++ b/acceptance/tests/lookup/configuration_interpolation.rb
@@ -7,12 +7,14 @@ test_name 'C99578: lookup should allow interpolation in configs and data' do
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
   master_confdir = master.puppet('master')['confdir']
 
-  step "backup hiera config file" do
-    on master, "cp #{master_confdir}/hiera.yaml #{master_confdir}/hiera.bak"
+  hiera_conf_backup = master.tmpfile('C99578-hiera-yaml')
+
+  step "backup global hiera.yaml" do
+    on(master, "cp -a #{master_confdir}/hiera.yaml #{hiera_conf_backup}", :acceptable_exit_codes => [0,1])
   end
 
   teardown do
-    on master, "mv #{master_confdir}/hiera.bak #{master_confdir}/hiera.yaml"
+    on(master, "mv #{hiera_conf_backup} #{master_confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
   end
 
   step "create hiera configs in #{tmp_environment} and global" do

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -11,10 +11,16 @@ test_name 'C99630: hiera v3 custom backend' do
   existing_loadpath = read_tk_config_string(on(master, "cat #{puppetserver_config}").stdout.strip)['jruby-puppet']['ruby-load-path'].first
   confdir = master.puppet('master')['confdir']
 
+  hiera_conf_backup = master.tmpfile('C99629-hiera-yaml')
+
+  step "backup global hiera.yaml" do
+    on(master, "cp -a #{confdir}/hiera.yaml #{hiera_conf_backup}", :acceptable_exit_codes => [0,1])
+  end
+
   teardown do
     step 'delete custom backend, restore default hiera config' do
-      on(master, "rm #{existing_loadpath}/hiera/backend/custom_backend.rb")
-      on(master, "mv /tmp/hiera.yaml #{confdir}/")
+      on(master, "rm #{existing_loadpath}/hiera/backend/custom_backend.rb", :acceptable_exit_codes => [0,1])
+      on(master, "mv #{hiera_conf_backup} #{confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
     end
   end
 

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -2,6 +2,11 @@ test_name 'C99044: lookup should allow rich data as values' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+  # The following two lines are required for the puppetserver service to
+  # start correctly. These should be removed when PUP-7102 is resolved.
+  confdir = master.puppet('master')['confdir']
+  on(master, "chown puppet:puppet #{confdir}/hiera.yaml")
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -8,13 +8,19 @@ test_name 'C99629: hiera v5 can use v3 config and data' do
   tmp_environment2 = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath2  = "#{environmentpath}/#{tmp_environment2}"
 
+  hiera_conf_backup = master.tmpfile('C99629-hiera-yaml')
+
   step "create hiera v3 global config and data" do
     confdir = master.puppet('master')['confdir']
     codedir = master.puppet('master')['codedir']
 
+    step "backup global hiera.yaml" do
+      on(master, "cp -a #{confdir}/hiera.yaml #{hiera_conf_backup}", :acceptable_exit_codes => [0,1])
+    end
+
     teardown do
-      step "remove global hiera.yaml" do
-        on(master, "rm #{confdir}/hiera.yaml")
+      step "restore global hiera.yaml" do
+        on(master, "mv #{hiera_conf_backup} #{confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
       end
     end
 

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -7,10 +7,15 @@ test_name 'C99572: v4 hieradata with v5 configs' do
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
 
   confdir = master.puppet('master')['confdir']
+  hiera_conf_backup = master.tmpfile('C99572-hiera-yaml')
+
+  step "backup global hiera.yaml" do
+    on(master, "cp -a #{confdir}/hiera.yaml #{hiera_conf_backup}", :acceptable_exit_codes => [0,1])
+  end
 
   teardown do
-    step "remove global hiera.yaml" do
-      on(master, "rm #{confdir}/hiera.yaml")
+    step "restore global hiera.yaml" do
+      on(master, "mv #{hiera_conf_backup} #{confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
     end
   end
 


### PR DESCRIPTION
This commit updates the v3_config_and_data test to ensure that it
manages the hiera.yaml config if it exists.