### PR TITLE
(PUP-7587) Puppet Type System should treat Hash and Array subclasses as objects

### DIFF
--- a/lib/puppet/pops/serialization/serializer.rb
+++ b/lib/puppet/pops/serialization/serializer.rb
@@ -93,25 +93,31 @@ module Serialization
     # @param [Object] value the value to write
     # @api private
     def write_tabulated_first_time(value)
-      case value
-      when Symbol, Regexp, SemanticPuppet::Version, SemanticPuppet::VersionRange, Time::Timestamp, Time::Timespan, Types::PBinaryType::Binary
+      case
+      when value.instance_of?(Symbol),
+          value.instance_of?(Regexp),
+          value.instance_of?(SemanticPuppet::Version),
+          value.instance_of?(SemanticPuppet::VersionRange),
+          value.instance_of?(Time::Timestamp),
+          value.instance_of?(Time::Timespan),
+          value.instance_of?(Types::PBinaryType::Binary)
         push_written(value)
         @writer.write(value)
-      when Array
+      when value.instance_of?(Array)
         push_written(value)
         start_array(value.size)
         value.each { |elem| write(elem) }
-      when Hash
+      when value.instance_of?(Hash)
         push_written(value)
         start_map(value.size)
         value.each_pair { |key, val| write(key); write(val) }
-      when Types::PSensitiveType::Sensitive
+      when value.instance_of?(Types::PSensitiveType::Sensitive)
         start_sensitive
         write(value.unwrap)
-      when Types::PTypeReferenceType
+      when value.instance_of?(Types::PTypeReferenceType)
         push_written(value)
         @writer.write(value)
-      when Types::PuppetObject
+      when value.is_a?(Types::PuppetObject)
         value._pcore_type.write(value, self)
       else
         impl_class = value.class

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -647,7 +647,7 @@ class PScalarType < PAnyType
   def instance?(o, guard = nil)
     if o.is_a?(String) || o.is_a?(Numeric) || o.is_a?(TrueClass) || o.is_a?(FalseClass) || o.is_a?(Regexp)
       true
-    elsif o.is_a?(Array) || o.is_a?(Hash) || o.is_a?(PAnyType) || o.is_a?(NilClass)
+    elsif o.instance_of?(Array) || o.instance_of?(Hash) || o.is_a?(PAnyType) || o.is_a?(NilClass)
       false
     else
       assignable?(TypeCalculator.infer(o))
@@ -1196,7 +1196,8 @@ class PCollectionType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    if o.is_a?(Array) || o.is_a?(Hash)
+    # The inferred type of a class derived from Array or Hash is either Runtime or Object. It's not assignable to the Collection type.
+    if o.instance_of?(Array) || o.instance_of?(Hash)
       @size_type.nil? || @size_type.instance?(o.size)
     else
       false
@@ -1871,7 +1872,8 @@ class PStructType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    return false unless o.is_a?(Hash)
+    # The inferred type of a class derived from Hash is either Runtime or Object. It's not assignable to the Struct type.
+    return false unless o.instance_of?(Hash)
     matched = 0
     @elements.all? do |e|
       key = e.name
@@ -2043,7 +2045,8 @@ class PTupleType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    return false unless o.is_a?(Array)
+    # The inferred type of a class derived from Array is either Runtime or Object. It's not assignable to the Tuple type.
+    return false unless o.instance_of?(Array)
     if @size_type
       return false unless @size_type.instance?(o.size, guard)
     else
@@ -2372,7 +2375,8 @@ class PArrayType < PCollectionType
   end
 
   def instance?(o, guard = nil)
-    return false unless o.is_a?(Array)
+    # The inferred type of a class derived from Array is either Runtime or Object. It's not assignable to the Array type.
+    return false unless o.instance_of?(Array)
     return false unless o.all? {|element| @element_type.instance?(element, guard) }
     size_t = size_type
     size_t.nil? || size_t.instance?(o.size, guard)
@@ -2521,7 +2525,8 @@ class PHashType < PCollectionType
   end
 
   def instance?(o, guard = nil)
-    return false unless o.is_a?(Hash)
+    # The inferred type of a class derived from Hash is either Runtime or Object. It's not assignable to the Hash type.
+    return false unless o.instance_of?(Hash)
     if o.keys.all? {|key| @key_type.instance?(key, guard) } && o.values.all? {|value| @value_type.instance?(value, guard) }
       size_t = size_type
       size_t.nil? || size_t.instance?(o.size, guard)

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -866,6 +866,28 @@ describe 'The string converter' do
       end
     end
 
+    context 'that is subclassed' do
+      let(:array) { ['a', 2] }
+      let(:derived_array) do
+        Class.new(Array).new(array)
+      end
+
+      let(:hash) { {'first' => 1, 'second' => 2} }
+      let(:derived_hash) do
+        Class.new(Hash)[hash]
+      end
+
+      it 'formats a derived array as a Runtime' do
+        expect(converter.convert(array)).to eq('[\'a\', 2]')
+        expect(converter.convert(derived_array)).to eq('["a", 2]')
+      end
+
+      it 'formats a derived hash as a Runtime' do
+        expect(converter.convert(hash)).to eq('{\'first\' => 1, \'second\' => 2}')
+        expect(converter.convert(derived_hash)).to eq('{"first"=>1, "second"=>2}')
+      end
+    end
+
     it 'errors when format is not recognized' do
       expect do
       string_formats = { Puppet::Pops::Types::PHashType::DEFAULT => "%k"}

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -91,7 +91,7 @@ describe 'The type calculator' do
     TypeFactory.struct(type_hash)
   end
 
-  def object_t
+  def any_t
     TypeFactory.any
   end
 
@@ -1033,7 +1033,7 @@ describe 'The type calculator' do
       it 'Default key optionality is controlled by value assignability to undef' do
         t1 = struct_t({'member' => string_t})
         expect(t1.elements[0].key_type).to eq(string_t('member'))
-        t1 = struct_t({'member' => object_t})
+        t1 = struct_t({'member' => any_t})
         expect(t1.elements[0].key_type).to eq(optional_t(string_t('member')))
       end
 
@@ -1054,7 +1054,7 @@ describe 'The type calculator' do
       end
 
       it 'Required members not optional even when value is' do
-        t1 = struct_t({not_undef_t('required_member') => object_t, not_undef_t('other_member') => string_t})
+        t1 = struct_t({not_undef_t('required_member') => any_t, not_undef_t('other_member') => string_t})
         t2 = struct_t({not_undef_t('other_member') => string_t})
         expect(t2).not_to be_assignable_to(t1)
       end
@@ -1100,11 +1100,11 @@ describe 'The type calculator' do
       end
 
       it 'a callable with a return type Any is assignable to the default callable' do
-        expect(callable_t([], object_t)).to be_assignable_to(PCallableType::DEFAULT)
+        expect(callable_t([], any_t)).to be_assignable_to(PCallableType::DEFAULT)
       end
 
       it 'a callable with a return type Any is equal to a callable with the same parameters and no return type' do
-        expect(callable_t([string_t], object_t)).to eql(callable_t(string_t))
+        expect(callable_t([string_t], any_t)).to eql(callable_t(string_t))
       end
 
       it 'a callable with a return type different than Any is not equal to a callable with the same parameters and no return type' do
@@ -1796,7 +1796,7 @@ describe 'The type calculator' do
       end
 
       it 'should consider nil to be a valid element value' do
-        struct = struct_t({not_undef_t('a') => object_t, 'b'=>String})
+        struct = struct_t({not_undef_t('a') => any_t, 'b'=>String})
         expect(calculator.instance?(struct, {'a'=>nil , 'b'=>'a'})).to eq(true)
       end
 
@@ -1859,8 +1859,8 @@ describe 'The type calculator' do
         the_block = factory.LAMBDA(params,factory.literal(42), nil).model
         the_closure = Evaluator::Closure::Dynamic.new(:fake_evaluator, the_block, :fake_scope)
         expect(calculator.instance?(all_callables_t, the_closure)).to be_truthy
-        expect(calculator.instance?(callable_t(object_t), the_closure)).to be_truthy
-        expect(calculator.instance?(callable_t(object_t, object_t), the_closure)).to be_falsey
+        expect(calculator.instance?(callable_t(any_t), the_closure)).to be_truthy
+        expect(calculator.instance?(callable_t(any_t, any_t), the_closure)).to be_falsey
       end
 
       it 'a Function instance should be considered a Callable' do
@@ -2117,9 +2117,9 @@ describe 'The type calculator' do
     end
 
     it 'ensures that Struct key types are not generalized' do
-      generic = struct_t({'a' => object_t}).generalize
+      generic = struct_t({'a' => any_t}).generalize
       expect(generic.to_s).to eq("Struct[{'a' => Any}]")
-      generic = struct_t({not_undef_t('a') => object_t}).generalize
+      generic = struct_t({not_undef_t('a') => any_t}).generalize
       expect(generic.to_s).to eq("Struct[{NotUndef['a'] => Any}]")
       generic = struct_t({optional_t('a') => string_t}).generalize
       expect(generic.to_s).to eq("Struct[{Optional['a'] => String}]")
@@ -2195,50 +2195,50 @@ describe 'The type calculator' do
     context 'and given is more generic' do
       it 'with callable' do
         required = callable_t(string_t)
-        given = callable_t(object_t)
+        given = callable_t(any_t)
         expect(calculator.callable?(required, given)).to eq(true)
       end
 
       it 'with args tuple' do
         required = callable_t(string_t)
-        given = tuple_t(object_t)
+        given = tuple_t(any_t)
         expect(calculator.callable?(required, given)).to eq(false)
       end
 
       it 'with args tuple having a block' do
         required = callable_t(string_t, callable_t(string_t))
-        given = tuple_t(string_t, callable_t(object_t))
+        given = tuple_t(string_t, callable_t(any_t))
         expect(calculator.callable?(required, given)).to eq(true)
       end
 
       it 'with args tuple having a block with captures rest' do
         required = callable_t(string_t, callable_t(string_t))
-        given = tuple_t(string_t, callable_t(object_t, 0, :default))
+        given = tuple_t(string_t, callable_t(any_t, 0, :default))
         expect(calculator.callable?(required, given)).to eq(true)
       end
     end
 
     context 'and given is more specific' do
       it 'with callable' do
-        required = callable_t(object_t)
+        required = callable_t(any_t)
         given = callable_t(string_t)
         expect(calculator.callable?(required, given)).to eq(false)
       end
 
       it 'with args tuple' do
-        required = callable_t(object_t)
+        required = callable_t(any_t)
         given = tuple_t(string_t)
         expect(calculator.callable?(required, given)).to eq(true)
       end
 
       it 'with args tuple having a block' do
-        required = callable_t(string_t, callable_t(object_t))
+        required = callable_t(string_t, callable_t(any_t))
         given = tuple_t(string_t, callable_t(string_t))
         expect(calculator.callable?(required, given)).to eq(false)
       end
 
       it 'with args tuple having a block with captures rest' do
-        required = callable_t(string_t, callable_t(object_t))
+        required = callable_t(string_t, callable_t(any_t))
         given = tuple_t(string_t, callable_t(string_t, 0, :default))
         expect(calculator.callable?(required, given)).to eq(false)
       end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -116,6 +116,14 @@ describe 'The type calculator' do
     PUnitType::DEFAULT
   end
 
+  def runtime_t(t, c)
+    TypeFactory.runtime(t, c)
+  end
+
+  def object_t(hash)
+    TypeFactory.object(hash)
+  end
+
   def types
     Types
   end
@@ -268,8 +276,46 @@ describe 'The type calculator' do
     end
 
     context 'array' do
+      let(:derived) do
+        Class.new(Array).new([1,2])
+      end
+
+      let(:derived_object) do
+        Class.new(Array) do
+          include PuppetObject
+
+          def self._pcore_type
+            @type ||= TypeFactory.object('name' => 'DerivedObjectArray')
+          end
+        end.new([1,2])
+      end
+
       it 'translates to PArrayType' do
         expect(calculator.infer([1,2]).class).to eq(PArrayType)
+      end
+
+      it 'translates derived Array to PRuntimeType' do
+        expect(calculator.infer(derived).class).to eq(PRuntimeType)
+      end
+
+      it 'translates derived Puppet Object Array to PObjectType' do
+        expect(calculator.infer(derived_object).class).to eq(PObjectType)
+      end
+
+      it 'Instance of derived Array class is not instance of Array type' do
+        expect(PArrayType::DEFAULT).not_to be_instance(derived)
+      end
+
+      it 'Instance of derived Array class is instance of Runtime type' do
+        expect(runtime_t('ruby', nil)).to be_instance(derived)
+      end
+
+      it 'Instance of derived Puppet Object Array class is not instance of Array type' do
+        expect(PArrayType::DEFAULT).not_to be_instance(derived_object)
+      end
+
+      it 'Instance of derived Puppet Object Array class is instance of Object type' do
+        expect(object_t('name' => 'DerivedObjectArray')).to be_instance(derived_object)
       end
 
       it 'with fixnum values translates to PArrayType[PIntegerType]' do
@@ -379,8 +425,46 @@ describe 'The type calculator' do
     end
 
     context 'hash' do
+      let(:derived) do
+        Class.new(Hash)[:first => 1, :second => 2]
+      end
+
+      let(:derived_object) do
+        Class.new(Hash) do
+          include PuppetObject
+
+          def self._pcore_type
+            @type ||= TypeFactory.object('name' => 'DerivedObjectHash')
+          end
+        end[:first => 1, :second => 2]
+      end
+
       it 'translates to PHashType' do
         expect(calculator.infer({:first => 1, :second => 2}).class).to eq(PHashType)
+      end
+
+      it 'translates derived Hash to PRuntimeType' do
+        expect(calculator.infer(derived).class).to eq(PRuntimeType)
+      end
+
+      it 'translates derived Puppet Object Hash to PObjectType' do
+        expect(calculator.infer(derived_object).class).to eq(PObjectType)
+      end
+
+      it 'Instance of derived Hash class is not instance of Hash type' do
+        expect(PHashType::DEFAULT).not_to be_instance(derived)
+      end
+
+      it 'Instance of derived Hash class is instance of Runtime type' do
+        expect(runtime_t('ruby', nil)).to be_instance(derived)
+      end
+
+      it 'Instance of derived Puppet Object Hash class is not instance of Hash type' do
+        expect(PHashType::DEFAULT).not_to be_instance(derived_object)
+      end
+
+      it 'Instance of derived Puppet Object Hash class is instance of Object type' do
+        expect(object_t('name' => 'DerivedObjectHash')).to be_instance(derived_object)
       end
 
       it 'with symbolic keys translates to PHashType[PRuntimeType[ruby, Symbol], value]' do


### PR DESCRIPTION
This PR changes how subclasses of `Array` and `Hash` are handled by the Puppet type system. A derived class that includes the `Puppet::Pops::Types::PuppetObject` module is considered a `Object` type. A derived class that doesn't include that module will be considered a `Runtime` type.