### PR TITLE
(PUP-3323) Support `source` in yum provider

### DIFF
--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -103,6 +103,13 @@ test_name "test the yum package provider" do
       end
       verify_absent agents, 'not_a_package'
     end
+
+    step 'Installing a known package using source succeeds' do
+      verify_absent agents, 'guid'
+      apply_manifest_on(agent, "package { 'guid': ensure => installed, source=>'/tmp/rpmrepo/RPMS/noarch/guid-1.0-1.noarch.rpm' }") do |result|
+        assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
+      end
+    end
   end
 
   ### Epoch tests ###

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -175,7 +175,15 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
         operation = :install
       end
       should = nil
-    when true, false, Symbol
+    when true, :present, :installed 
+      # if we have been given a source and we were not asked for a specific
+      # version feed it to yum directly
+      if @resource[:source]
+        wanted = @resource[:source]
+        self.debug "Downloading directly from #{wanted}"
+      end
+      should = nil
+    when false,:absent
       # pass
       should = nil
     else


### PR DESCRIPTION
If the source parameter is set when using the yum package provider, then use it with yum directly.  This has the advantage of bringing in a package's dependencies while allowing direct installation from the internet without already setting up a repository