### PR TITLE
(PUP-2280) Mark runs as failed when refresh events fail

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -170,7 +170,9 @@ class Puppet::Transaction::Report
 
   # @api private
   def compute_status(resource_metrics, change_metric)
-    if resources_failed_to_generate || (resource_metrics["failed"] || 0) > 0
+    if resources_failed_to_generate ||
+       (resource_metrics["failed"] || 0) > 0 ||
+       (resource_metrics["failed_to_restart"] || 0) > 0
       'failed'
     elsif change_metric > 0
       'changed'

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -233,7 +233,7 @@ describe Puppet::Transaction do
     expect(Puppet::FileSystem.exist?(path)).not_to be_truthy
   end
 
-  it "should not let one failed refresh result in other refreshes failing" do
+  it "one failed refresh should propagate its failure to dependent refreshes" do
     path = tmpfile("path")
     newfile = tmpfile("file")
       file = Puppet::Type.type(:file).new(
@@ -263,7 +263,7 @@ describe Puppet::Transaction do
 
     catalog = mk_catalog(file, exec1, exec2)
     catalog.apply
-    expect(Puppet::FileSystem.exist?(newfile)).to be_truthy
+    expect(Puppet::FileSystem.exist?(newfile)).to be_falsey
   end
 
   # Ensure when resources have been generated with eval_generate that event

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -292,6 +292,12 @@ describe Puppet::Transaction::Report do
         expect(@report.status).to eq('failed')
       end
 
+      it "should mark the report as 'failed' if resources failed to restart" do
+        add_statuses(1) { |status| status.failed_to_restart = true }
+        @report.finalize_report
+        expect(@report.status).to eq('failed')
+      end
+
       it "should mark the report as 'failed' if resources_failed_to_generate" do
         @report.resources_failed_to_generate = true
         @report.finalize_report

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -50,7 +50,7 @@ describe Puppet::Transaction do
     expect(transaction.report.resource_statuses[resource.to_s]).to equal(status)
   end
 
-  it "should not consider there to be failed resources if no statuses are marked failed" do
+  it "should not consider there to be failed or failed_to_restart resources if no statuses are marked failed" do
     resource = Puppet::Type.type(:notify).new :title => "foobar"
     transaction = transaction_with_resource(resource)
     transaction.evaluate
@@ -171,6 +171,13 @@ describe Puppet::Transaction do
     it "should report any_failed if any resources failed" do
       @resource.expects(:properties).raises ArgumentError
       @transaction.evaluate
+
+      expect(@transaction).to be_any_failed
+    end
+
+    it "should report any_failed if any resources failed to restart" do
+      @transaction.evaluate
+      @transaction.report.resource_statuses[@resource.to_s].failed_to_restart = true
 
       expect(@transaction).to be_any_failed
     end


### PR DESCRIPTION
Previously, if a 'refreshonly' exec failed, this failure was not
propagated into the report because refresh failures are tracked via a
different resource status, `failed_to_restart` as opposed to just
`failed`.

This commit updates the failure check logic in the transaction to
include checks of `failed_to_restart`, as well as a
similar update to the way the report status is calculated. A run is now
marked as failed if any of its resources are marked `failed_to_restart`.