### PR TITLE
(DO NOT MERGE)(maint) Set BUNDLE_SPECIFIC_PLATFORM=true

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
+# default for Bundler 2.0 - see issues:
+# https://github.com/bundler/bundler/issues/5339
+# https://github.com/bundler/bundler/issues/5536
+# without this variable set, Bundler issues a message like:
+# Unable to use the platform-specific (universal-darwin) version of facter (2.4.6) because it has different dependencies
+#  from the  version. To use the platform-specific version of the gem, run `bundle config specific_platform true` and
+#  install again.
+ENV['BUNDLE_SPECIFIC_PLATFORM'] = 'true' unless ENV.has_key?('BUNDLE_SPECIFIC_PLATFORM')
 
 def location_for(place, fake_version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/


### PR DESCRIPTION
**This might be one to outright close, but note that without it we're not using platform-specific Facter which depends on CFPropertyList**

 - Bundler, under some circumstances, may not install platform-specific
   gems.  For instance, using a bundle install of the Puppet Gemfile
   will not install the universal-darwin version of Facter.

 - Set the environment variable BUNDLE_SPECIFIC_PLATFORM also
   had to be set to properly use platform-specific versions of any
   gems that have been referenced.  This will be the default behavior
   in Bundler 2, and given platform-specific versions of Facter are
   shipped - should always be the case for Puppet. Without setting
   this Bundler will raise a warning during installation.