### PR TITLE
(PUP-6596) Bump CFPropertyList to 2.3.5 

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -29,7 +29,7 @@ gem_rdoc_options:
 gem_platform_dependencies:
   universal-darwin:
     gem_runtime_dependencies:
-      CFPropertyList: '~> 2.2.6'
+      CFPropertyList: '~> 2.2'
   x86-mingw32:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -114,6 +114,8 @@ module Puppet::Util::Plist
         plist_format = CFPropertyList::List::FORMAT_XML
       elsif format.to_sym == :binary
         plist_format = CFPropertyList::List::FORMAT_BINARY
+      elsif format.to_sym == :plain
+        plist_format = CFPropertyList::List::FORMAT_PLAIN
       else
         raise FormatError.new "Unknown plist format #{format}"
       end

--- a/tasks/cfpropertylist.rake
+++ b/tasks/cfpropertylist.rake
@@ -1,6 +1,6 @@
 task 'cfpropertylist' do
   if defined? Pkg::Config and Pkg::Config.project_root
-    cfp_version = "2.2.7"
+    cfp_version = "2.3.5"
     libdir = File.join(Pkg::Config.project_root, "lib")
     source = "https://github.com/ckruse/CFPropertyList/archive/cfpropertylist-#{cfp_version}.tar.gz"
     target_dir = Pkg::Util::File.mktemp


### PR DESCRIPTION
Supercedes #5186 

- 2.3.5 is necessary for Ruby 2.4 compatibility
 - 2.3.3 addresses a serious bug in parsing large blocks of XML
   and adds support for the plain ASCII format to puppet/util/plist

 Note that the gem dependency is set to ~> 2.2 for now to increase
 Facter compatibility. Facter 2.0.1 through 2.4.6 depend on ~> 2.2.6
 which would conflict with Puppet were Puppet to specify ~> 2.3.5.

 When Facter 2.5.0 is finally released for compatibility with gem
 workflows and the Puppet 5 gem, it will have its compatiblity set
 to ~> 2.2 as well, which will allow it to continue to work with
 older versions of Puppet, even if the more desirable 2.3.5 is not
 installed.

 This change will not change any shipping agent packages, which define
 dependencies elsewhere - but it will impact any source installs of
 gem or gem workflows (such as module development) or CI like
 AppVeyor or TravisCI.