### PR TITLE
PUP-6164: Tech-debt: links.puppetlabs.com -> links.puppet.com

### DIFF
--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -4,7 +4,7 @@ confine :except, :platform => 'cisco_nexus' #See BKR-749
 #
 # This test is intended to ensure that puppet agent --enable/--disable
 #  work properly, both in terms of complying with our public "API" around
-#  lockfile semantics ( http://links.puppetlabs.com/agent_lockfiles ), and
+#  lockfile semantics ( http://links.puppet.com/agent_lockfiles ), and
 #  in terms of actually restricting or allowing new agent runs to begin.
 #
 

--- a/lib/puppet/agent/disabler.rb
+++ b/lib/puppet/agent/disabler.rb
@@ -10,7 +10,7 @@ require 'puppet/util/json_lockfile'
 #  because it used by external tools such as mcollective.
 #
 # For more information, please see docs on the website.
-#  http://links.puppetlabs.com/agent_lockfiles
+#  http://links.puppet.com/agent_lockfiles
 module Puppet::Agent::Disabler
   DISABLED_MESSAGE_JSON_KEY = "disabled_message"
 

--- a/lib/puppet/agent/locker.rb
+++ b/lib/puppet/agent/locker.rb
@@ -11,7 +11,7 @@ require 'puppet/error'
 # Puppet API because it used by external tools such as mcollective.
 #
 # For more information, please see docs on the website.
-#  http://links.puppetlabs.com/agent_lockfiles
+#  http://links.puppet.com/agent_lockfiles
 module Puppet::Agent::Locker
   # Yield if we get a lock, else raise Puppet::LockError. Return
   # value of block yielded.

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -197,10 +197,10 @@ Copyright (c) 2012 Puppet Inc., LLC Licensed under the Apache 2.0 License
     end
 
     if options[:rack]
-      Puppet.deprecation_warning(_("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information."))
+      Puppet.deprecation_warning(_("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppet.com/deprecate-rack-webrick-servers for more information."))
       start_rack_master
     else
-      Puppet.deprecation_warning(_("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information."))
+      Puppet.deprecation_warning(_("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppet.com/deprecate-rack-webrick-servers for more information."))
       start_webrick_master
     end
   end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1336,7 +1336,7 @@ EOT
         makes to the master. WARNING: This setting is mutually exclusive with
         node_name_fact.  Changing this setting also requires changes to the default
         auth.conf configuration on the Puppet Master.  Please see
-        http://links.puppetlabs.com/node_name_value for more information."
+        http://links.puppet.com/node_name_value for more information."
     },
     :node_name_fact => {
       :default => "",
@@ -1344,7 +1344,7 @@ EOT
         makes to the master. WARNING: This setting is mutually exclusive with
         node_name_value.  Changing this setting also requires changes to the default
         auth.conf configuration on the Puppet Master.  Please see
-        http://links.puppetlabs.com/node_name_fact for more information.",
+        http://links.puppet.com/node_name_fact for more information.",
       :hook => proc do |value|
         if !value.empty? and Puppet[:node_name_value] != Puppet[:certname]
           raise "Cannot specify both the node_name_value and node_name_fact settings"

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -70,7 +70,7 @@ require 'hiera/puppet_function'
 # # "Key 'classes' not found".
 # ~~~
 #
-# See [the documentation](http://links.puppetlabs.com/hierainclude) for more information
+# See [the documentation](http://links.puppet.com/hierainclude) for more information
 # and a more detailed example of how `hiera_include` uses array merge lookups to classify
 # nodes.
 #

--- a/lib/puppet/network/http/request.rb
+++ b/lib/puppet/network/http/request.rb
@@ -60,7 +60,7 @@ Puppet::Network::HTTP::Request = Struct.new(:headers, :params, :method, :path, :
   private
 
   def valid_network_format?(format)
-    # YAML in network requests is not supported. See http://links.puppetlabs.com/deprecate_yaml_on_network
+    # YAML in network requests is not supported. See http://links.puppet.com/deprecate_yaml_on_network
     format != nil && format.name != :yaml && format.name != :b64_zlib_yaml
   end
 end

--- a/lib/puppet/parser/ast/node.rb
+++ b/lib/puppet/parser/ast/node.rb
@@ -4,7 +4,7 @@ class Puppet::Parser::AST::Node < Puppet::Parser::AST::TopLevelConstruct
   def initialize(names, context = {})
     raise ArgumentError, "names should be an array" unless names.is_a? Array
     if context[:parent]
-      raise Puppet::DevError, "Node inheritance is removed in Puppet 4.0.0. See http://links.puppetlabs.com/puppet-node-inheritance-deprecation"
+      raise Puppet::DevError, "Node inheritance is removed in Puppet 4.0.0. See http://links.puppet.com/puppet-node-inheritance-deprecation"
     end
 
     @names = names

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -89,7 +89,7 @@ Note that calls using the 'override level' option are not directly supported by 
 result must be post processed to get exactly the same result, for example using simple hash/array `+` or
 with calls to stdlib's `deep_merge` function depending on kind of hiera call and setting of merge in hiera.yaml.
 
-See [the documentation](http://links.puppetlabs.com/hierainclude) for more information
+See [the documentation](http://links.puppet.com/hierainclude) for more information
 and a more detailed example of how `hiera_include` uses array merge lookups to classify
 nodes.
 

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -235,7 +235,7 @@ module Issues
   end
 
   APPENDS_DELETES_NO_LONGER_SUPPORTED = hard_issue :APPENDS_DELETES_NO_LONGER_SUPPORTED, :operator do
-    _("The operator '%{operator}' is no longer supported. See http://links.puppetlabs.com/remove-plus-equals") % { operator: operator }
+    _("The operator '%{operator}' is no longer supported. See http://links.puppet.com/remove-plus-equals") % { operator: operator }
   end
 
   # For unsupported operators (e.g. += and -= in puppet 4).
@@ -583,7 +583,7 @@ module Issues
 
   DISCONTINUED_IMPORT = hard_issue :DISCONTINUED_IMPORT do
     #TRANSLATORS "import" is a function name and should not be translated
-    _("Use of 'import' has been discontinued in favor of a manifest directory. See http://links.puppetlabs.com/puppet-import-deprecation")
+    _("Use of 'import' has been discontinued in favor of a manifest directory. See http://links.puppet.com/puppet-import-deprecation")
   end
 
   IDEM_EXPRESSION_NOT_LAST = issue :IDEM_EXPRESSION_NOT_LAST do
@@ -615,7 +615,7 @@ module Issues
   end
 
   ILLEGAL_NODE_INHERITANCE = issue :ILLEGAL_NODE_INHERITANCE do
-    _("Node inheritance is not supported in Puppet >= 4.0.0. See http://links.puppetlabs.com/puppet-node-inheritance-deprecation")
+    _("Node inheritance is not supported in Puppet >= 4.0.0. See http://links.puppet.com/puppet-node-inheritance-deprecation")
   end
 
   ILLEGAL_OVERRIDEN_TYPE = issue :ILLEGAL_OVERRIDEN_TYPE, :actual do

--- a/locales/puppet.pot
+++ b/locales/puppet.pot
@@ -358,11 +358,11 @@ msgid "Could not change user to %{user}. User does not exist and is required to 
 msgstr ""
 
 #: ../lib/puppet/application/master.rb:207
-msgid "The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information."
+msgid "The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppet.com/deprecate-rack-webrick-servers for more information."
 msgstr ""
 
 #: ../lib/puppet/application/master.rb:210
-msgid "The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information."
+msgid "The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppet.com/deprecate-rack-webrick-servers for more information."
 msgstr ""
 
 #: ../lib/puppet/application/master.rb:270
@@ -3941,7 +3941,7 @@ msgid "No value for required variable '$%{name}' in assignment to variables from
 msgstr ""
 
 #: ../lib/puppet/pops/issues.rb:238
-msgid "The operator '%{operator}' is no longer supported. See http://links.puppetlabs.com/remove-plus-equals"
+msgid "The operator '%{operator}' is no longer supported. See http://links.puppet.com/remove-plus-equals"
 msgstr ""
 
 #: ../lib/puppet/pops/issues.rb:244
@@ -4250,7 +4250,7 @@ msgstr ""
 
 #. TRANSLATORS "import" is a function name and should not be translated
 #: ../lib/puppet/pops/issues.rb:578
-msgid "Use of 'import' has been discontinued in favor of a manifest directory. See http://links.puppetlabs.com/puppet-import-deprecation"
+msgid "Use of 'import' has been discontinued in favor of a manifest directory. See http://links.puppet.com/puppet-import-deprecation"
 msgstr ""
 
 #: ../lib/puppet/pops/issues.rb:582
@@ -4282,7 +4282,7 @@ msgid "No matching entry for selector parameter with value '%{param}'"
 msgstr ""
 
 #: ../lib/puppet/pops/issues.rb:610
-msgid "Node inheritance is not supported in Puppet >= 4.0.0. See http://links.puppetlabs.com/puppet-node-inheritance-deprecation"
+msgid "Node inheritance is not supported in Puppet >= 4.0.0. See http://links.puppet.com/puppet-node-inheritance-deprecation"
 msgstr ""
 
 #: ../lib/puppet/pops/issues.rb:614

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -355,7 +355,7 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
       end
 
       it "should log a deprecation notice when running a WEBrick server" do
-        Puppet.expects(:deprecation_warning).with("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
+        Puppet.expects(:deprecation_warning).with("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppet.com/deprecate-rack-webrick-servers for more information.")
 
         @master.main
       end
@@ -394,7 +394,7 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
         end
 
         it "should log a deprecation notice" do
-          Puppet.expects(:deprecation_warning).with("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppetlabs.com/deprecate-rack-webrick-servers for more information.")
+          Puppet.expects(:deprecation_warning).with("The Rack Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppet.com/deprecate-rack-webrick-servers for more information.")
 
           @master.main
         end


### PR DESCRIPTION
Resolving old tech-debts: Renaming links.puppetlabs.com to links.puppet.com