### PR TITLE
(PUP-25) Ensure that resource defaults are evaluated before collections

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -169,6 +169,8 @@ class Puppet::Parser::Compiler
       # New capability mappings may have been defined when the site was evaluated
       Puppet::Util::Profiler.profile(_("Compile: Evaluated site capability mappings"), [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
 
+      Puppet::Util::Profiler.profile(_("Compile: Evaluated resource defaults"), [:compiler, :evaluate_resource_defaults]) { evaluate_resource_defaults }
+
       Puppet::Util::Profiler.profile(_("Compile: Evaluated generators"), [:compiler, :evaluate_generators]) { evaluate_generators }
 
       Puppet::Util::Profiler.profile(_("Compile: Validate Catalog pre-finish"), [:compiler, :validate_pre_finish]) do
@@ -608,6 +610,10 @@ class Puppet::Parser::Compiler
     if !remaining.empty?
       raise Puppet::ParseError, _("Failed to realize virtual resources %{resources}") % { resources: remaining.join(', ') }
     end
+  end
+
+  def evaluate_resource_defaults
+    resources.each { |resource| resource.add_defaults }
   end
 
   # Make sure all of our resources and such have done any last work

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -67,6 +67,8 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
 
         Puppet::Util::Profiler.profile(_("Env Compile: Evaluated application instances"), [:compiler, :evaluate_applications]) { evaluate_applications }
 
+        Puppet::Util::Profiler.profile(_("Env Compile: Evaluated resource defaults"), [:compiler, :evaluate_resource_defaults]) { evaluate_resource_defaults }
+
         Puppet::Util::Profiler.profile(_("Env Compile: Prune"), [:compiler, :prune_catalog]) { prune_catalog }
 
         Puppet::Util::Profiler.profile(_("Env Compile: Validate Catalog pre-finish"), [:compiler, :validate_pre_finish]) do

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -99,7 +99,6 @@ class Puppet::Parser::Resource < Puppet::Resource
   #
   def finish_evaluation
     return if @evaluation_finished
-    add_defaults
     add_scope_tags
     @evaluation_finished = true
   end
@@ -299,18 +298,21 @@ class Puppet::Parser::Resource < Puppet::Resource
     nil
   end
 
-  private
-
   # Add default values from our definition.
+  # @api private
   def add_defaults
     scope.lookupdefaults(self.type).each do |name, param|
       unless @parameters.include?(name)
         self.debug "Adding default for #{name}"
 
-        @parameters[name] = param.dup
+        param = param.dup
+        @parameters[name] = param
+        tag(*param.value) if param.name == :tag
       end
     end
   end
+
+  private
 
   def add_scope_tags
     scope_resource = scope.resource

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -53,6 +53,9 @@ class CompilerTestResource
   def resource_type
     self.class
   end
+
+  def add_defaults
+  end
 end
 
 describe Puppet::Parser::Compiler do


### PR DESCRIPTION
This commit moves the evaluation of resource defaults so that it happens
before the evaluation of generators and collections. In addition, the
`add_defaults` method will now also set a tag if the name of the
parameter that receives a default value is `:tag`