### PR TITLE
(PUP-7605) Ensure that resource title is a String (get rid of :main)

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -577,7 +577,7 @@ class Puppet::Parser::Compiler
     krt = environment.known_resource_types
     @main = krt.find_hostclass('') || krt.add(Puppet::Resource::Type.new(:hostclass, ''))
     @topscope.source = @main
-    @main_resource = Puppet::Parser::Resource.new('class', Puppet::Resource::MAIN, :scope => @topscope, :source => @main)
+    @main_resource = Puppet::Parser::Resource.new(Puppet::Resource::TYPE_CLASS, '', :scope => @topscope, :source => @main)
     @topscope.resource = @main_resource
 
     add_resource(@topscope, @main_resource)

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -577,7 +577,7 @@ class Puppet::Parser::Compiler
     krt = environment.known_resource_types
     @main = krt.find_hostclass('') || krt.add(Puppet::Resource::Type.new(:hostclass, ''))
     @topscope.source = @main
-    @main_resource = Puppet::Parser::Resource.new('class', :main, :scope => @topscope, :source => @main)
+    @main_resource = Puppet::Parser::Resource.new('class', Puppet::Resource::MAIN, :scope => @topscope, :source => @main)
     @topscope.resource = @main_resource
 
     add_resource(@topscope, @main_resource)
@@ -637,7 +637,7 @@ class Puppet::Parser::Compiler
   end
 
   def add_resource_metaparams
-    unless main = catalog.resource(:class, :main)
+    unless main = catalog.resource(:class, Puppet::Resource::MAIN)
       #TRANSLATORS "main" is a function name and should not be translated
       raise _("Couldn't find main")
     end
@@ -716,7 +716,7 @@ class Puppet::Parser::Compiler
       @catalog.version = environment.known_resource_types.version
     end
 
-    @catalog.add_resource(Puppet::Parser::Resource.new("stage", :main, :scope => @topscope))
+    @catalog.add_resource(Puppet::Parser::Resource.new("stage", Puppet::Resource::MAIN, :scope => @topscope))
 
     # local resource array to maintain resource ordering
     @resources = []

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -59,11 +59,11 @@ class Puppet::Parser::Resource < Puppet::Resource
   def add_edge_to_stage
     return unless self.class?
 
-    unless stage = catalog.resource(:stage, self[:stage] || (scope && scope.resource && scope.resource[:stage]) || :main)
-      raise ArgumentError, _("Could not find stage %{stage} specified by %{resource}") % { stage: self[:stage] || :main, resource: self }
+    unless stage = catalog.resource(:stage, self[:stage] || (scope && scope.resource && scope.resource[:stage]) || MAIN)
+      raise ArgumentError, _("Could not find stage %{stage} specified by %{resource}") % { stage: self[:stage] || MAIN, resource: self }
     end
 
-    self[:stage] ||= stage.title unless stage.title == :main
+    self[:stage] ||= stage.title unless MAIN == stage.title
     catalog.add_edge(stage, self)
   end
 

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -298,6 +298,11 @@ class Puppet::Resource
 
       @type, @title = self.class.type_and_title(type, title)
 
+      if TYPE_CLASS == @type && MAIN == @title && '' != title
+        # The main class can only be created using the empty string
+        raise ArgumentError, _("'main' is a reserved class name")
+      end
+
       rt = resource_type
 
       if strict? && rt.nil?

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -117,7 +117,7 @@ class Puppet::Resource::Type
     static_parent = evaluate_parent_type(resource)
     scope = static_parent || resource.scope
 
-    scope = scope.newscope(:source => self, :resource => resource) unless resource.title == :main
+    scope = scope.newscope(:source => self, :resource => resource) unless Puppet::Resource::MAIN == resource.title
     scope.compiler.add_class(name) unless definition?
 
     set_resource_parameters(resource, scope)

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -2374,7 +2374,11 @@ end
       self.title = resource.title
     else
       # This should only ever happen for components
-      self.title = resource.ref
+      if is_a?(Puppet::Type::Component)
+        self.reference = resource
+      else
+        self.title = resource.ref
+      end
     end
 
     [:file, :line, :catalog, :exported, :virtual].each do |getter|

--- a/lib/puppet/type/component.rb
+++ b/lib/puppet/type/component.rb
@@ -49,6 +49,10 @@ Puppet::Type.newtype(:component) do
     reference.to_s
   end
 
+  def reference=(resource)
+    @reference = resource
+  end
+
   # We want our title to just be the whole reference, rather than @title.
   def title
     ref

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -40,7 +40,7 @@ module Puppet::Util::Tagging
   # since that results in testing the same string twice
   #
   def tag_if_valid(name)
-    if name.is_a?(String) && name =~ ValidTagRegex && Puppet::Resource::MAIN != name
+    if name.is_a?(String) && name =~ ValidTagRegex
       name = name.downcase
       @tags ||= new_tags
       if @tags.add?(name) && name.include?('::')

--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -40,7 +40,7 @@ module Puppet::Util::Tagging
   # since that results in testing the same string twice
   #
   def tag_if_valid(name)
-    if name.is_a?(String) && name =~ ValidTagRegex
+    if name.is_a?(String) && name =~ ValidTagRegex && Puppet::Resource::MAIN != name
       name = name.downcase
       @tags ||= new_tags
       if @tags.add?(name) && name.include?('::')

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -13,7 +13,7 @@ class CompilerTestResource
 
   def [](attr)
     return nil if (attr == :stage || attr == :alias)
-    :main
+    Puppet::Resource::MAIN
   end
 
   def ref

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -704,7 +704,7 @@ describe Puppet::Parser::Compiler do
         catalog = @compiler.compile
 
         r2 = catalog.resources.detect {|r| r.title == 'Bar::Foo' }
-        expect(r2.tags).to eq(Puppet::Util::TagSet.new(['bar::foo', 'class', 'bar', 'foo']))
+        expect(r2.tags).to eq(Puppet::Util::TagSet.new(%w(bar::foo class bar foo main)))
       end
     end
 

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -12,7 +12,7 @@ class CompilerTestResource
 
   def [](attr)
     return nil if (attr == :stage || attr == :alias)
-    :main
+    'main'
   end
 
   def ref
@@ -410,7 +410,7 @@ describe Puppet::Parser::Compiler do
       end
 
       it "should add each container's metaparams to its contained resources" do
-        main = @catalog.resource(:class, :main)
+        main = @catalog.resource(:class, Puppet::Resource::MAIN)
         main[:noop] = true
 
         resource1 = add_resource("meh", main)
@@ -420,7 +420,7 @@ describe Puppet::Parser::Compiler do
       end
 
       it "should add metaparams recursively" do
-        main = @catalog.resource(:class, :main)
+        main = @catalog.resource(:class, Puppet::Resource::MAIN)
         main[:noop] = true
 
         resource1 = add_resource("meh", main)
@@ -431,7 +431,7 @@ describe Puppet::Parser::Compiler do
       end
 
       it "should prefer metaparams from immediate parents" do
-        main = @catalog.resource(:class, :main)
+        main = @catalog.resource(:class, Puppet::Resource::MAIN)
         main[:noop] = true
 
         resource1 = add_resource("meh", main)
@@ -444,7 +444,7 @@ describe Puppet::Parser::Compiler do
       end
 
       it "should merge tags downward" do
-        main = @catalog.resource(:class, :main)
+        main = @catalog.resource(:class, Puppet::Resource::MAIN)
         main.tag("one")
 
         resource1 = add_resource("meh", main)
@@ -457,7 +457,7 @@ describe Puppet::Parser::Compiler do
       end
 
       it "should work if only middle resources have metaparams set" do
-        main = @catalog.resource(:class, :main)
+        main = @catalog.resource(:class, Puppet::Resource::MAIN)
 
         resource1 = add_resource("meh", main)
         resource1[:noop] = true
@@ -501,7 +501,7 @@ describe Puppet::Parser::Compiler do
     end
 
     it "should not add non-class resources that don't specify a stage to the 'main' stage" do
-      main = @compiler.catalog.resource(:stage, :main)
+      main = @compiler.catalog.resource(:stage, Puppet::Resource::MAIN)
       resource = resource(:file, "foo")
       @compiler.add_resource(@scope, resource)
 

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -128,7 +128,7 @@ describe Puppet::Parser::Resource do
       source = stub('source')
       source.stubs(:module_name)
       @scope = Puppet::Parser::Scope.new(@compiler, :source => source)
-      @catalog.add_resource(Puppet::Parser::Resource.new("stage", :main, :scope => @scope))
+      @catalog.add_resource(Puppet::Parser::Resource.new("stage", Puppet::Resource::MAIN, :scope => @scope))
     end
 
     it "should evaluate the associated AST definition" do
@@ -177,7 +177,7 @@ describe Puppet::Parser::Resource do
     end
 
     it "should add edges from the class resources to the parent's stage if no stage is specified" do
-      main      = @compiler.catalog.resource(:stage, :main)
+      main      = @compiler.catalog.resource(:stage, Puppet::Resource::MAIN)
       foo_stage = Puppet::Parser::Resource.new(:stage, :foo_stage, :scope => @scope, :catalog => @catalog)
       @compiler.add_resource(@scope, foo_stage)
       @compiler.environment.known_resource_types.add Puppet::Resource::Type.new(:hostclass, "foo", {})
@@ -252,7 +252,7 @@ describe Puppet::Parser::Resource do
     end
 
     it "should add edges from top-level class resources to the main stage if no stage is specified" do
-      main = @compiler.catalog.resource(:stage, :main)
+      main = @compiler.catalog.resource(:stage, Puppet::Resource::MAIN)
       @compiler.environment.known_resource_types.add Puppet::Resource::Type.new(:hostclass, "foo", {})
       resource = Puppet::Parser::Resource.new(:class, "foo", :scope => @scope, :catalog => @catalog)
       @compiler.add_resource(@scope, resource)

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -240,7 +240,7 @@ describe Puppet::Parser::Scope do
         klass = newclass(name)
 
         catalog = Puppet::Resource::Catalog.new
-        catalog.add_resource(Puppet::Parser::Resource.new("stage", :main, :scope => Puppet::Parser::Scope.new(@compiler)))
+        catalog.add_resource(Puppet::Parser::Resource.new("stage", Puppet::Resource::MAIN, :scope => Puppet::Parser::Scope.new(@compiler)))
 
         Puppet::Parser::Resource.new("class", name, :scope => @scope, :source => mock('source'), :catalog => catalog).evaluate
 

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -554,8 +554,8 @@ describe Puppet::Resource::Type do
       @type.evaluate_code(@resource)
     end
 
-    it "should not create a subscope for the :main class" do
-      @resource.stubs(:title).returns(:main)
+    it "should not create a subscope for the 'main' class" do
+      @resource.stubs(:title).returns(Puppet::Resource::MAIN)
       @type.expects(:subscope).never
       @type.expects(:set_resource_parameters).with(@resource, @scope)
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -207,31 +207,46 @@ describe Puppet::Resource do
       end
 
       describe "and its name is set to the empty string" do
-        it "should set its title to :main" do
-          expect(Puppet::Resource.new("class", "").title).to eq(:main)
+        it "should set its title to 'main'" do
+          expect(Puppet::Resource.new("class", "").title).to eq(Puppet::Resource::MAIN)
         end
 
         describe "and a class exists whose name is the empty string" do # this was a bit tough to track down
-          it "should set its title to :main" do
+          it "should set its title to 'main'" do
             @type = Puppet::Resource::Type.new(:hostclass, "")
             environment.known_resource_types.add @type
 
-            expect(Puppet::Resource.new("class", "", :environment => environment).title).to eq(:main)
+            expect(Puppet::Resource.new("class", "", :environment => environment).title).to eq(Puppet::Resource::MAIN)
+          end
+        end
+      end
+
+      describe "and its name is set to 'main'" do
+        it "should set its title to 'main'" do
+          expect(Puppet::Resource.new("class", Puppet::Resource::MAIN).title).to eq(Puppet::Resource::MAIN)
+        end
+
+        describe "and a class exists whose name is the empty string" do # this was a bit tough to track down
+          it "should set its title to 'main'" do
+            @type = Puppet::Resource::Type.new(:hostclass, "")
+            environment.known_resource_types.add @type
+
+            expect(Puppet::Resource.new("class", Puppet::Resource::MAIN, :environment => environment).title).to eq(Puppet::Resource::MAIN)
           end
         end
       end
 
       describe "and its name is set to :main" do
-        it "should set its title to :main" do
-          expect(Puppet::Resource.new("class", :main).title).to eq(:main)
+        it "should set its title to 'main'" do
+          expect(Puppet::Resource.new("class", :main).title).to eq(Puppet::Resource::MAIN)
         end
 
         describe "and a class exists whose name is the empty string" do # this was a bit tough to track down
-          it "should set its title to :main" do
+          it "should set its title to 'main'" do
             @type = Puppet::Resource::Type.new(:hostclass, "")
             environment.known_resource_types.add @type
 
-            expect(Puppet::Resource.new("class", :main, :environment => environment).title).to eq(:main)
+            expect(Puppet::Resource.new("class", :main, :environment => environment).title).to eq(Puppet::Resource::MAIN)
           end
         end
       end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -222,32 +222,8 @@ describe Puppet::Resource do
       end
 
       describe "and its name is set to 'main'" do
-        it "should set its title to 'main'" do
-          expect(Puppet::Resource.new("class", Puppet::Resource::MAIN).title).to eq(Puppet::Resource::MAIN)
-        end
-
-        describe "and a class exists whose name is the empty string" do # this was a bit tough to track down
-          it "should set its title to 'main'" do
-            @type = Puppet::Resource::Type.new(:hostclass, "")
-            environment.known_resource_types.add @type
-
-            expect(Puppet::Resource.new("class", Puppet::Resource::MAIN, :environment => environment).title).to eq(Puppet::Resource::MAIN)
-          end
-        end
-      end
-
-      describe "and its name is set to :main" do
-        it "should set its title to 'main'" do
-          expect(Puppet::Resource.new("class", :main).title).to eq(Puppet::Resource::MAIN)
-        end
-
-        describe "and a class exists whose name is the empty string" do # this was a bit tough to track down
-          it "should set its title to 'main'" do
-            @type = Puppet::Resource::Type.new(:hostclass, "")
-            environment.known_resource_types.add @type
-
-            expect(Puppet::Resource.new("class", :main, :environment => environment).title).to eq(Puppet::Resource::MAIN)
-          end
+        it 'should raise a reserved class name error' do
+          expect { Puppet::Resource.new('class', Puppet::Resource::MAIN) }.to raise_error(/'main' is a reserved class name/)
         end
       end
     end

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
+require 'puppet/transaction/resource_harness'
 require 'puppet/type/component'
 
 describe Puppet::Transaction::ResourceHarness do

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-require 'puppet/transaction/resource_harness'
+require 'puppet/type/component'
 
 describe Puppet::Transaction::ResourceHarness do
   include PuppetSpec::Files

--- a/spec/unit/type/component_spec.rb
+++ b/spec/unit/type/component_spec.rb
@@ -42,10 +42,6 @@ describe component do
       expect(component.new(:name => "Class[foo]").pathbuilder).to eq(["Foo"])
     end
 
-    it "should produce the class name even for the class named main" do
-      expect(component.new(:name => "Class[main]").pathbuilder).to eq(['main'])
-    end
-
     it "should produce a resource reference if the component does not model a class" do
       expect(component.new(:name => "Foo[bar]").pathbuilder).to eq(["Foo[bar]"])
     end

--- a/spec/unit/type/component_spec.rb
+++ b/spec/unit/type/component_spec.rb
@@ -43,7 +43,7 @@ describe component do
     end
 
     it "should produce the class name even for the class named main" do
-      expect(component.new(:name => "Class[main]").pathbuilder).to eq(["Main"])
+      expect(component.new(:name => "Class[main]").pathbuilder).to eq(['main'])
     end
 
     it "should produce a resource reference if the component does not model a class" do


### PR DESCRIPTION
This commit ensures that a resource title is a String. A Symbol (like
:main) is still accepted but will be converted into a String.