### PR TITLE
Backport relevant master branch code to 4.10.x

### DIFF
--- a/acceptance/lib/puppet/acceptance/classifier_utils.rb
+++ b/acceptance/lib/puppet/acceptance/classifier_utils.rb
@@ -170,7 +170,8 @@ module Puppet
           Puppet::Acceptance::ClassifierUtils.tmpdirs << cert_dir
 
           @ca_cert_file = File.join(cert_dir, "cacert.pem")
-          File.open(@ca_cert_file, "w") do |f|
+          # RFC 1421 states PEM is 7-bit ASCII https://tools.ietf.org/html/rfc1421
+          File.open(@ca_cert_file, "w:ASCII") do |f|
             f.write(ca_cert)
           end
         end

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -55,6 +55,36 @@ end
 agents.each do |agent|
 
   ## Setup
+  step "Verify a non-existent service is considered stopped and disabled" do
+    on(agent, puppet_resource('service', 'sloth_daemon'), :catch_failures => true, :catch_changes => true) do |result|
+      assert_match(/ensure[[:space:]]+=>[[:space:]]+'stopped'/, result.stdout, "non-existent service service should be stopped, but received #{result.stdout}")
+      assert_match(/enable[[:space:]]+=>[[:space:]]+'false'/, result.stdout, "non-existent service should be disabled, but received #{result.stdout}")
+    end
+  end
+
+  step "Verify stopping and disabling a non-existent service is a no-op" do
+    manifest = <<-PP
+      service { 'sloth_daemon' : ensure => stopped, enable => false }
+    PP
+    apply_manifest_on(agent, manifest, :catch_changes => true)
+  end
+  
+  step "Verify starting a non-existent service prints an error message but does not fail the run without detailed exit codes" do
+    manifest = <<-PP
+      service { 'sloth_daemon' : ensure => running }
+    PP
+    apply_manifest_on(agent, manifest) do |result|
+      assert_match(/Error:.*The sloth_daemon Subsystem is not on file/, result.stderr, "non-existent service should error when started, but received #{result.stderr}")
+    end
+  end
+
+  step "Verify starting a non-existent service with detailed exit codes correctly returns an error code" do
+    manifest = <<-PP
+      service { 'sloth_daemon' : ensure => running }
+    PP
+    apply_manifest_on(agent, manifest, :acceptable_exit_codes => [4])
+  end
+
   step "Setup on #{agent}"
   sloth_daemon_path = agent.tmpfile("sloth_daemon.sh")
   create_remote_file(agent, sloth_daemon_path, sloth_daemon_script)

--- a/lib/puppet/indirector/key/file.rb
+++ b/lib/puppet/indirector/key/file.rb
@@ -39,7 +39,8 @@ class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
     super
 
     begin
-      Puppet.settings.setting(:publickeydir).open_file(public_key_path(request.key), 'w') do |f|
+      # RFC 1421 states PEM is 7-bit ASCII https://tools.ietf.org/html/rfc1421
+      Puppet.settings.setting(:publickeydir).open_file(public_key_path(request.key), 'w:ASCII') do |f|
         f.print request.instance.content.public_key.to_pem
       end
     rescue => detail

--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -138,7 +138,7 @@ class Puppet::Interface
   attr_reader :name
 
   # The version of the face
-  # @return [SemVer]
+  # @return [SemanticPuppet::Version]
   attr_reader :version
 
   # The autoloader instance for the face
@@ -154,10 +154,7 @@ class Puppet::Interface
     end
 
     @name    = Puppet::Interface::FaceCollection.underscorize(name)
-
-    # SemVer is deprecated but in 4.x we must use it here (the attr_reader is public api). The
-    # extra boolean argument suppresses the deprecation warning.
-    @version = SemVer.new(version, true)
+    @version = SemanticPuppet::Version.parse(version)
 
     # The few bits of documentation we actually demand.  The default license
     # is a favour to our end users; if you happen to get that in a core face

--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -41,8 +41,13 @@ module Puppet::Interface::FaceCollection
     return @faces[name][:current] if pattern == :current
 
     versions = @faces[name].keys - [ :current ]
-    found    = SemVer.find_matching(pattern, versions)
+    range = pattern.is_a?(SemanticPuppet::Version) ? SemanticPuppet::VersionRange.new(pattern, pattern) : SemanticPuppet::VersionRange.parse(pattern)
+    found = find_matching(range, versions)
     return @faces[name][found]
+  end
+
+  def self.find_matching(range, versions)
+    versions.select { |v| range === v }.sort.last
   end
 
   # try to load the face, and return it.

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -65,8 +65,7 @@ class Puppet::Module
     @environment = environment
 
     assert_validity
-
-    load_metadata if has_metadata?
+    load_metadata
 
     @absolute_path_to_manifests = Puppet::FileSystem::PathPattern.absolute(manifests)
   end
@@ -86,24 +85,12 @@ class Puppet::Module
   end
 
   def has_metadata?
-    return false unless metadata_file
-
-    return false unless Puppet::FileSystem.exist?(metadata_file)
-
     begin
-      metadata =  JSON.parse(File.read(metadata_file, :encoding => 'utf-8'))
-    rescue JSON::JSONError => e
-      msg = "#{name} has an invalid and unparsable metadata.json file. The parse error: #{e.message}"
-      case Puppet[:strict]
-      when :off, :warning
-        Puppet.warning(msg)
-      when :error
-        raise FaultyMetadata, msg
-      end
-      return false
+      load_metadata
+      @metadata.is_a?(Hash) && !@metadata.empty?
+    rescue Puppet::Module::MissingMetadata
+      false
     end
-
-    return metadata.is_a?(Hash) && !metadata.keys.empty?
   end
 
   FILETYPES.each do |type, location|
@@ -151,14 +138,33 @@ class Puppet::Module
     @license_file = File.join(path, "License")
   end
 
+  def read_metadata
+    md_file = metadata_file
+    md_file.nil? ? {} : JSON.parse(File.read(md_file, :encoding => 'utf-8'))
+  rescue Errno::ENOENT
+    {}
+  rescue JSON::JSONError => e
+    msg = "#{name} has an invalid and unparsable metadata.json file. The parse error: #{e.message}"
+    case Puppet[:strict]
+    when :off, :warning
+      Puppet.warning(msg)
+    when :error
+      raise FaultyMetadata, msg
+    end
+    {}
+  end
+
   def load_metadata
-    @metadata = data = JSON.parse(File.read(metadata_file, :encoding => 'utf-8'))
+    return if instance_variable_defined?(:@metadata)
+
+    @metadata = data = read_metadata
+    return if data.empty?
+
     @forge_name = data['name'].gsub('-', '/') if data['name']
 
     [:source, :author, :version, :license, :dependencies].each do |attr|
-      unless value = data[attr.to_s]
-        raise MissingMetadata, "No #{attr} module metadata provided for #{self.name}"
-      end
+      value = data[attr.to_s]
+      raise MissingMetadata, "No #{attr} module metadata provided for #{self.name}" if value.nil?
 
       if attr == :dependencies
         unless value.is_a?(Array)

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -320,9 +320,8 @@ class Puppet::Module
 
       if version_string
         begin
-          # Suppress deprecation warnings from SemVer in 4.9. In 5.0, this will be SemanticPuppet instead
-          required_version_semver_range = SemVer[version_string, true]
-          actual_version_semver = SemVer.new(dep_mod.version, true)
+          required_version_semver_range = SemanticPuppet::VersionRange.parse(version_string)
+          actual_version_semver = SemanticPuppet::Version.parse(dep_mod.version)
         rescue ArgumentError
           error_details[:reason] = :non_semantic_version
           unmet_dependencies << error_details

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -75,7 +75,7 @@ module Puppet::ModuleTool
           raise ArgumentError, "Could not parse filename to obtain the username, module name and version.  (#{@release_name})"
         end
 
-        unless SemVer.valid?(version)
+        unless SemanticPuppet::Version.valid?(version)
           raise ArgumentError, "Invalid version format: #{version} (Semantic Versions are acceptable: http://semver.org)"
         end
 

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -258,7 +258,7 @@ module Puppet::ModuleTool
           @remote = { "#{@module_name}@#{@version}" => { } }
           @versions = {
             @module_name => [
-              { :vstring => @version, :semver => SemVer.new(@version) }
+              { :vstring => @version, :semver => SemanticPuppet::Version.parse(@version) }
             ]
           }
         else

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -57,7 +57,7 @@ module Puppet::ModuleTool
               :path    => mod.modulepath,
             }
             if @options[:version] && mod.version
-              next unless SemVer[@options[:version]].include?(SemVer.new(mod.version))
+              next unless SemanticPuppet::VersionRange.parse(@options[:version]).include?(SemanticPuppet::Version.parse(mod.version))
             end
             @installed << mod
           elsif mod_name =~ /#{@name}/

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -188,7 +188,7 @@ module Puppet::ModuleTool
 
     # Validates that the version string can be parsed as per SemVer.
     def validate_version(version)
-      return if SemVer.valid?(version)
+      return if SemanticPuppet::Version.valid?(version)
 
       err = "version string cannot be parsed as a valid Semantic Version"
       raise ArgumentError, "Invalid 'version' field in metadata.json: #{err}"

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -36,7 +36,7 @@ module Puppet::ModuleTool::Shared
       mod_name, releases = pair
       mod_name = mod_name.gsub('/', '-')
       releases.each do |rel|
-        semver = SemVer.new(rel['version'] || '0.0.0') rescue SemVer::MIN
+        semver = SemanticPuppet::Version.parse(rel['version']) rescue SemanticPuppet::Version::MIN
         @versions[mod_name] << { :vstring => rel['version'], :semver => semver }
         @versions[mod_name].sort! { |a, b| a[:semver] <=> b[:semver] }
         @urls["#{mod_name}@#{rel['version']}"] = rel['file']
@@ -76,10 +76,10 @@ module Puppet::ModuleTool::Shared
       }
 
       if forced?
-        range = SemVer[@version] rescue SemVer['>= 0.0.0']
+        range = SemanticPuppet::VersionRange.parse(@version) rescue SemanticPuppet::VersionRange.parse('>= 0.0.0')
       else
         range = (@conditions[mod]).map do |r|
-          SemVer[r[:dependency]] rescue SemVer['>= 0.0.0']
+          SemanticPuppet::VersionRange.parse(r[:dependency]) rescue SemanticPuppet::VersionRange.parse('>= 0.0.0')
         end.inject(&:&)
       end
 
@@ -97,7 +97,7 @@ module Puppet::ModuleTool::Shared
       end
 
       if !(forced? || @installed[mod].empty? || source.last[:name] == :you)
-        next if range === SemVer.new(@installed[mod].first.version)
+        next if range === SemanticPuppet::Version.parse(@installed[mod].first.version)
         action = :upgrade
       elsif @installed[mod].empty?
         action = :install

--- a/lib/puppet/pops/issue_reporter.rb
+++ b/lib/puppet/pops/issue_reporter.rb
@@ -69,7 +69,7 @@ class IssueReporter
         break if emitted >= max_errors
       end
       warnings_message = (emit_warnings && warnings.size > 0) ? ", and #{warnings.size} warnings" : ""
-      giving_up_message = "Found #{errors.size} errors#{warnings_message}. Giving up"
+      giving_up_message = "Language validation logged #{errors.size} errors#{warnings_message}. Giving up"
       exception = emit_exception.new(giving_up_message)
       exception.file = errors[0].file
       raise exception

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -263,11 +263,11 @@ class RubyGenerator < TypeFormatter
       bld << "  end\n"
 
       bld << "\n  def eql?(o)\n"
-      bld << "    super.eql?(o) &&\n" unless obj.parent.nil?
+      bld << "    super &&\n" unless obj.parent.nil?
       bld << "    self.class.eql?(o.class) &&\n" if include_class
       eq_names.each { |eqn| bld << '    @' << eqn << '.eql?(o.' <<  eqn << ") &&\n" }
       bld.chomp!(" &&\n")
-      bld << "\n  end\n"
+      bld << "\n  end\n  alias == eql?\n"
     end
   end
 end

--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -8,6 +8,7 @@ class Puppet::Provider::Exec < Puppet::Provider
     output = nil
     status = nil
     dir = nil
+    sensitive = resource.parameters[:command].sensitive
 
     checkexe(command)
 
@@ -23,7 +24,7 @@ class Puppet::Provider::Exec < Puppet::Provider
 
     dir ||= Dir.pwd
 
-    debug "Executing#{check ? " check": ""} '#{command}'"
+    debug "Executing#{check ? " check": ""} '#{sensitive ? '[redacted]' : command}'"
     begin
       # Do our chdir
       Dir.chdir(dir) do
@@ -59,7 +60,8 @@ class Puppet::Provider::Exec < Puppet::Provider
           output = Puppet::Util::Execution.execute(command, :failonfail => false, :combine => true,
                                   :uid => resource[:user], :gid => resource[:group],
                                   :override_locale => false,
-                                  :custom_environment => environment)
+                                  :custom_environment => environment,
+                                  :sensitive => sensitive)
         end
         # The shell returns 127 if the command is missing.
         if output.exitstatus == 127

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -138,7 +138,6 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
       Puppet.debug("Service #{@resource[:name]} is #{args[-1]}")
       return state
     end
-    self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
     self.debug(detail.message)
     return :stopped

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -91,56 +91,56 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
   end
 
   def restart
-      execute([command(:lssrc), "-Ss", @resource[:name]]).each_line do |line|
-        args = line.split(":")
+    execute([command(:lssrc), "-Ss", @resource[:name]]).each_line do |line|
+      args = line.split(":")
 
-        next unless args[0] == @resource[:name]
+      next unless args[0] == @resource[:name]
 
-        # Subsystems with the -K flag can get refreshed (HUPed)
-        # While subsystems with -S (signals) must be stopped/started
-        method = args[11]
-        do_refresh = case method
-          when "-K" then :true
-          when "-S" then :false
-          else self.fail("Unknown service communication method #{method}")
-        end
-
-        begin
-          if do_refresh == :true
-            execute([command(:refresh), "-s", @resource[:name]])
-          else
-            self.stop
-            self.start
-          end
-          return :true
-        rescue Puppet::ExecutionFailure => detail
-          raise Puppet::Error.new("Unable to restart service #{@resource[:name]}, error was: #{detail}", detail )
-        end
+      # Subsystems with the -K flag can get refreshed (HUPed)
+      # While subsystems with -S (signals) must be stopped/started
+      method = args[11]
+      do_refresh = case method
+        when "-K" then :true
+        when "-S" then :false
+        else self.fail("Unknown service communication method #{method}")
       end
-      self.fail("No such service found")
+
+      begin
+        if do_refresh == :true
+          execute([command(:refresh), "-s", @resource[:name]])
+        else
+          self.stop
+          self.start
+        end
+        return :true
+      rescue Puppet::ExecutionFailure => detail
+        raise Puppet::Error.new("Unable to restart service #{@resource[:name]}, error was: #{detail}", detail )
+      end
+    end
+    self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
+    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   def status
-      execute([command(:lssrc), "-s", @resource[:name]]).each_line do |line|
-        args = line.split
+    execute([command(:lssrc), "-s", @resource[:name]]).each_line do |line|
+      args = line.split
 
-        # This is the header line
-        next unless args[0] == @resource[:name]
+      # This is the header line
+      next unless args[0] == @resource[:name]
 
-        # PID is the 3rd field, but inoperative subsystems
-        # skip this so split doesn't work right
-        state = case args[-1]
-          when "active" then :running
-          when "inoperative" then :stopped
-        end
-        Puppet.debug("Service #{@resource[:name]} is #{args[-1]}")
-        return state
+      # PID is the 3rd field, but inoperative subsystems
+      # skip this so split doesn't work right
+      state = case args[-1]
+        when "active" then :running
+        when "inoperative" then :stopped
       end
-      self.fail("No such service found")
+      Puppet.debug("Service #{@resource[:name]} is #{args[-1]}")
+      return state
+    end
+    self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
+    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
 end

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -140,7 +140,8 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
     end
     self.fail("No such service found")
   rescue Puppet::ExecutionFailure => detail
-    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
+    self.debug(detail.message)
+    return :stopped
   end
 
 end

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
-  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "9"]
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
-  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "9"]
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -216,7 +216,9 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
 
   def open_security_passwd
     # helper method for tests
-    File.open("/etc/security/passwd", 'r')
+    # AIX reference indicates this file is ASCII
+    # https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.files/passwd_security.htm
+    Puppet::FileSystem.open("/etc/security/passwd", nil, "r:ASCII")
   end
 
   #--------------------------------
@@ -255,7 +257,10 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     user = @resource[:name]
 
     # Puppet execute does not support strings as input, only files.
-    tmpfile = Tempfile.new('puppet_#{user}_pw')
+    # The password is expected to be in an encrypted format given -e is specified:
+    # https://www.ibm.com/support/knowledgecenter/ssw_aix_71/com.ibm.aix.cmds1/chpasswd.htm
+    # /etc/security/passwd is specified as an ASCII file per the AIX documentation
+    tmpfile = Tempfile.new("puppet_#{user}_pw", :encoding => Encoding::ASCII)
     tmpfile << "#{user}:#{value}\n"
     tmpfile.close()
 

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -173,7 +173,8 @@ class Puppet::SSL::CertificateAuthority
     20.times { pass += (rand(74) + 48).chr }
 
     begin
-      Puppet.settings.setting(:capass).open('w') { |f| f.print pass }
+      # random password is limited to ASCII characters 48 ('0') through 122 ('z')
+      Puppet.settings.setting(:capass).open('w:ASCII') { |f| f.print pass }
     rescue Errno::EACCES => detail
       raise Puppet::Error, "Could not write CA password: #{detail}", detail.backtrace
     end
@@ -216,7 +217,8 @@ class Puppet::SSL::CertificateAuthority
   # file so this one is considered used.
   def next_serial
     serial = 1
-    Puppet.settings.setting(:serial).exclusive_open('a+') do |f|
+    # the serial is 4 hex digits - limited to ASCII
+    Puppet.settings.setting(:serial).exclusive_open('a+:ASCII') do |f|
       f.rewind
       serial = f.read.chomp.hex
       if serial == 0

--- a/lib/puppet/ssl/configuration.rb
+++ b/lib/puppet/ssl/configuration.rb
@@ -50,7 +50,10 @@ class Configuration
 
   # read_file makes testing easier.
   def read_file(path)
-    File.read(path)
+    # https://www.ietf.org/rfc/rfc2459.txt defines the x509 V3 certificate format
+    # CA bundles are concatenated X509 certificates, but may also include
+    # comments, which could have UTF-8 characters
+    Puppet::FileSystem.read(path, :encoding => Encoding::UTF_8)
   end
   private :read_file
 end

--- a/lib/puppet/ssl/inventory.rb
+++ b/lib/puppet/ssl/inventory.rb
@@ -8,7 +8,10 @@ class Puppet::SSL::Inventory
   # Add a certificate to our inventory.
   def add(cert)
     cert = cert.content if cert.is_a?(Puppet::SSL::Certificate)
-    Puppet.settings.setting(:cert_inventory).open("a") do |f|
+    # RFC 5280 says the cert subject may contain UTF8 - https://www.ietf.org/rfc/rfc5280.txt
+    # Note however that Puppet generated SSL files must only contain ASCII characters
+    # based on the validate_certname method of Puppet::SSL::Base
+    Puppet.settings.setting(:cert_inventory).open('a:UTF-8') do |f|
       f.print format(cert)
     end
   end
@@ -28,7 +31,8 @@ class Puppet::SSL::Inventory
   def rebuild
     Puppet.notice "Rebuilding inventory file"
 
-    Puppet.settings.setting(:cert_inventory).open('w') do |f|
+    # RFC 5280 says the cert subject may contain UTF8 - https://www.ietf.org/rfc/rfc5280.txt
+    Puppet.settings.setting(:cert_inventory).open('w:UTF-8') do |f|
       Puppet::SSL::Certificate.indirection.search("*").each do |cert|
         f.print format(cert.content)
       end
@@ -40,7 +44,10 @@ class Puppet::SSL::Inventory
   def serials(name)
     return [] unless Puppet::FileSystem.exist?(@path)
 
-    File.readlines(@path).collect do |line|
+    # RFC 5280 says the cert subject may contain UTF8 - https://www.ietf.org/rfc/rfc5280.txt
+    # Note however that Puppet generated SSL files must only contain ASCII characters
+    # based on the validate_certname method of Puppet::SSL::Base
+    File.readlines(@path, :encoding => Encoding::UTF_8).collect do |line|
       /^(\S+).+\/CN=#{name}$/.match(line)
     end.compact.map { |m| Integer(m[1]) }
   end

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -38,15 +38,19 @@ DOC
   def password
     return nil unless password_file and Puppet::FileSystem.exist?(password_file)
 
-    ::File.read(password_file)
+    # Puppet generates files at the default Puppet[:capass] using ASCII
+    # User configured :passfile could be in any encoding
+    # Use BINARY given the string is passed to an OpenSSL API accepting bytes
+    # note this is only called internally
+    Puppet::FileSystem.read(password_file, :encoding => Encoding::BINARY)
   end
 
   # Optionally support specifying a password file.
   def read(path)
     return super unless password_file
 
-    #@content = wrapped_class.new(::File.read(path), password)
-    @content = wrapped_class.new(::File.read(path), password)
+    # RFC 1421 states PEM is 7-bit ASCII https://tools.ietf.org/html/rfc1421
+    @content = wrapped_class.new(Puppet::FileSystem.read(path, :encoding => Encoding::ASCII), password)
   end
 
   def to_s

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1218,6 +1218,10 @@ class Type
     resource = Puppet::Resource.new(self, title)
     resource.catalog = hash.delete(:catalog)
 
+    if sensitive = hash.delete(:sensitive_parameters)
+      resource.sensitive_parameters = sensitive
+    end
+
     hash.each do |param, value|
       resource[param] = value
     end

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -739,7 +739,9 @@ module Puppet
     def unknown_keys_in_file(keyfile)
       names = []
       name_index = 0
-      File.new(keyfile).each do |line|
+      # RFC 4716 specifies UTF-8 allowed in public key files per https://www.ietf.org/rfc/rfc4716.txt
+      # the authorized_keys file may contain UTF-8 comments
+      Puppet::FileSystem.open(keyfile, nil, 'r:UTF-8').each do |line|
         next unless line =~ Puppet::Type.type(:ssh_authorized_key).keyline_regex
         # the name is stored in the 4th capture of the regex
         name = $4

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -10,6 +10,7 @@ require 'puppet/util/platform'
 require 'puppet/util/symbolic_file_mode'
 require 'puppet/file_system/uniquefile'
 require 'securerandom'
+require 'puppet/util/character_encoding'
 
 module Puppet
 module Util

--- a/lib/puppet/util/character_encoding.rb
+++ b/lib/puppet/util/character_encoding.rb
@@ -1,0 +1,96 @@
+# A module to centralize heuristics/practices for managing character encoding in Puppet
+require 'puppet/util'
+
+module Puppet::Util::CharacterEncoding
+  class << self
+    #TODO make encoding warnings a category/silenceable#.
+
+    # @api public
+    # @param [String] string a string to transcode / force_encode to utf-8
+    # @return [String] string if already utf-8, OR
+    #   a copy of string with external encoding set to utf-8 if bytes are valid utf-8 OR
+    #   a copy of string transcoded to utf-8
+    # @raise [Puppet::Error] a failure to legitimately set external encoding or
+    #   transcode string
+    def convert_to_utf_8(string)
+      return string if string.encoding == Encoding::UTF_8
+
+      value_to_encode = string.dup
+
+      begin
+        if valid_utf_8?(value_to_encode)
+          # Before we try to transcode the string, check if it is valid UTF-8 as
+          # currently constitued (in its non-UTF-8 encoding), and if it is, limit
+          # ourselves to setting the external encoding of the string to UTF-8
+          # rather than actually transcoding it. We do this to handle
+          # a couple scenarios:
+
+          # The first scenario is that the string was originally valid UTF-8 but
+          # the current puppet run is not in a UTF-8 environment. In this case,
+          # the string will likely have invalid byte sequences (i.e.,
+          # string.valid_encoding? == false), and attempting to transcode will
+          # fail with Encoding::InvalidByteSequenceError, referencing the
+          # invalid byte sequence in the original, pre-transcode, string. We
+          # might have gotten here, for example, if puppet is run first in a
+          # user context with UTF-8 encoding (setting the "is" value to UTF-8)
+          # and then later run via cron without UTF-8 specified, resulting in in
+          # EN_US (ISO-8859-1) on many systems. In this scenario we're
+          # effectively best-guessing this string originated as UTF-8 and only
+          # set external encoding to UTF-8 - transcoding would have failed
+          # anyway.
+
+          # The second scenario (more rare, I expect) is that this string does
+          # NOT have invalid byte sequences (string.valid_encoding? == true),
+          # but is *ALSO valid unicode*.
+          # Our example case is "\u16A0" - "RUNIC LETTER FEHU FEOH FE"
+          # http://www.fileformat.info/info/unicode/char/16A0/index.htm
+          # 0xE1 0x9A 0xA0 / 225 154 160
+          # These bytes are valid in ISO-8859-1 but the character they represent
+          # transcodes cleanly in ruby to *different* characters in UTF-8.
+          # That's not what we want if the user intended the original string as
+          # UTF-8. We can only guess, so if the string is valid UTF-8 as
+          # currently constituted, we default to assuming the string originated
+          # in UTF-8 and do not transcode it - we only set external encoding.
+          value_to_encode.force_encoding(Encoding::UTF_8)
+        elsif transcodable?(value_to_encode)
+          # If the string is not currently valid UTF-8 but it can be transcoded,
+          # we can guess this string was not originally unicode. We need it to
+          # be now, so transcode it to UTF-8. For strings with original
+          # encodings like SHIFT_JIS, this should be the final result.
+          value_to_encode.encode!(Encoding::UTF_8)
+        else
+          # If the string is neither valid UTF-8 as-is nor is transcodable, fail
+          # at this point. It requires user remediation.
+          raise EncodingError
+        end
+      rescue EncodingError => detail
+        # catch both our own self-determined failure to transcode as well as any
+        # error on ruby's part, ie Encoding::InvalidByteSequenceError or
+        # Encoding::UndefinedConversionError.
+        raise Puppet::Error, "#{detail.inspect}: #{value_to_encode.dump} is not valid UTF-8 and cannot be transcoded by Puppet."
+      end
+
+      return value_to_encode
+    end
+
+    private
+
+    # Do our best to determine if a string is valid
+    # UTF-8 via String#valid_encoding?
+    # @api private
+    # @param [String] string a string to test
+    # @return [Boolean] whether we think the string is UTF-8 or not
+    def valid_utf_8?(string)
+      string.dup.force_encoding(Encoding::UTF_8).valid_encoding?
+    end
+
+    # Trying to encode! a string with existing invalid byte sequences raises
+    # Encoding::InvalidByteSequenceError, so we don't consider it transcodable
+    # @api private
+    # @param [String] string a string to test
+    # @return [Boolean] whether we think the string can be transcoded
+    def transcodable?(string)
+      string.valid_encoding?
+    end
+  end
+end

--- a/lib/puppet/util/character_encoding.rb
+++ b/lib/puppet/util/character_encoding.rb
@@ -67,7 +67,7 @@ module Puppet::Util::CharacterEncoding
         # catch both our own self-determined failure to transcode as well as any
         # error on ruby's part, ie Encoding::InvalidByteSequenceError or
         # Encoding::UndefinedConversionError.
-        raise Puppet::Error, "#{detail.inspect}: #{value_to_encode.dump} is not valid UTF-8 and cannot be transcoded by Puppet."
+        raise Puppet::Error, _("#{detail.inspect}: #{value_to_encode.dump} is not valid UTF-8 and cannot be transcoded by Puppet.")
       end
 
       return value_to_encode

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -153,15 +153,18 @@ module Puppet::Util::Execution
         :squelch => false,
         :override_locale => true,
         :custom_environment => {},
+        :sensitive => false,
     }
 
     options = default_options.merge(options)
 
-    if command.is_a?(Array)
+    if options[:sensitive]
+      command_str = '[redacted]'
+    elsif command.is_a?(Array)
       command = command.flatten.map(&:to_s)
-      str = command.join(" ")
+      command_str = command.join(" ")
     elsif command.is_a?(String)
-      str = command
+      command_str = command
     end
 
     user_log_s = ''
@@ -176,9 +179,9 @@ module Puppet::Util::Execution
     end
 
     if respond_to? :debug
-      debug "Executing#{user_log_s}: '#{str}'"
+      debug "Executing#{user_log_s}: '#{command_str}'"
     else
-      Puppet.debug "Executing#{user_log_s}: '#{str}'"
+      Puppet.debug "Executing#{user_log_s}: '#{command_str}'"
     end
 
     null_file = Puppet.features.microsoft_windows? ? 'NUL' : '/dev/null'
@@ -229,7 +232,7 @@ module Puppet::Util::Execution
       end
 
       if options[:failonfail] and exit_status != 0
-        raise Puppet::ExecutionFailure, "Execution of '#{str}' returned #{exit_status}: #{output.strip}"
+        raise Puppet::ExecutionFailure, "Execution of '#{command_str}' returned #{exit_status}: #{output.strip}"
       end
     ensure
       if !options[:squelch] && stdout

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -26,4 +26,4 @@ gettext:
     - 'lib/puppet/pops/types/type_formatter.rb'
     # The semantic_puppet gem is temporarily vendored (PUP-7114), and it
     # handles its own translation.
-    - 'lib/semantic_puppet/**/*.rb'
+    - 'lib/puppet/vendor/**/*.rb'

--- a/spec/integration/ssl/key_spec.rb
+++ b/spec/integration/ssl/key_spec.rb
@@ -1,0 +1,104 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/ssl/key'
+
+describe Puppet::SSL::Key do
+  include PuppetSpec::Files
+
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ܎
+
+  before do
+    # Get a safe temporary file
+    dir = tmpdir('key_integration_testing')
+
+    Puppet.settings[:confdir] = dir
+    Puppet.settings[:vardir] = dir
+
+    # This is necessary so the terminus instances don't lie around.
+    # and so that Puppet::SSL::Key.indirection.save may be used
+    Puppet::SSL::Key.indirection.termini.clear
+  end
+
+  describe 'with a custom user-specified passfile' do
+
+    before do
+      # write custom password file to where Puppet expects
+      password_file = tmpfile('passfile')
+      Puppet[:passfile] = password_file
+      Puppet::FileSystem.open(password_file, nil, 'w:UTF-8') { |f| f.print(mixed_utf8) }
+    end
+
+    it 'should use the configured password file if it is not the CA key' do
+      key = Puppet::SSL::Key.new('test')
+      expect(key.password_file).to eq(Puppet[:passfile])
+      expect(key.password).to eq(mixed_utf8.force_encoding(Encoding::BINARY))
+    end
+
+    it "should be able to read an existing private key given the correct password" do
+      Puppet[:keylength] = '50'
+
+      key_name = 'test'
+      # use OpenSSL APIs to generate a private key
+      private_key = OpenSSL::PKey::RSA.generate(512)
+
+      # stash it in Puppets private key directory
+      FileUtils.mkdir_p(Puppet[:privatekeydir])
+      pem_path = File.join(Puppet[:privatekeydir], "#{key_name}.pem")
+      Puppet::FileSystem.open(pem_path, nil, 'w:UTF-8') do |f|
+        # with password protection enabled
+        pem = private_key.to_pem(OpenSSL::Cipher::DES.new(:EDE3, :CBC), mixed_utf8)
+        f.print(pem)
+      end
+
+      # indirector loads existing .pem off disk instead of replacing it
+      host = Puppet::SSL::Host.new(key_name)
+      host.generate
+
+      # newly loaded host private key matches the manually created key
+      # Private-Key: (512 bit) style data
+      expect(host.key.content.to_text).to eq(private_key.to_text)
+      # -----BEGIN RSA PRIVATE KEY-----
+      expect(host.key.content.to_s).to eq(private_key.to_s)
+      expect(host.key.password).to eq(mixed_utf8.force_encoding(Encoding::BINARY))
+    end
+
+    it 'should export the private key to PEM using the password' do
+      Puppet[:keylength] = '50'
+
+      key_name = 'test'
+
+      # uses specified :passfile when writing the private key
+      key = Puppet::SSL::Key.new(key_name)
+      key.generate
+      Puppet::SSL::Key.indirection.save(key)
+
+      # indirector writes file here
+      pem_path = File.join(Puppet[:privatekeydir], "#{key_name}.pem")
+
+      # note incorrect password is an error
+      expect do
+        Puppet::FileSystem.open(pem_path, nil, 'r:ASCII') do |f|
+          reloaded_key = OpenSSL::PKey::RSA.new(f.read, 'invalid_password')
+        end
+      end.to raise_error(OpenSSL::PKey::RSAError)
+
+      # but when specifying the correct password
+      reloaded_key = nil
+      Puppet::FileSystem.open(pem_path, nil, 'r:ASCII') do |f|
+        reloaded_key = OpenSSL::PKey::RSA.new(f.read, mixed_utf8)
+      end
+
+      # the original key matches the manually reloaded key
+      # Private-Key: (512 bit) style data
+      expect(key.content.to_text).to eq(reloaded_key.to_text)
+      # -----BEGIN RSA PRIVATE KEY-----
+      expect(key.content.to_s).to eq(reloaded_key.to_s)
+    end
+  end
+end

--- a/spec/integration/type/user_spec.rb
+++ b/spec/integration/type/user_spec.rb
@@ -8,9 +8,16 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
   include PuppetSpec::Compiler
 
   context "when set to purge ssh keys from a file" do
+    # different UTF-8 widths
+    # 1-byte A
+    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+    # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+    let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ𠜎
+
     let(:tempfile) do
       file_containing('user_spec', <<-EOF)
-        # comment
+        # comment #{mixed_utf8}
         ssh-rsa KEY-DATA key-name
         ssh-rsa KEY-DATA key name
         EOF
@@ -22,12 +29,12 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
 
     it "should purge authorized ssh keys" do
       apply_compiled_manifest(manifest)
-      expect(File.read(tempfile)).not_to match(/key-name/)
+      expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/key-name/)
     end
 
     it "should purge keys with spaces in the comment string" do
       apply_compiled_manifest(manifest)
-      expect(File.read(tempfile)).not_to match(/key name/)
+      expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/key name/)
     end
 
     context "with other prefetching resources evaluated first" do
@@ -35,14 +42,14 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
 
       it "should purge authorized ssh keys" do
         apply_compiled_manifest(manifest)
-        expect(File.read(tempfile)).not_to match(/key-name/)
+        expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/key-name/)
       end
     end
 
     context "with multiple unnamed keys" do
       let(:tempfile) do
         file_containing('user_spec', <<-EOF)
-          # comment
+          # comment #{mixed_utf8}
           ssh-rsa KEY-DATA1
           ssh-rsa KEY-DATA2
           EOF
@@ -50,7 +57,7 @@ describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.m
 
       it "should purge authorized ssh keys" do
         apply_compiled_manifest(manifest)
-        expect(File.read(tempfile)).not_to match(/KEY-DATA/)
+        expect(File.read(tempfile, :encoding => Encoding::UTF_8)).not_to match(/KEY-DATA/)
       end
     end
   end

--- a/spec/unit/indirector/key/file_spec.rb
+++ b/spec/unit/indirector/key/file_spec.rb
@@ -66,7 +66,7 @@ describe Puppet::SSL::Key::File do
     it "should save the public key when saving the private key" do
       fh = StringIO.new
 
-      Puppet.settings.setting(:publickeydir).expects(:open_file).with(@public_key_path, 'w').yields fh
+      Puppet.settings.setting(:publickeydir).expects(:open_file).with(@public_key_path, 'w:ASCII').yields fh
       Puppet.settings.setting(:privatekeydir).stubs(:open_file)
       @public_key.expects(:to_pem).returns "my pem"
 

--- a/spec/unit/indirector/ssl_file_spec.rb
+++ b/spec/unit/indirector/ssl_file_spec.rb
@@ -221,7 +221,7 @@ describe Puppet::Indirector::SslFile do
           @searcher.class.store_in @setting
           fh = mock 'filehandle'
           fh.stubs :print
-          Puppet.settings.setting(@setting).expects(:open_file).with(@certpath, 'w').yields fh
+          Puppet.settings.setting(@setting).expects(:open_file).with(@certpath, 'w:ASCII').yields fh
 
           @searcher.save(@request)
         end
@@ -233,7 +233,7 @@ describe Puppet::Indirector::SslFile do
 
           fh = mock 'filehandle'
           fh.stubs :print
-          Puppet.settings.setting(@setting).expects(:open).with('w').yields fh
+          Puppet.settings.setting(@setting).expects(:open).with('w:ASCII').yields fh
           @searcher.save(@request)
         end
       end
@@ -246,7 +246,7 @@ describe Puppet::Indirector::SslFile do
 
           fh = mock 'filehandle'
           fh.stubs :print
-          Puppet.settings.setting(:cakey).expects(:open).with('w').yields fh
+          Puppet.settings.setting(:cakey).expects(:open).with('w:ASCII').yields fh
           @searcher.stubs(:ca?).returns true
           @searcher.save(@request)
         end

--- a/spec/unit/interface/face_collection_spec.rb
+++ b/spec/unit/interface/face_collection_spec.rb
@@ -47,7 +47,7 @@ describe Puppet::Interface::FaceCollection do
 
   describe "::[]" do
     before :each do
-      subject.instance_variable_get("@faces")[:foo][SemVer.new('0.0.1')] = 10
+      subject.instance_variable_get("@faces")[:foo][SemanticPuppet::Version.parse('0.0.1')] = 10
     end
 
     it "should return the face with the given name" do
@@ -66,13 +66,13 @@ describe Puppet::Interface::FaceCollection do
     end
 
     it "should return true if the face specified is registered" do
-      subject.instance_variable_get("@faces")[:foo][SemVer.new('0.0.1')] = 10
+      subject.instance_variable_get("@faces")[:foo][SemanticPuppet::Version.parse('0.0.1')] = 10
       expect(subject["foo", '0.0.1']).to eq(10)
     end
 
     it "should attempt to require the face if it is not registered" do
       subject.expects(:require).with do |file|
-        subject.instance_variable_get("@faces")[:bar][SemVer.new('0.0.1')] = true
+        subject.instance_variable_get("@faces")[:bar][SemanticPuppet::Version.parse('0.0.1')] = true
         file == 'puppet/face/bar'
       end
       expect(subject["bar", '0.0.1']).to be_truthy
@@ -130,14 +130,14 @@ describe Puppet::Interface::FaceCollection do
         get_action_for_face(:huzzah, :obsolete, :current)
 
       expect(action).to be_an_instance_of Puppet::Interface::Action
-      expect(action.face.version).to eq(SemVer.new('1.0.0'))
+      expect(action.face.version).to eq(SemanticPuppet::Version.parse('1.0.0'))
     end
 
     it "should load the full older version of a face" do
       action = Puppet::Face::FaceCollection.
         get_action_for_face(:huzzah, :obsolete, :current)
 
-      expect(action.face.version).to eq(SemVer.new('1.0.0'))
+      expect(action.face.version).to eq(SemanticPuppet::Version.parse('1.0.0'))
       expect(action.face).to be_action :obsolete_in_core
     end
 
@@ -145,11 +145,11 @@ describe Puppet::Interface::FaceCollection do
       action = Puppet::Face::FaceCollection.
         get_action_for_face(:huzzah, :obsolete, :current)
 
-      expect(action.face.version).to eq(SemVer.new('1.0.0'))
+      expect(action.face.version).to eq(SemanticPuppet::Version.parse('1.0.0'))
       expect(action.face).to be_action :obsolete_in_core
 
       current = Puppet::Face[:huzzah, :current]
-      expect(current.version).to eq(SemVer.new('2.0.1'))
+      expect(current.version).to eq(SemanticPuppet::Version.parse('2.0.1'))
       expect(current).not_to be_action :obsolete_in_core
       expect(current).not_to be_action :obsolete
     end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -170,7 +170,6 @@ describe Puppet::Module do
 
     it "should list modules that are missing" do
       metadata_file = "#{@modpath}/needy/metadata.json"
-      Puppet::FileSystem.expects(:exist?).with(metadata_file).returns true
       mod = PuppetSpec::Modules.create(
         'needy',
         @modpath,
@@ -196,7 +195,6 @@ describe Puppet::Module do
 
     it "should list modules that are missing and have invalid names" do
       metadata_file = "#{@modpath}/needy/metadata.json"
-      Puppet::FileSystem.expects(:exist?).with(metadata_file).returns true
       mod = PuppetSpec::Modules.create(
         'needy',
         @modpath,
@@ -305,7 +303,6 @@ describe Puppet::Module do
       env = Puppet::Node::Environment.create(:testing, [@modpath])
 
       metadata_file = "#{@modpath}/foobar/metadata.json"
-      Puppet::FileSystem.expects(:exist?).with(metadata_file).times(3).returns true
       mod = PuppetSpec::Modules.create(
         'foobar',
         @modpath,
@@ -364,10 +361,6 @@ describe Puppet::Module do
     it "should only list unmet dependencies" do
       env = Puppet::Node::Environment.create(:testing, [@modpath])
 
-      [name, 'satisfied'].each do |mod_name|
-        metadata_file = "#{@modpath}/#{mod_name}/metadata.json"
-        Puppet::FileSystem.expects(:exist?).with(metadata_file).twice.returns true
-      end
       mod = PuppetSpec::Modules.create(
         name,
         @modpath,
@@ -588,60 +581,70 @@ end
 
 describe Puppet::Module do
   include PuppetSpec::Files
-  before do
-    @modpath = tmpdir('modpath')
-    @module = PuppetSpec::Modules.create('mymod', @modpath)
+
+  let!(:modpath) do
+    path = tmpdir('modpath')
+    PuppetSpec::Modules.create('mymod', path)
+    path
   end
 
+  let!(:mymodpath) { File.join(modpath, 'mymod') }
+
+  let!(:mymod_metadata) { File.join(mymodpath, 'metadata.json') }
+
+  let(:mymod) { Puppet::Module.new('mymod', mymodpath, nil) }
+
   it "should use 'License' in its current path as its metadata file" do
-    expect(@module.license_file).to eq("#{@modpath}/mymod/License")
+    expect(mymod.license_file).to eq("#{modpath}/mymod/License")
   end
 
   it "should cache the license file" do
-    @module.expects(:path).once.returns nil
-    @module.license_file
-    @module.license_file
+    mymod.expects(:path).once.returns nil
+    mymod.license_file
+    mymod.license_file
   end
 
   it "should use 'metadata.json' in its current path as its metadata file" do
-    expect(@module.metadata_file).to eq("#{@modpath}/mymod/metadata.json")
+    expect(mymod_metadata).to eq("#{modpath}/mymod/metadata.json")
   end
 
-  it "should have metadata if it has a metadata file and its data is not empty" do
-    Puppet::FileSystem.expects(:exist?).with(@module.metadata_file).returns true
-    File.stubs(:read).with(@module.metadata_file, {:encoding => 'utf-8'}).returns "{\"foo\" : \"bar\"}"
+  it "should not have metadata if it has a metadata file and its data is valid but empty json hash" do
+    File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns "{}"
 
-    expect(@module).to be_has_metadata
+    expect(mymod).not_to be_has_metadata
   end
 
-  it "should not have metadata if has a metadata file and its data is empty" do
-    Puppet::FileSystem.expects(:exist?).with(@module.metadata_file).returns true
-    File.stubs(:read).with(@module.metadata_file, {:encoding => 'utf-8'}).returns "This is some invalid json.\n"
-    expect(@module).not_to be_has_metadata
+  it "should not have metadata if it has a metadata file and its data is empty" do
+    File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns ""
+
+    expect(mymod).not_to be_has_metadata
+  end
+
+  it "should not have metadata if has a metadata file and its data is invalid" do
+    File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns "This is some invalid json.\n"
+    expect(mymod).not_to be_has_metadata
   end
 
   it "should know if it is missing a metadata file" do
-    Puppet::FileSystem.expects(:exist?).with(@module.metadata_file).returns false
+    File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).raises(Errno::ENOENT)
 
-    expect(@module).not_to be_has_metadata
+    expect(mymod).not_to be_has_metadata
   end
 
   it "should be able to parse its metadata file" do
-    expect(@module).to respond_to(:load_metadata)
+    expect(mymod).to respond_to(:load_metadata)
   end
 
   it "should parse its metadata file on initialization if it is present" do
-    Puppet::Module.any_instance.expects(:has_metadata?).returns true
     Puppet::Module.any_instance.expects(:load_metadata)
 
     Puppet::Module.new("yay", "/path", mock("env"))
   end
 
   it "should tolerate failure to parse" do
-    Puppet::FileSystem.expects(:exist?).with(@module.metadata_file).returns true
-    File.stubs(:read).with(@module.metadata_file, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
+    File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
 
-    expect(@module.has_metadata?).to be_falsey
+    expect(mymod.has_metadata?).to be_falsey
   end
 
   describe 'when --strict is warning' do
@@ -650,10 +653,9 @@ describe Puppet::Module do
     end
 
     it "should warn about a failure to parse" do
-      Puppet::FileSystem.expects(:exist?).with(@module.metadata_file).returns true
-      File.stubs(:read).with(@module.metadata_file, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
+      File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
 
-      expect(@module.has_metadata?).to be_falsey
+      expect(mymod.has_metadata?).to be_falsey
       expect(@logs).to have_matching_log(/mymod has an invalid and unparsable metadata\.json file/)
     end
   end
@@ -664,10 +666,9 @@ describe Puppet::Module do
       end
 
       it "should warn about a failure to parse" do
-        Puppet::FileSystem.expects(:exist?).with(@module.metadata_file).returns true
-        File.stubs(:read).with(@module.metadata_file, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
+        File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
 
-        expect(@module.has_metadata?).to be_falsey
+        expect(mymod.has_metadata?).to be_falsey
         expect(@logs).to have_matching_log(/mymod has an invalid and unparsable metadata\.json file.*/)
       end
     end
@@ -678,47 +679,39 @@ describe Puppet::Module do
       end
 
       it "should fail on a failure to parse" do
-        Puppet::FileSystem.expects(:exist?).with(@module.metadata_file).returns true
-        File.stubs(:read).with(@module.metadata_file, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
+        File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
 
         expect do
-        expect(@module.has_metadata?).to be_falsey
+        expect(mymod.has_metadata?).to be_falsey
         end.to raise_error(/mymod has an invalid and unparsable metadata\.json file/)
       end
     end
 
   def a_module_with_metadata(data)
-    text = data.to_pson
-
-    mod = Puppet::Module.new("foo", "/path", mock("env"))
-    mod.stubs(:metadata_file).returns "/my/file"
-    File.stubs(:read).with("/my/file", {:encoding => 'utf-8'}).returns text
-    mod
+    File.stubs(:read).with("/path/metadata.json", {:encoding => 'utf-8'}).returns data.to_pson
+    Puppet::Module.new("foo", "/path", mock("env"))
   end
 
   describe "when loading the metadata file" do
-    before do
-      @data = {
+    let(:data) do
+      {
         :license       => "GPL2",
         :author        => "luke",
         :version       => "1.0",
         :source        => "http://foo/",
         :dependencies  => []
       }
-      @module = a_module_with_metadata(@data)
     end
 
     %w{source author version license}.each do |attr|
       it "should set #{attr} if present in the metadata file" do
-        @module.load_metadata
-        expect(@module.send(attr)).to eq(@data[attr.to_sym])
+        mod = a_module_with_metadata(data)
+        expect(mod.send(attr)).to eq(data[attr.to_sym])
       end
 
       it "should fail if #{attr} is not present in the metadata file" do
-        @data.delete(attr.to_sym)
-        @text = @data.to_pson
-        File.stubs(:read).with("/my/file", {:encoding => 'utf-8'}).returns @text
-        expect { @module.load_metadata }.to raise_error(
+        data.delete(attr.to_sym)
+        expect { a_module_with_metadata(data) }.to raise_error(
           Puppet::Module::MissingMetadata,
           "No #{attr} module metadata provided for foo"
         )
@@ -742,8 +735,8 @@ describe Puppet::Module do
         EOF
       end
 
+      Puppet::Module.any_instance.stubs(:metadata_file).returns metadata_json
       mod = Puppet::Module.new('foo', '/path', mock('env'))
-      mod.stubs(:metadata_file).returns metadata_json
 
       mod.load_metadata
       expect(mod.author).to eq(rune_utf8)
@@ -773,17 +766,17 @@ describe Puppet::Module do
   end
 
   it "should know what other modules require it" do
-    env = Puppet::Node::Environment.create(:testing, [@modpath])
+    env = Puppet::Node::Environment.create(:testing, [modpath])
 
     dependable = PuppetSpec::Modules.create(
       'dependable',
-      @modpath,
+      modpath,
       :metadata => {:author => 'puppetlabs'},
       :environment => env
     )
     PuppetSpec::Modules.create(
       'needy',
-      @modpath,
+      modpath,
       :metadata => {
         :author => 'beggar',
         :dependencies => [{
@@ -795,7 +788,7 @@ describe Puppet::Module do
     )
     PuppetSpec::Modules.create(
       'wantit',
-      @modpath,
+      modpath,
       :metadata => {
         :author => 'spoiled',
         :dependencies => [{

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -411,6 +411,30 @@ describe 'Puppet Ruby Generator' do
           expect(inst.age).to eql(30)
           expect(inst.another).to be_nil
         end
+
+        it 'two instances with the same attribute values are equal using #eql?' do
+          inst1 = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          expect(inst1.eql?(inst2)).to be_truthy
+        end
+
+        it 'two instances with the same attribute values are equal using #==' do
+          inst1 = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          expect(inst1 == inst2).to be_truthy
+        end
+
+        it 'two instances with the different attribute in super class values are different' do
+          inst1 = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = second.create('Bob Engineer', '42 Cool Street', '12345', 'bob@example.com', 23)
+          expect(inst1 == inst2).to be_falsey
+        end
+
+        it 'two instances with the different attribute in sub class values are different' do
+          inst1 = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = second.create('Bob Builder', '42 Cool Street', '12345', 'bob@other.com', 23)
+          expect(inst1 == inst2).to be_falsey
+        end
       end
 
       context 'the #from_hash class method' do
@@ -540,6 +564,30 @@ describe 'Puppet Ruby Generator' do
           expect(inst.what).to eql('what is this')
           expect(inst.age).to eql(30)
           expect(inst.another).to be_nil
+        end
+
+        it 'two instances with the same attribute values are equal using #eql?' do
+          inst1 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          expect(inst1.eql?(inst2)).to be_truthy
+        end
+
+        it 'two instances with the same attribute values are equal using #==' do
+          inst1 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          expect(inst1 == inst2).to be_truthy
+        end
+
+        it 'two instances with the different attribute in super class values are different' do
+          inst1 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Engineer', '42 Cool Street', '12345', 'bob@example.com', 23)
+          expect(inst1 == inst2).to be_falsey
+        end
+
+        it 'two instances with the different attribute in sub class values are different' do
+          inst1 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@example.com', 23)
+          inst2 = PuppetSpec::RubyGenerator::My::SecondGenerated.create('Bob Builder', '42 Cool Street', '12345', 'bob@other.com', 23)
+          expect(inst1 == inst2).to be_falsey
         end
       end
 

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -167,6 +167,11 @@ _EOF_
       @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', "myservice"]).returns sample_output
       expect(@provider.status).to eq(nil)
     end
+
+    it "should consider a non-existing service to be have a status of :stopped" do
+      @provider.expects(:execute).with(['/usr/bin/lssrc', '-s', 'myservice']).raises(Puppet::ExecutionFailure, "fail")
+      expect(@provider.status).to eq(:stopped)
+    end
   end
 
   describe "when restarting a service" do

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -9,7 +9,7 @@ describe Puppet do
 
   context "#version" do
     it "should be valid semver" do
-      expect(SemVer).to be_valid Puppet.version
+      expect(SemanticPuppet::Version).to be_valid Puppet.version
     end
   end
 

--- a/spec/unit/ssl/base_spec.rb
+++ b/spec/unit/ssl/base_spec.rb
@@ -45,6 +45,15 @@ describe Puppet::SSL::Certificate do
     end
   end
 
+  describe "when initializing wrapped class from a file with #read" do
+    it "should open the file with ASCII encoding" do
+      path = '/foo/bar/cert'
+      Puppet::SSL::Base.stubs(:valid_certname).returns(true)
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("bar")
+      @base.read(path)
+    end
+  end
+
   describe "#digest_algorithm" do
     let(:content) { stub 'content' }
     let(:base) {

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -167,7 +167,7 @@ describe Puppet::SSL::CertificateAuthority do
       Puppet::FileSystem.expects(:exist?).with(Puppet[:capass]).returns false
 
       fh = StringIO.new
-      Puppet.settings.setting(:capass).expects(:open).with('w').yields fh
+      Puppet.settings.setting(:capass).expects(:open).with('w:ASCII').yields fh
 
       @ca.stubs(:sign)
 
@@ -1067,7 +1067,7 @@ describe "CertificateAuthority.generate" do
   end
 
   def expect_to_write_the_ca_password
-    Puppet.settings.setting(:capass).expects(:open).with('w')
+    Puppet.settings.setting(:capass).expects(:open).with('w:ASCII')
   end
 
   def expect_ca_initialization

--- a/spec/unit/ssl/certificate_request_attributes_spec.rb
+++ b/spec/unit/ssl/certificate_request_attributes_spec.rb
@@ -9,6 +9,12 @@ describe Puppet::SSL::CertificateRequestAttributes do
       "custom_attributes" => {
         "1.3.6.1.4.1.34380.2.2"=>[3232235521, 3232235777], # system IPs in hex
         "1.3.6.1.4.1.34380.2.0"=>"hostname.domain.com",
+        # different UTF-8 widths
+        # 1-byte A
+        # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+        # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+        # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+        "1.2.840.113549.1.9.7"=>"utf8passwordA\u06FF\u16A0\u{2070E}"
       }
     }
   end

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should be able to read requests from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my request")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my request")
       my_req = mock 'request'
       OpenSSL::X509::Request.expects(:new).with("my request").returns(my_req)
       expect(request.read(path)).to equal(my_req)

--- a/spec/unit/ssl/certificate_spec.rb
+++ b/spec/unit/ssl/certificate_spec.rb
@@ -162,7 +162,7 @@ describe Puppet::SSL::Certificate do
 
     it "should be able to read certificates from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my certificate")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my certificate")
       certificate = mock 'certificate'
       OpenSSL::X509::Certificate.expects(:new).with("my certificate").returns(certificate)
       expect(@certificate.read(path)).to equal(certificate)

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -5,6 +5,14 @@ require 'puppet/ssl/inventory'
 
 describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? do
   let(:cert_inventory) { File.expand_path("/inven/tory") }
+
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ܎
+
   before do
     @class = Puppet::SSL::Inventory
   end
@@ -56,7 +64,7 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
     describe "and adding a certificate" do
 
       it "should use the Settings to write to the file" do
-        Puppet.settings.setting(:cert_inventory).expects(:open).with("a")
+        Puppet.settings.setting(:cert_inventory).expects(:open).with('a:UTF-8')
 
         @inventory.add(@cert)
       end
@@ -66,13 +74,29 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
         cert.content = @cert
 
         fh = StringIO.new
-        Puppet.settings.setting(:cert_inventory).expects(:open).with("a").yields(fh)
+        Puppet.settings.setting(:cert_inventory).expects(:open).with('a:UTF-8').yields(fh)
 
         @inventory.expects(:format).with(@cert).returns "myformat"
 
         @inventory.add(@cert)
 
         expect(fh.string).to eq("myformat")
+      end
+
+      it "can use UTF-8 in the CN per RFC 5280" do
+        cert = Puppet::SSL::Certificate.new("mycert")
+        cert.content = stub 'cert',
+          :serial => 1,
+          :not_before => Time.now,
+          :not_after => Time.now,
+          :subject => "/CN=#{mixed_utf8}"
+
+        fh = StringIO.new
+        Puppet.settings.setting(:cert_inventory).expects(:open).with('a:UTF-8').yields(fh)
+
+        @inventory.add(cert)
+
+        expect(fh.string).to match(/\/CN=#{mixed_utf8}/)
       end
     end
 
@@ -118,7 +142,7 @@ describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? d
       end
 
       it "should return the all the serial numbers from the lines matching the provided name" do
-        File.expects(:readlines).with(cert_inventory).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
+        File.expects(:readlines).with(cert_inventory, :encoding => Encoding::UTF_8).returns ["0x00f blah blah /CN=me\n", "0x001 blah blah /CN=you\n", "0x002 blah blah /CN=me\n"]
 
         expect(@inventory.serials("me")).to eq([15, 2])
       end

--- a/spec/unit/ssl/key_spec.rb
+++ b/spec/unit/ssl/key_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::SSL::Key do
 
     it "should be able to read keys from disk" do
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my key")
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).returns(key)
       expect(@key.read(path)).to equal(key)
@@ -76,9 +76,9 @@ describe Puppet::SSL::Key do
 
       path = "/my/path"
 
-      File.stubs(:read).with(path).returns("my key")
+      Puppet::FileSystem.stubs(:read).with(path, :encoding => Encoding::ASCII).returns("my key")
       OpenSSL::PKey::RSA.expects(:new).with("my key", nil).returns(mock('key'))
-      File.expects(:read).with("/path/to/password").never
+      Puppet::FileSystem.expects(:read).with("/path/to/password", :encoding => Encoding::BINARY).never
 
       @key.read(path)
     end
@@ -88,8 +88,8 @@ describe Puppet::SSL::Key do
       @key.password_file = "/path/to/password"
 
       path = "/my/path"
-      File.expects(:read).with(path).returns("my key")
-      File.expects(:read).with("/path/to/password").returns("my password")
+      Puppet::FileSystem.expects(:read).with(path, :encoding => Encoding::ASCII).returns("my key")
+      Puppet::FileSystem.expects(:read).with("/path/to/password", :encoding => Encoding::BINARY).returns("my password")
 
       key = mock 'key'
       OpenSSL::PKey::RSA.expects(:new).with("my key", "my password").returns(key)
@@ -155,7 +155,7 @@ describe Puppet::SSL::Key do
     describe "with a password file set" do
       it "should return a nil password if the password file does not exist" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns false
-        File.expects(:read).with("/path/to/pass").never
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", :encoding => Encoding::BINARY).never
 
         @instance.password_file = "/path/to/pass"
 
@@ -164,7 +164,7 @@ describe Puppet::SSL::Key do
 
       it "should return the contents of the password file as its password" do
         Puppet::FileSystem.expects(:exist?).with("/path/to/pass").returns true
-        File.expects(:read).with("/path/to/pass").returns "my password"
+        Puppet::FileSystem.expects(:read).with("/path/to/pass", :encoding => Encoding::BINARY).returns "my password"
 
         @instance.password_file = "/path/to/pass"
 

--- a/spec/unit/util/character_encoding_spec.rb
+++ b/spec/unit/util/character_encoding_spec.rb
@@ -1,0 +1,66 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util/character_encoding'
+
+describe Puppet::Util::CharacterEncoding do
+  describe "::convert_to_utf_8" do
+    context "when passed a UTF-8 string" do
+      it "should return the string unaltered" do
+        utf8_string = "\u06FF\u2603"
+        expect(Puppet::Util::CharacterEncoding.convert_to_utf_8(utf8_string)).to eq(utf8_string)
+      end
+    end
+
+    context "when passed a string not in UTF-8 encoding" do
+      context "the bytes of which represent valid UTF-8" do
+        # I think this effectively what the ruby Etc module is doing when it
+        # returns strings read in from /etc/passwd and /etc/group
+        let(:iso_8859_1_string) { [225, 154, 160].pack('C*').force_encoding(Encoding::ISO_8859_1) }
+        let(:result) { Puppet::Util::CharacterEncoding.convert_to_utf_8(iso_8859_1_string) }
+
+        it "should set external encoding to UTF-8" do
+          expect(result.encoding).to eq(Encoding::UTF_8)
+        end
+
+        it "should not modify the bytes (transcode) the string" do
+          expect(result.bytes.to_a).to eq([225, 154, 160])
+        end
+      end
+
+      context "the bytes of which do not represent valid UTF-8" do
+        it "should transcode the string to UTF-8 if it is transcodable" do
+          # http://www.fileformat.info/info/unicode/char/3050/index.htm
+          # ぐ - HIRAGANA LETTER GU
+          # In Shift_JIS: \x82 \xae - 130 174
+          # In Unicode: \u3050 - \xe3 \x81 \x90 - 227 129 144
+          # if we were only ruby > 2.3.0, we could do String.new("\x82\xae", :encoding => Encoding::Shift_JIS)
+          as_shift_jis = [130, 174].pack('C*').force_encoding(Encoding::Shift_JIS)
+          as_utf8 = "\u3050"
+
+          # this is not valid UTF-8
+          expect(as_shift_jis.dup.force_encoding(Encoding::UTF_8).valid_encoding?).to be_falsey
+
+          result = Puppet::Util::CharacterEncoding.convert_to_utf_8(as_shift_jis)
+          expect(result).to eq(as_utf8)
+          # largely redundant but reinforces the point - this was transcoded:
+          expect(result.bytes.to_a).to eq([227, 129, 144])
+        end
+
+        it "should raise an exception if not transcodable" do
+          # An admittedly contrived case, but perhaps not so improbable
+          # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
+          # 希 Han Character 'rare; hope, expect, strive for'
+          # In EUC_KR: \xfd \xf1 - 253 241
+          # In Unicode: \u5e0c - \xe5 \xb8 \x8c - 229 184 140
+
+          # If the original system value is in EUC_KR, and puppet (ruby) is run
+          # in ISO_8859_1, this value will be read in as ASCII, with invalid
+          # escape sequences in that encoding. It is also not valid unicode
+          # as-is. This scenario is one we can't recover from, so fail.
+          as_ascii = [254, 241].pack('C*').force_encoding(Encoding::ASCII)
+          expect { Puppet::Util::CharacterEncoding.convert_to_utf_8(as_ascii) }.to raise_error(Puppet::Error, /not valid UTF-8/)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -596,7 +596,7 @@ describe Puppet::Util::Execution do
 
         expect {
           subject.execute('fail command', :failonfail => true, :sensitive => true)
-        }.to raise_error(Puppet::ExecutionFailure, /Execution of '\[redacted]' returned 1/)
+        }.to raise_error(Puppet::ExecutionFailure, /Execution of '\[redacted\]' returned 1/)
       end
 
       it "should not raise an error if failonfail is false and the child failed" do


### PR DESCRIPTION
The following is a list of actions performed based on PRs merged to master which should land in the 4.10.x release - more info at https://gist.github.com/Iristyle/8a3236d04e246a7a1159c188fb4ca133


#### A merge-up to master results in only 2 conflicts:

* `locales/puppet.pot` based on automation generating translations
* `lib/puppet/pops/types/ruby_generator.rb` due to PUP-7212 / PUP-7222 / PUP-7227 code landing

#### A merge-down to stable is clean

## History Added In This Order

#### Features / refactors / other code changes that could plausibly be Puppet 4

* [PR 5472 - (PUP-4283) Update Puppet Module Tool to use SemanticPuppet::Version](http://github.com/puppetlabs/puppet/pull/5472) - [PUP-4283](https://tickets.puppetlabs.com/browse/PUP-4283)
    * git cherry-pick 4d297235bb666dd2770955f1740af0bc91eb4b8d
        * resolved conflicts

#### Features / refactors / other code changes that could plausibly be Puppet 4

* [PR 5505 - (PUP-5027) Prevent that metadata.json is parsed multiple times](http://github.com/puppetlabs/puppet/pull/5505) - [PUP-5027](https://tickets.puppetlabs.com/browse/PUP-5027)
    * git cherry-pick f2e8e6649d392d5d3b7b8e79efbf15815adcdcc8
        * resolved conflicts
* [PR 5504 - (PUP-7100) Add Hiera version 5 lookup_key function for eyaml](http://github.com/puppetlabs/puppet/pull/5504) - [PUP-7100](https://tickets.puppetlabs.com/browse/PUP-7100)
    * this code was already brought into stable via another backport - skipping the 5 commits:
    * b42ef28cfec54a6072a489b5a631624cbd42d92f
    * 26ca009b5aeca8d4b8c5e3057ceb79830b467ba5
    * 078273acbe99cff80d35d805e6bd168ff189f607
    * a7790be2c3e16999bf6bdb3bd29e3cc627f95ae4
    * 66457e73e076cf19589f90d17626f95457e22a78

#### Bugfixes that should probably be Puppet 4

* [PR 5557 - (PUP-6006) Change phrasing of multiple errors final error](http://github.com/puppetlabs/puppet/pull/5557) - [PUP-6006](https://tickets.puppetlabs.com/browse/PUP-6006)
    * git cherry-pick efcdf580b1013541da3f92104e0ac3ebac52f901

#### Glisan Agent UTF-8

* [PR 5522 - (PUP-7122) Add wrapper for gettext:update_pot rake task](http://github.com/puppetlabs/puppet/pull/5522) - [PUP-7122](https://tickets.puppetlabs.com/browse/PUP-7122)
    * git cherry-pick d32d3e26ea624a4d1ac7f0bd83b0fcf5e242814d
    * note: only took one commit as i18n.rake no longer exists

#### Bugfixes that should probably be Puppet 4

* [PR 5615 - (PUP-7168) Add `#==` alias for `#eql?` method of Pcore Objects](http://github.com/puppetlabs/puppet/pull/5615) - [PUP-7168](https://tickets.puppetlabs.com/browse/PUP-7168)
    * git cherry-pick 36d98197a60d388cd47055ed3e413e77319dc37b

#### Features / refactors / other code changes that could plausibly be Puppet 4

* [PR 5502 - (PUP-6494) Support sensitive commands in Exec resource type.](http://github.com/puppetlabs/puppet/pull/5502) - [PUP-6494](https://tickets.puppetlabs.com/browse/PUP-6494)
    * git cherry-pick e1dd130100316f7fcaf7f2dc095f6b50c98cc6be

#### Bugfixes that should probably be Puppet 4

* [PR 5546 - (PUP-7129) Use systemd service provider for Debian 9 (Strech)](http://github.com/puppetlabs/puppet/pull/5546) - [PUP-7129](https://tickets.puppetlabs.com/browse/PUP-7129)
    * git cherry-pick e20c4bd2a5a38fe34ef052be37be254db2a1d965
    * git cherry-pick 5bd1a659f7e8b3d57028f964d07f37575e8f9f90

#### Glisan Agent UTF-8    

* [PR 5594 - (PUP-7152) AIX encrypted user passwords are ASCII](http://github.com/puppetlabs/puppet/pull/5594) - [PUP-7152](https://tickets.puppetlabs.com/browse/PUP-7152)
    * git cherry-pick d6aaca5877b20f0772aaaba7ceefa19f93f72cdc
* [PR 5593 - (PUP-7151) Read selinux module version as BINARY](http://github.com/puppetlabs/puppet/pull/5593) - [PUP-7151](https://tickets.puppetlabs.com/browse/PUP-7151)
    * git cherry-pick 80af250667b05d37c65dcd2cd50973a25c1be325

#### Bugfixes that should probably be Puppet 4

* [PR 5632 - (PUP-7191) consider non-existent services on AIX to be stopped/disabled rather than failing](http://github.com/puppetlabs/puppet/pull/5632) - [PUP-7191](https://tickets.puppetlabs.com/browse/PUP-7191)
    * git cherry-pick 68aea974d7144bb6e6830ccfe92774f6315361fe
    * git cherry-pick 55a67e6b1b6d7246cba921b6d8514fb381dab83c
    * git cherry-pick b63c540cc205eb1e897db9d33da8111d859e2847
    * git cherry-pick 55a67e6b1b6d7246cba921b6d8514fb381dab83c

#### Glisan Agent UTF-8

* [PR 5384 - (PUP-7134) Use Puppet::FileSystem for file access / explicitly specify encodings for SSL files ](http://github.com/puppetlabs/puppet/pull/5384) - [PUP-7134](https://tickets.puppetlabs.com/browse/PUP-7134)
    * git cherry-pick dfebcf700cd17ee7f2bc33374d55fff9568aa05e
    * git cherry-pick a8406be58b8bef6cf8cce843cdeff692fe916125
    * git cherry-pick f0dab056df37adcb1fd014df1a13620aaac52722
    * git cherry-pick 4ad7717fbf0453466a62af1b49a776afd93a5bb9

#### Bugfixes that should probably be Puppet 4

* [PR 5639 - (PUP-7214) PUP-6663 causes a regression of PUP-535](http://github.com/puppetlabs/puppet/pull/5639) - [PUP-7214](https://tickets.puppetlabs.com/browse/PUP-7214)
  * Note - this was backported to Puppet 4 already
* [PR 5650 - (PUP-7102) Fail with error on access problems with environment directory](http://github.com/puppetlabs/puppet/pull/5650) - [PUP-7102](https://tickets.puppetlabs.com/browse/PUP-7102)
    * GIVEN NEXT PR REVERTED, DID NOT PERFORM - git cherry-pick e4a4e09323436c5e44bc3b3154f42cd020c05a92
    * GIVEN NEXT PR REVERTED, DID NOT PERFORM - git cherry-pick ae58568128348a4a425444b98cec78e9420f13a9
* [PR 5667 - Revert "(PUP-7102) Fail with error on access problems with environment directory"](https://github.com/puppetlabs/puppet/pull/5667)
    * GIVEN THIS REVERTED PRIOR PR, DID NOT PERFORM - git cherry-pick b1d12540ae06943e3a793d5136ee1fe57b90684d

#### Glisan Agent UTF-8

* [PR 5633 - (pup-7021) establish central string encoding conversion](http://github.com/puppetlabs/puppet/pull/5633) - [pup-7021](https://tickets.puppetlabs.com/browse/pup-7021)
    * git cherry-pick df46662011d00f95345a9e846115042de1249166
    * git cherry-pick 346036876996ff1a6d7c169a818c7453c0cc47a6

#### MISC
* [(maint) fix minor spec regex warning](https://github.com/puppetlabs/puppet/pull/5661)
    * git cherry-pick 56cda69cbed18b3ce5fc2037efe338256165f67f

## Commits Not Added

#### Removals / changes that should wait for Puppet 5

* [PR 4999 - (PUP-6372) Remove unused Puppet::Transaction.failed? method](http://github.com/puppetlabs/puppet/pull/4999) - [PUP-6372](https://tickets.puppetlabs.com/browse/PUP-6372)
* [PR 5479 - (PUP-5434) Remove deprecated experimental lookup implementation](http://github.com/puppetlabs/puppet/pull/5479) - [PUP-5434](https://tickets.puppetlabs.com/browse/PUP-5434)
* [PR 5491 - (PUP-6481) Remove external_facts feature](http://github.com/puppetlabs/puppet/pull/5491) - [PUP-6481](https://tickets.puppetlabs.com/browse/PUP-6481)
* [PR 5492 - (PUP-6219) Remove deprecated req_bits setting](http://github.com/puppetlabs/puppet/pull/5492) - [PUP-6219](https://tickets.puppetlabs.com/browse/PUP-6219)
* [PR 5493 - (PUP-3670) Remove Facts#strip_internal method](http://github.com/puppetlabs/puppet/pull/5493) - [PUP-3670](https://tickets.puppetlabs.com/browse/PUP-3670)
* [PR 5494 - (PUP-4933) Remove deprecated cfacter setting](http://github.com/puppetlabs/puppet/pull/5494) - [PUP-4933](https://tickets.puppetlabs.com/browse/PUP-4933)
* [PR 5642 - (PUP-5973) Remove symbol string monkey patch](http://github.com/puppetlabs/puppet/pull/5642) - [PUP-5973](https://tickets.puppetlabs.com/browse/PUP-5973)
* [PR 5616 - Revert "Merge pull request #5276 from DavidS/notify-everywhere (PUP-6783)"](http://github.com/puppetlabs/puppet/pull/5616)
* [PR 5619 - (PUP-7142) Autoload Pcore types from TypeSet.](http://github.com/puppetlabs/puppet/pull/5619) - [PUP-7142](https://tickets.puppetlabs.com/browse/PUP-7142)
* [PR 5626 - (maint) Remove redundant code from AST Model Factory](http://github.com/puppetlabs/puppet/pull/5626)
* [PR 5641 - (PUP-7212) Add a Pcore Annotation type and an annotate function](http://github.com/puppetlabs/puppet/pull/5641) - [PUP-7212](https://tickets.puppetlabs.com/browse/PUP-7212)
* [PR 5645 - (PUP-7222) Add RubyMethod annotation and let RubyGenerator act on it](http://github.com/puppetlabs/puppet/pull/5645) - [PUP-7222](https://tickets.puppetlabs.com/browse/PUP-7222)
* [PR 5646 - (PUP-7227) Add "reference" as a valid Pcore Object attribute kind](http://github.com/puppetlabs/puppet/pull/5646) - [PUP-7227](https://tickets.puppetlabs.com/browse/PUP-7227)

#### Breaking changes that must wait for Puppet 5

* [PR 4584 - (PUP-5609) Protect shared state with filesystem lock](http://github.com/puppetlabs/puppet/pull/4584) - [PUP-5609](https://tickets.puppetlabs.com/browse/PUP-5609)
* [PR 5480 - (PUP-6112) Make trusted_server_facts always be true](http://github.com/puppetlabs/puppet/pull/5480) - [PUP-6112](https://tickets.puppetlabs.com/browse/PUP-6112)
* [PR 5610 - (PUP-7173) server_set facts rb failing with undefined local variable or method `master opts](http://github.com/puppetlabs/puppet/pull/5610) - [PUP-7173](https://tickets.puppetlabs.com/browse/PUP-7173)
* [PR 5510 - (PUP-4947) Make app management keywords standard](http://github.com/puppetlabs/puppet/pull/5510) - [PUP-4947](https://tickets.puppetlabs.com/browse/PUP-4947)
* [PR 5603 - (maint) update version.rb for 5.0](http://github.com/puppetlabs/puppet/pull/5603)
* [PR 5617 - (PUP-7175) lookup.rb failing automatic parameter lookup with module data binding](http://github.com/puppetlabs/puppet/pull/5617) - [PUP-7175](https://tickets.puppetlabs.com/browse/PUP-7175)
* [PR 5556 - (PUP-3170) Cap integer size](http://github.com/puppetlabs/puppet/pull/5556) - [PUP-3170](https://tickets.puppetlabs.com/browse/PUP-3170)
    * git cherry-pick 112e3b3ac03394258ac0b47d47b7faff5638c2c4
    * git cherry-pick 956f7556870fe90e54d7a6fae17b410ed509422c
    * git cherry-pick 0a5c85a109889fe70535dc261e27245e82a76fc5
    * git cherry-pick 189a6f8b8f21919353e6f650eea2e8fc59e623a2
    * git cherry-pick 67f22dfd0262009dd740b7d148e89c2050add3df
    * git cherry-pick 33252a1c9a938cb19366992e9b9f306950a314ff
    * git cherry-pick e2ba08435e7487e641a437b0ed9f111ae92c4e7e
    * git cherry-pick 5094ac2a0f0d6d6e1bcc4c70a3f89b47fac1e783
* [PR 5511 - (PUP-5954) Make class merge an error](http://github.com/puppetlabs/puppet/pull/5511) - [PUP-5954](https://tickets.puppetlabs.com/browse/PUP-5954)
    * git cherry-pick 75a81f6cb9e81b4b3094c1e6324c462da6f61f43
    * git cherry-pick 0a36704e2f7a6ca09ce84b7ea471ab45031434a8
    * git cherry-pick e9356dd36f47ded66e82d5174c2f035fc5c0ddcb
* [PR 5477 - (PUP-6930) Make DUPLICATE_DEFAULT an error](http://github.com/puppetlabs/puppet/pull/5477) - [PUP-6930](https://tickets.puppetlabs.com/browse/PUP-6930)
    * git cherry-pick c2d14d8359ac51d65e881f2e6b33b67a0ed4ccd4
    * git cherry-pick 485518c0353525a1dab3639ffe3e70211551af25
