### PR TITLE
(PUP-7350) Update minitar to 0.6.1

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -41,7 +41,7 @@ gem_platform_dependencies:
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'
-      minitar: '~> 0.5.4'
+      minitar: '~> 0.6.1'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.6'
@@ -52,7 +52,7 @@ gem_platform_dependencies:
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'
-      minitar: '~> 0.5.4'
+      minitar: '~> 0.6.1'
 bundle_platforms:
   universal-darwin: all
   x86-mingw32: mingw


### PR DESCRIPTION
We have updated the minitar component in the agent, and subsequently we will
need to update minitar for the puppet gem as well