### PR TITLE
(PUP-7469) Add tests for runtime string conversion

### DIFF
--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -544,23 +544,10 @@ class StringConverter
     when :s
       val.to_s
     when :q
-      val.to_s.inspect
-    when :puppet
-      puppet_safe(val.to_s)
-    when :i, :d, :x, :o, :f, :puppet
-      converted = convert(o, PNumericType) # rest is default
-      "%#{f}" % converted
+      val.inspect
     else
-      raise FormatError.new('Runtime', f.format, 'sqidxof')
+      raise FormatError.new('Runtime', f.format, 'sq')
     end
-  end
-
-  # Given an unsafe string make it safe for puppet
-  def puppet_safe(str)
-    str = str.inspect # all specials are now quoted
-    # all $ variables must be quoted
-    str.gsub!("\$", "\\\$")
-    str
   end
 
   # Basically string_PAnyType converts the value to a String and then formats it according

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -874,6 +874,22 @@ describe 'The string converter' do
     end
   end
 
+  context 'when converting a runtime type' do
+    [ :sym, (1..3), Time.now ].each do |value|
+      it "the default string representation for #{value} is #to_s" do
+        expect(converter.convert(value, :default)).to eq(value.to_s)
+      end
+
+      it "the '%q' string representation for #{value} is #inspect" do
+        expect(converter.convert(value, '%q')).to eq(value.inspect)
+      end
+    end
+
+    it 'an unknown format raises an error' do
+      expect { converter.convert(:sym, '%b') }.to raise_error("Illegal format 'b' specified for value of Runtime type - expected one of the characters 'sq'")
+    end
+  end
+
   context 'when converting regexp' do
     it 'the default string representation is "regexp"' do
       expect(converter.convert(/.*/, :default)).to eq('.*')


### PR DESCRIPTION
This commit adds some well needed tests for the `StringConverter` method
`string_PRuntimeType`. It also removes some dead code from that method.