### PR TITLE
(PUP-3940) Send proper mime types in the Accept header

### DIFF
--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -104,8 +104,9 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     network_formats = model.supported_formats.reject do |format|
       [:yaml, :b64_zlib_yaml].include?(format)
     end
+    mime_types = network_formats.map { |f| model.get_format(f).mime }
     common_headers = {
-      "Accept"                                     => network_formats.join(", "),
+      "Accept"                                     => mime_types.join(', '),
       Puppet::Network::HTTP::HEADER_PUPPET_VERSION => Puppet.version
     }
 

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -10,6 +10,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   include Puppet::Network::HTTP::Compression.module
 
   IndirectedRoutes = Puppet::Network::HTTP::API::IndirectedRoutes
+  EXCLUDED_FORMATS = [:yaml, :b64_zlib_yaml, :dot]
 
   class << self
     attr_reader :server_setting, :port_setting
@@ -101,9 +102,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   # Provide appropriate headers.
   def headers
     # yaml is not allowed on the network
-    network_formats = model.supported_formats.reject do |format|
-      [:yaml, :b64_zlib_yaml, :dot].include?(format)
-    end
+    network_formats = model.supported_formats - EXCLUDED_FORMATS
     mime_types = network_formats.map { |f| model.get_format(f).mime }
     common_headers = {
       "Accept"                                     => mime_types.join(', '),

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -102,7 +102,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   def headers
     # yaml is not allowed on the network
     network_formats = model.supported_formats.reject do |format|
-      [:yaml, :b64_zlib_yaml].include?(format)
+      [:yaml, :b64_zlib_yaml, :dot].include?(format)
     end
     mime_types = network_formats.map { |f| model.get_format(f).mime }
     common_headers = {

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -16,6 +16,10 @@ module Puppet
   Puppet::Type.type(:file).newparam(:source) do
     include Puppet::Network::HTTP::Compression.module
 
+    BINARY_MIME_TYPES = [
+      Puppet::Network::FormatHandler.format_for('binary').mime
+    ].join(', ').freeze
+
     attr_accessor :source, :local
     desc <<-'EOT'
       A source file, which will be copied into place on the local system. This
@@ -289,7 +293,7 @@ module Puppet
 
       request.do_request(:fileserver) do |req|
         connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)
-        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => "binary"}), &block)
+        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => BINARY_MIME_TYPES}), &block)
       end
     end
 

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -287,6 +287,12 @@ describe Puppet::Indirector::REST do
     expect(terminus.headers['Accept']).to eq('application/json, text/pson')
   end
 
+  it 'excludes dot from the Accept header' do
+    model.expects(:supported_formats).returns([:json, :dot])
+
+    expect(terminus.headers['Accept']).to eq('application/json')
+  end
+
   describe "when creating an HTTP client" do
     it "should use the class's server and port if the indirection request provides neither" do
       @request = stub 'request', :key => "foo", :server => nil, :port => nil

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -278,13 +278,13 @@ describe Puppet::Indirector::REST do
   it 'excludes yaml from the Accept header' do
     model.expects(:supported_formats).returns([:json, :pson, :yaml, :binary])
 
-    expect(terminus.headers['Accept']).to eq('json, pson, binary')
+    expect(terminus.headers['Accept']).to eq('application/json, text/pson, application/octet-stream')
   end
 
   it 'excludes b64_zlib_yaml from the Accept header' do
     model.expects(:supported_formats).returns([:json, :pson, :b64_zlib_yaml])
 
-    expect(terminus.headers['Accept']).to eq('json, pson')
+    expect(terminus.headers['Accept']).to eq('application/json, text/pson')
   end
 
   describe "when creating an HTTP client" do
@@ -432,10 +432,10 @@ describe Puppet::Indirector::REST do
       expect(terminus.find(request)).to eq(model.new('name', 'decoded body'))
     end
 
-    it "provides an Accept header containing the list of supported formats joined with commas" do
-      connection.expects(:get).with(anything, has_entry("Accept" => "supported, formats")).returns(response)
+    it "provides an Accept header containing the list of supported mime types joined with commas" do
+      connection.expects(:get).with(anything, has_entry("Accept" => "application/json, text/pson")).returns(response)
 
-      terminus.model.expects(:supported_formats).returns %w{supported formats}
+      terminus.model.expects(:supported_formats).returns [:json, :pson]
       terminus.find(request)
     end
 
@@ -538,9 +538,9 @@ describe Puppet::Indirector::REST do
     end
 
     it "should provide an Accept header containing the list of supported formats joined with commas" do
-      connection.expects(:get).with(anything, has_entry("Accept" => "supported, formats")).returns(mock_response(200, ''))
+      connection.expects(:get).with(anything, has_entry("Accept" => "application/json, text/pson")).returns(mock_response(200, ''))
 
-      terminus.model.expects(:supported_formats).returns %w{supported formats}
+      terminus.model.expects(:supported_formats).returns [:json, :pson]
       terminus.search(request)
     end
 
@@ -597,9 +597,9 @@ describe Puppet::Indirector::REST do
     end
 
     it "should provide an Accept header containing the list of supported formats joined with commas" do
-      connection.expects(:delete).with(anything, has_entry("Accept" => "supported, formats")).returns(response)
+      connection.expects(:delete).with(anything, has_entry("Accept" => "application/json, text/pson")).returns(response)
 
-      terminus.model.expects(:supported_formats).returns %w{supported formats}
+      terminus.model.expects(:supported_formats).returns [:json, :pson]
       terminus.destroy(request)
     end
 
@@ -657,10 +657,10 @@ describe Puppet::Indirector::REST do
     end
 
     it "should provide an Accept header containing the list of supported formats joined with commas" do
-      connection.expects(:put).with(anything, anything, has_entry("Accept" => "supported, formats")).returns(response)
+      connection.expects(:put).with(anything, anything, has_entry("Accept" => "application/json, text/pson")).returns(response)
 
       instance.expects(:render).returns('')
-      model.expects(:supported_formats).returns %w{supported formats}
+      model.expects(:supported_formats).returns [:json, :pson]
       instance.expects(:mime).returns "supported"
 
       terminus.save(request)

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -612,6 +612,19 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         resource.write(source)
       end
 
+      it 'should request binary content' do
+        response.stubs(:code).returns('200')
+        Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)
+        source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
+
+        conn.unstub(:request_get)
+        conn.expects(:request_get).with do |_, options|
+          expect(options).to include('Accept' => 'application/octet-stream')
+        end.yields(response)
+
+        resource.write(source)
+      end
+
       describe 'when handling file_content responses' do
         before do
           File.open(filename, 'w') {|f| f.write "initial file content"}


### PR DESCRIPTION
Previously, puppet sent the format names in the Accept header, e.g. `Accept: pson`. This modifies puppet to send the proper mime type, e.g. `Accept: application/json, text/pson`. It is backwards compatible with all puppet ruby REST endpoints, because it historically has always accepted either the format name or mime type. It is backwards compatible with puppetserver REST endpoints for CA and static_file_content, because puppetserver ignores the `Accept` header and always returns content as `text/plain` or `application/octet-stream` respectively.