### PR TITLE
(PUP-7574) Introduce proper support for Hash properties.

### DIFF
--- a/lib/puppet/property/deep_hash.rb
+++ b/lib/puppet/property/deep_hash.rb
@@ -1,0 +1,59 @@
+require 'puppet/property'
+
+# This subclass of Puppet::Property manages a Hash or a deep Hash
+# (hash with inner hashes) by comparing only keys in the current state (_is_)
+# that are also present in the desired state (_should_).
+#
+# It is useful for resources that have a JSON or YAML representation that is
+# easily parsed to a Hash.
+module Puppet
+  class Property
+    class DeepHash < Property
+      def _deep_intersect(current_state, desired_state)
+        diff = {}
+
+        current_state.each do |key, value|
+          next unless desired_state.keys.include? key
+          if value.is_a? Hash
+            diff[key] = _deep_intersect(value, desired_state[key])
+          else
+            diff[key] = value
+          end
+        end
+
+        diff
+      end
+
+      def _deep_transform_values_in_object(object, &block)
+        case object
+        when Hash
+          object.each_with_object({}) do |(key, value), result|
+            result[key] = _deep_transform_values_in_object(value, &block)
+          end
+        when Array
+          object.map { |e| _deep_transform_values_in_object(e, &block) }
+        else
+          yield(object)
+        end
+      end
+
+      def should
+        _deep_transform_values_in_object(super) { |value| value == :undef ? nil : value }
+      end
+
+      def insync?(is)
+        desired_state = should
+        _deep_intersect(is, desired_state) == desired_state
+      end
+
+      def change_to_s(current_value, new_value)
+        changed_keys = (new_value.to_a - current_value.to_a).collect { |key, _| key }
+
+        current_value = current_value.delete_if { |key, _| !changed_keys.include? key }.inspect
+        new_value = new_value.delete_if { |key, _| !changed_keys.include? key }.inspect
+
+        super(current_value, new_value)
+      end
+    end
+  end
+end

--- a/spec/unit/property/deep_hash_spec.rb
+++ b/spec/unit/property/deep_hash_spec.rb
@@ -1,0 +1,131 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/property/deep_hash'
+
+klass = Puppet::Property::DeepHash
+
+describe klass do
+
+  it "should be a subclass of Property" do
+    expect(klass.superclass).to eq(Puppet::Property)
+  end
+
+  before do
+    # Wow that's a messy interface to the resource.
+    klass.initvars
+    @resource = stub 'resource', :[]= => nil, :property => nil
+    @property = klass.new(:resource => @resource)
+  end
+
+  describe 'when calling insync' do
+
+    describe 'for plain hashes' do
+
+      it 'is not in sync if hashes do not match' do
+        @property.should = { 'name' => 'dummy', 'value' => 'anotherResource' }
+
+        is = { 'name' => 'dummy', 'value' => 'resource' }
+
+        expect(@property.insync?(is)).to be false
+      end
+
+      it 'is synced if hashes are equal' do
+        @property.should = { 'name' => 'dummy', 'value' => 'resource' }
+
+        is = { 'name' => 'dummy', 'value' => 'resource' }
+
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if hashes are equal including array values' do
+        @property.should = { 'name' => 'dummy', 'value' => %w(a b c) }
+
+        is = { 'value' => %w(a b c), 'name' => 'dummy' }
+
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if there are unmanaged properties' do
+        @property.should = { 'name' => 'dummy' }
+
+        is = { 'name' => 'dummy', 'port' => 8080, 'enabled' => false }
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is in sync if _should_ is undef and _is_ is nil' do
+        @property.should = { 'name' => 'dummy', 'value' => :undef }
+
+        is = { 'name' => 'dummy', 'value' => nil }
+
+        expect(@property.insync?(is)).to be true 
+      end
+
+    end
+
+    describe 'for nested hashes' do
+
+      it 'is not in sync if nested hashes do not match' do
+        @property.should = { 'name' => 'dummy', 'nested-hash' => { 'my-resource' => 'match' } }
+
+        is = { 'name' => 'dummy', 'nested-hash' => { 'my-resource' => 'matchzzz' } }
+
+        expect(@property.insync?(is)).to be false
+      end
+
+      it 'is synced if nested hashes are equal' do
+        @property.should = { 'name' => 'dummy', 'nested-hash' => { 'my-resource' => 'match' } }
+
+        is = { 'name' => 'dummy', 'nested-hash' => { 'my-resource' => 'match' } }
+
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if hashes are equal but in different order' do
+        @property.should = { 'name' => 'dummy', 'nested-hash' => { 'my-resource' => 'match', 'a-resource' => 'default' }, 'value' => 'resource' }
+
+        is = { 'value' => 'resource', 'name' => 'dummy', 'nested-hash' => { 'a-resource' => 'default', 'my-resource' => 'match' } }
+
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if hashes and inner arrays are equal' do
+        @property.should = { 'name' => 'dummy', 'nested-hash' => { 'value' => %w(a b c) } }
+
+        is = { 'nested-hash' => { 'value' => %w(a b c) }, 'name' => 'dummy' }
+
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if hashes and typed inner arrays are equal' do
+        @property.should = { 'name' => 'dummy', 'nested-hash' => { 'value' => [true, false, true] } }
+
+        is = { 'nested-hash' => { 'value' => [true, false, true] }, 'name' => 'dummy' }
+
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if there are unmanaged properties' do
+        @property.should = { 'name' => 'dummy', 'nested-hash' => { 'enabled' => true } }
+
+        is = { 'name' => 'dummy', 'port' => 8080, 'enabled' => false, 'nested-hash' => { 'enabled' => true, 'a-numeric-resource' => 42 } }
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if there are unmanaged hash properties' do
+        @property.should = { 'name' => 'dummy' }
+
+        is = { 'name' => 'dummy', 'port' => 8080, 'enabled' => false, 'nested-hash' => { 'enabled' => true, 'a-numeric-resource' => 42 } }
+        expect(@property.insync?(is)).to be true
+      end
+
+      it 'is synced if there are unmanaged properties' do
+        @property.should = { 'name' => 'dummy', 'nested-hash' => { 'enabled' => true } }
+
+        is = { 'name' => 'dummy', 'port' => 8080, 'enabled' => false, 'nested-hash' => { 'enabled' => true, 'a-numeric-resource' => 42 } }
+        expect(@property.insync?(is)).to be true
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Some resources may have a JSON/YAML representation that is easy parsed to a ruby Hash, but there isn't the concept of managed and unmanaged keys for vanilla Ruby Hashes comparison. This Puppet::Property subclass aims to fill this gap by providing utilities to compare hashes - even deep nested ones - and properly report changes.