### PR TITLE
(maint) Define puppetserver-config

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -9,8 +9,9 @@
     'setup/common/pre-suite/040_ValidateSignCert.rb',
     'setup/aio/pre-suite/045_EnsureMasterStarted.rb',
   ],
-  :is_puppetserver             => true,
-  :'use-service'               => true, # use service scripts to start/stop stuff
-  :puppetservice               => 'puppetserver',
-  :'puppetserver-confdir'      => '/etc/puppetlabs/puppetserver/conf.d',
+  'is_puppetserver'            => true,
+  'use-service'                => true, # use service scripts to start/stop stuff
+  'puppetservice'              => 'puppetserver',
+  'puppetserver-confdir'       => '/etc/puppetlabs/puppetserver/conf.d',
+  'puppetserver-config'        => '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
 }.merge(eval File.read('config/common/options.rb'))


### PR DESCRIPTION
Puppet's acceptance options did not define `puppetserver-config` causing
the beaker `modify_tk_auth` helper to execute `cat`, which hangs beaker.

This commit adds an option for puppetserver-config and converts several
of the options to match what puppetserver uses in their acceptance
setup. Note beaker options can be resolved using either symbol or
string:

    (byebug) @options['use-service']
    true
    (byebug) @options[:'use-service']
    true
    (byebug) @options['puppetservice']
    "puppetserver"
    (byebug) @options[:'puppetservice']
    "puppetserver"
    (byebug) @options['puppetserver-config']
    "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf"
    (byebug) @options[:'puppetserver-config']
    "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf"
    (byebug) @options['puppetserver-confdir']
    "/etc/puppetlabs/puppetserver/conf.d"
    (byebug) @options[:'puppetserver-confdir']
    "/etc/puppetlabs/puppetserver/conf.d"