### PR TITLE
(PUP-7340) Fix context_spec failure

### DIFF
--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -160,6 +160,8 @@ module Puppet::Test
 
       Puppet.settings.send(:clear_everything_for_tests)
 
+      Puppet.lookup(:environments).clear_all
+
       Puppet::Util::Storage.clear
       Puppet::Util::ExecutionStub.reset
 

--- a/spec/unit/pops/lookup/context_spec.rb
+++ b/spec/unit/pops/lookup/context_spec.rb
@@ -171,10 +171,6 @@ describe 'Puppet::Pops::Lookup::Context' do
 
       context 'and multiple compilations' do
 
-        after(:each) do
-          Puppet.lookup(:environments).clear_all
-        end
-
         it 'will reuse cached_file_data and not call block again' do
           Puppet.settings[:environment_timeout] = 'unlimited'
 

--- a/spec/unit/pops/lookup/context_spec.rb
+++ b/spec/unit/pops/lookup/context_spec.rb
@@ -171,13 +171,12 @@ describe 'Puppet::Pops::Lookup::Context' do
 
       context 'and multiple compilations' do
 
-        before(:each) { Puppet.settings[:environment_timeout] = 'unlimited' }
         after(:each) do
-          Puppet.settings[:environment_timeout] = 0
           Puppet.lookup(:environments).clear_all
         end
 
         it 'will reuse cached_file_data and not call block again' do
+          Puppet.settings[:environment_timeout] = 'unlimited'
 
           code1 = <<-PUPPET.unindent
             $ctx = Puppet::LookupContext.new(nil)


### PR DESCRIPTION
 - Environment timeouts were configured improperly for this test.
   They were passing when run in parallel because the
   :environment_timeout setting is global state, and tests on
   different threads may interfere with one another