### PR TITLE
(PUP-7330) Ensure that lookup CLI initializes loaders

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -217,7 +217,7 @@ class Puppet::Parser::Compiler
     {
       :current_environment => environment,
       :global_scope => @topscope,             # 4x placeholder for new global scope
-      :loaders  => lambda {|| loaders() },    # 4x loaders
+      :loaders  => @loaders,                  # 4x loaders
       :injector => lambda {|| injector() }    # 4x API - via context instead of via compiler
     }
   end
@@ -357,7 +357,7 @@ class Puppet::Parser::Compiler
     end
   end
 
-  # Evaluates each specified class in turn. If there are any classes that 
+  # Evaluates each specified class in turn. If there are any classes that
   # can't be found, an error is raised. This method really just creates resource objects
   # that point back to the classes, and then the resources are themselves
   # evaluated later in the process.
@@ -440,10 +440,6 @@ class Puppet::Parser::Compiler
   def injector
     create_injector if @injector.nil?
     @injector
-  end
-
-  def loaders
-    @loaders ||= Puppet::Pops::Loaders.new(environment)
   end
 
   def boot_injector
@@ -751,6 +747,9 @@ class Puppet::Parser::Compiler
     # MOVED HERE - SCOPE IS NEEDED (MOVE-SCOPE)
     # Create the initial scope, it is needed early
     @topscope = Puppet::Parser::Scope.new(self)
+
+    # Initialize loaders and Pcore
+    @loaders = Puppet::Pops::Loaders.new(environment)
 
     # Need to compute overrides here, and remember them, because we are about to
     # enter the magic zone of known_resource_types and initial import.

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -474,7 +474,7 @@ describe 'the 4x function api' do
         # evaluate a puppet call
         source = "testing::test(10) |$x| { $x+1 }"
         program = parser.parse_string(source, __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).returns(the_loader)
+        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns(the_loader)
         expect(parser.evaluate(scope, program)).to eql(11)
       end
     end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -45,11 +45,11 @@ describe 'loaders' do
     let(:pp_resources) { config_dir('pp_resources') }
     let(:environments) { Puppet::Environments::Directories.new(my_fixture_dir, []) }
     let(:env) { Puppet::Node::Environment.create(:'pp_resources', [File.join(pp_resources, 'modules')]) }
-    let(:scope) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)).newscope(nil) }
+    let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
     let(:loader) { Puppet::Pops::Loaders.loaders.find_loader(nil) }
     around(:each) do |example|
-      Puppet.override(:environments => environments, :current_environment => scope.environment, :global_scope => scope) do
-        Puppet.override(:loaders => Puppet::Pops::Loaders.new(env)) do
+      Puppet.override(:environments => environments) do
+        Puppet.override(:loaders => compiler.loaders) do
           example.run
         end
       end


### PR DESCRIPTION
Under some very rare circumstances, such as when the running the lookup
CLI command and the only available data provider for Hiera was a custom
backend written in Ruby, the Pcore would not be initialized by the
compiler since no loader was ever requested. This in turn, resulted in
that the `Puppet::LookupKey` and `Puppet::LookupValue` types never got
initialized.

This commit changes the compiler so that it performs the task of
initializing loaders and Pcore during its own initialization instead of
performing it lazily when the loaders are first requested.

The change in behavior broke a couple of tests that made assumptions on
the deferred loader initialization. This commit fixes those tests as
well.

The problem was triggered by commit 12b8ab94cd75c3db9feb858c4eccf61d9b6940db