### PR TITLE
(PUP-7110) Execute agent run in separate contract

### DIFF
--- a/lib/puppet/util/at_fork.rb
+++ b/lib/puppet/util/at_fork.rb
@@ -1,0 +1,35 @@
+require 'puppet'
+
+# A module for building AtFork handlers. These handlers are objects providing
+# pre/post fork callbacks modeled after those registered by the `pthread_atfork`
+# function.
+# Currently there are two AtFork handler implementations:
+# - a noop implementation used on all platforms except Solaris (and possibly
+#   even there as a fallback)
+# - a Solaris implementation which ensures the forked process runs in a different
+#   contract than the parent process. This is necessary for agent runs started by
+#   the puppet agent service to be able to restart that service without being
+#   killed in the process as a consequence of running in the same contract as the
+#   service.
+module Puppet::Util::AtFork
+  @handler_class = loop do
+    if Facter.value(:operatingsystem) == 'Solaris'
+      begin
+        require 'puppet/util/at_fork/solaris'
+        # using break to return a value from the loop block
+        break Puppet::Util::AtFork::Solaris
+      rescue LoadError => detail
+        Puppet.log_exception(detail, _('Failed to load Solaris implementation of the Puppet::Util::AtFork handler. Child process contract management will be unavailable, which means that agent runs executed by the puppet agent service will be killed when they attempt to restart the service.'))
+        # fall through to use the no-op implementation
+      end
+    end
+
+    require 'puppet/util/at_fork/noop'
+    # using break to return a value from the loop block
+    break Puppet::Util::AtFork::Noop
+  end
+
+  def self.get_handler
+    @handler_class.new
+  end
+end

--- a/lib/puppet/util/at_fork/noop.rb
+++ b/lib/puppet/util/at_fork/noop.rb
@@ -1,0 +1,18 @@
+# A noop implementation of the Puppet::Util::AtFork handler
+class Puppet::Util::AtFork::Noop
+  class << self
+    def new
+      # no need to instantiate every time, return the class object itself
+      self
+    end
+
+    def prepare
+    end
+
+    def parent
+    end
+
+    def child
+    end
+  end
+end

--- a/lib/puppet/util/at_fork/solaris.rb
+++ b/lib/puppet/util/at_fork/solaris.rb
@@ -1,0 +1,158 @@
+require 'puppet'
+require 'fiddle'
+
+# Early versions of Fiddle relied on the deprecated DL module and used
+# classes defined in the namespace of that module instead of classes defined
+# in the Fiddle's own namespace e.g. DL::Handle instead of Fiddle::Handle.
+# We don't support those.
+raise LoadError, _('The loaded Fiddle version is not supported.') unless defined?(Fiddle::Handle)
+
+# Solaris implementation of the Puppet::Util::AtFork handler.
+# The callbacks defined in this implementation ensure the forked process runs
+# in a different contract than the parent process. This is necessary in order
+# for the child process to be able to survive termination of the contract its
+# parent process runs in. This is needed notably for an agent run executed
+# by a puppet agent service to be able to restart that service without being
+# killed in the process as a consequence of running in the same contract as
+# the service, as all processes in the contract are killed when the contract
+# is terminated during the service restart.
+class Puppet::Util::AtFork::Solaris
+  private
+
+  {
+    'libcontract.so.1' => [
+      #function name,            return value type, parameter types, ...
+      [:ct_ctl_abandon,          Fiddle::TYPE_INT,  Fiddle::TYPE_INT],
+      [:ct_tmpl_activate,        Fiddle::TYPE_INT,  Fiddle::TYPE_INT],
+      [:ct_tmpl_clear,           Fiddle::TYPE_INT,  Fiddle::TYPE_INT],
+
+      [:ct_tmpl_set_informative, Fiddle::TYPE_INT,  Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+      [:ct_tmpl_set_critical,    Fiddle::TYPE_INT,  Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+      [:ct_pr_tmpl_set_param,    Fiddle::TYPE_INT,  Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+      [:ct_pr_tmpl_set_fatal,    Fiddle::TYPE_INT,  Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+
+      [:ct_status_read,          Fiddle::TYPE_INT,  Fiddle::TYPE_INT, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP],
+
+      [:ct_status_get_id,        Fiddle::TYPE_INT,  Fiddle::TYPE_VOIDP],
+      [:ct_status_free,          Fiddle::TYPE_VOID, Fiddle::TYPE_VOIDP],
+    ],
+  }.each do |library, functions|
+    libhandle = Fiddle::Handle.new(library)
+
+    functions.each do |f|
+      define_method f[0], Fiddle::Function.new(libhandle[f[0].to_s], f[2..-1], f[1]).method(:call).to_proc
+    end
+  end
+
+  CTFS_PR_ROOT = File.join('', %w(system contract process))
+  CTFS_PR_TEMPLATE = File.join(CTFS_PR_ROOT, %q(template))
+  CTFS_PR_LATEST = File.join(CTFS_PR_ROOT, %q(latest))
+
+  CT_PR_PGRPONLY = 0x4
+  CT_PR_EV_HWERR = 0x20
+
+  CTD_COMMON = 0
+
+  def raise_if_error(&block)
+    unless (e = yield) == 0
+      e = SystemCallError.new(nil, e)
+      raise e, e.message, caller
+    end
+  end
+
+  def activate_new_contract_template
+    begin
+      tmpl = File.open(CTFS_PR_TEMPLATE, File::RDWR)
+
+      begin
+        tmpl_fd = tmpl.fileno
+
+        raise_if_error { ct_pr_tmpl_set_param(tmpl_fd, CT_PR_PGRPONLY) }
+        raise_if_error { ct_pr_tmpl_set_fatal(tmpl_fd, CT_PR_EV_HWERR) }
+        raise_if_error { ct_tmpl_set_critical(tmpl_fd, 0) }
+        raise_if_error { ct_tmpl_set_informative(tmpl_fd, CT_PR_EV_HWERR) }
+
+        raise_if_error { ct_tmpl_activate(tmpl_fd) }
+      rescue
+        tmpl.close
+        raise
+      end
+
+      @tmpl = tmpl
+    rescue => detail
+      Puppet.log_exception(detail, _('Failed to activate a new process contract template'))
+    end
+  end
+
+  def deactivate_contract_template(parent)
+    return if @tmpl.nil?
+
+    tmpl = @tmpl
+    @tmpl = nil
+
+    begin
+      raise_if_error { ct_tmpl_clear(tmpl.fileno) }
+    rescue => detail
+      Puppet.log_exception(detail, parent \
+        ? _('Failed to deactivate process contract template in the parent process')
+        : _('Failed to deactivate process contract template in the child process')
+      )
+      exit(1)
+    ensure
+      tmpl.close
+    end
+  end
+
+  def get_latest_child_contract_id
+    begin
+      stat = File.open(CTFS_PR_LATEST, File::RDONLY)
+
+      begin
+        stathdl = Fiddle::Pointer.new(0)
+
+        raise_if_error { ct_status_read(stat.fileno, CTD_COMMON, stathdl.ref) }
+        ctid = ct_status_get_id(stathdl)
+        ct_status_free(stathdl)
+      ensure
+        stat.close
+      end
+
+      ctid
+    rescue => detail
+      Puppet.log_exception(detail, _('Failed to get latest child process contract id'))
+      nil
+    end
+  end
+
+  def abandon_latest_child_contract
+    ctid = get_latest_child_contract_id
+    return if ctid.nil?
+
+    begin
+      ctl = File.open(File.join(CTFS_PR_ROOT, ctid.to_s, %q(ctl)), File::WRONLY)
+
+      begin
+        raise_if_error { ct_ctl_abandon(ctl.fileno) }
+      ensure
+        ctl.close
+      end
+    rescue => detail
+      Puppet.log_exception(detail, _('Failed to abandon a child process contract'))
+    end
+  end
+
+  public
+
+  def prepare
+    activate_new_contract_template
+  end
+
+  def parent
+    deactivate_contract_template(true)
+    abandon_latest_child_contract
+  end
+
+  def child
+    deactivate_contract_template(false)
+  end
+end

--- a/spec/unit/util/at_fork_spec.rb
+++ b/spec/unit/util/at_fork_spec.rb
@@ -1,0 +1,150 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe 'Puppet::Util::AtFork' do
+  EXPECTED_HANDLER_METHODS = [:prepare, :parent, :child]
+
+  before :each do
+    Puppet::Util.class_exec do
+      const_set(:AtFork, Module.new)
+    end
+  end
+
+  after :each do
+    Puppet::Util.class_exec do
+      remove_const(:AtFork)
+    end
+  end
+
+  describe '.get_handler' do
+    context 'when on Solaris' do
+      before :each do
+        Facter.expects(:value).with(:operatingsystem).returns('Solaris')
+      end
+
+      after :each do
+        Object.class_exec do
+          remove_const(:Fiddle) if const_defined?(:Fiddle)
+        end
+      end
+
+      def stub_solaris_handler(stub_noop_too = false)
+        Puppet::Util::AtFork.stubs(:require).with() do |lib|
+          if lib == 'puppet/util/at_fork/solaris'
+            load lib + '.rb'
+            true
+          elsif stub_noop_too && lib == 'puppet/util/at_fork/noop'
+            Puppet::Util::AtFork.class_exec do
+              const_set(:Noop, Class.new)
+            end
+            true
+          else
+            false
+          end
+        end.returns(true)
+
+        unless stub_noop_too
+          Object.class_exec do
+            const_set(:Fiddle, Module.new do
+              const_set(:TYPE_VOIDP, nil)
+              const_set(:TYPE_VOID,  nil)
+              const_set(:TYPE_INT,   nil)
+              const_set(:DLError,    Class.new(StandardError))
+              const_set(:Handle,     Class.new)
+              const_set(:Function,   Class.new)
+            end)
+          end
+        end
+
+        TOPLEVEL_BINDING.eval('self').stubs(:require).with() do |lib|
+          if lib == 'fiddle'
+            raise LoadError, 'no fiddle' if stub_noop_too
+          else
+            Kernel.require lib
+          end
+          true
+        end.returns(true)
+      end
+
+      it %q(should return the Solaris specific AtFork handler) do
+        Puppet::Util::AtFork.stubs(:require).with() do |lib|
+          if lib == 'puppet/util/at_fork/solaris'
+            Puppet::Util::AtFork.class_exec do
+              const_set(:Solaris, Class.new)
+            end
+            true
+          else
+            false
+          end
+        end.returns(true)
+        load 'puppet/util/at_fork.rb'
+        expect(Puppet::Util::AtFork.get_handler.class).to eq(Puppet::Util::AtFork::Solaris)
+      end
+
+      it %q(should return the Noop handler when Fiddle could not be loaded) do
+        stub_solaris_handler(true)
+        load 'puppet/util/at_fork.rb'
+        expect(Puppet::Util::AtFork.get_handler.class).to eq(Puppet::Util::AtFork::Noop)
+      end
+
+      it %q(should fail when libcontract cannot be loaded) do
+        stub_solaris_handler
+        Fiddle::Handle.expects(:new).with(regexp_matches(/^libcontract.so.*/)).raises(Fiddle::DLError, 'no such library')
+        expect { load 'puppet/util/at_fork.rb' }.to raise_error(Fiddle::DLError, 'no such library')
+      end
+
+      it %q(should fail when libcontract doesn't define all the necessary functions) do
+        stub_solaris_handler
+        handle = stub('Fiddle::Handle')
+        Fiddle::Handle.expects(:new).with(regexp_matches(/^libcontract.so.*/)).returns(handle)
+        handle.expects(:[]).raises(Fiddle::DLError, 'no such method')
+        expect { load 'puppet/util/at_fork.rb' }.to raise_error(Fiddle::DLError, 'no such method')
+      end
+
+      it %q(the returned Solaris specific handler should respond to the expected methods) do
+        stub_solaris_handler
+        handle = stub('Fiddle::Handle')
+        Fiddle::Handle.expects(:new).with(regexp_matches(/^libcontract.so.*/)).returns(handle)
+        handle.stubs(:[]).returns(nil)
+        Fiddle::Function.stubs(:new).returns(Proc.new {})
+        load 'puppet/util/at_fork.rb'
+        expect(Puppet::Util::AtFork.get_handler.public_methods).to include(*EXPECTED_HANDLER_METHODS)
+      end
+    end
+
+    context 'when NOT on Solaris' do
+      before :each do
+        Facter.expects(:value).with(:operatingsystem).returns(nil)
+      end
+
+      def stub_noop_handler(namespace_only = false)
+        Puppet::Util::AtFork.stubs(:require).with() do |lib|
+          if lib == 'puppet/util/at_fork/noop'
+            if namespace_only
+              Puppet::Util::AtFork.class_exec do
+                const_set(:Noop, Class.new)
+              end
+            else
+              load lib + '.rb'
+            end
+            true
+          else
+            false
+          end
+        end.returns(true)
+      end
+
+      it %q(should return the Noop AtFork handler) do
+        stub_noop_handler(true)
+        load 'puppet/util/at_fork.rb'
+        expect(Puppet::Util::AtFork.get_handler.class).to eq(Puppet::Util::AtFork::Noop)
+      end
+
+      it %q(the returned Noop handler should respond to the expected methods) do
+        stub_noop_handler
+        load 'puppet/util/at_fork.rb'
+        expect(Puppet::Util::AtFork.get_handler.public_methods).to include(*EXPECTED_HANDLER_METHODS)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this commit, it was not possible to restart/stop a puppet agent service on Solaris from an agent run executed by that very service without killing the agent run along with the service.
This was because services on Solaris run in so called contracts - a kind of process groups - and during a service restart/stop all processes in the contract are killed. Under normal circumstances the contract is inherited during fork system call so the child process is a member of the same contract as its parent process. This was the case of the puppet run executed by the puppet agent service on Solaris too, and that is why the puppet run could not restart/stop the puppet agent service without killing itself.
So in this commit we simply make sure the agent run is executed in a different contract than its parent (the puppet agent service) which fixes the issue.