### PR TITLE
(PUP-7420) Ensure unique explain logs in debug output

### DIFF
--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -28,7 +28,7 @@ module Lookup
     override_values = lookup_invocation.override_values
     result_with_name = names.reduce([nil, not_found]) do |memo, key|
       value = override_values.include?(key) ? assert_type(["Value found for key '%s' in override hash", key], value_type, override_values[key]) : not_found
-      catch(:no_such_key) { value = search_and_merge(key, lookup_invocation, merge) } if value.equal?(not_found)
+      catch(:no_such_key) { value = search_and_merge(key, lookup_invocation, merge, false) } if value.equal?(not_found)
       break [key, assert_type('Found value', value_type, value)] unless value.equal?(not_found)
       memo
     end
@@ -72,9 +72,9 @@ module Lookup
   end
 
   # @api private
-  def self.search_and_merge(name, lookup_invocation, merge)
+  def self.search_and_merge(name, lookup_invocation, merge, apl = true)
     answer = lookup_invocation.lookup_adapter.lookup(name, lookup_invocation, merge)
-    lookup_invocation.emit_debug_info("Automatic Parameter Lookup of '#{name}") if Puppet[:debug]
+    lookup_invocation.emit_debug_info("Automatic Parameter Lookup of '#{name}'") if apl && Puppet[:debug]
     answer
   end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -438,6 +438,30 @@ describe "The lookup function" do
       expect(lookup('a')).to eql('value a (from environment)')
     end
 
+    context 'with log-level debug' do
+      before(:each) { Puppet[:log_level] = 'debug' }
+
+      it 'does not report a regular lookup as APL' do
+        expect(lookup('a')).to eql('value a (from environment)')
+        expect(debugs.count { |dbg| dbg =~ /\A\s*Automatic Parameter Lookup of/ }).to eql(0)
+      end
+
+      it 'reports regular lookup as lookup' do
+        expect(lookup('a')).to eql('value a (from environment)')
+        expect(debugs.count { |dbg| dbg =~ /\A\s*Lookup of/ }).to eql(1)
+      end
+
+      it 'does not report APL as lookup' do
+        collect_notices("class mod_a($a) { notice($a) }; include mod_a")
+        expect(debugs.count { |dbg| dbg =~ /\A\s*Lookup of/ }).to eql(0)
+      end
+
+      it 'reports APL as APL' do
+        collect_notices("class mod_a($a) { notice($a) }; include mod_a")
+        expect(debugs.count { |dbg| dbg =~ /\A\s*Automatic Parameter Lookup of/ }).to eql(1)
+      end
+    end
+
     context 'that has no lookup configured' do
       let(:environment_files) do
         {


### PR DESCRIPTION
This commit ensures that regular lookups and APLs are explained with a
correct heading and only once in a debug log. Before this commit, the
regular lookup would be logged twice, where the second time appeared to
be an APL.