### PR TITLE
(PUP-7591) Add the ability to test against puppetserver latest

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -34,17 +34,16 @@ MASTER_PACKAGES = {
 }
 
 step "Install puppetserver..." do
-  if ENV['SERVER_VERSION']
-    install_puppetlabs_dev_repo(master, 'puppetserver', ENV['SERVER_VERSION'])
+  if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
+    server_version = 'latest'
+    server_download_url = "http://nightlies.puppet.com"
+  else
+    server_version = ENV['SERVER_VERSION']
+    server_download_url = "http://builds.delivery.puppetlabs.net"
+  end
+    install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
     install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
     master.install_package('puppetserver')
-  else
-    # beaker can't install puppetserver from nightlies (BKR-673)
-    repo_configs_dir = 'repo-configs'
-    install_repos_on(master, 'puppetserver', 'nightly', repo_configs_dir)
-    install_repos_on(master, 'puppet-agent', ENV['SHA'], repo_configs_dir)
-    install_packages_on(master, MASTER_PACKAGES)
-  end
 end
 
 # make sure install is sane, beaker has already added puppet and ruby


### PR DESCRIPTION
This commit adds the ability to specify SERVER_VERSION=latest when running
puppet tests to test against server latest packages from nightlies.

Sanity checks are added to ensure that if SERVER_VERSION or SHA are set to
latest, download URLs are set correctly to pull from nightlies