### PR TITLE
(PUP-5756) remove dependency on eventlog

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -39,7 +39,6 @@ gem_platform_dependencies:
       ffi: '~> 1.9.6'
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
-      win32-eventlog: '= 0.6.5'
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
@@ -50,7 +49,6 @@ gem_platform_dependencies:
       ffi: '~> 1.9.6'
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
-      win32-eventlog: '= 0.6.5'
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -4,13 +4,14 @@ require 'fileutils'
 require 'win32/daemon'
 require 'win32/dir'
 require 'win32/process'
-require 'win32/eventlog'
+
+# This file defines utilities for logging to eventlog. While it lives inside
+# Puppet, it is completely independent and loads no other parts of Puppet, so we
+# can safely require *just* it.
+require 'puppet/util/windows/eventlog'
 
 class WindowsDaemon < Win32::Daemon
   CREATE_NEW_CONSOLE          = 0x00000010
-  EVENTLOG_ERROR_TYPE         = 0x0001
-  EVENTLOG_WARNING_TYPE       = 0x0002
-  EVENTLOG_INFORMATION_TYPE   = 0x0004
 
   @run_thread = nil
   @LOG_TO_FILE = false
@@ -127,23 +128,16 @@ class WindowsDaemon < Win32::Daemon
         File.open(LOG_FILE, 'a:UTF-8') { |f| f.puts("#{Time.now} Puppet (#{level}): #{msg}") }
       end
 
-      case level
-        when :debug, :info, :notice
-          report_windows_event(EVENTLOG_INFORMATION_TYPE,0x01,msg.to_s)
-        when :err, :alert, :emerg, :crit
-          report_windows_event(EVENTLOG_ERROR_TYPE,0x03,msg.to_s)
-        else
-          report_windows_event(EVENTLOG_WARNING_TYPE,0x02,msg.to_s)
-      end
+      native_type, native_id = Puppet::Util::Windows::EventLog.to_native(level)
+      report_windows_event(native_type, native_id, msg.to_s)
     end
   end
 
   def report_windows_event(type,id,message)
     begin
       eventlog = nil
-      eventlog = Win32::EventLog.open("Application")
+      eventlog = Puppet::Util::Windows::EventLog.open("Puppet")
       eventlog.report_event(
-        :source      => "Puppet",
         :event_type  => type,   # EVENTLOG_ERROR_TYPE, etc
         :event_id    => id,     # 0x01 or 0x02, 0x03 etc.
         :data        => message # "the message"

--- a/lib/puppet/feature/eventlog.rb
+++ b/lib/puppet/feature/eventlog.rb
@@ -1,5 +1,5 @@
 require 'puppet/util/feature'
 
 if Puppet.features.microsoft_windows?
-  Puppet.features.add(:eventlog, :libs => %{win32/eventlog})
+  Puppet.features.add(:eventlog)
 end

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -170,6 +170,17 @@ class Puppet::Util::Log
   def Log.newmessage(msg)
     return if @levels.index(msg.level) < @loglevel
 
+    if msg.message.valid_encoding?
+      message = Puppet::Util::CharacterEncoding.convert_to_utf_8(msg.message)
+    else
+      message = _("Received a log message with invalid encoding:")
+      message << Puppet::Util::CharacterEncoding.convert_to_utf_8(msg.message.dump) << "\n"
+      # We only select the last 10 callers in the stack to avoid being spammy
+      message << _("Backtrace:") << "\n" << caller[0..10].join("\n")
+    end
+
+    msg.message = message
+
     queuemessage(msg) if @destinations.length == 0
 
     @destinations.each do |name, dest|

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -236,7 +236,7 @@ Puppet::Util::Log.newdesttype :eventlog do
     @eventlog.report_event(
       :event_type  => native_type,
       :event_id    => native_id,
-      :data        => (msg.source and msg.source != 'Puppet' ? "#{msg.source}: " : '') + msg.to_s
+      :data        => (msg.source && msg.source != 'Puppet' ? "#{msg.source}: " : '') + msg.to_s
     )
   end
 

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -10,6 +10,7 @@ module Puppet::Util::Windows
   module SID
     class Principal; end
   end
+  class EventLog; end
 
   if Puppet::Util::Platform.windows?
     # these reference platform specific gems
@@ -29,5 +30,6 @@ module Puppet::Util::Windows
     require 'puppet/util/windows/security_descriptor'
     require 'puppet/util/windows/adsi'
     require 'puppet/util/windows/registry'
+    require 'puppet/util/windows/eventlog'
   end
 end

--- a/lib/puppet/util/windows/eventlog.rb
+++ b/lib/puppet/util/windows/eventlog.rb
@@ -1,0 +1,192 @@
+require 'ffi'
+
+# Puppet::Util::Windows::EventLog needs to be requirable without having loaded
+# any other parts of Puppet so it can be leveraged independently by the code
+# that runs Puppet as a service on Windows.
+#
+# For this reason we:
+# - Define Puppet::Util::Windows
+# - Replicate logic that exists elsewhere in puppet/util/windows
+# - Raise generic RuntimeError instead of Puppet::Util::Windows::Error if its not defined
+module Puppet; module Util; module Windows ; end ; end ; end
+
+class Puppet::Util::Windows::EventLog
+  extend FFI::Library
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa363679(v=vs.85).aspx
+  EVENTLOG_ERROR_TYPE       = 0x0001
+  EVENTLOG_WARNING_TYPE     = 0x0002
+  EVENTLOG_INFORMATION_TYPE = 0x0004
+
+  # These are duplicate definitions from Puppet::Util::Windows::ApiTypes,
+  # established here so this class can be standalone from Puppet, and public so
+  # we can reference them in tests.
+  NULL_HANDLE = 0
+  WIN32_FALSE = 0
+
+  # Register an event log handle for the application
+  # @param source_name [String] the name of the event source to retrieve a handle for
+  # @return [void]
+  # @api public
+  def initialize(source_name = 'Puppet')
+    @eventlog_handle = RegisterEventSourceW(FFI::Pointer::NULL, wide_string(source_name))
+    if @eventlog_handle == NULL_HANDLE
+      raise EventLogError.new("RegisterEventSourceW failed to open Windows eventlog", FFI.errno)
+    end
+  end
+
+  # Close this instance's event log handle
+  # @return [void]
+  # @api public
+  def close
+    DeregisterEventSource(@eventlog_handle)
+  ensure
+    @eventlog_handle = nil
+  end
+
+  # Report an event to this instance's event log handle. Accepts a string to
+  #   report (:data => <string>) and event type (:event_type => FixNum) and id
+  # (:event_id => FixNum) as returned by #to_native. The additional arguments to
+  # ReportEventW seen in this method aren't exposed - though ReportEventW
+  # technically can accept multiple strings as well as raw binary data to log,
+  # we accept a single string from Puppet::Util::Log
+  #
+  # @param args [Hash{Symbol=>Object}] options to the associated log event
+  # @return [void]
+  # @api public
+  def report_event(args = {})
+    raise ArgumentError, "data must be a string, not #{args[:data].class}" unless args[:data].is_a?(String)
+    from_string_to_wide_string(args[:data]) do |message_ptr|
+      FFI::MemoryPointer.new(:pointer) do |message_array_ptr|
+        message_array_ptr.write_pointer(message_ptr)
+        user_sid = FFI::Pointer::NULL
+        raw_data = FFI::Pointer::NULL
+        raw_data_size = 0
+        num_strings = 1
+        eventlog_category = 0
+        report_result = ReportEventW(@eventlog_handle, args[:event_type],
+          eventlog_category, args[:event_id], user_sid,
+          num_strings, raw_data_size, message_array_ptr, raw_data)
+
+        if report_result == WIN32_FALSE
+          raise EventLogError.new("ReportEventW failed to report event to Windows eventlog", FFI.errno)
+        end
+      end
+    end
+  end
+
+  class << self
+    # Feels more natural to do Puppet::Util::Window::EventLog.open("MyApplication")
+    alias :open :new
+
+    # Query event identifier info for a given log level
+    # @param level [Symbol] an event log level
+    # @return [Array] Win API Event ID, Puppet Event ID
+    # @api public
+    def to_native(level)
+      case level
+      when :debug,:info,:notice
+        [EVENTLOG_INFORMATION_TYPE, 0x01]
+      when :warning
+        [EVENTLOG_WARNING_TYPE, 0x02]
+      when :err,:alert,:emerg,:crit
+        [EVENTLOG_ERROR_TYPE, 0x03]
+      else
+        raise ArgumentError, "Invalid log level #{level}"
+      end
+    end
+  end
+
+  private
+  # For the purposes of allowing this class to be standalone, the following are
+  # duplicate definitions from elsewhere in Puppet:
+
+  # If we're loaded via Puppet we should keep the previous behavior of raising
+  # Puppet::Util::Windows::Error on errors. If we aren't, at least concatenate
+  # the error code to the exception message to pass this information on to the
+  # user
+  if defined?(Puppet::Util::Windows::Error)
+    EventLogError = Puppet::Util::Windows::Error
+  else
+    class EventLogError < RuntimeError
+      def initialize(msg, code)
+        super(msg + " (Win32 error: #{code})")
+      end
+    end
+  end
+
+  # Private duplicate of Puppet::Util::Windows::String::wide_string
+  # Not for use outside of EventLog! - use Puppet::Util::Windows instead
+  # @api private
+  def wide_string(str)
+    # if given a nil string, assume caller wants to pass a nil pointer to win32
+    return nil if str.nil?
+    # ruby (< 2.1) does not respect multibyte terminators, so it is possible
+    # for a string to contain a single trailing null byte, followed by garbage
+    # causing buffer overruns.
+    #
+    # See http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=41920&view=revision
+    newstr = str + "\0".encode(str.encoding)
+    newstr.encode!('UTF-16LE')
+  end
+
+  # Private duplicate of Puppet::Util::Windows::ApiTypes::from_string_to_wide_string
+  # Not for use outside of EventLog! - Use Puppet::Util::Windows instead
+  # @api private
+  def from_string_to_wide_string(str, &block)
+    str = wide_string(str)
+    FFI::MemoryPointer.new(:uchar, str.bytesize) do |ptr|
+      # uchar here is synonymous with byte
+      ptr.put_array_of_uchar(0, str.bytes.to_a)
+
+      yield ptr
+    end
+
+    # ptr has already had free called, so nothing to return
+    nil
+  end
+
+  ffi_convention :stdcall
+
+  # The following are typedefs in Puppet::Util::Winodws::ApiTypes, but here we
+  # use their original FFI counterparts:
+  # :uintptr_t for :handle
+  # :int32 for :win32_bool
+  # :uint16 for :word
+  # :uint32 for :dword
+  # :pointer for :lpvoid
+  # :uchar for :byte
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa363678(v=vs.85).aspx
+  # HANDLE RegisterEventSource(
+  # _In_ LPCTSTR lpUNCServerName,
+  # _In_ LPCTSTR lpSourceName
+  # );
+  ffi_lib :advapi32
+  attach_function :RegisterEventSourceW, [:buffer_in, :buffer_in], :uintptr_t
+  private :RegisterEventSourceW
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa363642(v=vs.85).aspx
+  # BOOL DeregisterEventSource(
+  # _Inout_ HANDLE hEventLog
+  # );
+  ffi_lib :advapi32
+  attach_function :DeregisterEventSource, [:uintptr_t], :int32
+  private :DeregisterEventSource
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa363679(v=vs.85).aspx
+  # BOOL ReportEvent(
+  #   _In_ HANDLE  hEventLog,
+  #   _In_ WORD    wType,
+  #   _In_ WORD    wCategory,
+  #   _In_ DWORD   dwEventID,
+  #   _In_ PSID    lpUserSid,
+  #   _In_ WORD    wNumStrings,
+  #   _In_ DWORD   dwDataSize,
+  #   _In_ LPCTSTR *lpStrings,
+  #   _In_ LPVOID  lpRawData
+  # );
+  ffi_lib :advapi32
+  attach_function :ReportEventW, [:uintptr_t, :uint16, :uint16, :uint32, :pointer, :uint16, :uint32, :pointer, :pointer], :int32
+  private :ReportEventW
+end

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -195,8 +195,8 @@ describe ":eventlog", :if => Puppet::Util::Platform.windows? do
 
   def expects_message_with_type(klass, level, eventlog_type, eventlog_id)
     eventlog = stub('eventlog')
-    eventlog.expects(:report_event).with(has_entries(:source => "Puppet", :event_type => eventlog_type, :event_id => eventlog_id, :data => "a hitchhiker: don't panic"))
-    Win32::EventLog.stubs(:open).returns(eventlog)
+    eventlog.expects(:report_event).with(has_entries(:event_type => eventlog_type, :event_id => eventlog_id, :data => "a hitchhiker: don't panic"))
+    Puppet::Util::Windows::EventLog.stubs(:open).returns(eventlog)
 
     msg = Puppet::Util::Log.new(:level => level, :message => "don't panic", :source => "a hitchhiker")
     dest = klass.new
@@ -207,9 +207,8 @@ describe ":eventlog", :if => Puppet::Util::Platform.windows? do
     expect(Puppet.features.eventlog?).to be_truthy
   end
 
-  it "logs to the Application event log" do
-    eventlog = stub('eventlog')
-    Win32::EventLog.expects(:open).with('Application').returns(stub('eventlog'))
+  it "logs to the Puppet Application event log" do
+    Puppet::Util::Windows::EventLog.expects(:open).with('Puppet').returns(stub('eventlog'))
 
     klass.new
   end

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -251,20 +251,20 @@ describe Puppet::Util::Log do
 
   describe Puppet::Util::Log::DestEventlog, :if => Puppet.features.eventlog? do
     before :each do
-      Win32::EventLog.stubs(:open).returns(stub 'mylog')
-      Win32::EventLog.stubs(:report_event)
-      Win32::EventLog.stubs(:close)
+      Puppet::Util::Windows::EventLog.stubs(:open).returns(stub 'mylog')
+      Puppet::Util::Windows::EventLog.stubs(:report_event)
+      Puppet::Util::Windows::EventLog.stubs(:close)
       Puppet.features.stubs(:eventlog?).returns(true)
     end
 
-    it "should restrict its suitability" do
-      Puppet.features.expects(:eventlog?).returns(false)
+    it "should restrict its suitability to Windows" do
+      Puppet.features.expects(:microsoft_windows?).returns(false)
 
       expect(Puppet::Util::Log::DestEventlog.suitable?('whatever')).to eq(false)
     end
 
-    it "should open the 'Application' event log" do
-      Win32::EventLog.expects(:open).with('Application')
+    it "should open the 'Puppet' event log" do
+      Puppet::Util::Windows::EventLog.expects(:open).with('Puppet')
 
       Puppet::Util::Log.newdestination(:eventlog)
     end
@@ -272,7 +272,7 @@ describe Puppet::Util::Log do
     it "should close the event log" do
       log = stub('myeventlog')
       log.expects(:close)
-      Win32::EventLog.expects(:open).returns(log)
+      Puppet::Util::Windows::EventLog.expects(:open).returns(log)
 
       Puppet::Util::Log.newdestination(:eventlog)
       Puppet::Util::Log.close(:eventlog)

--- a/spec/unit/util/windows/eventlog_spec.rb
+++ b/spec/unit/util/windows/eventlog_spec.rb
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+
+require 'puppet/util/windows'
+
+describe Puppet::Util::Windows::EventLog, :if => Puppet.features.microsoft_windows? do
+
+  before(:each) { @event_log = Puppet::Util::Windows::EventLog.new }
+  after(:each) { @event_log.close }
+
+  describe "class constants" do
+    it "should define NULL_HANDLE as 0" do
+      expect(Puppet::Util::Windows::EventLog::NULL_HANDLE).to eq(0)
+    end
+
+    it "should define WIN32_FALSE as 0" do
+      expect(Puppet::Util::Windows::EventLog::WIN32_FALSE).to eq(0)
+    end
+  end
+
+  describe "self.open" do
+    it "sets a handle to the event log" do
+      default_name = Puppet::Util::Windows::String.wide_string('Puppet')
+      # return nil explicitly just to reinforce that we're not leaking eventlog handle
+      Puppet::Util::Windows::EventLog.any_instance.expects(:RegisterEventSourceW).with(nil, default_name).returns(nil)
+      Puppet::Util::Windows::EventLog.new
+    end
+
+    context "when it fails to open the event log" do
+      before do
+        # RegisterEventSourceW will return NULL on failure
+        # Stubbing prevents leaking eventlog handle
+        Puppet::Util::Windows::EventLog.any_instance.stubs(:RegisterEventSourceW).returns(Puppet::Util::Windows::EventLog::NULL_HANDLE)
+      end
+
+      it "raises an exception warning that the event log failed to open" do
+        expect { Puppet::Util::Windows::EventLog.open('foo') }.to raise_error(Puppet::Util::Windows::EventLog::EventLogError, /failed to open Windows eventlog/)
+      end
+
+      it "passes the exit code to the exception constructor" do
+        fake_error = Puppet::Util::Windows::EventLog::EventLogError.new('foo', 87)
+        FFI.stubs(:errno).returns(87)
+        # All we're testing here is that the constructor actually receives the exit code from FFI.errno (87)
+        # We do so because `expect to...raise_error` doesn't support multiple parameter match arguments
+        # We return fake_error just because `raise` expects an exception class
+        Puppet::Util::Windows::EventLog::EventLogError.expects(:new).with(regexp_matches(/failed to open Windows eventlog/), 87).returns(fake_error)
+        expect { Puppet::Util::Windows::EventLog.open('foo') }.to raise_error(Puppet::Util::Windows::EventLog::EventLogError)
+      end
+    end
+  end
+
+  describe "#close" do
+    it "closes the handle to the event log" do
+      @handle = "12345"
+      Puppet::Util::Windows::EventLog.any_instance.stubs(:RegisterEventSourceW).returns(@handle)
+      event_log = Puppet::Util::Windows::EventLog.new
+      event_log.expects(:DeregisterEventSource).with(@handle).returns(1)
+      event_log.close
+    end
+  end
+
+  describe "#report_event" do
+    it "raises an exception if the message passed is not a string" do
+      expect { @event_log.report_event(:data => 123, :event_type => nil, :event_id => nil) }.to raise_error(ArgumentError, /data must be a string/)
+    end
+
+    context "when an event report fails" do
+      before do
+        # ReportEventW returns 0 on failure, which is mapped to WIN32_FALSE
+        @event_log.stubs(:ReportEventW).returns(Puppet::Util::Windows::EventLog::WIN32_FALSE)
+      end
+
+      it "raises an exception warning that the event report failed" do
+        expect { @event_log.report_event(:data => 'foo', :event_type => Puppet::Util::Windows::EventLog::EVENTLOG_ERROR_TYPE, :event_id => 0x03) }.to raise_error(Puppet::Util::Windows::EventLog::EventLogError, /failed to report event/)
+      end
+
+      it "passes the exit code to the exception constructor" do
+        fake_error = Puppet::Util::Windows::EventLog::EventLogError.new('foo', 5)
+        FFI.stubs(:errno).returns(5)
+        # All we're testing here is that the constructor actually receives the exit code from FFI.errno (5)
+        # We do so because `expect to...raise_error` doesn't support multiple parameter match arguments
+        # We return fake_error just because `raise` expects an exception class
+        Puppet::Util::Windows::EventLog::EventLogError.expects(:new).with(regexp_matches(/failed to report event/), 5).returns(fake_error)
+        expect { @event_log.report_event(:data => 'foo', :event_type => Puppet::Util::Windows::EventLog::EVENTLOG_ERROR_TYPE, :event_id => 0x03) }.to raise_error(Puppet::Util::Windows::EventLog::EventLogError)
+      end
+    end
+  end
+
+  describe "self.to_native" do
+
+    it "raises an exception if the log level is not supported" do
+      expect { Puppet::Util::Windows::EventLog.to_native(:foo) }.to raise_error(ArgumentError)
+    end
+
+    # This is effectively duplicating the data assigned to the constants in
+    # Puppet::Util::Windows::EventLog but since these are public constants we
+    # ensure their values don't change lightly.
+    log_levels_to_type_and_id = {
+      :debug    => [0x0004, 0x01],
+      :info     => [0x0004, 0x01],
+      :notice   => [0x0004, 0x01],
+      :warning  => [0x0002, 0x02],
+      :err      => [0x0001, 0x03],
+      :alert    => [0x0001, 0x03],
+      :emerg    => [0x0001, 0x03],
+      :crit     => [0x0001, 0x03],
+    }
+
+    shared_examples_for "#to_native" do |level|
+      it "should return the correct INFORMATION_TYPE and ID" do
+        result = Puppet::Util::Windows::EventLog.to_native(level)
+        expect(result).to eq(log_levels_to_type_and_id[level])
+      end
+    end
+
+    log_levels_to_type_and_id.each_key do |level|
+      describe "logging at #{level}" do
+        it_should_behave_like "#to_native", level
+      end
+    end
+  end
+end


### PR DESCRIPTION
This re-opens https://github.com/puppetlabs/puppet/pull/5509, which was reverted due to CI failures when ruby returned a binary string that originated in Encoding::Windows_31J that we attempted to report (see the last comments in PUP-5756).

This PR adds two new commits on top of the previous PR, one that improves our handling of conversion of BINARY strings in Puppet::Util::CharacterEncoding, and a second to leverage this in our EventLog reporting. A different approach would be to update the base Log class, but given CharacterEncoding hasn't been out in the wild yet I'm a little wary of patching everything to use it - one logging class felt like a reasonable test given this is where we saw the original error.

    (PUP-5756) (PUP-7021) better handling of BINARY string conversion

    Prior to this commit, we would transcode to UTF-8 a string not composed of
    valid UTF-8 bytes but valid in its current encoding. This presents a challenge
    for BINARY strings, which if originating in an encoding other to UTF-8 are
    otherwise valid, but cannot be transcoded (because we have no idea where they
    came from). In order to transcode successfully, we need an originating
    encoding to work with. Rather than just blindly call encode! with binary
    strings, we can take one more guess as to their origin - which is that they
    originated in `Encoding.default_external`. I.e., if a system is running in
    Encoding::Windows_31J, and a string is returned as BINARY, we can guess that
    the string might have been Encoding::Windows_31J. This perhaps substantially
    increases our odds that we'll be able to conver the (binary) string to UTF-8
    successfully.

and

    (PUP-5756) convert eventlog entries to UTF-8

    This commit updates the EventLog destination to utilize
    Puppet::Util::CharacterEncoding to convert messages to UTF-8. This sanitization
    will be particularly helpful in the case where we get back messages from ruby
    in BINARY that we can't convert cleanly to UTF-16LE without some intermediate
    conversions.