### PR TITLE
(PUP-7425) Fix .gemspec for Vanagon packages

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -49,8 +49,14 @@ Gem::Specification.new do |s|
 
   # loads platform specific gems like ffi, win32 platform gems
   # as additional runtime dependencies
+  gem_deps_path = File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml')
+
+  # inside of a Vanagon produced package, project_data.yaml does not exist
+  next unless File.exist?(gem_deps_path)
+
+  # so only load these dependencies from a git clone / bundle install workflow
   require 'yaml'
-  data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
+  data = YAML.load_file(gem_deps_path)
   bundle_platforms = data['bundle_platforms']
   x64_platform = Gem::Platform.local.cpu == 'x64'
   data['gem_platform_dependencies'].each_pair do |gem_platform, info|


### PR DESCRIPTION
This PR is a follow on to #5797 

 - 19f78a20b70660b30fff8c0c49e8b9a9b3c99b40 introduced a refactoring to
   the Gemfile / .gemspec to support the Bundler workflow in use for
   the `ci:test:git` task.

   What was not realized at the time was that the .gemspec is copied
   verbatim when building puppet-agent packages with Vanagon per
   https://github.com/puppetlabs/puppet-agent/blob/37985352cb330aad2f8f3e8ad89f9267d6beb4fe/configs/components/puppet.rb#L166

   This is to present `puppet` as a legitimate gem within the
   puppet-agent package / Ruby runtime.

   Interestingly, this varies from how the Puppet gem is produced where
   a .gemspec that includes platform specific dependencies is built on
   the fly from project_data.yaml using the rake task from the
   packaging repo per `gem.rake`:

   https://github.com/puppetlabs/packaging/blob/3fdd5da0b82c7518e88d5fa9a38de0dfc80eea98/tasks/gem.rake

   PA-1077 exists to help consolidate gem / .gemspec behavior so that
   gem behavior is served from a single source of truth, but is beyond
   the scope of the current effort.

 - .gemspec has therefore been updated to not attempt loading
   project_data.yaml should the file not exist, so that Bundler workflow
   around platform-specific gem dependencies remains intact, but that
   shipped packages don't look for a file that doesn't exist in the
   puppet-agent package.