### PR TITLE
(PUP-7529) Handling of non-leading tildes in rpmvercmp

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -219,6 +219,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
         # if they both have ~, strip it
         str1 = str1[1..-1]
         str2 = str2[1..-1]
+        next
       elsif /^~/.match(str1)
         return -1
       elsif /^~/.match(str2)

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -499,6 +499,10 @@ describe provider_class do
     it { expect(provider.rpmvercmp("1.0~rc1~git123", "1.0~rc1")).to eq(-1) }
     it { expect(provider.rpmvercmp("1.0~rc1", "1.0~rc1~git123")).to eq(1) }
     it { expect(provider.rpmvercmp("1.0~rc1", "1.0arc1")).to eq(-1) }
+    it { expect(provider.rpmvercmp("", "~")).to eq(1) }
+    it { expect(provider.rpmvercmp("~", "~~")).to eq(1) }
+    it { expect(provider.rpmvercmp("~", "~+~")).to eq(1) }
+    it { expect(provider.rpmvercmp("~", "~a")).to eq(-1) }
 
     # non-upstream test cases
     it { expect(provider.rpmvercmp("405", "406")).to eq(-1) }


### PR DESCRIPTION
`rpmvercmp` handles only the leading tilde.
So,  the following test fails.

```
it { expect(provider.rpmvercmp("~", "~~")).to eq(1) }
```

A tilde must sort before everything else.
https://github.com/rpm-software-management/rpm/issues/214