### PR TITLE
(PUP-7357) Verify agent can parse a JSON catalog

### DIFF
--- a/acceptance/tests/agent/agent_parses_json_catalog.rb
+++ b/acceptance/tests/agent/agent_parses_json_catalog.rb
@@ -1,0 +1,23 @@
+test_name "C99978: Agent parses a JSON catalog"
+tag 'risk:medium'
+
+require 'puppet/acceptance/common_utils'
+require 'json'
+
+step "Agent parses a JSON catalog" do
+  agents.each do |agent|
+    # Path to a ruby binary
+    ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
+  
+    # Refresh the catalog
+    on(agent, puppet("agent --test --server #{master}"))
+
+    # The catalog file should be parseable JSON
+    json_catalog = File.join(agent.puppet['client_datadir'], 'catalog',
+                             "#{agent.puppet['certname']}.json")
+    on(agent, "cat #{json_catalog} | #{ruby} -rjson -e 'JSON.parse(STDIN.read)'")
+
+    # Can the agent parse it as JSON?
+    on(agent, puppet("catalog find --terminus json --server #{master} > /dev/null"))
+  end
+end


### PR DESCRIPTION
Confirm that the agent can parse a JSON catalog and that the catalog request prefers JSON to PSON.