### PR TITLE
(PUP-7155) Allow single or double quoted home dir

### DIFF
--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
+    home_dir = result.stdout.match(/home\s*=>\s*['"]([^'"]+)['"]/m)[1].gsub(/\\\\/, '\\')
   end
   home_dir
 end
@@ -50,7 +50,7 @@ agents.each do |agent|
   step "modify the user"
   new_home_dir = "#{home_dir}_foo"
   on agent, puppet_resource('user', name, ["ensure=present", "home='#{new_home_dir}'"]) do |result|
-    found_home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
+    found_home_dir = result.stdout.match(/home\s*=>\s*['"]([^'"]+)['"]/m)[1].gsub(/\\\\/, '\\')
     assert_equal new_home_dir, found_home_dir, "Failed to change home property of user"
   end
 

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1]
+    home_dir = result.stdout.match(/home\s*=>\s*['"]([^'"]+)['"]/m)[1]
   end
   home_dir
 end


### PR DESCRIPTION
Due to earlier commits for PUP-7155, the home directory is double quoted
on Windows, but single quoted on Linux, due to Windows using a backslash
path separator. Update the test so it accepts both single or double
quotes.