### PR TITLE
(PUP-7255) Graceful downgrade or fail when communicating with 4.x masters

### DIFF
--- a/lib/puppet/indirector/report/rest.rb
+++ b/lib/puppet/indirector/report/rest.rb
@@ -1,10 +1,23 @@
 require 'puppet/indirector/rest'
+require 'semantic_puppet'
 
 class Puppet::Transaction::Report::Rest < Puppet::Indirector::REST
   desc "Get server report over HTTP via REST."
   use_server_setting(:report_server)
   use_port_setting(:report_port)
   use_srv_service(:report)
+
+  def handle_response(request, response)
+    if !response.is_a?(Net::HTTPSuccess)
+      server_version = response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION]
+      if server_version &&
+         SemanticPuppet::Version.parse(server_version).major < 5 &&
+         Puppet[:preferred_serialization_format] != 'pson'
+        mime = indirection.model.default_format
+        raise Puppet::Error.new(_("Server version %{version} does not accept reports in '%{mime}', use `preferred_serialization_format=pson`") % {version: server_version, mime: mime})
+      end
+    end
+  end
 
   private
 

--- a/lib/puppet/indirector/report/rest.rb
+++ b/lib/puppet/indirector/report/rest.rb
@@ -11,10 +11,10 @@ class Puppet::Transaction::Report::Rest < Puppet::Indirector::REST
     if !response.is_a?(Net::HTTPSuccess)
       server_version = response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION]
       if server_version &&
-         SemanticPuppet::Version.parse(server_version).major < 5 &&
+         SemanticPuppet::Version.parse(server_version).major < Puppet::Indirector::REST::MAJOR_VERSION_JSON_DEFAULT &&
          Puppet[:preferred_serialization_format] != 'pson'
-        mime = indirection.model.default_format
-        raise Puppet::Error.new(_("Server version %{version} does not accept reports in '%{mime}', use `preferred_serialization_format=pson`") % {version: server_version, mime: mime})
+        format = Puppet[:preferred_serialization_format]
+        raise Puppet::Error.new(_("Server version %{version} does not accept reports in '%{format}', use `preferred_serialization_format=pson`") % {version: server_version, format: format})
       end
     end
   end

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -12,6 +12,9 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
 
   IndirectedRoutes = Puppet::Network::HTTP::API::IndirectedRoutes
 
+  # puppet major version where JSON is enabled by default
+  MAJOR_VERSION_JSON_DEFAULT = 5
+
   class << self
     attr_reader :server_setting, :port_setting
   end
@@ -260,7 +263,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   def handle_response(request, response)
     server_version = response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION]
     if server_version &&
-       SemanticPuppet::Version.parse(server_version).major < 5 &&
+       SemanticPuppet::Version.parse(server_version).major < MAJOR_VERSION_JSON_DEFAULT &&
        Puppet[:preferred_serialization_format] != 'pson'
       Puppet.warning("Downgrading to PSON for future requests")
       Puppet[:preferred_serialization_format] = 'pson'

--- a/spec/unit/indirector/report/rest_spec.rb
+++ b/spec/unit/indirector/report/rest_spec.rb
@@ -65,6 +65,8 @@ describe Puppet::Transaction::Report::Rest do
     describe "when handling the response" do
       describe "when the server major version is less than 5" do
         it "raises if the save fails and we're not using pson" do
+          Puppet[:preferred_serialization_format] = "json"
+
           response = mock_response('500', '{}', 'text/pson')
           response.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns("4.10.1")
           connection.expects(:put).returns response

--- a/spec/unit/indirector/report/rest_spec.rb
+++ b/spec/unit/indirector/report/rest_spec.rb
@@ -45,23 +45,47 @@ describe Puppet::Transaction::Report::Rest do
   end
 
   describe "#save" do
-    let(:http_method) { :put }
     let(:response) { mock_response(200, 'body') }
     let(:connection) { stub('mock http connection', :put => response, :verify_callback= => nil) }
     let(:instance) { model.new('the thing', 'some contents') }
     let(:request) { save_request(instance.name, instance) }
+    let(:body) { ["store", "http"].to_pson }
 
     before :each do
       terminus.stubs(:network).returns(connection)
     end
 
     it "deserializes the response as an array of report processor names" do
-      processors = ["store", "http"]
-      body = processors.to_pson()
       response = mock_response('200', body, 'text/pson')
       connection.expects(:put).returns response
 
       expect(terminus.save(request)).to eq(["store", "http"])
+    end
+
+    describe "when handling the response" do
+      describe "when the server major version is less than 5" do
+        it "raises if the save fails and we're not using pson" do
+          response = mock_response('500', '{}', 'text/pson')
+          response.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns("4.10.1")
+          connection.expects(:put).returns response
+
+          expect {
+            terminus.save(request)
+          }.to raise_error(Puppet::Error, /Server version 4.10.1 does not accept reports in 'json'/)
+        end
+
+        it "raises with HTTP 500 if the save fails and we're already using pson" do
+          Puppet[:preferred_serialization_format] = "pson"
+
+          response = mock_response('500', '{}', 'text/pson')
+          response.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns("4.10.1")
+          connection.expects(:put).returns response
+
+          expect {
+            terminus.save(request)
+          }.to raise_error(Net::HTTPError, /Error 500 on SERVER/)
+        end
+      end
     end
   end
 end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -11,7 +11,7 @@ HTTP_ERROR_CODES = [300, 400, 500]
 # Just one from each category since the code makes no real distinctions
 shared_examples_for "a REST terminus method" do |terminus_method|
 
-  describe "when the server's major version is less than 5" do
+  describe "when handling the response" do
     let(:response) do
       mock_response(200, 'OK')
     end

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -11,6 +11,43 @@ HTTP_ERROR_CODES = [300, 400, 500]
 # Just one from each category since the code makes no real distinctions
 shared_examples_for "a REST terminus method" do |terminus_method|
 
+  describe "when the server's major version is less than 5" do
+    let(:response) do
+      mock_response(200, 'OK')
+    end
+
+    it "falls back to pson for future requests" do
+      response.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns("4.10.1")
+      terminus.send(terminus_method, request)
+
+      expect(Puppet[:preferred_serialization_format]).to eq("pson")
+    end
+
+    it "doesn't change the serialization format if the X-Puppet-Version header is missing" do
+      response.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns(nil)
+
+      terminus.send(terminus_method, request)
+
+      expect(Puppet[:preferred_serialization_format]).to eq("json")
+    end
+
+    it "doesn't change the serialization format if the server major version is 5" do
+      response.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns("5.0.3")
+
+      terminus.send(terminus_method, request)
+
+      expect(Puppet[:preferred_serialization_format]).to eq("json")
+    end
+
+    it "doesn't change the serialization format if the current format is already pson" do
+      response.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns("4.10.1")
+      Puppet[:preferred_serialization_format] = "pson"
+      terminus.send(terminus_method, request)
+
+      expect(Puppet[:preferred_serialization_format]).to eq("pson")
+    end
+  end
+
   HTTP_ERROR_CODES.each do |code|
     describe "when the response code is #{code}" do
       let(:message) { 'error messaged!!!' }


### PR DESCRIPTION
~PR https://github.com/puppetlabs/puppet/pull/5923, must be merged first.~

During a normal agent run, if the node response comes from a server whose major version is less than ours, then issue a warning, downgrade to pson, and continue the run. The agent will prefer pson for all future requests for that single run (excluding certs or binary file content). For pull-based requests, e.g. catalog, the agent will list pson first in the `Accept` header. For push-based requests, e.g. report, the agent will send the Content-Type as pson.

```
$ bx puppet agent -t
Warning: Downgrading to PSON for future requests
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
...
Info: Applying configuration version '1496559506'
Notice: Applied catalog in 0.01 seconds
```

During a cached catalog run, the agent will issue an error and exit. Alternatively, we could downgrade to pson and retry the request, but that seems like more trouble than it's worth, since we always say to upgrade the master first, and older masters don't correctly return HTTP 415.

```
$ bx puppet agent -t --use_cached_catalog
Info: Using cached catalog from environment 'production'
Info: Applying configuration version '1496559506'
Notice: Applied catalog in 0.01 seconds
Error: Could not send report: Server version 4.10.1 does not accept reports in 'json', use `preferred_serialization_format=pson`
```