### PR TITLE
(PUP-7465) Ensure that multiple entries can be used for a title_pattern

### DIFF
--- a/lib/puppet/generate/models/type/type.rb
+++ b/lib/puppet/generate/models/type/type.rb
@@ -37,14 +37,15 @@ module Puppet
             @parameters = type.parameters.map do |name|
               Property.new(type.paramclass(name))
             end
+            sc = Puppet::Pops::Types::StringConverter.singleton
             @title_patterns = Hash[type.title_patterns.map do |mapping|
               [
-                "/#{mapping[0].source.gsub(/\//, '\/')}/",
-                mapping[1].map { |names|
+                sc.convert(mapping[0], '%p'),
+                sc.convert(mapping[1].map do |names|
                   next if names.empty?
-                  raise Puppet::Error, 'title patterns that use procs are not supported.' if names.size != 1
-                  Puppet::Pops::Types::StringConverter.convert(names[0].to_s, '%p')
-                }
+                  raise Puppet::Error, _('title patterns that use procs are not supported.') unless names.size == 1
+                  names[0].to_s
+                end, '%p')
               ]
             end]
             @isomorphic = type.isomorphic?

--- a/lib/puppet/generate/templates/type/pcore.erb
+++ b/lib/puppet/generate/templates/type/pcore.erb
@@ -34,7 +34,7 @@ Puppet::Resource::ResourceType3.new(
   ],
   {
 <%- title_patterns.each_with_index do |mapping, index| -%>
-    <%= mapping[0] %> => [<%= mapping[1].join(', ')%>]<%= "," if index + 1 < title_patterns.size %>
+    <%= mapping[0] %> => <%= mapping[1] %><%= "," if index + 1 < title_patterns.size %>
 <%- end -%>
   },
   <%= isomorphic -%>,

--- a/lib/puppet/pops/resource/resource_type_impl.rb
+++ b/lib/puppet/pops/resource/resource_type_impl.rb
@@ -155,7 +155,7 @@ class ResourceTypeImpl
           # TechDebt: The case of having one namevar and an empty title patterns is unspecified behavior in puppet.
           # Here, it may lead to an empty map which may or may not trigger the wanted/expected behavior.
           #
-          @title_patterns_hash.map {|k,v| [ k, [ v.map {|n| n.to_sym } ] ] }
+          @title_patterns_hash.map { |k,v| [ k, v.map { |n| [ n.to_sym ] } ] }
         end
       else
         if @title_patterns_hash.nil? || @title_patterns_hash.empty?
@@ -166,7 +166,7 @@ class ResourceTypeImpl
           #
           raise Puppet::DevError,"you must specify title patterns when there are two or more key attributes"
         end
-        @title_patterns_hash.nil? ? [] : @title_patterns_hash.map {|k,v| [ k, [ v.map {|n| n.to_sym } ] ] }
+        @title_patterns_hash.nil? ? [] : @title_patterns_hash.map { |k,v| [ k, v.map { |n| [ n.to_sym] } ] }
       end
   end
 

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -839,8 +839,9 @@ class StringConverter
     f = get_format(val_type, format_map)
     case f.format
     when :p
-      str_regexp = '/'
-      str_regexp << (val.options == 0 ? val.source : val.to_s).gsub(/\//, '\/') << '/'
+      rx_s = val.options == 0 ? val.source : val.to_s
+      rx_s = rx_s.gsub(/\//, '\/') unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+      str_regexp = "/#{rx_s}/"
       f.orig_fmt == '%p' ? str_regexp : Kernel.format(f.orig_fmt.gsub('p', 's'), str_regexp)
     when :s
       str_regexp = val.options == 0 ? val.source : val.to_s

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -840,7 +840,7 @@ class StringConverter
     case f.format
     when :p
       str_regexp = '/'
-      str_regexp << (val.options == 0 ? val.source : val.to_s) << '/'
+      str_regexp << (val.options == 0 ? val.source : val.to_s).gsub(/\//, '\/') << '/'
       f.orig_fmt == '%p' ? str_regexp : Kernel.format(f.orig_fmt.gsub('p', 's'), str_regexp)
     when :s
       str_regexp = val.options == 0 ? val.source : val.to_s

--- a/spec/integration/parser/pcore_resource_spec.rb
+++ b/spec/integration/parser/pcore_resource_spec.rb
@@ -57,6 +57,17 @@ describe 'when pcore described resources types are in use' do
               end
             end;end
             EOF
+            'test3.rb' => <<-RUBY,
+              Puppet::Type.newtype(:test3) do
+                newproperty(:message)
+                newparam(:a) { isnamevar }
+                newparam(:b) { isnamevar }
+                newparam(:c) { isnamevar }
+                def self.title_patterns
+                  [ [ /^((.+)\\/(.*))$/,  [[:a], [:b], [:c]]] ]
+                end
+              end
+            RUBY
             'cap.rb' => <<-EOF
             module Puppet
             Type.newtype(:cap, :is_capability => true) do
@@ -112,12 +123,16 @@ describe 'when pcore described resources types are in use' do
         test2 { 'b':
           message => 'b works'
         }
+        test3 { 'x/y':
+          message => 'x/y works'
+        }
         cap { 'c':
           message => 'c works'
         }
       MANIFEST
       expect(catalog.resource(:test1, "a")['message']).to eq('a works')
       expect(catalog.resource(:test2, "b")['message']).to eq('b works')
+      expect(catalog.resource(:test3, "x/y")['message']).to eq('x/y works')
       expect(catalog.resource(:cap, "c")['message']).to eq('c works')
     end
 

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -906,6 +906,11 @@ describe 'The string converter' do
         string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
         expect(converter.convert(/[a-z]\s*/m, string_formats)).to eq('/(?m-ix:[a-z]\s*)/')
       end
+
+      it 'the format %p produces \'/foo\/bar/\' for expression /foo\/bar/' do
+        string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
+        expect(converter.convert(/foo\/bar/, string_formats)).to eq('/foo\/bar/')
+      end
     end
 
     it 'errors when format is not recognized' do


### PR DESCRIPTION
This PR fixes a bug in how the title pattern array for a Pcore
ResourceImpl was constructed. Before the fix, all entries for a specific
pattern were incorrectly wrapped in one single array. After the fix,
each entry is wrapped in an array of its own.