### PR TITLE
(PUP-7579) Allow tags to contain Unicode words

### DIFF
--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -1,7 +1,7 @@
 require 'puppet/util/tag_set'
 
 module Puppet::Util::Tagging
-  ValidTagRegex = /\A[0-9A-Za-z_][0-9A-Za-z_:.-]*\Z/
+  ValidTagRegex = /\A[[:alnum:]_][[:alnum:]_:.-]*\Z/
 
   # Add a tag to the current tag set.
   # When a tag set is used for a scope, these tags will be added to all of

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -48,6 +48,61 @@ describe Puppet::Util::Tagging do
     expect { tagger.tag("good.tag") }.to_not raise_error
   end
 
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  let (:mixed_utf8) { "A\u06FF\u16A0\u{2070E}" } # Aۿᚠ܎
+
+  it "should allow UTF-8 alphanumeric characters" do
+    expect { tagger.tag(mixed_utf8) }.not_to raise_error
+  end
+
+  # completely non-exhaustive list of a few UTF-8 punctuation characters
+  # http://www.fileformat.info/info/unicode/block/general_punctuation/utf8test.htm
+  [
+    "\u2020", # dagger †
+    "\u203B", # reference mark ※
+    "\u204F", # reverse semicolon ⁏
+    "!",
+    "@",
+    "#",
+    "$",
+    "%",
+    "^",
+    "&",
+    "*",
+    "(",
+    ")",
+    "-",
+    "+",
+    "=",
+    "{",
+    "}",
+    "[",
+    "]",
+    "|",
+    "\\",
+    "/",
+    "?",
+    "<",
+    ">",
+    ",",
+    ".",
+    "~",
+    ",",
+    ":",
+    ";",
+    "\"",
+    "'",
+  ].each do |char|
+    it "should not allow UTF-8 punctuation characters" do
+      expect { tagger.tag(char) }.to raise_error(Puppet::ParseError)
+    end
+  end
+
+
   it "should add qualified classes as tags" do
     tagger.tag("one::two")
     expect(tagger.tags).to include("one::two")


### PR DESCRIPTION
  - The regex for tags was originally /^\w[-\w:]*$/ in a Luke commit
    from 10 years ago f98be4a7198326b26f1072c401b3e337f340db40

  - Over the years it has received updates to modernize it and has
    shuffled around.

  - 0badfce72bafc767bf3099718c63324f51108996 changed it from

    /^\w[-\w:.]*$/

    to

    /^[0-9A-Za-z_][0-9A-Za-z_:.-]*$/

    for performance reasons.

  - The concat module depends on tags, and as such requires that tags
    can contain other valid content.  The regex here is too
    restrictive for that purpose and should be returned to its
    original intent - word characters.

    However, it now needs to be updated to accept word characters in
    any language.

  - This now allows for the follow manifest to not cause an error:

  puppet apply -e 'notify { "hi": tag => "_メインディレクトリ_醸造所"  }'