### PR TITLE
(PUP-7747) Update vendored semantic_puppet gem to 1.0.1

### DIFF
--- a/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet/gem_version.rb
+++ b/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet/gem_version.rb
@@ -1,3 +1,3 @@
 module SemanticPuppet
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet/version.rb
+++ b/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet/version.rb
@@ -30,7 +30,7 @@ module SemanticPuppet
         false
       else
         prerelease = match[4]
-        prerelease.nil? || prerelease.split('.').all? { |x| !(x =~ /^0\d+/) }
+        prerelease.nil? || prerelease.split('.').all? { |x| !(x =~ /^0\d+$/) }
       end
     end
 


### PR DESCRIPTION
This commit updates the vendored `semantic_puppet` to version 1.0.1
which provides a fix for MODULES-5159.