### PR TITLE
(PUP-1890) Fix double encoding forge request URIs

### DIFF
--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -53,12 +53,13 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
   #   bad HTTP response
   def search(term)
     matches = []
-    uri = "/v3/modules?query=#{Puppet::Util.uri_query_encode(term)}"
+    uri = "/v3/modules?query=#{term}"
     if Puppet[:module_groups]
-      uri += "&module_groups=#{Puppet::Util.uri_query_encode(Puppet[:module_groups])}"
+      uri += "&module_groups=#{Puppet[:module_groups]}"
     end
 
     while uri
+      # make_http_request URI encodes parameters
       response = make_http_request(uri)
 
       if response.code == '200'
@@ -90,11 +91,12 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     name = input.tr('/', '-')
     uri = "/v3/releases?module=#{name}"
     if Puppet[:module_groups]
-      uri += "&module_groups=#{Puppet::Util.uri_query_encode(Puppet[:module_groups])}"
+      uri += "&module_groups=#{Puppet[:module_groups]}"
     end
     releases = []
 
     while uri
+      # make_http_request URI encodes parameters
       response = make_http_request(uri)
 
       if response.code == '200'

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -55,7 +55,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     matches = []
     uri = "/v3/modules?query=#{term}"
     if Puppet[:module_groups]
-      uri += "&module_groups=#{Puppet[:module_groups]}"
+      uri += "&module_groups=#{Puppet[:module_groups].gsub('+', ' ')}"
     end
 
     while uri
@@ -91,7 +91,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     name = input.tr('/', '-')
     uri = "/v3/releases?module=#{name}"
     if Puppet[:module_groups]
-      uri += "&module_groups=#{Puppet[:module_groups]}"
+      uri += "&module_groups=#{Puppet[:module_groups].gsub('+', ' ')}"
     end
     releases = []
 

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -57,6 +57,7 @@ class Puppet::Forge
       end
     end
 
+    # responsible for properly encoding a URI
     def get_request_object(path)
       headers = {
         "User-Agent" => user_agent,

--- a/spec/unit/forge/forge_spec.rb
+++ b/spec/unit/forge/forge_spec.rb
@@ -1,0 +1,112 @@
+# encoding: utf-8
+require 'spec_helper'
+require 'net/http'
+require 'puppet/forge/repository'
+
+describe Puppet::Forge do
+  before(:all) do
+    # any local http proxy will break these tests
+    ENV['http_proxy'] = nil
+    ENV['HTTP_PROXY'] = nil
+  end
+
+  let(:host) { 'fake.com' }
+  let(:forge) { Puppet::Forge.new("http://#{host}") }
+  # creates a repository like Puppet::Forge::Repository.new('http://fake.com', USER_AGENT)
+
+  # different UTF-8 widths
+  # 1-byte A
+  # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+  # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+  # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+  let (:mixed_utf8_query_param) { "foo + A\u06FF\u16A0\u{2070E}" } # Aۿᚠ
+  let (:mixed_utf8_query_param_encoded) { "foo%20%2B%20A%DB%BF%E1%9A%A0%F0%A0%9C%8E"}
+  let (:empty_json) { '{ "results": [], "pagination" : { "next" : null } }' }
+  let (:ok_response) { stub('response', :code => '200', :body => empty_json) }
+
+  describe "making a" do
+    before :each do
+      proxy_settings_of("proxy", 1234)
+    end
+
+    context "search request" do
+
+      it "includes any defined module_groups, ensuring to only encode them once in the URI" do
+        Puppet[:module_groups] = 'base+pe'
+
+        # ignores Puppet::Forge::Repository#read_response, provides response to search
+        performs_an_http_request(ok_response) do |http|
+          encoded_uri = "/v3/modules?query=#{mixed_utf8_query_param_encoded}&module_groups=base%2Bpe"
+          http.expects(:request).with(responds_with(:path, encoded_uri))
+        end
+
+        forge.search(mixed_utf8_query_param)
+      end
+
+      it "single encodes the search term in the URI" do
+        # ignores Puppet::Forge::Repository#read_response, provides response to search
+        performs_an_http_request(ok_response) do |http|
+          encoded_uri = "/v3/modules?query=#{mixed_utf8_query_param_encoded}"
+          http.expects(:request).with(responds_with(:path, encoded_uri))
+        end
+
+        forge.search(mixed_utf8_query_param)
+      end
+    end
+
+    context "fetch request" do
+
+      it "includes any defined module_groups, ensuring to only encode them once in the URI" do
+        Puppet[:module_groups] = 'base+pe'
+        module_name = 'puppetlabs-acl'
+
+        # ignores Puppet::Forge::Repository#read_response, provides response to fetch
+        performs_an_http_request(ok_response) do |http|
+          encoded_uri = "/v3/releases?module=#{module_name}&module_groups=base%2Bpe"
+          http.expects(:request).with(responds_with(:path, encoded_uri))
+        end
+
+        forge.fetch(module_name)
+      end
+
+      it "single encodes the module name term in the URI" do
+        module_name = "puppetlabs-#{mixed_utf8_query_param}"
+
+        # ignores Puppet::Forge::Repository#read_response, provides response to fetch
+        performs_an_http_request(ok_response) do |http|
+          encoded_uri = "/v3/releases?module=puppetlabs-#{mixed_utf8_query_param_encoded}"
+          http.expects(:request).with(responds_with(:path, encoded_uri))
+        end
+
+        forge.fetch(module_name)
+      end
+    end
+
+    def performs_an_http_request(result = nil, &block)
+      proxy_args = ["proxy", 1234, nil, nil]
+      mock_proxy(80, proxy_args, result, &block)
+    end
+  end
+
+  def proxy_settings_of(host, port)
+    Puppet[:http_proxy_host] = host
+    Puppet[:http_proxy_port] = port
+  end
+
+  def mock_proxy(port, proxy_args, result, &block)
+    http = mock("http client")
+    proxy = mock("http proxy")
+    proxy_class = mock("http proxy class")
+
+    Net::HTTP.expects(:Proxy).with(*proxy_args).returns(proxy_class)
+    proxy_class.expects(:new).with(host, port).returns(proxy)
+
+    proxy.expects(:open_timeout=)
+    proxy.expects(:read_timeout=)
+
+    proxy.expects(:start).yields(http).returns(result)
+    yield http
+
+    proxy
+  end
+end

--- a/spec/unit/forge/forge_spec.rb
+++ b/spec/unit/forge/forge_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Forge do
 
         # ignores Puppet::Forge::Repository#read_response, provides response to search
         performs_an_http_request(ok_response) do |http|
-          encoded_uri = "/v3/modules?query=#{mixed_utf8_query_param_encoded}&module_groups=base%2Bpe"
+          encoded_uri = "/v3/modules?query=#{mixed_utf8_query_param_encoded}&module_groups=base%20pe"
           http.expects(:request).with(responds_with(:path, encoded_uri))
         end
 
@@ -62,7 +62,7 @@ describe Puppet::Forge do
 
         # ignores Puppet::Forge::Repository#read_response, provides response to fetch
         performs_an_http_request(ok_response) do |http|
-          encoded_uri = "/v3/releases?module=#{module_name}&module_groups=base%2Bpe"
+          encoded_uri = "/v3/releases?module=#{module_name}&module_groups=base%20pe"
           http.expects(:request).with(responds_with(:path, encoded_uri))
         end
 


### PR DESCRIPTION
 - b182a70 introduced a change to
   additionally encode URI parameters for "module_groups" when making
   a forge search or fetch request. This decision was made given other
   query terms were being escaped in the URI as it was being built.

   As it turns out this URI was being passed into the
   Puppet::Forge::Repository class get_request_object method which
   was also calling uri_encode.

   As a result of the Puppet[:module_groups] setting being typically
   set to base+pe in PE, queries were being sent to the forge that
   included &module_groups=base%252Bpe instead of the correct
   &module_groups=base%2Bpe as they were in the past.

 - The interesting thing about this change is that it uncovered a
   latent problem with how query has been handled in the past.

   Any values that required percent encoding in the past would have
   been double encoded by calling URI.encode on their values twice,
   meaning many punctuation characters would have never worked as a
   search term.

 - Add some tests to verify that the URIs are not double encoded.

Part 2

 - PE is configured to set module_groups to base+pe_only per
   puppetlabs/puppetlabs-puppet_enterprise@4597d2f

 - Unfortunately due to prior PMT behavior, this code seems to have
   believed it must encode the space in the query parameter passed to
   the forge inside an acutal configuration file, rather than
   allowing the PMT code to percent-encode its query parameters.

   Had the config value been set to "base pe_only" there likely would
   be no problem with configuration as-is, as the space would have
   been encoded to %20 in the old code AND in the new code.

   However, since 'base+pe_only' is set in existing configuration
   files and the new code correctly encodes + to %2B in a query
   parameter, rather than relying on a URI.escape bug that doesn't
   encode + AND the leniency of existing Forge query parameter
   handling on the server allowing + for space rather than requiring
   it to be properly encoded as %20, we're a bit stuck with respect
   to providing backward compatibility.

 - The solution is to treat any configuration value containing a +
   as a space for the sake of later percent-encoding. As a side effect
   this prevents the + character from ever being able to be used in
   a module_groups name, but given it's an internal setting, that
   seems acceptable here.

 - The old query to the forge looked like:

   <snip>&module_groups=base+pe_only

   while the new query looks like the more correct:

   <snip>&module_groups=base%20pe_only