### PR TITLE
(PUP-7648) Fix ci:test:git pre-suite on OSX 10.11

### DIFF
--- a/acceptance/setup/git/pre-suite/000_EnvSetup.rb
+++ b/acceptance/setup/git/pre-suite/000_EnvSetup.rb
@@ -48,6 +48,14 @@ hosts.each do |host|
 
   host['puppetbindir'] = '/usr/bin' if platform == 'windows'
 
+  if host['platform'] =~ /osx/
+    # because of OSX SIP, /usr/bin is not writable and /usr/local/bin is preferred
+    host['puppetbindir'] = '/usr/local/bin'
+    # inject /usr/local/bin into ~/.ssh/environment until BKR-1139 is released
+    # this helps to resolve bundle, puppet and other Ruby binstubs // no restart necessary
+    on host, 'sed -i \'\' "s/^PATH=PATH:/PATH=PATH:\/usr\/local\/bin:/" ~/.ssh/environment'
+  end
+
   # Beakers add_aio_defaults_on helper is not appropriate here as it
   # also alters puppetbindir / privatebindir to use package installed
   # paths rather than git installed paths


### PR DESCRIPTION
- A number of problems prevented ci:test:git from executing properly
   on OSX 10.11:

   * When performing a `gem install bundler`, system Ruby places the
     binstub in /usr/local/bin. However, the SSH environment is not
     configured with /usr/local/bin in PATH. There are multiple
     solutions to this problem:

      - Add /usr/local/bin to ~/.ssh/environment in Beaker - covered
        in BKR-1139. This allows any additional binaries that might
        be installed (homebrew, git, other Ruby gems with binstubs
        such as puppet and facter) to be available. This is the most
        effective universal solution but requires a Beaker release.

        A workaround is in place to do this in 000_EnvSetup of the
        pre-suite until Beaker changes land.

      - Add to the host[:host_env] hash of environment variables via
        a Beaker options file, so that PATH is augmented with
        /usr/local/bin. Unfortunately this requires setting additional
        hosts / options files on disk prior to any code running in
        the Puppet pre-suite, to be picked up during Beakers host
        initialization and injected into ~/.ssh/environment correctly.
        Otherwise, the PATH would have to be manipulated in each new
        SSH command. Due to beaker-hostgenerator commonly being used
        to execute, its simpler to avoid this option.

        Note that beaker-hostgenerator should also allow arbitrary
        settings injection using {} syntax, but this doesn't appear to
        work properly with ci:test:git and it's uncertain if it
        properly handles the :host_env hash when writing to YAML.

   * When performing `bundle install`, ensure Ruby is configured to
     use OSX platform specific gems where possible. This impacts
     the inclusion of CFPropertyList.

   * Due to OSX SIP (System Integrity Protection) /usr/bin is not
     writable and /usr/local/bin should be used instead. Override
     Beakers default puppetbindir setting to /usr/local/bin and use
     that as the --binstub directory when installing the Puppet source
     with Bundler. binstubs should continue to use /usr/bin/ruby as
     the interpreter.

   * Similarly, when calling install.rb, provide --bindir as the same
     /usr/local/bin as the system Ruby binstub dir is not otherwise
     writable. Beaker helpers will fully qualify the path to puppet
     using the puppetbindir setting already.