### PR TITLE
(PUP-7372) Confine Hiera 3 interpolations to the global layer

### DIFF
--- a/lib/puppet/pops/lookup/global_data_provider.rb
+++ b/lib/puppet/pops/lookup/global_data_provider.rb
@@ -15,11 +15,16 @@ class GlobalDataProvider < ConfiguredDataProvider
       # Hiera version 3 needs access to special scope variables
       scope = lookup_invocation.scope
       unless scope.is_a?(Hiera::Scope)
-        lookup_invocation = Invocation.new(
+        hiera_invocation = Invocation.new(
           Hiera::Scope.new(scope),
           lookup_invocation.override_values,
           lookup_invocation.default_values,
           lookup_invocation.explainer)
+
+        # Confine to global scope unless an environment data provider has been defined (same as for hiera_xxx functions)
+        adapter = lookup_invocation.lookup_adapter
+        hiera_invocation.set_global_only unless adapter.global_only? || adapter.has_environment_data_provider?(lookup_invocation)
+        lookup_invocation = hiera_invocation
       end
 
       merge = MergeStrategy.strategy(merge)

--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -69,7 +69,17 @@ module Interpolation
 
   def interpolate_method(method_key)
     @@interpolate_methods ||= begin
-      global_lookup = lambda { |key, lookup_invocation, _| Lookup.lookup(key, nil, '', true, nil, lookup_invocation) }
+      global_lookup = lambda do |key, lookup_invocation, _|
+        if lookup_invocation.scope.is_a?(Hiera::Scope) && !lookup_invocation.global_only?
+          # "unwrap" the Hiera::Scope
+          lookup_invocation = Invocation.new(
+            lookup_invocation.scope.real,
+            lookup_invocation.override_values,
+            lookup_invocation.default_values,
+            lookup_invocation.explainer)
+        end
+        Lookup.lookup(key, nil, '', true, nil, lookup_invocation)
+      end
       scope_lookup = lambda do |key, lookup_invocation, subject|
         segments = split_key(key) { |problem| Puppet::DataBinding::LookupError.new("#{problem} in string: #{subject}") }
         root_key = segments.shift

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -60,6 +60,7 @@ class LookupAdapter < DataAdapter
         end
         lookup_invocation.with(:data, key.to_s) do
           catch(:no_such_key) { return do_lookup(key, lookup_invocation, merge) }
+          throw :no_such_key if lookup_invocation.global_only?
           key.dig(lookup_invocation, lookup_default_in_module(key, lookup_invocation))
         end
       end


### PR DESCRIPTION
This commit ensures that a data file that is reached using a Hiera 3
configuration and that in turn contains interpolation expressions that
use the 'hiera' or 'lookup' function, will have that lookup confined
to the global layer unless an environment data provider, version 5
is present. It also ensures that when an interpolation that originas
from Hiera 3 is calling out, that the special `Hiera::Scope` class
is unwrapped.

This was not the case earlier which resulted in that the special class
`Hiera::Scope` was passed on to the environment and module layers which
resulted in errors as they tried to access the `Scope#environment`
method which is not present in that class. Other side-effects of passing
that scope would be to make the special variables that it contains
available to data configured using Hiera 5.