### PR TITLE
(PUP-7122) Add wrapper for gettext:update_pot rake task

### DIFF
--- a/tasks/i18n.rake
+++ b/tasks/i18n.rake
@@ -17,4 +17,9 @@ namespace :gettext do
   task :generate_po, [:language] => :load_gettext_tasks do |t, args|
     Rake::Task["gettext:po"].invoke(args[:language])
   end
+
+  desc "Update POT file if strings have changed"
+  task :update_pot => :load_gettext_tasks do
+    Rake::Task["gettext:update_pot"].invoke
+  end
 end

--- a/tasks/i18n.rake
+++ b/tasks/i18n.rake
@@ -8,11 +8,6 @@ namespace :gettext do
     GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
   end
 
-  desc "Generate a new POT file"
-  task :generate_pot => :load_gettext_tasks do
-    Rake::Task["gettext:pot"].invoke
-  end
-
   desc "Generate a PO file for the given locale"
   task :generate_po, [:language] => :load_gettext_tasks do |t, args|
     Rake::Task["gettext:po"].invoke(args[:language])


### PR DESCRIPTION
This adds a wrapper rake task for a new update_pot task that has been
added to the gettext-setup gem. This task will cache the old POT file,
generate a new one, diff them, and only replace the old one if actual
string changes have occurred. This can be used to reduce churn from
changing dates and SHAs.

This is a cherry-pick from master: 23cdb61ac041d299f9bb1418b6b8131194470efe