### PR TITLE
(PUP-7359) Add evaluation of interpolation expressions in encrypted data

### DIFF
--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -70,9 +70,11 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
   end
 
   def decrypt(data, context)
-    return context.interpolate(data) unless encrypted?(data)
-    tokens = Hiera::Backend::Eyaml::Parser::ParserFactory.hiera_backend_parser.parse(data)
-    tokens.map(&:to_plain_text).join.chomp
+    if encrypted?(data)
+      tokens = Hiera::Backend::Eyaml::Parser::ParserFactory.hiera_backend_parser.parse(data)
+      data = tokens.map(&:to_plain_text).join.chomp
+    end
+    context.interpolate(data)
   end
 
   def encrypted?(data)

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2028,6 +2028,7 @@ describe "The lookup function" do
       let(:data_files) do
         {
           'common.eyaml' => <<-YAML.unindent
+            # a: Encrypted value 'a' (from environment)
             a: >
               ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEw
               DQYJKoZIhvcNAQEBBQAEggEAUwwNRA5ZKM87SLnjnJfzDFRQbeheSYMTOhcr
@@ -2041,6 +2042,7 @@ describe "The lookup function" do
               dCILO7I8QqU=]
             hash_a:
               "hash_%{ipl_suffix}":
+                # aaa: Encrypted value hash_a.hash_aa.aaa (from environment)
                 aaa: >
                   ENC[PKCS7,MIIBqQYJKoZIhvcNAQcDoIIBmjCCAZYCAQAxggEhMIIBHQIBADAFMAACAQEw
                   DQYJKoZIhvcNAQEBBQAEggEAhvGXL5RxVUs9wdqJvpCyXtfCHrm2HbG/u30L
@@ -2053,6 +2055,7 @@ describe "The lookup function" do
                   ovm/gEB4oPlYJswoXuWqcEBfwZzbpy96x3b2Le/yoa72ylbPAUc5GfLENvFQ
                   zXpTtSmQE0fixY4JMaBTke65ZRvoiOQO]
             array_a:
+              # - "array_a[0]"
               - >
                 ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEw
                 DQYJKoZIhvcNAQEBBQAEggEAmXZfyfU77vVCZqHpR10qhD0Jy9DpMGBgal97
@@ -2063,6 +2066,7 @@ describe "The lookup function" do
                 MieIkHj93bX3gIEcenECLdWaEzcPa7MHgl6zevQKg4H0JVmcvKYyfHYqcrVE
                 PqizKDA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDf259KZEay1widVSFy
                 I9zGgBAICjm0x2GeqoCnHdiAA+jt]
+              # - "array_a[1]"
               - >
                 ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEw
                 DQYJKoZIhvcNAQEBBQAEggEATVy4hHG356INFKOswAhoravh66iJljp+Vn3o
@@ -2073,6 +2077,17 @@ describe "The lookup function" do
                 t22zpYK4J8lgCBV2gKfrOWSi9MAs6JhCeOb8wNLMmAUTbc0WrFJxoCwAPX0z
                 MAjsNjA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBC4v4bNE4gFlbLmVY+9
                 BtSLgBBm7U0wu6d6s9wF9Ek9IHPe]
+            # ref_a: "A resolved = '%{hiera('a')}'"
+            ref_a: >
+                ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEw
+                DQYJKoZIhvcNAQEBBQAEggEAFSuUp+yk+oaA7b5ekT0u360CQ9Q2sIQ/bTcM
+                jT3XLjm8HIGYPcysOEnuo8WcAxJFY5iya4yQ7Y/UhMWXaTi7Vzv/6BmyPDwz
+                +7Z2Mf0r0PvS5+ylue6aem/3bXPOmXTKTf68OCehTRXlDUs8/av9gnsDzojp
+                yiUTBZvKxhIP2n//GyoHgyATveHT0lxPVpdMycB347DtWS7IduCxx0+KiOOw
+                DXYFlYbIVxVInwgERxtsfYSr+Fu0/mkjtRsQm+dPzMQOATE9Val2gGKsV6bi
+                kdm1OM9HrwVsFj6Lma6FYmr89Bcm/1uEc8fiOMtNK3z2+nwunWBMNCGneMYD
+                C5IJejBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAeiZDGQyXHkZlV5ceT
+                iCxpgCDDatuVvbPEEi8rKOC7xhPHZ22zLEEV//l7C9jxq+DZcA==]
             YAML
         }
       end
@@ -2085,6 +2100,10 @@ describe "The lookup function" do
 
       it 'evaluates interpolated keys' do
         expect(lookup('hash_a')).to include('hash_aa')
+      end
+
+      it 'evaluates interpolations in encrypted values' do
+        expect(lookup('ref_a')).to eql("A resolved = 'Encrypted value 'a' (from environment)'")
       end
 
       it 'can read encrypted values inside a hash' do


### PR DESCRIPTION
Before this commit, the `eyaml_lookup_key` function would not evaluate
interpolation expressions that were embedded in encrypted data. This
commit ensures that it does and adds a test to assert that function.