### PR TITLE
(Spike) track canonical resource username before encoding fixup in nameservice

### DIFF
--- a/benchmarks/puppet_etc_resolution/benchmarker.rb
+++ b/benchmarks/puppet_etc_resolution/benchmarker.rb
@@ -1,0 +1,28 @@
+require 'puppet'
+
+class Benchmarker
+  def initialize(target, size)
+    @size = size
+    puts "Benchmarker #{@resolver}"
+  end
+
+  def setup
+    if Etc.getpwnam('root').nil?
+      puts "Etc not functional on this host"
+      exit
+    end
+  end
+
+  def generate
+  end
+
+  def run(args=nil)
+    0.upto(@size) do |i|
+      # This just does a search of all users on the system, and on a system
+      # that uses Useradd, resolves these users via Etc. Really only useful to
+      # compare the 'Puppet::Etc' values to the 'Etc' values.
+      #
+      Puppet::Resource.indirection.search('User', {})
+    end
+  end
+end

--- a/benchmarks/puppet_etc_resolution/description
+++ b/benchmarks/puppet_etc_resolution/description
@@ -1,0 +1,3 @@
+Benchmark scenario: Search for users
+Benchmark target: overhead of searching for users
+

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -138,14 +138,16 @@ Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
       resources = find_or_save_resources(type, name, params)
 
       if options[:to_yaml]
-        text = resources.
-          map { |resource| resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml }.
-          join("\n")
+        text = resources.map do |resource|
+          r = resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml
+          r.encoding == Encoding.default_external? ? r : r.force_encoding(Encoding.default_external).scrub!
+        end.join("\n")
         text.prepend("#{type.downcase}:\n")
       else
-        text = resources.
-          map { |resource| resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest }.
-          join("\n")
+        text = resources.map do |resource|
+          r = resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest
+          r.encoding == Encoding.default_external ? r : r.force_encoding(Encoding.default_external).scrub!
+         end.join("\n")
       end
 
       options[:edit] ?

--- a/lib/puppet/etc.rb
+++ b/lib/puppet/etc.rb
@@ -2,11 +2,28 @@ require 'puppet/util/character_encoding'
 # Wrapper around Ruby Etc module allowing us to manage encoding in a single
 # place.
 # This represents a subset of Ruby's Etc module, only the methods required by Puppet.
-# Etc returns strings in variable encoding depending on
-# environment. For Puppet we specifically want UTF-8 as our input from the Etc
-# module - which is our input for many resource instance 'is' values. The
-# associated 'should' value will basically always be coming from Puppet in
-# UTF-8. Etc is defined for Windows but calls to it return nil.
+
+# On Ruby 2.1.0 and later, Etc returns strings in variable encoding depending on
+# environment. The string returned will be labeled with the environment's
+# encoding (Encoding.default_external), with one exception: If the environment
+# encoding is 7-bit ASCII, and any individual character bit representation is
+# equal to or greater than 128 - \x80 - 0b10000000 - signifying the smallest
+# 8-bit big-endian value, the returned string will be in BINARY encoding instead
+# of environment encoding.
+#
+# Barring that exception, the returned string will be labeled as encoding
+# Encoding.default_external, regardless of validity or byte-width. For example,
+# ruby will label a string containing a four-byte characters such as "\u{2070E}"
+# as EUC_KR even though EUC_KR is a two-byte width encoding.
+#
+# On Ruby 2.0.0 and earlier, Etc will always return string values in BINARY,
+# ignoring encoding altogether.
+#
+# For Puppet we specifically want UTF-8 as our input from the Etc module - which
+# is our input for many resource instance 'is' values. The associated 'should'
+# value will basically always be coming from Puppet in UTF-8 - and written to
+# disk as UTF-8. Etc is defined for Windows but the majority calls to it return
+# nil and Puppet does not use it.
 #
 # We only use Etc for retrieving existing property values from the system. For
 # setting property values, providers leverage system tools (i.e., `useradd`)
@@ -18,7 +35,7 @@ module Puppet::Etc
     # On first call opens /etc/group and returns parse of first entry. Each subsquent call
     # returns new struct the next entry or nil if EOF. Call ::endgrent to close file.
     def getgrent
-      convert_field_values_to_utf8!(::Etc.getgrent)
+      override_field_values_to_utf8!(::Etc.getgrent)
     end
 
     # closes handle to /etc/group file
@@ -35,7 +52,7 @@ module Puppet::Etc
     # On first call opens /etc/passwd and returns parse of first entry. Each subsquent call
     # returns new struct for the next entry or nil if EOF. Call ::endgrent to close file.
     def getpwent
-      convert_field_values_to_utf8!(::Etc.getpwent)
+      override_field_values_to_utf8!(::Etc.getpwent)
     end
 
     # closes handle to /etc/passwd file
@@ -53,69 +70,68 @@ module Puppet::Etc
     # returns an Etc::Passwd struct corresponding to the entry or raises
     # ArgumentError if none
     def getpwnam(username)
-      convert_field_values_to_utf8!(::Etc.getpwnam(username))
+      override_field_values_to_utf8!(::Etc.getpwnam(username))
     end
 
     # Etc::getgrnam searches /etc/group file for an entry corresponding to groupname.
     # returns an Etc::Group struct corresponding to the entry or raises
     # ArgumentError if none
     def getgrnam(groupname)
-      convert_field_values_to_utf8!(::Etc.getgrnam(groupname))
+      override_field_values_to_utf8!(::Etc.getgrnam(groupname))
     end
 
     # Etc::getgrid searches /etc/group file for an entry corresponding to id.
     # returns an Etc::Group struct corresponding to the entry or raises
     # ArgumentError if none
     def getgrgid(id)
-      convert_field_values_to_utf8!(::Etc.getgrgid(id))
+      override_field_values_to_utf8!(::Etc.getgrgid(id))
     end
 
     # Etc::getpwuid searches /etc/passwd file for an entry corresponding to id.
     # returns an Etc::Passwd struct corresponding to the entry or raises
     # ArgumentError if none
     def getpwuid(id)
-      convert_field_values_to_utf8!(::Etc.getpwuid(id))
+      override_field_values_to_utf8!(::Etc.getpwuid(id))
     end
 
     private
-    # Utility method for converting the String values of a struct returned by
+    # Utility method for overriding the String values of a struct returned by
     # the Etc module to UTF-8. Structs returned by the ruby Etc module contain
     # members with fields of type String, Integer, or Array of Strings, so we
     # handle these types. Otherwise ignore fields.
     #
-    # NOTE: If a string cannot be converted to UTF-8, this leaves the original
-    # string string intact in the Struct.
+    # NOTE: If a string cannot be overidden to UTF-8 because it would be invalid
+    # in that encoding, this leaves the original string intact and unmodified in
+    # the Struct.
     #
     # Warning! This is a destructive method - the struct passed is modified!
     #
     # @api private
     # @param [Etc::Passwd or Etc::Group struct]
     # @return [Etc::Passwd or Etc::Group struct] the original struct with values
-    #   converted to UTF-8 if possible, or the original value intact if not
-    def convert_field_values_to_utf8!(struct)
+    #   overidden to UTF-8 if possible, or the original value intact if not
+    def override_field_values_to_utf8!(struct)
       return nil if struct.nil?
       struct.each_with_index do |value, index|
         if value.is_a?(String)
-            converted = Puppet::Util::CharacterEncoding.convert_to_utf_8!(value)
-            struct[index] = converted if !converted.nil?
+          Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(value) if value.encoding != Encoding::UTF_8
         elsif value.is_a?(Array)
-          struct[index] = convert_array_values_to_utf8!(value)
+          override_array_values_to_utf8!(value)
         end
       end
     end
 
-    # Helper method for ::convert_field_values_to_utf8!
+    # Helper method for ::override_field_values_to_utf8!
     #
     # Warning! This is a destructive method - the array passed is modified!
     #
     # @api private
-    # @param [Array] object containing String values to convert to UTF-8
-    # @return [Array] original Array with String values converted to UTF-8 if
-    #   convertible, or original, unmodified values if not.
-    def convert_array_values_to_utf8!(string_array)
-      string_array.map! do |elem|
-        converted = Puppet::Util::CharacterEncoding.convert_to_utf_8!(elem)
-        converted.nil? ? elem : converted
+    # @param [Array] object containing String values to override to UTF-8
+    # @return [Array] original Array with String values overidden to UTF-8 if
+    #   they would be valid in UTF-8 or original, unmodified values if not.
+    def override_array_values_to_utf8!(string_array)
+      string_array.each do |elem|
+        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(elem)
       end
     end
   end

--- a/lib/puppet/etc.rb
+++ b/lib/puppet/etc.rb
@@ -114,7 +114,7 @@ module Puppet::Etc
       return nil if struct.nil?
       struct.each_with_index do |value, index|
         if value.is_a?(String)
-          Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(value) if value.encoding != Encoding::UTF_8
+          value.force_encoding(Encoding::UTF_8)
         elsif value.is_a?(Array)
           override_array_values_to_utf8!(value)
         end
@@ -131,7 +131,7 @@ module Puppet::Etc
     #   they would be valid in UTF-8 or original, unmodified values if not.
     def override_array_values_to_utf8!(string_array)
       string_array.each do |elem|
-        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(elem)
+        elem.force_encoding(Encoding::UTF_8)
       end
     end
   end

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -203,7 +203,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   [:expiry, :password_min_age, :password_max_age, :password].each do |shadow_property|
     define_method(shadow_property) do
       if Puppet.features.libshadow?
-        if ent = Shadow::Passwd.getspnam(@resource.name)
+        if ent = Shadow::Passwd.getspnam(canonical_name)
           method = self.class.option(shadow_property, :method)
           return unmunge(shadow_property, ent.send(method))
         end

--- a/lib/puppet/util/character_encoding.rb
+++ b/lib/puppet/util/character_encoding.rb
@@ -48,29 +48,6 @@ module Puppet::Util::CharacterEncoding
       return nil
     end
 
-    # Warning! This is a destructive method - the string supplied is modified!
-    # Given a string, tests if that string's bytes represent valid UTF-8, and if
-    # so sets the external encoding of the string to UTF-8. Does not modify the
-    # byte representation of the string. If the string does not represent valid
-    # UTF-8, does not set the external encoding.
-    #
-    # This method is intended for situations where we do not believe that the
-    # encoding associated with a string is an accurate reflection of its actual
-    # bytes, i.e., effectively when we believe Ruby is incorrect in its assertion
-    # of the encoding of the string.
-    #
-    # @api public
-    # @param [String] string set external encoding (re-label) to utf-8
-    # @return [nil] (string is modified in place)
-    def override_encoding_to_utf_8!(string)
-      if valid_utf_8_bytes?(string)
-        string.force_encoding(Encoding::UTF_8)
-      else
-        Puppet.debug(_("%{value} is not valid UTF-8 and result of overriding encoding would be invalid.") % { value: string.dump })
-      end
-      nil
-    end
-
     private
 
     # Do our best to determine if a string is valid UTF-8 via String#valid_encoding? without permanently

--- a/spec/lib/puppet_spec/character_encoding.rb
+++ b/spec/lib/puppet_spec/character_encoding.rb
@@ -1,0 +1,12 @@
+# A support module for testing character encoding
+module PuppetSpec::CharacterEncoding
+  def self.with_external_encoding(encoding, &blk)
+    original_encoding = Encoding.default_external
+    begin
+      Encoding.default_external = encoding
+      yield
+    ensure
+      Encoding.default_external = original_encoding
+    end
+  end
+end

--- a/spec/unit/etc_spec.rb
+++ b/spec/unit/etc_spec.rb
@@ -1,89 +1,313 @@
 require 'puppet'
 require 'spec_helper'
+require 'puppet_spec/character_encoding'
 
 # The Ruby::Etc module is largely non-functional on Windows - many methods
 # simply return nil regardless of input, the Etc::Group struct is not defined,
 # and Etc::Passwd is missing fields
-describe Puppet::Etc, :if => !Puppet.features.microsoft_windows? do
-  let(:bin) { 'bin'.force_encoding(Encoding::ISO_8859_1) }
-  let(:root) { 'root'.force_encoding(Encoding::ISO_8859_1) }
-  let(:x) { 'x'.force_encoding(Encoding::ISO_8859_1) }
-  let(:daemon) { 'daemon'.force_encoding(Encoding::ISO_8859_1) }
-  let(:root_comment) { 'i am the root user'.force_encoding(Encoding::ISO_8859_1) }
-  let(:user_struct_iso_8859_1) { Etc::Passwd.new(root, x, 0, 0, root_comment) }
-  let(:group_struct_iso_8859_1) { Etc::Group.new(bin, x, 1, [root, bin, daemon]) }
+# We want to test that:
+# - We correctly set external encoding values IF they're valid UTF-8 bytes
+# - We do not modify non-UTF-8 values if they're NOT valid UTF-8 bytes
 
+describe Puppet::Etc, :if => !Puppet.features.microsoft_windows? do
   # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
   # 希 Han Character 'rare; hope, expect, strive for'
   # In EUC_KR: \xfd \xf1 - 253 241
-  # Not convertible to UTF-8, likely to be read in as BINARY by Ruby unless system is in EUC_KR
-  let(:not_convertible) { [254, 241].pack('C*') }
+  # In UTF-8: \u5e0c - \xe5 \xb8 \x8c - 229 184 140
+  let(:euc_kr) { [253, 241].pack('C*').force_encoding(Encoding::EUC_KR) } # valid_encoding? == true
+  let(:euc_kr_as_binary) { [253, 241].pack('C*') } # valid_encoding? == true
+  let(:euc_kr_as_utf_8) { [253, 241].pack('C*').force_encoding(Encoding::UTF_8) } # valid_encoding? == false
 
   # characters representing different UTF-8 widths
   # 1-byte A
   # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
   # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
   # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
-  #
-  # Should all convert cleanly to UTF-8
-  # Unless the system is in UTF-8, these will likely be read in as BINARY by Ruby
-  let(:convertible_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ𠜎
-  let(:convertible_binary) { "A\u06FF\u16A0\u{2070E}".force_encoding(Encoding::BINARY) }
+  let(:mixed_utf_8) { "A\u06FF\u16A0\u{2070E}".force_encoding(Encoding::UTF_8) } # Aۿᚠ𠜎
+  let(:mixed_utf_8_as_binary) { "A\u06FF\u16A0\u{2070E}".force_encoding(Encoding::BINARY) }
+  let(:mixed_utf_8_as_euc_kr) { "A\u06FF\u16A0\u{2070E}".force_encoding(Encoding::EUC_KR) }
 
-  # For the methods described which actually expect an encoding conversion, we
-  # only superficially test via #force_encoding - the deeper level testing is in
-  # character_encoding_spec.rb which handles testing transcoding etc.
+  # An uninteresting value that ruby might return in an Etc struct.
+  let(:root) { 'root' }
 
-  describe "getgrent" do
-    context "given an original system Etc Group struct with ISO-8850-1 string values" do
-      before { Etc.expects(:getgrent).returns(group_struct_iso_8859_1) }
-      let(:converted) { Puppet::Etc.getgrent }
+  # Set up example Etc Group structs with values representative of what we would
+  # get back in these encodings
 
-      it "should return a struct with :name and :passwd field values converted to UTF-8" do
-        [converted.name, converted.passwd].each do |value|
-          expect(value.encoding).to eq(Encoding::UTF_8)
-        end
+  # For each struct we build, we duplicate the strings because our methods under
+  # test are destructive, and we want to ensure when we're comparing to
+  # "original" values they really are original. Otherwise the modified :let
+  # values above obscure our veracity.
+  let(:utf_8_group_struct) do
+    group = Etc::Group.new
+    # In a UTF-8 environment, these values will come back as UTF-8, even if
+    # they're not valid UTF-8. We do not modify anything about either the
+    # valid or invalid UTF-8 strings.
+
+    # Group member contains a mix of valid and invalid UTF-8-labeled strings
+    group.mem = [mixed_utf_8, root.force_encoding(Encoding::UTF_8), euc_kr_as_utf_8]
+    # group name contains same EUC_KR bytes labeled as UTF-8
+    group.name = euc_kr_as_utf_8
+    # group passwd field is valid UTF-8
+    group.passwd = mixed_utf_8
+    duplicate_struct_values(group)
+  end
+
+  let(:euc_kr_group_struct) do
+    # In an EUC_KR environment, values will come back as EUC_KR, even if they're
+    # not valid in that encoding. For values that are valid in UTF-8 we expect
+    # their external encoding to be set to UTF-8 by Puppet::Etc. For values that
+    # are invalid in UTF-8, we expect the string to be kept intact, unmodified,
+    # as we can't transcode it.
+    group = Etc::Group.new
+    group.mem = [euc_kr, root.force_encoding(Encoding::EUC_KR), mixed_utf_8_as_euc_kr]
+    group.name = euc_kr
+    group.passwd = mixed_utf_8_as_euc_kr
+    duplicate_struct_values(group)
+  end
+
+  let(:ascii_group_struct) do
+    # In a POSIX environment, any strings containing only values under
+    # code-point 128 will be returned as ASCII, whereas anything above that
+    # point will be returned as BINARY. In either case we override the encoding
+    # to UTF-8 if that would be valid.
+    group = Etc::Group.new
+    group.mem = [euc_kr_as_binary, root.force_encoding(Encoding::ASCII), mixed_utf_8_as_binary]
+    group.name = euc_kr_as_binary
+    group.passwd = mixed_utf_8_as_binary
+    duplicate_struct_values(group)
+  end
+
+  let(:utf_8_user_struct) do
+    user = Etc::Passwd.new
+    # user name contains same EUC_KR bytes labeled as UTF-8
+    user.name = euc_kr_as_utf_8
+    # group passwd field is valid UTF-8
+    user.passwd = mixed_utf_8
+    duplicate_struct_values(user)
+  end
+
+  let(:euc_kr_user_struct) do
+    user = Etc::Passwd.new
+    user.name = euc_kr
+    user.passwd = mixed_utf_8_as_euc_kr
+    duplicate_struct_values(user)
+  end
+
+  let(:ascii_user_struct) do
+    user = Etc::Passwd.new
+    user.name = euc_kr_as_binary
+    user.passwd = mixed_utf_8_as_binary
+    duplicate_struct_values(user)
+  end
+
+  # Simple helper method that returns a copy of the passed struct with all
+  # values inside set to copies of themselves. Essentially an Etc::Struct deep
+  # copy.
+  def duplicate_struct_values(struct)
+    dup = struct.dup
+    struct.each_with_index do |value, index|
+      next if value.nil?
+      if value.is_a?(String)
+        dup[index] = value.dup
+      else
+        dup[index] = value.map! { |elem| elem.dup }
+      end
+    end
+    dup
+  end
+
+  shared_examples "methods that return an overridden group struct from Etc" do |params|
+    context "when Encoding.default_external is UTF-8" do
+      before do
+        Etc.expects(subject).with(*params).returns(utf_8_group_struct)
       end
 
-      it "should return a struct with a :mem array with all field values converted to UTF-8" do
-        converted.mem.each { |elem| expect(elem.encoding).to eq(Encoding::UTF_8) }
+      let(:overridden) {
+        PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::UTF_8) do
+          Puppet::Etc.send(subject, *params)
+        end
+      }
+
+      it "should leave the valid UTF-8 values in arrays unmodified" do
+        expect(overridden.mem[0]).to eq(mixed_utf_8)
+        expect(overridden.mem[1]).to eq(root)
+      end
+
+      it "should leave the invalid UTF-8 values in arrays unmodified"do
+        expect(overridden.mem[2]).to eq(euc_kr_as_utf_8)
+      end
+
+      it "should leave the valid UTF-8 values unmodified" do
+        expect(overridden.passwd).to eq(mixed_utf_8)
+      end
+
+      it "should leave the invalid UTF-8 values unmodified" do
+        expect(overridden.name).to eq(euc_kr_as_utf_8)
       end
     end
 
-    context "given an original Etc::Group struct with field values that cannot be converted to UTF-8" do
-      let(:group) { Etc::Group.new }
+    context "when Encoding.default_external is EUC_KR (i.e., neither UTF-8 nor POSIX)" do
       before do
-        # group membership contains valid and invalid UTF-8
-        group.mem = [convertible_binary, not_convertible]
-        # group name contains a value that is invalid UTF-8
-        group.name = not_convertible
-        # group passwd field is valid UTF-8
-        group.passwd = convertible_binary
-
-        Etc.expects(:getgrent).returns(group)
+        Etc.expects(subject).with(*params).returns(euc_kr_group_struct)
       end
 
-      let(:converted) { Puppet::Etc.getgrent }
+      let(:overridden) {
+        PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::EUC_KR) do
+          Puppet::Etc.send(subject, *params)
+        end
+      }
 
-      it "should convert convertible values in arrays to UTF-8" do
-        expect(converted.mem[0]).to eq("A\u06FF\u16A0\u{2070E}")
-        expect(converted.mem[0].encoding).to eq(Encoding::UTF_8) # just being explicit
+      it "should override EUC_KR-labeled values in arrays to UTF-8 if that would result in valid UTF-8" do
+        expect(overridden.mem[2]).to eq(mixed_utf_8)
+        expect(overridden.mem[1]).to eq(root)
       end
 
-      it "should leave the unconvertible values unmodified" do
-        expect(converted.name).to eq([254, 241].pack('C*'))
-        expect(converted.name.encoding).to eq(Encoding::BINARY) # just being explicit
+      it "should leave EUC_KR-labeled values that would not be valid UTF-8 in arrays unmodified" do
+        expect(overridden.mem[0]).to eq(euc_kr)
       end
 
-      it "should leave unconvertible values in arrays unmodifed" do
-        expect(converted.mem[1]).to eq([254, 241].pack('C*'))
-        expect(converted.mem[1].encoding).to eq(Encoding::BINARY) # just being explicit
+      it "should override EUC_KR-labeled values to UTF-8 if that would result in valid UTF-8" do
+        expect(overridden.passwd).to eq(mixed_utf_8)
       end
 
-      it "should convert values that can be converted to UTf-8" do
-        expect(converted.passwd).to eq("A\u06FF\u16A0\u{2070E}")
-        expect(converted.passwd.encoding).to eq(Encoding::UTF_8) # just being explicit
+      it "should leave EUC_KR-labeled values that would not be valid UTF-8 unmodified" do
+        expect(overridden.name).to eq(euc_kr)
       end
+    end
+
+    context "when Encoding.default_external is POSIX (ASCII-7bit)" do
+      before do
+        Etc.expects(subject).with(*params).returns(ascii_group_struct)
+      end
+
+      let(:overridden) {
+        PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::ASCII) do
+          Puppet::Etc.send(subject, *params)
+        end
+      }
+
+      it "should not modify binary values in arrays that would be invalid UTF-8" do
+        expect(overridden.mem[0]).to eq(euc_kr_as_binary)
+      end
+
+      it "should set the encoding to UTF-8 on binary values in arrays that would be valid UTF-8" do
+        expect(overridden.mem[1]).to eq(root.force_encoding(Encoding::UTF_8))
+        expect(overridden.mem[2]).to eq(mixed_utf_8)
+      end
+
+      it "should not modify binary values that would be invalid UTF-8" do
+        expect(overridden.name).to eq(euc_kr_as_binary)
+      end
+
+      it "should set the encoding to UTF-8 on binary values that would be valid UTF-8" do
+        expect(overridden.passwd).to eq(mixed_utf_8)
+      end
+    end
+  end
+
+  shared_examples "methods that return an overridden user struct from Etc" do |params|
+    context "when Encoding.default_external is UTF-8" do
+      before do
+        Etc.expects(subject).with(*params).returns(utf_8_user_struct)
+      end
+
+      let(:overridden) {
+        PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::UTF_8) do
+          Puppet::Etc.send(subject, *params)
+        end
+      }
+
+      it "should leave the valid UTF-8 values unmodified" do
+        expect(overridden.passwd).to eq(mixed_utf_8)
+      end
+
+      it "should leave the invalid UTF-8 values unmodified" do
+        expect(overridden.name).to eq(euc_kr_as_utf_8)
+      end
+    end
+
+    context "when Encoding.default_external is EUC_KR (i.e., neither UTF-8 nor POSIX)" do
+      before do
+        Etc.expects(subject).with(*params).returns(euc_kr_user_struct)
+      end
+
+      let(:overridden) {
+        PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::EUC_KR) do
+          Puppet::Etc.send(subject, *params)
+        end
+      }
+
+      it "should override valid UTF-8 EUC_KR-labeled values to UTF-8" do
+        expect(overridden.passwd).to eq(mixed_utf_8)
+      end
+
+      it "should leave invalid EUC_KR-labeled values unmodified" do
+        expect(overridden.name).to eq(euc_kr)
+      end
+    end
+
+    context "when Encoding.default_external is POSIX (ASCII-7bit)" do
+      before do
+        Etc.expects(subject).with(*params).returns(ascii_user_struct)
+      end
+
+      let(:overridden) {
+        PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::ASCII) do
+          Puppet::Etc.send(subject, *params)
+        end
+      }
+
+      it "should not modify binary values that would be invalid UTF-8" do
+        expect(overridden.name).to eq(euc_kr_as_binary)
+      end
+
+      it "should set the encoding to UTF-8 on binary values that would be valid UTF-8" do
+        expect(overridden.passwd).to eq(mixed_utf_8)
+      end
+    end
+  end
+
+  describe :getgrent do
+    it_should_behave_like "methods that return an overridden group struct from Etc"
+  end
+
+  describe :getgrnam do
+    it_should_behave_like "methods that return an overridden group struct from Etc", 'foo'
+
+    it "should call Etc.getgrnam with the supplied group name" do
+      Etc.expects(:getgrnam).with('foo')
+      Puppet::Etc.getgrnam('foo')
+    end
+  end
+
+  describe :getgrgid do
+    it_should_behave_like "methods that return an overridden group struct from Etc", 0
+
+    it "should call Etc.getgrgid with supplied group id" do
+      Etc.expects(:getgrgid).with(0)
+      Puppet::Etc.getgrgid(0)
+    end
+  end
+
+  describe :getpwent do
+    it_should_behave_like "methods that return an overridden user struct from Etc"
+  end
+
+  describe :getpwnam do
+    it_should_behave_like "methods that return an overridden user struct from Etc", 'foo'
+
+    it "should call Etc.getpwnam with that username" do
+      Etc.expects(:getpwnam).with('foo')
+      Puppet::Etc.getpwnam('foo')
+    end
+  end
+
+  describe :getpwuid do
+    it_should_behave_like "methods that return an overridden user struct from Etc", 2
+
+    it "should call Etc.getpwuid with the id" do
+      Etc.expects(:getpwuid).with(2)
+      Puppet::Etc.getpwuid(2)
     end
   end
 
@@ -101,43 +325,6 @@ describe Puppet::Etc, :if => !Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "getpwent" do
-    context "given an original system Etc Passwd struct with ISO-8859-1 string values" do
-      before { Etc.expects(:getpwent).returns(user_struct_iso_8859_1) }
-      let(:converted) { Puppet::Etc.getpwent }
-
-      it "should return an Etc Passwd struct with field values converted to UTF-8" do
-        [converted.name, converted.passwd, converted.gecos].each do |value|
-          expect(value.encoding).to eq(Encoding::UTF_8)
-        end
-      end
-    end
-
-    context "given an original Etc::Passwd struct with field values that cannot be converted to UTF-8" do
-      let(:user) { Etc::Passwd.new }
-      before do
-        # user comment field cannot be converted to UTF-8
-        user.gecos =  not_convertible
-        # user passwd field is valid UTF-8
-        user.passwd = convertible_binary
-
-        Etc.expects(:getpwent).returns(user)
-      end
-
-      let(:converted) { Puppet::Etc.getpwent }
-
-      it "should leave the unconvertible values unmodified" do
-        expect(converted.gecos).to eq([254, 241].pack('C*'))
-        expect(converted.gecos.encoding).to eq(Encoding::BINARY) # just being explicit
-      end
-
-      it "should convert values that can be converted to UTf-8" do
-        expect(converted.passwd).to eq("A\u06FF\u16A0\u{2070E}")
-        expect(converted.passwd.encoding).to eq(Encoding::UTF_8) # just being explicit
-      end
-    end
-  end
-
   describe "endpwent" do
     it "should call Etc.endpwent" do
       Etc.expects(:endpwent)
@@ -151,84 +338,4 @@ describe Puppet::Etc, :if => !Puppet.features.microsoft_windows? do
       Puppet::Etc.setpwent
     end
   end
-
-  describe "getpwnam" do
-    context "given a username to query" do
-      it "should call Etc.getpwnam with that username" do
-        Etc.expects(:getpwnam).with('foo')
-        Puppet::Etc.getpwnam('foo')
-      end
-    end
-
-    context "given an original system Etc Passwd struct with ISO-8859-1 string values" do
-      it "should return an Etc Passwd struct with field values converted to UTF-8" do
-        Etc.expects(:getpwnam).with('root').returns(user_struct_iso_8859_1)
-        converted = Puppet::Etc.getpwnam('root')
-        [converted.name, converted.passwd, converted.gecos].each do |value|
-          expect(value.encoding).to eq(Encoding::UTF_8)
-        end
-      end
-    end
-  end
-
-  describe "getgrnam" do
-    context "given a group name to query" do
-      it "should call Etc.getgrnam with that group name" do
-        Etc.expects(:getgrnam).with('foo')
-        Puppet::Etc.getgrnam('foo')
-      end
-    end
-
-    context "given an original system Etc Group struct with ISO-8859-1 string values" do
-      it "should return an Etc Group struct with field values converted to UTF-8" do
-        Etc.expects(:getgrnam).with('bin').returns(group_struct_iso_8859_1)
-        converted = Puppet::Etc.getgrnam('bin')
-        [converted.name, converted.passwd].each do |value|
-          expect(value.encoding).to eq(Encoding::UTF_8)
-        end
-        converted.mem.each { |elem| expect(elem.encoding).to eq(Encoding::UTF_8) }
-      end
-    end
-  end
-
-  describe "getgrgid" do
-    context "given a group ID to query" do
-      it "should call Etc.getgrgid with the id" do
-        Etc.expects(:getgrgid).with(0)
-        Puppet::Etc.getgrgid(0)
-      end
-    end
-
-    context "given an original Etc Group struct with field values in ISO-8859-1" do
-      it "should return an Etc Group struct with field values converted to UTF-8" do
-        Etc.expects(:getgrgid).with(1).returns(group_struct_iso_8859_1)
-        converted = Puppet::Etc.getgrgid(1)
-        [converted.name, converted.passwd].each do |value|
-          expect(value.encoding).to eq(Encoding::UTF_8)
-        end
-        converted.mem.each { |elem| expect(elem.encoding).to eq(Encoding::UTF_8) }
-      end
-    end
-  end
-
-  describe "getpwid" do
-    context "given a UID to query" do
-      it "should call Etc.getpwuid with the id" do
-        Etc.expects(:getpwuid).with(2)
-        Puppet::Etc.getpwuid(2)
-      end
-    end
-  end
-
-  context "given an orginal Etc Passwd struct with field values in ISO-8859-1" do
-    it "should return an Etc Passwd struct with field values converted to UTF-8" do
-      Etc.expects(:getpwuid).with(0).returns(user_struct_iso_8859_1)
-      converted = Puppet::Etc.getpwuid(0)
-      [converted.name, converted.passwd, converted.gecos].each do |value|
-        expect(value.encoding).to eq(Encoding::UTF_8)
-      end
-    end
-  end
-
-
 end

--- a/spec/unit/util/character_encoding_spec.rb
+++ b/spec/unit/util/character_encoding_spec.rb
@@ -105,34 +105,4 @@ describe Puppet::Util::CharacterEncoding do
       end
     end
   end
-
-  describe "::override_encoding_to_utf_8!" do
-    context "given a string with bytes that represent valid UTF-8" do
-      it "should set the external encoding of the string to UTF-8" do
-        # ☃ - unicode snowman
-        # \u2603 - \xe2 \x98 \x83 - 226 152 131
-        snowman = [226, 152, 131].pack('C*')
-        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(snowman)
-        expect(snowman).to eq("\u2603")
-        expect(snowman.encoding).to eq(Encoding::UTF_8)
-      end
-    end
-
-    context "given a string with bytes that do not represent valid UTF-8" do
-      # Ø - Latin capital letter O with stroke
-      # In ISO-8859-1: \xd8 - 216
-      # Invalid in UTF-8 without transcoding
-      let(:oslash) { [216].pack('C*').force_encoding(Encoding::ISO_8859_1) }
-      let(:foo) { 'foo' }
-      it "should issue a debug message" do
-        Puppet.expects(:debug).with(regexp_matches(/not valid UTF-8/))
-        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(oslash)
-      end
-
-      it "should not modify the string" do
-        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(oslash)
-        expect(oslash).to eq([216].pack('C*').force_encoding(Encoding::ISO_8859_1))
-      end
-    end
-  end
 end

--- a/spec/unit/util/character_encoding_spec.rb
+++ b/spec/unit/util/character_encoding_spec.rb
@@ -1,14 +1,16 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/util/character_encoding'
+require 'puppet_spec/character_encoding'
 
 describe Puppet::Util::CharacterEncoding do
   describe "::convert_to_utf_8!" do
     context "when passed a string that is already UTF-8" do
       context "with valid encoding" do
-        it "should return the string unaltered" do
+        it "should not modify the string" do
           utf8_string = "\u06FF\u2603"
-          expect(Puppet::Util::CharacterEncoding.convert_to_utf_8!(utf8_string)).to eq(utf8_string)
+          Puppet::Util::CharacterEncoding.convert_to_utf_8!(utf8_string)
+          expect(utf8_string).to eq("\u06FF\u2603")
         end
       end
 
@@ -16,72 +18,120 @@ describe Puppet::Util::CharacterEncoding do
         let(:invalid_utf8_string) { "\xfd\xf1".force_encoding(Encoding::UTF_8) }
 
         it "should issue a debug message" do
-          Puppet.expects(:debug).with(regexp_matches(/not valid UTF-8/))
+          Puppet.expects(:debug).with(regexp_matches(/encoding is invalid/))
           Puppet::Util::CharacterEncoding.convert_to_utf_8!(invalid_utf8_string)
         end
 
-        it "should return nil" do
-          expect(Puppet::Util::CharacterEncoding.convert_to_utf_8!(invalid_utf8_string)).to be_nil
+        it "should not modify the string" do
+          Puppet::Util::CharacterEncoding.convert_to_utf_8!(invalid_utf8_string)
+          expect(invalid_utf8_string).to eq("\xfd\xf1".force_encoding(Encoding::UTF_8))
         end
       end
     end
 
     context "when passed a string not in UTF-8 encoding" do
-      context "the bytes of which represent valid UTF-8" do
-        # I think this effectively what the ruby Etc module is doing when it
-        # returns strings read in from /etc/passwd and /etc/group
-        let(:iso_8859_1_string) { [225, 154, 160].pack('C*').force_encoding(Encoding::ISO_8859_1) }
-        let(:result) { Puppet::Util::CharacterEncoding.convert_to_utf_8!(iso_8859_1_string) }
+      it "should be able to convert BINARY to UTF-8 by labeling as Encoding.default_external" do
+        # そ - HIRAGANA LETTER SO
+        # In Windows_31J: \x82 \xbb - 130 187
+        # In Unicode: \u305d - \xe3 \x81 \x9d - 227 129 157
 
-        it "should set external encoding to UTF-8" do
-          expect(result.encoding).to eq(Encoding::UTF_8)
+        # When received as BINARY are not transcodable, but by "guessing"
+        # Encoding.default_external can transcode to UTF-8
+        win_31j = [130, 187].pack('C*')
+
+        PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::Windows_31J) do
+          Puppet::Util::CharacterEncoding.convert_to_utf_8!(win_31j)
         end
 
-        it "should not modify the bytes (transcode) the string" do
-          expect(result.bytes.to_a).to eq([225, 154, 160])
+        expect(win_31j).to eq("\u305d")
+        expect(win_31j.bytes.to_a).to eq([227, 129, 157])
+      end
+
+      context "that is BINARY encoded but invalid in Encoding.default_external" do
+        let(:invalid_win_31j) { [255, 254, 253].pack('C*') } # these bytes are not valid windows_31j
+
+        it "should leave the string umodified" do
+          PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::Windows_31J) do
+            Puppet::Util::CharacterEncoding.convert_to_utf_8!(invalid_win_31j)
+          end
+          expect(invalid_win_31j.bytes.to_a).to eq([255, 254, 253])
+          expect(invalid_win_31j.encoding).to eq(Encoding::BINARY)
+        end
+
+        it "should issue a debug message that the string was not transcodable" do
+          Puppet.expects(:debug).with(regexp_matches(/cannot be transcoded/))
+          PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::Windows_31J) do
+            Puppet::Util::CharacterEncoding.convert_to_utf_8!(invalid_win_31j)
+          end
         end
       end
 
-      context "the bytes of which do not represent valid UTF-8" do
-        it "should transcode the string to UTF-8 if it is transcodable" do
-          # http://www.fileformat.info/info/unicode/char/3050/index.htm
-          # ぐ - HIRAGANA LETTER GU
-          # In Shift_JIS: \x82 \xae - 130 174
-          # In Unicode: \u3050 - \xe3 \x81 \x90 - 227 129 144
-          # if we were only ruby > 2.3.0, we could do String.new("\x82\xae", :encoding => Encoding::Shift_JIS)
-          as_shift_jis = [130, 174].pack('C*').force_encoding(Encoding::Shift_JIS)
-          as_utf8 = "\u3050"
+      it "should transcode the string to UTF-8 if it is transcodable" do
+        # http://www.fileformat.info/info/unicode/char/3050/index.htm
+        # ぐ - HIRAGANA LETTER GU
+        # In Shift_JIS: \x82 \xae - 130 174
+        # In Unicode: \u3050 - \xe3 \x81 \x90 - 227 129 144
+        # if we were only ruby > 2.3.0, we could do String.new("\x82\xae", :encoding => Encoding::Shift_JIS)
+        shift_jis = [130, 174].pack('C*').force_encoding(Encoding::Shift_JIS)
 
-          # this is not valid UTF-8
-          expect(as_shift_jis.dup.force_encoding(Encoding::UTF_8).valid_encoding?).to be_falsey
+        Puppet::Util::CharacterEncoding.convert_to_utf_8!(shift_jis)
+        expect(shift_jis).to eq("\u3050")
+        # largely redundant but reinforces the point - this was transcoded:
+        expect(shift_jis.bytes.to_a).to eq([227, 129, 144])
+      end
 
-          result = Puppet::Util::CharacterEncoding.convert_to_utf_8!(as_shift_jis)
-          expect(result).to eq(as_utf8)
-          # largely redundant but reinforces the point - this was transcoded:
-          expect(result.bytes.to_a).to eq([227, 129, 144])
+      context "when not transcodable" do
+        # An admittedly contrived case, but perhaps not so improbable
+        # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
+        # 希 Han Character 'rare; hope, expect, strive for'
+        # In EUC_KR: \xfd \xf1 - 253 241
+        # In Unicode: \u5e0c - \xe5 \xb8 \x8c - 229 184 140
+
+        # In this case, this EUC_KR character has been read in as ASCII and is
+        # invalid in that encoding. This would raise an EncodingError
+        # exception on transcode but we catch this issue a debug message -
+        # leaving the original string unaltered.
+        let(:euc_kr) { [253, 241].pack('C*').force_encoding(Encoding::ASCII) }
+
+        it "should issue a debug message" do
+          Puppet.expects(:debug).with(regexp_matches(/cannot be transcoded/))
+          Puppet::Util::CharacterEncoding.convert_to_utf_8!(euc_kr)
         end
 
-        context "if it is not transcodable" do
-          let(:as_ascii) { [254, 241].pack('C*').force_encoding(Encoding::ASCII) }
-          it "should issue a debug message and return nil if not transcodable" do
-            # An admittedly contrived case, but perhaps not so improbable
-            # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
-            # 希 Han Character 'rare; hope, expect, strive for'
-            # In EUC_KR: \xfd \xf1 - 253 241
-            # In Unicode: \u5e0c - \xe5 \xb8 \x8c - 229 184 140
-
-            # If the original system value is in EUC_KR, and puppet (ruby) is run
-            # in ISO_8859_1, this value will be read in as ASCII, with invalid
-            # escape sequences in that encoding. It is also not valid unicode
-            # as-is. This scenario is one we can't recover from, so fail.
-            Puppet.expects(:debug).with(regexp_matches(/not valid UTF-8/))
-            Puppet::Util::CharacterEncoding.convert_to_utf_8!(as_ascii)
-          end
-
-          it "should return nil" do
-            expect(Puppet::Util::CharacterEncoding.convert_to_utf_8!(as_ascii)).to be_nil
-          end
+        it "should not modify the string" do
+          Puppet::Util::CharacterEncoding.convert_to_utf_8!(euc_kr)
+          expect(euc_kr).to eq([253, 241].pack('C*').force_encoding(Encoding::ASCII))
         end
+      end
+    end
+  end
+
+  describe "::override_encoding_to_utf_8!" do
+    context "given a string with bytes that represent valid UTF-8" do
+      it "should set the external encoding of the string to UTF-8" do
+        # ☃ - unicode snowman
+        # \u2603 - \xe2 \x98 \x83 - 226 152 131
+        snowman = [226, 152, 131].pack('C*')
+        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(snowman)
+        expect(snowman).to eq("\u2603")
+        expect(snowman.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+
+    context "given a string with bytes that do not represent valid UTF-8" do
+      # Ø - Latin capital letter O with stroke
+      # In ISO-8859-1: \xd8 - 216
+      # Invalid in UTF-8 without transcoding
+      let(:oslash) { [216].pack('C*').force_encoding(Encoding::ISO_8859_1) }
+      let(:foo) { 'foo' }
+      it "should issue a debug message" do
+        Puppet.expects(:debug).with(regexp_matches(/not valid UTF-8/))
+        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(oslash)
+      end
+
+      it "should not modify the string" do
+        Puppet::Util::CharacterEncoding.override_encoding_to_utf_8!(oslash)
+        expect(oslash).to eq([216].pack('C*').force_encoding(Encoding::ISO_8859_1))
       end
     end
   end


### PR DESCRIPTION
includes #5828 