### PR TITLE
(PUP-7594) Hiera hash keys are being converted to strings recursively.

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -106,7 +106,9 @@ class HieraConfig
   def self.symkeys_to_string(struct)
     case(struct)
     when Hash
-      Hash[struct.map { |k,v| [k.to_s, symkeys_to_string(v)] }]
+      map = {}
+      struct.each_pair {|k,v| map[ k.is_a?(Symbol) ? k.to_s : k] = symkeys_to_string(v) }
+      map
     when Array
       struct.map { |v| symkeys_to_string(v) }
     else

--- a/spec/unit/pops/lookup/lookup_spec.rb
+++ b/spec/unit/pops/lookup/lookup_spec.rb
@@ -57,6 +57,11 @@ describe 'The lookup API' do
           mod::c: mod::c (from module)
           mod::e: mod::e (from module)
           mod::f: mod::f (from module)
+          mod::g:
+            :symbol: value
+            key: value
+            6: value
+            2.7: value
           YAML
       }
     }
@@ -135,6 +140,17 @@ describe 'The lookup API' do
 
     it 'environment layer wins over module layer' do
       expect(Lookup.lookup('mod::f', nil, 'not found', true, nil, invocation)).to eql('mod::f (from environment)')
+    end
+
+    it 'returns the correct types for hash keys' do
+      expect(Lookup.lookup('mod::g', nil, 'not found', true, nil, invocation)).to eql(
+	      {
+		      "symbol" => "value",
+		      "key" => "value",
+		      6 => "value",
+		      2.7 => "value",
+	      }
+      )
     end
 
     context "with 'global_only' set to true in the invocation" do


### PR DESCRIPTION
Puppet 4.9+ currently converts hiera hash elements into strings unconditiionally. YAML.load_file() will deserialize say an Integer to a ruby Fixnum, but the function symkeys_to_string converts every key to a string, regardless of whether it is a symbol.