### PR TITLE
(PUP-7732) Acceptance audit

### DIFF
--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -1,6 +1,12 @@
 test_name "the agent --disable/--enable functionality should manage the agent lockfile properly"
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 
+tag 'audit:integration', # lockfile uses the standard `vardir` location to store/query lockfile.
+                         # The validation of the `vardir` at the OS level
+                         # should be accomplished in another test.
+    'audit:medium',
+    'audit:refactor'     # This test should not require a master. Remove the use of `with_puppet_running_on`.
+
 #
 # This test is intended to ensure that puppet agent --enable/--disable
 #  work properly, both in terms of complying with our public "API" around

--- a/acceptance/tests/agent/agent_parses_json_catalog.rb
+++ b/acceptance/tests/agent/agent_parses_json_catalog.rb
@@ -1,5 +1,10 @@
 test_name "C99978: Agent parses a JSON catalog"
-tag 'risk:medium'
+
+tag 'risk:medium',
+    'audit:high',        # tests defined catalog format
+    'audit:integration', # There is no OS specific risk here.
+    'server',
+    'catalog:json'
 
 require 'puppet/acceptance/common_utils'
 require 'json'

--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -1,5 +1,9 @@
 test_name "fallback to the cached catalog"
 
+tag 'audit:medium',
+    'audit:integration', # This test is not OS sensitive.
+    'audit:refactor'     # A catalog fixture can be used for this test. Remove the usage of `with_puppet_running_on`.
+
 step "run agents once to cache the catalog" do
   with_puppet_running_on master, {} do
     on(agents, puppet("agent -t --server #{master}"))

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -1,5 +1,8 @@
 test_name "aix package provider should work correctly"
 
+tag 'audit:medium',
+    'audit:acceptance'  # OS specific by definition.
+
 confine :to, :platform => /aix/
 
 dir = "/tmp/aix-packages-#{$$}"

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -1,5 +1,8 @@
 test_name "NIM package provider should work correctly"
 
+tag 'audit:medium',
+    'audit:acceptance'  # OS specific by definition
+
 confine :to, :platform => "aix"
 
 # NOTE: This test is duplicated in the pe_acceptance_tests repo

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -1,5 +1,10 @@
 test_name "node_name_fact should be used to determine the node name for puppet agent"
 
+tag 'audit:medium',
+    'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
+                          # Testing of passenger master is no longer needed.
+    'server'
+
 success_message = "node_name_fact setting was correctly used to determine the node name"
 
 testdir = master.tmpdir("nodenamefact")

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_apply.rb
@@ -1,5 +1,9 @@
 test_name "node_name_fact should be used to determine the node name for puppet apply"
 
+tag 'audit:medium',
+    'audit:integration',  # Ruby level integration tests already exist. This acceptance test can be deleted.
+    'audit:delete'
+
 success_message = "node_name_fact setting was correctly used to determine the node name"
 
 node_names = []

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -1,5 +1,10 @@
 test_name "node_name_value should be used as the node name for puppet agent"
 
+tag 'audit:medium',
+    'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
+                          # Testing of passenger master is no longer needed.
+    'server'
+
 success_message = "node_name_value setting was correctly used as the node name"
 testdir = master.tmpdir('nodenamevalue')
 

--- a/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_apply.rb
@@ -1,5 +1,9 @@
 test_name "node_name_value should be used as the node name for puppet apply"
 
+tag 'audit:medium',
+    'audit:integration',  # Ruby level integration tests already exist. This acceptance test can be deleted.
+    'audit:delete'
+
 success_message = "node_name_value setting was correctly used as the node name"
 
 manifest = %Q[

--- a/acceptance/tests/allow_symlinks_as_config_directories.rb
+++ b/acceptance/tests/allow_symlinks_as_config_directories.rb
@@ -1,4 +1,8 @@
 test_name "Should allow symlinks to directories as configuration directories"
+
+tag 'audit:low',
+    'audit:acceptance'  # Need to cover risk of OS/ruby symlink behavior (OSX, Solaris).
+
 confine :except, :platform => 'windows'
 
 agents.each do |agent|

--- a/acceptance/tests/apply/augeas/hosts.rb
+++ b/acceptance/tests/apply/augeas/hosts.rb
@@ -1,8 +1,12 @@
 test_name "Augeas hosts file" do
 
-skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
+tag 'risk:medium',
+    'audit:medium',
+    'audit:acceptance',
+    'audit:refactor' # move to puppet types test directory, this is not testing puppet apply
+                     # reduce to a single manifest and apply
 
-tag 'risk:medium'
+skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
 
   confine :except, :platform => [
     'windows',

--- a/acceptance/tests/apply/augeas/puppet.rb
+++ b/acceptance/tests/apply/augeas/puppet.rb
@@ -1,8 +1,12 @@
 test_name "Augeas puppet configuration" do
 
-  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
+  tag 'risk:medium',
+      'audit:medium',
+      'audit:acceptance',
+      'audit:refactor'      # move to types test dir
+                            # remove spurious `puppet config set`
 
-  tag 'risk:medium'
+  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
 
   confine :except, :platform => 'windows'
   confine :to, {}, hosts.select { |host| ! host[:roles].include?('master') }

--- a/acceptance/tests/apply/augeas/services.rb
+++ b/acceptance/tests/apply/augeas/services.rb
@@ -1,8 +1,12 @@
 test_name "Augeas services file" do
 
-  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
+  tag 'risk:medium',
+      'audit:medium',
+      'audit:acceptance',
+      'audit:refactor'      # move to types test dir
+                            # use single manifest/apply
 
-  tag 'risk:medium'
+  skip_test 'requires augeas which is included in AIO' if @options[:type] != 'aio'
 
   confine :except, :platform => 'windows'
   confine :except, :platform => 'osx'

--- a/acceptance/tests/apply/classes/parameterized_classes.rb
+++ b/acceptance/tests/apply/classes/parameterized_classes.rb
@@ -1,5 +1,8 @@
 test_name "parametrized classes"
 
+tag 'audit:high',
+    'audit:unit'   # This should be covered at the unit layer.
+
 ########################################################################
 step "should allow param classes"
 manifest = %q{

--- a/acceptance/tests/apply/classes/should_allow_param_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_override.rb
@@ -1,5 +1,8 @@
 test_name "should allow param override"
 
+tag 'audit:high',
+    'audit:unit'   # This should be covered at the unit layer.
+
 manifest = %q{
 class parent {
   notify { 'msg':

--- a/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
@@ -1,5 +1,8 @@
 test_name "should allow overriding a parameter to undef in inheritence"
 
+tag 'audit:high',
+    'audit:unit'   # This should be covered at the unit layer.
+
 agents.each do |agent|
   dir = agent.tmpdir('class_undef_override')
   out = File.join(dir, 'class_undef_override_out')

--- a/acceptance/tests/apply/classes/should_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_include_resources_from_class.rb
@@ -1,4 +1,8 @@
 test_name "resources declared in a class can be applied with include"
+
+tag 'audit:high',
+    'audit:unit'   # This should be covered at the unit layer.
+
 manifest = %q{
 class x {
   notify{'a':}

--- a/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
@@ -1,4 +1,8 @@
 test_name "resources declared in classes are not applied without include"
+
+tag 'audit:high',
+    'audit:unit'   # This should be covered at the unit layer.
+
 manifest = %q{ class x { notify { 'test': message => 'never invoked' } } }
 apply_manifest_on(agents, manifest) do
     fail_test "found the notify despite not including it" if

--- a/acceptance/tests/apply/hashes/should_not_reassign.rb
+++ b/acceptance/tests/apply/hashes/should_not_reassign.rb
@@ -1,4 +1,9 @@
 test_name "hash reassignment should fail"
+
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 manifest = %q{
 $my_hash = {'one' => '1', 'two' => '2' }
 $my_hash['one']='1.5'

--- a/acceptance/tests/apply/puppet_apply_graph.rb
+++ b/acceptance/tests/apply/puppet_apply_graph.rb
@@ -1,5 +1,9 @@
 test_name 'puppet apply should generate a graph'
 
+tag 'audit:low',
+    'audit:integration',  # Core testing of `vardir` should occur in another test.
+    'audit:refactor'      # The test should validate that the content of the dot file is sane.
+
 agents.each do |agent|
   step "Create var temp directory"
   vardir = agent.tmpdir('vardir')

--- a/acceptance/tests/apply/puppet_apply_trace.rb
+++ b/acceptance/tests/apply/puppet_apply_trace.rb
@@ -1,5 +1,9 @@
 test_name 'puppet apply --trace should provide a stack trace'
 
+tag 'audit:low',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 agents.each do |agent|
   on(agent, puppet('apply --trace -e "blue < 2"'), :acceptable_exit_codes => 1) do
     assert_match(/\.rb:\d+:in `\w+'/m, stderr, "Did not print expected stack trace on stderr")

--- a/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
+++ b/acceptance/tests/concurrency/ticket_2659_concurrent_catalog_requests.rb
@@ -1,5 +1,9 @@
 test_name "concurrent catalog requests (PUP-2659)"
 
+tag 'audit:low',
+    'audit:integration',
+    'server'
+
 # we're only testing the effects of loading a master with concurrent requests
 confine :except, :platform => 'windows'
 confine :except, :platform => /osx/ # see PUP-4820

--- a/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
+++ b/acceptance/tests/config/apply_file_metadata_specified_in_config.rb
@@ -1,5 +1,8 @@
 test_name "#17371 file metadata specified in puppet.conf needs to be applied"
 
+tag 'audit:low',
+    'audit:acceptance'
+
 # when owner/group works on windows for settings, this confine should be removed.
 confine :except, :platform => 'windows'
 confine :except, :platform => /solaris-10/ # See PUP-5200

--- a/acceptance/tests/cycle_detection.rb
+++ b/acceptance/tests/cycle_detection.rb
@@ -1,5 +1,9 @@
 test_name "cycle detection and reporting"
 
+tag 'audit:high',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:delete'
+
 step "check we report a simple cycle"
 manifest = <<EOT
 notify { "a1": require => Notify["a2"] }

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -3,6 +3,12 @@ extend Puppet::Acceptance::StaticCatalogUtils
 
 test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri" do
 
+  tag 'audit:medium',
+      'audit:acceptance',
+      'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
+      'server'
+
+
   skip_test 'requires puppetserver installation' if @options[:type] != 'aio'
 
   basedir = master.tmpdir(File.basename(__FILE__, '.*'))

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -1,4 +1,9 @@
 test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
+
+  tag 'audit:medium',
+      'audit:acceptance',
+      'server'
+
   master_reportdir = create_tmpdir_for_user(master, 'reportdir')
 
   def remove_reports_on_master(master_reportdir, agent_node_name)

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -1,5 +1,10 @@
 test_name "Environment control of static catalogs"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
+    'server'
+
 skip_test 'requires puppetserver to test static catalogs' if @options[:type] != 'aio'
 
 require 'json'

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -2,6 +2,12 @@ test_name "C97172: static catalogs support utf8" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+  tag 'audit:medium',
+      'audit:acceptance',
+      'audit:refactor',  # Review for agent side UTF validation.
+      'server'
+
+
   app_type = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)
 

--- a/acceptance/tests/doc/should_print_function_reference.rb
+++ b/acceptance/tests/doc/should_print_function_reference.rb
@@ -1,4 +1,9 @@
 test_name "verify we can print the function reference"
+
+tag 'audit:low',
+    'audit:unit',
+    'audit:delete'
+
 on(agents, puppet_doc("-r", "function")) do
     fail_test "didn't print function reference" unless
         stdout.include? 'Function Reference'

--- a/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
+++ b/acceptance/tests/doc/ticket_4120_cannot_generate_type_reference.rb
@@ -1,4 +1,9 @@
 test_name "verify we can print the function reference"
+
+tag 'audit:low',
+    'audit:unit',
+    'audit:delete'
+
 confine :except, :platform => /^eos-/
 
 on(agents, puppet_doc("-r", "type")) do

--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -2,6 +2,11 @@
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 test_name 'PUP-4033: Ensure aio path spec is honored'
 
+tag 'audit:high',
+    'audit:acceptance',
+    'audit:refactor'    # move to puppet-agent acceptance
+
+
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils
 

--- a/acceptance/tests/ensure_version_file.rb
+++ b/acceptance/tests/ensure_version_file.rb
@@ -1,6 +1,10 @@
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 
+tag 'audit:high',
+    'audit:acceptance',
+    'audit:refactor'  # This should be folded into `ensure_puppet-agent_paths` test
+
 # ensure a version file is created according to the puppet-agent path specification:
 # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
 

--- a/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
+++ b/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
@@ -1,5 +1,11 @@
 test_name 'PUP-4413 3x forbidden environment names should be allowed in 4x'
 
+tag 'audit:medium',
+    'audit:unit',  # This should be covered at the unit layer.
+    'audit:refactor',
+    'audit:delete'
+
+
 step 'setup environments'
 
 testdir = create_tmpdir_for_user(master, 'forbidden_env')

--- a/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
+++ b/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
@@ -4,6 +4,12 @@
 # details see PUP-3591.
 test_name "Agent should pluginsync with the environment the agent resolves to"
 
+tag 'audit:high',
+    'audit:integration',
+    'audit:refactor',  # Inquire as to whether this is still a risk with puppet 5+
+                       # Use mk_temp_environment_with_teardown helper
+    'server'
+
 testdir = create_tmpdir_for_user master, 'environment_resolve'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -1,5 +1,11 @@
 test_name 'PUP-3755 Test an un-assigned broken environment'
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',     # Use mk_temp_environment_with_teardown helper
+    'server'
+
+
 step 'setup environments'
 
 testdir = create_tmpdir_for_user(master, 'confdir')

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -1,5 +1,9 @@
 test_name "Can enumerate environments via an HTTP endpoint"
 
+tag 'audit:high',
+    'audit:integration',
+    'server'
+
 confine :except, :platform => /osx/ # see PUP-4820
 
 def master_port(agent)

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -2,6 +2,10 @@ test_name 'C59122: ensure provider from same env as custom type' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',  # This behavior is specific to the master to 'do the right thing'
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   file_correct    = "#{tmp_environment}-correct.txt"

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -1,5 +1,9 @@
 test_name 'ensure production environment created by master if missing'
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 testdir = create_tmpdir_for_user master, 'prod-env-created'
 
 step 'make environmentpath'

--- a/acceptance/tests/environment/directory_environment_with_environment_conf.rb
+++ b/acceptance/tests/environment/directory_environment_with_environment_conf.rb
@@ -2,6 +2,13 @@ test_name 'Use a directory environment from environmentpath with an environment.
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:low',
+    'audit:integration',
+    'audit:refactor'    # Is this a component of a larger workflow scenario?
+                        # Do we have customer examples of this usage to
+                        # support the continued existance of this feature?
+
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 testdir = create_tmpdir_for_user master, 'use-environment-conf'

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -2,6 +2,10 @@ test_name "Master should produce error if enc specifies a nonexistent environmen
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:unit',
+    'server'
+
 testdir = create_tmpdir_for_user master, 'nonexistent_env'
 
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -4,6 +4,12 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:unit',  # The error responses for the agent should be covered by Ruby unit tests.
+                   # The server 404/400 response should be covered by server integration tests.
+    'server'
+
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step 'setup environments'

--- a/acceptance/tests/environment/environment_scenario-default.rb
+++ b/acceptance/tests/environment/environment_scenario-default.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/environment_scenario-existing.rb
+++ b/acceptance/tests/environment/environment_scenario-existing.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
+++ b/acceptance/tests/environment/environment_scenario-master_environmentpath.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -4,6 +4,10 @@ extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:high',
+    'audit:refactor',
+    'audit:delete'  # These validations are covered by other tests.
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 step "setup environments"

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -2,6 +2,10 @@ test_name "Agent should use agent environment if there is an enc that does not s
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 testdir = create_tmpdir_for_user master, 'use_agent_env'

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -1,5 +1,10 @@
 test_name "Agent should use agent environment if there is no enc-specified environment"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',  # This can be combined with use_agent_environment_when_enc_doesnt_specify test
+    'server'
+
 testdir = create_tmpdir_for_user master, 'use_agent_env'
 
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -2,6 +2,10 @@ test_name "Agent should use environment given by ENC"
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 testdir = create_tmpdir_for_user master, 'use_enc_env'
 
 if master.is_pe?

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,5 +1,10 @@
 test_name "Agent should use environment given by ENC for fetching remote files"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',    # This test should be rolled into use_enc_environment
+    'server'
+
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -1,5 +1,10 @@
 test_name "Agent should use environment given by ENC for pluginsync"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',    # This test should be rolled into use_enc_environment
+    'server'
+
 testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
 create_remote_file master, "#{testdir}/enc.rb", <<END

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -2,6 +2,10 @@ test_name "Use environments from the environmentpath"
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 classify_nodes_as_agent_specified_if_classifer_present
 
 testdir = create_tmpdir_for_user master, 'use_environmentpath'

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -2,6 +2,10 @@ test_name 'C98115 compilation should get new values in variables on each compila
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
+++ b/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
@@ -17,6 +17,10 @@ skip_test "Test only supported on Jetty" unless @options[:is_puppetserver]
 #
 test_name "Puppet agent and master work when both configured with externally issued certificates from independent intermediate CAs"
 
+tag 'audit:medium',
+    'audit:integration',  # This could also be a component in a platform workflow test.
+    'server'
+
 step "Copy certificates and configuration files to the master..."
 fixture_dir = File.expand_path('../fixtures', __FILE__)
 testdir = master.tmpdir('jetty_external_root_ca')

--- a/acceptance/tests/face/4654_facts_face.rb
+++ b/acceptance/tests/face/4654_facts_face.rb
@@ -1,5 +1,9 @@
 test_name "Puppet facts face should resolve custom and external facts"
 
+tag 'audit:medium',
+    'audit:integration'   # The facter acceptance tests should be acceptance.
+                          # However, the puppet face merely needs to interact with libfacter.
+                          # So, this should be an integration test.
 #
 # This test is intended to ensure that custom and external facts present
 # on the agent are resolved and displayed by the puppet facts face.

--- a/acceptance/tests/face/help_test.rb
+++ b/acceptance/tests/face/help_test.rb
@@ -1,6 +1,8 @@
 test_name 'Test `puppet help` workflow'
 
-tag 'risk:medium'
+tag 'risk:medium',
+    'audit:low',
+    'audit:unit' # basic command line handling
 
 hosts.each do |host|
 

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -4,6 +4,11 @@ test_name "Exercise loading a face from a module"
 confine :except, :platform => 'windows'
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
+tag 'audit:medium',
+    'audit:acceptance',    # This has been OS sensitive.
+    'audit:refactor'       # Remove the confine against windows and refactor to
+                           # accommodate the Windows platform.
+
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 initialize_temp_dirs

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -1,4 +1,9 @@
 test_name 'parser validate' do
+
+tag 'audit:medium',
+    'audit:unit'   # Parser validation should be core to ruby
+                   # and platform agnostic.
+
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
   require 'puppet/acceptance/temp_file_utils'

--- a/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
+++ b/acceptance/tests/helpful_error_message_when_hostname_not_match_server_certificate.rb
@@ -2,6 +2,13 @@ test_name "generate a helpful error message when hostname doesn't match server c
 
 skip_test( 'Changing certnames of the master will break PE/Passenger installations' ) if master.is_using_passenger?
 
+tag 'audit:low',
+    'audit:integration',
+    'server',
+    'audit:delete'        # This test is unlikely to regress and is of
+                          # such low risk that it is not worth the cost
+                          # of automatically guarding against it failing.
+
 certname = "foobar_not_my_hostname"
 dns_alt_names = "one_cert,two_cert,red_cert,blue_cert"
 

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -2,6 +2,13 @@ test_name 'C98346: Binary data type' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
+tag 'audit:high',
+    'audit:integration',  # Tests that binary data is retains integrity
+                          # between server and agent transport/application.
+                          # The weak link here is final ruby translation and
+                          # should not be OS sensitive.
+    'server'
+
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/language/break.rb
+++ b/acceptance/tests/language/break.rb
@@ -1,4 +1,10 @@
 test_name 'C98162 - Validate `break` terminates execution in a block of code' do
+
+tag 'audit:low',
+    'audit:unit',   # This is testing core ruby functionality that is covered by
+                    # existing spec tests.
+    'audit:delete'
+
   agents.each do |agent|
 
     step 'apply class with break' do

--- a/acceptance/tests/language/class_inheritance.rb
+++ b/acceptance/tests/language/class_inheritance.rb
@@ -1,5 +1,8 @@
 test_name 'C14943: Class inheritance works correctly' do
 
+tag 'audit:low',
+    'audit:unit'   # This is testing core ruby functionality
+
   agents.each do |agent|
     test_manifest = <<MANIFEST
       class bar { notice("This is class bar") }

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -2,6 +2,11 @@ test_name "C94788: exported resources using a yaml terminus for storeconfigs" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',     # This could be a component of a larger workflow scenario.
+    'server'
+
   # user resource doesn't have a provider on arista
   skip_test if agents.any? {|agent| agent['platform'] =~ /^eos/ } # see PUP-5404, ARISTA-42
   skip_test 'requires puppetserver to service restart' if @options[:type] != 'aio'

--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -1,5 +1,10 @@
 test_name 'Puppet executes functions written in the Puppet language'
 
+tag 'audit:high',
+    'audit:integration',
+    'audit:refactor',     # use mk_tmp_environment_with_teardown helper for environment construction
+    'server'
+
 teardown do
   on master, 'rm -rf /etc/puppetlabs/code/modules/jenny'
   on master, 'rm -rf /etc/puppetlabs/code/environments/tommy'

--- a/acceptance/tests/language/next.rb
+++ b/acceptance/tests/language/next.rb
@@ -1,4 +1,10 @@
 test_name 'C98162 - Validate `next` immediately returns from a block of code' do
+
+tag 'audit:low',
+    'audit:unit',   # This is testing core ruby functionality that is covered by
+                    # existing spec tests.
+    'audit:delete'
+
   agents.each do |agent|
 
     step 'apply class with next' do

--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -2,6 +2,12 @@ test_name 'C99627: can use Object types in the catalog and apply/agent' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:high',
+    'audit:integration',
+    'audit:refactor'     # The use of apply on a reference system should
+                         # be adequate to test puppet. Running this in
+                         # context of server/agent should not be necessary.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -2,6 +2,10 @@ test_name 'C98345: ensure puppet generate assures env. isolation' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   tmp_environment2 = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -1,4 +1,10 @@
 test_name 'C98097 - generated pcore resource types should be loaded instead of ruby for custom types' do
+
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',    # use `mk_temp_environment_with_teardown` helper to build environment
+    'server'
+
   environment = 'production'
   step 'setup - install module with custom ruby resource type' do
     #{{{

--- a/acceptance/tests/language/resource_refs_with_nested_arrays.rb
+++ b/acceptance/tests/language/resource_refs_with_nested_arrays.rb
@@ -1,5 +1,8 @@
 test_name "#7681: Allow using array variables in resource references"
 
+tag 'audit:high',
+    'audit:unit'
+
 agents.each do |agent|
   test_manifest = <<MANIFEST
 $exec_names = ["first", "second"]

--- a/acceptance/tests/language/return.rb
+++ b/acceptance/tests/language/return.rb
@@ -1,4 +1,8 @@
 test_name 'C98162 - Validate `return` immediately returns from a block of code' do
+
+tag 'audit:medium',
+    'audit:unit'
+
   agents.each do |agent|
 
     step 'apply class with return' do

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -2,6 +2,14 @@ test_name 'C98120, C98077: Sensitive Data is redacted on CLI, logs, reports' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
+tag 'audit:high',
+    'audit:acceptance',   # Tests that sensitive data is retains integrity
+                          # between server and agent transport/application.
+                          # Leaving at acceptance layer due to validate
+                          # written logs.
+    'server'
+
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -2,6 +2,10 @@ test_name 'C64667: ensure server_facts is set and error if any value is overwrit
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance', # Validating server/client interaction
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -19,6 +19,10 @@ test_name "Exercise a module with 4x function and 4x system function"
 
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
+
+tag 'audit:medium',
+    'audit:unit'    # This should be covered adequately by unit tests
+
 initialize_temp_dirs
 
 agents.each do |agent|

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -2,6 +2,13 @@ test_name 'C99578: lookup should allow interpolation in hiera3 configs' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',  # This test specifically tests interpolation on the master.
+                       # Recommend adding an additonal test that validates
+                       # lookup in a masterless setup.
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -2,6 +2,13 @@ test_name 'C99578: hiera5 lookup config with interpolated scoped nested variable
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',  # This test specifically tests interpolation on the master.
+                       # Recommend adding an additonal test that validates
+                       # lookup in a masterless setup.
+    'server'
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -4,6 +4,11 @@ test_name 'C99630: hiera v3 custom backend' do
   require 'puppet/acceptance/temp_file_utils.rb'
   extend Puppet::Acceptance::TempFileUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -2,6 +2,12 @@ test_name "Lookup data using the agnostic lookup function" do
   # pre-docs:
   # https://puppet-on-the-edge.blogspot.com/2015/01/puppet-40-data-in-modules-and.html
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+                       # Use mk_tmp_environment_with_teardown to create environment.
+
   testdir = master.tmpdir('lookup')
 
   module_name                     = "data_module"

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -2,6 +2,11 @@ test_name 'C99044: lookup should allow rich data as values' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local environment.
+
   # The following two lines are required for the puppetserver service to
   # start correctly. These should be removed when PUP-7102 is resolved.
   confdir = master.puppet('master')['confdir']

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -2,6 +2,11 @@ test_name 'C99903: merge strategies' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -2,6 +2,11 @@ test_name 'C99629: hiera v5 can use v3 config and data' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -2,6 +2,11 @@ test_name 'C99572: v4 hieradata with v5 configs' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor',  # Master is not needed for this test. Refactor
+                       # to use puppet apply with a local module tree.
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/modules/build/build_agent.rb
+++ b/acceptance/tests/modules/build/build_agent.rb
@@ -1,5 +1,8 @@
 test_name "puppet module build (agent)"
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 agents.each do |agent|
   teardown do
     on agent, 'rm -rf bar'

--- a/acceptance/tests/modules/build/build_basic.rb
+++ b/acceptance/tests/modules/build/build_basic.rb
@@ -1,5 +1,10 @@
 test_name 'CODEMGMT-69 - Build a Module Using "metadata.json" Only'
 
+tag 'audit:medium',
+    'audit:acceptance'
+    'audit:refactor'   # Wrap steps in blocks in accordance with Beaker style guide
+
+
 #Init
 temp_module_path = '/tmp/nginx'
 metadata_json_file_path = File.join(temp_module_path, 'metadata.json')

--- a/acceptance/tests/modules/build/build_ignore_module_file.rb
+++ b/acceptance/tests/modules/build/build_ignore_module_file.rb
@@ -1,5 +1,9 @@
 test_name 'PUP-3981 - C63215 - Build Module Should Ignore Module File'
 
+tag 'audit:low',
+    'audit:acceptance'
+    'audit:refactor'   # Wrap steps in blocks in accordance with Beaker style guide
+
 #Init
 temp_module_path = master.tmpdir('build_ignore_module_file_test')
 metadata_json_file_path = File.join(temp_module_path, 'metadata.json')

--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -1,5 +1,8 @@
 test_name "puppet module build should verify there are no symlinks in module"
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 confine :except, :platform => 'windows'
 
 modauthor = 'foo'

--- a/acceptance/tests/modules/build/build_should_not_create_changes.rb
+++ b/acceptance/tests/modules/build/build_should_not_create_changes.rb
@@ -1,5 +1,8 @@
 test_name "puppet module build should not result in changed files"
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 modauthor = 'foo'
 modname = 'bar'
 defaultversion = '0.1.0'

--- a/acceptance/tests/modules/changes/invalid_module_install_path.rb
+++ b/acceptance/tests/modules/changes/invalid_module_install_path.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on an invalid module install path)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not requiered for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/missing_checksums_json.rb
+++ b/acceptance/tests/modules/changes/missing_checksums_json.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module which is missing checksums.json)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/missing_metadata_json.rb
+++ b/acceptance/tests/modules/changes/missing_metadata_json.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module which is missing metadata.json)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module with a modified file)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on a module with a removed file)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,5 +1,10 @@
 test_name 'puppet module changes (on an unmodified module)'
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step 'Setup'
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/generate/basic_generate.rb
+++ b/acceptance/tests/modules/generate/basic_generate.rb
@@ -2,6 +2,9 @@ test_name "puppet module generate (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (already installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (already installed elsewhere)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (already installed with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (agent)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:delete'     # This behavior is validated with other tests in this suite
+
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/force_ignores_dependencies.rb
+++ b/acceptance/tests/modules/install/force_ignores_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (force ignores dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "git"
 module_dependencies   = ["apache"]

--- a/acceptance/tests/modules/install/ignoring_dependencies.rb
+++ b/acceptance/tests/modules/install/ignoring_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (ignoring dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (nonexistent directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (nonexistent module)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nonexistent"
 module_dependencies  = []

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -2,6 +2,9 @@ test_name "puppet module install (with debug)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:unit'
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_dependencies.rb
+++ b/acceptance/tests/modules/install/with_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_environment.rb
+++ b/acceptance/tests/modules/install/with_environment.rb
@@ -2,6 +2,11 @@ test_name 'puppet module install (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 tmpdir = master.tmpdir('module-install-with-environment')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -2,6 +2,9 @@ test_name "puppet module install (with existing module directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:unit',
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -4,6 +4,11 @@ test_name "puppet module install (with modulepath)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 codedir = master.puppet('master')['codedir']
 module_author = "pmtacceptance"
 module_name   = "nginx"

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with necessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with no dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_dependencies = []

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with unnecessary dependency upgrade)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "java"
 module_dependencies   = ["stdlub"]

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -2,6 +2,11 @@ test_name "puppet module install (with unsatisfied constraints)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "pmtacceptance"
 module_name   = "git"
 module_reference = "#{module_author}-#{module_name}"

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -2,6 +2,10 @@ test_name "puppet module install (with version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Install via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Wrap steps in blocks in accordance with Beaker style guide
+
 confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -1,5 +1,10 @@
 test_name "puppet module list (with circular dependencies)"
 
+tag 'audit:low',
+    'audit:integration',
+    'audit:refactor'     # Master is not required for this test.
+                         # Refactor to use agent.
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/appleseed"
   on master, "rm -rf #{master['sitemoduledir']}/crakorn"

--- a/acceptance/tests/modules/list/with_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_installed_modules.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with installed modules)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with invalid dependencies)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_missing_dependencies.rb
+++ b/acceptance/tests/modules/list/with_missing_dependencies.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with missing dependencies)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with modulepath)"
 
+tag 'audit:low',
+    'audit:unit'
+
 codedir = master.puppet('master')['codedir']
 
 step "Setup"

--- a/acceptance/tests/modules/list/with_no_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_no_installed_modules.rb
@@ -1,5 +1,7 @@
 test_name "puppet module list (with no installed modules)"
 
+tag 'audit:low',
+    'audit:unit'
 
 step "List the installed modules"
 modulesdir = master.tmpdir('puppet_module')

--- a/acceptance/tests/modules/list/with_repeated_dependencies.rb
+++ b/acceptance/tests/modules/list/with_repeated_dependencies.rb
@@ -1,5 +1,8 @@
 test_name "puppet module list (with repeated dependencies)"
 
+tag 'audit:low',
+    'audit:unit'
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"
   on master, "rm -rf #{master['distmoduledir']}/steward"

--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -1,5 +1,8 @@
 test_name 'puppet module search should print a reasonable message on communication errors'
 
+tag 'audit:low',
+    'audit:integration'
+
 step 'Setup'
 stub_hosts_on(master, 'forgeapi.puppet.com' => '127.0.0.2')
 

--- a/acceptance/tests/modules/search/formatting.rb
+++ b/acceptance/tests/modules/search/formatting.rb
@@ -1,5 +1,8 @@
 test_name 'puppet module search output should be well structured'
 
+tag 'audit:low',
+    'audit:unit'
+
 step 'Setup'
 stub_forge_on(master)
 

--- a/acceptance/tests/modules/search/multiple_search_terms.rb
+++ b/acceptance/tests/modules/search/multiple_search_terms.rb
@@ -1,5 +1,9 @@
 test_name 'puppet module search should handle multiple search terms sensibly'
 
+tag 'audit:low',
+    'audit:unit',
+    'audit:delete'
+
 #step 'Setup'
 #stub_forge_on(master)
 

--- a/acceptance/tests/modules/search/no_results.rb
+++ b/acceptance/tests/modules/search/no_results.rb
@@ -1,5 +1,8 @@
 test_name 'puppet module search should print a reasonable message for no results'
 
+tag 'audit:low',
+    'audit:unit'
+
 module_name   = "module_not_appearing_in_this_forge"
 
 step 'Setup'

--- a/acceptance/tests/modules/search/ssl_errors.rb
+++ b/acceptance/tests/modules/search/ssl_errors.rb
@@ -1,5 +1,8 @@
 begin test_name 'puppet module search should print a reasonable message on ssl errors'
 
+tag 'audit:low',
+    'audit:unit'
+
 step "Search against a website where the certificate is not signed by a public authority"
 
 # This might seem silly, but a master has a self-signed certificate and is a

--- a/acceptance/tests/modules/uninstall/using_directory_name.rb
+++ b/acceptance/tests/modules/uninstall/using_directory_name.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (using directory name)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/apache"
   on master, "rm -rf #{master['distmoduledir']}/crakorn"

--- a/acceptance/tests/modules/uninstall/using_version_filter.rb
+++ b/acceptance/tests/modules/uninstall/using_version_filter.rb
@@ -2,6 +2,11 @@ test_name "puppet module uninstall (with module installed)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 module_author = "jimmy"
 module_name   = "crakorn"
 module_dependencies = []

--- a/acceptance/tests/modules/uninstall/with_active_dependency.rb
+++ b/acceptance/tests/modules/uninstall/with_active_dependency.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with active dependency)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 step "Setup"
 apply_manifest_on master, <<-PP
 file {

--- a/acceptance/tests/modules/uninstall/with_environment.rb
+++ b/acceptance/tests/modules/uninstall/with_environment.rb
@@ -2,6 +2,11 @@ test_name 'puppet module uninstall (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 tmpdir = master.tmpdir('module-uninstall-with-environment')
 
 step 'Setup'

--- a/acceptance/tests/modules/uninstall/with_module_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_module_installed.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with module installed)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"
 end

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with modulepath)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 codedir = master.puppet('master')['codedir']
 
 teardown do

--- a/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
@@ -1,5 +1,10 @@
 test_name "puppet module uninstall (with multiple modules installed)"
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 if master.is_pe?
   skip_test
 end

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (in a secondary directory)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/introducing_new_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (introducing new dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/not_upgradable.rb
+++ b/acceptance/tests/modules/upgrade/not_upgradable.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (not upgradable)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
+++ b/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
@@ -4,6 +4,11 @@ extend Puppet::Acceptance::ModuleUtils
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 prod_env_modulepath = "#{environmentpath}/production/modules"
 
 orig_installed_modules = get_installed_modules_for_hosts hosts

--- a/acceptance/tests/modules/upgrade/to_a_specific_version.rb
+++ b/acceptance/tests/modules/upgrade/to_a_specific_version.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (to a specific version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/to_installed_version.rb
+++ b/acceptance/tests/modules/upgrade/to_installed_version.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (to installed version)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_it.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with constraints on it)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_constraints_on_its_dependencies.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with constraints on its dependencies)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_environment.rb
+++ b/acceptance/tests/modules/upgrade/with_environment.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with environment)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 tmpdir = master.tmpdir('module-upgrade-withenv')
 
 module_author = "pmtacceptance"

--- a/acceptance/tests/modules/upgrade/with_local_changes.rb
+++ b/acceptance/tests/modules/upgrade/with_local_changes.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with local changes)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -4,6 +4,11 @@ extend Puppet::Acceptance::ModuleUtils
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 fq_prod_env_modpath = "#{environmentpath}/production/modules"
 
 stub_forge_on(master)

--- a/acceptance/tests/modules/upgrade/with_update_available.rb
+++ b/acceptance/tests/modules/upgrade/with_update_available.rb
@@ -2,6 +2,11 @@ test_name "puppet module upgrade (with update available)"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:low',       # Module management via pmt is not the primary support workflow
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -5,6 +5,10 @@ extend Puppet::Acceptance::TempFileUtils
 
 test_name "ticket #16753 node data should be cached in yaml to allow it to be queried"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 node_name = "woy_node_#{SecureRandom.hex}"
 
 # Only used when running under webrick

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -1,5 +1,9 @@
 test_name "Puppet applies resources without dependencies in file order over the network"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 testdir = master.tmpdir('application_order')
 
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -1,5 +1,8 @@
 test_name 'Calling all functions.. test in progress!'
 
+tag 'audit:medium',
+    'audit:acceptance'
+
 # create single manifest calling all functions
 step 'Apply manifest containing all function calls'
 def manifest_call_each_function_from_array(functions)

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -1,5 +1,9 @@
 test_name "Lookup data using the hiera parser function"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 testdir = master.tmpdir('hiera')
 
 step 'Setup'

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -1,5 +1,9 @@
 test_name "Lookup data using the hiera_array parser function"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 testdir = master.tmpdir('hiera')
 
 step 'Setup'

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -1,5 +1,9 @@
 test_name "Lookup data using the hiera_hash parser function"
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 testdir = master.tmpdir('hiera')
 
 step 'Setup'

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -1,5 +1,9 @@
 test_name "Calling Hiera function from inside templates"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+
 @module_name = "hieratest"
 @coderoot = master.tmpdir("#{@module_name}")
 

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -2,6 +2,9 @@ require 'puppet/acceptance/environment_utils'
 test_name 'C97760: Bignum in reduce() should not cause exception' do
   extend Puppet::Acceptance::EnvironmentUtils
 
+tag 'audit:medium',
+    'audit:unit'
+
   skip_test "This test needs to be reworked to not rely on merge, see PUP-6994"
 
   app_type = File.basename(__FILE__, '.*')

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -1,4 +1,10 @@
 test_name "Puppet Lookup Command"
+
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 # doc:
 # https://docs.puppetlabs.com/puppet/latest/reference/lookup_quick_module.html
 

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -1,5 +1,9 @@
 test_name "pluginsync should not error when modulepath is a symlink and no modules have plugin directories"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 step "Create a modulepath directory which is a symlink and includes a module without facts.d or lib directories"
 basedir = master.tmpdir("symlink_modulepath")
 

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,6 +1,10 @@
 test_name "Pluginsync'ed external facts should be resolvable on the agent"
 confine :except, :platform => 'cisco_nexus' #See BKR-749
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that external facts downloaded onto an agent via
 # pluginsync are resolvable. In Linux, the external fact should have the same

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,5 +1,9 @@
 test_name "Pluginsync'ed custom facts should be resolvable during application runs"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that custom facts downloaded onto an agent via
 # pluginsync are resolvable by puppet applications besides agent/apply.

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,5 +1,9 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that pluginsync syncs app definitions to the agents.
 # Further, the apps should be runnable on the agent after the sync has occurred.

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -1,5 +1,9 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that pluginsync syncs face definitions to the agents.
 # Further, the face should be runnable on the agent after the sync has occurred.

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,5 +1,9 @@
 test_name "the pluginsync functionality should sync feature definitions"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 #
 # This test is intended to ensure that pluginsync syncs feature definitions to
 # the agents.  It checks the feature twice; once to make sure that it gets

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -1,5 +1,9 @@
 test_name "earlier modules take precendence over later modules in the modulepath"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'
+
 step "Create some modules in the modulepath"
 basedir = master.tmpdir("module_precedence")
 

--- a/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
+++ b/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
@@ -1,5 +1,8 @@
 test_name "puppet apply should create a file and report an MD5"
 
+tag 'audit:medium',
+    'audit:unit'
+
 agents.each do |agent|
   file = agent.tmpfile('hello-world')
   manifest = "file{'#{file}': content => 'test'}"

--- a/acceptance/tests/puppet_apply_basics.rb
+++ b/acceptance/tests/puppet_apply_basics.rb
@@ -4,6 +4,9 @@
 
 test_name "Trivial puppet tests"
 
+tag 'audit:medium',
+    'audit:unit'
+
 step "check that puppet apply displays notices"
 agents.each do |host|
   apply_manifest_on(host, "notice 'Hello World'") do

--- a/acceptance/tests/puppet_apply_should_show_a_notice.rb
+++ b/acceptance/tests/puppet_apply_should_show_a_notice.rb
@@ -1,5 +1,9 @@
 test_name "puppet apply should show a notice"
 
+tag 'audit:medium',
+    'audit:unit',
+    'audit:delete'   # This is a duplicate of puppet_apply_basics.rb
+
 agents.each do |host|
   apply_manifest_on(host, "notice 'Hello World'") do
     assert_match(/.*: Hello World/, stdout, "#{host}: the notice didn't show")

--- a/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
+++ b/acceptance/tests/puppet_master_help_should_mention_puppet_master.rb
@@ -1,4 +1,8 @@
 test_name "puppet master help should mention puppet master"
+
+tag 'audit:medium',
+    'audit:unit'
+
 on master, puppet_master('--help') do
     fail_test "puppet master wasn't mentioned" unless stdout.include? 'puppet master'
 end

--- a/acceptance/tests/reports/cached_catalog_status_in_report.rb
+++ b/acceptance/tests/reports/cached_catalog_status_in_report.rb
@@ -1,4 +1,8 @@
 test_name "PUP-5867: The report specifies whether a cached catalog was used, and if so, why" do
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
+
   master_reportdir = create_tmpdir_for_user(master, 'report_dir')
 
   teardown do

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -7,6 +7,11 @@ test_name "C98092 - a new resource should not be reported as a corrective change
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor',    # Uses a server currently but is testing agent report
+      'broken:images'
+
   test_file_name  = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file        = {}

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -7,6 +7,11 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor',    # Uses a server currently, but is testing agent report
+      'broken:images'
+
   test_file_name  = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file        = {}

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -10,6 +10,12 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
   test_file_name     = File.basename(__FILE__, '.*')
   tmp_environment    = mk_tmp_environment_with_teardown(master, test_file_name)
   tmp_file           = {}
+
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor',    # Uses a server currently, but is testing agent report
+      'broken:images'
+
   original_test_data = 'this is my original important data'
   modified_test_data = 'this is my modified important data'
 

--- a/acceptance/tests/reports/failover_master.rb
+++ b/acceptance/tests/reports/failover_master.rb
@@ -1,4 +1,8 @@
 test_name "The report specifies which master was contacted during failover" do
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
+
   master_reportdir = create_tmpdir_for_user(master, 'report_dir')
   master_port = 8140
 

--- a/acceptance/tests/reports/finalized_on_cycle.rb
+++ b/acceptance/tests/reports/finalized_on_cycle.rb
@@ -2,6 +2,8 @@ test_name "Reports are finalized on resource cycles"
 # PUP-4548: Skip Windows until PUP-4547 can be resolved.
 confine :except, :platform => 'windows'
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'
+tag 'audit:medium',
+    'audit:integration'
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -1,5 +1,9 @@
 test_name "Report submission"
 
+tag 'audit:medium',
+    'audit:integration',
+    'server'             # Tests actual master-side report processing
+
 if master.is_pe?
   require "time"
 

--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -1,6 +1,12 @@
 test_name "Cron: should allow changing parameters after creation"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils
 

--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -4,7 +4,7 @@ confine :except, :platform => /^eos-/ # See PUP-5500
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -1,6 +1,11 @@
 test_name "Cron: check idempotency"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -4,7 +4,7 @@ confine :except, :platform => /^eos-/ # See PUP-5500
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -1,6 +1,11 @@
 test_name "should create cron"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -4,7 +4,7 @@ confine :except, :platform => /^eos-/ # See PUP-5500
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -1,6 +1,9 @@
 test_name "puppet should match existing job"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:unit'
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -4,7 +4,7 @@ confine :except, :platform => /^eos-/ # See PUP-5500
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -1,6 +1,11 @@
 test_name "puppet should remove a crontab entry as expected"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
@@ -1,6 +1,9 @@
 test_name "(#656) leading and trailing whitespace in cron entries should should be stripped"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:unit'
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -1,6 +1,11 @@
 test_name "puppet should remove a crontab entry based on command matching"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreparably damage a
+                       # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -1,6 +1,11 @@
 test_name "puppet should update existing crontab entry"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreparably damage a
+                       # host running this, or require special permissions.
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils

--- a/acceptance/tests/resource/exec/accept_multi-line_commands.rb
+++ b/acceptance/tests/resource/exec/accept_multi-line_commands.rb
@@ -1,5 +1,8 @@
 test_name "Be able to execute multi-line commands (#9996)"
 confine :except, :platform => 'windows'
+tag 'audit:high',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance'
 
 agents.each do |agent|
   temp_file_name = agent.tmpfile('9996-multi-line-commands')

--- a/acceptance/tests/resource/exec/should_not_run_command_creates.rb
+++ b/acceptance/tests/resource/exec/should_not_run_command_creates.rb
@@ -1,4 +1,7 @@
 test_name "should not run command creates"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 agents.each do |agent|
   touch      = agent.tmpfile('touched')

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -1,6 +1,10 @@
 test_name "tests that puppet correctly runs an exec."
 # original author: Dan Bode  --daniel 2010-12-23
 
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
+
 def before(agent)
   step "file to be touched should not exist."
   touched = agent.tmpfile('test-exec')

--- a/acceptance/tests/resource/exec/should_set_path.rb
+++ b/acceptance/tests/resource/exec/should_set_path.rb
@@ -1,4 +1,7 @@
 test_name "the path statement should work to locate commands"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 agents.each do |agent|
   file = agent.tmpfile('touched-should-set-path')

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -1,4 +1,7 @@
 test_name "Content Attribute"
+tag 'audit:high',
+    'audit:refactor',   # Use block stype test_name
+    'audit:acceptance'
 
 agents.each do |agent|
   target = agent.tmpfile('content_file_test')

--- a/acceptance/tests/resource/file/should_create_directory.rb
+++ b/acceptance/tests/resource/file/should_create_directory.rb
@@ -1,4 +1,7 @@
 test_name "should create directory"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 agents.each do |agent|
   target = agent.tmpfile("create-dir")

--- a/acceptance/tests/resource/file/should_create_empty.rb
+++ b/acceptance/tests/resource/file/should_create_empty.rb
@@ -1,4 +1,7 @@
 test_name "should create empty file for 'present'"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 agents.each do |agent|
   target = agent.tmpfile("empty")

--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -1,4 +1,7 @@
 test_name "should create symlink"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 def message
   'hello world'

--- a/acceptance/tests/resource/file/should_default_mode.rb
+++ b/acceptance/tests/resource/file/should_default_mode.rb
@@ -1,4 +1,7 @@
 test_name "file resource: set default modes"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 def regexp_mode(mode)
   Regexp.new("mode\s*=>\s*'0?#{mode}'")

--- a/acceptance/tests/resource/file/should_default_mode.rb
+++ b/acceptance/tests/resource/file/should_default_mode.rb
@@ -28,7 +28,7 @@ agents.each do |agent|
     assert_no_match(/foobar/, stdout)
   end
 
-  step "set execute git on file if explicitly specified"
+  step "set execute bit on file if explicitly specified"
   file_750 = "#{parent}/file_750.txt"
   on(agent, puppet_resource("file", file_750, "ensure=file", "mode=0750")) do
     assert_match(regexp_mode(750), stdout)

--- a/acceptance/tests/resource/file/should_remove_dir.rb
+++ b/acceptance/tests/resource/file/should_remove_dir.rb
@@ -1,4 +1,7 @@
 test_name "should remove directory, but force required"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 agents.each do |agent|
   target = agent.tmpdir("delete-dir")

--- a/acceptance/tests/resource/file/should_remove_file.rb
+++ b/acceptance/tests/resource/file/should_remove_file.rb
@@ -1,4 +1,7 @@
 test_name "should remove file"
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 agents.each do |agent|
   target = agent.tmpfile('delete-file')

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -2,6 +2,11 @@ test_name "The source attribute"
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance',
+    'server'
+
 @target_file_on_windows = 'C:/windows/temp/source_attr_test'
 @target_file_on_nix     = '/tmp/source_attr_test'
 @target_dir_on_windows  = 'C:/windows/temp/source_attr_test_dir'

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -3,6 +3,8 @@ test_name 'file resource: symbolic modes' do
   confine :except, :platform => /^solaris-10/
   confine :except, :platform => /^windows/
   confine :to, {}, hosts.select {|host| !host[:roles].include?('master')}
+  tag 'audit:high',
+      'audit:acceptance'
 
   require 'puppet/acceptance/temp_file_utils'
   extend Puppet::Acceptance::TempFileUtils

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -1,4 +1,7 @@
 test_name 'Ensure a file resource can have a UTF-8 source attribute, content, and path when served via a module' do
+  tag 'audit:high',
+      'broken:images',
+      'audit:acceptance'
 
   skip_test 'requires a master for serving module content' if master.nil?
 

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -1,5 +1,9 @@
 test_name "#7680: 'links => follow' should use the file source content"
 
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
+
 agents.each do |agent|
   if agent.platform.variant == 'windows'
     # symlinks are supported only on Vista+ (version 6.0 and higher)

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -1,5 +1,8 @@
 test_name "#8740: should not enumerate root directory"
 confine :except, :platform => 'windows'
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 target = "/test-socket-#{$$}"
 

--- a/acceptance/tests/resource/group/should_create.rb
+++ b/acceptance/tests/resource/group/should_create.rb
@@ -3,7 +3,7 @@ confine :except, :platform => /^cisco_/ # See PUP-5828
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_create.rb
+++ b/acceptance/tests/resource/group/should_create.rb
@@ -1,5 +1,10 @@
 test_name "should create a group"
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:high',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_destroy.rb
+++ b/acceptance/tests/resource/group/should_destroy.rb
@@ -3,7 +3,7 @@ confine :except, :platform => /^cisco_/ # See PUP-5828
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_destroy.rb
+++ b/acceptance/tests/resource/group/should_destroy.rb
@@ -1,5 +1,10 @@
 test_name "should destroy a group"
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:high',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -4,7 +4,7 @@ confine :except, :platform => /^cisco_/ # See PUP-5828
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -1,6 +1,11 @@
 test_name "should modify gid of existing group"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:high',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"
 gid1  = (rand(989999).to_i + 10000)

--- a/acceptance/tests/resource/group/should_not_create_existing.rb
+++ b/acceptance/tests/resource/group/should_not_create_existing.rb
@@ -3,7 +3,7 @@ confine :except, :platform => /^cisco_/ # See PUP-5828
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "gr#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_not_create_existing.rb
+++ b/acceptance/tests/resource/group/should_not_create_existing.rb
@@ -1,5 +1,10 @@
 test_name "group should not create existing group"
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:high',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 name = "gr#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
+++ b/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
@@ -1,5 +1,10 @@
 test_name "should not destroy a group that doesn't exist"
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:high',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 name = "test-group-#{Time.new.to_i}"
 

--- a/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
+++ b/acceptance/tests/resource/group/should_not_destoy_unexisting.rb
@@ -3,7 +3,7 @@ confine :except, :platform => /^cisco_/ # See PUP-5828
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "test-group-#{Time.new.to_i}"

--- a/acceptance/tests/resource/group/should_query.rb
+++ b/acceptance/tests/resource/group/should_query.rb
@@ -3,7 +3,7 @@ confine :except, :platform => /^cisco_/ # See PUP-5828
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/group/should_query.rb
+++ b/acceptance/tests/resource/group/should_query.rb
@@ -1,5 +1,10 @@
 test_name "test that we can query and find a group that exists."
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:high',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -1,5 +1,8 @@
 test_name "should query all groups"
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:high',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:integration' # Does not modify system running test
 
 agents.each do |agent|
   step "query natively"

--- a/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
+++ b/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
@@ -1,4 +1,11 @@
 test_name "should not delete data when existing content is malformed"
+
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   file = agent.tmpfile('host-not-delete-data')
 

--- a/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
+++ b/acceptance/tests/resource/host/pup_2289_should_not_destroy_data_when_malformed.rb
@@ -3,7 +3,7 @@ test_name "should not delete data when existing content is malformed"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_create.rb
+++ b/acceptance/tests/resource/host/should_create.rb
@@ -1,5 +1,11 @@
 test_name "host should create"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   target = agent.tmpfile('host-create')
 

--- a/acceptance/tests/resource/host/should_create.rb
+++ b/acceptance/tests/resource/host/should_create.rb
@@ -3,7 +3,7 @@ test_name "host should create"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_create_aliases.rb
+++ b/acceptance/tests/resource/host/should_create_aliases.rb
@@ -1,5 +1,11 @@
 test_name "host should create aliases"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   target  = agent.tmpfile('host-create-aliases')
 

--- a/acceptance/tests/resource/host/should_create_aliases.rb
+++ b/acceptance/tests/resource/host/should_create_aliases.rb
@@ -3,7 +3,7 @@ test_name "host should create aliases"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_destroy.rb
+++ b/acceptance/tests/resource/host/should_destroy.rb
@@ -1,5 +1,11 @@
 test_name "should be able to remove a host record"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   file = agent.tmpfile('host-destroy')
   line = "127.0.0.7 test1"

--- a/acceptance/tests/resource/host/should_destroy.rb
+++ b/acceptance/tests/resource/host/should_destroy.rb
@@ -3,7 +3,7 @@ test_name "should be able to remove a host record"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_modify_alias.rb
+++ b/acceptance/tests/resource/host/should_modify_alias.rb
@@ -3,7 +3,7 @@ test_name "should be able to modify a host alias"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_modify_alias.rb
+++ b/acceptance/tests/resource/host/should_modify_alias.rb
@@ -1,5 +1,11 @@
 test_name "should be able to modify a host alias"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   file = agent.tmpfile('host-modify-alias')
 

--- a/acceptance/tests/resource/host/should_modify_ip.rb
+++ b/acceptance/tests/resource/host/should_modify_ip.rb
@@ -1,5 +1,11 @@
 test_name "should be able to modify a host address"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   file = agent.tmpfile('host-modify-ip')
 

--- a/acceptance/tests/resource/host/should_modify_ip.rb
+++ b/acceptance/tests/resource/host/should_modify_ip.rb
@@ -3,7 +3,7 @@ test_name "should be able to modify a host address"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_not_create_existing.rb
+++ b/acceptance/tests/resource/host/should_not_create_existing.rb
@@ -1,5 +1,11 @@
 test_name "should not create host if it exists"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   file = agent.tmpfile('host-not-create-existing')
 

--- a/acceptance/tests/resource/host/should_not_create_existing.rb
+++ b/acceptance/tests/resource/host/should_not_create_existing.rb
@@ -3,7 +3,7 @@ test_name "should not create host if it exists"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/host/should_query_all.rb
+++ b/acceptance/tests/resource/host/should_query_all.rb
@@ -3,7 +3,7 @@ test_name "should query all hosts from hosts file"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 content = %q{127.0.0.1 test1 test1.local

--- a/acceptance/tests/resource/host/should_query_all.rb
+++ b/acceptance/tests/resource/host/should_query_all.rb
@@ -1,5 +1,11 @@
 test_name "should query all hosts from hosts file"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 content = %q{127.0.0.1 test1 test1.local
 127.0.0.2 test2 test2.local
 127.0.0.3 test3 test3.local

--- a/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
+++ b/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
@@ -1,5 +1,11 @@
 test_name "#4131: should not create host without IP attribute"
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 agents.each do |agent|
   file = agent.tmpfile('4131-require-ip')
 

--- a/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
+++ b/acceptance/tests/resource/host/ticket_4131_should_not_create_without_ip.rb
@@ -3,7 +3,7 @@ test_name "#4131: should not create host without IP attribute"
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 agents.each do |agent|

--- a/acceptance/tests/resource/mailalias/create.rb
+++ b/acceptance/tests/resource/mailalias/create.rb
@@ -2,6 +2,12 @@ test_name "should create an email alias"
 
 confine :except, :platform => 'windows' 
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 agents.each do |agent|
   teardown do

--- a/acceptance/tests/resource/mailalias/create.rb
+++ b/acceptance/tests/resource/mailalias/create.rb
@@ -5,7 +5,7 @@ confine :except, :platform => 'windows'
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mailalias/destroy.rb
+++ b/acceptance/tests/resource/mailalias/destroy.rb
@@ -5,7 +5,7 @@ confine :except, :platform => 'windows'
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mailalias/destroy.rb
+++ b/acceptance/tests/resource/mailalias/destroy.rb
@@ -2,6 +2,12 @@ test_name "should delete an email alias"
 
 confine :except, :platform => 'windows'
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 agents.each do |agent|
   teardown do

--- a/acceptance/tests/resource/mailalias/modify.rb
+++ b/acceptance/tests/resource/mailalias/modify.rb
@@ -2,6 +2,12 @@ test_name "should modify an email alias"
 
 confine :except, :platform => 'windows'
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 agents.each do |agent|
   teardown do

--- a/acceptance/tests/resource/mailalias/modify.rb
+++ b/acceptance/tests/resource/mailalias/modify.rb
@@ -5,7 +5,7 @@ confine :except, :platform => 'windows'
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mailalias/query.rb
+++ b/acceptance/tests/resource/mailalias/query.rb
@@ -5,7 +5,7 @@ confine :except, :platform => 'windows'
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/mailalias/query.rb
+++ b/acceptance/tests/resource/mailalias/query.rb
@@ -2,6 +2,12 @@ test_name "should be able to find an exisitng email alias"
 
 confine :except, :platform => 'windows'
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 agents.each do |agent|
   teardown do

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -7,6 +7,12 @@ confine :except, :platform => /^eos-/ # Mount provider not supported on Arista E
 confine :except, :platform => /^cisco_/ # See PUP-5826
 confine :except, :platform => /^huawei/ # See PUP-6126
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils
 

--- a/acceptance/tests/resource/mount/defined.rb
+++ b/acceptance/tests/resource/mount/defined.rb
@@ -10,7 +10,7 @@ confine :except, :platform => /^huawei/ # See PUP-6126
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/mount_utils'

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -7,6 +7,12 @@ confine :except, :platform => /^eos-/ # Mount provider not supported on Arista E
 confine :except, :platform => /^cisco_/ # See PUP-5826
 confine :except, :platform => /^huawei/ # See PUP-6126
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils
 

--- a/acceptance/tests/resource/mount/destroy.rb
+++ b/acceptance/tests/resource/mount/destroy.rb
@@ -10,7 +10,7 @@ confine :except, :platform => /^huawei/ # See PUP-6126
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/mount_utils'

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -7,6 +7,12 @@ confine :except, :platform => /^eos-/ # Mount provider not supported on Arista E
 confine :except, :platform => /^cisco_/ # See PUP-5826
 confine :except, :platform => /^huawei/ # See PUP-6126
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils
 

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -10,7 +10,7 @@ confine :except, :platform => /^huawei/ # See PUP-6126
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/mount_utils'

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -7,6 +7,12 @@ confine :except, :platform => /^eos-/ # Mount provider not supported on Arista E
 confine :except, :platform => /^cisco_/ # See PUP-5826
 confine :except, :platform => /^huawei/ # See PUP-6126
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils
 

--- a/acceptance/tests/resource/mount/mounted.rb
+++ b/acceptance/tests/resource/mount/mounted.rb
@@ -10,7 +10,7 @@ confine :except, :platform => /^huawei/ # See PUP-6126
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/mount_utils'

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -7,6 +7,12 @@ confine :except, :platform => /^eos-/ # Mount provider not supported on Arista E
 confine :except, :platform => /^cisco_/ # See PUP-5826
 confine :except, :platform => /^huawei/ # See PUP-6126
 
+tag 'audit:low',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils
 

--- a/acceptance/tests/resource/mount/query.rb
+++ b/acceptance/tests/resource/mount/query.rb
@@ -10,7 +10,7 @@ confine :except, :platform => /^huawei/ # See PUP-6126
 tag 'audit:low',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/mount_utils'

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -4,6 +4,10 @@ confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
 confine :except, :platform => /centos-4|el-4/ # PUP-5227
 confine :except, :hypervisor => 'ec2' # PUP-7774
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Uses a provider that depends on AIO packaging
+
 require 'puppet/acceptance/rpm_util'
 extend Puppet::Acceptance::RpmUtils
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -1,6 +1,11 @@
 # Redmine (#22529)
 test_name "Puppet returns only resource package declaration when querying an uninstalled package" do
 
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done at the integration (or unit) layer though
+                         # actual changing of resources could irreprebly damage a
+                         # host running this, or require special permissions.
+
   resource_declaration_regex = %r@package \{ 'not-installed-on-this-host':
   ensure => '(?:purged|absent)',
 \}@m

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -3,7 +3,7 @@ test_name "Puppet returns only resource package declaration when querying an uni
 
   tag 'audit:medium',
       'audit:acceptance' # Could be done at the integration (or unit) layer though
-                         # actual changing of resources could irreprebly damage a
+                         # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.
 
   resource_declaration_regex = %r@package \{ 'not-installed-on-this-host':

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS basic tests"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_holdable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_holdable.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_holdable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_holdable.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS versionable"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/should_be_idempotent.rb
+++ b/acceptance/tests/resource/package/ips/should_be_idempotent.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS idempotency"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/should_be_idempotent.rb
+++ b/acceptance/tests/resource/package/ips/should_be_idempotent.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_updatable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updatable.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_updatable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updatable.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS test for updatable (update, latest)"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/should_be_versionable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_versionable.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_be_versionable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_versionable.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS versionable"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS basic tests"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_query.rb
+++ b/acceptance/tests/resource/package/ips/should_query.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/ips/should_query.rb
+++ b/acceptance/tests/resource/package/ips/should_query.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS query"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/should_remove.rb
+++ b/acceptance/tests/resource/package/ips/should_remove.rb
@@ -1,6 +1,12 @@
 test_name "Package:IPS basic tests"
 confine :to, :platform => 'solaris-11'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils
 

--- a/acceptance/tests/resource/package/ips/should_remove.rb
+++ b/acceptance/tests/resource/package/ips/should_remove.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris-11'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -6,7 +6,7 @@ confine :except, :platform => /centos-4|el-4/ # PUP-5227
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/rpm_util'

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -3,6 +3,12 @@ test_name "test the yum package provider"
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
 confine :except, :platform => /centos-4|el-4/ # PUP-5227
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/rpm_util'
 extend Puppet::Acceptance::RpmUtils
 

--- a/acceptance/tests/resource/scheduled_task/should_create.rb
+++ b/acceptance/tests/resource/scheduled_task/should_create.rb
@@ -1,5 +1,11 @@
 test_name "should create a scheduled task"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/resource/scheduled_task/should_create.rb
+++ b/acceptance/tests/resource/scheduled_task/should_create.rb
@@ -3,7 +3,7 @@ test_name "should create a scheduled task"
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/scheduled_task/should_destroy.rb
+++ b/acceptance/tests/resource/scheduled_task/should_destroy.rb
@@ -3,7 +3,7 @@ test_name "should delete a scheduled task"
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/scheduled_task/should_destroy.rb
+++ b/acceptance/tests/resource/scheduled_task/should_destroy.rb
@@ -1,5 +1,11 @@
 test_name "should delete a scheduled task"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -2,6 +2,12 @@ require 'rexml/document'
 
 test_name "should modify a scheduled task"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/resource/scheduled_task/should_modify.rb
+++ b/acceptance/tests/resource/scheduled_task/should_modify.rb
@@ -5,7 +5,7 @@ test_name "should modify a scheduled task"
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/scheduled_task/should_query.rb
+++ b/acceptance/tests/resource/scheduled_task/should_query.rb
@@ -1,5 +1,11 @@
 test_name "test that we can query and find a scheduled task that exists."
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 name = "pl#{rand(999999).to_i}"
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/resource/scheduled_task/should_query.rb
+++ b/acceptance/tests/resource/scheduled_task/should_query.rb
@@ -3,7 +3,7 @@ test_name "test that we can query and find a scheduled task that exists."
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 name = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -1,5 +1,11 @@
 test_name 'AIX Service Provider Testing'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 confine :to, :platform =>  'aix'
 
 require 'puppet/acceptance/service_utils'

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -3,7 +3,7 @@ test_name 'AIX Service Provider Testing'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 confine :to, :platform =>  'aix'

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -5,6 +5,11 @@ test_name 'SysV on default Systemd Service Provider Validation' do
     stdout =~ /systemctl/
   end
 
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done at the integration (or unit) layer though
+                         # actual changing of resources could irreprebly damage a
+                         # host running this, or require special permissions.
+
   require 'puppet/acceptance/service_utils'
   extend Puppet::Acceptance::ServiceUtils
 

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -7,7 +7,7 @@ test_name 'SysV on default Systemd Service Provider Validation' do
 
   tag 'audit:medium',
       'audit:acceptance' # Could be done at the integration (or unit) layer though
-                         # actual changing of resources could irreprebly damage a
+                         # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.
 
   require 'puppet/acceptance/service_utils'

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -1,5 +1,11 @@
 test_name 'Mac OS X launchd Provider Testing'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 confine :to, {:platform => /osx/}, agents
 
 require 'puppet/acceptance/service_utils'

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -3,7 +3,7 @@ test_name 'Mac OS X launchd Provider Testing'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 confine :to, {:platform => /osx/}, agents

--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -3,6 +3,10 @@ test_name "Puppet and Mcollective services should be manageable with Puppet"
 confine :except, :platform => 'windows' # See MCO-727
 confine :except, :platform => /centos-4|el-4/ # PUP-5257
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # uses services from a running puppet-agent install
+
 #
 # This test is intended to ensure that the Puppet and Mcollective services can
 # be directly managed by Puppet. See PUP-5053, PUP-5257, and RE-5574 for

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -4,7 +4,7 @@ tag 'audit:medium',
     'audit:refactor',  # Investigate merging with init_on_systemd.rb
                        # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 confine :to, :platform => /el-|centos|fedora|debian|sles|ubuntu-v/

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -1,5 +1,11 @@
 test_name 'SysV and Systemd Service Provider Validation'
 
+tag 'audit:medium',
+    'audit:refactor',  # Investigate merging with init_on_systemd.rb
+                       # Use block style `test_name`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
 
 confine :to, :platform => /el-|centos|fedora|debian|sles|ubuntu-v/
 # osx covered by launchd_provider.rb

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -1,5 +1,9 @@
 test_name "`puppet resource service` should list running services without calling dangerous init scripts"
 
+tag 'audit:medium',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:integration' # Doesn't change the system it runs on
+
 confine :except, :platform => 'windows'
 confine :except, :platform => 'solaris'
 confine :except, :platform => /^cisco_/ # See PUP-5827

--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -1,5 +1,10 @@
 test_name "should query all services"
 
+tag 'audit:medium',
+    'audit:refactor',   # Investigate combining with should_not_change_the_system.rb
+                        # Use block style `test_name`
+    'audit:integration' # Doesn't change the system it runs on
+
 agents.each do |agent|
   step "query with puppet"
   on(agent, puppet_resource('service'), :accept_all_exit_codes => true) do

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -4,7 +4,7 @@ confine :to, :platform => 'solaris'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 require 'puppet/acceptance/solaris_util'

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -1,6 +1,12 @@
 test_name "SMF: basic tests"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::SMFUtils
 

--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -5,6 +5,13 @@ confine :to, :platform => 'ubuntu'
 # vivid and above use systemd rather than upstart
 confine :except, :platform => /ubuntu-1?[v-z|5-9]/
 
+tag 'audit:low',
+    'audit:delete',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 # pick any ubuntu agent
 agent = agents.first
 skip_test "No suitable hosts found" if agent.nil?

--- a/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
+++ b/acceptance/tests/resource/service/ticket_14297_handle_upstart.rb
@@ -9,7 +9,7 @@ tag 'audit:low',
     'audit:delete',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 # pick any ubuntu agent

--- a/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
+++ b/acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb
@@ -1,5 +1,8 @@
 test_name "#4123: should list all running services on Redhat/CentOS"
 confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
+tag 'audit:medium',
+    'audit:refactor',   # Use block style `test_run`
+    'audit:integration' # Doesn't change the system it runs on
 
 step "Validate services running agreement ralsh vs. OS service count"
 # This will remotely exec:

--- a/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
+++ b/acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb
@@ -1,5 +1,8 @@
 test_name "#4124: should list all disabled services on Redhat/CentOS"
 confine :to, :platform => /(el|centos|oracle|redhat|scientific)-5/
+tag 'audit:medium',
+    'audit:refactor',   # Use block style `test_run`
+    'audit:integration' # Doesn't change the system it runs on
 
 step "Validate disabled services agreement ralsh vs. OS service count"
 # This will remotely exec:

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -3,6 +3,12 @@ extend Puppet::Acceptance::ServiceUtils
 
 test_name 'Systemd masked services are unmasked before attempting to start'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'
 
 # This test in intended to ensure that a service which was previously marked

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -6,7 +6,7 @@ test_name 'Systemd masked services are unmasked before attempting to start'
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'

--- a/acceptance/tests/resource/ssh_authorized_key/create.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/create.rb
@@ -1,5 +1,11 @@
 test_name "should create an entry for an SSH authorized key"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 confine :except, :platform => ['windows']
 
 auth_keys = '~/.ssh/authorized_keys'

--- a/acceptance/tests/resource/ssh_authorized_key/create.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/create.rb
@@ -3,7 +3,7 @@ test_name "should create an entry for an SSH authorized key"
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -1,5 +1,11 @@
 test_name "should delete an entry for an SSH authorized key"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 confine :except, :platform => ['windows']
 
 auth_keys = '~/.ssh/authorized_keys'

--- a/acceptance/tests/resource/ssh_authorized_key/destroy.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/destroy.rb
@@ -3,7 +3,7 @@ test_name "should delete an entry for an SSH authorized key"
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/ssh_authorized_key/modify.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/modify.rb
@@ -1,5 +1,11 @@
 test_name "should update an entry for an SSH authorized key"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 confine :except, :platform => ['windows']
 
 auth_keys = '~/.ssh/authorized_keys'

--- a/acceptance/tests/resource/ssh_authorized_key/modify.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/modify.rb
@@ -3,7 +3,7 @@ test_name "should update an entry for an SSH authorized key"
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/ssh_authorized_key/query.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/query.rb
@@ -1,5 +1,11 @@
 test_name "should be able to find an existing SSH authorized key"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 skip_test("This test is blocked by PUP-1605")
 
 confine :except, :platform => ['windows']

--- a/acceptance/tests/resource/ssh_authorized_key/query.rb
+++ b/acceptance/tests/resource/ssh_authorized_key/query.rb
@@ -3,7 +3,7 @@ test_name "should be able to find an existing SSH authorized key"
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 skip_test("This test is blocked by PUP-1605")

--- a/acceptance/tests/resource/sshkey/create.rb
+++ b/acceptance/tests/resource/sshkey/create.rb
@@ -1,6 +1,11 @@
 test_name "(PUP-5508) Should add an SSH key to the correct ssh_known_hosts file on OS X/macOS" do
 # TestRail test case C93370
 
+tag 'audit:medium',
+    'audit:acceptance' # Could be done at the integration (or unit) layer though
+                       # actual changing of resources could irreprebly damage a
+                       # host running this, or require special permissions.
+
 confine :to, :platform => /osx/
 
 keyname = "pl#{rand(999999).to_i}"

--- a/acceptance/tests/resource/sshkey/create.rb
+++ b/acceptance/tests/resource/sshkey/create.rb
@@ -3,7 +3,7 @@ test_name "(PUP-5508) Should add an SSH key to the correct ssh_known_hosts file 
 
 tag 'audit:medium',
     'audit:acceptance' # Could be done at the integration (or unit) layer though
-                       # actual changing of resources could irreprebly damage a
+                       # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
 
 confine :to, :platform => /osx/

--- a/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
+++ b/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
@@ -1,6 +1,9 @@
 # This test is to verify multi tidy resources with same path but
 # different matches should not cause error as found in the bug PUP-6508
 test_name "PUP-6655 - C98145 tidy resources should be non-isomorphic" do
+  tag 'audit:medium',
+      'audit:integration'
+
   agents. each do |agent|
     dir = agent.tmpdir('tidy-test-dir')
     on(agent, "mkdir -p #{dir}")

--- a/acceptance/tests/resource/tidy/should_remove_old_files.rb
+++ b/acceptance/tests/resource/tidy/should_remove_old_files.rb
@@ -1,5 +1,9 @@
 test_name "Tidying files by date"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:integration'
+
 agents.each do |agent|
   step "Create a directory of old and new files"
   dir = agent.tmpdir('tidy-test')

--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -2,6 +2,13 @@ test_name "should allow password, salt, and iteration attributes in OSX"
 
 confine :to, :platform => /osx/
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
 agents.each do |agent|
   teardown do
     puppet_resource("user", 'testuser', "ensure=absent")

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -1,6 +1,12 @@
 test_name "should create a user"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -2,6 +2,12 @@ test_name "verifies that puppet resource creates a user and assigns the correct 
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 user = "pl#{rand(999999).to_i}"
 group = "gp#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_destroy.rb
+++ b/acceptance/tests/resource/user/should_destroy.rb
@@ -1,6 +1,12 @@
 test_name "should delete a user"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -1,5 +1,12 @@
 test_name "should manage user shell"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
 name = "pl#{rand(999999).to_i}"
 
 confine :except, :platform => 'windows'

--- a/acceptance/tests/resource/user/should_modify.rb
+++ b/acceptance/tests/resource/user/should_modify.rb
@@ -1,6 +1,12 @@
 test_name "should modify a user"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -3,6 +3,12 @@ confine :except, :platform => 'windows'
 confine :except, :platform => /aix/ # PUP-5358
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 user = "u#{rand(99999).to_i}"
 group1 = "#{user}o"

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -1,6 +1,12 @@
 test_name "should modify a user when no longer managing home (#20726)"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 require 'puppet/acceptance/windows_utils'
 extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -1,6 +1,12 @@
 test_name "should modify a user without changing home directory (pending #19542)"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 require 'puppet/acceptance/windows_utils'
 extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -1,6 +1,12 @@
 test_name "tests that user resource will not add users that already exist."
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 user  = "u#{rand(999999).to_i}"
 group = "g#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_not_destoy_unexisting.rb
+++ b/acceptance/tests/resource/user/should_not_destoy_unexisting.rb
@@ -1,6 +1,12 @@
 test_name "ensure that puppet does not report removing a user that does not exist"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_not_modify_disabled.rb
+++ b/acceptance/tests/resource/user/should_not_modify_disabled.rb
@@ -2,6 +2,12 @@ test_name 'PUP-6586 Ensure puppet does not continually reset password for disabl
 
   confine :to, :platform => 'windows'
 
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                         # in ways that might require special permissions
+                         # or be harmful to the system running the test
+
   name = "pl#{rand(99999).to_i}"
 
   teardown do

--- a/acceptance/tests/resource/user/should_query.rb
+++ b/acceptance/tests/resource/user/should_query.rb
@@ -1,6 +1,12 @@
 test_name "test that we can query and find a user that exists."
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -1,5 +1,8 @@
 test_name "should query all users"
 confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:integration'
 
 agents.each do |agent|
   next if agent == master

--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -9,6 +9,12 @@
 # Where applicable, we should be able to do this in different locales
 test_name 'PUP-6777 Manage users with UTF-8 comments' do
 
+  tag 'audit:high',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                         # in ways that might require special permissions
+                         # or be harmful to the system running the test
+
   # PUP-7049 / ARISTA-42 - user provider bug on Arista
   # AIX providers are separate from most other platforms,
   # and have not been made unicode-aware yet.

--- a/acceptance/tests/resource/zfs/basic_tests.rb
+++ b/acceptance/tests/resource/zfs/basic_tests.rb
@@ -1,6 +1,11 @@
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZFSUtils
 

--- a/acceptance/tests/resource/zfs/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zfs/should_be_idempotent.rb
@@ -1,6 +1,11 @@
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZFSUtils
 

--- a/acceptance/tests/resource/zfs/should_create.rb
+++ b/acceptance/tests/resource/zfs/should_create.rb
@@ -1,6 +1,11 @@
 test_name "ZFS: should create"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZFSUtils
 

--- a/acceptance/tests/resource/zfs/should_query.rb
+++ b/acceptance/tests/resource/zfs/should_query.rb
@@ -1,6 +1,11 @@
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZFSUtils
 

--- a/acceptance/tests/resource/zfs/should_remove.rb
+++ b/acceptance/tests/resource/zfs/should_remove.rb
@@ -1,6 +1,11 @@
 test_name "ZFS: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZFSUtils
 

--- a/acceptance/tests/resource/zone/dataset.rb
+++ b/acceptance/tests/resource/zone/dataset.rb
@@ -2,6 +2,11 @@ test_name "Zone: dataset configuration"
 
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 

--- a/acceptance/tests/resource/zone/set_ip.rb
+++ b/acceptance/tests/resource/zone/set_ip.rb
@@ -3,6 +3,11 @@ confine :to, :platform => 'solaris'
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 teardown do
   step "Zone: ip - cleanup"
   agents.each do |agent|

--- a/acceptance/tests/resource/zone/set_path.rb
+++ b/acceptance/tests/resource/zone/set_path.rb
@@ -1,6 +1,11 @@
 test_name "Zone:Path configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 

--- a/acceptance/tests/resource/zone/should_be_created_and_removed.rb
+++ b/acceptance/tests/resource/zone/should_be_created_and_removed.rb
@@ -2,6 +2,11 @@ test_name "Zone: should be created and removed"
 
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 

--- a/acceptance/tests/resource/zone/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zone/should_be_idempotent.rb
@@ -2,6 +2,11 @@ test_name "Zone: should be idempotent"
 
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 

--- a/acceptance/tests/resource/zone/statemachine.rb
+++ b/acceptance/tests/resource/zone/statemachine.rb
@@ -1,6 +1,11 @@
 test_name "Zone:Statemachine configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 

--- a/acceptance/tests/resource/zone/stepstates.rb
+++ b/acceptance/tests/resource/zone/stepstates.rb
@@ -1,5 +1,11 @@
 test_name "Zone:statemachine single states"
 confine :to, :platform => 'solaris'
+
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 

--- a/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
+++ b/acceptance/tests/resource/zone/ticket_4840_should_create_zone_with_zpool.rb
@@ -1,6 +1,11 @@
 test_name "Zone: ticket #4840 - verify that the given manifest works."
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 

--- a/acceptance/tests/resource/zpool/basic_tests.rb
+++ b/acceptance/tests/resource/zpool/basic_tests.rb
@@ -1,6 +1,11 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
 

--- a/acceptance/tests/resource/zpool/should_be_idempotent.rb
+++ b/acceptance/tests/resource/zpool/should_be_idempotent.rb
@@ -1,6 +1,11 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
 

--- a/acceptance/tests/resource/zpool/should_create.rb
+++ b/acceptance/tests/resource/zpool/should_create.rb
@@ -1,6 +1,11 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
 

--- a/acceptance/tests/resource/zpool/should_query.rb
+++ b/acceptance/tests/resource/zpool/should_query.rb
@@ -1,6 +1,11 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
 

--- a/acceptance/tests/resource/zpool/should_remove.rb
+++ b/acceptance/tests/resource/zpool/should_remove.rb
@@ -1,6 +1,11 @@
 test_name "ZPool: configuration"
 confine :to, :platform => 'solaris'
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require drastically changing the system running the test
+
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZPoolUtils
 

--- a/acceptance/tests/ruby_compiler_optimization.rb
+++ b/acceptance/tests/ruby_compiler_optimization.rb
@@ -1,6 +1,10 @@
 test_name 'ensure ruby compiler optimization is >= 2'
 
-tag 'risk:medium'
+tag 'risk:medium',
+    'audit:low',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance',
+    'audit:delete'      # why is this packaging detail a test?
 
 step 'Validate ruby compiler optimization is >= 2' do
   hosts.each do |host|

--- a/acceptance/tests/security/cve-2013-1640_facter_string.rb
+++ b/acceptance/tests/security/cve-2013-1640_facter_string.rb
@@ -2,6 +2,10 @@
 # template compilation on the master allowing remote code execution by
 # any authenticated client.
 test_name "CVE 2013-1640 Remote Code Execution" do
+
+  tag 'audit:high',       # low risk, high (security) impact
+      'audit:integration'
+
   confine :except, :platform => 'windows'
   confine :except, :platform => 'cisco_nexus' # See BKR-749
 

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -5,6 +5,10 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
   confine :except, :platform => /osx/ # see PUP-4820
   confine :except, :platform => /aix/
 
+  tag 'audit:high',        # risk low, high (security) impact
+      'audit:integration',
+      'server'
+
   with_puppet_running_on master, {} do
     # Ensure each agent has a signed cert
     on agents, puppet('agent', "-t --server #{master}" )

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -1,5 +1,9 @@
 test_name "CVE 2013-1652 Poison node cache" do
 
+  tag 'audit:high',        # low risk, high (security) impact
+      'audit:integration', # master side only
+      'server'
+
   step "Determine suitability of the test" do
     skip_test( "This test will only run on Puppet 3.x" ) if
       on(master, puppet('--version')).stdout =~ /\A2\./

--- a/acceptance/tests/security/cve-2013-2275_report_acl.rb
+++ b/acceptance/tests/security/cve-2013-2275_report_acl.rb
@@ -1,4 +1,10 @@
 test_name "(#19531) report save access control"
+
+tag 'audit:high',        # low risk, high (security) impact
+    'audit:refactor',    # Use block style `test_name`
+    'audit:integration', # issue completely on the server side
+    'server'
+
 step "Verify puppet only allows saving reports from the node matching the certificate"
 
 fake_report = <<-EOYAML

--- a/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
+++ b/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
@@ -1,6 +1,10 @@
 test_name "CVE 2013-4761 Injection of bad class names causing code loading" do
   confine :except, :platform => 'windows'
 
+  tag 'audit:high',        # low risk, high (security) impact
+      'audit:integration', # issue is completely on the master side
+      'server'
+
   testdir = create_tmpdir_for_user master, 'class-names-injection'
   exploit_path = "#{testdir}/exploit.rb"
   exploited_path = "#{testdir}/exploited"

--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -1,4 +1,9 @@
 test_name "Priority of server_list setting over server setting" do
+
+  tag 'audit:medium',
+      'audit:unit',
+      'audit:refactor'     # is only testing agent side behavior, should remove server
+
   master_port = 8140
 
   step "Conflict warnings for server settings"

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -8,6 +8,10 @@ disable_pe_enterprise_mcollective_agent_classes
 test_name "autosign command and csr attributes behavior (#7243,#7244)" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
+  tag 'audit:high',        # cert/ca core behavior
+      'audit:integration',
+      'server'             # Ruby implementation is deprecated
+
   def assert_key_generated(name)
     assert_match(/Creating a new SSL key for #{name}/, stdout, "Expected agent to create a new SSL key for autosigning")
   end

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -12,6 +12,10 @@ initialize_temp_dirs
 test_name "certificate extensions available as trusted data" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
+  tag 'audit:high',        # ca/cert core functionality
+      'audit:integration',
+      'server'             # Ruby implimentation is deprecated
+
   agent_certnames = []
 
   teardown do

--- a/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
+++ b/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
@@ -3,6 +3,10 @@ extend Puppet::Acceptance::CAUtils
 
 test_name "Puppet cert generate behavior (#6112)" do
 
+  tag 'audit:low',          # cli/ca behavior for non-standard workflows
+      'audit:integration',
+      'server'              # Ruby CA is deprecated
+
   # This acceptance test documents the behavior of `puppet cert generate` calls
   # for three cases:
   #

--- a/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
+++ b/acceptance/tests/ssl/ticket_5274_private_key_modes.rb
@@ -3,6 +3,11 @@ require 'puppet/acceptance/common_utils'
 
 confine :except, :platform => 'windows'
 
+tag 'audit:medium',      # low risk of change, high (security) impact if changed
+    'audit:refactor',    # Use block style `test_name`
+    'audit:integration', # afaict, code creates and manages these files (not packaging)
+    'server'             # this code path in Ruby is deprecated...
+
 def get_setting(host, ssldir, command)
   on(host, puppet("agent --ssldir #{ssldir} #{command}")).stdout.chomp
 end

--- a/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
+++ b/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
@@ -1,5 +1,9 @@
 test_name "#4655: Allow setting the default stage for parameterized classes"
 
+tag 'audit:low',      # basic language functionality for relatively little used concept
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'
+
 agents.each do |agent|
   temp_file_name = agent.tmpfile('4655-stage-in-parameterized-class')
 test_manifest = <<HERE

--- a/acceptance/tests/ticket_12572_no_last_run_summary_diff.rb
+++ b/acceptance/tests/ticket_12572_no_last_run_summary_diff.rb
@@ -1,5 +1,9 @@
 test_name "#12572: Don't print a diff for last_run_summary when show_diff is on"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_namme`
+    'audit:unit'
+
 agents.each do |host|
   # Have to run apply twice in order to make sure a diff would be relevant
   on host, puppet_apply("--verbose --show_diff"), :stdin => "notice 'hello'"

--- a/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
+++ b/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
@@ -1,4 +1,8 @@
 test_name 'C99977 corrupted clientbucket' do
+
+  tag 'audit:medium',
+      'audit:integration'
+
   agents.each do |agent|
     tmpfile = agent.tmpfile('c99977file')
     unmanaged_content = "unmanaged\n"

--- a/acceptance/tests/ticket_13489_service_refresh.pp
+++ b/acceptance/tests/ticket_13489_service_refresh.pp
@@ -1,5 +1,9 @@
 test_name "#13489: refresh service"
 
+tag 'audit:low',      # basic Service type behavior on windows
+    'audit:refactor', # Use block style `test_namme`
+    'audit:unit'
+
 confine :to, :platform => 'windows'
 
 manifest = <<MANIFEST

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -7,6 +7,11 @@ extend Puppet::Acceptance::TempFileUtils
 initialize_temp_dirs()
 all_tests_passed = false
 
+tag 'audit:medium',      # tests basic custom module/pluginsync handling?
+    'audit:refactor',    # Use block style `test_namme`
+    'audit:integration',
+    'server'
+
 ###############################################################################
 # BEGIN TEST LOGIC
 ###############################################################################

--- a/acceptance/tests/ticket_15560_managehome.rb
+++ b/acceptance/tests/ticket_15560_managehome.rb
@@ -1,5 +1,11 @@
 test_name "#15560: Manage home directories"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_namme`
+                       # refactor to be OS agnostic and added to the resource/user
+                       # tests. managehome is currently not covered there.
+    'audit:acceptance'
+
 confine :to, :platform => 'windows'
 
 username = "pl#{rand(99999).to_i}"

--- a/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
+++ b/acceptance/tests/ticket_17458_puppet_command_prints_help.rb
@@ -1,5 +1,9 @@
 test_name "puppet command with an unknown external command prints help"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'      # basic command line handling
+
 on(agents, puppet('unknown'), :acceptable_exit_codes => [1]) do
   assert_match(/See 'puppet help' for help on available puppet subcommands/, stdout)
 end

--- a/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
+++ b/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
@@ -1,4 +1,8 @@
 test_name 'C100297 - A resource triggered by a refresh that fails should be reported as a failure when using --detailed-exitcodes' do
+
+  tag 'audit:medium',
+      'audit:integration' # Service type interaction with --detailed-exitcodes
+
   manifest =<<EOS
     exec{'true':
       command => 'true',

--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -1,5 +1,11 @@
 test_name "(PUP-2455) Service provider should start Solaris init service in its own SMF contract"
 
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_name`
+                       # Use mk_temp_environment_with_teardown
+                       # Combine with Service resource tests
+    'audit:acceptance' # Service provider functionality
+
 skip_test unless agents.any? {|agent| agent['platform'] =~ /solaris/ }
 
 sleepy_daemon_initscript = <<INITSCRIPT

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -1,6 +1,10 @@
 test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 
 agent_hostnames = agents.map {|a| a.to_s}
+tag 'audit:medium',  # CA functionality
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit',
+    'server'
 
 with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true,
                                              'autosign' => false}}) do

--- a/acceptance/tests/ticket_3656_requiring_multiple_resources.rb
+++ b/acceptance/tests/ticket_3656_requiring_multiple_resources.rb
@@ -1,4 +1,9 @@
 test_name "#3656: requiring multiple resources"
+
+tag 'audit:high',    # basic language functionality
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'
+
 apply_manifest_on agents, %q{
     notify { 'foo': }
     notify { 'bar': }

--- a/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
+++ b/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
@@ -2,6 +2,11 @@ test_name "#3961: puppet ca should produce certs spec"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/
 
+tag 'audit:high',        # basic CA functionality
+    'audit:refactor',     # Use block style `test_name`
+    'audit:integration',
+    'server'
+
 target  = "working3961.example.org"
 
 expect = ['Signed certificate request for ca',

--- a/acceptance/tests/ticket_4059_ralsh_can_change_settings.rb
+++ b/acceptance/tests/ticket_4059_ralsh_can_change_settings.rb
@@ -1,5 +1,9 @@
 test_name "#4059: ralsh can change settings"
 
+tag 'audit:unit',     # Basic RALSH smoke test
+    'audit:refactor', # Use block style `test_run`
+    'audit:low'
+
 agents.each do |agent|
   target = agent.tmpfile('hosts-#4059')
   content = "host example.com ensure=present ip=127.0.0.1 target=#{target}"

--- a/acceptance/tests/ticket_4233_resource_with_a_newline.rb
+++ b/acceptance/tests/ticket_4233_resource_with_a_newline.rb
@@ -9,6 +9,10 @@ test_name "#4233: resource with a newline"
 # Look for the line in the output and fail the test
 # if we find it.
 
+tag 'audit:low',      # basic parser functionality
+    'audit:refactor', # Use block style `test_run`
+    'audit:unit'
+
 agents.each do |host|
   resource = host.echo('-e "\nHello World\n"')
   apply_manifest_on(host, "exec { '#{resource}': }") do

--- a/acceptance/tests/ticket_4285_file_resource_fail_when_name_defined_instead_of_path.rb
+++ b/acceptance/tests/ticket_4285_file_resource_fail_when_name_defined_instead_of_path.rb
@@ -1,5 +1,9 @@
 test_name "Bug #4285: ArgumentError: Cannot alias File[mytitle] to [nil]"
 
+tag 'audit:low',     # Wierd File type name parameter handling
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'
+
 agents.each do |host|
   dir = host.tmpdir('4285-aliasing')
 

--- a/acceptance/tests/ticket_4289_facter_should_recognize_OEL_operatingsystemrelease.rb
+++ b/acceptance/tests/ticket_4289_facter_should_recognize_OEL_operatingsystemrelease.rb
@@ -7,6 +7,12 @@
 
 test_name "#4289: facter should recognize OEL operatingsystemrelease"
 
+tag 'audit:low',      # Special Facter OEL handling
+    'audit:refactor', # Use block style `test_name`
+    'audit:delete',   # This is a facter test
+    'audit:unit'      # This is OS specific, but I would assume that
+                      # facter unit tests would catch this...
+
 # REVISIT: We don't actually have support for this yet - we need a "not
 # applicable" option, I guess, that can be based on detected stuff, which is
 # cleaner than this is... --daniel 2010-12-22

--- a/acceptance/tests/ticket_4293_define_and_use_a_define_within_a_class.rb
+++ b/acceptance/tests/ticket_4293_define_and_use_a_define_within_a_class.rb
@@ -6,6 +6,11 @@
 # Description: using a defined type in the class it's declared in
 # causes an error.
 
+tag 'audit:high', # basic language functionality
+    'audit:unit',
+    'audit:refactor', # Use block style `test_name`
+    'audit:delete'
+
 manifest = <<PP
 class foo {
   define do_notify($msg) {

--- a/acceptance/tests/ticket_4404_should_allow_stage_main_on_left_side_of_relationship.rb
+++ b/acceptance/tests/ticket_4404_should_allow_stage_main_on_left_side_of_relationship.rb
@@ -8,6 +8,11 @@
 # Stage[main] -> Stage[last]
 # works as expected
 
+tag 'audit:high', # basic language functionality
+    'audit:unit',
+    'audit:refactor', # Use block style `test_name`
+    'audit:delete'
+
 apply_manifest_on agents, %q{
   stage { [ "pre", "post" ]: }
   Stage["pre"] -> Stage["main"] -> Stage["post"]

--- a/acceptance/tests/ticket_4423_cannot_declare_two_parameterized_classes.rb
+++ b/acceptance/tests/ticket_4423_cannot_declare_two_parameterized_classes.rb
@@ -8,6 +8,11 @@
 
 test_name "#4423: cannot declare two parameterized classes"
 
+tag 'audit:high', # basic language functionality
+    'audit:unit',
+    'audit:refactor', # Use block style `test_name`
+    'audit:delete'
+
 class1 = %q{
     class rainbow($color) {
       notify { "color": message => "Color is [${color}]" }

--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -2,6 +2,12 @@ test_name "ticket 4622 filebucket diff test."
 confine :except, :platform => 'windows'
 skip_test 'skip test, no non-Windows agents specified' if agents.empty?
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',    # look into combining with ticket_6541_invalid_filebucket_files.rb
+                         # Use block style `test_run`
+    'server'
+
 def get_checksum_from_backup_on(host, filename, bucket_locale)
   on host, puppet("filebucket backup #{filename} #{bucket_locale}"), :acceptable_exit_codes => [ 0, 2 ]
   output = result.stdout.strip.split(": ")

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -5,6 +5,11 @@
 #
 test_name "Ticket 5477, Puppet Master does not detect newly created site.pp file"
 
+tag 'audit:medium',
+    'audit:integration',
+    'audit:refactor',     # Use block style `test_name`
+    'server'
+
 testdir = master.tmpdir('missing_site_pp')
 manifest_file = "#{testdir}/environments/production/manifests/site.pp"
 

--- a/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
+++ b/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
@@ -1,5 +1,8 @@
 test_name 'Ensure hiera lookup occurs if class param is undef' do
 
+  tag 'audit:medium',
+      'audit:unit'    # basic auto lookup functionality
+
   agents.each do |agent|
 
     testdir = agent.tmpdir('undef')

--- a/acceptance/tests/ticket_6418_file_recursion_and_audit.rb
+++ b/acceptance/tests/ticket_6418_file_recursion_and_audit.rb
@@ -5,6 +5,10 @@
 
 test_name "#6418: file recursion and audit"
 
+tag 'audit:low',
+    'audit:refactor',    # Use block style `test_name`
+    'audit:integration'
+
 agents.each do |agent|
   dir = agent.tmpdir('6418-recurse-audit')
 

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -1,5 +1,10 @@
 test_name "#6541: file type truncates target when filebucket cannot retrieve hash"
 
+tag 'audit:medium',
+    'audit:integration', # file type and file bucket interop
+    'audit:refactor'     # look into combining with ticket_4622_filebucket_diff_test.rb
+                         # Use block style `test_run`
+
 agents.each do |agent|
   target=agent.tmpfile('6541-target')
 

--- a/acceptance/tests/ticket_6710_relationship_syntax_should_work_with_title_arrays.rb
+++ b/acceptance/tests/ticket_6710_relationship_syntax_should_work_with_title_arrays.rb
@@ -1,5 +1,9 @@
 test_name "#6710: Relationship syntax should work with title arrays"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'     # basic language syntax
+
 # Jeff McCune <jeff@puppetlabs.com>
 # 2011-03-14
 #

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,5 +1,9 @@
 test_name "#6857: redact password hashes when applying in noop mode"
 
+tag 'audit:medium',
+    'audit:refactor',    # Use block style `test_name`
+    'audit:integration'
+
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils
 

--- a/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
+++ b/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
@@ -1,5 +1,9 @@
 test_name "providers should be useable in the same run they become suitable"
 
+tag 'audit:high',       # autoloader, core puppet agent run functionality
+    'audit:refactor',    # Use block style `test_name`
+    'audit:integration' # does not require packages, probably implicitly assumed in many other places
+
 agents.each do |agent|
   dir = agent.tmpdir('provider-6907')
 

--- a/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
+++ b/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
@@ -1,5 +1,9 @@
 test_name "#6928: Puppet --parseonly should return deprication message"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'
+
 # Create good and bad formatted manifests
 step "Master: create valid, invalid formatted manifests"
 create_remote_file(master, '/tmp/good.pp', %w{notify{good:}} )

--- a/acceptance/tests/ticket_7101_template_compile.rb
+++ b/acceptance/tests/ticket_7101_template_compile.rb
@@ -1,5 +1,9 @@
 test_name "#7101: template compile"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'     # basic template handling
+
 agents.each do |agent|
   template = agent.tmpfile('template_7101.erb')
   target = agent.tmpfile('file_7101.erb')

--- a/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rb
+++ b/acceptance/tests/ticket_7139_puppet_resource_file_qualified_paths.rb
@@ -1,5 +1,9 @@
 test_name "#7139: Puppet resource file fails on path with leading '/'"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'     # basic puppet file resource validation?
+
 agents.each do |agent|
   target = agent.tmpfile('ticket-7139')
 

--- a/acceptance/tests/ticket_7165_no_refresh_after_starting_service.rb
+++ b/acceptance/tests/ticket_7165_no_refresh_after_starting_service.rb
@@ -1,5 +1,9 @@
 test_name "Bug #7165: Don't refresh service immediately after starting it"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'     # testing basic service type behavior
+
 confine :except, :platform => 'windows'
 
 agents.each do |host|

--- a/acceptance/tests/ticket_7728_don't_log_whits_on_failure.rb
+++ b/acceptance/tests/ticket_7728_don't_log_whits_on_failure.rb
@@ -1,5 +1,9 @@
 test_name "#7728: Don't log whits on resource failure"
 
+tag 'audit:low',
+    'audit:refactor', # Use block style `test_name`
+    'audit:unit'
+
 manifest = %Q{
   class foo {
     exec { "test": command => "false", path => ['/bin', '/usr/bin'] }

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -1,5 +1,11 @@
 test_name "#9862: puppet runs without service user or group present"
 
+tag 'audit:medium',     # startup/configuration, high impact, low risk
+    'audit:refactor',    # Use block style `test_name`
+    'audit:integration' # could easily be acceptance, not package dependant,
+                        # but changing a person running the tests users and
+                        # groups can be very onerous
+
 # puppet doesn't try to manage ownership on windows.
 confine :except, :platform => 'windows'
 confine :except, :platform => /solaris-10/ # See PUP-5200

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -1,4 +1,10 @@
 test_name 'utf-8 characters in cached catalog' do
+
+  tag 'audit:high',        # utf-8 is high impact in general
+      'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
+      'audit:refactor',    # use mk_temp_environment_with_teardown
+      'server'
+
   confine :except, :platform => [
     'windows',      # PUP-6983
     'cumulus',      # PUP-7147

--- a/acceptance/tests/utf8/utf8-in-file-resource.rb
+++ b/acceptance/tests/utf8/utf8-in-file-resource.rb
@@ -1,5 +1,8 @@
 test_name 'utf-8 characters in resource title and param values' do
 
+  tag 'audit:high',       # utf-8 is high impact in general
+      'audit:integration' # not package dependent but may want to vary platform by LOCALE/encoding
+
   confine :except, :platform => [
     'windows',    # PUP-6983
     'eos-4',      # PUP-7146

--- a/acceptance/tests/utf8/utf8-in-function-args.rb
+++ b/acceptance/tests/utf8/utf8-in-function-args.rb
@@ -1,4 +1,9 @@
 test_name 'utf-8 characters in function parameters' do
+
+  tag 'audit:high',        # utf-8 is high impact in general
+      'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
+      'audit:refactor'     # if keeping, use mk_temp_environment_with_teardown
+
   confine :except, :platform => [
     'windows',      # PUP-6983
     'eos-4',        # PUP-7146

--- a/acceptance/tests/utf8/utf8-in-puppet-describe.rb
+++ b/acceptance/tests/utf8/utf8-in-puppet-describe.rb
@@ -1,4 +1,11 @@
 test_name 'utf-8 characters in module doc string, puppet describe' do
+
+  tag 'audit:medium',      # utf-8 is high impact in general, puppet describe low risk?
+      'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
+      'audit:refactor'     # if keeping, use mk_temp_environment_with_teardown
+                           # remove with_puppet_running_on unless pluginsync is absolutely necessary
+                           # (if it is, add 'server' tag
+
   platforms = hosts.map {|val| val[:platform]}
   if (platforms.any? { |val| /^eos-/ =~ val})
     skip_test "Skipping because Puppet describe fails when the Arista module is installed (ARISTA-51)"

--- a/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
+++ b/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
@@ -12,31 +12,31 @@ confine :to, :platform => 'windows'
 
 pass_exitcode_manifest = <<-MANIFEST
 winexitcode::execute { '0':
-	exit_code => 0
+  exit_code => 0
 }
 MANIFEST
 
 upper_8bit_boundary_manifest = <<-MANIFEST
 winexitcode::execute { '255':
-	exit_code => 255
+  exit_code => 255
 }
 MANIFEST
 
 cross_8bit_boundary_manifest = <<-MANIFEST
 winexitcode::execute { '256':
-	exit_code => 256
+  exit_code => 256
 }
 MANIFEST
 
 upper_32bit_boundary_manifest = <<-MANIFEST
 winexitcode::execute { '4294967295':
-	exit_code => 4294967295
+  exit_code => 4294967295
 }
 MANIFEST
 
 cross_32bit_boundary_manifest = <<-MANIFEST
 winexitcode::execute { '4294967296':
-	exit_code => 0
+  exit_code => 0
 }
 MANIFEST
 
@@ -75,30 +75,30 @@ agents.each do |agent|
 end
 
 agents.each do |agent|
-	step "Verify '0' is a Valid Exit Code"
+  step "Verify '0' is a Valid Exit Code"
 
-	#Apply the manifest and verify Puppet returns success.
-	on(agent, puppet('apply', '--debug'), :stdin => pass_exitcode_manifest)
+  #Apply the manifest and verify Puppet returns success.
+  on(agent, puppet('apply', '--debug'), :stdin => pass_exitcode_manifest)
 
-	step "Verify Unsigned 8bit Upper Boundary"
+  step "Verify Unsigned 8bit Upper Boundary"
 
-	#Apply the manifest and verify Puppet returns success.
-	on(agent, puppet('apply', '--debug'), :stdin => upper_8bit_boundary_manifest)
+  #Apply the manifest and verify Puppet returns success.
+  on(agent, puppet('apply', '--debug'), :stdin => upper_8bit_boundary_manifest)
 
-	step "Verify Unsigned 8bit Cross Boundary"
+  step "Verify Unsigned 8bit Cross Boundary"
 
-	#Apply the manifest and verify Puppet returns success.
-	on(agent, puppet('apply', '--debug'), :stdin => cross_8bit_boundary_manifest)
+  #Apply the manifest and verify Puppet returns success.
+  on(agent, puppet('apply', '--debug'), :stdin => cross_8bit_boundary_manifest)
 
-	step "Verify Unsigned 32bit Upper Boundary"
+  step "Verify Unsigned 32bit Upper Boundary"
 
-	#Apply the manifest and verify Puppet returns success.
-	on(agent, puppet('apply', '--debug'), :stdin => upper_32bit_boundary_manifest)
+  #Apply the manifest and verify Puppet returns success.
+  on(agent, puppet('apply', '--debug'), :stdin => upper_32bit_boundary_manifest)
 
-	step "Verify Unsigned 32bit Cross Boundary"
+  step "Verify Unsigned 32bit Cross Boundary"
 
-	#Apply the manifest and verify Puppet returns success.
-	on(agent, puppet('apply', '--debug'), :stdin => cross_32bit_boundary_manifest)
+  #Apply the manifest and verify Puppet returns success.
+  on(agent, puppet('apply', '--debug'), :stdin => cross_32bit_boundary_manifest)
 
   step "Verify Negative Exit Code Rollover Boundary"
 

--- a/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
+++ b/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
@@ -1,6 +1,12 @@
-test_name "Windows Exit Codes - Acceptance Tests"
+test_name "Windows Exec `exit_code` Parameter Acceptance Test"
 
-tag 'risk:medium'
+tag 'risk:medium',
+    'audit:medium',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:integration' # exec resource succeeds when the `exit_code` parameter
+                        # is given a windows specific exit code and a exec
+                        # returns that exit code, ie. it either correctly matches
+                        # exit_code parameter to returned exit code, or ignores both (;
 
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
+++ b/acceptance/tests/windows/QA-563_windows_exit_mcollective.rb
@@ -1,6 +1,9 @@
 test_name 'MCollective service exits on windows agent'
 
-tag 'risk:medium'
+tag 'risk:medium',
+    'audit:medium',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:acceptance'
 
 confine :to, :platform => 'windows'
 confine :to, {}, hosts.select { |host| (host[:roles].include?('aio')) }

--- a/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
+++ b/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
@@ -33,7 +33,7 @@ end
 step "Create Temp Folder"
 
 agents.each do |agent|
-  on(agent, puppet('apply', '--debug'), :stdin => temp_folder)    
+  on(agent, puppet('apply', '--debug'), :stdin => temp_folder)
 end
 
 step "Create Dash Dot File 100 Times"

--- a/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
+++ b/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
@@ -1,6 +1,9 @@
 test_name "QA-760 - Windows Files Containing '-' and '.'"
 
-tag 'risk:medium'
+tag 'risk:medium',
+    'audit:medium',
+    'audit:refactor',   # Use block style `test_name`
+    'audit:integration'
 
 confine(:to, :platform => 'windows')
 

--- a/acceptance/tests/windows/env_windows_installdir_fact.rb
+++ b/acceptance/tests/windows/env_windows_installdir_fact.rb
@@ -3,6 +3,10 @@
 # present and accurate.
 test_name 'PA-466: Ensure env_windows_installdir fact is present and correct' do
 
+  tag 'audit:low',       # important runtime environment/packaging integration, rarely changed?
+      'audit:delete',    # Move to puppet-agent suite
+      'audit:acceptance'
+
   confine :to, :platform => 'windows'
 
   require 'json'

--- a/acceptance/tests/windows/eventlog.rb
+++ b/acceptance/tests/windows/eventlog.rb
@@ -1,5 +1,15 @@
 test_name "Write to Windows eventlog"
 
+tag 'audit:medium',    # core feature, high impact, but low risk
+    'audit:refactor',  # Use block style `test_name`
+    'audit:acceptance' # unclear if this is an important packaging level feature
+                       # test (warrants acceptance level) that wouldn't also be
+                       # caught by other test (perhaps combine with other tests),
+                       # or if the functionality is assumed by other acceptance tests
+                       # (then this test can be deleted), or if packaging can be
+                       # assumed and the logging functionality can be tested at the
+                       # integration level.
+
 confine :to, :platform => 'windows'
 
 require 'puppet/acceptance/common_utils'

--- a/acceptance/tests/windows/winexitcode/manifests/execute.pp
+++ b/acceptance/tests/windows/winexitcode/manifests/execute.pp
@@ -1,13 +1,13 @@
 define winexitcode::execute (
-	$exit_code = 0,
+  $exit_code = 0,
 ) {
 
-	include winexitcode
+include winexitcode
 
-	exec { "testcommand_${exit_code}":
-		command   => "c:\\Windows\\System32\\cmd.exe /c c:\\tmp\\test.bat ${title}",
-		returns   => $exit_code,
-		logoutput => true,
-		require   => Class['winexitcode'],
-	}
+  exec { "testcommand_${exit_code}":
+    command   => "c:\\Windows\\System32\\cmd.exe /c c:\\tmp\\test.bat ${title}",
+    returns   => $exit_code,
+    logoutput => true,
+    require   => Class['winexitcode'],
+  }
 }

--- a/acceptance/tests/windows/winexitcode/manifests/init.pp
+++ b/acceptance/tests/windows/winexitcode/manifests/init.pp
@@ -1,13 +1,13 @@
 class winexitcode {
-	file { "c:\\tmp":
-		ensure  => directory,
-	  mode    => '0660',
-	  owner   => 'Administrator',
-	  group   => 'Administrators',
-	}
-	->
-	file { "c:\\tmp\\test.bat":
-  	ensure  => file,
+  file { "c:\\tmp":
+    ensure  => directory,
+    mode    => '0660',
+    owner   => 'Administrator',
+    group   => 'Administrators',
+  }
+  ->
+  file { "c:\\tmp\\test.bat":
+    ensure  => file,
     mode    => '0660',
     owner   => 'Administrator',
     group   => 'Administrators',


### PR DESCRIPTION
This is the content of https://github.com/puppetlabs/puppet/pull/6057 rebased onto 5.0.x with the rebase error mentioned [in this comment](https://github.com/puppetlabs/puppet/pull/6057#discussion_r127303903) fixed and `resource/exec/should_run_bad_command.rb` and `resource/exec/should_accept_large_output.rb` removed (since they are only in `master`).

The two exec tests will need to be updated with this is merged up to master.