### PR TITLE
(PUP-7380) Skip augesu test on Cisco XR

### DIFF
--- a/acceptance/tests/apply/augeas/hosts.rb
+++ b/acceptance/tests/apply/augeas/hosts.rb
@@ -4,7 +4,10 @@ skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
 
 tag 'risk:medium'
 
-  confine :except, :platform => 'windows'
+  confine :except, :platform => [
+    'windows',
+    'cisco_ios',   # PUP-7380
+  ]
   confine :to, {}, hosts.select { |host| ! host[:roles].include?('master') }
 
   step "Backup the hosts file" do


### PR DESCRIPTION
We have found that the new Cisco eXR 6.1.3 VM image has /etc/hosts
as a mount point, so the augeus host test fails to rename the it.