### PR TITLE
(PUP-7182) Improve error messages from Hiera 5

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -738,5 +738,81 @@ module Issues
   ILLEGAL_BOM = hard_issue :ILLEGAL_BOM, :format_name, :bytes do
     "Illegal #{format_name} Byte Order mark at beginning of input: #{bytes} - remove these from the puppet source"
   end
+
+  HIERA_UNSUPPORTED_VERSION = hard_issue :HIERA_UNSUPPORTED_VERSION, :version do
+    "This runtime does not support hiera.yaml version #{version}"
+  end
+
+  HIERA_VERSION_3_NOT_GLOBAL = hard_issue :HIERA_VERSION_3_NOT_GLOBAL, :where do
+    "hiera.yaml version 3 cannot be used in #{label.a_an(where)}"
+  end
+
+  HIERA_UNSUPPORTED_VERSION_IN_GLOBAL = hard_issue :HIERA_UNSUPPORTED_VERSION_IN_GLOBAL do
+    'hiera.yaml version 4 cannot be used in the global layer'
+  end
+
+  HIERA_UNDEFINED_VARIABLE = hard_issue :HIERA_UNDEFINED_VARIABLE, :name do
+    "Undefined variable '#{name}'"
+  end
+
+  HIERA_BACKEND_MULTIPLY_DEFINED = hard_issue :HIERA_BACKEND_MULTIPLY_DEFINED, :name, :first_line do
+    msg = "Backend '#{name}' is defined more than once"
+    fl = first_line
+    fl ? "#{msg}. First defined at line #{fl}" : msg
+  end
+
+  HIERA_NO_PROVIDER_FOR_BACKEND = hard_issue :HIERA_NO_PROVIDER_FOR_BACKEND, :name do
+    "No data provider is registered for backend '#{name}'"
+  end
+
+  HIERA_HIERARCHY_NAME_MULTIPLY_DEFINED = hard_issue :HIERA_HIERARCHY_NAME_MULTIPLY_DEFINED, :name, :first_line do
+    msg = "Hierarchy name '#{name}' defined more than once"
+    fl = first_line
+    fl ? "#{msg}. First defined at line #{fl}" : msg
+  end
+
+  HIERA_V3_BACKEND_NOT_GLOBAL = hard_issue :HIERA_V3_BACKEND_NOT_GLOBAL do
+    "'hiera3_backend' is only allowed in the global layer"
+  end
+
+  HIERA_V3_BACKEND_REPLACED_BY_DATA_HASH = hard_issue :HIERA_V3_BACKEND_REPLACED_BY_DATA_HASH, :function_name do
+    "Use \"data_hash: #{function_name}_data\" instead of \"hiera3_backend: #{function_name}\""
+  end
+
+  HIERA_MISSING_DATA_PROVIDER_FUNCTION = hard_issue :HIERA_MISSING_DATA_PROVIDER_FUNCTION, :name do
+    "One of #{label.combine_strings(Lookup::HieraConfig::FUNCTION_KEYS)} must be defined in hierarchy '#{name}'"
+  end
+
+  HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS = hard_issue :HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS, :name do
+    "Only one of #{label.combine_strings(Lookup::HieraConfig::FUNCTION_KEYS)} can be defined in hierarchy '#{name}'"
+  end
+
+  HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS_IN_DEFAULT = hard_issue :HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS_IN_DEFAULT do
+    "Only one of #{label.combine_strings(Lookup::HieraConfig::FUNCTION_KEYS)} can be defined in defaults"
+  end
+
+  HIERA_MULTIPLE_LOCATION_SPECS = hard_issue :HIERA_MULTIPLE_LOCATION_SPECS, :name do
+    "Only one of #{label.combine_strings(Lookup::HieraConfig::LOCATION_KEYS)} can be defined in hierarchy '#{name}'"
+  end
+
+  HIERA_OPTION_RESERVED_BY_PUPPET = hard_issue :HIERA_OPTION_RESERVED_BY_PUPPET, :key, :name do
+    "Option key '#{key}' used in hierarchy '#{name}' is reserved by Puppet"
+  end
+
+  HIERA_DATA_PROVIDER_FUNCTION_NOT_FOUND = hard_issue :HIERA_DATA_PROVIDER_FUNCTION_NOT_FOUND, :function_type, :function_name do
+    "Unable to find '#{function_type}' function named '#{function_name}'"
+  end
+
+  HIERA_INTERPOLATION_ALIAS_NOT_ENTIRE_STRING = hard_issue :HIERA_INTERPOLATION_ALIAS_NOT_ENTIRE_STRING do
+    "'alias' interpolation is only permitted if the expression is equal to the entire string"
+  end
+
+  HIERA_INTERPOLATION_UNKNOWN_INTERPOLATION_METHOD = hard_issue :HIERA_INTERPOLATION_UNKNOWN_INTERPOLATION_METHOD, :name do
+    "Unknown interpolation method '#{name}'"
+  end
+
+  HIERA_INTERPOLATION_METHOD_SYNTAX_NOT_ALLOWED = hard_issue :HIERA_INTERPOLATION_METHOD_SYNTAX_NOT_ALLOWED do
+    'Interpolation using method syntax is not allowed in this context'
+  end
 end
 end

--- a/lib/puppet/pops/lookup/data_dig_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_dig_function_provider.rb
@@ -23,20 +23,23 @@ class DataDigFunctionProvider < FunctionProvider
 
   def invoke_with_location(lookup_invocation, location, key, merge)
     if location.nil?
-      value = data_dig(key, lookup_invocation, nil, merge)
-      lookup_invocation.report_found(key, validate_data_value(self, value))
-      key.undig(value)
+      key.undig(lookup_invocation.report_found(key, validated_data_dig(key, lookup_invocation, nil, merge)))
     else
       lookup_invocation.with(:location, location) do
-        value = data_dig(key, lookup_invocation, location, merge)
-        lookup_invocation.report_found(key, validate_data_value(self, value))
-        key.undig(value)
+        key.undig(lookup_invocation.report_found(key, validated_data_dig(key, lookup_invocation, location, merge)))
       end
     end
   end
 
   def label
     'Data Dig'
+  end
+
+  def validated_data_dig(key, lookup_invocation, location, merge)
+    validate_data_value(data_dig(key, lookup_invocation, location, merge)) do
+      msg = "Value for key '#{key}', returned from #{full_name}"
+      location.nil? ? msg : "#{msg}, when using location '#{location}',"
+    end
   end
 
   private
@@ -69,6 +72,10 @@ class V3BackendFunctionProvider < DataDigFunctionProvider
     # tells the V3 backend to pick it up from the config.
     resolution_type = lookup_invocation.hiera_v3_merge_behavior? ? :hash : convert_merge(merge)
     @backend.lookup(key.to_s, lookup_invocation.scope, lookup_invocation.hiera_v3_location_overrides, resolution_type, context = {:recurse_guard => nil})
+  end
+
+  def full_name
+    "hiera version 3 backend '#{options[HieraConfig::KEY_BACKEND]}'"
   end
 
   private

--- a/lib/puppet/pops/lookup/data_hash_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_hash_function_provider.rb
@@ -54,12 +54,19 @@ class DataHashFunctionProvider < FunctionProvider
       lookup_invocation.report_not_found(root_key)
       throw :no_such_key
     end
-    interpolate(parent_data_provider.validate_data_value(self, value), lookup_invocation, true)
+    value = parent_data_provider.validate_data_value(value) do
+      msg = "Value for key '#{root_key}', in hash returned from #{full_name}"
+      location.nil? ? msg : "#{msg}, when using location '#{location}',"
+    end
+    interpolate(value, lookup_invocation, true)
   end
 
   def data_hash(lookup_invocation, location)
     ctx = function_context(lookup_invocation, location)
-    ctx.data_hash ||= parent_data_provider.validate_data_hash(self, call_data_hash_function(ctx, lookup_invocation, location))
+    ctx.data_hash ||= parent_data_provider.validate_data_hash(call_data_hash_function(ctx, lookup_invocation, location)) do
+      msg = "Value returned from #{full_name}"
+      location.nil? ? msg : "#{msg}, when using location '#{location}',"
+    end
   end
 
   def call_data_hash_function(ctx, lookup_invocation, location)
@@ -100,7 +107,11 @@ class V4DataHashFunctionProvider < DataHashFunctionProvider
   TAG = 'v4_data_hash'.freeze
 
   def name
-    "deprecated API function \"#{function_name}\""
+    "Deprecated API function \"#{function_name}\""
+  end
+
+  def full_name
+    "deprecated API function '#{function_name}'"
   end
 
   def call_data_hash_function(ctx, lookup_invocation, location)

--- a/lib/puppet/pops/lookup/environment_data_provider.rb
+++ b/lib/puppet/pops/lookup/environment_data_provider.rb
@@ -15,7 +15,7 @@ class EnvironmentDataProvider < ConfiguredDataProvider
       config
     else
       if Puppet[:strict] == :error
-        raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in an environment"
+        config.fail(Issues::HIERA_VERSION_3_NOT_GLOBAL, :where => 'environment')
       else
         Puppet.warn_once(:hiera_v3_at_env_root, config.config_path, 'hiera.yaml version 3 found at the environment root was ignored')
       end

--- a/lib/puppet/pops/lookup/global_data_provider.rb
+++ b/lib/puppet/pops/lookup/global_data_provider.rb
@@ -45,7 +45,7 @@ class GlobalDataProvider < ConfiguredDataProvider
   protected
 
   def assert_config_version(config)
-    raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in the global layer" if config.version == 4
+    config.fail(Issues::HIERA_UNSUPPORTED_VERSION_IN_GLOBAL) if config.version == 4
     config
   end
 

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -154,7 +154,9 @@ class HieraConfig
     when 3
       HieraConfigV3.new(config_root, config_path, loaded_config)
     else
-      raise Puppet::DataBinding::LookupError, "#{@config_path}: This runtime does not support #{CONFIG_FILE_NAME} version '#{version}'"
+      issue = Issues::HIERA_UNSUPPORTED_VERSION
+      raise Puppet::DataBinding::LookupError.new(
+        issue.format(:version => version),  config_path, nil, nil, nil, issue.issue_code)
     end
   end
 
@@ -173,6 +175,11 @@ class HieraConfig
     @data_providers = nil
   end
 
+  def fail(issue, args = EMPTY_HASH, line = nil)
+    raise Puppet::DataBinding::LookupError.new(
+      issue.format(args.merge(:label => self)),  @config_path, line, nil, nil, issue.issue_code)
+  end
+
   # Returns the data providers for this config
   #
   # @param lookup_invocation [Invocation] Invocation data containing scope, overrides, and defaults
@@ -184,10 +191,45 @@ class HieraConfig
         lookup_invocation.report_text { 'Hiera configuration recreated due to change of scope variables used in interpolation expressions' }
       end
       slc_invocation = ScopeLookupCollectingInvocation.new(lookup_invocation.scope)
-      @data_providers = create_configured_data_providers(slc_invocation, parent_data_provider)
+      begin
+        @data_providers = create_configured_data_providers(slc_invocation, parent_data_provider)
+      rescue StandardError => e
+        # Raise a LookupError with a RUNTIME_ERROR issue to prevent this being translated to an evaluation error triggered in the pp file
+        # where the lookup started
+        if e.message =~ /^Undefined variable '([^']+)'/
+          var = $1
+          fail(Issues::HIERA_UNDEFINED_VARIABLE, { :name => var }, find_line_matching(/%\{['"]?#{var}['"]?}/))
+        end
+        raise e
+      end
       @scope_interpolations = slc_invocation.scope_interpolations
     end
     @data_providers
+  end
+
+  # Find first line in configuration that matches regexp after given line. Comments are stripped
+  def find_line_matching(regexp, start_line = 1)
+    line_number = 0
+    File.foreach(@config_path) do |line|
+      line_number += 1
+      next if line_number < start_line
+      quote = nil
+      stripped = ''
+      line.each_codepoint do |cp|
+        if cp == 0x22 || cp == 0x27 # double or single quote
+          if quote == cp
+            quote = nil
+          elsif quote.nil?
+            quote = cp
+          end
+        elsif cp == 0x23 # unquoted hash mark
+          break
+        end
+        stripped << cp
+      end
+      return line_number if stripped =~ regexp
+    end
+    nil
   end
 
   def scope_interpolations_stable?(lookup_invocation)
@@ -323,7 +365,15 @@ class HieraConfigV3 < HieraConfig
     data_providers = {}
 
     [@config[KEY_BACKENDS]].flatten.each do |backend|
-      raise Puppet::DataBinding::LookupError, "#{@config_path}: Backend '#{backend}' defined more than once" if data_providers.include?(backend)
+      if data_providers.include?(backend)
+        first_line = find_line_matching(/[^\w]#{backend}(?:[^\w]|$)/)
+        line = find_line_matching(/[^\w]#{backend}(?:[^\w]|$)/, first_line + 1) if first_line
+        unless line
+          line = first_line
+          first_line = nil
+        end
+        fail(Issues::HIERA_BACKEND_MULTIPLY_DEFINED, { :name => backend, :first_line => first_line }, line)
+      end
       original_paths = [@config[KEY_HIERARCHY]].flatten
       backend_config = @config[backend]
       if backend_config.nil?
@@ -434,7 +484,9 @@ class HieraConfigV4 < HieraConfig
   def factory_create_data_provider(lookup_invocation, name, parent_data_provider, provider_name, datadir, original_paths)
     service_type = Registry.hash_of_path_based_data_provider_factories
     provider_factory = Puppet.lookup(:injector).lookup(nil, service_type, PATH_BASED_DATA_PROVIDER_FACTORIES_KEY)[provider_name]
-    raise Puppet::DataBinding::LookupError, "#{@config_path}: No data provider is registered for backend '#{provider_name}' " unless provider_factory
+    unless provider_factory
+      fail(Issues::HIERA_NO_PROVIDER_FOR_BACKEND, { :name => provider_name }, find_line_matching(/[^\w]#{provider_name}(?:[^\w]|$)/))
+    end
 
     paths = original_paths.map { |path| interpolate(path, lookup_invocation, false) }
     paths = provider_factory.resolve_paths(datadir, original_paths, paths, lookup_invocation)
@@ -454,7 +506,15 @@ class HieraConfigV4 < HieraConfig
 
     @config[KEY_HIERARCHY].each do |he|
       name = he[KEY_NAME]
-      raise Puppet::DataBinding::LookupError, "#{@config_path}: Name '#{name}' defined more than once" if data_providers.include?(name)
+      if data_providers.include?(name)
+        first_line = find_line_matching(/\s+name:\s+['"]?#{name}(?:[^\w]|$)/)
+        line = find_line_matching(/\s+name:\s+['"]?#{name}(?:[^\w]|$)/, first_line + 1) if first_line
+        unless line
+          line = first_line
+          first_line = nil
+        end
+        fail(Issues::HIERA_HIERARCHY_NAME_MULTIPLY_DEFINED, { :name => name, :first_line => first_line }, line)
+      end
       original_paths = he[KEY_PATHS] || [he[KEY_PATH] || name]
       datadir = @config_root + (he[KEY_DATADIR] || default_datadir)
       provider_name = he[KEY_BACKEND]
@@ -539,7 +599,15 @@ class HieraConfigV5 < HieraConfig
     data_providers = {}
     @config[KEY_HIERARCHY].each do |he|
       name = he[KEY_NAME]
-      raise Puppet::DataBinding::LookupError, "#{@config_path}: Name '#{name}' defined more than once" if data_providers.include?(name)
+      if data_providers.include?(name)
+        first_line = find_line_matching(/\s+name:\s+['"]?#{name}(?:[^\w]|$)/)
+        line = find_line_matching(/\s+name:\s+['"]?#{name}(?:[^\w]|$)/, first_line + 1) if first_line
+        unless line
+          line = first_line
+          first_line = nil
+        end
+        fail(Issues::HIERA_HIERARCHY_NAME_MULTIPLY_DEFINED, { :name => name, :first_line => first_line }, line)
+      end
       function_kind = ALL_FUNCTION_KEYS.find { |key| he.include?(key) }
       if function_kind.nil?
         function_kind = FUNCTION_KEYS.find { |key| defaults.include?(key) }
@@ -574,13 +642,13 @@ class HieraConfigV5 < HieraConfig
       options = options.nil? ? EMPTY_HASH : interpolate(options, lookup_invocation, false)
       if(function_kind == KEY_V3_BACKEND)
         unless parent_data_provider.is_a?(GlobalDataProvider)
-          # hiera3_backend is not allowed in environments and modules
-          raise Puppet::DataBinding::LookupError, "#{@config_path}: '#{KEY_V3_BACKEND}' is only allowed in the global layer"
+          fail(Issues::HIERA_V3_BACKEND_NOT_GLOBAL, EMPTY_HASH, find_line_matching(/\s+#{function_kind}:/))
         end
 
         if function_name == 'json' || function_name == 'yaml' || function_name == 'hocon' &&  Puppet.features.hocon?
           # Disallow use of backends that have corresponding "data_hash" functions in version 5
-          raise Puppet::DataBinding::LookupError, "#{@config_path}: Use \"#{KEY_DATA_HASH}: #{function_name}_data\" instead of \"#{KEY_V3_BACKEND}: #{function_name}\""
+          fail(Issues::HIERA_V3_BACKEND_REPLACED_BY_DATA_HASH, { :function_name => function_name },
+            find_line_matching(/\s+#{function_kind}:\s*['"]?#{function_name}(?:[^\w]|$)/))
         end
         v3options = { :datadir => entry_datadir.to_s }
         options.each_pair { |k, v| v3options[k.to_sym] = v }
@@ -629,30 +697,22 @@ class HieraConfigV5 < HieraConfig
       case ALL_FUNCTION_KEYS.count { |key| he.include?(key) }
       when 0
         if defaults.nil? || FUNCTION_KEYS.count { |key| defaults.include?(key) } == 0
-          raise Puppet::DataBinding::LookupError,
-            "#{@config_path}: One of #{combine_strings(FUNCTION_KEYS)} must defined in hierarchy '#{name}'"
+          fail(Issues::HIERA_MISSING_DATA_PROVIDER_FUNCTION, :name => name)
         end
       when 1
         # OK
-      when 0
-        raise Puppet::DataBinding::LookupError,
-          "#{@config_path}: One of #{combine_strings(FUNCTION_KEYS)} must defined in hierarchy '#{name}'"
       else
-        raise Puppet::DataBinding::LookupError,
-          "#{@config_path}: Only one of #{combine_strings(FUNCTION_KEYS)} can be defined in hierarchy '#{name}'"
+        fail(Issues::HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS, :name => name)
       end
 
       if LOCATION_KEYS.count { |key| he.include?(key) } > 1
-        raise Puppet::DataBinding::LookupError,
-          "#{@config_path}: Only one of #{combine_strings(LOCATION_KEYS)} can be defined in hierarchy '#{name}'"
+        fail(Issues::HIERA_MULTIPLE_LOCATION_SPECS, :name => name)
       end
 
       options = he[KEY_OPTIONS]
       unless options.nil?
         RESERVED_OPTION_KEYS.each do |key|
-          if options.include?(key)
-            raise Puppet::DataBinding::LookupError, "#{@config_path}: Option key '#{key}' used in hierarchy '#{name}' is reserved by Puppet"
-          end
+          fail(Issues::HIERA_OPTION_RESERVED_BY_PUPPET, :key => key, :name => name) if options.include?(key)
         end
       end
     end
@@ -664,8 +724,7 @@ class HieraConfigV5 < HieraConfig
     when 0, 1
       # OK
     else
-      raise Puppet::DataBinding::LookupError,
-        "#{@config_path}: Only one of #{combine_strings(FUNCTION_KEYS)} can be defined in defaults"
+      fail(Issues::HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS_IN_DEFAULT)
     end
   end
 

--- a/lib/puppet/pops/lookup/location_resolver.rb
+++ b/lib/puppet/pops/lookup/location_resolver.rb
@@ -25,6 +25,11 @@ module Lookup
     def exist?
       @exist
     end
+
+    # @return the resolved location as a string
+    def to_s
+      @location.to_s
+    end
   end
 
   # Helper methods to resolve interpolated locations

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -85,6 +85,7 @@ class LookupAdapter < DataAdapter
       end
     end
   rescue Puppet::DataBinding::LookupError => detail
+    raise detail unless detail.issue_code.nil?
     error = Puppet::Error.new("Lookup of key '#{lookup_invocation.top_key}' failed: #{detail.message}")
     error.set_backtrace(detail.backtrace)
     raise error

--- a/lib/puppet/pops/lookup/module_data_provider.rb
+++ b/lib/puppet/pops/lookup/module_data_provider.rb
@@ -21,23 +21,24 @@ class ModuleDataProvider < ConfiguredDataProvider
   #
   # @param data_hash [Hash] The data hash
   # @return [Hash] The possibly pruned hash
-  def validate_data_hash(data_provider, data_hash)
+  def validate_data_hash(data_hash)
     super
     module_prefix = "#{module_name}::"
     data_hash.each_key.reduce(data_hash) do |memo, k|
       next memo if k == LOOKUP_OPTIONS || k.start_with?(module_prefix)
-      msg = 'must use keys qualified with the name of the module'
+      msg = "#{yield} must use keys qualified with the name of the module"
       memo = memo.clone if memo.equal?(data_hash)
       memo.delete(k)
-      Puppet.warning("Module '#{module_name}': #{data_provider.name} #{msg}")
+      Puppet.warning("Module '#{module_name}': #{msg}")
       memo
     end
+    data_hash
   end
 
   protected
 
   def assert_config_version(config)
-    raise Puppet::DataBinding::LookupError, "#{config.name} cannot be used in a module" unless config.version > 3
+    config.fail(Issues::HIERA_VERSION_3_NOT_GLOBAL, :where => 'module') unless config.version > 3
     config
   end
 

--- a/spec/unit/data_providers/function_data_provider_spec.rb
+++ b/spec/unit/data_providers/function_data_provider_spec.rb
@@ -90,7 +90,7 @@ describe "when using function data provider" do
     env_loader.add_entry(:function, 'environment::data', f.new(compiler.topscope, env_loader), nil)
     expect do
       compiler.compile()
-    end.to raise_error(/Value returned from deprecated API function "environment::data" has wrong type/)
+    end.to raise_error(/Value returned from deprecated API function 'environment::data' has wrong type/)
   end
 
   it 'raises an error if the module data function does not return a hash' do
@@ -109,7 +109,7 @@ describe "when using function data provider" do
     module_loader.add_entry(:function, 'abc::data', f.new(compiler.topscope, module_loader), nil)
     expect do
       compiler.compile()
-    end.to raise_error(/Value returned from deprecated API function "abc::data" has wrong type/)
+    end.to raise_error(/Value returned from deprecated API function 'abc::data' has wrong type/)
   end
 
   def parent_fixture(dir_name)

--- a/spec/unit/functions/lookup_fixture_spec.rb
+++ b/spec/unit/functions/lookup_fixture_spec.rb
@@ -383,7 +383,7 @@ describe 'The lookup function' do
         expect { compiler.compile }.to raise_error(Puppet::ParseError, /did not find a value for the name 'bad_data::b'/)
       end
       warnings = logs.select { |log| log.level == :warning }.map { |log| log.message }
-      expect(warnings).to include("Module 'bad_data': deprecated API function \"bad_data::data\" must use keys qualified with the name of the module")
+      expect(warnings).to include("Module 'bad_data': Value returned from deprecated API function 'bad_data::data' must use keys qualified with the name of the module")
     end
 
     it 'will succeed finding prefixed keys even when a key in the function provided module data is not prefixed' do
@@ -397,7 +397,7 @@ describe 'The lookup function' do
         expect(resources).to include('module_c')
       end
       warnings = logs.select { |log| log.level == :warning }.map { |log| log.message }
-      expect(warnings).to include("Module 'bad_data': deprecated API function \"bad_data::data\" must use keys qualified with the name of the module")
+      expect(warnings).to include("Module 'bad_data': Value returned from deprecated API function 'bad_data::data' must use keys qualified with the name of the module")
     end
 
     it 'will resolve global, environment, and module correctly' do
@@ -429,7 +429,7 @@ describe 'The lookup function' do
         compiler.compile
       end
       warnings = logs.select { |log| log.level == :warning }.map { |log| log.message }
-      expect(warnings).to include("Module 'bad_data': deprecated API function \"bad_data::data\" must use keys qualified with the name of the module")
+      expect(warnings).to include("Module 'bad_data': Value returned from deprecated API function 'bad_data::data' must use keys qualified with the name of the module")
     end
 
     it 'a warning will be logged when key in the hiera provided module data is not prefixed' do
@@ -439,7 +439,7 @@ describe 'The lookup function' do
         compiler.compile
       end
       warnings = logs.select { |log| log.level == :warning }.map { |log| log.message }
-      expect(warnings).to include("Module 'hieraprovider': Hierarchy entry \"two paths\" must use keys qualified with the name of the module")
+      expect(warnings).to include("Module 'hieraprovider': Value returned from data_hash function 'json_data', when using location '#{environmentpath}/production/modules/hieraprovider/data/first.json', must use keys qualified with the name of the module")
     end
   end
 
@@ -514,7 +514,7 @@ describe 'The lookup function' do
         end
         expect(lookup_invocation.explainer.explain).to include(<<-EOS.unindent('  '))
           Module "abc" Data Provider (hiera configuration version 5)
-            deprecated API function "abc::data"
+            Deprecated API function "abc::data"
               No such key: "abc::x"
         EOS
       end
@@ -530,13 +530,13 @@ describe 'The lookup function' do
               Global Data Provider (hiera configuration version 5)
                 No such key: "abc::e"
               Environment Data Provider (hiera configuration version 5)
-                deprecated API function "environment::data"
+                Deprecated API function "environment::data"
                   Found key: "abc::e" value: {
                     "k1" => "env_e1",
                     "k3" => "env_e3"
                   }
               Module "abc" Data Provider (hiera configuration version 5)
-                deprecated API function "abc::data"
+                Deprecated API function "abc::data"
                   Found key: "abc::e" value: {
                     "k1" => "module_e1",
                     "k2" => "module_e2"
@@ -576,7 +576,7 @@ describe 'The lookup function' do
               Global Data Provider (hiera configuration version 5)
                 No such key: "hieraprovider::test::not_found"
               Environment Data Provider (hiera configuration version 5)
-                deprecated API function "environment::data"
+                Deprecated API function "environment::data"
                   No such key: "hieraprovider::test::not_found"
               Module "hieraprovider" Data Provider (hiera configuration version 4)
                 Using configuration "#{environmentpath}/production/modules/hieraprovider/hiera.yaml"
@@ -636,7 +636,7 @@ describe 'The lookup function' do
                     :branches => [
                       {
                         :type => :data_provider,
-                        :name => 'deprecated API function "environment::data"',
+                        :name => 'Deprecated API function "environment::data"',
                         :key => 'abc::e',
                         :value => { 'k1' => 'env_e1', 'k3' => 'env_e3' },
                         :event => :found
@@ -650,7 +650,7 @@ describe 'The lookup function' do
                     :branches => [
                       {
                         :type => :data_provider,
-                        :name => 'deprecated API function "abc::data"',
+                        :name => 'Deprecated API function "abc::data"',
                         :key => 'abc::e',
                         :event => :found,
                         :value => {


### PR DESCRIPTION
This commit contains an overhaul of the errors raised by the lookup
framework. Most errors are converted into proper issues and added to
lib/puppet/pops/issues.rb and, as such, allowed to be propagated all
the way to the log while retaining location information.

Many errors originating from the hiera.yaml will now also have line
information. This is accomplished by a combination of regexps and a
fairly naive parser that is aware of strings and comments.

The errors that were reported when a value was found that didn't conform
to the Puppet::LookupValue have been changed to explicitly state the
originating location and, when appropriate, the key of the culprit.

Unit tests were added to the unit/functions/lookup_spec.rb to cover all
the added issues.