### PR TITLE
(SERVER-1766) Use tk-auth rules when running acceptance under puppetserver

### DIFF
--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -12,20 +12,13 @@ end
 node_names.uniq!
 
 if @options[:is_puppetserver]
-  step "Ensure legacy auth.conf is disabled for test" do
+  step "Prepare for custom tk-auth rules" do
+    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
     modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
   end
 
   teardown do
     modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
-  end
-
-  step "Backup the tk auth.conf file" do
-    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
-  end
-
-  teardown do
-    # restore the original tk auth.conf file
     on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
   end
 

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -48,7 +48,6 @@ authorization: {
     tka_node_rules = node_names.map do |node_name|
       <<-NODE_RULES
         {
-            # Allow nodes to retrieve their own catalog
             match-request: {
                 path: "/puppet/v3/catalog/#{node_name}"
                 type: path
@@ -59,7 +58,6 @@ authorization: {
             name: "puppetlabs catalog"
         },
         {
-            # Allow nodes to retrieve only their own node definition
             match-request: {
                 path: "/puppet/v3/node/#{node_name}"
                 type: path
@@ -70,7 +68,6 @@ authorization: {
             name: "puppetlabs node"
         },
         {
-            # Allow nodes to store only their own reports
             match-request: {
                 path: "/puppet/v3/report/#{node_name}"
                 type: path
@@ -85,8 +82,6 @@ authorization: {
 
     tka_footer = <<-FOOTER
         {
-          # Deny everything else. This ACL is not strictly
-          # necessary, but illustrates the default policy
           match-request: {
             path: "/"
             type: path

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -4,21 +4,14 @@ success_message = "node_name_value setting was correctly used as the node name"
 testdir = master.tmpdir('nodenamevalue')
 
 if @options[:is_puppetserver]
-  step "Ensure legacy auth.conf is disabled for test" do
+  step "Prepare for custom tk-auth rules" do
+    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
     modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
   end
 
   teardown do
-    modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
-  end
-
-  step "Backup the tk auth.conf file" do
-    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
-  end
-
-  teardown do
-    # restore the original tk auth.conf file
     on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
+    modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
   end
 
   step "Setup tk-auth rules" do

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -1,10 +1,11 @@
 test_name "node_name_value should be used as the node name for puppet agent"
 
 success_message = "node_name_value setting was correctly used as the node name"
-in_testdir = master.tmpdir('nodenamevalue')
+testdir = master.tmpdir('nodenamevalue')
 
-authfile = "#{in_testdir}/auth.conf"
-authconf = <<-AUTHCONF
+step "setup auth.conf rules" do
+  authfile = "#{testdir}/auth.conf"
+  authconf = <<-AUTHCONF
 path /puppet/v3/catalog/specified_node_name
 auth yes
 allow *
@@ -16,59 +17,62 @@ allow *
 path /puppet/v3/report/specified_node_name
 auth yes
 allow *
-AUTHCONF
+  AUTHCONF
 
-manifest_file = "#{in_testdir}/environments/production/manifests/manifest.pp"
-manifest = <<-MANIFEST
-  Exec { path => "/usr/bin:/bin" }
-  node default {
-    notify { "false": }
-  }
-  node specified_node_name {
-    notify { "#{success_message}": }
-  }
-MANIFEST
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+    file { '#{authfile}':
+      ensure => file,
+      mode => '0644',
+      content => '#{authconf}',
+    }
+  MANIFEST
+end
 
-apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
-  File {
-    ensure => directory,
-    mode => '0777',
-  }
+step "Setup site.pp for node name based classification" do
 
-  file {
-    '#{in_testdir}':;
-    '#{in_testdir}/environments':;
-    '#{in_testdir}/environments/production':;
-    '#{in_testdir}/environments/production/manifests':;
-  }
-
-  file { '#{manifest_file}':
-    ensure => file,
-    mode => '0644',
-    content => '#{manifest}',
-  }
-
-  file { '#{authfile}':
-    ensure => file,
-    mode => '0644',
-    content => '#{authconf}',
-  }
-MANIFEST
-
-with_these_opts = {
-  'main' => {
-    'environmentpath' => "#{in_testdir}/environments",
-  },
-  'master' => {
-    'rest_authconfig' => "#{in_testdir}/auth.conf",
-    'node_terminus'   => 'plain',
-  },
+  site_manifest = <<-SITE_MANIFEST
+node default {
+  notify { "false": }
 }
+node specified_node_name {
+  notify { "#{success_message}": }
+}
+  SITE_MANIFEST
 
-with_puppet_running_on master, with_these_opts, in_testdir do
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+    $directories = [
+      '#{testdir}',
+      '#{testdir}/environments',
+      '#{testdir}/environments/production',
+      '#{testdir}/environments/production/manifests',
+    ]
 
-  on(agents, puppet('agent', "-t --node_name_value specified_node_name --server #{master}"), :acceptable_exit_codes => [0,2]) do
-    assert_match(/defined 'message'.*#{success_message}/, stdout)
+    file { $directories:
+      ensure => directory,
+      mode => '0755',
+    }
+
+    file { '#{testdir}/environments/production/manifests/manifest.pp':
+      ensure => file,
+      mode => '0644',
+      content => '#{site_manifest}',
+    }
+  MANIFEST
+end
+
+step "Ensure nodes are classified based on the node name fact" do
+  master_opts = {
+    'main' => {
+      'environmentpath' => "#{testdir}/environments",
+    },
+    'master' => {
+      'rest_authconfig' => "#{testdir}/auth.conf",
+      'node_terminus'   => 'plain',
+    },
+  }
+  with_puppet_running_on(master, master_opts, testdir) do
+    on(agents, puppet('agent', "-t --node_name_value specified_node_name --server #{master}"), :acceptable_exit_codes => [0,2]) do
+      assert_match(/defined 'message'.*#{success_message}/, stdout)
+    end
   end
-
 end

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -3,9 +3,93 @@ test_name "node_name_value should be used as the node name for puppet agent"
 success_message = "node_name_value setting was correctly used as the node name"
 testdir = master.tmpdir('nodenamevalue')
 
-step "setup auth.conf rules" do
-  authfile = "#{testdir}/auth.conf"
-  authconf = <<-AUTHCONF
+if @options[:is_puppetserver]
+  step "Ensure legacy auth.conf is disabled for test" do
+    modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
+  end
+
+  teardown do
+    modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
+  end
+
+  step "Backup the tk auth.conf file" do
+    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
+  end
+
+  teardown do
+    # restore the original tk auth.conf file
+    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
+  end
+
+  step "Setup tk-auth rules" do
+    tk_auth = <<-TK_AUTH
+authorization: {
+    version: 1
+    rules: [
+        {
+            match-request: {
+                path: "/puppet/v3/file"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/catalog/specified_node_name"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs catalog"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/node/specified_node_name"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/report/specified_node_name"
+                type: path
+                method: put
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+          match-request: {
+            path: "/"
+            type: path
+          }
+          deny: "*"
+          sort-order: 999
+          name: "puppetlabs deny all"
+        }
+    ]
+}
+    TK_AUTH
+
+    apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+      file { '/etc/puppetlabs/puppetserver/conf.d/auth.conf':
+        ensure => file,
+        mode => '0644',
+        content => '#{tk_auth}',
+      }
+    MANIFEST
+  end
+else
+  step "setup auth.conf rules" do
+    authfile = "#{testdir}/auth.conf"
+    authconf = <<-AUTHCONF
 path /puppet/v3/catalog/specified_node_name
 auth yes
 allow *
@@ -17,15 +101,16 @@ allow *
 path /puppet/v3/report/specified_node_name
 auth yes
 allow *
-  AUTHCONF
+    AUTHCONF
 
-  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
-    file { '#{authfile}':
-      ensure => file,
-      mode => '0644',
-      content => '#{authconf}',
-    }
-  MANIFEST
+    apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+      file { '#{authfile}':
+        ensure => file,
+        mode => '0644',
+        content => '#{authconf}',
+      }
+    MANIFEST
+  end
 end
 
 step "Setup site.pp for node name based classification" do

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -6,7 +6,97 @@ extend Puppet::Acceptance::TempFileUtils
 test_name "ticket #16753 node data should be cached in yaml to allow it to be queried"
 
 node_name = "woy_node_#{SecureRandom.hex}"
-auth_contents = <<AUTHCONF
+
+# Only used when running under webrick
+authfile = get_test_file_path master, "auth.conf"
+
+temp_dirs = initialize_temp_dirs
+temp_yamldir = File.join(temp_dirs[master.name], "yamldir")
+
+on master, "mkdir -p #{temp_yamldir}"
+user = puppet_user master
+group = puppet_group master
+on master, "chown #{user}:#{group} #{temp_yamldir}"
+
+if @options[:is_puppetserver]
+  step "Ensure legacy auth.conf is disabled for test" do
+    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
+    modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
+  end
+
+  teardown do
+    modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
+    on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
+  end
+
+  step "Setup tk-auth rules" do
+    tk_auth = <<-TK_AUTH
+authorization: {
+    version: 1
+    rules: [
+        {
+            match-request: {
+                path: "/puppet/v3/file"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/catalog/#{node_name}"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs catalog"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/node/#{node_name}"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/report/#{node_name}"
+                type: path
+                method: put
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+          match-request: {
+            path: "/"
+            type: path
+          }
+          deny: "*"
+          sort-order: 999
+          name: "puppetlabs deny all"
+        }
+    ]
+}
+    TK_AUTH
+
+    apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+      file { '/etc/puppetlabs/puppetserver/conf.d/auth.conf':
+        ensure => file,
+        mode => '0644',
+        content => '#{tk_auth}',
+      }
+    MANIFEST
+  end
+else
+  step "setup legacy auth.conf rules" do
+    auth_contents = <<-AUTHCONF
 path /puppet/v3/catalog/#{node_name}
 auth yes
 allow *
@@ -18,21 +108,13 @@ allow *
 path /puppet/v3/report/#{node_name}
 auth yes
 allow *
-AUTHCONF
+    AUTHCONF
 
-temp_dirs = initialize_temp_dirs
+    create_test_file master, "auth.conf", auth_contents, {}
 
-create_test_file master, "auth.conf", auth_contents, {}
-
-authfile = get_test_file_path master, "auth.conf"
-on master, "chmod 644 #{authfile}"
-
-temp_yamldir = File.join(temp_dirs[master.name], "yamldir")
-
-on master, "mkdir -p #{temp_yamldir}"
-user = puppet_user master
-group = puppet_group master
-on master, "chown #{user}:#{group} #{temp_yamldir}"
+    on master, "chmod 644 #{authfile}"
+  end
+end
 
 master_opts = {
   'master' => {
@@ -45,7 +127,6 @@ with_puppet_running_on master, master_opts do
 
   # only one agent is needed because we only care about the file written on the master
   run_agent_on(agents[0], "--no-daemonize --verbose --onetime --node_name_value #{node_name} --server #{master}")
-
 
   yamldir = on(master, puppet('master', '--configprint', 'yamldir')).stdout.chomp
   on master, puppet('node', 'search', '"*"', '--node_terminus', 'yaml', '--clientyamldir', yamldir, '--render-as', 'json') do

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -19,7 +19,7 @@ group = puppet_group master
 on master, "chown #{user}:#{group} #{temp_yamldir}"
 
 if @options[:is_puppetserver]
-  step "Ensure legacy auth.conf is disabled for test" do
+  step "Prepare for custom tk-auth rules" do
     on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
     modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
   end


### PR DESCRIPTION
/cc @rlinehan @jpinsonault @camlow325 

If we like this approach I can apply it to other instances where we need to modify auth.conf.
