### PR TITLE
(maint) Improve hiera.yaml v3 warnings

### DIFF
--- a/lib/puppet/pops/lookup/environment_data_provider.rb
+++ b/lib/puppet/pops/lookup/environment_data_provider.rb
@@ -17,7 +17,7 @@ class EnvironmentDataProvider < ConfiguredDataProvider
       if Puppet[:strict] == :error
         config.fail(Issues::HIERA_VERSION_3_NOT_GLOBAL, :where => 'environment')
       else
-        Puppet.warn_once(:hiera_v3_at_env_root, config.config_path, 'hiera.yaml version 3 found at the environment root was ignored')
+        Puppet.warn_once(:hiera_v3_at_env_root, config.config_path, _('hiera.yaml version 3 found at the environment root was ignored'), config.config_path)
       end
       nil
     end

--- a/lib/puppet/pops/lookup/module_data_provider.rb
+++ b/lib/puppet/pops/lookup/module_data_provider.rb
@@ -66,7 +66,7 @@ class ModuleDataProvider < ConfiguredDataProvider
       if Puppet[:strict] == :error
         config.fail(Issues::HIERA_VERSION_3_NOT_GLOBAL, :where => 'module')
       else
-        Puppet.warn_once(:hiera_v3_at_module_root, config.config_path, _('hiera.yaml version 3 found at module root was ignored'))
+        Puppet.warn_once(:hiera_v3_at_module_root, config.config_path, _('hiera.yaml version 3 found at module root was ignored'), config.config_path)
       end
       nil
     end


### PR DESCRIPTION
When a hiera.yaml file version 3 is found at the environment root or
module root Puppet will print a warning, indicating the file will not be
used. Prior to this commit it was not clear exactly which file the
warning pertained to.

This commit adds the specific file to the warning, making it clear what
file is causing the warning to be raised.

Given hiera.yaml v3 files at global, environment, and module, this is the difference in warning output.

Old output:
```
[root@master puppetlabs]# puppet apply -e 'include doozer'
Warning: /etc/puppetlabs/puppet/hiera.yaml: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5
   (in /etc/puppetlabs/puppet/hiera.yaml)
Warning: hiera.yaml version 3 found at the environment root was ignored
   (file & line not available)
Warning: hiera.yaml version 3 found at module root was ignored
   (file & line not available)
...
```

New output:
```
[root@master puppetlabs]# puppet apply -e 'include doozer'
Warning: /etc/puppetlabs/puppet/hiera.yaml: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5
   (in /etc/puppetlabs/puppet/hiera.yaml)
Warning: hiera.yaml version 3 found at the environment root was ignored
   (in /etc/puppetlabs/code/environments/production/hiera.yaml)
Warning: hiera.yaml version 3 found at module root was ignored
   (in /etc/puppetlabs/code/environments/production/modules/doozer/hiera.yaml)
...
```

