### PR TITLE
(PUP-3486) Disable puppetserver CA service for test

### DIFF
--- a/acceptance/tests/external_ca_support/fixtures/auth.conf
+++ b/acceptance/tests/external_ca_support/fixtures/auth.conf
@@ -1,60 +1,149 @@
-# Puppet 4.0.0 auth.conf, modified to allow requests from example.org for
+# Puppetserver 2.2.0 auth.conf, modified to allow requests from example.org for
 # external ca testing.
 
-# allow nodes to retrieve their own catalog
-path ~ ^/puppet/v3/catalog/([^/]+)$
-method find
-allow *.example.org
-allow $1
-
-# allow nodes to retrieve their own node definition
-path ~ ^/puppet/v3/node/([^/]+)$
-method find
-allow *.example.org
-allow $1
-
-# allow all nodes to access the certificates services
-path /puppet-ca/v1/certificate_revocation_list/ca
-method find
-allow *
-
-# allow all nodes to store their own reports
-path ~ ^/puppet/v3/report/([^/]+)$
-method save
-allow *.example.org
-allow $1
-
-# Allow all nodes to access all file services; this is necessary for
-# pluginsync, file serving from modules, and file serving from custom
-# mount points (see fileserver.conf). Note that the `/file` prefix matches
-# requests to both the file_metadata and file_content paths. See "Examples"
-# above if you need more granular access control for custom mount points.
-path /puppet/v3/file
-allow *
-
-### Unauthenticated ACLs, for clients without valid certificates; authenticated
-### clients can also access these paths, though they rarely need to.
-
-# allow access to the CA certificate; unauthenticated nodes need this
-# in order to validate the puppet master's certificate
-path /puppet-ca/v1/certificate/ca
-auth any
-method find
-allow *
-
-# allow nodes to retrieve the certificate they requested earlier
-path /puppet-ca/v1/certificate/
-auth any
-method find
-allow *
-
-# allow nodes to request a new certificate
-path /puppet-ca/v1/certificate_request
-auth any
-method find, save
-allow *
-
-# deny everything else; this ACL is not strictly necessary, but
-# illustrates the default policy.
-path /
-auth any
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to retrieve their own catalog
+            match-request: {
+                path: "^/puppet/v3/catalog/([^/]+)$"
+                type: regex
+                method: [get, post]
+            }
+            allow: [
+                "$1",
+                "*.example.org"
+            ]
+            sort-order: 500
+            name: "puppetlabs catalog"
+        },
+        {
+            # Allow nodes to retrieve the certificate they requested earlier
+            match-request: {
+                path: "/puppet-ca/v1/certificate/"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs certificate"
+        },
+        {
+            # Allow all nodes to access the certificate revocation list
+            match-request: {
+                path: "/puppet-ca/v1/certificate_revocation_list/ca"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs crl"
+        },
+        {
+            # Allow nodes to request a new certificate
+            match-request: {
+                path: "/puppet-ca/v1/certificate_request"
+                type: path
+                method: [get, put]
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs csr"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/environments"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs environments"
+        },
+        {
+            # Allow nodes to access all file services; this is necessary for
+            # pluginsync, file serving from modules, and file serving from
+            # custom mount points (see fileserver.conf). Note that the `/file`
+            # prefix matches requests to file_metadata, file_content, and
+            # file_bucket_file paths.
+            match-request: {
+                path: "/puppet/v3/file"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file"
+        },
+        {
+            # Allow nodes to retrieve only their own node definition
+            match-request: {
+                path: "^/puppet/v3/node/([^/]+)$"
+                type: regex
+                method: get
+            }
+            allow: [
+                "$1",
+                "*.example.org"
+            ]
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            # Allow nodes to store only their own reports
+            match-request: {
+                path: "^/puppet/v3/report/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: [
+                "$1",
+                "*.example.org"
+            ]
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/status"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
+        },
+        {
+            # Allow all users access to the experimental endpoint
+            # which currently only provides a dashboard web ui.
+            match-request: {
+                path: "/puppet/experimental"
+                type: path
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs experimental"
+        },
+        {
+          # Deny everything else. This ACL is not strictly
+          # necessary, but illustrates the default policy
+          match-request: {
+            path: "/"
+            type: path
+          }
+          deny: "*"
+          sort-order: 999
+          name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
+++ b/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
@@ -20,6 +20,7 @@ test_name "Puppet agent and master work when both configured with externally iss
 step "Copy certificates and configuration files to the master..."
 fixture_dir = File.expand_path('../fixtures', __FILE__)
 testdir = master.tmpdir('jetty_external_root_ca')
+backupdir = master.tmpdir('jetty_external_root_ca_backup')
 fixtures = PuppetX::Acceptance::ExternalCertFixtures.new(fixture_dir, testdir)
 
 jetty_confdir = master['puppetserver-confdir']
@@ -27,10 +28,21 @@ jetty_confdir = master['puppetserver-confdir']
 # Register our cleanup steps early in a teardown so that they will happen even
 # if execution aborts part way.
 teardown do
-  step "Restore /etc/hosts and webserver.conf"
-  on master, "cp -p '#{testdir}/hosts' /etc/hosts"
-  on master, "cp -p '#{testdir}/webserver.conf.orig' '#{jetty_confdir}/webserver.conf'"
+  step "Restore /etc/hosts and puppetserver configs; Restart puppetserver"
+  on master, "cp -p '#{backupdir}/hosts' /etc/hosts"
+  # Please note that the escaped `\cp` command below is intentional. Most
+  # linux systems alias `cp` to `cp -i` which causes interactive mode to be
+  # invoked when copying directories that do not yet exist at the target
+  # location, even when using the force flag. The escape ensures that an
+  # alias is not used.
+  on master, "\\cp -frp #{backupdir}/puppetserver/* #{jetty_confdir}/../"
+  on(master, "service #{master['puppetservice']} restart")
 end
+
+# Backup files in scope for modification by test
+on master, "cp -p /etc/hosts '#{backupdir}/hosts'"
+on master, "cp -rp '#{jetty_confdir}/..' '#{backupdir}/puppetserver'"
+
 
 # Read all of the CA certificates.
 
@@ -53,12 +65,7 @@ create_remote_file master, "#{testdir}/master_rogue.key", fixtures.master_key_ro
 ##
 # Now create the master and agent puppet.conf
 #
-# We need to create the public directory for Passenger and the modules
-# directory to avoid `Error: Could not evaluate: Could not retrieve information
-# from environment production source(s) puppet://master1.example.org/plugins`
-on master, "mkdir -p #{testdir}/etc/{master/{public,modules/empty/lib},agent}"
-# Backup /etc/hosts
-on master, "cp -p /etc/hosts '#{testdir}/hosts'"
+on master, "mkdir -p #{testdir}/etc/agent"
 
 # Make master1.example.org resolve if it doesn't already.
 on master, "grep -q -x '#{fixtures.host_entry}' /etc/hosts || echo '#{fixtures.host_entry}' >> /etc/hosts"
@@ -68,16 +75,14 @@ create_remote_file master, "#{testdir}/etc/agent/puppet.conf.crl", fixtures.agen
 create_remote_file master, "#{testdir}/etc/agent/puppet.conf.email", fixtures.agent_conf_email
 
 # auth.conf to allow *.example.com access to the rest API
-create_remote_file master, "#{testdir}/etc/master/auth.conf", fixtures.auth_conf
-
-create_remote_file master, "#{testdir}/etc/master/config.ru", fixtures.config_ru
+create_remote_file master, "#{jetty_confdir}/auth.conf", fixtures.auth_conf
+# set use-legacy-auth-conf = false
+# to override the default setting in older puppetserver versions
+modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
 
 step "Set filesystem permissions and ownership for the master"
 # These permissions are required for the JVM to start Puppet as puppet
-on master, "chown -R puppet:puppet #{testdir}/etc/master"
-on master, "chown -R puppet:puppet #{testdir}/*.crt"
-on master, "chown -R puppet:puppet #{testdir}/*.key"
-on master, "chown -R puppet:puppet #{testdir}/*.crl"
+on master, "chown -R puppet:puppet #{testdir}/*.{crt,key,crl}"
 
 # These permissions are just for testing, end users should protect their
 # private keys.
@@ -93,18 +98,21 @@ on master, "mkdir -p #{testdir}/etc/agent/ssl/{public_keys,certs,certificate_req
 create_remote_file master, "#{testdir}/etc/agent/ssl/certs/#{fixtures.agent_name}.pem", fixtures.agent_cert
 create_remote_file master, "#{testdir}/etc/agent/ssl/private_keys/#{fixtures.agent_name}.pem", fixtures.agent_key
 
-on master, "cp -p '#{jetty_confdir}/webserver.conf' '#{testdir}/webserver.conf.orig'"
 create_remote_file master, "#{jetty_confdir}/webserver.conf",
                    fixtures.jetty_webserver_conf_for_trustworthy_master
 
 master_opts = {
     'master' => {
-        'ca' => false,
         'certname' => fixtures.master_name,
         'ssl_client_header' => "HTTP_X_CLIENT_DN",
         'ssl_client_verify_header' => "HTTP_X_CLIENT_VERIFY"
     }
 }
+
+# disable CA service
+# https://github.com/puppetlabs/puppetserver/blob/master/documentation/configuration.markdown#service-bootstrapping
+create_remote_file master, "#{jetty_confdir}/../services.d/ca.cfg", "puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service"
+on(master, "service #{master['puppetservice']} restart")
 
 step "Start the Puppet master service..."
 with_puppet_running_on(master, master_opts) do


### PR DESCRIPTION
This commit updates the
`acceptance/tests/external_ca_support/jetty_external_root_ca.rb` test
to disable the puppetserver CA service rather than using the `ca = false`
setting in the `puppet.conf` file. The `auth.conf` file is also updated to
used the HOCON syntax and proper location for use with puppetserver.

[skip ci]