### PR TITLE
(PUP-7029) - Update spec file to run tests on Fedora 25 and 26

### DIFF
--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:package).provider(:dnf)
 
 context 'default' do
-  [ 19, 20, 21 ].each do |ver|
+  [ '19', '20', '21' ].each do |ver|
     it "should not be the default provider on fedora#{ver}" do
       Facter.stubs(:value).with(:osfamily).returns(:redhat)
       Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
@@ -15,7 +15,7 @@ context 'default' do
     end
   end
 
-  [ 22, 23, 24 ].each do |ver|
+  [ '22', '23', '24', '25', '26' ].each do |ver|
     it "should be the default provider on fedora#{ver}" do
       Facter.stubs(:value).with(:osfamily).returns(:redhat)
       Facter.stubs(:value).with(:operatingsystem).returns(:fedora)


### PR DESCRIPTION
The spec file for the dnf provider was not updated to run tests on
Fedora 25.