### PR TITLE
(docs)(DOC-2736): Correct wording for clarification.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1934,7 +1934,7 @@ EOT
     :default => false,
     :type => :boolean,
     :desc => <<-'EOT'
-      Makes the parser raise errors when referencing unknown variables. (This does not affect
+      Causes an evaluation error when referencing unknown variables. (This does not affect
       referencing variables that are explicitly set to undef).
     EOT
     }


### PR DESCRIPTION
Pretty small change, but makes it a little more specific.