### PR TITLE
(PUP-7503) Fix hostname mismatch error reporting with Ruby 2.4

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -219,17 +219,17 @@ module Puppet::Network::HTTP
       end
       response
     rescue OpenSSL::SSL::SSLError => error
-      if error.message.include? _("certificate verify failed")
+      # can be nil
+      peer_cert = @verify.peer_certs.last
+
+      if peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert.content, site.host)
+        valid_certnames = [peer_cert.name, *peer_cert.subject_alt_names].uniq
+        msg = valid_certnames.length > 1 ? _("one of %{certnames}") % { certnames: valid_certnames.join(', ') } : valid_certnames.first
+        msg += _("Server hostname '%{host}' did not match server certificate; expected %{msg}") % { host: site.host, msg: msg }
+        raise Puppet::Error, msg, error.backtrace
+      elsif error.message.include? "certificate verify failed"
         msg = error.message
         msg << ": [" + @verify.verify_errors.join('; ') + "]"
-        raise Puppet::Error, msg, error.backtrace
-      elsif error.message =~ /hostname.*not match.*server certificate/
-        leaf_ssl_cert = @verify.peer_certs.last
-
-        valid_certnames = [leaf_ssl_cert.name, *leaf_ssl_cert.subject_alt_names].uniq
-        msg = valid_certnames.length > 1 ? _("one of %{certnames}") % { certnames: valid_certnames.join(', ') } : valid_certnames.first
-        msg = _("Server hostname '%{host}' did not match server certificate; expected %{msg}") % { host: site.host, msg: msg }
-
         raise Puppet::Error, msg, error.backtrace
       else
         raise

--- a/lib/puppet/ssl/validator/default_validator.rb
+++ b/lib/puppet/ssl/validator/default_validator.rb
@@ -69,12 +69,12 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
   # @api private
   #
   def call(preverify_ok, store_context)
+    current_cert = store_context.current_cert
+    @peer_certs << Puppet::SSL::Certificate.from_instance(current_cert)
+
     # We must make a copy since the scope of the store_context will be lost
     # across invocations of this method.
     if preverify_ok
-      current_cert = store_context.current_cert
-      @peer_certs << Puppet::SSL::Certificate.from_instance(current_cert)
-
       # If we've copied all of the certs in the chain out of the SSL library
       if @peer_certs.length == store_context.chain.length
         # (#20027) The peer cert must be issued by a specific authority
@@ -100,7 +100,6 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
           @verify_errors << error_string
         end
       else
-        current_cert = store_context.current_cert
         @verify_errors << "#{error_string} for #{current_cert.subject}"
       end
     end


### PR DESCRIPTION
Ruby 2.4 introduced a change to OpenSSL that adds a step to
certificate preverification that checks that the hostname matches what
is in the certificate. While this is not enabled by default for most use
cases, any use of `set_params` to configure OpenSSL will enable it.
In the past, the hostname was verified in a post-connection verification
step and produced a specific error message. Now it simply emits a generic
SSL error. Since we still want to give a more informative error message,
this commit changes our error handling to explicitly check for a hostname
mismatch when we receive an SSL error and emit our custom descriptive
message. Note that in Ruby 2.4, this duplicates work already done by Ruby,
but it allows us to be consistent with our error reporting.