### PR TITLE
(PUP-1723) Include context when logging yumrepo chmod

### DIFF
--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -181,7 +181,7 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
   # Save all yum repository files and force the mode to 0644
   # @api private
   # @return [void]
-  def self.store
+  def self.store(resource)
     inifile = self.virtual_inifile
     inifile.store
 
@@ -189,7 +189,7 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
     inifile.each_file do |file|
       current_mode = Puppet::FileSystem.stat(file).mode & 0777
       unless current_mode == target_mode
-        Puppet.info "changing mode of #{file} from %03o to %03o" % [current_mode, target_mode]
+        resource.info "changing mode of #{file} from %03o to %03o" % [current_mode, target_mode]
         Puppet::FileSystem.chmod(target_mode, file)
       end
     end
@@ -245,7 +245,7 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
   # @api public
   # @return [void]
   def flush
-    self.class.store
+    self.class.store(self)
   end
 
   # Generate setters and getters for our INI properties.


### PR DESCRIPTION
Previously if a yumrepo inifile's permissions were not 644, puppet would
log a global info message:

    Info: changing mode of /etc/yum.repos.d/puppet-agent.repo from 600
    to 644

This commit passes the `resource` instance to the `store` method so that
the info message is generated relative to that context. The resulting
message looks like:

    Info: Yumrepo[IUS](provider=inifile): changing mode of
    /etc/yum.repos.d/puppet-agent.repo from 600 to 644