### PR TITLE
(PUP-6675) Use pipes instead of temporary files for Puppet exec

### DIFF
--- a/acceptance/tests/resource/exec/should_accept_large_output.rb
+++ b/acceptance/tests/resource/exec/should_accept_large_output.rb
@@ -1,0 +1,26 @@
+test_name "tests that puppet correctly captures large and empty output."
+
+agents.each do |agent|
+  testfile = agent.tmpfile('should_accept_large_output')
+
+  # Generate >64KB file to exceed pipe buffer.
+  lorem_ipsum = <<EOF
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+EOF
+  create_remote_file(agent, testfile, lorem_ipsum*1024)
+
+  apply_manifest_on(agent, "exec {'cat #{testfile}': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin', 'C:/cygwin/bin'], logoutput => true}") do
+    fail_test "didn't seem to run the command" unless
+      stdout.include? 'executed successfully'
+    fail_test "didn't print output correctly" unless
+      stdout.lines.select {|line| line =~ /\/returns:/}.count == 4097
+  end
+
+  apply_manifest_on(agent, "exec {'echo': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin', 'C:/cygwin/bin'], logoutput => true}") do
+    fail_test "didn't seem to run the command" unless
+      stdout.include? 'executed successfully'
+  end
+end

--- a/acceptance/tests/resource/exec/should_run_bad_command.rb
+++ b/acceptance/tests/resource/exec/should_run_bad_command.rb
@@ -1,0 +1,67 @@
+test_name "tests that puppet can run badly written scripts that fork and inherit descriptors"
+
+def sleepy_daemon_script(agent)
+  if agent['platform'] =~ /win/
+    # Windows uses a shorter sleep, because it's expected to wait until the end.
+    return <<INITSCRIPT
+echo hello
+start /b ping.exe 127.0.0.1 -n 1
+INITSCRIPT
+  else
+    return <<INITSCRIPT
+echo hello
+/bin/sleep 60 &
+INITSCRIPT
+  end
+end
+
+# TODO: taken from pxp-agent, find common home
+def stop_sleep_process(targets, accept_no_pid_found = false)
+  targets = [targets].flatten
+
+  targets.each do |target|
+    case target['platform']
+    when /osx/
+      command = "ps -e -o pid,comm | grep sleep | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+    when /win/
+      command = "ps -efW | grep PING | sed 's/^[^0-9]*[0-9]*[^0-9]*//g' | cut -d ' ' -f1"
+    else
+      command = "ps -ef | grep 'bin/sleep ' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
+    end
+
+    # A failed test may leave an orphaned sleep process, handle multiple matches.
+    pids = nil
+    on(target, command) do |output|
+      pids = output.stdout.chomp.split
+      if pids.empty? && !accept_no_pid_found
+        raise("Did not find a pid for a sleep process on #{target}")
+      end
+    end
+
+    pids.each do |pid|
+      target['platform'] =~ /win/ ?
+        on(target, "taskkill /F /pid #{pid}") :
+        on(target, "kill -s TERM #{pid}")
+    end
+  end
+end
+
+teardown do
+  # On Windows, Puppet waits until the sleep process exits before exiting
+  stop_sleep_process(agents.select {|agent| agent['platform'] =~ /win/}, true)
+  # Requiring a sleep process asserts that Puppet exited before the sleep process.
+  stop_sleep_process(agents.reject {|agent| agent['platform'] =~ /win/})
+end
+
+agents.each do |agent|
+  ext = if agent['platform'] =~ /win/ then '.bat' else '' end
+  daemon = agent.tmpfile('sleepy_daemon') + ext
+  create_remote_file(agent, daemon, sleepy_daemon_script(agent))
+  on(agent, "chmod +x #{daemon}")
+
+  apply_manifest_on(agent, "exec {'#{daemon}': logoutput => true}") do
+    fail_test "didn't seem to run the command" unless
+      stdout.include? 'executed successfully'
+  end
+end
+

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -188,18 +188,69 @@ module Puppet::Util::Execution
 
     begin
       stdin = Puppet::FileSystem.open(options[:stdinfile] || null_file, nil, 'r')
-      stdout = options[:squelch] ? Puppet::FileSystem.open(null_file, nil, 'w') : Puppet::FileSystem::Uniquefile.new('puppet')
+      # On Windows, continue to use the file-based approach to avoid breaking people's existing
+      # manifests. If they use a script that doesn't background cleanly, such as
+      # `start /b ping 127.0.0.1`, we couldn't handle it with pipes as there's no non-blocking
+      # read available.
+      if options[:squelch]
+        stdout = Puppet::FileSystem.open(null_file, nil, 'w')
+      elsif Puppet.features.posix?
+        reader, stdout = IO.pipe
+      else
+        stdout = Puppet::FileSystem::Uniquefile.new('puppet')
+      end
       stderr = options[:combine] ? stdout : Puppet::FileSystem.open(null_file, nil, 'w')
 
       exec_args = [command, options, stdin, stdout, stderr]
+      output = ''
 
+      # We close stdin/stdout/stderr immediately after fork/exec as they're no longer needed by
+      # this process. In most cases they could be closed later, but when `stdout` is the "writer"
+      # pipe we must close it or we'll never reach eof on the `reader` pipe.
       if execution_stub = Puppet::Util::ExecutionStub.current_value
-        return execution_stub.call(*exec_args)
+        child_pid = execution_stub.call(*exec_args)
+        [stdin, stdout, stderr].each {|io| io.close rescue nil}
+        return child_pid
       elsif Puppet.features.posix?
         child_pid = nil
         begin
           child_pid = execute_posix(*exec_args)
-          exit_status = Process.waitpid2(child_pid).last.exitstatus
+          [stdin, stdout, stderr].each {|io| io.close rescue nil}
+          if options[:squelch]
+            exit_status = Process.waitpid2(child_pid).last.exitstatus
+          else
+            # Use non-blocking read to check for data. After each attempt,
+            # check whether the child is done. This is done in case the child
+            # forks and inherits stdout, as happens in `foo &`.
+            until results = Process.waitpid2(child_pid, Process::WNOHANG)
+
+              # If not done, wait for data to read with a timeout
+              # This timeout is selected to keep activity low while waiting on
+              # a long process, while not waiting too long for the pathological
+              # case where stdout is never closed.
+              ready = IO.select([reader], [], [], 0.1)
+              begin
+                output << reader.read_nonblock(4096) if ready
+              rescue Errno::EAGAIN
+              rescue EOFError
+              end
+            end
+
+            # Read any remaining data. Allow for but don't expect EOF.
+            begin
+              loop do
+                output << reader.read_nonblock(4096)
+              end
+            rescue Errno::EAGAIN
+            rescue EOFError
+            end
+
+            # Force to external encoding to preserve prior behavior when reading a file.
+            # Wait until after reading all data so we don't encounter corruption when
+            # reading part of a multi-byte unicode character if default_external is UTF-8.
+            output.force_encoding(Encoding.default_external)
+            exit_status = results.last.exitstatus
+          end
           child_pid = nil
         rescue Timeout::Error => e
           # NOTE: For Ruby 2.1+, an explicit Timeout::Error class has to be
@@ -216,28 +267,30 @@ module Puppet::Util::Execution
       elsif Puppet.features.microsoft_windows?
         process_info = execute_windows(*exec_args)
         begin
+          [stdin, stderr].each {|io| io.close rescue nil}
           exit_status = Puppet::Util::Windows::Process.wait_process(process_info.process_handle)
+
+          # read output in if required
+          unless options[:squelch]
+            output = wait_for_output(stdout)
+            Puppet.warning _("Could not get output") unless output
+          end
         ensure
           FFI::WIN32.CloseHandle(process_info.process_handle)
           FFI::WIN32.CloseHandle(process_info.thread_handle)
         end
       end
 
-      [stdin, stdout, stderr].each {|io| io.close rescue nil}
-
-      # read output in if required
-      unless options[:squelch]
-        output = wait_for_output(stdout)
-        Puppet.warning _("Could not get output") unless output
-      end
-
       if options[:failonfail] and exit_status != 0
         raise Puppet::ExecutionFailure, _("Execution of '%{str}' returned %{exit_status}: %{output}") % { str: command_str, exit_status: exit_status, output: output.strip }
       end
     ensure
-      if !options[:squelch] && stdout
-        # if we opened a temp file for stdout, we need to clean it up.
-        stdout.close!
+      # Make sure all handles are closed in case an exception was thrown attempting to execute.
+      [stdin, stdout, stderr].each {|io| io.close rescue nil}
+      if !options[:squelch]
+        # if we opened a pipe, we need to clean it up.
+        reader.close if reader
+        stdout.close! if Puppet.features.microsoft_windows?
       end
     end
 

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -1,6 +1,8 @@
 #! /usr/bin/env ruby
+# encoding: UTF-8
 require 'spec_helper'
 require 'puppet/file_system/uniquefile'
+require 'puppet_spec/character_encoding'
 
 describe Puppet::Util::Execution do
   include Puppet::Util::Execution
@@ -25,9 +27,11 @@ describe Puppet::Util::Execution do
         FFI::WIN32.stubs(:CloseHandle).with(process_handle)
         FFI::WIN32.stubs(:CloseHandle).with(thread_handle)
       else
+        Process.stubs(:waitpid2).with(pid, Process::WNOHANG).returns(nil, [pid, stub('child_status', :exitstatus => exitstatus)])
         Process.stubs(:waitpid2).with(pid).returns([pid, stub('child_status', :exitstatus => exitstatus)])
       end
     end
+
 
     describe "#execute_posix (stubs)", :unless => Puppet.features.microsoft_windows? do
       before :each do
@@ -215,82 +219,136 @@ describe Puppet::Util::Execution do
           end
         end
 
-        describe "when squelch is not set" do
-          it "should set stdout to a temporary output file" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+        describe "on POSIX", :if => Puppet.features.posix? do
+          describe "when squelch is not set" do
+            it "should set stdout to a pipe" do
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,_|
+                stdout.class == IO
+              end.returns(rval)
 
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,_|
-              stdout.path == outfile.path
-            end.returns(rval)
+              Puppet::Util::Execution.execute('test command', :squelch => false)
+            end
 
-            Puppet::Util::Execution.execute('test command', :squelch => false)
+            it "should set stderr to the same file as stdout if combine is true" do
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout == stderr
+              end.returns(rval)
+
+              Puppet::Util::Execution.execute('test command', :squelch => false, :combine => true)
+            end
+
+            it "should set stderr to the null device if combine is false" do
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.class == IO and stderr.path == null_file
+              end.returns(rval)
+
+              Puppet::Util::Execution.execute('test command', :squelch => false, :combine => false)
+            end
+
+            it "should default combine to true when no options are specified" do
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout == stderr
+              end.returns(rval)
+
+              Puppet::Util::Execution.execute('test command')
+            end
+
+            it "should default combine to false when options are specified, but combine is not" do
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.class == IO and stderr.path == null_file
+              end.returns(rval)
+
+              Puppet::Util::Execution.execute('test command', :failonfail => false)
+            end
+
+            it "should default combine to false when an empty hash of options is specified" do
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.class == IO and stderr.path == null_file
+              end.returns(rval)
+
+              Puppet::Util::Execution.execute('test command', {})
+            end
           end
+        end
 
-          it "should set stderr to the same file as stdout if combine is true" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+        describe "on Windows", :if => Puppet.features.microsoft_windows? do
+          describe "when squelch is not set" do
+            it "should set stdout to a temporary output file" do
+              outfile = Puppet::FileSystem::Uniquefile.new('stdout')
+              Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
 
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == outfile.path
-            end.returns(rval)
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,_|
+                stdout.path == outfile.path
+              end.returns(rval)
 
-            Puppet::Util::Execution.execute('test command', :squelch => false, :combine => true)
-          end
+              Puppet::Util::Execution.execute('test command', :squelch => false)
+            end
 
-          it "should set stderr to the null device if combine is false" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+            it "should set stderr to the same file as stdout if combine is true" do
+              outfile = Puppet::FileSystem::Uniquefile.new('stdout')
+              Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
 
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == null_file
-            end.returns(rval)
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.path == outfile.path and stderr.path == outfile.path
+              end.returns(rval)
 
-            Puppet::Util::Execution.execute('test command', :squelch => false, :combine => false)
-          end
+              Puppet::Util::Execution.execute('test command', :squelch => false, :combine => true)
+            end
 
-          it "should combine stdout and stderr if combine is true" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+            it "should set stderr to the null device if combine is false" do
+              outfile = Puppet::FileSystem::Uniquefile.new('stdout')
+              Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
 
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == outfile.path
-            end.returns(rval)
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.path == outfile.path and stderr.path == null_file
+              end.returns(rval)
 
-            Puppet::Util::Execution.execute('test command', :combine => true)
-          end
+              Puppet::Util::Execution.execute('test command', :squelch => false, :combine => false)
+            end
 
-          it "should default combine to true when no options are specified" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+            it "should combine stdout and stderr if combine is true" do
+              outfile = Puppet::FileSystem::Uniquefile.new('stdout')
+              Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
 
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == outfile.path
-            end.returns(rval)
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.path == outfile.path and stderr.path == outfile.path
+              end.returns(rval)
 
-            Puppet::Util::Execution.execute('test command')
-          end
+              Puppet::Util::Execution.execute('test command', :combine => true)
+            end
 
-          it "should default combine to false when options are specified, but combine is not" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+            it "should default combine to true when no options are specified" do
+              outfile = Puppet::FileSystem::Uniquefile.new('stdout')
+              Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
 
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == null_file
-            end.returns(rval)
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.path == outfile.path and stderr.path == outfile.path
+              end.returns(rval)
 
-            Puppet::Util::Execution.execute('test command', :failonfail => false)
-          end
+              Puppet::Util::Execution.execute('test command')
+            end
 
-          it "should default combine to false when an empty hash of options is specified" do
-            outfile = Puppet::FileSystem::Uniquefile.new('stdout')
-            Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+            it "should default combine to false when options are specified, but combine is not" do
+              outfile = Puppet::FileSystem::Uniquefile.new('stdout')
+              Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
 
-            Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
-              stdout.path == outfile.path and stderr.path == null_file
-            end.returns(rval)
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.path == outfile.path and stderr.path == null_file
+              end.returns(rval)
 
-            Puppet::Util::Execution.execute('test command', {})
+              Puppet::Util::Execution.execute('test command', :failonfail => false)
+            end
+
+            it "should default combine to false when an empty hash of options is specified" do
+              outfile = Puppet::FileSystem::Uniquefile.new('stdout')
+              Puppet::FileSystem::Uniquefile.stubs(:new).returns(outfile)
+
+              Puppet::Util::Execution.expects(executor).with do |_,_,_,stdout,stderr|
+                stdout.path == outfile.path and stderr.path == null_file
+              end.returns(rval)
+
+              Puppet::Util::Execution.execute('test command', {})
+            end
           end
         end
       end
@@ -536,9 +594,10 @@ describe Puppet::Util::Execution do
       end
 
       it "should close the stdin/stdout/stderr files used by the child" do
-        stdin = mock 'file', :close
-        stdout = mock 'file', :close
-        stderr = mock 'file', :close
+        stdin = mock 'file'
+        stdout = mock 'file'
+        stderr = mock 'file'
+        [stdin, stdout, stderr].each {|io| io.expects(:close).at_least_once}
 
         File.expects(:open).
             times(3).
@@ -549,38 +608,113 @@ describe Puppet::Util::Execution do
         Puppet::Util::Execution.execute('test command', {:squelch => true, :combine => false})
       end
 
-      it "should read and return the output if squelch is false" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
-        stdout.write("My expected command output")
+      describe "on POSIX", :if => Puppet.features.posix? do
+        context "reading the output" do
+          before :each do
+            r, w = IO.pipe
+            IO.expects(:pipe).returns([r, w])
+            w.write("My expected \u2744 command output")
+          end
 
-        expect(Puppet::Util::Execution.execute('test command')).to eq("My expected command output")
+          it "should return output with external encoding ISO_8859_1" do
+            result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::ISO_8859_1) do
+              Puppet::Util::Execution.execute('test command')
+            end
+            expect(result.encoding).to eq(Encoding::ISO_8859_1)
+            expect(result).to eq("My expected \u2744 command output".force_encoding(Encoding::ISO_8859_1))
+          end
+
+          it "should return output with external encoding UTF_8" do
+            result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::UTF_8) do
+              Puppet::Util::Execution.execute('test command')
+            end
+            expect(result.encoding).to eq(Encoding::UTF_8)
+            expect(result).to eq("My expected \u2744 command output")
+          end
+        end
+
+        it "should not read the output if squelch is true" do
+          IO.expects(:pipe).never
+
+          expect(Puppet::Util::Execution.execute('test command', :squelch => true)).to eq('')
+        end
+
+        it "should close the pipe used for output if squelch is false" do
+          r, w = IO.pipe
+          IO.expects(:pipe).returns([r, w])
+
+          expect(Puppet::Util::Execution.execute('test command')).to eq("")
+          expect(r.closed?)
+          expect(w.closed?)
+        end
+
+        it "should close the pipe used for output if squelch is false and an error is raised" do
+          r, w = IO.pipe
+          IO.expects(:pipe).returns([r, w])
+
+          if Puppet.features.microsoft_windows?
+            Puppet::Util::Execution.expects(:execute_windows).raises(Exception, 'execution failed')
+          else
+            Puppet::Util::Execution.expects(:execute_posix).raises(Exception, 'execution failed')
+          end
+
+          expect {
+            subject.execute('fail command')
+          }.to raise_error(Exception, 'execution failed')
+          expect(r.closed?)
+          expect(w.closed?)
+        end
       end
+      describe "on Windows", :if => Puppet.features.microsoft_windows? do
+        context "reading the output" do
+          before :each do
+            stdout = Puppet::FileSystem::Uniquefile.new('test')
+            Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
+            stdout.write("My expected \u2744 command output")
+          end
 
-      it "should not read the output if squelch is true" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
-        stdout.write("My expected command output")
+          it "should return output with external encoding ISO_8859_1" do
+            result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::ISO_8859_1) do
+              Puppet::Util::Execution.execute('test command')
+            end
+            expect(result.encoding).to eq(Encoding::ISO_8859_1)
+            expect(result).to eq("My expected \u2744 command output".force_encoding(Encoding::ISO_8859_1))
+          end
 
-        expect(Puppet::Util::Execution.execute('test command', :squelch => true)).to eq('')
-      end
+          it "should return output with external encoding UTF_8" do
+            result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::UTF_8) do
+              Puppet::Util::Execution.execute('test command')
+            end
+            expect(result.encoding).to eq(Encoding::UTF_8)
+            expect(result).to eq("My expected \u2744 command output")
+          end
+        end
 
-      it "should delete the file used for output if squelch is false" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        path = stdout.path
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
+        it "should not read the output if squelch is true" do
+          stdout = Puppet::FileSystem::Uniquefile.new('test')
+          Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
+          stdout.write("My expected command output")
 
-        Puppet::Util::Execution.execute('test command')
+          expect(Puppet::Util::Execution.execute('test command', :squelch => true)).to eq('')
+        end
 
-        expect(Puppet::FileSystem.exist?(path)).to be_falsey
-      end
+        it "should delete the file used for output if squelch is false" do
+          stdout = Puppet::FileSystem::Uniquefile.new('test')
+          path = stdout.path
+          Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
 
-      it "should not raise an error if the file is open" do
-        stdout = Puppet::FileSystem::Uniquefile.new('test')
-        Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
-        file = File.new(stdout.path, 'r')
+          Puppet::Util::Execution.execute('test command')
 
-        Puppet::Util::Execution.execute('test command')
+          expect(Puppet::FileSystem.exist?(path)).to be_falsey
+        end
+
+        it "should not raise an error if the file is open" do
+          stdout = Puppet::FileSystem::Uniquefile.new('test')
+          Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
+          file = File.new(stdout.path, 'r')
+
+          Puppet::Util::Execution.execute('test command')
+        end
       end
 
       it "should raise an error if failonfail is true and the child failed" do
@@ -710,7 +844,7 @@ describe Puppet::Util::Execution do
       Puppet::Util::Execution.stubs(:execute).raises(Puppet::ExecutionFailure, "failed to execute")
       expect {
         Puppet::Util::Execution.execfail('echo hello', nil)
-      }.to raise_error(TypeError), /exception class\/object expected/
+      }.to raise_error(TypeError, /exception class\/object expected/)
     end
   end
 end


### PR DESCRIPTION
Under selinux, when Puppet is invoked by another process with
reduced privileges, any sub-programs invoked by Puppet will not
inherit Puppet's selinux priveleges. This specifically causes silent
failures when invoking applications that don't normally have the
ability to write files - such as iptables-save or hostname -
because Puppet redirects their output to a temporary file.

Use pipes instead of a temporary file to capture the output of
subprocesses on POSIX systems. Poorly behaved scripts need special
handling, as a plain foo & will inherit stdout and not close it.
Read from the pipe without requiring EOF.

On Windows, we retain the old file-based IO to avoid breaking poorly
written scripts - start /b ping 127.0.0.1 captures stdout - and to
retain the current behavior when Puppet is terminated - a new Puppet run
can start even if a subprocess was left running by the prior process.

When reading from the pipe in blocks, we allow binary format. This is
primarily to avoid issues if we read only some bytes of a multi-byte
UTF-8 character. At the end, we assign the default external encoding and
convert to UTF-8, our standardized internal encoding.