### PR TITLE
(PUP-7516) Fix Fedora25 createrepo failures

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -12,6 +12,7 @@ PACKAGES = {
     'git',
     'ruby',
     'rubygem-json',
+    'rubygem-io-console'
   ],
   :debian => [
     ['git', 'git-core'],


### PR DESCRIPTION
 - On 5/3/2017 version 7.43.0-5.fc25 of python-pycurl was released to
   address issue https://bugzilla.redhat.com/show_bug.cgi?id=1446850

```
   ImportError: pycurl: libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (nss)
```

 - Puppet performs some package tests with yum and dnf providers by
   installing / using createrepo.  Createrepo requires python and a
   number of python dependencies, including the python-pycurl bindings
   for curl.  These bindings depend on the curl package.

   Unfortunately on Fedora 25, the baseline curl package installed on
   images is curl-7.50.3-1.fc25.x86_64. This curl package in
   conjunction with the newer python-pycurl 7.43.0-5.fc25 will
   generate an error when calling createrepo:

```
   ImportError: pycurl: libcurl link-time version (7.50.3) is older than compile-time version (7.51.0)
```

 - One solution to this problem is to downgrade the python-pycurl
   package to the older working version with:

```
   yum downgrade python-pycurl-7.43.0-4.fc25
```

 - Another solution would be to not mirror the newer package.

 - Given both of these options are brittle, it's been decided that
   when installing createrepo, curl should be upgraded at the same
   time. In testing, the newer curl 7.51.0-6.fc25 has been found to
   be compatible with the updated python-pycurl, allowing createrepo
   to function again without crashing.

 - To be able to upgrade curl, which may already be installed on a
   target machine, requires that the `--best` parameter be passed
   to yum / dnf install (both package managers have the feature). It
   also requires memoizing whether or not the package has been
   previously installed in Puppet::Acceptance::RpmUtils#setup_rpm.
   That method currently checked if a package was installed and would
   skip installing it if it was already present. Since that prevents a
   desirable upgrade of curl, make it track whether or not an install
   / upgrade has been attempted.

   8c1751e defined the original setup
   method which is modified here


 - On Fedora 25, Bundler will outright crash as it has a hard
   dependency on io/console by way of the Thor CLI library.

   Bundler 1.14-6 vendors Thor 0.19.1

   https://github.com/bundler/bundler/blob/v1.14.6/lib/bundler/vendor/thor/lib/thor/version.rb
   https://github.com/erikhuda/thor/blob/v0.19.1/lib/thor/shell/basic.rb#L2

   The hard dependency has been removed in an as of yet unshipped
   version of Thor via erikhuda/thor#539
   meaning that at some point it will not be necessary to have
   io/console installed for Bundler.

   For now, it remains a hard dependency,
   without which calling Bundler will fail with an error like:

```
 /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- io/console (LoadError)
  from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/shell/basic.rb:2:in `<top (required)>'
  from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/shell/color.rb:1:in `<top (required)>'
  from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/shell.rb:17:in `shell'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/ui/shell.rb:15:in `initialize'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/cli.rb:13:in `new'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/cli.rb:13:in `rescue in start'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/cli.rb:17:in `start'
  from /usr/local/share/gems/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'
  from /usr/local/share/gems/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
  from /usr/local/share/gems/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
  from /usr/local/bin/bundle:23:in `load'
  from /usr/local/bin/bundle:23:in `<main>'
```