### PR TITLE
Make DragonFly BSD work out of the box

### DIFF
--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
 
   commands :pkgin => "pkgin"
 
-  defaultfor :operatingsystem => [ :dragonfly , :smartos, :netbsd ]
+  defaultfor :operatingsystem => [ :smartos, :netbsd ]
 
   has_feature :installable, :uninstallable, :upgradeable, :versionable
 

--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
 
   confine :operatingsystem => [:freebsd, :dragonfly]
 
-  defaultfor :operatingsystem => :freebsd
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
 
   has_feature :versionable
   has_feature :upgradeable

--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -44,7 +44,7 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
     when 'OpenBSD'
       :openbsd
     when 'DragonFly'
-      :pkgin
+      :pkgng
     when 'OpenWrt'
       :opkg
     end


### PR DESCRIPTION
DragonFly BSD has been using pkgng for a few years now. This changes the default
package provider on it to be pkgng as is correct for it, and adjusts the spec
tests for it accordingly.