### PR TITLE
(PUP-7413) remove check for `:select_terminus` in indirection

### DIFF
--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -313,13 +313,7 @@ class Puppet::Indirector::Indirection
   # Setup a request, pick the appropriate terminus, check the request's authorization, and return it.
   def prepare(request)
     # Pick our terminus.
-    if respond_to?(:select_terminus)
-      unless terminus_name = select_terminus(request)
-        raise ArgumentError, _("Could not determine appropriate terminus for %{request}") % { request: request.description }
-      end
-    else
-      terminus_name = terminus_class
-    end
+    terminus_name = terminus_class
 
     dest_terminus = terminus(terminus_name)
     check_authorization(request, dest_terminus)

--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -14,42 +14,7 @@ shared_examples_for "Indirection Delegator" do
     @indirection.send(@method, "mystuff", :one => :two)
   end
 
-  it "should let the :select_terminus method choose the terminus using the created request if the :select_terminus method is available" do
-    # Define the method, so our respond_to? hook matches.
-    class << @indirection
-      def select_terminus(request)
-      end
-    end
-
-    request = Puppet::Indirector::Request.new(:indirection, :find, "me", nil)
-
-    @indirection.stubs(:request).returns request
-
-    @indirection.expects(:select_terminus).with(request).returns :test_terminus
-
-    @indirection.stubs(:check_authorization)
-    @terminus.expects(@method)
-
-    @indirection.send(@method, "me")
-  end
-
-  it "should fail if the :select_terminus hook does not return a terminus name" do
-    # Define the method, so our respond_to? hook matches.
-    class << @indirection
-      def select_terminus(request)
-      end
-    end
-
-    request = Puppet::Indirector::Request.new(:indirection, :find, "me", nil)
-
-    @indirection.stubs(:request).returns request
-
-    @indirection.expects(:select_terminus).with(request).returns nil
-
-    expect { @indirection.send(@method, "me") }.to raise_error(ArgumentError)
-  end
-
-  it "should choose the terminus returned by the :terminus_class method if no :select_terminus method is available" do
+  it "should choose the terminus returned by the :terminus_class" do
     @indirection.expects(:terminus_class).returns :test_terminus
 
     @terminus.expects(@method)


### PR DESCRIPTION
The last class in Puppet that defined `:select_terminus` was removed in 40ee670
in Puppet 2.7.18, but this check has remained in Indirection.rb ever since. The
method it is in is defined as api private, and it's now just cruft. Remove it
because its superfluous. A github search didn't show code that actually defined
this method, except for repos that vendored an old version of puppet.

Signed-off-by: Moses Mendoza <moses@puppet.com>