### PR TITLE
(PUP-2280) Add test for failed refresh = fail run

### DIFF
--- a/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
+++ b/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
@@ -1,0 +1,32 @@
+test_name 'C100297 - A resource triggered by a refresh that fails should be reported as a failure when using --detailed-exitcodes' do
+  manifest =<<EOS
+    exec{'true':
+      command => 'true',
+      path => ['/bin', '/usr/bin'],
+    }
+
+    exec{'false':
+      command => 'false',
+      path => ['/bin', '/usr/bin'],
+      refreshonly => true,
+      subscribe => Exec['true'],
+    }
+
+    exec{'require_echo':
+      command => 'echo "This should not happen due to a failed requirement."',
+      path => ['/bin', '/usr/bin'],
+      logoutput => true,
+      require => Exec['false'],
+    }
+EOS
+
+  agents.each do |agent|
+    step 'Apply manifest with fail on refresh. Ensure that this results in a failed dependency' do
+      apply_manifest_on(agent, manifest, :expect_failures => true) do |res|
+        assert_no_match(/require_echo.*returns: executed successfully/, res.stdout)
+        assert_match(/require_echo.*Skipping because of failed dependencies/, res.stderr)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This commit adds an acceptance test to verify that a puppet run fails
when using `--detailed-exitcodes` when a resource triggered by a
refresh fails.