### PR TITLE
(PUP-7305) Add file cache to Hiera

### DIFF
--- a/benchmarks/hiera_include_one/benchmarker.rb
+++ b/benchmarks/hiera_include_one/benchmarker.rb
@@ -1,0 +1,99 @@
+require 'fileutils'
+
+class Benchmarker
+  include FileUtils
+
+  def initialize(target, size)
+    @target = target
+    @size = size > 1000 ? size : 1000
+  end
+
+  def setup
+    require 'puppet'
+    @config = File.join(@target, 'puppet.conf')
+    Puppet.initialize_settings(['--config', @config])
+    envs = Puppet.lookup(:environments)
+    @node = Puppet::Node.new('testing', :environment => envs.get('benchmarking'))
+  end
+
+  def run(args=nil)
+    @size.times do
+      @compiler = Puppet::Parser::Compiler.new(@node)
+      @compiler.compile do |catalog|
+        scope = @compiler.topscope
+        scope['confdir'] = 'test'
+          hiera_func = @compiler.loaders.puppet_system_loader.load(:function, 'hiera_include')
+          hiera_func.call(scope, 'common_entry')
+        catalog
+      end
+    end
+  end
+
+  def generate
+    env_dir = File.join(@target, 'environments', 'benchmarking')
+    manifests_dir = File.join(env_dir, 'manifests')
+    dummy_class_manifest = File.join(manifests_dir, 'foo.pp')
+    hiera_yaml = File.join(@target, 'hiera.yaml')
+    datadir = File.join(@target, 'data')
+    localdir = File.dirname(File.realpath(__FILE__))
+    common_yaml = File.join(datadir, 'common.yaml')
+    groups_yaml = File.join(datadir, 'groups.yaml')
+
+    mkdir_p(env_dir)
+    mkdir_p(manifests_dir)
+    mkdir_p(datadir)
+
+    File.open(hiera_yaml, 'w') do |f|
+      f.puts(<<-YAML)
+---
+:backends: yaml
+:yaml:
+   :datadir: #{datadir}
+:hierarchy:
+   - common
+   - groups
+:logger: noop
+      YAML
+    end
+
+    File.open(groups_yaml, 'w') do |f|
+      f.puts(<<-YAML)
+---
+puppet:
+  staff:
+    groups:
+      YAML
+
+      0.upto(50).each do |i|
+        f.puts("      group#{i}:")
+        0.upto(125).each do |j|
+          f.puts("        - user#{j}")
+        end
+      end
+    end
+
+    File.open(dummy_class_manifest, 'w') do |f|
+      f.puts("class dummy_class { }")
+    end
+
+    File.open(common_yaml, 'w') do |f|
+      f.puts(<<-YAML)
+        common_entry:
+          - dummy_class
+      YAML
+    end
+
+    templates = File.dirname(File.realpath(__FILE__))
+
+    render(File.join(templates, 'puppet.conf.erb'),
+      File.join(@target, 'puppet.conf'),
+      :location => @target)
+  end
+
+  def render(erb_file, output_file, bindings)
+    site = ERB.new(File.read(erb_file))
+    File.open(output_file, 'w') do |fh|
+      fh.write(site.result(OpenStruct.new(bindings).instance_eval { binding }))
+    end
+  end
+end

--- a/benchmarks/hiera_include_one/description
+++ b/benchmarks/hiera_include_one/description
@@ -1,0 +1,2 @@
+Benchmark scenario: Large nested hierarchy dataset, many compilations, one lookup per compile
+Benchmark target: hiera include.

--- a/benchmarks/hiera_include_one/puppet.conf.erb
+++ b/benchmarks/hiera_include_one/puppet.conf.erb
@@ -1,0 +1,5 @@
+confdir = <%= location %>
+vardir = <%= location %>
+codedir = <%= location %>
+environmentpath = <%= File.join(location, 'environments') %>
+environment_timeout = 0

--- a/lib/puppet/functions/hocon_data.rb
+++ b/lib/puppet/functions/hocon_data.rb
@@ -15,10 +15,12 @@ Puppet::Functions.create_function(:hocon_data) do
 
   def hocon_data(options, context)
     path = options['path']
-    begin
-      Hocon.parse(Puppet::FileSystem.read(path, :encoding => 'utf-8'))
-    rescue Hocon::ConfigError => ex
-      raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+    context.cached_file_data(path) do |content|
+      begin
+        Hocon.parse(content)
+      rescue Hocon::ConfigError => ex
+        raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+      end
     end
   end
 end

--- a/lib/puppet/functions/json_data.rb
+++ b/lib/puppet/functions/json_data.rb
@@ -8,11 +8,13 @@ Puppet::Functions.create_function(:json_data) do
 
   def json_data(options, context)
     path = options['path']
-    begin
-      JSON.parse(Puppet::FileSystem.read(path, :encoding => 'utf-8'))
-    rescue JSON::ParserError => ex
-      # Filename not included in message, so we add it here.
-      raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+    context.cached_file_data(path) do |content|
+      begin
+        JSON.parse(content)
+      rescue JSON::ParserError => ex
+        # Filename not included in message, so we add it here.
+        raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+      end
     end
   end
 end

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -9,18 +9,21 @@ Puppet::Functions.create_function(:yaml_data) do
   end
 
   def yaml_data(options, context)
-    begin
-      path = options['path']
-      data = YAML.load_file(path)
-      unless data.is_a?(Hash)
-        Puppet.warning("#{path}: file does not contain a valid yaml hash")
-        data = {}
+    path = options['path']
+    context.cached_file_data(path) do |content|
+      begin
+        data = YAML.load(content, path)
+        if data.is_a?(Hash)
+          Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
+        else
+          Puppet.warning("#{path}: file does not contain a valid yaml hash")
+          {}
+        end
+      rescue YAML::SyntaxError => ex
+        # Psych errors includes the absolute path to the file, so no need to add that
+        # to the message
+        raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
       end
-      Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data.nil? ? {} : data)
-    rescue YAML::SyntaxError => ex
-      # Psych errors includes the absolute path to the file, so no need to add that
-      # to the message
-      raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
     end
   end
 end

--- a/lib/puppet/pops/lookup/configured_data_provider.rb
+++ b/lib/puppet/pops/lookup/configured_data_provider.rb
@@ -13,7 +13,7 @@ class ConfiguredDataProvider
   end
 
   def config(lookup_invocation)
-    @config ||= assert_config_version(HieraConfig.create(configuration_path(lookup_invocation)))
+    @config ||= assert_config_version(HieraConfig.create(lookup_invocation, configuration_path(lookup_invocation)))
   end
 
   # @return [Pathname] the path to the configuration

--- a/lib/puppet/pops/lookup/context.rb
+++ b/lib/puppet/pops/lookup/context.rb
@@ -2,19 +2,73 @@ require_relative 'interpolation'
 
 module Puppet::Pops
 module Lookup
+# The EnvironmentContext is adapted to the current environment
+#
+class EnvironmentContext < Adaptable::Adapter
+  class FileData
+    attr_reader :data
+
+    def initialize(path, inode, mtime, size, data)
+      @path = path
+      @inode = inode
+      @mtime = mtime
+      @size = size
+      @data = data
+    end
+
+    def valid?(stat)
+      stat.ino == @inode && stat.mtime == @mtime && stat.size == @size
+    end
+  end
+
+  attr_reader :environment_name
+
+  def self.create_adapter(environment)
+    new(environment)
+  end
+
+  def initialize(environment)
+    @environment_name = environment.name
+    @file_data_cache = {}
+  end
+
+  # Loads the contents of the file given by _path_. The content is then yielded to the provided block in
+  # case a block is given, and the returned value from that block is cached and returned by this method.
+  # If no block is given, the content is stored instead.
+  #
+  # The cache is retained as long as the inode, mtime, and size of the file remains unchanged.
+  #
+  # @param path [String] path to the file to be read
+  # @yieldparam content [String] the content that was read from the file
+  # @yieldreturn [Object] some result based on the content
+  # @return [Object] the content, or if a block was given, the return value of the block
+  #
+  def cached_file_data(path)
+    file_data = @file_data_cache[path]
+    stat = Puppet::FileSystem.stat(path)
+    unless file_data && file_data.valid?(stat)
+      Puppet.debug("File at '#{path}' was changed, reloading") if file_data
+      content = Puppet::FileSystem.read(path, :encoding => 'utf-8')
+      file_data = FileData.new(path, stat.ino, stat.mtime, stat.size, block_given? ? yield(content) : content)
+      @file_data_cache[path] = file_data
+    end
+    file_data.data
+  end
+end
+
 # A FunctionContext is created for each unique hierarchy entry and adapted to the Compiler (and hence shares
 # the compiler's life-cycle).
 # @api private
 class FunctionContext
   include Interpolation
 
-  attr_reader :environment_name, :module_name, :function
+  attr_reader :module_name, :function
   attr_accessor :data_hash
 
-  def initialize(environment_name, module_name, function)
+  def initialize(environment_context, module_name, function)
     @data_hash = nil
     @cache = {}
-    @environment_name = environment_name
+    @environment_context = environment_context
     @module_name = module_name
     @function = function
   end
@@ -51,6 +105,14 @@ class FunctionContext
       Types::Iterable.on(@cache)
     end
   end
+
+  def cached_file_data(path, &block)
+    @environment_context.cached_file_data(path, &block)
+  end
+
+  def environment_name
+    @environment_context.environment_name
+  end
 end
 
 # The Context is created once for each call to a function. It provides a combination of the {Invocation} object needed
@@ -73,10 +135,12 @@ class Context
     key_type = tf.optional(tf.scalar)
     @type = Pcore::create_object_type(loader, ir, self, 'Puppet::LookupContext', 'Any',
       {
-        'environment_name' => Types::PStringType::NON_EMPTY,
+        'environment_name' => {
+          Types::KEY_TYPE => Types::PStringType::NON_EMPTY,
+          Types::KEY_KIND => Types::PObjectType::ATTRIBUTE_KIND_DERIVED
+        },
         'module_name' => {
-          Types::KEY_TYPE => tf.optional(Types::PStringType::NON_EMPTY),
-          Types::KEY_VALUE => nil
+          Types::KEY_TYPE => tf.variant(Types::PStringType::NON_EMPTY, Types::PUndefType::DEFAULT)
         }
       },
       {
@@ -90,19 +154,19 @@ class Context
         'cached_entries' => tf.variant(
           tf.callable([0, 0, tf.callable(1,1)], tf.undef),
           tf.callable([0, 0, tf.callable(2,2)], tf.undef),
-          tf.callable([0, 0], tf.iterable(tf.tuple([key_type, tf.any])))
-        )
+          tf.callable([0, 0], tf.iterable(tf.tuple([key_type, tf.any])))),
+        'cached_file_data' => tf.callable(tf.string, tf.optional(tf.callable([1, 1])))
       }
     ).resolve(Types::TypeParser.singleton, loader)
   end
 
   # Mainly for test purposes. Makes it possible to create a {Context} in Puppet code provided that a current {Invocation} exists.
-  def self.from_asserted_args(environment_name, module_name)
-    new(FunctionContext.new(environment_name, module_name, nil), Invocation.current)
+  def self.from_asserted_args(module_name)
+    new(FunctionContext.new(EnvironmentContext.adapt(Puppet.lookup(:environments).get(Puppet[:environment])), module_name, nil), Invocation.current)
   end
 
   # Public methods delegated to the {FunctionContext}
-  def_delegators :@function_context, :cache, :cache_all, :cache_has_key, :cached_value, :cached_entries, :environment_name, :module_name
+  def_delegators :@function_context, :cache, :cache_all, :cache_has_key, :cached_value, :cached_entries, :environment_name, :module_name, :cached_file_data
 
   def initialize(function_context, lookup_invocation)
     @lookup_invocation = lookup_invocation

--- a/lib/puppet/pops/lookup/function_provider.rb
+++ b/lib/puppet/pops/lookup/function_provider.rb
@@ -21,9 +21,12 @@ class FunctionProvider
 
   # @return [FunctionContext] the function context associated with this provider
   def function_context(lookup_invocation, location)
+    @contexts[location] ||= create_function_context(lookup_invocation)
+  end
+
+  def create_function_context(lookup_invocation)
     scope = lookup_invocation.scope
-    compiler = scope.compiler
-    @contexts[location] ||= FunctionContext.new(compiler.environment.name, module_name, function(scope))
+    FunctionContext.new(EnvironmentContext.adapt(scope.compiler.environment), module_name, function(scope))
   end
 
   def module_name

--- a/spec/unit/pops/lookup/context_spec.rb
+++ b/spec/unit/pops/lookup/context_spec.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
+require 'puppet_spec/files'
 require 'puppet_spec/compiler'
 
 module Puppet::Pops
@@ -9,28 +10,28 @@ describe 'Puppet::Pops::Lookup::Context' do
   context 'an instance' do
     include PuppetSpec::Compiler
     it 'can be created' do
-      code = "notice(type(Puppet::LookupContext.new('e', 'm')))"
+      code = "notice(type(Puppet::LookupContext.new('m')))"
       expect(eval_and_collect_notices(code)[0]).to match(/Object\[\{name => 'Puppet::LookupContext'/)
     end
 
     it 'returns its environment_name' do
-      code = "notice(Puppet::LookupContext.new('e', 'm').environment_name)"
-      expect(eval_and_collect_notices(code)[0]).to eql('e')
+      code = "notice(Puppet::LookupContext.new('m').environment_name)"
+      expect(eval_and_collect_notices(code)[0]).to eql('production')
     end
 
     it 'returns its module_name' do
-      code = "notice(Puppet::LookupContext.new('e', 'm').module_name)"
+      code = "notice(Puppet::LookupContext.new('m').module_name)"
       expect(eval_and_collect_notices(code)[0]).to eql('m')
     end
 
     it 'can use an undef module_name' do
-      code = "notice(type(Puppet::LookupContext.new('e', undef).module_name))"
+      code = "notice(type(Puppet::LookupContext.new(undef).module_name))"
       expect(eval_and_collect_notices(code)[0]).to eql('Undef')
     end
 
     it 'can store and retrieve a value using the cache' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache('ze_key', 'ze_value')
         notice($ctx.cached_value('ze_key'))
       PUPPET
@@ -39,7 +40,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'the cache method returns the value that is cached' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         notice($ctx.cache('ze_key', 'ze_value'))
       PUPPET
       expect(eval_and_collect_notices(code)[0]).to eql('ze_value')
@@ -47,7 +48,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'can store and retrieve a hash using the cache' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
         $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
       PUPPET
@@ -56,7 +57,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'can use the cache to merge hashes' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
         $ctx.cache_all({ 'v3' => 'third', 'v4' => 'fourth' })
         $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
@@ -66,7 +67,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'can use the cache to merge hashes and individual entries' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
         $ctx.cache('v3', 'third')
         $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
@@ -76,7 +77,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'can iterate the cache using one argument block' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
         $ctx.cached_entries |$entry| { notice($entry[0]); notice($entry[1]) }
       PUPPET
@@ -85,7 +86,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'can replace individual cached entries' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
         $ctx.cache('v2', 'changed')
         $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
@@ -95,7 +96,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'can replace multiple cached entries' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second', 'v3' => 'third' })
         $ctx.cache_all({ 'v1' => 'one', 'v3' => 'three' })
         $ctx.cached_entries |$key, $value| { notice($key); notice($value) }
@@ -105,7 +106,7 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'cached_entries returns an Iterable when called without a block' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.cache_all({ 'v1' => 'first', 'v2' => 'second' })
         $iter = $ctx.cached_entries
         notice(type($iter, generalized))
@@ -116,10 +117,117 @@ describe 'Puppet::Pops::Lookup::Context' do
 
     it 'will throw :no_such_key when not_found is called' do
       code = <<-PUPPET.unindent
-        $ctx = Puppet::LookupContext.new('e', 'm')
+        $ctx = Puppet::LookupContext.new('m')
         $ctx.not_found
       PUPPET
       expect { eval_and_collect_notices(code) }.to throw_symbol(:no_such_key)
+    end
+
+    context 'with cached_file_data' do
+      include PuppetSpec::Files
+
+      let(:code_dir) { Puppet[:environmentpath] }
+      let(:env_name) { 'testing' }
+      let(:env_dir) { File.join(code_dir, env_name) }
+      let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, 'modules')]) }
+      let(:node) { Puppet::Node.new('test', :environment => env) }
+      let(:data_yaml) { 'data.yaml' }
+      let(:data_path) { File.join(populated_env_dir, 'data', data_yaml) }
+      let(:populated_env_dir) do
+        dir_contained_in(code_dir,
+          {
+            env_name => {
+              'data' => {
+                data_yaml => <<-YAML.unindent
+                  a: value a
+                  YAML
+              }
+            }
+          }
+        )
+        PuppetSpec::Files.record_tmp(File.join(env_dir))
+        env_dir
+      end
+
+      it 'can use cached_file_data without a block' do
+        code = <<-PUPPET.unindent
+          $ctx = Puppet::LookupContext.new(nil)
+          $yaml_data = $ctx.cached_file_data('#{data_path}')
+          notice($yaml_data)
+        PUPPET
+        expect(eval_and_collect_notices(code, node)).to eql(["a: value a\n"])
+      end
+
+      it 'can use cached_file_data with a block' do
+        code = <<-PUPPET.unindent
+          $ctx = Puppet::LookupContext.new(nil)
+          $yaml_data = $ctx.cached_file_data('#{data_path}') |$content| {
+            { 'parsed' => $content }
+          }
+          notice($yaml_data)
+        PUPPET
+        expect(eval_and_collect_notices(code, node)).to eql(["{parsed => a: value a\n}"])
+      end
+
+      context 'and multiple compilations' do
+
+        before(:each) { Puppet.settings[:environment_timeout] = 'unlimited' }
+        after(:each) do
+          Puppet.settings[:environment_timeout] = 0
+          Puppet.lookup(:environments).clear_all
+        end
+
+        it 'will reuse cached_file_data and not call block again' do
+
+          code1 = <<-PUPPET.unindent
+            $ctx = Puppet::LookupContext.new(nil)
+            $yaml_data = $ctx.cached_file_data('#{data_path}') |$content| {
+              { 'parsed' => $content }
+            }
+            notice($yaml_data)
+            PUPPET
+
+          code2 = <<-PUPPET.unindent
+            $ctx = Puppet::LookupContext.new(nil)
+            $yaml_data = $ctx.cached_file_data('#{data_path}') |$content| {
+              { 'parsed' => 'should not be called' }
+            }
+            notice($yaml_data)
+            PUPPET
+
+          logs = []
+          Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+            Puppet[:code] = code1
+            Puppet::Parser::Compiler.compile(node)
+            Puppet[:code] = code2
+            Puppet::Parser::Compiler.compile(node)
+          end
+          logs = logs.select { |log| log.level == :notice }.map { |log| log.message }
+          expect(logs.uniq.size).to eql(1)
+        end
+
+        it 'will invalidate cache if file changes' do
+          code = <<-PUPPET.unindent
+            $ctx = Puppet::LookupContext.new(nil)
+            $yaml_data = $ctx.cached_file_data('#{data_path}') |$content| {
+              { 'parsed' => $content }
+            }
+            notice($yaml_data)
+            PUPPET
+
+          logs = []
+          Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+            Puppet[:code] = code
+            Puppet::Parser::Compiler.compile(node)
+
+            # Change contents!
+            File.write(data_path, "b: value b\n")
+            Puppet::Parser::Compiler.compile(node)
+          end
+          logs = logs.select { |log| log.level == :notice }.map { |log| log.message }
+          expect(logs).to eql(["{parsed => a: value a\n}", "{parsed => b: value b\n}"])
+        end
+      end
     end
 
     context 'when used in an Invocation' do
@@ -144,7 +252,7 @@ describe 'Puppet::Pops::Lookup::Context' do
       it 'will not call explain unless explanations are active' do
         invocation.lookup('dummy', nil) do
           code = <<-PUPPET.unindent
-            $ctx = Puppet::LookupContext.new('e', 'm')
+            $ctx = Puppet::LookupContext.new('m')
             $ctx.explain || { notice('stop calling'); 'bad' }
           PUPPET
           expect(compile_and_get_notices(code)).to be_empty
@@ -154,7 +262,7 @@ describe 'Puppet::Pops::Lookup::Context' do
       it 'will call explain when explanations are active' do
         invocation_with_explain.lookup('dummy', nil) do
           code = <<-PUPPET.unindent
-            $ctx = Puppet::LookupContext.new('e', 'm')
+            $ctx = Puppet::LookupContext.new('m')
             $ctx.explain || { notice('called'); 'good' }
           PUPPET
           expect(compile_and_get_notices(code)).to eql(['called'])
@@ -165,7 +273,7 @@ describe 'Puppet::Pops::Lookup::Context' do
       it 'will call interpolate to resolve interpolation' do
         invocation.lookup('dummy', nil) do
           code = <<-PUPPET.unindent
-            $ctx = Puppet::LookupContext.new('e', 'm')
+            $ctx = Puppet::LookupContext.new('m')
             notice($ctx.interpolate('-- %{testing} --'))
           PUPPET
           expect(compile_and_get_notices(code, { 'testing' => 'called' })).to eql(['-- called --'])


### PR DESCRIPTION
This PR adds a file cache with environment life-cycle to the lookup context that is passed to all data provider functions. It also adds a new benchmark named `hiera_include_one` which recreates the compiler between each call to `hiera_include`. This benchmark should display a significant difference before and after the subsequent commits that adds the cache. The FileCache is enabled for the _hiera.yaml_ configuration and all bundled data provider functions (`yaml_data`, `json_data`, `hocon_data`, and `eyaml_lookup_key`).