### PR TITLE
(PUP-7740) Fix acceptance puppetserver install

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -80,17 +80,16 @@ step "Install puppetserver..." do
       fail_test("EC2 master found, but it was not an `el` host: The specified `puppet-agent` build (#{ENV['SHA']}) cannot be installed.")
     end
   else
-    if ENV['SERVER_VERSION']
-      install_puppetlabs_dev_repo(master, 'puppetserver', ENV['SERVER_VERSION'])
-      install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
-      master.install_package('puppetserver')
+    if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
+      server_version = 'latest'
+      server_download_url = "http://nightlies.puppet.com"
     else
-      # beaker can't install puppetserver from nightlies (BKR-673)
-      repo_configs_dir = 'repo-configs'
-      install_repos_on(master, 'puppetserver', 'nightly', repo_configs_dir)
-      install_repos_on(master, 'puppet-agent', ENV['SHA'], repo_configs_dir)
-      install_packages_on(master, MASTER_PACKAGES)
+      server_version = ENV['SERVER_VERSION']
+      server_download_url = "http://builds.delivery.puppetlabs.net"
     end
+    install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
+    install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
+    master.install_package('puppetserver')
   end
 end
 


### PR DESCRIPTION
This commit corrects the logic for puppetserver install during
acceptance tests to install from nightlies when the SERVER_VERSION
is unspecified or set to 'latest'.