### PR TITLE
(PUP-5912) Ensure that label for an anonymous class is a string, not nil

### DIFF
--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -122,7 +122,8 @@ class ModelLabelProvider
       simple_name = o.name.split('::').last
       simple_name[1..-5] + "-Type"
     else
-      o.name
+      n = o.name
+      n.nil? ? 'Anonymous Class' : n
     end
   end
 end


### PR DESCRIPTION
This commit changes the Puppet::Pops::Model::ModelLabelProvider so that
it returns the string 'Anonymous Class' when passed a class that has
no name.