### PR TITLE
(PUP-7356) Remove expect failure clientbucket test

### DIFF
--- a/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
+++ b/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
@@ -41,13 +41,9 @@ test_name 'C99977 corrupted clientbucket' do
 
     step 'manage file again' do
       apply_manifest_on(agent, manifest) do |result|
-        expect_failure('no stdrr') do
-          assert_equal('', result.stderr)
-        end
-        expect_failure('file managed') do
-          on(agent, "cat #{tmpfile}") do |r2|
-            assert_equal(managed_content, r2.stdout)
-          end
+        assert_match(/Warning: Existing backup does not match its expected sum, .*Overwriting corrupted backup/, result.stderr)
+        on(agent, "cat #{tmpfile}") do |r2|
+          assert_equal(managed_content, r2.stdout)
         end
       end
     end


### PR DESCRIPTION
This commit removes the expect_failure conditions for the validation
steps in the corrupted clientbucket test. This issue has been fixed
and these are no longer expected to fail. Validation of the 'Warning'
emitted to STDOUT has also been added.

[skip ci]