### PR TITLE
(PUP-7782) Handle non-string messages when generating exceptions

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -3,7 +3,7 @@ module Puppet
   class Error < RuntimeError
     attr_accessor :original
     def initialize(message, original=nil)
-      super(Puppet::Util::CharacterEncoding.scrub(message))
+      super(Puppet::Util::CharacterEncoding.scrub(message.to_s))
       @original = original
     end
   end


### PR DESCRIPTION
During exception creation, Puppet::Error scrubs the provided message.
Scrubbing is only viable against strings, which causes an error to be
raised if the provided message is another type. This patch converts
messages to strings before passing them to the scrub call.