### PR TITLE
(PUP-6395)(docs) Change references to mode to be quoted strings

### DIFF
--- a/lib/puppet/type/file/group.rb
+++ b/lib/puppet/type/file/group.rb
@@ -10,7 +10,7 @@ module Puppet
       On Windows, a user (such as "Administrator") can be set as a file's group
       and a group (such as "Administrators") can be set as a file's owner;
       however, a file's owner and group shouldn't be the same. (If the owner
-      is also the group, files with modes like `0640` will cause log churn, as
+      is also the group, files with modes like `"0640"` will cause log churn, as
       they will always appear out of sync.)
     EOT
 

--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -20,7 +20,7 @@ module Puppet
       [the puppetlabs/acl module.](https://forge.puppetlabs.com/puppetlabs/acl)
 
       Numeric modes should use the standard octal notation of
-      `<SETUID/SETGID/STICKY><OWNER><GROUP><OTHER>` (e.g. '0644').
+      `<SETUID/SETGID/STICKY><OWNER><GROUP><OTHER>` (for example, "0644").
 
       * Each of the "owner," "group," and "other" digits should be a sum of the
         permissions for that class of users, where read = 4, write = 2, and
@@ -50,7 +50,7 @@ module Puppet
           * g (group's current permissions)
           * o (other's current permissions)
 
-      Thus, mode `0664` could be represented symbolically as either `a=r,ug+w`
+      Thus, mode `"0664"` could be represented symbolically as either `a=r,ug+w`
       or `ug=rw,o=r`.  However, symbolic modes are more expressive than numeric
       modes: a mode only affects the specified bits, so `mode => 'ug+w'` will
       set the user and group write bits, without affecting any other bits.
@@ -66,8 +66,8 @@ module Puppet
         `FILE_GENERIC_WRITE`, and `FILE_GENERIC_EXECUTE` access rights; a
         file's owner always has the `FULL_CONTROL` right
       * "Other" users can't have any permissions a file's group lacks,
-        and its group can't have any permissions its owner lacks; that is, 0644
-        is an acceptable mode, but 0464 is not.
+        and its group can't have any permissions its owner lacks; that is, "0644"
+        is an acceptable mode, but "0464" is not.
     EOT
 
     validate do |value|

--- a/lib/puppet/type/file/owner.rb
+++ b/lib/puppet/type/file/owner.rb
@@ -9,7 +9,7 @@ module Puppet
       On Windows, a group (such as "Administrators") can be set as a file's owner
       and a user (such as "Administrator") can be set as a file's group; however,
       a file's owner and group shouldn't be the same. (If the owner is also
-      the group, files with modes like `0640` will cause log churn, as they
+      the group, files with modes like `"0640"` will cause log churn, as they
       will always appear out of sync.)
     EOT
 


### PR DESCRIPTION
Because the file mode attribute must be a quoted string, we should display it that way when referencing it in the docs.