### PR TITLE
(PUP-7473) remove dead code in Puppet::Type::instances

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1161,12 +1161,6 @@ class Type
     # Put the default provider first, then the rest of the suitable providers.
     provider_instances = {}
     providers_by_source.collect do |provider|
-      self.properties.find_all do |property|
-        provider.supports_parameter?(property)
-      end.collect do |property|
-        property.name
-      end
-
       provider.instances.collect do |instance|
         # We always want to use the "first" provider instance we find, unless the resource
         # is already managed and has a different provider set


### PR DESCRIPTION
This block removed in this commit iterates over all of the properties of the
type, checks if the given provider supports the property, and returns an array
of all the supported property names.  Except we don't do anything with the
result.  Before commit 53241a91, which was a maint commit to remove superfluous
variables we never used, the result of this block was assigned to the variable
`all_properties` - which was never used. The commit removed the variable, but
not the associated block.  I believe the intention was to filter out properties
that weren't supported by the provider before we called `newattr` on them,
except `newattr` already does this filtering, and provides helpful debug output
that a provider doesn't support a property so we're not managing it. Hence we
remove it here to avoid useless confusion/object iteration/creation.

Signed-off-by: Moses Mendoza <moses@puppet.com>