### PR TITLE
(PUP-7371) Fix bug with missing undef in type mismatch description

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -293,6 +293,11 @@ module Types
       super(path)
       @expected = (expected.is_a?(Array) ? PVariantType.maybe_create(expected) : expected).normalize
       @actual = actual.normalize
+      @optional = false
+    end
+
+    def set_optional
+      @optional = true
     end
 
     def ==(o)
@@ -323,8 +328,17 @@ module Types
       e = expected
       a = actual
       multi = false
-      if e.is_a?(PVariantType)
+      if @optional
+        if e.is_a?(PVariantType)
+          e = [PUndefType::DEFAULT] + e.types
+        else
+          e = [PUndefType::DEFAULT, e]
+        end
+      elsif e.is_a?(PVariantType)
         e = e.types
+      end
+
+      if e.is_a?(Array)
         if report_detailed?(e, a)
           a = detailed_actual_to_s(e, a)
           e = e.map { |t| t.to_alias_expanded_s }
@@ -764,7 +778,10 @@ module Types
     end
 
     def describe_POptionalType(expected, actual, path)
-      actual.is_a?(PUndefType) ? [] : describe(expected.optional_type, actual, path)
+      return EMPTY_ARRAY if actual.is_a?(PUndefType)
+      descriptions = describe(expected.optional_type, actual, path)
+      descriptions.each { |description| description.set_optional }
+      descriptions
     end
 
     def describe_PEnumType(expected, actual, path)
@@ -776,7 +793,7 @@ module Types
     end
 
     def describe_PTypeAliasType(expected, actual, path)
-      resolved_type = expected.resolved_type.normalize
+      resolved_type = expected.resolved_type
       describe(resolved_type, actual, path).map do |description|
         if description.is_a?(ExpectedActualMismatch) && description.expected.equal?(resolved_type)
           description.swap_expected(expected)
@@ -804,7 +821,7 @@ module Types
         expected_size = expected.size_type
         actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
         if expected_size.nil? || expected_size.assignable?(actual_size)
-          descriptions << TypeMismatch.new(path, expected, actual)
+          descriptions << TypeMismatch.new(path, expected, PArrayType.new(actual.element_type))
         else
           descriptions << SizeMismatch.new(path, expected_size, actual_size)
         end
@@ -834,7 +851,7 @@ module Types
         expected_size = expected.size_type
         actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
         if expected_size.nil? || expected_size.assignable?(actual_size)
-          descriptions << TypeMismatch.new(path, expected, actual)
+          descriptions << TypeMismatch.new(path, expected, PHashType.new(actual.key_type, actual.value_type))
         else
           descriptions << SizeMismatch.new(path, expected_size, actual_size)
         end
@@ -864,7 +881,7 @@ module Types
         actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
         expected_size = PIntegerType.new(elements.count { |e| !e.key_type.assignable?(PUndefType::DEFAULT) }, elements.size)
         if expected_size.assignable?(actual_size)
-          descriptions << TypeMismatch.new(path, expected, actual)
+          descriptions << TypeMismatch.new(path, expected, PHashType.new(actual.key_type, actual.value_type))
         else
           descriptions << SizeMismatch.new(path, expected_size, actual_size)
         end
@@ -990,6 +1007,7 @@ module Types
       if unresolved
         [UnresolvedTypeReference.new(path, unresolved)]
       else
+        expected = expected.normalize
         case expected
         when PVariantType
           describe_PVariantType(expected, actual, path)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2522,7 +2522,7 @@ class PHashType < PCollectionType
       key_t = key_t.normalize(guard) unless key_t.nil?
       value_t = @value_type
       value_t = value_t.normalize(guard) unless value_t.nil?
-      @size_type.nil? && @key_type.equal?(key_t) && @value_type.equal?(value_t) ? self : PHashType.new(key_t, value_t, nil)
+      @size_type.nil? && @key_type.equal?(key_t) && @value_type.equal?(value_t) ? self : PHashType.new(key_t, value_t, @size_type)
     end
   end
 
@@ -2668,7 +2668,7 @@ class PVariantType < PAnyType
   # @return [PAnyType] the resulting type
   # @api public
   def self.maybe_create(types)
-    types = types.uniq
+    types = flatten_variants(types).uniq
     types.size == 1 ? types[0] : new(types)
   end
 
@@ -2713,24 +2713,15 @@ class PVariantType < PAnyType
 
       if types.size == 1
         types[0]
-      elsif types.any? { |t| t.is_a?(PUndefType) }
-        # Undef entry present. Use an OptionalType with a normalized Variant of all types that are not Undef
-        POptionalType.new(PVariantType.maybe_create(types.reject { |ot| ot.is_a?(PUndefType) }).normalize(guard)).normalize(guard)
+      elsif types.any? { |t| t.is_a?(PUndefType) || t.is_a?(POptionalType) }
+        # Undef entry present. Use an OptionalType with a normalized Variant without Undefs and Optional wrappers
+        POptionalType.new(PVariantType.maybe_create(types.reject { |t| t.is_a?(PUndefType) }.map { |t| t.is_a?(POptionalType) ? t.type : t })).normalize
       else
         # Merge all variants into this one
-        types = types.map do |t|
-          if t.is_a?(PVariantType)
-            modified = true
-            t.types
-          else
-            t
-          end
-        end
-        types.flatten! if modified
+        types = PVariantType.flatten_variants(types)
         size_before_merge = types.size
 
         types = swap_not_undefs(types)
-        types = swap_optionals(types)
         types = merge_enums(types)
         types = merge_patterns(types)
         types = merge_version_ranges(types)
@@ -2746,6 +2737,20 @@ class PVariantType < PAnyType
         end
       end
     end
+  end
+
+  def self.flatten_variants(types)
+    modified = false
+    types = types.map do |t|
+      if t.is_a?(PVariantType)
+        modified = true
+        t.types
+      else
+        t
+      end
+    end
+    types.flatten! if modified
+    types
   end
 
   def hash
@@ -2804,20 +2809,6 @@ class PVariantType < PAnyType
       # A variant is assignable if o is assignable to any of its types
       types.any? { |option_t| option_t.assignable?(o, guard) }
     end
-  end
-
-  # @api private
-  def swap_optionals(array)
-    if array.size > 1
-      parts = array.partition {|t| t.is_a?(POptionalType) }
-      optionals = parts[0]
-      if optionals.size > 1
-        others = parts[1]
-        others <<  POptionalType.new(PVariantType.maybe_create(optionals.map { |optional| optional.type }).normalize)
-        array = others
-      end
-    end
-    array
   end
 
   # @api private

--- a/spec/unit/functions/dig_spec.rb
+++ b/spec/unit/functions/dig_spec.rb
@@ -50,7 +50,7 @@ describe 'the dig function' do
   end
 
   it 'errors if not given a non Collection as the starting point' do
-    expect { compile_to_catalog(<<-SOURCE)}.to raise_error(/'dig' parameter 'data' expects a Collection value, got String/)
+    expect { compile_to_catalog(<<-SOURCE)}.to raise_error(/'dig' parameter 'data' expects a value of type Undef or Collection, got String/)
     "hello".dig(1, yes, 2)
     SOURCE
   end

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -150,6 +150,15 @@ describe 'the type mismatch describer' do
       /parameter 'arg' expects a match for Enum\['a', 'b'\], got 'c'/))
   end
 
+  it "will include Undef when describing a mismatch against a Variant where one of the types is Undef" do
+    code = <<-CODE
+      define check(Variant[Undef,String,Integer,Hash,Array] $arg) {}
+      check{ x: arg => 2.4 }
+    CODE
+    expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
+      /parameter 'arg' expects a value of type Undef, String, Integer, Hash, or Array/))
+  end
+
   it "will not disclose a Sensitive that doesn't match an enum in a define call" do
     code = <<-CODE
       define check_enums(Enum[a,b] $arg) {}

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -330,13 +330,12 @@ describe 'Puppet Type System' do
       end
 
       it 'can be normalized in groups, the result is a Variant containing the resulting normalizations' do
-        expect(groups.normalize).to eq(tf.variant(
-          tf.range(8, 28),
-          tf.float_range(10.0, 28.0),
-          tf.enum('a', 'b', 'c'),
-          tf.pattern('a', 'b', 'c'),
-          tf.optional(tf.range(1,20)))
-        )
+        expect(groups.normalize).to eq(tf.optional(
+          tf.variant(
+            tf.range(1, 28),
+            tf.float_range(10.0, 28.0),
+            tf.enum('a', 'b', 'c'),
+            tf.pattern('a', 'b', 'c'))))
       end
     end
 


### PR DESCRIPTION
The mismatch describer "forgot" that a type was optional when describing
it and in some cases simply dropped that type out of the description.
This commit ensures that the optional status is remembered and reported.

The commit also improves the type generalization of the `Variant` type
with respect to `Undef` and `Optional` so that a type that contains
either one becomes an `Optional` type that contains neither.

A side effect from fixing the above was that some tests needed to be
adjusted.