### PR TITLE
(PUP-7381) Consistent use of YAML

### DIFF
--- a/lib/puppet/indirector/node/yaml.rb
+++ b/lib/puppet/indirector/node/yaml.rb
@@ -8,15 +8,6 @@ class Puppet::Node::Yaml < Puppet::Indirector::Yaml
   protected
 
   def fix(object)
-    # This looks very strange because when the object is read from disk the
-    # environment is a string and by assigning it back onto the object it gets
-    # converted to a Puppet::Node::Environment.
-    #
-    # The Puppet::Node class can't handle this itself because we are loading
-    # with just straight YAML, which doesn't give the object a chance to modify
-    # things as it is loaded. Instead YAML simply sets the instance variable
-    # and leaves it at that.
-    object.environment = object.environment
     object
   end
 end

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -39,7 +39,7 @@ class Puppet::Node
   def to_data_hash
     result = {
       'name' => name,
-      'environment' => environment.name,
+      'environment' => environment.name.to_s,
     }
     result['classes'] = classes unless classes.empty?
     result['parameters'] = parameters unless parameters.empty?

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -27,7 +27,10 @@ class Puppet::Node
     @name       = data['name']       || (raise ArgumentError, _("No name provided in serialized data"))
     @classes    = data['classes']    || []
     @parameters = data['parameters'] || {}
-    @environment_name = data['environment']
+    env_name = data['environment']
+    env_name = env_name.intern unless env_name.nil?
+    @environment_name = env_name
+    environment = env_name
   end
 
   def self.from_data_hash(data)

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -36,6 +36,10 @@ class Puppet::Node
     node
   end
 
+  def to_yaml_properties
+    [:@classes, :@environment, :@name, :@parameters]
+  end
+
   def to_data_hash
     result = {
       'name' => name,

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -343,6 +343,7 @@ class Puppet::Resource
         # set the type name to the symbolic name
         type = type.name
       end
+      @exported = false
 
       # Set things like strictness first.
       attributes.each do |attr, value|

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -25,6 +25,8 @@ class Puppet::Resource
   extend Puppet::Indirector
   indirects :resource, :terminus_class => :ral
 
+  EMPTY_HASH = {}.freeze
+
   ATTRIBUTES = [:file, :line, :exported].freeze
   TYPE_CLASS = 'Class'.freeze
   TYPE_NODE  = 'Node'.freeze
@@ -98,7 +100,7 @@ class Puppet::Resource
       hash
     end
 
-    data["exported"] ||= false
+    data['exported'] ||= false
 
     ext_params = {}
     params = {}
@@ -286,7 +288,7 @@ class Puppet::Resource
   #   be the full resource name in the form of `"Type[Title]"`.
   #
   # @api public
-  def initialize(type, title = nil, attributes = {})
+  def initialize(type, title = nil, attributes = EMPTY_HASH)
     @parameters = {}
     @sensitive_parameters = []
     if type.is_a?(Puppet::Resource)
@@ -617,7 +619,7 @@ class Puppet::Resource
     raise Puppet::ParseError.new(_("no parameter named '%{name}'") % { name: name }, file, line) unless valid_parameter?(name)
   end
 
-  def prune_parameters(options = {})
+  def prune_parameters(options = EMPTY_HASH)
     properties = resource_type.properties.map(&:name)
 
     dup.collect do |attribute, value|

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -105,14 +105,15 @@ class Puppet::Resource
     self.to_hash.each_pair do |param, value|
       # Don't duplicate the title as the namevar
       unless param == namevar && value == title
+        name = param.to_s
         value = Puppet::Resource.value_to_json_data(value)
         if is_json_type?(value)
-          params[param] = value
+          params[name] = value
         elsif !rich_data_enabled
           Puppet.warning(_("Resource '%{resource}' contains a %{klass} value. It will be converted to the String '%{value}'") % { resource: to_s, klass: value.class.name, value: value })
-          params[param] = value
+          params[name] = value
         else
-          ext_params[param] = value
+          ext_params[name] = value
         end
       end
     end

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -70,9 +70,8 @@ class Puppet::Resource
     end
 
     ATTRIBUTES.each do |a|
-      if value = data[a.to_s]
-        send(a.to_s + "=", value)
-      end
+      value = data[a.to_s]
+      send("#{a}=", value) unless value.nil?
     end
   end
 
@@ -112,7 +111,7 @@ class Puppet::Resource
     }
     ATTRIBUTES.each do |param|
       value = send(param)
-      data[param.to_s] = value if value
+      data[param.to_s] = value unless value.nil?
     end
 
     data['exported'] ||= false

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -101,7 +101,7 @@ module Puppet
       YAML_ATTRIBUTES = %w{@resource @file @line @evaluation_time @change_count
                            @out_of_sync_count @tags @time @events @out_of_sync
                            @changed @resource_type @title @skipped @failed
-                           @containment_path}.
+                           @containment_path @corrective_change}.
         map(&:to_sym)
 
       def self.from_data_hash(data)

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -191,14 +191,8 @@ module Puppet
         @failed = data['failed']
         @corrective_change = data['corrective_change']
         @events = data['events'].map do |event|
-          # in YAML (for reports) we serialize this as an object, but
-          # in PSON it becomes a hash. Depending on where we came from
-          # we might not need to deserialize it.
-          if event.class == Puppet::Transaction::Event
-            event
-          else
-            Puppet::Transaction::Event.from_data_hash(event)
-          end
+          # Older versions contain tags that causes Psych to create instances directly
+          event.is_a?(Puppet::Transaction::Event) ? event : Puppet::Transaction::Event.from_data_hash(event)
         end
       end
 
@@ -219,7 +213,7 @@ module Puppet
           'skipped' => @skipped,
           'change_count' => @change_count,
           'out_of_sync_count' => @out_of_sync_count,
-          'events' => @events,
+          'events' => @events.map { |event| event.to_data_hash },
           'corrective_change' => @corrective_change,
         }
       end

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -57,7 +57,7 @@ class Puppet::Transaction::Event
       'desired_value' => @desired_value,
       'historical_value' => @historical_value,
       'message' => @message,
-      'name' => @name,
+      'name' => @name.nil? ? nil : @name.to_s,
       'status' => @status,
       'time' => @time.iso8601(9),
       'redacted' => @redacted,

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -315,11 +315,11 @@ class Puppet::Transaction::Report
     }
 
     # The following is include only when set
-    hash['master_used'] = @master_used if @master_used
-    hash['catalog_uuid'] = @catalog_uuid if @catalog_uuid
-    hash['code_id'] = @code_id if @code_id
-    hash['job_id'] = @job_id if @job_id
-    hash['cached_catalog_status'] = @cached_catalog_status if @cached_catalog_status
+    hash['master_used'] = @master_used unless @master_used.nil?
+    hash['catalog_uuid'] = @catalog_uuid unless @catalog_uuid.nil?
+    hash['code_id'] = @code_id unless @code_id.nil?
+    hash['job_id'] = @job_id unless @job_id.nil?
+    hash['cached_catalog_status'] = @cached_catalog_status unless @cached_catalog_status.nil?
     hash
   end
 

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -326,7 +326,7 @@ class Puppet::Util::Log
 
   def to_data_hash
     {
-      'level' => @level,
+      'level' => @level.to_s,
       'message' => to_s,
       'source' => @source,
       'tags' => @tags.to_a,

--- a/lib/puppet/util/metric.rb
+++ b/lib/puppet/util/metric.rb
@@ -4,15 +4,22 @@ require 'puppet/network/format_support'
 
 # A class for handling metrics.  This is currently ridiculously hackish.
 class Puppet::Util::Metric
+  include Puppet::Util::PsychSupport
   include Puppet::Network::FormatSupport
 
   attr_accessor :type, :name, :value, :label
   attr_writer :values
 
   def self.from_data_hash(data)
-    metric = new(data['name'], data['label'])
-    metric.values = data['values']
+    metric = allocate
+    metric.initialize_from_hash(data)
     metric
+  end
+
+  def initialize_from_hash(data)
+    @name = data['name']
+    @label = data['label'] || self.class.labelize(@name)
+    @values = data['values']
   end
 
   def to_data_hash

--- a/lib/puppet/util/psych_support.rb
+++ b/lib/puppet/util/psych_support.rb
@@ -7,12 +7,8 @@
 # that is given a hash with attribute to value mappings.
 #
 module Puppet::Util::PsychSupport
-  # This method is called from the Psych Yaml deserializer.
-  # The serializer calls this instead of doing the initialization itself using
-  # `instance_variable_set`. The Status class requires this because it serializes its TagSet
-  # as an `Array` in order to optimize the size of the serialized result.
-  # When this array is later deserialized it must be reincarnated as a TagSet. The standard
-  # Psych way of doing this via poking values into instance variables cannot do this.
+  # This method is called from the Psych Yaml deserializer when it encounters a tag
+  # in the form !ruby/object:<class name>.
   #
   def init_with(psych_coder)
     # The PsychCoder has a hashmap of instance variable name (sans the @ symbol) to values
@@ -28,11 +24,7 @@ module Puppet::Util::PsychSupport
   # objects we manage have asymmetrical serialization and deserialization.
   #
   def encode_with(psych_encoder)
-    tag = Psych.dump_tags[self.class]
-    unless tag
-      klass = self.class == Object ? nil : self.class.name
-      tag   = ['!ruby/object', klass].compact.join(':')
-    end
+    tag = Psych.dump_tags[self.class] || "!ruby/object:#{self.class.name}"
     psych_encoder.represent_map(tag, to_data_hash)
   end
 end

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -16,6 +16,7 @@ class Puppet::Util::TagSet < Set
     self.new(data)
   end
 
+  # TODO: A method named #to_data_hash should not return an array
   def to_data_hash
     to_a
   end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -103,6 +103,15 @@ describe Puppet::Node do
       )
       expect(node.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(node.to_data_hash.keys.sort)
     end
+
+    it 'to_data_hash returns value that is instance of to Data' do
+      node = Puppet::Node.new("hello",
+        :environment => 'bar',
+        :classes => ['erth', 'aiu'],
+        :parameters => {"hostname"=>"food"}
+      )
+      expect(Puppet::Pops::Types::TypeFactory.data.instance?(node.to_data_hash)).to be_truthy
+    end
   end
 
   describe "when serializing using yaml" do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -198,9 +198,9 @@ describe Puppet::Node do
       expect(Puppet::Node).to read_json_attribute('parameters').from(@node.to_json).as({"a" => "b", "c" => "d"})
     end
 
-    it "deserializes environment to environment_name as a string" do
+    it "deserializes environment to environment_name as a symbol" do
       @node.environment = environment
-      expect(Puppet::Node).to read_json_attribute('environment_name').from(@node.to_json).as('bar')
+      expect(Puppet::Node).to read_json_attribute('environment_name').from(@node.to_json).as(:bar)
     end
   end
 end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -94,6 +94,15 @@ describe Puppet::Node do
       expect(node.environment_name).to eq(:bar)
       expect(node.parameters['environment']).to eq('bar')
     end
+
+    it 'to_yaml_properties and to_data_hash references the same attributes' do
+      node = Puppet::Node.new("hello",
+        :environment => 'bar',
+        :classes => ['erth', 'aiu'],
+        :parameters => {"hostname"=>"food"}
+      )
+      expect(node.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(node.to_data_hash.keys.sort)
+    end
   end
 
   describe "when serializing using yaml" do

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -184,6 +184,10 @@ describe Puppet::Resource::Status do
     expect(status.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(status.to_data_hash.keys.sort)
   end
 
+  it 'to_data_hash returns value that is instance of to Data' do
+    expect(Puppet::Pops::Types::TypeFactory.data.instance?(status.to_data_hash)).to be_truthy
+  end
+
   def events_as_hashes(report)
     report.events.collect do |e|
       {

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -142,38 +142,46 @@ describe Puppet::Resource::Status do
     end
   end
 
+  let(:status) do
+    s = @status
+    s.file = "/foo.rb"
+    s.line = 27
+    s.evaluation_time = 2.7
+    s.tags = %w{one two}
+    s << Puppet::Transaction::Event.new(:name => :mode_changed, :status => 'audit')
+    s.failed = false
+    s.changed = true
+    s.out_of_sync = true
+    s.skipped = false
+    s
+  end
+
   it "should round trip through pson" do
-    @status.file = "/foo.rb"
-    @status.line = 27
-    @status.evaluation_time = 2.7
-    @status.tags = %w{one two}
-    @status << Puppet::Transaction::Event.new(:name => :mode_changed, :status => 'audit')
-    @status.failed = false
-    @status.changed = true
-    @status.out_of_sync = true
-    @status.skipped = false
+    expect(status.containment_path).to eq(@containment_path)
 
-    expect(@status.containment_path).to eq(@containment_path)
+    tripped = Puppet::Resource::Status.from_data_hash(PSON.parse(status.to_pson))
 
-    tripped = Puppet::Resource::Status.from_data_hash(PSON.parse(@status.to_pson))
+    expect(tripped.title).to eq(status.title)
+    expect(tripped.containment_path).to eq(status.containment_path)
+    expect(tripped.file).to eq(status.file)
+    expect(tripped.line).to eq(status.line)
+    expect(tripped.resource).to eq(status.resource)
+    expect(tripped.resource_type).to eq(status.resource_type)
+    expect(tripped.evaluation_time).to eq(status.evaluation_time)
+    expect(tripped.tags).to eq(status.tags)
+    expect(tripped.time).to eq(status.time)
+    expect(tripped.failed).to eq(status.failed)
+    expect(tripped.changed).to eq(status.changed)
+    expect(tripped.out_of_sync).to eq(status.out_of_sync)
+    expect(tripped.skipped).to eq(status.skipped)
 
-    expect(tripped.title).to eq(@status.title)
-    expect(tripped.containment_path).to eq(@status.containment_path)
-    expect(tripped.file).to eq(@status.file)
-    expect(tripped.line).to eq(@status.line)
-    expect(tripped.resource).to eq(@status.resource)
-    expect(tripped.resource_type).to eq(@status.resource_type)
-    expect(tripped.evaluation_time).to eq(@status.evaluation_time)
-    expect(tripped.tags).to eq(@status.tags)
-    expect(tripped.time).to eq(@status.time)
-    expect(tripped.failed).to eq(@status.failed)
-    expect(tripped.changed).to eq(@status.changed)
-    expect(tripped.out_of_sync).to eq(@status.out_of_sync)
-    expect(tripped.skipped).to eq(@status.skipped)
+    expect(tripped.change_count).to eq(status.change_count)
+    expect(tripped.out_of_sync_count).to eq(status.out_of_sync_count)
+    expect(events_as_hashes(tripped)).to eq(events_as_hashes(status))
+  end
 
-    expect(tripped.change_count).to eq(@status.change_count)
-    expect(tripped.out_of_sync_count).to eq(@status.out_of_sync_count)
-    expect(events_as_hashes(tripped)).to eq(events_as_hashes(@status))
+  it 'to_yaml_properties and to_data_hash references the same attributes' do
+    expect(status.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(status.to_data_hash.keys.sort)
   end
 
   def events_as_hashes(report)

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -682,6 +682,11 @@ describe Puppet::Resource do
     it 'to_yaml_properties and to_data_hash references the same attributes' do
       expect(@resource.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(@resource.to_data_hash.keys.sort)
     end
+
+    it 'to_data_hash returns value that is instance of to Data' do
+      Puppet::Pops::Types::TypeAsserter.assert_instance_of('', Puppet::Pops::Types::TypeFactory.data, @resource.to_data_hash)
+      expect(Puppet::Pops::Types::TypeFactory.data.instance?(@resource.to_data_hash)).to be_truthy
+    end
   end
 
   describe "when converting to a RAL resource" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -678,6 +678,10 @@ describe Puppet::Resource do
       newresource = Puppet::Resource.convert_from('json', text)
       expect(newresource).to equal_resource_attributes_of(@resource)
     end
+
+    it 'to_yaml_properties and to_data_hash references the same attributes' do
+      expect(@resource.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(@resource.to_data_hash.keys.sort)
+    end
   end
 
   describe "when converting to a RAL resource" do

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -140,6 +140,10 @@ describe Puppet::Transaction::Event do
     it 'to_yaml_properties and to_data_hash references the same attributes' do
       expect(event.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(event.to_data_hash.keys.sort)
     end
+
+    it 'to_data_hash returns value that is instance of to Data' do
+      expect(Puppet::Pops::Types::TypeFactory.data.instance?(event.to_data_hash)).to be_truthy
+    end
   end
 
   it "should round trip through pson" do

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -121,17 +121,24 @@ describe Puppet::Transaction::Event do
   end
 
   describe "When converting to YAML" do
-    it "should include only documented attributes" do
-      resource = Puppet::Type.type(:file).new(:title => make_absolute("/tmp/foo"))
-      event = Puppet::Transaction::Event.new(:source_description => "/my/param", :resource => resource,
-                                             :file => "/foo.rb", :line => 27, :tags => %w{one two},
-                                             :desired_value => 7, :historical_value => 'Brazil',
-                                             :message => "Help I'm trapped in a spec test",
-                                             :name => :mode_changed, :previous_value => 6, :property => :mode,
-                                             :status => 'success',
-                                             :redacted => false,
-                                             :corrective_change => false)
+    let(:resource) { Puppet::Type.type(:file).new(:title => make_absolute('/tmp/foo')) }
+    let(:event) do
+      Puppet::Transaction::Event.new(:source_description => "/my/param", :resource => resource,
+        :file => "/foo.rb", :line => 27, :tags => %w{one two},
+        :desired_value => 7, :historical_value => 'Brazil',
+        :message => "Help I'm trapped in a spec test",
+        :name => :mode_changed, :previous_value => 6, :property => :mode,
+        :status => 'success',
+        :redacted => false,
+        :corrective_change => false)
+    end
+
+    it 'should include only documented attributes' do
       expect(event.to_yaml_properties).to match_array(Puppet::Transaction::Event::YAML_ATTRIBUTES)
+    end
+
+    it 'to_yaml_properties and to_data_hash references the same attributes' do
+      expect(event.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(event.to_data_hash.keys.sort)
     end
   end
 

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -497,6 +497,10 @@ describe Puppet::Transaction::Report do
       report = generate_report
       expect(report.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(report.to_data_hash.keys.sort)
     end
+
+    it 'to_data_hash returns value that is instance of to Data' do
+      expect(Puppet::Pops::Types::TypeFactory.data.instance?(generate_report.to_data_hash)).to be_truthy
+    end
   end
 
   it "defaults to serializing to json" do

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -492,6 +492,11 @@ describe Puppet::Transaction::Report do
       report.resources_failed_to_generate = true
       expect(report.to_yaml_properties).not_to include(:@resources_failed_to_generate)
     end
+
+    it 'to_yaml_properties and to_data_hash references the same attributes' do
+      report = generate_report
+      expect(report.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(report.to_data_hash.keys.sort)
+    end
   end
 
   it "defaults to serializing to json" do
@@ -613,7 +618,7 @@ describe Puppet::Transaction::Report do
     status.changed = true
     status.add_event(event)
 
-    report = Puppet::Transaction::Report.new('apply', 1357986, 'test_environment', "df34516e-4050-402d-a166-05b03b940749")
+    report = Puppet::Transaction::Report.new('apply', 1357986, 'test_environment', "df34516e-4050-402d-a166-05b03b940749", '42')
     report << Puppet::Util::Log.new(:level => :warning, :message => "log message")
     report.add_times("timing", 4)
     report.code_id = "some code id"
@@ -630,7 +635,7 @@ describe Puppet::Transaction::Report do
     status.changed = true
     status.failed_because("bad stuff happened")
 
-    report = Puppet::Transaction::Report.new('apply', 1357986, 'test_environment', "df34516e-4050-402d-a166-05b03b940749")
+    report = Puppet::Transaction::Report.new('apply', 1357986, 'test_environment', "df34516e-4050-402d-a166-05b03b940749", '42')
     report << Puppet::Util::Log.new(:level => :warning, :message => "log message")
     report.add_times("timing", 4)
     report.code_id = "some code id"

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -484,13 +484,13 @@ describe Puppet::Transaction::Report do
     it "should not include @external_times" do
       report = Puppet::Transaction::Report.new('apply')
       report.add_times('config_retrieval', 1.0)
-      expect(report.to_yaml_properties).not_to include('@external_times')
+      expect(report.to_yaml_properties).not_to include(:@external_times)
     end
 
     it "should not include @resources_failed_to_generate" do
       report = Puppet::Transaction::Report.new("apply")
       report.resources_failed_to_generate = true
-      expect(report.to_yaml_properties).not_to include('@resources_failed_to_generate')
+      expect(report.to_yaml_properties).not_to include(:@resources_failed_to_generate)
     end
   end
 

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -564,6 +564,7 @@ describe Puppet::Transaction::Report do
     expect(tripped.kind).to eq(report.kind)
     expect(tripped.status).to eq(report.status)
     expect(tripped.environment).to eq(report.environment)
+    expect(tripped.corrective_change).to eq(report.corrective_change)
 
     expect(logs_as_strings(tripped)).to eq(logs_as_strings(report))
     expect(metrics_as_hashes(tripped)).to eq(metrics_as_hashes(report))

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -133,7 +133,7 @@ describe Puppet::Util::Log.desttypes[:logstash_event] do
       dest = described_class.new
       result = dest.format(@msg)
       expect(result["version"]).to eq(1)
-      expect(result["level"]).to   eq(:info)
+      expect(result["level"]).to   eq('info')
       expect(result["message"]).to eq("So long, and thanks for all the fish.")
       expect(result["source"]).to  eq("a dolphin")
       # timestamp should be within 10 seconds

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -526,8 +526,9 @@ describe Puppet::Util::Log do
     end
   end
 
+  let(:log) { Puppet::Util::Log.new(:level => 'notice', :message => 'hooray', :file => 'thefile', :line => 1729, :source => 'specs', :tags => ['a', 'b', 'c']) }
+
   it "should round trip through pson" do
-    log = Puppet::Util::Log.new(:level => 'notice', :message => 'hooray', :file => 'thefile', :line => 1729, :source => 'specs', :tags => ['a', 'b', 'c'])
     tripped = Puppet::Util::Log.from_data_hash(PSON.parse(log.to_pson))
 
     expect(tripped.file).to eq(log.file)
@@ -537,5 +538,9 @@ describe Puppet::Util::Log do
     expect(tripped.source).to eq(log.source)
     expect(tripped.tags).to eq(log.tags)
     expect(tripped.time).to eq(log.time)
+  end
+
+  it 'to_yaml_properties and to_data_hash references the same attributes' do
+    expect(log.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(log.to_data_hash.keys.sort)
   end
 end

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -543,4 +543,8 @@ describe Puppet::Util::Log do
   it 'to_yaml_properties and to_data_hash references the same attributes' do
     expect(log.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(log.to_data_hash.keys.sort)
   end
+
+  it 'to_data_hash returns value that is instance of to Data' do
+    expect(Puppet::Pops::Types::TypeFactory.data.instance?(log.to_data_hash)).to be_truthy
+  end
 end

--- a/spec/unit/util/metric_spec.rb
+++ b/spec/unit/util/metric_spec.rb
@@ -87,4 +87,8 @@ describe Puppet::Util::Metric do
   it 'to_yaml_properties and to_data_hash references the same attributes' do
     expect(metric.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(metric.to_data_hash.keys.sort)
   end
+
+  it 'to_data_hash returns value that is instance of to Data' do
+    expect(Puppet::Pops::Types::TypeFactory.data.instance?(metric.to_data_hash)).to be_truthy
+  end
 end

--- a/spec/unit/util/metric_spec.rb
+++ b/spec/unit/util/metric_spec.rb
@@ -69,15 +69,22 @@ describe Puppet::Util::Metric do
     expect(@metric["foo"]).to eq(0)
   end
 
-  it "should round trip through pson" do
+  let(:metric) do
     metric = Puppet::Util::Metric.new("foo", "mylabel")
     metric.newvalue("v1", 10.1, "something")
     metric.newvalue("v2", 20, "something else")
+    metric
+  end
 
+  it "should round trip through pson" do
     tripped = Puppet::Util::Metric.from_data_hash(PSON.parse(metric.to_pson))
 
     expect(tripped.name).to eq(metric.name)
     expect(tripped.label).to eq(metric.label)
     expect(tripped.values).to eq(metric.values)
+  end
+
+  it 'to_yaml_properties and to_data_hash references the same attributes' do
+    expect(metric.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(metric.to_data_hash.keys.sort)
   end
 end


### PR DESCRIPTION
This PR unifies how several Puppet structures, defined in Ruby, interact with the YAML/Psych processor. The objective is to make the code insensitive to ruby versions and also to, to the extent possible, make the data serialized with JSON the same as the data serialized with YAML. One key factor in that effort is to get rid of the YAML tags that causes the YAML.load to directly create object instances.

This PR gets rid of such tags but retains them at the top level. The tags are still needed there for two reasons.
- Puppets own yaml indirections rely on this tag when deserializing.
- Other clients, like the MCO PuppetAgentMgr also relies on such tags.
