### PR TITLE
(PUP-7261) Include `charset` parameter in the Content-Type

### DIFF
--- a/lib/puppet/network/format.rb
+++ b/lib/puppet/network/format.rb
@@ -5,7 +5,7 @@ require 'puppet/confiner'
 class Puppet::Network::Format
   include Puppet::Confiner
 
-  attr_reader :name, :mime
+  attr_reader :name, :mime, :charset
   attr_accessor :intern_method, :render_method, :intern_multiple_method, :render_multiple_method, :weight, :required_methods, :extension
 
   def init_attribute(name, default)
@@ -34,6 +34,7 @@ class Puppet::Network::Format
     init_attribute(:weight, 5)
     init_attribute(:required_methods, method_list.keys)
     init_attribute(:extension, name.to_s)
+    init_attribute(:charset, nil)
 
     method_list.each do |method, value|
       init_attribute(method, value)
@@ -58,6 +59,10 @@ class Puppet::Network::Format
 
   def mime=(mime)
     @mime = mime.to_s.downcase
+  end
+
+  def charset=(charset)
+    @charset = charset
   end
 
   def render(instance)

--- a/lib/puppet/network/format.rb
+++ b/lib/puppet/network/format.rb
@@ -5,8 +5,8 @@ require 'puppet/confiner'
 class Puppet::Network::Format
   include Puppet::Confiner
 
-  attr_reader :name, :mime, :charset
-  attr_accessor :intern_method, :render_method, :intern_multiple_method, :render_multiple_method, :weight, :required_methods, :extension
+  attr_reader :name, :mime
+  attr_accessor :intern_method, :render_method, :intern_multiple_method, :render_multiple_method, :weight, :required_methods, :extension, :charset
 
   def init_attribute(name, default)
     value = @options.delete(name)
@@ -59,10 +59,6 @@ class Puppet::Network::Format
 
   def mime=(mime)
     @mime = mime.to_s.downcase
-  end
-
-  def charset=(charset)
-    @charset = charset
   end
 
   def render(instance)

--- a/lib/puppet/network/format.rb
+++ b/lib/puppet/network/format.rb
@@ -9,11 +9,9 @@ class Puppet::Network::Format
   attr_accessor :intern_method, :render_method, :intern_multiple_method, :render_multiple_method, :weight, :required_methods, :extension
 
   def init_attribute(name, default)
-    if value = @options[name]
-      @options.delete(name)
-    else
-      value = default
-    end
+    value = @options.delete(name)
+    value = default if value.nil?
+
     self.send(name.to_s + "=", value)
   end
 

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -63,7 +63,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
   end
 end
 
-Puppet::Network::FormatHandler.create(:s, :mime => "text/plain", :extension => "txt")
+Puppet::Network::FormatHandler.create(:s, :mime => "text/plain", :charset => 'utf-8', :extension => "txt")
 
 # By default, to_binary is called to render and from_binary called to intern. Note unlike
 # text-based formats (json, yaml, etc), we don't use to_data_hash for binary.
@@ -99,7 +99,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:pson, :weight => 10, :
   end
 end
 
-Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'application/json', :weight => 15, :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
+Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'application/json', :charset => 'utf-8', :weight => 15, :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
   def intern(klass, text)
     data_to_instance(klass, JSON.parse(text))
   end

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -63,7 +63,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
   end
 end
 
-Puppet::Network::FormatHandler.create(:s, :mime => "text/plain", :charset => 'utf-8', :extension => "txt")
+Puppet::Network::FormatHandler.create(:s, :mime => "text/plain", :charset => Encoding::UTF_8, :extension => "txt")
 
 # By default, to_binary is called to render and from_binary called to intern. Note unlike
 # text-based formats (json, yaml, etc), we don't use to_data_hash for binary.
@@ -99,7 +99,7 @@ Puppet::Network::FormatHandler.create_serialized_formats(:pson, :weight => 10, :
   end
 end
 
-Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'application/json', :charset => 'utf-8', :weight => 15, :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
+Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'application/json', :charset => Encoding::UTF_8, :weight => 15, :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
   def intern(klass, text)
     data_to_instance(klass, JSON.parse(text))
   end

--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -43,9 +43,11 @@ module Puppet::Network::HTTP::Compression
         raise Net::HTTPError.new(_("Unknown content encoding - %{encoding}") % { encoding: response['content-encoding'] }, response)
       end
 
-      yield uncompressor
-
-      uncompressor.close
+      begin
+        yield uncompressor
+      ensure
+        uncompressor.close
+      end
     end
 
     def add_accept_encoding(headers={})
@@ -87,6 +89,7 @@ module Puppet::Network::HTTP::Compression
 
       def close
         @uncompressor.finish
+      ensure
         @uncompressor.close
       end
     end

--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -56,7 +56,7 @@ module Puppet::Network::HTTP::Compression
     # This adapters knows how to uncompress both 'zlib' stream (the deflate algorithm from Content-Encoding)
     # and GZip streams.
     class ZlibAdapter
-      def initialize
+      def initialize(uncompressor = Zlib::Inflate.new(15 + 32))
         # Create an inflater that knows to parse GZip streams and zlib streams.
         # This uses a property of the C Zlib library, documented as follow:
         #   windowBits can also be greater than 15 for optional gzip decoding. Add
@@ -64,7 +64,7 @@ module Puppet::Network::HTTP::Compression
         #   detection, or add 16 to decode only the gzip format (the zlib format will
         #   return a Z_DATA_ERROR).  If a gzip stream is being decoded, strm->adler is
         #   a crc32 instead of an adler32.
-        @uncompressor = Zlib::Inflate.new(15 + 32)
+        @uncompressor = uncompressor
         @first = true
       end
 

--- a/lib/puppet/network/http/handler.rb
+++ b/lib/puppet/network/http/handler.rb
@@ -36,6 +36,10 @@ module Puppet::Network::HTTP::Handler
     raise NotImplementedError
   end
 
+  # The mime type is always passed to the `set_content_type` method, so
+  # it is no longer necessary to retrieve the Format's mime type.
+  #
+  # @deprecated
   def format_to_mime(format)
     format.is_a?(Puppet::Network::Format) ? format.mime : format
   end

--- a/lib/puppet/network/http/rack/rest.rb
+++ b/lib/puppet/network/http/rack/rest.rb
@@ -35,7 +35,7 @@ class Puppet::Network::HTTP::RackREST
   end
 
   def set_content_type(response, format)
-    response[ContentType] = format_to_mime(format)
+    response[ContentType] = format
   end
 
   # produce the body of the response

--- a/lib/puppet/network/http/response.rb
+++ b/lib/puppet/network/http/response.rb
@@ -9,13 +9,15 @@ class Puppet::Network::HTTP::Response
     mime = format.mime
     charset = format.charset
 
-    if charset && body.is_a?(String)
-      # REMIND: not all charsets are valid ruby encodings, e.g. ISO-2022-KR
-      encoding = Encoding.find(charset)
+    if charset
+      if body.is_a?(String)
+        # REMIND: not all charsets are valid ruby encodings, e.g. ISO-2022-KR
+        encoding = Encoding.find(charset)
 
-      if body.encoding != encoding
-        # REMIND this can raise if body contains invalid UTF-8
-        body.encode!(encoding)
+        if body.encoding != encoding
+          # REMIND this can raise if body contains invalid UTF-8
+          body.encode!(encoding)
+        end
       end
 
       mime += "; charset=#{charset}"

--- a/lib/puppet/network/http/response.rb
+++ b/lib/puppet/network/http/response.rb
@@ -11,7 +11,6 @@ class Puppet::Network::HTTP::Response
 
     if charset
       if body.is_a?(String) && body.encoding != charset
-        # REMIND this can raise if body contains invalid UTF-8
         body.encode!(charset)
       end
 

--- a/lib/puppet/network/http/response.rb
+++ b/lib/puppet/network/http/response.rb
@@ -10,17 +10,12 @@ class Puppet::Network::HTTP::Response
     charset = format.charset
 
     if charset
-      if body.is_a?(String)
-        # REMIND: not all charsets are valid ruby encodings, e.g. ISO-2022-KR
-        encoding = Encoding.find(charset)
-
-        if body.encoding != encoding
-          # REMIND this can raise if body contains invalid UTF-8
-          body.encode!(encoding)
-        end
+      if body.is_a?(String) && body.encoding != charset
+        # REMIND this can raise if body contains invalid UTF-8
+        body.encode!(charset)
       end
 
-      mime += "; charset=#{charset}"
+      mime += "; charset=#{charset.name.downcase}"
     end
 
     @handler.set_content_type(@response, mime)

--- a/lib/puppet/network/http/webrick/rest.rb
+++ b/lib/puppet/network/http/webrick/rest.rb
@@ -80,7 +80,7 @@ class Puppet::Network::HTTP::WEBrickREST < WEBrick::HTTPServlet::AbstractServlet
 
   # Set the specified format as the content type of the response.
   def set_content_type(response, format)
-    response["content-type"] = format_to_mime(format)
+    response["content-type"] = format
   end
 
   def set_response(response, result, status = 200)

--- a/spec/unit/network/format_spec.rb
+++ b/spec/unit/network/format_spec.rb
@@ -129,6 +129,15 @@ describe Puppet::Network::Format do
     it "should support overriding the extension" do
       expect(Puppet::Network::Format.new(:foo, :extension => "bar").extension).to eq("bar")
     end
+
+    it "doesn't support charset by default" do
+      expect(Puppet::Network::Format.new(:foo).charset).to be_nil
+    end
+
+    it "allows charset to be set to 'utf-8'" do
+      expect(Puppet::Network::Format.new(:foo, :charset => 'utf-8').charset).to eq('utf-8')
+    end
+
     [:intern_method, :intern_multiple_method, :render_multiple_method, :render_method].each do |method|
       it "should allow assignment of the #{method}" do
         expect(Puppet::Network::Format.new(:foo, method => :foo).send(method)).to eq(:foo)

--- a/spec/unit/network/format_spec.rb
+++ b/spec/unit/network/format_spec.rb
@@ -135,7 +135,7 @@ describe Puppet::Network::Format do
     end
 
     it "allows charset to be set to 'utf-8'" do
-      expect(Puppet::Network::Format.new(:foo, :charset => 'utf-8').charset).to eq('utf-8')
+      expect(Puppet::Network::Format.new(:foo, :charset => Encoding::UTF_8).charset).to eq(Encoding::UTF_8)
     end
 
     [:intern_method, :intern_multiple_method, :render_multiple_method, :render_method].each do |method|

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -47,6 +47,10 @@ describe "Puppet Network Format" do
       expect(msgpack.mime).to eq("application/x-msgpack")
     end
 
+    it "should have a nil charset" do
+      expect(msgpack.charset).to be_nil
+    end
+
     it "should have a weight of 20" do
       expect(msgpack.weight).to eq(20)
     end
@@ -86,6 +90,11 @@ describe "Puppet Network Format" do
 
     it "should have its mime type set to text/yaml" do
       expect(yaml.mime).to eq("text/yaml")
+    end
+
+    # we shouldn't be using yaml on the network
+    it "should have a nil charset" do
+      expect(yaml.charset).to be_nil
     end
 
     it "should be supported on Strings" do
@@ -150,6 +159,10 @@ describe "Puppet Network Format" do
       expect(text.mime).to eq("text/plain")
     end
 
+    it "should use 'utf-8' charset" do
+      expect(text.charset).to eq('utf-8')
+    end
+
     it "should use 'txt' as its extension" do
       expect(text.extension).to eq("txt")
     end
@@ -172,6 +185,10 @@ describe "Puppet Network Format" do
 
     it "should have its mimetype set to application/octet-stream" do
       expect(binary.mime).to eq("application/octet-stream")
+    end
+
+    it "should have a nil charset" do
+      expect(binary.charset).to be_nil
     end
 
     it "should not be supported by default" do
@@ -214,6 +231,10 @@ describe "Puppet Network Format" do
 
     it "should have its mime type set to text/pson" do
       expect(pson.mime).to eq("text/pson")
+    end
+
+    it "should have a nil charset" do
+      expect(pson.charset).to be_nil
     end
 
     it "should require the :render_method" do
@@ -294,6 +315,10 @@ describe "Puppet Network Format" do
 
     it "should have its mime type set to application/json" do
       expect(json.mime).to eq("application/json")
+    end
+
+    it "should use 'utf-8' charset" do
+      expect(json.charset).to eq('utf-8')
     end
 
     it "should require the :render_method" do

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -160,7 +160,7 @@ describe "Puppet Network Format" do
     end
 
     it "should use 'utf-8' charset" do
-      expect(text.charset).to eq('utf-8')
+      expect(text.charset).to eq(Encoding::UTF_8)
     end
 
     it "should use 'txt' as its extension" do
@@ -318,7 +318,7 @@ describe "Puppet Network Format" do
     end
 
     it "should use 'utf-8' charset" do
-      expect(json.charset).to eq('utf-8')
+      expect(json.charset).to eq(Encoding::UTF_8)
     end
 
     it "should require the :render_method" do

--- a/spec/unit/network/http/compression_spec.rb
+++ b/spec/unit/network/http/compression_spec.rb
@@ -174,8 +174,6 @@ describe "http compression" do
       end
 
       it "should close the underlying adapter if the yielded block raises" do
-        pending("We need to close the stream even if finish raises")
-
         stubs_response_with(response, 'identity', data)
         adapter = stub_everything 'adapter'
         Puppet::Network::HTTP::Compression::IdentityAdapter.expects(:new).returns(adapter)
@@ -226,8 +224,6 @@ describe "http compression" do
       end
 
       it "should close the stream even if finish raises" do
-        pending("We need to ensure close is called")
-
         inflater = stub 'inflater'
         inflater.expects(:finish).raises(Zlib::BufError)
         inflater.expects(:close)

--- a/spec/unit/network/http/compression_spec.rb
+++ b/spec/unit/network/http/compression_spec.rb
@@ -2,6 +2,20 @@
 require 'spec_helper'
 
 describe "http compression" do
+  let(:data)            { "uncompresseddata" }
+  let(:response)        { stub 'response' }
+  let(:compressed_zlib) { Zlib::Deflate.deflate(data) }
+  let(:compressed_gzip) do
+    str = StringIO.new
+    writer = Zlib::GzipWriter.new(str)
+    writer.write(data)
+    writer.close.string
+  end
+
+  def stubs_response_with(response, content_encoding, body)
+    response.stubs(:[]).with('content-encoding').returns(content_encoding)
+    response.stubs(:body).returns(body)
+  end
 
   describe "when zlib is not available" do
     before(:each) do
@@ -24,8 +38,8 @@ describe "http compression" do
     end
 
     it "should not tamper the body" do
-      response = stub 'response', :body => "data"
-      expect(@uncompressor.uncompress_body(response)).to eq("data")
+      response = stub 'response', :body => data
+      expect(@uncompressor.uncompress_body(response)).to eq(data)
     end
 
     it "should yield an identity uncompressor" do
@@ -37,23 +51,19 @@ describe "http compression" do
   end
 
   describe "when zlib is available" do
-    before(:each) do
-      Puppet.features.stubs(:zlib?).returns true
-
-      require 'puppet/network/http/compression'
-      class HttpUncompressor
-        include Puppet::Network::HTTP::Compression::Active
-      end
-
-      @uncompressor = HttpUncompressor.new
+    require 'puppet/network/http/compression'
+    class ActiveUncompressor
+      include Puppet::Network::HTTP::Compression::Active
     end
+
+    let(:uncompressor) { ActiveUncompressor.new }
 
     it "should have a module function that returns the Active underlying module" do
       expect(Puppet::Network::HTTP::Compression.module).to eq(Puppet::Network::HTTP::Compression::Active)
     end
 
     it "should add an Accept-Encoding header supporting compression" do
-      headers = @uncompressor.add_accept_encoding({})
+      headers = uncompressor.add_accept_encoding({})
       expect(headers).to have_key('accept-encoding')
       expect(headers['accept-encoding']).to match(/gzip/)
       expect(headers['accept-encoding']).to match(/deflate/)
@@ -61,43 +71,34 @@ describe "http compression" do
     end
 
     describe "when uncompressing response body" do
-      before do
-        @response = stub 'response'
-        @response.stubs(:[]).with('content-encoding')
-        @response.stubs(:body).returns("mydata")
+      context "without compression" do
+        it "should return untransformed response body with no content-encoding" do
+          stubs_response_with(response, nil, data)
+
+          expect(uncompressor.uncompress_body(response)).to eq(data)
+        end
+
+        it "should return untransformed response body with 'identity' content-encoding" do
+          stubs_response_with(response, 'identity', data)
+
+          expect(uncompressor.uncompress_body(response)).to eq(data)
+        end
       end
 
-      it "should return untransformed response body with no content-encoding" do
-        expect(@uncompressor.uncompress_body(@response)).to eq("mydata")
-      end
+      context "with 'zlib' content-encoding" do
+        it "should use a Zlib inflater" do
+          stubs_response_with(response, 'deflate', compressed_zlib)
 
-      it "should return untransformed response body with 'identity' content-encoding" do
-        @response.stubs(:[]).with('content-encoding').returns('identity')
-        expect(@uncompressor.uncompress_body(@response)).to eq("mydata")
-      end
+          expect(uncompressor.uncompress_body(response)).to eq(data)
+        end
 
-      it "should use a Zlib inflater with 'deflate' content-encoding" do
-        @response.stubs(:[]).with('content-encoding').returns('deflate')
-
-        inflater = stub 'inflater'
-        Zlib::Inflate.expects(:new).returns(inflater)
-        inflater.expects(:inflate).with("mydata").returns "uncompresseddata"
-
-        expect(@uncompressor.uncompress_body(@response)).to eq("uncompresseddata")
       end
 
       context "with 'gzip' content-encoding" do
         it "should use a GzipReader" do
-          @response.stubs(:[]).with('content-encoding').returns('gzip')
+          stubs_response_with(response, 'gzip', compressed_gzip)
 
-          io = stub 'io'
-          StringIO.expects(:new).with("mydata").returns io
-
-          reader = stub 'gzip reader'
-          Zlib::GzipReader.expects(:new).with(io, :encoding => Encoding::BINARY).returns(reader)
-          reader.expects(:read).returns "uncompresseddata"
-
-          expect(@uncompressor.uncompress_body(@response)).to eq("uncompresseddata")
+          expect(uncompressor.uncompress_body(response)).to eq(data)
         end
 
         it "should correctly decompress PSON containing UTF-8 in Binary Encoding" do
@@ -117,10 +118,9 @@ describe "http compression" do
             default_external = Encoding.default_external
             Encoding.default_external = Encoding::ISO_8859_1
 
-            @response.stubs(:[]).with('content-encoding').returns('gzip')
-            @response.stubs(:body).returns(compressed_body)
+            stubs_response_with(response, 'gzip', compressed_body)
 
-            uncompressed = @uncompressor.uncompress_body(@response)
+            uncompressed = uncompressor.uncompress_body(response)
             # By default Zlib::GzipReader decompresses into Encoding.default_external, and we want to ensure our result is BINARY too
             expect(uncompressed.encoding).to eq(Encoding::BINARY)
             expect(uncompressed).to eq("\"foo\xDB\xBF\xE1\x9A\xA0\xF0\xA0\x9C\x8E\"".force_encoding(Encoding::BINARY))
@@ -132,89 +132,110 @@ describe "http compression" do
     end
 
     describe "when uncompressing by chunk" do
-      before do
-        @response = stub 'response'
-        @response.stubs(:[]).with('content-encoding')
-
-        @inflater = stub_everything 'inflater'
-        Zlib::Inflate.stubs(:new).returns(@inflater)
-      end
-
       it "should yield an identity uncompressor with no content-encoding" do
-        @uncompressor.uncompress(@response) { |u|
-          expect(u).to be_instance_of(Puppet::Network::HTTP::Compression::IdentityAdapter)
+        stubs_response_with(response, nil, data)
+
+        expect { |b|
+          uncompressor.uncompress(response).yield_once_with(Puppet::Network::HTTP::Compression::IdentityAdapter, &b)
         }
       end
 
       it "should yield an identity uncompressor with 'identity' content-encoding" do
-        @response.stubs(:[]).with('content-encoding').returns 'identity'
-        @uncompressor.uncompress(@response) { |u|
-          expect(u).to be_instance_of(Puppet::Network::HTTP::Compression::IdentityAdapter)
+        stubs_response_with(response, 'identity', data)
+
+        expect { |b|
+          uncompressor.uncompress(response).yield_once_with(Puppet::Network::HTTP::Compression::IdentityAdapter, &b)
         }
       end
 
-      %w{gzip deflate}.each do |c|
-        it "should yield a Zlib uncompressor with '#{c}' content-encoding" do
-          @response.stubs(:[]).with('content-encoding').returns c
-          @uncompressor.uncompress(@response) { |u|
-            expect(u).to be_instance_of(Puppet::Network::HTTP::Compression::Active::ZlibAdapter)
-          }
-        end
+      it "should yield a Zlib uncompressor with 'gzip' content-encoding" do
+        stubs_response_with(response, 'gzip', compressed_gzip)
+
+        expect { |b|
+          uncompressor.uncompress(response).yield_once_with(Puppet::Network::HTTP::Compression::ZlibAdapter, &b)
+        }
+      end
+
+      it "should yield a Zlib uncompressor with 'deflate' content-encoding" do
+        stubs_response_with(response, 'deflate', compressed_zlib)
+
+        expect { |b|
+          uncompressor.uncompress(response).yield_once_with(Puppet::Network::HTTP::Compression::ZlibAdapter, &b)
+        }
       end
 
       it "should close the underlying adapter" do
+        stubs_response_with(response, 'identity', data)
         adapter = stub_everything 'adapter'
         Puppet::Network::HTTP::Compression::IdentityAdapter.expects(:new).returns(adapter)
 
         adapter.expects(:close)
-        @uncompressor.uncompress(@response) { |u| }
+        uncompressor.uncompress(response) { |u| }
+      end
+
+      it "should close the underlying adapter if the yielded block raises" do
+        pending("We need to close the stream even if finish raises")
+
+        stubs_response_with(response, 'identity', data)
+        adapter = stub_everything 'adapter'
+        Puppet::Network::HTTP::Compression::IdentityAdapter.expects(:new).returns(adapter)
+
+        adapter.expects(:close)
+        expect {
+          uncompressor.uncompress(response) { |u| raise ArgumentError, "whoops" }
+        }.to raise_error(ArgumentError, "whoops")
       end
     end
 
     describe "zlib adapter" do
-      before do
-        @inflater = stub_everything 'inflater'
-        Zlib::Inflate.stubs(:new).returns(@inflater)
-        @adapter = Puppet::Network::HTTP::Compression::Active::ZlibAdapter.new
-      end
-
       it "should initialize the underlying inflater with gzip/zlib header parsing" do
         Zlib::Inflate.expects(:new).with(15+32)
+
         Puppet::Network::HTTP::Compression::Active::ZlibAdapter.new
       end
 
-      it "should inflate the given chunk" do
-        @inflater.expects(:inflate).with("chunk")
-        @adapter.uncompress("chunk")
-      end
+      it "should return the given chunk" do
+        adapter = Puppet::Network::HTTP::Compression::Active::ZlibAdapter.new
 
-      it "should return the inflated chunk" do
-        @inflater.stubs(:inflate).with("chunk").returns("uncompressed")
-        expect(@adapter.uncompress("chunk")).to eq("uncompressed")
+        expect(adapter.uncompress(compressed_zlib)).to eq(data)
       end
 
       it "should try a 'regular' inflater on Zlib::DataError" do
-        @inflater.expects(:inflate).raises(Zlib::DataError.new("not a zlib stream"))
-        inflater = stub_everything 'inflater2'
-        inflater.expects(:inflate).with("chunk").returns("uncompressed")
-        Zlib::Inflate.expects(:new).with.returns(inflater)
-        @adapter.uncompress("chunk")
+        inflater = Zlib::Inflate.new(15 + 32)
+        inflater.expects(:inflate).raises(Zlib::DataError.new("not a zlib stream"))
+        adapter = Puppet::Network::HTTP::Compression::Active::ZlibAdapter.new(inflater)
+
+        expect(adapter.uncompress(compressed_zlib)).to eq(data)
       end
 
       it "should raise the error the second time" do
-        @inflater.stubs(:inflate).raises(Zlib::DataError.new("not a zlib stream"))
-        Zlib::Inflate.expects(:new).with.returns(@inflater)
-        expect { @adapter.uncompress("chunk") }.to raise_error(Zlib::DataError, /not a zlib stream/)
+        inflater = Zlib::Inflate.new(15 + 32)
+        inflater.expects(:inflate).raises(Zlib::DataError.new("not a zlib stream"))
+        adapter = Puppet::Network::HTTP::Compression::Active::ZlibAdapter.new(inflater)
+
+        expect { adapter.uncompress("this is not compressed data") }.to raise_error(Zlib::DataError, /incorrect header check/)
       end
 
-      it "should finish the stream on close" do
-        @inflater.expects(:finish)
-        @adapter.close
+      it "should finish and close the stream" do
+        inflater = stub 'inflater'
+        inflater.expects(:finish)
+        inflater.expects(:close)
+        adapter = Puppet::Network::HTTP::Compression::Active::ZlibAdapter.new(inflater)
+
+        adapter.close
       end
 
-      it "should close the stream on close" do
-        @inflater.expects(:close)
-        @adapter.close
+      it "should close the stream even if finish raises" do
+        pending("We need to ensure close is called")
+
+        inflater = stub 'inflater'
+        inflater.expects(:finish).raises(Zlib::BufError)
+        inflater.expects(:close)
+
+        adapter = Puppet::Network::HTTP::Compression::Active::ZlibAdapter.new(inflater)
+        expect {
+          adapter.close
+        }.to raise_error(Zlib::BufError)
       end
     end
   end

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -68,7 +68,7 @@ describe Puppet::Network::HTTP::Handler do
 
       res_body = JSON(res[:body])
 
-      expect(res[:content_type_header]).to eq("application/json")
+      expect(res[:content_type_header]).to eq("application/json; charset=utf-8")
       expect(res_body["issue_kind"]).to eq("HANDLER_NOT_FOUND")
       expect(res_body["message"]).to eq("Not Found: No route for GET /vtest/foo")
       expect(res[:status]).to eq(404)
@@ -92,7 +92,7 @@ describe Puppet::Network::HTTP::Handler do
 
       res_body = JSON(res[:body])
 
-      expect(res[:content_type_header]).to eq("application/json")
+      expect(res[:content_type_header]).to eq("application/json; charset=utf-8")
       expect(res_body["issue_kind"]).to eq(Puppet::Network::HTTP::Issues::RUNTIME_ERROR.to_s)
       expect(res_body["message"]).to eq("Server Error: the sky is falling!")
       expect(res[:status]).to eq(500)

--- a/spec/unit/network/http/response_spec.rb
+++ b/spec/unit/network/http/response_spec.rb
@@ -1,20 +1,32 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
+require 'puppet_spec/files'
 require 'puppet_spec/handler'
 require 'puppet/network/http'
 
 describe Puppet::Network::HTTP::Response do
+  include PuppetSpec::Files
+
   let(:handler) { PuppetSpec::Handler.new }
   let(:response) { {} }
   let(:subject) { described_class.new(handler, response) }
   let(:body_utf8) { JSON.dump({ "foo" => "bar"}).encode('UTF-8') }
   let(:body_shift_jis) { [130, 174].pack('C*').force_encoding(Encoding::Shift_JIS) }
 
-  it "passes the status code and body to the handler" do
-    handler.expects(:set_response).with(response, body_utf8, 200)
+  context "when passed a respose body" do
+    it "passes the status code and body to the handler" do
+      handler.expects(:set_response).with(response, body_utf8, 200)
 
-    subject.respond_with(200, 'application/json', body_utf8)
+      subject.respond_with(200, 'application/json', body_utf8)
+    end
+
+    it "accepts a File body" do
+      file = tmpfile('response_spec')
+      handler.expects(:set_response).with(response, file, 200)
+
+      subject.respond_with(200, 'application/octet-stream', file)
+    end
   end
 
   context "when passed a content type" do

--- a/spec/unit/network/http/response_spec.rb
+++ b/spec/unit/network/http/response_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Network::HTTP::Response do
   let(:body_shift_jis) { [130, 174].pack('C*').force_encoding(Encoding::Shift_JIS) }
   let(:invalid_shift_jis) { "\xC0\xFF".force_encoding(Encoding::Shift_JIS) }
 
-  context "when passed a respose body" do
+  context "when passed a response body" do
     it "passes the status code and body to the handler" do
       handler.expects(:set_response).with(response, body_utf8, 200)
 

--- a/spec/unit/network/http/response_spec.rb
+++ b/spec/unit/network/http/response_spec.rb
@@ -1,0 +1,33 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+require 'puppet_spec/handler'
+require 'puppet/network/http'
+
+describe Puppet::Network::HTTP::Response do
+  let(:handler) { PuppetSpec::Handler.new }
+  let(:response) { {} }
+  let(:subject) { described_class.new(handler, response) }
+  let(:body) { JSON.dump({ "foo" => "bar"}) }
+
+  it "passes the status code and body to the handler" do
+    handler.expects(:set_response).with(response, body, 200)
+
+    subject.respond_with(200, 'application/json', body)
+  end
+
+  context "content types" do
+    it "accepts content-type as a mime string" do
+      handler.expects(:set_content_type).with(response, 'application/json')
+
+      subject.respond_with(200, 'application/json', body)
+    end
+
+    it "accepts content-type as a format object" do
+      formatter = Puppet::Network::FormatHandler.format(:json)
+      handler.expects(:set_content_type).with(response, formatter)
+
+      subject.respond_with(200, formatter, body)
+    end
+  end
+end

--- a/spec/unit/network/http/response_spec.rb
+++ b/spec/unit/network/http/response_spec.rb
@@ -8,26 +8,76 @@ describe Puppet::Network::HTTP::Response do
   let(:handler) { PuppetSpec::Handler.new }
   let(:response) { {} }
   let(:subject) { described_class.new(handler, response) }
-  let(:body) { JSON.dump({ "foo" => "bar"}) }
+  let(:body_utf8) { JSON.dump({ "foo" => "bar"}).encode('UTF-8') }
+  let(:body_shift_jis) { [130, 174].pack('C*').force_encoding(Encoding::Shift_JIS) }
 
   it "passes the status code and body to the handler" do
-    handler.expects(:set_response).with(response, body, 200)
+    handler.expects(:set_response).with(response, body_utf8, 200)
 
-    subject.respond_with(200, 'application/json', body)
+    subject.respond_with(200, 'application/json', body_utf8)
   end
 
-  context "content types" do
-    it "accepts content-type as a mime string" do
-      handler.expects(:set_content_type).with(response, 'application/json')
+  context "when passed a content type" do
+    it "accepts a mime string" do
+      handler.expects(:set_content_type).with(response, 'application/json; charset=utf-8')
 
-      subject.respond_with(200, 'application/json', body)
+      subject.respond_with(200, 'application/json', body_utf8)
     end
 
-    it "accepts content-type as a format object" do
+    it "accepts a format object" do
       formatter = Puppet::Network::FormatHandler.format(:json)
-      handler.expects(:set_content_type).with(response, formatter)
+      handler.expects(:set_content_type).with(response, 'application/json; charset=utf-8')
 
-      subject.respond_with(200, formatter, body)
+      subject.respond_with(200, formatter, body_utf8)
+    end
+  end
+
+  context "when resolving charset" do
+    context "with binary content" do
+      it "omits the charset" do
+        body_binary = [0xDEADCAFE].pack('L')
+
+        formatter = Puppet::Network::FormatHandler.format(:binary)
+        handler.expects(:set_content_type).with(response, 'application/octet-stream')
+
+        subject.respond_with(200, formatter, body_binary)
+      end
+    end
+
+    context "with text/plain content" do
+      let(:formatter) { Puppet::Network::FormatHandler.format(:s) }
+
+      it "sets the charset to UTF-8 for content already in that format" do
+        body_pem = "BEGIN CERTIFICATE".encode('UTF-8')
+
+        handler.expects(:set_content_type).with(response, 'text/plain; charset=utf-8')
+
+        subject.respond_with(200, formatter, body_pem)
+      end
+
+      it "encodes the content to UTF-8 for content not already in UTF-8" do
+        handler.expects(:set_content_type).with(response, 'text/plain; charset=utf-8')
+        handler.expects(:set_response).with(response, body_shift_jis.encode('utf-8'), 200)
+
+        subject.respond_with(200, formatter, body_shift_jis)
+      end
+    end
+
+    context "with application/json content" do
+      let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+
+      it "sets the charset to UTF-8 for content already in that format" do
+        handler.expects(:set_content_type).with(response, 'application/json; charset=utf-8')
+
+        subject.respond_with(200, formatter, body_utf8)
+      end
+
+      it "encodes the content to UTF-8 for content not already in UTF-8" do
+        handler.expects(:set_content_type).with(response, 'application/json; charset=utf-8')
+        handler.expects(:set_response).with(response, body_shift_jis.encode('utf-8'), 200)
+
+        subject.respond_with(200, formatter, body_shift_jis)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR marks text-based formats (json, text/plain) as supporting a `charset` parameter.

If the response body is a string and the serialization format supports charset, then Puppet will encode the body in that charset (if it isn't already), and include the `charset` parameter in the `Content-Type` header. In a future PR, Puppet's HTTP client will use that information to decode the response body, such as when the response is compressed.

The `charset` parameter will be omitted is the response body is a file or if the `Content-Type` is a binary format (`application/octet-stream`, `msgpack`), `pson`, or `yaml`.

We don't include it with `pson` because old agent's don't know about `charset`. We don't include it with `yaml` because it's not a network serialization format.