### PR TITLE
(PUP-7642) Allow rich-data of unknown type in reports

### DIFF
--- a/lib/puppet/pops/serialization/from_data_converter.rb
+++ b/lib/puppet/pops/serialization/from_data_converter.rb
@@ -1,10 +1,34 @@
 module Puppet::Pops
 module Serialization
+  # Class that can process the `Data` produced by the {ToDataConverter} class and reassemble
+  # the objects that were converted.
+  #
+  # @api public
   class FromDataConverter
+    # Convert the given `Data` _value_ according to the given _options_ and return the resulting `RichData`.
+    #
+    # @param value [Data] the value to convert
+    # @param options {Symbol => <Boolean,String>} options hash
+    # @option options [Loaders::Loader] :loader the loader to use. Can be `nil` in which case the default is
+    #    determined by the {Types::TypeParser}.
+    # @option options [Boolean] :allow_unresolved `true` to allow that rich_data hashes are kept "as is" if the
+    #    designated '__pcore_type__' cannot be resolved. Defaults to `false`.
+    # @return [RichData] the processed result.
+    #
+    # @api public
     def self.convert(value, options = EMPTY_HASH)
       new(options).convert(value)
     end
 
+    # Create a new instance of the processor
+    #
+    # @param options {Symbol => Object} options hash
+    # @option options [Loaders::Loader] :loader the loader to use. Can be `nil` in which case the default is
+    #    determined by the {Types::TypeParser}.
+    # @option options [Boolean] :allow_unresolved `true` to allow that rich_data hashes are kept "as is" if the
+    #    designated '__pcore_type__' cannot be resolved. Defaults to `false`.
+    #
+    # @api public
     def initialize(options = EMPTY_HASH)
       @allow_unresolved = options[:allow_unresolved]
       @allow_unresolved = false if @allow_unresolved.nil?
@@ -65,6 +89,12 @@ module Serialization
       end
     end
 
+    # Convert the given `Data` _value_ and return the resulting `RichData`
+    #
+    # @param value [Data] the value to convert
+    # @return [RichData] the processed result
+    #
+    # @api public
     def convert(value)
       if value.is_a?(Hash)
         pcore_type = value[PCORE_TYPE_KEY]

--- a/lib/puppet/pops/serialization/from_data_converter.rb
+++ b/lib/puppet/pops/serialization/from_data_converter.rb
@@ -5,7 +5,7 @@ module Serialization
   #
   # @api public
   class FromDataConverter
-    # Convert the given `Data` _value_ according to the given _options_ and return the resulting `RichData`.
+    # Converts the given `Data` _value_ according to the given _options_ and returns the resulting `RichData`.
     #
     # @param value [Data] the value to convert
     # @param options {Symbol => <Boolean,String>} options hash
@@ -20,7 +20,7 @@ module Serialization
       new(options).convert(value)
     end
 
-    # Create a new instance of the processor
+    # Creates a new instance of the processor
     #
     # @param options {Symbol => Object} options hash
     # @option options [Loaders::Loader] :loader the loader to use. Can be `nil` in which case the default is
@@ -89,7 +89,7 @@ module Serialization
       end
     end
 
-    # Convert the given `Data` _value_ and return the resulting `RichData`
+    # Converts the given `Data` _value_ and returns the resulting `RichData`
     #
     # @param value [Data] the value to convert
     # @return [RichData] the processed result

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -22,7 +22,7 @@ module Serialization
       new(options).convert(value)
     end
 
-    # Create a new instance of the processer
+    # Create a new instance of the processor
     #
     # @param options {Symbol => Object} options hash
     # @option options [Boolean] :rich_data `true` if rich data is enabled
@@ -52,6 +52,8 @@ module Serialization
     #
     # @param value [Object] the value to convert
     # @return [Data] the processed result. An object assignable to `Data`.
+    #
+    # @api public
     def convert(value)
       @path = []
       @values = {}

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -38,7 +38,10 @@ class Puppet::Transaction::Event
   alias == eql?
 
   def initialize_from_hash(data)
-    data = Puppet::Pops::Serialization::FromDataConverter.convert(data)
+    data = Puppet::Pops::Serialization::FromDataConverter.convert(data, {
+      :allow_unresolved => true,
+      :loader => Puppet::Pops::Loaders.static_loader
+    })
     @property = data['property']
     @previous_value = data['previous_value']
     @desired_value = data['desired_value']

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -408,11 +408,21 @@ module Serialization
       })
     end
 
-    it 'fails when deserializer is unaware of the referenced type' do
-      write(type.create(32))
+    context 'fails when deserializer is unaware of the referenced type' do
+      it 'fails by default' do
+        write(type.create(32))
 
-      # Should fail since no loader knows about 'MyType'
-      expect{ read }.to raise_error(Puppet::Error, 'No implementation mapping found for Puppet Type MyType')
+        # Should fail since no loader knows about 'MyType'
+        expect{ read }.to raise_error(Puppet::Error, 'No implementation mapping found for Puppet Type MyType')
+      end
+
+      context "succeds but produces an rich_type hash when deserializer has 'allow_unresolved' set to true" do
+        let(:from_converter) { FromDataConverter.new(:allow_unresolved => true) }
+        it do
+          write(type.create(32))
+          expect(read).to eql({'__pcore_type__'=>'MyType', 'x'=>32})
+        end
+      end
     end
 
     it 'succeeds when deserializer is aware of the referenced type' do


### PR DESCRIPTION
Before this commit, an attempt to send a report containing custom rich
data types (Objects) to a server would result in an "No implementation
mapping found for Puppet Type xxx" error. Since there's really no reason
why such types should be internalized in a report, this is now changed
so that it instead keeps the original rich-data hash.