### PR TITLE
(PUP-7155) Expect double quoted strings

### DIFF
--- a/acceptance/tests/resource/scheduled_task/should_create.rb
+++ b/acceptance/tests/resource/scheduled_task/should_create.rb
@@ -22,10 +22,10 @@ agents.each do |agent|
 
   step "verify task properties"
   on agent, puppet_resource('scheduled_task', name) do
-    assert_match(/command\s*=>\s*'c:\\windows\\system32\\notepad.exe'/, stdout)
+    assert_match(/command\s*=>\s*"c:\\\\windows\\\\system32\\\\notepad.exe"/, stdout)
     assert_match(/arguments\s*=>\s*'foo bar baz'/, stdout)
     assert_match(/enabled\s*=>\s*'true'/, stdout)
-    assert_match(/working_dir\s*=>\s*'c:\\windows'/, stdout)
+    assert_match(/working_dir\s*=>\s*"c:\\\\windows"/, stdout)
   end
 
   step "delete the task"

--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -26,7 +26,7 @@ agents.each do |agent|
   # and unfortunately schtasks.exe and the MMC snap-in may get out of sync
   step "verify the arguments were updated from Puppet"
   on agent, puppet_resource('scheduled_task', name) do
-    assert_match(/command\s*=>\s*'c:\\windows\\system32\\notepad2.exe'/, stdout)
+    assert_match(/command\s*=>\s*"c:\\\\windows\\\\system32\\\\notepad2.exe"/, stdout)
     assert_match(/arguments\s*=>\s*'args-#{verylongstring}'/, stdout)
   end
 

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
+    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
   end
   home_dir
 end
@@ -50,7 +50,7 @@ agents.each do |agent|
   step "modify the user"
   new_home_dir = "#{home_dir}_foo"
   on agent, puppet_resource('user', name, ["ensure=present", "home='#{new_home_dir}'"]) do |result|
-    found_home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
+    found_home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
     assert_equal new_home_dir, found_home_dir, "Failed to change home property of user"
   end
 

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
+    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1]
   end
   home_dir
 end


### PR DESCRIPTION
puppet resource now emits double quotes for strings containing
backslashes, which must also be escaped. Update the acceptance tests to
match the new output.