### PR TITLE
(PUP-7572) Tag Tests breaking Image Acceptance

### DIFF
--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -4,10 +4,12 @@ test_name "C98092 - a new resource should not be reported as a corrective change
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+  tag 'broken:images'
+
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
-  
+
   agents.each do |agent|
     tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
   end
@@ -15,15 +17,15 @@ extend Puppet::Acceptance::EnvironmentUtils
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''
           on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
-        end 
+        end
       end
     end
   end
 
   step 'create file resource - site.pp to verify corrective change flag' do
-    file_contents     = 'this is a test'   
+    file_contents     = 'this is a test'
     manifest = <<MANIFEST
 file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
   ensure => file,
@@ -32,7 +34,7 @@ file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
 file { \$test_path:
   content => @(UTF8)
     #{file_contents}
-    | UTF8 
+    | UTF8
 }
   ',
 }

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -4,6 +4,8 @@ extend Puppet::Acceptance::EnvironmentUtils
 
 test_name "C98093 - a resource changed outside of Puppet will be reported as a corrective change" do
 
+  tag 'broken:images'
+
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
@@ -15,7 +17,7 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
+        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''
           on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
         end
       end
@@ -66,7 +68,7 @@ MANIFEST
         step 'Run agent to correct the files absence' do
           on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
         end
- 
+
         #Verify the file resource is created
         step 'Verify the file resource is created' do
           on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
@@ -98,7 +100,7 @@ MANIFEST
           file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
           assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
           corrective_change_value =  file_resource_details["corrective_change"]
-          assert_equal(true, corrective_change_value, 'corrective_change flag should be true') 
+          assert_equal(true, corrective_change_value, 'corrective_change flag should be true')
         end
       end
     end

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -4,12 +4,14 @@ extend Puppet::Acceptance::EnvironmentUtils
 
 test_name "C98094 - a resource changed via Puppet manifest will not be reported as a corrective change" do
 
+  tag 'broken:images'
+
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file = {}
   original_test_data = 'this is my original important data'
   modified_test_data = 'this is my modified important data'
- 
+
   agents.each do |agent|
     tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
   end

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -1,8 +1,11 @@
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+
 test_name 'Ensure a file resource can have a UTF-8 source attribute, content, and path when served via a module' do
+
   skip_test 'requires a master for serving module content' if master.nil?
+  tag 'broken:images'
 
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))
   agent_tmp_dirs = {}
@@ -79,4 +82,3 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
     end
   end
 end
-


### PR DESCRIPTION
These tests break the Image Acceptance Test suite, so are being tagged
so that they can be excluded pending further investigation as part of
ticket PUP-7521

This was labelelled IMAGES-555 but Travis is unable to accept this as PR
prefix.

This replaces #5860 