### PR TITLE
(PUP-6084) Make reference to Class[<upper case name>] be an error

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -616,6 +616,8 @@ class AccessOperator
     return result_type_array ? result : result.pop
   end
 
+  NS = '::'.freeze
+
   def access_PHostClassType(o, scope, keys)
     blamed = keys.size == 0 ? @semantic : @semantic.keys[0]
     keys_orig_size = keys.size
@@ -642,30 +644,14 @@ class AccessOperator
     end
 
     if o.class_name.nil?
-      # The type argument may be a Resource Type - the Puppet Language allows a reference such as
-      # Class[Foo], and this is interpreted as Class[Resource[Foo]] - which is ok as long as the resource
-      # does not have a title. This should probably be deprecated.
-      #
       result = keys.each_with_index.map do |c, i|
-        name = if c.is_a?(Types::PResourceType) && !c.type_name.nil? && c.title.nil?
-                 strict_check(c, i)
-                 # type_name is already downcase. Don't waste time trying to downcase again
-                 c.type_name
-               elsif c.is_a?(String)
-                 c.downcase
-               elsif c.is_a?(Types::PTypeReferenceType)
-                 strict_check(c, i)
-                 c.type_string.downcase
-               else
-                 fail(Issues::ILLEGAL_HOSTCLASS_NAME, @semantic.keys[i], {:name => c})
-               end
+        fail(Issues::ILLEGAL_HOSTCLASS_NAME, @semantic.keys[i], {:name => c}) unless c.is_a?(String)
+        name = c.downcase
+        # Remove leading '::' since all references are global, and 3x runtime does the wrong thing
+        name = name[2..-1] if name[0,2] == NS
 
-        if name =~ Patterns::NAME
-          # Remove leading '::' since all references are global, and 3x runtime does the wrong thing
-          Types::PHostClassType.new(name.sub(/^::/, EMPTY_STRING))
-        else
-          fail(Issues::ILLEGAL_NAME, @semantic.keys[i], {:name=>c})
-        end
+        fail(Issues::ILLEGAL_NAME, @semantic.keys[i], {:name=>c}) unless name =~ Patterns::NAME
+        Types::PHostClassType.new(name)
       end
     else
       # lookup class resource and return one or more parameter values
@@ -687,21 +673,6 @@ class AccessOperator
     # returns single type as type, else an array of types
     return result_type_array ? result : result.pop
   end
-
-  # PUP-6083 - Using Class[Foo] is deprecated since an arbitrary foo will trigger a "resource not found"
-  # @api private
-  def strict_check(name, index)
-    if Puppet[:strict] != :off
-      msg = 'Upper cased class-name in a Class[<class-name>] is deprecated, class-name should be a lowercase string'
-      case Puppet[:strict]
-      when :error
-        fail(Issues::ILLEGAL_HOSTCLASS_NAME, @semantic.keys[index], {:name => name})
-      when :warning
-        Puppet.warn_once(:deprecation, 'ClassReferenceInUpperCase', msg)
-      end
-    end
-  end
-
 end
 end
 end

--- a/spec/integration/parser/class_spec.rb
+++ b/spec/integration/parser/class_spec.rb
@@ -5,15 +5,15 @@ describe "Class expressions" do
   extend PuppetSpec::Language
 
   produces(
-    "class hi { }"                                       => '!defined(Class[Hi])',
+    "class hi { }"                                       => '!defined(Class[hi])',
 
-    "class hi { } include hi"                            => 'defined(Class[Hi])',
-    "include(hi) class hi { }"                           => 'defined(Class[Hi])',
+    "class hi { } include hi"                            => 'defined(Class[hi])',
+    "include(hi) class hi { }"                           => 'defined(Class[hi])',
 
-    "class hi { } class { hi: }"                         => 'defined(Class[Hi])',
-    "class { hi: } class hi { }"                         => 'defined(Class[Hi])',
+    "class hi { } class { hi: }"                         => 'defined(Class[hi])',
+    "class { hi: } class hi { }"                         => 'defined(Class[hi])',
 
-    "class bye { } class hi inherits bye { } include hi" => 'defined(Class[Hi]) and defined(Class[Bye])')
+    "class bye { } class hi inherits bye { } include hi" => 'defined(Class[hi]) and defined(Class[bye])')
 
   produces(<<-EXAMPLE => 'defined(Notify[foo]) and defined(Notify[bar]) and !defined(Notify[foo::bar])')
     class bar { notify { 'bar': } }

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -355,9 +355,11 @@ describe Puppet::Parser::Compiler do
         end
       end
 
-      describe 'and classname is a Resource Reference and strict == :error' do
+      describe 'and classname is a Resource Reference' do
+        # tested with strict == off since this was once conditional on strict
+        # can be removed in a later version.
         before(:each) do
-          Puppet[:strict] = :error
+          Puppet[:strict] = :off
         end
 
         it 'is reported as an error' do
@@ -366,38 +368,6 @@ describe Puppet::Parser::Compiler do
               notice Class[ToothFairy]
             PP
           }.to raise_error(/Illegal Class name in class reference. A TypeReference\['ToothFairy'\]-Type cannot be used where a String is expected/)
-        end
-      end
-
-      describe 'and classname is a Resource Reference and strict == :warning' do
-        before(:each) do
-          Puppet[:strict] = :warning
-        end
-
-        it 'is reported as a deprecation warning' do
-          expect { 
-            compile_to_catalog(<<-PP)
-              notice Class[ToothFairy]
-            PP
-            expect(@logs).to have_matching_log(/Upper cased class-name in a Class\[<class-name>\] is deprecated, class-name should be a lowercase string/)
-
-          }.to_not raise_error()
-        end
-      end
-
-      describe 'and classname is a Resource Reference and strict == :off' do
-        before(:each) do
-          Puppet[:strict] = :off
-        end
-
-        it 'is not reported' do
-          expect { 
-            compile_to_catalog(<<-PP)
-              notice Class[ToothFairy]
-            PP
-            expect(@logs).to_not have_matching_log(/Warning: Upper cased class-name in a Class\[<class-name>\] is deprecated, class-name should be a lowercase string/)
-
-          }.to_not raise_error()
         end
       end
 


### PR DESCRIPTION
This removes the deprecated (since Puppet 4.6.0) construct of
referencing a class with an upper case name, for example Class[Foo] by
making it always be an error.

This is removed since Foo evaluates to a type reference, and it may be a
type alias or a Resource. It may also be a type that requires
parameters. The use of an upper case name thus creates unssesary type
loading, and potentially a mysterious error.

The correct reference is always a String, and this string is always in
lower case.