### PR TITLE
(PUP-7555) Doc removal of auth support in default fileserver.conf file

### DIFF
--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -57,6 +57,27 @@
 # (ie exactly as if auth yes was present).
 #
 
+# CONTROLLING FILE ACCESS (previously in fileserver.conf)
+
+# In previous versions of Puppet, you controlled file access by adding
+# rules to fileserver.conf. In Puppet 5 with Puppet Server, you can control
+# file access in auth.conf by controlling the /file_metadata(s)/<mount point>
+# and /file_content(s)/<mount point> paths. See the Puppet Server
+# documentation at
+# https://docs.puppet.com/puppetserver/latest/config_file_auth.html.
+#
+# If you are not using Puppet Server, or are using Puppet Server but with the
+# "jruby-puppet.use-legacy-auth-conf" setting set to "true", you could set the
+# desired file access in a new rule in this file. For example:
+#
+# path ~ ^/file_(metadata|content)s?/extra_files/
+# auth yes
+# allow /^(.+)\.example\.com$/
+# allow_ip 192.168.100.0/24
+#
+# If added to auth.conf BEFORE the default "path /file" rule, this rule
+# will add stricter restrictions to the extra_files mount point.
+
 ### Authenticated ACLs - these rules apply only when the client
 ### has a valid certificate and is thus authenticated
 

--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -61,9 +61,9 @@
 
 # In previous versions of Puppet, you controlled file access by adding
 # rules to fileserver.conf. In Puppet 5 with Puppet Server, you can control
-# file access in auth.conf by controlling the /file_metadata(s)/<mount point>
-# and /file_content(s)/<mount point> paths. See the Puppet Server
-# documentation at
+# file access in auth.conf by controlling the /file_metadata(s)/<mount point>,
+# /file_content(s)/<mount point>, and /static_file_content/<file> paths. See the
+# Puppet Server documentation at
 # https://docs.puppet.com/puppetserver/latest/config_file_auth.html.
 #
 # If you are not using Puppet Server, or are using Puppet Server but with the

--- a/conf/fileserver.conf
+++ b/conf/fileserver.conf
@@ -32,43 +32,6 @@
 # auth.conf by controlling the /file_metadata(s)/<mount point> and
 # /file_content(s)/<mount point> paths.
 #
-# For auth.conf functionality, it is recommended that you use Puppet Server as
-# your Puppet master, with the "jruby-puppet.use-legacy-auth-conf" setting
-# either set to "false" or, for Puppet Server 5 or later, not present.  The
-# legacy auth.conf format used by Ruby Puppet code is expected to eventually be
-# dropped in favor of the HOCON-based auth.conf format that Puppet Server uses.
-#
-# If you are using Puppet Server and have the "jruby-puppet.use-legacy-auth-conf"
-# setting in the "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf" file
-# set to "false", you can set the desired file access in a new rule in the
-# "/etc/puppetlabs/puppetserver/conf.d/auth.conf" file. For example:
-#
-# {
-#   match-request: {
-#     path: "^/file_(metadata|content)s?/extra_files/"
-#     type: regex
-#   }
-#   allow: "/^(.+)\.example\.com$/"
-#   sort-order: 200
-#   name: "extra files mount"
-# }
-#
-# If added to auth.conf with a "sort-order" LESS than that of the default
-# "path /file" rule, this rule will add stricter restrictions to the extra_files
-# mount point. The "sort-order" parameter sets the order in which Puppet Server
-# evaluates the rule by prioritizing it on a numeric value between 1 and 399 (to
-# be evaluated before default Puppet rules) or 601 to 998 (to be evaluated after
-# Puppet), with lower-numbered values evaluated first.
-#
-# If you are not using Puppet Server or are using Puppet Server but with the
-# "jruby-puppet.use-legacy-auth-conf" setting set to "true", you could set the
-# desired file access in a new rule in the "/etc/puppetlabs/puppet/auth.conf"
-# file. For example:
-#
-# path ~ ^/file_(metadata|content)s?/extra_files/
-# auth yes
-# allow /^(.+)\.example\.com$/
-# allow_ip 192.168.100.0/24
-#
-# If added to auth.conf BEFORE the default "path /file" rule, this rule
-# will add stricter restrictions to the extra_files mount point.
+# For details and an example, see the auth.conf file. If you're using Puppet
+# Server, see the Puppet Server documentation at
+# https://docs.puppet.com/puppetserver/latest/config_file_auth.html.

--- a/conf/fileserver.conf
+++ b/conf/fileserver.conf
@@ -27,11 +27,43 @@
 
 # PERMISSIONS
 
-# Every static mount point should have an `allow *` line; setting more
-# granular permissions in this file is deprecated. Instead, you can
-# control file access in auth.conf by controlling the
-# /file_metadata(s)/<mount point> and /file_content(s)/<mount point> paths.
-# For example:
+# The ability to set permissions - for example, using the allow, allow_ip, or
+# deny directives - has been removed. Instead, you can control file access in
+# auth.conf by controlling the /file_metadata(s)/<mount point> and
+# /file_content(s)/<mount point> paths.
+#
+# For auth.conf functionality, it is recommended that you use Puppet Server as
+# your Puppet master, with the "jruby-puppet.use-legacy-auth-conf" setting
+# either set to "false" or, for Puppet Server 5 or later, not present.  The
+# legacy auth.conf format used by Ruby Puppet code is expected to eventually be
+# dropped in favor of the HOCON-based auth.conf format that Puppet Server uses.
+#
+# If you are using Puppet Server and have the "jruby-puppet.use-legacy-auth-conf"
+# setting in the "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf" file
+# set to "false", you can set the desired file access in a new rule in the
+# "/etc/puppetlabs/puppetserver/conf.d/auth.conf" file. For example:
+#
+# {
+#   match-request: {
+#     path: "^/file_(metadata|content)s?/extra_files/"
+#     type: regex
+#   }
+#   allow: "/^(.+)\.example\.com$/"
+#   sort-order: 200
+#   name: "extra files mount"
+# }
+#
+# If added to auth.conf with a "sort-order" LESS than that of the default
+# "path /file" rule, this rule will add stricter restrictions to the extra_files
+# mount point. The "sort-order" parameter sets the order in which Puppet Server
+# evaluates the rule by prioritizing it on a numeric value between 1 and 399 (to
+# be evaluated before default Puppet rules) or 601 to 998 (to be evaluated after
+# Puppet), with lower-numbered values evaluated first.
+#
+# If you are not using Puppet Server or are using Puppet Server but with the
+# "jruby-puppet.use-legacy-auth-conf" setting set to "true", you could set the
+# desired file access in a new rule in the "/etc/puppetlabs/puppet/auth.conf"
+# file. For example:
 #
 # path ~ ^/file_(metadata|content)s?/extra_files/
 # auth yes


### PR DESCRIPTION
This commit adds some documentation to the default fileserver.conf file
which indicates that, per PUP-6359, the use of auth directives is no
longer supported in the file.  The commit expands the example showing
how to implement auth directives in the auth.conf file instead of
fileserver.conf to include info about the format that Puppet Server's
HOCON-based auth.conf file uses.