### PR TITLE
(PUP-7418) Fix problem with interpolated lookups

### DIFF
--- a/lib/puppet/pops/lookup/invocation.rb
+++ b/lib/puppet/pops/lookup/invocation.rb
@@ -10,6 +10,15 @@ class Invocation
     @current
   end
 
+  # Creates a new instance with same settings as this instance but with a new given scope
+  # and yields with that scope.
+  #
+  # @param scope [Puppet::Parser::Scope] The new scope
+  # @return [Invocation] the new instance
+  def with_scope(scope)
+    yield(Invocation.new(scope, override_values, default_values, explainer))
+  end
+
   # Creates a context object for a lookup invocation. The object contains the current scope, overrides, and default
   # values and may optionally contain an {ExplanationAcceptor} instance that will receive book-keeping information
   # about the progress of the lookup.
@@ -53,9 +62,10 @@ class Invocation
     @explainer = explainer
   end
 
-  def lookup(key, module_name)
+  def lookup(key, module_name = nil)
+    key = LookupKey.new(key) unless key.is_a?(LookupKey)
     @top_key = key
-    @module_name = module_name
+    @module_name = module_name.nil? ? key.module_name : module_name
     save_current = self.class.current
     if save_current.equal?(self)
       yield

--- a/spec/unit/pops/lookup/interpolation_spec.rb
+++ b/spec/unit/pops/lookup/interpolation_spec.rb
@@ -16,7 +16,7 @@ describe 'Puppet::Pops::Lookup::Interpolation' do
       root_key = segments.shift
       found = data[root_key]
       found = sub_lookup(key, lookup_invocation, segments, found) unless segments.empty?
-      Lookup.expects(:lookup).with(key, nil, '', true, nil, lookup_invocation).returns(found)
+      Lookup.expects(:lookup).with(key, nil, '', true, nil, is_a(Lookup::Invocation)).returns(found)
     end
   end
 


### PR DESCRIPTION
Before this commit, an interpolation using a module prefixed key and a
function that in turn made a full lookup (alias, lookup, or hiera),
would reset the `module_name` in the lookup invocation. This would
normally go undetected since the value, when found, would end the
lookup. During a deep_merge however, when the sub-lookup was made from
global or environment layer, the lookup's desire to find more data in
the module layer would not be satisfied correctly unless the sub-lookup
was targeting the same module as the original lookup.

This commit ensures that a new invocation is used for the sub-lookup,
leaving the original invocation untouched.