### PR TITLE
(PUP-4962) Pack array as little-endian

### DIFF
--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -41,16 +41,16 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
       end
 
       it "fails if the contents collide with existing contents" do
-        # This is the shortest known MD5 collision. See https://eprint.iacr.org/2010/643.pdf
+        # This is the shortest known MD5 collision (little endian). See https://eprint.iacr.org/2010/643.pdf
         first_contents = [0x6165300e,0x87a79a55,0xf7c60bd0,0x34febd0b,
                           0x6503cf04,0x854f709e,0xfb0fc034,0x874c9c65,
                           0x2f94cc40,0x15a12deb,0x5c15f4a3,0x490786bb,
-                          0x6d658673,0xa4341f7d,0x8fd75920,0xefd18d5a].pack("I" * 16)
+                          0x6d658673,0xa4341f7d,0x8fd75920,0xefd18d5a].pack("V" * 16)
 
         collision_contents = [0x6165300e,0x87a79a55,0xf7c60bd0,0x34febd0b,
                               0x6503cf04,0x854f749e,0xfb0fc034,0x874c9c65,
                               0x2f94cc40,0x15a12deb,0xdc15f4a3,0x490786bb,
-                              0x6d658673,0xa4341f7d,0x8fd75920,0xefd18d5a].pack("I" * 16)
+                              0x6d658673,0xa4341f7d,0x8fd75920,0xefd18d5a].pack("V" * 16)
 
         checksum_value = save_bucket_file(first_contents, "/foo/bar")
 


### PR DESCRIPTION
Previously the unit test failed on big-endian IBM z Sytems, because the
array contains integers in little-endian. Pack using "V" 32-bit
unsigned, VAX (little-endian) byte order, instead of "I" unsigned
int, native endian.