### PR TITLE
(PUP-2551) Simplify lowercase certname warning

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -678,13 +678,13 @@ deprecated and has been replaced by 'always_retry_plugins'."
         for more details.)
 
         * For best compatibility, you should limit the value of `certname` to
-          only use letters, numbers, periods, underscores, and dashes. (That is,
+          only use lowercase letters, numbers, periods, underscores, and dashes. (That is,
           it should match `/\A[a-z0-9._-]+\Z/`.)
         * The special value `ca` is reserved, and can't be used as the certname
           for a normal node.
 
         Defaults to the node's fully qualified domain name.",
-      :hook => proc { |value| raise(ArgumentError, "Certificate names must be lower case; see #1168") unless value == value.downcase }},
+      :hook => proc { |value| raise(ArgumentError, "Certificate names must be lower case") unless value == value.downcase }},
     :dns_alt_names => {
       :default => '',
       :desc    => <<EOT,


### PR DESCRIPTION
(PUP-2551) Updates to simplify the certname case warning as well as the attached documentation.
[puppethack] 