### PR TITLE
(PUP-7766) Ensure that --modulepath is propagated to static environment

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -251,9 +251,11 @@ module Puppet
       # doesn't exist
       default_environment = Puppet[:environment].to_sym
       if default_environment == :production
+        modulepath = settings[:modulepath]
+        modulepath = modulepath.nil? ? basemodulepath : Puppet::Node::Environment.split_path(modulepath)
         loaders << Puppet::Environments::StaticPrivate.new(
           Puppet::Node::Environment.create(default_environment,
-                                           basemodulepath,
+                                           modulepath,
                                            Puppet::Node::Environment::NO_MANIFEST))
       end
     end

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -252,7 +252,7 @@ module Puppet
       default_environment = Puppet[:environment].to_sym
       if default_environment == :production
         modulepath = settings[:modulepath]
-        modulepath = modulepath.nil? ? basemodulepath : Puppet::Node::Environment.split_path(modulepath)
+        modulepath = (modulepath.nil? || '' == modulepath) ? basemodulepath : Puppet::Node::Environment.split_path(modulepath)
         loaders << Puppet::Environments::StaticPrivate.new(
           Puppet::Node::Environment.create(default_environment,
                                            modulepath,

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -38,6 +38,16 @@ describe Puppet do
     expect($LOAD_PATH).to include two
   end
 
+  it 'should propagate --modulepath to base environment' do
+    Puppet::Node::Environment.expects(:create).with(
+      is_a(Symbol), ['/my/modules'], Puppet::Node::Environment::NO_MANIFEST)
+    expect(Puppet.base_context({
+      :environmentpath => '/envs',
+      :basemodulepath => '/base/modules',
+      :modulepath => '/my/modules'
+    })).to be_a(Hash)
+  end
+
   context "Puppet::OLDEST_RECOMMENDED_RUBY_VERSION" do
     it "should have an oldest recommended ruby version constant" do
       expect(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION).not_to be_nil

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -48,6 +48,16 @@ describe Puppet do
     })).to be_a(Hash)
   end
 
+  it 'empty modulepath does not override basemodulepath' do
+    Puppet::Node::Environment.expects(:create).with(
+      is_a(Symbol), ['/base/modules'], Puppet::Node::Environment::NO_MANIFEST)
+    expect(Puppet.base_context({
+      :environmentpath => '/envs',
+      :basemodulepath => '/base/modules',
+      :modulepath => ''
+    })).to be_a(Hash)
+  end
+
   context "Puppet::OLDEST_RECOMMENDED_RUBY_VERSION" do
     it "should have an oldest recommended ruby version constant" do
       expect(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION).not_to be_nil


### PR DESCRIPTION
Before this commit, the static environment that is created when puppet
runs without an existing environment directory, was configured using the
`basemodulepath` regardless of if the `--modulepath` was given or not.

This commit ensures that this command line argument is propagated
correctly.