### PR TITLE
(#17616) Clean Bundler environment when run under Bundler

### DIFF
--- a/lib/puppet/feature/bundled_environment.rb
+++ b/lib/puppet/feature/bundled_environment.rb
@@ -1,0 +1,9 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:bundled_environment) do
+  if defined?(Bundler) && Bundler.respond_to?(:with_clean_env)
+    true
+  else
+    false
+  end
+end

--- a/lib/puppet/provider/exec/posix.rb
+++ b/lib/puppet/provider/exec/posix.rb
@@ -39,10 +39,18 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
   end
 
   def run(command, check = false)
-    if resource[:umask]
-      Puppet::Util::withumask(resource[:umask]) { super(command, check) }
+    run = lambda do
+      if resource[:umask]
+        Puppet::Util::withumask(resource[:umask]) { super(command, check) }
+      else
+        super(command, check)
+      end
+    end
+
+    if Puppet.features.bundled_environment?
+      Bundler.with_clean_env { run.call }
     else
-      super(command, check)
+      run.call
     end
   end
 end

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -171,4 +171,16 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
   def uninstall_options
     join_options(resource[:uninstall_options])
   end
+
+  def execute(*args)
+    self.class.execute(*args)
+  end
+
+  def self.execute(*args)
+    if Puppet.features.bundled_environment?
+      Bundler.with_clean_env { super(*args) }
+    else
+      super(*args)
+    end
+  end
 end


### PR DESCRIPTION
This is a reworked version of #1516. Actually, the problem that I am trying to solve is slightly different to the problem described in [#17616](https://projects.puppetlabs.com/issues/17616), but I believe that the solution is essentially the same.

Basically, we install and distribute Puppet from source rather than using a package built for our platform. The reason that we do this is because we have additional Ruby dependencies that we need to distribute and it makes our boostrapping process easier if we bundle everything together into a single artifact. We are currently in the process of updating from Puppet 3.8 to Puppet 4.10, but we have noticed that we are no longer able to run `puppet` as a standalone binstub generated with `bundle install --standalone --binstubs`. Specifically, this is the error message when attempting to do so:

```
/etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet.rb:76:in `singleton class': undefined method `version' for nil:NilClass (NoMethodError)
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet.rb:55:in `<module:Puppet>'
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet.rb:49:in `<top (required)>'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet/util/command_line.rb:12:in `<top (required)>'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/bin/puppet:4:in `<top (required)>'
    from /etc/puppet/bin/puppet:14:in `load'
    from /etc/puppet/bin/puppet:14:in `<main>'
```

I had originally submitted bundler/bundler#5601 to address this issue but, after some discussion upstream, I believe that it would better to instead modify Puppet so that command execution is isolated from the Bundler environment. Basically, I am trying to make `puppet apply` work for us when executed with `bundle exec`. The only issue that we are currently experiencing when attempting to do so manifests in the following snippet of our Puppet manifests (which comes from the [sbadia/gitlab](https://forge.puppet.com/sbadia/gitlab) module):

```puppet
  exec { 'install gitlab':
    command => "bundle install${gitlab_bundler_jobs_flag} --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
    cwd     => "${git_home}/gitlab",
    unless  => 'bundle check',
    timeout => 0,
    require => [
      Gitlab::Config::Database['gitlab'],
      Gitlab::Config::Unicorn['gitlab'],
      File["${git_home}/gitlab/config/gitlab.yml"],
      Gitlab::Config::Resque['gitlab'],
    ],
    notify  => Exec['run migrations'],
  }
```

The problem is that the environment variables injected into the environment by Bundler interfere with the execution of this Puppet resource.

NOTE: This pull request probably needs some more work, but I figured that I would submit for review early in order to determine whether this change is likely to be accepted upstream.