### PR TITLE
(PUP-7485) Ensure that global functions and types are publicly available

### DIFF
--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -129,7 +129,11 @@ module Adapters
         default_loader
       else
         loader_name = loader_name_by_source(loaders.environment, model, file)
-        loader_name.nil? ? default_loader || loaders.find_loader(nil) : loaders[loader_name]
+        if loader_name.nil?
+          default_loader || loaders[Loader::ENVIRONMENT_PRIVATE]
+        else
+          loaders[loader_name]
+        end
       end
     end
 
@@ -152,7 +156,7 @@ module Adapters
     # @api private
     def self.loader_name_by_source(environment, instance, file)
       file = find_file(instance) if file.nil?
-      return nil if file.nil?
+      return nil if file.nil? || EMPTY_STRING == file
       pn_adapter = PathsAndNameCacheAdapter.adapt(environment) do |a|
         a.paths ||= environment.modulepath.map { |p| Pathname.new(p) }
         a.cache ||= {}

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -145,8 +145,10 @@ module Adapters
     #
     # The method returns `nil` when no module could be found.
     #
-    # @param scope
-    # @param instance
+    # @param environment [Puppet::Node::Environment] the current environment
+    # @param instance [Model::PopsObject] the AST for the code
+    # @param file [String] the path to the file for the code or `nil`
+    # @return [String] the name of the loader associated with the source
     # @api private
     def self.loader_name_by_source(environment, instance, file)
       file = find_file(instance) if file.nil?

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -21,6 +21,10 @@
 #
 module Puppet::Pops
 module Loader
+
+ENVIRONMENT = 'environment'.freeze
+ENVIRONMENT_PRIVATE = 'environment private'.freeze
+
 class Loader
   attr_reader :loader_name
 

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -21,8 +21,6 @@ module Loader
 # @api private
 #
 module ModuleLoaders
-  ENVIRONMENT = 'environment'.freeze
-
   def self.system_loader_from(parent_loader, loaders)
     # Puppet system may be installed in a fixed location via RPM, installed as a Gem, via source etc.
     # The only way to find this across the different ways puppet can be installed is

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -170,7 +170,7 @@ class Loaders
   # @raise [Puppet::ParseError] if no loader can be found
   # @api private
   def find_loader(module_name)
-    if module_name.nil? || module_name == ''
+    if module_name.nil? || EMPTY_STRING == module_name
       # TODO : Later when fdefinition can be private, a decision is needed regarding what that means.
       #        A private environment loader could be used for logic outside of modules, then only that logic
       #        would see the definition.
@@ -248,8 +248,6 @@ class Loaders
     # available modules. (3x is everyone sees everything).
     # Puppet binder currently reads confdir/bindings - that is bad, it should be using the new environment support.
 
-    # The environment is not a namespace, so give it a nil "module_name"
-    loader_name = "environment:#{environment.name}"
     # env_conf is setup from the environment_dir value passed into Puppet::Environments::Directories.new
     env_conf = Puppet.lookup(:environments).get_conf(environment.name)
     env_path = env_conf.nil? || !env_conf.is_a?(Puppet::Settings::EnvironmentConf) ? nil : env_conf.path_to_env
@@ -259,7 +257,7 @@ class Loaders
 
     if env_path.nil?
       # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?
-      loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, loader_name))
+      loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, Loader::ENVIRONMENT))
     else
       # View the environment as a module to allow loading from it - this module is always called 'environment'
       loader = Loader::ModuleLoaders.environment_loader_from(@runtime3_type_loader, self, env_path)
@@ -273,7 +271,7 @@ class Loaders
     # Code in the environment gets to see all modules (since there is no metadata for the environment)
     # but since this is not given to the module loaders, they can not load global code (since they can not
     # have prior knowledge about this
-    loader = add_loader_by_name(Loader::DependencyLoader.new(loader, 'environment private', @module_resolver.all_module_loaders()))
+    loader = add_loader_by_name(Loader::DependencyLoader.new(loader, Loader::ENVIRONMENT_PRIVATE, @module_resolver.all_module_loaders()))
 
     # The module loader gets the private loader via a lazy operation to look up the module's private loader.
     # This does not work for an environment since it is not resolved the same way.

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -171,14 +171,8 @@ class Loaders
   # @api private
   def find_loader(module_name)
     if module_name.nil? || EMPTY_STRING == module_name
-      # TODO : Later when fdefinition can be private, a decision is needed regarding what that means.
-      #        A private environment loader could be used for logic outside of modules, then only that logic
-      #        would see the definition.
-      #
-      # Use the private loader, this definition may see the environment's dependencies (currently, all modules)
-      loader = private_environment_loader()
-      raise Puppet::ParseError, 'Internal Error: did not find public loader' if loader.nil?
-      loader
+      # Use the public environment loader
+      public_environment_loader
     else
       # TODO : Later check if definition is private, and then add it to private_loader_for_module
       #

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -88,7 +88,7 @@ describe 'loaders' do
     loaders = Puppet::Pops::Loaders.new(empty_test_env)
 
     expect(loaders.public_environment_loader()).to be_a(Puppet::Pops::Loader::SimpleEnvironmentLoader)
-    expect(loaders.public_environment_loader().to_s).to eql("(SimpleEnvironmentLoader 'environment:*test*')")
+    expect(loaders.public_environment_loader().to_s).to eql("(SimpleEnvironmentLoader 'environment')")
     expect(loaders.private_environment_loader()).to be_a(Puppet::Pops::Loader::DependencyLoader)
     expect(loaders.private_environment_loader().to_s).to eql("(DependencyLoader 'environment private' [])")
   end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -389,53 +389,13 @@ describe 'loaders' do
     end
   end
 
-  context 'loading types' do
+  context 'loading' do
     let(:env_name) { 'testenv' }
     let(:environments_dir) { Puppet[:environmentpath] }
     let(:env_dir) { File.join(environments_dir, env_name) }
     let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, 'modules')]) }
-    let(:metadata_json) {
-      <<-JSON
-      {
-        "name": "example/%1$s",
-        "version": "0.0.2",
-        "source": "git@github.com/example/example-%1$s.git",
-        "dependencies": [],
-        "author": "Bob the Builder",
-        "license": "Apache-2.0"%2$s
-      }
-      JSON
-    }
-
-    let(:env_dir_files) do
-      {
-        'modules' => {
-          'a' => {
-            'manifests' => {
-              'init.pp' => 'class a { notice(A::A) }'
-            },
-            'types' => {
-              'a.pp' => 'type A::A = Variant[B::B, String]',
-              'n.pp' => 'type A::N = C::C'
-            },
-            'metadata.json' => sprintf(metadata_json, 'a', ', "dependencies": [{ "name": "example/b" }]')
-          },
-          'b' => {
-            'types' => {
-              'b.pp' => 'type B::B = Variant[C::C, Float]',
-              'x.pp' => 'type B::X = A::A'
-            },
-            'metadata.json' => sprintf(metadata_json, 'b', ', "dependencies": [{ "name": "example/c" }]')
-          },
-          'c' => {
-            'types' => {
-              'c.pp' => 'type C::C = Integer'
-            },
-            'metadata.json' => sprintf(metadata_json, 'c', '')
-          },
-        }
-      }
-    end
+    let(:node) { Puppet::Node.new("test", :environment => env) }
+    let(:env_dir_files) {}
 
     let(:populated_env_dir) do
       dir_contained_in(environments_dir, env_name => env_dir_files)
@@ -443,46 +403,138 @@ describe 'loaders' do
       env_dir
     end
 
-    before(:each) do
-      Puppet.push_context(:loaders => Puppet::Pops::Loaders.new(env))
+    context 'non autoloaded types and functions' do
+      let(:env_dir_files) {
+        {
+          'modules' => {
+            'tstf' => {
+              'manifests' => {
+                'init.pp' => <<-PUPPET.unindent
+                  class tstf {
+                    notice(testfunc())
+                  }
+                  PUPPET
+              }
+            },
+            'tstt' => {
+              'manifests' => {
+                'init.pp' => <<-PUPPET.unindent
+                  class tstt {
+                    notice(assert_type(GlobalType, 23))
+                  }
+                  PUPPET
+              }
+            }
+          }
+        }
+      }
+
+      it 'finds the function from a module' do
+        expect(eval_and_collect_notices(<<-PUPPET.unindent, node)).to eq(['hello from testfunc'])
+          function testfunc() {
+            'hello from testfunc'
+          }
+          include 'tstf'
+          PUPPET
+      end
+
+      it 'finds the type from a module' do
+        expect(eval_and_collect_notices(<<-PUPPET.unindent, node)).to eq(['23'])
+          type GlobalType = Integer
+          include 'tstt'
+          PUPPET
+      end
     end
 
-    after(:each) do
-      Puppet.pop_context
-    end
+    context 'types' do
+      let(:env_name) { 'testenv' }
+      let(:environments_dir) { Puppet[:environmentpath] }
+      let(:env_dir) { File.join(environments_dir, env_name) }
+      let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, 'modules')]) }
+      let(:metadata_json) {
+        <<-JSON
+        {
+          "name": "example/%1$s",
+          "version": "0.0.2",
+          "source": "git@github.com/example/example-%1$s.git",
+          "dependencies": [],
+          "author": "Bob the Builder",
+          "license": "Apache-2.0"%2$s
+        }
+        JSON
+      }
 
-    it 'resolves types using the loader that loaded the type a -> b -> c' do
-      type = Puppet::Pops::Types::TypeParser.singleton.parse('A::A', Puppet::Pops::Loaders.find_loader('a'))
-      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
-      expect(type.name).to eql('A::A')
-      type = type.resolved_type
-      expect(type).to be_a(Puppet::Pops::Types::PVariantType)
-      type = type.types[0]
-      expect(type.name).to eql('B::B')
-      type = type.resolved_type
-      expect(type).to be_a(Puppet::Pops::Types::PVariantType)
-      type = type.types[0]
-      expect(type.name).to eql('C::C')
-      type = type.resolved_type
-      expect(type).to be_a(Puppet::Pops::Types::PIntegerType)
-    end
+      let(:env_dir_files) do
+        {
+          'modules' => {
+            'a' => {
+              'manifests' => {
+                'init.pp' => 'class a { notice(A::A) }'
+              },
+              'types' => {
+                'a.pp' => 'type A::A = Variant[B::B, String]',
+                'n.pp' => 'type A::N = C::C'
+              },
+              'metadata.json' => sprintf(metadata_json, 'a', ', "dependencies": [{ "name": "example/b" }]')
+            },
+            'b' => {
+              'types' => {
+                'b.pp' => 'type B::B = Variant[C::C, Float]',
+                'x.pp' => 'type B::X = A::A'
+              },
+              'metadata.json' => sprintf(metadata_json, 'b', ', "dependencies": [{ "name": "example/c" }]')
+            },
+            'c' => {
+              'types' => {
+                'c.pp' => 'type C::C = Integer'
+              },
+              'metadata.json' => sprintf(metadata_json, 'c', '')
+            },
+          }
+        }
+      end
 
-    it 'will not resolve implicit transitive dependencies, a -> c' do
-      type = Puppet::Pops::Types::TypeParser.singleton.parse('A::N', Puppet::Pops::Loaders.find_loader('a'))
-      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
-      expect(type.name).to eql('A::N')
-      type = type.resolved_type
-      expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
-      expect(type.type_string).to eql('C::C')
-    end
+      before(:each) do
+        Puppet.push_context(:loaders => Puppet::Pops::Loaders.new(env))
+      end
 
-    it 'will not resolve reverse dependencies, b -> a' do
-      type = Puppet::Pops::Types::TypeParser.singleton.parse('B::X', Puppet::Pops::Loaders.find_loader('b'))
-      expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
-      expect(type.name).to eql('B::X')
-      type = type.resolved_type
-      expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
-      expect(type.type_string).to eql('A::A')
+      after(:each) do
+        Puppet.pop_context
+      end
+
+      it 'resolves types using the loader that loaded the type a -> b -> c' do
+        type = Puppet::Pops::Types::TypeParser.singleton.parse('A::A', Puppet::Pops::Loaders.find_loader('a'))
+        expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+        expect(type.name).to eql('A::A')
+        type = type.resolved_type
+        expect(type).to be_a(Puppet::Pops::Types::PVariantType)
+        type = type.types[0]
+        expect(type.name).to eql('B::B')
+        type = type.resolved_type
+        expect(type).to be_a(Puppet::Pops::Types::PVariantType)
+        type = type.types[0]
+        expect(type.name).to eql('C::C')
+        type = type.resolved_type
+        expect(type).to be_a(Puppet::Pops::Types::PIntegerType)
+      end
+
+      it 'will not resolve implicit transitive dependencies, a -> c' do
+        type = Puppet::Pops::Types::TypeParser.singleton.parse('A::N', Puppet::Pops::Loaders.find_loader('a'))
+        expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+        expect(type.name).to eql('A::N')
+        type = type.resolved_type
+        expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
+        expect(type.type_string).to eql('C::C')
+      end
+
+      it 'will not resolve reverse dependencies, b -> a' do
+        type = Puppet::Pops::Types::TypeParser.singleton.parse('B::X', Puppet::Pops::Loaders.find_loader('b'))
+        expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+        expect(type.name).to eql('B::X')
+        type = type.resolved_type
+        expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
+        expect(type.type_string).to eql('A::A')
+      end
     end
   end
 


### PR DESCRIPTION
Prior to this PR, a global function or type that was not declared so that it was available to the auto-loader, would not be reachable from a module. This PR changes this so that such a function becomes known to the public environment loader.
