### PR TITLE
(PUP-7156) Fix Puppet::Acceptance::RpmUtils#setup

### DIFF
--- a/acceptance/lib/puppet/acceptance/rpm_util.rb
+++ b/acceptance/lib/puppet/acceptance/rpm_util.rb
@@ -15,13 +15,23 @@ module Puppet
       end
 
       def setup(agent)
+        @@setup_packages[agent] ||= {}
         cmd = rpm_provider(agent)
         required_packages = ['createrepo', 'curl', 'rpm-build']
         required_packages.each do |pkg|
-          unless @@setup_packages.has_key?(pkg) && ((on agent, "#{cmd} list installed #{pkg}", :acceptable_exit_codes => (0..255)).exit_code == 0) then
-            on agent, "#{cmd} install -y #{pkg} --best"
-            @@setup_packages[pkg] = true
+          pkg_installed = (on agent, "#{cmd} list installed #{pkg}", :acceptable_exit_codes => (0..255)).exit_code == 0
+          # package not present, so perform a new install
+          if !pkg_installed
+            on agent, "#{cmd} install -y #{pkg}"
+          # package is present, but has not yet attempted an upgrade
+          # note that this may influence YUM cache behavior
+          elsif !@@setup_packages[agent].has_key?(pkg)
+            # first pass, always attempt an upgrade to latest version
+            # fixes Fedora 25 curl compat with python-pycurl for instance
+            on agent, "#{cmd} upgrade -y #{pkg}"
           end
+
+          @@setup_packages[agent][pkg] = true
         end
       end
 

--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -11,8 +11,9 @@ PACKAGES = {
   :redhat => [
     'git',
     'ruby',
-    'rubygem-json',
-    'rubygem-io-console'
+    'rubygem-json',       # invalid on RHEL6
+    'rubygem-io-console', # required for Fedora25 to bundle install
+    'rubygem-rdoc'        # required for Fedora25 to install gems
   ],
   :debian => [
     ['git', 'git-core'],


### PR DESCRIPTION
#### (PUP-7156) Fix Puppet::Acceptance::RpmUtils#setup

- An assumption was made in 2a8ee90
   that all versions of yum and dnf have a --best option during
   install.

   It turns out this isn't accuracte, so yum / dnf install cannot be
   used to both install and upgrade.

   Separate install / upgrade into two discrete options

 - Furthermore, state tracking in RpmUtils for upgraded packages was
   being managed across all agents instead of on an agent by agent
   basis.

 - Note that depending on `yum install` or `yum upgrade` actions the
   yum cache may be considered current, so that when a new repo is
   added to /etc/yum.repos.d that it may not actually be queried
   despite having new content.


#### Fix Fedora ci:test:git via rubygem-rdoc

 - Some gem install tests require rubygem-rdoc
 - Added note about why ci:test:git won't work on RHEL6


Fixes #5852 