### PR TITLE
(PUP-3042) Make logged errors in report set status == failed

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -147,8 +147,10 @@ class Puppet::Transaction::Report
   end
 
   # @api private
-  def <<(msg)
-    @logs << msg
+  def <<(log_entry)
+    # runtime errors after completion of report are added after report has finalized
+    @status = 'failed' if log_entry.level == :err
+    @logs << log_entry
     self
   end
 
@@ -176,7 +178,7 @@ class Puppet::Transaction::Report
 
   # @api private
   def compute_status(resource_metrics, change_metric)
-    if resources_failed_to_generate || (resource_metrics["failed"] || 0) > 0
+    if resources_failed_to_generate || (resource_metrics["failed"] || 0) > 0 || @logs.any? { |lg| lg.level == :err }
       'failed'
     elsif change_metric > 0
       'changed'

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -701,6 +701,16 @@ describe Puppet::Transaction::Report do
         expect(report.corrective_change).to eq(false)
         expect(get_cc_count(report)).to eq(0)
       end
+
+      it "a circular dependency is reported with status == failed" do
+        resources = [
+          Puppet::Type.type(:notify).new(:title => 'a', :before => 'Notify[b]'),
+          Puppet::Type.type(:notify).new(:title => 'b', :before => 'Notify[a]')
+          ]
+        report = run_catalogs(resources, resources, true, true)
+
+        expect(report.status).to eq('failed')
+      end
     end
   end
 end

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -147,12 +147,14 @@ describe Puppet::Transaction::Report do
     end
 
     it "should add new logs to the log list" do
-      @report << "log"
-      expect(@report.logs[-1]).to eq("log")
+      lg = Puppet::Util::Log.new(:level => :err, :message => 'log')
+      @report << lg
+      expect(@report.logs[-1]).to eq(lg)
     end
 
     it "should return self" do
-      r = @report << "log"
+      lg = Puppet::Util::Log.new(:level => :err, :message => 'log')
+      r = @report << lg
       expect(r).to equal(@report)
     end
   end


### PR DESCRIPTION
Before this, a circular dependency would not alter the state of a report
for an agent run. This is bad because users are then not alerted to the
problem and believe that the catalog application was correct.

Now the report's status is set to 'failed' if there is any error
included in the logs of the report.

Logs are given to the report both before it is finalized and after. This
requires a check when computing the status at the time the report is
finalized, and when any additional runtime log entries are added to the
report.

A test is added for the specific error of circular dependencies. The
status will however be set to 'failed' for any logged error.

This alters two tests that assumed that it was ok to call << with a
string where it should have been an instance of Puppet::Util::Log. (The
`<<` method is api private.)