### PR TITLE
(PUP-7671) Ensure that TypeCollection uses downcased name for load

### DIFF
--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -231,6 +231,7 @@ class Puppet::Resource::TypeCollection
           debug_once "Not attempting to load #{type} #{fqname} as this object was missing during a prior compilation"
         end
       else
+        fqname = munge_name(fqname)
         result = loader.try_load_fqname(type, fqname)
         @notfound[ fqname ] = result.nil?
       end

--- a/spec/integration/resource/type_collection_spec.rb
+++ b/spec/integration/resource/type_collection_spec.rb
@@ -83,5 +83,11 @@ describe Puppet::Resource::TypeCollection do
       mk_module(name, :define => true, :mydefine => ["mymod::mydefine"])
       expect(@code.find_definition("mymod::mydefine").name).to eq("mymod::mydefine")
     end
+
+    it 'should be able to load definitions from their own file using uppercased name' do
+      name = 'mymod'
+      mk_module(name, :define => true, :mydefine => ['mymod::mydefine'])
+      expect(@code.find_definition('Mymod::Mydefine')).not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
Before this commit, if the `TypeCollection#find_or_load` was called with
uppercase characters in the name, it would make an attempt to first find
a resource using a munged (downcased) name, and then, if the resource
was not found, load the resource using the name without downcasing it.

This commit ensures that both find and load uses a downcased name.