### PR TITLE
(PUP-7313) Improve compiler initialization performance

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -863,36 +863,8 @@ class Puppet::Parser::Compiler
     settings_type.evaluate_code(settings_resource)
 
     scope = @topscope.class_scope(settings_type)
-
-    env = environment
-    settings_hash = {}
-    Puppet.settings.each do |name, setting|
-      next if name == :name
-      s_name = name.to_s
-      # Construct a hash (in anticipation it will be set in top scope under a name like $settings)
-      settings_hash[s_name] = transform_setting(env[name])
-      scope[s_name] = settings_hash[s_name]
-    end
+    scope.merge_settings(environment.name)
   end
-
-  def transform_setting(val)
-    case val
-    when Integer, Float, String, TrueClass, FalseClass, NilClass
-      val
-    when Symbol
-      val == :undef ? nil : val.to_s
-    when Array
-      val.map {|entry| transform_setting(entry) }
-    when Hash
-      result = {}
-      val.each {|k,v| result[transform_setting(k)] = transform_setting(v) }
-      result
-    else
-      # not ideal, but required as there are settings values that are special
-      val.to_s
-    end
-  end
-  private :transform_setting
 
   # Return an array of all of the unevaluated resources.  These will be definitions,
   # which need to get evaluated into native resources.

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -748,7 +748,7 @@ class Puppet::Parser::Scope
   # to be reassigned.
   #   It's preferred that you use self[]= instead of this; only use this
   # when you need to set options.
-  def setvar(name, value, options = {})
+  def setvar(name, value, options = EMPTY_HASH)
     if name =~ /^[0-9]+$/
       raise Puppet::ParseError.new("Cannot assign to a numeric match result variable '$#{name}'") # unless options[:ephemeral]
     end
@@ -845,12 +845,12 @@ class Puppet::Parser::Scope
   #
   # @param varname [String] The variable name to which the value is assigned. Must not contain `::`
   # @param value [String] The value to assign to the given variable name.
-  # @param options [Hash] Additional options, not part of api.
+  # @param options [Hash] Additional options, not part of api and no longer used.
   #
   # @api public
   #
-  def []=(varname, value, options = EMPTY_HASH)
-    setvar(varname, value, options)
+  def []=(varname, value, _ = nil)
+    setvar(varname, value)
   end
 
   def append_value(bound_value, new_value)

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -620,7 +620,7 @@ module Types
         if param_hash.include?(name)
           result << describe(value_type, TypeCalculator.singleton.infer_set(value), [ParameterPathElement.new(name)]) unless value_type.instance?(value)
         else
-          result << MissingParameter.new(nil, name) unless elem.key_type.assignable?(PUndefType::DEFAULT) unless missing_ok
+          result << MissingParameter.new(nil, name) unless missing_ok || elem.key_type.is_a?(POptionalType)
         end
       end
       result

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1066,8 +1066,12 @@ Generated on #{Time.now}.
     # cache so that we don't spread values from one env
     # to another.
     cached_env = @cache[environment || NONE]
+
+    # Avoid two lookups in cache_env unless val is nil. When it is, it's important
+    # to check if the key is included so that further processing (that will result
+    # in nil again) is avoided.
     val = cached_env[param]
-    return val if val || cached_env.include?(param)
+    return val if !val.nil? || cached_env.include?(param)
 
     # Short circuit to nil for undefined settings.
     return nil unless @config.include?(param)

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -44,6 +44,8 @@ class Puppet::Settings
   # The acceptable sections of the puppet.conf configuration file.
   ALLOWED_SECTION_NAMES = ['main', 'master', 'agent', 'user'].freeze
 
+  NONE = 'none'.freeze
+
   # This method is intended for puppet internal use only; it is a convenience method that
   # returns reasonable application default settings values for a given run_mode.
   def self.app_defaults_for_run_mode(run_mode)
@@ -384,12 +386,12 @@ class Puppet::Settings
     end
   end
 
-  def_delegator :@config, :each
+  def_delegators :@config, :each, :each_pair, :each_key
 
   # Iterate over each section name.
   def eachsection
     yielded = []
-    @config.each do |name, object|
+    @config.each_value do |object|
       section = object.section
       unless yielded.include? section
         yield section
@@ -549,7 +551,7 @@ class Puppet::Settings
     if @config[:environment]
       env = self.value(:environment).to_sym
     else
-      env = "none"
+      env = NONE
     end
 
     # Call any hooks we should be calling.
@@ -1046,26 +1048,33 @@ Generated on #{Time.now}.
   #
   # @raise [InterpolationError]
   def value(param, environment = nil, bypass_interpolation = false)
-    param = param.to_sym
     environment &&= environment.to_sym
+    value_sym(param.to_sym, environment, bypass_interpolation)
+  end
 
-    setting = @config[param]
-
-    # Short circuit to nil for undefined settings.
-    return nil if setting.nil?
-
+  # Find the correct value using symbols and our search path.
+  #
+  # @param param [Symbol] The value to look up
+  # @param environment [Symbol] The environment to check for the value
+  # @param bypass_interpolation [true, false] Whether to skip interpolation
+  #
+  # @return [Object] The looked up value
+  #
+  # @raise [InterpolationError]
+  def value_sym(param, environment = nil, bypass_interpolation = false)
     # Check the cache first.  It needs to be a per-environment
     # cache so that we don't spread values from one env
     # to another.
-    if @cache[environment||"none"].has_key?(param)
-      return @cache[environment||"none"][param]
-    elsif bypass_interpolation
-      val = values(environment, self.preferred_run_mode).lookup(param)
-    else
-      val = values(environment, self.preferred_run_mode).interpolate(param)
-    end
+    cached_env = @cache[environment || NONE]
+    val = cached_env[param]
+    return val if val || cached_env.include?(param)
 
-    @cache[environment||"none"][param] = val
+    # Short circuit to nil for undefined settings.
+    return nil unless @config.include?(param)
+
+    vals = values(environment, preferred_run_mode)
+    val = bypass_interpolation ? vals.lookup(param) : vals.interpolate(param)
+    cached_env[param] = val
     val
   end
 


### PR DESCRIPTION
This PR contains a series of commits that aim to improve the time it takes for the Puppet compiler to initialize. The main problem that it solves concerns initialization of the compiler scope from the Puppet settings. That slowness of that initialization gets worse as the number of settings increases.