### PR TITLE
(PUP-7368) Add ability to declare function argument mismatch handlers

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -48,11 +48,11 @@
 #
 # Special dispatches designed to create error messages for an argument mismatch
 # can be added using the keyword `argument_mismatch` instead of `dispatch`. The
-# function appointed by an `argument_mismatch` will be called with arguments
-# just like a normal `dispatch` function would, but the function must produce a
-# string. The string is then used as the message in the `ArgumentError` that is
-# raised when the function returns. A block parameter can be given, but it is not
-# propagated in the function call.
+# method appointed by an `argument_mismatch` will be called with arguments
+# just like a normal `dispatch` would, but the method must produce a string.
+# The string is then used as the message in the `ArgumentError` that is raised
+# when the method returns. A block parameter can be given, but it is not
+# propagated in the method call.
 #
 # Documentation for the function should be placed as comments to the
 # implementation method(s).

--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -46,6 +46,14 @@
 # specifies the method that should be called for that signature. When a
 # matching signature is found, the corresponding method is called.
 #
+# Special dispatches designed to create error messages for an argument mismatch
+# can be added using the keyword `argument_mismatch` instead of `dispatch`. The
+# function appointed by an `argument_mismatch` will be called with arguments
+# just like a normal `dispatch` function would, but the function must produce a
+# string. The string is then used as the message in the `ArgumentError` that is
+# raised when the function returns. A block parameter can be given, but it is not
+# propagated in the function call.
+#
 # Documentation for the function should be placed as comments to the
 # implementation method(s).
 #
@@ -70,6 +78,27 @@
 #
 #     def string_min(a, b)
 #       a.downcase <= b.downcase ? a : b
+#     end
+#   end
+#
+# @example Using an argument mismatch handler
+#   Puppet::Functions.create_function('math::min') do
+#     dispatch :numeric_min do
+#       param 'Numeric', :a
+#       param 'Numeric', :b
+#     end
+#
+#     argument_mismatch :on_error do
+#       param 'Any', :a
+#       param 'Any', :b
+#     end
+#
+#     def numeric_min(a, b)
+#       a <= b ? a : b
+#     end
+#
+#     def on_error(a, b)
+#       'both arguments must be of type Numeric'
 #     end
 #   end
 #
@@ -224,7 +253,7 @@ module Puppet::Functions
       simple_name = func_name.split(/::/)[-1]
       type, names = default_dispatcher(the_class, simple_name)
       last_captures_rest = (type.size_range[1] == Float::INFINITY)
-      the_class.dispatcher.add_dispatch(type, simple_name, names, nil, nil, nil, last_captures_rest)
+      the_class.dispatcher.add(Puppet::Pops::Functions::Dispatch.new(type, simple_name, names, last_captures_rest))
     end
 
     # The function class is returned as the result of the create function method
@@ -285,7 +314,22 @@ module Puppet::Functions
     # @api public
     def self.dispatch(meth_name, &block)
       builder().instance_eval do
-        dispatch(meth_name, &block)
+        dispatch(meth_name, false, &block)
+      end
+    end
+
+    # Like `dispatch` but used for a specific type of argument mismatch. Will not be include in the list of valid
+    # parameter overloads for the function.
+    #
+    # @param meth_name [Symbol] The name of the implementation method to call
+    #   when the signature defined in the block matches the arguments to a call
+    #   to the function.
+    # @return [Void]
+    #
+    # @api public
+    def self.argument_mismatch(meth_name, &block)
+      builder().instance_eval do
+        dispatch(meth_name, true, &block)
       end
     end
 
@@ -500,7 +544,7 @@ module Puppet::Functions
     end
 
     # @api private
-    def dispatch(meth_name, &block)
+    def dispatch(meth_name, argument_mismatch_handler, &block)
       # an array of either an index into names/types, or an array with
       # injection information [type, name, injection_name] used when the call
       # is being made to weave injections into the given arguments.
@@ -514,9 +558,10 @@ module Puppet::Functions
       @block_type = nil
       @block_name = nil
       @return_type = nil
+      @argument_mismatch_hander = argument_mismatch_handler
       self.instance_eval &block
       callable_t = create_callable(@types, @block_type, @return_type, @min, @max)
-      @dispatcher.add_dispatch(callable_t, meth_name, @names, @block_name, @injections, @weaving, @max == :default)
+      @dispatcher.add(Puppet::Pops::Functions::Dispatch.new(callable_t, meth_name, @names, @max == :default, @block_name, @injections, @weaving, @argument_mismatch_hander))
     end
 
     # Handles creation of a callable type from strings specifications of puppet

--- a/lib/puppet/pops/evaluator/callable_signature.rb
+++ b/lib/puppet/pops/evaluator/callable_signature.rb
@@ -97,4 +97,11 @@ class Puppet::Pops::Evaluator::CallableSignature
   def infinity?(x)
     x == Float::INFINITY
   end
+
+  # @return [Boolean] true if this signature represents an argument mismatch, false otherwise
+  #
+  # @api private
+  def argument_mismatch_handler?
+    false
+  end
 end

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -21,15 +21,24 @@ class Dispatch < Evaluator::CallableSignature
   # @api public
   attr_reader :block_name
 
+  # @param type [Puppet::Pops::Types::PArrayType, Puppet::Pops::Types::PTupleType] - type describing signature
+  # @param method_name [String] the name of the method that will be called when type matches given arguments
+  # @param param_names [Array<String>] names matching the number of parameters specified by type (or empty array)
+  # @param block_name [String,nil] name of block parameter, no nil
+  # @param injections [Array<Array>] injection data for weaved parameters
+  # @param weaving [Array<Integer,Array>] weaving knits
+  # @param last_captures [Boolean] true if last parameter is captures rest
+  # @param argument_mismatch_handler [Boolean] true if this is a dispatch for an argument mismatch
   # @api private
-  def initialize(type, method_name, param_names, block_name, injections, weaving, last_captures)
+  def initialize(type, method_name, param_names, last_captures = false, block_name = nil, injections = EMPTY_ARRAY, weaving = EMPTY_ARRAY, argument_mismatch_handler = false)
     @type = type
     @method_name = method_name
-    @param_names = param_names || []
-    @block_name = block_name
-    @injections = injections || []
-    @weaving = weaving
+    @param_names = param_names
     @last_captures = last_captures
+    @block_name = block_name
+    @injections = injections
+    @weaving = weaving
+    @argument_mismatch_handler = argument_mismatch_handler
   end
 
   # @api private
@@ -39,7 +48,11 @@ class Dispatch < Evaluator::CallableSignature
 
   # @api private
   def last_captures_rest?
-    !! @last_captures
+    @last_captures
+  end
+
+  def argument_mismatch_handler?
+    @argument_mismatch_handler
   end
 
   # @api private

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -211,12 +211,10 @@ class PObjectType < PMetaType
       # TODO: Assumes Ruby implementation for now
       if(callable_type.is_a?(PVariantType))
         callable_type.types.map do |ct|
-          Functions::Dispatch.new(ct, name, [],
-            ct.block_type.nil? ? nil : 'block', nil, nil, false)
+          Functions::Dispatch.new(ct, name, [], false, ct.block_type.nil? ? nil : 'block')
         end
       else
-        [Functions::Dispatch.new(callable_type, name, [],
-          callable_type.block_type.nil? ? nil : 'block', nil, nil, false)]
+        [Functions::Dispatch.new(callable_type, name, [], false, callable_type.block_type.nil? ? nil : 'block')]
       end
     end
 
@@ -436,7 +434,7 @@ class PObjectType < PMetaType
       # This method should accept a hash and assume that type assertion has been made already (it is made
       # by the dispatch added here).
       if impl_class.respond_to?(:from_asserted_hash)
-        dispatcher.add_dispatch(from_hash_type, :from_hash, ['hash'], nil, EMPTY_ARRAY, EMPTY_ARRAY, false)
+        dispatcher.add(Functions::Dispatch.new(from_hash_type, :from_hash, ['hash']))
         def from_hash(hash)
           self.class.impl_class.from_asserted_hash(hash)
         end
@@ -444,7 +442,7 @@ class PObjectType < PMetaType
 
       # Add the dispatch that uses the standard #from_asserted_args or #new method on the class. It's assumed that the
       # method performs no assertions.
-      dispatcher.add_dispatch(create_type, :create, param_names, nil, EMPTY_ARRAY, EMPTY_ARRAY, false)
+      dispatcher.add(Functions::Dispatch.new(create_type, :create, param_names))
       if impl_class.respond_to?(:from_asserted_args)
         def create(*args)
           self.class.impl_class.from_asserted_args(*args)

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -196,21 +196,21 @@ describe 'the type mismatch describer' do
     it 'reports a missing block as "expects a block"' do
       callable = parser.parse('Callable[String,String,Callable]')
       args_tuple = parser.parse('Tuple[String,String]')
-      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], 'block', nil, nil, false)
+      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], false, 'block')
       expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' expects a block")
     end
 
     it 'reports an unexpected block as "does not expect a block"' do
       callable = parser.parse('Callable[String,String]')
       args_tuple = parser.parse('Tuple[String,String,Callable]')
-      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'], nil, nil, nil, false)
+      dispatch = Functions::Dispatch.new(callable, 'foo', ['a','b'])
       expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' does not expect a block")
     end
 
     it 'reports a block return type mismatch' do
       callable = parser.parse('Callable[[0,0,Callable[ [0,0],String]],Undef]')
       args_tuple = parser.parse('Tuple[Callable[[0,0],Integer]]')
-      dispatch = Functions::Dispatch.new(callable, 'foo', [], 'block', nil, nil, false)
+      dispatch = Functions::Dispatch.new(callable, 'foo', [], false, 'block')
       expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' block return expects a String value, got Integer")
     end
   end


### PR DESCRIPTION
This commit adds an alternative `dispatch` to a function. It is named
`argument_mismatch`. The function that it calls must produce a String
that represents a message describing that the matched arguments are in
fact in error. An `ArgumentError` is then raised when the function returns
that string.

An `argument_mismatch` dispatcher will be excluded when the default
argument mismatch handler describes viable options. It is also excluded
from the list of dispatchers returned from the `Dispatcher`.

A function may have zero to many `argument_mismatch` declarations and
when none of them matches, the default mismatch describer still kicks
in.