### PR TITLE
(PUP-7652) Allow quotes in report yaml uuid value for catalog_uuid test

### DIFF
--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -16,7 +16,7 @@ test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
   def get_catalog_uuid_from_report(master_reportdir, agent_node_name)
     report_catalog_uuid = nil
     on(master, "cat #{master_reportdir}/#{agent_node_name}/*") do
-      report_catalog_uuid = stdout.match(/catalog_uuid: ([a-z0-9\-]*)/)[1]
+      report_catalog_uuid = stdout.match(/catalog_uuid: '?([a-z0-9\-]*)'?/)[1]
     end
     report_catalog_uuid
   end


### PR DESCRIPTION
Previously, the catalog_uuid_correlates_catalogs_with_reports.rb test
expected the value that it finds for the catalog_uuid in a report yaml
file for an agent run would not be surrounded with single quotes.
Starting with Ruby 2.3.2, however, some uuid values may be surrounded
with single quotes.  Quoting around the value is legal for the yaml
generator to do in either case.  This commit changes the test to
optionally allow for quotes around the value so that it will pass
reliably across Ruby versions.