### PR TITLE
(PUP-7523) Dup RUBY_VERSION in Gem::Version

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   # Beaker 3.0.0 to 3.10.0 depends on net-ssh 3.3.0beta1
   # Beaker 3.11.0+ depends on net-ssh 4.0+
   # be lenient to allow module testing where Beaker and Puppet are in same Gemfile
-  s.add_runtime_dependency(%q<net-ssh>, [">= 3.0", "< 5"]) if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
+  s.add_runtime_dependency(%q<net-ssh>, [">= 3.0", "< 5"]) if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
 
   # loads platform specific gems like ffi, win32 platform gems
   # as additional runtime dependencies

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,6 +1,6 @@
 require 'puppet/version'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.3")
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("1.9.3")
   raise LoadError, "Puppet #{Puppet.version} requires ruby 1.9.3 or greater."
 end
 
@@ -164,7 +164,7 @@ module Puppet
 
   # Now that settings are loaded we have the code loaded to be able to issue
   # deprecation warnings. Warn if we're on a deprecated ruby version.
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
     Puppet.deprecation_warning("Support for ruby version #{RUBY_VERSION} is deprecated and will be removed in a future release. See https://docs.puppet.com/puppet/latest/system_requirements.html#ruby for a list of supported ruby versions.")
   end
 

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -827,7 +827,7 @@ class StringConverter
     case f.format
     when :p
       rx_s = val.options == 0 ? val.source : val.to_s
-      rx_s = rx_s.gsub(/\//, '\/') unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+      rx_s = rx_s.gsub(/\//, '\/') unless Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
       str_regexp = "/#{rx_s}/"
       f.orig_fmt == '%p' ? str_regexp : Kernel.format(f.orig_fmt.gsub('p', 's'), str_regexp)
     when :s


### PR DESCRIPTION
The following fails on some buggy versions of rubygems in ruby 1.9.3[1]:

    irb(main):001:0> Gem::Version.new(RUBY_VERSION)
    RuntimeError: can't modify frozen String

As a result, puppet will not run when installed as a gem, until rubygems
is updated.

This commits `dup`s the version string as is done elsewhere[2].

[1] https://github.com/bundler/bundler/issues/3187
[2] https://github.com/puppetlabs/modulesync_configs/commit/be386b44b329e95dc8732155e76bee4353e61216