### PR TITLE
(maint) correct apply_catalog code comment

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -160,8 +160,7 @@ class Puppet::Configurer
     nil
   end
 
-  # Retrieve (optionally) and apply a catalog. If a catalog is passed in
-  # the options, then apply that one, otherwise retrieve it.
+  # Apply supplied catalog and return associated application report
   def apply_catalog(catalog, options)
     report = options[:report]
     begin


### PR DESCRIPTION
Once upon a time Puppet::Configurer#apply_catalog would retrieve a catalog if
not supplied, but this is no longer the case. Update the code comment to
reflect reality because its confusing.

Signed-off-by: Moses Mendoza <moses@puppet.com>