### PR TITLE
(maint) Update locale detection to use gettext-setup wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 3.2.1', '< 4'])
 # gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ['>= 0.1.3', '< 2'])
 # i18n support (gettext-setup and dependencies)
 gem 'gettext-setup', '>= 0.10', '< 1.0', :require => false
-gem 'locale', '~> 2.1', :require => false
 
 group(:development, :test) do
   gem "rake", "10.1.1", :require => false

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -27,7 +27,6 @@ require 'puppet/external/pson/pure'
 # supplied by gettext-setup. Can be removed in Puppet 5. See PUP-7116.
 begin
   require 'gettext-setup'
-  require 'locale'
   Puppet::GETTEXT_AVAILABLE = true
 rescue LoadError
   def _(msg)
@@ -80,7 +79,7 @@ module Puppet
         else
           GettextSetup.initialize(locale_path, :file_format => :mo)
         end
-        FastGettext.locale = GettextSetup.negotiate_locale(Locale.current.language)
+        GettextSetup.negotiate_locale!(GettextSetup.candidate_locales)
       end
     end
 


### PR DESCRIPTION
This commit switches to using `GettextSetup.candidate_locales` instead
of calling out to the Locale gem directly to detect the locale.
Internally gettext-setup uses the locale gem anyway, but the wrapper
methods provide additional sorting and fallback features. This also
allows us to remove our dependency on Locale gem.