### PR TITLE
(PUP-7528) Update Windows ci:test:git to Ruby 2.4

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -107,9 +107,9 @@ hosts.each do |host|
     step "#{host} Selected architecture #{arch}"
 
     revision = if arch == 'x64'
-                 '2.1.x-x64'
+                 '2.4.x-x64'
                else
-                 '2.1.x-x86'
+                 '2.4.x-x86'
                end
 
     step "#{host} Install ruby from git using revision #{revision}"


### PR DESCRIPTION
Now that Ruby 2.4 builds have been added to puppet-win32-ruby, this
commit updates puppet to use Ruby 2.4 when running acceptance tests on
Windows via ci:test:git.

Note that some tests are still failing when run this way. These failures
are being investigated separately.