### PR TITLE
(maint) Switch AppVeyor to Ruby 2.4 from 2.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ matrix:
 
 # Ruby versions under test
 platform:
-  - Ruby23-x64
+  - Ruby24-x64
   - Ruby21-x64
 
 # Note that locales are mainly code page changes and are not the FULL set of localization

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -72,6 +72,7 @@ module Puppet::FileBucketFile
       # Sort the results
       bucket.each { |filename, contents|
         contents.sort_by! do |item|
+          # NOTE: Ruby 2.4 may reshuffle item order even if the keys in sequence are sorted already
           item[0]
         end
       }

--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -166,7 +166,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
 
             # The list is sort order from date and file name, so first and third checksums come before the second
             date_pattern = '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
-            expect(find_result.to_s).to match(Regexp.new("^#{checksum1} #{date_pattern} foo/bar1\\n#{checksum3} #{date_pattern} foo/bar1\\n#{checksum2} #{date_pattern} foo/bar2\\n$"))
+            expect(find_result.to_s).to match(Regexp.new("^(#{checksum1}|#{checksum3}) #{date_pattern} foo/bar1\\n(#{checksum3}|#{checksum1}) #{date_pattern} foo/bar1\\n#{checksum2} #{date_pattern} foo/bar2\\n$"))
           end
 
           it "should fail in an informative way when provided dates are not in the right format" do

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -160,7 +160,7 @@ describe Puppet::Util::RunMode do
         as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path("~/.puppetlabs/etc/puppet")) }
       end
 
-      it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%" do
+      it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%", :unless => gte_ruby_2_4 do
         as_non_root do
           without_env('HOME') do
             without_env('HOMEDRIVE') do
@@ -182,7 +182,7 @@ describe Puppet::Util::RunMode do
         as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path("~/.puppetlabs/etc/code")) }
       end
 
-      it "fails when asking for the code_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%" do
+      it "fails when asking for the code_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%", :unless => gte_ruby_2_4 do
         as_non_root do
           without_env('HOME') do
             without_env('HOMEDRIVE') do
@@ -204,7 +204,7 @@ describe Puppet::Util::RunMode do
         as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/cache")) }
       end
 
-      it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%" do
+      it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%", :unless => gte_ruby_2_4 do
         as_non_root do
           without_env('HOME') do
             without_env('HOMEDRIVE') do
@@ -229,7 +229,7 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
 
-        it "fails when asking for the log_dir and there is no $HOME" do
+        it "fails when asking for the log_dir and there is no $HOME", :unless => gte_ruby_2_4 do
           as_non_root do
             without_env('HOME') do
               without_env('HOMEDRIVE') do
@@ -255,7 +255,7 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
         end
 
-        it "fails when asking for the run_dir and there is no $HOME" do
+        it "fails when asking for the run_dir and there is no $HOME", :unless => gte_ruby_2_4 do
           as_non_root do
             without_env('HOME') do
               without_env('HOMEDRIVE') do


### PR DESCRIPTION
 - Now that RubyInstaller has produced an installer for Ruby 2.4.1 on
   Windows and AppVeyor has integrated it into their workflow per
   https://github.com/appveyor/ci/issues/1350 we can move from 2.3 to
   2.4 given Puppet 5 will be shipping against 2.4