### PR TITLE
(PUP-6114) Adds new HTTP headers for checksum validation.

### DIFF
--- a/lib/puppet/type/file/checksum.rb
+++ b/lib/puppet/type/file/checksum.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:file).newparam(:checksum) do
 
     The default checksum type is md5."
 
-  newvalues "md5", "md5lite", "sha256", "sha256lite", "mtime", "ctime", "none"
+  newvalues "md5", "md5lite", "sha256", "sha256lite", "sha1", "sha1lite", "mtime", "ctime", "none"
 
   defaultto do
     Puppet[:digest_algorithm].to_sym


### PR DESCRIPTION
* This is primarily for the support of the artifactory HTTP headers for 
checksum validation. However, other headers could be configured in 
defaults for other providers

Resurrecting #4828, looking to implement the ideas from @MikaelSmith's previous comment:

> These [artifactory headers] are non-standard, and could potentially be used for a different purpose on other websites. As such, I'm not comfortable hard-coding these headers as fallbacks.
>
> However, this could be done as settings that can be configured in puppet.conf. See https://github.com/puppetlabs/puppet/blob/master/lib/puppet/defaults.rb#L825-L839 for an example of a setting that takes an array. My suggestion would be to introduce 3 settings - one each for custom md5, sha1, and sha256 headers - that can be an array of possible headers. Then #initialize would iterate through them to look for a valid checksum.

Might need some help on the defaults bit 😄 