### PR TITLE
DOCUMENT-692: Add another reduce example

### DIFF
--- a/lib/puppet/functions/reduce.rb
+++ b/lib/puppet/functions/reduce.rb
@@ -94,6 +94,37 @@
 # # $combine contains [dabc, 10]
 # ~~~
 #
+# @example Using the `reduce` function to reduce a hash of hashes
+#
+# ~~~ puppet
+# # Reduce a hash of hashes $data, merging defaults into the inner hashes.
+# $data = {
+#   'connection1' => {
+#     'username' => 'user1',
+#     'password' => 'pass1',
+#   },
+#   'connection_name2' => {
+#     'username' => 'user2',
+#     'password' => 'pass2',
+#   },
+# }
+#
+# $defaults = {
+#   'maxActive' => '20',
+#   'maxWait'   => '10000',
+#   'username'  => 'defaultuser',
+#   'password'  => 'defaultpass',
+# }
+#
+# $merged = $data.reduce( {} ) |$memo, $x| {
+#   $memo + { $x[0] => $defaults + $data[$x[0]] }
+# }
+# # At the start of the lambda's first iteration, $memo is set to {}, and $x is set to
+# # the first [key, value] tuple. The key in $data is, therefore, given by $x[0]. In
+# # subsequent rounds, $memo retains the value returned by the expression, i.e.
+# # $memo + { $x[0] => $defaults + $data[$x[0]] }.
+# ~~~
+#
 # @since 4.0.0
 #
 Puppet::Functions.create_function(:reduce) do

--- a/lib/puppet/parser/functions/reduce.rb
+++ b/lib/puppet/parser/functions/reduce.rb
@@ -99,6 +99,37 @@ $combine = $data.reduce( [d, 4] ) |$memo, $value| {
 # $combine contains [dabc, 10]
 ~~~
 
+**Example**: Using the `reduce` function to reduce a hash of hashes
+
+~~~ puppet
+# Reduce a hash of hashes $data, merging defaults into the inner hashes.
+$data = {
+  'connection1' => {
+    'username' => 'user1',
+    'password' => 'pass1',
+  },
+  'connection_name2' => {
+    'username' => 'user2',
+    'password' => 'pass2',
+  },
+}
+
+$defaults = {
+  'maxActive' => '20',
+  'maxWait'   => '10000',
+  'username'  => 'defaultuser',
+  'password'  => 'defaultpass',
+}
+
+$merged = $data.reduce( {} ) |$memo, $x| {
+  $memo + { $x[0] => $defaults + $data[$x[0]] }
+}
+# At the start of the lambda's first iteration, $memo is set to {}, and $x is set to
+# the first [key, value] tuple. The key in $data is, therefore, given by $x[0]. In
+# subsequent rounds, $memo retains the value returned by the expression, i.e.
+# $memo + { $x[0] => $defaults + $data[$x[0]] }.
+~~~
+
 - Since 4.0.0
 DOC
 ) do |args|


### PR DESCRIPTION
This adds an example of how to use the `reduce` function to iteratively
update a Hash of Hashes.