### PR TITLE
(PUP-7306) Accept newline in literal regular expressions

### DIFF
--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -179,7 +179,7 @@ class Lexer2
   PATTERN_COMMENT   = %r{#.*\r?}
   PATTERN_MLCOMMENT = %r{/\*(.*?)\*/}m
 
-  PATTERN_REGEX     = %r{/[^/\n]*/}
+  PATTERN_REGEX     = %r{/[^/]*/}
   PATTERN_REGEX_END = %r{/}
   PATTERN_REGEX_A   = %r{\A/} # for replacement to ""
   PATTERN_REGEX_Z   = %r{/\Z} # for replacement to ""

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -412,6 +412,14 @@ describe 'Lexer2' do
     expect(tokens_scanned_from("1 / /./")).to match_tokens2(:NUMBER, :DIV, :REGEX)
   end
 
+  it "should accept newline in a regular expression" do
+    scanned = tokens_scanned_from("/\n.\n/")
+    # Note that strange formatting here is important
+    expect(scanned[0][1][:value]).to eql(/
+.
+/)
+  end
+
   context 'when lexer lexes heredoc' do
     it 'lexes tag, syntax and escapes, margin and right trim' do
       code = <<-CODE


### PR DESCRIPTION
Prior to this, puppet did not recognize newlines inside a regular
expression (the opening '/' and closing '/') would have to be on the
same line.
That is bad because the language specifications states that Puppet
Regexp is compatible with the implementation of Regexp used in Ruby
since 1.9.3 and it accepts newlines.

Without this fix, some regular expressions generated by for example URI
cannot be understood by puppet.

This fix removes the constraint that no newlines between the opening and
closing '/' are allowed.