### PR TITLE
(PUP-7102) Fail with error on access problems with environment directory

### DIFF
--- a/acceptance/tests/environment/directory_environment_with_access_problems.rb
+++ b/acceptance/tests/environment/directory_environment_with_access_problems.rb
@@ -2,6 +2,8 @@ test_name 'Ensure that agent receives proper error message when environment is i
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'server'
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 testdir = create_tmpdir_for_user master, 'env-with-access-problem'

--- a/acceptance/tests/environment/directory_environment_with_access_problems.rb
+++ b/acceptance/tests/environment/directory_environment_with_access_problems.rb
@@ -1,0 +1,42 @@
+test_name 'Ensure that agent receives proper error message when environment is inaccessible'
+require 'puppet/acceptance/classifier_utils'
+extend Puppet::Acceptance::ClassifierUtils
+
+classify_nodes_as_agent_specified_if_classifer_present
+
+testdir = create_tmpdir_for_user master, 'env-with-access-problem'
+
+apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+File {
+  ensure => directory,
+  owner => #{master.puppet['user']},
+  group => #{master.puppet['group']},
+  mode => "0770",
+}
+
+file {
+  "#{testdir}":;
+  "#{testdir}/environments":;
+  "#{testdir}/environments/direnv":
+    owner => 'root',
+    group => 'root',
+    mode => "0700"
+}
+MANIFEST
+
+master_opts = {
+  'master' => {
+    'environmentpath' => "#{testdir}/environments",
+  }
+}
+
+with_puppet_running_on master, master_opts, testdir do
+  agents.each do |agent|
+    on(agent,
+       puppet("agent", "-t", "--server", master, "--environment", "direnv"),
+       :acceptable_exit_codes => [1]) do |result|
+
+      assert_match(/Permission denied - .*\/environments\/direnv/, result.stderr)
+    end
+  end
+end

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -213,9 +213,36 @@ module Puppet::Environments
     end
 
     def valid_directory?(envdir)
-      name = Puppet::FileSystem.basename_string(envdir)
-      Puppet::FileSystem.directory?(envdir) &&
-         Puppet::Node::Environment.valid_name?(name)
+      return false unless Puppet::Node::Environment.valid_name?(Puppet::FileSystem.basename_string(envdir))
+
+      # Make an attempt to access the directory to determine if it's invalid
+      # due to permission problems or simply because it doesn't exist
+      begin
+        stat = Puppet::FileSystem.stat(envdir)
+      rescue Errno::ENOENT
+        false
+      rescue Errno::EACCES
+        # If the stat on envdir failed with Errno::EACCES, then the problem is in a parent directory and
+        # should be reported as such.
+        prev = envdir
+        current = Puppet::FileSystem.dir(prev)
+        while current
+          begin
+            break if Puppet::FileSystem.stat(current).readable?
+          rescue Errno::EACCES
+          end
+          prev = current
+          current = Puppet::FileSystem.dir(prev)
+        end
+        raise Errno::EACCES, prev.to_s
+      end
+
+      if stat && stat.directory?
+        raise Errno::EACCES, envdir.to_s unless stat.readable?
+        true
+      else
+        false
+      end
     end
 
     def valid_directories

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -220,7 +220,7 @@ module Puppet::Environments
       begin
         stat = Puppet::FileSystem.stat(envdir)
       rescue Errno::ENOENT
-        false
+        return false
       rescue Errno::EACCES
         # If the stat on envdir failed with Errno::EACCES, then the problem is in a parent directory and
         # should be reported as such.

--- a/lib/puppet/file_system/memory_file.rb
+++ b/lib/puppet/file_system/memory_file.rb
@@ -4,29 +4,43 @@ class Puppet::FileSystem::MemoryFile
   attr_reader :path, :children
 
   def self.a_missing_file(path)
-    new(path, :exist? => false, :executable? => false)
+    new(path, :exist? => false, :executable? => false, :readable? => false)
   end
 
   def self.a_regular_file_containing(path, content)
-    new(path, :exist? => true, :executable? => false, :content => content)
+    new(path, :exist? => true, :directory? => false, :executable? => false, :content => content, :readable? => true)
+  end
+
+  def self.an_unreadable_regular_file(path)
+    new(path, :exist? => true, :directory => false, :executable? => false, :readable? => false)
   end
 
   def self.an_executable(path)
-    new(path, :exist? => true, :executable? => true)
+    new(path, :exist? => true, :directory => false, :executable? => true, :readable? => true)
   end
 
   def self.a_directory(path, children = [])
     new(path,
+      :exist? => true,
+      :executable? => true,
+      :directory? => true,
+      :children => children,
+      :readable? => true)
+  end
+
+  def self.an_unreadable_directory(path, children = [])
+    new(path,
         :exist? => true,
-        :excutable? => true,
+        :executable? => true,
         :directory? => true,
-        :children => children)
+        :children => children,
+        :readable? => false)
   end
 
   def initialize(path, properties)
     @path = path
     @properties = properties
-    @children = (properties[:children] || []).collect do |child|
+    @children = (properties[:children] || []).map do |child|
       child.duplicate_as(File.join(@path, child.path))
     end
   end
@@ -34,6 +48,7 @@ class Puppet::FileSystem::MemoryFile
   def directory?; @properties[:directory?]; end
   def exist?; @properties[:exist?]; end
   def executable?; @properties[:executable?]; end
+  def readable?; @properties[:readable?]; end
 
   def each_line(&block)
     handle.each_line(&block)

--- a/lib/puppet/file_system/memory_file.rb
+++ b/lib/puppet/file_system/memory_file.rb
@@ -1,7 +1,7 @@
 # An in-memory file abstraction. Commonly used with Puppet::FileSystem::File#overlay
 # @api private
 class Puppet::FileSystem::MemoryFile
-  attr_reader :path, :children
+  attr_reader :path
 
   def self.a_missing_file(path)
     new(path, :exist? => false, :executable? => false, :readable? => false)
@@ -43,6 +43,11 @@ class Puppet::FileSystem::MemoryFile
     @children = (properties[:children] || []).map do |child|
       child.duplicate_as(File.join(@path, child.path))
     end
+  end
+
+  def children
+    raise Errno::EACCES, @path unless readable?
+    @children
   end
 
   def directory?; @properties[:directory?]; end

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -115,11 +115,14 @@ class Puppet::FileSystem::MemoryImpl
   end
 
   def all_children_of(files)
-    children = files.collect(&:children).flatten
-    if children.empty?
-      []
-    else
-      children + all_children_of(children)
+    children = []
+    files.each do |file|
+      begin
+        children.concat(file.children)
+      rescue Errno::EACCES
+      end
     end
+    children.concat(all_children_of(children)) unless children.empty?
+    children
   end
 end

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -19,6 +19,10 @@ class Puppet::FileSystem::MemoryImpl
     path.file?
   end
 
+  def readable?(path)
+    path.readable?
+  end
+
   def executable?(path)
     path.executable?
   end
@@ -33,6 +37,11 @@ class Puppet::FileSystem::MemoryImpl
 
   def pathname(path)
     find(path) || Puppet::FileSystem::MemoryFile.a_missing_file(path)
+  end
+
+  def dir(path)
+    dirname = File.dirname(path_string(path))
+    find(dirname) || Puppet::FileSystem::MemoryFile.a_directory(dirname, [path])
   end
 
   def basename(path)
@@ -59,6 +68,36 @@ class Puppet::FileSystem::MemoryImpl
     else
       return handle
     end
+  end
+
+  class MemoryStat
+    def initialize(path)
+      @path = path
+    end
+
+    def directory?
+      @path.directory?
+    end
+
+    def file?
+      @path.directory?
+    end
+
+    def executable?
+      @path.executable?
+    end
+
+    def readable?
+      @path.readable?
+    end
+
+    def writable?
+      @path.executable?
+    end
+  end
+
+  def stat(path)
+    MemoryStat.new(path)
   end
 
   def assert_path(path)

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -116,6 +116,38 @@ describe Puppet::Environments do
         ]
       end
 
+      context 'with access permission issues' do
+        let(:directory_tree) do
+          FS::MemoryFile.a_directory(File.expand_path('envdir'), [
+            FS::MemoryFile.a_directory('an_environment', [FS::MemoryFile.a_missing_file('environment.conf')]),
+            FS::MemoryFile.an_unreadable_directory('unreadable_environment', [])
+          ])
+        end
+
+        it 'raises error if a directory on the environment path is unreadable' do
+          loader_from(:filesystem => [directory_tree],
+            :directory => directory_tree) do |loader|
+            expect  { loader.list }.to raise_error(Errno::EACCES, /^Permission denied - .*\/envdir\/unreadable_environment$/)
+          end
+        end
+      end
+
+      context 'with access permission issues on parent' do
+        let(:directory_tree) do
+          FS::MemoryFile.an_unreadable_directory(File.expand_path('envdir'), [
+            FS::MemoryFile.an_unreadable_directory('an_environment', [FS::MemoryFile.a_missing_file('environment.conf')]),
+            FS::MemoryFile.an_unreadable_directory('unreadable_environment', [])
+          ])
+        end
+
+        it 'raises error if that reports the parent directory as the culprit' do
+          loader_from(:filesystem => [directory_tree],
+            :directory => directory_tree) do |loader|
+            expect  { loader.list }.to raise_error(Errno::EACCES, /^Permission denied - .*\/envdir$/)
+          end
+        end
+      end
+
       let(:content) do
         <<-EOF
 manifest=#{manifestdir}


### PR DESCRIPTION
This PR ensures that access problems on a directory that is a
candidate to be an environment (reachable using the environmentpath)
or the parent of such a directory results in an error and that puppet
gives up.