### PR TITLE
(PUP-7336) Fix problem with interpolated global dotted key references

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -188,7 +188,7 @@ class HieraConfig
         @scope_interpolations.all? do |key, root_key, segments, old_value|
           value = scope[root_key]
           unless value.nil? || segments.empty?
-            found = '';
+            found = nil;
             catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
             value = found;
           end

--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -92,8 +92,8 @@ module Interpolation
             end
           end
         end
-        unless segments.empty?
-          found = '';
+        unless value.nil? || segments.empty?
+          found = nil;
           catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
           value = found;
         end


### PR DESCRIPTION
Before this PR, Hiera would consider an interpolation expression in the hiera.yaml that referenced a variable using a global key with subkey (a dotted key), to be initally set, although it wasn't. This was caused by the subkey lookup which transferred the nil value into an emtpy string. As a result, Hiera would skip that global key since global keys are known to be immutable (once set, they cannot change). This made Hiera miss that the value of such keys went from undefined to defined.