### PR TITLE
(PUP-7312) Confine systemd provider to /lib/systemd/system

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -1,5 +1,7 @@
 # Manage systemd services using systemctl
 
+require 'puppet/file_system'
+
 Puppet::Type.type(:service).provide :systemd, :parent => :base do
   desc "Manages `systemd` services using `systemctl`.
 
@@ -9,14 +11,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "systemctl"
 
-  if Facter.value(:osfamily).downcase == 'debian'
-    # With multiple init systems on Debian, it is possible to have
-    # pieces of systemd around (e.g. systemctl) but not really be
-    # using systemd.  We do not do this on other platforms as it can
-    # cause issues when running in a chroot without /run mounted
-    # (PUP-5577)
-    confine :exists => "/run/systemd/system"
-  end
+  confine :true => Puppet::FileSystem.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd')
 
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8"]

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -15,6 +15,11 @@ describe test_title, unless: Puppet::Util::Platform.jruby? do
     expect(provider_class).to be_suitable
   end
 
+  it "should be considered suitable if /proc/1/exe is present and contains 'systemd'",
+    :if => File.exist?('/proc/1/exe') && File.open('/proc/1/exe').grep(/systemd/).size > 0
+    expect(provider_class).to be_suitable
+  end
+
   it "should not be cosidered suitable if systemctl is absent",
     :unless => (File.executable?('/bin/systemctl') or File.executable?('/usr/bin/systemctl')) do
     expect(provider_class).not_to be_suitable


### PR DESCRIPTION
/run/systemd/system does not exist when running Puppet in a chroot environment
/lib/systemd/system is always available irregardless of the environment and is therefore a safe alternative