### PR TITLE
(PUP-7742) Ensure getpwent and getgrent iterators are properly closed

### DIFF
--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -25,7 +25,8 @@ class Puppet::Provider::NameService < Puppet::Provider
     def instances
       objects = []
       begin
-        while ent = Puppet::Etc.send("get#{section}ent")
+        method = Puppet::Etc.method(:"get#{section}ent")
+        while ent = method.call
           objects << new(:name => ent.name, :canonical_name => ent.canonical_name, :ensure => :present)
         end
       ensure

--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -24,11 +24,12 @@ class Puppet::Provider::NameService < Puppet::Provider
 
     def instances
       objects = []
-      Puppet::Etc.send("set#{section}ent")
       begin
         while ent = Puppet::Etc.send("get#{section}ent")
           objects << new(:name => ent.name, :canonical_name => ent.canonical_name, :ensure => :present)
         end
+      ensure
+        Puppet::Etc.send("end#{section}ent")
       end
       objects
     end


### PR DESCRIPTION
A regression introduced in PUP-7498 commit e45ae7c where an iteration
was introduced that started with `setpwent` or `setgrent` and then iterated
each entry with the corresponding `getpwent` or `getgrent` until no more
entries were found. A call to `endpwent` or `endgrent` was never made.

In essence, this means that the internal iterator is reset to the start
before each iteration so it should be fine. The problem is that on some
platforms (notably on CentOS 7) the lack of the call to `endpwent` or
`endgrent`, causes a cached iterator to be reused. It is never refreshed
with new values. Consequently, a call to `useradd` would succeed, but the
added user would then not be found.

This commit replaces the initial call to `setpwent` or `setgrent` with
an ensured call to `endpwent` or `endgrend` at the end. The initial
set call was deemed unnecessary since it should be considered a serious
problem if the iterator is left open somewhere else. It's better to make
such problems abundantly apparent than adding attempts to overcome them.

This commit contains no tests. A proper acceptance test must be written
that asserts this functionality on CentOS-7 (the first platform where the
problem was discovered).