### PR TITLE
(PUP-7436) Fix bug causing ephemeral undef not to override parent scope

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -85,7 +85,7 @@ class Puppet::Parser::Scope
 
     def [](name)
       val = @symbols[name]
-      val.nil? && !@symbols.include?(val) ? super : val
+      val.nil? && !@symbols.include?(name) ? super : val
     end
 
     def is_local_scope?

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -578,6 +578,14 @@ describe Puppet::Parser::Scope do
       @scope.unset_ephemeral_var
       expect(@scope["apple"]).to eq(nil)
     end
+
+    it 'should store an undef in local scope and let it override parent scope' do
+      @scope['cloaked'] = 'Cloak me please'
+      @scope.new_ephemeral(true)
+      @scope['cloaked'] = nil
+      expect(@scope['cloaked']).to eq(nil)
+    end
+
     it "should be created from a hash" do
       @scope.ephemeral_from({ "apple" => :fruit, "strawberry" => :berry})
       expect(@scope["apple"]).to eq(:fruit)


### PR DESCRIPTION
This commit fixes a bug in the ephemeral local scope of a
`Puppet::Parser::Scope` that caused key declared with an undef value to
become invisible. Instead of returning such a value, the lookup
traversal continued to the parent scope. The value of found in the
parent scope was then returned.