### PR TITLE
(PUP-7321) Update REST API docs for Puppet 5

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -77,6 +77,10 @@ available and how to interact with it.
 These services are all directly used by the Puppet agent application, in order
 to manage the configuration of a node.
 
+These endpoints accept payload formats formatted as JSON or PSON (MIME types of
+`application/json` and `text/pson`, respectively) except for `File Content` and
+`File Bucket File` which always use `application/octet-stream`.
+
 * [Catalog](./http_catalog.md)
 * [Node](./http_node.md)
 * [File Bucket File](./http_file_bucket_file.md)
@@ -159,6 +163,10 @@ documents provide additional specification.
 
 ### SSL Certificate Related Services
 
+These endpoints only accept plain text payload formats. Historically, Puppet has
+used the MIME type `s` to mean `text/plain`. In Puppet 5, it will always use
+`text/plain`, but will continue to accept `s` to mean the same thing.
+
 * [Certificate](./http_certificate.md)
 * [Certificate Signing Requests](./http_certificate_request.md)
 * [Certificate Status](./http_certificate_status.md)
@@ -170,6 +178,7 @@ Serialization Formats
 Puppet sends messages using several different serialization formats. Not all
 REST services support all of the formats.
 
+* [JSON](https://tools.ietf.org/html/rfc7159)
 * [PSON](./pson.md)
-* [YAML](http://www.yaml.org/spec/1.2/spec.html)
 
+`YAML` was supported in earlier versions of puppet, but is no longer for security reasons.

--- a/api/docs/http_catalog.md
+++ b/api/docs/http_catalog.md
@@ -17,7 +17,7 @@ POST, GET
 
 ### Supported Response Formats
 
-PSON
+`application/json`, `text/pson`
 
 ### Notes
 
@@ -34,10 +34,9 @@ The examples below use the POST method.
 Four parameters should be provided to the POST or GET:
 
 - `environment`: the environment name.
-- `facts_format`: must be `pson`.
-- `facts`: serialized pson of the facts hash. One odd note: due to a long-ago misunderstanding in the code, this is
-doubly-escaped (it should just be singly-escaped). To keep backward compatibility, the extraneous
-escaping is still used/supported.
+- `facts_format`: must be `application/json` or `pson`.
+- `facts`: serialized pson of the facts hash. Since facts can contain `&`, which
+  is also the HTTP query parameter delimiter, facts are doubly-escaped.
 - `transaction_uuid`: a transaction uuid identifying the entire transaction (shows up in the report as well).
 
 Two optional parameters are required for static catalogs:
@@ -60,10 +59,10 @@ Optional parameters that may be provided to the POST or GET:
 
     POST /puppet/v3/catalog/elmo.mydomain.com
 
-    environment=env&configured_environment=canary_env&facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c
+    environment=env&configured_environment=canary_env&facts_format=application%2Fjson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c
 
     HTTP 200 OK
-    Content-Type: text/pson
+    Content-Type: application/json
 
     {
       "tags": [
@@ -168,10 +167,10 @@ Optional parameters that may be provided to the POST or GET:
 ~~~
 POST /puppet/v3/catalog/elmo.mydomain.com
 
-environment=env&configured_environment=canary_env&facts_format=pson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c&static_catalog=true&checksum_type=sha256.md5
+environment=env&configured_environment=canary_env&facts_format=application%2Fjson&facts=%7B%22name%22%3A%22elmo.mydomain.com%22%2C%22values%22%3A%7B%22architecture%22%3A%22x86_64%22%7D&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c&static_catalog=true&checksum_type=sha256.md5
 
 HTTP 200 OK
-Content-Type: text/pson
+Content-Type: application/json
 
 {
   "tags": [

--- a/api/docs/http_certificate.md
+++ b/api/docs/http_certificate.md
@@ -22,7 +22,7 @@ GET
 
 ### Supported Response Formats
 
-s (denotes a string of text)
+`text/plain`
 
 The returned certificate is always in the `.pem` format.
 

--- a/api/docs/http_certificate_request.md
+++ b/api/docs/http_certificate_request.md
@@ -15,7 +15,7 @@ Find
 Get a submitted CSR
 
     GET /puppet-ca/v1/certificate_request/:nodename?environment=:environment
-    Accept: s
+    Accept: text/plain
 
 Save
 ----
@@ -39,7 +39,7 @@ Server doesn't support it, and we don't plan to add support in the future.
 List submitted CSRs
 
     GET /puppet-ca/v1/certificate_requests/:ignored_pattern?environment=:environment
-    Accept: s
+    Accept: text/plain
 
 The `:ignored_pattern` parameter is not used, but must still be provided.
 
@@ -49,7 +49,7 @@ Destroy
 Delete a submitted CSR
 
     DELETE /puppet-ca/v1/certificate_request/:nodename?environment=:environment
-    Accept: s
+    Accept: text/plain
 
 ### Supported HTTP Methods
 
@@ -61,7 +61,7 @@ GET, PUT, DELETE
 
 ### Supported Response Formats
 
-s (denotes a string of text)
+`text/plain`
 
 The returned CSR is always in the `.pem` format.
 

--- a/api/docs/http_certificate_revocation_list.md
+++ b/api/docs/http_certificate_revocation_list.md
@@ -19,7 +19,7 @@ Find
 Get the submitted CRL
 
     GET /puppet-ca/v1/certificate_revocation_list/:nodename?environment=:environment
-    Accept: s
+    Accept: text/plain
 
 ### Supported HTTP Methods
 
@@ -27,7 +27,7 @@ GET
 
 ### Supported Response Formats
 
-s (denotes a string of text)
+`text/plain`
 
 The returned CRL is always in the `.pem` format.
 

--- a/api/docs/http_certificate_status.md
+++ b/api/docs/http_certificate_status.md
@@ -13,7 +13,7 @@ Find
 ----
 
     GET /puppet-ca/v1/certificate_status/:certname?environment=:environment
-    Accept: pson
+    Accept: text/pson
 
 Retrieve information about the specified certificate. Similar to `puppet
 cert --list :certname`.
@@ -22,7 +22,7 @@ Search
 -----
 
     GET /puppet-ca/v1/certificate_statuses/:any_key?environment=:environment
-    Accept: pson
+    Accept: text/pson
 
 Retrieve information about all known certificates. Similar to `puppet
 cert --list --all`. A key is required but is ignored.
@@ -47,7 +47,7 @@ Delete
 -----
 
     DELETE /puppet-ca/v1/certificate_status/:hostname?environment=:environment
-    Accept: pson
+    Accept: text/pson
 
 Cause the certificate authority to discard all SSL information regarding
 a host (including any certificates, certificate requests, and keys).
@@ -75,7 +75,7 @@ GET, PUT, DELETE
 
 ### Supported Response Formats
 
-PSON
+`text/pson`
 
 This endpoint can produce yaml as well, but the returned data is
 incomplete.

--- a/api/docs/http_environment.md
+++ b/api/docs/http_environment.md
@@ -15,6 +15,10 @@ Get the catalog for an environment
 
     GET /puppet/v3/environment/:environment
 
+### Supported Response Formats
+
+`application/json`
+
 ### Parameters
 
 None

--- a/api/docs/http_environments.md
+++ b/api/docs/http_environments.md
@@ -12,6 +12,10 @@ Get the list of known environments.
 
     GET /puppet/v3/environments
 
+### Supported Response Formats
+
+`application/json`
+
 ### Parameters
 
 None

--- a/api/docs/http_file_bucket_file.md
+++ b/api/docs/http_file_bucket_file.md
@@ -50,7 +50,7 @@ GET, HEAD, PUT
 
 ### Supported Response Formats
 
-`binary` or `application/octet-stream` (a string of the raw file contents)
+`application/octet-stream`
 
 ### Parameters
 
@@ -73,7 +73,7 @@ None
 #### Retrieving a file
 
     > GET /puppet/v3/file_bucket_file/md5/4949e56d376cc80ce5387e8e89a75396//home/user/myfile.txt?environment=production HTTP/1.1
-    > Accept: binary
+    > Accept: application/octet-stream
 
 
     < HTTP/1.1 200 OK
@@ -84,7 +84,7 @@ None
 #### Wrong file name
 
     > GET /puppet/v3/file_bucket_file/md5/4949e56d376cc80ce5387e8e89a75396//home/user/wrong_name?environment=production HTTP/1.1
-    > Accept: binary
+    > Accept: application/octet-stream
 
 
     < HTTP/1.1 404 Not Found

--- a/api/docs/http_file_content.md
+++ b/api/docs/http_file_content.md
@@ -25,7 +25,7 @@ GET
 
 ### Supported Response Formats
 
-binary (the raw binary content)
+`application/octet-stream`
 
 ### Parameters
 
@@ -38,7 +38,7 @@ None
 #### File found
 
     GET /puppet/v3/file_content/modules/example/my_file?environment=env
-    Accept: binary
+    Accept: application/octet-stream
 
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
@@ -50,7 +50,7 @@ None
 #### File not found
 
     GET /puppet/v3/file_content/modules/example/not_found?environment=env
-    Accept: binary
+    Accept: application/octet-stream
 
     HTTP/1.1 404 Not Found
     Content-Type: text/plain

--- a/api/docs/http_file_metadata.md
+++ b/api/docs/http_file_metadata.md
@@ -33,7 +33,7 @@ GET
 
 ### Supported Response Formats
 
-PSON
+`application/json`, `text/pson`
 
 ### Parameters
 
@@ -133,9 +133,9 @@ Get a list of metadata for multiple files
 
 GET
 
-### Supported Format
+### Supported Response Formats
 
-Accept: pson, text/pson
+`application/json`, `text/pson`
 
 ### Parameters
 

--- a/api/docs/http_node.md
+++ b/api/docs/http_node.md
@@ -22,7 +22,7 @@ GET
 
 ### Supported Response Formats
 
-PSON
+`application/json`, `text/pson`
 
 ### Parameters
 
@@ -38,10 +38,10 @@ environment, which might differ from what the client believes is its current env
 ### Examples
 
     > GET /puppet/v3/node/mycertname?environment=production&transaction_uuid=aff261a2-1a34-4647-8c20-ff662ec11c4c&configured_environment=production HTTP/1.1
-    > Accept: pson, b64_zlib_yaml, yaml, raw
+    > Accept: application/json, text/pson
 
     < HTTP/1.1 200 OK
-    < Content-Type: text/pson
+    < Content-Type: application/json
     < Content-Length: 4630
 
     {

--- a/api/docs/http_report.md
+++ b/api/docs/http_report.md
@@ -21,7 +21,7 @@ PUT
 
 ### Supported Format(s)
 
-PSON
+`application/json`, `text/pson`
 
 ### Parameters
 
@@ -44,7 +44,7 @@ Here is an example of a PUT request. (Note that the content-length is not correc
 example is formatted for readability)
 
     PUT /puppet/v3/report/kermit.com?environment=production HTTP/1.0
-    ContentType: text/pson
+    Content-Type: application/json
     Content-Length: 1428
 
     {"host"=>"kermit.com",

--- a/api/docs/http_status.md
+++ b/api/docs/http_status.md
@@ -19,7 +19,7 @@ GET
 
 ### Supported Response Formats
 
-PSON
+`application/json`, `text/pson`
 
 ### Parameters
 
@@ -30,7 +30,7 @@ None
     GET /puppet/v3/status/whatever?environment=env
 
     HTTP 200 OK
-    Content-Type: text/pson
+    Content-Type: application/json
 
     {"is_alive":true,"version":"3.3.2"}
 


### PR DESCRIPTION
Add `application/json` as a supported format.

Use `text/pson` and `text/plain` consistently.

YAML is no longer accepted.