### PR TITLE
(PUP-7360) Strip patch version from deprecation message URL

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -61,7 +61,7 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
   def lookup(scope, key, default, has_default, override, &default_block)
     unless Puppet[:strict] == :off
       Puppet.warn_once(:deprecation, self.class.name,
-        "The function '#{self.class.name}' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html")
+        "The function '#{self.class.name}' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/#{Puppet.major_minor_version}/reference/deprecated_language.html")
     end
     lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {})
     adapter = lookup_invocation.lookup_adapter

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -78,7 +78,7 @@ The returned value's data type depends on the types of the results. In the examp
 above, Hiera matches the 'users' key and returns it as a hash.
 
 The `hiera` function is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/#{Puppet.major_minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -66,7 +66,7 @@ $allusers = hiera_array('users') | $key | { "Key \'${key}\' not found" }
 value is a hash, Puppet raises a type mismatch error.
 
 `hiera_array` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/#{Puppet.major_minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -76,7 +76,7 @@ $allusers = hiera_hash('users') | $key | { "Key \'${key}\' not found" }
 found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 
 `hiera_hash` is deprecated in favor of using `lookup` and will be removed in 6.0.0.
-See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+See  https://docs.puppet.com/puppet/#{Puppet.major_minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -76,7 +76,7 @@ hiera_include('classes') | $key | {"Key \'${key}\' not found" }
 ~~~
 
 `hiera_include` is deprecated in favor of using a combination of `include`and `lookup` and will be
-removed in 6.0.0. See  https://docs.puppet.com/puppet/#{Puppet.version}/reference/deprecated_language.html.
+removed in 6.0.0. See  https://docs.puppet.com/puppet/#{Puppet.major_minor_version}/reference/deprecated_language.html.
 Replace the calls as follows:
 
 | from  | to |

--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -72,6 +72,10 @@ module Puppet
     @puppet_version = version
   end
 
+  def self.major_minor_version
+    self.version.sub(/\A(\d+\.\d+)\..*$/, '\1')
+  end
+
   ##
   # read_version_file reads the content of the "VERSION" file that lives in the
   # same directory as this source code file.

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -259,9 +259,10 @@ describe 'when calling' do
       end
     end
 
-    it 'should log deprecation errors' do
+    it 'should log deprecation errors containing version stripped from patch number' do
       func('a')
-      expect(warnings).to include(/The function 'hiera' is deprecated in favor of using 'lookup'. See https:/)
+      expect(warnings).to include(
+        /The function 'hiera' is deprecated in favor of using 'lookup'\. See https:\/\/docs.puppet.com\/puppet\/\d+\.\d+\/reference\/deprecated_language\.html/)
     end
 
     context 'with environment with configured data provider' do


### PR DESCRIPTION
The URL contained in the deprecation message from some functions and
also is present in many function API docs, incorrectly contained the
full major.minor.patch triplet. This commit ensures that the patch
number is no longer included.