### PR TITLE
(MAINT) IMAGES-555 Tag Tests that break Image Acceptance

### DIFF
--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -1,4 +1,5 @@
 test_name "the agent --disable/--enable functionality should manage the agent lockfile properly"
+tag
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 
 #

--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -1,4 +1,5 @@
 test_name "fallback to the cached catalog"
+tag
 
 step "run agents once to cache the catalog" do
   with_puppet_running_on master, {} do

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -1,4 +1,5 @@
 test_name "aix package provider should work correctly"
+tag
 
 confine :to, :platform => /aix/
 

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -1,4 +1,5 @@
 test_name "NIM package provider should work correctly"
+tag
 
 confine :to, :platform => "aix"
 

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -1,4 +1,5 @@
 test_name "node_name_fact should be used to determine the node name for puppet agent"
+tag
 
 success_message = "node_name_fact setting was correctly used to determine the node name"
 

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
@@ -1,4 +1,5 @@
 test_name "node_name_fact should be used to determine the node name for puppet apply"
+tag
 
 success_message = "node_name_fact setting was correctly used to determine the node name"
 

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -1,4 +1,5 @@
 test_name "node_name_value should be used as the node name for puppet agent"
+tag
 
 success_message = "node_name_value setting was correctly used as the node name"
 testdir = master.tmpdir('nodenamevalue')

--- a/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
@@ -1,4 +1,5 @@
 test_name "node_name_value should be used as the node name for puppet apply"
+tag
 
 success_message = "node_name_value setting was correctly used as the node name"
 

--- a/acceptance/tests/allow_symlinks_as_config_directories.rb
+++ b/acceptance/tests/allow_symlinks_as_config_directories.rb
@@ -1,4 +1,5 @@
 test_name "Should allow symlinks to directories as configuration directories"
+tag
 confine :except, :platform => 'windows'
 
 agents.each do |agent|

--- a/acceptance/tests/apply/classes/parameterized_classes.rb
+++ b/acceptance/tests/apply/classes/parameterized_classes.rb
@@ -1,4 +1,5 @@
 test_name "parametrized classes"
+tag
 
 ########################################################################
 step "should allow param classes"

--- a/acceptance/tests/apply/classes/should_allow_param_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_override.rb
@@ -1,4 +1,5 @@
 test_name "should allow param override"
+tag
 
 manifest = %q{
 class parent {
@@ -17,4 +18,3 @@ apply_manifest_on(agents, manifest) do
     fail_test "parameter override didn't work" unless
         stdout.include? "defined 'message' as 'child'"
 end
-

--- a/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
@@ -1,4 +1,5 @@
 test_name "should allow overriding a parameter to undef in inheritence"
+tag
 
 agents.each do |agent|
   dir = agent.tmpdir('class_undef_override')

--- a/acceptance/tests/apply/classes/should_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_include_resources_from_class.rb
@@ -1,4 +1,5 @@
 test_name "resources declared in a class can be applied with include"
+tag
 manifest = %q{
 class x {
   notify{'a':}

--- a/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
@@ -1,4 +1,5 @@
 test_name "resources declared in classes are not applied without include"
+tag
 manifest = %q{ class x { notify { 'test': message => 'never invoked' } } }
 apply_manifest_on(agents, manifest) do
     fail_test "found the notify despite not including it" if

--- a/acceptance/tests/apply/hashes/should_not_reassign.rb
+++ b/acceptance/tests/apply/hashes/should_not_reassign.rb
@@ -1,4 +1,5 @@
 test_name "hash reassignment should fail"
+tag
 manifest = %q{
 $my_hash = {'one' => '1', 'two' => '2' }
 $my_hash['one']='1.5'

--- a/acceptance/tests/apply/puppet_apply_graph.rb
+++ b/acceptance/tests/apply/puppet_apply_graph.rb
@@ -1,4 +1,5 @@
 test_name 'puppet apply should generate a graph'
+tag
 
 agents.each do |agent|
   step "Create var temp directory"

--- a/acceptance/tests/apply/puppet_apply_trace.rb
+++ b/acceptance/tests/apply/puppet_apply_trace.rb
@@ -1,4 +1,5 @@
 test_name 'puppet apply --trace should provide a stack trace'
+tag
 
 agents.each do |agent|
   on(agent, puppet('apply --trace -e "blue < 2"'), :acceptable_exit_codes => 1) do

--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -1,4 +1,5 @@
 test_name "concurrent catalog requests (PUP-2659)"
+tag
 
 # we're only testing the effects of loading a master with concurrent requests
 confine :except, :platform => 'windows'

--- a/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
+++ b/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
@@ -1,4 +1,5 @@
 test_name "#17371 file metadata specified in puppet.conf needs to be applied"
+tag
 
 # when owner/group works on windows for settings, this confine should be removed.
 confine :except, :platform => 'windows'

--- a/acceptance/tests/cycle_detection.rb
+++ b/acceptance/tests/cycle_detection.rb
@@ -1,4 +1,5 @@
 test_name "cycle detection and reporting"
+tag
 
 step "check we report a simple cycle"
 manifest = <<EOT

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -2,6 +2,7 @@ require 'puppet/acceptance/static_catalog_utils'
 extend Puppet::Acceptance::StaticCatalogUtils
 
 test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri" do
+  tag
 
   skip_test 'requires puppetserver installation' if @options[:type] != 'aio'
 

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -1,4 +1,5 @@
 test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
+  tag
   master_reportdir = create_tmpdir_for_user(master, 'reportdir')
 
   def remove_reports_on_master(master_reportdir, agent_node_name)

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -1,4 +1,5 @@
 test_name "Environment control of static catalogs"
+tag
 
 skip_test 'requires puppetserver to test static catalogs' if @options[:type] != 'aio'
 

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -2,6 +2,7 @@ test_name "C97172: static catalogs support utf8" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+  tag
   app_type = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)
 

--- a/acceptance/tests/doc/should_print_function_reference.rb
+++ b/acceptance/tests/doc/should_print_function_reference.rb
@@ -1,4 +1,5 @@
 test_name "verify we can print the function reference"
+tag
 on(agents, puppet_doc("-r", "function")) do
     fail_test "didn't print function reference" unless
         stdout.include? 'Function Reference'

--- a/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
+++ b/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
@@ -1,4 +1,5 @@
 test_name "verify we can print the function reference"
+tag
 confine :except, :platform => /^eos-/
 
 on(agents, puppet_doc("-r", "type")) do

--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -1,6 +1,7 @@
 # ensure installs and code honor new puppet-agent path spec:
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 test_name 'PUP-4033: Ensure aio path spec is honored'
+tag
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils
@@ -173,4 +174,3 @@ agents.each do |agent|
     end
   end
 end
-

--- a/acceptance/tests/ensure_version_file.rb
+++ b/acceptance/tests/ensure_version_file.rb
@@ -5,6 +5,7 @@ extend Puppet::Acceptance::TempFileUtils
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 
 test_name 'PA-466: Ensure version file is created on agent' do
+  tag
 
   skip_test 'requires version file which is created by AIO' if @options[:type] != 'aio'
 
@@ -27,4 +28,3 @@ test_name 'PA-466: Ensure version file is created on agent' do
     end
   end
 end
-

--- a/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
+++ b/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
@@ -1,4 +1,5 @@
 test_name 'PUP-4413 3x forbidden environment names should be allowed in 4x'
+tag
 
 step 'setup environments'
 

--- a/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
+++ b/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
@@ -3,6 +3,7 @@
 # facts puppet could pluginsync with the incorrect environment. For more
 # details see PUP-3591.
 test_name "Agent should pluginsync with the environment the agent resolves to"
+tag
 
 testdir = create_tmpdir_for_user master, 'environment_resolve'
 

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -1,4 +1,5 @@
 test_name 'PUP-3755 Test an un-assigned broken environment'
+tag
 
 step 'setup environments'
 

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -1,4 +1,5 @@
 test_name "Can enumerate environments via an HTTP endpoint"
+tag
 
 confine :except, :platform => /osx/ # see PUP-4820
 

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -1,6 +1,7 @@
 test_name 'C59122: ensure provider from same env as custom type' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
+  tag
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -1,4 +1,5 @@
 test_name 'ensure production environment created by master if missing'
+tag
 
 testdir = create_tmpdir_for_user master, 'prod-env-created'
 

--- a/acceptance/tests/environment/directory_environment_with_environment_conf.rb
+++ b/acceptance/tests/environment/directory_environment_with_environment_conf.rb
@@ -1,4 +1,5 @@
 test_name 'Use a directory environment from environmentpath with an environment.conf'
+tag
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -1,4 +1,5 @@
 test_name "Master should produce error if enc specifies a nonexistent environment"
+tag
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -1,4 +1,5 @@
 test_name 'Test behavior of directory environments when environmentpath is set to a non-existent directory'
+tag
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -1,4 +1,5 @@
 test_name "Test behavior of default environment"
+tag
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'

--- a/acceptance/tests/environment/environment_scenario-existing.rb
+++ b/acceptance/tests/environment/environment_scenario-existing.rb
@@ -1,4 +1,5 @@
 test_name "Test a specific, existing directory environment configuration"
+tag
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'

--- a/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
+++ b/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
@@ -1,4 +1,5 @@
 test_name "Test behavior of a directory environment when environmentpath is set in the master section"
+tag
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -1,4 +1,5 @@
 test_name "Test for an environment that does not exist"
+tag
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -1,4 +1,5 @@
 test_name "Agent should use agent environment if there is an enc that does not specify the environment"
+tag
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -1,4 +1,5 @@
 test_name "Agent should use agent environment if there is no enc-specified environment"
+tag
 
 testdir = create_tmpdir_for_user master, 'use_agent_env'
 

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -1,4 +1,5 @@
 test_name "Agent should use environment given by ENC"
+tag
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,4 +1,5 @@
 test_name "Agent should use environment given by ENC for fetching remote files"
+tag
 
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -1,4 +1,5 @@
 test_name "Agent should use environment given by ENC for pluginsync"
+tag
 
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -1,4 +1,5 @@
 test_name "Use environments from the environmentpath"
+tag
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -1,6 +1,7 @@
 test_name 'C98115 compilation should get new values in variables on each compilation' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
+  tag
 
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
+++ b/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
@@ -16,6 +16,7 @@ skip_test "Test only supported on Jetty" unless @options[:is_puppetserver]
 #  - CA disabled on the master `ca = false`
 #
 test_name "Puppet agent and master work when both configured with externally issued certificates from independent intermediate CAs"
+tag
 
 step "Copy certificates and configuration files to the master..."
 fixture_dir = File.expand_path('../fixtures', __FILE__)

--- a/acceptance/tests/face/4654_facts_face.rb
+++ b/acceptance/tests/face/4654_facts_face.rb
@@ -1,4 +1,5 @@
 test_name "Puppet facts face should resolve custom and external facts"
+tag
 
 #
 # This test is intended to ensure that custom and external facts present

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -1,4 +1,5 @@
 test_name "Exercise loading a face from a module"
+tag
 
 # Because the module tool does not work on windows, we can't run this test there
 confine :except, :platform => 'windows'

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -1,4 +1,5 @@
 test_name 'parser validate' do
+  tag
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
   require 'puppet/acceptance/temp_file_utils'

--- a/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
+++ b/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
@@ -1,4 +1,5 @@
 test_name "generate a helpful error message when hostname doesn't match server certificate"
+tag
 
 skip_test( 'Changing certnames of the master will break PE/Passenger installations' ) if master.is_using_passenger?
 

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -1,4 +1,5 @@
 test_name 'C98346: Binary data type' do
+  tag
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 

--- a/acceptance/tests/language/break.rb
+++ b/acceptance/tests/language/break.rb
@@ -1,4 +1,5 @@
 test_name 'C98162 - Validate `break` terminates execution in a block of code' do
+  tag
   agents.each do |agent|
 
     step 'apply class with break' do

--- a/acceptance/tests/language/class_inheritance.rb
+++ b/acceptance/tests/language/class_inheritance.rb
@@ -1,4 +1,5 @@
 test_name 'C14943: Class inheritance works correctly' do
+  tag
 
   agents.each do |agent|
     test_manifest = <<MANIFEST

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -1,6 +1,7 @@
 test_name "C94788: exported resources using a yaml terminus for storeconfigs" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
+  tag
 
   # user resource doesn't have a provider on arista
   skip_test if agents.any? {|agent| agent['platform'] =~ /^eos/ } # see PUP-5404, ARISTA-42

--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,4 +1,5 @@
 test_name 'Puppet executes functions written in the Puppet language'
+tag
 
 teardown do
   on master, 'rm -rf /etc/puppetlabs/code/modules/jenny'
@@ -125,4 +126,3 @@ step 'Call an env-specific function in a non-default environment' do
   fail_test 'Failed to call env-specific function from that environment' \
     unless rc.stdout.include?('This is the two::bar() function in the tommy environment')
 end
-

--- a/acceptance/tests/language/next.rb
+++ b/acceptance/tests/language/next.rb
@@ -1,4 +1,5 @@
 test_name 'C98162 - Validate `next` immediately returns from a block of code' do
+  tag
   agents.each do |agent|
 
     step 'apply class with next' do

--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -1,4 +1,5 @@
 test_name 'C99627: can use Object types in the catalog and apply/agent' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -1,4 +1,5 @@
 test_name 'C98345: ensure puppet generate assures env. isolation' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -1,4 +1,5 @@
 test_name 'C98097 - generated pcore resource types should be loaded instead of ruby for custom types' do
+  tag
   environment = 'production'
   step 'setup - install module with custom ruby resource type' do
     #{{{

--- a/acceptance/tests/language/resource_refs_with_nested_arrays.rb
+++ b/acceptance/tests/language/resource_refs_with_nested_arrays.rb
@@ -1,4 +1,5 @@
 test_name "#7681: Allow using array variables in resource references"
+tag
 
 agents.each do |agent|
   test_manifest = <<MANIFEST

--- a/acceptance/tests/language/return.rb
+++ b/acceptance/tests/language/return.rb
@@ -1,4 +1,5 @@
 test_name 'C98162 - Validate `return` immediately returns from a block of code' do
+  tag
   agents.each do |agent|
 
     step 'apply class with return' do

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -1,4 +1,5 @@
 test_name 'C98120, C98077: Sensitive Data is redacted on CLI, logs, reports' do
+  tag
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -1,4 +1,5 @@
 test_name 'C64667: ensure server_facts is set and error if any value is overwritten by an agent' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -1,4 +1,5 @@
 test_name "Exercise a module with 4x function and 4x system function"
+tag
 
 # Purpose:
 # Test that a packed puppet can call a 4x system function, and that a 4x function in

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -1,4 +1,5 @@
 test_name 'C99578: lookup should allow interpolation in hiera3 configs' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -1,4 +1,5 @@
 test_name 'C99578: hiera5 lookup config with interpolated scoped nested variables' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -1,4 +1,5 @@
 test_name 'C99630: hiera v3 custom backend' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
   require 'puppet/acceptance/temp_file_utils.rb'

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -1,4 +1,5 @@
 test_name "Lookup data using the agnostic lookup function" do
+  tag
   # pre-docs:
   # https://puppet-on-the-edge.blogspot.com/2015/01/puppet-40-data-in-modules-and.html
 

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -1,4 +1,5 @@
 test_name 'C99044: lookup should allow rich data as values' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -1,4 +1,5 @@
 test_name 'C99903: merge strategies' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -1,4 +1,5 @@
 test_name 'C99629: hiera v5 can use v3 config and data' do
+  tag
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -1,4 +1,5 @@
 test_name 'C99572: v4 hieradata with v5 configs' do
+  tag
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 

--- a/acceptance/tests/modules/build/build_agent.rb
+++ b/acceptance/tests/modules/build/build_agent.rb
@@ -1,4 +1,5 @@
 test_name "puppet module build (agent)"
+tag
 
 agents.each do |agent|
   teardown do

--- a/acceptance/tests/modules/build/build_basic.rb
+++ b/acceptance/tests/modules/build/build_basic.rb
@@ -1,4 +1,5 @@
 test_name 'CODEMGMT-69 - Build a Module Using "metadata.json" Only'
+tag
 
 #Init
 temp_module_path = '/tmp/nginx'

--- a/acceptance/tests/modules/build/build_ignore_module_file.rb
+++ b/acceptance/tests/modules/build/build_ignore_module_file.rb
@@ -1,4 +1,5 @@
 test_name 'PUP-3981 - C63215 - Build Module Should Ignore Module File'
+tag
 
 #Init
 temp_module_path = master.tmpdir('build_ignore_module_file_test')

--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -1,4 +1,5 @@
 test_name "puppet module build should verify there are no symlinks in module"
+tag
 
 confine :except, :platform => 'windows'
 

--- a/acceptance/tests/modules/build/build_should_not_create_changes.rb
+++ b/acceptance/tests/modules/build/build_should_not_create_changes.rb
@@ -1,4 +1,5 @@
 test_name "puppet module build should not result in changed files"
+tag
 
 modauthor = 'foo'
 modname = 'bar'

--- a/acceptance/tests/modules/changes/invalid_module_install_path.rb
+++ b/acceptance/tests/modules/changes/invalid_module_install_path.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on an invalid module install path)'
+tag
 
 step 'Setup'
 

--- a/acceptance/tests/modules/changes/missing_checksums_json.rb
+++ b/acceptance/tests/modules/changes/missing_checksums_json.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on a module which is missing checksums.json)'
+tag
 
 step 'Setup'
 

--- a/acceptance/tests/modules/changes/missing_metadata_json.rb
+++ b/acceptance/tests/modules/changes/missing_metadata_json.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on a module which is missing metadata.json)'
+tag
 
 step 'Setup'
 

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on a module with a modified file)'
+tag
 
 step 'Setup'
 

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on a module with a removed file)'
+tag
 
 step 'Setup'
 

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on an unmodified module)'
+tag
 
 step 'Setup'
 

--- a/acceptance/tests/modules/generate/basic_generate.rb
+++ b/acceptance/tests/modules/generate/basic_generate.rb
@@ -1,4 +1,5 @@
 test_name "puppet module generate (agent)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (already installed)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (already installed elsewhere)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (already installed with local changes)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (agent)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/force_ignores_dependencies.rb
+++ b/acceptance/tests/modules/install/force_ignores_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (force ignores dependencies)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (ignoring dependencies)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (nonexistent directory)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (nonexistent module)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with debug)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with dependencies)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module install (with environment)'
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with existing module directory)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 test_name "puppet module install (with modulepath)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with necessary dependency upgrade)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with no dependencies)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with unnecessary dependency upgrade)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with unsatisfied constraints)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -1,4 +1,5 @@
 test_name "puppet module install (with version)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
@@ -23,4 +24,3 @@ agents.each do |agent|
     assert_module_installed_on_disk(agent, module_name)
   end
 end
-

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module list (with circular dependencies)"
+tag
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module list (with environment)'
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/list/with_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_installed_modules.rb
@@ -1,4 +1,5 @@
 test_name "puppet module list (with installed modules)"
+tag
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module list (with invalid dependencies)"
+tag
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"

--- a/acceptance/tests/modules/list/with_missing_dependencies.rb
+++ b/acceptance/tests/modules/list/with_missing_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module list (with missing dependencies)"
+tag
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -1,4 +1,5 @@
 test_name "puppet module list (with modulepath)"
+tag
 
 codedir = master.puppet('master')['codedir']
 

--- a/acceptance/tests/modules/list/with_no_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_no_installed_modules.rb
@@ -1,4 +1,5 @@
 test_name "puppet module list (with no installed modules)"
+tag
 
 
 step "List the installed modules"

--- a/acceptance/tests/modules/list/with_repeated_dependencies.rb
+++ b/acceptance/tests/modules/list/with_repeated_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module list (with repeated dependencies)"
+tag
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"

--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module search should print a reasonable message on communication errors'
+tag
 
 step 'Setup'
 stub_hosts_on(master, 'forgeapi.puppet.com' => '127.0.0.2')

--- a/acceptance/tests/modules/search/formatting.rb
+++ b/acceptance/tests/modules/search/formatting.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module search output should be well structured'
+tag
 
 step 'Setup'
 stub_forge_on(master)

--- a/acceptance/tests/modules/search/multiple_search_terms.rb
+++ b/acceptance/tests/modules/search/multiple_search_terms.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module search should handle multiple search terms sensibly'
+tag
 
 #step 'Setup'
 #stub_forge_on(master)

--- a/acceptance/tests/modules/search/no_results.rb
+++ b/acceptance/tests/modules/search/no_results.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module search should print a reasonable message for no results'
+tag
 
 module_name   = "module_not_appearing_in_this_forge"
 

--- a/acceptance/tests/modules/search/ssl_errors.rb
+++ b/acceptance/tests/modules/search/ssl_errors.rb
@@ -1,4 +1,5 @@
 begin test_name 'puppet module search should print a reasonable message on ssl errors'
+tag
 
 step "Search against a website where the certificate is not signed by a public authority"
 

--- a/acceptance/tests/modules/uninstall/using_directory_name.rb
+++ b/acceptance/tests/modules/uninstall/using_directory_name.rb
@@ -1,4 +1,5 @@
 test_name "puppet module uninstall (using directory name)"
+tag
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/apache"

--- a/acceptance/tests/modules/uninstall/using_version_filter.rb
+++ b/acceptance/tests/modules/uninstall/using_version_filter.rb
@@ -1,4 +1,5 @@
 test_name "puppet module uninstall (with module installed)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/uninstall/with_active_dependency.rb
+++ b/acceptance/tests/modules/uninstall/with_active_dependency.rb
@@ -1,4 +1,5 @@
 test_name "puppet module uninstall (with active dependency)"
+tag
 
 step "Setup"
 apply_manifest_on master, <<-PP

--- a/acceptance/tests/modules/uninstall/with_environment.rb
+++ b/acceptance/tests/modules/uninstall/with_environment.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module uninstall (with environment)'
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/uninstall/with_module_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_module_installed.rb
@@ -1,4 +1,5 @@
 test_name "puppet module uninstall (with module installed)"
+tag
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -1,4 +1,5 @@
 test_name "puppet module uninstall (with modulepath)"
+tag
 
 codedir = master.puppet('master')['codedir']
 

--- a/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
@@ -1,4 +1,5 @@
 test_name "puppet module uninstall (with multiple modules installed)"
+tag
 
 if master.is_pe?
   skip_test

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (in a secondary directory)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (introducing new dependencies)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/not_upgradable.rb
+++ b/acceptance/tests/modules/upgrade/not_upgradable.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (not upgradable)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
+++ b/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (that was installed twice)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 require 'puppet/acceptance/environment_utils'

--- a/acceptance/tests/modules/upgrade/to_a_specific_version.rb
+++ b/acceptance/tests/modules/upgrade/to_a_specific_version.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (to a specific version)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (to installed version)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (with constraints on it)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (with constraints on its dependencies)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/with_environment.rb
+++ b/acceptance/tests/modules/upgrade/with_environment.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (with environment)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/with_local_changes.rb
+++ b/acceptance/tests/modules/upgrade/with_local_changes.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (with local changes)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (with scattered dependencies)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 require 'puppet/acceptance/environment_utils'

--- a/acceptance/tests/modules/upgrade/with_update_available.rb
+++ b/acceptance/tests/modules/upgrade/with_update_available.rb
@@ -1,4 +1,5 @@
 test_name "puppet module upgrade (with update available)"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -4,6 +4,7 @@ require 'yaml'
 extend Puppet::Acceptance::TempFileUtils
 
 test_name "ticket #16753 node data should be cached in yaml to allow it to be queried"
+tag
 
 node_name = "woy_node_#{SecureRandom.hex}"
 

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -1,4 +1,5 @@
 test_name "Puppet applies resources without dependencies in file order over the network"
+tag
 
 testdir = master.tmpdir('application_order')
 

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -1,4 +1,5 @@
 test_name 'Calling all functions.. test in progress!'
+tag
 
 # create single manifest calling all functions
 step 'Apply manifest containing all function calls'

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -1,4 +1,5 @@
 test_name "Lookup data using the hiera parser function"
+tag
 
 testdir = master.tmpdir('hiera')
 

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -1,4 +1,5 @@
 test_name "Lookup data using the hiera_array parser function"
+tag
 
 testdir = master.tmpdir('hiera')
 

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -1,4 +1,5 @@
 test_name "Lookup data using the hiera_hash parser function"
+tag
 
 testdir = master.tmpdir('hiera')
 

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -1,4 +1,5 @@
 test_name "Calling Hiera function from inside templates"
+tag
 
 @module_name = "hieratest"
 @coderoot = master.tmpdir("#{@module_name}")

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -1,5 +1,6 @@
 require 'puppet/acceptance/environment_utils'
 test_name 'C97760: Bignum in reduce() should not cause exception' do
+  tag
   extend Puppet::Acceptance::EnvironmentUtils
 
   skip_test "This test needs to be reworked to not rely on merge, see PUP-6994"

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -1,4 +1,5 @@
 test_name "Puppet Lookup Command"
+tag
 # doc:
 # https://docs.puppetlabs.com/puppet/latest/reference/lookup_quick_module.html
 

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -1,4 +1,5 @@
 test_name "pluginsync should not error when modulepath is a symlink and no modules have plugin directories"
+tag
 
 step "Create a modulepath directory which is a symlink and includes a module without facts.d or lib directories"
 basedir = master.tmpdir("symlink_modulepath")

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,4 +1,5 @@
 test_name "Pluginsync'ed external facts should be resolvable on the agent"
+tag
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 
 #

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,4 +1,5 @@
 test_name "Pluginsync'ed custom facts should be resolvable during application runs"
+tag
 
 #
 # This test is intended to ensure that custom facts downloaded onto an agent via

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,4 +1,5 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
+tag
 
 #
 # This test is intended to ensure that pluginsync syncs app definitions to the agents.

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -1,4 +1,5 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
+tag
 
 #
 # This test is intended to ensure that pluginsync syncs face definitions to the agents.

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,4 +1,5 @@
 test_name "the pluginsync functionality should sync feature definitions"
+tag
 
 #
 # This test is intended to ensure that pluginsync syncs feature definitions to

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -1,4 +1,5 @@
 test_name "earlier modules take precendence over later modules in the modulepath"
+tag
 
 step "Create some modules in the modulepath"
 basedir = master.tmpdir("module_precedence")

--- a/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
+++ b/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
@@ -1,4 +1,5 @@
 test_name "puppet apply should create a file and report an MD5"
+tag
 
 agents.each do |agent|
   file = agent.tmpfile('hello-world')

--- a/acceptance/tests/puppet_apply_basics.rb
+++ b/acceptance/tests/puppet_apply_basics.rb
@@ -3,6 +3,7 @@
 # Unified into a single file because they are literally one-line tests!
 
 test_name "Trivial puppet tests"
+tag
 
 step "check that puppet apply displays notices"
 agents.each do |host|

--- a/acceptance/tests/puppet_apply_should_show_a_notice.rb
+++ b/acceptance/tests/puppet_apply_should_show_a_notice.rb
@@ -1,4 +1,5 @@
 test_name "puppet apply should show a notice"
+tag
 
 agents.each do |host|
   apply_manifest_on(host, "notice 'Hello World'") do

--- a/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
+++ b/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
@@ -1,4 +1,5 @@
 test_name "puppet master help should mention puppet master"
+tag
 on master, puppet_master('--help') do
     fail_test "puppet master wasn't mentioned" unless stdout.include? 'puppet master'
 end

--- a/acceptance/tests/reports/cached_catalog_status_in_report.rb
+++ b/acceptance/tests/reports/cached_catalog_status_in_report.rb
@@ -1,4 +1,5 @@
 test_name "PUP-5867: The report specifies whether a cached catalog was used, and if so, why" do
+  tag
   master_reportdir = create_tmpdir_for_user(master, 'report_dir')
 
   teardown do

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -4,10 +4,12 @@ test_name "C98092 - a new resource should not be reported as a corrective change
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+  tag 'broken:images'
+
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
-  
+
   agents.each do |agent|
     tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
   end
@@ -15,15 +17,15 @@ extend Puppet::Acceptance::EnvironmentUtils
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''
           on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
-        end 
+        end
       end
     end
   end
 
   step 'create file resource - site.pp to verify corrective change flag' do
-    file_contents     = 'this is a test'   
+    file_contents     = 'this is a test'
     manifest = <<MANIFEST
 file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
   ensure => file,
@@ -32,7 +34,7 @@ file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
 file { \$test_path:
   content => @(UTF8)
     #{file_contents}
-    | UTF8 
+    | UTF8
 }
   ',
 }

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -4,6 +4,8 @@ extend Puppet::Acceptance::EnvironmentUtils
 
 test_name "C98093 - a resource changed outside of Puppet will be reported as a corrective change" do
 
+  tag 'broken:images'
+
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
@@ -15,7 +17,7 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''
           on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
         end
       end
@@ -66,7 +68,7 @@ MANIFEST
         step 'Run agent to correct the files absence' do
           on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
         end
- 
+
         #Verify the file resource is created
         step 'Verify the file resource is created' do
           on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
@@ -98,7 +100,7 @@ MANIFEST
           file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
           assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
           corrective_change_value =  file_resource_details["corrective_change"]
-          assert_equal(true, corrective_change_value, 'corrective_change flag should be true') 
+          assert_equal(true, corrective_change_value, 'corrective_change flag should be true')
         end
       end
     end

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -4,12 +4,14 @@ extend Puppet::Acceptance::EnvironmentUtils
 
 test_name "C98094 - a resource changed via Puppet manifest will not be reported as a corrective change" do
 
+  tag 'broken:images'
+
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
   original_test_data = 'this is my original important data'
   modified_test_data = 'this is my modified important data'
- 
+
   agents.each do |agent|
     tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
   end

--- a/acceptance/tests/reports/failover_master.rb
+++ b/acceptance/tests/reports/failover_master.rb
@@ -1,4 +1,5 @@
 test_name "The report specifies which master was contacted during failover" do
+  tag
   master_reportdir = create_tmpdir_for_user(master, 'report_dir')
   master_port = 8140
 

--- a/acceptance/tests/reports/finalized_on_cycle.rb
+++ b/acceptance/tests/reports/finalized_on_cycle.rb
@@ -1,4 +1,5 @@
 test_name "Reports are finalized on resource cycles"
+tag
 # PUP-4548: Skip Windows until PUP-4547 can be resolved.
 confine :except, :platform => 'windows'
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -1,4 +1,5 @@
 test_name "Report submission"
+tag
 
 if master.is_pe?
   require "time"

--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -1,4 +1,5 @@
 test_name "Cron: should allow changing parameters after creation"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -1,4 +1,5 @@
 test_name "Cron: check idempotency"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -1,4 +1,5 @@
 test_name "should create cron"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -1,4 +1,5 @@
 test_name "puppet should match existing job"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -1,4 +1,5 @@
 test_name "puppet should remove a crontab entry as expected"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 

--- a/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
@@ -1,4 +1,5 @@
 test_name "(#656) leading and trailing whitespace in cron entries should should be stripped"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -1,4 +1,5 @@
 test_name "puppet should remove a crontab entry based on command matching"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -1,4 +1,5 @@
 test_name "puppet should update existing crontab entry"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
 

--- a/acceptance/tests/resource/exec/accept_multi-line_commands.rb
+++ b/acceptance/tests/resource/exec/accept_multi-line_commands.rb
@@ -1,4 +1,5 @@
 test_name "Be able to execute multi-line commands (#9996)"
+tag
 confine :except, :platform => 'windows'
 
 agents.each do |agent|

--- a/acceptance/tests/resource/exec/should_not_run_command_creates.rb
+++ b/acceptance/tests/resource/exec/should_not_run_command_creates.rb
@@ -1,4 +1,5 @@
 test_name "should not run command creates"
+tag
 
 agents.each do |agent|
   touch      = agent.tmpfile('touched')

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -1,4 +1,5 @@
 test_name "tests that puppet correctly runs an exec."
+tag
 # original author: Dan Bode  --daniel 2010-12-23
 
 def before(agent)
@@ -29,5 +30,3 @@ agents.each do |agent|
   end
   after(agent, touched)
 end
-
-

--- a/acceptance/tests/resource/exec/should_set_path.rb
+++ b/acceptance/tests/resource/exec/should_set_path.rb
@@ -1,4 +1,5 @@
 test_name "the path statement should work to locate commands"
+tag
 
 agents.each do |agent|
   file = agent.tmpfile('touched-should-set-path')

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -1,4 +1,5 @@
 test_name "Content Attribute"
+tag
 
 agents.each do |agent|
   target = agent.tmpfile('content_file_test')

--- a/acceptance/tests/resource/file/should_create_directory.rb
+++ b/acceptance/tests/resource/file/should_create_directory.rb
@@ -1,4 +1,5 @@
 test_name "should create directory"
+tag
 
 agents.each do |agent|
   target = agent.tmpfile("create-dir")

--- a/acceptance/tests/resource/file/should_create_empty.rb
+++ b/acceptance/tests/resource/file/should_create_empty.rb
@@ -1,4 +1,5 @@
 test_name "should create empty file for 'present'"
+tag
 
 agents.each do |agent|
   target = agent.tmpfile("empty")

--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -1,4 +1,5 @@
 test_name "should create symlink"
+tag
 
 def message
   'hello world'

--- a/acceptance/tests/resource/file/should_default_mode.rb
+++ b/acceptance/tests/resource/file/should_default_mode.rb
@@ -1,4 +1,5 @@
 test_name "file resource: set default modes"
+tag
 
 def regexp_mode(mode)
   Regexp.new("mode\s*=>\s*'0?#{mode}'")
@@ -39,4 +40,3 @@ agents.each do |agent|
 
   on(agent, "rm -rf #{parent}")
 end
-

--- a/acceptance/tests/resource/file/should_remove_dir.rb
+++ b/acceptance/tests/resource/file/should_remove_dir.rb
@@ -1,4 +1,5 @@
 test_name "should remove directory, but force required"
+tag
 
 agents.each do |agent|
   target = agent.tmpdir("delete-dir")

--- a/acceptance/tests/resource/file/should_remove_file.rb
+++ b/acceptance/tests/resource/file/should_remove_file.rb
@@ -1,4 +1,5 @@
 test_name "should remove file"
+tag
 
 agents.each do |agent|
   target = agent.tmpfile('delete-file')

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -1,4 +1,5 @@
 test_name "The source attribute"
+tag
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -1,4 +1,5 @@
 test_name "file resource: symbolic modes"
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^solaris-10/
 confine :except, :platform => /^windows/

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -1,8 +1,11 @@
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+
 test_name 'Ensure a file resource can have a UTF-8 source attribute, content, and path when served via a module' do
+
   skip_test 'requires a master for serving module content' if master.nil?
+  tag 'broken:images'
 
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))
   agent_tmp_dirs = {}
@@ -79,4 +82,3 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
     end
   end
 end
-

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -3,6 +3,7 @@ extend Puppet::Acceptance::EnvironmentUtils
 
 
 test_name 'Ensure a file resource can have a UTF-8 source attribute, content, and path when served via a module' do
+  tag
 
   skip_test 'requires a master for serving module content' if master.nil?
   tag 'broken:images'

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -1,4 +1,5 @@
 test_name "#7680: 'links => follow' should use the file source content"
+tag
 
 agents.each do |agent|
   if agent.platform.variant == 'windows'
@@ -42,5 +43,3 @@ agents.each do |agent|
     on agent, "rm -f '#{file}'"
   end
 end
-
-

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -1,4 +1,5 @@
 test_name "#8740: should not enumerate root directory"
+tag
 confine :except, :platform => 'windows'
 
 target = "/test-socket-#{$$}"

--- a/acceptance/tests/resource/group/should_create.rb
+++ b/acceptance/tests/resource/group/should_create.rb
@@ -1,4 +1,5 @@
 test_name "should create a group"
+tag
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_destroy.rb
+++ b/acceptance/tests/resource/group/should_destroy.rb
@@ -1,4 +1,5 @@
 test_name "should destroy a group"
+tag
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -1,4 +1,5 @@
 test_name "should modify gid of existing group"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/group/should_not_create_existing.rb
+++ b/acceptance/tests/resource/group/should_not_create_existing.rb
@@ -1,4 +1,5 @@
 test_name "group should not create existing group"
+tag
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
 name = "gr#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
+++ b/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
@@ -1,4 +1,5 @@
 test_name "should not destroy a group that doesn't exist"
+tag
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
 name = "test-group-#{Time.new.to_i}"
@@ -13,4 +14,3 @@ on(agents, puppet_resource('group', name, 'ensure=absent')) do
   fail_test "it looks like we tried to remove the group" if
     stdout.include? "/Group[#{name}]/ensure: removed"
 end
-

--- a/acceptance/tests/resource/group/should_query.rb
+++ b/acceptance/tests/resource/group/should_query.rb
@@ -1,4 +1,5 @@
 test_name "test that we can query and find a group that exists."
+tag
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -1,4 +1,5 @@
 test_name "should query all groups"
+tag
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
+++ b/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
@@ -1,4 +1,5 @@
 test_name "should not delete data when existing content is malformed"
+tag
 agents.each do |agent|
   file = agent.tmpfile('host-not-delete-data')
 

--- a/acceptance/tests/resource/host/should_create.rb
+++ b/acceptance/tests/resource/host/should_create.rb
@@ -1,4 +1,5 @@
 test_name "host should create"
+tag
 
 agents.each do |agent|
   target = agent.tmpfile('host-create')

--- a/acceptance/tests/resource/host/should_create_aliases.rb
+++ b/acceptance/tests/resource/host/should_create_aliases.rb
@@ -1,4 +1,5 @@
 test_name "host should create aliases"
+tag
 
 agents.each do |agent|
   target  = agent.tmpfile('host-create-aliases')

--- a/acceptance/tests/resource/host/should_destroy.rb
+++ b/acceptance/tests/resource/host/should_destroy.rb
@@ -1,4 +1,5 @@
 test_name "should be able to remove a host record"
+tag
 
 agents.each do |agent|
   file = agent.tmpfile('host-destroy')

--- a/acceptance/tests/resource/host/should_modify_alias.rb
+++ b/acceptance/tests/resource/host/should_modify_alias.rb
@@ -1,4 +1,5 @@
 test_name "should be able to modify a host alias"
+tag
 
 agents.each do |agent|
   file = agent.tmpfile('host-modify-alias')

--- a/acceptance/tests/resource/host/should_modify_ip.rb
+++ b/acceptance/tests/resource/host/should_modify_ip.rb
@@ -1,4 +1,5 @@
 test_name "should be able to modify a host address"
+tag
 
 agents.each do |agent|
   file = agent.tmpfile('host-modify-ip')

--- a/acceptance/tests/resource/host/should_not_create_existing.rb
+++ b/acceptance/tests/resource/host/should_not_create_existing.rb
@@ -1,4 +1,5 @@
 test_name "should not create host if it exists"
+tag
 
 agents.each do |agent|
   file = agent.tmpfile('host-not-create-existing')

--- a/acceptance/tests/resource/host/should_query_all.rb
+++ b/acceptance/tests/resource/host/should_query_all.rb
@@ -1,4 +1,5 @@
 test_name "should query all hosts from hosts file"
+tag
 
 content = %q{127.0.0.1 test1 test1.local
 127.0.0.2 test2 test2.local

--- a/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
+++ b/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
@@ -1,4 +1,5 @@
 test_name "#4131: should not create host without IP attribute"
+tag
 
 agents.each do |agent|
   file = agent.tmpfile('4131-require-ip')

--- a/acceptance/tests/resource/mailalias/create.rb
+++ b/acceptance/tests/resource/mailalias/create.rb
@@ -1,6 +1,7 @@
 test_name "should create an email alias"
+tag
 
-confine :except, :platform => 'windows' 
+confine :except, :platform => 'windows'
 
 name = "pl#{rand(999999).to_i}"
 agents.each do |agent|
@@ -23,4 +24,4 @@ agents.each do |agent|
   on(agent, "cat /etc/aliases")  do |res|
     assert_match(/#{name}:.*foo,bar,baz/, res.stdout, "mailalias not in aliases file")
   end
-end  
+end

--- a/acceptance/tests/resource/mailalias/destroy.rb
+++ b/acceptance/tests/resource/mailalias/destroy.rb
@@ -1,4 +1,5 @@
 test_name "should delete an email alias"
+tag
 
 confine :except, :platform => 'windows'
 
@@ -32,4 +33,4 @@ agents.each do |agent|
   on(agent, "cat /etc/aliases")  do |res|
     assert_no_match(/#{name}:.*foo,bar,baz/, res.stdout, "mailalias was not removed from aliases file")
   end
-end  
+end

--- a/acceptance/tests/resource/mailalias/modify.rb
+++ b/acceptance/tests/resource/mailalias/modify.rb
@@ -1,4 +1,5 @@
 test_name "should modify an email alias"
+tag
 
 confine :except, :platform => 'windows'
 

--- a/acceptance/tests/resource/mailalias/query.rb
+++ b/acceptance/tests/resource/mailalias/query.rb
@@ -1,4 +1,5 @@
 test_name "should be able to find an exisitng email alias"
+tag
 
 confine :except, :platform => 'windows'
 

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -1,4 +1,5 @@
 test_name "defined should create an entry in filesystem table"
+tag
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -1,4 +1,5 @@
 test_name "should delete an entry in filesystem table and unmount it"
+tag
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -1,4 +1,5 @@
 test_name "should modify an entry in filesystem table"
+tag
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -1,4 +1,5 @@
 test_name "mounted should create an entry in filesystem table and mount it"
+tag
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -1,4 +1,5 @@
 test_name "should be able to find an existing filesystem table entry"
+tag
 
 confine :except, :platform => ['windows']
 confine :except, :platform => /osx/ # See PUP-4823

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -1,4 +1,5 @@
 test_name "ticket 1073: common package name in two different providers should be allowed"
+tag
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
 confine :except, :platform => /centos-4|el-4/ # PUP-5227
@@ -132,4 +133,3 @@ apply_manifest_on(agents, remove_manifest) do |result|
 end
 
 verify_absent agents, 'guid'
-

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -1,5 +1,6 @@
 # Redmine (#22529)
 test_name "Puppet returns only resource package declaration when querying an uninstalled package" do
+  tag
 
   resource_declaration_regex = %r@package \{ 'not-installed-on-this-host':
   ensure => '(?:purged|absent)',

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS basic tests"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_holdable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_holdable.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS versionable"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_idempotent.rb
+++ b/acceptance/tests/resource/package/ips/should_be_idempotent.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS idempotency"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_updatable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updatable.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS test for updatable (update, latest)"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_versionable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_versionable.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS versionable"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS basic tests"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_query.rb
+++ b/acceptance/tests/resource/package/ips/should_query.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS query"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_remove.rb
+++ b/acceptance/tests/resource/package/ips/should_remove.rb
@@ -1,4 +1,5 @@
 test_name "Package:IPS basic tests"
+tag
 confine :to, :platform => 'solaris-11'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -1,4 +1,5 @@
 test_name "test the yum package provider"
+tag
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
 confine :except, :platform => /centos-4|el-4/ # PUP-5227

--- a/acceptance/tests/resource/scheduled_task/should_create.rb
+++ b/acceptance/tests/resource/scheduled_task/should_create.rb
@@ -1,4 +1,5 @@
 test_name "should create a scheduled task"
+tag
 
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'

--- a/acceptance/tests/resource/scheduled_task/should_destroy.rb
+++ b/acceptance/tests/resource/scheduled_task/should_destroy.rb
@@ -1,4 +1,5 @@
 test_name "should delete a scheduled task"
+tag
 
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'

--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -1,4 +1,5 @@
 require 'rexml/document'
+tag
 
 test_name "should modify a scheduled task"
 

--- a/acceptance/tests/resource/scheduled_task/should_query.rb
+++ b/acceptance/tests/resource/scheduled_task/should_query.rb
@@ -1,4 +1,5 @@
 test_name "test that we can query and find a scheduled task that exists."
+tag
 
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -1,4 +1,5 @@
 test_name 'AIX Service Provider Testing'
+tag
 
 confine :to, :platform =>  'aix'
 
@@ -68,7 +69,7 @@ agents.each do |agent|
     PP
     apply_manifest_on(agent, manifest, :catch_changes => true)
   end
-  
+
   step "Verify starting a non-existent service prints an error message but does not fail the run without detailed exit codes" do
     manifest = <<-PP
       service { 'sloth_daemon' : ensure => running }

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -1,4 +1,5 @@
 test_name 'SysV on default Systemd Service Provider Validation' do
+  tag
 
   confine :to, :platform => /el-|centos|fedora/ do |h|
     on h, 'which systemctl', :acceptable_exit_codes => [0, 1]

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -1,4 +1,5 @@
 test_name 'Mac OS X launchd Provider Testing'
+tag
 
 confine :to, {:platform => /osx/}, agents
 

--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -1,4 +1,5 @@
 test_name "Puppet and Mcollective services should be manageable with Puppet"
+tag
 
 confine :except, :platform => 'windows' # See MCO-727
 confine :except, :platform => /centos-4|el-4/ # PUP-5257

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -1,4 +1,5 @@
 test_name 'SysV and Systemd Service Provider Validation'
+tag
 
 
 confine :to, :platform => /el-|centos|fedora|debian|sles|ubuntu-v/

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -1,4 +1,5 @@
 test_name "`puppet resource service` should list running services without calling dangerous init scripts"
+tag
 
 confine :except, :platform => 'windows'
 confine :except, :platform => 'solaris'

--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -1,4 +1,5 @@
 test_name "should query all services"
+tag
 
 agents.each do |agent|
   step "query with puppet"

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -1,4 +1,5 @@
 test_name "SMF: basic tests"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -1,4 +1,5 @@
 test_name 'Upstart Testing'
+tag
 
 # only run these on ubuntu vms
 confine :to, :platform => 'ubuntu'

--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -1,4 +1,5 @@
 test_name "#4123: should list all running services on Redhat/CentOS"
+tag
 confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
 
 step "Validate services running agreement ralsh vs. OS service count"

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -1,4 +1,5 @@
 test_name "#4124: should list all disabled services on Redhat/CentOS"
+tag
 confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
 
 step "Validate disabled services agreement ralsh vs. OS service count"

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -2,6 +2,7 @@ require 'puppet/acceptance/service_utils'
 extend Puppet::Acceptance::ServiceUtils
 
 test_name 'Systemd masked services are unmasked before attempting to start'
+tag
 
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'
 

--- a/acceptance/tests/resource/ssh_authorized_key/create.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/create.rb
@@ -1,4 +1,5 @@
 test_name "should create an entry for an SSH authorized key"
+tag
 
 confine :except, :platform => ['windows']
 

--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -1,4 +1,5 @@
 test_name "should delete an entry for an SSH authorized key"
+tag
 
 confine :except, :platform => ['windows']
 

--- a/acceptance/tests/resource/ssh_authorized_key/modify.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/modify.rb
@@ -1,4 +1,5 @@
 test_name "should update an entry for an SSH authorized key"
+tag
 
 confine :except, :platform => ['windows']
 

--- a/acceptance/tests/resource/ssh_authorized_key/query.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/query.rb
@@ -1,4 +1,5 @@
 test_name "should be able to find an existing SSH authorized key"
+tag
 
 skip_test("This test is blocked by PUP-1605")
 

--- a/acceptance/tests/resource/sshkey/create.rb
+++ b/acceptance/tests/resource/sshkey/create.rb
@@ -1,4 +1,5 @@
 test_name "(PUP-5508) Should add an SSH key to the correct ssh_known_hosts file on OS X/macOS" do
+  tag
 # TestRail test case C93370
 
 confine :to, :platform => /osx/
@@ -44,7 +45,7 @@ step 'Verify that the default file is empty or non-existent' do
   # Is it even there?
   rc = on(agent, "[ ! -e #{ssh_known_hosts} ]",
           :acceptable_exit_codes => [0, 1])
-  if rc.exit_code == 1 
+  if rc.exit_code == 1
     # If it's there, it should be empty
     on(agent, "cat #{ssh_known_hosts}") do |res|
       fail_test "Default #{ssh_known_hosts} file not empty" \

--- a/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
+++ b/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
@@ -1,6 +1,7 @@
 # This test is to verify multi tidy resources with same path but
 # different matches should not cause error as found in the bug PUP-6508
 test_name "PUP-6655 - C98145 tidy resources should be non-isomorphic" do
+  tag
   agents. each do |agent|
     dir = agent.tmpdir('tidy-test-dir')
     on(agent, "mkdir -p #{dir}")

--- a/acceptance/tests/resource/tidy/should_remove_old_files.rb
+++ b/acceptance/tests/resource/tidy/should_remove_old_files.rb
@@ -1,4 +1,5 @@
 test_name "Tidying files by date"
+tag
 
 agents.each do |agent|
   step "Create a directory of old and new files"

--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -1,4 +1,5 @@
 test_name "should allow password, salt, and iteration attributes in OSX"
+tag
 
 confine :to, :platform => /osx/
 

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -1,4 +1,5 @@
 test_name "should create a user"
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -1,4 +1,5 @@
 test_name "verifies that puppet resource creates a user and assigns the correct group"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828

--- a/acceptance/tests/resource/user/should_destroy.rb
+++ b/acceptance/tests/resource/user/should_destroy.rb
@@ -1,4 +1,5 @@
 test_name "should delete a user"
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -1,4 +1,5 @@
 test_name "should manage user shell"
+tag
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_modify.rb
+++ b/acceptance/tests/resource/user/should_modify.rb
@@ -1,4 +1,5 @@
 test_name "should modify a user"
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -1,4 +1,5 @@
 test_name "verify that we can modify the gid"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /aix/ # PUP-5358
 confine :except, :platform => /^eos-/ # See ARISTA-37

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -1,4 +1,5 @@
 test_name "should modify a user when no longer managing home (#20726)"
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -1,4 +1,5 @@
 test_name "should modify a user without changing home directory (pending #19542)"
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -1,4 +1,5 @@
 test_name "tests that user resource will not add users that already exist."
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_not_destoy_unexisting.rb
+++ b/acceptance/tests/resource/user/should_not_destoy_unexisting.rb
@@ -1,4 +1,5 @@
 test_name "ensure that puppet does not report removing a user that does not exist"
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_not_modify_disabled.rb
+++ b/acceptance/tests/resource/user/should_not_modify_disabled.rb
@@ -1,4 +1,5 @@
 test_name 'PUP-6586 Ensure puppet does not continually reset password for disabled user' do
+  tag
 
   confine :to, :platform => 'windows'
 
@@ -33,5 +34,3 @@ MANIFEST
     end
   end
 end
-
-

--- a/acceptance/tests/resource/user/should_query.rb
+++ b/acceptance/tests/resource/user/should_query.rb
@@ -1,4 +1,5 @@
 test_name "test that we can query and find a user that exists."
+tag
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -1,4 +1,5 @@
 test_name "should query all users"
+tag
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
 agents.each do |agent|

--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -8,6 +8,7 @@
 # - modify an existing ASCII comment to a UTF-8 one
 # Where applicable, we should be able to do this in different locales
 test_name 'PUP-6777 Manage users with UTF-8 comments' do
+  tag
 
   # PUP-7049 / ARISTA-42 - user provider bug on Arista
   confine :except, :platform => /^eos-/

--- a/acceptance/tests/resource/zfs/basic_tests.rb
+++ b/acceptance/tests/resource/zfs/basic_tests.rb
@@ -1,4 +1,5 @@
 test_name "ZFS: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zfs/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zfs/should_be_idempotent.rb
@@ -1,4 +1,5 @@
 test_name "ZFS: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zfs/should_create.rb
+++ b/acceptance/tests/resource/zfs/should_create.rb
@@ -1,4 +1,5 @@
 test_name "ZFS: should create"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zfs/should_query.rb
+++ b/acceptance/tests/resource/zfs/should_query.rb
@@ -1,4 +1,5 @@
 test_name "ZFS: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zfs/should_remove.rb
+++ b/acceptance/tests/resource/zfs/should_remove.rb
@@ -1,4 +1,5 @@
 test_name "ZFS: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zone/dataset.rb
+++ b/acceptance/tests/resource/zone/dataset.rb
@@ -1,4 +1,5 @@
 test_name "Zone: dataset configuration"
+tag
 
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/set_ip.rb
+++ b/acceptance/tests/resource/zone/set_ip.rb
@@ -1,4 +1,5 @@
 test_name "Zone:IP ip-type and ip configuration"
+tag
 confine :to, :platform => 'solaris'
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils

--- a/acceptance/tests/resource/zone/set_path.rb
+++ b/acceptance/tests/resource/zone/set_path.rb
@@ -1,4 +1,5 @@
 test_name "Zone:Path configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'
@@ -46,4 +47,3 @@ agents.each do |agent|
     assert_match(/set zonepath=.tstzones.mnt/, result.stdout, "err: #{agent}")
   end
 end
-

--- a/acceptance/tests/resource/zone/should_be_created_and_removed.rb
+++ b/acceptance/tests/resource/zone/should_be_created_and_removed.rb
@@ -1,4 +1,5 @@
 test_name "Zone: should be created and removed"
+tag
 
 confine :to, :platform => 'solaris'
 
@@ -16,7 +17,7 @@ config_inherit_string = ""
 agents.each do |agent|
   #inherit /sbin on solaris10 until PUP-3722
   config_inherit_string = "inherit=>'/sbin'" if agent['platform'] =~ /solaris-10/
-  
+
   step "Zone: setup"
   setup agent
   #-----------------------------------

--- a/acceptance/tests/resource/zone/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zone/should_be_idempotent.rb
@@ -1,4 +1,5 @@
 test_name "Zone: should be idempotent"
+tag
 
 confine :to, :platform => 'solaris'
 

--- a/acceptance/tests/resource/zone/statemachine.rb
+++ b/acceptance/tests/resource/zone/statemachine.rb
@@ -1,4 +1,5 @@
 test_name "Zone:Statemachine configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zone/stepstates.rb
+++ b/acceptance/tests/resource/zone/stepstates.rb
@@ -1,4 +1,5 @@
 test_name "Zone:statemachine single states"
+tag
 confine :to, :platform => 'solaris'
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils

--- a/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
+++ b/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
@@ -1,4 +1,5 @@
 test_name "Zone: ticket #4840 - verify that the given manifest works."
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -1,4 +1,5 @@
 test_name "ZPool: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zpool/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zpool/should_be_idempotent.rb
@@ -1,4 +1,5 @@
 test_name "ZPool: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zpool/should_create.rb
+++ b/acceptance/tests/resource/zpool/should_create.rb
@@ -1,4 +1,5 @@
 test_name "ZPool: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -1,4 +1,5 @@
 test_name "ZPool: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/zpool/should_remove.rb
+++ b/acceptance/tests/resource/zpool/should_remove.rb
@@ -1,4 +1,5 @@
 test_name "ZPool: configuration"
+tag
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/security/cve-2013-1640_facter_string.rb
+++ b/acceptance/tests/security/cve-2013-1640_facter_string.rb
@@ -2,6 +2,7 @@
 # template compilation on the master allowing remote code execution by
 # any authenticated client.
 test_name "CVE 2013-1640 Remote Code Execution" do
+  tag
   confine :except, :platform => 'windows'
   confine :except, :platform => 'cisco_nexus' # See BKR-749
 

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -1,6 +1,7 @@
 require 'json'
 
 test_name "CVE 2013-1652 Improper query parameter validation" do
+  tag
   confine :except, :platform => 'windows'
   confine :except, :platform => /osx/ # see PUP-4820
   confine :except, :platform => /aix/

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -1,4 +1,5 @@
 test_name "CVE 2013-1652 Poison node cache" do
+  tag
 
   step "Determine suitability of the test" do
     skip_test( "This test will only run on Puppet 3.x" ) if

--- a/acceptance/tests/security/cve-2013-2275_report_acl.rb
+++ b/acceptance/tests/security/cve-2013-2275_report_acl.rb
@@ -1,4 +1,5 @@
 test_name "(#19531) report save access control"
+tag
 step "Verify puppet only allows saving reports from the node matching the certificate"
 
 fake_report = <<-EOYAML

--- a/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
+++ b/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
@@ -1,4 +1,5 @@
 test_name "CVE 2013-4761 Injection of bad class names causing code loading" do
+  tag
   confine :except, :platform => 'windows'
 
   testdir = create_tmpdir_for_user master, 'class-names-injection'

--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -1,4 +1,5 @@
 test_name "Priority of server_list setting over server setting" do
+  tag
   master_port = 8140
 
   step "Conflict warnings for server settings"

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -6,6 +6,7 @@ extend Puppet::Acceptance::ClassifierUtils
 disable_pe_enterprise_mcollective_agent_classes
 
 test_name "autosign command and csr attributes behavior (#7243,#7244)" do
+  tag
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
   def assert_key_generated(name)

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -10,6 +10,7 @@ disable_pe_enterprise_mcollective_agent_classes
 initialize_temp_dirs
 
 test_name "certificate extensions available as trusted data" do
+  tag
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
   agent_certnames = []

--- a/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
+++ b/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
@@ -2,6 +2,7 @@ require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CAUtils
 
 test_name "Puppet cert generate behavior (#6112)" do
+  tag
 
   # This acceptance test documents the behavior of `puppet cert generate` calls
   # for three cases:

--- a/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
+++ b/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
@@ -1,4 +1,5 @@
 test_name "PUP-5274: CA and host private keys should not be world readable"
+tag
 require 'puppet/acceptance/common_utils'
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
+++ b/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
@@ -1,4 +1,5 @@
 test_name "#4655: Allow setting the default stage for parameterized classes"
+tag
 
 agents.each do |agent|
   temp_file_name = agent.tmpfile('4655-stage-in-parameterized-class')

--- a/acceptance/tests/ticket_12572_no_last_run_summary_diff.rb
+++ b/acceptance/tests/ticket_12572_no_last_run_summary_diff.rb
@@ -1,4 +1,5 @@
 test_name "#12572: Don't print a diff for last_run_summary when show_diff is on"
+tag
 
 agents.each do |host|
   # Have to run apply twice in order to make sure a diff would be relevant

--- a/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
+++ b/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
@@ -1,4 +1,5 @@
 test_name 'C99977 corrupted clientbucket' do
+  tag
   agents.each do |agent|
     tmpfile = agent.tmpfile('c99977file')
     unmanaged_content = "unmanaged\n"

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -1,4 +1,5 @@
 test_name "the $libdir setting hook is called on startup"
+tag
 
 require 'puppet/acceptance/temp_file_utils'
 

--- a/acceptance/tests/ticket_15560_managehome.rb
+++ b/acceptance/tests/ticket_15560_managehome.rb
@@ -1,4 +1,5 @@
 test_name "#15560: Manage home directories"
+tag
 
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
+++ b/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
@@ -1,4 +1,5 @@
 test_name "puppet command with an unknown external command prints help"
+tag
 
 on(agents, puppet('unknown'), :acceptable_exit_codes => [1]) do
   assert_match(/See 'puppet help' for help on available puppet subcommands/, stdout)

--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -1,4 +1,5 @@
 test_name "(PUP-2455) Service provider should start Solaris init service in its own SMF contract"
+tag
 
 skip_test unless agents.any? {|agent| agent['platform'] =~ /solaris/ }
 

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -1,4 +1,5 @@
 test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
+tag
 
 agent_hostnames = agents.map {|a| a.to_s}
 

--- a/acceptance/tests/ticket_3656_requiring_multiple_resources.rb
+++ b/acceptance/tests/ticket_3656_requiring_multiple_resources.rb
@@ -1,4 +1,5 @@
 test_name "#3656: requiring multiple resources"
+tag
 apply_manifest_on agents, %q{
     notify { 'foo': }
     notify { 'bar': }

--- a/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
+++ b/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
@@ -1,4 +1,5 @@
 test_name "#3961: puppet ca should produce certs spec"
+tag
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/
 

--- a/acceptance/tests/ticket_4059_ralsh_can_change_settings.rb
+++ b/acceptance/tests/ticket_4059_ralsh_can_change_settings.rb
@@ -1,4 +1,5 @@
 test_name "#4059: ralsh can change settings"
+tag
 
 agents.each do |agent|
   target = agent.tmpfile('hosts-#4059')

--- a/acceptance/tests/ticket_4233_resource_with_a_newline.rb
+++ b/acceptance/tests/ticket_4233_resource_with_a_newline.rb
@@ -1,4 +1,5 @@
 test_name "#4233: resource with a newline"
+tag
 
 # 2010-07-22 Jeff McCune <jeff@puppetlabs.com>
 # AffectedVersion: 2.6.0rc3

--- a/acceptance/tests/ticket_4285_file_resource_fail_when_name_defined_instead_of_path.rb
+++ b/acceptance/tests/ticket_4285_file_resource_fail_when_name_defined_instead_of_path.rb
@@ -1,4 +1,5 @@
 test_name "Bug #4285: ArgumentError: Cannot alias File[mytitle] to [nil]"
+tag
 
 agents.each do |host|
   dir = host.tmpdir('4285-aliasing')

--- a/acceptance/tests/ticket_4289_facter_should_recognize_OEL_operatingsystemrelease.rb
+++ b/acceptance/tests/ticket_4289_facter_should_recognize_OEL_operatingsystemrelease.rb
@@ -6,6 +6,7 @@
 # test script only applicable to OEL, provided based on ticked info, not verified.
 
 test_name "#4289: facter should recognize OEL operatingsystemrelease"
+tag
 
 # REVISIT: We don't actually have support for this yet - we need a "not
 # applicable" option, I guess, that can be based on detected stuff, which is

--- a/acceptance/tests/ticket_4423_cannot_declare_two_parameterized_classes.rb
+++ b/acceptance/tests/ticket_4423_cannot_declare_two_parameterized_classes.rb
@@ -7,6 +7,7 @@
 # Make sure two parameterized classes are able to be declared.
 
 test_name "#4423: cannot declare two parameterized classes"
+tag
 
 class1 = %q{
     class rainbow($color) {

--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -1,4 +1,5 @@
 test_name "ticket 4622 filebucket diff test."
+tag
 confine :except, :platform => 'windows'
 skip_test 'skip test, no non-Windows agents specified' if agents.empty?
 

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -4,6 +4,7 @@
 # puppetmaster does not detect when site.pp is created. This requires a restart
 #
 test_name "Ticket 5477, Puppet Master does not detect newly created site.pp file"
+tag
 
 testdir = master.tmpdir('missing_site_pp')
 manifest_file = "#{testdir}/environments/production/manifests/site.pp"

--- a/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
+++ b/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
@@ -1,4 +1,5 @@
 test_name 'Ensure hiera lookup occurs if class param is undef' do
+  tag
 
   agents.each do |agent|
 

--- a/acceptance/tests/ticket_6418_file_recursion_and_audit.rb
+++ b/acceptance/tests/ticket_6418_file_recursion_and_audit.rb
@@ -4,6 +4,7 @@
 # FixedVersion:
 
 test_name "#6418: file recursion and audit"
+tag
 
 agents.each do |agent|
   dir = agent.tmpdir('6418-recurse-audit')

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -1,4 +1,5 @@
 test_name "#6541: file type truncates target when filebucket cannot retrieve hash"
+tag
 
 agents.each do |agent|
   target=agent.tmpfile('6541-target')

--- a/acceptance/tests/ticket_6710_relationship_syntax_should_work_with_title_arrays.rb
+++ b/acceptance/tests/ticket_6710_relationship_syntax_should_work_with_title_arrays.rb
@@ -1,4 +1,5 @@
 test_name "#6710: Relationship syntax should work with title arrays"
+tag
 
 # Jeff McCune <jeff@puppetlabs.com>
 # 2011-03-14
@@ -12,4 +13,3 @@ apply_manifest_on agents, %q{
   notify { left: } -> notify { right: }
   notify { left_one_to_many: } -> notify { [ right_one_to_many_1, right_one_to_many_2 ]: }
 }
-

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,4 +1,5 @@
 test_name "#6857: redact password hashes when applying in noop mode"
+tag
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils

--- a/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
+++ b/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
@@ -1,4 +1,5 @@
 test_name "providers should be useable in the same run they become suitable"
+tag
 
 agents.each do |agent|
   dir = agent.tmpdir('provider-6907')

--- a/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
+++ b/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
@@ -1,4 +1,5 @@
 test_name "#6928: Puppet --parseonly should return deprication message"
+tag
 
 # Create good and bad formatted manifests
 step "Master: create valid, invalid formatted manifests"

--- a/acceptance/tests/ticket_7101_template_compile.rb
+++ b/acceptance/tests/ticket_7101_template_compile.rb
@@ -1,4 +1,5 @@
 test_name "#7101: template compile"
+tag
 
 agents.each do |agent|
   template = agent.tmpfile('template_7101.erb')

--- a/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rb
+++ b/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rb
@@ -1,4 +1,5 @@
 test_name "#7139: Puppet resource file fails on path with leading '/'"
+tag
 
 agents.each do |agent|
   target = agent.tmpfile('ticket-7139')

--- a/acceptance/tests/ticket_7165_no_refresh_after_starting_service.rb
+++ b/acceptance/tests/ticket_7165_no_refresh_after_starting_service.rb
@@ -1,4 +1,5 @@
 test_name "Bug #7165: Don't refresh service immediately after starting it"
+tag
 
 confine :except, :platform => 'windows'
 

--- a/acceptance/tests/ticket_7728_don't_log_whits_on_failure.rb
+++ b/acceptance/tests/ticket_7728_don't_log_whits_on_failure.rb
@@ -1,4 +1,5 @@
 test_name "#7728: Don't log whits on resource failure"
+tag
 
 manifest = %Q{
   class foo {

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -1,4 +1,5 @@
 test_name "#9862: puppet runs without service user or group present"
+tag
 
 # puppet doesn't try to manage ownership on windows.
 confine :except, :platform => 'windows'

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -1,4 +1,5 @@
 test_name 'utf-8 characters in cached catalog' do
+  tag
   confine :except, :platform => [
     'windows',      # PUP-6983
     'cumulus',      # PUP-7147
@@ -17,7 +18,7 @@ test_name 'utf-8 characters in cached catalog' do
   agents.each do |agent|
     puts "agent name: #{agent.hostname}, platform: #{agent.platform}"
     agent_vardir = agent.tmpdir("agent_vardir")
-    agent_file = agent.tmpfile("file" + utf8chars) 
+    agent_file = agent.tmpfile("file" + utf8chars)
     teardown do
       on(agent, "rm -rf #{agent_vardir} #{agent_file}")
     end
@@ -27,10 +28,10 @@ test_name 'utf-8 characters in cached catalog' do
         "rm -rf #{agent_file}",
         :environment => {:LANG => "en_US.UTF-8"}
       )
-    
+
       master_manifest =
 <<PP
-    
+
 File {
   ensure => directory,
   mode => "0755",
@@ -57,7 +58,7 @@ file { "#{agent_file}" :
 }
 
 PP
-        
+
       apply_manifest_on(
         master,
         master_manifest,
@@ -77,8 +78,8 @@ PP
         'use_cached_catalog' => 'true'
       }
     }
-    
-    with_puppet_running_on(master, master_opts, codedir) do 
+
+    with_puppet_running_on(master, master_opts, codedir) do
       step "apply utf-8 catalog" do
         on(
           agent,
@@ -91,7 +92,7 @@ PP
           }
         )
       end
-    
+
       step "verify cached catalog" do
         catalog_file_name =
           "#{agent_vardir}/client_data/catalog/#{agent.node_name}.json"
@@ -113,7 +114,7 @@ PP
           )
         end
       end
-  
+
       step "apply cached catalog" do
         on(
           agent,
@@ -139,5 +140,4 @@ PP
       end
     end
   end
-end 
- 
+end

--- a/acceptance/tests/utf8/utf8-in-file-resource.rb
+++ b/acceptance/tests/utf8/utf8-in-file-resource.rb
@@ -1,4 +1,5 @@
 test_name 'utf-8 characters in resource title and param values' do
+  tag
 
   confine :except, :platform => [
     'windows',    # PUP-6983
@@ -7,13 +8,13 @@ test_name 'utf-8 characters in resource title and param values' do
     'cisco_ios',  # PUP-7150
     'aix',        # PUP-7194
     'huawei',     # PUP-7195
-  ]   
+  ]
 
   # utf8chars = "€‰ㄘ万竹ÜÖ"
   utf8chars = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
   agents.each do |agent|
     puts "agent name: #{agent.node_name}, platform: #{agent.platform}"
-    agent_file = agent.tmpfile("file" + utf8chars) 
+    agent_file = agent.tmpfile("file" + utf8chars)
     teardown do
       on(agent, "rm -rf #{agent_file}")
     end
@@ -27,7 +28,7 @@ test_name 'utf-8 characters in resource title and param values' do
 file { "#{agent_file}" :
   ensure => file,
   mode => "0644",
-  content => "This is the file content. file #{utf8chars} 
+  content => "This is the file content. file #{utf8chars}
 ",
 }
 
@@ -39,7 +40,7 @@ PP
         manifest,
         {
           :acceptable_exit_codes => [2],
-          :catch_failures => true, 
+          :catch_failures => true,
           :environment => {:LANG => "en_US.UTF-8"}
         }
       )
@@ -65,7 +66,7 @@ PP
         manifest,
         {
           :acceptable_exit_codes => [2],
-          :catch_failures => true, 
+          :catch_failures => true,
           :environment => {:LANG => "en_US.UTF-8"}
         }
       )
@@ -83,4 +84,3 @@ PP
     end
   end
 end
-

--- a/acceptance/tests/utf8/utf8-in-function-args.rb
+++ b/acceptance/tests/utf8/utf8-in-function-args.rb
@@ -1,4 +1,5 @@
 test_name 'utf-8 characters in function parameters' do
+  tag
   confine :except, :platform => [
     'windows',      # PUP-6983
     'eos-4',        # PUP-7146

--- a/acceptance/tests/utf8/utf8-in-puppet-describe.rb
+++ b/acceptance/tests/utf8/utf8-in-puppet-describe.rb
@@ -1,8 +1,9 @@
 test_name 'utf-8 characters in module doc string, puppet describe' do
+  tag
   platforms = hosts.map {|val| val[:platform]}
   if (platforms.any? { |val| /^eos-/ =~ val})
     skip_test "Skipping because Puppet describe fails when the Arista module is installed (ARISTA-51)"
-  end 
+  end
 
   # utf8chars = "€‰ㄘ万竹ÜÖ"
   utf8chars = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
@@ -12,7 +13,7 @@ test_name 'utf-8 characters in module doc string, puppet describe' do
   teardown do
     on(master, "rm -rf #{master_mod_dir}")
   end
-  master_manifest = 
+  master_manifest =
 <<MASTER_MANIFEST
 
 File {
@@ -62,14 +63,14 @@ MASTER_MANIFEST
   with_puppet_running_on(master, master_opts, master_mod_dir) do
     agents.each do |agent|
       puts "agent name: #{agent.hostname}, platform: #{agent.platform}"
-      step "Run puppet agent for plugin sync" do 
+      step "Run puppet agent for plugin sync" do
         on(
           agent, puppet("agent", "-t", "--server #{master.node_name}"),
           :acceptable_exit_codes => [0, 2]
         )
       end
 
-      step "Puppet describe for master-hosted mytype" do 
+      step "Puppet describe for master-hosted mytype" do
         on(agent, puppet("describe", "master_mytype")) do |result|
           assert_match(
             /master_mytype.*such as #{utf8chars}/m,

--- a/acceptance/tests/windows/env_windows_installdir_fact.rb
+++ b/acceptance/tests/windows/env_windows_installdir_fact.rb
@@ -2,6 +2,7 @@
 # fact via environment.bat on Windows systems. Test to ensure it is both
 # present and accurate.
 test_name 'PA-466: Ensure env_windows_installdir fact is present and correct' do
+  tag
 
   confine :to, :platform => 'windows'
 

--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -1,4 +1,5 @@
 test_name "Write to Windows eventlog"
+tag
 
 confine :to, :platform => 'windows'
 


### PR DESCRIPTION
These tests break the Image Acceptance Test suite, so are being tagged
so that they can be excluded pending further investigation as part of
ticket PUP-7521

This was labelelled IMAGES-555 but Travis is unable to accept this as PR
prefix.