### PR TITLE
(PUP-7761) Allow user to be created with null passwords

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -161,7 +161,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       next if property == :expiry and @resource.forcelocal?
       # the value needs to be quoted, mostly because -c might
       # have spaces in it
-      if value = @resource.should(property) and value != ""
+      if value = @resource.should(property)
         cmd << flag(property) << munge(property, value)
       end
     end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -66,6 +66,14 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       provider.create
     end
 
+    it "should be able to create users with null passwords" do
+      described_class.has_feature :manages_passwords
+      resource[:ensure] = :present
+      resource[:password] = ''
+      provider.expects(:execute).with(includes('-p'), kind_of(Hash))
+      provider.create
+    end
+
     it "should add -o when allowdupe is enabled and the user is being created" do
       resource[:allowdupe] = true
       provider.expects(:execute).with(includes('-o'), kind_of(Hash))


### PR DESCRIPTION
Permit users to be created using the useradd provider with
null passwords, if specified.