### PR TITLE
(PUP-7650) Remove dead code and unnecessary call to #downcase

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_resource_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_resource_support.rb
@@ -67,12 +67,10 @@ module Runtime3ResourceSupport
   end
 
   def self.find_resource_type(scope, type_name)
-    type_name = type_name.to_s.downcase
     find_builtin_resource_type(scope, type_name) || find_defined_resource_type(scope, type_name)
   end
 
   def self.find_resource_type_or_class(scope, name)
-    type_name = type_name.to_s.downcase
     find_builtin_resource_type(scope, name) || find_defined_resource_type(scope, name) || find_hostclass(scope, name)
   end
 


### PR DESCRIPTION
This commit removes two unnecessary calls to #downcase. One is actually
dead code since the downcased value is never used. The other is redundant
since all resolvers of type names will downcase the name.

Downcasing is either performed by `TypedCollection#munge_name` (for
defined resources or host classes), `Puppet::Type#type` (for resource
types), or `Puppet::Pops::Loader::TypedName#initialize` (for generated
resource types).