### PR TITLE
(docs) Clarify the behavior of the group resource type's _membership attributes

### DIFF
--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -79,10 +79,9 @@ module Puppet
     end
 
     newproperty(:members, :array_matching => :all, :required_features => :manages_members) do
-      desc "The members of the group. For directory services where group
-      membership is stored in the group objects, not the users. Use
-      with auth_membership to determine whether the specified members
-      are inclusive or the minimum."
+      desc "The members of the group. For platforms or directory services where group
+        membership is stored in the group objects, not the users. This parameter's
+        behavior can be configured with `auth_membership`."
 
       def change_to_s(currentvalue, newvalue)
         currentvalue = currentvalue.join(",") if currentvalue != :absent
@@ -118,9 +117,12 @@ module Puppet
     end
 
     newparam(:auth_membership, :boolean => true, :parent => Puppet::Parameter::Boolean) do
-      desc "Whether the provider is authoritative for group membership. This
-        must be set to true to allow setting the group to no members with
-        `members => [],`."
+      desc "Configures the behavior of the `members` parameter.
+
+        * `false` (default) --- The provided list of group members is partial,
+          and Puppet **ignores** any members that aren't listed there.
+        * `true` --- The provided list of of group members is comprehensive, and
+          Puppet **purges** any members that aren't listed there."
       defaultto false
     end
 
@@ -146,7 +148,8 @@ module Puppet
     end
 
     newproperty(:attributes, :parent => Puppet::Property::KeyValue, :required_features => :manages_aix_lam) do
-      desc "Specify group AIX attributes in an array of `key=value` pairs."
+      desc "Specify group AIX attributes, as an array of `'key=value'` strings. This
+        parameter's behavior can be configured with `attribute_membership`."
 
       def membership
         :attribute_membership
@@ -162,9 +165,12 @@ module Puppet
     end
 
     newparam(:attribute_membership) do
-      desc "Whether specified attribute value pairs should be treated as the only attributes
-        of the user or whether they should merely
-        be treated as the minimum list."
+      desc "AIX only. Configures the behavior of the `attributes` parameter.
+
+        * `minimum` (default) --- The provided list of attributes is partial, and Puppet
+          **ignores** any attributes that aren't listed there.
+        * `inclusive` --- The provided list of attributes is comprehensive, and
+          Puppet **purges** any attributes that aren't listed there."
 
       newvalues(:inclusive, :minimum)
 


### PR DESCRIPTION
When this PR is merged, **please close [DOCUMENT-356](https://tickets.puppetlabs.com/browse/DOCUMENT-356).**

For the record, I investigated the two group providers that use auth_membership. 

DirectoryService: `true` purges.

``` ruby
      remove_unwanted_members(current_members, value) if @resource[:auth_membership] and not current_members.nil?
```

Windows ADSI: `true` purges.

``` ruby
    group.set_members(members, @resource[:auth_membership])
# ...
    def set_members(desired_members, inclusive = true)
      # ...
      if inclusive
        if desired_hash.empty?
          members_to_remove = current_hash.values
        else
          members_to_remove = (current_hash.keys - desired_hash.keys).map { |sid| current_hash[sid] }
        end

        remove_member_sids(*members_to_remove)
      end
```