### PR TITLE
(maint) Merge stable to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 sudo: false
-before_install:
-  - gem update --system --no-doc
 bundler_args: --without development extra
 script:
   - "bundle exec rake $CHECK"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 sudo: false
 before_install:
-  - gem install bundler -v 1.10
   - gem update --system --no-doc
-bundler_args: --without development
+bundler_args: --without development extra
 script:
   - "bundle exec rake $CHECK"
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -28,15 +28,17 @@ gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 2.0', '< 4'])
 # PUP-7115 - return to a gem dependency in Puppet 5
 # gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ['>= 0.1.3', '< 2'])
-gem "rake", "10.1.1", :require => false
 # Hiera has an unbound dependency on json_pure
 # json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0
 gem 'json_pure', '~> 1.8', :require => false
 # i18n support (gettext-setup and dependencies)
 gem 'gettext-setup', '>= 0.10', '< 1.0', :require => false
 gem 'locale', '~> 2.1', :require => false
+# net-ssh is a runtime dependency of Puppet::Util::NetworkDevice::Transport::Ssh
+gem "net-ssh", '~> 2.1', :require => false
 
 group(:development, :test) do
+  gem "rake", "10.1.1", :require => false
   gem "rspec", "~> 3.1", :require => false
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false
@@ -75,9 +77,7 @@ end
 
 group(:extra) do
   gem "rack", "~> 1.4", :require => false
-  gem "net-ssh", '~> 2.1', :require => false
   gem "puppetlabs_spec_helper", :require => false
-  gem "tzinfo", :require => false
   gem "msgpack", :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ group(:development, :test) do
   gem "json-schema", "2.1.1", :require => false, :platforms => [:ruby, :jruby]
 
   gem "rubocop", "~> 0.39.0", :platforms => [:ruby]
+  # pin rainbow gem as 2.2.1 requires rubygems 2.6.9+ and (donotwant)
+  gem "rainbow", "< 2.2.1", :platforms => [:ruby]
 
   gem 'rdoc', "~> 4.1", :platforms => [:ruby]
 

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,6 +1,6 @@
 require 'puppet/version'
 
-if RUBY_VERSION < "1.9.3"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3")
   raise LoadError, _("Puppet %{version} requires ruby 1.9.3 or greater.") % { version: Puppet.version }
 end
 
@@ -164,7 +164,7 @@ module Puppet
 
   # Now that settings are loaded we have the code loaded to be able to issue
   # deprecation warnings. Warn if we're on a deprecated ruby version.
-  if RUBY_VERSION < Puppet::OLDEST_RECOMMENDED_RUBY_VERSION
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
     Puppet.deprecation_warning(_("Support for ruby version %{version} is deprecated and will be removed in a future release. See https://docs.puppet.com/puppet/latest/system_requirements.html#ruby for a list of supported ruby versions.") % { version: RUBY_VERSION })
   end
 


### PR DESCRIPTION
* upstream/stable:
  (maint) Fix Puppet version check comparison
  (maint) Mark net-ssh as Gemfile runtime dependency
  (maint) Remove tzinfo gem from Gemfile
  (maint) Move rake to Gemfile development / test
  (maint) TravisCI should not bundle install extra
  (maint) Remove TravisCI gem install of bundler

Preserve `gem update --system --no-doc` needed for ruby 2.4 (df0b1d0)

Preserve `extra` bundler_arg to be consistent with appveyor (f32b8dc)