### PR TITLE
(PUP-7518) i18n module loading

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -68,6 +68,17 @@ class Puppet::Module
     load_metadata
 
     @absolute_path_to_manifests = Puppet::FileSystem::PathPattern.absolute(manifests)
+
+    # i18n initialization for modules
+    if Puppet::GETTEXT_AVAILABLE
+      begin
+        initialize_i18n
+      rescue Exception => e
+        Puppet.warning _("GettextSetup initialization for %{module_name} failed with: %{error_message}") % { module_name: name, error_message: e.message }
+      end
+    else
+      Puppet.warning _("GettextSetup is not available, skipping GettextSetup initialization for %{module_name}.") % { module_name: name }
+    end
   end
 
   # @deprecated The puppetversion module metadata field is no longer used.
@@ -353,7 +364,26 @@ class Puppet::Module
     self.environment == other.environment
   end
 
+  def initialize_i18n
+    module_name = @forge_name.gsub("/","-") if @forge_name
+    return if module_name.nil? || i18n_initialized?(module_name)
+
+    locales_path = File.absolute_path('locales', path)
+
+    begin
+      GettextSetup.initialize(locales_path)
+      Puppet.debug "#{module_name} initialized for i18n: #{GettextSetup.translation_repositories[module_name]}"
+    rescue
+      config_path = File.absolute_path('config.yaml', locales_path)
+      Puppet.debug "Could not find locales configuration file for #{module_name} at #{config_path}. Skipping i18n initialization."
+    end
+  end
+
   private
+
+  def i18n_initialized?(module_name)
+    GettextSetup.translation_repositories.has_key? module_name
+  end
 
   def wanted_manifests_from(pattern)
     begin

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -440,6 +440,35 @@ describe Puppet::Module do
     end
   end
 
+
+  describe "initialize_i18n" do
+
+    let(:modpath) { tmpdir('modpath') }
+    let(:modname) { 'puppetlabs-i18n'}
+    let(:modroot) { "#{modpath}/#{modname}/" }
+    let(:config_path) { "#{modroot}/locales/config.yaml" }
+    let(:mod_obj) { PuppetSpec::Modules.create( modname, modpath, :metadata => { :dependencies => [] }, :env => env ) }
+
+    it "is expected to initialize an un-initialized module" do
+      expect(GettextSetup.translation_repositories.has_key? modname).to be false
+
+      FileUtils.mkdir_p("#{mod_obj.path}/locales")
+      config = {
+        "gettext" => {
+          "project_name" => modname
+        }
+      }
+      File.open(config_path, 'w') { |file| file.write(config.to_yaml) }
+
+      mod_obj.initialize_i18n
+
+      expect(GettextSetup.translation_repositories.has_key? modname).to be true
+    end
+    it "is expected return nil if module is intiailized" do
+      expect(mod_obj.initialize_i18n).to be nil
+    end
+  end
+
   describe "when managing supported platforms" do
     it "should support specifying a supported platform" do
       mod.supports "solaris"


### PR DESCRIPTION
This adds to Puppet::Module to "initialize" a module for translations. Each module must be added to FastGettext.translation_repositories, so that translations in the modules code will be available to Puppet. Two methods are added here, one to check if a module has been initialized and another to initialize. To initialize, we are just wrapping GettextSetup.initialize basically.