### PR TITLE
(PUP-7402) Update test now that trailing slash alias works

### DIFF
--- a/acceptance/tests/resource/file/should_create_directory.rb
+++ b/acceptance/tests/resource/file/should_create_directory.rb
@@ -23,27 +23,15 @@ agents.each do |agent|
     file {$dir:
       ensure => directory,
     }
-    if !defined(File["${same_dir}"]) {
-      file { $same_dir:
-        ensure => directory,
-      }
+    file { $same_dir:
+      ensure => directory,
     }
   PP
 
   step "verify we can't create same dir resource with a trailing slash" do
     options = {:acceptable_exit_codes => [1]}
     on(agent, puppet_apply("--noop #{dir_manifest}"), options) do |result|
-      assert_match('Error: Cannot alias File', result.output,
-                   'duplicate directory resources did not fail properly')
-    end
-
-    on(agent, puppet_apply("--noop --no-app_management #{dir_manifest}"), options) do |result|
-      assert_match('Error: Cannot alias File', result.output,
-                   'duplicate directory resources did not fail properly')
-    end
-
-    on(agent, puppet_apply("--noop --app_management #{dir_manifest}"), options) do |result|
-      assert_match('Error: Cannot alias File', result.output,
+      assert_match('Cannot alias File', result.output,
                    'duplicate directory resources did not fail properly')
     end
   end


### PR DESCRIPTION
Previously, the test added two resources to the catalog where one had a
trailing slash. The test relied on `defined` returning false, as it did
before commit ae066f9.

As of ae066f9, puppet will now detect that the resource with the
trailing slash has the same name as the one without. So this test
started failing (since we never tried to add a duplicate resource).

This commit updates the test to unconditionally add the duplicate. It
also removes the app_management cases since that property is deprecated
and no longer controls any behavior.

    Error: Evaluation Error: Error while evaluating a Resource
    Statement, Cannot alias File[/tmp/create-dir.foyI4D/] ...

[skip ci]