### PR TITLE
(PUP-7627) Changes CreateSymbolicLinkW return from BOOL to BOOLEAN

### DIFF
--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -165,6 +165,9 @@ module Puppet::Util::Windows::APITypes
   # https://blogs.msdn.com/b/oldnewthing/archive/2011/03/28/10146459.aspx
   FFI.typedef :int32, :win32_bool
 
+  # The BOOLEAN data type (different to BOOL) is only 1 byte.
+  FFI.typedef :int8, :boolean
+
   # Same as a LONG, a 32-bit signed integer
   FFI.typedef :int32, :hresult
 

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -397,7 +397,7 @@ module Puppet::Util::Windows::File
   begin
     ffi_lib :kernel32
     attach_function_private :CreateSymbolicLinkW,
-      [:lpwstr, :lpwstr, :dword], :win32_bool
+      [:lpwstr, :lpwstr, :dword], :boolean
   rescue LoadError
   end
 


### PR DESCRIPTION
I was tracking down why CreateSymbolicLinkW was returning non-zero when
failing on one test VM and not a different one
(https://github.com/puppetlabs/puppetlabs_spec_helper/pull/192).

Turns out CreateSymbolicLinkW returns a `BOOLEAN` (1 byte) rather than a
`BOOL` (4 bytes), so I was getting random garbage in the upper 3 bytes
and therefore a non-zero result.