### PR TITLE
(PUP-7597) Add Hiera5 default yaml files

### DIFF
--- a/conf/hiera.yaml
+++ b/conf/hiera.yaml
@@ -1,0 +1,11 @@
+---
+# Hiera 5 Global configuration file
+
+version: 5
+
+# defaults:
+#   data_hash: yaml_data
+# hierarchy:
+#  - name: Common
+#    data_hash: yaml_data
+hierarchy: []

--- a/ext/hiera/hiera.yaml
+++ b/ext/hiera/hiera.yaml
@@ -1,0 +1,15 @@
+---
+version: 5
+defaults:
+  # The default value for "datadir" is "data" under the same directory as the hiera.yaml
+  # file (this file)
+  # When specifying a datadir, make sure the directory exists.
+  # See https://docs.puppet.com/puppet/4.10/environments.html for further details on environments.
+  # datadir: data
+  # data_hash: yaml_data
+hierarchy:
+  - name: "Per-node data (yaml version)"
+    path: "nodes/%{::trusted.certname}.yaml"
+  - name: "Other YAML hierarchy levels"
+    paths:
+      - "common.yaml"

--- a/install.rb
+++ b/install.rb
@@ -493,7 +493,7 @@ end
 # Change directory into the puppet root so we don't get the wrong files for install.
 FileUtils.cd File.dirname(__FILE__) do
   # Set these values to what you want installed.
-  configs = glob(%w{conf/auth.conf conf/puppet.conf})
+  configs = glob(%w{conf/auth.conf conf/puppet.conf conf/hiera.yaml})
   bins  = glob(%w{bin/*})
   rdoc  = glob(%w{bin/* lib/**/*.rb README* }).reject { |e| e=~ /\.(bat|cmd)$/ }
   ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }


### PR DESCRIPTION
This is installed by PA instead of the previous hiera3 format file.
There are 2 files to be installed:
1. Empty (commented) global file in configuration directory
2. Production configuration file in production environment directory

This is #5927 targetted to master