### PR TITLE
(PUP-7616) Fix broken Puppet::Property#xxx_to_s methods

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -202,11 +202,11 @@ class Puppet::Property < Puppet::Parameter
   def change_to_s(current_value, newvalue)
     begin
       if current_value == :absent
-        return "defined '#{name}' as #{self.class.format_value_for_display should_to_s(newvalue)}"
+        return "defined '#{name}' as #{should_to_s(newvalue)}"
       elsif newvalue == :absent or newvalue == [:absent]
-        return "undefined '#{name}' from #{self.class.format_value_for_display is_to_s(current_value)}"
+        return "undefined '#{name}' from #{is_to_s(current_value)}"
       else
-        return "#{name} changed #{self.class.format_value_for_display is_to_s(current_value)} to #{self.class.format_value_for_display should_to_s(newvalue)}"
+        return "#{name} changed #{is_to_s(current_value)} to #{should_to_s(newvalue)}"
       end
     rescue Puppet::Error, Puppet::DevError
       raise
@@ -396,12 +396,13 @@ class Puppet::Property < Puppet::Parameter
   end
 
   # Produces a pretty printing string for the given value.
-  # This default implementation simply returns the given argument. A derived implementation
-  # may perform property specific pretty printing when the _is_ and _should_ values are not
-  # already in suitable form.
+  # This default implementation calls {#format_value_for_display} on the class. A derived
+  # implementation may perform property specific pretty printing when the _is_ values
+  # are not already in suitable form.
+  # @param value [Object] the value to format as a string
   # @return [String] a pretty printing string
-  def is_to_s(currentvalue)
-    currentvalue
+  def is_to_s(value)
+    self.class.format_value_for_display(value)
   end
 
   # Emits a log message at the log level specified for the associated resource.
@@ -544,12 +545,14 @@ class Puppet::Property < Puppet::Parameter
     @should = values.collect { |val| self.munge(val) }
   end
 
-  # Formats the given newvalue (following _should_ type conventions) for inclusion in a string describing a change.
-  # @return [String] Returns the given newvalue in string form with space separated entries if it is an array.
-  # @see #change_to_s
-  #
-  def should_to_s(newvalue)
-    [newvalue].flatten.join(" ")
+  # Produces a pretty printing string for the given value.
+  # This default implementation calls {#format_value_for_display} on the class. A derived
+  # implementation may perform property specific pretty printing when the _should_ values
+  # are not already in suitable form.
+  # @param value [Object] the value to format as a string
+  # @return [String] a pretty printing string
+  def should_to_s(value)
+    self.class.format_value_for_display(value)
   end
 
   # Synchronizes the current value _(is)_ and the wanted value _(should)_ by calling {#set}.

--- a/lib/puppet/property/list.rb
+++ b/lib/puppet/property/list.rb
@@ -7,17 +7,8 @@ module Puppet
     #
     class List < Property
 
-      def should_to_s(should_value)
-        #just return the should value
-        should_value
-      end
-
       def is_to_s(currentvalue)
-        if currentvalue == :absent
-          return _("absent")
-        else
-          return currentvalue.join(delimiter)
-        end
+        currentvalue == :absent ? super(currentvalue) : currentvalue.join(delimiter)
       end
 
       def membership

--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -111,7 +111,7 @@ Puppet::Type.newtype(:cron) do
 
     def should_to_s(value = @should)
       if value
-        if name == :command || value.is_a?(Array) && value[0].is_a?(Symbol)
+        if name == :command || (value.is_a?(Array) && value[0].is_a?(Symbol))
           value = value[0]
         end
         super(value)
@@ -122,7 +122,7 @@ Puppet::Type.newtype(:cron) do
 
     def is_to_s(value = @is)
       if value
-        if name == :command || value.is_a?(Array) && value[0].is_a?(Symbol)
+        if name == :command || (value.is_a?(Array) && value[0].is_a?(Symbol))
           value = value[0]
         end
         super(value)

--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -109,28 +109,23 @@ Puppet::Type.newtype(:cron) do
       false
     end
 
-    def should_to_s(newvalue = @should)
-      if newvalue
-        newvalue = [newvalue] unless newvalue.is_a?(Array)
-        if self.name == :command or newvalue[0].is_a? Symbol
-          newvalue[0]
-        else
-          newvalue.join(",")
+    def should_to_s(value = @should)
+      if value
+        if name == :command || value.is_a?(Array) && value[0].is_a?(Symbol)
+          value = value[0]
         end
+        super(value)
       else
         nil
       end
     end
 
-    def is_to_s(currentvalue = @is)
-      if currentvalue
-        return currentvalue unless currentvalue.is_a?(Array)
-
-        if self.name == :command or currentvalue[0].is_a? Symbol
-          currentvalue[0]
-        else
-          currentvalue.join(",")
+    def is_to_s(value = @is)
+      if value
+        if name == :command || value.is_a?(Array) && value[0].is_a?(Symbol)
+          value = value[0]
         end
+        super(value)
       else
         nil
       end
@@ -335,18 +330,6 @@ Puppet::Type.newtype(:cron) do
         return is.sort == @should.sort
       else
         return is == @should
-      end
-    end
-
-    def is_to_s(newvalue)
-      if newvalue
-        if newvalue.is_a?(Array)
-          newvalue.join(",")
-        else
-          newvalue
-        end
-      else
-        nil
       end
     end
 

--- a/lib/puppet/type/file/group.rb
+++ b/lib/puppet/type/file/group.rb
@@ -31,11 +31,11 @@ module Puppet
 
     # We want to print names, not numbers
     def is_to_s(currentvalue)
-      provider.gid2name(currentvalue) || currentvalue
+      super(provider.gid2name(currentvalue) || currentvalue)
     end
 
     def should_to_s(newvalue)
-      provider.gid2name(newvalue) || newvalue
+      super(provider.gid2name(newvalue) || newvalue)
     end
   end
 end

--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -161,7 +161,7 @@ module Puppet
     end
 
     def should_to_s(should_value)
-      should_value.rjust(4, "0")
+      "'#{should_value.rjust(4, '0')}'"
     end
 
     def is_to_s(currentvalue)
@@ -170,7 +170,7 @@ module Puppet
         # present to absent the mode will have a value of `:absent`.
         super
       else
-        currentvalue.rjust(4, "0")
+        "'#{currentvalue.rjust(4, '0')}'"
       end
     end
   end

--- a/lib/puppet/type/file/owner.rb
+++ b/lib/puppet/type/file/owner.rb
@@ -33,11 +33,11 @@ module Puppet
 
     # We want to print names, not numbers
     def is_to_s(currentvalue)
-      provider.uid2name(currentvalue) || currentvalue
+      super(provider.uid2name(currentvalue) || currentvalue)
     end
 
     def should_to_s(newvalue)
-      provider.uid2name(newvalue) || newvalue
+      super(provider.uid2name(newvalue) || newvalue)
     end
   end
 end

--- a/lib/puppet/type/mailalias.rb
+++ b/lib/puppet/type/mailalias.rb
@@ -12,22 +12,6 @@ module Puppet
       desc "Where email should be sent.  Multiple values
         should be specified as an array.  The file and the
         recipient entries are mutually exclusive."
-
-      def is_to_s(value)
-        if value.include?(:absent)
-          super
-        else
-          value.join(",")
-        end
-      end
-
-      def should_to_s(value)
-        if value.include?(:absent)
-          super
-        else
-          value.join(",")
-        end
-      end
     end
 
     newproperty(:file) do

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -206,7 +206,7 @@ module Puppet
       # Provide a bit more information when logging upgrades.
       def should_to_s(newvalue = @should)
         if @latest
-          @latest.to_s
+          super(@latest)
         else
           super(newvalue)
         end

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -174,11 +174,11 @@ Puppet::Type.newtype(:scheduled_task) do
     end
 
     def should_to_s(new_value=@should)
-      self.class.format_value_for_display(new_value)
+      super(new_value)
     end
 
     def is_to_s(current_value=@is)
-      self.class.format_value_for_display(current_value)
+      super(current_value)
     end
   end
 end

--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -112,22 +112,6 @@ module Puppet
 
       defaultto do :absent end
 
-      def is_to_s(value)
-        if value == :absent or value.include?(:absent)
-          super
-        else
-          value.join(",")
-        end
-      end
-
-      def should_to_s(value)
-        if value == :absent or value.include?(:absent)
-          super
-        else
-          value.join(",")
-        end
-      end
-
       validate do |value|
         unless value == :absent or value =~ /^[-a-z0-9A-Z_]+(?:=\".*?\")?$/
           raise Puppet::Error, _("Option %{value} is not valid. A single option must either be of the form 'option' or 'option=\"value\". Multiple options must be provided as an array") % { value: value }

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -430,7 +430,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               it "should log that the mode changed" do
                 report = catalog.apply.report
 
-                expect(report.logs.first.message).to eq("mode changed '0644' to '0600'")
+                expect(report.logs.first.message).to eq("mode changed 0644 to 0600")
                 expect(report.logs.first.source).to eq("/File[#{path}]/mode")
               end
             end

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -430,7 +430,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               it "should log that the mode changed" do
                 report = catalog.apply.report
 
-                expect(report.logs.first.message).to eq("mode changed 0644 to 0600")
+                expect(report.logs.first.message).to eq("mode changed '0644' to '0600'")
                 expect(report.logs.first.source).to eq("/File[#{path}]/mode")
               end
             end

--- a/spec/unit/property/list_spec.rb
+++ b/spec/unit/property/list_spec.rb
@@ -35,8 +35,8 @@ describe list_class do
       expect(@property.is_to_s(["foo","bar"])).to eq("foo,bar")
     end
 
-    it "should be able to correctly convert ':absent' to a string" do
-      expect(@property.is_to_s(:absent)).to eq("absent")
+    it "should be able to correctly convert ':absent' to a quoted string" do
+      expect(@property.is_to_s(:absent)).to eq("'absent'")
     end
 
     describe "when adding should to current" do

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -233,7 +233,7 @@ describe Puppet::Transaction::ResourceHarness do
         @harness.evaluate(resource)
       end.to raise_error(Exception)
 
-      expect(@logs.first.message).to eq("change from absent to present failed: Exception")
+      expect(@logs.first.message).to eq("change from 'absent' to 'present' failed: Exception")
       expect(@logs.first.level).to eq(:err)
     end
 
@@ -296,7 +296,7 @@ describe Puppet::Transaction::ResourceHarness do
 
     it "should log and pass the exception through" do
       expect { @harness.evaluate(@resource) }.to raise_error(Exception, /baz/)
-      expect(@logs.first.message).to eq("change from absent to 1 failed: baz")
+      expect(@logs.first.message).to eq("change from 'absent' to 1 failed: baz")
       expect(@logs.first.level).to eq(:err)
     end
   end
@@ -325,7 +325,7 @@ describe Puppet::Transaction::ResourceHarness do
 
     it "should log and pass the exception through" do
       expect { @harness.evaluate(@resource) }.to raise_error(Exception, /slithy/)
-      expect(@logs.first.message).to eq("change from absent to 1 failed: slithy")
+      expect(@logs.first.message).to eq("change from 'absent' to 1 failed: slithy")
       expect(@logs.first.level).to eq(:err)
     end
   end

--- a/spec/unit/type/file/group_spec.rb
+++ b/spec/unit/type/file/group_spec.rb
@@ -47,13 +47,13 @@ describe Puppet::Type.type(:file).attrclass(:group) do
       it "should use the name of the user if it can find it" do
         resource.provider.stubs(:gid2name).with(1001).returns 'foos'
 
-        expect(group.send(prop_to_s, 1001)).to eq('foos')
+        expect(group.send(prop_to_s, 1001)).to eq("'foos'")
       end
 
       it "should use the id of the user if it can't" do
         resource.provider.stubs(:gid2name).with(1001).returns nil
 
-        expect(group.send(prop_to_s, 1001)).to eq(1001)
+        expect(group.send(prop_to_s, 1001)).to eq('1001')
       end
     end
   end

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -173,8 +173,8 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
     end
 
     describe 'when passed :absent' do
-      it 'returns :absent' do
-        expect(mode.is_to_s(:absent)).to eq(:absent)
+      it "returns 'absent'" do
+        expect(mode.is_to_s(:absent)).to eq("'absent'")
       end
     end
   end

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -140,17 +140,17 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
   describe '#should_to_s' do
     describe 'with a 3-digit mode' do
       it 'returns a 4-digit mode with a leading zero' do
-        expect(mode.should_to_s('755')).to eq('0755')
+        expect(mode.should_to_s('755')).to eq("'0755'")
       end
     end
 
     describe 'with a 4-digit mode' do
       it 'returns the 4-digit mode when the first digit is a zero' do
-        expect(mode.should_to_s('0755')).to eq('0755')
+        expect(mode.should_to_s('0755')).to eq("'0755'")
       end
 
       it 'returns the 4-digit mode when the first digit is not a zero' do
-        expect(mode.should_to_s('1755')).to eq('1755')
+        expect(mode.should_to_s('1755')).to eq("'1755'")
       end
     end
   end
@@ -158,17 +158,17 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
   describe '#is_to_s' do
     describe 'with a 3-digit mode' do
       it 'returns a 4-digit mode with a leading zero' do
-        expect(mode.is_to_s('755')).to eq('0755')
+        expect(mode.is_to_s('755')).to eq("'0755'")
       end
     end
 
     describe 'with a 4-digit mode' do
       it 'returns the 4-digit mode when the first digit is a zero' do
-        expect(mode.is_to_s('0755')).to eq('0755')
+        expect(mode.is_to_s('0755')).to eq("'0755'")
       end
 
       it 'returns the 4-digit mode when the first digit is not a zero' do
-        expect(mode.is_to_s('1755')).to eq('1755')
+        expect(mode.is_to_s('1755')).to eq("'1755'")
       end
     end
 

--- a/spec/unit/type/file/owner_spec.rb
+++ b/spec/unit/type/file/owner_spec.rb
@@ -45,13 +45,13 @@ describe Puppet::Type.type(:file).attrclass(:owner) do
       it "should use the name of the user if it can find it" do
         resource.provider.stubs(:uid2name).with(1001).returns 'foo'
 
-        expect(owner.send(prop_to_s, 1001)).to eq('foo')
+        expect(owner.send(prop_to_s, 1001)).to eq("'foo'")
       end
 
       it "should use the id of the user if it can't" do
         resource.provider.stubs(:uid2name).with(1001).returns nil
 
-        expect(owner.send(prop_to_s, 1001)).to eq(1001)
+        expect(owner.send(prop_to_s, 1001)).to eq('1001')
       end
     end
   end

--- a/spec/unit/type/ssh_authorized_key_spec.rb
+++ b/spec/unit/type/ssh_authorized_key_spec.rb
@@ -149,12 +149,12 @@ describe Puppet::Type.type(:ssh_authorized_key), :unless => Puppet.features.micr
 
       it "property should return well formed string of arrays from is_to_s" do
         resource = described_class.new(:name => "whev", :type => :rsa, :user => "nobody", :options => ["a","b","c"])
-        expect(resource.property(:options).is_to_s(["a","b","c"])).to eq "a,b,c"
+        expect(resource.property(:options).is_to_s(["a","b","c"])).to eq "['a', 'b', 'c']"
       end
 
       it "property should return well formed string of arrays from should_to_s" do
         resource = described_class.new(:name => "whev", :type => :rsa, :user => "nobody", :options => ["a","b","c"])
-        expect(resource.property(:options).should_to_s(["a","b","c"])).to eq "a,b,c"
+        expect(resource.property(:options).should_to_s(["a","b","c"])).to eq "['a', 'b', 'c']"
       end
 
     end


### PR DESCRIPTION
Prior to this commit, the method `Property#change_to_s` method would
call `#is_to_s` and `#should_to_s` to get a "pretty printed" string and
then pass that string to `#format_value_for_display` to pretty print it
again. This is now changed so that the `#format_value_for_display` is
instead called from the default implementations of `#is_to_s` and
`#should_to_s`.