### PR TITLE
(PUP-7475) Fix problem with multiple backslashes in regexp literal

### DIFF
--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -203,7 +203,7 @@ class Lexer2
   # PERFORMANCE NOTE:
   # Comparison against a frozen string is faster (than unfrozen).
   #
-  STRING_BSLASH_BSLASH = '\\'.freeze
+  STRING_BSLASH_SLASH = '\/'.freeze
 
   attr_reader :locator
 
@@ -376,8 +376,10 @@ class Lexer2
           # regexp position is a regexp, else a div
           if regexp_acceptable? && value = scn.scan(PATTERN_REGEX)
             # Ensure an escaped / was not matched
-            while value[-2..-2] == STRING_BSLASH_BSLASH # i.e. \\
-              value += scn.scan_until(PATTERN_REGEX_END)
+            while escaped_end(value)
+              more = scn.scan_until(PATTERN_REGEX_END)
+              return emit(TOKEN_DIV, before) unless more
+              value << more
             end
             regex = value.sub(PATTERN_REGEX_A, '').sub(PATTERN_REGEX_Z, '').gsub(PATTERN_REGEX_ESC, '/')
             emit_completed([:REGEX, Regexp.new(regex), scn.pos-before], before)
@@ -595,6 +597,21 @@ class Lexer2
     end
     @selector.each { |k,v| k.freeze }
     @selector.freeze
+  end
+
+  # Determine if last char of value is escaped by a backslash
+  def escaped_end(value)
+    escaped = false
+    if value.end_with?(STRING_BSLASH_SLASH)
+      value[1...-1].each_codepoint do |cp|
+        if cp == 0x5c # backslash
+          escaped = !escaped
+        else
+          escaped = false
+        end
+      end
+    end
+    escaped
   end
 
   # Clears the lexer state (it is not required to call this as it will be garbage collected

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -412,6 +412,34 @@ describe 'Lexer2' do
     expect(tokens_scanned_from("1 / /./")).to match_tokens2(:NUMBER, :DIV, :REGEX)
   end
 
+  it 'should lex regexp with escaped slash' do
+    scanned = tokens_scanned_from('/\//')
+    expect(scanned).to match_tokens2(:REGEX)
+    expect(scanned[0][1][:value]).to eql(Regexp.new('/'))
+  end
+
+  it 'should lex regexp with escaped backslash' do
+    scanned = tokens_scanned_from('/\\\\/')
+    expect(scanned).to match_tokens2(:REGEX)
+    expect(scanned[0][1][:value]).to eql(Regexp.new('\\\\'))
+  end
+
+  it 'should lex regexp with escaped backslash followed escaped slash ' do
+    scanned = tokens_scanned_from('/\\\\\\//')
+    expect(scanned).to match_tokens2(:REGEX)
+    expect(scanned[0][1][:value]).to eql(Regexp.new('\\\\/'))
+  end
+
+  it 'should lex regexp with escaped slash followed escaped backslash ' do
+    scanned = tokens_scanned_from('/\\/\\\\/')
+    expect(scanned).to match_tokens2(:REGEX)
+    expect(scanned[0][1][:value]).to eql(Regexp.new('/\\\\'))
+  end
+
+  it 'should not lex regexp with escaped ending slash' do
+    expect(tokens_scanned_from('/\\/')).to match_tokens2(:DIV, :OTHER, :DIV)
+  end
+
   it "should accept newline in a regular expression" do
     scanned = tokens_scanned_from("/\n.\n/")
     # Note that strange formatting here is important


### PR DESCRIPTION
Before this commit, it was not possible to declare a regexp that ended
with an escaped backslash because there was no logic to determine if
the backslash was preceded by a backslash.

This commit adds code to ensure that only an uneven number of subsequent
backslashes causes an escape of the token that follows.