### PR TITLE
(PUP-3042) Report resources in a cycle as failed

### DIFF
--- a/lib/puppet/graph/relationship_graph.rb
+++ b/lib/puppet/graph/relationship_graph.rb
@@ -102,8 +102,11 @@ class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
     overly_deferred_resource_handler = options[:overly_deferred_resource_handler] || lambda { |resource| }
     canceled_resource_handler = options[:canceled_resource_handler] || lambda { |resource| }
     teardown = options[:teardown] || lambda {}
+    graph_cycle_handler = options[:graph_cycle_handler] || lambda { [] }
 
-    report_cycles_in_graph
+    if cycles = report_cycles_in_graph
+      graph_cycle_handler.call(cycles)
+    end
 
     enqueue_roots
 

--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -222,13 +222,13 @@ class Puppet::Graph::SimpleGraph
     return found.sort
   end
 
+  # @return [Array] array of dependency cycles (arrays)
   def report_cycles_in_graph
     cycles = find_cycles_in_graph
-    n = cycles.length           # where is "pluralize"? --daniel 2011-01-22
-    return if n == 0
-    s = n == 1 ? '' : 's'
+    number_of_cycles = cycles.length
+    return if number_of_cycles == 0
 
-    message = n_("Found %{num} dependency cycle:\n", "Found %{num} dependency cycles:\n", n) % { num: n }
+    message = n_("Found %{num} dependency cycle:\n", "Found %{num} dependency cycles:\n", number_of_cycles) % { num: number_of_cycles }
     cycles.each do |cycle|
       paths = paths_in_cycle(cycle)
       message += paths.map{ |path| '(' + path.join(" => ") + ')'}.join("\n") + "\n"
@@ -242,8 +242,8 @@ class Puppet::Graph::SimpleGraph
       #TRANSLATORS OmniGraffle and GraphViz and program names and should not be translated
       message += _("Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz")
     end
-
-    raise Puppet::Error, message
+    Puppet.err(message)
+    cycles
   end
 
   def write_cycles_to_graph(cycles)

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -131,12 +131,19 @@ module Puppet
 
       def failed_because(detail)
         @real_resource.log_exception(detail, _("Could not evaluate: %{detail}") % { detail: detail })
-        failed = true
         # There's a contract (implicit unfortunately) that a status of failed
         # will always be accompanied by an event with some explanatory power.  This
         # is useful for reporting/diagnostics/etc.  So synthesize an event here
         # with the exception detail as the message.
-        add_event(@real_resource.event(:name => :resource_error, :status => "failure", :message => detail.to_s))
+        fail_with_event(detail.to_s)
+      end
+
+      # Both set the status state to failed and generate a corresponding
+      # Puppet::Transaction::Event failure with the given message.
+      # @param message [String] the reason for a status failure
+      def fail_with_event(message)
+        failed = true
+        add_event(@real_resource.event(:name => :resource_error, :status => "failure", :message => message))
       end
 
       def initialize(resource)

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -157,10 +157,8 @@ class Puppet::Transaction
     graph_cycle_handler = lambda do |cycles|
       cycles.flatten.uniq.each do |resource|
         # We add a failed resource event to the status to ensure accurate
-        # reporting through the event manager. Adding an event via #add_event
-        # with status of 'failure' causes the status itself to be failed.
-        event = resource.event(:name => :resource_error, :status => "failure", :message => _('resource is part of a dependency cycle'))
-        resource_status(resource).add_event(event)
+        # reporting through the event manager.
+        resource_status(resource).fail_with_event(_('resource is part of a dependency cycle'))
       end
       raise Puppet::Error, _('One or more resource dependency cycles detected in graph')
     end

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -148,6 +148,23 @@ class Puppet::Transaction
       persistence.save if catalog.host_config?
     end
 
+    # Graph cycles are returned as an array of arrays
+    # - outer array is an array of cycles
+    # - each inner array is an array of resources involved in a cycle
+    # Short circuit resource evaluation if we detect cycle(s) in the graph. Mark
+    # each corresponding resource as failed in the report before we fail to
+    # ensure accurate reporting.
+    graph_cycle_handler = lambda do |cycles|
+      cycles.flatten.uniq.each do |resource|
+        # We add a failed resource event to the status to ensure accurate
+        # reporting through the event manager. Adding an event via #add_event
+        # with status of 'failure' causes the status itself to be failed.
+        event = resource.event(:name => :resource_error, :status => "failure", :message => _('resource is part of a dependency cycle'))
+        resource_status(resource).add_event(event)
+      end
+      raise Puppet::Error, _('One or more resource dependency cycles detected in graph')
+    end
+
     # Generate the relationship graph, set up our generator to use it
     # for eval_generate, then kick off our traversal.
     generator.relationship_graph = relationship_graph
@@ -155,6 +172,7 @@ class Puppet::Transaction
                                 :pre_process => pre_process,
                                 :overly_deferred_resource_handler => overly_deferred_resource_handler,
                                 :canceled_resource_handler => canceled_resource_handler,
+                                :graph_cycle_handler => graph_cycle_handler,
                                 :teardown => teardown) do |resource|
       if resource.is_a?(Puppet::Type::Component)
         Puppet.warning _("Somehow left a component in the relationship graph")

--- a/spec/unit/functions/contain_spec.rb
+++ b/spec/unit/functions/contain_spec.rb
@@ -172,7 +172,7 @@ describe 'The "contain" function' do
 
       expect { apply_compiled_manifest(manifest) }.to raise_error(
         Puppet::Error,
-        /Found 1 dependency cycle/
+        /One or more resource dependency cycles detected in graph/
       )
     end
   end

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -6,67 +6,68 @@ require 'puppet/resource/status'
 describe Puppet::Resource::Status do
   include PuppetSpec::Files
 
+  let(:resource) { Puppet::Type.type(:file).new(:path => make_absolute("/my/file")) }
+  let(:containment_path) { ["foo", "bar", "baz"] }
+  let(:status) { Puppet::Resource::Status.new(resource) }
+
   before do
-    @resource = Puppet::Type.type(:file).new :path => make_absolute("/my/file")
-    @containment_path = ["foo", "bar", "baz"]
-    @resource.stubs(:pathbuilder).returns @containment_path
-    @status = Puppet::Resource::Status.new(@resource)
+    resource.stubs(:pathbuilder).returns(containment_path)
   end
 
   it "should compute type and title correctly" do
-    expect(@status.resource_type).to eq("File")
-    expect(@status.title).to eq(make_absolute("/my/file"))
+    expect(status.resource_type).to eq("File")
+    expect(status.title).to eq(make_absolute("/my/file"))
   end
 
   [:file, :line, :evaluation_time].each do |attr|
     it "should support #{attr}" do
-      @status.send(attr.to_s + "=", "foo")
-      expect(@status.send(attr)).to eq("foo")
+      status.send(attr.to_s + "=", "foo")
+      expect(status.send(attr)).to eq("foo")
     end
   end
 
   [:skipped, :failed, :restarted, :failed_to_restart, :changed, :out_of_sync, :scheduled].each do |attr|
     it "should support #{attr}" do
-      @status.send(attr.to_s + "=", "foo")
-      expect(@status.send(attr)).to eq("foo")
+      status.send(attr.to_s + "=", "foo")
+      expect(status.send(attr)).to eq("foo")
     end
 
     it "should have a boolean method for determining whehter it was #{attr}" do
-      @status.send(attr.to_s + "=", "foo")
-      expect(@status).to send("be_#{attr}")
+      status.send(attr.to_s + "=", "foo")
+      expect(status).to send("be_#{attr}")
     end
   end
 
   it "should accept a resource at initialization" do
-    expect(Puppet::Resource::Status.new(@resource).resource).not_to be_nil
+    expect(Puppet::Resource::Status.new(resource).resource).not_to be_nil
   end
 
   it "should set its source description to the resource's path" do
-    @resource.expects(:path).returns "/my/path"
-    expect(Puppet::Resource::Status.new(@resource).source_description).to eq("/my/path")
+    resource.expects(:path).returns "/my/path"
+    expect(Puppet::Resource::Status.new(resource).source_description).to eq("/my/path")
   end
 
   it "should set its containment path" do
-    expect(Puppet::Resource::Status.new(@resource).containment_path).to eq(@containment_path)
+  expect(Puppet::Resource::Status.new(resource).containment_path).to eq(containment_path)
   end
 
   [:file, :line].each do |attr|
     it "should copy the resource's #{attr}" do
-      @resource.expects(attr).returns "foo"
-      expect(Puppet::Resource::Status.new(@resource).send(attr)).to eq("foo")
+      resource.expects(attr).returns "foo"
+      expect(Puppet::Resource::Status.new(resource).send(attr)).to eq("foo")
     end
   end
 
   it "should copy the resource's tags" do
-    @resource.expects(:tags).returns %w{foo bar}
-    status = Puppet::Resource::Status.new(@resource)
+    resource.expects(:tags).returns %w{foo bar}
+    status = Puppet::Resource::Status.new(resource)
     expect(status).to be_tagged("foo")
     expect(status).to be_tagged("bar")
   end
 
   it "should always convert the resource to a string" do
-    @resource.expects(:to_s).returns "foo"
-    expect(Puppet::Resource::Status.new(@resource).resource).to eq("foo")
+    resource.expects(:to_s).returns "foo"
+    expect(Puppet::Resource::Status.new(resource).resource).to eq("foo")
   end
 
   it "should support tags" do
@@ -74,111 +75,113 @@ describe Puppet::Resource::Status do
   end
 
   it "should create a timestamp at its creation time" do
-    expect(@status.time).to be_instance_of(Time)
+    expect(status.time).to be_instance_of(Time)
   end
 
   it "should support adding events" do
     event = Puppet::Transaction::Event.new(:name => :foobar)
-    @status.add_event(event)
-    expect(@status.events).to eq([event])
+    status.add_event(event)
+    expect(status.events).to eq([event])
   end
 
   it "should use '<<' to add events" do
     event = Puppet::Transaction::Event.new(:name => :foobar)
-    expect(@status << event).to equal(@status)
-    expect(@status.events).to eq([event])
+    expect(status << event).to equal(status)
+    expect(status.events).to eq([event])
   end
 
   it "records an event for a failure caused by an error" do
-    @status.failed_because(StandardError.new("the message"))
+    status.failed_because(StandardError.new("the message"))
 
-    expect(@status.events[0].message).to eq("the message")
-    expect(@status.events[0].status).to eq("failure")
-    expect(@status.events[0].name).to eq(:resource_error)
+    expect(status.events[0].message).to eq("the message")
+    expect(status.events[0].status).to eq("failure")
+    expect(status.events[0].name).to eq(:resource_error)
   end
 
   it "should count the number of successful events and set changed" do
-    3.times{ @status << Puppet::Transaction::Event.new(:status => 'success') }
-    expect(@status.change_count).to eq(3)
+    3.times{ status << Puppet::Transaction::Event.new(:status => 'success') }
+    expect(status.change_count).to eq(3)
 
-    expect(@status.changed).to eq(true)
-    expect(@status.out_of_sync).to eq(true)
+    expect(status.changed).to eq(true)
+    expect(status.out_of_sync).to eq(true)
   end
 
   it "should not start with any changes" do
-    expect(@status.change_count).to eq(0)
+    expect(status.change_count).to eq(0)
 
-    expect(@status.changed).to eq(false)
-    expect(@status.out_of_sync).to eq(false)
+    expect(status.changed).to eq(false)
+    expect(status.out_of_sync).to eq(false)
   end
 
   it "should not treat failure, or noop events as changed" do
-    ['failure', 'noop'].each do |s| @status << Puppet::Transaction::Event.new(:status => s) end
-    expect(@status.change_count).to eq(0)
-    expect(@status.changed).to eq(false)
+    ['failure', 'noop'].each do |s| status << Puppet::Transaction::Event.new(:status => s) end
+    expect(status.change_count).to eq(0)
+    expect(status.changed).to eq(false)
   end
 
   ['failure', 'noop', 'success'].each do |event_status|
     it "should treat #{event_status} events as out of sync" do
-      3.times do @status << Puppet::Transaction::Event.new(:status => event_status) end
-      expect(@status.out_of_sync_count).to eq(3)
-      expect(@status.out_of_sync).to eq(true)
+      3.times do status << Puppet::Transaction::Event.new(:status => event_status) end
+      expect(status.out_of_sync_count).to eq(3)
+      expect(status.out_of_sync).to eq(true)
     end
   end
 
-  let(:status) do
-    s = @status
-    s.file = "/foo.rb"
-    s.line = 27
-    s.evaluation_time = 2.7
-    s.tags = %w{one two}
-    s << Puppet::Transaction::Event.new(:name => :mode_changed)
-    s.failed = false
-    s.changed = true
-    s.out_of_sync = true
-    s.skipped = false
-    s
-  end
+  context 'when serializing' do
+    let(:status) do
+      s = Puppet::Resource::Status.new(resource)
+      s.file = "/foo.rb"
+      s.line = 27
+      s.evaluation_time = 2.7
+      s.tags = %w{one two}
+      s << Puppet::Transaction::Event.new(:name => :mode_changed)
+      s.failed = false
+      s.changed = true
+      s.out_of_sync = true
+      s.skipped = false
+      s
+    end
 
-  it "should round trip through json" do
-    expect(status.containment_path).to eq(@containment_path)
+    it "should round trip through json" do
+      expect(status.containment_path).to eq(containment_path)
 
-    tripped = Puppet::Resource::Status.from_data_hash(JSON.parse(status.to_json))
+      tripped = Puppet::Resource::Status.from_data_hash(JSON.parse(status.to_json))
 
-    expect(tripped.title).to eq(status.title)
-    expect(tripped.containment_path).to eq(status.containment_path)
-    expect(tripped.file).to eq(status.file)
-    expect(tripped.line).to eq(status.line)
-    expect(tripped.resource).to eq(status.resource)
-    expect(tripped.resource_type).to eq(status.resource_type)
-    expect(tripped.evaluation_time).to eq(status.evaluation_time)
-    expect(tripped.tags).to eq(status.tags)
-    expect(tripped.time).to eq(status.time)
-    expect(tripped.failed).to eq(status.failed)
-    expect(tripped.changed).to eq(status.changed)
-    expect(tripped.out_of_sync).to eq(status.out_of_sync)
-    expect(tripped.skipped).to eq(status.skipped)
+      expect(tripped.title).to eq(status.title)
+      expect(tripped.containment_path).to eq(status.containment_path)
+      expect(tripped.file).to eq(status.file)
+      expect(tripped.line).to eq(status.line)
+      expect(tripped.resource).to eq(status.resource)
+      expect(tripped.resource_type).to eq(status.resource_type)
+      expect(tripped.evaluation_time).to eq(status.evaluation_time)
+      expect(tripped.tags).to eq(status.tags)
+      expect(tripped.time).to eq(status.time)
+      expect(tripped.failed).to eq(status.failed)
+      expect(tripped.changed).to eq(status.changed)
+      expect(tripped.out_of_sync).to eq(status.out_of_sync)
+      expect(tripped.skipped).to eq(status.skipped)
 
-    expect(tripped.change_count).to eq(status.change_count)
-    expect(tripped.out_of_sync_count).to eq(status.out_of_sync_count)
-    expect(events_as_hashes(tripped)).to eq(events_as_hashes(status))
-  end
+      expect(tripped.change_count).to eq(status.change_count)
+      expect(tripped.out_of_sync_count).to eq(status.out_of_sync_count)
+      expect(events_as_hashes(tripped)).to eq(events_as_hashes(status))
+    end
 
-  it 'to_data_hash returns value that is instance of to Data' do
-    expect(Puppet::Pops::Types::TypeFactory.data.instance?(status.to_data_hash)).to be_truthy
-  end
+    it 'to_data_hash returns value that is instance of to Data' do
+      expect(Puppet::Pops::Types::TypeFactory.data.instance?(status.to_data_hash)).to be_truthy
+    end
 
-  def events_as_hashes(report)
-    report.events.collect do |e|
-      {
-        :property => e.property,
-        :previous_value => e.previous_value,
-        :desired_value => e.desired_value,
-        :message => e.message,
-        :name => e.name,
-        :status => e.status,
-        :time => e.time,
-      }
+    def events_as_hashes(report)
+      report.events.collect do |e|
+        {
+          :property => e.property,
+          :previous_value => e.previous_value,
+          :desired_value => e.desired_value,
+          :message => e.message,
+          :name => e.name,
+          :status => e.status,
+          :time => e.time,
+        }
+      end
     end
   end
 end

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -90,12 +90,22 @@ describe Puppet::Resource::Status do
     expect(status.events).to eq([event])
   end
 
-  it "records an event for a failure caused by an error" do
-    status.failed_because(StandardError.new("the message"))
+  it "fails and records a failure event with a given message" do
+    status.fail_with_event("foo fail")
+    event = status.events[0]
 
-    expect(status.events[0].message).to eq("the message")
-    expect(status.events[0].status).to eq("failure")
-    expect(status.events[0].name).to eq(:resource_error)
+    expect(event.message).to eq("foo fail")
+    expect(event.status).to eq("failure")
+    expect(event.name).to eq(:resource_error)
+    expect(status.failed?).to be_truthy
+  end
+
+  it "fails and records a failure event with a given exception" do
+    error = StandardError.new("the message")
+    resource.expects(:log_exception).with(error, "Could not evaluate: the message")
+    status.expects(:fail_with_event).with("the message")
+
+    status.failed_because(error)
   end
 
   it "should count the number of successful events and set changed" do

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -675,23 +675,26 @@ describe Puppet::Transaction do
   end
 
   it "errors with a dependency cycle for a resource that requires itself" do
+    Puppet.expects(:err).with(regexp_matches(/Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m))
     expect do
       apply_compiled_manifest(<<-MANIFEST)
         notify { cycle: require => Notify[cycle] }
       MANIFEST
-    end.to raise_error(Puppet::Error, /Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m)
+    end.to raise_error(Puppet::Error, 'One or more resource dependency cycles detected in graph')
   end
 
   it "errors with a dependency cycle for a self-requiring resource also required by another resource" do
+    Puppet.expects(:err).with(regexp_matches(/Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m))
     expect do
       apply_compiled_manifest(<<-MANIFEST)
         notify { cycle: require => Notify[cycle] }
         notify { other: require => Notify[cycle] }
       MANIFEST
-    end.to raise_error(Puppet::Error, /Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m)
+    end.to raise_error(Puppet::Error, 'One or more resource dependency cycles detected in graph')
   end
 
   it "errors with a dependency cycle for a resource that requires itself and another resource" do
+    Puppet.expects(:err).with(regexp_matches(/Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m))
     expect do
       apply_compiled_manifest(<<-MANIFEST)
         notify { cycle:
@@ -699,10 +702,11 @@ describe Puppet::Transaction do
         }
         notify { other: }
       MANIFEST
-    end.to raise_error(Puppet::Error, /Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m)
+    end.to raise_error(Puppet::Error, 'One or more resource dependency cycles detected in graph')
   end
 
   it "errors with a dependency cycle for a resource that is later modified to require itself" do
+    Puppet.expects(:err).with(regexp_matches(/Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m))
     expect do
       apply_compiled_manifest(<<-MANIFEST)
         notify { cycle: }
@@ -710,7 +714,41 @@ describe Puppet::Transaction do
           require => Notify[cycle]
         }
       MANIFEST
-    end.to raise_error(Puppet::Error, /Found 1 dependency cycle:.*\(Notify\[cycle\] => Notify\[cycle\]\)/m)
+    end.to raise_error(Puppet::Error, 'One or more resource dependency cycles detected in graph')
+  end
+
+  context "when generating a report for a transaction with a dependency cycle" do
+    let(:catalog) do
+      compile_to_ral(<<-MANIFEST)
+        notify { foo: require => Notify[bar] }
+        notify { bar: require => Notify[foo] }
+      MANIFEST
+    end
+
+    let(:prioritizer) { Puppet::Graph::SequentialPrioritizer.new }
+    let(:transaction) { Puppet::Transaction.new(catalog,
+                                          Puppet::Transaction::Report.new("apply"),
+                                          prioritizer) }
+
+    before(:each) do
+      expect { transaction.evaluate }.to raise_error(Puppet::Error)
+      transaction.report.finalize_report
+    end
+
+    it "should report resources involved in a dependency cycle as failed" do
+      expect(transaction.report.resource_statuses['Notify[foo]']).to be_failed
+      expect(transaction.report.resource_statuses['Notify[bar]']).to be_failed
+    end
+
+    it "should generate a failure event for a resource in a dependency cycle" do
+      status = transaction.report.resource_statuses['Notify[foo]']
+      expect(status.events.first.status).to eq('failure')
+      expect(status.events.first.message).to eq('resource is part of a dependency cycle')
+    end
+
+    it "should report that the transaction is failed" do
+      expect(transaction.report.status).to eq('failed')
+    end
   end
 
   it "reports a changed resource with a successful run" do


### PR DESCRIPTION
Prior to this commit, when a dependency cycle was detected in the resource
graph, the transaction would fail immediately with an error describing the
cycle. However, the resources in question were not considered problematic in
anyway. This commit updates transaction evaluation to consider resources
involved in a cycle as failed:

- Rather than fail when detecting resource dependency cycles, we return this
  information back up to the caller to decide what to do with. Erroring was an
  unexpected side-effect anyway given the name of the method is
  `report_cycles_in_graph`. Still emit an error message though, as this is
  thematically inline with "reporting cycles".

- Add a new handler defined in the context of Puppet::Transaction that is
  invoked in the context of relationship graph traversal with the detected
  dependency cycles. Because the handler is defined in the context of
  Puppet::Transaction our transaction report is in scope.

- Given access to the report, mark all resources involved in a dependency cycle
  as failed, and then fail the transaction. This has the same behavioral
  characteristics as before (failing to evaluate *any* resources in the graph
  upon discovery of a dependency cycle), but the final report should note the
  failed resources.