### PR TITLE
(packaging) Bump version to 5.0.1

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 
 module Puppet
-  PUPPETVERSION = '5.0.0'
+  PUPPETVERSION = '5.0.1'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This updates Puppet's version number for the upcoming 5.0.1
release.