### PR TITLE
(PUP-7515) update hiera functions with deprecation info

### DIFF
--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -1,3 +1,7 @@
+# The `eyaml_lookup_key` is a hiera 5 `lookup_key` data provider function.
+# See [the configuration guide documentation](https://docs.puppet.com/puppet/latest/hiera_config_yaml_5.html#configuring-a-hierarchy-level-hiera-eyaml) for
+# how to use this function.
+#
 # @since 5.0.0
 #
 Puppet::Functions.create_function(:eyaml_lookup_key) do

--- a/lib/puppet/functions/hiera.rb
+++ b/lib/puppet/functions/hiera.rb
@@ -2,6 +2,11 @@ require 'hiera/puppet_function'
 # Performs a standard priority lookup of the hierarchy and returns the most specific value
 # for a given key. The returned value can be any type of data.
 #
+# This function is deprecated in favor of the `lookup` function. While this function
+# continues to work, it does **not** support:
+# * `lookup_options` stored in the data
+# * lookup across global, environment, and module layers
+#
 # The function takes up to three arguments, in this order:
 #
 # 1. A string key that Hiera searches for in the hierarchy. **Required**.
@@ -71,8 +76,10 @@ require 'hiera/puppet_function'
 # above, Hiera matches the 'users' key and returns it as a hash.
 #
 # See
-# [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
-# for more information about Hiera lookup functions.
+# [the 'Using the lookup function' documentation](https://docs.puppet.com/puppet/latest/hiera_use_function.html) for how to perform lookup of data.
+# Also see
+# [the 'Using the deprecated hiera functions' documentation](https://docs.puppet.com/puppet/latest/hiera_use_hiera_functions.html)
+# for more information about the Hiera 3 functions.
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/hiera_array.rb
+++ b/lib/puppet/functions/hiera_array.rb
@@ -5,6 +5,11 @@ require 'hiera/puppet_function'
 # included in the results. This is called an
 # [array merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.html#array-merge).
 #
+# This function is deprecated in favor of the `lookup` function. While this function
+# continues to work, it does **not** support:
+# * `lookup_options` stored in the data
+# * lookup across global, environment, and module layers
+#
 # The `hiera_array` function takes up to three arguments, in this order:
 #
 # 1. A string key that Hiera searches for in the hierarchy. **Required**.
@@ -60,8 +65,10 @@ require 'hiera/puppet_function'
 # value is a hash, Puppet raises a type mismatch error.
 #
 # See
-# [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
-# for more information about Hiera lookup functions.
+# [the 'Using the lookup function' documentation](https://docs.puppet.com/puppet/latest/hiera_use_function.html) for how to perform lookup of data.
+# Also see
+# [the 'Using the deprecated hiera functions' documentation](https://docs.puppet.com/puppet/latest/hiera_use_hiera_functions.html)
+# for more information about the Hiera 3 functions.
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/hiera_hash.rb
+++ b/lib/puppet/functions/hiera_hash.rb
@@ -1,6 +1,12 @@
 require 'hiera/puppet_function'
 
 # Finds all matches of a key throughout the hierarchy and returns them in a merged hash.
+#
+# This function is deprecated in favor of the `lookup` function. While this function
+# continues to work, it does **not** support:
+# * `lookup_options` stored in the data
+# * lookup across global, environment, and module layers
+#
 # If any of the matched hashes share keys, the final hash uses the value from the
 # highest priority match. This is called a
 # [hash merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.html#hash-merge).
@@ -70,8 +76,10 @@ require 'hiera/puppet_function'
 # found in the data sources are strings or arrays, Puppet raises a type mismatch error.
 #
 # See
-# [the documentation](https://docs.puppetlabs.com/hiera/latest/puppet.html#hiera-lookup-functions)
-# for more information about Hiera lookup functions.
+# [the 'Using the lookup function' documentation](https://docs.puppet.com/puppet/latest/hiera_use_function.html) for how to perform lookup of data.
+# Also see
+# [the 'Using the deprecated hiera functions' documentation](https://docs.puppet.com/puppet/latest/hiera_use_hiera_functions.html)
+# for more information about the Hiera 3 functions.
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -4,6 +4,18 @@ require 'hiera/puppet_function'
 # [array merge lookup](https://docs.puppetlabs.com/hiera/latest/lookup_types.html#array-merge)
 # that retrieves the value for a user-specified key from Hiera's data.
 #
+# This function is deprecated in favor of the `lookup` function in combination with `include`.
+# While this function continues to work, it does **not** support:
+# * `lookup_options` stored in the data
+# * lookup across global, environment, and module layers
+#
+# @example Using `lookup` and `include` instead of of the deprecated `hiera_include`
+# 
+# ~~~puppet
+# # In site.pp, outside of any node definitions and below any top-scope variables:
+# lookup('classes', Array[String], 'unique').include
+# ~~~
+#
 # The `hiera_include` function requires:
 #
 # - A string key name to use for classes.
@@ -70,9 +82,11 @@ require 'hiera/puppet_function'
 # # "Key 'classes' not found".
 # ~~~
 #
-# See [the documentation](http://links.puppetlabs.com/hierainclude) for more information
-# and a more detailed example of how `hiera_include` uses array merge lookups to classify
-# nodes.
+# See
+# [the 'Using the lookup function' documentation](https://docs.puppet.com/puppet/latest/hiera_use_function.html) for how to perform lookup of data.
+# Also see
+# [the 'Using the deprecated hiera functions' documentation](https://docs.puppet.com/puppet/latest/hiera_use_hiera_functions.html)
+# for more information about the Hiera 3 functions.
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/hocon_data.rb
+++ b/lib/puppet/functions/hocon_data.rb
@@ -1,3 +1,9 @@
+# The `hocon_data` is a hiera 5 `data_hash` data provider function.
+# See [the configuration guide documentation](https://docs.puppet.com/puppet/latest/hiera_config_yaml_5.html#configuring-a-hierarchy-level-built-in-backends) for
+# how to use this function.
+#
+# Note that this function is not supported without a hocon library being present.
+#
 # @since 4.9.0
 #
 Puppet::Functions.create_function(:hocon_data) do

--- a/lib/puppet/functions/json_data.rb
+++ b/lib/puppet/functions/json_data.rb
@@ -1,3 +1,7 @@
+# The `json_data` is a hiera 5 `data_hash` data provider function.
+# See [the configuration guide documentation](https://docs.puppet.com/puppet/latest/hiera_config_yaml_5.html#configuring-a-hierarchy-level-built-in-backends) for
+# how to use this function.
+#
 # @since 4.8.0
 #
 Puppet::Functions.create_function(:json_data) do

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -1,3 +1,7 @@
+# The `yaml_data` is a hiera 5 `data_hash` data provider function.
+# See [the configuration guide documentation](https://docs.puppet.com/puppet/latest/hiera_config_yaml_5.html#configuring-a-hierarchy-level-built-in-backends) for
+# how to use this function.
+#
 # @since 4.8.0
 #
 require 'yaml'


### PR DESCRIPTION
This updates the hiera_xxx functions to clearly show that they are deprecated. They now also contain links to hiera 5 documentation instead of the old hiera 3.

This PR also contains an update of the hiera 5 data functions as they had no documentation at all earlier. Now they have a brief explanation what the function is about plus a link to the on-line documentation. (Without this users looking at the function reference will not understand what those functions are).