### PR TITLE
(PUP-7590) Fix merge of PUP-1600 - symbols not used in AST

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -371,7 +371,7 @@ module Issues
   end
 
   CLASS_NOT_VIRTUALIZABLE = issue :CLASS_NOT_VIRTUALIZABLE do
-    "Classes are not virtualizable"
+    _("Classes are not virtualizable")
   end
 
   # When an attempt is made to use multiple keys (to produce a range in Ruby - e.g. $arr[2,-1]).

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -669,7 +669,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     # (This can be revised as there are static constructs that are illegal, but require updating many
     # tests that expect the detailed reporting).
     type_name_expr = o.type_name
-    if o.form && o.form != :regular && type_name_expr.is_a?(Model::QualifiedName) && type_name_expr.value == 'class'
+    if o.form && o.form != 'regular' && type_name_expr.is_a?(Model::QualifiedName) && type_name_expr.value == 'class'
       acceptor.accept(Issues::CLASS_NOT_VIRTUALIZABLE, o)
     end
   end

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -98,6 +98,13 @@ describe "validating 4x" do
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
+    it 'does not produce an error for regular class resource' do
+      acceptor = validate(parse('class { test: }'))
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(0)
+      expect(acceptor).not_to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
+    end
+
     it 'produces an error for exported class resource' do
       acceptor = validate(parse('@@class { test: }'))
       expect(acceptor.warning_count).to eql(0)


### PR DESCRIPTION
When PUP-1600 was merged, the fact that the AST on master uses strings
for enums instead of symbols. This led to warning/error about attempts
to virtualize a class for perfectly valid code.

This went undetected because of a missing unit tests that tested that
the check put in place was not triggered by valid code. A test is now
added.