### PR TITLE
(PUP-7484) Move resource defaults initialization to initializer

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -85,8 +85,6 @@ class Puppet::Parser::Compiler
       end
     end
 
-    # A resource added as the result of evaluating a definition must have its defaults set
-    resource.add_defaults if @evaluating_generators
     @resources << resource
 
     # Note that this will fail if the resource is not unique.
@@ -554,27 +552,22 @@ class Puppet::Parser::Compiler
   # be defined resources.
   def evaluate_generators
     count = 0
-    @evaluating_generators = true
-    begin
-      loop do
-        done = true
+    loop do
+      done = true
 
-        Puppet::Util::Profiler.profile(_("Iterated (%{count}) on generators") % { count: count + 1 }, [:compiler, :iterate_on_generators]) do
-          # Call collections first, then definitions.
-          done = false if evaluate_collections
-          done = false if evaluate_definitions
-        end
-
-        break if done
-
-        count += 1
-
-        if count > 1000
-          raise Puppet::ParseError, _("Somehow looped more than 1000 times while evaluating host catalog")
-        end
+      Puppet::Util::Profiler.profile(_("Iterated (%{count}) on generators") % { count: count + 1 }, [:compiler, :iterate_on_generators]) do
+        # Call collections first, then definitions.
+        done = false if evaluate_collections
+        done = false if evaluate_definitions
       end
-    ensure
-      @evaluating_generators = false
+
+      break if done
+
+      count += 1
+
+      if count > 1000
+        raise Puppet::ParseError, _("Somehow looped more than 1000 times while evaluating host catalog")
+      end
     end
   end
 

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -169,8 +169,6 @@ class Puppet::Parser::Compiler
       # New capability mappings may have been defined when the site was evaluated
       Puppet::Util::Profiler.profile(_("Compile: Evaluated site capability mappings"), [:compiler, :evaluate_capability_mappings]) { evaluate_capability_mappings }
 
-      Puppet::Util::Profiler.profile(_("Compile: Evaluated resource defaults"), [:compiler, :evaluate_resource_defaults]) { evaluate_resource_defaults }
-
       Puppet::Util::Profiler.profile(_("Compile: Evaluated generators"), [:compiler, :evaluate_generators]) { evaluate_generators }
 
       Puppet::Util::Profiler.profile(_("Compile: Validate Catalog pre-finish"), [:compiler, :validate_pre_finish]) do
@@ -610,10 +608,6 @@ class Puppet::Parser::Compiler
     if !remaining.empty?
       raise Puppet::ParseError, _("Failed to realize virtual resources %{resources}") % { resources: remaining.join(', ') }
     end
-  end
-
-  def evaluate_resource_defaults
-    resources.each { |resource| resource.add_defaults }
   end
 
   # Make sure all of our resources and such have done any last work

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -129,8 +129,6 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   end
 
   def add_resource(scope, resource)
-    # A resource added as the result of evaluating a generator (collector or definition) must have its defaults set
-    resource.add_defaults if @evaluating_generators
     @resources << resource
     @catalog.add_resource(resource)
 

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -67,8 +67,6 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
 
         Puppet::Util::Profiler.profile(_("Env Compile: Evaluated application instances"), [:compiler, :evaluate_applications]) { evaluate_applications }
 
-        Puppet::Util::Profiler.profile(_("Env Compile: Evaluated resource defaults"), [:compiler, :evaluate_resource_defaults]) { evaluate_resource_defaults }
-
         Puppet::Util::Profiler.profile(_("Env Compile: Prune"), [:compiler, :prune_catalog]) { prune_catalog }
 
         Puppet::Util::Profiler.profile(_("Env Compile: Validate Catalog pre-finish"), [:compiler, :validate_pre_finish]) do

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -99,6 +99,7 @@ class Puppet::Parser::Resource < Puppet::Resource
   #
   def finish_evaluation
     return if @evaluation_finished
+    add_defaults
     add_scope_tags
     @evaluation_finished = true
   end
@@ -298,21 +299,18 @@ class Puppet::Parser::Resource < Puppet::Resource
     nil
   end
 
+  private
+
   # Add default values from our definition.
-  # @api private
   def add_defaults
     scope.lookupdefaults(self.type).each do |name, param|
       unless @parameters.include?(name)
         self.debug "Adding default for #{name}"
 
-        param = param.dup
-        @parameters[name] = param
-        tag(*param.value) if param.name == :tag
+        @parameters[name] = param.dup
       end
     end
   end
-
-  private
 
   def add_scope_tags
     scope_resource = scope.resource

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -460,6 +460,17 @@ class Puppet::Parser::Scope
     values
   end
 
+  # Check if the given value is a known default for the given type
+  #
+  def is_default?(type, key, value)
+    defaults_for_type = @defaults[type]
+    unless defaults_for_type.nil?
+      default_param = defaults_for_type[key]
+      return true if !default_param.nil? && value == default_param.value
+    end
+    !parent.nil? && parent.is_default?(type, key, value)
+  end
+
   # Look up a defined type.
   def lookuptype(name)
     # This happens a lot, avoid making a call to make a call

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -350,13 +350,14 @@ module Runtime3Support
       end
       t = Runtime3ResourceSupport.find_resource_type(scope, r.type_name)
       resource = Puppet::Parser::Resource.new(
-        t, r.title,
-        :parameters => evaluated_parameters,
-        :file => file,
-        :line => line,
-        # WTF is this? Which source is this? The file? The name of the context ?
-        :source => scope.source,
-        :scope => scope
+        t, r.title, {
+          :parameters => evaluated_parameters,
+          :file => file,
+          :line => line,
+          # WTF is this? Which source is this? The file? The name of the context ?
+          :source => scope.source,
+          :scope => scope
+        }, false # defaults should not override
       )
 
       scope.compiler.add_override(resource)

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -53,9 +53,6 @@ class CompilerTestResource
   def resource_type
     self.class
   end
-
-  def add_defaults
-  end
 end
 
 describe Puppet::Parser::Compiler do

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -51,6 +51,7 @@ describe Puppet::Parser::Resource do
   it "should get its environment from its scope" do
     scope = stub 'scope', :source => stub("source"), :namespaces => nil
     scope.expects(:environment).returns("foo").at_least_once
+    scope.expects(:lookupdefaults).returns({})
     expect(Puppet::Parser::Resource.new("file", "whatever", :scope => scope).environment).to eq("foo")
   end
 
@@ -283,6 +284,70 @@ describe Puppet::Parser::Resource do
       expect(edges).to include(['One[a]', 'Notify[bob says hello]'])
       expect(edges).to include(['One[b]', 'Notify[bill says hello]'])
     end
+
+    it 'should override default values with new defaults' do
+      Puppet[:code] = <<-PUPPET.unindent
+        class foo {
+          File {
+            ensure => file,
+            mode   => '644',
+            owner  => 'root',
+            group  => 'root',
+          }
+        
+          file { '/tmp/foo':
+            ensure  => directory
+          }
+        
+          File['/tmp/foo'] { mode => '0755' }
+        }
+        include foo
+        PUPPET
+
+      catalog = Puppet::Parser::Compiler.compile(Puppet::Node.new 'anyone')
+      file = catalog.resource('File[/tmp/foo]')
+      expect(file).to be_a(Puppet::Resource)
+      expect(file['mode']).to eql('0755')
+    end
+  end
+
+  describe 'when evaluating resource defaults' do
+    let(:resource) { Puppet::Parser::Resource.new('file', 'whatever', :scope => @scope, :source => @source) }
+
+    it 'should add all defaults available from the scope' do
+      @scope.expects(:lookupdefaults).with('File').returns(:owner => param(:owner, 'default', @source))
+
+      expect(resource[:owner]).to eq('default')
+    end
+
+    it 'should not replace existing parameters with defaults' do
+      @scope.expects(:lookupdefaults).with('File').returns(:owner => param(:owner, 'replaced', @source))
+      r = Puppet::Parser::Resource.new('file', 'whatever', :scope => @scope, :source => @source, :parameters => [ param(:owner, 'oldvalue', @source) ])
+      expect(r[:owner]).to eq('oldvalue')
+    end
+
+    it 'should override defaults with new parameters' do
+      @scope.expects(:lookupdefaults).with('File').returns(:owner => param(:owner, 'replaced', @source))
+
+      resource.set_parameter(:owner, 'newvalue')
+      expect(resource[:owner]).to eq('newvalue')
+    end
+
+    it 'should add a copy of each default, rather than the actual default parameter instance' do
+      newparam = param(:owner, 'default', @source)
+      other = newparam.dup
+      other.value = "other"
+      newparam.expects(:dup).returns(other)
+      @scope.expects(:lookupdefaults).with('File').returns(:owner => newparam)
+
+      expect(resource[:owner]).to eq('other')
+    end
+
+    it "should tag with value of default parameter named 'tag'" do
+      @scope.expects(:lookupdefaults).with('File').returns(:tag => param(:tag, 'the_tag', @source))
+
+      expect(resource.tags).to include('the_tag')
+    end
   end
 
   describe "when finishing" do
@@ -292,34 +357,8 @@ describe Puppet::Parser::Resource do
 
     it "should do nothing if it has already been finished" do
       @resource.finish
-      @resource.expects(:add_defaults).never
+      @resource.expects(:add_scope_tags).never
       @resource.finish
-    end
-
-    it "should add all defaults available from the scope" do
-      @resource.scope.expects(:lookupdefaults).with(@resource.type).returns(:owner => param(:owner, "default", @resource.source))
-      @resource.finish
-
-      expect(@resource[:owner]).to eq("default")
-    end
-
-    it "should not replace existing parameters with defaults" do
-      @resource.set_parameter :owner, "oldvalue"
-      @resource.scope.expects(:lookupdefaults).with(@resource.type).returns(:owner => :replaced)
-      @resource.finish
-
-      expect(@resource[:owner]).to eq("oldvalue")
-    end
-
-    it "should add a copy of each default, rather than the actual default parameter instance" do
-      newparam = param(:owner, "default", @resource.source)
-      other = newparam.dup
-      other.value = "other"
-      newparam.expects(:dup).returns(other)
-      @resource.scope.expects(:lookupdefaults).with(@resource.type).returns(:owner => newparam)
-      @resource.finish
-
-      expect(@resource[:owner]).to eq("other")
     end
 
     it "converts parameters with Sensitive values to unwrapped values and metadata" do

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -285,7 +285,7 @@ describe Puppet::Parser::Resource do
       expect(edges).to include(['One[b]', 'Notify[bill says hello]'])
     end
 
-    it 'should override default values with new defaults' do
+    it 'should override default value with new value' do
       Puppet[:code] = <<-PUPPET.unindent
         class foo {
           File {

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -285,14 +285,20 @@ describe Puppet::Parser::Resource do
     end
   end
 
-  describe 'when evaluating resource defaults' do
+  describe "when finishing" do
     before do
       @resource = Puppet::Parser::Resource.new("file", "whatever", :scope => @scope, :source => @source)
     end
 
+    it "should do nothing if it has already been finished" do
+      @resource.finish
+      @resource.expects(:add_defaults).never
+      @resource.finish
+    end
+
     it "should add all defaults available from the scope" do
       @resource.scope.expects(:lookupdefaults).with(@resource.type).returns(:owner => param(:owner, "default", @resource.source))
-      @resource.add_defaults
+      @resource.finish
 
       expect(@resource[:owner]).to eq("default")
     end
@@ -300,7 +306,7 @@ describe Puppet::Parser::Resource do
     it "should not replace existing parameters with defaults" do
       @resource.set_parameter :owner, "oldvalue"
       @resource.scope.expects(:lookupdefaults).with(@resource.type).returns(:owner => :replaced)
-      @resource.add_defaults
+      @resource.finish
 
       expect(@resource[:owner]).to eq("oldvalue")
     end
@@ -311,28 +317,9 @@ describe Puppet::Parser::Resource do
       other.value = "other"
       newparam.expects(:dup).returns(other)
       @resource.scope.expects(:lookupdefaults).with(@resource.type).returns(:owner => newparam)
-      @resource.add_defaults
+      @resource.finish
 
       expect(@resource[:owner]).to eq("other")
-    end
-
-    it "should tag with value of default parameter named 'tag'" do
-      @resource.scope.expects(:lookupdefaults).with(@resource.type).returns(:tag => param(:tag, 'the_tag', @resource.source))
-      @resource.add_defaults
-
-      expect(@resource.tags).to include('the_tag')
-    end
-  end
-
-  describe "when finishing" do
-    before do
-      @resource = Puppet::Parser::Resource.new("file", "whatever", :scope => @scope, :source => @source)
-    end
-
-    it "should do nothing if it has already been finished" do
-      @resource.finish
-      @resource.expects(:add_scope_tags).never
-      @resource.finish
     end
 
     it "converts parameters with Sensitive values to unwrapped values and metadata" do


### PR DESCRIPTION
In PUP-25, an attempt was made to add another phase to the compiler that
was responsible for setting default values. That was not sufficient since
new resources were created after the fact.

The PR for PUP-7484 that went in prior to this one attempted to fix this
by setting resource defaults on all resources created after the phase
where defaults had been set. This wasn't good enough either, since in
some cases, resources are created during evaluate_main phase.

This commit uses a simpler and more straight forward approach. Defaults
are now assigned in the Puppet::Parser::Resource#initialize method. The
method has an additional and optional argument that enables this behavior
to be turned off (needed when creating resources for the sake of
overriding parameter defaults).