### PR TITLE
(PUP-7423) Make Pcore loader available for relevant CLI commands

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -177,8 +177,11 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
     else
       text = Puppet::FileSystem.read(options[:catalog], :encoding => 'utf-8')
     end
-    catalog = read_catalog(text)
-    apply_catalog(catalog)
+    env = Puppet.lookup(:environments).get(Puppet[:environment])
+    Puppet.override(:current_environment => env, :loaders => Puppet::Pops::Loaders.new(env)) do
+      catalog = read_catalog(text)
+      apply_catalog(catalog)
+    end
   end
 
   def main
@@ -269,7 +272,7 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
           catalog.write_resource_file
         end
 
-        exit_status = apply_catalog(catalog)
+        exit_status = Puppet.override(:loaders => Puppet::Pops::Loaders.new(apply_environment)) { apply_catalog(catalog) }
 
         if not exit_status
           exit(1)

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -279,6 +279,15 @@ describe Puppet::Application::Apply do
         expect { @apply.main }.to exit_with 0
       end
 
+      it 'should make the Puppet::Pops::Loaders available when applying the compiled catalog' do
+        Puppet::Resource::Catalog.indirection.expects(:find).returns(@catalog)
+        @apply.expects(:apply_catalog).with(@catalog) do
+          fail('Loaders not found') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
+          true
+        end.returns(0)
+        expect { @apply.main }.to exit_with 0
+      end
+
       it "should transform the catalog to ral" do
 
         @catalog.expects(:to_ral).returns(@catalog)
@@ -458,6 +467,20 @@ describe Puppet::Application::Apply do
           with(:catalog => "mycatalog", :pluginsync => false)
 
         @apply.apply
+      end
+
+      it 'should make the Puppet::Pops::Loaders available when applying a catalog' do
+        @apply.options[:catalog] = temporary_catalog
+        catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
+        @apply.expects(:read_catalog).with('something') do
+          fail('Loaders not found') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
+          true
+        end.returns(catalog)
+        @apply.expects(:apply_catalog).with(catalog) do
+          fail('Loaders not found') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
+          true
+        end
+        expect { @apply.apply }.not_to raise_error
       end
     end
   end

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -360,6 +360,14 @@ describe Puppet::Application::Device do
         expect { @device.main }.to exit_with 0
       end
 
+      it "should make the Puppet::Pops::Loaaders available" do
+        @configurer.expects(:run).with(:network_device => true, :pluginsync => true) do
+          fail('Loaders not available') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
+          true
+        end.at_least_once.returns(6,2)
+        expect { @device.main }.to exit_with 0
+      end
+
       it "exits 2 when --detailed-exitcodes and successful runs" do
         @device.options.stubs(:[]).with(:detailed_exitcodes).returns(true)
         @configurer.stubs(:run).returns(0,2)

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -154,4 +154,21 @@ describe Puppet::Application::Resource do
       @resource_app.main
     end
   end
+
+  describe 'when handling a custom type' do
+    it 'the Puppet::Pops::Loaders instance is available' do
+      Puppet::Type.newtype(:testing) do
+        newparam(:name) do
+          isnamevar
+        end
+        def self.instances
+          fail('Loader not found') unless Puppet::Pops::Loaders.find_loader(nil).is_a?(Puppet::Pops::Loader::Loader)
+          @instances ||= [new(:name => name)]
+        end
+      end
+      @resource_app.command_line.stubs(:args).returns(['testing', 'hello'])
+      @resource_app.expects(:puts).with { |args| expect(args).to eql("testing { 'hello':\n}") }
+      expect { @resource_app.main }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This PR ensures that a `Puppet::Pops::Loaders` instance is created and adapted to the current environment when executing the `apply`, `device` or `resource` command. This enables subsequent ruby code to access the instance and load Pcore types dynamically.