### PR TITLE
(PUP-7304) Defer validation of hiera data values until lookup

### DIFF
--- a/lib/puppet/pops/lookup/data_hash_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_hash_function_provider.rb
@@ -54,7 +54,7 @@ class DataHashFunctionProvider < FunctionProvider
       lookup_invocation.report_not_found(root_key)
       throw :no_such_key
     end
-    interpolate(value, lookup_invocation, true)
+    interpolate(parent_data_provider.validate_data_value(self, value), lookup_invocation, true)
   end
 
   def data_hash(lookup_invocation, location)

--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -70,26 +70,23 @@ module DataProvider
     raise NotImplementedError, "Subclass of #{DataProvider.name} must implement 'name' method"
   end
 
-  # Asserts that _data_hash_ is a valid hash.
+  # Asserts that _data_hash_ is a hash.
   #
   # @param data_provider [DataProvider] The data provider that produced the hash
   # @param data_hash [Hash{String=>Object}] The data hash
   # @return [Hash{String=>Object}] The data hash
   def validate_data_hash(data_provider, data_hash)
     Types::TypeAsserter.assert_instance_of(nil, Types::PHashType::DEFAULT, data_hash) { "Value returned from #{data_provider.name}" }
-    data_hash.each_pair { |k, v| validate_data_entry(data_provider, k, v) }
-    data_hash
   end
 
-  def validate_data_value(data_provider, value, where = '')
+  # Asserts that _data_value_ is of valid type.
+  #
+  # @param data_provider [DataProvider] The data provider that produced the hash
+  # @param data_value [Object] The data value
+  # @return [Object] The data value
+  def validate_data_value(data_provider, value)
     # The DataProvider.value_type is self recursive so further recursive check of collections is needed here
-    Types::TypeAsserter.assert_instance_of(nil, DataProvider.value_type, value) { "Value #{where}returned from #{data_provider.name}" }
-  end
-
-  def validate_data_entry(data_provider, key, value)
-    Types::TypeAsserter.assert_instance_of(nil, DataProvider.key_type, key) { "Key in hash returned from #{data_provider.name}" }
-    validate_data_value(data_provider, value, 'in hash ')
-    nil
+    Types::TypeAsserter.assert_instance_of(nil, DataProvider.value_type, value) { "Value returned from #{data_provider.name}" }
   end
 end
 end


### PR DESCRIPTION
Before this commit, the full hash returned by a `data_hash` function
would be validated. This is now changed so that each value is instead
validated when it is looked up.