### PR TITLE
(PUP-7330) Ensure that lookup types are registered with loader

### DIFF
--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -3,36 +3,32 @@ module Lookup
 # @api private
 module DataProvider
   def self.key_type
-    ensure_types_initialized
     @key_type
   end
 
   def self.value_type
-    ensure_types_initialized
     @value_type
   end
 
-  def self.ensure_types_initialized
-    if @key_type.nil?
-      (@key_type, @value_type) = Pcore::register_aliases(
-        # The Pcore type for all keys and subkeys in a data hash.
-        'Puppet::LookupKey' => 'Variant[String,Numeric]',
+  def self.register_types(loader)
+    (@key_type, @value_type) = Pcore::register_aliases({
+      # The Pcore type for all keys and subkeys in a data hash.
+      'Puppet::LookupKey' => 'Variant[String,Numeric]',
 
-        # The Pcore type for all values and sub-values in a data hash. The
-        # type is self-recursive to enforce the same constraint on values contained
-        # in arrays and hashes
-        'Puppet::LookupValue' => <<-PUPPET
-          Variant[
-            Scalar,
-            Undef,
-            Sensitive,
-            Type,
-            Hash[Puppet::LookupKey, Puppet::LookupValue],
-            Array[Puppet::LookupValue]
-          ]
+      # The Pcore type for all values and sub-values in a data hash. The
+      # type is self-recursive to enforce the same constraint on values contained
+      # in arrays and hashes
+      'Puppet::LookupValue' => <<-PUPPET
+        Variant[
+          Scalar,
+          Undef,
+          Sensitive,
+          Type,
+          Hash[Puppet::LookupKey, Puppet::LookupValue],
+          Array[Puppet::LookupValue]
+        ]
         PUPPET
-      )
-    end
+    }, Pcore::RUNTIME_NAME_AUTHORITY, loader)
   end
 
   # Performs a lookup with an endless recursion check.

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -41,6 +41,7 @@ module Pcore
 
       Resource.register_ptypes(loader, ir)
       Lookup::Context.register_ptype(loader, ir);
+      Lookup::DataProvider.register_types(loader)
     end
   end
 
@@ -81,11 +82,10 @@ module Pcore
   end
 
   def self.register_implementations(impls, name_authority = RUNTIME_NAME_AUTHORITY)
-    Loaders.loaders.register_implementations(impls, name_authority = RUNTIME_NAME_AUTHORITY)
+    Loaders.loaders.register_implementations(impls, name_authority)
   end
 
-  def self.register_aliases(aliases, name_authority = RUNTIME_NAME_AUTHORITY)
-    loader = Loaders.loaders.private_environment_loader
+  def self.register_aliases(aliases, name_authority = RUNTIME_NAME_AUTHORITY, loader = Loaders.loaders.private_environment_loader)
     aliases.each do |name, type_string|
       add_type(Types::PTypeAliasType.new(name, Types::TypeFactory.type_reference(type_string), nil), loader, name_authority)
     end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1693,7 +1693,7 @@ describe "The lookup function" do
             'mod_a' => {
               'functions' => {
                 'pp_lookup_key.pp' => <<-PUPPET.unindent
-                function mod_a::pp_lookup_key($key, $options, $context) {
+                function mod_a::pp_lookup_key(Puppet::LookupKey $key, Hash[String,String] $options, Puppet::LookupContext $context) >> Puppet::LookupValue {
                   case $key {
                     'mod_a::really_interpolated': { $context.interpolate("-- %{lookup('mod_a::a')} --") }
                     'mod_a::recursive': { lookup($key) }


### PR DESCRIPTION
This commit ensures that the `Puppet::LookupKey` and
`Puppet::LookupValue` types are made known to the puppet type loader.