### PR TITLE
(PUP-7602) Support binary data in catalogs

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -3,7 +3,7 @@ module Puppet
   class Error < RuntimeError
     attr_accessor :original
     def initialize(message, original=nil)
-      super(message)
+      super(Puppet::Util::CharacterEncoding.scrub(message))
       @original = original
     end
   end

--- a/lib/puppet/indirector/catalog/json.rb
+++ b/lib/puppet/indirector/catalog/json.rb
@@ -10,7 +10,7 @@ class Puppet::Resource::Catalog::Json < Puppet::Indirector::JSON
     if utf8.valid_encoding?
       model.convert_from('json', utf8)
     else
-      Puppet.info("Unable to deserialize catalog from json, retrying with pson")
+      Puppet.info(_("Unable to deserialize catalog from json, retrying with pson"))
       model.convert_from('pson', text.force_encoding(Encoding::BINARY))
     end
   end
@@ -18,7 +18,7 @@ class Puppet::Resource::Catalog::Json < Puppet::Indirector::JSON
   def to_json(object)
     object.render('json')
   rescue Puppet::Network::FormatHandler::FormatError
-    Puppet.info("Unable to serialize catalog to json, retrying with pson")
+    Puppet.info(_("Unable to serialize catalog to json, retrying with pson"))
     object.render('pson').force_encoding(Encoding::BINARY)
   end
 end

--- a/lib/puppet/indirector/catalog/json.rb
+++ b/lib/puppet/indirector/catalog/json.rb
@@ -3,4 +3,22 @@ require 'puppet/indirector/json'
 
 class Puppet::Resource::Catalog::Json < Puppet::Indirector::JSON
   desc "Store catalogs as flat files, serialized using JSON."
+
+  def from_json(text)
+    utf8 = text.force_encoding(Encoding::UTF_8)
+
+    if utf8.valid_encoding?
+      model.convert_from('json', utf8)
+    else
+      Puppet.info("Unable to deserialize catalog from json, retrying with pson")
+      model.convert_from('pson', text.force_encoding(Encoding::BINARY))
+    end
+  end
+
+  def to_json(object)
+    object.render('json')
+  rescue Puppet::Network::FormatHandler::FormatError
+    Puppet.info("Unable to serialize catalog to json, retrying with pson")
+    object.render('pson').force_encoding(Encoding::BINARY)
+  end
 end

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -14,7 +14,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     filename = path(request.key)
     FileUtils.mkdir_p(File.dirname(filename))
 
-    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::ASCII_8BIT) }
+    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::BINARY) }
   rescue TypeError => detail
     Puppet.log_exception(detail, _("Could not save %{json} %{request}: %{detail}") % { json: self.name, request: request.key, detail: detail })
   end
@@ -51,7 +51,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     json = nil
 
     begin
-      json = Puppet::FileSystem.read(file).force_encoding(Encoding::ASCII_8BIT)
+      json = Puppet::FileSystem.read(file, :encoding => Encoding::BINARY)
     rescue Errno::ENOENT
       return nil
     rescue => detail
@@ -66,7 +66,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
   end
 
   def from_json(text)
-    model.convert_from('json', text)
+    model.convert_from('json', text.force_encoding(Encoding::UTF_8))
   end
 
   def to_json(object)

--- a/lib/puppet/network/format_handler.rb
+++ b/lib/puppet/network/format_handler.rb
@@ -62,7 +62,11 @@ module Puppet::Network::FormatHandler
     else
       out = format(format)
     end
-    raise ArgumentError, "No format matches the given format name or mime-type (#{format})" if out.nil?
+
+    if out.nil?
+      raise ArgumentError, _("No format matches the given format name or mime-type (%{format})") % {format: format}
+    end
+
     out.name
   end
 
@@ -74,7 +78,8 @@ module Puppet::Network::FormatHandler
   #   (most preferred is first)
   # @param supported [Array<Symbol>] the names of the supported formats (the
   #   most preferred format is first)
-  # @return [Puppet::Network::Format, nil] the most suitable format
+  # @return [Array<Puppet::Network::Format>] the most suitable formats that
+  #   are both accepted and supported
   # @api private
   def self.most_suitable_formats_for(accepted, supported)
     accepted.collect do |format|

--- a/lib/puppet/network/format_handler.rb
+++ b/lib/puppet/network/format_handler.rb
@@ -62,7 +62,7 @@ module Puppet::Network::FormatHandler
     else
       out = format(format)
     end
-    raise ArgumentError, "No format match the given format name or mime-type (#{format})" if out.nil?
+    raise ArgumentError, "No format matches the given format name or mime-type (#{format})" if out.nil?
     out.name
   end
 
@@ -76,8 +76,8 @@ module Puppet::Network::FormatHandler
   #   most preferred format is first)
   # @return [Puppet::Network::Format, nil] the most suitable format
   # @api private
-  def self.most_suitable_format_for(accepted, supported)
-    format_name = accepted.collect do |format|
+  def self.most_suitable_formats_for(accepted, supported)
+    accepted.collect do |format|
       format.to_s.sub(/;q=.*$/, '')
     end.collect do |format|
       if format == ALL_MEDIA_TYPES
@@ -85,12 +85,10 @@ module Puppet::Network::FormatHandler
       else
         format_to_canonical_name_or_nil(format)
       end
-    end.find do |format|
+    end.compact.find_all do |format|
       supported.include?(format)
-    end
-
-    if format_name
-      format_for(format_name)
+    end.collect do |format|
+      format_for(format)
     end
   end
 

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -179,11 +179,11 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
   end
 
   def accepted_response_formatter_for(model_class, request)
-    request.response_formatter_for(model_class.supported_formats)
+    request.response_formatters_for(model_class.supported_formats).first
   end
 
   def accepted_response_formatter_or_json_for(model_class, request)
-    request.response_formatter_for(model_class.supported_formats, "application/json")
+    request.response_formatters_for(model_class.supported_formats, "application/json").first
   end
 
   def read_body_into_model(model_class, request)

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -369,7 +369,7 @@ class Puppet::Settings
       begin
         setting.handle(self.value(setting.name))
       rescue InterpolationError => err
-        raise InterpolationError, err, err.backtrace unless options[:ignore_interpolation_dependency_errors]
+        raise InterpolationError, err.message, err.backtrace unless options[:ignore_interpolation_dependency_errors]
         #swallow. We're not concerned if we can't call hooks because dependencies don't exist yet
         #we'll get another chance after application defaults are initialized
       end

--- a/spec/unit/indirector/catalog/json_spec.rb
+++ b/spec/unit/indirector/catalog/json_spec.rb
@@ -1,12 +1,67 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
+require 'puppet_spec/files'
 require 'puppet/resource/catalog'
 require 'puppet/indirector/catalog/json'
 
 describe Puppet::Resource::Catalog::Json do
-  # This is it for local functionality: we don't *do* anything else.
+  include PuppetSpec::Files
+
+  # This is it for local functionality
   it "should be registered with the catalog store indirection" do
     expect(Puppet::Resource::Catalog.indirection.terminus(:json)).
       to be_an_instance_of described_class
+  end
+
+  describe "when handling requests" do
+    let(:binary) { "\xC0\xFF".force_encoding(Encoding::BINARY) }
+    let(:key)    { 'foo' }
+    let(:file)   { subject.path(key) }
+    let(:catalog) do
+      catalog = Puppet::Resource::Catalog.new(key, Puppet::Node::Environment.create(:testing, []))
+      catalog.add_resource(Puppet::Resource.new(:file, '/tmp/a_file', :parameters => { :content => binary }))
+      catalog
+    end
+
+    before :each do
+      Puppet.run_mode.stubs(:master?).returns(true)
+      Puppet[:server_datadir] = tmpdir('jsondir')
+      FileUtils.mkdir_p(File.join(Puppet[:server_datadir], 'indirector_testing'))
+    end
+
+    def with_content(text)
+      FileUtils.mkdir_p(File.dirname(file))
+      File.binwrite(file, text)
+      yield if block_given?
+    end
+
+    it 'saves a catalog containing binary content' do
+      request = subject.indirection.request(:save, key, catalog)
+
+      subject.save(request)
+    end
+
+    it 'finds a catalog containing binary content' do
+      request = subject.indirection.request(:save, key, catalog)
+      subject.save(request)
+
+      request = subject.indirection.request(:find, key, nil)
+      parsed_catalog = subject.find(request)
+
+      content = parsed_catalog.resource(:file, '/tmp/a_file')[:content]
+      expect(content.bytes).to eq(binary.bytes)
+    end
+
+    it 'searches for catalogs contains binary content' do
+      request = subject.indirection.request(:save, key, catalog)
+      subject.save(request)
+
+      request = subject.indirection.request(:search, '*', nil)
+      parsed_catalogs = subject.search(request)
+
+      expect(parsed_catalogs.size).to eq(1)
+      content = parsed_catalogs.first.resource(:file, '/tmp/a_file')[:content]
+      expect(content.bytes).to eq(binary.bytes)
+    end
   end
 end

--- a/spec/unit/indirector/catalog/json_spec.rb
+++ b/spec/unit/indirector/catalog/json_spec.rb
@@ -49,7 +49,7 @@ describe Puppet::Resource::Catalog::Json do
       parsed_catalog = subject.find(request)
 
       content = parsed_catalog.resource(:file, '/tmp/a_file')[:content]
-      expect(content.bytes).to eq(binary.bytes)
+      expect(content.bytes.to_a).to eq(binary.bytes.to_a)
     end
 
     it 'searches for catalogs contains binary content' do
@@ -61,7 +61,7 @@ describe Puppet::Resource::Catalog::Json do
 
       expect(parsed_catalogs.size).to eq(1)
       content = parsed_catalogs.first.resource(:file, '/tmp/a_file')[:content]
-      expect(content.bytes).to eq(binary.bytes)
+      expect(content.bytes.to_a).to eq(binary.bytes.to_a)
     end
   end
 end

--- a/spec/unit/indirector/catalog/json_spec.rb
+++ b/spec/unit/indirector/catalog/json_spec.rb
@@ -29,12 +29,6 @@ describe Puppet::Resource::Catalog::Json do
       FileUtils.mkdir_p(File.join(Puppet[:server_datadir], 'indirector_testing'))
     end
 
-    def with_content(text)
-      FileUtils.mkdir_p(File.dirname(file))
-      File.binwrite(file, text)
-      yield if block_given?
-    end
-
     it 'saves a catalog containing binary content' do
       request = subject.indirection.request(:save, key, catalog)
 

--- a/spec/unit/network/format_handler_spec.rb
+++ b/spec/unit/network/format_handler_spec.rb
@@ -71,12 +71,12 @@ describe Puppet::Network::FormatHandler do
       expect(suitable_in_setup_formats(["three"])).to eq([])
     end
 
-    it "skips unsupported, but accepted, formats" do
+    it "returns only the accepted and supported format" do
       expect(suitable_in_setup_formats(["three", "two"])).to eq([format_two])
     end
 
-    it "gives the first acceptable and suitable format" do
-      expect(suitable_in_setup_formats(["three", "one", "two"])).to eq([format_one, format_two])
+    it "returns only accepted and supported formats, in order of accepted" do
+      expect(suitable_in_setup_formats(["three", "two", "one"])).to eq([format_two, format_one])
     end
 
     it "allows specifying acceptable formats by mime type" do

--- a/spec/unit/network/format_handler_spec.rb
+++ b/spec/unit/network/format_handler_spec.rb
@@ -50,7 +50,7 @@ describe Puppet::Network::FormatHandler do
     end
   end
 
-  describe "#most_suitable_format_for" do
+  describe "#most_suitable_formats_for" do
     before :each do
       Puppet::Network::FormatHandler.create(:one, :extension => "foo", :mime => "text/one")
       Puppet::Network::FormatHandler.create(:two, :extension => "bar", :mime => "application/two")
@@ -60,35 +60,35 @@ describe Puppet::Network::FormatHandler do
     let(:format_two) { Puppet::Network::FormatHandler.format(:two) }
 
     def suitable_in_setup_formats(accepted)
-      Puppet::Network::FormatHandler.most_suitable_format_for(accepted, [:one, :two])
+      Puppet::Network::FormatHandler.most_suitable_formats_for(accepted, [:one, :two])
     end
 
     it "finds the most preferred format when anything is acceptable" do
-      expect(Puppet::Network::FormatHandler.most_suitable_format_for(["*/*"], [:two, :one])).to eq(format_two)
+      expect(Puppet::Network::FormatHandler.most_suitable_formats_for(["*/*"], [:two, :one])).to eq([format_two])
     end
 
     it "finds no format when none are acceptable" do
-      expect(suitable_in_setup_formats(["three"])).to be_nil
+      expect(suitable_in_setup_formats(["three"])).to eq([])
     end
 
     it "skips unsupported, but accepted, formats" do
-      expect(suitable_in_setup_formats(["three", "two"])).to eq(format_two)
+      expect(suitable_in_setup_formats(["three", "two"])).to eq([format_two])
     end
 
     it "gives the first acceptable and suitable format" do
-      expect(suitable_in_setup_formats(["three", "one", "two"])).to eq(format_one)
+      expect(suitable_in_setup_formats(["three", "one", "two"])).to eq([format_one, format_two])
     end
 
     it "allows specifying acceptable formats by mime type" do
-      expect(suitable_in_setup_formats(["text/one"])).to eq(format_one)
+      expect(suitable_in_setup_formats(["text/one"])).to eq([format_one])
     end
 
     it "ignores quality specifiers" do
-      expect(suitable_in_setup_formats(["two;q=0.8", "text/one;q=0.9"])).to eq(format_two)
+      expect(suitable_in_setup_formats(["two;q=0.8", "text/one;q=0.9"])).to eq([format_two, format_one])
     end
 
     it "allows specifying acceptable formats by canonical name" do
-      expect(suitable_in_setup_formats([:one])).to eq(format_one)
+      expect(suitable_in_setup_formats([:one])).to eq([format_one])
     end
   end
 end

--- a/spec/unit/network/http/request_spec.rb
+++ b/spec/unit/network/http/request_spec.rb
@@ -76,13 +76,13 @@ describe Puppet::Network::HTTP::Request do
       end
     end
 
-    it "selects the first format supported by the server and accepted by the client" do
-      request = a_request(headers.merge('accept' => 'application/json, pson'))
-      expect(request.response_formatters_for([:json, :msgpack])).to eq([json_formatter])
+    it "returns accepted and supported formats, in the accepted order" do
+      request = a_request(headers.merge('accept' => 'application/json, application/x-msgpack, text/pson'))
+      expect(request.response_formatters_for([:pson, :json])).to eq([json_formatter, pson_formatter])
     end
 
     it "selects the second format if the first one isn't supported by the server" do
-      request = a_request(headers.merge('accept' => 'application/json, pson'))
+      request = a_request(headers.merge('accept' => 'application/json, text/pson'))
       expect(request.response_formatters_for([:pson])).to eq([pson_formatter])
     end
 

--- a/spec/unit/network/http/request_spec.rb
+++ b/spec/unit/network/http/request_spec.rb
@@ -7,6 +7,9 @@ require 'puppet/network/http'
 describe Puppet::Network::HTTP::Request do
   include PuppetSpec::Network
 
+  let(:json_formatter) { Puppet::Network::FormatHandler.format(:json) }
+  let(:pson_formatter) { Puppet::Network::FormatHandler.format(:pson) }
+
   def headers
     {
       'accept' => 'application/json',
@@ -26,7 +29,7 @@ describe Puppet::Network::HTTP::Request do
   context "when resolving the formatter for the request body" do
     it "returns the formatter for that Content-Type" do
       request = a_request(headers.merge("content-type" => "application/json"))
-      expect(request.formatter).to eq(Puppet::Network::FormatHandler.format(:json))
+      expect(request.formatter).to eq(json_formatter)
     end
 
     it "raises HTTP 400 if Content-Type is missing" do
@@ -63,44 +66,44 @@ describe Puppet::Network::HTTP::Request do
       it "raises HTTP 400 if the server doesn't specify a default" do
         request = a_request({})
         expect {
-          request.response_formatter_for([:json])
+          request.response_formatters_for([:json])
         }.to raise_error(bad_request_error, /Missing required Accept header/)
       end
 
       it "uses the server default" do
         request = a_request({})
-        expect(request.response_formatter_for([:json], 'application/json').name).to eq(:json)
+        expect(request.response_formatters_for([:json], 'application/json')).to eq([json_formatter])
       end
     end
 
-    it "selects the first format supported by the server" do
+    it "selects the first format supported by the server and accepted by the client" do
       request = a_request(headers.merge('accept' => 'application/json, pson'))
-      expect(request.response_formatter_for([:json, :msgpack]).name).to eq(:json)
+      expect(request.response_formatters_for([:json, :msgpack])).to eq([json_formatter])
     end
 
     it "selects the second format if the first one isn't supported by the server" do
       request = a_request(headers.merge('accept' => 'application/json, pson'))
-      expect(request.response_formatter_for([:pson]).name).to eq(:pson)
+      expect(request.response_formatters_for([:pson])).to eq([pson_formatter])
     end
 
     it "raises HTTP 406 if Accept doesn't include any server-supported formats" do
       request = a_request(headers.merge('accept' => 'application/ogg'))
       expect {
-        request.response_formatter_for([:json])
+        request.response_formatters_for([:json])
       }.to raise_error(not_acceptable_error, /No supported formats are acceptable \(Accept: application\/ogg\)/)
     end
 
     it "raises HTTP 406 if Accept resolves to unsafe yaml" do
       request = a_request(headers.merge('accept' => 'yaml'))
       expect {
-        request.response_formatter_for([:json])
+        request.response_formatters_for([:json])
       }.to raise_error(not_acceptable_error, /No supported formats are acceptable \(Accept: yaml\)/)
     end
 
     it "raises HTTP 406 if Accept resolves to unsafe b64_zlib_yaml" do
       request = a_request(headers.merge('accept' => 'b64_zlib_yaml'))
       expect {
-        request.response_formatter_for([:json])
+        request.response_formatters_for([:json])
       }.to raise_error(not_acceptable_error, /No supported formats are acceptable \(Accept: b64_zlib_yaml\)/)
     end
   end


### PR DESCRIPTION
* Scrub Puppet::Error message strings, so they are always valid encodings.
* Add support for serializing binary catalogs as PSON when read/writing to local JSON files and when serializing in HTTP responses.
* When processing REST `find` and `search` requests, if we fail to serialize to a given format, fallback to the next best format, eventually returning 406 if none are acceptable.