### PR TITLE
(PUP-7009) Fix Windows ci:test:git

### DIFF
--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -1,5 +1,5 @@
 {
-  :type                        => 'foss',
+  :type                        => :git,
   :install                     => [
     'puppet',
   ],

--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -112,7 +112,8 @@ hosts.each do |host|
 
     step "#{host} Install ruby from git using revision #{revision}"
     # TODO remove this step once we are installing puppet from msi packages
-    install_from_git_on(host, "/opt/puppet-git-repos",
+    win_path = on(host, 'cygpath -m /opt/puppet-git-repos').stdout.chomp
+    install_from_git_on(host, win_path,
                      :name => 'puppet-win32-ruby',
                      :path => build_git_url('puppet-win32-ruby'),
                      :rev  => revision)


### PR DESCRIPTION
Depends on #5779 


 - This builds on top of changes that were necessary to make a
   Bundler workflow behave properly with a Gemfile that references
   the Puppet source as a gem via git repo / SHA - see PUP-7425
   for details on that problem

 - With changes to host images so that the Git package is installed
   rather than using the problematic Cygwin git, passing Cygwin
   style paths like /opt/puppet-git-repos now are considered to be
   regular style Windows paths. This would result in puppet-win32-ruby
   being cloned to c:\opt\puppet-git-repos rather than the path that
   Cygwin maps /opt/puppet-git-repos to, which would cause issue with
   later steps inside Cygwin.

 - Also fixed a few issues with the Gemfile approach:

   * Bundler supports binstubs, but they use Cygwin style paths
     inside the shebang.  While this does resolve correctly when
     launching from Cygwin, since the Ruby is not a Cygwin based Ruby
     it doesn't understand the Cygwin style path thats being sent to
     the interpreter.

     This is not an issue for Beaker runs as the helpers run batch
     files through cmd.exe rather than executing binstubs inside Cygwin.

     Left some inline docs about fixing this problem in an interactive
     SSH session by creating aliases that launch .bat files through
     cmd.exe rather than their Cygwin counterparts which rely on the
     shebang. This can allows for commands `gem`, `puppet` and `facter`
     to work seamlessly in both Cygwin and under cmd.exe
   * When Bundler installs Puppet from gem, it properly writes the
     binstub Ruby wrapper, but fails to write the `puppet.bat` as it
     does for other gems which have binaries (like Facter). Since all
     batch files are the same shim, copy `facter.bat` over to
     `puppet.bat`
   * As mentioned, PUP-7425 addresses a problem where gems not
     explicitly referenced in a .gemspec are unable to be found.
     Previously, the Bundler written .gemspec for Puppet did not
     reference win32-service, win32-eventlog, win32-process or
     minitar, which could cause problems when trying to load Puppet
     or use some of its functionality. Only the gems win32-dir,
     win32-security and ffi were able to be loaded as Facter
     transitively depended on them. While there might have been
     another workaround, the refactor of Gemfile / .gemspec seemed
     the most sensible.

- Previous iterations of ci:test:git used the packaging helpers inside
   of install.rb to write additional files / directories.

   On Windows, install.rb is also responsible for laying down
   puppetres.dll, the resource DLL used in event log messages.