### PR TITLE
Merge 4.10.x -> 5.0.x

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -22,6 +22,7 @@ gem 'uuidtools', :require => false
 group(:test) do
   gem "rspec", "~> 2.14.0", :require => false
   gem "mocha", "~> 0.10.5", :require => false
+  gem "master_manipulator", "~> 2.1", :require => false
 end
 
 if File.exists? "#{__FILE__}.local"

--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -1,0 +1,83 @@
+test_name 'C100303: Resource type statement triggered auto-loading works both with and without generated types' do
+  tag 'risk:medium'
+
+  require 'puppet/acceptance/environment_utils.rb'
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  require 'master_manipulator'
+  extend MasterManipulator::Log
+
+  puppet_server_log      = puppet_server_log_path(master)
+  app_type               = File.basename(__FILE__, '.*')
+  tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
+  fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"
+
+  relative_type_dir    = 'modules/one/lib/puppet/type'
+  relative_type_1_path = "#{relative_type_dir}/type_tst.rb"
+  step 'create custom type' do
+    on(master, "mkdir -p #{fq_tmp_environmentpath}/#{relative_type_dir}")
+
+    custom_type = <<-END
+    Puppet::Type.newtype(:type_tst) do
+      newparam(:name, :namevar => true) do
+        Puppet.notice("found_type_tst")
+      end
+    end
+    END
+    create_remote_file(master, "#{fq_tmp_environmentpath}/#{relative_type_1_path}", custom_type)
+
+    site_pp = <<-PP
+    Resource['type_tst'] { 'found_type': }
+    PP
+    create_sitepp(master, tmp_environment, site_pp)
+  end
+
+  on(master, "chmod -R 755 /tmp/#{tmp_environment}")
+
+  # rotate the server log so that it won't rotate during the test
+  rotate_puppet_server_log(master)
+
+  with_puppet_running_on(master, {}) do
+    agents.each do |agent|
+      on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+         :acceptable_exit_codes => 0) do |puppet_result|
+        assert_match(/Notice: found_type_tst/, puppet_result.stdout, 'Expected to see output from new type: type_tst')
+      end
+    end
+  end
+  type_message_count = 0
+  step 'ensure that we got a message for the type' do
+    on(master, "cat #{puppet_server_log}") do |cat_result|
+      assert_match(/\[puppetserver\] Puppet found_type_tst/, cat_result.stdout, 'Expected to see entry for new type type_tst')
+      type_message_count = cat_result.stdout.split(/\[puppetserver\] Puppet found_type_tst/).length
+    end
+  end
+
+  step 'generate pcore files' do
+    on(master, puppet("generate types --environment #{tmp_environment}")) do |puppet_result|
+      assert_match(/Notice: Generating '.*\/type_tst\.pp' using 'pcore' format/, puppet_result.stdout,
+                   'Expected to see Generating message for type: type_tst')
+      assert_match(/Notice: found_type_tst/, puppet_result.stdout, 'Expected to see generate output from new type: type_tst')
+    end
+  end
+
+  # restart so that we will load and use the generated types
+  on(master, "service #{master['puppetservice']} restart")
+
+  agents.each do |agent|
+    step 'rerun agents after generate, ensure proper runs' do
+      on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+         :acceptable_exit_codes => 0) do |puppet_result|
+        assert_match(/Notice: found_type_tst/, puppet_result.stdout, 'Expected to see output from new type: type_tst')
+      end
+    end
+  end
+
+  step 'ensure that there are no new messages' do
+    on(master, "cat #{puppet_server_log}") do |cat_result|
+      type_message_recount = cat_result.stdout.split(/\[puppetserver\] Puppet found_type_tst/).length
+      step "COUNT #{type_message_count} #{type_message_recount}"
+      assert_equal(type_message_count, type_message_recount, 'Expected the message count to not change')
+    end
+  end
+end

--- a/acceptance/tests/loader/resource_triggers_autoload.rb
+++ b/acceptance/tests/loader/resource_triggers_autoload.rb
@@ -1,0 +1,49 @@
+test_name 'C100296: can auto-load defined types using a Resource statement' do
+  tag 'risk:medium'
+
+  require 'puppet/acceptance/environment_utils.rb'
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  app_type               = File.basename(__FILE__, '.*')
+  tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
+  fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"
+
+  relative_define_type_dir    = 'modules/one/manifests'
+  relative_define_type_1_path = "#{relative_define_type_dir}/tst1.pp"
+  relative_define_type_2_path = "#{relative_define_type_dir}/tst2.pp"
+  step 'create custom type in two environments' do
+    on(master, "mkdir -p #{fq_tmp_environmentpath}/#{relative_define_type_dir}")
+
+    define_type_1 = <<-END
+    define one::tst1($var) {
+      notify { "tst1: ${var}": }
+    }
+    END
+    define_type_2 = <<-END
+    define one::tst2($var) {
+      notify { "tst2: ${var}": }
+    }
+    END
+    create_remote_file(master, "#{fq_tmp_environmentpath}/#{relative_define_type_1_path}", define_type_1)
+    create_remote_file(master, "#{fq_tmp_environmentpath}/#{relative_define_type_2_path}", define_type_2)
+
+    site_pp = <<-PP
+    each(['tst1', 'tst2']) |$nr| {
+      Resource["one::${nr}"] { "some_title_${nr}": var => "Define found one::${nr}" }
+    }
+    PP
+    create_sitepp(master, tmp_environment, site_pp)
+  end
+
+  on(master, "chmod -R 755 /tmp/#{tmp_environment}")
+
+  with_puppet_running_on(master, {}) do
+    agents.each do |agent|
+      on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+         :acceptable_exit_codes => 2) do |puppet_result|
+        assert_match(/Notice: tst1: Define found one::tst1/, puppet_result.stdout, 'Expected to see output from define notify')
+        assert_match(/Notice: tst2: Define found one::tst2/, puppet_result.stdout, 'Expected to see output from define notify')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR includes a merge-up from 4.10.x to 5.0.x following the revert of the accidental merge of 5.0.x into 4.10.x. To avoid bringing the changes from that revert into this branch, I kept everything in this branch, which caused the changes from Eric's autoloader test commit to get lost. I subsequently cherry-picked that commit from 4.10.x onto 5.0.x.