### PR TITLE
(PUP-4755) prefer explicit [main] section header

### DIFF
--- a/lib/puppet/settings/ini_file.rb
+++ b/lib/puppet/settings/ini_file.rb
@@ -93,14 +93,11 @@ class Puppet::Settings::IniFile
   end
 
   def write(fh)
-    # If no real section line for the default section exists, convert the
-    # existing DefaultSection object into a regular SectionLine so that when we
-    # write the file, the section line part will actually be written
-    # (DefaultSection objects don't write the section line)
-    if settings_exist_in_default_section?
-      unless section_exists_with_default_section_name?
-        set_default_section_write_sectionline(true)
-      end
+    # If no real section line for the default section exists, configure the
+    # DefaultSection object to write its section line. (DefaultSection objects
+    # don't write the section line unless explicitly configured to do so)
+    if settings_exist_in_default_section? && !section_exists_with_default_section_name?
+      set_default_section_write_sectionline(true)
     end
 
     fh.truncate(0)

--- a/spec/unit/settings/ini_file_spec.rb
+++ b/spec/unit/settings/ini_file_spec.rb
@@ -44,7 +44,7 @@ describe Puppet::Settings::IniFile do
     expect(config_fh.string).to eq "[the_section]\n#{mixed_utf8} = #{mixed_utf8.reverse}\n"
   end
 
-  it "does not add a [main] section to a file when it isn't needed" do
+  it "adds a [main] section to a file when it's needed" do
     config_fh = a_config_file_containing(<<-CONF)
     [section]
     name = different value
@@ -56,6 +56,7 @@ describe Puppet::Settings::IniFile do
     end
 
     expect(config_fh.string).to eq(<<-CONF)
+[main]
 name = value
     [section]
     name = different value
@@ -151,7 +152,7 @@ name = value
     CONFIG
   end
 
-  it "considers settings outside a section to be in section 'main'" do
+  it "considers settings found outside a section to be in section 'main'" do
     config_fh = a_config_file_containing(<<-CONFIG)
     name = original value
     CONFIG
@@ -161,6 +162,7 @@ name = value
     end
 
     expect(config_fh.string).to eq <<-CONFIG
+[main]
     name = changed value
     CONFIG
   end


### PR DESCRIPTION
The `puppet config set` command previously allowed and preferred
that the [main] section header be omitted, and [main] settings be
written in the ini file as global.

This commit rejects that standard, preferring instead that the [main]
section header always be explicitly written in the file when `puppet
config` is used.