### PR TITLE
(PUP-7357) Verify agent can parse a JSON catalog

### DIFF
--- a/acceptance/tests/agent/agent_parses_json_catalog.rb
+++ b/acceptance/tests/agent/agent_parses_json_catalog.rb
@@ -1,0 +1,23 @@
+test_name "C99978: Agent parses a JSON catalog"
+tag 'risk:medium'
+
+require 'json'
+
+step "Refresh the catalog" do
+  on(agents, puppet("agent --test --server #{master}"))
+end
+
+step "Agent parses a JSON catalog" do
+  agents.each do |agent|
+    # Is it there and can we read it?
+    json_catalog = File.join(agent.puppet['client_datadir'], 'catalog',
+                             "#{agent.puppet['certname']}.json")
+    on(agent, "[[ -r #{json_catalog} ]]", {:acceptable_exit_codes => [0]})
+
+    # The catalog file should be parseable JSON
+    on(agent, "cat #{json_catalog} | ruby -rjson -e 'JSON.parse(STDIN.read)'")
+
+    # Can the agent parse it as JSON?
+    on(agent, puppet("catalog find --terminus json --server #{master} > /dev/null"))
+  end
+end


### PR DESCRIPTION
Now that JSON is preferred to PSON (PUP-7259), verify that that the agent can parse a JSON catalog. This is the first of several tests for PUP-7357.