### PR TITLE
(PUP-7732) Audit Acceptance Tests

### DIFF
--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -1,6 +1,12 @@
 test_name "the agent --disable/--enable functionality should manage the agent lockfile properly"
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 
+tag 'audit:integration', # lockfile uses the standard `vardir` location to store/query lockfile.
+                         # The validation of the `vardir` at the OS level
+                         # should be accomplished in another test.
+    'audit:medium',
+    'audit:refactor'     # This test should not require a master. Remove the use of `with_puppet_running_on`.
+
 #
 # This test is intended to ensure that puppet agent --enable/--disable
 #  work properly, both in terms of complying with our public "API" around

--- a/acceptance/tests/agent/agent_parses_json_catalog.rb
+++ b/acceptance/tests/agent/agent_parses_json_catalog.rb
@@ -1,5 +1,10 @@
 test_name "C99978: Agent parses a JSON catalog"
-tag 'risk:medium'
+
+tag 'risk:medium',
+    'audit:high',        # tests defined catalog format
+    'audit:integration', # There is no OS specific risk here.
+    'server',
+    'catalog:json'
 
 require 'puppet/acceptance/common_utils'
 require 'json'

--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -1,5 +1,9 @@
 test_name "fallback to the cached catalog"
 
+tag 'audit:medium',
+    'audit:integration', # This test is not OS sensitive.
+    'audit:refactor'     # A catalog fixture can be used for this test. Remove the usage of `with_puppet_running_on`.
+
 step "run agents once to cache the catalog" do
   with_puppet_running_on master, {} do
     on(agents, puppet("agent -t --server #{master}"))

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -1,5 +1,8 @@
 test_name "aix package provider should work correctly"
 
+tag 'audit:medium',
+    'audit:acceptance'  # OS specific by definition.
+
 confine :to, :platform => /aix/
 
 dir = "/tmp/aix-packages-#{$$}"

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -1,5 +1,8 @@
 test_name "NIM package provider should work correctly"
 
+tag 'audit:medium',
+    'audit:acceptance'  # OS specific by definition
+
 confine :to, :platform => "aix"
 
 # NOTE: This test is duplicated in the pe_acceptance_tests repo

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -1,5 +1,10 @@
 test_name "node_name_fact should be used to determine the node name for puppet agent"
 
+tag 'audit:medium',
+    'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
+                          # Testing of passenger master is no longer needed.
+    'server'
+
 success_message = "node_name_fact setting was correctly used to determine the node name"
 
 testdir = master.tmpdir("nodenamefact")

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
@@ -1,5 +1,9 @@
 test_name "node_name_fact should be used to determine the node name for puppet apply"
 
+tag 'audit:medium',
+    'audit:integration',  # Ruby level integration tests already exist. This acceptance test can be deleted.
+    'audit:delete'
+
 success_message = "node_name_fact setting was correctly used to determine the node name"
 
 node_names = []

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -1,5 +1,10 @@
 test_name "node_name_value should be used as the node name for puppet agent"
 
+tag 'audit:medium',
+    'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
+                          # Testing of passenger master is no longer needed.
+    'server'
+
 success_message = "node_name_value setting was correctly used as the node name"
 testdir = master.tmpdir('nodenamevalue')
 

--- a/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
@@ -1,5 +1,9 @@
 test_name "node_name_value should be used as the node name for puppet apply"
 
+tag 'audit:medium',
+    'audit:integration',  # Ruby level integration tests already exist. This acceptance test can be deleted.
+    'audit:delete'
+
 success_message = "node_name_value setting was correctly used as the node name"
 
 manifest = %Q[

--- a/acceptance/tests/allow_symlinks_as_config_directories.rb
+++ b/acceptance/tests/allow_symlinks_as_config_directories.rb
@@ -1,4 +1,8 @@
 test_name "Should allow symlinks to directories as configuration directories"
+
+tag 'audit:low',
+    'audit:acceptance'  # Need to cover risk of OS/ruby symlink behavior (OSX, Solaris).
+
 confine :except, :platform => 'windows'
 
 agents.each do |agent|

--- a/acceptance/tests/apply/augeas/hosts.rb
+++ b/acceptance/tests/apply/augeas/hosts.rb
@@ -1,8 +1,10 @@
 test_name "Augeas hosts file" do
 
-skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
+tag 'risk:medium',
+    'audit:medium',
+    'audit:acceptance'
 
-tag 'risk:medium'
+skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
 
   confine :except, :platform => [
     'windows',

--- a/acceptance/tests/apply/augeas/puppet.rb
+++ b/acceptance/tests/apply/augeas/puppet.rb
@@ -1,8 +1,10 @@
 test_name "Augeas puppet configuration" do
 
-  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
+  tag 'risk:medium',
+      'audit:medium',
+      'audit:acceptance'
 
-  tag 'risk:medium'
+  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
 
   confine :except, :platform => 'windows'
   confine :to, {}, hosts.select { |host| ! host[:roles].include?('master') }

--- a/acceptance/tests/apply/augeas/services.rb
+++ b/acceptance/tests/apply/augeas/services.rb
@@ -1,8 +1,10 @@
 test_name "Augeas services file" do
 
-  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
+  tag 'risk:medium',
+      'audit:medium',
+      'audit:acceptance'
 
-  tag 'risk:medium'
+  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
 
   confine :except, :platform => 'windows'
   confine :except, :platform => 'osx'

--- a/acceptance/tests/apply/classes/parameterized_classes.rb
+++ b/acceptance/tests/apply/classes/parameterized_classes.rb
@@ -1,5 +1,9 @@
 test_name "parametrized classes"
 
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 ########################################################################
 step "should allow param classes"
 manifest = %q{

--- a/acceptance/tests/apply/classes/should_allow_param_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_override.rb
@@ -1,5 +1,9 @@
 test_name "should allow param override"
 
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 manifest = %q{
 class parent {
   notify { 'msg':

--- a/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
@@ -1,5 +1,10 @@
 test_name "should allow overriding a parameter to undef in inheritence"
 
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
+
 agents.each do |agent|
   dir = agent.tmpdir('class_undef_override')
   out = File.join(dir, 'class_undef_override_out')

--- a/acceptance/tests/apply/classes/should_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_include_resources_from_class.rb
@@ -1,4 +1,9 @@
 test_name "resources declared in a class can be applied with include"
+
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 manifest = %q{
 class x {
   notify{'a':}

--- a/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
@@ -1,4 +1,9 @@
 test_name "resources declared in classes are not applied without include"
+
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 manifest = %q{ class x { notify { 'test': message => 'never invoked' } } }
 apply_manifest_on(agents, manifest) do
     fail_test "found the notify despite not including it" if

--- a/acceptance/tests/apply/hashes/should_not_reassign.rb
+++ b/acceptance/tests/apply/hashes/should_not_reassign.rb
@@ -1,4 +1,9 @@
 test_name "hash reassignment should fail"
+
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 manifest = %q{
 $my_hash = {'one' => '1', 'two' => '2' }
 $my_hash['one']='1.5'

--- a/acceptance/tests/apply/puppet_apply_graph.rb
+++ b/acceptance/tests/apply/puppet_apply_graph.rb
@@ -1,5 +1,9 @@
 test_name 'puppet apply should generate a graph'
 
+tag 'audit:low',
+    'audit:integration',  # Core testing of `vardir` should occur in another test.
+    'audit:refactor'      # The test should validate that the content of the dot file is sane.
+
 agents.each do |agent|
   step "Create var temp directory"
   vardir = agent.tmpdir('vardir')

--- a/acceptance/tests/apply/puppet_apply_trace.rb
+++ b/acceptance/tests/apply/puppet_apply_trace.rb
@@ -1,5 +1,9 @@
 test_name 'puppet apply --trace should provide a stack trace'
 
+tag 'audit:low',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 agents.each do |agent|
   on(agent, puppet('apply --trace -e "blue < 2"'), :acceptable_exit_codes => 1) do
     assert_match(/\.rb:\d+:in `\w+'/m, stderr, "Did not print expected stack trace on stderr")

--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -1,5 +1,9 @@
 test_name "concurrent catalog requests (PUP-2659)"
 
+tag 'audit:low',
+    'audit:integration',  # Testing server
+    'server'
+
 # we're only testing the effects of loading a master with concurrent requests
 confine :except, :platform => 'windows'
 confine :except, :platform => /osx/ # see PUP-4820

--- a/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
+++ b/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
@@ -1,5 +1,8 @@
 test_name "#17371 file metadata specified in puppet.conf needs to be applied"
 
+tag 'audit:low',
+    'audit:acceptance'
+
 # when owner/group works on windows for settings, this confine should be removed.
 confine :except, :platform => 'windows'
 confine :except, :platform => /solaris-10/ # See PUP-5200

--- a/acceptance/tests/cycle_detection.rb
+++ b/acceptance/tests/cycle_detection.rb
@@ -1,5 +1,9 @@
 test_name "cycle detection and reporting"
 
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 step "check we report a simple cycle"
 manifest = <<EOT
 notify { "a1": require => Notify["a2"] }

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -3,6 +3,12 @@ extend Puppet::Acceptance::StaticCatalogUtils
 
 test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri" do
 
+  tag 'audit:medium',
+      'audit:acceptance',
+      'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
+      'server'
+
+
   skip_test 'requires puppetserver installation' if @options[:type] != 'aio'
 
   basedir = master.tmpdir(File.basename(__FILE__, '.*'))

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -1,4 +1,9 @@
 test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
+
+  tag 'audit:medium',
+      'audit:acceptance',
+      'server'
+
   master_reportdir = create_tmpdir_for_user(master, 'reportdir')
 
   def remove_reports_on_master(master_reportdir, agent_node_name)

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -1,5 +1,10 @@
 test_name "Environment control of static catalogs"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
+    'server'
+
 skip_test 'requires puppetserver to test static catalogs' if @options[:type] != 'aio'
 
 require 'json'

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -2,6 +2,12 @@ test_name "C97172: static catalogs support utf8" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+  tag 'audit:medium',
+      'audit:acceptance',
+      'audit:refactor',  # Review for agent side UTF validation.
+      'server'
+
+
   app_type = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)
 

--- a/acceptance/tests/doc/should_print_function_reference.rb
+++ b/acceptance/tests/doc/should_print_function_reference.rb
@@ -1,4 +1,9 @@
 test_name "verify we can print the function reference"
+
+tag 'audit:low',
+    'audit:unit',
+    'audit:delete'
+
 on(agents, puppet_doc("-r", "function")) do
     fail_test "didn't print function reference" unless
         stdout.include? 'Function Reference'

--- a/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
+++ b/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
@@ -1,4 +1,9 @@
 test_name "verify we can print the function reference"
+
+tag 'audit:low',
+    'audit:unit',
+    'audit:delete'
+
 confine :except, :platform => /^eos-/
 
 on(agents, puppet_doc("-r", "type")) do

--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -2,6 +2,11 @@
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 test_name 'PUP-4033: Ensure aio path spec is honored'
 
+tag 'audit:high',
+    'audit:acceptance',
+    'audit:refactor'    # move to puppet-agent acceptance
+
+
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils
 

--- a/acceptance/tests/ensure_version_file.rb
+++ b/acceptance/tests/ensure_version_file.rb
@@ -1,6 +1,10 @@
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 
+tag 'audit:high',
+    'audit:acceptance',
+    'audit:refactor'  # This should be folded into `ensure_puppet-agent_paths` test
+
 # ensure a version file is created according to the puppet-agent path specification:
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 

--- a/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
+++ b/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
@@ -1,5 +1,11 @@
 test_name 'PUP-4413 3x forbidden environment names should be allowed in 4x'
 
+tag 'audit:medium',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:refactor',
+    'audit:delete'
+
+
 step 'setup environments'
 
 testdir = create_tmpdir_for_user(master, 'forbidden_env')

--- a/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
+++ b/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
@@ -4,6 +4,12 @@
 # details see PUP-3591.
 test_name "Agent should pluginsync with the environment the agent resolves to"
 
+tag 'audit:high',
+    'audit:integration',
+    'audit:refactor',  # Inquire as to whether this is still a risk with puppet 5+
+                       # Use mk_temp_environment_with_teardown helper
+    'server'
+
 testdir = create_tmpdir_for_user master, 'environment_resolve'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -1,5 +1,11 @@
 test_name 'PUP-3755 Test an un-assigned broken environment'
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',     # Use mk_temp_environment_with_teardown helper
+    'server'
+
+
 step 'setup environments'
 
 testdir = create_tmpdir_for_user(master, 'confdir')

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -1,5 +1,9 @@
 test_name "Can enumerate environments via an HTTP endpoint"
 
+tag 'audit:high',
+    'audit:integration',
+    'server'
+
 confine :except, :platform => /osx/ # see PUP-4820
 
 def master_port(agent)

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -2,6 +2,10 @@ test_name 'C59122: ensure provider from same env as custom type' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',  # This behavior is specific to the master to 'do the right thing'
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   file_correct    = "#{tmp_environment}-correct.txt"

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -1,5 +1,9 @@
 test_name 'ensure production environment created by master if missing'
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 testdir = create_tmpdir_for_user master, 'prod-env-created'
 
 step 'make environmentpath'

--- a/acceptance/tests/environment/directory_environment_with_environment_conf.rb
+++ b/acceptance/tests/environment/directory_environment_with_environment_conf.rb
@@ -2,6 +2,13 @@ test_name 'Use a directory environment from environmentpath with an environment.
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:low',
+    'audit:integration',
+    'audit:refactor'    # Is this a component of a larger workflow scenario?
+                        # Do we have customer examples of this usage to
+                        # support the continued existance of this feature?
+
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 testdir = create_tmpdir_for_user master, 'use-environment-conf'

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -2,6 +2,10 @@ test_name "Master should produce error if enc specifies a nonexistent environmen
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:unit',
+    'server'
+
 testdir = create_tmpdir_for_user master, 'nonexistent_env'
 
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -4,6 +4,12 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:unit',  # The error responses for the agent should be covered by Ruby unit tests.
+                   # The server 404/400 response should be covered by server integration tests.
+    'server'
+
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step 'setup environments'

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/environment_scenario-existing.rb
+++ b/acceptance/tests/environment/environment_scenario-existing.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
+++ b/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -2,6 +2,10 @@ test_name "Agent should use agent environment if there is an enc that does not s
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 testdir = create_tmpdir_for_user master, 'use_agent_env'

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -1,5 +1,10 @@
 test_name "Agent should use agent environment if there is no enc-specified environment"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',  # This can be combined with use_agent_environment_when_enc_doesnt_specify test
+    'server'
+
 testdir = create_tmpdir_for_user master, 'use_agent_env'
 
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -2,6 +2,10 @@ test_name "Agent should use environment given by ENC"
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 testdir = create_tmpdir_for_user master, 'use_enc_env'
 
 if master.is_pe?

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,5 +1,10 @@
 test_name "Agent should use environment given by ENC for fetching remote files"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',    # This test should be rolled into use_enc_environment
+    'server'
+
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -1,5 +1,10 @@
 test_name "Agent should use environment given by ENC for pluginsync"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',    # This test should be rolled into use_enc_environment
+    'server'
+
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -2,6 +2,10 @@ test_name "Use environments from the environmentpath"
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 testdir = create_tmpdir_for_user master, 'use_environmentpath'

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -2,6 +2,10 @@ test_name 'C98115 compilation should get new values in variables on each compila
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
+++ b/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
@@ -17,6 +17,10 @@ skip_test "Test only supported on Jetty" unless @options[:is_puppetserver]
 #
 test_name "Puppet agent and master work when both configured with externally issued certificates from independent intermediate CAs"
 
+tag 'audit:medium',
+    'audit:integration',  # This could also be a component in a platform workflow test.
+    'server'
+
 step "Copy certificates and configuration files to the master..."
 fixture_dir = File.expand_path('../fixtures', __FILE__)
 testdir = master.tmpdir('jetty_external_root_ca')

--- a/acceptance/tests/face/4654_facts_face.rb
+++ b/acceptance/tests/face/4654_facts_face.rb
@@ -1,5 +1,9 @@
 test_name "Puppet facts face should resolve custom and external facts"
 
+tag 'audit:medium',
+    'audit:integration'   # The facter acceptance tests should be acceptance.
+                          # However, the puppet face merely needs to interact with libfacter.
+                          # So, this should be an integration test.
 #
 # This test is intended to ensure that custom and external facts present
 # on the agent are resolved and displayed by the puppet facts face.

--- a/acceptance/tests/face/help_test.rb
+++ b/acceptance/tests/face/help_test.rb
@@ -1,6 +1,8 @@
 test_name 'Test `puppet help` workflow'
 
-tag 'risk:medium'
+tag 'risk:medium',
+    'audit:low',
+    'audit:unit' # basic command line handling
 
 hosts.each do |host|
 

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -4,6 +4,11 @@ test_name "Exercise loading a face from a module"
 confine :except, :platform => 'windows'
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
+tag 'audit:medium',
+    'audit:acceptance',    # This has been OS sensitive.
+    'audit:refactor'       # Remove the confine against windows and refactor to
+                           # accommodate the Windows platform.
+
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 initialize_temp_dirs

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -1,4 +1,9 @@
 test_name 'parser validate' do
+
+tag 'audit:medium',
+    'audit:unit'   # Parser validation should be core to ruby
+                   # and platform agnostic.
+
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
   require 'puppet/acceptance/temp_file_utils'

--- a/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
+++ b/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
@@ -2,6 +2,13 @@ test_name "generate a helpful error message when hostname doesn't match server c
 
 skip_test( 'Changing certnames of the master will break PE/Passenger installations' ) if master.is_using_passenger?
 
+tag 'audit:low',
+    'audit:integration',
+    'server',
+    'audit:delete'        # This test is unlikely to regress and is of
+                          # such low risk that it is not worth the cost
+                          # of automatically guarding against it failing.
+
 certname = "foobar_not_my_hostname"
 dns_alt_names = "one_cert,two_cert,red_cert,blue_cert"
 

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -2,6 +2,13 @@ test_name 'C98346: Binary data type' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
+tag 'audit:high',
+    'audit:integration',  # Tests that binary data is retains integrity
+                          # between server and agent transport/application.
+                          # The weak link here is final ruby translation and
+                          # should not be OS sensitive.
+    'server'
+
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/language/break.rb
+++ b/acceptance/tests/language/break.rb
@@ -1,4 +1,10 @@
 test_name 'C98162 - Validate `break` terminates execution in a block of code' do
+
+tag 'audit:low',
+    'audit:unit',   # This is testing core ruby functionality that is covered by
+                    # existing spec tests.
+    'audit:delete'
+
   agents.each do |agent|
 
     step 'apply class with break' do

--- a/acceptance/tests/language/class_inheritance.rb
+++ b/acceptance/tests/language/class_inheritance.rb
@@ -1,5 +1,8 @@
 test_name 'C14943: Class inheritance works correctly' do
 
+tag 'audit:low',
+    'audit:unit'   # This is testing core ruby functionality
+
   agents.each do |agent|
     test_manifest = <<MANIFEST
       class bar { notice("This is class bar") }

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -2,6 +2,11 @@ test_name "C94788: exported resources using a yaml terminus for storeconfigs" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',     # This could be a component of a larger workflow scenario.
+    'server'
+
   # user resource doesn't have a provider on arista
   skip_test if agents.any? {|agent| agent['platform'] =~ /^eos/ } # see PUP-5404, ARISTA-42
   skip_test 'requires puppetserver to service restart' if @options[:type] != 'aio'

--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,5 +1,10 @@
 test_name 'Puppet executes functions written in the Puppet language'
 
+tag 'audit:high',
+    'audit:integration',
+    'audit:refactor',     # use mk_tmp_environment_with_teardown helper for environment construction
+    'server'
+
 teardown do
   on master, 'rm -rf /etc/puppetlabs/code/modules/jenny'
   on master, 'rm -rf /etc/puppetlabs/code/environments/tommy'

--- a/acceptance/tests/language/next.rb
+++ b/acceptance/tests/language/next.rb
@@ -1,4 +1,10 @@
 test_name 'C98162 - Validate `next` immediately returns from a block of code' do
+
+tag 'audit:low',
+    'audit:unit',   # This is testing core ruby functionality that is covered by
+                    # existing spec tests.
+    'audit:delete'
+
   agents.each do |agent|
 
     step 'apply class with next' do

--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -2,6 +2,12 @@ test_name 'C99627: can use Object types in the catalog and apply/agent' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:high',
+    'audit:integration',
+    'audit:refactor'     # The use of apply on a reference system should
+                         # be adequate to test puppet. Running this in
+                         # context of server/agent should not be necessary.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -2,6 +2,10 @@ test_name 'C98345: ensure puppet generate assures env. isolation' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   tmp_environment2 = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -1,4 +1,10 @@
 test_name 'C98097 - generated pcore resource types should be loaded instead of ruby for custom types' do
+
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',    # use `mk_temp_environment_with_teardown` helper to build environment
+    'server'
+
   environment = 'production'
   step 'setup - install module with custom ruby resource type' do
     #{{{

--- a/acceptance/tests/language/resource_refs_with_nested_arrays.rb
+++ b/acceptance/tests/language/resource_refs_with_nested_arrays.rb
@@ -1,5 +1,8 @@
 test_name "#7681: Allow using array variables in resource references"
 
+tag 'audit:high',
+    'audit:unit'
+
 agents.each do |agent|
   test_manifest = <<MANIFEST
 $exec_names = ["first", "second"]

--- a/acceptance/tests/language/return.rb
+++ b/acceptance/tests/language/return.rb
@@ -1,4 +1,8 @@
 test_name 'C98162 - Validate `return` immediately returns from a block of code' do
+
+tag 'audit:medium',
+    'audit:unit'
+
   agents.each do |agent|
 
     step 'apply class with return' do

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -2,6 +2,14 @@ test_name 'C98120, C98077: Sensitive Data is redacted on CLI, logs, reports' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
+tag 'audit:high',
+    'audit:acceptance',   # Tests that sensitive data is retains integrity
+                          # between server and agent transport/application.
+                          # Leaving at acceptance layer due to validate
+                          # written logs.
+    'server'
+
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -2,6 +2,10 @@ test_name 'C64667: ensure server_facts is set and error if any value is overwrit
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance', # Validating server/client interaction
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -19,6 +19,10 @@ test_name "Exercise a module with 4x function and 4x system function"
 
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
+
+tag 'audit:medium',
+    'audit:unit'    # This should be covered adequately by unit tests
+
 initialize_temp_dirs
 
 agents.each do |agent|

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -2,6 +2,13 @@ test_name 'C99578: lookup should allow interpolation in hiera3 configs' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',  # This test specifically tests interpolation on the master.
+                       # Recommend adding an additonal test that validates
+                       # lookup in a masterless setup.
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -2,6 +2,13 @@ test_name 'C99578: hiera5 lookup config with interpolated scoped nested variable
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',  # This test specifically tests interpolation on the master.
+                       # Recommend adding an additonal test that validates
+                       # lookup in a masterless setup.
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -4,6 +4,11 @@ test_name 'C99630: hiera v3 custom backend' do
   require 'puppet/acceptance/temp_file_utils.rb'
   extend Puppet::Acceptance::TempFileUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -2,6 +2,12 @@ test_name "Lookup data using the agnostic lookup function" do
   # pre-docs:
   # https://puppet-on-the-edge.blogspot.com/2015/01/puppet-40-data-in-modules-and.html
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+                       # Use mk_tmp_environment_with_teardown to create environment.
+
   testdir = master.tmpdir('lookup')
 
   module_name                     = "data_module"

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -2,6 +2,11 @@ test_name 'C99044: lookup should allow rich data as values' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local environment.
+
   # The following two lines are required for the puppetserver service to
   # start correctly. These should be removed when PUP-7102 is resolved.
   confdir = master.puppet('master')['confdir']

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -2,6 +2,11 @@ test_name 'C99903: merge strategies' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -2,6 +2,11 @@ test_name 'C99629: hiera v5 can use v3 config and data' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -2,6 +2,11 @@ test_name 'C99572: v4 hieradata with v5 configs' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/modules/build/build_agent.rb
+++ b/acceptance/tests/modules/build/build_agent.rb
@@ -1,5 +1,8 @@
 test_name "puppet module build (agent)"
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 agents.each do |agent|
   teardown do
     on agent, 'rm -rf bar'

--- a/acceptance/tests/modules/build/build_basic.rb
+++ b/acceptance/tests/modules/build/build_basic.rb
@@ -1,5 +1,10 @@
 test_name 'CODEMGMT-69 - Build a Module Using "metadata.json" Only'
 
+tag 'audit:medium',
+    'audit:acceptance'
+    'audit:refactor'   # Wrap steps in blocks in accordance with Beaker style guide
+
+
 #Init
 temp_module_path = '/tmp/nginx'
 metadata_json_file_path = File.join(temp_module_path, 'metadata.json')

--- a/acceptance/tests/modules/build/build_ignore_module_file.rb
+++ b/acceptance/tests/modules/build/build_ignore_module_file.rb
@@ -1,5 +1,9 @@
 test_name 'PUP-3981 - C63215 - Build Module Should Ignore Module File'
 
+tag 'audit:low',
+    'audit:acceptance'
+    'audit:refactor'   # Wrap steps in blocks in accordance with Beaker style guide
+
 #Init
 temp_module_path = master.tmpdir('build_ignore_module_file_test')
 metadata_json_file_path = File.join(temp_module_path, 'metadata.json')

--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -1,5 +1,8 @@
 test_name "puppet module build should verify there are no symlinks in module"
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 confine :except, :platform => 'windows'
 
 modauthor = 'foo'

--- a/acceptance/tests/modules/build/build_should_not_create_changes.rb
+++ b/acceptance/tests/modules/build/build_should_not_create_changes.rb
@@ -1,5 +1,8 @@
 test_name "puppet module build should not result in changed files"
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 modauthor = 'foo'
 modname = 'bar'
 defaultversion = '0.1.0'

--- a/acceptance/tests/modules/changes/invalid_module_install_path.rb
+++ b/acceptance/tests/modules/changes/invalid_module_install_path.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on an invalid module install path)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not requiered for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/missing_checksums_json.rb
+++ b/acceptance/tests/modules/changes/missing_checksums_json.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module which is missing checksums.json)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/missing_metadata_json.rb
+++ b/acceptance/tests/modules/changes/missing_metadata_json.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module which is missing metadata.json)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module with a modified file)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module with a removed file)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on an unmodified module)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/generate/basic_generate.rb
+++ b/acceptance/tests/modules/generate/basic_generate.rb
@@ -2,6 +2,9 @@ test_name "puppet module generate (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (already installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (already installed elsewhere)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (already installed with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:delete'     # This behavior is validated with other tests in this suite
+
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/force_ignores_dependencies.rb
+++ b/acceptance/tests/modules/install/force_ignores_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (force ignores dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "git"
 module_dependencies   = ["apache"]

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (ignoring dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (nonexistent directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (nonexistent module)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nonexistent"
 module_dependencies  = []

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -2,6 +2,9 @@ test_name "puppet module install (with debug)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:unit'
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -2,6 +2,11 @@ test_name 'puppet module install (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 tmpdir = master.tmpdir('module-install-with-environment')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -2,6 +2,9 @@ test_name "puppet module install (with existing module directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:unit',
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -4,6 +4,11 @@ test_name "puppet module install (with modulepath)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 codedir = master.puppet('master')['codedir']
 module_author = "pmtacceptance"
 module_name   = "nginx"

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with necessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with no dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with unnecessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with unsatisfied constraints)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "git"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Wrap steps in blocks in accordance with Beaker style guide
+
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -1,5 +1,10 @@
 test_name "puppet module list (with circular dependencies)"
 
+tag 'audit:low',
+    'audit:integration',
+    'audit:refactor'     # Master is not required for this test.
+                         # Refactor to use agent.
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/appleseed"
   on master, "rm -rf #{master['sitemoduledir']}/crakorn"

--- a/acceptance/tests/modules/list/with_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_installed_modules.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with installed modules)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with invalid dependencies)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_missing_dependencies.rb
+++ b/acceptance/tests/modules/list/with_missing_dependencies.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with missing dependencies)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with modulepath)"
 
+tag 'audit:low',
+    'audit:unit'
+
 codedir = master.puppet('master')['codedir']
 
 step "Setup"

--- a/acceptance/tests/modules/list/with_no_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_no_installed_modules.rb
@@ -1,5 +1,7 @@
 test_name "puppet module list (with no installed modules)"
 
+tag 'audit:low',
+    'audit:unit'
 
 step "List the installed modules"
 modulesdir = master.tmpdir('puppet_module')

--- a/acceptance/tests/modules/list/with_repeated_dependencies.rb
+++ b/acceptance/tests/modules/list/with_repeated_dependencies.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with repeated dependencies)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"
   on master, "rm -rf #{master['distmoduledir']}/steward"

--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -1,5 +1,8 @@
 test_name 'puppet module search should print a reasonable message on communication errors'
 
+tag 'audit:low',
+    'audit:integration'
+
 step 'Setup'
 stub_hosts_on(master, 'forgeapi.puppet.com' => '127.0.0.2')
 

--- a/acceptance/tests/modules/search/formatting.rb
+++ b/acceptance/tests/modules/search/formatting.rb
@@ -1,5 +1,8 @@
 test_name 'puppet module search output should be well structured'
 
+tag 'audit:low',
+    'audit:unit'
+
 step 'Setup'
 stub_forge_on(master)
 

--- a/acceptance/tests/modules/search/multiple_search_terms.rb
+++ b/acceptance/tests/modules/search/multiple_search_terms.rb
@@ -1,5 +1,9 @@
 test_name 'puppet module search should handle multiple search terms sensibly'
 
+tag 'audit:low',
+    'audit:unit',
+    'audit:delete'
+
 #step 'Setup'
 #stub_forge_on(master)
 

--- a/acceptance/tests/modules/search/no_results.rb
+++ b/acceptance/tests/modules/search/no_results.rb
@@ -1,5 +1,8 @@
 test_name 'puppet module search should print a reasonable message for no results'
 
+tag 'audit:low',
+    'audit:unit'
+
 module_name   = "module_not_appearing_in_this_forge"
 
 step 'Setup'

--- a/acceptance/tests/modules/search/ssl_errors.rb
+++ b/acceptance/tests/modules/search/ssl_errors.rb
@@ -1,5 +1,8 @@
 begin test_name 'puppet module search should print a reasonable message on ssl errors'
 
+tag 'audit:low',
+    'audit:unit'
+
 step "Search against a website where the certificate is not signed by a public authority"
 
 # This might seem silly, but a master has a self-signed certificate and is a

--- a/acceptance/tests/modules/uninstall/using_directory_name.rb
+++ b/acceptance/tests/modules/uninstall/using_directory_name.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (using directory name)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/apache"
   on master, "rm -rf #{master['distmoduledir']}/crakorn"

--- a/acceptance/tests/modules/uninstall/using_version_filter.rb
+++ b/acceptance/tests/modules/uninstall/using_version_filter.rb
@@ -2,6 +2,11 @@ test_name "puppet module uninstall (with module installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "jimmy"
 module_name   = "crakorn"
 module_dependencies = []

--- a/acceptance/tests/modules/uninstall/with_active_dependency.rb
+++ b/acceptance/tests/modules/uninstall/with_active_dependency.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with active dependency)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step "Setup"
 apply_manifest_on master, <<-PP
 file {

--- a/acceptance/tests/modules/uninstall/with_environment.rb
+++ b/acceptance/tests/modules/uninstall/with_environment.rb
@@ -2,6 +2,11 @@ test_name 'puppet module uninstall (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 tmpdir = master.tmpdir('module-uninstall-with-environment')
 
 step 'Setup'

--- a/acceptance/tests/modules/uninstall/with_module_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_module_installed.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with module installed)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"
 end

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with modulepath)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 codedir = master.puppet('master')['codedir']
 
 teardown do

--- a/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with multiple modules installed)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 if master.is_pe?
   skip_test
 end

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (in a secondary directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (introducing new dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/not_upgradable.rb
+++ b/acceptance/tests/modules/upgrade/not_upgradable.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (not upgradable)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
+++ b/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
@@ -4,6 +4,11 @@ extend Puppet::Acceptance::ModuleUtils
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 prod_env_modulepath = "#{environmentpath}/production/modules"
 
 orig_installed_modules = get_installed_modules_for_hosts hosts

--- a/acceptance/tests/modules/upgrade/to_a_specific_version.rb
+++ b/acceptance/tests/modules/upgrade/to_a_specific_version.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (to a specific version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (to installed version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with constraints on it)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with constraints on its dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_environment.rb
+++ b/acceptance/tests/modules/upgrade/with_environment.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with environment)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 tmpdir = master.tmpdir('module-upgrade-withenv')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/upgrade/with_local_changes.rb
+++ b/acceptance/tests/modules/upgrade/with_local_changes.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -4,6 +4,11 @@ extend Puppet::Acceptance::ModuleUtils
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 fq_prod_env_modpath = "#{environmentpath}/production/modules"
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/upgrade/with_update_available.rb
+++ b/acceptance/tests/modules/upgrade/with_update_available.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with update available)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -5,6 +5,10 @@ extend Puppet::Acceptance::TempFileUtils
 
 test_name "ticket #16753 node data should be cached in yaml to allow it to be queried"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 node_name = "woy_node_#{SecureRandom.hex}"
 
 # Only used when running under webrick

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -1,5 +1,9 @@
 test_name "Puppet applies resources without dependencies in file order over the network"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 testdir = master.tmpdir('application_order')
 
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -1,5 +1,8 @@
 test_name 'Calling all functions.. test in progress!'
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 # create single manifest calling all functions
 step 'Apply manifest containing all function calls'
 def manifest_call_each_function_from_array(functions)

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -1,5 +1,9 @@
 test_name "Lookup data using the hiera parser function"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 testdir = master.tmpdir('hiera')
 
 step 'Setup'

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -1,5 +1,9 @@
 test_name "Lookup data using the hiera_array parser function"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 testdir = master.tmpdir('hiera')
 
 step 'Setup'

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -1,5 +1,9 @@
 test_name "Lookup data using the hiera_hash parser function"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 testdir = master.tmpdir('hiera')
 
 step 'Setup'

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -1,5 +1,9 @@
 test_name "Calling Hiera function from inside templates"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 @module_name = "hieratest"
 @coderoot = master.tmpdir("#{@module_name}")
 

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -2,6 +2,9 @@ require 'puppet/acceptance/environment_utils'
 test_name 'C97760: Bignum in reduce() should not cause exception' do
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:unit'
+
   skip_test "This test needs to be reworked to not rely on merge, see PUP-6994"
 
   app_type = File.basename(__FILE__, '.*')

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -1,4 +1,10 @@
 test_name "Puppet Lookup Command"
+
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 # doc:
 # https://docs.puppetlabs.com/puppet/latest/reference/lookup_quick_module.html
 

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -1,5 +1,9 @@
 test_name "pluginsync should not error when modulepath is a symlink and no modules have plugin directories"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 step "Create a modulepath directory which is a symlink and includes a module without facts.d or lib directories"
 basedir = master.tmpdir("symlink_modulepath")
 

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,6 +1,10 @@
 test_name "Pluginsync'ed external facts should be resolvable on the agent"
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that external facts downloaded onto an agent via
 # pluginsync are resolvable. In Linux, the external fact should have the same

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,5 +1,9 @@
 test_name "Pluginsync'ed custom facts should be resolvable during application runs"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that custom facts downloaded onto an agent via
 # pluginsync are resolvable by puppet applications besides agent/apply.

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,5 +1,9 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that pluginsync syncs app definitions to the agents.
 # Further, the apps should be runnable on the agent after the sync has occurred.

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -1,5 +1,9 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that pluginsync syncs face definitions to the agents.
 # Further, the face should be runnable on the agent after the sync has occurred.

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,5 +1,9 @@
 test_name "the pluginsync functionality should sync feature definitions"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that pluginsync syncs feature definitions to
 # the agents.  It checks the feature twice; once to make sure that it gets

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -1,5 +1,9 @@
 test_name "earlier modules take precendence over later modules in the modulepath"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 step "Create some modules in the modulepath"
 basedir = master.tmpdir("module_precedence")
 

--- a/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
+++ b/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
@@ -1,5 +1,8 @@
 test_name "puppet apply should create a file and report an MD5"
 
+tag 'audit:medium',
+    'audit:unit'
+
 agents.each do |agent|
   file = agent.tmpfile('hello-world')
   manifest = "file{'#{file}': content => 'test'}"

--- a/acceptance/tests/puppet_apply_basics.rb
+++ b/acceptance/tests/puppet_apply_basics.rb
@@ -4,6 +4,9 @@
 
 test_name "Trivial puppet tests"
 
+tag 'audit:medium',
+    'audit:unit'
+
 step "check that puppet apply displays notices"
 agents.each do |host|
   apply_manifest_on(host, "notice 'Hello World'") do

--- a/acceptance/tests/puppet_apply_should_show_a_notice.rb
+++ b/acceptance/tests/puppet_apply_should_show_a_notice.rb
@@ -1,5 +1,9 @@
 test_name "puppet apply should show a notice"
 
+tag 'audit:medium',
+    'audit:unit',
+    'audit:delete'   # This is a duplicate of puppet_apply_basics.rb
+
 agents.each do |host|
   apply_manifest_on(host, "notice 'Hello World'") do
     assert_match(/.*: Hello World/, stdout, "#{host}: the notice didn't show")

--- a/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
+++ b/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
@@ -1,4 +1,8 @@
 test_name "puppet master help should mention puppet master"
+
+tag 'audit:medium',
+    'audit:unit'
+
 on master, puppet_master('--help') do
     fail_test "puppet master wasn't mentioned" unless stdout.include? 'puppet master'
 end


### PR DESCRIPTION
These commits add audit tags to tests in order to facilitate the
proper application of test tiering and layering in the future.
The `audit` tags are intended to be removed once the corresponding
work has been completed.

Also, the `server` tag has been added to any tests that should be
executed in the context of `puppetserver` and not in the context
of `puppet` or `puppet-agent` testing.