### PR TITLE
PUP-7685: puppet resource user may show double groups

### DIFF
--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -261,7 +261,12 @@ class Puppet::Provider::NameService < Puppet::Provider
     # reading of the file.
     Puppet::Etc.endgrent
 
-    groups.join(",")
+    uniq_groups = groups.uniq
+    if groups != uniq_groups
+      debug("Removing any duplicate group entries")
+    end
+    # remove any double listed groups
+    uniq_groups.join(",")
   end
 
   # Convert the Etc struct into a hash.


### PR DESCRIPTION
This patch resolves PUP-7685