### PR TITLE
(PUP-6060) set node cache terminus to nil

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -61,15 +61,8 @@ class Puppet::Application::Lookup < Puppet::Application
     end
   end
 
-  # Sets up the 'node_cache_terminus' default to use the Write Only Yaml terminus :write_only_yaml.
-  # If this is not wanted, the setting ´node_cache_terminus´ should be set to nil.
-  # @see Puppet::Node::WriteOnlyYaml
-  # @see #setup_node_cache
-  # @see puppet issue 16753
-  #
   def app_defaults
     super.merge({
-      :node_cache_terminus => :write_only_yaml,
       :facts_terminus => 'yaml'
     })
   end
@@ -336,7 +329,6 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       # If we want to lookup the node we are currently on
       # we must returning these settings to their default values
       Puppet.settings[:facts_terminus] = 'facter'
-      Puppet.settings[:node_cache_terminus] = nil
     end
 
     node = Puppet::Node.indirection.find(node) unless node.is_a?(Puppet::Node) # to allow unit tests to pass a node instance

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -135,15 +135,8 @@ Copyright (c) 2012 Puppet Inc., LLC Licensed under the Apache 2.0 License
     HELP
   end
 
-  # Sets up the 'node_cache_terminus' default to use the Write Only Yaml terminus :write_only_yaml.
-  # If this is not wanted, the setting ´node_cache_terminus´ should be set to nil.
-  # @see Puppet::Node::WriteOnlyYaml
-  # @see #setup_node_cache
-  # @see puppet issue 16753
-  #
   def app_defaults
     super.merge({
-      :node_cache_terminus => :write_only_yaml,
       :facts_terminus => 'yaml'
     })
   end
@@ -256,11 +249,10 @@ Copyright (c) 2012 Puppet Inc., LLC Licensed under the Apache 2.0 License
     Puppet::SSL::Oids.load_custom_oid_file(Puppet[:trusted_oid_mapping_file])
   end
 
-  # Sets up a special node cache "write only yaml" that collects and stores node data in yaml
-  # but never finds or reads anything (this since a real cache causes stale data to be served
-  # in circumstances when the cache can not be cleared).
-  # @see puppet issue 16753
-  # @see Puppet::Node::WriteOnlyYaml
+  # Honor the :node_cache_terminus setting if users have specified it directly.
+  # We normally want this nil as use-cases for querying nodes should be going to
+  # PuppetDB.
+  # @see PUP-6060
   # @return [void]
   def setup_node_cache
     Puppet::Node.indirection.cache_class = Puppet[:node_cache_terminus]

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -415,8 +415,7 @@ deprecated and has been replaced by 'always_retry_plugins'."
       :type       => :terminus,
       :default    => nil,
       :desc       => "How to store cached nodes.
-      Valid values are (none), 'json', 'msgpack', 'yaml' or write only yaml ('write_only_yaml').
-      The master application defaults to 'write_only_yaml', all others to none.",
+      Valid values are (none), 'json', 'msgpack', 'yaml' or write only yaml ('write_only_yaml').",
     },
     :data_binding_terminus => {
       :type    => :terminus,

--- a/lib/puppet/indirector/node/write_only_yaml.rb
+++ b/lib/puppet/indirector/node/write_only_yaml.rb
@@ -11,7 +11,12 @@ require 'puppet/indirector/yaml'
 # @api private
 #
 class Puppet::Node::WriteOnlyYaml < Puppet::Indirector::Yaml
-  desc "Store node information as flat files, serialized using YAML,
+  def initialize
+    Puppet.warn_once(:deprecation, 'Puppet::Node::WriteOnlyYaml', _('Puppet::Node::WriteOnlyYaml is deprecated and will be removed in a future release of Puppet.'))
+    super
+  end
+
+  desc "(Deprecated) Store node information as flat files, serialized using YAML,
     does not deserialize (write only)."
 
   # Overridden to always return nil. This is a write only terminus.

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -13,7 +13,6 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
     Puppet::Util::Log.stubs(:newdestination)
 
     Puppet::Node.indirection.stubs(:terminus_class=)
-    Puppet::Node.indirection.stubs(:cache_class=)
     Puppet::Node::Facts.indirection.stubs(:terminus_class=)
     Puppet::Node::Facts.indirection.stubs(:cache_class=)
     Puppet::Transaction::Report.indirection.stubs(:terminus_class=)
@@ -206,10 +205,27 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
 
         @master.setup
       end
-
-
     end
 
+    it "should not set Puppet[:node_cache_terminus] by default" do
+      # This is normally called early in the application lifecycle but in our
+      # spec testing we don't actually do a full application initialization so
+      # we call it here to validate the (possibly) overridden settings are as we
+      # expect
+      @master.initialize_app_defaults
+      @master.setup
+
+      expect(Puppet[:node_cache_terminus]).to be(nil)
+    end
+
+    it "should honor Puppet[:node_cache_terminus] by setting the cache_class to its value" do
+      # PUP-6060 - ensure we honor this value if specified
+      @master.initialize_app_defaults
+      Puppet[:node_cache_terminus] = 'plain'
+      @master.setup
+
+      expect(Puppet::Node.indirection.cache_class).to eq(:plain)
+    end
   end
 
   describe "when running" do

--- a/spec/unit/indirector/node/write_only_yaml_spec.rb
+++ b/spec/unit/indirector/node/write_only_yaml_spec.rb
@@ -1,0 +1,12 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/node'
+require 'puppet/indirector/node/write_only_yaml'
+
+describe Puppet::Node::WriteOnlyYaml do
+  it "should be deprecated" do
+    Puppet.expects(:warn_once).with(:deprecation, 'Puppet::Node::WriteOnlyYaml', 'Puppet::Node::WriteOnlyYaml is deprecated and will be removed in a future release of Puppet.')
+    described_class.new
+  end
+end


### PR DESCRIPTION
(PUP-6060) stop setting node_cache_terminus

This PR stops overriding the default `node_cache_terminus` for lookup and master applications to `write_only_yaml` and removes the setting of Puppet::Node's indirection cache_class. In the case of the master application, with this, Puppet::Node's indirection won't cache by default and so won't use the write_only_yaml cache. Per PUP-6060, with the advent of PuppetDB, workflows using lists of nodes are better off querying it than these yaml files on the master, and since this was a `write_only` cache we were always querying the node terminus for nodes anyway. With respect to the lookup application, while we set the `node_cache_terminus` setting, we never set to the `Puppet::Node` indirection cache_class to its value, which meant it was never set at all - the code removed from lookup never had any effect. This PR is largely cleanup - for our current deployments, puppet server deploys its own version of the master application that also sets `node_cache_terminus`. A separate PR is raised in puppet-server to remove it there as well. Since there are no more callers to this terminus, we deprecate it.
