### PR TITLE
(PUP-7592) Disable unicode user comment test on AIX

### DIFF
--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -10,7 +10,9 @@
 test_name 'PUP-6777 Manage users with UTF-8 comments' do
 
   # PUP-7049 / ARISTA-42 - user provider bug on Arista
-  confine :except, :platform => /^eos-/
+  # AIX providers are separate from most other platforms,
+  # and have not been made unicode-aware yet.
+  confine :except, :platform => /^(eos|aix)-/
 
   user0 = "foo#{rand(99999).to_i}"
   user1 = "bar#{rand(99999).to_i}"


### PR DESCRIPTION
The AIX providers have not yet been made unicode-aware,
so this test is not valid on that platform.