### PR TITLE
(PUP-7281) Add ability to declare options as an entry in Hiera defaults

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -799,6 +799,10 @@ module Issues
     "Option key '#{key}' used in hierarchy '#{name}' is reserved by Puppet"
   end
 
+  HIERA_DEFAULT_OPTION_RESERVED_BY_PUPPET = hard_issue :HIERA_DEFAULT_OPTION_RESERVED_BY_PUPPET, :key do
+    "Option key '#{key}' used in defaults is reserved by Puppet"
+  end
+
   HIERA_DATA_PROVIDER_FUNCTION_NOT_FOUND = hard_issue :HIERA_DATA_PROVIDER_FUNCTION_NOT_FOUND, :function_type, :function_name do
     "Unable to find '#{function_type}' function named '#{function_name}'"
   end

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -567,7 +567,8 @@ class HieraConfigV5 < HieraConfig
           tf.optional(KEY_DATA_HASH) => nes_t,
           tf.optional(KEY_LOOKUP_KEY) => nes_t,
           tf.optional(KEY_DATA_DIG) => nes_t,
-          tf.optional(KEY_DATADIR) => nes_t
+          tf.optional(KEY_DATADIR) => nes_t,
+          tf.optional(KEY_OPTIONS) => tf.hash_kv(option_name_t, tf.data),
         }),
       tf.optional(KEY_HIERARCHY) => tf.array_of(tf.struct(
         {
@@ -638,7 +639,7 @@ class HieraConfigV5 < HieraConfig
         nil
       end
       next if @config_path.nil? && !locations.nil? && locations.empty? # Default config and no existing paths found
-      options = he[KEY_OPTIONS]
+      options = he[KEY_OPTIONS] || defaults[KEY_OPTIONS]
       options = options.nil? ? EMPTY_HASH : interpolate(options, lookup_invocation, false)
       if(function_kind == KEY_V3_BACKEND)
         unless parent_data_provider.is_a?(GlobalDataProvider)
@@ -725,6 +726,13 @@ class HieraConfigV5 < HieraConfig
       # OK
     else
       fail(Issues::HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS_IN_DEFAULT)
+    end
+
+    options = defaults[KEY_OPTIONS]
+    unless options.nil?
+      RESERVED_OPTION_KEYS.each do |key|
+        fail(Issues::HIERA_DEFAULT_OPTION_RESERVED_BY_PUPPET, :key => key) if options.include?(key)
+      end
     end
   end
 


### PR DESCRIPTION
This commit makes it possible to declare an `options` hash under the
hiera.yaml `defaults` entry. That hash will then be used by all entries
beneath `hierarchy` that does not declare an `options` entry of their
own. The `options` hash is never merged. If an entry declares it, it
replaces the default.