### PR TITLE
(PUP-7133) Remove deprecated `always_cache_features` setting

### DIFF
--- a/ext/rack/config.ru
+++ b/ext/rack/config.ru
@@ -20,10 +20,10 @@ ARGV << "--logdir"  << "/var/log/puppetlabs/puppetmaster"
 ARGV << "--rundir"  << "/var/run/puppetlabs/puppetmaster"
 ARGV << "--codedir"  << "/etc/puppetlabs/code"
 
-# always_cache_features is a performance improvement and safe for a master to
+# disable always_retry_plugsin as a performance improvement. This is safe for a master to
 # apply. This is intended to allow agents to recognize new features that may be
 # delivered during catalog compilation.
-ARGV << "--always_cache_features"
+ARGV << "--no-always_retry_plugins"
 
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -292,31 +292,6 @@ module Puppet
         <https://docs.puppet.com/puppet/latest/reference/environments.html>",
       :type    => :path,
     },
-    :always_cache_features => {
-      :type     => :boolean,
-      :default  => false,
-      :hook     => proc { |value|
-        Puppet.deprecation_warning "Setting 'always_cache_features' is
-deprecated and has been replaced by 'always_retry_plugins'."
-      },
-      :desc     => <<-'EOT'
-        This setting is deprecated and has been replaced by always_retry_plugins.
-
-        Affects how we cache attempts to load Puppet 'features'.  If false, then
-        calls to `Puppet.features.<feature>?` will always attempt to load the
-        feature (which can be an expensive operation) unless it has already been
-        loaded successfully.  This makes it possible for a single agent run to,
-        e.g., install a package that provides the underlying capabilities for
-        a feature, and then later load that feature during the same run (even if
-        the feature had been tested earlier and had not been available).
-
-        If this setting is set to true, then features will only be checked once,
-        and if they are not available, the negative result is cached and returned
-        for all subsequent attempts to load the feature.  This behavior is almost
-        always appropriate for the server, and can result in a significant performance
-        improvement for features that are checked frequently.
-      EOT
-    },
     :always_retry_plugins => {
         :type     => :boolean,
         :default  => true,

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -32,7 +32,7 @@ class Puppet::Util::Feature
       #    configured to always cache
       if block_given?     ||
           @results[name]  ||
-          (@results.has_key?(name) && (Puppet[:always_cache_features] || !Puppet[:always_retry_plugins]))
+          (@results.has_key?(name) && (!Puppet[:always_retry_plugins]))
         @results[name]
       else
         @results[name] = test(name, options)

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -56,12 +56,6 @@ Whether to allow a new certificate request to overwrite an existing certificate\
 .
 .IP "" 0
 .
-.SS "always_cache_features"
-Affects how we cache attempts to load Puppet \'features\'\. If false, then calls to \fBPuppet\.features\.<feature>?\fR will always attempt to load the feature (which can be an expensive operation) unless it has already been loaded successfully\. This makes it possible for a single agent run to, e\.g\., install a package that provides the underlying capabilities for a feature, and then later load that feature during the same run (even if the feature had been tested earlier and had not been available)\.
-.
-.P
-If this setting is set to true, then features will only be checked once, and if they are not available, the negative result is cached and returned for all subsequent attempts to load the feature\. This behavior is almost always appropriate for the server, and can result in a significant performance improvement for features that are checked frequently\.
-.
 .IP "\(bu" 4
 \fIDefault\fR: false
 .


### PR DESCRIPTION
The `always_cache_features` setting has been deprecated in favor of
`always_retry_plugins` for some time. This commit removes it.