### PR TITLE
(PUP-6290) Ignore, warn, or fail when evaluated resources are overridden

### DIFF
--- a/lib/puppet/pops/evaluator/collector_transformer.rb
+++ b/lib/puppet/pops/evaluator/collector_transformer.rb
@@ -27,7 +27,7 @@ class CollectorTransformer
       overrides = {
         :parameters => o.operations.map{ |x| @@evaluator.evaluate(x, scope)}.flatten,
         :file       => o.file,
-        :line       => [o.line, o.pos],
+        :line       => o.line,
         :source     => scope.source,
         :scope      => scope
       }

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -339,7 +339,6 @@ describe 'collectors' do
         end
 
         it 'and --strict=warning, it warns about the attempt to override and skips it' do
-          pending('Fix for PUP-6290')
           Puppet[:strict] = :warning
           expect_the_message_to_be(['given'], manifest)
           expect(warnings).to include(
@@ -347,7 +346,6 @@ describe 'collectors' do
         end
 
         it 'and --strict=error, it fails compilation' do
-          pending('Fix for PUP-6290')
           Puppet[:strict] = :error
           expect { compile_to_catalog(manifest) }.to raise_error(
             /Attempt to override an already evaluated resource, defined at line 4, with new values at line 6/)

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -312,7 +312,48 @@ describe 'collectors' do
         MANIFEST
       end
 
+      context 'when overriding an already evaluated resource' do
+        let(:logs) { [] }
+        let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+        let(:manifest) { <<-MANIFEST }
+          define foo($message) {
+            notify { "testing": message => $message }
+          }
+          foo { test: message => 'given' }
+          define delayed {
+            Foo <|  |> { message => 'overridden' }
+          }
+          delayed {'do it now': }
+        MANIFEST
+
+        around(:each) do |example|
+          Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+            example.run
+          end
+        end
+
+        it 'and --strict=off, it silently skips the override' do
+          Puppet[:strict] = :off
+          expect_the_message_to_be(['given'], manifest)
+          expect(warnings).to be_empty
+        end
+
+        it 'and --strict=warning, it warns about the attempt to override and skips it' do
+          pending('Fix for PUP-6290')
+          Puppet[:strict] = :warning
+          expect_the_message_to_be(['given'], manifest)
+          expect(warnings).to include(
+            /Attempt to override an already evaluated resource, defined at line 4, with new values at line 6/)
+        end
+
+        it 'and --strict=error, it fails compilation' do
+          pending('Fix for PUP-6290')
+          Puppet[:strict] = :error
+          expect { compile_to_catalog(manifest) }.to raise_error(
+            /Attempt to override an already evaluated resource, defined at line 4, with new values at line 6/)
+          expect(warnings).to be_empty
+        end
+      end
     end
   end
-
 end


### PR DESCRIPTION
This commit changes the `Puppet::Parser::Resource#set_parameter` so that
it checks if the resource has already been evaluated. If that's the case,
then the behavior is controlled by the setting of `Puppet[:strict]`:

strict=off, the attempt silently sets the parameter although no
re-evaluation of the resource takes place. In essence, the new value is
ignored (same as before this commit).

strict=warning, same as strict=off, but the attempt is also logged as a
warning.

strict=error, compilation fails.