### PR TITLE
(PUP-7484) Ensure that generated resources get defaults assigned

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -528,12 +528,12 @@ class Puppet::Parser::Compiler
     exceptwrap do
       Puppet::Util::Profiler.profile(_("Evaluated definitions"), [:compiler, :evaluate_definitions]) do
         urs = unevaluated_resources.each do |resource|
-         begin
+          begin
             resource.evaluate
-         rescue Puppet::Pops::Evaluator::PuppetStopIteration => detail
-           # needs to be handled specifically as the error has the file/line/position where this
-           # occurred rather than the resource
-           fail(Puppet::Pops::Issues::RUNTIME_ERROR, detail, {:detail => detail.message}, detail)
+          rescue Puppet::Pops::Evaluator::PuppetStopIteration => detail
+            # needs to be handled specifically as the error has the file/line/position where this
+            # occurred rather than the resource
+            fail(Puppet::Pops::Issues::RUNTIME_ERROR, detail, {:detail => detail.message}, detail)
 
           rescue Puppet::Error => e
             # PuppetError has the ability to wrap an exception, if so, use the wrapped exception's

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -129,6 +129,8 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   end
 
   def add_resource(scope, resource)
+    # A resource added as the result of evaluating a generator (collector or definition) must have its defaults set
+    resource.add_defaults if @evaluating_generators
     @resources << resource
     @catalog.add_resource(resource)
 


### PR DESCRIPTION
The fix in PUP-25, where the assignment of resource parameter default
values was moved to take place before resource generators was evaluated,
resulted in that no defaults were assigned to the generated resources.

This commit ensures that resources created during the evaluation of
generators will get their parameter defaults assigned.