### PR TITLE
(PUP-7480) Stub gettext pluralization function

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -33,6 +33,14 @@ rescue LoadError
   def _(msg)
     msg
   end
+
+  def n_(*args, &block)
+    # assume two string args (singular and plural English form) and the count
+    # to pluralize on
+    plural = args[2] == 1 ? args[0] : args[1]
+    # if a block is passed, prefer that over the string selection above
+    block ? block.call : plural
+  end
   Puppet::GETTEXT_AVAILABLE = false
 end
 

--- a/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
@@ -50,7 +50,7 @@ class PuppetResourceTypeImplInstantiator
     end
 
     unless statements.size == 1
-      raise ArgumentError, _("The code loaded from %{source_ref} must contain only the creation of resource type '%{typen_name}' - it has additional logic.") % { source_ref: source_ref, type_name: typed_name.name }
+      raise ArgumentError, _("The code loaded from %{source_ref} must contain only the creation of resource type '%{type_name}' - it has additional logic.") % { source_ref: source_ref, type_name: typed_name.name }
     end
 
     closure_scope = Puppet.lookup(:global_scope) { {} }


### PR DESCRIPTION
Puppet should be able to run without the gettext-setup gem. We had
previously stubbed the basic `_` translation function to avoid errors
when the gem is missing, but later string externalization commits also
made use of the `n_` function for pluralization handling. This commit
adds a stub for that method.