### PR TITLE
(PUP-7155) Avoid unnecessary unicode escapes in formatted strings

### DIFF
--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -28,9 +28,9 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
   # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
   # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
   mixed_utf8_0 = "A\u06FF"
-  reported_mixed_utf8_0 = '"A\\\\u\\{6FF\\}"'
+  reported_mixed_utf8_0 = '\'A\u{6FF}\''
   mixed_utf8_1 = "\u16A0\u{2070E}"
-  reported_mixed_utf8_1 = '"\\\\u\\{16A0\\}\\\\u\\{2070E\\}"'
+  reported_mixed_utf8_1 = '\'\u{16A0}\u{2070E}\''
 
   teardown do
     # remove user on all agents

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -127,7 +127,7 @@ describe 'The string converter' do
       end
 
       it 'quoted 5-byte unicode chars' do
-        expect(converter.convert("smile \u{1f603}.", string_formats)).to eq('"smile \\u{1F603}."')
+        expect(converter.convert("smile \u{1f603}.", string_formats)).to eq("'smile \u{1F603}.'")
       end
 
       it 'quoted 2-byte unicode chars' do

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -369,7 +369,7 @@ describe Puppet::Type.type(:user) do
             is.force_encoding(Encoding::ASCII_8BIT)
             should.force_encoding(Encoding::UTF_8)
             expect(Encoding.compatible?(is, should)).to be_falsey
-            expect(comment_property.change_to_s(is,should)).to match(/changed "\\u\{E2\}\\u\{98\}\\u\{83\}" to "\\u\{DB\}\\u\{BF\}"/)
+            expect(comment_property.change_to_s(is,should)).to match(/changed '\u{E2}\u{98}\u{83}' to '\u{DB}\u{BF}'/)
           end
         end
 
@@ -378,7 +378,7 @@ describe Puppet::Type.type(:user) do
             is.force_encoding(Encoding::UTF_8)
             should.force_encoding(Encoding::UTF_8)
             expect(Encoding.compatible?(is, should)).to be_truthy
-            expect(comment_property.change_to_s(is,should)).to match(/changed "\\u\{2603\}" to "\\u\{6FF\}"/)
+            expect(comment_property.change_to_s(is,should)).to match(/changed '\u{2603}' to '\u{6FF}'/u)
           end
         end
       end


### PR DESCRIPTION
This commit changes the StringFormatter's '%p' representation of a
String so that it does not expand characters in the range above 0x7f
into unicode escapes.