### PR TITLE
(docs) Fix the hiera_config default value fix in configuration reference

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -32,7 +32,7 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
       val = 'Unix/Linux: /var/run/puppetlabs -- Windows: C:\ProgramData\PuppetLabs\puppet\var\run -- Non-root user: ~/.puppetlabs/var/run'
     elsif name.to_s == 'logdir'
       val = 'Unix/Linux: /var/log/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\var\log -- Non-root user: ~/.puppetlabs/var/log'
-    elsif name.to_s == 'hiera.yaml'
+    elsif name.to_s == 'hiera_config'
       val = '$confdir/hiera.yaml. However, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
     end
 


### PR DESCRIPTION
I tried to fix this earlier in commit f9df9c4a2, but apparently my brain
glitched out and I didn't use the correct setting name. This fixes the fix.

NB for reviewers: To see the result of this, run `puppet doc -r configuration`, pipe it to the pager of your choice, and scroll down to the `hiera_config` setting. 