### PR TITLE
(PUP-7273) Improve hiera function error message when path is missing

### DIFF
--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -19,6 +19,13 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
   def eyaml_lookup_key(key, options, context)
     return context.cached_value(key) if context.cache_has_key(key)
 
+    # Can't do this with an argument_mismatch dispatcher since there is no way to declare a struct that at least
+    # contains some keys but may contain other arbitrary keys.
+    unless options.include?('path')
+      raise ArgumentError,
+        "'eyaml_lookup_key': one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this lookup_key function"
+    end
+
     # nil key is used to indicate that the cache contains the raw content of the eyaml file
     raw_data = context.cached_value(nil)
     if raw_data.nil?

--- a/lib/puppet/functions/hocon_data.rb
+++ b/lib/puppet/functions/hocon_data.rb
@@ -13,6 +13,11 @@ Puppet::Functions.create_function(:hocon_data) do
     param 'Puppet::LookupContext', :context
   end
 
+  argument_mismatch :missing_path do
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+
   def hocon_data(options, context)
     path = options['path']
     context.cached_file_data(path) do |content|
@@ -22,5 +27,9 @@ Puppet::Functions.create_function(:hocon_data) do
         raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
       end
     end
+  end
+
+  def missing_path(options, context)
+    "one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this data_hash function"
   end
 end

--- a/lib/puppet/functions/json_data.rb
+++ b/lib/puppet/functions/json_data.rb
@@ -6,6 +6,11 @@ Puppet::Functions.create_function(:json_data) do
     param 'Puppet::LookupContext', :context
   end
 
+  argument_mismatch :missing_path do
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+
   def json_data(options, context)
     path = options['path']
     context.cached_file_data(path) do |content|
@@ -16,5 +21,9 @@ Puppet::Functions.create_function(:json_data) do
         raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
       end
     end
+  end
+
+  def missing_path(options, context)
+    "one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this data_hash function"
   end
 end

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -8,6 +8,11 @@ Puppet::Functions.create_function(:yaml_data) do
     param 'Puppet::LookupContext', :context
   end
 
+  argument_mismatch :missing_path do
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+
   def yaml_data(options, context)
     path = options['path']
     context.cached_file_data(path) do |content|
@@ -25,5 +30,9 @@ Puppet::Functions.create_function(:yaml_data) do
         raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
       end
     end
+  end
+
+  def missing_path(options, context)
+    "one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this data_hash function"
   end
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1818,6 +1818,60 @@ describe "The lookup function" do
             expect(e.message).to match(/Lookup using Hocon data_hash function is not supported without hocon library/)
           end
         end
+
+        context 'with missing path declaraion' do
+          context 'and yaml_data function' do
+            let(:hiera_yaml) { <<-YAML.unindent }
+              version: 5
+              hierarchy:
+                - name: Yaml
+                  data_hash: yaml_data
+              YAML
+
+            it 'fails and reports the missing path' do
+              expect { lookup('a') }.to raise_error(/one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this data_hash function/)
+            end
+          end
+
+          context 'and json_data function' do
+            let(:hiera_yaml) { <<-YAML.unindent }
+              version: 5
+              hierarchy:
+                - name: Json
+                  data_hash: json_data
+              YAML
+
+            it 'fails and reports the missing path' do
+              expect { lookup('a') }.to raise_error(/one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this data_hash function/)
+            end
+          end
+
+          context 'and hocon_data function' do
+            let(:hiera_yaml) { <<-YAML.unindent }
+              version: 5
+              hierarchy:
+                - name: Hocon
+                  data_hash: hocon_data
+              YAML
+
+            it 'fails and reports the missing path' do
+              expect { lookup('a') }.to raise_error(/one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this data_hash function/)
+            end
+          end
+
+          context 'and eyaml_lookup_key function' do
+            let(:hiera_yaml) { <<-YAML.unindent }
+              version: 5
+              hierarchy:
+                - name: Yaml
+                  lookup_key: eyaml_lookup_key
+              YAML
+
+            it 'fails and reports the missing path' do
+              expect { lookup('a') }.to raise_error(/one of 'path', 'paths' 'glob', 'globs' or 'mapped_paths' must be declared in hiera.yaml when using this lookup_key function/)
+            end
+          end
+        end
       end
 
       context 'with a hiera3_backend that has no paths' do


### PR DESCRIPTION
Before this commit, a missing path declaration in hiera.yaml resulted in
an error explaing that the options hash sent to a data_hash function that
required a path had an incorrect size (0 instead of 1). While correct,
that message was not very informative. This commit leverages the new
`argument_mismatch` dispatcher added by PUP-7368 to generate more useful
errors when the path is missing.