### PR TITLE
(PUP-6405) Use `pip freeze --all`

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -44,7 +44,8 @@ Puppet::Type.type(:package).provide :pip,
 
     # Pip can also upgrade pip, but it's not listed in freeze so need to special case it
     # Pip list would also show pip installed version, but "pip list" doesn't exist for older versions of pip (E.G v1.0)
-    if version = self.pip_version
+    # Not needed when "pip freeze --all" is available
+    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') == -1 && version = self.pip_version
       packages << new({:ensure => version, :name => File.basename(pip_cmd), :provider => name})
     end
 

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -31,7 +31,11 @@ Puppet::Type.type(:package).provide :pip,
     packages = []
     pip_cmd = self.pip_cmd
     return [] unless pip_cmd
-    execpipe "#{pip_cmd} freeze" do |process|
+    command = [pip_cmd, 'freeze']
+    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') >= 0 # a >= b
+      command << '--all'
+    end
+    execpipe command do |process|
       process.collect do |line|
         next unless options = parse(line)
         packages << new(options)

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -65,8 +65,23 @@ describe provider_class do
           provider_class.expects(:which).with(pip_cmd).returns("/fake/bin/#{pip_cmd}")
           p = stub("process")
           p.expects(:collect).yields("real_package==1.2.5")
-          provider_class.expects(:execpipe).with("/fake/bin/#{pip_cmd} freeze").yields(p)
+          provider_class.expects(:execpipe).with(["/fake/bin/#{pip_cmd}", "freeze"]).yields(p)
           provider_class.instances
+        end
+      end
+
+      context "with pip version >= 8.1.0" do
+        versions = ['8.1.0', '9.0.1']
+        versions.each do |version|
+          it "should use the --all option when version is '#{version}'" do
+            Puppet.features.stubs(:microsoft_windows?).returns (osfamily == 'windows')
+            provider_class.stubs(:pip_cmd).returns('/fake/bin/pip')
+            provider_class.stubs(:pip_version).returns(version)
+            p = stub("process")
+            p.expects(:collect).yields("real_package==1.2.5")
+            provider_class.expects(:execpipe).with(["/fake/bin/pip", "freeze", "--all"]).yields(p)
+            provider_class.instances
+          end
         end
       end
 


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/PUP-6405

This pull request adds management of the "core" pip packages. The current special case only handles the pip package while this pull request will take care of all the others.

I would feel better if I receive confirmations about a few topics:

1. Someone double check the unit tests: I am not experienced in Ruby.
1. Make sure version 8.1.0 of pip is really the one that implemented the `freeze --all` option: the jira issue explains more why I am confused about this.
