### PR TITLE
(PUP-7487) Default facts and reports to JSON

### DIFF
--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -30,8 +30,10 @@ module Puppet::Configurer::FactHandler
   def facts_for_uploading
     facts = find_facts
 
-    text = facts.render(:pson)
-
-    {:facts_format => :pson, :facts => CGI.escape(text)}
+    if Puppet[:preferred_serialization_format] == "pson"
+      {:facts_format => :pson, :facts => CGI.escape(facts.render(:pson)) }
+    else
+      {:facts_format => 'application/json', :facts => facts.render(:json) }
+    end
   end
 end

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -398,10 +398,6 @@ class Puppet::Transaction::Report
     status
   end
 
-  def self.default_format
-    :pson
-  end
-
   private
 
   # Mark the report as corrective, if there are any resource_status marked corrective.

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -160,27 +160,27 @@ describe Puppet::Node::Facts, "when indirecting" do
       end
     end
 
-    describe "using pson" do
+    describe "using json" do
       before :each do
         @timestamp = Time.parse("Thu Oct 28 11:16:31 -0700 2010")
         @expiration = Time.parse("Thu Oct 28 11:21:31 -0700 2010")
       end
 
-      it "should accept properly formatted pson" do
-        pson = %Q({"name": "foo", "expiration": "#{@expiration}", "timestamp": "#{@timestamp}", "values": {"a": "1", "b": "2", "c": "3"}})
-        format = Puppet::Network::FormatHandler.format('pson')
-        facts = format.intern(Puppet::Node::Facts,pson)
+      it "should accept properly formatted json" do
+        json = %Q({"name": "foo", "expiration": "#{@expiration}", "timestamp": "#{@timestamp}", "values": {"a": "1", "b": "2", "c": "3"}})
+        format = Puppet::Network::FormatHandler.format('json')
+        facts = format.intern(Puppet::Node::Facts, json)
         expect(facts.name).to eq('foo')
         expect(facts.expiration).to eq(@expiration)
         expect(facts.timestamp).to eq(@timestamp)
         expect(facts.values).to eq({'a' => '1', 'b' => '2', 'c' => '3'})
       end
 
-      it "should generate properly formatted pson" do
+      it "should generate properly formatted json" do
         Time.stubs(:now).returns(@timestamp)
         facts = Puppet::Node::Facts.new("foo", {'a' => 1, 'b' => 2, 'c' => 3})
         facts.expiration = @expiration
-        result = PSON.parse(facts.to_pson)
+        result = JSON.parse(facts.to_json)
         expect(result['name']).to eq(facts.name)
         expect(result['values']).to eq(facts.values)
         expect(result['timestamp']).to eq(facts.timestamp.iso8601(9))
@@ -192,19 +192,19 @@ describe Puppet::Node::Facts, "when indirecting" do
         facts = Puppet::Node::Facts.new("foo", {'a' => 1, 'b' => 2, 'c' => 3})
         facts.expiration = @expiration
 
-        expect(facts.to_pson).to validate_against('api/schemas/facts.json')
+        expect(facts.to_json).to validate_against('api/schemas/facts.json')
       end
 
       it "should not include nil values" do
         facts = Puppet::Node::Facts.new("foo", {'a' => 1, 'b' => 2, 'c' => 3})
-        pson = PSON.parse(facts.to_pson)
-        expect(pson).not_to be_include("expiration")
+        json= JSON.parse(facts.to_json)
+        expect(json).not_to be_include("expiration")
       end
 
       it "should be able to handle nil values" do
-        pson = %Q({"name": "foo", "values": {"a": "1", "b": "2", "c": "3"}})
-        format = Puppet::Network::FormatHandler.format('pson')
-        facts = format.intern(Puppet::Node::Facts,pson)
+        json = %Q({"name": "foo", "values": {"a": "1", "b": "2", "c": "3"}})
+        format = Puppet::Network::FormatHandler.format('json')
+        facts = format.intern(Puppet::Node::Facts, json)
         expect(facts.name).to eq('foo')
         expect(facts.expiration).to be_nil
       end

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -146,10 +146,10 @@ describe Puppet::Resource::Status do
     s
   end
 
-  it "should round trip through pson" do
+  it "should round trip through json" do
     expect(status.containment_path).to eq(@containment_path)
 
-    tripped = Puppet::Resource::Status.from_data_hash(PSON.parse(status.to_pson))
+    tripped = Puppet::Resource::Status.from_data_hash(JSON.parse(status.to_json))
 
     expect(tripped.title).to eq(status.title)
     expect(tripped.containment_path).to eq(status.containment_path)

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -138,7 +138,7 @@ describe Puppet::Transaction::Event do
     end
   end
 
-  it "should round trip through pson" do
+  it "should round trip through json" do
       resource = Puppet::Type.type(:file).new(:title => make_absolute("/tmp/foo"))
       event = Puppet::Transaction::Event.new(
         :source_description => "/my/param",
@@ -154,7 +154,7 @@ describe Puppet::Transaction::Event do
         :property => :mode,
         :status => 'success')
 
-      tripped = Puppet::Transaction::Event.from_data_hash(PSON.parse(event.to_pson))
+      tripped = Puppet::Transaction::Event.from_data_hash(JSON.parse(event.to_json))
 
       expect(tripped.audited).to eq(event.audited)
       expect(tripped.property).to eq(event.property)
@@ -167,7 +167,7 @@ describe Puppet::Transaction::Event do
       expect(tripped.time).to eq(event.time)
   end
 
-  it "should round trip an event for an inspect report through pson" do
+  it "should round trip an event for an inspect report through json" do
       resource = Puppet::Type.type(:file).new(:title => make_absolute("/tmp/foo"))
       event = Puppet::Transaction::Event.new(
         :audited => true,
@@ -181,7 +181,7 @@ describe Puppet::Transaction::Event do
         :property => :mode,
         :status => 'success')
 
-      tripped = Puppet::Transaction::Event.from_data_hash(PSON.parse(event.to_pson))
+      tripped = Puppet::Transaction::Event.from_data_hash(JSON.parse(event.to_json))
 
       expect(tripped.desired_value).to be_nil
       expect(tripped.historical_value).to be_nil

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -499,8 +499,6 @@ describe Puppet::Transaction::Report do
   end
 
   it "defaults to serializing to json" do
-    pending("PUP-7259 sending reports in JSON not yet supported")
-
     expect(Puppet::Transaction::Report.default_format).to eq(:json)
   end
 
@@ -543,12 +541,12 @@ describe Puppet::Transaction::Report do
     end
   end
 
-  it "generates pson which validates against the report schema" do
+  it "generates json which validates against the report schema" do
     report = generate_report
     expect(report.render).to validate_against('api/schemas/report.json')
   end
 
-  it "generates pson for error report which validates against the report schema" do
+  it "generates json for error report which validates against the report schema" do
     error_report = generate_report_with_error
     expect(error_report.render).to validate_against('api/schemas/report.json')
   end

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -528,8 +528,8 @@ describe Puppet::Util::Log do
 
   let(:log) { Puppet::Util::Log.new(:level => 'notice', :message => 'hooray', :file => 'thefile', :line => 1729, :source => 'specs', :tags => ['a', 'b', 'c']) }
 
-  it "should round trip through pson" do
-    tripped = Puppet::Util::Log.from_data_hash(PSON.parse(log.to_pson))
+  it "should round trip through json" do
+    tripped = Puppet::Util::Log.from_data_hash(JSON.parse(log.to_json))
 
     expect(tripped.file).to eq(log.file)
     expect(tripped.line).to eq(log.line)

--- a/spec/unit/util/metric_spec.rb
+++ b/spec/unit/util/metric_spec.rb
@@ -76,8 +76,8 @@ describe Puppet::Util::Metric do
     metric
   end
 
-  it "should round trip through pson" do
-    tripped = Puppet::Util::Metric.from_data_hash(PSON.parse(metric.to_pson))
+  it "should round trip through json" do
+    tripped = Puppet::Util::Metric.from_data_hash(JSON.parse(metric.to_json))
 
     expect(tripped.name).to eq(metric.name)
     expect(tripped.label).to eq(metric.label)


### PR DESCRIPTION
Submit facts and reports as json by default. Fallback to pson if `preferred_serialization_format=pson`.