### PR TITLE
(MAINT) Fix assert_review environment_utils test helper

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -348,9 +348,9 @@ module Puppet
 
       def assert_review(review)
         failures = []
-        review.each do |scenario, failed|
+        review.each do |failed|
           if !failed.empty?
-            problems = "Problems in the '#{scenario}' output reported above:\n  #{failed.join("\n  ")}"
+            problems = "Problems in the output reported above:\n  #{failed}"
             logger.warn(problems)
             failures << problems
           end


### PR DESCRIPTION
Previously, users of the `assert_review` helper passed in an array with
failure strings, the results from a call to the `review_results` helper.
The `assert_review` helper, however, appeared to assume that the
argument was a hash with a key denoting the scenario and value
containing any failures, leading to an 'undef method empty? for
nil:NilClass' error as it processed any failures.

This commit changes the `assert_review` helper to instead treat its
parameter as an array of failure strings, allowing for any failures
found to be listed out properly in an assertion message.