### PR TITLE
(PUP-7517) Allow agent daemon to time out stalled runs

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -1,6 +1,8 @@
 require 'puppet/application'
 require 'puppet/error'
 
+require 'timeout'
+
 # A general class for triggering a run of another
 # class.
 class Puppet::Agent
@@ -12,6 +14,10 @@ class Puppet::Agent
 
   require 'puppet/util/splayer'
   include Puppet::Util::Splayer
+
+  # Special exception class used to signal an agent run has timed out.
+  class RunTimeoutError < Exception
+  end
 
   attr_reader :client_class, :client, :should_fork
 
@@ -40,12 +46,26 @@ class Puppet::Agent
       splay client_options.fetch :splay, Puppet[:splay]
       result = run_in_fork(should_fork) do
         with_client(client_options[:transaction_uuid]) do |client|
+          client_args = client_options.merge(:pluginsync => Puppet::Configurer.should_pluginsync?)
           begin
-            client_args = client_options.merge(:pluginsync => Puppet::Configurer.should_pluginsync?)
-            lock { client.run(client_args) }
+            lock do
+              # NOTE: Timeout is pretty heinous as the location in which it
+              # throws an error is entirely unpredictable, which means that
+              # it can interrupt code blocks that perform cleanup or enforce
+              # sanity. The only thing a Puppet agent should do after this
+              # error is thrown is die with as much dignity as possible.
+              Timeout.timeout(Puppet[:runtimeout], RunTimeoutError) do
+                client.run(client_args)
+              end
+            end
           rescue Puppet::LockError
             Puppet.notice "Run of #{client_class} already in progress; skipping  (#{lockfile_path} exists)"
             return
+          rescue RunTimeoutError => detail
+            Puppet.log_exception(detail, _("Execution of %{client_class} did not complete within %{runtimeout} seconds and was terminated.") %
+              {client_class: client_class,
+              runtimeout: Puppet[:runtimeout]})
+            return 1
           rescue StandardError => detail
             Puppet.log_exception(detail, "Could not run #{client_class}: #{detail}")
           end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1521,6 +1521,13 @@ EOT
           \"never run.\" If you want puppet agent to never run, you should start
           it with the `--no-client` option. #{AS_DURATION}",
     },
+    :runtimeout => {
+      :default  => 0,
+      :type     => :duration,
+      :desc     => "The maximum amount of time an agent run is allowed to take.
+          A Puppet agent run that exceeds this timeout will be aborted.
+          Defaults to 0, which is unlimited. #{AS_DURATION}",
+    },
     :ca_server => {
       :default    => "$server",
       :desc       => "The server to use for certificate


### PR DESCRIPTION
On occasion, a puppet agent can end up waiting indefinitely on some process
that will never return or terminate. This patch adds a new setting, runtimeout,
that can be used to specify the maximum duration allowed for a puppet
run. When set to a non-zero value, the agent daemon will send a SIGTERM to any
agent run it starts which exceeds this value.

This patch does not handle runs started outside of the agent daemon by
`puppet agent --onetime`.