### PR TITLE
(PUP-6256) Ensure that agent run returns exit code instead of log entry

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -49,6 +49,7 @@ class Puppet::Agent
             return
           rescue StandardError => detail
             Puppet.log_exception(detail, _("Could not run %{client_class}: %{detail}") % { client_class: client_class, detail: detail })
+            1
           end
         end
       end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -217,6 +217,17 @@ describe Puppet::Agent do
         @agent.run
       end
 
+      it 'should exit with 1 if an exception is raised' do
+        client = AgentTestClient.new
+        AgentTestClient.expects(:new).returns client
+
+        client.expects(:run).raises(StandardError)
+
+        Kernel.expects(:fork).yields
+        @agent.expects(:exit).with(1)
+        @agent.run
+      end
+
       it "should re-raise exit happening in the child" do
         Process.stubs(:waitpid2).returns [123, (stub 'process::status', :exitstatus => -1)]
         expect { @agent.run }.to raise_error(SystemExit)


### PR DESCRIPTION
Before this commit, the `Agent#run` method would pass a block to the
`Agent#run_in_fork` that, in case a `StandardError` was raised, would
log the exception and then return the created `Log` instance. Since the
caller of the block expects an exit code, which it passes on in a call
to exit, it would fail with another exception when it instead passed
the returned `Log` instance.

This commit ensures that the block instead returns the integer 1 in case
a `StandardError` is raised.