### PR TITLE
(PUP-7373) Zypper is default package provider on SUSE

### DIFF
--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -33,6 +33,12 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
       else
         :yum
       end
+    when 'Suse'
+      if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemmajrelease), '10') >= 0
+        :zypper
+      else
+        :rug
+      end
     when 'FreeBSD'
       :ports
     when 'OpenBSD'


### PR DESCRIPTION
PUP-2728 updated the default package provider to be `zypper` instead of `rug` on SUSE-family OSes. This PR, ticketed in PUP-7373, updates the package provider integration spec test to expect `zypper` as the default package provider on SUSE-family OSes 10.x and newer and `rug` on anything older.