### PR TITLE
(PUP-7470) Use a feature check instead of inspecting `Gem.loaded_specs['gettext-setup']`

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -73,7 +73,7 @@ module Puppet
       end
 
       if locale_path
-        if Gem.loaded_specs['gettext-setup'].version < Gem::Version.new('0.8')
+        if GettextSetup.method(:initialize).parameters.count == 1
           # Will load translations from PO files only
           GettextSetup.initialize(locale_path)
         else


### PR DESCRIPTION
`Gem.loaded_specs['gettext_setup']` doesn't work with Bundler's standalone binstubs, which intentionally avoids a dependency on RubyGems and, instead, manipulates Ruby's `$LOAD_PATH` directly. As such, Puppet 4 doesn't currently work using Bundler's standalone binstubs (Puppet 3, however, works fine):

```
/etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet.rb:76:in `singleton class': undefined method `version' for nil:NilClass (NoMethodError)
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet.rb:55:in `<module:Puppet>'
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet.rb:49:in `<top (required)>'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/lib/puppet/util/command_line.rb:12:in `<top (required)>'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/rbenv/versions/2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /etc/puppet/vendor/bundle/ruby/2.1.0/gems/puppet-4.10.0/bin/puppet:4:in `<top (required)>'
    from /etc/puppet/bin/puppet:14:in `load'
    from /etc/puppet/bin/puppet:14:in `<main>'
```

See some relevant context in bundler/bundler#5601.