### PR TITLE
(PUP-7596) Remove rspec configuration for win32_console

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,17 +84,6 @@ RSpec.configure do |config|
   oldtmpdir = Puppet::FileSystem.expand_path(Dir.tmpdir())
   ENV['TMPDIR'] = tmpdir
 
-  if Puppet::Util::Platform.windows?
-    config.output_stream = $stdout
-    config.error_stream = $stderr
-
-    config.formatters.each do |f|
-      if not f.instance_variable_get(:@output).kind_of?(::File)
-        f.instance_variable_set(:@output, $stdout)
-      end
-    end
-  end
-
   Puppet::Test::TestHelper.initialize
 
   config.before :all do


### PR DESCRIPTION
Previously the spec_helper would configure rspec to output all to STDOUT due to
issues with the win32_console gem.  However as that gem was removed in Puppet 4,
it is no longer required.  This commit removes the redundant rspec configuration.