### PR TITLE
(PUP-1890) Change URI escaping to support UTF-8

### DIFF
--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -32,7 +32,7 @@ if master.is_pe?
       require "json"
 
       puppetdb_url = URI("http://localhost:8080/v3/reports")
-      puppetdb_url.query = URI.escape(%Q{query=["=","certname","#{agent}"]})
+      puppetdb_url.query = CGI.escape(%Q{query=["=","certname","#{agent}"]})
       result = Net::HTTP.get(puppetdb_url)
       json = JSON.load(result)
       puts json.first["receive-time"]

--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -32,6 +32,6 @@ module Puppet::Configurer::FactHandler
 
     text = facts.render(:pson)
 
-    {:facts_format => :pson, :facts => CGI.escape(text)}
+    {:facts_format => :pson, :facts => Puppet::Util.uri_query_encode(text)}
   end
 end

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -31,7 +31,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
 
   def content_uri=(path)
     begin
-      uri = URI.parse(URI.escape(path))
+      uri = URI.parse(Puppet::Util.uri_encode(path))
     rescue URI::InvalidURIError => detail
       raise(ArgumentError, "Could not understand URI #{path}: #{detail}")
     end

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -38,7 +38,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     raise(ArgumentError, "Cannot use opaque URLs '#{path}'") unless uri.hierarchical?
     raise(ArgumentError, "Must use URLs of type puppet as content URI") if uri.scheme != "puppet"
 
-    @content_uri = path
+    @content_uri = path.encode(Encoding::UTF_8)
   end
 
   class MetaStat

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -53,9 +53,9 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
   #   bad HTTP response
   def search(term)
     matches = []
-    uri = "/v3/modules?query=#{URI.escape(term)}"
+    uri = "/v3/modules?query=#{Puppet::Util.uri_query_encode(term)}"
     if Puppet[:module_groups]
-      uri += "&module_groups=#{Puppet[:module_groups]}"
+      uri += "&module_groups=#{Puppet::Util.uri_query_encode(Puppet[:module_groups])}"
     end
 
     while uri
@@ -90,7 +90,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     name = input.tr('/', '-')
     uri = "/v3/releases?module=#{name}"
     if Puppet[:module_groups]
-      uri += "&module_groups=#{Puppet[:module_groups]}"
+      uri += "&module_groups=#{Puppet::Util.uri_query_encode(Puppet[:module_groups])}"
     end
     releases = []
 

--- a/lib/puppet/forge/cache.rb
+++ b/lib/puppet/forge/cache.rb
@@ -24,6 +24,7 @@ class Puppet::Forge
         uri = url.is_a?(::URI) ? url : ::URI.parse(url)
         unless cached_file.file?
           if uri.scheme == 'file'
+            # CGI.unescape butchers Uris that are escaped properly
             FileUtils.cp(URI.unescape(uri.path), cached_file)
           else
             # TODO: Handle HTTPS; probably should use repository.contact

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -72,7 +72,7 @@ class Puppet::Forge
         headers = headers.merge({"Authorization" => forge_authorization})
       end
 
-      request = Net::HTTP::Get.new(URI.escape(path), headers)
+      request = Net::HTTP::Get.new(Puppet::Util.uri_encode(path), headers)
 
       unless @uri.user.nil? || @uri.password.nil? || forge_authorization
         request.basic_auth(@uri.user, @uri.password)

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -105,7 +105,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     # This does that, while preserving any user-specified server or port.
     source_path = Pathname.new(metadata.full_path)
     path = source_path.relative_path_from(environment_path).to_s
-    source_as_uri = URI.parse(URI.escape(source))
+    source_as_uri = URI.parse(Puppet::Util.uri_encode(source))
     server = source_as_uri.host
     port = ":#{source_as_uri.port}" if source_as_uri.port
     return "puppet://#{server}#{port}/#{path}"
@@ -130,7 +130,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   # for the 'modules' mount and the resolved path is of the form:
   #   $codedir/environments/$environment/*/*/files/**
   def inlineable_metadata?(metadata, source, environment_path)
-    source_as_uri = URI.parse(URI.escape(source))
+    source_as_uri = URI.parse(Puppet::Util.uri_encode(source))
+
     location = Puppet::Module::FILETYPES['files']
 
     !!(source_as_uri.path =~ /^\/modules\// &&

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -26,7 +26,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       if text_facts.is_a?(Puppet::Node::Facts)
         facts = text_facts
       elsif format == 'pson'
-        # We unescape here because the corresponding code in Puppet::Configurer::FactHandler escapes
+        # We unescape here because the corresponding code in Puppet::Configurer::FactHandler encodes with Puppet::Util.uri_query_encode
         facts = Puppet::Node::Facts.convert_from('pson', CGI.unescape(text_facts))
       else
         raise ArgumentError, "Unsupported facts format"

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -41,6 +41,8 @@ class Puppet::Indirector::Request
     end
   end
 
+  # @api private
+  # @deprecated used only internally to be removed in Puppet 5
   def escaped_key
     # Puppet::Network::HTTP::API::IndirectedRoutes is the only caller to escaped_key
     # and these fragments only appear in the path part of a URI

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -42,7 +42,9 @@ class Puppet::Indirector::Request
   end
 
   def escaped_key
-    URI.escape(key)
+    # Puppet::Network::HTTP::API::IndirectedRoutes is the only caller to escaped_key
+    # and these fragments only appear in the path part of a URI
+    Puppet::Util.uri_encode(key)
   end
 
   # LAK:NOTE This is a messy interface to the cache, and it's only
@@ -143,7 +145,7 @@ class Puppet::Indirector::Request
 
   def encode_params(params)
     params.collect do |key, value|
-      "#{key}=#{CGI.escape(value.to_s)}"
+      "#{key}=#{Puppet::Util.uri_query_encode(value.to_s)}"
     end.join("&")
   end
 
@@ -243,9 +245,8 @@ class Puppet::Indirector::Request
   def set_uri_key(key)
     @uri = key
     begin
-      # calling URI.escape for UTF-8 characters will % escape them
-      # and the resulting string components of the URI are now ASCII
-      uri = URI.parse(URI.escape(key))
+      # calling uri_encode for UTF-8 characters will % escape them and keep them UTF-8
+      uri = URI.parse(Puppet::Util.uri_encode(key))
     rescue => detail
       raise ArgumentError, "Could not understand URL #{key}: #{detail}", detail.backtrace
     end
@@ -274,8 +275,6 @@ class Puppet::Indirector::Request
       @protocol = uri.scheme
     end
 
-    # The unescaped bytes are correct but in ASCII and must be treated
-    # as UTF-8 for the sake of performing string comparisons later
-    @key = URI.unescape(uri.path.sub(/^\//, '')).force_encoding(Encoding::UTF_8)
+    @key = URI.unescape(uri.path.sub(/^\//, ''))
   end
 end

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -87,7 +87,8 @@ class Puppet::Network::HTTP::RackREST
     # in the indirector / HTTP layer which consumes this path, however, assumes
     # that it has already been unescaped, so it is unescaped here.
     if request.path
-      URI.unescape(request.path)
+      # don't use CGI.unescape which mangles space handling
+      URI.unescape(request.path.encode(Encoding::UTF_8))
     end
   end
 

--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -87,7 +87,7 @@ module Puppet::Resource::CapabilityFinder
         Puppet::Util::Puppetdb.query_puppetdb(["from", "resources", query])
       # For PuppetDB < 4, use the old internal method action()
       else
-        url = "/pdb/query/v4/resource?query=#{CGI.escape(query.to_json)}"
+        url = "/pdb/query/v4/resource?query=#{Puppet::Util.uri_query_encode(query.to_json)}"
         response = Puppet::Util::Puppetdb::Http.action(url) do |conn, uri|
           conn.get(uri, { 'Accept' => 'application/json'})
         end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -416,13 +416,17 @@ module Util
   #   Note that with no specified scheme, authority or query parameter delimiter
   #  ? that a naked string will be treated as a path.
   #
+  # @param [Hash{Symbol=>String} opts] Options to alter encoding
+  # @option opts [Array<Symbol>] :allow_fragment defaults to false. When false
+  #   will treat # as part of a path or query and not a fragment delimiter
+  #
   # @return [String] a new string containing appropriate portions of the URI
   #   encoded per the rules of RFC3986.
   #   In particular,
   #   path will not encode +, but will encode space as %20
   #   query will encode + as %2B and space as %20
   #   fragment behaves like query
-  def uri_encode(path)
+  def uri_encode(path, opts = { :allow_fragment => false })
     raise ArgumentError.new('path may not be nil') if path.nil?
 
     # ensure string starts as UTF-8 for the sake of Ruby 1.9.3
@@ -441,7 +445,7 @@ module Util
     encoded += URI.escape(parts[:path]) unless parts[:path].nil?
 
     encoded += ('?' + uri_query_encode(parts[:query])) unless parts[:query].nil?
-    encoded += ('#' + uri_query_encode(parts[:fragment])) unless parts[:fragment].nil?
+    encoded += ((opts[:allow_fragment] ? '#' : '%23') + uri_query_encode(parts[:fragment])) unless parts[:fragment].nil?
 
     encoded
   end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -321,7 +321,9 @@ module Util
       end
     end
 
-    params[:path] = URI.escape(path)
+    # URI::Generic.build doesn't like a path encoded with CGI.escape
+    # but as long as the source "path" is UTF-8, then CGI.escape is correct
+    params[:path] = URI.escape(path.encode(Encoding::UTF_8)).force_encoding(Encoding::UTF_8)
 
     begin
       URI::Generic.build(params)
@@ -335,7 +337,9 @@ module Util
   def uri_to_path(uri)
     return unless uri.is_a?(URI)
 
-    path = URI.unescape(uri.path)
+    # CGI.unescape doesn't handle space rules properly in uri paths
+    # URI.unescape does, but returns strings in their original encoding
+    path = URI.unescape(uri.path.encode(Encoding::UTF_8))
 
     if Puppet.features.microsoft_windows? and uri.scheme == 'file'
       if uri.host

--- a/lib/puppet/util/rdoc/generators/puppet_generator.rb
+++ b/lib/puppet/util/rdoc/generators/puppet_generator.rb
@@ -383,7 +383,7 @@ module Generators
       resources.each do |r|
         res << {
           "name" => CGI.escapeHTML(r.name),
-          "aref" => CGI.escape(path_prefix)+"\#"+CGI.escape(r.aref)
+          "aref" => Puppet::Util.uri_encode(path_prefix)+"\#"+Puppet::Util.uri_query_encode(r.aref)
         }
       end
       res

--- a/spec/unit/configurer/fact_handler_spec.rb
+++ b/spec/unit/configurer/fact_handler_spec.rb
@@ -72,7 +72,7 @@ describe Puppet::Configurer::FactHandler do
   it "should serialize and CGI escape the fact values for uploading" do
     facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
     Puppet::Node::Facts.indirection.save(facts)
-    text = CGI.escape(facthandler.find_facts.render(:pson))
+    text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:pson))
 
     expect(facthandler.facts_for_uploading).to eq({:facts_format => :pson, :facts => text})
   end
@@ -80,7 +80,22 @@ describe Puppet::Configurer::FactHandler do
   it "should properly accept facts containing a '+'" do
     facts = Puppet::Node::Facts.new('foo', 'afact' => 'a+b')
     Puppet::Node::Facts.indirection.save(facts)
-    text = CGI.escape(facthandler.find_facts.render(:pson))
+    text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:pson))
+
+    expect(facthandler.facts_for_uploading).to eq({:facts_format => :pson, :facts => text})
+  end
+
+  it "should properly accept facts containing UTF-8 characters in their names and values" do
+    # different UTF-8 widths
+    # 1-byte A
+    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+    # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+    mixed_utf8 = "A\u06FF\u16A0\u{2070E}" # Aۿᚠ܎
+
+    facts = Puppet::Node::Facts.new('foo', "name-#{mixed_utf8}" => "value-#{mixed_utf8}")
+    Puppet::Node::Facts.indirection.save(facts)
+    text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:pson))
 
     expect(facthandler.facts_for_uploading).to eq({:facts_format => :pson, :facts => text})
   end
@@ -89,7 +104,10 @@ describe Puppet::Configurer::FactHandler do
     facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
     Puppet::Node::Facts.indirection.save(facts)
 
-    expect(CGI.unescape(facthandler.facts_for_uploading[:facts])).to validate_against('api/schemas/facts.json')
+    # prefer URI.unescape but validate CGI also works
+    encoded_facts = facthandler.facts_for_uploading[:facts]
+    expect(URI.unescape(encoded_facts)).to validate_against('api/schemas/facts.json')
+    expect(CGI.unescape(encoded_facts)).to validate_against('api/schemas/facts.json')
   end
 
 end

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -107,6 +107,27 @@ describe Puppet::FileServing::Metadata do
         expect(metadata.content_uri).to eq(uri)
       end
 
+      it "should accept UTF-8 characters" do
+        # different UTF-8 widths
+        # 1-byte A
+        # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+        # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+        # 4-byte <U+070E> - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+        mixed_utf8 = "A\u06FF\u16A0\u{2070E}" # Aۿᚠ<U+070E>
+
+        uri = "puppet:///modules/foo/files/ #{mixed_utf8}"
+        metadata.content_uri = uri
+        expect(metadata.content_uri).to eq(uri)
+        expect(metadata.content_uri.encoding).to eq(Encoding::UTF_8)
+      end
+
+      it "should always set it as UTF-8" do
+        uri = "puppet:///modules/foo/files/".encode(Encoding::ASCII)
+        metadata.content_uri = uri
+        expect(metadata.content_uri).to eq(uri)
+        expect(metadata.content_uri.encoding).to eq(Encoding::UTF_8)
+      end
+
       it "should fail if uri is opaque" do
         expect { metadata.content_uri = 'scheme:www.example.com' }.to raise_error ArgumentError, "Cannot use opaque URLs 'scheme:www.example.com'"
       end

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -121,10 +121,10 @@ describe Puppet::Forge::Repository do
       expect(request['Authorization']).to eq(token)
     end
 
-    it "escapes the received URI" do
+    it "encodes the received URI" do
       unescaped_uri = "héllo world !! ç à"
       performs_an_http_request do |http|
-        http.expects(:request).with(responds_with(:path, URI.escape(unescaped_uri)))
+        http.expects(:request).with(responds_with(:path, Puppet::Util.uri_encode(unescaped_uri)))
       end
 
       repository.make_http_request(unescaped_uri)
@@ -197,10 +197,10 @@ describe Puppet::Forge::Repository do
       expect(request['User-Agent']).to match(/\bRuby\b/)
     end
 
-    it "escapes the received URI" do
+    it "encodes the received URI" do
       unescaped_uri = "héllo world !! ç à"
       performs_an_authenticated_http_request do |http|
-        http.expects(:request).with(responds_with(:path, URI.escape(unescaped_uri)))
+        http.expects(:request).with(responds_with(:path, Puppet::Util.uri_encode(unescaped_uri)))
       end
 
       repository.make_http_request(unescaped_uri)

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -258,7 +258,7 @@ describe Puppet::Resource::Catalog::Compiler do
     def a_request_that_contains(facts, format = :pson)
       request = Puppet::Indirector::Request.new(:catalog, :find, "hostname", nil)
       request.options[:facts_format] = format.to_s
-      request.options[:facts] = CGI.escape(facts.render(format))
+      request.options[:facts] = Puppet::Util.uri_encode(facts.render(format))
       request
     end
 

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -149,6 +149,21 @@ describe Puppet::Indirector::Request do
         expect(request.key.encoding).to eq(Encoding::UTF_8)
       end
 
+      it "should set the request key properly given a UTF-8 URI" do
+        # different UTF-8 widths
+        # 1-byte A
+        # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+        # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+        # 4-byte <U+070E> - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+        mixed_utf8 = "A\u06FF\u16A0\u{2070E}" # Aۿᚠ<U+070E>
+
+        key = "a/path/stu ff/#{mixed_utf8}"
+        req = Puppet::Indirector::Request.new(:ind, :method, "http:///#{key}", nil)
+        expect(req.key).to eq(key)
+        expect(req.key.encoding).to eq(Encoding::UTF_8)
+        expect(req.uri).to eq("http:///#{key}")
+      end
+
       it "should set the :uri attribute to the full URI" do
         expect(Puppet::Indirector::Request.new(:ind, :method, "http:///a/path/stu ff", nil).uri).to eq('http:///a/path/stu ff')
       end
@@ -231,7 +246,7 @@ describe Puppet::Indirector::Request do
   end
 
   it "should be able to return the URI-escaped key" do
-    expect(Puppet::Indirector::Request.new(:myind, :find, "my key", nil).escaped_key).to eq(URI.escape("my key"))
+    expect(Puppet::Indirector::Request.new(:myind, :find, "my key", nil).escaped_key).to eq(Puppet::Util.uri_encode("my key"))
   end
 
   it "should set its environment to an environment instance when a string is specified as its environment" do

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -127,13 +127,13 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should not URI unescape the indirection key" do
-      escaped = URI.escape("foo bar")
+      escaped = Puppet::Util.uri_encode("foo bar")
       indirection, _, key, _ = handler.uri2indirection("GET", "#{master_url_prefix}/node/#{escaped}", params)
       expect(key).to eq(escaped)
     end
 
     it "should not unescape the URI passed through in a call to check_authorization" do
-      key_escaped = URI.escape("foo bar")
+      key_escaped = Puppet::Util.uri_encode("foo bar")
       uri_escaped = "#{master_url_prefix}/node/#{key_escaped}"
       handler.expects(:check_authorization).with(anything, uri_escaped, anything)
       indirection, _, _, _ = handler.uri2indirection("GET", uri_escaped, params)
@@ -199,7 +199,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should use the escaped key as the remainder of the URI" do
-      escaped = URI.escape("with spaces")
+      escaped = Puppet::Util.uri_encode("with spaces")
       expect(handler.class.request_to_uri_and_body(request).first.split("/")[4].sub(/\?.+/, '')).to eq(escaped)
     end
 

--- a/spec/unit/network/http/rack/rest_spec.rb
+++ b/spec/unit/network/http/rack/rest_spec.rb
@@ -67,7 +67,7 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
 
       it "should return the unescaped path for an escaped request path" do
         unescaped_path = '/foo/bar baz'
-        escaped_path = URI.escape(unescaped_path)
+        escaped_path = Puppet::Util.uri_encode(unescaped_path)
         req = mk_req(escaped_path)
         expect(@handler.path(req)).to eq(unescaped_path)
       end
@@ -170,7 +170,7 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
       end
 
       it "should CGI-decode the HTTP parameters" do
-        encoding = CGI.escape("foo bar")
+        encoding = Puppet::Util.uri_query_encode("foo bar")
         req = mk_req("/?foo=#{encoding}")
         result = @handler.params(req)
         expect(result[:foo]).to eq("foo bar")
@@ -201,7 +201,7 @@ describe "Puppet::Network::HTTP::RackREST", :if => Puppet.features.rack? do
       end
 
       it "should treat YAML encoded parameters like it was any string" do
-        escaping = CGI.escape(YAML.dump(%w{one two}))
+        escaping = Puppet::Util.uri_query_encode(YAML.dump(%w{one two}))
         req = mk_req("/?foo=#{escaping}")
         expect(@handler.params(req)[:foo]).to eq("---\n- one\n- two\n")
       end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -315,6 +315,35 @@ describe Puppet::Util do
       expect(Puppet::Util.path_to_uri("/foo bar").path).to eq("/foo%20bar")
     end
 
+    it "should properly URI encode + and space in path" do
+      expect(Puppet::Util.path_to_uri("/foo+foo bar").path).to eq("/foo+foo%20bar")
+    end
+
+    # reserved characters are different for each part
+    # https://web.archive.org/web/20151229061347/http://blog.lunatech.com/2009/02/03/what-every-web-developer-must-know-about-url-encoding#Thereservedcharactersaredifferentforeachpart
+    # "?" is allowed unescaped anywhere within a query part,
+    # "/" is allowed unescaped anywhere within a query part,
+    # "=" is allowed unescaped anywhere within a path parameter or query parameter value, and within a path segment,
+    # ":@-._~!$&'()*+,;=" are allowed unescaped anywhere within a path segment part,
+    # "/?:@-._~!$&'()*+,;=" are allowed unescaped anywhere within a fragment part.
+    it "should properly URI encode + and space in path and query" do
+      path = "/foo+foo bar?foo+foo bar"
+      uri = Puppet::Util.path_to_uri(path)
+
+      # Ruby 1.9.3 URI#to_s has a bug that returns ASCII always
+      # despite parts being UTF-8 strings
+      expected_encoding = RUBY_VERSION == '1.9.3' ? Encoding::ASCII : Encoding::UTF_8
+
+      expect(uri.to_s.encoding).to eq(expected_encoding)
+      expect(uri.path).to eq("/foo+foo%20bar")
+      # either + or %20 is correct for an encoded space in query
+      # + is usually used for backward compatibility, but %20 is preferred for compat with Uri.unescape
+      expect(uri.query).to eq("foo%2Bfoo%20bar")
+      # complete roundtrip
+      expect(URI.unescape(uri.to_s)).to eq("file:#{path}")
+      expect(URI.unescape(uri.to_s).encoding).to eq(expected_encoding)
+    end
+
     it "should perform UTF-8 URI escaping" do
       uri = Puppet::Util.path_to_uri("/#{mixed_utf8}")
 
@@ -355,7 +384,85 @@ describe Puppet::Util do
         it "should convert UNC #{path} to absolute URI" do
           uri = Puppet::Util.path_to_uri("\\\\server\\#{path}")
           expect(uri.host).to eq('server')
-          expect(uri.path).to eq('/' + path)
+          expect(uri.path).to eq('/' + Puppet::Util.uri_encode(path))
+        end
+      end
+    end
+  end
+
+  describe "#uri_encode" do
+    # different UTF-8 widths
+    # 1-byte A
+    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+    # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+    let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ܎
+    let (:mixed_utf8_urlencoded) { "A%DB%BF%E1%9A%A0%F0%A0%9C%8E" }
+
+    it "should perform URI escaping" do
+      expect(Puppet::Util.uri_encode("/foo bar")).to eq("/foo%20bar")
+    end
+
+    [
+      "A\u06FF\u16A0\u{2070E}",
+      "A\u06FF\u16A0\u{2070E}".force_encoding(Encoding::BINARY)
+    ].each do |uri_string|
+      it "should perform UTF-8 URI escaping, even when input strings are not UTF-8" do
+        uri = Puppet::Util.uri_encode(mixed_utf8)
+
+        expect(uri.encoding).to eq(Encoding::UTF_8)
+        expect(uri).to eq(mixed_utf8_urlencoded)
+      end
+    end
+
+    it "should be usable by URI::parse" do
+      uri = URI::parse(Puppet::Util.uri_encode("puppet://server/path/to/#{mixed_utf8}"))
+
+      expect(uri.scheme).to eq('puppet')
+      expect(uri.host).to eq('server')
+      expect(uri.path).to eq("/path/to/#{mixed_utf8_urlencoded}")
+    end
+
+    it "should be usable by URI::Generic.build" do
+      params = {
+        :scheme => 'file',
+        :host => 'foobar',
+        :path => Puppet::Util.uri_encode("/path/to/#{mixed_utf8}")
+      }
+
+      uri = URI::Generic.build(params)
+
+      expect(uri.scheme).to eq('file')
+      expect(uri.host).to eq('foobar')
+      expect(uri.path).to eq("/path/to/#{mixed_utf8_urlencoded}")
+    end
+
+    describe "when using platform :posix" do
+      before :each do
+        Puppet.features.stubs(:posix).returns true
+        Puppet.features.stubs(:microsoft_windows?).returns false
+      end
+
+      %w[/ /foo /foo/../bar].each do |path|
+        it "should not replace / in #{path} with %2F" do
+          expect(Puppet::Util.uri_encode(path)).to eq(path)
+        end
+      end
+    end
+
+    describe "when using platform :windows" do
+      before :each do
+        Puppet.features.stubs(:posix).returns false
+        Puppet.features.stubs(:microsoft_windows?).returns true
+      end
+
+      it "should url encode \\ as %5C, but not replace : as %3F" do
+        expect(Puppet::Util.uri_encode('c:\\foo\\bar\\baz')).to eq('c:%5Cfoo%5Cbar%5Cbaz')
+      end
+
+      %w[C:/ C:/foo/bar].each do |path|
+        it "should not replace / in #{path} with %2F" do
+          expect(Puppet::Util.uri_encode(path)).to eq(path)
         end
       end
     end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -505,6 +505,32 @@ describe Puppet::Util do
       end
     end
 
+    describe "with fragment support" do
+      context "disabled by default" do
+        it "should encode # as %23 in path" do
+          encoded = Puppet::Util.uri_encode("/foo bar#fragment")
+          expect(encoded).to eq("/foo%20bar%23fragment")
+        end
+
+        it "should encode # as %23 in query" do
+          encoded = Puppet::Util.uri_encode("/foo bar?baz+qux#fragment")
+          expect(encoded).to eq("/foo%20bar?baz%2Bqux%23fragment")
+        end
+      end
+
+      context "optionally enabled" do
+        it "should leave fragment delimiter # after encoded paths" do
+          encoded = Puppet::Util.uri_encode("/foo bar#fragment", { :allow_fragment => true })
+          expect(encoded).to eq("/foo%20bar#fragment")
+        end
+
+        it "should leave fragment delimiter # after encoded query" do
+          encoded = Puppet::Util.uri_encode("/foo bar?baz+qux#fragment", { :allow_fragment => true })
+          expect(encoded).to eq("/foo%20bar?baz%2Bqux#fragment")
+        end
+      end
+    end
+
     describe "when using platform :windows" do
       before :each do
         Puppet.features.stubs(:posix).returns false


### PR DESCRIPTION
 - URI is obsolete and has some undesirable behaviors:
    - URI.escape returns strings in US-ASCII instead of UTF-8
    - URI.parse returns strings in their source encoding instead of
      UTF-8
 - CGI behaves correctly with UTF-8, but returns more characters
   encoded, which might mess with URI.parse