### PR TITLE
(PUP-7329) This change fixes a regex in describe.rb.

### DIFF
--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -11,7 +11,7 @@ class Formatter
     work = (opts[:scrub] ? scrub(txt) : txt)
     indent = (opts[:indent] ? opts[:indent] : 0)
     textLen = @width - indent
-    patt = Regexp.new("^(.{0,#{textLen}})[ \n]")
+    patt = Regexp.new("\\A(.{0,#{textLen}})[ \n]")
     prefix = " " * indent
 
     res = []

--- a/spec/unit/application/describe_spec.rb
+++ b/spec/unit/application/describe_spec.rb
@@ -76,4 +76,23 @@ describe Puppet::Application::Describe do
       @describe.run_command
     end
   end
+
+  it "should format text with long non-space runs without garbling" do
+    @f = Formatter.new(76)
+
+    @teststring = <<TESTSTRING
+. 12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 nick@magpie.puppetlabs.lan
+**this part should not repeat!**
+TESTSTRING
+
+    @expected_result = <<EXPECTED
+.
+1234567890123456789012345678901234567890123456789012345678901234567890123456
+7890123456789012345678901234567890 nick@magpie.puppetlabs.lan
+**this part should not repeat!**
+EXPECTED
+
+    result = @f.wrap(@teststring, {:indent => 0, :scrub => true})
+    expect(result).to eql(@expected_result)
+  end
 end


### PR DESCRIPTION
Before this fix a long line without spaces in a puppet type description
causes puppet describe to fail at formatting the description.  This is a
side effect of anchoring the match expression to ^, beginning of string,
when it should be anchored with \A, beginning of line.

For example, with this type, (described by modules/mytype_module/lib/puppet/type/mytype.rb):

    Puppet::Type.newtype(:mytype) do
      @doc = ". 12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 nick@magpie.puppetlabs.lan
    **this part should not repeat!**
    "
      newparam(:name) do
        isnamevar
        desc " name parameter for mytype"
      end
    end
would give this result before the fix:

    [root@syqs5cacqx016cd type]# puppet describe mytype

    mytype
    ======
    .
    **this part should not
    **this part should not
    7890123456789012345678901234567890123456789012345678901234567890
    nick@magpie.puppetlabs.lan
    **this part should not repeat!**

    Parameters
    ----------

    - **name**
        name parameter for mytype
    [root@syqs5cacqx016cd type]#

    After the fix, the result is this :

    [root@syqs5cacqx016cd type]# puppet describe mytype

    mytype
    ======
    .
    1234567890123456789012345678901234567890123456789012345678901234567890123456
    7890123456789012345678901234567890 nick@magpie.puppetlabs.lan
    **this part should not repeat!**

    Parameters
    ----------

    - **name**
        name parameter for mytype
    [root@syqs5cacqx016cd type]#