### PR TITLE
(MAINT) Explicitly configure autosign to false for dup-csr test

### DIFF
--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -2,7 +2,8 @@ test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 
 agent_hostnames = agents.map {|a| a.to_s}
 
-with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true}}) do
+with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true,
+                                             'autosign' => false}}) do
   agents_with_cert_name = {}
   agents.each do |agent|
     step "Collect fqdn for the agent"


### PR DESCRIPTION
The ticket_3360_allow_duplicate_csr_with_option_set.rb test contains a
couple of steps which sign certs via the puppet cert cli.  If the test
were run with the `autosign` setting in the puppet.conf set to `true`,
the sign steps could "fail" because they end up being no-ops since CSRs
are signed immediately as they are submitted.  This commit sets
`autosign` to `false` while the test is running in order to ensure that
the CSRs have not already been signed before the cli sign steps in the
test are run.