### PR TITLE
(PUP-7599) Fix authorized keys acceptance tests

### DIFF
--- a/acceptance/tests/resource/ssh_authorized_key/create.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/create.rb
@@ -14,11 +14,12 @@ agents.each do |agent|
   #------- SETUP -------#
   step "(setup) backup #{auth_keys} file"
   on(agent, "cp #{auth_keys} /tmp/auth_keys", :acceptable_exit_codes => [0,1])
+  on(agent, "chown $LOGNAME #{auth_keys}")
 
   #------- TESTS -------#
   step "create an authorized key entry with puppet (present)"
   args = ['ensure=present',
-          "user='root'",
+          "user='$LOGNAME'",
           "type='rsa'",
           "key='mykey'",
          ]

--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -17,11 +17,13 @@ agents.each do |agent|
 
   step "(setup) create an authorized key in the #{auth_keys} file"
   on(agent, "echo '' >> #{auth_keys} && echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+  on(agent, "chown $LOGNAME #{auth_keys}")
+
 
   #------- TESTS -------#
   step "delete an authorized key entry with puppet (absent)"
   args = ['ensure=absent',
-          "user='root'",
+          "user='$LOGNAME'",
           "type='rsa'",
           "key='mykey'",
          ]

--- a/acceptance/tests/resource/ssh_authorized_key/modify.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/modify.rb
@@ -17,11 +17,12 @@ agents.each do |agent|
 
   step "(setup) create an authorized key in the #{auth_keys} file"
   on(agent, "echo '' >> #{auth_keys} && echo 'ssh-rsa mykey #{name}' >> #{auth_keys}")
+  on(agent, "chown $LOGNAME #{auth_keys}")
 
   #------- TESTS -------#
   step "update an authorized key entry with puppet (present)"
   args = ['ensure=present',
-          "user='root'",
+          "user='$LOGNAME'",
           "type='rsa'",
           "key='mynewshinykey'",
          ]


### PR DESCRIPTION
New version of beaker exposed an oversight in the tests that
the user would be root, this is not the case on Cisco Nexus