### PR TITLE
(PUP-7623) Ignore override with default value

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -332,6 +332,9 @@ class Puppet::Parser::Resource < Puppet::Resource
     # than replacing an existing one.
     (set_parameter(param) and return) unless current = @parameters[param.name]
 
+    # Parameter is already set - if overriding with a default - simply ignore the setting of the default value
+    return if scope.is_default?(type, param.name, param.value)
+
     # The parameter is already set.  Fail if they're not allowed to override it.
     unless param.source.child_of?(current.source) || param.source.equal?(current.source) && scope.is_default?(type, param.name, current.value)
       msg = "Parameter '#{param.name}' is already set on #{self}"


### PR DESCRIPTION
Before this, if an override was performed and the resource had a value,
an attempt would be made to override it with a default value. That
resulted in an error.

This behavior changed when the evaluation and setting of default values
was made earlier in the process to allow collections to be based on
default values being set. As a consequence we ended up with the new
behavior where an attempt is made to override a set value with a default
one.

This commit fixes the problem by simply checking if an override is made
with a default value, and if so simply ignore this.