### PR TITLE
(PUP-7781) Add payload_gpgcheck param to the yumrepo type (4.10.x branch)

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -104,6 +104,15 @@ Puppet::Type.newtype(:yumrepo) do
     munge(&munge_yum_bool)
   end
 
+  newproperty(:payload_gpgcheck) do
+    desc "Whether to check the GPG signature of the packages payload.
+      #{YUM_BOOLEAN_DOC}
+      #{ABSENT_DOC}"
+
+    newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
+  end
+
   newproperty(:repo_gpgcheck) do
     desc "Whether to check the GPG signature on repodata.
       #{YUM_BOOLEAN_DOC}

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -174,6 +174,11 @@ describe Puppet::Type.type(:yumrepo) do
       it_behaves_like "a yumrepo parameter that can be absent", :gpgcheck
     end
 
+    describe "payload_gpgcheck" do
+      it_behaves_like "a yumrepo parameter that expects a boolean parameter", :payload_gpgcheck
+      it_behaves_like "a yumrepo parameter that can be absent", :payload_gpgcheck
+    end
+
     describe "repo_gpgcheck" do
       it_behaves_like "a yumrepo parameter that expects a boolean parameter", :repo_gpgcheck
       it_behaves_like "a yumrepo parameter that can be absent", :repo_gpgcheck


### PR DESCRIPTION
RHEL 7.4 introduces a new booelean parameter payload_gpgcheck to do a
signature check on the payload sections of packages before installing
it.