### PR TITLE
(PUP-7665) URI encode JSON facts for uploading

### DIFF
--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -33,7 +33,7 @@ module Puppet::Configurer::FactHandler
     if Puppet[:preferred_serialization_format] == "pson"
       {:facts_format => :pson, :facts => Puppet::Util.uri_query_encode(facts.render(:pson)) }
     else
-      {:facts_format => 'application/json', :facts => facts.render(:json) }
+      {:facts_format => 'application/json', :facts => Puppet::Util.uri_query_encode(facts.render(:json)) }
     end
   end
 end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -87,7 +87,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       # PSON is deprecated, but continue to accept from older agents
       return Puppet::Node::Facts.convert_from('pson', CGI.unescape(facts))
     elsif format == 'application/json'
-      return Puppet::Node::Facts.convert_from('json', facts)
+      return Puppet::Node::Facts.convert_from('json', CGI.unescape(facts))
     else
       raise ArgumentError, "Unsupported facts format"
     end

--- a/spec/unit/configurer/fact_handler_spec.rb
+++ b/spec/unit/configurer/fact_handler_spec.rb
@@ -69,92 +69,82 @@ describe Puppet::Configurer::FactHandler do
     end
   end
 
-  context "when serializing as pson" do
-    before :each do
-      Puppet[:preferred_serialization_format] = 'pson'
-    end
+  context "when serializing" do
+    facts_with_special_characters = [
+      { :hash => { 'afact' => 'a+b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%2Bb' + '%22%7D' },
+      { :hash => { 'afact' => 'a b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%20b' + '%22%7D' },
+      { :hash => { 'afact' => 'a&b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%26b' + '%22%7D' },
+      { :hash => { 'afact' => 'a*b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%2Ab' + '%22%7D' },
+      { :hash => { 'afact' => 'a=b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%3Db' + '%22%7D' },
+      # different UTF-8 widths
+      # 1-byte A
+      # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+      # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+      # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+      { :hash => { 'afact' => "A\u06FF\u16A0\u{2070E}" }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'A%DB%BF%E1%9A%A0%F0%A0%9C%8E' + '%22%7D' },
+    ]
 
-    it "should serialize and CGI escape the fact values for uploading" do
-      facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
-      Puppet::Node::Facts.indirection.save(facts)
-      text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:pson))
+    context "as pson" do
+      before :each do
+        Puppet[:preferred_serialization_format] = 'pson'
+      end
 
-      expect(facthandler.facts_for_uploading).to eq({:facts_format => :pson, :facts => text})
-    end
-
-  [
-    { :hash => { 'afact' => 'a+b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%2Bb' + '%22%7D' },
-    { :hash => { 'afact' => 'a b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%20b' + '%22%7D' },
-    { :hash => { 'afact' => 'a&b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%26b' + '%22%7D' },
-    { :hash => { 'afact' => 'a*b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%2Ab' + '%22%7D' },
-    { :hash => { 'afact' => 'a=b' }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'a%3Db' + '%22%7D' },
-    # different UTF-8 widths
-    # 1-byte A
-    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
-    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
-    # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
-    { :hash => { 'afact' => "A\u06FF\u16A0\u{2070E}" }, :encoded => '%22values%22%3A%7B%22afact%22%3A%22' + 'A%DB%BF%E1%9A%A0%F0%A0%9C%8E' + '%22%7D' },
-
-  ].each do |test_fact|
-      it "should properly accept the fact #{test_fact[:hash]}" do
-        facts = Puppet::Node::Facts.new(Puppet[:node_name_value], test_fact[:hash])
+      it "should serialize and CGI escape the fact values for uploading" do
+        facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
         Puppet::Node::Facts.indirection.save(facts)
         text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:pson))
 
-        to_upload = facthandler.facts_for_uploading
-        expect(to_upload).to eq({:facts_format => :pson, :facts => text})
-        expect(text).to include(test_fact[:encoded])
+        expect(facthandler.facts_for_uploading).to eq({:facts_format => :pson, :facts => text})
+      end
 
-        # this is not sufficient to test whether these values are sent via HTTP GET or HTTP POST in actual catalog request
-        expect(JSON.parse(URI.unescape(to_upload[:facts]))['values']).to eq(test_fact[:hash])
+      facts_with_special_characters.each do |test_fact|
+        it "should properly accept the fact #{test_fact[:hash]}" do
+          facts = Puppet::Node::Facts.new(Puppet[:node_name_value], test_fact[:hash])
+          Puppet::Node::Facts.indirection.save(facts)
+          text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:pson))
+
+          to_upload = facthandler.facts_for_uploading
+          expect(to_upload).to eq({:facts_format => :pson, :facts => text})
+          expect(text).to include(test_fact[:encoded])
+
+          # this is not sufficient to test whether these values are sent via HTTP GET or HTTP POST in actual catalog request
+          expect(JSON.parse(URI.unescape(to_upload[:facts]))['values']).to eq(test_fact[:hash])
+        end
       end
     end
-  end
 
-  context "when serializing as json" do
-    it "should serialize the fact values for uploading" do
+    context "as json" do
+      it "should serialize and CGI escape the fact values for uploading" do
+        facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
+        Puppet::Node::Facts.indirection.save(facts)
+        text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:json))
+
+        expect(facthandler.facts_for_uploading).to eq({:facts_format => 'application/json', :facts => text})
+      end
+
+      facts_with_special_characters.each do |test_fact|
+        it "should properly accept the fact #{test_fact[:hash]}" do
+          facts = Puppet::Node::Facts.new(Puppet[:node_name_value], test_fact[:hash])
+          Puppet::Node::Facts.indirection.save(facts)
+          text = Puppet::Util.uri_query_encode(facthandler.find_facts.render(:json))
+
+          to_upload = facthandler.facts_for_uploading
+          expect(to_upload).to eq({:facts_format => 'application/json', :facts => text})
+          expect(text).to include(test_fact[:encoded])
+
+          expect(JSON.parse(URI.unescape(to_upload[:facts]))['values']).to eq(test_fact[:hash])
+        end
+      end
+    end
+
+    it "should generate valid facts data against the facts schema" do
       facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
       Puppet::Node::Facts.indirection.save(facts)
-      text = facthandler.find_facts.render(:json)
 
-      expect(facthandler.facts_for_uploading).to eq({:facts_format => 'application/json', :facts => text})
-    end
-
-  [
-    { 'afact' => 'a+b' },
-    { 'afact' => 'a b' },
-    { 'afact' => 'a&b' },
-    { 'afact' => 'a*b' },
-    { 'afact' => 'a=b' },
-    # different UTF-8 widths
-    # 1-byte A
-    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
-    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
-    # 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
-    { 'afact' => "A\u06FF\u16A0\u{2070E}" },
-
-  ].each do |test_fact|
-      it "should properly accept the fact #{test_fact}" do
-        facts = Puppet::Node::Facts.new(Puppet[:node_name_value], test_fact)
-        Puppet::Node::Facts.indirection.save(facts)
-        text = facthandler.find_facts.render(:json)
-
-        to_upload = facthandler.facts_for_uploading
-        expect(to_upload).to eq({:facts_format => 'application/json', :facts => text})
-
-        expect(JSON.parse((to_upload[:facts]))['values']).to eq(test_fact)
-      end
+      # prefer URI.unescape but validate CGI also works
+      encoded_facts = facthandler.facts_for_uploading[:facts]
+      expect(URI.unescape(encoded_facts)).to validate_against('api/schemas/facts.json')
+      expect(CGI.unescape(encoded_facts)).to validate_against('api/schemas/facts.json')
     end
   end
-
-  it "should generate valid facts data against the facts schema" do
-    facts = Puppet::Node::Facts.new(Puppet[:node_name_value], 'my_name_fact' => 'other_node_name')
-    Puppet::Node::Facts.indirection.save(facts)
-
-    # prefer URI.unescape but validate CGI also works
-    encoded_facts = facthandler.facts_for_uploading[:facts]
-    expect(URI.unescape(encoded_facts)).to validate_against('api/schemas/facts.json')
-    expect(CGI.unescape(encoded_facts)).to validate_against('api/schemas/facts.json')
-  end
-
 end

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -257,14 +257,14 @@ describe Puppet::Resource::Catalog::Compiler do
     def a_legacy_request_that_contains(facts, format = :pson)
       request = Puppet::Indirector::Request.new(:catalog, :find, "hostname", nil)
       request.options[:facts_format] = format.to_s
-      request.options[:facts] = Puppet::Util.uri_encode(facts.render(format))
+      request.options[:facts] = Puppet::Util.uri_query_encode(facts.render(format))
       request
     end
 
     def a_request_that_contains(facts)
       request = Puppet::Indirector::Request.new(:catalog, :find, "hostname", nil)
       request.options[:facts_format] = "application/json"
-      request.options[:facts] = facts.render('json')
+      request.options[:facts] = Puppet::Util.uri_query_encode(facts.render('json'))
       request
     end
 


### PR DESCRIPTION
- Using the new Puppet::Util.uri_query_encode facility, encode JSON facts for
  uploading as we do PSON facts. Update specs to expect encoded facts.
- Because we now encode the facts on upload, we also need to unencode them in
  the catalog compiler terminus.

Signed-off-by: Moses Mendoza <moses@puppet.com>