### PR TITLE
(PUP-7774) Skip common package name acceptance in EC2

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -2,6 +2,7 @@ test_name "ticket 1073: common package name in two different providers should be
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
 confine :except, :platform => /centos-4|el-4/ # PUP-5227
+confine :except, :hypervisor => 'ec2' # PUP-7774
 
 require 'puppet/acceptance/rpm_util'
 extend Puppet::Acceptance::RpmUtils


### PR DESCRIPTION
We can't install the `guid` package from Amazon repos when running in
EC2. Skip the test if the hypervisor is ec2. I could have checked an
`ec2` fact, but this should be quicker.