### PR TITLE
(maint) Fix intermittent AppVeyor failures / rewrite AppVeyor test_script as PowerShell

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ end
 # C Ruby (MRI) or Rubinius, but NOT Windows
 platforms :ruby do
   gem 'pry', :group => :development
-  gem 'yard', :group => :development
   gem 'redcarpet', '~> 2.0', :group => :development
   gem "racc", "1.4.9", :group => :development
 
@@ -59,6 +58,7 @@ group(:development, :test) do
   gem "rubocop", "~> 0.39.0", :platforms => [:ruby]
 
   gem 'rdoc', "~> 4.1", :platforms => [:ruby]
+  gem 'yard'
 
   # webmock requires addressable as as of 2.5.0 addressable started
   # requiring the public_suffix gem which requires Ruby 2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,17 +38,23 @@ before_test:
 
 test_script:
   # The sleep is needed to allow the Appveyor tracing to start correctly after a reboot (locale change)
-  - ps: Start-Sleep -Seconds 5
-  - SET
-  - chcp
-  - ps: Get-WinSystemLocale
-  - SET PATH=C:\%PLATFORM%\bin;%PATH%
-  - SET LOG_SPEC_ORDER=true
-  - bundle install --jobs 4 --retry 2 --without development extra
-  - type Gemfile.lock
-  - ruby -v
-  - bundle exec rake parallel:spec[2]
-
+  # - ps: Start-Sleep -Seconds 5
+  - timeout 6
+  - ps: |
+      chcp
+      Get-WinSystemLocale
+      $Env:PATH = "C:\${Env:PLATFORM}\bin;${Env:PATH}"
+      $Env:LOG_SPEC_ORDER = 'true'
+      Get-ChildItem Env: | % { Write-Output "$($_.Key): $($_.Value)"  }
+      bundle install --jobs 4 --retry 2 --without development extra
+      Get-Content Gemfile.lock
+      ruby -v
+      gem --version
+      bundle --version
+      bundle exec rake parallel:spec[2]
+      $exitCode = $LASTEXITCODE
+      Write-Output "Spec run exited with $exitCode"
+      $host.SetShouldExit($exitCode)
 on_failure:
   - appveyor PushArtifact .\spec_order.txt
 notifications:


### PR DESCRIPTION
 - AppVeyor is generating intermittent failures when executing
   `bundle exec rake parallel:spec[2]`, despite no spec tests
   actually failing.

   This has been narrowed down to a non-zero exitcode being returned
   from bundler when yard is not present due to:

   Document generation not available without yard. cannot load such file -- yard

   It's unclear why this only intermittently fails when executed
   through cmd, as it will always fail when executed within a
   PowerShell script (like the refactoring in the next commit)

 - Since `bundler` wants access to `yard`, move it out of the
   :developemnt group (which is currently not installed in
   AppVeyor / Travis) so that it's present in both the :test and
   :development groups - allowing it to be installed in those
   environments


- Previously test_script was a combination of individual batch
   commands and PowerShell code.  Unify the code as PowerShell given
   PowerShell is already being used for Get-WinSystemLocale.

   Be more explicit about exiting the script, by setting the PowerShell
   host exit status based on $LASTEXITCODE set by the execution of
   bundler.

 - This change combined with the prior move of the `yard` gem to a
   different gem group, should prevent spurious AppVeyor failures.

 - Note that sleep test_script used after a locale change is left as a
   distinct step (but moved from PowerShell to cmd) to ensure AppVeyor
   logs correctly.

 - Added 2 additional pieces of useful information while logging the
   AppVeyor environment -

   - gem version
   - bundler version