### PR TITLE
(packaging) Bump version to 4.10.4

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 
 module Puppet
-  PUPPETVERSION = '4.10.3'
+  PUPPETVERSION = '4.10.4'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This commit updates Puppet's version to 4.10.4 in anticipation of the
Puppet Agent 1.10.4 release.