### PR TITLE
(PUP-7328) Ensure that the 'settings' Class is created only once

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -851,11 +851,17 @@ class Puppet::Parser::Compiler
     @topscope.set_facts(facts_hash)
   end
 
-  def create_settings_scope
-    settings_type = Puppet::Resource::Type.new :hostclass, "settings"
-    environment.known_resource_types.add(settings_type)
+  SETTINGS = 'settings'.freeze
 
-    settings_resource = Puppet::Parser::Resource.new("class", "settings", :scope => @topscope)
+  def create_settings_scope
+    resource_types = environment.known_resource_types
+    settings_type = resource_types.hostclass(SETTINGS)
+    if settings_type.nil?
+      settings_type = Puppet::Resource::Type.new(:hostclass, SETTINGS)
+      resource_types.add(settings_type)
+    end
+
+    settings_resource = Puppet::Parser::Resource.new('class', SETTINGS, :scope => @topscope)
 
     @catalog.add_resource(settings_resource)
 

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -109,6 +109,20 @@ describe Puppet::Parser::Compiler do
 
   describe "when initializing" do
 
+    it 'should not create the settings class more than once' do
+      logs = []
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        Puppet[:code] = 'undef'
+        @compiler.compile
+
+        @compiler = Puppet::Parser::Compiler.new(@node)
+        Puppet[:code] = 'undef'
+        @compiler.compile
+      end
+      warnings = logs.select { |log| log.level == :warning }.map { |log| log.message }
+      expect(warnings).not_to include(/Class 'settings' is already defined/)
+    end
+
     it "should set its node attribute" do
       expect(@compiler.node).to equal(@node)
     end


### PR DESCRIPTION
Before this commit, each compilation would make an attempt to create
and add the 'settings' Class to the list of known resource types in the
environment. When more than one compilation was performed during the
life span of an environment, a warning "Class 'settings' is already
defined" would appear in the log. This is now changed so that the
compiler instead reuses the Class if it is already present in the
environment.