### PR TITLE
(PUP-7257) Accept JSON facts in catalog request

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -25,9 +25,12 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       # in Network::HTTP::Handler will automagically deserialize the value.
       if text_facts.is_a?(Puppet::Node::Facts)
         facts = text_facts
-      else
+      elsif format == 'pson'
         # We unescape here because the corresponding code in Puppet::Configurer::FactHandler escapes
+        # PSON is deprecated, but continue to accept from older agents
         facts = Puppet::Node::Facts.convert_from(format, CGI.unescape(text_facts))
+      else
+        facts = Puppet::Node::Facts.convert_from('json', text_facts)
       end
 
       unless facts.name == request.key


### PR DESCRIPTION
Accept JSON facts in catalog requests and continue to accept PSON from
older agents.

Note puppet has a long standing bug of double-escaping PSON facts. We
won't make the same mistake when sending facts as JSON.