### PR TITLE
(PUP-7753) Ensure that timestamps using space separator can be parsed.

### DIFF
--- a/lib/puppet/pops/time/timestamp.rb
+++ b/lib/puppet/pops/time/timestamp.rb
@@ -1,8 +1,8 @@
 module Puppet::Pops
 module Time
 class Timestamp < TimeData
-  DEFAULT_FORMATS_WO_TZ = ['%FT%T.%N', '%FT%T', '%F']
-  DEFAULT_FORMATS = ['%FT%T.%N %Z', '%FT%T %Z', '%F %Z'] + DEFAULT_FORMATS_WO_TZ
+  DEFAULT_FORMATS_WO_TZ = ['%FT%T.%N', '%FT%T', '%F %T.%N', '%F %T', '%F']
+  DEFAULT_FORMATS = ['%FT%T.%N %Z', '%FT%T %Z', '%F %T.%N %Z', '%F %T %Z', '%F %Z'] + DEFAULT_FORMATS_WO_TZ
 
   CURRENT_TIMEZONE = 'current'.freeze
   KEY_TIMEZONE = 'timezone'.freeze

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -51,13 +51,42 @@ describe 'Timestamp type' do
     end
 
     context 'a Timestamp instance' do
-      it 'can be created from a string' do
+      it 'can be created from a string with just a date' do
         code = <<-CODE
             $o = Timestamp('2015-03-01')
             notice($o)
             notice(type($o))
         CODE
         expect(eval_and_collect_notices(code)).to eq(['2015-03-01T00:00:00.000000000 UTC', "Timestamp['2015-03-01T00:00:00.000000000 UTC']"])
+      end
+
+      it 'can be created from a string and time separated by "T"' do
+        code = <<-CODE
+            notice(Timestamp('2015-03-01T11:12:13'))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['2015-03-01T11:12:13.000000000 UTC'])
+      end
+
+      it 'can be created from a string and time separated by space' do
+        code = <<-CODE
+            notice(Timestamp('2015-03-01 11:12:13'))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(['2015-03-01T11:12:13.000000000 UTC'])
+      end
+
+      it 'should error when none of the default formats can parse the string' do
+        code = <<-CODE
+            notice(Timestamp('2015#03#01 11:12:13'))
+        CODE
+        expect { eval_and_collect_notices(code) }.to raise_error(/Unable to parse/)
+      end
+
+      it 'should error when only part of the string is parsed' do
+        pending("Requires full rewrite of Timestamp parse since there's no way to detect trailing garbage using DateTime#strptime")
+        code = <<-CODE
+            notice(Timestamp('2015-03-01T11:12:13 bogus after'))
+        CODE
+        expect { eval_and_collect_notices(code) }.to raise_error(/Unable to parse/)
       end
 
       it 'can be created from a string and format' do


### PR DESCRIPTION
This commit adds default formats to enable parsing of timestamps where
the date and time part are separated by space. It also adds tests to
assert that such timestamps are fully parsed.

An attempt was made to check if a string is fully parsed so that partly
parsed strings would raise an error. Unfortunately, the parser in
`DateTime#strptime` that Puppet currently relies on, does not make this
possible. It parses up to the point where a format is fully satisfied
and then returns the result without detecting trailing garbage.

A test to detect such garbage is added in this commit, but since it
would require a complete rewrite of the parser, it's currently set
to "pending".