### PR TITLE
(PUP-7621) Ensure test directory is removed

### DIFF
--- a/acceptance/tests/modules/build/build_agent.rb
+++ b/acceptance/tests/modules/build/build_agent.rb
@@ -5,6 +5,9 @@ agents.each do |agent|
     on agent, 'rm -rf bar'
   end
 
+  step 'setup: ensure clean working directory'
+  on agent, 'rm -rf bar'
+
   step 'generate'
   on(agent, puppet('module generate foo-bar --skip-interview'))
 


### PR DESCRIPTION
This commit adds a setup step to the `modules/build/build_agent.rb`
acceptance test to ensure that the test directory does not exist
prior to the execution of the test.