### PR TITLE
(PUP-7301) Avoid unnecessary type inference

### DIFF
--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -82,14 +82,8 @@ module DataProvider
   end
 
   def validate_data_value(data_provider, value, where = '')
+    # The DataProvider.value_type is self recursive so further recursive check of collections is needed here
     Types::TypeAsserter.assert_instance_of(nil, DataProvider.value_type, value) { "Value #{where}returned from #{data_provider.name}" }
-    case value
-    when Hash
-      value.each_pair { |k, v| validate_data_entry(data_provider, k, v) }
-    when Array
-      value.each {|v| validate_data_value(data_provider, v, 'in array ') }
-    end
-    value
   end
 
   def validate_data_entry(data_provider, key, value)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -677,17 +677,14 @@ end
 # @api public
 #
 class PScalarType < PAnyType
-  KNOWN_SCALARS = [String, Integer, Float, TrueClass, FalseClass, Regexp, Time::Timestamp, Time::Timespan, SemanticPuppet::Version, SemanticPuppet::VersionRange]
-  KNOWN_NON_SCALARS = [Array, Hash, PAnyType, NilClass]
-
   def self.register_ptype(loader, ir)
     create_ptype(loader, ir, 'AnyType')
   end
 
   def instance?(o, guard = nil)
-    if KNOWN_SCALARS.any? { |scalar_class| o.is_a?(scalar_class) }
+    if o.is_a?(String) || o.is_a?(Numeric) || o.is_a?(TrueClass) || o.is_a?(FalseClass) || o.is_a?(Regexp) || o.is_a?(SemanticPuppet::VersionRange)
       true
-    elsif KNOWN_NON_SCALARS.any? { |scalar_class| o.is_a?(scalar_class) }
+    elsif o.is_a?(Array) || o.is_a?(Hash) || o.is_a?(PAnyType) || o.is_a?(NilClass)
       false
     else
       assignable?(TypeCalculator.infer(o))


### PR DESCRIPTION
Since type inference might potentially be very expensive (an instance
can be a very large hash or array), it should only be used unless there
are no cheaper alternatives.

This commit aims to limit the number of type inferences that are
performed during normal execution by:

1. Removing the need for inferring argument types in a call. Instead,
   the callable checks if the argument array is an instance of the
   parameter tuple and if the block is an instance of the block type.
2. Adding some `#instance?` methods where it is relatively easy to
   compute the result without inferring the type.

The rake task `benchmark:hiera_include` shows a very drastic improvement
with this commit in place.