### PR TITLE
(PUP-6692) Make $settings::all_local contain all "server settings"

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -704,14 +704,18 @@ class Puppet::Parser::Scope
     settings = Puppet.settings
     table = effective_symtable(false)
     global_table = compiler.qualified_variables
+    all_local = {}
     settings.each_key do |name|
       next if :name == name
       key = name.to_s
       value = transform_setting(settings.value_sym(name, env_name))
       table[key] = value
+      all_local[key] = value
       # also write the fqn into global table for direct lookup
       global_table["settings::#{key}"] = value
     end
+    # set the 'all_local' - a hash of all settings
+    global_table["settings::all_local"] = all_local
     nil
   end
 

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -170,6 +170,15 @@ describe Puppet::Parser::Compiler do
       MANIFEST
       expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
     end
+
+    it 'makes all server settings available as $settings::all_local hash' do
+      node = Puppet::Node.new("testing")
+      catalog = compile_to_catalog(<<-MANIFEST, node)
+          notify { 'test': message => $settings::all_local['strict'] == 'warning' }
+      MANIFEST
+      expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
+    end
+
   end
 
   context 'when working with $server_facts' do


### PR DESCRIPTION
This makes the qualified variable $settings::all_local contain all the
settings individually found as a variable in the $settings namespace.