### PR TITLE
(PUP-7611) Cannot squelch all deprecation warnings

### DIFF
--- a/lib/hiera/puppet_function.rb
+++ b/lib/hiera/puppet_function.rb
@@ -60,7 +60,7 @@ class Hiera::PuppetFunction < Puppet::Functions::InternalFunction
 
   def lookup(scope, key, default, has_default, override, &default_block)
     unless Puppet[:strict] == :off
-      Puppet.warn_once(:deprecation, self.class.name,
+      Puppet.warn_once('deprecations', self.class.name,
         "The function '#{self.class.name}' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/#{Puppet.minor_version}/reference/deprecated_language.html")
     end
     lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {})

--- a/lib/puppet/functions/strftime.rb
+++ b/lib/puppet/functions/strftime.rb
@@ -35,7 +35,7 @@ Puppet::Functions.create_function(:strftime) do
       file = nil
       line = nil
     end
-    Puppet.warn_once('deprecation', 'legacy#strftime',
+    Puppet.warn_once('deprecations', 'legacy#strftime',
       _('The argument signature (String format, [String timezone]) is deprecated for #strfime. See #strftime documentation and Timespan type for more info'),
       file, line)
     Puppet::Pops::Time::Timestamp.format_time(format, Time.now.utc, timezone)

--- a/lib/puppet/functions/strftime.rb
+++ b/lib/puppet/functions/strftime.rb
@@ -28,8 +28,16 @@ Puppet::Functions.create_function(:strftime) do
   end
 
   def legacy_strftime(format, timezone = nil)
+    stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+    if stacktrace.size > 0
+      file, line = stacktrace[0]
+    else
+      file = nil
+      line = nil
+    end
     Puppet.warn_once('deprecation', 'legacy#strftime',
-      _('The argument signature (String format, [String timezone]) is deprecated for #strfime. See #strftime documentation and Timespan type for more info'))
+      _('The argument signature (String format, [String timezone]) is deprecated for #strfime. See #strftime documentation and Timespan type for more info'),
+      file, line)
     Puppet::Pops::Time::Timestamp.format_time(format, Time.now.utc, timezone)
   end
 end

--- a/lib/puppet/indirector/node/write_only_yaml.rb
+++ b/lib/puppet/indirector/node/write_only_yaml.rb
@@ -12,7 +12,7 @@ require 'puppet/indirector/yaml'
 #
 class Puppet::Node::WriteOnlyYaml < Puppet::Indirector::Yaml
   def initialize
-    Puppet.warn_once(:deprecation, 'Puppet::Node::WriteOnlyYaml', _('Puppet::Node::WriteOnlyYaml is deprecated and will be removed in a future release of Puppet.'))
+    Puppet.warn_once('deprecations', 'Puppet::Node::WriteOnlyYaml', _('Puppet::Node::WriteOnlyYaml is deprecated and will be removed in a future release of Puppet.'))
     super
   end
 

--- a/lib/puppet/parser/ast/resource.rb
+++ b/lib/puppet/parser/ast/resource.rb
@@ -6,7 +6,7 @@ class Puppet::Parser::AST::Resource < Puppet::Parser::AST::Branch
   attr_accessor :type, :instances, :exported, :virtual
 
   def initialize(argshash)
-    Puppet.warn_once('deprecation', 'AST::Resource', _('Use of Puppet::Parser::AST::Resource is deprecated and not fully functional'))
+    Puppet.warn_once('deprecations', 'AST::Resource', _('Use of Puppet::Parser::AST::Resource is deprecated and not fully functional'))
     super(argshash)
   end
 

--- a/lib/puppet/parser/ast/resource_instance.rb
+++ b/lib/puppet/parser/ast/resource_instance.rb
@@ -4,7 +4,7 @@
 class Puppet::Parser::AST::ResourceInstance < Puppet::Parser::AST::Branch
   attr_accessor :title, :parameters
   def initialize(argshash)
-    Puppet.warn_once('deprecation', 'AST::ResourceInstance', _('Use of Puppet::Parser::AST::ResourceInstance is deprecated'))
+    Puppet.warn_once('deprecations', 'AST::ResourceInstance', _('Use of Puppet::Parser::AST::ResourceInstance is deprecated'))
     super(argshash)
   end
 end

--- a/lib/puppet/parser/ast/resourceparam.rb
+++ b/lib/puppet/parser/ast/resourceparam.rb
@@ -4,7 +4,7 @@ class Puppet::Parser::AST::ResourceParam < Puppet::Parser::AST::Branch
   attr_accessor :value, :param, :add
 
   def initialize(argshash)
-    Puppet.warn_once('deprecation', 'AST::ResourceParam', _('Use of Puppet::Parser::AST::ResourceParam is deprecated and not fully functional'))
+    Puppet.warn_once('deprecations', 'AST::ResourceParam', _('Use of Puppet::Parser::AST::ResourceParam is deprecated and not fully functional'))
     super(argshash)
   end
 

--- a/lib/puppet/parser/functions/contain.rb
+++ b/lib/puppet/parser/functions/contain.rb
@@ -25,6 +25,6 @@ allowing the function call to `contain` to directly continue.
 "
 ) do |classes|
   # Call the 4.x version of this function in case 3.x ruby code uses this function
-  Puppet.warn_once(:deprecation, '3xfunction#contain', _("Calling function_contain via the Scope class is deprecated. Use Scope#call_function instead"))
+  Puppet.warn_once('deprecations', '3xfunction#contain', _("Calling function_contain via the Scope class is deprecated. Use Scope#call_function instead"))
   call_function('contain', classes)
 end

--- a/lib/puppet/parser/functions/include.rb
+++ b/lib/puppet/parser/functions/include.rb
@@ -30,5 +30,5 @@ the future parser's resource and relationship expressions.
 ") do |classes|
   call_function('include', classes)
   #TRANSLATORS "function_include", "Scope", and "Scope#call_function" refer to Puppet internals and should not be translated
-  Puppet.warn_once(:deprecation, '3xfunction#include', _("Calling function_include via the Scope class is deprecated. Use Scope#call_function instead"))
+  Puppet.warn_once('deprecations', '3xfunction#include', _("Calling function_include via the Scope class is deprecated. Use Scope#call_function instead"))
 end

--- a/lib/puppet/parser/functions/require.rb
+++ b/lib/puppet/parser/functions/require.rb
@@ -36,5 +36,5 @@ resource and relationship expressions.
 - Since 4.7.0 Returns an Array[Type[Class]] with references to the required classes
 ") do |classes|
   call_function('require', classes)
-  Puppet.warn_once(:deprecation, '3xfunction#require', _("Calling function_require via the Scope class is deprecated. Use Scope#call_function instead"))
+  Puppet.warn_once('deprecations', '3xfunction#require', _("Calling function_require via the Scope class is deprecated. Use Scope#call_function instead"))
 end

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -516,7 +516,6 @@ class Puppet::Parser::Scope
   end
 
   UNDEFINED_VARIABLES_KIND = 'undefined_variables'.freeze
-  DEPRECATION_KIND = 'deprecation'.freeze
 
   # The exception raised when a throw is uncaught is different in different versions
   # of ruby. In >=2.2.0 it is UncaughtThrowError (which did not exist prior to this)

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -81,7 +81,7 @@ class HieraConfig
 
   def self.v4_function_config(config_root, function_name, owner)
     unless Puppet[:strict] == :off
-      Puppet.warn_once(:deprecation, 'legacy_provider_function',
+      Puppet.warn_once('deprecations', 'legacy_provider_function',
         _("Using of legacy data provider function '%{function_name}'. Please convert to a 'data_hash' function") % { function_name: function_name })
     end
     HieraConfigV5.new(config_root, nil,
@@ -423,7 +423,7 @@ class HieraConfigV3 < HieraConfig
 
   def validate_config(config, owner)
     unless Puppet[:strict] == :off
-      Puppet.warn_once(:deprecation, 'hiera.yaml',
+      Puppet.warn_once('deprecations', 'hiera.yaml',
         _("%{config_path}: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5") % { config_path: @config_path }, config_path.to_s)
     end
     config[KEY_VERSION] ||= 3
@@ -523,7 +523,7 @@ class HieraConfigV4 < HieraConfig
 
   def validate_config(config, owner)
     unless Puppet[:strict] == :off
-      Puppet.warn_once(:deprecation, 'hiera.yaml',
+      Puppet.warn_once('deprecations', 'hiera.yaml',
         _("%{config_path}: Use of 'hiera.yaml' version 4 is deprecated. It should be converted to version 5") % { config_path: @config_path }, config_path.to_s)
     end
     config[KEY_DATADIR] ||= 'data'

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -371,7 +371,7 @@ class LookupAdapter < DataAdapter
         mp = nil
       elsif mp_config.version >= 5
         unless provider_name.nil? || Puppet[:strict] == :off
-          Puppet.warn_once(:deprecation, "metadata.json#data_provider-#{module_name}",
+          Puppet.warn_once('deprecations', "metadata.json#data_provider-#{module_name}",
             _("Defining \"data_provider\": \"%{name}\" in metadata.json is deprecated. It is ignored since a '%{config}' with version >= 5 is present") % { name: provider_name, config: HieraConfig::CONFIG_FILE_NAME }, mod.metadata_file)
         end
         provider_name = nil
@@ -384,7 +384,7 @@ class LookupAdapter < DataAdapter
       unless Puppet[:strict] == :off
         msg = _("Defining \"data_provider\": \"%{name}\" in metadata.json is deprecated") % { name: provider_name }
         msg += _(". A '%{config}' file should be used instead") % { config: HieraConfig::CONFIG_FILE_NAME } if mp.nil?
-        Puppet.warn_once(:deprecation, "metadata.json#data_provider-#{module_name}", msg, mod.metadata_file)
+        Puppet.warn_once('deprecations', "metadata.json#data_provider-#{module_name}", msg, mod.metadata_file)
       end
 
       case provider_name
@@ -420,11 +420,11 @@ class LookupAdapter < DataAdapter
         ep = nil
       elsif ep_config.version >= 5
         unless provider_name.nil? || Puppet[:strict] == :off
-          Puppet.warn_once(:deprecation, 'environment.conf#data_provider',
+          Puppet.warn_once('deprecations', 'environment.conf#data_provider',
             _("Defining environment_data_provider='%{provider_name}' in environment.conf is deprecated") % { provider_name: provider_name }, env_path + 'environment.conf')
 
           unless provider_name == 'hiera'
-            Puppet.warn_once(:deprecation, 'environment.conf#data_provider_overridden',
+            Puppet.warn_once('deprecations', 'environment.conf#data_provider_overridden',
               _("The environment_data_provider='%{provider_name}' setting is ignored since '%{config_path}' version >= 5") % { provider_name: provider_name, config_path: config_path }, env_path + 'environment.conf')
           end
         end
@@ -438,7 +438,7 @@ class LookupAdapter < DataAdapter
       unless Puppet[:strict] == :off
         msg = _("Defining environment_data_provider='%{provider_name}' in environment.conf is deprecated") % { provider_name: provider_name }
         msg += _(". A '%{config}' file should be used instead") % { config: HieraConfig::CONFIG_FILE_NAME } if ep.nil?
-        Puppet.warn_once(:deprecation, 'environment.conf#data_provider', msg, env_path + 'environment.conf')
+        Puppet.warn_once('deprecations', 'environment.conf#data_provider', msg, env_path + 'environment.conf')
       end
 
       case provider_name

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -85,7 +85,7 @@ module TypeFactory
       size_type_or_value.nil? ? PStringType::DEFAULT : PStringType.new(size_type_or_value)
     else
       if Puppet[:strict] != :off
-        Puppet.warn_once(:deprecation, "TypeFactory#string_multi_args", "Passing more than one argument to TypeFactory#string is deprecated")
+        Puppet.warn_once('deprecations', "TypeFactory#string_multi_args", "Passing more than one argument to TypeFactory#string is deprecated")
       end
       deprecated_second_argument.size == 1 ? PStringType.new(deprecated_second_argument[0]) : PEnumType.new(*deprecated_second_argument)
     end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -85,7 +85,7 @@ module TypeFactory
       size_type_or_value.nil? ? PStringType::DEFAULT : PStringType.new(size_type_or_value)
     else
       if Puppet[:strict] != :off
-        Puppet.warn_once(:deprecatation, "TypeFactory#string_multi_args", "Passing more than one argument to TypeFactory#string is deprecated")
+        Puppet.warn_once(:deprecation, "TypeFactory#string_multi_args", "Passing more than one argument to TypeFactory#string is deprecated")
       end
       deprecated_second_argument.size == 1 ? PStringType.new(deprecated_second_argument[0]) : PEnumType.new(*deprecated_second_argument)
     end

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -550,7 +550,7 @@ module Types
     end
 
     def tense_deprecated
-      Puppet.warn_once(:deprecation, 'typemismatch#tense', "Passing a 'tense' argument to the TypeMismatchDescriber is deprecated and ignored. Everything is now reported using present tense")
+      Puppet.warn_once('deprecations', 'typemismatch#tense', "Passing a 'tense' argument to the TypeMismatchDescriber is deprecated and ignored. Everything is now reported using present tense")
     end
 
     # Validates that all entries in the give_hash exists in the given param_struct, that their type conforms

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1384,7 +1384,7 @@ class PStringType < PScalarDataType
   def initialize(size_type_or_value, deprecated_multi_args = EMPTY_ARRAY)
     unless deprecated_multi_args.empty?
       if Puppet[:strict] != :off
-        Puppet.warn_once(:deprecation, "PStringType#initialize_multi_args", "Passing more than one argument to PStringType#initialize is deprecated")
+        Puppet.warn_once('deprecations', "PStringType#initialize_multi_args", "Passing more than one argument to PStringType#initialize is deprecated")
       end
       size_type_or_value = deprecated_multi_args[0]
     end
@@ -1437,7 +1437,7 @@ class PStringType < PScalarDataType
   # @api private
   def values
     if Puppet[:strict] != :off
-      Puppet.warn_once(:deprecation, "PStringType#values", "Method PStringType#values is deprecated. Use #value instead")
+      Puppet.warn_once('deprecations', "PStringType#values", "Method PStringType#values is deprecated. Use #value instead")
     end
     @value.is_a?(String) ? [@value] : EMPTY_ARRAY
   end
@@ -2508,7 +2508,7 @@ class PHashType < PCollectionType
 
   def element_type
     if Puppet[:strict] != :off
-      Puppet.warn_once(:deprecation, 'Puppet::Pops::Types::PHashType#element_type',
+      Puppet.warn_once('deprecations', 'Puppet::Pops::Types::PHashType#element_type',
         'Puppet::Pops::Types::PHashType#element_type is deprecated, use #value_type instead')
     end
     @value_type

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1384,7 +1384,7 @@ class PStringType < PScalarDataType
   def initialize(size_type_or_value, deprecated_multi_args = EMPTY_ARRAY)
     unless deprecated_multi_args.empty?
       if Puppet[:strict] != :off
-        Puppet.warn_once(:deprecatation, "PStringType#initialize_multi_args", "Passing more than one argument to PStringType#initialize is deprecated")
+        Puppet.warn_once(:deprecation, "PStringType#initialize_multi_args", "Passing more than one argument to PStringType#initialize is deprecated")
       end
       size_type_or_value = deprecated_multi_args[0]
     end
@@ -1437,7 +1437,7 @@ class PStringType < PScalarDataType
   # @api private
   def values
     if Puppet[:strict] != :off
-      Puppet.warn_once(:deprecatation, "PStringType#values", "Method PStringType#values is deprecated. Use #value instead")
+      Puppet.warn_once(:deprecation, "PStringType#values", "Method PStringType#values is deprecated. Use #value instead")
     end
     @value.is_a?(String) ? [@value] : EMPTY_ARRAY
   end

--- a/spec/unit/indirector/node/write_only_yaml_spec.rb
+++ b/spec/unit/indirector/node/write_only_yaml_spec.rb
@@ -6,7 +6,7 @@ require 'puppet/indirector/node/write_only_yaml'
 
 describe Puppet::Node::WriteOnlyYaml do
   it "should be deprecated" do
-    Puppet.expects(:warn_once).with(:deprecation, 'Puppet::Node::WriteOnlyYaml', 'Puppet::Node::WriteOnlyYaml is deprecated and will be removed in a future release of Puppet.')
+    Puppet.expects(:warn_once).with('deprecations', 'Puppet::Node::WriteOnlyYaml', 'Puppet::Node::WriteOnlyYaml is deprecated and will be removed in a future release of Puppet.')
     described_class.new
   end
 end


### PR DESCRIPTION
This cleans up calls to warn_once with the intent of logging a deprecation. The correct form of category is `'deprecations'` (a String, in plural). 
