### PR TITLE
(PUP-6994) Limit Pcore Data type to native JSON and introduce RichData type.

### DIFF
--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -115,7 +115,6 @@ module Puppet
   require 'puppet/parser/ast/pops_bridge'
   require 'puppet/bindings'
   require 'puppet/functions'
-  require 'puppet/loaders'
 
   Puppet::Pops::Model.register_pcore_types
 end

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -62,7 +62,7 @@ module Adapters
     def self.loader_for_model_object(model, file = nil, default_loader = nil)
       loaders = Puppet.lookup(:loaders) { nil }
       if loaders.nil?
-        default_loader
+        default_loader || Loaders.static_loader
       else
         loader_name = loader_name_by_source(loaders.environment, model, file)
         loader_name.nil? ? default_loader || loaders.find_loader(nil) : loaders[loader_name]

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -36,6 +36,7 @@ class StaticLoader < Loader
       Nagios_serviceextinfo
       Nagios_servicegroup
       Nagios_timeperiod
+      Node
       Notify
       Package
       Resources
@@ -115,59 +116,7 @@ class StaticLoader < Loader
     # We are also not interested in their definition only that they exist.
     # These types are in all environments.
     #
-    %w{
-      Auegas
-      Component
-      Computer
-      Cron
-      Exec
-      File
-      Filebucket
-      Group
-      Host
-      Interface
-      K5login
-      Macauthorization
-      Mailalias
-      Maillist
-      Mcx
-      Mount
-      Nagios_command
-      Nagios_contact
-      Nagios_contactgroup
-      Nagios_host
-      Nagios_hostdependency
-      Nagios_hostescalation
-      Nagios_hostgroup
-      Nagios_hostextinfo
-      Nagios_service
-      Nagios_servicedependency
-      Nagios_serviceescalation
-      Nagios_serviceextinfo
-      Nagios_servicegroup
-      Nagios_timeperiod
-      Node
-      Notify
-      Package
-      Resources
-      Router
-      Schedule
-      Scheduled_task
-      Selboolean
-      Selmodule
-      Service
-      Ssh_authorized_key
-      Sshkey
-      Stage
-      Tidy
-      User
-      Vlan
-      Whit
-      Yumrepo
-      Zfs
-      Zone
-      Zpool
-    }.each { |name| create_resource_type_reference(name) }
+    BUILTIN_TYPE_NAMES.each { |name| create_resource_type_reference(name) }
   end
 
   def create_resource_type_reference(name)

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -62,14 +62,20 @@ class StaticLoader < Loader
   BUILTIN_TYPE_NAMES_LC = Set.new(BUILTIN_TYPE_NAMES.map { |n| n.downcase }).freeze
 
   BUILTIN_ALIASES = {
-    'Data' => 'Variant[ScalarData,Undef,Hash[String,Data],Array[Data]]'
+    'Data' => 'Variant[ScalarData,Undef,Hash[String,Data],Array[Data]]',
+    'RichDataKey' => 'Variant[String,Numeric]',
+    'RichData' => 'Variant[Scalar,SemVerRange,Binary,Sensitive,Type,TypeSet,Undef,Hash[RichDataKey,RichData],Array[RichData]]',
+
+    # Backward compatible aliases.
+    'Puppet::LookupKey' => 'RichDataKey',
+    'Puppet::LookupValue' => 'RichData'
   }.freeze
 
   attr_reader :loaded
   def initialize
     @loaded = {}
-    create_built_in_types()
-    create_resource_type_references()
+    create_built_in_types
+    create_resource_type_references
     register_aliases
   end
 

--- a/lib/puppet/pops/lookup/data_provider.rb
+++ b/lib/puppet/pops/lookup/data_provider.rb
@@ -11,24 +11,9 @@ module DataProvider
   end
 
   def self.register_types(loader)
-    (@key_type, @value_type) = Pcore::register_aliases({
-      # The Pcore type for all keys and subkeys in a data hash.
-      'Puppet::LookupKey' => 'Variant[String,Numeric]',
-
-      # The Pcore type for all values and sub-values in a data hash. The
-      # type is self-recursive to enforce the same constraint on values contained
-      # in arrays and hashes
-      'Puppet::LookupValue' => <<-PUPPET
-        Variant[
-          Scalar,
-          Undef,
-          Sensitive,
-          Type,
-          Hash[Puppet::LookupKey, Puppet::LookupValue],
-          Array[Puppet::LookupValue]
-        ]
-        PUPPET
-    }, Pcore::RUNTIME_NAME_AUTHORITY, loader)
+    tp = Types::TypeParser.singleton
+    @key_type = tp.parse('RichDataKey', loader)
+    @value_type = tp.parse('RichData', loader)
   end
 
   # Performs a lookup with an endless recursion check.

--- a/lib/puppet/pops/types/p_meta_type.rb
+++ b/lib/puppet/pops/types/p_meta_type.rb
@@ -19,6 +19,10 @@ class PMetaType < PAnyType
     super
   end
 
+  def instance?(o, guard = nil)
+    assignable?(TypeCalculator.infer(o), guard)
+  end
+
   # Called from the TypeParser once it has found a type using the Loader. The TypeParser will
   # interpret the contained expression and the resolved type is remembered. This method also
   # checks and remembers if the resolve type contains self recursion.

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -739,10 +739,6 @@ class PObjectType < PMetaType
     @parent.nil? ? false : @parent.kind_of_callable?(optional, guard)
   end
 
-  def instance?(o, guard = nil)
-    assignable?(TypeCalculator.infer(o), guard)
-  end
-
   def iterable?(guard = nil)
     @parent.nil? ? false : @parent.iterable?(guard)
   end

--- a/lib/puppet/pops/types/p_sem_ver_range_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_range_type.rb
@@ -4,9 +4,9 @@ module Types
 # An unparameterized type that represents all VersionRange instances
 #
 # @api public
-class PSemVerRangeType < PScalarType
+class PSemVerRangeType < PAnyType
   def self.register_ptype(loader, ir)
-    create_ptype(loader, ir, 'ScalarType')
+    create_ptype(loader, ir, 'AnyType')
   end
 
   # Check if a version is included in a version range. The version can be a string or

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -432,6 +432,10 @@ class TypeCalculator
       return PType.new(common_type(t1.type, t2.type))
     end
 
+    if common_rich_data?(t1,t2)
+      return TypeFactory.rich_data
+    end
+
     # If both are Runtime types
     if t1.is_a?(PRuntimeType) && t2.is_a?(PRuntimeType)
       if t1.runtime == t2.runtime && t1.runtime_type_name == t2.runtime_type_name
@@ -759,6 +763,11 @@ class TypeCalculator
   end
 
   private
+
+  def common_rich_data?(t1, t2)
+    d = TypeFactory.rich_data
+    d.assignable?(t1) && d.assignable?(t2)
+  end
 
   def common_data?(t1, t2)
     d = TypeFactory.data

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -214,11 +214,11 @@ class TypeCalculator
     when c == Class
       type = PType::DEFAULT
     when c == Array
-      # Assume array of data values
-      type = PArrayType::DATA
+      # Assume array of any
+      type = PArrayType::DEFAULT
     when c == Hash
-      # Assume hash with scalar keys and data values
-      type = PHashType::DATA
+      # Assume hash of any
+      type = PHashType::DEFAULT
    else
       type = PRuntimeType.new(:ruby, c.name)
     end

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -415,6 +415,10 @@ class TypeCalculator
       return PNumericType::DEFAULT
     end
 
+    if common_scalar_data?(t1, t2)
+      return PScalarDataType::DEFAULT
+    end
+
     if common_scalar?(t1, t2)
       return PScalarType::DEFAULT
     end
@@ -758,6 +762,10 @@ class TypeCalculator
 
   def common_data?(t1, t2)
     PDataType::DEFAULT.assignable?(t1) && PDataType::DEFAULT.assignable?(t2)
+  end
+
+  def common_scalar_data?(t1, t2)
+    PScalarDataType::DEFAULT.assignable?(t1) && PScalarDataType::DEFAULT.assignable?(t2)
   end
 
   def common_scalar?(t1, t2)

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -424,7 +424,7 @@ class TypeCalculator
     end
 
     if common_data?(t1,t2)
-      return PDataType::DEFAULT
+      return TypeFactory.data
     end
 
     # Meta types Type[Integer] + Type[String] => Type[Data]
@@ -761,7 +761,8 @@ class TypeCalculator
   private
 
   def common_data?(t1, t2)
-    PDataType::DEFAULT.assignable?(t1) && PDataType::DEFAULT.assignable?(t2)
+    d = TypeFactory.data
+    d.assignable?(t1) && d.assignable?(t2)
   end
 
   def common_scalar_data?(t1, t2)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -332,7 +332,7 @@ module TypeFactory
   # @api public
   #
   def self.data
-    PDataType::DEFAULT
+    @data_t ||= TypeParser.singleton.parse('Data', Loaders.static_loader)
   end
 
   # Creates an instance of the Undef type
@@ -440,7 +440,7 @@ module TypeFactory
   # @api public
   #
   def self.array_of_data
-    PArrayType::DATA
+    @array_of_data_t = PArrayType.new(data)
   end
 
   # Produces a type for Hash[Any,Any]
@@ -454,7 +454,7 @@ module TypeFactory
   # @api public
   #
   def self.hash_of_data
-    PHashType::DATA
+    @hash_of_data_t = PHashType.new(string, data)
   end
 
   # Produces a type for NotUndef[T]

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -422,6 +422,13 @@ module TypeFactory
     PHashType.new(key_type, value_type, size_type)
   end
 
+  # Produces a type for Array[Any]
+  # @api public
+  #
+  def self.array_of_any
+    PArrayType::DEFAULT
+  end
+
   # Produces a type for Array[Data]
   # @api public
   #
@@ -429,7 +436,14 @@ module TypeFactory
     PArrayType::DATA
   end
 
-  # Produces a type for Hash[Scalar, Data]
+  # Produces a type for Hash[Any,Any]
+  # @api public
+  #
+  def self.hash_of_any
+    PHashType::DEFAULT
+  end
+
+  # Produces a type for Hash[String,Data]
   # @api public
   #
   def self.hash_of_data

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -252,11 +252,18 @@ module TypeFactory
     PPatternType.new(patterns)
   end
 
-  # Produces the Literal type
+  # Produces the Scalar type
   # @api public
   #
   def self.scalar
     PScalarType::DEFAULT
+  end
+
+  # Produces the ScalarData type
+  # @api public
+  #
+  def self.scalar_data
+    PScalarDataType::DEFAULT
   end
 
   # Produces a CallableType matching all callables

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -335,6 +335,13 @@ module TypeFactory
     @data_t ||= TypeParser.singleton.parse('Data', Loaders.static_loader)
   end
 
+  # Produces the RichData type
+  # @api public
+  #
+  def self.rich_data
+    @rich_data_t ||= TypeParser.singleton.parse('RichData', Loaders.static_loader)
+  end
+
   # Creates an instance of the Undef type
   # @api public
   def self.undef

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -483,7 +483,7 @@ class TypeFormatter
   def format_type_alias_type(t, expand)
     if @type_set.nil?
       @bld << t.name
-      if expand
+      if expand && !Loader::StaticLoader::BUILTIN_ALIASES.include?(t.name)
         @bld << ' = '
         append_string(t.resolved_type)
       end

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -158,9 +158,6 @@ class TypeFormatter
   def string_PScalarDataType(_)  ; @bld << 'ScalarData'  ; end
 
   # @api private
-  def string_PDataType(_)    ; @bld << 'Data'    ; end
-
-  # @api private
   def string_PNumericType(_) ; @bld << 'Numeric' ; end
 
   # @api private

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -155,6 +155,9 @@ class TypeFormatter
   def string_PScalarType(_)  ; @bld << 'Scalar'  ; end
 
   # @api private
+  def string_PScalarDataType(_)  ; @bld << 'ScalarData'  ; end
+
+  # @api private
   def string_PDataType(_)    ; @bld << 'Data'    ; end
 
   # @api private

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -345,7 +345,7 @@ class TypeFormatter
     if t.has_empty_range?
       append_array('Array') { append_strings([0, 0]) }
     else
-      append_array('Array', t == PArrayType::DATA) do
+      append_array('Array', t == PArrayType::DEFAULT) do
         append_strings([t.element_type], true)
         append_elements(range_array_part(t.size_type), true)
         chomp_list
@@ -358,7 +358,7 @@ class TypeFormatter
     if t.has_empty_range?
       append_array('Hash') { append_strings([0, 0]) }
     else
-      append_array('Hash', t == PHashType::DATA) do
+      append_array('Hash', t == PHashType::DEFAULT) do
         append_strings([t.key_type, t.value_type], true)
         append_elements(range_array_part(t.size_type), true)
         chomp_list

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -330,9 +330,11 @@ module Types
       multi = false
       if @optional
         if e.is_a?(PVariantType)
-          e = [PUndefType::DEFAULT] + e.types
+          e = e.types
+          e = [PUndefType::DEFAULT] + e unless e.include?(PUndefType::DEFAULT)
         else
-          e = [PUndefType::DEFAULT, e]
+          er = all_resolved(e)
+          e = [PUndefType::DEFAULT, e] unless er.is_a?(PVariantType) && er.types.include?(PUndefType::DEFAULT)
         end
       elsif e.is_a?(PVariantType)
         e = e.types
@@ -445,7 +447,7 @@ module Types
       if e.is_a?(Array)
         e.map { |t| all_resolved(t) }
       else
-        e.is_a?(PTypeAliasType) ? e.resolved_type : e
+        e.is_a?(PTypeAliasType) ? all_resolved(e.resolved_type) : e
       end
     end
 
@@ -463,8 +465,7 @@ module Types
       if always_fully_detailed?(e, a)
         a.to_alias_expanded_s
       else
-        g = a.generalize
-        any_assignable?(e, g) ? a.to_alias_expanded_s : g.to_s
+        any_assignable?(e, a.generalize) ? a.to_alias_expanded_s : a.simple_name
       end
     end
   end
@@ -795,7 +796,7 @@ module Types
     def describe_PTypeAliasType(expected, actual, path)
       resolved_type = expected.resolved_type
       describe(resolved_type, actual, path).map do |description|
-        if description.is_a?(ExpectedActualMismatch) && description.expected.equal?(resolved_type)
+        if description.is_a?(ExpectedActualMismatch)
           description.swap_expected(expected)
         else
           description

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -168,7 +168,6 @@ class TypeParser
         'boolean'      => TypeFactory.boolean,
         'pattern'      => TypeFactory.pattern,
         'regexp'       => TypeFactory.regexp,
-        'data'         => TypeFactory.data,
         'array'        => TypeFactory.array_of_any,
         'hash'         => TypeFactory.hash_of_any,
         'class'        => TypeFactory.host_class,

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -169,16 +169,16 @@ class TypeParser
         'pattern'      => TypeFactory.pattern,
         'regexp'       => TypeFactory.regexp,
         'data'         => TypeFactory.data,
-        'array'        => TypeFactory.array_of_data,
-        'hash'         => TypeFactory.hash_of_data,
+        'array'        => TypeFactory.array_of_any,
+        'hash'         => TypeFactory.hash_of_any,
         'class'        => TypeFactory.host_class,
         'resource'     => TypeFactory.resource,
         'collection'   => TypeFactory.collection,
         'scalar'       => TypeFactory.scalar,
         'catalogentry' => TypeFactory.catalog_entry,
         'undef'        => TypeFactory.undef,
-        'notundef'     => TypeFactory.not_undef(),
-        'default'      => TypeFactory.default(),
+        'notundef'     => TypeFactory.not_undef,
+        'default'      => TypeFactory.default,
         'any'          => TypeFactory.any,
         'variant'      => TypeFactory.variant,
         'optional'     => TypeFactory.optional,
@@ -196,7 +196,7 @@ class TypeParser
         'semverrange'  => TypeFactory.sem_ver_range,
         'timestamp'    => TypeFactory.timestamp,
         'timespan'     => TypeFactory.timespan
-    }
+    }.freeze
   end
 
   # @api private

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -175,6 +175,7 @@ class TypeParser
         'resource'     => TypeFactory.resource,
         'collection'   => TypeFactory.collection,
         'scalar'       => TypeFactory.scalar,
+        'scalardata'   => TypeFactory.scalar_data,
         'catalogentry' => TypeFactory.catalog_entry,
         'undef'        => TypeFactory.undef,
         'notundef'     => TypeFactory.not_undef,

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -44,7 +44,6 @@ EMPTY_STRING = Puppet::Pops::EMPTY_STRING
 #
 # @api public
 #
-# TODO: See PUP-2978 for possible performance optimization
 class TypedModelObject < Object
   include PuppetObject
   include Visitable

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -645,7 +645,7 @@ class PScalarType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    if o.is_a?(String) || o.is_a?(Numeric) || o.is_a?(TrueClass) || o.is_a?(FalseClass) || o.is_a?(Regexp) || o.is_a?(SemanticPuppet::VersionRange)
+    if o.is_a?(String) || o.is_a?(Numeric) || o.is_a?(TrueClass) || o.is_a?(FalseClass) || o.is_a?(Regexp)
       true
     elsif o.is_a?(Array) || o.is_a?(Hash) || o.is_a?(PAnyType) || o.is_a?(NilClass)
       false

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -75,7 +75,6 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PPatternType,
       Puppet::Pops::Types::PEnumType,
       Puppet::Pops::Types::PSemVerType,
-      Puppet::Pops::Types::PSemVerRangeType,
       Puppet::Pops::Types::PTimespanType,
       Puppet::Pops::Types::PTimestampType,
     ]

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -7,6 +7,7 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PNotUndefType,
       Puppet::Pops::Types::PDataType,
       Puppet::Pops::Types::PScalarType,
+      Puppet::Pops::Types::PScalarDataType,
       Puppet::Pops::Types::PStringType,
       Puppet::Pops::Types::PNumericType,
       Puppet::Pops::Types::PIntegerType,
@@ -44,10 +45,28 @@ shared_context 'types_setup' do
     self.class.all_types
   end
 
+  def self.scalar_data_types
+    # PVariantType is also scalar data, if its types are all ScalarData
+    [
+      Puppet::Pops::Types::PScalarDataType,
+      Puppet::Pops::Types::PStringType,
+      Puppet::Pops::Types::PNumericType,
+      Puppet::Pops::Types::PIntegerType,
+      Puppet::Pops::Types::PFloatType,
+      Puppet::Pops::Types::PBooleanType,
+      Puppet::Pops::Types::PEnumType,
+    ]
+  end
+  def scalar_data_types
+    self.class.scalar_data_types
+  end
+
+
   def self.scalar_types
     # PVariantType is also scalar, if its types are all Scalar
     [
       Puppet::Pops::Types::PScalarType,
+      Puppet::Pops::Types::PScalarDataType,
       Puppet::Pops::Types::PStringType,
       Puppet::Pops::Types::PNumericType,
       Puppet::Pops::Types::PIntegerType,
@@ -105,7 +124,7 @@ shared_context 'types_setup' do
   end
 
   def self.data_compatible_types
-    result = scalar_types
+    result = scalar_data_types
     result << Puppet::Pops::Types::PDataType
     result << Puppet::Pops::Types::PArrayType::DATA
     result << Puppet::Pops::Types::PHashType::DATA

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -5,7 +5,6 @@ shared_context 'types_setup' do
     [ Puppet::Pops::Types::PAnyType,
       Puppet::Pops::Types::PUndefType,
       Puppet::Pops::Types::PNotUndefType,
-      Puppet::Pops::Types::PDataType,
       Puppet::Pops::Types::PScalarType,
       Puppet::Pops::Types::PScalarDataType,
       Puppet::Pops::Types::PStringType,
@@ -125,19 +124,21 @@ shared_context 'types_setup' do
 
   def self.data_compatible_types
     result = scalar_data_types
-    result << Puppet::Pops::Types::PDataType
-    result << Puppet::Pops::Types::PArrayType::DATA
-    result << Puppet::Pops::Types::PHashType::DATA
+    result << Puppet::Pops::Types::PArrayType.new(Puppet::Pops::Types::PScalarDataType::DEFAULT)
+    result << Puppet::Pops::Types::PHashType.new(Puppet::Pops::Types::PStringType::DEFAULT, Puppet::Pops::Types::PScalarDataType::DEFAULT)
     result << Puppet::Pops::Types::PUndefType
-    result << Puppet::Pops::Types::PNotUndefType.new(Puppet::Pops::Types::PDataType::DEFAULT)
-    result << Puppet::Pops::Types::PTupleType.new([Puppet::Pops::Types::PDataType::DEFAULT], Puppet::Pops::Types::PIntegerType.new(0, nil))
+    result << Puppet::Pops::Types::PNotUndefType.new(Puppet::Pops::Types::PScalarDataType::DEFAULT)
+    result << Puppet::Pops::Types::PTupleType.new([Puppet::Pops::Types::PScalarDataType::DEFAULT])
     result
   end
   def data_compatible_types
     self.class.data_compatible_types
   end
 
-  def type_from_class(c)
+  def self.type_from_class(c)
     c.is_a?(Class) ? c::DEFAULT : c
+  end
+  def type_from_class(c)
+    self.class.type_from_class(c)
   end
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2513,7 +2513,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect{lookup('mod_a::a')}.to raise_error(
-              "Return type of 'lookup_key' function named 'mod_a::pp_lookup_key' is incorrect, expects a value of type Undef, Scalar, Sensitive, Type, Hash, or Array, got Runtime")
+              "Return type of 'lookup_key' function named 'mod_a::pp_lookup_key' is incorrect, expects a RichData value, got Runtime")
           end
         end
       end

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -532,7 +532,7 @@ describe 'the new function' do
   context 'when invoked on Array' do
     { []            => 'Notify[Array[Unit], []]',
       [true]        => 'Notify[Array[Boolean], [true]]',
-      {'a'=>true, 'b' => false}   => 'Notify[Array[Array[Scalar]], [[a, true], [b, false]]]',
+      {'a'=>true, 'b' => false}   => 'Notify[Array[Array[ScalarData]], [[a, true], [b, false]]]',
       'abc'         => 'Notify[Array[String[1, 1]], [a, b, c]]',
       3             => 'Notify[Array[Integer], [0, 1, 2]]',
     }.each do |input, result|

--- a/spec/unit/pops/evaluator/basic_expressions_spec.rb
+++ b/spec/unit/pops/evaluator/basic_expressions_spec.rb
@@ -31,7 +31,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     it 'should evaluator types to types' do
-      array_type = Puppet::Pops::Types::PArrayType::DATA
+      array_type = Puppet::Pops::Types::PArrayType::DEFAULT
       expect(evaluate(fqr('Array'))).to eq(array_type)
     end
   end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -323,7 +323,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
                     'Array', 'Hash', 'CatalogEntry', 'Resource', 'Class', 'Undef', 'File' ],
 
       # Note, Data > Collection is false (so not included)
-      'Data'    => ['Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Array[Data]', 'Hash[String,Data]',],
+      'Data'    => ['ScalarData', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Array[Data]', 'Hash[String,Data]',],
       'Scalar' => ['Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern'],
       'Numeric' => ['Integer', 'Float'],
       'CatalogEntry' => ['Class', 'Resource', 'File'],

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -56,7 +56,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "banana::split" => 'banana::split',
       "false"         => false,
       "true"          => true,
-      "Array"         => types.array_of_data(),
+      "Array"         => types.array_of_any,
       "/.*/"          => /.*/
     }.each do |source, result|
         it "should parse and evaluate the expression '#{source}' to #{result}" do
@@ -323,7 +323,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
                     'Array', 'Hash', 'CatalogEntry', 'Resource', 'Class', 'Undef', 'File' ],
 
       # Note, Data > Collection is false (so not included)
-      'Data'    => ['Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Array', 'Hash',],
+      'Data'    => ['Scalar', 'Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern', 'Array[Data]', 'Hash[String,Data]',],
       'Scalar' => ['Numeric', 'Integer', 'Float', 'Boolean', 'String', 'Pattern'],
       'Numeric' => ['Integer', 'Float'],
       'CatalogEntry' => ['Class', 'Resource', 'File'],

--- a/spec/unit/pops/types/iterable_spec.rb
+++ b/spec/unit/pops/types/iterable_spec.rb
@@ -72,6 +72,7 @@ describe 'The iterable support' do
       PResourceType::DEFAULT,
       PRuntimeType::DEFAULT,
       PScalarType::DEFAULT,
+      PScalarDataType::DEFAULT,
       PType::DEFAULT,
       PUndefType::DEFAULT
     ]

--- a/spec/unit/pops/types/iterable_spec.rb
+++ b/spec/unit/pops/types/iterable_spec.rb
@@ -60,7 +60,6 @@ describe 'The iterable support' do
       PBooleanType::DEFAULT,
       PCallableType::DEFAULT,
       PCatalogEntryType::DEFAULT,
-      PDataType::DEFAULT,
       PDefaultType::DEFAULT,
       PFloatType::DEFAULT,
       PHostClassType::DEFAULT,

--- a/spec/unit/pops/types/type_acceptor_spec.rb
+++ b/spec/unit/pops/types/type_acceptor_spec.rb
@@ -48,9 +48,9 @@ describe 'the Puppet::Pops::Types::TypeAcceptor' do
     POptionalType
   ].each do |tc|
     it "should get a visit from the contained type of an #{tc.class.name} that accepts it" do
-      t = tc.new(PDataType::DEFAULT)
+      t = tc.new(PStringType::DEFAULT)
       t.accept(acceptor, nil)
-      expect(acceptor.visitors).to include(t, PDataType::DEFAULT)
+      expect(acceptor.visitors).to include(t, PStringType::DEFAULT)
     end
   end
 

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -297,16 +297,16 @@ describe 'The type calculator' do
         expect(calculator.infer([1,2.0]).element_type.class).to eq(PNumericType)
       end
 
-      it 'with fixnum and string values translates to PArrayType[PScalarType]' do
-        expect(calculator.infer([1,'two']).element_type.class).to eq(PScalarType)
+      it 'with fixnum and string values translates to PArrayType[PScalarDataType]' do
+        expect(calculator.infer([1,'two']).element_type.class).to eq(PScalarDataType)
       end
 
-      it 'with float and string values translates to PArrayType[PScalarType]' do
-        expect(calculator.infer([1.0,'two']).element_type.class).to eq(PScalarType)
+      it 'with float and string values translates to PArrayType[PScalarDataType]' do
+        expect(calculator.infer([1.0,'two']).element_type.class).to eq(PScalarDataType)
       end
 
-      it 'with fixnum, float, and string values translates to PArrayType[PScalarType]' do
-        expect(calculator.infer([1, 2.0,'two']).element_type.class).to eq(PScalarType)
+      it 'with fixnum, float, and string values translates to PArrayType[PScalarDataType]' do
+        expect(calculator.infer([1, 2.0,'two']).element_type.class).to eq(PScalarDataType)
       end
 
       it 'with fixnum and regexp values translates to PArrayType[PScalarType]' do
@@ -334,13 +334,13 @@ describe 'The type calculator' do
         expect(et.class).to eq(PEnumType)
       end
 
-      it 'with array of string values and array of fixnums translates to PArrayType[PArrayType[PScalarType]]' do
+      it 'with array of string values and array of fixnums translates to PArrayType[PArrayType[PScalarDataType]]' do
         et = calculator.infer([['first', 'array'], [1,2]])
         expect(et.class).to eq(PArrayType)
         et = et.element_type
         expect(et.class).to eq(PArrayType)
         et = et.element_type
-        expect(et.class).to eq(PScalarType)
+        expect(et.class).to eq(PScalarDataType)
       end
 
       it 'with hashes of string values translates to PArrayType[PHashType[PEnumType]]' do
@@ -352,13 +352,13 @@ describe 'The type calculator' do
         expect(et.class).to eq(PEnumType)
       end
 
-      it 'with hash of string values and hash of fixnums translates to PArrayType[PHashType[PScalarType]]' do
+      it 'with hash of string values and hash of fixnums translates to PArrayType[PHashType[PScalarDataType]]' do
         et = calculator.infer([{:first => 'first', :second => 'second' }, {:first => 1, :second => 2 }])
         expect(et.class).to eq(PArrayType)
         et = et.element_type
         expect(et.class).to eq(PHashType)
         et = et.value_type
-        expect(et.class).to eq(PScalarType)
+        expect(et.class).to eq(PScalarDataType)
       end
     end
 
@@ -549,6 +549,38 @@ describe 'The type calculator' do
       common_t = calculator.common_type(v_a, v_b)
       expect(common_t.class).to eq(PVariantType)
       expect(Set.new(common_t.types)).to  eq(Set.new([a_t1, a_t2]))
+    end
+
+    context 'commonality of scalar data types' do
+      it 'Numeric and String == ScalarData' do
+        expect(calculator.common_type(PNumericType::DEFAULT, PStringType::DEFAULT).class).to eq(PScalarDataType)
+      end
+
+      it 'Numeric and Boolean == ScalarData' do
+        expect(calculator.common_type(PNumericType::DEFAULT, PBooleanType::DEFAULT).class).to eq(PScalarDataType)
+      end
+
+      it 'String and Boolean == ScalarData' do
+        expect(calculator.common_type(PStringType::DEFAULT, PBooleanType::DEFAULT).class).to eq(PScalarDataType)
+      end
+    end
+
+    context 'commonality of scalar types' do
+      it 'Regexp and Integer == Scalar' do
+        expect(calculator.common_type(PRegexpType::DEFAULT, PScalarDataType::DEFAULT).class).to eq(PScalarType)
+      end
+
+      it 'Regexp and SemVer == ScalarData' do
+        expect(calculator.common_type(PRegexpType::DEFAULT, PSemVerType::DEFAULT).class).to eq(PScalarType)
+      end
+
+      it 'Timestamp and Timespan == ScalarData' do
+        expect(calculator.common_type(PTimestampType::DEFAULT, PTimespanType::DEFAULT).class).to eq(PScalarType)
+      end
+
+      it 'Timestamp and Boolean == ScalarData' do
+        expect(calculator.common_type(PTimestampType::DEFAULT, PBooleanType::DEFAULT).class).to eq(PScalarType)
+      end
     end
 
     context 'of callables' do
@@ -809,6 +841,7 @@ describe 'The type calculator' do
           PNotUndefType,
           PDataType,
           PScalarType,
+          PScalarDataType,
           ] - numeric_types
         t = PNumericType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
@@ -1939,6 +1972,7 @@ describe 'The type calculator' do
       expect(calculator.infer(PUndefType::DEFAULT     ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PDataType::DEFAULT      ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PScalarType::DEFAULT    ).is_a?(ptype)).to eq(true)
+      expect(calculator.infer(PScalarDataType::DEFAULT).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PStringType::DEFAULT    ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PNumericType::DEFAULT   ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PIntegerType::DEFAULT   ).is_a?(ptype)).to eq(true)
@@ -1964,6 +1998,7 @@ describe 'The type calculator' do
       expect(calculator.infer(PUndefType::DEFAULT     ).to_s).to eq('Type[Undef]')
       expect(calculator.infer(PDataType::DEFAULT      ).to_s).to eq('Type[Data]')
       expect(calculator.infer(PScalarType::DEFAULT    ).to_s).to eq('Type[Scalar]')
+      expect(calculator.infer(PScalarDataType::DEFAULT).to_s).to eq('Type[ScalarData]')
       expect(calculator.infer(PStringType::DEFAULT    ).to_s).to eq('Type[String]')
       expect(calculator.infer(PNumericType::DEFAULT   ).to_s).to eq('Type[Numeric]')
       expect(calculator.infer(PIntegerType::DEFAULT   ).to_s).to eq('Type[Integer]')
@@ -1993,7 +2028,7 @@ describe 'The type calculator' do
       int_t    = PIntegerType::DEFAULT
       string_t = PStringType::DEFAULT
       expect(calculator.infer([int_t]).to_s).to eq('Array[Type[Integer], 1, 1]')
-      expect(calculator.infer([int_t, string_t]).to_s).to eq('Array[Type[Scalar], 2, 2]')
+      expect(calculator.infer([int_t, string_t]).to_s).to eq('Array[Type[ScalarData], 2, 2]')
     end
 
     it 'should infer PType as the type of ruby classes' do
@@ -2096,7 +2131,7 @@ describe 'The type calculator' do
 
     it "does not reduce by combining types when using infer_set" do
       element_type = calculator.infer(['a','b',1,2]).element_type
-      expect(element_type.class).to eq(PScalarType)
+      expect(element_type.class).to eq(PScalarDataType)
       inferred_type = calculator.infer_set(['a','b',1,2])
       expect(inferred_type.class).to eq(PTupleType)
       element_types = inferred_type.types

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -293,11 +293,11 @@ describe 'The type calculator' do
         expect(t.values).to eq(['a', 'b', 'c'])
       end
 
-      it 'with fixnum and float values translates to PArrayType[PNumericType]' do
+      it 'with integer and float values translates to PArrayType[PNumericType]' do
         expect(calculator.infer([1,2.0]).element_type.class).to eq(PNumericType)
       end
 
-      it 'with fixnum and string values translates to PArrayType[PScalarDataType]' do
+      it 'with integer and string values translates to PArrayType[PScalarDataType]' do
         expect(calculator.infer([1,'two']).element_type.class).to eq(PScalarDataType)
       end
 
@@ -305,11 +305,11 @@ describe 'The type calculator' do
         expect(calculator.infer([1.0,'two']).element_type.class).to eq(PScalarDataType)
       end
 
-      it 'with fixnum, float, and string values translates to PArrayType[PScalarDataType]' do
+      it 'with integer, float, and string values translates to PArrayType[PScalarDataType]' do
         expect(calculator.infer([1, 2.0,'two']).element_type.class).to eq(PScalarDataType)
       end
 
-      it 'with fixnum and regexp values translates to PArrayType[PScalarType]' do
+      it 'with integer and regexp values translates to PArrayType[PScalarType]' do
         expect(calculator.infer([1, /two/]).element_type.class).to eq(PScalarType)
       end
 
@@ -321,8 +321,24 @@ describe 'The type calculator' do
         expect(calculator.infer(['one', :two]).element_type.class).to eq(PAnyType)
       end
 
-      it 'with fixnum and nil values translates to PArrayType[PIntegerType]' do
+      it 'with integer and nil values translates to PArrayType[PIntegerType]' do
         expect(calculator.infer([1, nil]).element_type.class).to eq(PIntegerType)
+      end
+
+      it 'with integer value, and array of string values, translates to Array[Data]' do
+        expect(calculator.infer([1, ['two']]).element_type.name).to eq('Data')
+      end
+
+      it 'with integer value, and hash of string => string values, translates to Array[Data]' do
+        expect(calculator.infer([1, {'two' => 'three'} ]).element_type.name).to eq('Data')
+      end
+
+      it 'with integer value, and hash of integer => string values, translates to Array[RichData]' do
+        expect(calculator.infer([1, {2 => 'three'} ]).element_type.name).to eq('RichData')
+      end
+
+      it 'with integer, regexp, and binary values translates to Array[RichData]' do
+        expect(calculator.infer([1, /two/, PBinaryType::Binary.from_string('three')]).element_type.name).to eq('RichData')
       end
 
       it 'with arrays of string values translates to PArrayType[PArrayType[PStringType]]' do

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1095,8 +1095,8 @@ describe 'The type calculator' do
         String     => PStringType::DEFAULT,
         Regexp     => PRegexpType::DEFAULT,
         Regexp     => PRegexpType::DEFAULT,
-        Array      => TypeFactory.array_of_data,
-        Hash       => TypeFactory.hash_of_data
+        Array      => TypeFactory.array_of_any,
+        Hash       => TypeFactory.hash_of_any
       }.each do |ruby_type, puppet_type |
           expect(ruby_type).to be_assignable_to(puppet_type)
       end
@@ -1919,17 +1919,17 @@ describe 'The type calculator' do
       expect(calculator.type(Regexp).class).to eq(PRegexpType)
     end
 
-    it 'should yield \'PArrayType[PDataType]\' for Array' do
+    it 'should yield \'PArrayType[PAnyType]\' for Array' do
       t = calculator.type(Array)
       expect(t.class).to eq(PArrayType)
-      expect(t.element_type.class).to eq(PDataType)
+      expect(t.element_type.class).to eq(PAnyType)
     end
 
-    it 'should yield \'PHashType[PScalarType,PDataType]\' for Hash' do
+    it 'should yield \'PHashType[PAnyType,PAnyType]\' for Hash' do
       t = calculator.type(Hash)
       expect(t.class).to eq(PHashType)
-      expect(t.key_type.class).to eq(PScalarType)
-      expect(t.value_type.class).to eq(PDataType)
+      expect(t.key_type.class).to eq(PAnyType)
+      expect(t.value_type.class).to eq(PAnyType)
     end
   end
 
@@ -1971,8 +1971,8 @@ describe 'The type calculator' do
       expect(calculator.infer(PRegexpType::DEFAULT    ).to_s).to eq('Type[Regexp]')
       expect(calculator.infer(PBooleanType::DEFAULT   ).to_s).to eq('Type[Boolean]')
       expect(calculator.infer(PCollectionType::DEFAULT).to_s).to eq('Type[Collection]')
-      expect(calculator.infer(PArrayType::DEFAULT     ).to_s).to eq('Type[Array[?]]')
-      expect(calculator.infer(PHashType::DEFAULT      ).to_s).to eq('Type[Hash[?, ?]]')
+      expect(calculator.infer(PArrayType::DEFAULT     ).to_s).to eq('Type[Array]')
+      expect(calculator.infer(PHashType::DEFAULT      ).to_s).to eq('Type[Hash]')
       expect(calculator.infer(PIterableType::DEFAULT  ).to_s).to eq('Type[Iterable]')
       expect(calculator.infer(PRuntimeType::DEFAULT   ).to_s).to eq('Type[Runtime[?, ?]]')
       expect(calculator.infer(PHostClassType::DEFAULT ).to_s).to eq('Type[Class]')
@@ -2210,18 +2210,16 @@ describe 'The type calculator' do
   end
 
   matcher :be_assignable_to do |type|
-    calc = TypeCalculator.singleton
-
     match do |actual|
-      calc.assignable?(type, actual)
+      type.is_a?(PAnyType) && type.assignable?(actual)
     end
 
     failure_message do |actual|
-      "#{calc.string(actual)} should be assignable to #{calc.string(type)}"
+      "#{TypeFormatter.string(actual)} should be assignable to #{TypeFormatter.string(type)}"
     end
 
     failure_message_when_negated do |actual|
-      "#{calc.string(actual)} is assignable to #{calc.string(type)} when it should not"
+      "#{TypeFormatter.string(actual)} is assignable to #{TypeFormatter.string(type)} when it should not"
     end
   end
 end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -760,28 +760,21 @@ describe 'The type calculator' do
     end
 
     context 'for Data, such that' do
-      it 'all scalars + array and hash are assignable to Data' do
-        t = PDataType::DEFAULT
-        data_compatible_types.each { |t2|
-          expect(type_from_class(t2)).to be_assignable_to(t)
-        }
-      end
-
-      it 'a scalar, hash, or array is assignable to Data' do
-        t = PDataType::DEFAULT
-        data_compatible_types.each { |t2| expect(type_from_class(t2)).to be_assignable_to(t) }
+      let(:data) { TypeFactory.data }
+      data_compatible_types.map { |t2| type_from_class(t2) }.each do |tc|
+        it "#{tc.name} is assignable to Data" do
+          expect(tc).to be_assignable_to(data)
+        end
       end
 
       it 'Data is not assignable to any of its subtypes' do
-        t = PDataType::DEFAULT
-        types_to_test = data_compatible_types- [PDataType]
-        types_to_test.each {|t2| expect(t).not_to be_assignable_to(type_from_class(t2)) }
+        types_to_test = data_compatible_types
+        types_to_test.each {|t2| expect(data).not_to be_assignable_to(type_from_class(t2)) }
       end
 
       it 'Data is not assignable to any disjunct type' do
-        tested_types = all_types - [PAnyType, POptionalType, PDataType] - scalar_types
-        t = PDataType::DEFAULT
-        tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
+        tested_types = all_types - [PAnyType, POptionalType] - scalar_types
+        tested_types.each {|t2| expect(data).not_to be_assignable_to(t2::DEFAULT) }
       end
     end
 
@@ -816,7 +809,7 @@ describe 'The type calculator' do
       end
 
       it 'Scalar is not assignable to any disjunct type' do
-        tested_types = all_types - [PAnyType, POptionalType, PNotUndefType, PDataType] - scalar_types
+        tested_types = all_types - [PAnyType, POptionalType, PNotUndefType] - scalar_types
         t = PScalarType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
       end
@@ -839,7 +832,6 @@ describe 'The type calculator' do
           PAnyType,
           POptionalType,
           PNotUndefType,
-          PDataType,
           PScalarType,
           PScalarDataType,
           ] - numeric_types
@@ -887,8 +879,7 @@ describe 'The type calculator' do
           PAnyType,
           POptionalType,
           PNotUndefType,
-          PIterableType,
-          PDataType] - collection_types
+          PIterableType] - collection_types
         t = PArrayType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
       end
@@ -926,8 +917,7 @@ describe 'The type calculator' do
           PAnyType,
           POptionalType,
           PNotUndefType,
-          PIterableType,
-          PDataType] - collection_types
+          PIterableType] - collection_types
         t = PHashType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
       end
@@ -998,8 +988,7 @@ describe 'The type calculator' do
           PAnyType,
           POptionalType,
           PNotUndefType,
-          PIterableType,
-          PDataType] - collection_types
+          PIterableType] - collection_types
         t = PTupleType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
       end
@@ -1020,8 +1009,7 @@ describe 'The type calculator' do
           PAnyType,
           POptionalType,
           PNotUndefType,
-          PIterableType,
-          PDataType] - collection_types
+          PIterableType] - collection_types
         t = PStructType::DEFAULT
         tested_types.each {|t2| expect(t).not_to be_assignable_to(t2::DEFAULT) }
       end
@@ -1639,7 +1627,6 @@ describe 'The type calculator' do
       types_to_test = all_types - [
         PAnyType,
         PUndefType,
-        PDataType,
         POptionalType,
         ]
 
@@ -1970,7 +1957,6 @@ describe 'The type calculator' do
     it 'should infer PType as the type of all other types' do
       ptype = PType
       expect(calculator.infer(PUndefType::DEFAULT     ).is_a?(ptype)).to eq(true)
-      expect(calculator.infer(PDataType::DEFAULT      ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PScalarType::DEFAULT    ).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PScalarDataType::DEFAULT).is_a?(ptype)).to eq(true)
       expect(calculator.infer(PStringType::DEFAULT    ).is_a?(ptype)).to eq(true)
@@ -1996,7 +1982,6 @@ describe 'The type calculator' do
 
     it 'should infer PType as the type of all other types' do
       expect(calculator.infer(PUndefType::DEFAULT     ).to_s).to eq('Type[Undef]')
-      expect(calculator.infer(PDataType::DEFAULT      ).to_s).to eq('Type[Data]')
       expect(calculator.infer(PScalarType::DEFAULT    ).to_s).to eq('Type[Scalar]')
       expect(calculator.infer(PScalarDataType::DEFAULT).to_s).to eq('Type[ScalarData]')
       expect(calculator.infer(PStringType::DEFAULT    ).to_s).to eq('Type[String]')

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -172,7 +172,7 @@ describe 'The type factory' do
     it 'hash_of_data returns PHashType[PStringType,PDataType]' do
       ht = TypeFactory.hash_of_data
       expect(ht.class()).to eq(PHashType)
-      expect(ht.key_type.class).to eq(PScalarType)
+      expect(ht.key_type.class).to eq(PStringType)
       expect(ht.value_type.class).to eq(PDataType)
     end
 

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -41,8 +41,8 @@ describe 'The type factory' do
       expect(TypeFactory.scalar().class()).to eq(PScalarType)
     end
 
-    it 'data() returns PDataType' do
-      expect(TypeFactory.data().class()).to eq(PDataType)
+    it 'data() returns Data' do
+      expect(TypeFactory.data.name).to eq('Data')
     end
 
     it 'optional() returns POptionalType' do
@@ -163,17 +163,17 @@ describe 'The type factory' do
       expect(at.element_type.class).to eq(PIntegerType)
     end
 
-    it 'array_of_data returns PArrayType[PDataType]' do
+    it 'array_of_data returns Array[Data]' do
       at = TypeFactory.array_of_data
       expect(at.class()).to eq(PArrayType)
-      expect(at.element_type.class).to eq(PDataType)
+      expect(at.element_type.name).to eq('Data')
     end
 
-    it 'hash_of_data returns PHashType[PStringType,PDataType]' do
+    it 'hash_of_data returns Hash[String,Data]' do
       ht = TypeFactory.hash_of_data
       expect(ht.class()).to eq(PHashType)
       expect(ht.key_type.class).to eq(PStringType)
-      expect(ht.value_type.class).to eq(PDataType)
+      expect(ht.value_type.name).to eq('Data')
     end
 
     it 'ruby(1) returns PRuntimeType[ruby, \'Integer\']' do

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -169,7 +169,7 @@ describe 'The type factory' do
       expect(at.element_type.class).to eq(PDataType)
     end
 
-    it 'hash_of_data returns PHashType[PScalarType,PDataType]' do
+    it 'hash_of_data returns PHashType[PStringType,PDataType]' do
       ht = TypeFactory.hash_of_data
       expect(ht.class()).to eq(PHashType)
       expect(ht.key_type.class).to eq(PScalarType)

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -99,7 +99,7 @@ FORMATTED
       expect(s.string(f.boolean)).to eq('Boolean')
     end
 
-    it "should yield 'Data' for PDataType" do
+    it "should yield 'Data' for the Data type" do
       expect(s.string(f.data)).to eq('Data')
     end
 

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -150,8 +150,8 @@ FORMATTED
       expect(s.string(f.array_of(f.integer))).to eq('Array[Integer]')
     end
 
-    it "should yield 'Array' for PArrayType::DATA" do
-      expect(s.string(f.array_of_data)).to eq('Array')
+    it "should yield 'Array' for PArrayType::DEFAULT" do
+      expect(s.string(f.array_of_any)).to eq('Array')
     end
 
     it "should yield 'Array[0, 0]' for an empty array" do
@@ -260,8 +260,8 @@ FORMATTED
       expect(s.string(f.hash_of(f.string, f.string, f.range(2, :default)))).to eq('Hash[String, String, 2, default]')
     end
 
-    it "should yield 'Hash' for PHashType::DATA" do
-      expect(s.string(f.hash_of_data)).to eq('Hash')
+    it "should yield 'Hash' for PHashType::DEFAULT" do
+      expect(s.string(f.hash_of_any)).to eq('Hash')
     end
 
     it "should yield 'Class' for a PHostClassType" do

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -223,11 +223,11 @@ describe TypeParser do
 
   context 'without a scope' do
     it "interprets anything that is not a built in type to be a type reference" do
-      expect(parser.parse('File')).to eq(types.type_reference('File'))
+      expect(parser.parse('TestType')).to eq(types.type_reference('TestType'))
     end
 
     it "interprets anything that is not a built in type with parameterers to be type reference with parameters" do
-      expect(parser.parse("File['/tmp/foo']")).to eq(types.type_reference("File['/tmp/foo']"))
+      expect(parser.parse("TestType['/tmp/foo']")).to eq(types.type_reference("TestType['/tmp/foo']"))
     end
   end
 

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -54,12 +54,12 @@ describe TypeParser do
     expect(the_type_parsed_from(types.default)).to be_the_type(types.default)
   end
 
-  it "interprets an unparameterized Array as an Array of Data" do
-    expect(parser.parse("Array")).to be_the_type(types.array_of_data)
+  it "interprets an unparameterized Array as an Array of Any" do
+    expect(parser.parse("Array")).to be_the_type(types.array_of_any)
   end
 
-  it "interprets an unparameterized Hash as a Hash of Scalar to Data" do
-    expect(parser.parse("Hash")).to be_the_type(types.hash_of_data)
+  it "interprets an unparameterized Hash as a Hash of Any, Any" do
+    expect(parser.parse("Hash")).to be_the_type(types.hash_of_any)
   end
 
   it "interprets a parameterized Array[0, 0] as an empty hash with no key and value type" do

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -439,7 +439,7 @@ describe 'Puppet Type System' do
       type Foo = Variant[Foo,String,Integer]
       assert_type(Foo, /x/)
       CODE
-      expect { eval_and_collect_notices(code) }.to raise_error(/expects a value of type String or Integer, got Regexp/)
+      expect { eval_and_collect_notices(code) }.to raise_error(/expects a Foo = Variant\[String, Integer\] value, got Regexp/)
     end
 
     it 'will handle a scalar correctly in combinations of nested aliased variants' do


### PR DESCRIPTION
This PR changes the Pcore `Data` type so that it is limited to the types that can be expressed in native JSON. This is done by first introducing a `ScalarData`, a subset of `Scalar` that is limited to the JSON scalars `String`, `Integer`, `Float`, and `Boolean`, and then having `Data` use that instead of `Scalar`. A `Hash` must have keys of `String` type to be assignable to `Data`.

An unparameterized `Hash` or `Array` will now use `Any` for the contained key and value types.

The PR also introduces a `RichData` type as a variant of all types except `Runtime`. The contained `Hash` is keyed by a `RichDataKey` which is a variant of `String` and `Numeric`

The `Puppet::LookupKey` is changed into an alias for `RichDataKey` and the `Puppet::LookupValue` is changed into an alias for `RichData`.