### PR TITLE
(maint) Allow use of beaker 3.x in acceptance tests

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.5.0')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.10')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake", "~> 10.1"


### PR DESCRIPTION
This updates the Gemspec to allow the use of beaker 3.x, which
is needed to include support for new platforms (Ubuntu 16.10
in particular, which was added in beaker 3.10).