### PR TITLE
(PUP-7360) Add a minor_version method to make docs links easier

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -61,7 +61,7 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
   def lookup(scope, key, default, has_default, override, &default_block)
     unless Puppet[:strict] == :off
       Puppet.warn_once(:deprecation, self.class.name,
-        "The function '#{self.class.name}' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html")
+        "The function '#{self.class.name}' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/#{Puppet.minor_version}/reference/deprecated_language.html")
     end
     lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {})
     adapter = lookup_invocation.lookup_adapter

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -78,7 +78,7 @@ The returned value's data type depends on the types of the results. In the examp
 above, Hiera matches the 'users' key and returns it as a hash.
 
 The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/#{Puppet.minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -66,7 +66,7 @@ $allusers = hiera_array('users') | $key | { "Key \'${key}\' not found" }
 value is a hash, Puppet raises a type mismatch error.
 
 `hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/#{Puppet.minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -76,7 +76,7 @@ $allusers = hiera_hash('users') | $key | { "Key \'${key}\' not found" }
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
 `hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/#{Puppet.minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -76,7 +76,7 @@ hiera_include('classes') | $key | {"Key \'${key}\' not found" }
 ~~~
 
 `hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
-removed in 6.0.0. See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+removed in 6.0.0. See  https://docs.puppet.com/puppet/#{Puppet.minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -5,7 +5,6 @@
 # The version can be set programmatically because we want to allow the
 # Raketasks and such to set the version based on the output of `git describe`
 
-
 module Puppet
   PUPPETVERSION = '4.10.0'
 
@@ -66,6 +65,11 @@ module Puppet
       @puppet_version = version
     end
     @puppet_version ||= PUPPETVERSION
+  end
+
+  # @return [String] containing the puppet version to minor specificity, e.g. "3.0"
+  def self.minor_version
+    self.version.split('.')[0..1].join('.')
   end
 
   def self.version=(version)

--- a/spec/unit/version_spec.rb
+++ b/spec/unit/version_spec.rb
@@ -27,6 +27,7 @@ describe "Puppet.version Public API" do
     it "respects the version= setter" do
       Puppet.version = '1.2.3'
       expect(Puppet.version).to eq('1.2.3')
+      expect(Puppet.minor_version).to eq('1.2')
     end
   end
 
@@ -38,10 +39,12 @@ describe "Puppet.version Public API" do
       end.returns('3.0.1-260-g9ca4e54')
 
       expect(Puppet.version).to eq('3.0.1-260-g9ca4e54')
+      expect(Puppet.minor_version).to eq('3.0')
     end
     it "respects the version= setter" do
       Puppet.version = '1.2.3'
       expect(Puppet.version).to eq('1.2.3')
+      expect(Puppet.minor_version).to eq('1.2')
     end
   end
 
@@ -50,6 +53,7 @@ describe "Puppet.version Public API" do
       Puppet.expects(:read_version_file).never
       Puppet.version = '1.2.3'
       expect(Puppet.version).to eq('1.2.3')
+      expect(Puppet.minor_version).to eq('1.2')
     end
   end
 end


### PR DESCRIPTION
Sometimes error messages link to versioned docs pages. The docs pages
are only versioned by minor numbers, such as `4.9`. Ergo, it would be
nice to have a method to generate those easily. This adds that method.

This "reimplements" some version parsing because attempts to load the
SemanticPuppet library became too heavy and fragile.