### PR TITLE
(PUP-7303) Ensure exemption of global vars from hiera stability check

### DIFF
--- a/benchmarks/hiera_conf_interpol/benchmarker.rb
+++ b/benchmarks/hiera_conf_interpol/benchmarker.rb
@@ -1,0 +1,72 @@
+require 'fileutils'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size > 100 ? size : 100
+  end
+
+  def setup
+    require 'puppet'
+    @config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', @config])
+    envs = Puppet.lookup(:environments)
+    @node = Puppet::Node.new('testing', :environment => envs.get('benchmarking'))
+  end
+
+  def run(args=nil)
+    @compiler = Puppet::Parser::Compiler.new(@node)
+    @compiler.compile do |catalog|
+      scope = @compiler.topscope
+      50.times { |index| scope["d#{index}"] = "dir_#{index}" }
+      @size.times do
+        100.times do |index|
+          invocation = Puppet::Pops::Lookup::Invocation.new(scope)
+          Puppet::Pops::Lookup.lookup('a', nil, nil, true, nil, invocation)
+        end
+      end
+      catalog
+    end
+  end
+
+  def generate
+    env_dir = File.join(@target, 'environments', 'benchmarking')
+    hiera_yaml = File.join(@target, 'hiera.yaml')
+    datadir = File.join(@target, 'data')
+
+    mkdir_p(env_dir)
+    File.open(hiera_yaml, 'w') do |f|
+      f.puts('version: 5')
+      f.puts('hierarchy:')
+      50.times do |index|
+        5.times do |repeat|
+          f.puts("  - name: Entry_#{index}_#{repeat}")
+          f.puts("    path: \"%{::d#{index}}/data_#{repeat}\"")
+        end
+      end
+    end
+
+    dir_0_dir = File.join(datadir, 'dir_0')
+    mkdir_p(dir_0_dir)
+
+    data_0_yaml = File.join(dir_0_dir, 'data_0.yaml')
+    File.open(data_0_yaml, 'w') do |f|
+      f.puts('a: value a')
+    end
+
+    templates = File.join('benchmarks', 'hiera_conf_interpol')
+
+    render(File.join(templates, 'puppet.conf.erb'),
+      File.join(@target, 'puppet.conf'),
+      :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/hiera_conf_interpol/description
+++ b/benchmarks/hiera_conf_interpol/description
@@ -1,0 +1,2 @@
+Benchmark scenario: Many lookups using a Hiera configuration with many interpolations
+Benchmark target: hiera lookup.

--- a/benchmarks/hiera_conf_interpol/puppet.conf.erb
+++ b/benchmarks/hiera_conf_interpol/puppet.conf.erb
@@ -1,0 +1,5 @@
+confdir = <%= location %>
+vardir = <%= location %>
+codedir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>
+environment_timeout = 0

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -303,7 +303,7 @@ describe "The lookup function" do
           hierarchy:
             - name: "Varying"
               data_hash: yaml_data
-              path: "x%{::var.sub}.yaml"
+              path: "x%{var.sub}.yaml"
           YAML
       end
 
@@ -331,11 +331,11 @@ describe "The lookup function" do
         Puppet[:log_level] = 'debug'
         collect_notices("notice('success')") do |scope|
           expect(lookup_func.call(scope, 'y')).to eql('value y from x')
-          var = { 'sub' => '_d' }
-          scope['var'] = var
+          scope['var'] = { 'sub' => '_d' }
           expect(lookup_func.call(scope, 'y')).to eql('value y from x_d')
-          var['sub'] = '_e'
-          expect(lookup_func.call(scope, 'y')).to eql('value y from x_e')
+          nested_scope = scope.compiler.new_scope
+          nested_scope['var'] = { 'sub' => '_e' }
+          expect(lookup_func.call(nested_scope, 'y')).to eql('value y from x_e')
         end
         expect(notices).to eql(['success'])
         expect(debugs.any? { |m| m =~ /Hiera configuration recreated due to change of scope variables used in interpolation expressions/ }).to be_truthy

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -333,7 +333,7 @@ describe "The lookup function" do
           expect(lookup_func.call(scope, 'y')).to eql('value y from x')
           scope['var'] = { 'sub' => '_d' }
           expect(lookup_func.call(scope, 'y')).to eql('value y from x_d')
-          nested_scope = scope.compiler.new_scope
+          nested_scope = scope.compiler.newscope(scope)
           nested_scope['var'] = { 'sub' => '_e' }
           expect(lookup_func.call(nested_scope, 'y')).to eql('value y from x_e')
         end


### PR DESCRIPTION
This commit changes the hiera configuration stability check so that it
no longer checks global variables once they have been set.