### PR TITLE
(PUP-7738) Ensure that Puppet can be used with semantic_puppet gem.

### DIFF
--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -23,7 +23,7 @@ Puppet::Face.define(:module, '1.0.0') do
 
     when_invoked do |term, options|
       Puppet::ModuleTool.set_option_defaults options
-      Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new(Puppet[:module_repository], options[:strict_semver]), options).run
+      Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new(options[:module_repository] || Puppet[:module_repository], options[:strict_semver]), options).run
     end
 
     when_rendering :console do |results, term, options|

--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -23,7 +23,7 @@ Puppet::Face.define(:module, '1.0.0') do
 
     when_invoked do |term, options|
       Puppet::ModuleTool.set_option_defaults options
-      Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new, options).run
+      Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new(Puppet[:module_repository], options[:strict_semver]), options).run
     end
 
     when_rendering :console do |results, term, options|

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -19,9 +19,10 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
 
   attr_reader :host, :repository
 
-  def initialize(host = Puppet[:module_repository])
+  def initialize(host = Puppet[:module_repository], strict_semver = true)
     @host = host
     @repository = Puppet::Forge::Repository.new(host, USER_AGENT)
+    @strict_semver = strict_semver
   end
 
   # Return a list of module metadata hashes that match the search query.
@@ -216,7 +217,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     l = list.map do |release|
       metadata = release['metadata']
       begin
-        ModuleRelease.new(self, release)
+        ModuleRelease.new(self, release, @strict_semver)
       rescue ArgumentError => e
         Puppet.warning _("Cannot consider release %{name}-%{version}: %{error}") % { name: metadata['name'], version: metadata['version'], error: e }
         false

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -63,12 +63,14 @@ class Puppet::Module
       if strict
         if @semver_gem_version.major < 1
           Puppet.warn_once('strict_version_ranges', 'version_range_cannot_be_strict',
-            _('VersionRanges will never be strict when using non-vendored SemanticPuppet gem, version %{version}') % { version: @semver_gem_version} )
+            _('VersionRanges will never be strict when using non-vendored SemanticPuppet gem, version %{version}') % { version: @semver_gem_version},
+            nil, nil, :notice)
         end
       else
         if @semver_gem_version.major >= 1
           Puppet.warn_once('strict_version_ranges', 'version_range_always_strict',
-            _('VersionRanges will always be strict when using non-vendored SemanticPuppet gem, version %{version}') % { version: @semver_gem_version} )
+            _('VersionRanges will always be strict when using non-vendored SemanticPuppet gem, version %{version}') % { version: @semver_gem_version},
+            nil, nil, :notice)
         end
       end
       @parse_range_method.call(range)

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -64,13 +64,13 @@ class Puppet::Module
         if @semver_gem_version.major < 1
           Puppet.warn_once('strict_version_ranges', 'version_range_cannot_be_strict',
             _('VersionRanges will never be strict when using non-vendored SemanticPuppet gem, version %{version}') % { version: @semver_gem_version},
-            nil, nil, :notice)
+            :default, :default, :notice)
         end
       else
         if @semver_gem_version.major >= 1
           Puppet.warn_once('strict_version_ranges', 'version_range_always_strict',
             _('VersionRanges will always be strict when using non-vendored SemanticPuppet gem, version %{version}') % { version: @semver_gem_version},
-            nil, nil, :notice)
+            :default, :default, :notice)
         end
       end
       @parse_range_method.call(range)

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -52,6 +52,11 @@ class Puppet::Module
     return false
   end
 
+  # @api private
+  def self.parse_range(range, strict)
+    SemanticPuppet::VersionRange.parse(range, strict)
+  end
+
   attr_reader :name, :environment, :path, :metadata
   attr_writer :environment
 
@@ -328,7 +333,7 @@ class Puppet::Module
 
       if version_string
         begin
-          required_version_semver_range = SemanticPuppet::VersionRange.parse(version_string, @strict_semver)
+          required_version_semver_range = self.class.parse_range(version_string, @strict_semver)
           actual_version_semver = SemanticPuppet::Version.parse(dep_mod.version)
         rescue ArgumentError
           error_details[:reason] = :non_semantic_version

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -132,7 +132,7 @@ module Puppet
       options[:target_dir] = face_environment.full_modulepath.first
 
       # Default false to retain backward compatibility with SemanticPuppet 0.1.4
-      options[:strict_semver] = false
+      options[:strict_semver] = false unless options.include?(:strict_semver)
     end
 
     # Given a hash of options, we should discover or create a

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -174,7 +174,7 @@ module Puppet
       range = dep['version_requirement'] || '>= 0.0.0'
 
       begin
-        parsed_range = SemanticPuppet::VersionRange.parse(range, strict_semver)
+        parsed_range = Module.parse_range(range, strict_semver)
       rescue ArgumentError => e
         Puppet.debug "Error in #{where} parsing dependency #{dep_name} (#{e.message}); using empty range."
         parsed_range = SemanticPuppet::VersionRange::EMPTY_RANGE

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -60,7 +60,7 @@ module Puppet::ModuleTool
         begin
           if installed_module = installed_modules[name]
             unless forced?
-              if SemanticPuppet::VersionRange.parse(version, @strict_semver).include? installed_module.version
+              if Puppet::Module.parse_range(version, @strict_semver).include? installed_module.version
                 results[:result] = :noop
                 results[:version] = installed_module.version
                 return results
@@ -104,7 +104,7 @@ module Puppet::ModuleTool
               # locking it to upgrades within the same major version.
               installed_range = ">=#{version} #{version.major}.x"
               graph.add_constraint('installed', mod, installed_range) do |node|
-                SemanticPuppet::VersionRange.parse(installed_range, @strict_semver).include? node.version
+                Puppet::Module.parse_range(installed_range, @strict_semver).include? node.version
               end
 
               release.mod.dependencies.each do |dep|
@@ -112,7 +112,7 @@ module Puppet::ModuleTool
 
                 range = dep['version_requirement']
                 graph.add_constraint("#{mod} constraint", dep_name, range) do |node|
-                  SemanticPuppet::VersionRange.parse(range, @strict_semver).include? node.version
+                  Puppet::Module.parse_range(range, @strict_semver).include? node.version
                 end
               end
             end
@@ -206,7 +206,7 @@ module Puppet::ModuleTool
       end
 
       def build_single_module_graph(name, version)
-        range = SemanticPuppet::VersionRange.parse(version, @strict_semver)
+        range = Puppet::Module.parse_range(version, @strict_semver)
         graph = SemanticPuppet::Dependency::Graph.new(name => range)
         releases = SemanticPuppet::Dependency.fetch_releases(name)
         releases.each { |release| release.dependencies.clear }

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -186,7 +186,7 @@ module Puppet::ModuleTool
       private
 
       def module_repository
-        @repo ||= Puppet::Forge.new
+        @repo ||= Puppet::Forge.new(Puppet[:module_repository], @strict_semver)
       end
 
       def local_tarball_source

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -58,7 +58,7 @@ module Puppet::ModuleTool
               :path    => mod.modulepath,
             }
             if @options[:version] && mod.version
-              next unless SemanticPuppet::VersionRange.parse(@options[:version], @strict_semver).include?(SemanticPuppet::Version.parse(mod.version))
+              next unless Puppet::Module.parse_range(@options[:version], @strict_semver).include?(SemanticPuppet::Version.parse(mod.version))
             end
             @installed << mod
           elsif mod_name =~ /#{@name}/

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -91,7 +91,7 @@ module Puppet::ModuleTool
           if available_versions.empty?
             raise NoCandidateReleasesError, results.merge(:module_name => name, :source => module_repository.host)
           elsif results[:requested_version] != :latest
-            requested = SemanticPuppet::VersionRange.parse(results[:requested_version], @strict_semver)
+            requested = Puppet::Module.parse_range(results[:requested_version], @strict_semver)
             unless available_versions.any? {|m| requested.include? m.version}
               raise NoCandidateReleasesError, results.merge(:module_name => name, :source => module_repository.host)
             end
@@ -120,7 +120,7 @@ module Puppet::ModuleTool
               # module, locking it to upgrades within the same major version.
               installed_range = ">=#{version} #{version.major}.x"
               graph.add_constraint('installed', installed_module, installed_range) do |node|
-                SemanticPuppet::VersionRange.parse(installed_range, @strict_semver).include? node.version
+                Puppet::Module.parse_range(installed_range, @strict_semver).include? node.version
               end
 
               release.mod.dependencies.each do |dep|
@@ -128,7 +128,7 @@ module Puppet::ModuleTool
 
                 range = dep['version_requirement']
                 graph.add_constraint("#{installed_module} constraint", dep_name, range) do |node|
-                  SemanticPuppet::VersionRange.parse(range, @strict_semver).include? node.version
+                  Puppet::Module.parse_range(range, @strict_semver).include? node.version
                 end
               end
             end
@@ -228,7 +228,7 @@ module Puppet::ModuleTool
       end
 
       def build_single_module_graph(name, version)
-        range = SemanticPuppet::VersionRange.parse(version, @strict_semver)
+        range = Puppet::Module.parse_range(version, @strict_semver)
         graph = SemanticPuppet::Dependency::Graph.new(name => range)
         releases = SemanticPuppet::Dependency.fetch_releases(name)
         releases.each { |release| release.dependencies.clear }

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -216,7 +216,7 @@ module Puppet::ModuleTool
 
       private
       def module_repository
-        @repo ||= Puppet::Forge.new
+        @repo ||= Puppet::Forge.new(Puppet[:module_repository], @strict_semver)
       end
 
       def installed_modules_source

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -76,10 +76,10 @@ module Puppet::ModuleTool::Shared
       }
 
       if forced?
-        range = SemanticPuppet::VersionRange.parse(@version, @strict_semver) rescue SemanticPuppet::VersionRange.parse('>= 0.0.0', @strict_semver)
+        range = Puppet::Module.parse_range(@version, @strict_semver) rescue Puppet::Module.parse_range('>= 0.0.0', @strict_semver)
       else
         range = (@conditions[mod]).map do |r|
-          SemanticPuppet::VersionRange.parse(r[:dependency], @strict_semver) rescue SemanticPuppet::VersionRange.parse('>= 0.0.0', @strict_semver)
+          Puppet::Module.parse_range(r[:dependency], @strict_semver) rescue Puppet::Module.parse_range('>= 0.0.0', @strict_semver)
         end.inject(&:&)
       end
 

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -155,6 +155,7 @@ module Logging
   FILE_AND_LINE = MM::TUPLE
   FILE_NO_LINE  = MM.new(MM::NOT_NIL, nil).freeze
   NO_FILE_LINE  = MM.new(nil, MM::NOT_NIL).freeze
+  SUPPRESS_FILE_LINE = MM.new(:default, :default).freeze
 
   # Logs a (non deprecation) warning once for a given key.
   #
@@ -162,8 +163,8 @@ module Logging
   #   kind must be one of the defined kinds for the Puppet[:disable_warnings] setting.
   # @param message [String] The message to log (logs via warning)
   # @param key [String] Key used to make this warning unique
-  # @param file [String,nil] the File related to the warning
-  # @param line [Integer,nil] the Line number related to the warning
+  # @param file [String,:default,nil] the File related to the warning
+  # @param line [Integer,:default,nil] the Line number related to the warning
   #   warning as unique
   # @param level [Symbol] log level to use, defaults to :warning
   #
@@ -176,6 +177,8 @@ module Logging
         $unique_warnings[key] = message
         call_trace =
         case MM.new(file, line)
+        when SUPPRESS_FILE_LINE
+          ''
         when FILE_AND_LINE
           _("\n   (at %{file}:%{line})") % { file: file, line: line }
         when FILE_NO_LINE

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -165,9 +165,10 @@ module Logging
   # @param file [String,nil] the File related to the warning
   # @param line [Integer,nil] the Line number related to the warning
   #   warning as unique
+  # @param level [Symbol] log level to use, defaults to :warning
   #
   # Either :file and :line and/or :key must be passed.
-  def warn_once(kind, key, message, file = nil, line = nil)
+  def warn_once(kind, key, message, file = nil, line = nil, level = :warning)
     return if Puppet[:disable_warnings].include?(kind)
     $unique_warnings ||= {}
     if $unique_warnings.length < 100 then
@@ -184,7 +185,7 @@ module Logging
         else
           _("\n   (file & line not available)")
         end
-        warning("#{message}#{call_trace}")
+        send_log(level, "#{message}#{call_trace}")
       end
     end
   end

--- a/spec/unit/face/module/search_spec.rb
+++ b/spec/unit/face/module/search_spec.rb
@@ -176,7 +176,7 @@ describe "puppet module search" do
       searcher = mock("Searcher")
       options[:module_repository] = "http://forge.example.com"
 
-      Puppet::Forge.expects(:new).with().returns(forge)
+      Puppet::Forge.expects(:new).with("http://forge.example.com", false).returns(forge)
       Puppet::ModuleTool::Applications::Searcher.expects(:new).with("puppetlabs-apache", forge, has_entries(options)).returns(searcher)
       searcher.expects(:run)
 

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -822,7 +822,7 @@ describe Puppet::Module do
 
   context 'when parsing VersionRange' do
     let(:logs) { [] }
-    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+    let(:notices) { logs.select { |log| log.level == :notice }.map { |log| log.message } }
 
     it 'can parse a strict range' do
       expect(Puppet::Module.parse_range('>=1.0.0', true).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
@@ -842,44 +842,44 @@ describe Puppet::Module do
         end
       end
 
-      it 'will warn when non-strict ranges cannot be parsed' do
+      it 'will notify when non-strict ranges cannot be parsed' do
         Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('1.0.0'))
         Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, true) })
 
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
           expect(Puppet::Module.parse_range('>=1.0.0', false).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
         end
-        expect(warnings).to include(/VersionRanges will always be strict when using non-vendored SemanticPuppet gem, version 1\.0\.0/)
+        expect(notices).to include(/VersionRanges will always be strict when using non-vendored SemanticPuppet gem, version 1\.0\.0/)
       end
 
-      it 'will warn when strict ranges cannot be parsed' do
+      it 'will notify when strict ranges cannot be parsed' do
         Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('0.1.4'))
         Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, false) })
 
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
           expect(Puppet::Module.parse_range('>=1.0.0', true).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_truthy
         end
-        expect(warnings).to include(/VersionRanges will never be strict when using non-vendored SemanticPuppet gem, version 0\.1\.4/)
+        expect(notices).to include(/VersionRanges will never be strict when using non-vendored SemanticPuppet gem, version 0\.1\.4/)
       end
 
-      it 'will not warn when strict ranges can be parsed' do
+      it 'will not notify when strict ranges can be parsed' do
         Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('1.0.0'))
         Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, true) })
 
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
           expect(Puppet::Module.parse_range('>=1.0.0', true).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
         end
-        expect(warnings).to be_empty
+        expect(notices).to be_empty
       end
 
-      it 'will not warn when non-strict ranges can be parsed' do
+      it 'will not notify when non-strict ranges can be parsed' do
         Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('0.1.4'))
         Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, false) })
 
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
           expect(Puppet::Module.parse_range('>=1.0.0', false).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_truthy
         end
-        expect(warnings).to be_empty
+        expect(notices).to be_empty
       end
     end
   end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -819,4 +819,17 @@ describe Puppet::Module do
       }
     ])
   end
+
+  context 'when parsing VersionRange' do
+    let(:logs) { [] }
+    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+
+    it 'can parse a strict range' do
+      expect(Puppet::Module.parse_range('>=1.0.0', true).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
+    end
+
+    it 'can parse a non-strict range' do
+      expect(Puppet::Module.parse_range('>=1.0.0', false).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_truthy
+    end
+  end
 end

--- a/spec/unit/module_tool_spec.rb
+++ b/spec/unit/module_tool_spec.rb
@@ -229,6 +229,28 @@ TREE
       end
     end
 
+    describe ':strict_semver' do
+      context 'when set' do
+        let(:options) do
+          { :strict_semver => true }
+        end
+
+        it 'is not overridden by default' do
+          expect(subject).to include :strict_semver => true
+        end
+      end
+
+      context 'when unset' do
+        let(:options) do
+          { }
+        end
+
+        it 'defaults to false' do
+          expect(subject).to include :strict_semver => false
+        end
+      end
+    end
+
     describe ':target_dir' do
       let(:options) do
         { :target_dir => 'foo' }

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -210,7 +210,7 @@ describe Puppet::Parser::Scope do
     end
 
     it "warns once for a non found variable" do
-      Puppet.expects(:warning).once
+      Puppet.expects(:send_log).with(:warning, is_a(String)).once
       expect([@scope["santa_claus"],@scope["santa_claus"]]).to eq([nil, nil])
     end
 


### PR DESCRIPTION
This commit adds an arity check to be able to call the method
`SemanticPuppet::VersionRange#parse` with one or two arguments from the
`Puppet::Module#parse_range` method.

When the arity is found to be just 1, a check is made if the gem version
of the semantic_puppet gem is < 1.0.0, in which case it is assumed that
the parse method is incapable of creating a range that adheres to strict
semantics. A warning is logged if a request for a strict range is made.
Conversely, if the gem version is >=1.0.0, it is assumed that strict
semantics will be honored and a warning is issued if a request for a
non-strict range is made.