### PR TITLE
(PUP-7492) Prevent that an interpolated alias interpolates again

### DIFF
--- a/lib/puppet/pops/lookup/interpolation.rb
+++ b/lib/puppet/pops/lookup/interpolation.rb
@@ -57,10 +57,11 @@ module Interpolation
           # Alias is only permitted if the entire string is equal to the interpolate expression
           fail(Issues::HIERA_INTERPOLATION_ALIAS_NOT_ENTIRE_STRING) if is_alias && subject != match
           value = interpolate_method(method_key).call(key, lookup_invocation, subject)
-          value = lookup_invocation.check(method_key == :scope ? "scope:#{key}" : key) { interpolate(value, lookup_invocation, allow_methods) }
 
           # break gsub and return value immediately if this was an alias substitution. The value might be something other than a String
           return value if is_alias
+
+          value = lookup_invocation.check(method_key == :scope ? "scope:#{key}" : key) { interpolate(value, lookup_invocation, allow_methods) }
         end
         value.nil? ? '' : value
       end

--- a/spec/unit/pops/lookup/interpolation_spec.rb
+++ b/spec/unit/pops/lookup/interpolation_spec.rb
@@ -6,18 +6,39 @@ module Puppet::Pops
 describe 'Puppet::Pops::Lookup::Interpolation' do
   include Lookup::SubLookup
 
+  class InterpolationTestAdapter < Lookup::LookupAdapter
+    include Lookup::SubLookup
+
+    def initialize(data, interpolator)
+      @data = data
+      @interpolator = interpolator
+    end
+
+    def track(name)
+    end
+
+    def lookup(name, lookup_invocation, merge)
+      track(name)
+      segments = split_key(name)
+      root_key = segments.shift
+      found = @data[root_key]
+      found = sub_lookup(name, lookup_invocation, segments, found) unless segments.empty?
+      @interpolator.interpolate(found, lookup_invocation, true)
+    end
+  end
+
   let(:interpolator) { Class.new { include Lookup::Interpolation }.new }
   let(:scope) { {} }
+  let(:data) { {} }
+  let(:adapter) { InterpolationTestAdapter.new(data, interpolator) }
   let(:lookup_invocation) { Lookup::Invocation.new(scope, {}, {}, nil) }
 
+  before(:each) do
+    Lookup::Invocation.any_instance.stubs(:lookup_adapter).returns(adapter)
+  end
+
   def expect_lookup(*keys)
-    keys.each do |key|
-      segments = split_key(key)
-      root_key = segments.shift
-      found = data[root_key]
-      found = sub_lookup(key, lookup_invocation, segments, found) unless segments.empty?
-      Lookup.expects(:lookup).with(key, nil, '', true, nil, is_a(Lookup::Invocation)).returns(found)
-    end
+    keys.each { |key| adapter.expects(:track).with(key) }
   end
 
   context 'when interpolating nested data' do
@@ -242,7 +263,8 @@ describe 'Puppet::Pops::Lookup::Interpolation' do
     end
 
     it 'should not find a subkey that is matched within a string' do
-      expect{ expect_lookup('key.subkey') }.to raise_error(/Got String when a hash-like object was expected to access value using 'subkey' from key 'key.subkey'/)
+      expect{ interpolator.interpolate("%{lookup('key.subkey')}", lookup_invocation, true) }.to raise_error(
+        /Got String when a hash-like object was expected to access value using 'subkey' from key 'key.subkey'/)
     end
   end
 


### PR DESCRIPTION
This commit fixes a problem that caused a resolved "%{alias('key')}" to
be subject to interpolation once again after the alias had been resolve
which meant that sometimes, an alias would return a different value than
the key that it was an alias for.
