### PR TITLE
(PUP-5047) POSIX Exec throws error when group has no name

### DIFF
--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -141,6 +141,7 @@ module Puppet::Util::SUIDManager
 
   # Make sure the passed argument is a number.
   def convert_xid(type, id)
+    return id if id.kind_of? Integer
     map = {:gid => :group, :uid => :user}
     raise ArgumentError, _("Invalid id type %{type}") % { type: type } unless map.include?(type)
     ret = Puppet::Util.send(type, id)


### PR DESCRIPTION
On Macs which are domain-joined, lookups between group ID and name can
fail if the domain isn't accessible at that moment. In these situations,
lookups on files and other objects return a GID for the user that is
already an integer, which is then passed to convert_xid, which tries to
re-lookup that GID and fails, returning an "Invalid group: ###" error.

This PR bails early if the user/group ID is already numeric, and thus
doesn't need to be looked up.