### PR TITLE
(PUP-6675) Use pipes instead of temporary files for Puppet exec

### DIFF
--- a/acceptance/tests/resource/exec/should_accept_large_output.rb
+++ b/acceptance/tests/resource/exec/should_accept_large_output.rb
@@ -1,0 +1,26 @@
+test_name "tests that puppet correctly captures large and empty output."
+
+agents.each do |agent|
+  testfile = agent.tmpfile('should_accept_large_output')
+
+  # Generate >64KB file to exceed pipe buffer.
+  lorem_ipsum = <<EOF
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+EOF
+  create_remote_file(agent, testfile, lorem_ipsum*1024)
+
+  apply_manifest_on(agent, "exec {'cat #{testfile}': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin'], logoutput => true}") do
+    fail_test "didn't seem to run the command" unless
+      stdout.include? 'executed successfully'
+    fail_test "didn't print output correctly" unless
+      stdout.lines.select {|line| line =~ /\/returns:/}.count == 4097
+  end
+
+  apply_manifest_on(agent, "exec {'echo': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin'], logoutput => true}") do
+    fail_test "didn't seem to run the command" unless
+      stdout.include? 'executed successfully'
+  end
+end

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -29,6 +29,7 @@ describe Puppet::Util::Execution do
       end
     end
 
+
     describe "#execute_posix (stubs)", :unless => Puppet.features.microsoft_windows? do
       before :each do
         # Most of the things this method does are bad to do during specs. :/
@@ -216,78 +217,49 @@ describe Puppet::Util::Execution do
         end
 
         describe "when squelch is not set" do
-          it "should set stdout to a temporary output file" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
-
+          it "should set stdout to a pipe" do
             Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,_|
-              stdout.path == outfile.path
+              stdout.class == IO
             end.returns(rval)
 
             Puppet::Util::Execution.execute('test command', :squelch => false)
           end
 
           it "should set stderr to the same file as stdout if combine is true" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
-
             Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == outfile.path
+              stdout == stderr
             end.returns(rval)
 
             Puppet::Util::Execution.execute('test command', :squelch => false, :combine => true)
           end
 
           it "should set stderr to the null device if combine is false" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
-
             Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == null_file
+              stdout.class == IO and stderr.path == null_file
             end.returns(rval)
 
             Puppet::Util::Execution.execute('test command', :squelch => false, :combine => false)
           end
 
-          it "should combine stdout and stderr if combine is true" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
-
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == outfile.path
-            end.returns(rval)
-
-            Puppet::Util::Execution.execute('test command', :combine => true)
-          end
-
           it "should default combine to true when no options are specified" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
-
             Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == outfile.path
+              stdout == stderr
             end.returns(rval)
 
             Puppet::Util::Execution.execute('test command')
           end
 
           it "should default combine to false when options are specified, but combine is not" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
-
             Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == null_file
+              stdout.class == IO and stderr.path == null_file
             end.returns(rval)
 
             Puppet::Util::Execution.execute('test command', :failonfail => false)
           end
 
           it "should default combine to false when an empty hash of options is specified" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
-
             Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == null_file
+              stdout.class == IO and stderr.path == null_file
             end.returns(rval)
 
             Puppet::Util::Execution.execute('test command', {})
@@ -536,9 +508,10 @@ describe Puppet::Util::Execution do
       end
 
       it "should close the stdin/stdout/stderr files used by the child" do
-        stdin = mock 'file', :close
-        stdout = mock 'file', :close
-        stderr = mock 'file', :close
+        stdin = mock 'file'
+        stdout = mock 'file'
+        stderr = mock 'file'
+        [stdin, stdout, stderr].each {|io| io.expects(:close).at_least_once}
 
         File.expects(:open).
             times(3).
@@ -550,37 +523,43 @@ describe Puppet::Util::Execution do
       end
 
       it "should read and return the output if squelch is false" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
-        stdout.write("My expected command output")
+        r, w = IO.pipe
+        IO.expects(:pipe).returns([r, w])
+        w.write("My expected command output")
 
         expect(Puppet::Util::Execution.execute('test command')).to eq("My expected command output")
       end
 
       it "should not read the output if squelch is true" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
-        stdout.write("My expected command output")
+        IO.expects(:pipe).never
 
         expect(Puppet::Util::Execution.execute('test command', :squelch => true)).to eq('')
       end
 
-      it "should delete the file used for output if squelch is false" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        path = stdout.path
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
+      it "should close the pipe used for output if squelch is false" do
+        r, w = IO.pipe
+        IO.expects(:pipe).returns([r, w])
 
-        Puppet::Util::Execution.execute('test command')
-
-        expect(Puppet::FileSystem.exist?(path)).to be_falsey
+        expect(Puppet::Util::Execution.execute('test command')).to eq("")
+        expect(r.closed?)
+        expect(w.closed?)
       end
 
-      it "should not raise an error if the file is open" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
-        file = File.new(stdout.path, 'r')
+      it "should close the pipe used for output if squelch is false and an error is raised" do
+        r, w = IO.pipe
+        IO.expects(:pipe).returns([r, w])
 
-        Puppet::Util::Execution.execute('test command')
+        if Puppet.features.microsoft_windows?
+          Puppet::Util::Execution.expects(:execute_windows).raises(Exception, 'execution failed')
+        else
+          Puppet::Util::Execution.expects(:execute_posix).raises(Exception, 'execution failed')
+        end
+
+        expect {
+          subject.execute('fail command')
+        }.to raise_error(Exception, 'execution failed')
+        expect(r.closed?)
+        expect(w.closed?)
       end
 
       it "should raise an error if failonfail is true and the child failed" do


### PR DESCRIPTION
Under selinux, when Puppet is invoked by another process with reduced
privileges, any sub-programs invoked by Puppet will not inherit Puppet's
selinux priveleges. This specifically causes silent failures when
invoking applications that don't normally have the ability to write
files - such as iptables-save or hostname - because Puppet redirects
their output to a temporary file.

Use pipes instead of a temporary file to capture the output of
subprocesses.