### PR TITLE
(PUP-6359) Fail fileserver auth for mounts with non-global allow

### DIFF
--- a/lib/puppet/indirector/file_server.rb
+++ b/lib/puppet/indirector/file_server.rb
@@ -15,7 +15,15 @@ class Puppet::Indirector::FileServer < Puppet::Indirector::Terminus
 
     # If we're not serving this mount, then access is denied.
     return false unless mount
-    mount.allowed?(request.node, request.ip)
+
+    # If there are no auth directives or there is an 'allow *' directive, then
+    # access is allowed.
+    if mount.empty? || mount.globalallow?
+      return true
+    end
+
+    Puppet.err _("Denying %{method} request for %{desc} on fileserver mount '%{mount_name}'. Use of auth directives for 'fileserver.conf' mount points is no longer supported. Remove these directives and use the 'auth.conf' file instead for access control.") % { method: request.method, desc: request.description, mount_name: mount.name }
+    return false
   end
 
   # Find our key using the fileserver.

--- a/spec/integration/indirector/file_content/file_server_spec.rb
+++ b/spec/integration/indirector/file_content/file_server_spec.rb
@@ -70,6 +70,7 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
 
     # Use a real mount, so the integration is a bit deeper.
     mount1 = Puppet::FileServing::Configuration::Mount::File.new("one")
+    mount1.stubs(:globalallow?).returns true
     mount1.stubs(:allowed?).returns true
     mount1.path = File.join(path, "%h")
 

--- a/spec/integration/indirector/file_metadata/file_server_spec.rb
+++ b/spec/integration/indirector/file_metadata/file_server_spec.rb
@@ -50,6 +50,7 @@ describe Puppet::Indirector::FileMetadata::FileServer, " when finding files" do
 
         # Use a real mount, so the integration is a bit deeper.
         mount1 = Puppet::FileServing::Configuration::Mount::File.new("one")
+        mount1.stubs(:globalallow?).returns true
         mount1.stubs(:allowed?).returns true
         mount1.path = File.join(env_path, "%h")
 

--- a/spec/unit/indirector/file_server_spec.rb
+++ b/spec/unit/indirector/file_server_spec.rb
@@ -249,6 +249,7 @@ describe Puppet::Indirector::FileServer do
       @configuration.stubs(:split_path).with(@request).returns([@mount, "rel/path"])
       @request.stubs(:node).returns("mynode")
       @request.stubs(:ip).returns("myip")
+      @mount.stubs(:name).returns "myname"
       @mount.stubs(:allowed?).with("mynode", "myip").returns "something"
     end
 
@@ -274,8 +275,22 @@ describe Puppet::Indirector::FileServer do
       expect(@file_server).not_to be_authorized(@request)
     end
 
-    it "should return the results of asking the mount whether the node and IP are authorized" do
-      expect(@file_server.authorized?(@request)).to eq("something")
+    it "should return true when no auth directives are defined for the mount point" do
+      @mount.stubs(:empty?).returns true
+      @mount.stubs(:globalallow?).returns nil
+      expect(@file_server).to be_authorized(@request)
+    end
+
+    it "should return true when a global allow directive is defined for the mount point" do
+      @mount.stubs(:empty?).returns false
+      @mount.stubs(:globalallow?).returns true
+      expect(@file_server).to be_authorized(@request)
+    end
+
+    it "should return false when a non-global allow directive is defined for the mount point" do
+      @mount.stubs(:empty?).returns false
+      @mount.stubs(:globalallow?).returns false
+      expect(@file_server).not_to be_authorized(@request)
     end
   end
 end


### PR DESCRIPTION
The use of security directives in fileserver.conf mount points has been
deprecated for multiple releases in favor of the use of the auth.conf file.
This commit is a step toward complete removal of support for these
directives.

With this commit, requests will be denied access to a mount point at the
fileserver indirector layer, with a corresponding error message logged, if any
non-global allow (allow *) directives are present in the mount point definition.

Previously, requests made to mount points for which no security directives were
defined would fail authentication at the fileserver indirector layer.  With
this commit, these requests would be granted authentication at the fileserver
indirector layer.