### PR TITLE
(PUP-7259) Support JSON and PSON

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
   s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])
-  s.add_runtime_dependency(%q<hiera>, [">= 2.0", "< 4"])
+  s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
   # PUP-7115 - return to a gem dependency in Puppet 5
   # s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])
   s.add_runtime_dependency(%q<gettext-setup>, [">= 0.10", "< 1"])

--- a/Gemfile
+++ b/Gemfile
@@ -25,12 +25,9 @@ end
 
 gem "puppet", :path => File.dirname(__FILE__), :require => false
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
-gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
+gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 3.2.1', '< 4'])
 # PUP-7115 - return to a gem dependency in Puppet 5
 # gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ['>= 0.1.3', '< 2'])
-# Hiera has an unbound dependency on json_pure
-# json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0
-gem 'json_pure', '~> 1.8', :require => false
 # i18n support (gettext-setup and dependencies)
 gem 'gettext-setup', '>= 0.10', '< 1.0', :require => false
 gem 'locale', '~> 2.1', :require => false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -18,7 +18,7 @@ gem_required_ruby_version: '>= 1.9.3'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0', '< 4']
-  hiera: ['>= 2.0', '< 4']
+  hiera: ['>= 3.2.1', '< 4']
   json_pure: '~> 1.8'
   # PUP-7115 - return to a gem dependency in Puppet 5
   # semantic_puppet: ['>= 0.1.3', '< 2']

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -17,6 +17,7 @@ require 'puppet/settings'
 require 'puppet/util/feature'
 require 'puppet/util/suidmanager'
 require 'puppet/util/run_mode'
+# PSON is deprecated, use JSON instead
 require 'puppet/external/pson/common'
 require 'puppet/external/pson/version'
 require 'puppet/external/pson/pure'

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -338,7 +338,6 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   def read_catalog(text)
     begin
       catalog = Puppet::Resource::Catalog.convert_from(Puppet::Resource::Catalog.default_format,text)
-      catalog = Puppet::Resource::Catalog.pson_create(catalog) unless catalog.is_a?(Puppet::Resource::Catalog)
     rescue => detail
       raise Puppet::Error, "Could not deserialize catalog from pson: #{detail}", detail.backtrace
     end

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -336,10 +336,11 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
   private
 
   def read_catalog(text)
+    format = Puppet::Resource::Catalog.default_format
     begin
-      catalog = Puppet::Resource::Catalog.convert_from(Puppet::Resource::Catalog.default_format,text)
+      catalog = Puppet::Resource::Catalog.convert_from(format, text)
     rescue => detail
-      raise Puppet::Error, "Could not deserialize catalog from pson: #{detail}", detail.backtrace
+      raise Puppet::Error, "Could not deserialize catalog from #{format}: #{detail}", detail.backtrace
     end
 
     catalog.to_ral

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -340,7 +340,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     begin
       catalog = Puppet::Resource::Catalog.convert_from(format, text)
     rescue => detail
-      raise Puppet::Error, "Could not deserialize catalog from #{format}: #{detail}", detail.backtrace
+      raise Puppet::Error, _("Could not deserialize catalog from %{format}: %{detail}") % { format: format, detail: detail }, detail.backtrace
     end
 
     catalog.to_ral

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1480,7 +1480,7 @@ EOT
       :desc       => "The port to use for the certificate authority.",
     },
     :preferred_serialization_format => {
-      :default    => "pson",
+      :default    => "json",
       :desc       => "The preferred means of serializing
       ruby instances for passing over the wire.  This won't guarantee that all
       instances will be serialized using this method, since not all classes

--- a/lib/puppet/external/pson/common.rb
+++ b/lib/puppet/external/pson/common.rb
@@ -1,5 +1,9 @@
 require 'puppet/external/pson/version'
 
+# PSON is a vendored version of pure_json v1.1.9 plus puppet patches. It
+# is deprecated and should not be used for future work. Use JSON instead.
+#
+# @deprecated
 module PSON
   class << self
     # If _object_ is string-like parse the string and return the parsed result

--- a/lib/puppet/face/resource.rb
+++ b/lib/puppet/face/resource.rb
@@ -29,7 +29,7 @@ Puppet::Indirector::Face.define(:resource, '0.0.1') do
   find.examples <<-'EOT'
     Print information about a user on this system (API example):
 
-        puts Puppet::Face[:resource, '0.0.1'].find("user/luke").to_pson
+        puts Puppet::Face[:resource, '0.0.1'].find("user/luke").to_json
   EOT
 
   save = get_action(:save)

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -17,10 +17,6 @@ class Puppet::FileBucket::File
     [:binary]
   end
 
-  def self.default_format
-    :binary
-  end
-
   def initialize(contents, options = {})
     case contents
     when String

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -74,15 +74,6 @@ class Puppet::FileBucket::File
     self.new(contents)
   end
 
-  def to_data_hash
-    # Note that this serializes the entire data to a string and places it in a hash.
-    { "contents" => contents.to_binary }
-  end
-
-  def self.from_data_hash(data)
-    self.new(data["contents"])
-  end
-
   private
 
   class StringContents

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -4,8 +4,7 @@ require 'puppet/util'
 # The base class for JSON indirection terminus implementations.
 #
 # This should generally be preferred to the YAML base for any future
-# implementations, since it is ~ three times faster despite being pure Ruby
-# rather than a C implementation.
+# implementations, since it is faster and can load untrusted data safely.
 class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
   def find(request)
     load_json_from_file(path(request.key), request.key)

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -67,10 +67,10 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
   end
 
   def from_json(text)
-    model.convert_from('pson', text)
+    model.convert_from('json', text)
   end
 
   def to_json(object)
-    object.render('pson')
+    object.render('json')
   end
 end

--- a/lib/puppet/module_tool/dependency.rb
+++ b/lib/puppet/module_tool/dependency.rb
@@ -5,7 +5,6 @@ module Puppet::ModuleTool
 
   class Dependency
     include Puppet::Network::FormatSupport
-    alias :to_json :to_pson
 
     attr_reader :full_module_name, :username, :name, :version_requirement, :repository
 

--- a/lib/puppet/network/format.rb
+++ b/lib/puppet/network/format.rb
@@ -70,7 +70,8 @@ class Puppet::Network::Format
   def render_multiple(instances)
     # This method implicitly assumes that all instances are of the same type.
     return instances[0].class.send(render_multiple_method, instances) if instances[0].class.respond_to?(render_multiple_method)
-    raise NotImplementedError, "#{instances[0].class} does not respond to #{render_multiple_method}; can not render multiple instances to #{mime}"
+    raise NotImplementedError, _("%{klass} does not respond to %{method}; can not render multiple instances to %{mime}") \
+                               % { klass: instances[0].class, method: render_multiple_method, mime: mime }
   end
 
   def required_methods_present?(klass)

--- a/lib/puppet/network/format.rb
+++ b/lib/puppet/network/format.rb
@@ -70,7 +70,7 @@ class Puppet::Network::Format
   def render_multiple(instances)
     # This method implicitly assumes that all instances are of the same type.
     return instances[0].class.send(render_multiple_method, instances) if instances[0].class.respond_to?(render_multiple_method)
-    raise NotImplementedError, "#{instances[0].class} does not respond to #{render_multiple_method}; can not intern multiple instances to #{mime}"
+    raise NotImplementedError, "#{instances[0].class} does not respond to #{render_multiple_method}; can not render multiple instances to #{mime}"
   end
 
   def required_methods_present?(klass)

--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -88,6 +88,7 @@ module Puppet::Network::FormatSupport
     to_data_hash.to_msgpack(*args)
   end
 
+  # @deprecated, use to_json
   def to_pson(*args)
     to_data_hash.to_pson(*args)
   end

--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -35,9 +35,7 @@ module Puppet::Network::FormatSupport
     end
 
     def supported_formats
-      result = format_handler.formats.reject do |f|
-        f == :binary
-      end.collect do |f|
+      result = format_handler.formats.collect do |f|
         format_handler.format(f)
       end.find_all do |f|
         f.supported?(self)

--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -35,7 +35,9 @@ module Puppet::Network::FormatSupport
     end
 
     def supported_formats
-      result = format_handler.formats.collect do |f|
+      result = format_handler.formats.reject do |f|
+        f == :binary
+      end.collect do |f|
         format_handler.format(f)
       end.find_all do |f|
         f.supported?(self)

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -85,6 +85,7 @@ Puppet::Network::FormatHandler.create(:binary, :mime => "application/octet-strea
   end
 end
 
+# PSON is deprecated
 Puppet::Network::FormatHandler.create_serialized_formats(:pson, :weight => 10, :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
   def intern(klass, text)
     data_to_instance(klass, PSON.parse(text))

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -132,6 +132,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'applic
   # Unlike PSON, we do not need to unwrap the data envelope, because legacy 3.x agents
   # have never supported JSON
   def data_to_instance(klass, data)
+    return data if data.is_a?(klass)
     klass.from_data_hash(data)
   end
 end

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -65,24 +65,10 @@ end
 
 Puppet::Network::FormatHandler.create(:s, :mime => "text/plain", :extension => "txt")
 
-Puppet::Network::FormatHandler.create(:binary, :mime => "application/octet-stream", :weight => 1) do
-  def intern_multiple(klass, text)
-    raise NotImplementedError
-  end
-
-  def render_multiple(instances)
-    raise NotImplementedError
-  end
-
-  # LAK:NOTE The format system isn't currently flexible enough to handle
-  # what I need to support raw formats just for individual instances (rather
-  # than both individual and collections), but we don't yet have enough data
-  # to make a "correct" design.
-  #   So, we hack it so it works for singular but fail if someone tries it
-  # on plurals.
-  def supported?(klass)
-    true
-  end
+# By default, to_binary is called to render and from_binary called to intern. Note unlike
+# text-based formats (json, yaml, etc), we don't use to_data_hash for binary.
+Puppet::Network::FormatHandler.create(:binary, :mime => "application/octet-stream", :weight => 1,
+                                      :required_methods => [:render_method, :intern_method]) do
 end
 
 # PSON is deprecated

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -1,4 +1,5 @@
 require 'puppet/network/format_handler'
+require 'json'
 
 Puppet::Network::FormatHandler.create_serialized_formats(:msgpack, :weight => 20, :mime => "application/x-msgpack", :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
 
@@ -107,6 +108,30 @@ Puppet::Network::FormatHandler.create_serialized_formats(:pson, :weight => 10, :
       data = d
     end
     return data if data.is_a?(klass)
+    klass.from_data_hash(data)
+  end
+end
+
+Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'application/json', :weight => 15, :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
+  def intern(klass, text)
+    data_to_instance(klass, JSON.parse(text))
+  end
+
+  def intern_multiple(klass, text)
+    JSON.parse(text).collect do |data|
+      data_to_instance(klass, data)
+    end
+  end
+
+  # JSON monkey-patches Array, so this works.
+  # https://github.com/ruby/ruby/blob/ruby_1_9_3/ext/json/generator/generator.c#L1416
+  def render_multiple(instances)
+    instances.to_json
+  end
+
+  # Unlike PSON, we do not need to unwrap the data envelope, because legacy 3.x agents
+  # have never supported JSON
+  def data_to_instance(klass, data)
     klass.from_data_hash(data)
   end
 end

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -161,7 +161,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
 
   # Execute our destroy.
   def do_destroy(indirection, key, params, request, response)
-    formatter = accepted_response_formatter_or_pson_for(indirection.model, request)
+    formatter = accepted_response_formatter_or_json_for(indirection.model, request)
 
     result = indirection.destroy(key, params)
 
@@ -170,7 +170,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
 
   # Execute our save.
   def do_save(indirection, key, params, request, response)
-    formatter = accepted_response_formatter_or_pson_for(indirection.model, request)
+    formatter = accepted_response_formatter_or_json_for(indirection.model, request)
     sent_object = read_body_into_model(indirection.model, request)
 
     result = indirection.save(sent_object, key)
@@ -183,8 +183,8 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     request.response_formatter_for(model_class.supported_formats, accepted_formats)
   end
 
-  def accepted_response_formatter_or_pson_for(model_class, request)
-    accepted_formats = request.headers['accept'] || "text/pson"
+  def accepted_response_formatter_or_json_for(model_class, request)
+    accepted_formats = request.headers['accept'] || "application/json"
     request.response_formatter_for(model_class.supported_formats, accepted_formats)
   end
 

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -84,7 +84,7 @@ class Puppet::Resource
     self.to_hash.each_pair do |param, value|
       # Don't duplicate the title as the namevar
       unless param == namevar && value == title
-        value = Puppet::Resource.value_to_pson_data(value)
+        value = Puppet::Resource.value_to_json_data(value)
         if is_json_type?(value)
           params[param] = value
         elsif json_serializer.nil?
@@ -129,9 +129,9 @@ class Puppet::Resource
     end
   end
 
-  def self.value_to_pson_data(value)
+  def self.value_to_json_data(value)
     if value.is_a? Array
-      value.map{|v| value_to_pson_data(v) }
+      value.map{|v| value_to_json_data(v) }
     elsif value.is_a? Puppet::Resource
       value.to_s
     else
@@ -144,10 +144,11 @@ class Puppet::Resource
     when Hash
       x.inject({}) { |h,kv|
         k,v = kv
-        h[k] = self.class.value_to_pson_data(v)
+        h[k] = self.class.value_to_json_data(v)
         h
       }
-    else self.class.value_to_pson_data(x)
+    else
+      self.class.value_to_json_data(x)
     end
   end
 

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -307,7 +307,7 @@ ERROR_STRING
 
     # this is for backwards-compatibility
     # we should deprecate it and transition people to using
-    # pson[:fingerprints][:default]
+    # json[:fingerprints][:default]
     # It appears that we have no internal consumers of this api
     # --jeffweiss 30 aug 2012
     result[:fingerprint] = thing_to_use.fingerprint

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -390,11 +390,11 @@ class Puppet::Transaction::Report
   end
 
   def self.supported_formats
-    [:pson, :yaml]
+    [:json, :pson, :yaml]
   end
 
   def self.default_format
-    :pson
+    Puppet[:preferred_serialization_format].to_sym
   end
 
   private

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -389,6 +389,10 @@ class Puppet::Transaction::Report
     super - [:@external_times, :@resources_failed_to_generate]
   end
 
+  def self.default_format
+    :pson
+  end
+
   private
 
   # Mark the report as corrective, if there are any resource_status marked corrective.

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -389,14 +389,6 @@ class Puppet::Transaction::Report
     super - [:@external_times, :@resources_failed_to_generate]
   end
 
-  def self.supported_formats
-    [:json, :pson, :yaml]
-  end
-
-  def self.default_format
-    Puppet[:preferred_serialization_format].to_sym
-  end
-
   private
 
   # Mark the report as corrective, if there are any resource_status marked corrective.

--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -23,7 +23,7 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
   def lock(lock_data = nil)
     return false if locked?
 
-    super(lock_data.to_pson)
+    super(lock_data.to_json)
   end
 
   # Retrieve the (optional) lock data that was specified at the time the file
@@ -35,9 +35,9 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
     return nil unless file_locked?
     file_contents = super
     return nil if file_contents.nil? or file_contents.empty?
-    PSON.parse(file_contents)
-  rescue PSON::ParserError => e
-    Puppet.warning _("Unable to read lockfile data from %{path}: not in PSON") % { path: @file_path }
+    JSON.parse(file_contents)
+  rescue JSON::ParserError => e
+    Puppet.warning _("Unable to read lockfile data from %{path}: not in JSON") % { path: @file_path }
     nil
   end
 

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -340,10 +340,6 @@ class Puppet::Util::Log
     hash
   end
 
-  def to_pson(*args)
-    to_data_hash.to_pson(*args)
-  end
-
   def message=(msg)
     raise ArgumentError, "Puppet::Util::Log requires a message" unless msg
     @message = msg.to_s

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -136,7 +136,7 @@ Puppet::Util::Log.newdesttype :logstash_event do
 
   def handle(msg)
     message = format(msg)
-    $stdout.puts message.to_pson
+    $stdout.puts message.to_json
   end
 end
 

--- a/lib/puppet/util/metric.rb
+++ b/lib/puppet/util/metric.rb
@@ -23,10 +23,6 @@ class Puppet::Util::Metric
     }
   end
 
-  def to_pson(*args)
-    to_data_hash.to_pson(*args)
-  end
-
   # Return a specific value
   def [](name)
     if value = @values.find { |v| v[0] == name }

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -20,10 +20,6 @@ class Puppet::Util::TagSet < Set
     to_a
   end
 
-  def to_pson(*args)
-    to_data_hash.to_pson
-  end
-
   def join(*args)
     to_a.join(*args)
   end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -10,13 +10,13 @@ describe "apply" do
   end
 
   describe "when applying provided catalogs" do
-    it "can apply catalogs provided in a file in pson" do
-      file_to_create = tmpfile("pson_catalog")
+    it "can apply catalogs provided in a file in json" do
+      file_to_create = tmpfile("json_catalog")
       catalog = Puppet::Resource::Catalog.new('mine', Puppet.lookup(:environments).get(Puppet[:environment]))
       resource = Puppet::Resource.new(:file, file_to_create, :parameters => {:content => "my stuff"})
       catalog.add_resource resource
 
-      manifest = file_containing("manifest", catalog.to_pson)
+      manifest = file_containing("manifest", catalog.to_json)
 
       puppet = Puppet::Application[:apply]
       puppet.options[:catalog] = manifest
@@ -94,7 +94,7 @@ end
       it 'does not load the pcore type' do
         catalog = compile_to_catalog('applytest { "applytest was here":}', node)
         apply = Puppet::Application[:apply]
-        apply.options[:catalog] = file_containing('manifest', catalog.to_pson)
+        apply.options[:catalog] = file_containing('manifest', catalog.to_json)
 
         Puppet[:environmentpath] = envdir
         Puppet::Pops::Loader::Runtime3TypeLoader.any_instance.expects(:find).never
@@ -214,7 +214,7 @@ end
 
       Puppet[:environment] = env_name
       apply = Puppet::Application[:apply]
-      apply.options[:catalog] = file_containing('manifest', catalog.to_pson)
+      apply.options[:catalog] = file_containing('manifest', catalog.to_json)
       expect { apply.run_command; exit(0) }.to exit_with(0)
       expect(@logs.map(&:to_s)).to include('The Street 23')
     end
@@ -459,7 +459,7 @@ class amod::bad_type {
       it 'will notify a string that is the result of Regexp#inspect (from Runtime3xConverter)' do
         catalog = compile_to_catalog(execute, node)
         apply = Puppet::Application[:apply]
-        apply.options[:catalog] = file_containing('manifest', catalog.to_pson)
+        apply.options[:catalog] = file_containing('manifest', catalog.to_json)
         apply.expects(:apply_catalog).with do |catalog|
           catalog.resource(:notify, 'rx')['message'].is_a?(String)
           catalog.resource(:notify, 'bin')['message'].is_a?(String)
@@ -474,7 +474,7 @@ class amod::bad_type {
       it 'will notify a string that is the result of to_s on uknown data types' do
         logs = []
         json = Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-           compile_to_catalog('include amod::bad_type', node).to_pson
+           compile_to_catalog('include amod::bad_type', node).to_json
         end
         logs = logs.select { |log| log.level == :warning }.map { |log| log.message }
         expect(logs.empty?).to be_falsey
@@ -495,7 +495,7 @@ class amod::bad_type {
       it 'will notify a regexp using Regexp#to_s' do
         catalog = compile_to_catalog(execute, node)
         apply = Puppet::Application[:apply]
-        apply.options[:catalog] = file_containing('manifest', catalog.to_pson)
+        apply.options[:catalog] = file_containing('manifest', catalog.to_json)
         apply.expects(:apply_catalog).with do |catalog|
           catalog.resource(:notify, 'rx')['message'].is_a?(Regexp)
           catalog.resource(:notify, 'bin')['message'].is_a?(Puppet::Pops::Types::PBinaryType::Binary)
@@ -509,7 +509,7 @@ class amod::bad_type {
 
       it 'will raise an error on uknown data types' do
         catalog = compile_to_catalog('include amod::bad_type', node)
-        expect { catalog.to_pson }.to raise_error(/No Puppet Type found for Time/)
+        expect { catalog.to_json }.to raise_error(/No Puppet Type found for Time/)
       end
     end
 

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -137,8 +137,8 @@ describe "Puppet defaults" do
     end
   end
 
-  it "should default to pson for the preferred serialization format" do
-    expect(Puppet.settings.value(:preferred_serialization_format)).to eq("pson")
+  it "should default to json for the preferred serialization format" do
+    expect(Puppet.settings.value(:preferred_serialization_format)).to eq("json")
   end
 
   it "should have a setting for determining the configuration version and should default to an empty string" do

--- a/spec/integration/parser/catalog_spec.rb
+++ b/spec/integration/parser/catalog_spec.rb
@@ -96,7 +96,7 @@ describe "A catalog" do
   def master_and_agent_catalogs_for(manifest)
     compiler = Puppet::Resource::Catalog::Compiler.new
     master_catalog = compiler.filter(compile_to_catalog(manifest, node))
-    agent_catalog = Puppet::Resource::Catalog.convert_from(:pson, master_catalog.render(:pson))
+    agent_catalog = Puppet::Resource::Catalog.convert_from(:json, master_catalog.render(:json))
     [master_catalog, agent_catalog]
   end
 

--- a/spec/integration/resource/catalog_spec.rb
+++ b/spec/integration/resource/catalog_spec.rb
@@ -2,6 +2,11 @@
 require 'spec_helper'
 
 describe Puppet::Resource::Catalog do
+  it "should support json, pson, dot, yaml, binary" do
+    # msgpack is optional, so using include instead of eq
+    expect(Puppet::Resource::Catalog.supported_formats).to include(:json, :pson, :dot, :yaml, :binary)
+  end
+
   it "should support pson" do
     expect(Puppet::Resource::Catalog.supported_formats).to be_include(:pson)
   end

--- a/spec/integration/resource/catalog_spec.rb
+++ b/spec/integration/resource/catalog_spec.rb
@@ -2,15 +2,6 @@
 require 'spec_helper'
 
 describe Puppet::Resource::Catalog do
-  it "should support json, pson, dot, yaml, binary" do
-    # msgpack is optional, so using include instead of eq
-    expect(Puppet::Resource::Catalog.supported_formats).to include(:json, :pson, :dot, :yaml, :binary)
-  end
-
-  it "should support pson" do
-    expect(Puppet::Resource::Catalog.supported_formats).to be_include(:pson)
-  end
-
   describe "when using the indirector" do
     before do
       # This is so the tests work w/out networking.

--- a/spec/lib/matchers/json.rb
+++ b/spec/lib/matchers/json.rb
@@ -5,11 +5,11 @@ module JSONMatchers
     end
 
     def format
-      @format ||= Puppet::Network::FormatHandler.format('pson')
+      @format ||= Puppet::Network::FormatHandler.format('json')
     end
 
     def json(instance)
-      PSON.parse(instance.to_pson)
+      JSON.parse(instance.to_json)
     end
 
     def attr_value(attrs, instance)
@@ -59,7 +59,7 @@ module JSONMatchers
     end
 
     def format
-      @format ||= Puppet::Network::FormatHandler.format('pson')
+      @format ||= Puppet::Network::FormatHandler.format('json')
     end
 
     def from(value)

--- a/spec/lib/puppet_spec/modules.rb
+++ b/spec/lib/puppet_spec/modules.rb
@@ -16,7 +16,7 @@ module PuppetSpec::Modules
         metadata[:name] = "#{metadata[:author]}/#{name}"
 
         File.open(File.join(module_dir, 'metadata.json'), 'w') do |f|
-          f.write(metadata.to_pson)
+          f.write(metadata.to_json)
         end
       end
 
@@ -29,7 +29,7 @@ module PuppetSpec::Modules
 
       if metadata = options[:metadata]
         File.open(File.join(module_dir, 'metadata.json'), 'w') do |f|
-          f.write(metadata.to_pson)
+          f.write(metadata.to_json)
         end
       end
     end

--- a/spec/lib/puppet_spec/network.rb
+++ b/spec/lib/puppet_spec/network.rb
@@ -41,7 +41,7 @@ module PuppetSpec::Network
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
-        'content-type' => "text/pson"
+        'content-type' => "application/json"
       },
       :method => "HEAD",
       :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
@@ -53,12 +53,12 @@ module PuppetSpec::Network
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
-        'content-type' => request[:content_type_header] || "text/pson"
+        'content-type' => request[:content_type_header] || "application/json"
       },
       :method => "PUT",
       :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
       :params => params,
-      :body => request[:body].nil? ? data.render("pson") : request[:body]
+      :body => request[:body].nil? ? data.render("json") : request[:body]
     })
   end
 
@@ -66,7 +66,7 @@ module PuppetSpec::Network
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
-        'content-type' => "text/pson"
+        'content-type' => "application/json"
       },
       :method => "DELETE",
       :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
@@ -79,7 +79,7 @@ module PuppetSpec::Network
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
-        'content-type' => "text/pson"
+        'content-type' => "application/json"
       },
       :method => "GET",
       :path => "#{master_url_prefix}/#{data.class.indirection.name}/#{data.value}",
@@ -92,7 +92,7 @@ module PuppetSpec::Network
     Puppet::Network::HTTP::Request.from_hash({
       :headers => {
         'accept' => request[:accept_header],
-        'content-type' => "text/pson"
+        'content-type' => "application/json"
       },
       :method => "GET",
       :path => "#{master_url_prefix}/#{data.class.indirection.name}s/#{data.name}",

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -447,14 +447,6 @@ describe Puppet::Application::Apply do
         expect { @apply.apply }.to raise_error(Puppet::Error)
       end
 
-      it "should convert plain data structures into a catalog if deserialization does not do so" do
-        @apply.options[:catalog] = temporary_catalog
-        Puppet::Resource::Catalog.stubs(:convert_from).with(:pson,'"something"').returns({:foo => "bar"})
-        catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
-        Puppet::Resource::Catalog.expects(:pson_create).with({:foo => "bar"}).returns(catalog)
-        @apply.apply
-      end
-
       it "should convert the catalog to a RAL catalog and use a Configurer instance to apply it" do
         @apply.options[:catalog] = temporary_catalog
         catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -413,7 +413,7 @@ describe Puppet::Application::Apply do
       # We want this memoized, and to be able to adjust the content, so we
       # have to do it ourselves.
       def temporary_catalog(content = '"something"')
-        @tempfile = Tempfile.new('catalog.pson')
+        @tempfile = Tempfile.new('catalog.json')
         @tempfile.write(content)
         @tempfile.close
         @tempfile.path
@@ -422,7 +422,7 @@ describe Puppet::Application::Apply do
       it "should read the catalog in from disk if a file name is provided" do
         @apply.options[:catalog] = temporary_catalog
         catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
-        Puppet::Resource::Catalog.stubs(:convert_from).with(:pson,'"something"').returns(catalog)
+        Puppet::Resource::Catalog.stubs(:convert_from).with(:json,'"something"').returns(catalog)
         @apply.apply
       end
 
@@ -430,7 +430,7 @@ describe Puppet::Application::Apply do
         @apply.options[:catalog] = "-"
         $stdin.expects(:read).returns '"something"'
         catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
-        Puppet::Resource::Catalog.stubs(:convert_from).with(:pson,'"something"').returns(catalog)
+        Puppet::Resource::Catalog.stubs(:convert_from).with(:json,'"something"').returns(catalog)
         @apply.apply
       end
 
@@ -450,7 +450,7 @@ describe Puppet::Application::Apply do
       it "should convert the catalog to a RAL catalog and use a Configurer instance to apply it" do
         @apply.options[:catalog] = temporary_catalog
         catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
-        Puppet::Resource::Catalog.stubs(:convert_from).with(:pson,'"something"').returns catalog
+        Puppet::Resource::Catalog.stubs(:convert_from).with(:json,'"something"').returns catalog
         catalog.expects(:to_ral).returns "mycatalog"
 
         configurer = stub 'configurer'

--- a/spec/unit/file_bucket/file_spec.rb
+++ b/spec/unit/file_bucket/file_spec.rb
@@ -13,8 +13,8 @@ describe Puppet::FileBucket::File, :uses_checksums => true do
     expect(Puppet::FileBucket::File.default_format).to eq(:binary)
   end
 
-  it "accepts binary" do
-    expect(Puppet::FileBucket::File.supported_formats).to include(:binary)
+  it "only accepts binary" do
+    expect(Puppet::FileBucket::File.supported_formats).to eq([:binary])
   end
 
   describe "making round trips through network formats" do

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -14,12 +14,12 @@ describe Puppet::FileServing::Metadata do
     expect(Puppet::FileServing::Metadata.indirection.name).to eq(:file_metadata)
   end
 
-  it "should default to json" do
-    expect(Puppet::FileServing::Metadata.default_format).to eq(:json)
-  end
-
   it "should have a method that triggers attribute collection" do
     expect(Puppet::FileServing::Metadata.new(foobar)).to respond_to(:collect)
+  end
+
+  it "should default to json" do
+    expect(Puppet::FileServing::Metadata.default_format).to eq(:json)
   end
 
   it "should support json, pson, yaml" do

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -22,9 +22,9 @@ describe Puppet::FileServing::Metadata do
     expect(Puppet::FileServing::Metadata.new(foobar)).to respond_to(:collect)
   end
 
-  it "should support json, pson, yaml, binary" do
+  it "should support json, pson, yaml" do
     # msgpack is optional, so using include instead of eq
-    expect(Puppet::FileServing::Metadata.supported_formats).to include(:json, :pson, :yaml, :binary)
+    expect(Puppet::FileServing::Metadata.supported_formats).to include(:json, :pson, :yaml)
   end
 
   it "should support deserialization" do

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -14,12 +14,17 @@ describe Puppet::FileServing::Metadata do
     expect(Puppet::FileServing::Metadata.indirection.name).to eq(:file_metadata)
   end
 
+  it "should default to json" do
+    expect(Puppet::FileServing::Metadata.default_format).to eq(:json)
+  end
+
   it "should have a method that triggers attribute collection" do
     expect(Puppet::FileServing::Metadata.new(foobar)).to respond_to(:collect)
   end
 
-  it "should support pson serialization" do
-    expect(Puppet::FileServing::Metadata.new(foobar)).to respond_to(:to_pson)
+  it "should support json, pson, yaml, binary" do
+    # msgpack is optional, so using include instead of eq
+    expect(Puppet::FileServing::Metadata.supported_formats).to include(:json, :pson, :yaml, :binary)
   end
 
   it "should support deserialization" do
@@ -172,7 +177,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
         end
 
         it "should validate against the schema" do
-          expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
+          expect(metadata.to_json).to validate_against('api/schemas/file_metadata.json')
         end
 
         describe "when a source and content_uri are set" do
@@ -182,7 +187,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
           end
 
           it "should validate against the schema" do
-            expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
+            expect(metadata.to_json).to validate_against('api/schemas/file_metadata.json')
           end
         end
       end
@@ -209,7 +214,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
 
         it "should validate against the schema" do
           metadata.collect
-          expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
+          expect(metadata.to_json).to validate_against('api/schemas/file_metadata.json')
         end
       end
     end
@@ -278,7 +283,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
         end
 
         it "should validate against the schema" do
-          expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
+          expect(metadata.to_json).to validate_against('api/schemas/file_metadata.json')
         end
       end
     end
@@ -312,7 +317,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
       end
 
       it "should validate against the schema" do
-        expect(metadata.to_pson).to validate_against('api/schemas/file_metadata.json')
+        expect(metadata.to_json).to validate_against('api/schemas/file_metadata.json')
       end
     end
   end

--- a/spec/unit/indirector/json_spec.rb
+++ b/spec/unit/indirector/json_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Indirector::JSON do
       end
 
       it "raises a descriptive error when the file can't be read" do
-        with_content(model.new('foo').to_pson) do
+        with_content(model.new('foo').to_json) do
           # I don't like this, but there isn't a credible alternative that
           # also works on Windows, so a stub it is. At least the expectation
           # will fail if the implementation changes. Sorry to the next dev.
@@ -95,7 +95,7 @@ describe Puppet::Indirector::JSON do
       end
 
       it "should return an instance of the indirected object when valid" do
-        with_content(model.new(1).to_pson) do
+        with_content(model.new(1).to_json) do
           instance = subject.find(request)
           expect(instance).to be_an_instance_of model
           expect(instance.value).to eq(1)
@@ -161,7 +161,7 @@ describe Puppet::Indirector::JSON do
 
     def create_file(name, value = 12)
       File.open(subject.path(name, ''), 'w') do |f|
-        f.puts Puppet::IndirectorTesting.new(value).to_pson
+        f.puts Puppet::IndirectorTesting.new(value).to_json
       end
     end
 

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -277,15 +277,15 @@ describe Puppet::Indirector::REST do
   end
 
   it 'excludes yaml from the Accept header' do
-    model.expects(:supported_formats).returns([:pson, :yaml, :binary])
+    model.expects(:supported_formats).returns([:json, :pson, :yaml, :binary])
 
-    expect(terminus.headers['Accept']).to eq('pson, binary')
+    expect(terminus.headers['Accept']).to eq('json, pson, binary')
   end
 
   it 'excludes b64_zlib_yaml from the Accept header' do
-    model.expects(:supported_formats).returns([:pson, :b64_zlib_yaml])
+    model.expects(:supported_formats).returns([:json, :pson, :b64_zlib_yaml])
 
-    expect(terminus.headers['Accept']).to eq('pson')
+    expect(terminus.headers['Accept']).to eq('json, pson')
   end
 
   describe "when creating an HTTP client" do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -688,7 +688,7 @@ describe Puppet::Module do
     end
 
   def a_module_with_metadata(data)
-    File.stubs(:read).with("/path/metadata.json", {:encoding => 'utf-8'}).returns data.to_pson
+    File.stubs(:read).with("/path/metadata.json", {:encoding => 'utf-8'}).returns data.to_json
     Puppet::Module.new("foo", "/path", mock("env"))
   end
 

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -25,6 +25,14 @@ class FormatsTest
       'string' => @string
     }
   end
+
+  def to_binary
+    string
+  end
+
+  def self.from_binary(data)
+    self.new(data)
+  end
 end
 
 describe "Puppet Network Format" do
@@ -166,16 +174,30 @@ describe "Puppet Network Format" do
       expect(binary.mime).to eq("application/octet-stream")
     end
 
-    it "should always be supported" do
-      expect(binary).to be_supported(String)
+    it "should not be supported by default" do
+      expect(binary).to_not be_supported(String)
+    end
+
+    it "should render an instance as binary" do
+      instance = FormatsTest.new("foo")
+      expect(binary.render(instance)).to eq("foo")
+    end
+
+    it "should intern an instance from a JSON hash" do
+      instance = binary.intern(FormatsTest, "foo")
+      expect(instance.string).to eq("foo")
     end
 
     it "should fail if its multiple_render method is used" do
-      expect { binary.render_multiple("foo") }.to raise_error(NotImplementedError)
+      expect {
+        binary.render_multiple("foo")
+      }.to raise_error(NotImplementedError, /can not render multiple instances to application\/octet-stream/)
     end
 
     it "should fail if its multiple_intern method is used" do
-      expect { binary.intern_multiple(String, "foo") }.to raise_error(NotImplementedError)
+      expect {
+        binary.intern_multiple(String, "foo")
+      }.to raise_error(NotImplementedError, /can not intern multiple instances from application\/octet-stream/)
     end
 
     it "should have a weight of 1" do

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -128,7 +128,7 @@ describe "Puppet Network Format" do
       end.to raise_error(Puppet::Network::FormatHandler::FormatError, /did not contain a collection/)
     end
 
-    it "fails intelligibly instead of calling to_pson with something other than a hash when interning multiple" do
+    it "fails intelligibly instead of calling to_json with something other than a hash when interning multiple" do
       expect do
         yaml.intern_multiple(Puppet::Node, YAML.dump(["hello"]))
       end.to raise_error(Puppet::Network::FormatHandler::FormatError, /did not contain a valid instance/)

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -104,6 +104,13 @@ describe "Puppet Network Format" do
       expect { yaml.intern(String, YAML.dump(:foo))}.to raise_error(Puppet::Network::FormatHandler::FormatError)
     end
 
+    it "should skip data_to_hash if data is already an instance of the specified class" do
+      # The rest terminus for the report indirected type relies on this behavior
+      data = YAML.dump([1, 2])
+      instance = yaml.intern(Array, data)
+      expect(instance).to eq([1, 2])
+    end
+
     it "should load from yaml when deserializing an array" do
       text = YAML.dump(["foo"])
       expect(yaml.intern_multiple(String, text)).to eq(["foo"])
@@ -215,6 +222,13 @@ describe "Puppet Network Format" do
       expect(instance.string).to eq("parsed_pson")
     end
 
+    it "should skip data_to_hash if data is already an instance of the specified class" do
+      # The rest terminus for the report indirected type relies on this behavior
+      data = PSON.dump([1, 2])
+      instance = pson.intern(Array, data)
+      expect(instance).to eq([1, 2])
+    end
+
     it "should intern multiple instances from a pson array" do
       text = PSON.dump(
         [
@@ -286,6 +300,13 @@ describe "Puppet Network Format" do
       text = JSON.dump({"string" => "parsed_json"})
       instance = json.intern(FormatsTest, text)
       expect(instance.string).to eq("parsed_json")
+    end
+
+    it "should skip data_to_hash if data is already an instance of the specified class" do
+      # The rest terminus for the report indirected type relies on this behavior
+      data = JSON.dump([1, 2])
+      instance = json.intern(Array, data)
+      expect(instance).to eq([1, 2])
     end
 
     it "should intern multiple instances from a JSON array of hashes" do

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -31,21 +31,19 @@ describe "Puppet Network Format" do
   end
 
   describe "msgpack", :if => Puppet.features.msgpack? do
-    before do
-      @msgpack = Puppet::Network::FormatHandler.format(:msgpack)
-    end
+    let(:msgpack) { Puppet::Network::FormatHandler.format(:msgpack) }
 
     it "should have its mime type set to application/x-msgpack" do
-      expect(@msgpack.mime).to eq("application/x-msgpack")
+      expect(msgpack.mime).to eq("application/x-msgpack")
     end
 
     it "should have a weight of 20" do
-      expect(@msgpack.weight).to eq(20)
+      expect(msgpack.weight).to eq(20)
     end
 
     it "should fail when one element does not have a from_data_hash" do
       expect do
-        @msgpack.intern_multiple(Hash, MessagePack.pack(["foo"]))
+        msgpack.intern_multiple(Hash, MessagePack.pack(["foo"]))
       end.to raise_error(NoMethodError)
     end
 
@@ -74,146 +72,136 @@ describe "Puppet Network Format" do
   end
 
   describe "yaml" do
-    before do
-      @yaml = Puppet::Network::FormatHandler.format(:yaml)
-    end
+    let(:yaml) { Puppet::Network::FormatHandler.format(:yaml) }
 
     it "should have its mime type set to text/yaml" do
-      expect(@yaml.mime).to eq("text/yaml")
+      expect(yaml.mime).to eq("text/yaml")
     end
 
     it "should be supported on Strings" do
-      expect(@yaml).to be_supported(String)
+      expect(yaml).to be_supported(String)
     end
 
     it "should render by calling 'to_yaml' on the instance" do
       instance = mock 'instance'
       instance.expects(:to_yaml).returns "foo"
-      expect(@yaml.render(instance)).to eq("foo")
+      expect(yaml.render(instance)).to eq("foo")
     end
 
     it "should render multiple instances by calling 'to_yaml' on the array" do
       instances = [mock('instance')]
       instances.expects(:to_yaml).returns "foo"
-      expect(@yaml.render_multiple(instances)).to eq("foo")
+      expect(yaml.render_multiple(instances)).to eq("foo")
     end
 
     it "should deserialize YAML" do
-      expect(@yaml.intern(String, YAML.dump("foo"))).to eq("foo")
+      expect(yaml.intern(String, YAML.dump("foo"))).to eq("foo")
     end
 
     it "should deserialize symbols as strings" do
-      expect { @yaml.intern(String, YAML.dump(:foo))}.to raise_error(Puppet::Network::FormatHandler::FormatError)
+      expect { yaml.intern(String, YAML.dump(:foo))}.to raise_error(Puppet::Network::FormatHandler::FormatError)
     end
 
     it "should load from yaml when deserializing an array" do
       text = YAML.dump(["foo"])
-      expect(@yaml.intern_multiple(String, text)).to eq(["foo"])
+      expect(yaml.intern_multiple(String, text)).to eq(["foo"])
     end
 
-    it "fails intelligibly instead of calling to_pson with something other than a hash" do
+    it "fails intelligibly instead of calling to_json with something other than a hash" do
       expect do
-        @yaml.intern(Puppet::Node, '')
+        yaml.intern(Puppet::Node, '')
       end.to raise_error(Puppet::Network::FormatHandler::FormatError, /did not contain a valid instance/)
     end
 
     it "fails intelligibly when intern_multiple is called and yaml doesn't decode to an array" do
       expect do
-        @yaml.intern_multiple(Puppet::Node, '')
+        yaml.intern_multiple(Puppet::Node, '')
       end.to raise_error(Puppet::Network::FormatHandler::FormatError, /did not contain a collection/)
     end
 
     it "fails intelligibly instead of calling to_pson with something other than a hash when interning multiple" do
       expect do
-        @yaml.intern_multiple(Puppet::Node, YAML.dump(["hello"]))
+        yaml.intern_multiple(Puppet::Node, YAML.dump(["hello"]))
       end.to raise_error(Puppet::Network::FormatHandler::FormatError, /did not contain a valid instance/)
     end
   end
 
   describe "plaintext" do
-    before do
-      @text = Puppet::Network::FormatHandler.format(:s)
-    end
+    let(:text) { Puppet::Network::FormatHandler.format(:s) }
 
     it "should have its mimetype set to text/plain" do
-      expect(@text.mime).to eq("text/plain")
+      expect(text.mime).to eq("text/plain")
     end
 
     it "should use 'txt' as its extension" do
-      expect(@text.extension).to eq("txt")
+      expect(text.extension).to eq("txt")
     end
   end
 
   describe "dot" do
-    before do
-      @dot = Puppet::Network::FormatHandler.format(:dot)
-    end
+    let(:dot) { Puppet::Network::FormatHandler.format(:dot) }
 
     it "should have its mimetype set to text/dot" do
-      expect(@dot.mime).to eq("text/dot")
+      expect(dot.mime).to eq("text/dot")
     end
   end
 
   describe Puppet::Network::FormatHandler.format(:binary) do
-    before do
-      @format = Puppet::Network::FormatHandler.format(:binary)
-    end
+    let(:binary) { Puppet::Network::FormatHandler.format(:binary) }
 
     it "should exist" do
-      expect(@format).not_to be_nil
+      expect(binary).not_to be_nil
     end
 
     it "should have its mimetype set to application/octet-stream" do
-      expect(@format.mime).to eq("application/octet-stream")
+      expect(binary.mime).to eq("application/octet-stream")
     end
 
     it "should always be supported" do
-      expect(@format).to be_supported(String)
+      expect(binary).to be_supported(String)
     end
 
     it "should fail if its multiple_render method is used" do
-      expect { @format.render_multiple("foo") }.to raise_error(NotImplementedError)
+      expect { binary.render_multiple("foo") }.to raise_error(NotImplementedError)
     end
 
     it "should fail if its multiple_intern method is used" do
-      expect { @format.intern_multiple(String, "foo") }.to raise_error(NotImplementedError)
+      expect { binary.intern_multiple(String, "foo") }.to raise_error(NotImplementedError)
     end
 
     it "should have a weight of 1" do
-      expect(@format.weight).to eq(1)
+      expect(binary.weight).to eq(1)
     end
-  end
-
-  it "should include a pson format" do
-    expect(Puppet::Network::FormatHandler.format(:pson)).not_to be_nil
   end
 
   describe "pson" do
-    before do
-      @pson = Puppet::Network::FormatHandler.format(:pson)
+    let(:pson) { Puppet::Network::FormatHandler.format(:pson) }
+
+    it "should include a pson format" do
+      expect(pson).not_to be_nil
     end
 
     it "should have its mime type set to text/pson" do
-      expect(Puppet::Network::FormatHandler.format(:pson).mime).to eq("text/pson")
+      expect(pson.mime).to eq("text/pson")
     end
 
     it "should require the :render_method" do
-      expect(Puppet::Network::FormatHandler.format(:pson).required_methods).to be_include(:render_method)
+      expect(pson.required_methods).to be_include(:render_method)
     end
 
     it "should require the :intern_method" do
-      expect(Puppet::Network::FormatHandler.format(:pson).required_methods).to be_include(:intern_method)
+      expect(pson.required_methods).to be_include(:intern_method)
     end
 
     it "should have a weight of 10" do
-      expect(@pson.weight).to eq(10)
+      expect(pson.weight).to eq(10)
     end
 
     describe "when supported" do
       it "should render by calling 'to_pson' on the instance" do
         instance = PsonTest.new("foo")
         instance.expects(:to_pson).returns "foo"
-        expect(@pson.render(instance)).to eq("foo")
+        expect(pson.render(instance)).to eq("foo")
       end
 
       it "should render multiple instances by calling 'to_pson' on the array" do
@@ -221,14 +209,14 @@ describe "Puppet Network Format" do
 
         instances.expects(:to_pson).returns "foo"
 
-        expect(@pson.render_multiple(instances)).to eq("foo")
+        expect(pson.render_multiple(instances)).to eq("foo")
       end
 
       it "should intern by calling 'PSON.parse' on the text and then using from_data_hash to convert the data into an instance" do
         text = "foo"
         PSON.expects(:parse).with("foo").returns("type" => "PsonTest", "data" => "foo")
         PsonTest.expects(:from_data_hash).with("foo").returns "parsed_pson"
-        expect(@pson.intern(PsonTest, text)).to eq("parsed_pson")
+        expect(pson.intern(PsonTest, text)).to eq("parsed_pson")
       end
 
       it "should not render twice if 'PSON.parse' creates the appropriate instance" do
@@ -236,14 +224,14 @@ describe "Puppet Network Format" do
         instance = PsonTest.new("foo")
         PSON.expects(:parse).with("foo").returns(instance)
         PsonTest.expects(:from_data_hash).never
-        expect(@pson.intern(PsonTest, text)).to equal(instance)
+        expect(pson.intern(PsonTest, text)).to equal(instance)
       end
 
       it "should intern by calling 'PSON.parse' on the text and then using from_data_hash to convert the actual into an instance if the pson has no class/data separation" do
         text = "foo"
         PSON.expects(:parse).with("foo").returns("foo")
         PsonTest.expects(:from_data_hash).with("foo").returns "parsed_pson"
-        expect(@pson.intern(PsonTest, text)).to eq("parsed_pson")
+        expect(pson.intern(PsonTest, text)).to eq("parsed_pson")
       end
 
       it "should intern multiples by parsing the text and using 'class.intern' on each resulting data structure" do
@@ -251,66 +239,69 @@ describe "Puppet Network Format" do
         PSON.expects(:parse).with("foo").returns ["bar", "baz"]
         PsonTest.expects(:from_data_hash).with("bar").returns "BAR"
         PsonTest.expects(:from_data_hash).with("baz").returns "BAZ"
-        expect(@pson.intern_multiple(PsonTest, text)).to eq(%w{BAR BAZ})
+        expect(pson.intern_multiple(PsonTest, text)).to eq(%w{BAR BAZ})
       end
 
       it "fails intelligibly when given invalid data" do
         expect do
-          @pson.intern(Puppet::Node, '')
+          pson.intern(Puppet::Node, '')
         end.to raise_error(PSON::ParserError, /source did not contain any PSON/)
       end
     end
   end
 
   describe ":console format" do
-    subject { Puppet::Network::FormatHandler.format(:console) }
-    it { is_expected.to be_an_instance_of Puppet::Network::Format }
-    let :json do Puppet::Network::FormatHandler.format(:pson) end
+    let(:console) { Puppet::Network::FormatHandler.format(:console) }
+
+    it "should include a console format" do
+      expect(console).to be_an_instance_of Puppet::Network::Format
+    end
 
     [:intern, :intern_multiple].each do |method|
       it "should not implement #{method}" do
-        expect { subject.send(method, String, 'blah') }.to raise_error NotImplementedError
+        expect { console.send(method, String, 'blah') }.to raise_error NotImplementedError
       end
     end
 
     ["hello", 1, 1.0].each do |input|
       it "should just return a #{input.inspect}" do
-        expect(subject.render(input)).to eq(input)
+        expect(console.render(input)).to eq(input)
       end
     end
 
     [true, false, nil, Object.new].each do |input|
       it "renders #{input.class} using PSON" do
-        expect(subject.render(input)).to eq(input.to_pson)
+        expect(console.render(input)).to eq(input.to_pson)
       end
     end
 
     [[1, 2], ["one"], [{ 1 => 1 }]].each do |input|
       it "should render #{input.inspect} as one item per line" do
-        expect(subject.render(input)).to eq(input.collect { |item| item.to_s + "\n" }.join(''))
+        expect(console.render(input)).to eq(input.collect { |item| item.to_s + "\n" }.join(''))
       end
     end
 
     it "should render empty hashes as empty strings" do
-      expect(subject.render({})).to eq('')
+      expect(console.render({})).to eq('')
     end
 
     it "should render a non-trivially-keyed Hash as pretty printed PSON" do
       hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-      expect(subject.render(hash)).to eq(PSON.pretty_generate(hash).chomp)
+      expect(console.render(hash)).to eq(PSON.pretty_generate(hash).chomp)
     end
 
     it "should render a {String,Numeric}-keyed Hash into a table" do
+      pson = Puppet::Network::FormatHandler.format(:pson)
       object = Object.new
       hash = { "one" => 1, "two" => [], "three" => {}, "four" => object,
         5 => 5, 6.0 => 6 }
 
       # Gotta love ASCII-betical sort order.  Hope your objects are better
       # structured for display than my test one is. --daniel 2011-04-18
-      expect(subject.render(hash)).to eq <<EOT
+      expect(console.render(hash)).to eq <<EOT
 5      5
 6.0    6
-four   #{json.render(object).chomp}
+four   #{pson.render(object).chomp}
 one    1
 three  {}
 two    []
@@ -323,7 +314,7 @@ EOT
         "number" => { "1" => '1' * 40, "2" => '2' * 40, '3' => '3' * 40 },
         "text"   => { "a" => 'a' * 40, 'b' => 'b' * 40, 'c' => 'c' * 40 }
       }
-      expect(subject.render(hash)).to eq <<EOT
+      expect(console.render(hash)).to eq <<EOT
 number  {"1"=>"1111111111111111111111111111111111111111",
          "2"=>"2222222222222222222222222222222222222222",
          "3"=>"3333333333333333333333333333333333333333"}

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -339,7 +339,7 @@ describe "Puppet Network Format" do
     it "fails intelligibly when given invalid data" do
       expect do
         json.intern(Puppet::Node, '')
-      end.to raise_error(JSON::ParserError, /A JSON text must at least contain two octets/)
+      end.to raise_error(JSON::ParserError, /A JSON text must at least contain two octets|unexpected token at ''/)
     end
   end
 

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -255,12 +255,12 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     it "uses the first supported format for the response" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
-      request = a_request_that_finds(data, :accept_header => "unknown, pson")
+      request = a_request_that_finds(data, :accept_header => "unknown, application/json")
 
       handler.call(request, response)
 
-      expect(response.body).to eq(data.render(:pson))
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
+      expect(response.body).to eq(data.render(:json))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
     end
 
     it "raises not_acceptable_error when no accept header is provided" do
@@ -286,18 +286,18 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     it "should pass the result through without rendering it if the result is a string" do
       data = Puppet::IndirectorTesting.new("my data")
       data_string = "my data string"
-      request = a_request_that_finds(data, :accept_header => "text/pson")
+      request = a_request_that_finds(data, :accept_header => "application/json")
       indirection.expects(:find).returns(data_string)
 
       handler.call(request, response)
 
       expect(response.body).to eq(data_string)
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
     end
 
     it "should raise not_found_error when no model instance can be found" do
       data = Puppet::IndirectorTesting.new("my data")
-      request = a_request_that_finds(data, :accept_header => "unknown, text/pson")
+      request = a_request_that_finds(data, :accept_header => "unknown, application/json")
 
       expect {
         handler.call(request, response)
@@ -309,25 +309,25 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     it "uses the first supported format for the response" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
-      request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "unknown, text/pson")
+      request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "unknown, application/json")
 
       handler.call(request, response)
 
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
-      expect(response.body).to eq(Puppet::IndirectorTesting.render_multiple(:pson, [data]))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
+      expect(response.body).to eq(Puppet::IndirectorTesting.render_multiple(:json, [data]))
     end
 
     it "should return [] when searching returns an empty array" do
-      request = a_request_that_searches(Puppet::IndirectorTesting.new("nothing"), :accept_header => "unknown, text/pson")
+      request = a_request_that_searches(Puppet::IndirectorTesting.new("nothing"), :accept_header => "unknown, application/json")
 
       handler.call(request, response)
 
       expect(response.body).to eq("[]")
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
     end
 
     it "should raise not_found_error when searching returns nil" do
-      request = a_request_that_searches(Puppet::IndirectorTesting.new("nothing"), :accept_header => "unknown, text/pson")
+      request = a_request_that_searches(Puppet::IndirectorTesting.new("nothing"), :accept_header => "unknown, application/json")
       indirection.expects(:search).returns(nil)
 
       expect {
@@ -347,26 +347,26 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(Puppet::IndirectorTesting.indirection.find("my data")).to be_nil
     end
 
-    it "responds with pson when no Accept header is given" do
+    it "responds with json when no Accept header is given" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_destroys(data, :accept_header => nil)
 
       handler.call(request, response)
 
-      expect(response.body).to eq(data.render(:pson))
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
+      expect(response.body).to eq(data.render(:json))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
     end
 
     it "uses the first supported format for the response" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
-      request = a_request_that_destroys(data, :accept_header => "unknown, text/pson")
+      request = a_request_that_destroys(data, :accept_header => "unknown, application/json")
 
       handler.call(request, response)
 
-      expect(response.body).to eq(data.render(:pson))
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
+      expect(response.body).to eq(data.render(:json))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
     end
 
     it "raises an error and does not destroy when no accepted formats are known" do
@@ -399,12 +399,8 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
 
       handler.call(request, response)
 
-      # PUP-3272 this test fails when yaml is removed and pson is used. Instead of returning an
-      # empty string, the a string '""' is returned - Don't know what the expecation is, if this is
-      # corrent or not.
-      # (helindbe)
-      #
-      expect(Puppet::IndirectorTesting.indirection.find("test").name).to eq('')
+      saved = Puppet::IndirectorTesting.indirection.find("test")
+      expect(saved.name).to eq('')
     end
 
     it "saves the data sent in the request" do
@@ -417,24 +413,24 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(saved.name).to eq(data.name)
     end
 
-    it "responds with pson when no Accept header is given" do
+    it "responds with json when no Accept header is given" do
       data = Puppet::IndirectorTesting.new("my data")
       request = a_request_that_submits(data, :accept_header => nil)
 
       handler.call(request, response)
 
-      expect(response.body).to eq(data.render(:pson))
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
+      expect(response.body).to eq(data.render(:json))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
     end
 
     it "uses the first supported format for the response" do
       data = Puppet::IndirectorTesting.new("my data")
-      request = a_request_that_submits(data, :accept_header => "unknown, text/pson")
+      request = a_request_that_submits(data, :accept_header => "unknown, application/json")
 
       handler.call(request, response)
 
-      expect(response.body).to eq(data.render(:pson))
-      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:pson))
+      expect(response.body).to eq(data.render(:json))
+      expect(response.type).to eq(Puppet::Network::FormatHandler.format(:json))
     end
 
     it "raises an error and does not save when no accepted formats are known" do

--- a/spec/unit/network/http/api/master/v3_spec.rb
+++ b/spec/unit/network/http/api/master/v3_spec.rb
@@ -41,7 +41,7 @@ describe Puppet::Network::HTTP::API::Master::V3 do
     request = Puppet::Network::HTTP::Request.
         from_hash(:path => "#{master_url_prefix}/node/foo",
                   :params => {:environment => "production"},
-                  :headers => {"accept" => "text/pson"})
+                  :headers => {"accept" => "application/json"})
     master_routes.process(request, response)
 
     expect(response.code).to eq(200)

--- a/spec/unit/network/http/api_spec.rb
+++ b/spec/unit/network/http/api_spec.rb
@@ -79,7 +79,7 @@ describe Puppet::Network::HTTP::API do
       it "responds to v3 indirector requests" do
         req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/v3/node/foo",
                                                        :params => {:environment => "production"},
-                                                       :headers => {'accept' => "pson"})
+                                                       :headers => {'accept' => "application/json"})
         res = {}
         handler.process(req, res)
         expect(res[:status]).to eq(200)

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -18,8 +18,8 @@ describe Puppet::Network::HTTP::Handler do
 
   def a_request(method = "HEAD", path = "/production/#{indirection.name}/unknown")
     {
-      :accept_header => "pson",
-      :content_type_header => "text/pson",
+      :accept_header => "application/json",
+      :content_type_header => "application/json",
       :method => method,
       :path => path,
       :params => {},
@@ -147,18 +147,17 @@ describe Puppet::Network::HTTP::Handler do
 
     # PUP-3272
     # This used to be for YAML, and doing a to_yaml on an array.
-    # The result with to_pson is something different, the result is a string
+    # The result with to_json is something different, the result is a string
     # Which seems correct. Looks like this was some kind of nesting option "yaml inside yaml" ?
     # Removing the test
-#    it "should deserialize PSON parameters" do
-#      params = {'my_param' => [1,2,3].to_pson}
+#    it "should deserialize JSON parameters" do
+#      params = {'my_param' => [1,2,3].to_json}
 #
 #      decoded_params = handler.send(:decode_params, params)
 #
 #      decoded_params.should == {:my_param => [1,2,3]}
 #    end
   end
-
 
   describe "when resolving node" do
     it "should use a look-up from the ip address" do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -55,14 +55,14 @@ describe Puppet::Node do
       end
     end
 
-    it "can round-trip through pson" do
+    it "can round-trip through json" do
       facts = Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar',
                               :classes => ['erth', 'aiu'],
                               :parameters => {"hostname"=>"food"}
                              )
-      new_node = Puppet::Node.convert_from('pson', node.render('pson'))
+      new_node = Puppet::Node.convert_from('json', node.render('json'))
       expect(new_node.environment).to eq(node.environment)
       expect(new_node.parameters).to eq(node.parameters)
       expect(new_node.classes).to eq(node.classes)
@@ -76,7 +76,7 @@ describe Puppet::Node do
                               :classes => ['erth', 'aiu'],
                               :parameters => {"hostname"=>"food"}
                              )
-      expect(node.to_pson).to validate_against('api/schemas/node.json')
+      expect(node.to_json).to validate_against('api/schemas/node.json')
     end
 
     it "when missing optional parameters validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
@@ -84,7 +84,7 @@ describe Puppet::Node do
       node = Puppet::Node.new("hello",
                               :environment => 'bar'
                              )
-      expect(node.to_pson).to validate_against('api/schemas/node.json')
+      expect(node.to_json).to validate_against('api/schemas/node.json')
     end
 
     it "should allow its environment parameter to be set by attribute after initialization" do
@@ -159,7 +159,7 @@ describe Puppet::Node do
   describe "when converting from json" do
     before do
       @node = Puppet::Node.new("mynode")
-      @format = Puppet::Network::FormatHandler.format('pson')
+      @format = Puppet::Network::FormatHandler.format('json')
     end
 
     def from_json(json)
@@ -167,22 +167,22 @@ describe Puppet::Node do
     end
 
     it "sets its name" do
-      expect(Puppet::Node).to read_json_attribute('name').from(@node.to_pson).as("mynode")
+      expect(Puppet::Node).to read_json_attribute('name').from(@node.to_json).as("mynode")
     end
 
     it "includes the classes if set" do
       @node.classes = %w{a b c}
-      expect(Puppet::Node).to read_json_attribute('classes').from(@node.to_pson).as(%w{a b c})
+      expect(Puppet::Node).to read_json_attribute('classes').from(@node.to_json).as(%w{a b c})
     end
 
     it "includes parameters if set" do
       @node.parameters = {"a" => "b", "c" => "d"}
-      expect(Puppet::Node).to read_json_attribute('parameters').from(@node.to_pson).as({"a" => "b", "c" => "d"})
+      expect(Puppet::Node).to read_json_attribute('parameters').from(@node.to_json).as({"a" => "b", "c" => "d"})
     end
 
     it "deserializes environment to environment_name as a string" do
       @node.environment = environment
-      expect(Puppet::Node).to read_json_attribute('environment_name').from(@node.to_pson).as('bar')
+      expect(Puppet::Node).to read_json_attribute('environment_name').from(@node.to_json).as('bar')
     end
   end
 end

--- a/spec/unit/relationship_spec.rb
+++ b/spec/unit/relationship_spec.rb
@@ -151,40 +151,40 @@ describe Puppet::Relationship, " when matching edges with a non-standard event" 
   end
 end
 
-describe Puppet::Relationship, "when converting to pson" do
+describe Puppet::Relationship, "when converting to json" do
   before do
     @edge = Puppet::Relationship.new(:a, :b, :event => :random, :callback => :whatever)
   end
 
   it "should store the stringified source as the source in the data" do
-    expect(PSON.parse(@edge.to_pson)["source"]).to eq("a")
+    expect(JSON.parse(@edge.to_json)["source"]).to eq("a")
   end
 
   it "should store the stringified target as the target in the data" do
-    expect(PSON.parse(@edge.to_pson)['target']).to eq("b")
+    expect(JSON.parse(@edge.to_json)['target']).to eq("b")
   end
 
-  it "should store the psonified event as the event in the data" do
-    expect(PSON.parse(@edge.to_pson)["event"]).to eq("random")
+  it "should store the jsonified event as the event in the data" do
+    expect(JSON.parse(@edge.to_json)["event"]).to eq("random")
   end
 
   it "should not store an event when none is set" do
     @edge.event = nil
-    expect(PSON.parse(@edge.to_pson)["event"]).to be_nil
+    expect(JSON.parse(@edge.to_json)["event"]).to be_nil
   end
 
-  it "should store the psonified callback as the callback in the data" do
+  it "should store the jsonified callback as the callback in the data" do
     @edge.callback = "whatever"
-    expect(PSON.parse(@edge.to_pson)["callback"]).to eq("whatever")
+    expect(JSON.parse(@edge.to_json)["callback"]).to eq("whatever")
   end
 
   it "should not store a callback when none is set in the edge" do
     @edge.callback = nil
-    expect(PSON.parse(@edge.to_pson)["callback"]).to be_nil
+    expect(JSON.parse(@edge.to_json)["callback"]).to be_nil
   end
 end
 
-describe Puppet::Relationship, "when converting from pson" do
+describe Puppet::Relationship, "when converting from json" do
   before do
     @event = "random"
     @callback = "whatever"
@@ -194,13 +194,13 @@ describe Puppet::Relationship, "when converting from pson" do
       "event" => @event,
       "callback" => @callback
     }
-    @pson = {
+    @json = {
       "type" => "Puppet::Relationship",
       "data" => @data
     }
   end
 
-  def pson_result_should
+  def json_result_should
     Puppet::Relationship.expects(:new).with { |*args| yield args }
   end
 

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -790,43 +790,43 @@ describe Puppet::Resource::Catalog, "when compiling" do
   end
 end
 
-describe Puppet::Resource::Catalog, "when converting a resource catalog to pson" do
+describe Puppet::Resource::Catalog, "when converting a resource catalog to json" do
   include JSONMatchers
   include PuppetSpec::Compiler
 
   it "should validate an empty catalog against the schema" do
     empty_catalog = compile_to_catalog("")
-    expect(empty_catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(empty_catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   it "should validate a noop catalog against the schema" do
     noop_catalog = compile_to_catalog("create_resources('file', {})")
-    expect(noop_catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(noop_catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   it "should validate a single resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('file', {'/etc/foo'=>{'ensure'=>'present'}})")
-    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   it "should validate a virtual resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('@file', {'/etc/foo'=>{'ensure'=>'present'}})\nrealize(File['/etc/foo'])")
-    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   it "should validate a single exported resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('@@file', {'/etc/foo'=>{'ensure'=>'present'}})")
-    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   it "should validate a single sensitive parameter resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('file', {'/etc/foo'=>{'ensure'=>'present','content'=>Sensitive('hunter2')}})")
-    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   it "should validate a two resource catalog against the schema" do
     catalog = compile_to_catalog("create_resources('notify', {'foo'=>{'message'=>'one'}, 'bar'=>{'message'=>'two'}})")
-    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   it "should validate a two parameter class catalog against the schema" do
@@ -842,7 +842,7 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         two => 'world',
       }
     MANIFEST
-    expect(catalog.to_pson).to validate_against('api/schemas/catalog.json')
+    expect(catalog.to_json).to validate_against('api/schemas/catalog.json')
   end
 
   context 'when dealing with parameters that have non-Data values' do
@@ -978,7 +978,7 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
   end
 end
 
-describe Puppet::Resource::Catalog, "when converting to pson" do
+describe Puppet::Resource::Catalog, "when converting to json" do
   before do
     @catalog = Puppet::Resource::Catalog.new("myhost")
   end
@@ -991,20 +991,20 @@ describe Puppet::Resource::Catalog, "when converting to pson" do
   }.each do |param, value|
     it "emits a #{param} equal to #{value.inspect}" do
       @catalog.send(param.to_s + "=", value)
-      pson = PSON.parse(@catalog.to_pson)
+      json = JSON.parse(@catalog.to_json)
 
-      expect(pson[param.to_s]).to eq(@catalog.send(param))
+      expect(json[param.to_s]).to eq(@catalog.send(param))
     end
   end
 
   it "emits an array of classes" do
     @catalog.add_class('foo')
-    pson = PSON.parse(@catalog.to_pson)
+    json = JSON.parse(@catalog.to_json)
 
-    expect(pson['classes']).to eq(['foo'])
+    expect(json['classes']).to eq(['foo'])
   end
 
-  it "should convert its resources to a PSON-encoded array and store it as the 'resources' data" do
+  it "should convert its resources to a JSON-encoded array and store it as the 'resources' data" do
     one = stub 'one', :to_data_hash => "one_resource", :ref => "Foo[one]"
     two = stub 'two', :to_data_hash => "two_resource", :ref => "Foo[two]"
 
@@ -1015,11 +1015,11 @@ describe Puppet::Resource::Catalog, "when converting to pson" do
     @catalog.add_resource(two)
 
     # TODO this should really guarantee sort order
-    expect(PSON.parse(@catalog.to_pson,:create_additions => false)['resources'].sort).to eq(["one_resource", "two_resource"].sort)
+    expect(JSON.parse(@catalog.to_json,:create_additions => false)['resources'].sort).to eq(["one_resource", "two_resource"].sort)
 
   end
 
-  it "should convert its edges to a PSON-encoded array and store it as the 'edges' data" do
+  it "should convert its edges to a JSON-encoded array and store it as the 'edges' data" do
     one   = stub 'one',   :to_data_hash => "one_resource",   :ref => 'Foo[one]'
     two   = stub 'two',   :to_data_hash => "two_resource",   :ref => 'Foo[two]'
     three = stub 'three', :to_data_hash => "three_resource", :ref => 'Foo[three]'
@@ -1027,14 +1027,14 @@ describe Puppet::Resource::Catalog, "when converting to pson" do
     @catalog.add_edge(one, two)
     @catalog.add_edge(two, three)
 
-    @catalog.edges_between(one, two  )[0].expects(:to_data_hash).returns "one_two_pson"
-    @catalog.edges_between(two, three)[0].expects(:to_data_hash).returns "two_three_pson"
+    @catalog.edges_between(one, two  )[0].expects(:to_data_hash).returns "one_two_json"
+    @catalog.edges_between(two, three)[0].expects(:to_data_hash).returns "two_three_json"
 
-    expect(PSON.parse(@catalog.to_pson,:create_additions => false)['edges'].sort).to eq(%w{one_two_pson two_three_pson}.sort)
+    expect(JSON.parse(@catalog.to_json,:create_additions => false)['edges'].sort).to eq(%w{one_two_json two_three_json}.sort)
   end
 end
 
-describe Puppet::Resource::Catalog, "when converting from pson" do
+describe Puppet::Resource::Catalog, "when converting from json" do
   before do
     @data = {
       'name' => "myhost"
@@ -1055,7 +1055,7 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
                           Puppet::Resource.new(:file, "/bar").to_data_hash]
 
 
-    catalog = Puppet::Resource::Catalog.from_data_hash PSON.parse @data.to_pson
+    catalog = Puppet::Resource::Catalog.from_data_hash JSON.parse @data.to_json
 
     expect(catalog.name).to eq('myhost')
     expect(catalog.version).to eq(@data['version'])
@@ -1074,7 +1074,7 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
   end
 
   it "defaults the catalog_format to 0" do
-    catalog = Puppet::Resource::Catalog.from_data_hash PSON.parse @data.to_pson
+    catalog = Puppet::Resource::Catalog.from_data_hash JSON.parse @data.to_json
     expect(catalog.catalog_format).to eq(0)
   end
 
@@ -1082,13 +1082,13 @@ describe Puppet::Resource::Catalog, "when converting from pson" do
     @data['edges'] = [Puppet::Relationship.new("File[/missing]", "File[/bar]").to_data_hash]
     @data['resources'] = [Puppet::Resource.new(:file, "/bar").to_data_hash]
 
-    expect { Puppet::Resource::Catalog.from_data_hash PSON.parse @data.to_pson }.to raise_error(ArgumentError, /Could not find relationship source/)
+    expect { Puppet::Resource::Catalog.from_data_hash JSON.parse @data.to_json }.to raise_error(ArgumentError, /Could not find relationship source/)
   end
 
   it "should fail if the target resource cannot be found" do
     @data['edges'] = [Puppet::Relationship.new("File[/bar]", "File[/missing]").to_data_hash]
     @data['resources'] = [Puppet::Resource.new(:file, "/bar").to_data_hash]
 
-    expect { Puppet::Resource::Catalog.from_data_hash PSON.parse @data.to_pson }.to raise_error(ArgumentError, /Could not find relationship target/)
+    expect { Puppet::Resource::Catalog.from_data_hash JSON.parse @data.to_json }.to raise_error(ArgumentError, /Could not find relationship target/)
   end
 end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -14,6 +14,11 @@ describe Puppet::Resource::Catalog, "when compiling" do
     Puppet::Util::Storage.stubs(:store)
   end
 
+  it "should support json, pson, dot, yaml" do
+    # msgpack is optional, so using include instead of eq
+    expect(Puppet::Resource::Catalog.supported_formats).to include(:json, :pson, :dot, :yaml)
+  end
+
   # audit only resources are unmanaged
   # as are resources without properties with should values
   it "should write its managed resources' types, namevars" do

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -43,7 +43,7 @@ describe Puppet::Resource::Type do
     end
 
     def double_convert
-      Puppet::Resource::Type.from_data_hash(PSON.parse(@type.to_pson))
+      Puppet::Resource::Type.from_data_hash(JSON.parse(@type.to_json))
     end
 
     it "should include the name and type" do
@@ -52,7 +52,7 @@ describe Puppet::Resource::Type do
     end
 
     it "should validate with only name and kind" do
-      expect(@type.to_pson).to validate_against('api/schemas/resource_type.json')
+      expect(@type.to_json).to validate_against('api/schemas/resource_type.json')
     end
 
     it "should validate with all fields set" do
@@ -62,7 +62,7 @@ describe Puppet::Resource::Type do
       @type.file = "/etc/manifests/thing.pp"
       @type.parent = "one::two"
 
-      expect(@type.to_pson).to validate_against('api/schemas/resource_type.json')
+      expect(@type.to_json).to validate_against('api/schemas/resource_type.json')
     end
 
     it "should include any arguments" do
@@ -72,7 +72,7 @@ describe Puppet::Resource::Type do
     end
 
     it "should not include arguments if none are present" do
-      expect(@type.to_pson["arguments"]).to be_nil
+      expect(@type.to_json["arguments"]).to be_nil
     end
 
     [:line, :doc, :file, :parent].each do |attr|
@@ -82,13 +82,13 @@ describe Puppet::Resource::Type do
       end
 
       it "should not include #{attr} when not set" do
-        expect(@type.to_pson[attr.to_s]).to be_nil
+        expect(@type.to_json[attr.to_s]).to be_nil
       end
     end
 
     it "should not include docs if they are empty" do
       @type.doc = ""
-      expect(@type.to_pson["doc"]).to be_nil
+      expect(@type.to_json["doc"]).to be_nil
     end
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -648,11 +648,11 @@ describe Puppet::Resource do
       expect(newresource).to equal_resource_attributes_of(@resource)
     end
 
-    # PUP-3272, since serialization to network is done in pson, not yaml
-    it "should produce an equivalent pson object" do
-      text = @resource.render('pson')
+    # PUP-3272, since serialization to network is done in json, not yaml
+    it "should produce an equivalent json object" do
+      text = @resource.render('json')
 
-      newresource = Puppet::Resource.convert_from('pson', text)
+      newresource = Puppet::Resource.convert_from('json', text)
       expect(newresource).to equal_resource_attributes_of(@resource)
     end
   end
@@ -672,10 +672,10 @@ describe Puppet::Resource do
       expect(@resource.to_yaml_properties).to_not include(:@rstype)
     end
 
-    it "produces an equivalent pson object" do
-      text = @resource.render('pson')
+    it "produces an equivalent json object" do
+      text = @resource.render('json')
 
-      newresource = Puppet::Resource.convert_from('pson', text)
+      newresource = Puppet::Resource.convert_from('json', text)
       expect(newresource).to equal_resource_attributes_of(@resource)
     end
   end
@@ -753,50 +753,50 @@ describe Puppet::Resource do
       HEREDOC
     end
   end
-  describe "when converting to pson" do
+  describe "when converting to json" do
     # LAK:NOTE For all of these tests, we convert back to the resource so we can
     # trap the actual data structure then.
 
     it "should set its type to the provided type" do
-      expect(Puppet::Resource.from_data_hash(PSON.parse(Puppet::Resource.new("File", "/foo").to_pson)).type).to eq("File")
+      expect(Puppet::Resource.from_data_hash(JSON.parse(Puppet::Resource.new("File", "/foo").to_json)).type).to eq("File")
     end
 
     it "should set its title to the provided title" do
-      expect(Puppet::Resource.from_data_hash(PSON.parse(Puppet::Resource.new("File", "/foo").to_pson)).title).to eq("/foo")
+      expect(Puppet::Resource.from_data_hash(JSON.parse(Puppet::Resource.new("File", "/foo").to_json)).title).to eq("/foo")
     end
 
     it "should include all tags from the resource" do
       resource = Puppet::Resource.new("File", "/foo")
       resource.tag("yay")
 
-      expect(Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson)).tags).to eq(resource.tags)
+      expect(Puppet::Resource.from_data_hash(JSON.parse(resource.to_json)).tags).to eq(resource.tags)
     end
 
     it "should include the file if one is set" do
       resource = Puppet::Resource.new("File", "/foo")
       resource.file = "/my/file"
 
-      expect(Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson)).file).to eq("/my/file")
+      expect(Puppet::Resource.from_data_hash(JSON.parse(resource.to_json)).file).to eq("/my/file")
     end
 
     it "should include the line if one is set" do
       resource = Puppet::Resource.new("File", "/foo")
       resource.line = 50
 
-      expect(Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson)).line).to eq(50)
+      expect(Puppet::Resource.from_data_hash(JSON.parse(resource.to_json)).line).to eq(50)
     end
 
     it "should include the 'exported' value if one is set" do
       resource = Puppet::Resource.new("File", "/foo")
       resource.exported = true
 
-      expect(Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson)).exported?).to be_truthy
+      expect(Puppet::Resource.from_data_hash(JSON.parse(resource.to_json)).exported?).to be_truthy
     end
 
     it "should set 'exported' to false if no value is set" do
       resource = Puppet::Resource.new("File", "/foo")
 
-      expect(Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson)).exported?).to be_falsey
+      expect(Puppet::Resource.from_data_hash(JSON.parse(resource.to_json)).exported?).to be_falsey
     end
 
     it "should set all of its parameters as the 'parameters' entry" do
@@ -804,37 +804,33 @@ describe Puppet::Resource do
       resource[:foo] = %w{bar eh}
       resource[:fee] = %w{baz}
 
-      result = Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson))
+      result = Puppet::Resource.from_data_hash(JSON.parse(resource.to_json))
       expect(result["foo"]).to eq(%w{bar eh})
       expect(result["fee"]).to eq(%w{baz})
     end
 
     it "should set sensitive parameters as an array of strings" do
       resource = Puppet::Resource.new("File", "/foo", :sensitive_parameters => [:foo, :fee])
-      result = PSON.parse(resource.to_pson)
+      result = JSON.parse(resource.to_json)
       expect(result["sensitive_parameters"]).to eq ["foo", "fee"]
     end
 
     it "should serialize relationships as reference strings" do
       resource = Puppet::Resource.new("File", "/foo")
       resource[:requires] = Puppet::Resource.new("File", "/bar")
-      result = Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson))
+      result = Puppet::Resource.from_data_hash(JSON.parse(resource.to_json))
       expect(result[:requires]).to eq("File[/bar]")
     end
 
     it "should serialize multiple relationships as arrays of reference strings" do
       resource = Puppet::Resource.new("File", "/foo")
       resource[:requires] = [Puppet::Resource.new("File", "/bar"), Puppet::Resource.new("File", "/baz")]
-      result = Puppet::Resource.from_data_hash(PSON.parse(resource.to_pson))
+      result = Puppet::Resource.from_data_hash(JSON.parse(resource.to_json))
       expect(result[:requires]).to eq([ "File[/bar]",  "File[/baz]" ])
     end
   end
 
-  describe "when converting from pson" do
-    def pson_result_should
-      Puppet::Resource.expects(:new).with { |hash| yield hash }
-    end
-
+  describe "when converting from json" do
     before do
       @data = {
         'type' => "file",
@@ -867,12 +863,12 @@ describe Puppet::Resource do
       expect(Puppet::Resource.from_data_hash(@data).line).to eq(50)
     end
 
-    it "should 'exported' to true if set in the pson data" do
+    it "should 'exported' to true if set in the json data" do
       @data['exported'] = true
       expect(Puppet::Resource.from_data_hash(@data).exported).to be_truthy
     end
 
-    it "should 'exported' to false if not set in the pson data" do
+    it "should 'exported' to false if not set in the json data" do
       expect(Puppet::Resource.from_data_hash(@data).exported).to be_falsey
     end
 

--- a/spec/unit/status_spec.rb
+++ b/spec/unit/status_spec.rb
@@ -15,15 +15,15 @@ describe Puppet::Status do
     expect(Puppet::Status.new.status["is_alive"]).to eq(true)
   end
 
-  it "should return a pson hash" do
-    expect(Puppet::Status.new.status.to_pson).to eq('{"is_alive":true}')
+  it "should return a json hash" do
+    expect(Puppet::Status.new.status.to_json).to eq('{"is_alive":true}')
   end
 
-  it "should render to a pson hash" do
-    expect(PSON::pretty_generate(Puppet::Status.new)).to match(/"is_alive":\s*true/)
+  it "should render to a json hash" do
+    expect(JSON::pretty_generate(Puppet::Status.new)).to match(/"is_alive":\s*true/)
   end
 
-  it "should accept a hash from pson" do
+  it "should accept a hash from json" do
     status = Puppet::Status.new( { "is_alive" => false } )
     expect(status.status).to eq({ "is_alive" => false })
   end
@@ -36,10 +36,10 @@ describe Puppet::Status do
     Puppet::Status.new.name = "status"
   end
 
-  it "serializes to PSON that conforms to the status schema" do
+  it "serializes to JSON that conforms to the status schema" do
     status = Puppet::Status.new
     status.version = Puppet.version
 
-    expect(status.render('pson')).to validate_against('api/schemas/status.json')
+    expect(status.render('json')).to validate_against('api/schemas/status.json')
   end
 end

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -485,7 +485,8 @@ describe Puppet::Transaction::Report do
   end
 
   it "supports both json, pson and yaml" do
-    expect(Puppet::Transaction::Report.supported_formats).to eq([:json, :pson, :yaml])
+    # msgpack is optional, so using include instead of eq
+    expect(Puppet::Transaction::Report.supported_formats).to include(:json, :pson, :yaml)
   end
 
   it "can make a round trip through pson" do

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -480,18 +480,26 @@ describe Puppet::Transaction::Report do
     end
   end
 
-  it "defaults to serializing to pson" do
-    expect(Puppet::Transaction::Report.default_format).to eq(:pson)
+  it "defaults to serializing to json" do
+    expect(Puppet::Transaction::Report.default_format).to eq(:json)
   end
 
-  it "supports both yaml and pson" do
-    expect(Puppet::Transaction::Report.supported_formats).to eq([:pson, :yaml])
+  it "supports both json, pson and yaml" do
+    expect(Puppet::Transaction::Report.supported_formats).to eq([:json, :pson, :yaml])
   end
 
   it "can make a round trip through pson" do
     report = generate_report
 
     tripped = Puppet::Transaction::Report.convert_from(:pson, report.render)
+
+    expect_equivalent_reports(tripped, report)
+  end
+
+  it "can make a round trip through json" do
+    report = generate_report
+
+    tripped = Puppet::Transaction::Report.convert_from(:json, report.render)
 
     expect_equivalent_reports(tripped, report)
   end

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -481,6 +481,8 @@ describe Puppet::Transaction::Report do
   end
 
   it "defaults to serializing to json" do
+    pending("PUP-7259 sending reports in JSON not yet supported")
+
     expect(Puppet::Transaction::Report.default_format).to eq(:json)
   end
 

--- a/spec/unit/util/tag_set_spec.rb
+++ b/spec/unit/util/tag_set_spec.rb
@@ -29,11 +29,11 @@ describe Puppet::Util::TagSet do
     expect(Puppet::Util::TagSet.from_yaml(array.to_yaml)).to eq(Puppet::Util::TagSet.new(array))
   end
 
-  it 'round trips through pson' do
+  it 'round trips through json' do
     array = ['a', 'b', 1, 5.4]
     set.merge(array)
 
-    tes = Puppet::Util::TagSet.from_data_hash(PSON.parse(set.to_pson))
+    tes = Puppet::Util::TagSet.from_data_hash(JSON.parse(set.to_json))
     expect(tes).to eq(set)
   end
 


### PR DESCRIPTION
The agent now supports JSON and PSON, and will prefer to receive JSON (catalog), but always send PSON (facts, reports). Later PRs will allow the agent to send facts and reports in JSON as well, as well as gracefully handle when the agent tries to send data in a format that the server doesn't accept (415).

PSON is deprecated in documentation only.

Remove `binary` as a supported format for models which don't actually support it, e.g. catalog. We use `binary` when transferring file content (both the file type and file buckets). We use `s` (aka `text/plain`) for certificate related  PEM files. And for all others we support `json, pson, yaml`, where `yaml` is excluded for REST requests. Additionally, if msgpack is enabled, then it only affects the third "generic" bucket (and will have a higher precedence than json). The complete list of models and supported formats (excluding msgpack) is:

```
$ bundle exec irb
irb(main):001:0> require 'puppet'
true
irb(main):002:0> ObjectSpace.enum_for(:each_object).select do |obj| obj.respond_to?(:supported_formats) end.each do |obj| puts "OBJ: #{obj}"; puts "  #{obj.supported_formats}" end
OBJ: Puppet::Transaction::Event
  [:json, :pson, :yaml]
OBJ: Puppet::Util::Log
  [:json, :pson, :yaml]
OBJ: Puppet::Util::TagSet
  [:json, :pson, :yaml]
OBJ: Puppet::Resource::Catalog
  [:json, :pson, :yaml, :dot]
OBJ: Puppet::SSL::Host
  [:json, :pson, :yaml]
OBJ: Puppet::FileBucket::File
  [:binary]
OBJ: Puppet::SSL::Key
  [:s]
OBJ: Puppet::Node::Facts
  [:json, :pson, :yaml]
OBJ: Puppet::Relationship
  [:json, :pson, :yaml]
OBJ: Puppet::SSL::CertificateRevocationList
  [:s]
OBJ: Puppet::Resource::Type
  [:json, :pson, :yaml]
OBJ: Puppet::Status
  [:json, :pson, :yaml]
OBJ: Puppet::Resource
  [:json, :pson, :yaml]
OBJ: Puppet::Util::Metric
  [:json, :pson, :yaml]
OBJ: Puppet::Node
  [:json, :pson, :yaml]
OBJ: Puppet::SSL::Certificate
  [:s]
OBJ: Puppet::DataBinding
  [:yaml]
OBJ: Puppet::Transaction::Report
  [:json, :pson, :yaml]
OBJ: Puppet::Parser::Resource
  [:json, :pson, :yaml]
OBJ: Puppet::Resource::Status
  [:json, :pson, :yaml]
OBJ: Puppet::SSL::CertificateRequest
  [:s]
```

`DataBinding` only supports `yaml` because it doesn't implement the `from_data_hash` methods needed to support `json`, etc. It's not clear why that is.

Bump hiera minimum version to 3.2.1 to eliminate pure_json dependency