### PR TITLE
(PUP-7603) Make StringFormatter use single quotes more diligently

### DIFF
--- a/acceptance/tests/resource/scheduled_task/should_create.rb
+++ b/acceptance/tests/resource/scheduled_task/should_create.rb
@@ -22,10 +22,10 @@ agents.each do |agent|
 
   step "verify task properties"
   on agent, puppet_resource('scheduled_task', name) do
-    assert_match(/command\s*=>\s*"c:\\\\windows\\\\system32\\\\notepad.exe"/, stdout)
+    assert_match(/command\s*=>\s*'c:\\windows\\system32\\notepad.exe'/, stdout)
     assert_match(/arguments\s*=>\s*'foo bar baz'/, stdout)
     assert_match(/enabled\s*=>\s*'true'/, stdout)
-    assert_match(/working_dir\s*=>\s*"c:\\\\windows"/, stdout)
+    assert_match(/working_dir\s*=>\s*'c:\\windows'/, stdout)
   end
 
   step "delete the task"

--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -26,7 +26,7 @@ agents.each do |agent|
   # and unfortunately schtasks.exe and the MMC snap-in may get out of sync
   step "verify the arguments were updated from Puppet"
   on agent, puppet_resource('scheduled_task', name) do
-    assert_match(/command\s*=>\s*"c:\\\\windows\\\\system32\\\\notepad2.exe"/, stdout)
+    assert_match(/command\s*=>\s*'c:\\windows\\system32\\notepad2.exe'/, stdout)
     assert_match(/arguments\s*=>\s*'args-#{verylongstring}'/, stdout)
   end
 

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
+    home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
   end
   home_dir
 end
@@ -50,7 +50,7 @@ agents.each do |agent|
   step "modify the user"
   new_home_dir = "#{home_dir}_foo"
   on agent, puppet_resource('user', name, ["ensure=present", "home='#{new_home_dir}'"]) do |result|
-    found_home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
+    found_home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
     assert_equal new_home_dir, found_home_dir, "Failed to change home property of user"
   end
 

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*['"]([^'"]+)['"]/m)[1].gsub(/\\\\/, '\\')
+    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
   end
   home_dir
 end
@@ -50,7 +50,7 @@ agents.each do |agent|
   step "modify the user"
   new_home_dir = "#{home_dir}_foo"
   on agent, puppet_resource('user', name, ["ensure=present", "home='#{new_home_dir}'"]) do |result|
-    found_home_dir = result.stdout.match(/home\s*=>\s*['"]([^'"]+)['"]/m)[1].gsub(/\\\\/, '\\')
+    found_home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1].gsub(/\\\\/, '\\')
     assert_equal new_home_dir, found_home_dir, "Failed to change home property of user"
   end
 

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*['"]([^'"]+)['"]/m)[1]
+    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1]
   end
   home_dir
 end

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -11,7 +11,7 @@ pw = "Passwrd-#{rand(999999).to_i}"[0..11]
 def get_home_dir(host, user_name)
   home_dir = nil
   on host, puppet_resource('user', user_name) do |result|
-    home_dir = result.stdout.match(/home\s*=>\s*"([^"]+)"/m)[1]
+    home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
   end
   home_dir
 end

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -135,6 +135,7 @@ describe 'The string converter' do
       end
 
       it 'escape for $ in double quoted string' do
+        # Use \n in string to force double quotes
         expect(converter.convert("escape the $ sign\n", string_formats)).to eq('"escape the \$ sign\n"')
       end
 
@@ -143,6 +144,7 @@ describe 'The string converter' do
       end
 
       it 'escape for double quote but not for single quote in double quoted string' do
+        # Use \n in string to force double quotes
         expect(converter.convert("the ' single and \" double quote\n", string_formats)).to eq('"the \' single and \\" double quote\n"')
       end
 

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -134,16 +134,28 @@ describe 'The string converter' do
         expect(converter.convert("esc \u{1b}.", string_formats)).to eq('"esc \\u{1B}."')
       end
 
-      it 'escape for $' do
-        expect(converter.convert('escape the $ sign', string_formats)).to eq('"escape the \$ sign"')
+      it 'escape for $ in double quoted string' do
+        expect(converter.convert("escape the $ sign\n", string_formats)).to eq('"escape the \$ sign\n"')
       end
 
-      it 'escape for double qoute but not for single quote' do
-        expect(converter.convert('the \' single and " double quote', string_formats)).to eq('"the \' single and \\" double quote"')
+      it 'no escape for $ in single quoted string' do
+        expect(converter.convert('don\'t escape the $ sign', string_formats)).to eq("'don\\'t escape the $ sign'")
+      end
+
+      it 'escape for double quote but not for single quote in double quoted string' do
+        expect(converter.convert("the ' single and \" double quote\n", string_formats)).to eq('"the \' single and \\" double quote\n"')
+      end
+
+      it 'escape for single quote but not for double quote in single quoted string' do
+        expect(converter.convert('the \' single and " double quote', string_formats)).to eq("'the \\' single and \" double quote'")
       end
 
       it 'no escape for #' do
         expect(converter.convert('do not escape #{x}', string_formats)).to eq('\'do not escape #{x}\'')
+      end
+
+      it 'escape for last \\' do
+        expect(converter.convert('escape the last \\', string_formats)).to eq("'escape the last \\'")
       end
     end
 

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -352,7 +352,7 @@ describe 'Puppet Type System' do
     end
 
     it 'can be created with a runtime and, puppet name pattern, and runtime replacement' do
-      expect(tf.runtime('ruby', [/^MyPackage::(.*)$/, 'MyModule::\1']).to_s).to eq("Runtime[ruby, [/^MyPackage::(.*)$/, \"MyModule::\\\\1\"]]")
+      expect(tf.runtime('ruby', [/^MyPackage::(.*)$/, 'MyModule::\1']).to_s).to eq("Runtime[ruby, [/^MyPackage::(.*)$/, 'MyModule::\\1']]")
     end
 
     it 'will map a Puppet name to a runtime type' do


### PR DESCRIPTION
Prior to this commit, the StringFormatter would use double quotes for
all strings that contained control-, non-ascii-, dollar, or backslash
characters. Double quoting is however only needed for strings that
contain control- or non-ascii characters.

This commit changes how the detection is made so that single quotes are
used whenever possible.