### PR TITLE
(PUP-7627) Fix CreateSymbolicLinkW BOOL return type

### DIFF
--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -79,7 +79,7 @@ Puppet.features.add(:manages_symlinks) do
       def self.is_implemented
         begin
           ffi_lib :kernel32
-          attach_function :CreateSymbolicLinkW, [:lpwstr, :lpwstr, :dword], :win32_bool
+          attach_function :CreateSymbolicLinkW, [:lpwstr, :lpwstr, :dword], :boolean
 
           true
         rescue LoadError => err

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -165,6 +165,9 @@ module Puppet::Util::Windows::APITypes
   # https://blogs.msdn.com/b/oldnewthing/archive/2011/03/28/10146459.aspx
   FFI.typedef :int32, :win32_bool
 
+  # BOOLEAN (unlike BOOL) is a BYTE - typedef unsigned char BYTE;
+  FFI.typedef :uchar, :boolean
+
   # Same as a LONG, a 32-bit signed integer
   FFI.typedef :int32, :hresult
 

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -397,7 +397,7 @@ module Puppet::Util::Windows::File
   begin
     ffi_lib :kernel32
     attach_function_private :CreateSymbolicLinkW,
-      [:lpwstr, :lpwstr, :dword], :win32_bool
+      [:lpwstr, :lpwstr, :dword], :boolean
   rescue LoadError
   end
 


### PR DESCRIPTION
 - CreateSymbolicLinkW was intermittently returning non-zero on
   different tests hosts, under similar circumstances.

   Some discussion in:
   https://github.com/puppetlabs/puppetlabs_spec_helper/pull/192

   Note the original PR was wrong and updated in:
   https://github.com/puppetlabs/puppetlabs_spec_helper/commit/bb46874846eeefbb0f03939bb66129bfa4a02236

 - The signature for CreateSymbolicLinkW should return a BOOLEAN
   (BYTE - aka unsigned char) value not a BOOL (4 byte / 32-bit
   signed int).

   Based on the presence of random data in the incorrectly sized
   return value, the code may behave incorrectly.

 - Fix the problem by sizing the return value correctly