### PR TITLE
(PUP-7674) Ensure that resource collectors uses generated resources

### DIFF
--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -42,10 +42,10 @@ class CollectorTransformer
 
     case o.query
     when Model::VirtualQuery
-      newcoll = Collectors::CatalogCollector.new(scope, resource_type.name, code, overrides)
+      newcoll = Collectors::CatalogCollector.new(scope, resource_type, code, overrides)
     when Model::ExportedQuery
       match = match_unless_nop(o.query, scope)
-      newcoll = Collectors::ExportedCollector.new(scope, resource_type.name, match, code, overrides)
+      newcoll = Collectors::ExportedCollector.new(scope, resource_type, match, code, overrides)
     end
 
     scope.compiler.add_collection(newcoll)

--- a/lib/puppet/pops/evaluator/collectors/catalog_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/catalog_collector.rb
@@ -3,14 +3,14 @@ class Puppet::Pops::Evaluator::Collectors::CatalogCollector < Puppet::Pops::Eval
   # Creates a CatalogCollector using the AbstractCollector's 
   # constructor to set the scope and overrides
   #
-  # param [Symbol] type the resource type to be collected
+  # param [Puppet::CompilableResourceType] type the resource type to be collected
   # param [Proc] query the query which defines which resources to match
   def initialize(scope, type, query, overrides = nil)
     super(scope, overrides)
 
     @query = query
 
-    @type = Puppet::Resource.new(type, "whatever").type
+    @type = Puppet::Resource.new(type, 'whatever').type
   end
 
   # Collects virtual resources based off a collection in a manifest

--- a/lib/puppet/pops/evaluator/collectors/exported_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/exported_collector.rb
@@ -3,7 +3,7 @@ class Puppet::Pops::Evaluator::Collectors::ExportedCollector < Puppet::Pops::Eva
   # Creates an ExportedCollector using the AbstractCollector's
   # constructor to set the scope and overrides
   #
-  # param [Symbol] type the resource type to be collected
+  # param [Puppet::CompilableResourceType] type the resource type to be collected
   # param [Array] equery an array representation of the query (exported query)
   # param [Proc] cquery a proc representation of the query (catalog query)
   def initialize(scope, type, equery, cquery, overrides = nil)
@@ -12,7 +12,7 @@ class Puppet::Pops::Evaluator::Collectors::ExportedCollector < Puppet::Pops::Eva
     @equery = equery
     @cquery = cquery
 
-    @type = Puppet::Resource.new(type, "whatever").type
+    @type = Puppet::Resource.new(type, 'whatever').type
   end
 
   # Ensures that storeconfigs is present before calling AbstractCollector's

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -131,6 +131,18 @@ end
         expect(notices).to include('false')
         expect(notices).not_to include('the Puppet::Type says hello')
       end
+
+      it 'does not load the ruby type when when referenced from collector during compile' do
+        pending 'Fix for PUP-7674'
+        notices = eval_and_collect_notices("@applytest { 'applytest was here': }\nApplytest<| title == 'applytest was here' |>", node)
+        expect(notices).not_to include('the Puppet::Type says hello')
+      end
+
+      it 'does not load the ruby type when when referenced from exported collector during compile' do
+        pending 'Fix for PUP-7674'
+        notices = eval_and_collect_notices("@@applytest { 'applytest was here': }\nApplytest<<| |>>", node)
+        expect(notices).not_to include('the Puppet::Type says hello')
+      end
     end
   end
 

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -133,13 +133,11 @@ end
       end
 
       it 'does not load the ruby type when when referenced from collector during compile' do
-        pending 'Fix for PUP-7674'
         notices = eval_and_collect_notices("@applytest { 'applytest was here': }\nApplytest<| title == 'applytest was here' |>", node)
         expect(notices).not_to include('the Puppet::Type says hello')
       end
 
       it 'does not load the ruby type when when referenced from exported collector during compile' do
-        pending 'Fix for PUP-7674'
         notices = eval_and_collect_notices("@@applytest { 'applytest was here': }\nApplytest<<| |>>", node)
         expect(notices).not_to include('the Puppet::Type says hello')
       end


### PR DESCRIPTION
This commit changes the `CollectorTransformer` class so that it
propagates the resource type that it has already loaded down to the
collector that is created. Previously, only the name was passed down
which resulted in a load of a `Puppet::Type` when the collector created
a resource instance.