### PR TITLE
(PUP-7077) Fix Windows::File.replace_file on UNC

### DIFF
--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -48,11 +48,15 @@ module Puppet::Util::Windows::File
      FILE_EXECUTE |
      SYNCHRONIZE
 
+  REPLACEFILE_WRITE_THROUGH         = 0x1
+  REPLACEFILE_IGNORE_MERGE_ERRORS   = 0x2
+  REPLACEFILE_IGNORE_ACL_ERRORS     = 0x3
+
   def replace_file(target, source)
     target_encoded = wide_string(target.to_s)
     source_encoded = wide_string(source.to_s)
 
-    flags = 0x1
+    flags = REPLACEFILE_IGNORE_MERGE_ERRORS
     backup_file = nil
     result = ReplaceFileW(
       target_encoded,


### PR DESCRIPTION
 - Previously, anytime Puppet::Util:::Windows::File.replace_file is
   called, it used the Windows ReplaceFile API with the flag
   REPLACEFILE_WRITE_THROUGH

   MSDN documentation specifies:
   https://msdn.microsoft.com/en-us/library/windows/desktop/aa365512(v=vs.85).aspx

   "
   This value is not supported.
   "

   Unfortunately, this flag could prevent replace_file from behaving
   properly on a UNC share.  When dealing with a UNC path, a 0 byte
   file would get written, but due to the inability to set ACL
   permissionss and the absence of REPLACEFILE_IGNORE_MERGE_ERRORS
   being set on the API call - the file would fail to be written.

 - When the original code in 73e302bbf5ab4a6c5513a39070e2c907542775ae
   made the call to ReplaceFileW, it's my understanding that the flag
   value was selected because the intent was to ensure ACLs were
   properly copied.

   In reality, that flag seems to prevent file copies from
   succeeding in certain circumstances where ACLs are unable to
   copy, which is undesirable.

 - This change switches the flag to REPLACEFILE_IGNORE_MERGE_ERRORS:

   "
   Ignores errors that occur while merging information (such as
   attributes and ACLs) from the replaced file to the replacement
   file. Therefore, if you specify this flag and do not have
   WRITE_DAC access, the function succeeds but the ACLs are not
   preserved.
   "

 - This has been verified in a manual test setup.

   Create a UNC share that has Read and Change permissions, but not
   Full Control.  Create a puppet manifest that has a file resource
   with a source referring to the UNC path.  With the flag set to
   REPLACEFILE_IGNORE_MERGE_ERRORS the file creation / replacement
   succeeds as expected.

 - Note that users could already work around this problem in a manifest
   with an exec resource that uses cmd.exe to echo a file:

   cmd /c echo 'foo' > \\server\share\file.txt

 - Also note that there are no new tests for this because of the
   difficulty in creating UNC shares in an automated fashion.