### PR TITLE
(maint) Update comments in commit Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -92,8 +92,9 @@ task(:commits) do
       raise "\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n" \
         "\n\t\t#{commit_summary}\n" \
         "\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n"  \
-        "\t\t(pup-<digits>) # this is most common and should be a ticket at tickets.puppetlabs.com\n" \
+        "\t\t(PUP-<digits>) # this is most common and should be a ticket at tickets.puppet.com\n" \
         "\t\t(docs)\n" \
+        "\t\t(docs)(DOCUMENT-<digits>)\n" \
         "\t\t(maint)\n" \
         "\t\t(packaging)\n" \
         "\n\tThis test for the commit summary is case-insensitive.\n\n\n"


### PR DESCRIPTION
Without this patch applied, build failures caused by commit summaries
that fail to match patterns as specified in `Rakefile` are providing
instructions not in line with actual practice in this project.

The Jira ticket is usually given as PUP-<digits>; doc updates are given
usually as (docs) and occasionally as (docs)(DOC-<digits>).

This patch updates the hint to give instructions in line with the actual
practice in the project.