### PR TITLE
(PUP-6060) Manually set node_cache_terminus for woy test

### DIFF
--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -120,6 +120,7 @@ master_opts = {
   'master' => {
     'rest_authconfig' => authfile,
     'yamldir' => temp_yamldir,
+    'node_cache_terminus' => 'write_only_yaml',
   }
 }
 


### PR DESCRIPTION
The write_only_yaml cache test needs to explicitly set the node terminus as the default value is changing in Puppet 5.
