### PR TITLE
(packaging) Bump version to 4.10.5

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 
 module Puppet
-  PUPPETVERSION = '4.10.4'
+  PUPPETVERSION = '4.10.5'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This commit bumps Puppet's version to 4.10.5 in preparation for the
puppet-agent 1.10.5 release.