### PR TITLE
(PUP-7751) Correct misspelled sort_merged_arrays

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -243,7 +243,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
     #  raise "No node was given via the '--node' flag for the scope of the lookup.\n#{RUN_HELP}"
     #end
 
-    if (options[:sort_merge_arrays] || options[:merge_hash_arrays] || options[:prefix]) && options[:merge] != 'deep'
+    if (options[:sort_merged_arrays] || options[:merge_hash_arrays] || options[:prefix]) && options[:merge] != 'deep'
       raise "The options #{DEEP_MERGE_OPTIONS} are only available with '--merge deep'\n#{RUN_HELP}"
     end
 
@@ -260,7 +260,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
       if merge == 'deep'
         merge_options = {'strategy' => 'deep',
-          'sort_merge_arrays' => !options[:sort_merge_arrays].nil?,
+          'sort_merged_arrays' => !options[:sort_merged_arrays].nil?,
           'merge_hash_arrays' => !options[:merge_hash_arrays].nil?}
 
         if options[:prefix]

--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -375,7 +375,7 @@ module Puppet::Pops
           'knockout_prefix=>Optional[String],'\
           'merge_debug=>Optional[Boolean],'\
           'merge_hash_arrays=>Optional[Boolean],'\
-          'sort_merge_arrays=>Optional[Boolean],'\
+          'sort_merged_arrays=>Optional[Boolean],'\
           '}]')
     end
 

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -59,7 +59,7 @@ describe Puppet::Application::Lookup do
       lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
       lookup.stubs(:generate_scope).yields('scope')
 
-      expected_merge = { "strategy" => "deep", "sort_merge_arrays" => false, "merge_hash_arrays" => true }
+      expected_merge = { "strategy" => "deep", "sort_merged_arrays" => false, "merge_hash_arrays" => true }
 
       (Puppet::Pops::Lookup).expects(:lookup).with(['atton', 'kreia'], nil, nil, false, expected_merge, anything).returns('rand')
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -933,6 +933,8 @@ describe "The lookup function" do
                 bab: bab (from environment)
               bc:
                 bca: bca (from environment)
+            sa:
+              sa1: ['e', 'd', '--f']
             YAML
           'second.yaml' => <<-YAML.unindent,
             a:
@@ -946,6 +948,8 @@ describe "The lookup function" do
             c:
               ca:
                 cab: c.ca.cab
+            sa:
+              sa1: ['b', 'a', 'f', 'c']
             YAML
         }
       end
@@ -1024,6 +1028,28 @@ describe "The lookup function" do
 
         it 'finds lookup_options that matches a pattern' do
           expect(lookup('a')).to eql({'aa' => { 'aaa' => 'a.aa.aaa', 'aab' => 'a.aa.aab' }})
+        end
+      end
+
+      context 'and lookup options use a hash' do
+
+        let(:env_lookup_options) { <<-YAML.unindent }
+          lookup_options:
+            'sa':
+              merge:
+                strategy: deep
+                knockout_prefix: --
+                sort_merged_arrays: true
+        YAML
+
+        it 'applies knockout_prefix and sort_merged_arrays' do
+          expect(lookup('sa')).to eql({ 'sa1' => %w(a b c d e) })
+        end
+
+        it 'overrides knockout_prefix and sort_merged_arrays with explicitly given values' do
+          expect(
+            lookup('sa', 'merge' => { 'strategy' => 'deep', 'knockout_prefix' => '##', 'sort_merged_arrays' => false })).to(
+              eql({ 'sa1' => %w(b a f c e d --f) }))
         end
       end
     end


### PR DESCRIPTION
This commit corrects the spelling of the deep merge option
`sort_merged_arrays` (previously spelled "sort_merge_arrays") and adds
tests to assert its function.