### PR TITLE
(PUP-7757) Raise errors unless Timespan#parse consumes all input

### DIFF
--- a/lib/puppet/pops/time/timestamp.rb
+++ b/lib/puppet/pops/time/timestamp.rb
@@ -71,31 +71,43 @@ class Timestamp < TimeData
     parsed = nil
     if format.is_a?(Array)
       format.each do |fmt|
-        assert_no_tz_extractor(fmt) if has_timezone
-        begin
-          parsed = DateTime.strptime(str, fmt)
-          break
-        rescue ArgumentError
+        parsed = DateTime._strptime(str, fmt)
+        next if parsed.nil?
+        if parsed.include?(:leftover) || (has_timezone && parsed.include?(:zone))
+          parsed = nil
+          next
         end
+        break
       end
-      raise ArgumentError, _("Unable to parse '%{str}' using any of the formats %{formats}") % { str: str, formats: format.join(', ') } if parsed.nil?
+      if parsed.nil?
+        raise ArgumentError, _(
+          "Unable to parse '%{str}' using any of the formats %{formats}") % { str: str, formats: format.join(', ') }
+      end
     else
-      assert_no_tz_extractor(format) if has_timezone
-      begin
-        parsed = DateTime.strptime(str, format)
-      rescue ArgumentError
+      parsed = DateTime._strptime(str, format)
+      if parsed.nil? || parsed.include?(:leftover)
         raise ArgumentError, _("Unable to parse '%{str}' using format '%{format}'") % { str: str, format: format }
       end
+      if has_timezone && parsed.include?(:zone)
+        raise ArgumentError, _(
+          'Using a Timezone designator in format specification is mutually exclusive to providing an explicit timezone argument')
+      end
     end
-    parsed_time = parsed.to_time
-    parsed_time -= utc_offset(timezone) if has_timezone
-    from_time(parsed_time)
-  end
+    unless has_timezone
+      timezone = parsed[:zone]
+      has_timezone = !timezone.nil?
+    end
+    fraction = parsed[:sec_fraction]
 
-  def self.assert_no_tz_extractor(format)
-    if format =~ /[^%]%[zZ]/
-      raise ArgumentError, _('Using a Timezone designator in format specification is mutually exclusive to providing an explicit timezone argument')
-    end
+    # Convert msec rational found in _strptime hash to usec
+    fraction = fraction * 1000000 unless fraction.nil?
+
+    # Create the Time instance and adjust for timezone
+    parsed_time = ::Time.utc(parsed[:year], parsed[:mon], parsed[:mday], parsed[:hour], parsed[:min], parsed[:sec], fraction)
+    parsed_time -= utc_offset(timezone) if has_timezone
+
+    # Convert to Timestamp
+    from_time(parsed_time)
   end
 
   undef_method :-@, :+@, :div, :fdiv, :abs, :abs2, :magnitude # does not make sense on a Timestamp

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -50,7 +50,7 @@ describe 'the new function' do
       $b = Binary('YmluYXI=')
       notice($b == Binary($b))
 
-      $t = Timestamp('2012-03-04:09:10:11.001')
+      $t = Timestamp('2012-03-04T09:10:11.001')
       notice($t == Timestamp($t))
 
       type MyObject = Object[{attributes => {'type' => String}}]

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -12,6 +12,11 @@ describe 'Timestamp type' do
     expect(t).to eql(TypeFactory.timestamp('2015-03-01', '2016-12-24'))
   end
 
+  it 'DateTime#_strptime creates hash with :leftover field' do
+    expect(DateTime._strptime('2015-05-04 and bogus', '%F')).to include(:leftover)
+    expect(DateTime._strptime('2015-05-04T10:34:11.003 UTC and bogus', '%FT%T.%N %Z')).to include(:leftover)
+  end
+
   context 'when used in Puppet expressions' do
     include PuppetSpec::Compiler
     it 'is equal to itself only' do
@@ -96,7 +101,6 @@ describe 'Timestamp type' do
       end
 
       it 'should error when only part of the string is parsed' do
-        pending("Requires full rewrite of Timestamp parse since there's no way to detect trailing garbage using DateTime#strptime")
         code = <<-CODE
             notice(Timestamp('2015-03-01T11:12:13 bogus after'))
         CODE


### PR DESCRIPTION
This commit changes the Timestamp#parse method so that it uses the
method `DateTime#_strptime` instead of `DateTime#strptime` internally.
The `_strptime` returns a `Hash` instead of a `DateTime` and this hash
will contain the undocumented field `leftover` in case the parsed string
was not consumed in full. In Puppet, it's desirable to treat such data
as an error since it means that only part of a string represented the
desired `Timestamp`.

Some extra logic was added to process the parse result since it's now
in the form of a `Hash` instead of a `DateTime`. Also, the previous
begin/rescue was no longer needed.since the `_strptime` returns `nil`
instead of raising an ArgumentError for unparsable input.