### PR TITLE
(PUP-7554) Don't error on v3 hiera.yaml in module

### DIFF
--- a/lib/puppet/pops/lookup/module_data_provider.rb
+++ b/lib/puppet/pops/lookup/module_data_provider.rb
@@ -60,8 +60,16 @@ class ModuleDataProvider < ConfiguredDataProvider
   protected
 
   def assert_config_version(config)
-    config.fail(Issues::HIERA_VERSION_3_NOT_GLOBAL, :where => 'module') unless config.version > 3
-    config
+    if config.version > 3
+      config
+    else
+      if Puppet[:strict] == :error
+        config.fail(Issues::HIERA_VERSION_3_NOT_GLOBAL, :where => 'module')
+      else
+        Puppet.warn_once(:hiera_v3_at_module_root, config.config_path, _('hiera.yaml version 3 found at module root was ignored'))
+      end
+      nil
+    end
   end
 
   # Return the root of the module with the name equal to the configured module name

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2080,8 +2080,9 @@ describe "The lookup function" do
             }
           end
 
-          it 'raises an error' do
-            expect { lookup('mod_a::a') }.to raise_error(Puppet::Error, /hiera.yaml version 3 cannot be used in a module/)
+          it 'raises a warning' do
+            expect(lookup('mod_a::a')).to eql('value mod_a::a (from environment)')
+            expect(warnings).to include(/hiera.yaml version 3 found at module root was ignored/)
           end
         end
 


### PR DESCRIPTION
A v3 hiera.yaml in the root of a module directory should be a warning,
not an error. It should be roughly equivalent to not having a hiera.yaml
file there at all. This is to allow customers who currently have
hiera.yaml files in modules to install new versions of Puppet without
having to first refactor all their modules and CI systems.