### PR TITLE
(docs) Document behavior when file mode is omitted

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -13,6 +13,10 @@ module Puppet
       notation. This value **must** be specified as a string; do not use
       un-quoted numbers to represent file modes.
 
+      If the mode is omitted (or explicitly set to `undef`), Puppet does not
+      enforce permissions on existing files and creates new files with
+      permissions of `0644`.
+
       The `file` type uses traditional Unix permission schemes and translates
       them to equivalent permissions for systems which represent permissions
       differently, including Windows. For detailed ACL controls on Windows,


### PR DESCRIPTION
When this is merged, please resolve [DOCUMENT-661](https://tickets.puppetlabs.com/browse/DOCUMENT-661).

My source for the thing about 0644 for new files is this:

``` ruby
# lib/puppet/type/file.rb
  def write(property = nil)
    # ...
    else
      umask = mode ? 000 : 022
      Puppet::Util.withumask(umask) { ::File.open(self[:path], 'wb', mode_int ) { |f| property.write(f) if property } }
    end
    # .....
  end
```