### PR TITLE
(PUP-893) Deprecate `inspect` command and `audit` metaparameter

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -322,6 +322,15 @@ class Application
     @options = {}
   end
 
+  # call in setup of subclass to deprecate an application
+  def deprecate
+    @deprecated = true
+  end
+
+  def deprecated?
+    @deprecated
+  end
+
   # Execute the application.
   # @api public
   # @return [void]
@@ -339,6 +348,11 @@ class Application
     exit_on_fail("initialize")                                   { preinit }
     exit_on_fail("parse application options")                    { parse_options }
     exit_on_fail("prepare for execution")                        { setup }
+
+    if deprecated?
+      Puppet.deprecation_warning(_("`puppet %{name}` is deprecated and will be removed in a future release.") % { name: name })
+    end
+
     exit_on_fail("configure routes from #{Puppet[:route_file]}") { configure_indirector_routes }
     exit_on_fail("log runtime debug info")                       { log_runtime_environment }
     exit_on_fail("run")                                          { run_command }

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -19,6 +19,7 @@ puppet-inspect(8) -- Send an inspection report
 
 SYNOPSIS
 --------
+Note: this command is deprecated
 
 Prepares and submits an inspection report to the puppet master.
 
@@ -74,6 +75,8 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   end
 
   def setup
+    deprecate
+
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
     raise "Inspect requires reporting to be enabled. Set report=true in puppet.conf to enable reporting." unless Puppet[:report]

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1692,11 +1692,21 @@ EOT
     :archive_files => {
         :type     => :boolean,
         :default  => false,
-        :desc     => "During an inspect run, whether to archive files whose contents are audited to a file bucket.",
+        :desc     => "During an inspect run, whether to archive files whose contents are audited to a file bucket. Note that the `inspect` command is deprecated.",
+        :hook => proc { |value|
+          if Puppet[:strict] != :off
+            Puppet.deprecation_warning(_("Setting 'archive_files' is deprecated. It will be removed in a future release along with the `inspect` command."))
+          end
+        }
     },
     :archive_file_server => {
         :default  => "$server",
-        :desc     => "During an inspect run, the file bucket server to archive files to if archive_files is set.",
+        :desc     => "During an inspect run, the file bucket server to archive files to if archive_files is set. Note that the `inspect` command is deprecated.",
+        :hook => proc { |value|
+          if Puppet[:strict] != :off
+            Puppet.deprecation_warning(_("Setting 'archive_file_server' is deprecated. It will be removed in a future release along with the `inspect` command."))
+          end
+        }
     }
   )
 

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1291,7 +1291,9 @@ class Type
   end
 
   newmetaparam(:audit) do
-    desc "Marks a subset of this resource's unmanaged attributes for auditing. Accepts an
+    desc "(This metaparameter is deprecated and will be ignored in a future release.)
+
+      Marks a subset of this resource's unmanaged attributes for auditing. Accepts an
       attribute name, an array of attribute names, or `all`.
 
       Auditing a resource attribute has two effects: First, whenever a catalog
@@ -1312,6 +1314,14 @@ class Type
       and the second run will log the edit made by Puppet.)"
 
     validate do |list|
+      if Puppet.settings[:strict] != :off
+        dep_warning = _("The `audit` metaparameter is deprecated and will be ignored in a future release.")
+        if file && line
+          puppet_deprecation_warning(dep_warning, { :line => line, :file => file })
+        else
+          Puppet.deprecation_warning(dep_warning)
+        end
+      end
       list = Array(list).collect {|p| p.to_sym}
       unless list == [:all]
         list.each do |param|

--- a/spec/unit/application/inspect_spec.rb
+++ b/spec/unit/application/inspect_spec.rb
@@ -42,6 +42,11 @@ describe Puppet::Application::Inspect do
       Puppet::Resource::Catalog.indirection.expects(:terminus_class=).with(:yaml)
       expect { @inspect.setup }.not_to raise_error
     end
+
+    it "should be marked as deprecated" do
+      @inspect.setup
+      expect(@inspect.deprecated?).to be true
+    end
   end
 
   describe "when executing", :uses_checksums => true do
@@ -193,8 +198,10 @@ describe Puppet::Application::Inspect do
 
           @inspect.run_command
 
-          expect(@report.logs.first).not_to eq(nil)
-          expect(@report.logs.first.message).to match(/Could not back up/)
+          # First several errors are deprecation warnings, find correct log message
+          expect(@report.logs).to be_any { |l|
+            /Could not back up/.match(l.message)
+          }
         end
       end
 


### PR DESCRIPTION
This PR:
1) Adds a utility for deprecating applications based on Moses's work in https://github.com/puppetlabs/puppet/pull/5449/commits/7fefceae40d5ace8df2bd85aefa8bdee3246d9e1
2) Deprecates the `inspect` command
3) Deprecates the `audit` metaparameter