### PR TITLE
(PUP-7691) Ensure that the 4x loader is present when epp face executes

### DIFF
--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -316,34 +316,36 @@ Puppet::Face.define(:epp, '0.0.1') do
       options[:header] = options[:header].nil? ? true : options[:header]
 
       compiler = create_compiler(options)
+      compiler.with_context_overrides('For rendering epp') do
 
-      # Print to a buffer since the face needs to return the resulting string
-      # and the face API is "all or nothing"
-      #
-      buffer = StringIO.new
-      status = true
-      if options[:e]
-        buffer.print render_inline(options[:e], compiler, options)
-      elsif args.empty?
-        if ! STDIN.tty?
-          buffer.print render_inline(STDIN.read, compiler, options)
+        # Print to a buffer since the face needs to return the resulting string
+        # and the face API is "all or nothing"
+        #
+        buffer = StringIO.new
+        status = true
+        if options[:e]
+          buffer.print render_inline(options[:e], compiler, options)
+        elsif args.empty?
+          if ! STDIN.tty?
+            buffer.print render_inline(STDIN.read, compiler, options)
+          else
+            raise Puppet::Error, "No input to process given on command line or stdin"
+          end
         else
-          raise Puppet::Error, "No input to process given on command line or stdin"
-        end
-      else
-        show_filename = args.count > 1
-        file_nbr = 0
-        args.each do |file|
-          begin
-            buffer.print render_file(file, compiler, options, show_filename, file_nbr += 1)
-          rescue Puppet::ParseError => detail
-            Puppet.err(detail.message)
-            status = false
+          show_filename = args.count > 1
+          file_nbr = 0
+          args.each do |file|
+            begin
+              buffer.print render_file(file, compiler, options, show_filename, file_nbr += 1)
+            rescue Puppet::ParseError => detail
+              Puppet.err(detail.message)
+              status = false
+            end
           end
         end
+        raise Puppet::Error, "error while rendering epp" unless status
+        buffer.string
       end
-      raise Puppet::Error, "error while rendering epp" unless status
-      buffer.string
     end
   end
 

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -156,6 +156,10 @@ class Puppet::Parser::Compiler
   # Return a list of all of the defined classes.
   def_delegator :@catalog, :classes, :classlist
 
+  def with_context_overrides(description = '', &block)
+    Puppet.override( @context_overrides , description, &block)
+  end
+
   # Compiler our catalog.  This mostly revolves around finding and evaluating classes.
   # This is the main entry into our catalog.
   def compile

--- a/lib/puppet/parser/functions/assert_type.rb
+++ b/lib/puppet/parser/functions/assert_type.rb
@@ -56,5 +56,5 @@ For more information about data types, see the
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('assert_type')
+  Puppet::Parser::Functions::Error.is4x('assert_type')
 end

--- a/lib/puppet/parser/functions/binary_file.rb
+++ b/lib/puppet/parser/functions/binary_file.rb
@@ -20,5 +20,5 @@ To search for the existence of files, use the `find_file()` function.
 - since 4.8.0
 DOC
 ) do |args|
-  Error.is4x('binary_file')
+  Puppet::Parser::Functions::Error.is4x('binary_file')
 end

--- a/lib/puppet/parser/functions/break.rb
+++ b/lib/puppet/parser/functions/break.rb
@@ -35,5 +35,5 @@ Would notice the value `[10]`
 * Since 4.8.0
 DOC
 ) do |args|
-  Error.is4x('break')
+  Puppet::Parser::Functions::Error.is4x('break')
 end

--- a/lib/puppet/parser/functions/defined.rb
+++ b/lib/puppet/parser/functions/defined.rb
@@ -103,5 +103,5 @@ defined('$tmp_file2')
 - Since 4.0.0 includes all future parser features
 DOC
 ) do |vals|
-  Error.is4x('defined')
+  Puppet::Parser::Functions::Error.is4x('defined')
 end

--- a/lib/puppet/parser/functions/dig.rb
+++ b/lib/puppet/parser/functions/dig.rb
@@ -25,5 +25,5 @@ Would notice the value 100.
 * Since 4.5.0
 DOC
 ) do |args|
-  Error.is4x('dig')
+  Puppet::Parser::Functions::Error.is4x('dig')
 end

--- a/lib/puppet/parser/functions/each.rb
+++ b/lib/puppet/parser/functions/each.rb
@@ -100,5 +100,5 @@ documentation.
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('each')
+  Puppet::Parser::Functions::Error.is4x('each')
 end

--- a/lib/puppet/parser/functions/epp.rb
+++ b/lib/puppet/parser/functions/epp.rb
@@ -32,5 +32,5 @@ function fails to pass any required parameter.
 
 - Since 4.0.0") do |args|
 
-  Error.is4x('epp')
+  Puppet::Parser::Functions::Error.is4x('epp')
 end

--- a/lib/puppet/parser/functions/filter.rb
+++ b/lib/puppet/parser/functions/filter.rb
@@ -74,5 +74,5 @@ $filtered_data = $data.filter |$keys, $values| { $keys =~ /berry$/ and $values <
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('filter')
+  Puppet::Parser::Functions::Error.is4x('filter')
 end

--- a/lib/puppet/parser/functions/find_file.rb
+++ b/lib/puppet/parser/functions/find_file.rb
@@ -23,6 +23,6 @@ The function returns `undef` if none of the given paths were found
 - since 4.8.0
 DOC
 ) do |args|
-  Error.is4x('find_file')
+  Puppet::Parser::Functions::Error.is4x('find_file')
 end
 

--- a/lib/puppet/parser/functions/inline_epp.rb
+++ b/lib/puppet/parser/functions/inline_epp.rb
@@ -47,5 +47,5 @@ END
 - Since 3.5
 - Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8") do |arguments|
 
-  Error.is4x('inline_epp')
+  Puppet::Parser::Functions::Error.is4x('inline_epp')
 end

--- a/lib/puppet/parser/functions/lest.rb
+++ b/lib/puppet/parser/functions/lest.rb
@@ -45,5 +45,5 @@ Would notice the value `20`
 * Since 4.5.0
 DOC
 ) do |args|
-  Error.is4x('lest')
+  Puppet::Parser::Functions::Error.is4x('lest')
 end

--- a/lib/puppet/parser/functions/map.rb
+++ b/lib/puppet/parser/functions/map.rb
@@ -72,5 +72,5 @@ $transformed_data = $data.map |$key,$value| { $value }
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('map')
+  Puppet::Parser::Functions::Error.is4x('map')
 end

--- a/lib/puppet/parser/functions/match.rb
+++ b/lib/puppet/parser/functions/match.rb
@@ -39,5 +39,5 @@ $matches = ["abc123","def456"].match(/([a-z]+)([1-9]+)/)
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('match')
+  Puppet::Parser::Functions::Error.is4x('match')
 end

--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -934,6 +934,6 @@ $b = binary_file('mymodule/mypicture.jpg')
 
 DOC
 ) do |args|
-  Error.is4x('new')
+  Puppet::Parser::Functions::Error.is4x('new')
 end
 

--- a/lib/puppet/parser/functions/next.rb
+++ b/lib/puppet/parser/functions/next.rb
@@ -34,5 +34,5 @@ Would notice the value `[10, 200, 30]`
 * Since 4.8.0
 DOC
 ) do |args|
-  Error.is4x('next')
+  Puppet::Parser::Functions::Error.is4x('next')
 end

--- a/lib/puppet/parser/functions/reduce.rb
+++ b/lib/puppet/parser/functions/reduce.rb
@@ -102,5 +102,5 @@ $combine = $data.reduce( [d, 4] ) |$memo, $value| {
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('reduce')
+  Puppet::Parser::Functions::Error.is4x('reduce')
 end

--- a/lib/puppet/parser/functions/return.rb
+++ b/lib/puppet/parser/functions/return.rb
@@ -67,5 +67,5 @@ Note that the returned value is ignored if used in a class or user defined type.
 * Since 4.8.0
 DOC
 ) do |args|
-  Error.is4x('return')
+  Puppet::Parser::Functions::Error.is4x('return')
 end

--- a/lib/puppet/parser/functions/reverse_each.rb
+++ b/lib/puppet/parser/functions/reverse_each.rb
@@ -79,5 +79,5 @@ $transformed_data = map(reverse_each($data)) |$item| { $item * 10 }
 
 DOC
 ) do |args|
-  Error.is4x('reverse_each')
+  Puppet::Parser::Functions::Error.is4x('reverse_each')
 end

--- a/lib/puppet/parser/functions/slice.rb
+++ b/lib/puppet/parser/functions/slice.rb
@@ -35,5 +35,5 @@ to empty arrays for a hash.
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('slice')
+  Puppet::Parser::Functions::Error.is4x('slice')
 end

--- a/lib/puppet/parser/functions/step.rb
+++ b/lib/puppet/parser/functions/step.rb
@@ -80,5 +80,5 @@ $transformed_data contains [0,50,100,150,200]
 
 DOC
 ) do |args|
-  Error.is4x('step')
+  Puppet::Parser::Functions::Error.is4x('step')
 end

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -181,5 +181,5 @@ notice($duration.strftime('%M:%S')) # outputs '200:30'
 - Since 4.8.0
 DOC
 ) do |args|
-  Error.is4x('strftime')
+  Puppet::Parser::Functions::Error.is4x('strftime')
 end

--- a/lib/puppet/parser/functions/then.rb
+++ b/lib/puppet/parser/functions/then.rb
@@ -69,5 +69,5 @@ was not a String.
 
 DOC
 ) do |args|
-  Error.is4x('then')
+  Puppet::Parser::Functions::Error.is4x('then')
 end

--- a/lib/puppet/parser/functions/type.rb
+++ b/lib/puppet/parser/functions/type.rb
@@ -49,5 +49,5 @@ function type(Any $value, InferenceFidelity $fidelity = 'detailed') # returns Ty
 
 DOC
 ) do |args|
-  Error.is4x('type')
+  Puppet::Parser::Functions::Error.is4x('type')
 end

--- a/lib/puppet/parser/functions/with.rb
+++ b/lib/puppet/parser/functions/with.rb
@@ -24,5 +24,5 @@ $check_var = $x
 - Since 4.0.0
 DOC
 ) do |args|
-  Error.is4x('with')
+  Puppet::Parser::Functions::Error.is4x('with')
 end

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -238,7 +238,6 @@ describe Puppet::Face[:epp, :current] do
     end
 
     it 'initializes the 4x loader' do
-      pending 'fix for PUP-7691'
       expect(eppface.render({ :e => <<-EPP.unindent })).to eql("\nString\n\nInteger\n\nBoolean\n")
         <% $data = [type('a',generalized), type(2,generalized), type(true)] -%>
         <% $data.each |$value| { %>

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -237,6 +237,16 @@ describe Puppet::Face[:epp, :current] do
       expect(eppface.render({ :e => 'trusted is hash: <%= $trusted =~ Hash %>' })).to eql("trusted is hash: true")
     end
 
+    it 'initializes the 4x loader' do
+      pending 'fix for PUP-7691'
+      expect(eppface.render({ :e => <<-EPP.unindent })).to eql("\nString\n\nInteger\n\nBoolean\n")
+        <% $data = [type('a',generalized), type(2,generalized), type(true)] -%>
+        <% $data.each |$value| { %>
+        <%= $value %>
+        <% } -%>
+      EPP
+    end
+
     it "facts can be added to" do
       expect(eppface.render({
         :facts => {'the_crux' => 'biscuit'},


### PR DESCRIPTION
Before this commit, the command 'puppet epp' would fail when the epp-
template contained code that required the 4x loader. The reason was that
the compiler was not properly initialized with its overrides. This
commit ensures that the compiler adds the overrides just as it would
when doing a proper compile of a catalog.