### PR TITLE
(maint) cleanup exception in Configurer#find_functional_server

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -375,7 +375,7 @@ class Puppet::Configurer
               :transaction_uuid => @transaction_uuid,
               :fail_on_404 => false)
           found = true
-        rescue Exception => e
+        rescue
           # Nothing to see here
         end
       end


### PR DESCRIPTION
- We don't use the exception variable `e`, so we shouldn't retain it. Minor,
  but enough of these and we have a lot of extra expensive objects getting
  created.

- Don't `rescue Exception`, just rescue. `rescue` by default will rescue
  StandardError. Rescuing Exception is broader in its scope. It's most
  likely we just want to rescue if the rest indirection recieves a 404 because
  the node wasn't found (which raises Puppet::Error) or the server wasn't
  found, and we get an Errno::ECONNREFUSED. Both of these inherit from
  StandardError.

Signed-off-by: Moses Mendoza <moses@puppet.com>