### PR TITLE
(PUP-7390) Prefer minitar for PMT when available

### DIFF
--- a/lib/puppet/module_tool/tar.rb
+++ b/lib/puppet/module_tool/tar.rb
@@ -6,10 +6,10 @@ module Puppet::ModuleTool::Tar
   require 'puppet/module_tool/tar/mini'
 
   def self.instance
-    if Puppet::Util.which('tar') && ! Puppet::Util::Platform.windows?
-      Gnu.new
-    elsif Puppet.features.minitar? && Puppet.features.zlib?
+    if Puppet.features.minitar? && Puppet.features.zlib?
       Mini.new
+    elsif Puppet::Util.which('tar') && ! Puppet::Util::Platform.windows?
+      Gnu.new
     else
       raise RuntimeError, 'No suitable tar implementation found'
     end

--- a/spec/unit/module_tool/tar_spec.rb
+++ b/spec/unit/module_tool/tar_spec.rb
@@ -3,21 +3,27 @@ require 'puppet/module_tool/tar'
 
 describe Puppet::ModuleTool::Tar do
 
-  it "uses tar when present and not on Windows" do
+  [
+    { :name => 'ObscureLinuxDistro', :win => false }, 
+    { :name => 'Windows', :win => true }
+  ].each do |os|
+    it "always prefers minitar if it and zlib are present, even with tar available" do
+      Facter.stubs(:value).with('osfamily').returns os[:name]
+      Puppet::Util.stubs(:which).with('tar').returns '/usr/bin/tar'
+      Puppet::Util::Platform.stubs(:windows?).returns os[:win]
+      Puppet.stubs(:features).returns(stub(:minitar? => true, :zlib? => true))
+
+      expect(described_class.instance).to be_a_kind_of Puppet::ModuleTool::Tar::Mini
+    end
+  end
+
+  it "falls back to tar when minitar not present and not on Windows" do
     Facter.stubs(:value).with('osfamily').returns 'ObscureLinuxDistro'
     Puppet::Util.stubs(:which).with('tar').returns '/usr/bin/tar'
     Puppet::Util::Platform.stubs(:windows?).returns false
+    Puppet.stubs(:features).returns(stub(:minitar? => false))
 
     expect(described_class.instance).to be_a_kind_of Puppet::ModuleTool::Tar::Gnu
-  end
-
-  it "falls back to minitar when it and zlib are present" do
-    Facter.stubs(:value).with('osfamily').returns 'Windows'
-    Puppet::Util.stubs(:which).with('tar')
-    Puppet::Util::Platform.stubs(:windows?).returns true
-    Puppet.stubs(:features).returns(stub(:minitar? => true, :zlib? => true))
-
-    expect(described_class.instance).to be_a_kind_of Puppet::ModuleTool::Tar::Mini
   end
 
   it "fails when there is no possible implementation" do


### PR DESCRIPTION
 - For platforms that ship a minitar gem (currently Windows, about to
   include Solaris, and will eventually be *all* platforms), prefer
   that to a local `tar` binary.

   Solaris 10 currently doesn't work properly with the `tar` binary
   and will be soon bundled with the minitar gem.  However, to use
   the minitar gem, the priority ordering needs to be adjusted.

 - Currently only Windows ships the minitar gem (as it has a platform
   specific gem), but eventually all platforms will reference the
   minitar gem for the same reason - consistency and robustness.