### PR TITLE
(PUP-7340) Fix context_spec failure on OSX

### DIFF
--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -192,6 +192,9 @@ module Puppet::Test
         $old_env.each {|k, v| Puppet::Util.set_env(k, v, mode) }
       end
 
+      # Clear all environments
+      Puppet.lookup(:environments).clear_all
+
       # Restore the load_path late, to avoid messing with stubs from the test.
       $LOAD_PATH.clear
       $old_load_path.each {|x| $LOAD_PATH << x }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -161,6 +161,8 @@ RSpec.configure do |config|
   config.after :each do
     Puppet::Test::TestHelper.after_each_test()
 
+    Puppet.lookup(:environments).clear_all
+
     # TODO: would like to move this into puppetlabs_spec_helper, but there are namespace issues at the moment.
     PuppetSpec::Files.cleanup
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -161,8 +161,6 @@ RSpec.configure do |config|
   config.after :each do
     Puppet::Test::TestHelper.after_each_test()
 
-    Puppet.lookup(:environments).clear_all
-
     # TODO: would like to move this into puppetlabs_spec_helper, but there are namespace issues at the moment.
     PuppetSpec::Files.cleanup
 

--- a/spec/unit/pops/lookup/context_spec.rb
+++ b/spec/unit/pops/lookup/context_spec.rb
@@ -172,10 +172,6 @@ describe 'Puppet::Pops::Lookup::Context' do
       context 'and multiple compilations' do
 
         before(:each) { Puppet.settings[:environment_timeout] = 'unlimited' }
-        after(:each) do
-          Puppet.settings[:environment_timeout] = 0
-          Puppet.lookup(:environments).clear_all
-        end
 
         it 'will reuse cached_file_data and not call block again' do
 

--- a/spec/unit/pops/lookup/context_spec.rb
+++ b/spec/unit/pops/lookup/context_spec.rb
@@ -221,11 +221,11 @@ describe 'Puppet::Pops::Lookup::Context' do
             Puppet::Parser::Compiler.compile(node)
 
             # Change contents!
-            File.write(data_path, "b: value b\n")
+            File.write(data_path, "a: value is now A\n")
             Puppet::Parser::Compiler.compile(node)
           end
           logs = logs.select { |log| log.level == :notice }.map { |log| log.message }
-          expect(logs).to eql(["{parsed => a: value a\n}", "{parsed => b: value b\n}"])
+          expect(logs).to eql(["{parsed => a: value a\n}", "{parsed => a: value is now A\n}"])
         end
       end
     end


### PR DESCRIPTION
A test that wrote new content with the exact same size to a file and
then checked if the file had changed by comparing inode, mtime, and
size, failed on OSX since the time resolution was too low for the rapid
create, read, change, check cycle and the inode stayed the same. This
commit ensures that the size of the file changes.