### PR TITLE
(MAINT) Fix compiler warnings from jruby 9k

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -95,7 +95,7 @@ class Puppet::Module
   FILETYPES.each do |type, location|
     # A boolean method to let external callers determine if
     # we have files of a given type.
-    define_method(type +'?') do
+    define_method(type + '?') do
       type_subpath = subpath(location)
       unless Puppet::FileSystem.exist?(type_subpath)
         Puppet.debug("No #{type} found in subpath '#{type_subpath}' " +

--- a/lib/puppet/pops/parser/interpolation_support.rb
+++ b/lib/puppet/pops/parser/interpolation_support.rb
@@ -40,7 +40,7 @@ module Puppet::Pops::Parser::InterpolationSupport
         if varname = scn.scan(PATTERN_VARIABLE)
           # The $ is counted towards the variable
           enqueue_completed([:DQPRE, text, after-before-1], before)
-          enqueue_completed([:VARIABLE, varname, scn.pos - after + 1], after -1)
+          enqueue_completed([:VARIABLE, varname, scn.pos - after + 1], after - 1)
           break
         else
           # false $ variable start
@@ -81,7 +81,7 @@ module Puppet::Pops::Parser::InterpolationSupport
         if varname = scn.scan(PATTERN_VARIABLE)
           # The $ is counted towards the variable
           enqueue_completed([:DQMID, text, after-before-1], before)
-          enqueue_completed([:VARIABLE, varname, scn.pos - after +1], after -1)
+          enqueue_completed([:VARIABLE, varname, scn.pos - after + 1], after - 1)
           break
         else
           # false $ variable start
@@ -125,7 +125,7 @@ module Puppet::Pops::Parser::InterpolationSupport
         if varname = scn.scan(PATTERN_VARIABLE)
           # The $ is counted towards the variable
           enqueue_completed([:DQPRE, text, after-before-1], before)
-          enqueue_completed([:VARIABLE, varname, scn.pos - after + 1], after -1)
+          enqueue_completed([:VARIABLE, varname, scn.pos - after + 1], after - 1)
           break
         else
           # false $ variable start
@@ -165,7 +165,7 @@ module Puppet::Pops::Parser::InterpolationSupport
         if varname = scn.scan(PATTERN_VARIABLE)
           # The $ is counted towards the variable
           enqueue_completed([:DQMID, text, after-before-1], before)
-          enqueue_completed([:VARIABLE, varname, scn.pos - after +1], after -1)
+          enqueue_completed([:VARIABLE, varname, scn.pos - after + 1], after - 1)
           break
         else
           # false $ variable start


### PR DESCRIPTION
This commit fixes some miscellaneous compiler warnings which appear when
running the server under JRuby 9000.