### PR TITLE
(PUP-1391) puppet device cannot create certs when run as root

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1300,6 +1300,8 @@ EOT
         :default  => "$vardir/devices",
         :type     => :directory,
         :mode     => "0750",
+        :owner    => "service",
+        :group    => "service",
         :desc     => "The root directory of devices' $vardir.",
     },
     :deviceconfig => {


### PR DESCRIPTION
Prior to this commit, puppet device could not write to the privatekeydir and
certdir for devices.

drwxr-x---.  3 root      root        18 Jun 28 22:55 devices

With this commit, the $vardir/devices directory’s group is set to pe-puppet,
so that the puppet user can traverse the directory via the group permissions.

drwxr-x---.  3 root      pe-puppet   18 Jun 28 22:55 devices