### PR TITLE
(PUP-7425) Update required version of net-ssh

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -45,7 +45,10 @@ Gem::Specification.new do |s|
   # json_pure 2.0.2+ officially requires Ruby >= 2.0, but should have specified that in 2.0
   s.add_runtime_dependency(%q<json_pure>, "~> 1.8")
   # net-ssh is a runtime dependency of Puppet::Util::NetworkDevice::Transport::Ssh
-  s.add_runtime_dependency(%q<net-ssh>, "~> 2.1")
+  # Beaker 3.0.0 to 3.10.0 depends on net-ssh 3.3.0beta1
+  # Beaker 3.11.0+ depends on net-ssh 4.0+
+  # be lenient to allow module testing where Beaker and Puppet are in same Gemfile
+  s.add_runtime_dependency(%q<net-ssh>, [">= 3.0", "< 5"]) if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
 
   # loads platform specific gems like ffi, win32 platform gems
   # as additional runtime dependencies


### PR DESCRIPTION
 - The version of net-ssh Puppet previously consumed was ~> 2.1
   but this version conflicts with Beaker and can cause gem installs,
   particularly for module testing, to fail.

   Beaker 3 moved to net-ssh 3.3.0beta1 to resolve some Unicode
   related issues (see BKR-40 for further detail). When net-ssh 4
   became available, Beaker 3.11.0 and higher began consuming it to
   resolve other Bundler workflow problems.

   net-ssh usage is limited to `puppet device` support and should be
   safe to generally bump to a newer version, especially one that
   resolves known UTF-8 issues.

 - To allow for Puppet to run with any version of Beaker, allow
   net-ssh 3 and 4 versions to be used by adjusting the .gemspec
   accordingly.

   To continue to allow the Puppet gem to be tested against Ruby
   1.9.3, exclude net-ssh for Ruby < 2

   Note that the .gemspec in the repository is not yet the one used
   for packaging / shipping gems. It is however consumed inside
   agent packages that bundle / vendor specific gem versions.

 - Continue to not make net-ssh a part of project_data.yaml which
   feeds into the shipping .gemspec through packaging automation
   tasks. puppet-agent packages do currently include net-ssh 2.9.2
   (which will be updated soon in packaging to 4.1.0). At that time,
   Puppet server should not be negatively impacted by bumping the
   version of net-ssh to one incompatible with its JRuby / Ruby
   compatibility (1.9.3) given net-ssh usage is guarded behind a
   feature inside Puppet. puppet-agent itself already vendors Ruby
   2.1.9 and would be compatible.

   The gem situation is a bit more complex.

   The Puppet gem is currently marked as compatible with a minimum
   Ruby of 1.9.3.  Bundler may not use the RUBY_VERSION specified by
   the gem when resolving dependencies which could result in an attempt
   to install an incompatible net-ssh gem under 1.9.3. This likely
   *wouldn't* be a problem in a Beaker acceptance scenario, as Ruby
   1.9.3 already requires the older Beaker 2, which includes a more
   specific net-ssh dependency like ~> 2.9.

   However, it is unclear what other situations could fail to install
   net-ssh when Puppet is consumed as a gem, so for the sake of
   preventing disruption, net-ssh as a shipped gem dependency will
   remain omitted, to be handled at a later date.

For reference, BKR-995 updated the Beaker `net-ssh` dependency for `3.11.0` at https://github.com/puppetlabs/beaker/commit/7fb98233b2fa989d9c3795fb8c15169d5eb93f4f