### PR TITLE
(MAINT) Fix Docs pointer to latest.

### DIFF
--- a/ext/hiera/hiera.yaml
+++ b/ext/hiera/hiera.yaml
@@ -4,7 +4,7 @@ defaults:
   # The default value for "datadir" is "data" under the same directory as the hiera.yaml
   # file (this file)
   # When specifying a datadir, make sure the directory exists.
-  # See https://docs.puppet.com/puppet/4.10/environments.html for further details on environments.
+  # See https://docs.puppet.com/puppet/latest/environments.html for further details on environments.
   # datadir: data
   # data_hash: yaml_data
 hierarchy:


### PR DESCRIPTION
As per post-merge review comment on PR #5972 fix documentation URL to
point to "latest" to avoid link going stale.