### PR TITLE
(PUP-7464) Make json serialization handle :undef Symbol

### DIFF
--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -184,15 +184,7 @@ class Puppet::Resource
   end
 
   def yaml_property_munge(x)
-    case x
-    when Hash
-      x.inject({}) { |h,kv|
-        k,v = kv
-        h[k] = self.class.value_to_pson_data(v)
-        h
-      }
-    else self.class.value_to_pson_data(x)
-    end
+    self.value.to_pson_data(x)
   end
 
   YAML_ATTRIBUTES = [:@file, :@line, :@exported, :@type, :@title, :@tags, :@parameters]

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -168,10 +168,15 @@ class Puppet::Resource
   end
 
   def self.value_to_pson_data(value)
-    if value.is_a? Array
+    case value
+    when Array
       value.map{|v| value_to_pson_data(v) }
-    elsif value.is_a? Puppet::Resource
+    when Hash
+      Hash[ value.map {|k, v| [value_to_pson_data(k), value_to_pson_data(v)] } ]
+    when Puppet::Resource
       value.to_s
+    when :undef
+      nil
     else
       value
     end

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -176,7 +176,7 @@ class Puppet::Resource
       result
     elsif value.is_a?(Puppet::Resource)
       value.to_s
-    elsif value == :undef
+    elsif value.is_a?(Symbol) && value == :undef
       nil
     else
       value

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -168,14 +168,13 @@ class Puppet::Resource
   end
 
   def self.value_to_pson_data(value)
-    case value
-    when Array
+    if value.is_a?(Array)
       value.map{|v| value_to_pson_data(v) }
-    when Hash
+    elsif value.is_a?(Hash)
       Hash[ value.map {|k, v| [value_to_pson_data(k), value_to_pson_data(v)] } ]
-    when Puppet::Resource
+    elsif value.is_a?(Puppet::Resource)
       value.to_s
-    when :undef
+    elsif value == :undef
       nil
     else
       value

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -171,7 +171,9 @@ class Puppet::Resource
     if value.is_a?(Array)
       value.map{|v| value_to_pson_data(v) }
     elsif value.is_a?(Hash)
-      Hash[ value.map {|k, v| [value_to_pson_data(k), value_to_pson_data(v)] } ]
+      result = {}
+      value.each_pair { |k, v| result[value_to_pson_data(k)] = value_to_pson_data(v) }
+      result
     elsif value.is_a?(Puppet::Resource)
       value.to_s
     elsif value == :undef

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -972,6 +972,27 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to pson"
         expect(message).to be_a(String)
         expect(message).to eql('2016-09-15T08:32:16.123 UTC')
       end
+
+      it 'should convert param containing array with :undef entries' do
+        catalog = compile_to_catalog("notify {'foo': message => [ 10, undef, 20 ] }")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Array)
+        expect(message[0]).to eql(10)
+        expect(message[1]).to eql(nil)
+        expect(message[2]).to eql(20)
+      end
+
+      it 'should convert param containing hash with :undef entries' do
+        catalog = compile_to_catalog("notify {'foo': message => {a => undef, b => 10}}")
+        catalog2 = Puppet::Resource::Catalog.from_data_hash(JSON.parse(catalog.to_json))
+        message = catalog2.resource('notify', 'foo')['message']
+        expect(message).to be_a(Hash)
+        expect(message.has_key?('a')).to eql(true)
+        expect(message['a']).to eql(nil)
+        expect(message['b']).to eql(10)
+      end
+
     end
 
   end


### PR DESCRIPTION
Before this, an :undef symbol nested in an Array or Hash used as a
resource's parameter value would serialize the Ruby `:undef` symbol.

The support for rich data checks if the value is compliant with Json an
if not transforms the entire Array or Hash into a String.

This commit modifies the "to_pson" such that an `:undef` value is
transformed to `nil` (which can be represented in JSON). Prior to this
commit, only Array's where scanned for values in need of transformation,
now also Hashes are transformed.