### PR TITLE
(PUP-7442) Don't install epel repos

### DIFF
--- a/acceptance/config/common/options.rb
+++ b/acceptance/config/common/options.rb
@@ -6,7 +6,7 @@
   :xml                         => true,
   :timesync                    => false,
   :repo_proxy                  => true,
-  :add_el_extras               => true,
+  :add_el_extras               => false,
   :forge_host                  => 'forge-aio01-petest.puppetlabs.com',
   :'master-start-curl-retries' => 30,
 }


### PR DESCRIPTION
Puppet tests for passenger and active records storeconfigs used to rely
on epel repos. CI was failing with HTTP 404:

    http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm

Since we don't need epel anymore, configure beaker to not install it
during acceptance. Facter, hiera, and pxp-agent already do the same.

[skip ci]