### PR TITLE
(docs) correct code comment for Indirection#prepare

### DIFF
--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -310,7 +310,10 @@ class Puppet::Indirector::Indirection
     end
   end
 
-  # Setup a request, pick the appropriate terminus, check the request's authorization, and return it.
+  # Pick the appropriate terminus, check the request's authorization, and return it.
+  # @param [Puppet::Indirector::Request] request instance
+  # @return [Puppet::Indirector::Terminus] terminus instance (usually a subclass
+  #   of Puppet::Indirector::Terminus) for this request
   def prepare(request)
     # Pick our terminus.
     if respond_to?(:select_terminus)


### PR DESCRIPTION
The comment said this method prepares a request, which is not true. In fact,
this method never prepared a request - it was added in 2008 in f9881edd, but
even then it only selected the terminus and checked authorization. This commit
corrects the message and adds param/return doc strings so at least followers can
tell at a glance what's happening here.

Signed-off-by: Moses Mendoza <moses@puppet.com>