### PR TITLE
(PUP-7617) Only use Windows locale path on Windows

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -37,9 +37,9 @@ begin
 
   if File.exist?(local_locale_path)
     locale_path = local_locale_path
-  elsif File.exist?(win32_system_locale_path)
+  elsif Puppet::Util::Platform.windows? && File.exist?(win32_system_locale_path)
     locale_path = win32_system_locale_path
-  elsif File.exist?(posix_system_locale_path)
+  elsif !Puppet::Util::Platform.windows? && File.exist?(posix_system_locale_path)
     locale_path = posix_system_locale_path
   else
     # We couldn't load our locale data.


### PR DESCRIPTION
Because the config file for locale tooling is a relative path, in some
situations the Windows path is a valid path on Unix systems, even though
it does not point to the right location. This causes Puppet to look for
the locales config file in the wrong place and fail. This commit adds a
check, so we only try to use the Windows path on Windows, even if it is
valid elsewhere.