### PR TITLE
(PUP-7370) Ensure value returned from provider is checked only once.

### DIFF
--- a/lib/puppet/pops/lookup/data_dig_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_dig_function_provider.rb
@@ -78,6 +78,10 @@ class V3BackendFunctionProvider < DataDigFunctionProvider
     "hiera version 3 backend '#{options[HieraConfig::KEY_BACKEND]}'"
   end
 
+  def value_is_validated?
+    false
+  end
+
   private
 
   def instantiate_backend(lookup_invocation)

--- a/lib/puppet/pops/lookup/data_hash_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_hash_function_provider.rb
@@ -10,6 +10,10 @@ class DataHashFunctionProvider < FunctionProvider
 
   TAG = 'data_hash'.freeze
 
+  def self.trusted_return_type
+    @trusted_return_type ||= Types::PHashType.new(DataProvider.key_type, DataProvider.value_type)
+  end
+
   # Performs a lookup with the assumption that a recursive check has been made.
   #
   # @param key [LookupKey] The key to lookup
@@ -54,7 +58,7 @@ class DataHashFunctionProvider < FunctionProvider
       lookup_invocation.report_not_found(root_key)
       throw :no_such_key
     end
-    value = parent_data_provider.validate_data_value(value) do
+    value = validate_data_value(value) do
       msg = "Value for key '#{root_key}', in hash returned from #{full_name}"
       location.nil? ? msg : "#{msg}, when using location '#{location}',"
     end

--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -66,6 +66,11 @@ module DataProvider
     raise NotImplementedError, "Subclass of #{DataProvider.name} must implement 'name' method"
   end
 
+  # @returns `true` if the value provided by this instance can always be trusted, `false` otherwise
+  def value_is_validated?
+    false
+  end
+
   # Asserts that _data_hash_ is a hash. Will yield to obtain origin of value in case an error is produced
   #
   # @param data_hash [Hash{String=>Object}] The data hash
@@ -80,7 +85,7 @@ module DataProvider
   # @return [Object] The data value
   def validate_data_value(value, &block)
     # The DataProvider.value_type is self recursive so further recursive check of collections is needed here
-    unless DataProvider.value_type.instance?(value)
+    unless value_is_validated? || DataProvider.value_type.instance?(value)
       actual_type = Types::TypeCalculator.singleton.infer(value)
       raise Types::TypeAssertionError.new("#{yield} has wrong type, expects Puppet::LookupValue, got #{actual_type}", DataProvider.value_type, actual_type)
     end

--- a/lib/puppet/pops/types/type_asserter.rb
+++ b/lib/puppet/pops/types/type_asserter.rb
@@ -13,7 +13,7 @@ module TypeAsserter
   #
   # @api public
   def self.assert_assignable(subject, expected_type, type_to_check, &block)
-    report_type_mismatch(subject, expected_type, type_to_check) unless expected_type.assignable?(type_to_check)
+    report_type_mismatch(subject, expected_type, type_to_check, 'is incorrect', &block) unless expected_type.assignable?(type_to_check)
     type_to_check
   end
 
@@ -35,11 +35,11 @@ module TypeAsserter
     value
   end
 
-  def self.report_type_mismatch(subject, expected_type, actual_type)
+  def self.report_type_mismatch(subject, expected_type, actual_type, what = 'has wrong type')
     subject = yield(subject) if block_given?
     subject = subject[0] % subject[1..-1] if subject.is_a?(Array)
     raise TypeAssertionError.new(
-      TypeMismatchDescriber.singleton.describe_mismatch("#{subject} has wrong type,", expected_type, actual_type), expected_type, actual_type)
+      TypeMismatchDescriber.singleton.describe_mismatch("#{subject} #{what},", expected_type, actual_type), expected_type, actual_type)
   end
   private_class_method :report_type_mismatch
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2183,55 +2183,57 @@ describe "The lookup function" do
       end
 
       context 'using a lookup_key that is a puppet function' do
+        let(:puppet_function) { <<-PUPPET.unindent }
+          function mod_a::pp_lookup_key(Puppet::LookupKey $key, Hash[String,String] $options, Puppet::LookupContext $context) >> Puppet::LookupValue {
+            case $key {
+              'mod_a::really_interpolated': { $context.interpolate("-- %{lookup('mod_a::a')} --") }
+              'mod_a::recursive': { lookup($key) }
+              default: {
+                if $context.cache_has_key(mod_a::a) {
+                  $context.explain || { 'reusing cache' }
+                } else {
+                  $context.explain || { 'initializing cache' }
+                  $context.cache_all({
+                    mod_a::a => 'value mod_a::a (from mod_a)',
+                    mod_a::b => 'value mod_a::b (from mod_a)',
+                    mod_a::c => 'value mod_a::c (from mod_a)',
+                    mod_a::hash_a => {
+                      a => 'value mod_a::hash_a.a (from mod_a)',
+                      b => 'value mod_a::hash_a.b (from mod_a)'
+                    },
+                    mod_a::hash_b => {
+                      a => 'value mod_a::hash_b.a (from mod_a)',
+                      b => 'value mod_a::hash_b.b (from mod_a)'
+                    },
+                    mod_a::interpolated => "-- %{lookup('mod_a::a')} --",
+                    mod_a::a_a => "-- %{lookup('mod_a::hash_a.a')} --",
+                    mod_a::a_b => "-- %{lookup('mod_a::hash_a.b')} --",
+                    mod_a::b_a => "-- %{lookup('mod_a::hash_b.a')} --",
+                    mod_a::b_b => "-- %{lookup('mod_a::hash_b.b')} --",
+                    'mod_a::a.quoted.key' => 'value mod_a::a.quoted.key (from mod_a)',
+                    mod_a::sensitive => Sensitive('reduct me please'),
+                    mod_a::type => Object[{name => 'FindMe', 'attributes' => {'x' => String}}],
+                    mod_a::version => SemVer('3.4.1'),
+                    mod_a::version_range => SemVerRange('>=3.4.1'),
+                    mod_a::timestamp => Timestamp("1994-03-25T19:30:00"),
+                    mod_a::timespan => Timespan("3-10:00:00")
+                  })
+                }
+                if !$context.cache_has_key($key) {
+                  $context.not_found
+                }
+                $context.explain || { "returning value for $key" }
+                $context.cached_value($key)
+              }
+            }
+          }
+        PUPPET
+
         let(:mod_a_files) do
           {
             'mod_a' => {
               'functions' => {
-                'pp_lookup_key.pp' => <<-PUPPET.unindent
-                function mod_a::pp_lookup_key(Puppet::LookupKey $key, Hash[String,String] $options, Puppet::LookupContext $context) >> Puppet::LookupValue {
-                  case $key {
-                    'mod_a::really_interpolated': { $context.interpolate("-- %{lookup('mod_a::a')} --") }
-                    'mod_a::recursive': { lookup($key) }
-                    default: {
-                      if $context.cache_has_key(mod_a::a) {
-                        $context.explain || { 'reusing cache' }
-                      } else {
-                        $context.explain || { 'initializing cache' }
-                        $context.cache_all({
-                          mod_a::a => 'value mod_a::a (from mod_a)',
-                          mod_a::b => 'value mod_a::b (from mod_a)',
-                          mod_a::c => 'value mod_a::c (from mod_a)',
-                          mod_a::hash_a => {
-                            a => 'value mod_a::hash_a.a (from mod_a)',
-                            b => 'value mod_a::hash_a.b (from mod_a)'
-                          },
-                          mod_a::hash_b => {
-                            a => 'value mod_a::hash_b.a (from mod_a)',
-                            b => 'value mod_a::hash_b.b (from mod_a)'
-                          },
-                          mod_a::interpolated => "-- %{lookup('mod_a::a')} --",
-                          mod_a::a_a => "-- %{lookup('mod_a::hash_a.a')} --",
-                          mod_a::a_b => "-- %{lookup('mod_a::hash_a.b')} --",
-                          mod_a::b_a => "-- %{lookup('mod_a::hash_b.a')} --",
-                          mod_a::b_b => "-- %{lookup('mod_a::hash_b.b')} --",
-                          'mod_a::a.quoted.key' => 'value mod_a::a.quoted.key (from mod_a)',
-                          mod_a::sensitive => Sensitive('reduct me please'),
-                          mod_a::type => Object[{name => 'FindMe', 'attributes' => {'x' => String}}],
-                          mod_a::version => SemVer('3.4.1'),
-                          mod_a::version_range => SemVerRange('>=3.4.1'),
-                          mod_a::timestamp => Timestamp("1994-03-25T19:30:00"),
-                          mod_a::timespan => Timespan("3-10:00:00")
-                        })
-                      }
-                      if !$context.cache_has_key($key) {
-                        $context.not_found
-                      }
-                      $context.explain || { "returning value for $key" }
-                      $context.cached_value($key)
-                    }
-                  }
-                }
-              PUPPET
+                'pp_lookup_key.pp' => puppet_function
               },
               'hiera.yaml' => <<-YAML.unindent,
               ---
@@ -2304,6 +2306,19 @@ describe "The lookup function" do
             expect(notices).to eql(['success'])
           end
         end
+
+        context 'with declared but incompatible return_type' do
+          let(:puppet_function) { <<-PUPPET.unindent }
+            function mod_a::pp_lookup_key(Puppet::LookupKey $key, Hash[String,String] $options, Puppet::LookupContext $context) >> Runtime['ruby','Symbol'] {
+              undef
+            }
+            PUPPET
+
+          it 'fails and reports error' do
+            expect{lookup('mod_a::a')}.to raise_error(
+              "Return type of 'lookup_key' function named 'mod_a::pp_lookup_key' is incorrect, expects a value of type Scalar, Sensitive, Type, Hash, or Array, got Runtime")
+          end
+        end
       end
 
       context 'using a data_dig that is a ruby function' do
@@ -2320,6 +2335,7 @@ describe "The lookup function" do
                           param 'Array[String[1]]', :segments
                           param 'Hash[String,Any]', :options
                           param 'Puppet::LookupContext', :context
+                          return_type 'Puppet::LookupValue'
                         end
 
                         def ruby_dig(segments, options, context)
@@ -2399,15 +2415,13 @@ describe "The lookup function" do
         end
 
         it 'does not accept return of runtime type from function' do
-          expect(explain('mod_a::bad_type')).to include(
-            "Value for key 'mod_a::bad_type', returned from data_dig function 'mod_a::ruby_dig', " +
-            "when using location 'http://www.example.com/passed/as/option', has wrong type, expects Puppet::LookupValue, got Runtime")
+          # Message is produced by the called function, not by the lookup framework
+          expect(explain('mod_a::bad_type')).to include("value returned from function 'ruby_dig' has wrong type")
         end
 
         it 'does not accept return of runtime type embedded in hash from function' do
-          expect(explain('mod_a::bad_type_in_hash')).to include(
-            "Value for key 'mod_a::bad_type_in_hash', returned from data_dig function 'mod_a::ruby_dig', " +
-            "when using location 'http://www.example.com/passed/as/option', has wrong type, expects Puppet::LookupValue, got Hash[String, Runtime")
+          # Message is produced by the called function, not by the lookup framework
+          expect(explain('mod_a::bad_type_in_hash')).to include("value returned from function 'ruby_dig' has wrong type")
         end
 
         it 'will not merge hashes from environment and module unless strategy hash is used' do

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2316,7 +2316,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect{lookup('mod_a::a')}.to raise_error(
-              "Return type of 'lookup_key' function named 'mod_a::pp_lookup_key' is incorrect, expects a value of type Scalar, Sensitive, Type, Hash, or Array, got Runtime")
+              "Return type of 'lookup_key' function named 'mod_a::pp_lookup_key' is incorrect, expects a value of type Undef, Scalar, Sensitive, Type, Hash, or Array, got Runtime")
           end
         end
       end


### PR DESCRIPTION
A data provider function that declares a return type, must use a type that is assignable to `Puppet::LookupValue` or, in case the function is a `data_hash`, to `Hash[Puppet::LookupKey,Puppet::LookupValue]`. This PR ensures that an error is raised if the return type is incorrect.

In this PR, it's also ensured that the lookup framework will rely on function to do return type validation when all of its dispatchers declares a correct return type.
