### PR TITLE
(PUP-7391) Ensure that the BaseLoader can handle self recursion

### DIFF
--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -136,13 +136,21 @@ class BaseLoader < Loader
   # 4. give up
   #
   def internal_load(typed_name)
-    # avoid calling get_entry, by looking it up
+    # avoid calling get_entry by looking it up
     te = @named_values[typed_name]
-    te = parent.load_typed(typed_name) if te.nil? || te.value.nil?
-    te = find(typed_name) if te.nil? || te.value.nil?
-    te
-  end
+    return te unless te.nil? || te.value.nil?
 
+    te = parent.load_typed(typed_name)
+    return te unless te.nil? || te.value.nil?
+
+    # Under some circumstances, the call to the parent loader will have resulted in files being
+    # parsed that in turn contained references to the requested entity and hence, caused a
+    # recursive call into this loader. This means that the entry might be present now, so a new
+    # check must be made.
+    te = @named_values[typed_name]
+    te.nil? || te.value.nil? ? find(typed_name) : te
+  end
 end
 end
 end
+


### PR DESCRIPTION
This commit ensures that the BaseLoader#internal_load method is prepared
for the case when its call to the parent loader initiates another load
of the same entity that it is currently loading. When this happens, the
resulting recursion loads the type and when it returns, the type will
be present in the loader. A check is therefore inserted to prevent an
attempt to add the entity once again, since that would result in an
error.