### PR TITLE
(PUP-7486) useradd provider silently does not set password

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -96,7 +96,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   has_features :manages_homedir, :allows_duplicates, :manages_expiry
   has_features :system_users unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
 
-  has_features :manages_passwords, :manages_password_age if Puppet.features.libshadow?
+  has_features :manages_passwords, :manages_password_age
   has_features :manages_shell
 
   def check_allow_dup
@@ -207,6 +207,8 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
           method = self.class.option(shadow_property, :method)
           return unmunge(shadow_property, ent.send(method))
         end
+      else
+        self.fail Puppet::Error, "'#{shadow_property}' is set but libshadow is not available"
       end
       :absent
     end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -349,10 +349,10 @@ describe Puppet::Type.type(:user).provider(:useradd) do
         resource # just to link the resource to the provider
       end
 
-      it "should return absent if libshadow feature is not present" do
+      it "should raise exception if libshadow feature is not present" do
         Puppet.features.stubs(:libshadow?).returns false
         # Shadow::Passwd.expects(:getspnam).never # if we really don't have libshadow we dont have Shadow::Passwd either
-        expect(provider.send(property)).to eq(:absent)
+        expect { provider.send(property) }.to raise_error(Puppet::Error, "'#{property}' is set but libshadow is not available")
       end
 
       it "should return absent if user cannot be found", :if => Puppet.features.libshadow? do
@@ -372,9 +372,9 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       resource # just to link the resource to the provider
     end
 
-    it "should return absent if libshadow feature is not present" do
+    it "should raise exception if libshadow feature is not present" do
       Puppet.features.stubs(:libshadow?).returns false
-      expect(provider.expiry).to eq(:absent)
+      expect { provider.expiry }.to raise_error(Puppet::Error, /libshadow is not available/)
     end
 
     it "should return absent if user cannot be found", :if => Puppet.features.libshadow? do


### PR DESCRIPTION
If password-related parameters are set on User resources the client
should alarm when unable to enforce those parameters on the host. When
`ruby-libshadow` is unavailable the provider won't/can't set the
password-related parameters, but until now there was no indication in
the output on a client or server that the parameters were not applied.

A side affect of this warning is the `:manages_passwords` and
`:manages_password_age` features are always "on" for the `useradd` provider
in order to alarm during the application of the catalog. The removal of
validating `Puppet.features.libshadow?` at compile time is exchanged for
a better user experience at runtime.