### PR TITLE
(PUP-996) Make relationship with empty middle set work

### DIFF
--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -31,13 +31,6 @@ class Puppet::Parser::Relationship
   end
 
   def mk_relationship(source, target, catalog)
-    # There was once an assumption that this could be an array. These raise
-    # assertions are here as a sanity check for 4.0 and can be removed after
-    # a release or two
-    #TRANSLATORS "source" is a keyword and should not be translated
-    raise ArgumentError, _("source shouldn't be an array") if source.is_a?(Array)
-    #TRANSLATORS "target" is a keyword and should not be translated
-    raise ArgumentError, _("target shouldn't be an array") if target.is_a?(Array)
     source = source.to_s
     target = target.to_s
 

--- a/lib/puppet/parser/relationship.rb
+++ b/lib/puppet/parser/relationship.rb
@@ -3,10 +3,11 @@ class Puppet::Parser::Relationship
 
   PARAM_MAP = {:relationship => :before, :subscription => :notify}
 
-  def arrayify(resources)
+  def arrayify(resources, left)
     case resources
     when Puppet::Pops::Evaluator::Collectors::AbstractCollector
-      resources.collected.values
+      # on the LHS, go as far left as possible, else whatever the collected result is
+      left ? leftmost_alternative(resources) : resources.collected.values
     when Array
       resources
     else
@@ -15,8 +16,8 @@ class Puppet::Parser::Relationship
   end
 
   def evaluate(catalog)
-    arrayify(source).each do |s|
-      arrayify(target).each do |t|
+    arrayify(source, true).each do |s|
+      arrayify(target, false).each do |t|
         mk_relationship(s, t, catalog)
       end
     end
@@ -31,19 +32,52 @@ class Puppet::Parser::Relationship
   end
 
   def mk_relationship(source, target, catalog)
-    source = source.to_s
-    target = target.to_s
+    source_ref = canonical_ref(source)
+    target_ref = canonical_ref(target)
+    rel_param = param_name
 
-    unless source_resource = catalog.resource(source)
-      raise ArgumentError, _("Could not find resource '%{source}' for relationship on '%{target}'") % { source: source, target: target }
+    unless source_resource = catalog.resource(*source_ref)
+      raise ArgumentError, _("Could not find resource '%{source}' for relationship on '%{target}'") % { source: source.to_s, target: target.to_s }
     end
-    unless catalog.resource(target)
-      raise ArgumentError, _("Could not find resource '%{target}' for relationship from '%{source}'") % { target: target, source: source }
+    unless catalog.resource(*target_ref)
+      raise ArgumentError, _("Could not find resource '%{target}' for relationship from '%{source}'") % { target: target.to_s, source: source.to_s }
     end
     Puppet.debug {"Adding relationship from #{source} to #{target} with '#{param_name}'"}
-    if source_resource[param_name].class != Array
-      source_resource[param_name] = [source_resource[param_name]].compact
+    if source_resource[rel_param].class != Array
+      source_resource[rel_param] = [source_resource[rel_param]].compact
     end
-    source_resource[param_name] << target
+    source_resource[rel_param] << (target_ref[1].nil? ? target_ref[0] : "#{target_ref[0]}[#{target_ref[1]}]")
+  end
+
+  private
+
+  # Finds the leftmost alternative for a collector (if it is empty, try its empty alternative recursively until there is
+  # either nothing left, or a non empty set is found.
+  #
+  def leftmost_alternative(x)
+    if x.is_a?(Puppet::Pops::Evaluator::Collectors::AbstractCollector)
+      collected = x.collected
+      return collected.values unless collected.empty?
+      adapter = Puppet::Pops::Adapters::EmptyAlternativeAdapter.get(x)
+      adapter.nil? ? [] : leftmost_alternative(adapter.empty_alternative)
+    elsif x.is_a?(Array) && x.size == 1 && x[0].is_a?(Puppet::Pops::Evaluator::Collectors::AbstractCollector)
+      leftmost_alternative(x[0])
+    else
+      x
+    end
+  end
+
+  # Turns a PResourceType or PHostClassType into an array [type, title] and all other references to [ref, nil]
+  # This is needed since it is not possible to find resources in the catalog based on the type system types :-(
+  # (note, the catalog is also used on the agent side)
+  def canonical_ref(ref)
+    case ref
+    when Puppet::Pops::Types::PResourceType
+      [ref.type_name, ref.title]
+    when Puppet::Pops::Types::PHostClassType
+      ['class', ref.class_name]
+    else
+      [ref.to_s, nil]
+    end
   end
 end

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -11,6 +11,16 @@ module Adapters
     attr_accessor :documentation
   end
 
+  # An  empty alternative adapter is used when there is the need to
+  # attach a value to be used if the original is empty. This is used
+  # when a lazy evaluation takes place, and the decision how to handle an
+  # empty case must be delayed.
+  #
+  class EmptyAlternativeAdapter < Adaptable::Adapter
+    # @return [Object] The alternative value associated with an object
+    attr_accessor :empty_alternative
+  end
+
   # This class is for backward compatibility only. It's not really an adapter but it is
   # needed for the puppetlabs-strings gem
   # @deprecated

--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -151,8 +151,10 @@ class RelationshipOperator
       # Add the relationships to the catalog
       source.each {|s| target.each {|t| add_relationship(s, t, RELATION_TYPE[relationship_expression.operator], scope) }}
 
-      # Produce the transformed source RHS (if this is a chain, this does not need to be done again)
-      real.slice(1)
+      # The result is the transformed source RHS unless it is empty, in which case the transformed LHS is returned.
+      # This closes the gap created by an empty set of references in a chain of relationship
+      # such that X -> [ ] -> Y results in  X -> Y.
+      result = real[1].empty? ? real[0] : real[1]
     rescue NotCatalogTypeError => e
       fail(Issues::NOT_CATALOG_TYPE, relationship_expression, {:type => @type_calculator.string(e.type)})
     rescue IllegalRelationshipOperandError => e

--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -154,7 +154,22 @@ class RelationshipOperator
       # The result is the transformed source RHS unless it is empty, in which case the transformed LHS is returned.
       # This closes the gap created by an empty set of references in a chain of relationship
       # such that X -> [ ] -> Y results in  X -> Y.
-      result = real[1].empty? ? real[0] : real[1]
+      #result = real[1].empty? ? real[0] : real[1]
+      if real[1].empty?
+        # right side empty, simply use the left (whatever it may be)
+        result = real[0]
+      else
+        right = real[1]
+        if right.size == 1 && right[0].is_a?(Puppet::Pops::Evaluator::Collectors::AbstractCollector)
+          # the collector when evaluated later may result in an empty set, if so, the
+          # lazy relationship forming logic needs to have access to the left value.
+          adapter = Puppet::Pops::Adapters::EmptyAlternativeAdapter.adapt(right[0])
+          adapter.empty_alternative = real[0]
+        end
+        result = right
+      end
+      result
+
     rescue NotCatalogTypeError => e
       fail(Issues::NOT_CATALOG_TYPE, relationship_expression, {:type => @type_calculator.string(e.type)})
     rescue IllegalRelationshipOperandError => e

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1251,7 +1251,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       expect(scope.compiler).to have_relationship(['File', 'b', '~>', 'File', 'a'])
     end
 
-    it 'should cross the gap created by an intermediate empty set' do
+    it 'should close the gap created by an intermediate empty set' do
       source = "[File[a], File[aa]] -> [] ~> [File[b], File[bb]]"
       parser.evaluate_string(scope, source, __FILE__)
       expect(scope.compiler).to have_relationship(['File', 'a',  '~>', 'File', 'b'])

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1250,6 +1250,15 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       parser.evaluate_string(scope, source, __FILE__)
       expect(scope.compiler).to have_relationship(['File', 'b', '~>', 'File', 'a'])
     end
+
+    it 'should cross the gap created by an intermediate empty set' do
+      source = "[File[a], File[aa]] -> [] ~> [File[b], File[bb]]"
+      parser.evaluate_string(scope, source, __FILE__)
+      expect(scope.compiler).to have_relationship(['File', 'a',  '~>', 'File', 'b'])
+      expect(scope.compiler).to have_relationship(['File', 'aa', '~>', 'File', 'b'])
+      expect(scope.compiler).to have_relationship(['File', 'a',  '~>', 'File', 'bb'])
+      expect(scope.compiler).to have_relationship(['File', 'aa', '~>', 'File', 'bb'])
+    end
   end
 
   context "When evaluating heredoc" do


### PR DESCRIPTION
This makes chains or relationships close a gap in a chain of relationships. 
It used to break the chain.

Thus:
`[File[a], File[b]] -> [ ] ~> [File[aa], File[bb]]`
results in
```
a ~> aa
a ~> bb
b ~> aa
b ~> bb
```
This works for both explicitly empty sets, and for collections returning empty sets. Note that the gap is closed with the rightmost operator with a non-empty right set.