### PR TITLE
(PUP-7383) Skip cipher monkey patch on ruby 2.4+

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -35,7 +35,9 @@ class OpenSSL::SSL::SSLContext
   else
     DEFAULT_PARAMS[:options] = OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3
   end
-  DEFAULT_PARAMS[:ciphers] << ':!SSLv2'
+  if DEFAULT_PARAMS[:ciphers]
+    DEFAULT_PARAMS[:ciphers] << ':!SSLv2'
+  end
 
   alias __original_initialize initialize
   private :__original_initialize


### PR DESCRIPTION
Previously, we appended "!SSLv2" to the SSLContext
DEFAULT_PARAMS[:ciphers] to ensure that puppet never uses SSLv2, either
from our http client or when using open-uri. However, ruby 2.4 only
defines the `:ciphers` array if using openssl < 1.1.0[1]. As a result,
puppet as a gem running on newer systems would hard fail.

Check existence of array before trying to append to it.

[1] https://github.com/ruby/ruby/commit/c9dc016#diff-8406e11e4a42f9de6badcd0f6a6c4262R33