### PR TITLE
(maint) Fix intermittent AppVeyor OpenSSL fails 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,15 @@ test_script:
       $Env:PATH = "C:\${Env:PLATFORM}\bin;${Env:PATH}"
       $Env:LOG_SPEC_ORDER = 'true'
       Get-ChildItem Env: | % { Write-Output "$($_.Key): $($_.Value)"  }
+      if ( $(ruby --version) -match "^ruby\s+2\.4" ) {
+        # AppVeyor appears to have OpenSSL headers available already
+        # which msys2 would normally install with:
+        # pacman -S mingw-w64-x86_64-openssl --noconfirm
+        Write-Output "Building OpenSSL gem ~> 2.0.4 to fix Ruby 2.4 / AppVeyor issue"
+        gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc -- --with-openssl-dir=C:\msys64\mingw64
+      }
+      gem list openssl
+      ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"' 
       bundle install --jobs 4 --retry 2 --without development extra
       Get-Content Gemfile.lock
       ruby -v


### PR DESCRIPTION
 - RubyInstaller is currently shipping 2.4.1-1 to AppVeyor which
   contains an OpenSSL bug documented at:

   https://bugs.ruby-lang.org/issues/11033

   This bug can cause intermittent failures, which due to the
   fast fail flag being enabled in AppVeyor, will terminate
   all cells.

 - To compile under msys2 requires that OpenSSL source package
   be installed to c:\msys64\mingw64, which AppVeyor appears to
   already have setup correctly.

   Otherwise, pacman package manager would be used under msys2
   to install the source like:

   pacman -S mingw-w64-x86_64-openssl --noconfirm

   NOTE: pacman isn't actually in PATH on AppVeyor currently