### PR TITLE
(PUP-7382) Fix typo in ToDataConverter and add more tests

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -511,6 +511,7 @@ module Runtime3Support
       p[Issues::CLASS_NOT_VIRTUALIZABLE]      = Puppet[:strict] == :off ? :warning : Puppet[:strict]
       p[Issues::NUMERIC_COERCION]             = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
       p[Issues::SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING] = Puppet[:strict] == :off ? :warning : Puppet[:strict]
+      p[Issues::SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING] = Puppet[:strict] == :off ? :warning : Puppet[:strict]
     end
   end
 

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -844,7 +844,11 @@ module Issues
   end
 
   SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING = issue :SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING, :path, :klass, :value do
-    _("%{path} contains a %{klass} value. It will be converted to the String '%{value}'") % { path: path, klass: klass, value: value }
+    _("%{path} contains %{klass} value. It will be converted to the String '%{value}'") % { path: path, klass: label.a_an(klass), value: value }
+  end
+
+  SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING = issue :SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING, :path, :klass, :value do
+    _("%{path} contains a hash with %{klass} key. It will be converted to the String '%{value}'") % { path: path, klass: label.a_an(klass), value: value }
   end
 end
 end

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -176,9 +176,15 @@ module Serialization
       @rich_data ? value_to_data_hash(value) : unknown_to_string_with_warning(value)
     end
 
+    def unknown_key_to_string_with_warning(value)
+      str = value.to_s
+      serialization_issue(Issues::SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING, :path => path_to_s, :klass => value.class, :value => str)
+      str
+    end
+
     def unknown_to_string_with_warning(value)
       str = value.to_s
-      serialization_issue(Issues::SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING, :path => path_to_s, :klass => value.class.name, :value => str)
+      serialization_issue(Issues::SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING, :path => path_to_s, :klass => value.class, :value => str)
       str
     end
 
@@ -190,10 +196,10 @@ module Serialization
         hash.each_pair do |key, value|
           if key.is_a?(Symbol) && @symbol_as_string
             key = key.to_s
-          elsif !key.is_a(String)
-            key = unknown_to_string_with_warning(key)
+          elsif !key.is_a?(String)
+            key = unknown_key_to_string_with_warning(key)
           end
-          with(key) { result[key] = to_data(elem) }
+          with(key) { result[key] = to_data(value) }
         end
         result
       end

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -155,6 +155,31 @@ module Serialization
       expect(val2.unwrap).to be_a(Time::Timestamp)
       expect(val2.unwrap).to eql(sval)
     end
+
+    it 'Hash with Symbol keys' do
+      val = { :one => 'one', :two => 'two' }
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Hash)
+      expect(val2).to eql(val)
+    end
+
+    it 'Hash with Integer keys' do
+      val = { 1 => 'one', 2 => 'two' }
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Hash)
+      expect(val2).to eql(val)
+    end
+
+    it 'A Hash that references itself' do
+      val = {}
+      val['myself'] = val
+      write(val)
+      val2 = read
+      expect(val2).to be_a(Hash)
+      expect(val2['myself']).to equal(val2)
+    end
   end
 
   context 'can write and read' do
@@ -395,6 +420,63 @@ module Serialization
       write(obj)
       loaders.find_loader(nil).expects(:load).with(:type, 'mytype').returns(type)
       expect(read).to eql(obj)
+    end
+  end
+
+  context 'with rich_data set to false' do
+    let(:to_converter) { ToDataConverter.new(:message_prefix => 'Test Hash', :rich_data => false) }
+    let(:logs) { [] }
+    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+
+    it 'A Hash with Symbol keys is converted to hash with String keys with warning' do
+      val = { :one => 'one', :two => 'two' }
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Hash)
+        expect(val2).to eql({ 'one' => 'one', 'two' => 'two' })
+      end
+      expect(warnings).to eql([
+        "Test Hash contains a hash with a Symbol key. It will be converted to the String 'one'",
+        "Test Hash contains a hash with a Symbol key. It will be converted to the String 'two'"])
+    end
+
+    it 'A Hash with Version keys is converted to hash with String keys with warning' do
+      val = { SemanticPuppet::Version.parse('1.0.0') => 'one', SemanticPuppet::Version.parse('2.0.0') => 'two' }
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        write(val)
+        val2 = read
+        expect(val2).to be_a(Hash)
+        expect(val2).to eql({ '1.0.0' => 'one', '2.0.0' => 'two' })
+      end
+      expect(warnings).to eql([
+        "Test Hash contains a hash with a SemanticPuppet::Version key. It will be converted to the String '1.0.0'",
+        "Test Hash contains a hash with a SemanticPuppet::Version key. It will be converted to the String '2.0.0'"])
+    end
+
+    context 'and symbol_as_string is set to true' do
+      let(:to_converter) { ToDataConverter.new(:symbol_as_string => true) }
+
+      it 'A Hash with Symbol keys is silently converted to hash with String keys' do
+        val = { :one => 'one', :two => 'two' }
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          write(val)
+          val2 = read
+          expect(val2).to be_a(Hash)
+          expect(val2).to eql({ 'one' => 'one', 'two' => 'two' })
+        end
+        expect(warnings).to be_empty
+      end
+    end
+  end
+
+  context 'with local_reference set to false' do
+    let(:to_converter) { ToDataConverter.new(:local_reference => false) }
+
+    it 'A self referencing value will trigger an endless recursion error' do
+      val = {}
+      val['myself'] = val
+      expect { write(val) }.to raise_error(/Endless recursion detected when attempting to serialize value of class Hash/)
     end
   end
 end


### PR DESCRIPTION
This commit fixes a typo (is_a instead of is_a?) in the `ToDataConverter`
class and adds test to cover some areas of the `ToDataConverter` /
`FromDataConverter` code that was not tested.

A new `Issue` is also added to improve the message for the case when a hash
key must be converted to a `String`.