### PR TITLE
(maint) Stub gettext methods when locale files can't be found

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -27,13 +27,45 @@ require 'puppet/external/pson/pure'
 begin
   require 'gettext-setup'
   require 'locale'
+
+  # e.g. ~/code/puppet/locales. Also when running as a gem.
+  local_locale_path = File.absolute_path('../locales', File.dirname(__FILE__))
+  # e.g. /opt/puppetlabs/puppet/share/locale
+  posix_system_locale_path = File.absolute_path('../../../share/locale', File.dirname(__FILE__))
+  # e.g. C:\Program Files\Puppet Labs\Puppet\puppet\share\locale
+  win32_system_locale_path = File.absolute_path('../../../../../puppet/share/locale', File.dirname(__FILE__))
+
+  if File.exist?(local_locale_path)
+    locale_path = local_locale_path
+  elsif File.exist?(win32_system_locale_path)
+    locale_path = win32_system_locale_path
+  elsif File.exist?(posix_system_locale_path)
+    locale_path = posix_system_locale_path
+  else
+    # We couldn't load our locale data.
+    raise LoadError, "could not find locale data, skipping Gettext initialization"
+  end
+
+  Puppet::LOCALE_PATH = locale_path
   Puppet::GETTEXT_AVAILABLE = true
 rescue LoadError
   def _(msg)
     msg
   end
+
+  def n_(*args, &block)
+    # assume two string args (singular and plural English form) and the count
+    # to pluralize on
+    plural = args[2] == 1 ? args[0] : args[1]
+    # if a block is passed, prefer that over the string selection above
+    block ? block.call : plural
+  end
+
+  Puppet::LOCALE_PATH = nil
   Puppet::GETTEXT_AVAILABLE = false
 end
+
+
 
 #------------------------------------------------------------
 # the top-level module
@@ -53,34 +85,14 @@ module Puppet
   require 'puppet/environments'
 
   class << self
-    if Puppet::GETTEXT_AVAILABLE
-      # e.g. ~/code/puppet/locales. Also when running as a gem.
-      local_locale_path = File.absolute_path('../locales', File.dirname(__FILE__))
-      # e.g. /opt/puppetlabs/puppet/share/locale
-      posix_system_locale_path = File.absolute_path('../../../share/locale', File.dirname(__FILE__))
-      # e.g. C:\Program Files\Puppet Labs\Puppet\puppet\share\locale
-      win32_system_locale_path = File.absolute_path('../../../../../puppet/share/locale', File.dirname(__FILE__))
-
-      if File.exist?(local_locale_path)
-        locale_path = local_locale_path
-      elsif File.exist?(win32_system_locale_path)
-        locale_path = win32_system_locale_path
-      elsif File.exist?(posix_system_locale_path)
-        locale_path = posix_system_locale_path
+    if Puppet::GETTEXT_AVAILABLE && Puppet::LOCALE_PATH
+      if GettextSetup.method(:initialize).parameters.count == 1
+        # Will load translations from PO files only
+        GettextSetup.initialize(Puppet::LOCALE_PATH)
       else
-        # We couldn't load our locale data.
-        locale_path = nil
+        GettextSetup.initialize(Puppet::LOCALE_PATH, :file_format => :mo)
       end
-
-      if locale_path
-        if GettextSetup.method(:initialize).parameters.count == 1
-          # Will load translations from PO files only
-          GettextSetup.initialize(locale_path)
-        else
-          GettextSetup.initialize(locale_path, :file_format => :mo)
-        end
-        FastGettext.locale = GettextSetup.negotiate_locale(Locale.current.language)
-      end
+      FastGettext.locale = GettextSetup.negotiate_locale(Locale.current.language)
     end
 
     include Puppet::Util


### PR DESCRIPTION
If gettext-setup's config file can't be found, it fails to initialize,
causing `method undefined` errors for `_` and `n_`. This commit moves
the check for locale files into the same block that checks for
gettext-setup, and stubs the methods if either one can't be found.