### PR TITLE
(PUP-7155) Make Parameter#format_value_for_display use StringConverter

### DIFF
--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -9,12 +9,12 @@ gid2  = (rand(989999).to_i + 10000)
 agents.each do |agent|
   step "ensure that the group exists with gid #{gid1}"
   on(agent, puppet_resource('group', name, 'ensure=present', "gid=#{gid1}")) do
-    fail_test "missing gid notice" unless stdout =~ /gid +=> +'#{gid1}'/
+    fail_test "missing gid notice" unless stdout =~ /gid +=> +#{gid1}/
   end
 
   step "ensure that we can modify the GID of the group to #{gid2}"
   on(agent, puppet_resource('group', name, 'ensure=present', "gid=#{gid2}")) do
-    fail_test "missing gid notice" unless stdout =~ /gid +=> +'#{gid2}'/
+    fail_test "missing gid notice" unless stdout =~ /gid +=> +#{gid2}/
   end
 
   step "verify that the GID changed"

--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -26,7 +26,9 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
   # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
   # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
   mixed_utf8_0 = "A\u06FF"
+  reported_mixed_utf8_0 = '"A\\\\u\\{6FF\\}"'
   mixed_utf8_1 = "\u16A0\u{2070E}"
+  reported_mixed_utf8_1 = '"\\\\u\\{16A0\\}\\\\u\\{2070E\\}"'
 
   teardown do
     # remove user on all agents
@@ -55,7 +57,7 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
     EOF
     # Note setting LANG='<encoding>' environment like this has no effect on Windows agents.
     apply_manifest_on(agents, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "en_US.UTF-8"}) do |result|
-      assert_match(/changed '#{mixed_utf8_0}' to '#{mixed_utf8_1}'/, result.stdout, "failed to modify UTF-8 user comment in UTF-8 environment")
+      assert_match(/changed #{reported_mixed_utf8_0} to #{reported_mixed_utf8_1}/, result.stdout, "failed to modify UTF-8 user comment in UTF-8 environment")
     end
   end
 
@@ -79,7 +81,7 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
     EOF
     # Since LANG=<'encoding'> has no effect, this test is redundant on Windows - exclude it.
     apply_manifest_on(agents - windows_agents, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "en_US.ISO8859-1"}) do |result|
-      assert_match(/changed '#{mixed_utf8_0}' to '#{mixed_utf8_1}'/, result.stdout, "failed to modify UTF-8 user comment in ISO-8859-1 environment")
+      assert_match(/changed #{reported_mixed_utf8_0} to #{reported_mixed_utf8_1}/, result.stdout, "failed to modify UTF-8 user comment in ISO-8859-1 environment")
     end
   end
 
@@ -105,7 +107,7 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
     # OS X is known broken in POSIX locale with UTF-8 chars on OS X, so exclude OS X here.
     # Also since LANG=<'encoding'> has no effect, this test is redundant on Windows - exclude it.
     apply_manifest_on(agents - osx_agents - windows_agents, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "POSIX"}) do |result|
-      assert_match(/changed '#{mixed_utf8_0}' to '#{mixed_utf8_1}'/, result.stdout, "failed to modify UTF-8 user comment with POSIX environment")
+      assert_match(/changed #{reported_mixed_utf8_0} to #{reported_mixed_utf8_1}/, result.stdout, "failed to modify UTF-8 user comment with POSIX environment")
     end
   end
 
@@ -141,7 +143,7 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
     # and back.
     # OS X is known broken in POSIX locale with UTF-8 chars on OS X, so exclude OS X here.
     apply_manifest_on(agents - osx_agents, set_comment_utf8, :expect_changes => true, :environment => {:LANG => "POSIX"}) do |result|
-      assert_match(/changed 'bar' to '#{mixed_utf8_0}'/, result.stdout, "failed to modify user ASCII comment to UTF-8 comment with POSIX locale")
+      assert_match(/changed 'bar' to #{reported_mixed_utf8_0}/, result.stdout, "failed to modify user ASCII comment to UTF-8 comment with POSIX locale")
     end
   end
 
@@ -172,7 +174,7 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
     # ensure we can set create/modify ASCII comments to UTF-8 and back.
     # OS X is known broken in POSIX locale with UTF-8 chars, so exclude OS X here
     apply_manifest_on(agents - osx_agents, set_comment_ascii, :expect_changes => true, :environment => {:LANG => "POSIX"}) do |result|
-      assert_match(/changed '#{mixed_utf8_0}' to 'bar'/, result.stdout, "failed to modify user UTF-8 comment to ASCII comment with POSIX locale")
+      assert_match(/changed #{reported_mixed_utf8_0} to 'bar'/, result.stdout, "failed to modify user UTF-8 comment to ASCII comment with POSIX locale")
     end
   end
 end

--- a/lib/puppet/parameter.rb
+++ b/lib/puppet/parameter.rb
@@ -543,39 +543,14 @@ class Puppet::Parameter
   end
 
   # Produces a String with the value formatted for display to a human.
-  # When the parameter value is a:
   #
-  # * **single valued parameter value** the result is produced on the
-  #   form `'value'` where _value_ is the string form of the parameter's value.
-  #
-  # * **Array** the list of values is enclosed in `[]`, and
-  #   each produced value is separated by a comma.
-  #
-  # * **Hash** value is output with keys in sorted order enclosed in `{}` with each entry formatted
-  #   on the form `'k' => v` where
-  #   `k` is the key in string form and _v_ is the value of the key. Entries are comma separated.
-  #
-  # For both Array and Hash this method is called recursively to format contained values.
-  # @note this method does not protect against infinite structures.
+  # The output is created using the StringConverter with format '%#p' to produce
+  # human readable code that is understood by puppet.
   #
   # @return [String] The formatted value in string form.
   #
   def self.format_value_for_display(value)
-    if value.is_a? Array
-      formatted_values = value.collect {|v| format_value_for_display(v)}.join(', ')
-      "[#{formatted_values}]"
-    elsif value.is_a? Hash
-      # Sorting the hash keys for display is largely for having stable
-      # output to test against, but also helps when scanning for hash
-      # keys, since they will be in ASCIIbetical order.
-      hash = value.keys.sort {|a,b| a.to_s <=> b.to_s}.collect do |k|
-        "'#{k}' => #{format_value_for_display(value[k])}"
-      end.join(', ')
-
-      "{#{hash}}"
-    else
-      "'#{value}'"
-    end
+    Puppet::Pops::Types::StringConverter.convert(value, Puppet::Pops::Types::StringConverter::DEFAULT_PARAMETER_FORMAT)
   end
 
   # @comment Document post_compile_hook here as it does not exist anywhere (called from type if implemented)

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -826,15 +826,15 @@ class PObjectType < PMetaType
   # An Object type is only assignable from another Object type. The other type
   # or one of its parents must be equal to this type.
   def _assignable?(o, guard)
-    if self == o
-      true
-    else
-      if o.is_a?(PObjectType)
+    if o.is_a?(PObjectType)
+      if DEFAULT == self || self == o
+        true
+      else
         op = o.parent
         op.nil? ? false : assignable?(op, guard)
-      else
-        false
       end
+    else
+      false
     end
   end
 

--- a/lib/puppet/pops/types/p_runtime_type.rb
+++ b/lib/puppet/pops/types/p_runtime_type.rb
@@ -94,7 +94,7 @@ class PRuntimeType < PAnyType
   # @api private
   def _assignable?(o, guard)
     return false unless o.is_a?(PRuntimeType)
-    return false unless @runtime == o.runtime
+    return false unless @runtime.nil? || @runtime == o.runtime
     return true if @name_or_pattern.nil? # t1 is wider
 
     onp = o.name_or_pattern

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -289,6 +289,13 @@ class StringConverter
     PAnyType::DEFAULT      => Format.new('%s').freeze,    # unquoted string
   }.freeze
 
+  DEFAULT_PARAMETER_FORMAT = {
+    PCollectionType::DEFAULT => '%#p',
+    PObjectType::DEFAULT => '%#p',
+    PBinaryType::DEFAULT => '%p',
+    PStringType::DEFAULT => '%p',
+    PRuntimeType::DEFAULT => '%p'
+  }.freeze
 
   # Converts the given value to a String, under the direction of formatting rules per type.
   #

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -568,7 +568,20 @@ class StringConverter
     end
   end
 
-  def string_PRuntimeType(val_type, val, format_map, _)
+  def string_PRuntimeType(val_type, val, format_map, indent)
+    # Before giving up on this, and use a string representation of the unknown
+    # object, a check is made to see if the object can present itself as
+    # a hash or an array. If it can, then that representation is used instead.
+    if val.is_a?(Hash)
+      hash = val.to_hash
+      # Ensure that the returned value isn't derived from Hash
+      return string_PHashType(val_type, hash, format_map, indent) if hash.instance_of?(Hash)
+    elsif val.is_a?(Array)
+      array = val.to_a
+      # Ensure that the returned value isn't derived from Array
+      return string_PArrayType(val_type, array, format_map, indent) if array.instance_of?(Array)
+    end
+
     f = get_format(val_type, format_map)
     case f.format
     when :s

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -280,6 +280,7 @@ class StringConverter
   DEFAULT_ARRAY_DELIMITERS                      = ['[', ']'].freeze
 
   DEFAULT_STRING_FORMATS = {
+    PObjectType::DEFAULT   => Format.new('%p').freeze,    # call with initialization hash
     PFloatType::DEFAULT    => Format.new('%f').freeze,    # float
     PNumericType::DEFAULT  => Format.new('%d').freeze,    # decimal number
     PArrayType::DEFAULT    => DEFAULT_ARRAY_FORMAT.freeze,
@@ -542,6 +543,23 @@ class StringConverter
     result
   end
   private :validate_container_input
+
+  def string_PObjectType(val_type, val, format_map, indentation)
+    f = get_format(val_type, format_map)
+    case f.format
+    when :p
+      fmt = TypeFormatter.singleton
+      indentation = indentation.indenting(f.alt? || indentation.is_indenting?)
+      fmt = fmt.indented(indentation.level, 2) if indentation.is_indenting?
+      fmt.string(val)
+    when :s
+      val.to_s
+    when :q
+      val.inspect
+    else
+      raise FormatError.new('Object', f.format, 'spq')
+    end
+  end
 
   def string_PRuntimeType(val_type, val, format_map, _)
     f = get_format(val_type, format_map)
@@ -929,7 +947,7 @@ class StringConverter
 
   def is_container?(t)
     case t
-    when PArrayType, PHashType, PStructType, PTupleType
+    when PArrayType, PHashType, PStructType, PTupleType, PObjectType
       true
     else
       false

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -163,6 +163,11 @@ class StringConverter
       unless lower && higher
         return lower || higher
       end
+
+      # drop all formats in lower than is more generic in higher. Lower must never
+      # override higher
+      lower = lower.reject { |lk, _| higher.keys.any? { |hk| hk != lk && hk.assignable?(lk) }}
+
       merged = (lower.keys + higher.keys).uniq.map do |k|
         [k, merge(lower[k], higher[k])]
       end

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -548,10 +548,12 @@ class StringConverter
     case f.format
     when :s
       val.to_s
+    when :p
+      puppet_quote(val.to_s)
     when :q
       val.inspect
     else
-      raise FormatError.new('Runtime', f.format, 'sq')
+      raise FormatError.new('Runtime', f.format, 'spq')
     end
   end
 

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -325,8 +325,12 @@ class TypeFormatter
 
   def string_PuppetObject(t)
     @bld << t._pcore_type.name << '('
-    append_indented_string(t._pcore_init_hash, @indent || 0, @indent_width || 2, true)
-    @bld.chomp!
+    if @indent
+      append_indented_string(t._pcore_init_hash, @indent, @indent_width, true)
+      @bld.chomp!
+    else
+      append_string(t._pcore_init_hash)
+    end
     @bld << ')'
   end
 

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -782,6 +782,34 @@ describe 'The Object Type' do
       expect(eval_and_collect_notices(code)).to eql(['true'])
     end
 
+    it 'declared Object type is assignable to default Object type' do
+      code = <<-CODE
+      type MyObject = Object[{ attributes => { a => Integer }}]
+      notice(MyObject < Object)
+      notice(MyObject <= Object)
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['true', 'true'])
+    end
+
+    it 'default Object type not is assignable to declared Object type' do
+      code = <<-CODE
+      type MyObject = Object[{ attributes => { a => Integer }}]
+      notice(Object < MyObject)
+      notice(Object <= MyObject)
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['false', 'false'])
+    end
+
+    it 'default Object type is assignable to itself' do
+      code = <<-CODE
+      notice(Object < Object)
+      notice(Object <= Object)
+      notice(Object > Object)
+      notice(Object >= Object)
+      CODE
+      expect(eval_and_collect_notices(code)).to eql(['false', 'true', 'false', 'true'])
+    end
+
     it 'an object type is an instance of an object type type' do
       code = <<-CODE
       type MyObject = Object[{ attributes => { a => Integer }}]

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -723,7 +723,7 @@ describe 'The Object Type' do
       type Spec::MySecondObject = Object[{parent => Spec::MyObject, attributes => { b => String }}]
       notice(Spec::MySecondObject(42, 'Meaning of life'))
       CODE
-      expect(eval_and_collect_notices(code)).to eql(["Spec::MySecondObject({\n  'a' => 42,\n  'b' => 'Meaning of life'\n})"])
+      expect(eval_and_collect_notices(code)).to eql(["Spec::MySecondObject({'a' => 42, 'b' => 'Meaning of life'})"])
     end
   end
 

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -828,7 +828,7 @@ describe 'The string converter' do
         string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#1a', 'separator' =>"," } }
         result = [
         "{1 => [ 1,",
-        "    2,", 
+        "    2,",
         "    3]}"
         ].join("\n")
         formatted = converter.convert({ 1 => [1, 2, 3] }, string_formats)
@@ -843,7 +843,7 @@ describe 'The string converter' do
         result = [
         "{",
         "  1 => [ 1,",
-        "    2,", 
+        "    2,",
         "    3]",
         "}"
         ].join("\n")
@@ -1080,5 +1080,9 @@ describe 'The string converter' do
 
   it "allows format to be directly given (instead of as a type=> format hash)" do
     expect(converter.convert('hello', '%5.1s')).to eq('    h')
+  end
+
+  it 'an explicit format for a type will override more specific defaults' do
+    expect(converter.convert({ 'x' => 'X' }, { Puppet::Pops::Types::PCollectionType::DEFAULT => '%#p' })).to eq("{\n  'x' => 'X'\n}")
   end
 end

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -905,10 +905,14 @@ describe 'The string converter' do
       it "the '%q' string representation for #{value} is #inspect" do
         expect(converter.convert(value, '%q')).to eq(value.inspect)
       end
+
+      it "the '%p' string representation for #{value} is quoted #to_s" do
+        expect(converter.convert(value, '%p')).to eq("'#{value}'")
+      end
     end
 
     it 'an unknown format raises an error' do
-      expect { converter.convert(:sym, '%b') }.to raise_error("Illegal format 'b' specified for value of Runtime type - expected one of the characters 'sq'")
+      expect { converter.convert(:sym, '%b') }.to raise_error("Illegal format 'b' specified for value of Runtime type - expected one of the characters 'spq'")
     end
   end
 

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -359,6 +359,28 @@ describe 'Puppet Type System' do
       t = tf.runtime('ruby', [/^MyPackage::(.*)$/, 'MyModule::\1'])
       expect(t.from_puppet_name('MyPackage::MyType').to_s).to eq("Runtime[ruby, 'MyModule::MyType']")
     end
+
+    it 'with parameters is assignable to the default Runtime type' do
+      code = <<-CODE
+      notice(Runtime[ruby, 'Symbol'] < Runtime)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true'])
+    end
+
+    it 'with parameters is not assignable from the default Runtime type' do
+      code = <<-CODE
+      notice(Runtime < Runtime[ruby, 'Symbol'])
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['false'])
+    end
+
+    it 'default is assignable to itself' do
+      code = <<-CODE
+      notice(Runtime < Runtime)
+      notice(Runtime <= Runtime)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['false', 'true'])
+    end
   end
 
   context 'Type aliases' do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -727,7 +727,7 @@ describe Puppet::Resource do
         one::two { '/my/file':
           ensure => 'present',
           foo    => ['one', 'two'],
-          noop   => 'true',
+          noop   => true,
         }
       HEREDOC
     end
@@ -749,7 +749,7 @@ describe Puppet::Resource do
           /my/file:
             ensure: 'present'
             foo   : ['one', 'two']
-            noop  : 'true'
+            noop  : true
       HEREDOC
     end
   end

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -369,8 +369,7 @@ describe Puppet::Type.type(:user) do
             is.force_encoding(Encoding::ASCII_8BIT)
             should.force_encoding(Encoding::UTF_8)
             expect(Encoding.compatible?(is, should)).to be_falsey
-            # append Regexp with 'n' to set encoding to ASCII_8BIT
-            expect(comment_property.change_to_s(is,should)).to match(/changed '\xE2\x98\x83' to '\xDB\xBF'/n)
+            expect(comment_property.change_to_s(is,should)).to match(/changed "\\u\{E2\}\\u\{98\}\\u\{83\}" to "\\u\{DB\}\\u\{BF\}"/)
           end
         end
 
@@ -379,8 +378,7 @@ describe Puppet::Type.type(:user) do
             is.force_encoding(Encoding::UTF_8)
             should.force_encoding(Encoding::UTF_8)
             expect(Encoding.compatible?(is, should)).to be_truthy
-            # append Regexp with 'u' to set encoding to UTF_8
-            expect(comment_property.change_to_s(is,should)).to match(/changed '\u2603' to '\u06FF'/u)
+            expect(comment_property.change_to_s(is,should)).to match(/changed "\\u\{2603\}" to "\\u\{6FF\}"/)
           end
         end
       end


### PR DESCRIPTION
The `Parameter#format_value_for_display` method had many issues. Strings
containing quotes would be emitted without escaping the quotes. All
values would be quoted (including numbers, booleans, and objects). The
output, allegedly "formatted fo display to a human" did not include
newlines and indentation. Output was sorted alphabetically although
Puppet specifies hashes as ordered.

This commit replaces the body of the method with a call to the
`StringConverter` class which is designed to address all described
issues.