### PR TITLE
(PUP-7429) Change default string format for Regexp

### DIFF
--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -635,7 +635,7 @@ Defaults to `s` at top level and `p` inside array or hash.
 
 | Format    | Regexp Formats
 | ----      | --------------
-| s         | Delimiters `/ /`, alternate flag `#` replaces `/` delimiters with quotes.
+| s         | No delimiters, quoted if alternative flag `#` is used.
 | p         | Delimiters `/ /`.
 
 ### Undef to String

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -775,6 +775,19 @@ Accepts a single value as argument:
 Conversion to a `Struct` works exactly as conversion to a `Hash`, only that the constructed hash is
 asserted against the given struct type.
 
+Conversion to a Regexp
+---
+A `String` can be converted into a `Regexp`
+
+**Example**: Converting a String into a Regexp
+```puppet
+$s = '[a-z]+\.com'
+$r = Regexp($s)
+if('foo.com' =~ $r) {
+  ...
+}
+```
+
 Creating a SemVer
 ---
 

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -840,9 +840,9 @@ class StringConverter
     when :p
       Kernel.format(f.orig_fmt, val)
     when :s
-      str_regexp = val.inspect
-      str_regexp = f.alt? ? "\"#{str_regexp[1..-2]}\"" : str_regexp
-      Kernel.format(f.orig_fmt, str_regexp)
+      str_regexp = val.options == 0 ? val.source : val.to_s
+      str_regexp = puppet_quote(str_regexp) if f.alt?
+      f.orig_fmt == '%s' ? str_regexp : Kernel.format(f.orig_fmt, str_regexp)
     else
       raise FormatError.new('Regexp', f.format, 'rsp')
     end

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -844,7 +844,7 @@ class StringConverter
       str_regexp = puppet_quote(str_regexp) if f.alt?
       f.orig_fmt == '%s' ? str_regexp : Kernel.format(f.orig_fmt, str_regexp)
     else
-      raise FormatError.new('Regexp', f.format, 'rsp')
+      raise FormatError.new('Regexp', f.format, 'sp')
     end
   end
 

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -838,7 +838,9 @@ class StringConverter
     f = get_format(val_type, format_map)
     case f.format
     when :p
-      Kernel.format(f.orig_fmt, val)
+      str_regexp = '/'
+      str_regexp << (val.options == 0 ? val.source : val.to_s) << '/'
+      f.orig_fmt == '%p' ? str_regexp : Kernel.format(f.orig_fmt.gsub('p', 's'), str_regexp)
     when :s
       str_regexp = val.options == 0 ? val.source : val.to_s
       str_regexp = puppet_quote(str_regexp) if f.alt?

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1555,6 +1555,22 @@ class PRegexpType < PScalarType
         KEY_VALUE => nil
       })
   end
+
+
+  # Returns a new function that produces a Regexp instance
+  #
+  def self.new_function(_, loader)
+    @new_function ||= Puppet::Functions.create_loaded_function(:new_float, loader) do
+      dispatch :from_string do
+        param 'String', :pattern
+      end
+
+      def from_string(pattern)
+        Regexp.new(pattern)
+      end
+    end
+  end
+
   attr_reader :pattern
 
   def initialize(pattern)

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -875,19 +875,19 @@ describe 'The string converter' do
   end
 
   context 'when converting regexp' do
-    it 'the default string representation is /regexp/' do
-      expect(converter.convert(/.*/, :default)).to eq('/.*/')
+    it 'the default string representation is "regexp"' do
+      expect(converter.convert(/.*/, :default)).to eq('.*')
     end
 
-    { "%s"   => '/.*/',
-      "%6s"  => '  /.*/',
-      "%.2s" => '/.',
-      "%-6s" => '/.*/  ',
+    { "%s"   => '.*',
+      "%6s"  => '    .*',
+      "%.1s" => '.',
+      "%-6s" => '.*    ',
       "%p"   => '/.*/',
       "%6p"  => '  /.*/',
       "%-6p" => '/.*/  ',
       "%.2p" => '/.',
-      "%#s"  => '".*"',
+      "%#s"  => "'.*'",
       "%#p"  => '/.*/',
     }.each do |fmt, result |
       it "the format #{fmt} produces #{result}" do

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -900,7 +900,7 @@ describe 'The string converter' do
       expect do
       string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => "%k"}
       converter.convert(/.*/, string_formats)
-      end.to raise_error(/Illegal format 'k' specified for value of Regexp type - expected one of the characters 'rsp'/)
+      end.to raise_error(/Illegal format 'k' specified for value of Regexp type - expected one of the characters 'sp'/)
     end
   end
 

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -888,11 +888,23 @@ describe 'The string converter' do
       "%-6p" => '/.*/  ',
       "%.2p" => '/.',
       "%#s"  => "'.*'",
-      "%#p"  => '/.*/',
+      "%#p"  => '/.*/'
     }.each do |fmt, result |
       it "the format #{fmt} produces #{result}" do
         string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => fmt}
         expect(converter.convert(/.*/, string_formats)).to eq(result)
+      end
+    end
+
+    context 'that contains flags' do
+      it 'the format %s produces \'(?m-ix:[a-z]\s*)\' for expression /[a-z]\s*/m' do
+        string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%s'}
+        expect(converter.convert(/[a-z]\s*/m, string_formats)).to eq('(?m-ix:[a-z]\s*)')
+      end
+
+      it 'the format %p produces \'/(?m-ix:[a-z]\s*)/\' for expression /[a-z]\s*/m' do
+        string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
+        expect(converter.convert(/[a-z]\s*/m, string_formats)).to eq('/(?m-ix:[a-z]\s*)/')
       end
     end
 

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -558,6 +558,12 @@ describe 'Puppet Type System' do
       expect(func_class).to be_a(Class)
       expect(func_class.superclass).to be(Puppet::Functions::Function)
     end
+
+    it 'Regexp' do
+      func_class = tf.regexp.new_function(loader)
+      expect(func_class).to be_a(Class)
+      expect(func_class.superclass).to be(Puppet::Functions::Function)
+    end
   end
 
   context 'instantiation via new_function is not supported by' do
@@ -581,6 +587,11 @@ describe 'Puppet Type System' do
     it 'is supported by Integer' do
       int = tf.integer.create('32')
       expect(int).to eq(32)
+    end
+
+    it 'is supported by Regexp' do
+      rx = tf.regexp.create('[a-z]+')
+      expect(rx).to eq(/[a-z]+/)
     end
 
     it 'is supported by Optional[Integer]' do


### PR DESCRIPTION
This PR changes the default string format (the '%s' format) so that
a formatted regexp results in a string that isn't delimited with
slashes.

The reason for the change is that the slashes are language specific, and
as such, should be produced using the '%p' format (which they already
are). The '%s' format should produce a language agnostic representation
that is suitable to pass to the Regexp constructor.