### PR TITLE
(PUP-7576) fix face_base arity check

### DIFF
--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -236,7 +236,7 @@ class Puppet::Application::FaceBase < Puppet::Application
     # --daniel 2011-04-27
     if (arity = @action.positional_arg_count) > 0
       unless (count = arguments.length) == arity then
-        raise ArgumentError, n_("puppet %{face} %{action} takes %{arg_count} argument, but you gave %{given_count}", "puppet %{face} %{action} takes %{arg_count} arguments, but you gave %{given_count}", arity - 1) % { face: @face.name, action: @action.name, arg_count: arity-1, s: s, given_count: count-1 }
+        raise ArgumentError, n_("puppet %{face} %{action} takes %{arg_count} argument, but you gave %{given_count}", "puppet %{face} %{action} takes %{arg_count} arguments, but you gave %{given_count}", arity - 1) % { face: @face.name, action: @action.name, arg_count: arity-1, given_count: count-1 }
       end
     end
 


### PR DESCRIPTION
The exception raised when the wrong number of arguments is supplied to a face
command has an incorrect externalization that references an undefined variable,
`s`. This was a carry-over from a previous form that we replaced when it was
pluralized.

Signed-off-by: Moses Mendoza <moses@puppet.com>