### PR TITLE
(PUP-7615) Make squelching of faulty metadata.json possible

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -146,7 +146,9 @@ class Puppet::Module
   rescue JSON::JSONError => e
     msg = "#{name} has an invalid and unparsable metadata.json file. The parse error: #{e.message}"
     case Puppet[:strict]
-    when :off, :warning
+    when :off
+      Puppet.debug(msg)
+    when :warning
       Puppet.warning(msg)
     when :error
       raise FaultyMetadata, msg

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -665,7 +665,15 @@ describe Puppet::Module do
         Puppet[:strict] = :off
       end
 
-      it "should warn about a failure to parse" do
+      it "should not warn about a failure to parse" do
+        File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
+
+        expect(mymod.has_metadata?).to be_falsey
+        expect(@logs).to_not have_matching_log(/mymod has an invalid and unparsable metadata\.json file.*/)
+      end
+
+      it "should log debug output about a failure to parse when --debug is on" do
+        Puppet[:log_level] = :debug
         File.stubs(:read).with(mymod_metadata, {:encoding => 'utf-8'}).returns(my_fixture('trailing-comma.json'))
 
         expect(mymod.has_metadata?).to be_falsey


### PR DESCRIPTION
When running various puppet commands and there are modules installed
with faulty metadata, a user can be swamped with (in context) irrelevant
warnings.

This changes the output of warning when a metadata.json file cannot be
parsed such that:
* If --strict=off there will be no warning
* If --strict=off and --debug is on, then there is debug output

These continue to work as before:
* If --strict=warning, a warning is issued
* If --strict=error, an error is issued and the command stops