### PR TITLE
(PUP-7650) Ensure that Loader::TypedName always uses lower-case

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -171,7 +171,7 @@ class StaticLoader < Loader
   end
 
   def create_resource_type_reference(name)
-    typed_name = TypedName.new(:type, name.downcase)
+    typed_name = TypedName.new(:type, name)
     type = Puppet::Pops::Types::TypeFactory.resource(name)
     @loaded[ typed_name ] = NamedEntry.new(typed_name, type, __FILE__)
   end

--- a/lib/puppet/pops/loader/type_definition_instantiator.rb
+++ b/lib/puppet/pops/loader/type_definition_instantiator.rb
@@ -46,7 +46,7 @@ class TypeDefinitionInstantiator
   end
 
   def self.create_from_model(type_definition, loader)
-    typed_name = TypedName.new(:type, type_definition.name.downcase)
+    typed_name = TypedName.new(:type, type_definition.name)
     type = create_runtime_type(type_definition)
     loader.set_entry(
       typed_name,

--- a/lib/puppet/pops/loader/typed_name.rb
+++ b/lib/puppet/pops/loader/typed_name.rb
@@ -12,6 +12,7 @@ class TypedName
   attr_reader :compound_name
 
   def initialize(type, name, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+    name = name.downcase
     @type = type
     @name_authority = name_authority
     # relativize the name (get rid of leading ::), and make the split string available

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -94,7 +94,7 @@ class Loaders
     loader = @private_environment_loader
     types = obj_classes.map do |obj_class|
       type = obj_class._ptype
-      typed_name = Loader::TypedName.new(:type, type.name.downcase, name_authority)
+      typed_name = Loader::TypedName.new(:type, type.name, name_authority)
       entry = loader.loaded_entry(typed_name)
       loader.set_entry(typed_name, type, obj_class._plocation) if entry.nil? || entry.value.nil?
       type
@@ -119,7 +119,7 @@ class Loaders
 
     name = name.to_s
     caps_name = Types::TypeFormatter.singleton.capitalize_segments(name)
-    typed_name = Loader::TypedName.new(:type, name.downcase)
+    typed_name = Loader::TypedName.new(:type, name)
     rt3_loader.set_entry(typed_name, Types::PResourceType.new(caps_name), origin)
     nil
   end

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -77,7 +77,7 @@ module Pcore
   end
 
   def self.add_type(type, loader, name_authority = RUNTIME_NAME_AUTHORITY)
-    loader.set_entry(Loader::TypedName.new(:type, type.name.downcase, name_authority), type)
+    loader.set_entry(Loader::TypedName.new(:type, type.name, name_authority), type)
     type
   end
 
@@ -90,7 +90,7 @@ module Pcore
       add_type(Types::PTypeAliasType.new(name, Types::TypeFactory.type_reference(type_string), nil), loader, name_authority)
     end
     parser = Types::TypeParser.singleton
-    aliases.each_key.map { |name| loader.load(:type, name.downcase).resolve(parser, loader) }
+    aliases.each_key.map { |name| loader.load(:type, name).resolve(parser, loader) }
   end
 end
 end

--- a/lib/puppet/pops/serialization/deserializer.rb
+++ b/lib/puppet/pops/serialization/deserializer.rb
@@ -47,10 +47,13 @@ module Serialization
         result = type.read(val.attribute_count, self)
         if result.is_a?(Types::PObjectType)
           existing_type = loader.load(:type, result.name)
-
-          # Add result to the loader unless it is the exact same instance as the existing_type. The add
-          # will succeed when the existing_type is nil.
-          loader.add_entry(:type, result.name, result, nil) unless result.equal?(existing_type)
+          if result.eql?(existing_type)
+            result = existing_type
+          else
+            # Add result to the loader unless it is equal to the existing_type. The add
+            # will only succeed when the existing_type is nil.
+            loader.add_entry(:type, result.name, result, nil)
+          end
         end
         result
       when Extension::ObjectStart

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -279,7 +279,7 @@ class PTypeSetType < PMetaType
     if types.is_a?(Hash)
       types.each do |type_name, value|
         full_name = "#{@name}::#{type_name}".freeze
-        typed_name = Loader::TypedName.new(:type, full_name.downcase, name_auth)
+        typed_name = Loader::TypedName.new(:type, full_name, name_auth)
         type = Loader::TypeDefinitionInstantiator.create_type(full_name, value, name_auth)
         loader.set_entry(typed_name, type, Adapters::SourcePosAdapter.adapt(value).to_uri)
         types[type_name] = type
@@ -300,7 +300,7 @@ class PTypeSetType < PMetaType
     if types.is_a?(Hash)
       types.each do |type_name, value|
         full_name = "#{@name}::#{type_name}".freeze
-        typed_name = Loader::TypedName.new(:type, full_name.downcase, name_auth)
+        typed_name = Loader::TypedName.new(:type, full_name, name_auth)
         meta_name = value.is_a?(Hash) ? 'Object' : 'TypeAlias'
         type = Loader::TypeDefinitionInstantiator.create_named_type(full_name, meta_name, value, name_auth)
         loader.set_entry(typed_name, type)

--- a/lib/puppet/pops/types/type_set_reference.rb
+++ b/lib/puppet/pops/types/type_set_reference.rb
@@ -37,7 +37,7 @@ class TypeSetReference
   end
 
   def resolve(type_parser, loader)
-    typed_name = Loader::TypedName.new(:type, @name.downcase, @name_authority)
+    typed_name = Loader::TypedName.new(:type, @name, @name_authority)
     loaded_entry = loader.load_typed(typed_name)
     type_set = loaded_entry.nil? ? nil : loaded_entry.value
 

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -22,6 +22,16 @@ describe 'loader helper classes' do
     expect(tn.name).to eq('foo::bar')
     expect(tn.qualified?).to be_truthy
   end
+
+  it 'TypedName converts name to lower case' do
+    tn = Puppet::Pops::Loader::TypedName.new(:type, '::Foo::Bar')
+    expect(tn.name_parts).to eq(['foo', 'bar'])
+    expect(tn.name).to eq('foo::bar')
+  end
+
+  it 'TypedName is case insensitive' do
+    expect(Puppet::Pops::Loader::TypedName.new(:type, '::Foo::Bar')).to eq(Puppet::Pops::Loader::TypedName.new(:type, '::foo::bar'))
+  end
 end
 
 describe 'loaders' do

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -20,7 +20,7 @@ describe 'The Object Type' do
 
   def type_object_t(name, body_string)
     object = PObjectType.new(name, pp_parser.parse_string("{#{body_string}}").current.body)
-    loader.set_entry(Loader::TypedName.new(:type, name.downcase), object)
+    loader.set_entry(Loader::TypedName.new(:type, name), object)
     object
   end
 

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -16,7 +16,7 @@ module Puppet::Pops
       def type_set_t(name, body_string, name_authority)
         i12n_literal_hash = pp_parser.parse_string("{#{body_string}}").current.body
         typeset = PTypeSetType.new(name, i12n_literal_hash, name_authority)
-        loader.set_entry(Loader::TypedName.new(:type, name.downcase, name_authority), typeset)
+        loader.set_entry(Loader::TypedName.new(:type, name, name_authority), typeset)
         typeset
       end
 


### PR DESCRIPTION
Before this commit, if an instance of `Puppet::Pops::Loader::TypedName`
was created from a name that contained upper case letters, those letters
would be preserved. This meant that the responsibility for downcasing
the name was on the caller.

This commit removes the `downcase` from all calls to the `TypedName`
constructor and instead adds a `downcase` inside the `#initialize`
method.