### PR TITLE
(PUP-7583) Remove to_yaml_properties

### DIFF
--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -6,6 +6,7 @@ require 'set'
 class Puppet::Graph::SimpleGraph
   include Puppet::Util::PsychSupport
 
+  #
   # All public methods of this class must maintain (assume ^ ensure) the following invariants, where "=~=" means
   # equiv. up to order:
   #
@@ -519,11 +520,6 @@ class Puppet::Graph::SimpleGraph
       result
     end
     hash
-  end
-
-  def to_yaml_properties
-    (super + [:@vertices, :@edges] -
-     [:@in_to, :@out_from, :@upstream_from, :@downstream_from]).uniq
   end
 
   def multi_vertex_component?(component)

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -39,10 +39,6 @@ class Puppet::Node
     node
   end
 
-  def to_yaml_properties
-    [:@classes, :@environment, :@name, :@parameters]
-  end
-
   def to_data_hash
     result = {
       'name' => name,

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -6,13 +6,11 @@ require 'puppet/resource'
 class Puppet::Parser::Resource < Puppet::Resource
   require 'puppet/parser/resource/param'
   require 'puppet/util/tagging'
-  require 'puppet/parser/yaml_trimmer'
 
   include Puppet::Util
   include Puppet::Util::MethodHelper
   include Puppet::Util::Errors
   include Puppet::Util::Logging
-  include Puppet::Parser::YamlTrimmer
 
   attr_accessor :source, :scope, :collector_id
   attr_accessor :virtual, :override, :translated, :catalog, :evaluated

--- a/lib/puppet/parser/resource/param.rb
+++ b/lib/puppet/parser/resource/param.rb
@@ -1,11 +1,8 @@
-require 'puppet/parser/yaml_trimmer'
-
 # The parameters we stick in Resources.
 class Puppet::Parser::Resource::Param
   include Puppet::Util
   include Puppet::Util::Errors
   include Puppet::Util::MethodHelper
-  include Puppet::Parser::YamlTrimmer
 
   attr_accessor :name, :value, :source, :add, :file, :line
 

--- a/lib/puppet/parser/yaml_trimmer.rb
+++ b/lib/puppet/parser/yaml_trimmer.rb
@@ -1,7 +1,0 @@
-module Puppet::Parser::YamlTrimmer
-  REMOVE = [:@scope, :@source]
-
-  def to_yaml_properties
-    super - REMOVE
-  end
-end

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -132,18 +132,6 @@ class Puppet::Resource
     self.value.to_json_data(x)
   end
 
-  YAML_ATTRIBUTES = [:@file, :@line, :@exported, :@type, :@title, :@tags, :@parameters]
-
-  # Explicitly list the instance variables that should be serialized when
-  # converting to YAML.
-  #
-  # @api private
-  # @return [Array<Symbol>] The intersection of our explicit variable list and
-  #   all of the instance variables defined on this class.
-  def to_yaml_properties
-    YAML_ATTRIBUTES & super
-  end
-
   # Proxy these methods to the parameters hash.  It's likely they'll
   # be overridden at some point, but this works for now.
   %w{has_key? keys length delete empty? <<}.each do |method|

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -96,14 +96,6 @@ module Puppet
         failed_dependencies && !failed_dependencies.empty?
       end
 
-      # A list of instance variables that should be serialized with this object
-      # when converted to YAML.
-      YAML_ATTRIBUTES = %w{@resource @file @line @evaluation_time @change_count
-                           @out_of_sync_count @tags @time @events @out_of_sync
-                           @changed @resource_type @title @skipped @failed
-                           @containment_path @corrective_change}.
-        map(&:to_sym)
-
       def self.from_data_hash(data)
         obj = self.allocate
         obj.initialize_from_hash(data)
@@ -216,10 +208,6 @@ module Puppet
           'events' => @events.map { |event| event.to_data_hash },
           'corrective_change' => @corrective_change,
         }
-      end
-
-      def to_yaml_properties
-        YAML_ATTRIBUTES & super
       end
     end
   end

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -12,7 +12,6 @@ class Puppet::Transaction::Event
   include Puppet::Network::FormatSupport
 
   ATTRIBUTES = [:name, :resource, :property, :previous_value, :desired_value, :historical_value, :status, :message, :file, :line, :source_description, :audited, :invalidate_refreshes, :redacted, :corrective_change]
-  YAML_ATTRIBUTES = %w{@audited @property @previous_value @desired_value @historical_value @message @name @status @time @redacted @corrective_change}.map(&:to_sym)
   attr_accessor *ATTRIBUTES
   attr_accessor :time
   attr_reader :default_log_level
@@ -105,10 +104,6 @@ class Puppet::Transaction::Event
 
   def inspect
     %Q(#<#{self.class.name} @name="#{@name.inspect}" @message="#{@message.inspect}">)
-  end
-
-  def to_yaml_properties
-    YAML_ATTRIBUTES & super
   end
 
   # Calculate and set the corrective_change parameter, based on the old_system_value of the property.

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -398,12 +398,6 @@ class Puppet::Transaction::Report
     status
   end
 
-  # @api private
-  #
-  def to_yaml_properties
-    super - [:@external_times, :@resources_failed_to_generate]
-  end
-
   def self.default_format
     :pson
   end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -95,15 +95,6 @@ describe Puppet::Node do
       expect(node.parameters['environment']).to eq('bar')
     end
 
-    it 'to_yaml_properties and to_data_hash references the same attributes' do
-      node = Puppet::Node.new("hello",
-        :environment => 'bar',
-        :classes => ['erth', 'aiu'],
-        :parameters => {"hostname"=>"food"}
-      )
-      expect(node.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(node.to_data_hash.keys.sort)
-    end
-
     it 'to_data_hash returns value that is instance of to Data' do
       node = Puppet::Node.new("hello",
         :environment => 'bar',

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -132,16 +132,6 @@ describe Puppet::Resource::Status do
     end
   end
 
-  describe "When converting to YAML" do
-    it "should include only documented attributes" do
-      @status.file = "/foo.rb"
-      @status.line = 27
-      @status.evaluation_time = 2.7
-      @status.tags = %w{one two}
-      expect(@status.to_yaml_properties).to match_array(Puppet::Resource::Status::YAML_ATTRIBUTES)
-    end
-  end
-
   let(:status) do
     s = @status
     s.file = "/foo.rb"
@@ -178,10 +168,6 @@ describe Puppet::Resource::Status do
     expect(tripped.change_count).to eq(status.change_count)
     expect(tripped.out_of_sync_count).to eq(status.out_of_sync_count)
     expect(events_as_hashes(tripped)).to eq(events_as_hashes(status))
-  end
-
-  it 'to_yaml_properties and to_data_hash references the same attributes' do
-    expect(status.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(status.to_data_hash.keys.sort)
   end
 
   it 'to_data_hash returns value that is instance of to Data' do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -669,7 +669,7 @@ describe Puppet::Resource do
     end
 
     it "doesn't include transient instance variables (#4506)" do
-      expect(@resource.to_yaml_properties).to_not include(:@rstype)
+      expect(@resource.to_data_hash.keys).to_not include('rstype')
     end
 
     it "produces an equivalent json object" do
@@ -677,10 +677,6 @@ describe Puppet::Resource do
 
       newresource = Puppet::Resource.convert_from('json', text)
       expect(newresource).to equal_resource_attributes_of(@resource)
-    end
-
-    it 'to_yaml_properties and to_data_hash references the same attributes' do
-      expect(@resource.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(@resource.to_data_hash.keys.sort)
     end
 
     it 'to_data_hash returns value that is instance of to Data' do

--- a/spec/unit/transaction/event_spec.rb
+++ b/spec/unit/transaction/event_spec.rb
@@ -133,14 +133,6 @@ describe Puppet::Transaction::Event do
         :corrective_change => false)
     end
 
-    it 'should include only documented attributes' do
-      expect(event.to_yaml_properties).to match_array(Puppet::Transaction::Event::YAML_ATTRIBUTES)
-    end
-
-    it 'to_yaml_properties and to_data_hash references the same attributes' do
-      expect(event.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(event.to_data_hash.keys.sort)
-    end
-
     it 'to_data_hash returns value that is instance of to Data' do
       expect(Puppet::Pops::Types::TypeFactory.data.instance?(event.to_data_hash)).to be_truthy
     end

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -484,18 +484,13 @@ describe Puppet::Transaction::Report do
     it "should not include @external_times" do
       report = Puppet::Transaction::Report.new('apply')
       report.add_times('config_retrieval', 1.0)
-      expect(report.to_yaml_properties).not_to include(:@external_times)
+      expect(report.to_data_hash.keys).not_to include('external_times')
     end
 
     it "should not include @resources_failed_to_generate" do
       report = Puppet::Transaction::Report.new("apply")
       report.resources_failed_to_generate = true
-      expect(report.to_yaml_properties).not_to include(:@resources_failed_to_generate)
-    end
-
-    it 'to_yaml_properties and to_data_hash references the same attributes' do
-      report = generate_report
-      expect(report.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(report.to_data_hash.keys.sort)
+      expect(report.to_data_hash.keys).not_to include('resources_failed_to_generate')
     end
 
     it 'to_data_hash returns value that is instance of to Data' do

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -511,18 +511,18 @@ describe Puppet::Util::Log do
   describe "to_yaml" do
     it "should not include the @version attribute" do
       log = Puppet::Util::Log.new(:level => "notice", :message => :foo, :version => 100)
-      expect(log.to_yaml_properties).not_to include('@version')
+      expect(log.to_data_hash.keys).not_to include('version')
     end
 
-    it "should include attributes @level, @message, @source, @tags, and @time" do
+    it "should include attributes 'file', 'line', 'level', 'message', 'source', 'tags', and 'time'" do
       log = Puppet::Util::Log.new(:level => "notice", :message => :foo, :version => 100)
-      expect(log.to_yaml_properties).to match_array([:@level, :@message, :@source, :@tags, :@time])
+      expect(log.to_data_hash.keys).to match_array(%w(file line level message source tags time))
     end
 
-    it "should include attributes @file and @line if specified" do
+    it "should include attributes 'file' and 'line' if specified" do
       log = Puppet::Util::Log.new(:level => "notice", :message => :foo, :file => "foo", :line => 35)
-      expect(log.to_yaml_properties).to include(:@file)
-      expect(log.to_yaml_properties).to include(:@line)
+      expect(log.to_data_hash.keys).to include('file')
+      expect(log.to_data_hash.keys).to include('line')
     end
   end
 
@@ -538,10 +538,6 @@ describe Puppet::Util::Log do
     expect(tripped.source).to eq(log.source)
     expect(tripped.tags).to eq(log.tags)
     expect(tripped.time).to eq(log.time)
-  end
-
-  it 'to_yaml_properties and to_data_hash references the same attributes' do
-    expect(log.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(log.to_data_hash.keys.sort)
   end
 
   it 'to_data_hash returns value that is instance of to Data' do

--- a/spec/unit/util/metric_spec.rb
+++ b/spec/unit/util/metric_spec.rb
@@ -84,10 +84,6 @@ describe Puppet::Util::Metric do
     expect(tripped.values).to eq(metric.values)
   end
 
-  it 'to_yaml_properties and to_data_hash references the same attributes' do
-    expect(metric.to_yaml_properties.map {|attr| attr.to_s[1..-1]}.sort).to eql(metric.to_data_hash.keys.sort)
-  end
-
   it 'to_data_hash returns value that is instance of to Data' do
     expect(Puppet::Pops::Types::TypeFactory.data.instance?(metric.to_data_hash)).to be_truthy
   end


### PR DESCRIPTION
This commit removes the `#to_yaml_properties` method everywhere in the
Puppet code-base and adds an include of `Puppet::Util::PsychSupport`
where needed.

Some tests that only asserted the returned value from the removed
method was also removed. Other tests were rewritten so that they use
the keys of the hash returned from the `#to_data_hash` methods instead.