### PR TITLE
(PUP-7070) Remove stacktrace from HTTP error responses

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -134,8 +134,6 @@ error responses will uniformly be a JSON object with the following properties:
 
 * `message`: (`String`) A human readable message explaining the error.
 * `issue_kind`: (`String`) A unique label to identify the error class.
-* `stacktrace` (only for 5xx errors): (`Array<String>`) A stacktrace to where
-  the error occurred.
 
 A [JSON schema for the error objects](../schemas/error.json) is also available.
 

--- a/api/schemas/error.json
+++ b/api/schemas/error.json
@@ -11,11 +11,6 @@
         "issue_kind": {
             "description": "A unique label to identify the error class",
             "type": "string"
-        },
-        "stacktrace": {
-            "description": "**Deprecated**. For 5xx responses only, a message containing a deprecation warning. This property will be removed in a future release of Puppet.",
-            "type": "array",
-            "items": { "type": "string" }
         }
     },
     "required": ["message", "issue_kind"],

--- a/lib/puppet/network/http/error.rb
+++ b/lib/puppet/network/http/error.rb
@@ -55,15 +55,12 @@ module Puppet::Network::HTTP::Error
   class HTTPServerError < HTTPError
     CODE = 500
 
-    attr_reader :backtrace
-
     def initialize(original_error, issue_kind = Issues::RUNTIME_ERROR)
       super(_("Server Error: ") + original_error.message, CODE, issue_kind)
-      @backtrace = ["Warning: The 'stacktrace' property is deprecated and will be removed in a future version of Puppet. For security reasons, stacktraces are not returned with Puppet HTTP Error responses."]
     end
 
     def to_json
-      JSON({:message => message, :issue_kind => @issue_kind, :stacktrace => self.backtrace})
+      JSON({:message => message, :issue_kind => @issue_kind})
     end
   end
 end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -17,8 +17,7 @@ shared_examples_for "a REST terminus method" do |terminus_method|
       let(:body) do
         JSON.generate({
           :issue_kind => 'server-error',
-          :message    => message,
-          :stacktrace => ['worst/stack/trace/ever.rb:4']
+          :message    => message
         })
       end
       let(:response) { mock_response(code, body, 'application/json') }

--- a/spec/unit/network/http/error_spec.rb
+++ b/spec/unit/network/http/error_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Network::HTTP::Error do
   end
 
   describe Puppet::Network::HTTP::Error::HTTPServerError do
-    it "should serialize to JSON that matches the error schema and has a deprecated stacktrace property" do
+    it "should serialize to JSON that matches the error schema" do
       begin
         raise Exception, "a wild Exception appeared!"
       rescue Exception => e
@@ -24,7 +24,6 @@ describe Puppet::Network::HTTP::Error do
       error = Puppet::Network::HTTP::Error::HTTPServerError.new(culpable)
 
       expect(error.to_json).to validate_against('api/schemas/error.json')
-      expect(error.to_json).to match(/The 'stacktrace' property is deprecated/)
     end
   end
 

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -95,9 +95,6 @@ describe Puppet::Network::HTTP::Handler do
       expect(res[:content_type_header]).to eq("application/json")
       expect(res_body["issue_kind"]).to eq(Puppet::Network::HTTP::Issues::RUNTIME_ERROR.to_s)
       expect(res_body["message"]).to eq("Server Error: the sky is falling!")
-      expect(res_body["stacktrace"].is_a?(Array) && !res_body["stacktrace"].empty?).to be_truthy
-      expect(res_body["stacktrace"][0]).to match(/The 'stacktrace' property is deprecated/)
-      expect(res_body["stacktrace"] & original_stacktrace).to be_empty
       expect(res[:status]).to eq(500)
     end
 


### PR DESCRIPTION
Previously, our REST error responses contained a `stacktrace` element,
and in 4.x this was changed to a deprecation warning so that the server
did not leak sensitive information to the caller.

This commit removes the `stacktrace` element from the response, and
related schema and API docs. Note the `stacktrace` element was optional
according to our schema, so this should not be backwards incompatible.