### PR TITLE
(PUP-1606) Deprecate virtual class

### DIFF
--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -75,6 +75,13 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
     virtual = true
   end
 
+  if type_name == 'class' && (exported || virtual)
+    # cannot find current evaluator, so use another
+    evaluator = Puppet::Pops::Parser::EvaluatingParser.new.evaluator
+    # optionally fails depending on configured severity of issue
+    evaluator.runtime_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+  end
+
   instances.map do |title, params|
     # Add support for iteration if title is an array
     resource_titles = title.is_a?(Array) ? title  : [title]

--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -79,7 +79,7 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
     # cannot find current evaluator, so use another
     evaluator = Puppet::Pops::Parser::EvaluatingParser.new.evaluator
     # optionally fails depending on configured severity of issue
-    evaluator.runtime_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+    evaluator.runtime_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
   end
 
   instances.map do |title, params|

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -44,6 +44,30 @@ module Runtime3Support
     diagnostic_producer.accept(issue, semantic, options, except)
   end
 
+  # Optionally (based on severity) Fails the evaluation with a given issue
+  # If the given issue is configured to be of severity < :error it is only reported, and the function returns.
+  # The location the issue is reported against is found is based on the top file/line in the puppet call stack
+  #
+  # @param issue [Issue] the issue to report
+  # @param options [Hash] hash of optional named data elements for the given issue
+  # @return [!] this method may not return, nil if it does
+  # @raise [Puppet::ParseError] an evaluation error initialized from the arguments
+  #
+  def runtime_issue(issue, options={})
+    # Get position from puppet runtime stack
+    stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+    if stacktrace.size > 0
+      file, line = stacktrace[0]
+    else
+      file = nil
+      line = nil
+    end
+    # Use a SemanticError as the sourcepos
+    semantic = Puppet::Pops::SemanticError.new(issue, nil, options.merge({:file => file, :line => line}))
+    optionally_fail(issue,  semantic)
+    nil
+  end
+
   # Binds the given variable name to the given value in the given scope.
   # The reference object `o` is intended to be used for origin information - the 3x scope implementation
   # only makes use of location when there is an error. This is now handled by other mechanisms; first a check
@@ -498,6 +522,7 @@ module Runtime3Support
       # Store config issues, ignore or warning
       p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
       p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
+      p[Issues::CLASS_NOT_VIRTUALIZEABLE]     = Puppet[:strict] == :off ? :warning : Puppet[:strict]
     end
   end
 

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -522,7 +522,7 @@ module Runtime3Support
       # Store config issues, ignore or warning
       p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
       p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
-      p[Issues::CLASS_NOT_VIRTUALIZEABLE]     = Puppet[:strict] == :off ? :warning : Puppet[:strict]
+      p[Issues::CLASS_NOT_VIRTUALIZABLE]     = Puppet[:strict] == :off ? :warning : Puppet[:strict]
     end
   end
 

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -368,7 +368,7 @@ module Issues
     "Resource Defaults are not virtualizable"
   end
 
-  CLASS_NOT_VIRTUALIZEABLE = issue :CLASS_NOT_VIRTUALIZEABLE do
+  CLASS_NOT_VIRTUALIZABLE = issue :CLASS_NOT_VIRTUALIZABLE do
     "Classes are not virtualizable"
   end
 

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -368,6 +368,10 @@ module Issues
     "Resource Defaults are not virtualizable"
   end
 
+  CLASS_NOT_VIRTUALIZEABLE = issue :CLASS_NOT_VIRTUALIZEABLE do
+    "Classes are not virtualizable"
+  end
+
   # When an attempt is made to use multiple keys (to produce a range in Ruby - e.g. $arr[2,-1]).
   # This is not supported in 3x, but it allowed in 4x.
   #

--- a/lib/puppet/pops/semantic_error.rb
+++ b/lib/puppet/pops/semantic_error.rb
@@ -14,4 +14,16 @@ class Puppet::Pops::SemanticError < RuntimeError
     @semantic = semantic
     @options = options
   end
+
+  def file
+    @options[:file]
+  end
+
+  def line
+    @options[:line]
+  end
+
+  def pos
+    @options[:pos]
+  end
 end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -626,6 +626,10 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     # to enable better error message of the result of the expression rather than the static instruction.
     # (This can be revised as there are static constructs that are illegal, but require updating many
     # tests that expect the detailed reporting).
+    type_name_expr = o.type_name
+    if o.form && o.form != :regular && type_name_expr.is_a?(Model::QualifiedName) && type_name_expr.value == 'class'
+      acceptor.accept(Issues::CLASS_NOT_VIRTUALIZEABLE, o)
+    end
   end
 
   def check_ResourceBody(o)

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -628,7 +628,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     # tests that expect the detailed reporting).
     type_name_expr = o.type_name
     if o.form && o.form != :regular && type_name_expr.is_a?(Model::QualifiedName) && type_name_expr.value == 'class'
-      acceptor.accept(Issues::CLASS_NOT_VIRTUALIZEABLE, o)
+      acceptor.accept(Issues::CLASS_NOT_VIRTUALIZABLE, o)
     end
   end
 

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -31,6 +31,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::DUPLICATE_DEFAULT]             = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
+    p[Issues::CLASS_NOT_VIRTUALIZEABLE]      = Puppet[:strict] == :off ? :warning : Puppet[:strict]
     p
   end
 end

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -31,7 +31,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::DUPLICATE_DEFAULT]             = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
-    p[Issues::CLASS_NOT_VIRTUALIZEABLE]      = Puppet[:strict] == :off ? :warning : Puppet[:strict]
+    p[Issues::CLASS_NOT_VIRTUALIZABLE]      = Puppet[:strict] == :off ? :warning : Puppet[:strict]
     p
   end
 end

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -263,6 +263,21 @@ describe 'function for dynamically creating resources' do
       }.to raise_error(/Classes are not virtualizable/)
     end
 
+    [:off, :warning].each do | strictness |
+      it "should warn if strict = #{strictness} and class is virtual" do
+        Puppet[:strict] = strictness
+        collect_notices('class test{} create_resources("@class", {test => {}})')
+        expect(warnings).to include(/Classes are not virtualizable/)
+      end
+    end
+
+    it 'should error if strict = error and class is virtual' do
+      Puppet[:strict] = :error
+      expect{
+        compile_to_catalog('class test{} create_resources("@class", {test => {}})')
+      }.to raise_error(/Classes are not virtualizable/)
+    end
+
     it 'should be able to add edges' do
       rg = compile_to_relationship_graph(<<-MANIFEST)
         class bar($one) {

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -232,6 +232,9 @@ describe 'function for dynamically creating resources' do
   end
 
   describe 'when creating classes' do
+    let(:logs) { [] }
+    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+
     it 'should be able to create classes' do
       catalog = compile_to_catalog(<<-MANIFEST)
         class bar($one) {
@@ -245,12 +248,19 @@ describe 'function for dynamically creating resources' do
       expect(catalog.resource(:class, "bar")).not_to be_nil
     end
 
-    it 'should fail to create non-existing classes' do
-      expect do
-        compile_to_catalog(<<-MANIFEST)
-          create_resources('class', {'blah'=>{'one'=>'two'}})
-        MANIFEST
-      end.to raise_error(/Could not find declared class blah at line 1:11 on node test/)
+    [:off, :warning].each do | strictness |
+      it "should warn if strict = #{strictness} and class is exported" do
+        Puppet[:strict] = strictness
+        collect_notices('class test{} create_resources("@@class", {test => {}})')
+        expect(warnings).to include(/Classes are not virtualizable/)
+      end
+    end
+
+    it 'should error if strict = error and class is exported' do
+      Puppet[:strict] = :error
+      expect{
+        compile_to_catalog('class test{} create_resources("@@class", {test => {}})')
+      }.to raise_error(/Classes are not virtualizable/)
     end
 
     it 'should be able to add edges' do
@@ -291,4 +301,11 @@ describe 'function for dynamically creating resources' do
       }.to raise_error(Puppet::Error, /Syntax error at.*/)
     end
   end
+
+  def collect_notices(code)
+    Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+      compile_to_catalog(code)
+    end
+  end
+
 end

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -99,14 +99,14 @@ describe "validating 4x" do
       acceptor = validate(parse('@class { test: }'))
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
     it 'produces a  warning for exported class resource' do
       acceptor = validate(parse('@@class { test: }'))
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
   end
@@ -138,14 +138,14 @@ describe "validating 4x" do
       acceptor = validate(parse('@class { test: }'))
       expect(acceptor.warning_count).to eql(0)
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
     it 'produces an error for exported class resource' do
       acceptor = validate(parse('@@class { test: }'))
       expect(acceptor.warning_count).to eql(0)
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
   end
 
@@ -176,14 +176,14 @@ describe "validating 4x" do
       acceptor = validate(parse('@class { test: }'))
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
     it 'produces a  warning for exported class resource' do
       acceptor = validate(parse('@@class { test: }'))
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
   end
 

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -94,6 +94,21 @@ describe "validating 4x" do
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
     end
+
+    it 'produces a warning for virtual class resource' do
+      acceptor = validate(parse('@class { test: }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+    end
+
+    it 'produces a  warning for exported class resource' do
+      acceptor = validate(parse('@@class { test: }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+    end
+
   end
 
   context 'with --strict set to error' do
@@ -118,6 +133,20 @@ describe "validating 4x" do
       expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
     end
+
+    it 'produces an error for virtual class resource' do
+      acceptor = validate(parse('@class { test: }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+    end
+
+    it 'produces an error for exported class resource' do
+      acceptor = validate(parse('@@class { test: }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+    end
   end
 
   context 'with --strict set to off' do
@@ -141,6 +170,20 @@ describe "validating 4x" do
       expect(acceptor.warning_count).to eql(0)
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
+    end
+
+    it 'produces a warning for virtual class resource' do
+      acceptor = validate(parse('@class { test: }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
+    end
+
+    it 'produces a  warning for exported class resource' do
+      acceptor = validate(parse('@@class { test: }'))
+      expect(acceptor.warning_count).to eql(1)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZEABLE)
     end
   end
 


### PR DESCRIPTION
This adds warning/error under the control of --strict for resource stye class inclusion and `create_resources` when an attempt is made to use `@class` or `@@class` as neither virtual nor exported works with classes.