### PR TITLE
(PUP-6984)(PUP-5659) Allow references to resource aliases

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -638,7 +638,6 @@ class Puppet::Parser::Compiler
     names = Puppet::Type.metaparams.select do |name|
       !Puppet::Parser::Resource.relationship_parameter?(name)
     end
-
     data = {}
     catalog.walk(main, :out) do |source, target|
       if source_data = data[source] || metaparams_as_data(source, names)

--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -26,18 +26,14 @@ class Puppet::Parser::Compiler
             "'#{param.name}' is not a valid relationship to a capability", 
               param.file, param.line)
         end
-      elsif Puppet[:strict] != :off
-        # all other relationships requires the referenced resource to exist when mode is strict
+      else
+        # all other relationships requires the referenced resource to exist
         refs = param.value.is_a?(Array) ? param.value.flatten : [param.value]
         refs.each do |r|
           next if r.nil? || r == :undef
           unless catalog.resource(r.to_s)
             msg = "Could not find resource '#{r.to_s}' in parameter '#{param.name.to_s}'"
-            if Puppet[:strict] == :error
-              raise CatalogValidationError.new(msg, param.file, param.line)
-            else
-              Puppet.warn_once(:undefined_resources, r.to_s, msg, param.file, param.line)
-            end
+            raise CatalogValidationError.new(msg, param.file, param.line)
           end
         end
       end

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -154,7 +154,13 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
   private :add_resource_to_graph
 
   def create_resource_aliases(resource)
-    # Skip creating aliases and checking collisions for non-isomorphic resources.
+    # Explicit aliases must always be processed
+    # The alias setting logic checks, and does not error if the alias is set to an already set alias
+    # for the same resource (i.e. it is ok if alias == title
+    explicit_aliases = [resource[:alias]].flatten.compact
+    explicit_aliases.each {| given_alias | self.alias(resource, given_alias) }
+
+    # Skip creating uniqueness key alias and checking collisions for non-isomorphic resources.
     return unless resource.respond_to?(:isomorphic?) and resource.isomorphic?
 
     # Add an alias if the uniqueness key is valid and not the title, which has already been checked.
@@ -506,8 +512,9 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       'resources' => resources,
       'edges'     => edges.   collect { |e| e.to_data_hash },
       'classes'   => classes,
-    }.merge(metadata_hash.empty? ? {} : {'metadata' => metadata_hash})
-     .merge(recursive_metadata_hash.empty? ? {} : {'recursive_metadata' => recursive_metadata_hash})
+    }.merge(metadata_hash.empty? ?
+      {} : {'metadata' => metadata_hash}).merge(recursive_metadata_hash.empty? ?
+        {} : {'recursive_metadata' => recursive_metadata_hash})
   end
 
   # Convert our catalog into a RAL catalog.

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -11,7 +11,7 @@ class CompilerTestResource
   end
 
   def [](attr)
-    return nil if attr == :stage
+    return nil if (attr == :stage || attr == :alias)
     :main
   end
 

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -1008,6 +1008,9 @@ describe Puppet::Resource::Catalog, "when converting to pson" do
     one = stub 'one', :to_data_hash => "one_resource", :ref => "Foo[one]"
     two = stub 'two', :to_data_hash => "two_resource", :ref => "Foo[two]"
 
+    one.expects(:'[]').with(:alias).returns nil
+    two.expects(:'[]').with(:alias).returns nil
+
     @catalog.add_resource(one)
     @catalog.add_resource(two)
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1476,8 +1476,11 @@ describe Puppet::Settings do
 
       main = stub 'main_resource', :ref => "File[/maindir]"
       main.expects(:to_manifest).returns "maindir"
+      main.expects(:'[]').with(:alias).returns nil
       second = stub 'second_resource', :ref => "File[/seconddir]"
       second.expects(:to_manifest).returns "seconddir"
+      second.expects(:'[]').with(:alias).returns nil
+
       @settings.setting(:maindir).expects(:to_resource).returns main
       @settings.setting(:seconddir).expects(:to_resource).returns second
 


### PR DESCRIPTION
This PR combines fixes for PUP-5659 "Validate relationships formed via meta-parameter", and PUP-6984 "Make aliases work in resource references".
The behaviour in PUP-5659 was earlier controlled via `strict` and is now always an error. In order to make this change, it was also necessary to fix the problem of references to resources based on an alias would always error. Thus, `strict` could only be used by those that had no references to resources with aliases.

This was bad because it meant that compilation could not find the errors, and the errors would instead be runtime errors when the produced catalog was applied.

The problems were:
* explicit aliases were not added to the catalog when compiling
* validation conditional on strict when desired to always be validated