### PR TITLE
(maint) Address incorrect argument passing within Puppet

### DIFF
--- a/ext/upload_facts.rb
+++ b/ext/upload_facts.rb
@@ -102,7 +102,7 @@ HELP
     files.each do |file|
       facts = YAML.load_file(file)
 
-      request = Puppet::Indirector::Request.new(:facts, :save, facts)
+      request = Puppet::Indirector::Request.new(:facts, :save, facts, nil)
 
       # The terminus warns for us if we fail.
       if terminus.save(request)

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -311,13 +311,13 @@ class Application
   # handling of this.
   option("--version", "-V") do |arg|
     puts "#{Puppet.version}"
-    exit
+    exit(0)
   end
 
   # Every app responds to --help
   option("--help", "-h") do |v|
     puts help
-    exit
+    exit(0)
   end
 
   def app_defaults()

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -24,7 +24,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     else
       puts Puppet::Face[:help, :current].help(face.name)
     end
-    exit
+    exit(0)
   end
 
   attr_accessor :face, :action, :type, :arguments, :render_as

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -21,7 +21,7 @@ class Puppet::Application::Resource < Puppet::Application
       types << t.name.to_s
     end
     puts types.sort
-    exit
+    exit(0)
   end
 
   option("--param PARAM", "-p") do |arg|

--- a/lib/puppet/module_tool/dependency.rb
+++ b/lib/puppet/module_tool/dependency.rb
@@ -16,7 +16,7 @@ module Puppet::ModuleTool
       # TODO: add error checking, the next line raises ArgumentError when +full_module_name+ is invalid
       @username, @name = Puppet::ModuleTool.username_and_modname_from(full_module_name)
       @version_requirement = version_requirement
-      @repository = repository ? Puppet::Forge::Repository.new(repository) : nil
+      @repository = repository ? Puppet::Forge::Repository.new(repository, nil) : nil
     end
 
     # We override Object's ==, eql, and hash so we can more easily find identical

--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -32,7 +32,7 @@ module Puppet::Network::HTTP::Compression
     end
 
     def uncompress(response)
-      raise Net::HTTPError.new("No block passed") unless block_given?
+      raise Net::HTTPError.new("No block passed", response) unless block_given?
 
       case response['content-encoding']
       when 'gzip','deflate'

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -340,8 +340,6 @@ module Puppet::Util::Checksums
     end
   end
 
-  private_class_method
-
   # Perform an incremental checksum on a file.
   def checksum_file(digest, filename, lite = false)
     buffer = lite ? 512 : 4096

--- a/lib/puppet/util/instance_loader.rb
+++ b/lib/puppet/util/instance_loader.rb
@@ -41,7 +41,7 @@ module Puppet::Util::InstanceLoader
 
     # Use this method so they all get loaded
     loaded_instances(type).sort { |a,b| a.to_s <=> b.to_s }.each do |name|
-      mod = self.loaded_instance(name)
+      mod = self.loaded_instance(type, name)
       docs << "#{name}\n#{"-" * name.to_s.length}\n"
 
       docs << Puppet::Util::Docs.scrub(mod.doc) << "\n\n"


### PR DESCRIPTION
These were discovered with the aid of RubyMines `Incorrect call argument count` inspection, which is just one of many inspections it supports in code analysis..  There were a lot of false positives that turned up, but these seem legit.