### PR TITLE
(PUP-7612) Allow dotted key with integers to navigate integer hash keys

### DIFF
--- a/lib/puppet/pops/lookup/lookup_key.rb
+++ b/lib/puppet/pops/lookup/lookup_key.rb
@@ -16,7 +16,7 @@ class LookupKey
     @key = key
     @module_name = qual_index.nil? ? nil : root_key[0..qual_index-1].freeze
     @root_key = root_key
-    @segments = segments.empty? ? nil : segments.map { |segment| segment =~ /^[0-9]+$/ ? segment.to_i : segment }.freeze
+    @segments = segments.empty? ? nil : segments.freeze
   end
 
   def dig(lookup_invocation, value)

--- a/lib/puppet/pops/lookup/sub_lookup.rb
+++ b/lib/puppet/pops/lookup/sub_lookup.rb
@@ -30,7 +30,13 @@ module SubLookup
       raise yield('Syntax error') unless segments.size * 2 == count + 1
       segments.map! do |segment|
         segment.strip!
-        segment.start_with?('"') || segment.start_with?("'") ? segment[1..-2] : segment
+        if segment.start_with?('"') || segment.start_with?("'")
+          segment[1..-2]
+        elsif segment =~ /^(:?[+-]?[0-9]+)$/
+          segment.to_i
+        else
+          segment
+        end
       end
     else
       raise yield('Syntax error')
@@ -58,18 +64,13 @@ module SubLookup
             lookup_invocation.report_not_found(segment)
             throw :no_such_key
           end
-          if segment.is_a?(Integer) || segment =~ /^[0-9]+$/
-            segment = segment.to_i
-            unless value.instance_of?(Array)
-              raise Puppet::DataBinding::LookupError,
-                "Data Provider type mismatch: Got #{value.class.name} when Array was expected to access value using '#{segment}' from key '#{key}'"
-            end
-            unless segment < value.size
+          if segment.is_a?(Integer) && value.instance_of?(Array)
+            unless segment >= 0 && segment < value.size
               lookup_invocation.report_not_found(segment)
               throw :no_such_key
             end
           else
-            unless value.respond_to?(:'[]') && !(value.instance_of?(Array) || value.instance_of?(String))
+            unless value.respond_to?(:'[]') && !(value.is_a?(Array) || value.instance_of?(String))
               raise Puppet::DataBinding::LookupError,
                 "Data Provider type mismatch: Got #{value.class.name} when a hash-like object was expected to access value using '#{segment}' from key '#{key}'"
             end

--- a/spec/unit/pops/lookup/lookup_spec.rb
+++ b/spec/unit/pops/lookup/lookup_spec.rb
@@ -58,10 +58,12 @@ describe 'The lookup API' do
           mod::e: mod::e (from module)
           mod::f: mod::f (from module)
           mod::g:
-            :symbol: value
-            key: value
-            6: value
-            2.7: value
+            :symbol: symbol key value
+            key: string key value
+            6: integer key value
+            -4: negative integer key value
+            2.7: float key value
+            '6': string integer key value
           YAML
       }
     }
@@ -145,12 +147,26 @@ describe 'The lookup API' do
     it 'returns the correct types for hash keys' do
       expect(Lookup.lookup('mod::g', nil, 'not found', true, nil, invocation)).to eql(
 	      {
-		      "symbol" => "value",
-		      "key" => "value",
-		      6 => "value",
-		      2.7 => "value",
+          'symbol' => 'symbol key value',
+		      'key' => 'string key value',
+		      6 => 'integer key value',
+          -4 => 'negative integer key value',
+		      2.7 => 'float key value',
+          '6' => 'string integer key value'
 	      }
       )
+    end
+
+    it 'can navigate a hash with an integer key using a dotted key' do
+      expect(Lookup.lookup('mod::g.6', nil, 'not found', true, nil, invocation)).to eql('integer key value')
+    end
+
+    it 'can navigate a hash with a negative integer key using a dotted key' do
+      expect(Lookup.lookup('mod::g.-4', nil, 'not found', true, nil, invocation)).to eql('negative integer key value')
+    end
+
+    it 'can navigate a hash with an string integer key using a dotted key with quoted integer' do
+      expect(Lookup.lookup("mod::g.'6'", nil, 'not found', true, nil, invocation)).to eql('string integer key value')
     end
 
     context "with 'global_only' set to true in the invocation" do


### PR DESCRIPTION
Prior to this commit, Hiera would consider an unquoted integer in a
dotted key to be an index in an array. This is now changed so that an
unquoted integer key can be used for navigating a hash that uses integer
keys.