### PR TITLE
(maint) Only ci:test:quick ruby files

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -242,6 +242,8 @@ def get_test_sample
     s.empty?
   end.collect do |s|
     s.sub('acceptance/', '')
+  end.select do |s|
+    s =~ /\.rb$/
   end.find_all do |s|
     File.exist?(s)
   end


### PR DESCRIPTION
Previously, the quick task was trying to run `.sh` files as beaker tests
which were recently modified.

This commit ensures we only try to run files ending in `.rb`. If those
are not beaker tests then they need to be in a different directory
other than `tests`.

Supersedes PR #5744.

[skip ci]