### PR TITLE
(PUP-7334) Add Hiera default_hierarchy to module hiera.yaml

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -775,6 +775,10 @@ module Issues
     "'hiera3_backend' is only allowed in the global layer"
   end
 
+  HIERA_DEFAULT_HIERARCHY_NOT_IN_MODULE = hard_issue :HIERA_DEFAULT_HIERARCHY_NOT_IN_MODULE do
+    "'default_hierarchy' is only allowed in the module layer"
+  end
+
   HIERA_V3_BACKEND_REPLACED_BY_DATA_HASH = hard_issue :HIERA_V3_BACKEND_REPLACED_BY_DATA_HASH, :function_name do
     "Use \"data_hash: #{function_name}_data\" instead of \"hiera3_backend: #{function_name}\""
   end

--- a/lib/puppet/pops/lookup/configured_data_provider.rb
+++ b/lib/puppet/pops/lookup/configured_data_provider.rb
@@ -13,7 +13,13 @@ class ConfiguredDataProvider
   end
 
   def config(lookup_invocation)
-    @config ||= assert_config_version(HieraConfig.create(lookup_invocation, configuration_path(lookup_invocation)))
+    @config ||= assert_config_version(HieraConfig.create(lookup_invocation, configuration_path(lookup_invocation), self))
+  end
+
+  # Needed to assign generated version 4 config
+  # @deprecated
+  def config=(config)
+    @config = config
   end
 
   # @return [Pathname] the path to the configuration
@@ -46,7 +52,7 @@ class ConfiguredDataProvider
         lookup_invocation.report_not_found(key)
         throw :no_such_key
       end
-      merge_strategy.lookup(data_providers(lookup_invocation), lookup_invocation) do |data_provider|
+      merge_strategy.lookup(dps, lookup_invocation) do |data_provider|
         data_provider.unchecked_key_lookup(key, lookup_invocation, merge_strategy)
       end
     end

--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -41,6 +41,17 @@ module DataProvider
     lookup_invocation.check(key.to_s) { unchecked_key_lookup(key, lookup_invocation, merge) }
   end
 
+  # Performs a lookup using a module default hierarchy with an endless recursion check. All providers except
+  # the `ModuleDataProvider` will throw `:no_such_key` if this method is called.
+  #
+  # @param key [LookupKey] The key to lookup
+  # @param lookup_invocation [Invocation] The current lookup invocation
+  # @param merge [MergeStrategy,String,Hash{String=>Object},nil] Merge strategy or hash with strategy and options
+  #
+  def key_lookup_in_default(key, lookup_invocation, merge)
+    throw :no_such_key
+  end
+
   def lookup(key, lookup_invocation, merge)
     lookup_invocation.check(key.to_s) { unchecked_key_lookup(key, lookup_invocation, merge) }
   end

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -444,6 +444,7 @@ module Lookup
     def dump_on(io, indent, first_indent)
       io << indent << @name << "\n"
       indent = increase_indent(indent)
+      branches.each {|b| b.dump_on(io, indent, indent)}
       dump_outcome(io, indent)
     end
 

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -44,6 +44,7 @@ class HieraConfig
   KEY_NAME = 'name'.freeze
   KEY_VERSION = 'version'.freeze
   KEY_DATADIR = 'datadir'.freeze
+  KEY_DEFAULT_HIERARCHY = 'default_hierarchy'.freeze
   KEY_HIERARCHY = 'hierarchy'.freeze
   KEY_LOGGER = 'logger'.freeze
   KEY_OPTIONS = 'options'.freeze
@@ -78,7 +79,7 @@ class HieraConfig
     KEY_V4_DATA_HASH => V4DataHashFunctionProvider
   }
 
-  def self.v4_function_config(config_root, function_name)
+  def self.v4_function_config(config_root, function_name, owner)
     unless Puppet[:strict] == :off
       Puppet.warn_once(:deprecation, 'legacy_provider_function',
         "Using of legacy data provider function '#{function_name}'. Please convert to a 'data_hash' function")
@@ -92,7 +93,8 @@ class HieraConfig
             KEY_V4_DATA_HASH => function_name
           }
         ]
-      }.freeze
+      }.freeze,
+      owner
     )
   end
 
@@ -117,8 +119,9 @@ class HieraConfig
   #
   # @param lookup_invocation [Invocation] Invocation data containing scope, overrides, and defaults
   # @param config_path [Pathname] Absolute path to the configuration file
+  # @param owner [ConfiguredDataProvider] The data provider that will own the created configuration
   # @return [LookupConfiguration] the configuration
-  def self.create(lookup_invocation, config_path)
+  def self.create(lookup_invocation, config_path, owner)
     if config_path.is_a?(Hash)
       config_path = nil
       loaded_config = config_path
@@ -148,11 +151,11 @@ class HieraConfig
     version = version.nil? ? 3 : version.to_i
     case version
     when 5
-      HieraConfigV5.new(config_root, config_path, loaded_config)
+      HieraConfigV5.new(config_root, config_path, loaded_config, owner)
     when 4
-      HieraConfigV4.new(config_root, config_path, loaded_config)
+      HieraConfigV4.new(config_root, config_path, loaded_config, owner)
     when 3
-      HieraConfigV3.new(config_root, config_path, loaded_config)
+      HieraConfigV3.new(config_root, config_path, loaded_config, owner)
     else
       issue = Issues::HIERA_UNSUPPORTED_VERSION
       raise Puppet::DataBinding::LookupError.new(
@@ -167,11 +170,11 @@ class HieraConfig
   #
   # @param config_path [Pathname] Absolute path to the configuration
   # @param loaded_config [Hash] the loaded configuration
-  def initialize(config_root, config_path, loaded_config)
+  def initialize(config_root, config_path, loaded_config, owner)
     @config_root = config_root
     @config_path = config_path
     @loaded_config = loaded_config
-    @config = validate_config(self.class.symkeys_to_string(@loaded_config))
+    @config = validate_config(self.class.symkeys_to_string(@loaded_config), owner)
     @data_providers = nil
   end
 
@@ -180,19 +183,26 @@ class HieraConfig
       issue.format(args.merge(:label => self)),  @config_path, line, nil, nil, issue.issue_code)
   end
 
+  def has_default_hierarchy?
+    false
+  end
+
   # Returns the data providers for this config
   #
   # @param lookup_invocation [Invocation] Invocation data containing scope, overrides, and defaults
   # @param parent_data_provider [DataProvider] The data provider that loaded this configuration
   # @return [Array<DataProvider>] the data providers
-  def configured_data_providers(lookup_invocation, parent_data_provider)
+  def configured_data_providers(lookup_invocation, parent_data_provider, use_default_hierarchy = false)
     unless @data_providers && scope_interpolations_stable?(lookup_invocation)
       if @data_providers
         lookup_invocation.report_text { 'Hiera configuration recreated due to change of scope variables used in interpolation expressions' }
       end
       slc_invocation = ScopeLookupCollectingInvocation.new(lookup_invocation.scope)
       begin
-        @data_providers = create_configured_data_providers(slc_invocation, parent_data_provider)
+        @data_providers = create_configured_data_providers(slc_invocation, parent_data_provider, false)
+        if has_default_hierarchy?
+          @default_data_providers = create_configured_data_providers(slc_invocation, parent_data_provider, true)
+        end
       rescue StandardError => e
         # Raise a LookupError with a RUNTIME_ERROR issue to prevent this being translated to an evaluation error triggered in the pp file
         # where the lookup started
@@ -204,7 +214,7 @@ class HieraConfig
       end
       @scope_interpolations = slc_invocation.scope_interpolations
     end
-    @data_providers
+    use_default_hierarchy ? @default_data_providers : @data_providers
   end
 
   # Find first line in configuration that matches regexp after given line. Comments are stripped
@@ -252,11 +262,11 @@ class HieraConfig
   end
 
   # @api private
-  def create_configured_data_providers(lookup_invocation, parent_data_provider)
+  def create_configured_data_providers(lookup_invocation, parent_data_provider, use_default_hierarchy)
     self.class.not_implemented(self, 'create_configured_data_providers')
   end
 
-  def validate_config(config)
+  def validate_config(config, owner)
     self.class.not_implemented(self, 'validate_config')
   end
 
@@ -351,7 +361,7 @@ class HieraConfigV3 < HieraConfig
     }
   end
 
-  def create_configured_data_providers(lookup_invocation, parent_data_provider)
+  def create_configured_data_providers(lookup_invocation, parent_data_provider, _)
     scope = lookup_invocation.scope
     unless scope.is_a?(Hiera::Scope)
       lookup_invocation = Invocation.new(
@@ -409,7 +419,7 @@ class HieraConfigV3 < HieraConfig
     KEY_MERGE_BEHAVIOR => 'native'
   }
 
-  def validate_config(config)
+  def validate_config(config, owner)
     unless Puppet[:strict] == :off
       Puppet.warn_once(:deprecation, 'hiera.yaml',
         "#{@config_path}: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5", config_path.to_s)
@@ -500,7 +510,7 @@ class HieraConfigV4 < HieraConfig
     end
   end
 
-  def create_configured_data_providers(lookup_invocation, parent_data_provider)
+  def create_configured_data_providers(lookup_invocation, parent_data_provider, _)
     default_datadir = @config[KEY_DATADIR]
     data_providers = {}
 
@@ -532,7 +542,7 @@ class HieraConfigV4 < HieraConfig
     data_providers.values
   end
 
-  def validate_config(config)
+  def validate_config(config, owner)
     unless Puppet[:strict] == :off
       Puppet.warn_once(:deprecation, 'hiera.yaml',
         "#{@config_path}: Use of 'hiera.yaml' version 4 is deprecated. It should be converted to version 5", config_path.to_s)
@@ -560,6 +570,25 @@ class HieraConfigV5 < HieraConfig
     # The option name must start with a letter and end with a letter or digit. May contain underscore and dash.
     option_name_t = tf.pattern(/\A[A-Za-z](:?[0-9A-Za-z_-]*[0-9A-Za-z])?\z/)
 
+    hierarchy_t = tf.array_of(tf.struct(
+      {
+        KEY_NAME => nes_t,
+        tf.optional(KEY_OPTIONS) => tf.hash_kv(option_name_t, tf.data),
+        tf.optional(KEY_DATA_HASH) => nes_t,
+        tf.optional(KEY_LOOKUP_KEY) => nes_t,
+        tf.optional(KEY_V3_BACKEND) => nes_t,
+        tf.optional(KEY_V4_DATA_HASH) => nes_t,
+        tf.optional(KEY_DATA_DIG) => nes_t,
+        tf.optional(KEY_PATH) => nes_t,
+        tf.optional(KEY_PATHS) => tf.array_of(nes_t, tf.range(1, :default)),
+        tf.optional(KEY_GLOB) => nes_t,
+        tf.optional(KEY_GLOBS) => tf.array_of(nes_t, tf.range(1, :default)),
+        tf.optional(KEY_URI) => uri_t,
+        tf.optional(KEY_URIS) => tf.array_of(uri_t, tf.range(1, :default)),
+        tf.optional(KEY_MAPPED_PATHS) => tf.array_of(nes_t, tf.range(3, 3)),
+        tf.optional(KEY_DATADIR) => nes_t
+      }))
+
     @@CONFIG_TYPE = tf.struct({
       KEY_VERSION => tf.range(5, 5),
       tf.optional(KEY_DEFAULTS) => tf.struct(
@@ -570,35 +599,28 @@ class HieraConfigV5 < HieraConfig
           tf.optional(KEY_DATADIR) => nes_t,
           tf.optional(KEY_OPTIONS) => tf.hash_kv(option_name_t, tf.data),
         }),
-      tf.optional(KEY_HIERARCHY) => tf.array_of(tf.struct(
-        {
-          KEY_NAME => nes_t,
-          tf.optional(KEY_OPTIONS) => tf.hash_kv(option_name_t, tf.data),
-          tf.optional(KEY_DATA_HASH) => nes_t,
-          tf.optional(KEY_LOOKUP_KEY) => nes_t,
-          tf.optional(KEY_V3_BACKEND) => nes_t,
-          tf.optional(KEY_V4_DATA_HASH) => nes_t,
-          tf.optional(KEY_DATA_DIG) => nes_t,
-          tf.optional(KEY_PATH) => nes_t,
-          tf.optional(KEY_PATHS) => tf.array_of(nes_t, tf.range(1, :default)),
-          tf.optional(KEY_GLOB) => nes_t,
-          tf.optional(KEY_GLOBS) => tf.array_of(nes_t, tf.range(1, :default)),
-          tf.optional(KEY_URI) => uri_t,
-          tf.optional(KEY_URIS) => tf.array_of(uri_t, tf.range(1, :default)),
-          tf.optional(KEY_MAPPED_PATHS) => tf.array_of(nes_t, tf.range(3, 3)),
-          tf.optional(KEY_DATADIR) => nes_t
-        }))
+      tf.optional(KEY_HIERARCHY) => hierarchy_t,
+      tf.optional(KEY_DEFAULT_HIERARCHY) => hierarchy_t
     })
   end
 
-  def create_configured_data_providers(lookup_invocation, parent_data_provider)
+  def create_configured_data_providers(lookup_invocation, parent_data_provider, use_default_hierarchy)
     defaults = @config[KEY_DEFAULTS] || EMPTY_HASH
     datadir = defaults[KEY_DATADIR] || 'data'
 
     # Hashes enumerate their values in the order that the corresponding keys were inserted so it's safe to use
     # a hash for the data_providers.
     data_providers = {}
-    @config[KEY_HIERARCHY].each do |he|
+
+    if @config.include?(KEY_DEFAULT_HIERARCHY)
+      unless parent_data_provider.is_a?(ModuleDataProvider)
+        fail(Issues::HIERA_DEFAULT_HIERARCHY_NOT_IN_MODULE, EMPTY_HASH, find_line_matching(/\s+default_hierarchy:/))
+      end
+    elsif use_default_hierarchy
+      return data_providers
+    end
+
+    @config[use_default_hierarchy ? KEY_DEFAULT_HIERARCHY : KEY_HIERARCHY].each do |he|
       name = he[KEY_NAME]
       if data_providers.include?(name)
         first_line = find_line_matching(/\s+name:\s+['"]?#{name}(?:[^\w]|$)/)
@@ -642,15 +664,6 @@ class HieraConfigV5 < HieraConfig
       options = he[KEY_OPTIONS] || defaults[KEY_OPTIONS]
       options = options.nil? ? EMPTY_HASH : interpolate(options, lookup_invocation, false)
       if(function_kind == KEY_V3_BACKEND)
-        unless parent_data_provider.is_a?(GlobalDataProvider)
-          fail(Issues::HIERA_V3_BACKEND_NOT_GLOBAL, EMPTY_HASH, find_line_matching(/\s+#{function_kind}:/))
-        end
-
-        if function_name == 'json' || function_name == 'yaml' || function_name == 'hocon' &&  Puppet.features.hocon?
-          # Disallow use of backends that have corresponding "data_hash" functions in version 5
-          fail(Issues::HIERA_V3_BACKEND_REPLACED_BY_DATA_HASH, { :function_name => function_name },
-            find_line_matching(/\s+#{function_kind}:\s*['"]?#{function_name}(?:[^\w]|$)/))
-        end
         v3options = { :datadir => entry_datadir.to_s }
         options.each_pair { |k, v| v3options[k.to_sym] = v }
         data_providers[name] = create_hiera3_backend_provider(name, function_name, parent_data_provider, entry_datadir, locations, {
@@ -670,6 +683,10 @@ class HieraConfigV5 < HieraConfig
     data_providers.values
   end
 
+  def has_default_hierarchy?
+    @config.include?(KEY_DEFAULT_HIERARCHY)
+  end
+
   RESERVED_OPTION_KEYS = ['path', 'uri'].freeze
 
   DEFAULT_CONFIG_HASH = {
@@ -686,38 +703,59 @@ class HieraConfigV5 < HieraConfig
     ]
   }.freeze
 
-  def validate_config(config)
+  def validate_config(config, owner)
     config[KEY_DEFAULTS] ||= DEFAULT_CONFIG_HASH[KEY_DEFAULTS]
     config[KEY_HIERARCHY] ||= DEFAULT_CONFIG_HASH[KEY_HIERARCHY]
 
     Types::TypeAsserter.assert_instance_of(["The Lookup Configuration at '%s'", @config_path], self.class.config_type, config)
     defaults = config[KEY_DEFAULTS]
     validate_defaults(defaults) unless defaults.nil?
-    config[KEY_HIERARCHY].each do |he|
-      name = he[KEY_NAME]
-      case ALL_FUNCTION_KEYS.count { |key| he.include?(key) }
-      when 0
-        if defaults.nil? || FUNCTION_KEYS.count { |key| defaults.include?(key) } == 0
-          fail(Issues::HIERA_MISSING_DATA_PROVIDER_FUNCTION, :name => name)
-        end
-      when 1
-        # OK
-      else
-        fail(Issues::HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS, :name => name)
-      end
+    config[KEY_HIERARCHY].each { |he| validate_hierarchy(he, defaults, owner) }
 
-      if LOCATION_KEYS.count { |key| he.include?(key) } > 1
-        fail(Issues::HIERA_MULTIPLE_LOCATION_SPECS, :name => name)
+    if config.include?(KEY_DEFAULT_HIERARCHY)
+      unless owner.is_a?(ModuleDataProvider)
+        fail(Issues::HIERA_DEFAULT_HIERARCHY_NOT_IN_MODULE, EMPTY_HASH, find_line_matching(/(?:^|\s+)#{KEY_DEFAULT_HIERARCHY}:/))
       end
-
-      options = he[KEY_OPTIONS]
-      unless options.nil?
-        RESERVED_OPTION_KEYS.each do |key|
-          fail(Issues::HIERA_OPTION_RESERVED_BY_PUPPET, :key => key, :name => name) if options.include?(key)
-        end
-      end
+      config[KEY_DEFAULT_HIERARCHY].each { |he| validate_hierarchy(he, defaults, owner) }
     end
     config
+  end
+
+  def validate_hierarchy(he, defaults, owner)
+    name = he[KEY_NAME]
+    case ALL_FUNCTION_KEYS.count { |key| he.include?(key) }
+    when 0
+      if defaults.nil? || FUNCTION_KEYS.count { |key| defaults.include?(key) } == 0
+        fail(Issues::HIERA_MISSING_DATA_PROVIDER_FUNCTION, :name => name)
+      end
+    when 1
+      # OK
+    else
+      fail(Issues::HIERA_MULTIPLE_DATA_PROVIDER_FUNCTIONS, :name => name)
+    end
+
+    v3_backend = he[KEY_V3_BACKEND]
+    unless v3_backend.nil?
+      unless owner.is_a?(GlobalDataProvider)
+        fail(Issues::HIERA_V3_BACKEND_NOT_GLOBAL, EMPTY_HASH, find_line_matching(/\s+#{KEY_V3_BACKEND}:/))
+      end
+      if v3_backend == 'json' || v3_backend == 'yaml' || v3_backend == 'hocon' &&  Puppet.features.hocon?
+        # Disallow use of backends that have corresponding "data_hash" functions in version 5
+        fail(Issues::HIERA_V3_BACKEND_REPLACED_BY_DATA_HASH, { :function_name => v3_backend },
+          find_line_matching(/\s+#{KEY_V3_BACKEND}:\s*['"]?#{v3_backend}(?:[^\w]|$)/))
+      end
+    end
+
+    if LOCATION_KEYS.count { |key| he.include?(key) } > 1
+      fail(Issues::HIERA_MULTIPLE_LOCATION_SPECS, :name => name)
+    end
+
+    options = he[KEY_OPTIONS]
+    unless options.nil?
+      RESERVED_OPTION_KEYS.each do |key|
+        fail(Issues::HIERA_OPTION_RESERVED_BY_PUPPET, :key => key, :name => name) if options.include?(key)
+      end
+    end
   end
 
   def validate_defaults(defaults)

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -58,7 +58,10 @@ class LookupAdapter < DataAdapter
           merge = lookup_merge_options(key, lookup_invocation)
           lookup_invocation.report_merge_source(LOOKUP_OPTIONS) unless merge.nil?
         end
-        lookup_invocation.with(:data, key.to_s) { do_lookup(key, lookup_invocation, merge) }
+        lookup_invocation.with(:data, key.to_s) do
+          catch(:no_such_key) { return do_lookup(key, lookup_invocation, merge) }
+          key.dig(lookup_invocation, lookup_default_in_module(key, lookup_invocation))
+        end
       end
     end
   end
@@ -115,6 +118,43 @@ class LookupAdapter < DataAdapter
     provider.key_lookup(key, lookup_invocation, merge_strategy)
   end
 
+  def lookup_default_in_module(key, lookup_invocation)
+    module_name = lookup_invocation.module_name
+
+    # Do not attempt to do a lookup in a module unless the name is qualified.
+    throw :no_such_key if module_name.nil?
+
+    provider = module_provider(lookup_invocation, module_name)
+    throw :no_such_key if provider.nil? || !provider.config(lookup_invocation).has_default_hierarchy?
+
+    lookup_invocation.with(:scope, "Searching default_hierarchy of module \"#{module_name}\"") do
+      merge_strategy = nil
+      if merge_strategy.nil?
+        @module_default_lookup_options ||= {}
+        options = @module_default_lookup_options.fetch(module_name) do |k|
+          meta_invocation = Invocation.new(lookup_invocation.scope)
+          meta_invocation.lookup(LookupKey::LOOKUP_OPTIONS, k) do
+            opts = nil
+            lookup_invocation.with(:scope, "Searching for \"#{LookupKey::LOOKUP_OPTIONS}\"") do
+              catch(:no_such_key) do
+              opts = compile_patterns(
+                validate_lookup_options(
+                  provider.key_lookup_in_default(LookupKey::LOOKUP_OPTIONS, meta_invocation, MergeStrategy.strategy(HASH)), k))
+              end
+            end
+            @module_default_lookup_options[k] = opts
+          end
+        end
+        lookup_options = extract_lookup_options_for_key(key, options)
+        merge_strategy = lookup_options[MERGE] unless lookup_options.nil?
+      end
+
+      lookup_invocation.with(:scope, "Searching for \"#{key}\"") do
+        provider.key_lookup_in_default(key, lookup_invocation, merge_strategy)
+      end
+    end
+  end
+
   # Retrieve the merge options that match the given `name`.
   #
   # @param key [LookupKey] The key for which we want merge options
@@ -142,6 +182,10 @@ class LookupAdapter < DataAdapter
     else
       options = @lookup_options[module_name]
     end
+    extract_lookup_options_for_key(key, options)
+  end
+
+  def extract_lookup_options_for_key(key, options)
     return nil if options.nil?
 
     rk = key.root_key
@@ -360,7 +404,9 @@ class LookupAdapter < DataAdapter
       when 'hiera'
         mp || ModuleDataProvider.new(module_name)
       when 'function'
-        ModuleDataProvider.new(module_name, HieraConfig.v4_function_config(Pathname(mod.path), "#{module_name}::data"))
+        mp = ModuleDataProvider.new(module_name)
+        mp.config = HieraConfig.v4_function_config(Pathname(mod.path), "#{module_name}::data", mp)
+        mp
       else
         injector = Puppet.lookup(:injector) { nil }
         provider = injector.lookup(nil,
@@ -428,7 +474,9 @@ class LookupAdapter < DataAdapter
         # Use hiera.yaml or default settings if it is missing
         ep || EnvironmentDataProvider.new
       when 'function'
-        EnvironmentDataProvider.new(HieraConfigV5.v4_function_config(env_path, 'environment::data'))
+        ep = EnvironmentDataProvider.new
+        ep.config = HieraConfigV5.v4_function_config(env_path, 'environment::data', ep)
+        ep
       else
          injector = Puppet.lookup(:injector) { nil }
 


### PR DESCRIPTION
This commit adds the ability to declare a second hierarchy named
`default_hierarchy` to a hiera.yaml file that resides in a module root.
This hierarchy is only allowed in modules and will be consulted when, and
only when, a normal lookup does not find a value.

The `default_hierarchy` is insensitive to `lookup_options` declared in
the regular `hierarchy` and vice versa.

The `default_hierarchy` is also insensitive to any merge directives
passed in as a parameter in the lookup call.