### PR TITLE
(PUP-7364) Make generate_ast_model task restore method Program#current

### DIFF
--- a/lib/puppet/pops/model/ast.rb
+++ b/lib/puppet/pops/model/ast.rb
@@ -25,7 +25,7 @@ class PopsObject
   attr_reader :hash
 
   def initialize
-    @hash = -1052386662549381418
+    @hash = -1631630444118989922
   end
   def _pcore_init_hash
     {}
@@ -4664,6 +4664,10 @@ class Program < PopsObject
   attr_reader :body
   attr_reader :definitions
   attr_reader :locator
+
+  def current
+    self
+  end
 
   def source_text
     @locator.string

--- a/tasks/generate_ast_model.rake
+++ b/tasks/generate_ast_model.rake
@@ -19,7 +19,7 @@ module Puppet::Pops
       ruby = Types::RubyGenerator.new.module_definition_from_typeset(ast_model)
 
       # Replace ref() constructs to known Pcore types with directly initialized types. ref() cannot be used
-      # since it requires a parser (hen and egg problem)
+      # since it requires a parser (chicken-and-egg problem)
       ruby.gsub!(/^module Parser\nmodule Locator\n.*\nend\nend\nmodule Model\n/m, "module Model\n")
 
       # Remove generated RubyMethod annotations. The ruby methods are there now, no need to also have
@@ -47,6 +47,9 @@ module Puppet::Pops
 
       # Remove the generated ref() method. It's not needed by this model
       ruby.gsub!(/  def self\.ref\(type_string\)\n.*\n  end\n\n/, '')
+
+      # Add Program#current method for backward compatibility
+      ruby.gsub!(/(attr_reader :body\n  attr_reader :definitions\n  attr_reader :locator)/, "\\1\n\n  def current\n    self\n  end")
 
       # Replace the generated registration with a registration that uses the static loader. This will
       # become part of the Puppet bootstrap code and there will be no other loader until we have a


### PR DESCRIPTION
This commit changes the rake task `generate_ast_model` so that it emits
the method
```ruby
def current
  self
end
```
for the Puppet::Pops::Model::Program class.