### PR TITLE
(PUP-6517) Raise output and backtrace of rescued exception

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -119,11 +119,13 @@ class Puppet::Provider
 
   # Convenience methods - see class method with the same name.
   # @return (see self.execfail)
+  # @deprecated
   def execfail(*args)
     Puppet::Util::Execution.execfail(*args)
   end
 
   # (see Puppet::Util::Execution.execfail)
+  # @deprecated
   def self.execfail(*args)
     Puppet::Util::Execution.execfail(*args)
   end

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -132,8 +132,10 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
     end
 
     cmd = [command(:rpm), "-q", "--qf", "'#{self.class::NEVRA_FORMAT}'", "-p", source]
-    h = self.class.nevra_to_hash(execfail(cmd, Puppet::Error))
+    h = self.class.nevra_to_hash(execute(cmd))
     h[:ensure]
+  rescue Puppet::ExecutionFailure => e
+    raise Puppet::Error, e.message, e.backtrace
   end
 
   def install

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -98,11 +98,11 @@ module Puppet::Util::Execution
   # @raise [exception] under same conditions as {execute}, but raises the given `exception` with the output as argument
   # @return (see execute)
   # @api public
+  # @deprecated
   def self.execfail(command, exception)
-    output = execute(command)
-    return output
-  rescue Puppet::ExecutionFailure
-    raise exception, output, exception.backtrace
+    execute(command)
+  rescue Puppet::ExecutionFailure => detail
+    raise exception, detail.message, detail.backtrace
   end
 
   # Default empty options for {execute}

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -204,8 +204,17 @@ describe provider_class do
   describe "#latest" do
     it "retrieves version string after querying rpm for version from source file" do
       resource.expects(:[]).with(:source).returns('source-string')
-      Puppet::Util::Execution.expects(:execfail).with(["/bin/rpm", "-q", "--qf", "'#{nevra_format}'", "-p", "source-string"], Puppet::Error).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
+      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "--qf", "'#{nevra_format}'", "-p", "source-string"]).returns("myresource 0 1.2.3.4 5.el4 noarch\n")
       expect(provider.latest).to eq("1.2.3.4-5.el4")
+    end
+
+    it "raises an error if the rpm command fails" do
+      resource.expects(:[]).with(:source).returns('source-string')
+      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "-q", "--qf", "'#{nevra_format}'", "-p", "source-string"]).raises(Puppet::ExecutionFailure, 'rpm command failed')
+
+      expect {
+        provider.latest
+      }.to raise_error(Puppet::Error, 'rpm command failed')
     end
   end
 

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -675,13 +675,42 @@ describe Puppet::Util::Execution do
     it "should fail if asked to fail, and the child does" do
       Puppet::Util::Execution.stubs(:open).with('| echo hello 2>&1').returns('error message')
       Puppet::Util::Execution.expects(:exitstatus).returns(1)
-      expect { Puppet::Util::Execution.execpipe('echo hello') }.
-        to raise_error Puppet::ExecutionFailure, /error message/
+      expect {
+        Puppet::Util::Execution.execpipe('echo hello')
+      }.to raise_error Puppet::ExecutionFailure, /error message/
     end
 
     it "should not fail if asked not to fail, and the child does" do
       Puppet::Util::Execution.stubs(:open).returns('error message')
       expect(Puppet::Util::Execution.execpipe('echo hello', false)).to eq('error message')
+    end
+  end
+
+  describe "execfail" do
+    it "returns the executed command output" do
+      Puppet::Util::Execution.stubs(:execute).returns("process output")
+      expect(Puppet::Util::Execution.execfail('echo hello', Puppet::Error)).to eq('process output')
+    end
+
+    it "raises a caller-specified exception on failure with the backtrace" do
+      Puppet::Util::Execution.stubs(:execute).raises(Puppet::ExecutionFailure, "failed to execute")
+      expect {
+        Puppet::Util::Execution.execfail("this will fail", Puppet::Error)
+      }.to raise_error(Puppet::Error, /failed to execute/)
+    end
+
+    it "raises exceptions that don't extend ExecutionFailure" do
+      Puppet::Util::Execution.stubs(:execute).raises(ArgumentError, "failed to execute")
+      expect {
+        Puppet::Util::Execution.execfail("this will fail", Puppet::Error)
+      }.to raise_error(ArgumentError, /failed to execute/)
+    end
+
+    it "raises a TypeError if the exception class is nil" do
+      Puppet::Util::Execution.stubs(:execute).raises(Puppet::ExecutionFailure, "failed to execute")
+      expect {
+        Puppet::Util::Execution.execfail('echo hello', nil)
+      }.to raise_error(TypeError), /exception class\/object expected/
     end
   end
 end


### PR DESCRIPTION
Previously if `execfail` method failed to execute the command, it would
try to access the `backtrace` method on the exception class passed into
the method instead of the backtrace of the rescued exception.

This commit marks the execfail method as deprecated, since it's
confusing more than anything, and modifies the method to rescue the
exception and re-raise the rescued exception message and backtrace. It
also adds tests for the execfail method as previously there were none.