### PR TITLE
(PUP-7740) Enable EC2 master install

### DIFF
--- a/acceptance/README-ec2.md
+++ b/acceptance/README-ec2.md
@@ -1,0 +1,79 @@
+# Testing on EC2
+
+## How To
+This section will provide step-by-step instructions for deploying
+an environment that will allow the `puppet` acceptance test suite
+to be executed on an EC2 master and agent.
+
+1. Make sure you have your AWS key and id defined in `$HOME/.fog`
+See the [beaker AWS documentation](https://github.com/puppetlabs/beaker/blob/master/docs/how_to/hypervisors/aws.md)
+for details.
+
+1. Clone puppet repo
+   ```
+   git clone git@github.com:puppetlabs/puppet.git
+   ```
+
+1. Perform a `bundle install` to install the gems required to run the tests.
+   ```
+   pushd puppet/acceptance
+   bundle install
+   ```
+
+1. Get the puppet [EC2 image templates](https://github.com/puppetlabs/pe_acceptance_tests/blob/2016.5.x/config/image_templates/ec2.yaml).
+   Note: These are restricted to Puppet, Inc. employees.
+   ```
+   pushd ../../
+   git clone git@github.com:puppetlabs/pe_acceptance_tests.git
+   pushd pe_acceptance_tests
+   git checkout 2017.2.x
+   popd
+   popd
+   mkdir config/image_templates
+   cp ../../pe_acceptance_tests/config/image_templates/ec2.yaml config/image_templates/
+   ```
+
+1. Set the value for the external `forge_host`
+
+   This is important. The hostname for the Puppet, Inc. test forge is different
+   depending on which side of Puppet, Inc. netork the test system is on. See [OPS-9499
+   resolution](https://tickets.puppetlabs.com/browse/OPS-9499?focusedCommentId=320139&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-320139)
+   for details.
+
+   For EC2 instances, it should be defined as follows:
+   ```
+   export forge_host=forgenext-aio-petest-prod-1.puppetlabs.net
+   ```
+
+   NOTE: Since the Rakefile sets a default value for `forge_host` at the options
+   level, this cannot be overridden by setting it at the host level via
+   beaker-hostgenerator. Currently, it needs to be set as an ENV var.
+
+1. Create the Beaker config file
+   Amazon Linux example
+   ```
+   bundle exec beaker-hostgenerator "redhat6-64ma{hypervisor=ec2,user=ec2-user,amisize=m3.large,snapshot=pe,vmname=amazon-6-x86_64}-redhat6-64a{hypervisor=ec2,user=ec2-user,amisize=m3.large,snapshot=pe,vmname=amazon-6-x86_64}" > hosts.yaml
+   sed -i 's/---/---\nhost_tags:\n  lifetime: 2h/' hosts.yaml
+   ```
+
+1. Execute the acceptance test Rake task
+
+   The puppet test suite can be run using the `ci:test:aio` rake task.
+
+   You will need to substitute your own values for the following:
+       * puppet-agent SHA
+       * puppet-agent SUITE_VERSION
+       * puppetserver SERVER_VERSION (optional)
+
+   If a value is not specified for `SERVER_VERSION` puppetserver will be
+   installed from the latest available nightly.
+
+
+   ```
+   SHA=96b104a30eb1808abcf521e5b8d2f6a3a38752b6                                                                   \
+   SUITE_VERSION=4.99.0.363.g96b104a                                                                              \
+   SERVER_VERSION=2.7.2                                                                                           \
+   HOSTS=hosts.yaml                                                                                               \
+   TESTS=tests                                                                                                    \
+   bundle exec rake ci:test:aio
+   ```

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -34,16 +34,63 @@ MASTER_PACKAGES = {
 }
 
 step "Install puppetserver..." do
-  if ENV['SERVER_VERSION']
-    install_puppetlabs_dev_repo(master, 'puppetserver', ENV['SERVER_VERSION'])
-    install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
-    master.install_package('puppetserver')
+  if master[:hypervisor] == 'ec2'
+    if master[:platform].match(/(?:el|centos|oracle|redhat|scientific)/)
+      # An EC2 master instance does not have access to puppetlabs.net for getting
+      # dev repos.
+      #
+      # We will install the appropriate repo to satisfy the puppetserver requirement
+      # and then upgrade puppet-agent with the targeted SHA package afterwards.
+      #
+      # Currently, only an `el` master is supported for this operation.
+      if ENV['SERVER_VERSION']
+        variant, version = master['platform'].to_array
+        if ENV['SERVER_VERSION'].to_i < 5
+          logger.info "EC2 master found: Installing nightly build of puppet-agent repo to satisfy puppetserver dependency."
+          on(master, "rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-#{version}.noarch.rpm")
+        else
+          logger.info "EC2 master found: Installing nightly build of puppet-agent repo to satisfy puppetserver dependency."
+          on(master, "rpm -Uvh https://yum.puppetlabs.com/puppet5-release-el-#{version}.noarch.rpm")
+        end
+      else
+        logger.info "EC2 master found: Installing nightly build of puppet-agent repo to satisfy puppetserver dependency."
+        install_repos_on(master, 'puppet-agent', 'nightly', 'repo-configs')
+        install_repos_on(master, 'puppetserver', 'nightly', 'repo-configs')
+      end
+
+      master.install_package('puppetserver')
+
+      logger.info "EC2 master found: Installing #{ENV['SHA']} build of puppet-agent."
+      # Upgrade installed puppet-agent with targeted SHA.
+      opts = {
+        :puppet_collection => 'PC1',
+        :puppet_agent_sha => ENV['SHA'],
+        :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA'] ,
+        :dev_builds_url => "http://builds.delivery.puppetlabs.net"
+      }
+
+      copy_dir_local = File.join('tmp', 'repo_configs', master['platform'])
+      release_path_end, release_file = master.puppet_agent_dev_package_info( opts[:puppet_collection], opts[:puppet_agent_version], opts)
+      release_path = "#{opts[:dev_builds_url]}/puppet-agent/#{opts[:puppet_agent_sha]}/repos/"
+      release_path << release_path_end
+      fetch_http_file(release_path, release_file, copy_dir_local)
+      scp_to master, File.join(copy_dir_local, release_file), master.external_copy_base
+      on master, "rpm -Uvh #{File.join(master.external_copy_base, release_file)} --oldpackage --force"
+    else
+      fail_test("EC2 master found, but it was not an `el` host: The specified `puppet-agent` build (#{ENV['SHA']}) cannot be installed.")
+    end
   else
-    # beaker can't install puppetserver from nightlies (BKR-673)
-    repo_configs_dir = 'repo-configs'
-    install_repos_on(master, 'puppetserver', 'nightly', repo_configs_dir)
-    install_repos_on(master, 'puppet-agent', ENV['SHA'], repo_configs_dir)
-    install_packages_on(master, MASTER_PACKAGES)
+    if ENV['SERVER_VERSION']
+      install_puppetlabs_dev_repo(master, 'puppetserver', ENV['SERVER_VERSION'])
+      install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
+      master.install_package('puppetserver')
+    else
+      # beaker can't install puppetserver from nightlies (BKR-673)
+      repo_configs_dir = 'repo-configs'
+      install_repos_on(master, 'puppetserver', 'nightly', repo_configs_dir)
+      install_repos_on(master, 'puppet-agent', ENV['SHA'], repo_configs_dir)
+      install_packages_on(master, MASTER_PACKAGES)
+    end
   end
 end
 


### PR DESCRIPTION
This commit updates the aio install pre-suite to allow installing
an ec2 master dynamically on a el based system without intervention.
Due to the expectations of the nightly puppetserver repo, the nightly
puppet-agent is installed first and then over-written with the
puppet-agent version under test. The specification of a SERVER_VERSION
is also supported.

Documentation has also been added in a `README-ec2.md`
file.