### PR TITLE
(PUP-6566) Update copyright info in application help to "Puppet Inc."

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -309,7 +309,7 @@ Luke Kanies
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -152,7 +152,7 @@ Luke Kanies
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -250,7 +250,7 @@ Luke Kanies
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -226,7 +226,7 @@ David Lutterkort
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -155,7 +155,7 @@ Brice Figureau
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC
+Copyright (c) 2011 Puppet Inc., LLC
 Licensed under the Apache 2.0 License
       HELP
     end

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -57,7 +57,7 @@ puppet-doc(8) -- Generate Puppet references
 SYNOPSIS
 --------
 Generates a reference for all Puppet types. Largely meant for internal
-Puppet Labs use. (Deprecated)
+Puppet Inc. use. (Deprecated)
 
 
 USAGE
@@ -71,7 +71,7 @@ DESCRIPTION
 This deprecated command generates a Markdown document to stdout
 describing all installed Puppet types or all allowable arguments to
 puppet executables. It is largely meant for internal use and is used to
-generate the reference document available on the Puppet Labs web site.
+generate the reference document available on the Puppet Inc. web site.
 
 For Puppet module documentation (and all other use cases) this command
 has been superseded by the "puppet-strings"
@@ -104,7 +104,7 @@ Luke Kanies
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
 HELP
   end

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -146,7 +146,7 @@ Luke Kanies
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -64,12 +64,12 @@ the full list of acceptable settings.
 AUTHOR
 ------
 
-Puppet Labs
+Puppet Inc.
 
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -230,7 +230,7 @@ EXAMPLE
 
 COPYRIGHT
 ---------
-Copyright (c) 2015 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
 
     HELP

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -130,7 +130,7 @@ Luke Kanies
 
 COPYRIGHT
 ---------
-Copyright (c) 2012 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2012 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -123,7 +123,7 @@ Luke Kanies
 
 COPYRIGHT
 ---------
-Copyright (c) 2011 Puppet Labs, LLC Licensed under the Apache 2.0 License
+Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/face/ca.rb
+++ b/lib/puppet/face/ca.rb
@@ -1,7 +1,7 @@
 require 'puppet/face'
 
 Puppet::Face.define(:ca, '0.1.0') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Local Puppet Certificate Authority management."

--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:catalog, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Compile, save, view, and convert catalogs."

--- a/lib/puppet/face/certificate.rb
+++ b/lib/puppet/face/certificate.rb
@@ -2,7 +2,7 @@ require 'puppet/indirector/face'
 require 'puppet/ssl/host'
 
 Puppet::Indirector::Face.define(:certificate, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Provide access to the CA for certificate management."

--- a/lib/puppet/face/certificate_request.rb
+++ b/lib/puppet/face/certificate_request.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:certificate_request, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Manage certificate requests."

--- a/lib/puppet/face/certificate_revocation_list.rb
+++ b/lib/puppet/face/certificate_revocation_list.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:certificate_revocation_list, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Manage the list of revoked certificates."

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -2,7 +2,7 @@ require 'puppet/face'
 require 'puppet/settings/ini_file'
 
 Puppet::Face.define(:config, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Interact with Puppet's settings."

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -4,7 +4,7 @@ require 'puppet/parser/files'
 require 'puppet/file_system'
 
 Puppet::Face.define(:epp, '0.0.1') do
-  copyright "Puppet Labs", 2014
+  copyright "Puppet Inc.", 2014
   license   "Apache 2 license; see COPYING"
 
   summary "Interact directly with the EPP template parser/renderer."

--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -2,7 +2,7 @@ require 'puppet/indirector/face'
 require 'puppet/node/facts'
 
 Puppet::Indirector::Face.define(:facts, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Retrieve and store facts."

--- a/lib/puppet/face/file.rb
+++ b/lib/puppet/face/file.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:file, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Retrieve and store files in a filebucket"

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -5,7 +5,7 @@ require 'pathname'
 require 'erb'
 
 Puppet::Face.define(:help, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   _("Apache 2 license; see COPYING")
 
   summary _("Display Puppet help.")

--- a/lib/puppet/face/key.rb
+++ b/lib/puppet/face/key.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:key, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Create, save, and remove certificate keys."

--- a/lib/puppet/face/man.rb
+++ b/lib/puppet/face/man.rb
@@ -4,7 +4,7 @@ require 'pathname'
 require 'erb'
 
 Puppet::Face.define(:man, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Display Puppet manual pages."
@@ -75,7 +75,7 @@ Puppet::Face.define(:man, '0.0.1') do
         # ronn is a stupid about pager selection, we can be smarter. :)
         if pager then ENV['PAGER'] = pager end
 
-        args  = "--man --manual='Puppet Manual' --organization='Puppet Labs, LLC'"
+        args  = "--man --manual='Puppet Manual' --organization='Puppet Inc., LLC'"
         # manual pages could contain UTF-8 text
         IO.popen("#{ronn} #{args}", 'w:UTF-8') do |fh| fh.write text end
 

--- a/lib/puppet/face/module.rb
+++ b/lib/puppet/face/module.rb
@@ -5,7 +5,7 @@ require 'puppet/util/colors'
 Puppet::Face.define(:module, '1.0.0') do
   extend Puppet::Util::Colors
 
-  copyright "Puppet Labs", 2012
+  copyright "Puppet Inc.", 2012
   license   "Apache 2 license; see COPYING"
 
   summary "Creates, installs and searches for modules on the Puppet Forge."

--- a/lib/puppet/face/node.rb
+++ b/lib/puppet/face/node.rb
@@ -1,6 +1,6 @@
 require 'puppet/indirector/face'
 Puppet::Indirector::Face.define(:node, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "View and manage node definitions."

--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -2,7 +2,7 @@ require 'puppet/face'
 require 'puppet/parser'
 
 Puppet::Face.define(:parser, '0.0.1') do
-  copyright "Puppet Labs", 2014
+  copyright "Puppet Inc.", 2014
   license   "Apache 2 license; see COPYING"
 
   summary "Interact directly with the parser."

--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -3,7 +3,7 @@ require 'puppet/configurer/downloader_factory'
 require 'puppet/configurer/plugin_handler'
 
 Puppet::Face.define(:plugin, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Interact with the Puppet plugin system."

--- a/lib/puppet/face/report.rb
+++ b/lib/puppet/face/report.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:report, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "Create, display, and submit reports."

--- a/lib/puppet/face/resource.rb
+++ b/lib/puppet/face/resource.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:resource, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "API only: interact directly with resources via the RAL."

--- a/lib/puppet/face/resource_type.rb
+++ b/lib/puppet/face/resource_type.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:resource_type, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "View classes, defined resource types, and nodes from all manifests."

--- a/lib/puppet/face/status.rb
+++ b/lib/puppet/face/status.rb
@@ -1,7 +1,7 @@
 require 'puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:status, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
   summary "View puppet server status."

--- a/lib/puppet/module_tool/skeleton/templates/generator/examples/init.pp.erb
+++ b/lib/puppet/module_tool/skeleton/templates/generator/examples/init.pp.erb
@@ -1,4 +1,4 @@
-# The baseline for module testing used by Puppet Labs is that each manifest
+# The baseline for module testing used by Puppet Inc. is that each manifest
 # should have a corresponding test manifest that declares that class or defined
 # type.
 #

--- a/spec/integration/faces/documentation_spec.rb
+++ b/spec/integration/faces/documentation_spec.rb
@@ -43,10 +43,10 @@ describe "documentation of faces" do
       ########################################################################
       # Ensure that we have authorship and copyright information in *our* faces;
       # if you apply this to third party faces you might well be disappointed.
-      context "licensing of Puppet Labs face '#{face_name}'" do
+      context "licensing of Puppet Inc. face '#{face_name}'" do
         subject { Puppet::Face[face_name, :current] }
         its :license   do should =~ /Apache\s*2/ end
-        its :copyright do should =~ /Puppet Labs|Puppet Inc\./ end
+        its :copyright do should =~ /Puppet Inc\./ end
 
         # REVISIT: This is less that ideal, I think, but right now I am more
         # comfortable watching us ship with some copyright than without any; we

--- a/spec/lib/puppet/face/1.0.0/huzzah.rb
+++ b/spec/lib/puppet/face/1.0.0/huzzah.rb
@@ -1,6 +1,6 @@
 require 'puppet/face'
 Puppet::Face.define(:huzzah, '1.0.0') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
   summary "life is a thing for celebration"
   action(:obsolete_in_core) { when_invoked { |_| "you are in obsolete core now!" } }

--- a/spec/lib/puppet/face/basetest.rb
+++ b/spec/lib/puppet/face/basetest.rb
@@ -1,7 +1,7 @@
 require 'puppet/face'
 
 Puppet::Face.define(:basetest, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
   summary "This is just so tests don't fail"
 

--- a/spec/lib/puppet/face/huzzah.rb
+++ b/spec/lib/puppet/face/huzzah.rb
@@ -1,6 +1,6 @@
 require 'puppet/face'
 Puppet::Face.define(:huzzah, '2.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
   summary "life is a thing for celebration"
   action(:bar) { when_invoked { |options| "is where beer comes from" } }

--- a/spec/lib/puppet/face/version_matching.rb
+++ b/spec/lib/puppet/face/version_matching.rb
@@ -4,7 +4,7 @@ require 'puppet/face'
 # change this you need to ensure that is still correct. --daniel 2011-04-21
 ['1.0.0', '1.0.1', '1.1.0', '1.1.1', '2.0.0'].each do |version|
   Puppet::Face.define(:version_matching, version) do
-    copyright "Puppet Labs", 2011
+    copyright "Puppet Inc.", 2011
     license   "Apache 2 license; see COPYING"
     summary "version matching face #{version}"
     action(:version) { when_invoked { |options| version } }


### PR DESCRIPTION
This commit also updates a spec test that was allowing "Puppet Labs" as a
copyright name.