### PR TITLE
(PUP-7149) Add job_id to catalog compilation and reports

### DIFF
--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -47,10 +47,12 @@ be `true`.
 - `checksum_type`: a dot-separated list of checksum types supported by the agent, for use in file resources of a static
 catalog. The order signifies preference, highest first.
 
-An optional parameter can be provided to the POST or GET to notify a node classifier that the client requested a specific
-environment, which might differ from what the client believes is its current environment:
+Optional parameters that may be provided to the POST or GET:
 
-- `configured_environment`: the environment configured on the client.
+- `configured_environment`: the environment configured on the client. May be
+  provided to notify an ENC that the client requested a specific environment
+  which might differ from what the client believes is its current environment.
+- `job_id`: which orchestration job triggered this catalog request.
 
 ### Example Response
 

--- a/api/docs/http_report.md
+++ b/api/docs/http_report.md
@@ -52,6 +52,7 @@ example is formatted for readability)
      "configuration_version"=>1357986,
      "transaction_uuid"=>"df34516e-4050-402d-a166-05b03b940749",
      "code_id"=>null,
+     "job_id"=>null,
      "catalog_uuid"=>"827a74c8-cf98-44da-9ff7-18c5e4bee41e",
      "catalog_format"=>1,
      "report_format"=>5,

--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -100,6 +100,11 @@
             "type":        "string"
         },
 
+        "job_id": {
+            "description": "The id of the job that this transaction is a part of.",
+            "type":        ["string", "null"]
+        },
+
         "catalog_uuid": {
             "description": "A UUID covering a specific catalog.",
             "type":        "string"
@@ -122,7 +127,7 @@
         "report_format": {
             "description": "The report format version documented by this schema",
             "type":        "integer",
-            "enum":        ["6", 6]
+            "enum":        ["7", 7]
         },
 
         "puppet_version": {

--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -39,7 +39,7 @@ class Puppet::Agent
     block_run = Puppet::Application.controlled_run do
       splay client_options.fetch :splay, Puppet[:splay]
       result = run_in_fork(should_fork) do
-        with_client(client_options[:transaction_uuid]) do |client|
+        with_client(client_options[:transaction_uuid], client_options[:job_id]) do |client|
           begin
             client_args = client_options.merge(:pluginsync => Puppet::Configurer.should_pluginsync?)
             lock { client.run(client_args) }
@@ -88,9 +88,9 @@ class Puppet::Agent
 
   # Create and yield a client instance, keeping a reference
   # to it during the yield.
-  def with_client(transaction_uuid)
+  def with_client(transaction_uuid, job_id = nil)
     begin
-      @client = client_class.new(Puppet::Configurer::DownloaderFactory.new, transaction_uuid)
+      @client = client_class.new(Puppet::Configurer::DownloaderFactory.new, transaction_uuid, job_id)
     rescue StandardError => detail
       Puppet.log_exception(detail, _("Could not create instance of %{client_class}: %{detail}") % { client_class: client_class, detail: detail })
       return

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -56,12 +56,13 @@ class Puppet::Configurer
     end
   end
 
-  def initialize(factory = Puppet::Configurer::DownloaderFactory.new, transaction_uuid = nil)
+  def initialize(factory = Puppet::Configurer::DownloaderFactory.new, transaction_uuid = nil, job_id = nil)
     @running = false
     @splayed = false
     @cached_catalog_status = 'not_used'
     @environment = Puppet[:environment]
     @transaction_uuid = transaction_uuid || SecureRandom.uuid
+    @job_id = job_id
     @static_catalog = true
     @checksum_type = Puppet[:supported_checksum_types]
     @handler = Puppet::Configurer::PluginHandler.new(factory)
@@ -133,6 +134,7 @@ class Puppet::Configurer
     # set report host name now that we have the fact
     options[:report].host = Puppet[:node_name_value]
     query_options[:transaction_uuid] = @transaction_uuid
+    query_options[:job_id] = @job_id
     query_options[:static_catalog] = @static_catalog
 
     # Query params don't enforce ordered evaluation, so munge this list into a
@@ -185,7 +187,7 @@ class Puppet::Configurer
     # environment and transaction_uuid very early, this is to ensure
     # they are sent regardless of any catalog compilation failures or
     # exceptions.
-    options[:report] ||= Puppet::Transaction::Report.new("apply", nil, @environment, @transaction_uuid)
+    options[:report] ||= Puppet::Transaction::Report.new("apply", nil, @environment, @transaction_uuid, @job_id)
     report = options[:report]
     init_storage
 

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -51,6 +51,9 @@ class Puppet::Transaction::Report
   # The id of the code input to the compiler.
   attr_accessor :code_id
 
+  # The id of the job responsible for this run.
+  attr_accessor :job_id
+
   # A master generated catalog uuid, useful for connecting a single catalog to multiple reports.
   attr_accessor :catalog_uuid
 
@@ -206,7 +209,7 @@ class Puppet::Transaction::Report
   end
 
   # @api private
-  def initialize(kind, configuration_version=nil, environment=nil, transaction_uuid=nil)
+  def initialize(kind, configuration_version=nil, environment=nil, transaction_uuid=nil, job_id=nil)
     @metrics = {}
     @logs = []
     @resource_statuses = {}
@@ -214,11 +217,12 @@ class Puppet::Transaction::Report
     @host = Puppet[:node_name_value]
     @time = Time.now
     @kind = kind
-    @report_format = 6
+    @report_format = 7
     @puppet_version = Puppet.version
     @configuration_version = configuration_version
     @transaction_uuid = transaction_uuid
     @code_id = nil
+    @job_id = job_id
     @catalog_uuid = nil
     @cached_catalog_status = nil
     @master_used = nil
@@ -249,6 +253,10 @@ class Puppet::Transaction::Report
 
     if catalog_uuid = data['catalog_uuid']
       @catalog_uuid = catalog_uuid
+    end
+
+    if job_id = data['job_id']
+      @job_id = job_id
     end
 
     if code_id = data['code_id']
@@ -292,6 +300,7 @@ class Puppet::Transaction::Report
       'transaction_uuid' => @transaction_uuid,
       'catalog_uuid' => @catalog_uuid,
       'code_id' => @code_id,
+      'job_id' => @job_id,
       'cached_catalog_status' => @cached_catalog_status,
       'report_format' => @report_format,
       'puppet_version' => @puppet_version,

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -66,12 +66,23 @@ describe Puppet::Agent do
   it "should initialize the client's transaction_uuid if passed as a client_option" do
     client = mock 'client'
     transaction_uuid = 'foo'
-    AgentTestClient.expects(:new).with(anything, transaction_uuid).returns client
+    AgentTestClient.expects(:new).with(anything, transaction_uuid, nil).returns client
 
     client.expects(:run)
 
     @agent.stubs(:disabled?).returns false
     @agent.run(:transaction_uuid => transaction_uuid)
+  end
+
+  it "should initialize the client's job_id if passed as a client_option" do
+    client = mock 'client'
+    job_id = '289'
+    AgentTestClient.expects(:new).with(anything, anything, job_id).returns client
+
+    client.expects(:run)
+
+    @agent.stubs(:disabled?).returns false
+    @agent.run(:job_id => job_id)
   end
 
   it "should be considered running if the lock file is locked" do

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -199,6 +199,17 @@ describe Puppet::Configurer do
       @agent.run
     end
 
+    it "should create report with passed transaction_uuid and job_id" do
+      @agent = Puppet::Configurer.new(Puppet::Configurer::DownloaderFactory.new, "test_tuuid", "test_jid")
+      @agent.stubs(:init_storage)
+
+      report = Puppet::Transaction::Report.new('apply', nil, "test", "aaaa")
+      Puppet::Transaction::Report.expects(:new).with(anything, anything, anything, 'test_tuuid', 'test_jid').returns(report)
+      @agent.expects(:send_report).with(report)
+
+      @agent.run
+    end
+
     it "should send the report" do
       report = Puppet::Transaction::Report.new("apply", nil, "test", "aaaa")
       Puppet::Transaction::Report.expects(:new).returns(report)
@@ -372,6 +383,12 @@ describe Puppet::Configurer do
     it "sends the transaction uuid in a catalog request" do
       @agent.instance_variable_set(:@transaction_uuid, 'aaa')
       Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:transaction_uuid => 'aaa'))
+      @agent.run
+    end
+
+    it "sends the transaction uuid in a catalog request" do
+      @agent.instance_variable_set(:@job_id, 'aaa')
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:job_id => 'aaa'))
       @agent.run
     end
 

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -40,6 +40,14 @@ describe Puppet::Transaction::Report do
     expect(Puppet::Transaction::Report.new("inspect", "some configuration version", "some environment", "some transaction uuid").transaction_uuid).to eq("some transaction uuid")
   end
 
+  it "should take a 'transaction_uuid' as an argument" do
+    expect(Puppet::Transaction::Report.new("inspect", "some configuration version", "some environment", "some transaction uuid").transaction_uuid).to eq("some transaction uuid")
+  end
+
+  it "should take a 'job_id' as an argument" do
+    expect(Puppet::Transaction::Report.new('inspect', 'cv', 'env', 'tid', 'some job id').job_id).to eq('some job id')
+  end
+
   it "should be able to set configuration_version" do
     report = Puppet::Transaction::Report.new("inspect")
     report.configuration_version = "some version"
@@ -50,6 +58,12 @@ describe Puppet::Transaction::Report do
     report = Puppet::Transaction::Report.new("inspect")
     report.transaction_uuid = "some transaction uuid"
     expect(report.transaction_uuid).to eq("some transaction uuid")
+  end
+
+  it "should be able to set job_id" do
+    report = Puppet::Transaction::Report.new("inspect")
+    report.job_id = "some job id"
+    expect(report.job_id).to eq("some job id")
   end
 
   it "should be able to set code_id" do
@@ -532,6 +546,7 @@ describe Puppet::Transaction::Report do
     expect(tripped.time.to_i).to eq(report.time.to_i)
     expect(tripped.configuration_version).to eq(report.configuration_version)
     expect(tripped.transaction_uuid).to eq(report.transaction_uuid)
+    expect(tripped.job_id).to eq(report.job_id)
     expect(tripped.code_id).to eq(report.code_id)
     expect(tripped.catalog_uuid).to eq(report.catalog_uuid)
     expect(tripped.cached_catalog_status).to eq(report.cached_catalog_status)


### PR DESCRIPTION
This allows the job_id to be set when the agent is run directly. This
will be used to allow pxp_module_puppet to set job_id and
transaction_uuid for agent runs it initiates.