### PR TITLE
(PUP-7330) Add gen_hosts dependency for quick target

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -288,7 +288,7 @@ Run a limited but representative subset of acceptance tests through Beaker and i
   $ env SHA=<full sha> bundle exec rake ci:test:quick
 EOS
 
-  task :quick => 'ci:check_env' do
+  task :quick => ['ci:check_env', 'ci:gen_hosts'] do
     ENV['TESTS'] = get_test_sample.join(",")
     beaker_test(:aio)
   end


### PR DESCRIPTION
Add the `gen_hosts` task as a dependency of `ci:test:quick` so that the
beaker-hostgenerator file is created before calling beaker.

/cc @puppetlabs/agent-team 

This needs to be merged up to 4.10.x and master