### PR TITLE
(PUP-7256) Use JSON to render console format

### DIFF
--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -30,11 +30,7 @@ class Puppet::Application::FaceBase < Puppet::Application
   attr_accessor :face, :action, :type, :arguments, :render_as
 
   def render_as=(format)
-    if format == :json then
-      @render_as = Puppet::Network::FormatHandler.format(:pson)
-    else
-      @render_as = Puppet::Network::FormatHandler.format(format)
-    end
+    @render_as = Puppet::Network::FormatHandler.format(format)
     @render_as or raise ArgumentError, _("I don't know how to render '%{format}'") % { format: format }
   end
 

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -309,9 +309,8 @@ Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
 
     # Format defaults to text (:s) when producing an explanation and :yaml when producing the value
     format = options[:render_as] || (explain ? :s : :yaml)
-    renderer = Puppet::Network::FormatHandler.format(format == :json ? :pson : format)
+    renderer = Puppet::Network::FormatHandler.format(format)
     raise _("Unknown rendering format '%{format}'") % { format: format } if renderer.nil?
-
 
     generate_scope do |scope|
       lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, explain ? Puppet::Pops::Lookup::Explainer.new(explain_options, only_explain_options) : nil)

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -172,7 +172,7 @@ Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
         raise _("Could not compile catalog for %{node}") % { node: options[:node] }
       end
 
-      puts PSON::pretty_generate(catalog.to_resource, :allow_nan => true, :max_nesting => false)
+      puts JSON::pretty_generate(catalog.to_resource, :allow_nan => true, :max_nesting => false)
     rescue => detail
       Puppet.log_exception(detail, _("Failed to compile catalog for node %{node}: %{detail}") % { node: options[:node], detail: detail })
       exit(30)

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -135,9 +135,8 @@ module Puppet::ModuleTool
           f.write(metadata.to_json)
         end
 
-        # PSON.pretty_generate is a BINARY string
         Puppet::FileSystem.open(File.join(build_path, 'checksums.json'), nil, 'wb') do |f|
-          f.write(PSON.pretty_generate(Checksums.new(build_path)))
+          f.write(JSON.pretty_generate(Checksums.new(build_path)))
         end
       end
 

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -132,16 +132,14 @@ Puppet::Network::FormatHandler.create(:console,
                                       :mime   => 'text/x-console-text',
                                       :weight => 0) do
   def json
-    @json ||= Puppet::Network::FormatHandler.format(:pson)
+    @json ||= Puppet::Network::FormatHandler.format(:json)
   end
 
   def render(datum)
-    # String to String
-    return datum if datum.is_a? String
-    return datum if datum.is_a? Numeric
+    return datum if datum.is_a?(String) || datum.is_a?(Numeric)
 
     # Simple hash to table
-    if datum.is_a? Hash and datum.keys.all? { |x| x.is_a? String or x.is_a? Numeric }
+    if datum.is_a?(Hash) && datum.keys.all? { |x| x.is_a?(String) || x.is_a?(Numeric) }
       output = ''
       column_a = datum.empty? ? 2 : datum.map{ |k,v| k.to_s.length }.max + 2
       datum.sort_by { |k,v| k.to_s } .each do |key, value|
@@ -164,7 +162,7 @@ Puppet::Network::FormatHandler.create(:console,
     end
 
     # ...or pretty-print the inspect outcome.
-    return PSON.pretty_generate(datum)
+    JSON.pretty_generate(datum, :quirks_mode => true)
   end
 
   def render_multiple(data)

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -341,9 +341,9 @@ describe Puppet::Application::FaceBase do
         end
       end
 
-      it "should render a non-trivially-keyed Hash with using pretty printed PSON" do
+      it "should render a non-trivially-keyed Hash with using pretty printed JSON" do
         hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-        expect(app.render(hash, {})).to eq(PSON.pretty_generate(hash).chomp)
+        expect(app.render(hash, {})).to eq(JSON.pretty_generate(hash).chomp)
       end
 
       it "should render a {String,Numeric}-keyed Hash into a table" do
@@ -356,7 +356,7 @@ describe Puppet::Application::FaceBase do
         expect(app.render(hash, {})).to eq <<EOT
 5      5
 6.0    6
-four   #{object.to_pson.chomp}
+four   #{object.to_json.chomp}
 one    1
 three  {}
 two    []
@@ -406,7 +406,7 @@ EOT
         json = app.render({ :one => 1, :two => 2 }, {})
         expect(json).to match(/"one":\s*1\b/)
         expect(json).to match(/"two":\s*2\b/)
-        expect(PSON.parse(json)).to eq({ "one" => 1, "two" => 2 })
+        expect(JSON.parse(json)).to eq({ "one" => 1, "two" => 2 })
       end
     end
 
@@ -421,8 +421,8 @@ EOT
       expect { app.run }.to exit_with(1)
     end
 
-    it "should work if asked to render a NetworkHandler format" do
-      app.command_line.stubs(:args).returns %w{count_args a b c --render-as pson}
+    it "should work if asked to render json" do
+      app.command_line.stubs(:args).returns %w{count_args a b c --render-as json}
       expect {
         expect { app.run }.to exit_with(0)
       }.to have_printed(/3/)

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -244,15 +244,15 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
         expect { @master.compile }.to exit_with 0
       end
 
-      it "should convert the catalog to a pure-resource catalog and use 'PSON::pretty_generate' to pretty-print the catalog" do
+      it "should convert the catalog to a pure-resource catalog and use 'JSON::pretty_generate' to pretty-print the catalog" do
         catalog = Puppet::Resource::Catalog.new
-        PSON.stubs(:pretty_generate)
+        JSON.stubs(:pretty_generate)
         Puppet::Resource::Catalog.indirection.expects(:find).returns catalog
 
         catalog.expects(:to_resource).returns("rescat")
 
         @master.options[:node] = "foo"
-        PSON.expects(:pretty_generate).with('rescat', :allow_nan => true, :max_nesting => false)
+        JSON.expects(:pretty_generate).with('rescat', :allow_nan => true, :max_nesting => false)
 
         expect { @master.compile }.to exit_with 0
       end

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -378,42 +378,64 @@ describe "Puppet Network Format" do
       end
     end
 
-    ["hello", 1, 1.0].each do |input|
-      it "should just return a #{input.inspect}" do
-        expect(console.render(input)).to eq(input)
+    context "when rendering ruby types" do
+      ["hello", 1, 1.0].each do |input|
+        it "should just return a #{input.inspect}" do
+          expect(console.render(input)).to eq(input)
+        end
+      end
+
+      { true  => "true",
+        false => "false",
+        nil   => "null",
+      }.each_pair do |input, output|
+        it "renders #{input.class} as '#{output}'" do
+          expect(console.render(input)).to eq(output)
+        end
+      end
+
+      it "renders an Object as its quoted inspect value" do
+        obj = Object.new
+        expect(console.render(obj)).to eq("\"#{obj.inspect}\"")
       end
     end
 
-    [true, false, nil, Object.new].each do |input|
-      it "renders #{input.class} using PSON" do
-        expect(console.render(input)).to eq(input.to_pson)
+    context "when rendering arrays" do
+      {
+        []                => "",
+        [1, 2]            => "1\n2\n",
+        ["one"]           => "one\n",
+        [{1 => 1}]        => "{1=>1}\n",
+        [[1, 2], [3, 4]]  => "[1, 2]\n[3, 4]\n"
+      }.each_pair do |input, output|
+        it "should render #{input.inspect} as one item per line" do
+          expect(console.render(input)).to eq(output)
+        end
       end
     end
 
-    [[1, 2], ["one"], [{ 1 => 1 }]].each do |input|
-      it "should render #{input.inspect} as one item per line" do
-        expect(console.render(input)).to eq(input.collect { |item| item.to_s + "\n" }.join(''))
+    context "when rendering hashes" do
+      {
+        {}                                   => "",
+        {1 => 2}                             => "1  2\n",
+        {"one" => "two"}                     => "one  \"two\"\n", # odd that two is quoted but one isn't
+        {[1,2] => 3, [2,3] => 5, [3,4] => 7} => "{\n  \"[1, 2]\": 3,\n  \"[2, 3]\": 5,\n  \"[3, 4]\": 7\n}",
+        {{1 => 2} => {3 => 4}}               => "{\n  \"{1=>2}\": {\n    \"3\": 4\n  }\n}"
+      }.each_pair do |input, output|
+        it "should render #{input.inspect}" do
+          expect(console.render(input)).to eq(output)
+        end
       end
-    end
 
-    it "should render empty hashes as empty strings" do
-      expect(console.render({})).to eq('')
-    end
+      it "should render a {String,Numeric}-keyed Hash into a table" do
+        pson = Puppet::Network::FormatHandler.format(:pson)
+        object = Object.new
+        hash = { "one" => 1, "two" => [], "three" => {}, "four" => object, 5 => 5,
+                 6.0 => 6 }
 
-    it "should render a non-trivially-keyed Hash as pretty printed PSON" do
-      hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-      expect(console.render(hash)).to eq(PSON.pretty_generate(hash).chomp)
-    end
-
-    it "should render a {String,Numeric}-keyed Hash into a table" do
-      pson = Puppet::Network::FormatHandler.format(:pson)
-      object = Object.new
-      hash = { "one" => 1, "two" => [], "three" => {}, "four" => object,
-        5 => 5, 6.0 => 6 }
-
-      # Gotta love ASCII-betical sort order.  Hope your objects are better
-      # structured for display than my test one is. --daniel 2011-04-18
-      expect(console.render(hash)).to eq <<EOT
+        # Gotta love ASCII-betical sort order.  Hope your objects are better
+        # structured for display than my test one is. --daniel 2011-04-18
+        expect(console.render(hash)).to eq <<EOT
 5      5
 6.0    6
 four   #{pson.render(object).chomp}
@@ -421,15 +443,15 @@ one    1
 three  {}
 two    []
 EOT
-    end
+      end
 
-    it "should render a hash nicely with a multi-line value" do
-      pending "Moving to PSON rather than PP makes this unsupportable."
-      hash = {
-        "number" => { "1" => '1' * 40, "2" => '2' * 40, '3' => '3' * 40 },
-        "text"   => { "a" => 'a' * 40, 'b' => 'b' * 40, 'c' => 'c' * 40 }
-      }
-      expect(console.render(hash)).to eq <<EOT
+      it "should render a hash nicely with a multi-line value" do
+        pending "Moving to PSON rather than PP makes this unsupportable."
+        hash = {
+          "number" => { "1" => '1' * 40, "2" => '2' * 40, '3' => '3' * 40 },
+          "text"   => { "a" => 'a' * 40, 'b' => 'b' * 40, 'c' => 'c' * 40 }
+        }
+        expect(console.render(hash)).to eq <<EOT
 number  {"1"=>"1111111111111111111111111111111111111111",
          "2"=>"2222222222222222222222222222222222222222",
          "3"=>"3333333333333333333333333333333333333333"}
@@ -437,6 +459,45 @@ text    {"a"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
          "b"=>"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
          "c"=>"cccccccccccccccccccccccccccccccccccccccc"}
 EOT
+      end
+    end
+
+    context "when rendering face-related objects" do
+      it "pretty prints facts" do
+        tm = Time.new("2016-01-27T19:30:00")
+        values = {
+          "architecture" =>  "x86_64",
+          "os" => {
+            "release" => {
+              "full" => "15.6.0"
+            }
+          },
+          "system_uptime" => {
+            "seconds" => 505532
+          }
+        }
+        facts = Puppet::Node::Facts.new("foo", values)
+        facts.timestamp = tm
+
+        # For some reason, render omits the last newline, seems like a bug
+        expect(console.render(facts)).to eq(<<EOT.chomp)
+{
+  "name": "foo",
+  "values": {
+    "architecture": "x86_64",
+    "os": {
+      "release": {
+        "full": "15.6.0"
+      }
+    },
+    "system_uptime": {
+      "seconds": 505532
+    }
+  },
+  "timestamp": "#{tm.iso8601(9)}"
+}
+EOT
+      end
     end
   end
 end

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -444,22 +444,6 @@ three  {}
 two    []
 EOT
       end
-
-      it "should render a hash nicely with a multi-line value" do
-        pending "Moving to PSON rather than PP makes this unsupportable."
-        hash = {
-          "number" => { "1" => '1' * 40, "2" => '2' * 40, '3' => '3' * 40 },
-          "text"   => { "a" => 'a' * 40, 'b' => 'b' * 40, 'c' => 'c' * 40 }
-        }
-        expect(console.render(hash)).to eq <<EOT
-number  {"1"=>"1111111111111111111111111111111111111111",
-         "2"=>"2222222222222222222222222222222222222222",
-         "3"=>"3333333333333333333333333333333333333333"}
-text    {"a"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-         "b"=>"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-         "c"=>"cccccccccccccccccccccccccccccccccccccccc"}
-EOT
-      end
     end
 
     context "when rendering face-related objects" do

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -428,7 +428,7 @@ describe "Puppet Network Format" do
       end
 
       it "should render a {String,Numeric}-keyed Hash into a table" do
-        pson = Puppet::Network::FormatHandler.format(:pson)
+        json = Puppet::Network::FormatHandler.format(:json)
         object = Object.new
         hash = { "one" => 1, "two" => [], "three" => {}, "four" => object, 5 => 5,
                  6.0 => 6 }
@@ -438,7 +438,7 @@ describe "Puppet Network Format" do
         expect(console.render(hash)).to eq <<EOT
 5      5
 6.0    6
-four   #{pson.render(object).chomp}
+four   #{json.render(object).chomp}
 one    1
 three  {}
 two    []


### PR DESCRIPTION
* Add missing tests for the console format
* Use JSON instead of PSON to pretty print
* Use JSON instead of PSON when rendering console output for face-based applications



