### PR TITLE
(PUP-7772) Ensure string msg in ExecutionFailure

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -83,7 +83,7 @@ module Puppet::Util::Execution
     end
 
     if failonfail && exitstatus != 0
-      raise Puppet::ExecutionFailure, output
+      raise Puppet::ExecutionFailure, output.to_s
     end
 
     output

--- a/spec/integration/util/execution_spec.rb
+++ b/spec/integration/util/execution_spec.rb
@@ -15,6 +15,14 @@ describe Puppet::Util::Execution do
       Puppet::Util::Execution.execpipe('echo $LC_ALL'){ |line| out << line.read.chomp }
       expect(out).to eq("C")
     end
+
+    it "should raise an ExecutionFailure with a missing command and :failonfail set to true" do
+      expect {
+        failonfail = true
+        # NOTE: critical to return l in the block for `output` in method to be #<IO:(closed)>
+        Puppet::Util::Execution.execpipe('conan_the_librarion', failonfail) { |l| l }
+      }.to raise_error(Puppet::ExecutionFailure)
+    end
   end
 
   describe "#execute (non-Windows)", :if => !Puppet.features.microsoft_windows? do


### PR DESCRIPTION
- `Puppet::ExecutionFailure` is derived from `Puppet::Error`, which in
   future versions of Puppet (5.0.0+) performs additional scrubbing of
   passed strings to ensure that they match the output encoding.

   In that future case, the behavior of the initializer is subtly
   different from the current code:

   ```ruby
   def initialize(message, original=nil)
     super(message)
     @original = original
   end
   ```

   Calling `super` directly in the current code will call `RuntimeError`
   within Ruby, which despite the Ruby documentation, will implicitly
   call `.to_s` on the second parameter, which is always intended to be
   a string.  That means that Ruby allows things like:

   ```
   [1] pry(main)> raise RuntimeError, 2
   RuntimeError: 2

   [2] pry(main)> raise RuntimeError, ['foo']
   RuntimeError: ["foo"]

   [3] pry(main)> raise RuntimeError, StringIO.new('hi')
   RuntimeError: #<StringIO:0x007fdb040d4ee0>
   ```

 - `#execpipe` currently raises an `IO` object which `RuntimeError` is
   conveniently / implicitly calling `.to_s` against.

   In Puppet 5, the initializer changes to

   ```ruby
   def initialize(message, original=nil)
     super(Puppet::Util::CharacterEncoding.scrub(message))
     @original = original
   end
   ```

   In this case, when message is an `IO` object - the code crashes
   instead of implicitly calling `.to_s` and then performing the scrub.

 - Code is targeted at this older version as it's a very minor change
   and is a preventive measure in the event that any of the encoding
   scrubbing changes are backported to the LTS release based on
   customer demand.