### PR TITLE
(PUP-7310) Convert string interpolations to format strings in lib/puppet/face/help.rb

### DIFF
--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -78,11 +78,11 @@ Puppet::Face.define(:help, '0.0.1') do
   def render_application_help(applicationname)
     return Puppet::Application[applicationname].help
   rescue StandardError, LoadError => detail
-    msg = _(<<-MSG)
-Could not load help for the application #{applicationname}.
+    msg = _(<<-MSG) % { applicationname: applicationname, detail_msg: detail.message, }
+Could not load help for the application %{applicationname}.
 Please check the error logs for more information.
 
-Detail: "#{detail.message}"
+Detail: "%{detail_msg}"
 MSG
     fail ArgumentError, msg, detail.backtrace
   end
@@ -91,11 +91,11 @@ MSG
     face, action = load_face_help(facename, actionname, version)
     return template_for(face, action).result(binding)
   rescue StandardError, LoadError => detail
-    msg = _(<<-MSG)
-Could not load help for the face #{facename}.
+    msg = _(<<-MSG) % { facename: facename, detail_msg: detail.message, }
+Could not load help for the face %{facename}.
 Please check the error logs for more information.
 
-Detail: "#{detail.message}"
+Detail: "%{detail_msg}"
 MSG
     fail ArgumentError, msg, detail.backtrace
   end
@@ -105,7 +105,7 @@ MSG
     if actionname
       action = face.get_action(actionname.to_sym)
       if not action
-        fail ArgumentError, _("Unable to load action #{actionname} from #{face}")
+        fail ArgumentError, _("Unable to load action %{actionname} from %{face}") % { actionname: actionname, face: face, }
       end
     end
 


### PR DESCRIPTION
The gettext tooling does not work correctly with interpolated strings.
Any string marked for extraction into the POT file must therefore be
converted to use Ruby's string format syntax. This updates the extracted
strings in `lib/puppet/face/help.rb`, which was used as a proof of
concept for the gettext tooling.

This file was edited with the help of a [new script](https://github.com/Magisus/string-wrapper/blob/master/interpolation_extracter.rb) I wrote using the same Ruby AST rewriter I used to do the original extraction. It finds marked strings and performs the extraction, using a placeholder name for values that are not plain variables. I then went in and renamed the placeholder values to something more descriptive for the translator. This should in general avoid the need for extensive translator comments (and might actually improve clarity for the translators overall).