### PR TITLE
(PUP-5506) making the source parameter authoritative for gem provider

### DIFF
--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -56,7 +56,7 @@ context 'installing myresource' do
 
       it "should allow setting an install_options parameter" do
         resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-        provider.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
+        provider.expects(:execute).with { |args| args[2] == '--force' && args[3] == '--bindir=/usr/bin' }.returns ''
         provider.install
       end
 

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -41,7 +41,7 @@ describe provider_class do
 
     it "should allow setting an install_options parameter" do
       resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      provider.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
+      provider.expects(:execute).with { |args| args[2] == '--force' && args[3] == '--bindir=/usr/bin' }.returns ''
       provider.install
     end
   end


### PR DESCRIPTION
Prior to this commit, the 'install_options' attribute was passed to the gem
command after the 'source' attribute, preventing the use of '--clear-sources'
in 'install_options', as '--clear-sources' is positionally dependent.

With this commit, the 'install_options' attribute is passed first.

This was identified and resolved in MODULES-4815.

While the subject of the ticket is 'making the source parameter authoritative',
in MODULES-4815 we decided to maintain backwards compatibility and not imply
'--clear-sources' when the 'source' attribute is specified.