### PR TITLE
(PUP-7684) correct tests to use the real fqdn of the host

### DIFF
--- a/acceptance/lib/puppet/acceptance/agent_fqdn_utils.rb
+++ b/acceptance/lib/puppet/acceptance/agent_fqdn_utils.rb
@@ -1,0 +1,16 @@
+module Puppet
+  module Acceptance
+    module AgentFqdnUtils
+
+      @@hostname_to_fqdn = {}
+
+      # convert from an Beaker::Host (agent) to the systems fqdn as returned by facter
+      def agent_to_fqdn(agent)
+        unless @@hostname_to_fqdn.has_key?(agent.hostname)
+          @@hostname_to_fqdn[agent.hostname] = on(agent, facter('fqdn')).stdout.chomp
+        end
+        @@hostname_to_fqdn[agent.hostname]
+      end
+    end
+  end
+end

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -1,58 +1,59 @@
-require 'yaml'
-
 test_name "C98092 - a new resource should not be reported as a corrective change" do
-require 'puppet/acceptance/environment_utils'
-extend Puppet::Acceptance::EnvironmentUtils
 
-  test_file_name = File.basename(__FILE__, '.*')
-  tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
-  tmp_file = {}
-  
+  require 'yaml'
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  require 'puppet/acceptance/agent_fqdn_utils'
+  extend Puppet::Acceptance::AgentFqdnUtils
+
+  test_file_name  = File.basename(__FILE__, '.*')
+  tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
+  tmp_file        = {}
+
   agents.each do |agent|
-    tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
+    tmp_file[agent_to_fqdn(agent)] = agent.tmpfile(tmp_environment)
   end
 
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
-          on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
-        end 
+        if tmp_file.has_key?(agent_to_fqdn(agent)) && tmp_file[agent_to_fqdn(agent)] != ''
+          on(agent, "rm '#{tmp_file[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)
+        end
       end
     end
   end
 
   step 'create file resource - site.pp to verify corrective change flag' do
-    file_contents     = 'this is a test'   
-    manifest = <<MANIFEST
-file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
-  ensure => file,
-  content => '
-\$test_path = \$::fqdn ? #{tmp_file}
-file { \$test_path:
-  content => @(UTF8)
-    #{file_contents}
-    | UTF8 
-}
-  ',
-}
-MANIFEST
+    file_contents = 'this is a test'
+    manifest      = <<-MANIFEST
+    file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
+      ensure => file,
+      content => '
+    \$test_path = \$::fqdn ? #{tmp_file}
+    file { \$test_path:
+      content => @(UTF8)
+        #{file_contents}
+        | UTF8
+    }
+      ',
+    }
+    MANIFEST
     apply_manifest_on(master, manifest, :catch_failures => true)
   end
 
   step 'run agent(s)' do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        fqdn = agent.hostname
-
         #Run agent once to create new File resource
         step 'Run agent once to create new File resource' do
-          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
         end
 
         #Verify the file resource is created
         step 'Verify the file resource is created' do
-          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+          on(agent, "cat '#{tmp_file[agent_to_fqdn(agent)]}'").stdout do |file_result|
             assert_equal(file_contents, file_result, 'file contents did not match accepted')
           end
         end
@@ -65,22 +66,20 @@ MANIFEST
     agents.each do |agent|
       on(agent, puppet('config print statedir')) do |command_result|
         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-        on(agent, "cat #{report_path}").stdout do |report_contents|
+        on(agent, "cat '#{report_path}'").stdout do |report_contents|
 
           yaml_data = YAML::parse(report_contents)
           # Remove any Ruby class tags from the yaml
           yaml_data.root.each do |o|
-            if o.respond_to?(:tag=) and
-               o.tag != nil and
-               o.tag.start_with?("!ruby")
+            if o.respond_to?(:tag=) and o.tag != nil and o.tag.start_with?("!ruby")
               o.tag = nil
             end
           end
           report_yaml = yaml_data.to_ruby
 
-          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
-          assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
-          corrective_change_value =  file_resource_details["corrective_change"]
+          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent_to_fqdn(agent)]}]"]
+          assert(file_resource_details.has_key?("corrective_change"), 'corrective_change key is missing')
+          corrective_change_value = file_resource_details["corrective_change"]
           assert_equal(false, corrective_change_value, 'corrective_change flag should be false')
         end
       end

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -1,22 +1,25 @@
-require 'yaml'
-require 'puppet/acceptance/environment_utils'
-extend Puppet::Acceptance::EnvironmentUtils
-
 test_name "C98093 - a resource changed outside of Puppet will be reported as a corrective change" do
 
-  test_file_name = File.basename(__FILE__, '.*')
-  tmp_environment   = mk_tmp_environment_with_teardown(master, test_file_name)
-  tmp_file = {}
+  require 'yaml'
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  require 'puppet/acceptance/agent_fqdn_utils'
+  extend Puppet::Acceptance::AgentFqdnUtils
+
+  test_file_name  = File.basename(__FILE__, '.*')
+  tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
+  tmp_file        = {}
 
   agents.each do |agent|
-    tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
+    tmp_file[agent_to_fqdn(agent)] = agent.tmpfile(tmp_environment)
   end
 
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''  
-          on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+        if tmp_file.has_key?(agent_to_fqdn(agent)) && tmp_file[agent_to_fqdn(agent)] != ''
+          on(agent, "rm '#{tmp_file[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)
         end
       end
     end
@@ -24,52 +27,50 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
 
   step 'create file resource - site.pp to verify corrective change flag' do
     file_contents = 'this is a test'
-    manifest = <<MANIFEST
-file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
-  ensure => file,
-  content => '
-\$test_path = \$::fqdn ? #{tmp_file}
-file { \$test_path:
-  content => @(UTF8)
-    #{file_contents}
-    | UTF8
-}
-  ',
-}
-MANIFEST
+    manifest      = <<-MANIFEST
+      file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
+        ensure => file,
+        content => '
+      \$test_path = \$::fqdn ? #{tmp_file}
+      file { \$test_path:
+        content => @(UTF8)
+          #{file_contents}
+          | UTF8
+      }
+        ',
+      }
+    MANIFEST
     apply_manifest_on(master, manifest, :catch_failures => true)
   end
 
   step 'run agent(s)' do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        fqdn = agent.hostname
-
         #Run agent once to create new File resource
         step 'Run agent once to create new File resource' do
-          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
         end
 
         #Verify the file resource is created
         step 'Verify the file resource is created' do
-          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+          on(agent, "cat '#{tmp_file[agent_to_fqdn(agent)]}'").stdout do |file_result|
             assert_equal(file_contents, file_result, 'file contents did not match accepted')
           end
         end
 
         #Delete the file
         step 'Delete the file' do
-          on(agent, "rm #{tmp_file[fqdn]}", :accept_all_exit_codes => true)
+          on(agent, "rm '#{tmp_file[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)
         end
 
         #Run agent to correct the file's absence
         step 'Run agent to correct the files absence' do
-          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
         end
  
         #Verify the file resource is created
         step 'Verify the file resource is created' do
-          on(agent, "cat #{tmp_file[fqdn]}").stdout do |file_result|
+          on(agent, "cat '#{tmp_file[agent_to_fqdn(agent)]}'").stdout do |file_result|
             assert_equal(file_contents, file_result, 'file contents did not match accepted')
           end
         end
@@ -82,23 +83,21 @@ MANIFEST
     agents.each do |agent|
       on(agent, puppet('config print statedir')) do |command_result|
         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-        on(agent, "cat #{report_path}").stdout do |report_contents|
+        on(agent, "cat '#{report_path}'").stdout do |report_contents|
 
           yaml_data = YAML::parse(report_contents)
           # Remove any Ruby class tags from the yaml
           yaml_data.root.each do |o|
-            if o.respond_to?(:tag=) and
-               o.tag != nil and
-               o.tag.start_with?("!ruby")
+            if o.respond_to?(:tag=) and o.tag != nil and o.tag.start_with?("!ruby")
               o.tag = nil
             end
           end
           report_yaml = yaml_data.to_ruby
 
-          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
-          assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
-          corrective_change_value =  file_resource_details["corrective_change"]
-          assert_equal(true, corrective_change_value, 'corrective_change flag should be true') 
+          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent_to_fqdn(agent)]}]"]
+          assert(file_resource_details.has_key?("corrective_change"), 'corrective_change key is missing')
+          corrective_change_value = file_resource_details["corrective_change"]
+          assert_equal(true, corrective_change_value, 'corrective_change flag should be true')
         end
       end
     end

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -1,43 +1,46 @@
-require 'yaml'
-require 'puppet/acceptance/environment_utils'
-extend Puppet::Acceptance::EnvironmentUtils
-
 test_name "C98094 - a resource changed via Puppet manifest will not be reported as a corrective change" do
 
-  test_file_name = File.basename(__FILE__, '.*')
-  tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)
-  tmp_file = {}
+  require 'yaml'
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  require 'puppet/acceptance/agent_fqdn_utils'
+  extend Puppet::Acceptance::AgentFqdnUtils
+
+  test_file_name     = File.basename(__FILE__, '.*')
+  tmp_environment    = mk_tmp_environment_with_teardown(master, test_file_name)
+  tmp_file           = {}
   original_test_data = 'this is my original important data'
   modified_test_data = 'this is my modified important data'
  
   agents.each do |agent|
-    tmp_file[agent.hostname] = agent.tmpfile(tmp_environment)
+    tmp_file[agent_to_fqdn(agent)] = agent.tmpfile(tmp_environment)
   end
 
   teardown do
     step 'clean out produced resources' do
       agents.each do |agent|
-        if tmp_file.has_key?(agent.hostname) && tmp_file[agent.hostname] != ''
-          on(agent, "rm #{tmp_file[agent.hostname]}", :accept_all_exit_codes => true)
+        if tmp_file.has_key?(agent_to_fqdn(agent)) && tmp_file[agent_to_fqdn(agent)] != ''
+          on(agent, "rm '#{tmp_file[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)
         end
       end
     end
   end
 
   def create_manifest_for_file_resource(file_resource, file_contents, environment_name)
-    manifest = <<MANIFEST
-file { '#{environmentpath}/#{environment_name}/manifests/site.pp':
-  ensure => file,
-  content => '
-\$test_path = \$::fqdn ? #{file_resource}
-file { \$test_path:
-  content => @(UTF8)
-    #{file_contents}
-    | UTF8
-}
-  ',
-}
-MANIFEST
+    manifest = <<-MANIFEST
+      file { '#{environmentpath}/#{environment_name}/manifests/site.pp':
+        ensure => file,
+        content => '
+      \$test_path = \$::fqdn ? #{file_resource}
+      file { \$test_path:
+        content => @(UTF8)
+          #{file_contents}
+          | UTF8
+      }
+        ',
+      }
+    MANIFEST
     apply_manifest_on(master, manifest, :catch_failures => true)
   end
 
@@ -49,11 +52,11 @@ MANIFEST
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
         step 'Run agent once to create new File resource' do
-          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
         end
 
         step 'Verify the file resource is created' do
-          on(agent, "cat #{tmp_file[agent.hostname]}").stdout do |file_contents|
+          on(agent, "cat '#{tmp_file[agent_to_fqdn(agent)]}'").stdout do |file_contents|
             assert_equal(original_test_data, file_contents, 'file contents did not match expected contents')
           end
         end
@@ -65,11 +68,11 @@ MANIFEST
 
       agents.each do |agent|
         step 'Run agent a 2nd time to change the File resource' do
-          on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"),:acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
         end
 
         step 'Verify the file resource is created' do
-          on(agent, "cat #{tmp_file[agent.hostname]}").stdout do |file_contents|
+          on(agent, "cat '#{tmp_file[agent_to_fqdn(agent)]}'").stdout do |file_contents|
             assert_equal(modified_test_data, file_contents, 'file contents did not match expected contents')
           end
         end
@@ -82,21 +85,19 @@ MANIFEST
     agents.each do |agent|
       on(agent, puppet('config print statedir')) do |command_result|
         report_path = command_result.stdout.chomp + '/last_run_report.yaml'
-        on(agent, "cat #{report_path}").stdout do |report_contents|
+        on(agent, "cat '#{report_path}'").stdout do |report_contents|
 
           yaml_data = YAML::parse(report_contents)
           # Remove any Ruby class tags from the yaml
           yaml_data.root.each do |o|
-            if o.respond_to?(:tag=) and
-               o.tag != nil and
-               o.tag.start_with?("!ruby")
-               o.tag = nil
+            if o.respond_to?(:tag=) and o.tag != nil and o.tag.start_with?("!ruby")
+              o.tag = nil
             end
           end
-          report_yaml = yaml_data.to_ruby
-          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent.hostname]}]"]
-          assert(file_resource_details.has_key?("corrective_change"),'corrective_change key is missing')
-          corrective_change_value =  file_resource_details["corrective_change"]
+          report_yaml           = yaml_data.to_ruby
+          file_resource_details = report_yaml["resource_statuses"]["File[#{tmp_file[agent_to_fqdn(agent)]}]"]
+          assert(file_resource_details.has_key?("corrective_change"), 'corrective_change key is missing')
+          corrective_change_value = file_resource_details["corrective_change"]
           assert_equal(false, corrective_change_value, 'corrective_change flag for the changed resource should be false')
         end
       end

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -1,19 +1,22 @@
-require 'puppet/acceptance/environment_utils'
-extend Puppet::Acceptance::EnvironmentUtils
-
 test_name 'Ensure a file resource can have a UTF-8 source attribute, content, and path when served via a module' do
   skip_test 'requires a master for serving module content' if master.nil?
 
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
+
+  require 'puppet/acceptance/agent_fqdn_utils'
+  extend Puppet::Acceptance::AgentFqdnUtils
+
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))
-  agent_tmp_dirs = {}
+  agent_tmp_dirs  = {}
 
   agents.each do |agent|
-    agent_tmp_dirs[agent.hostname] = agent.tmpdir(tmp_environment)
+    agent_tmp_dirs[agent_to_fqdn(agent)] = agent.tmpdir(tmp_environment)
   end
 
   teardown do
     step 'remove all test files on agents' do
-      agents.each { |agent| on(agent, "rm -r #{agent_tmp_dirs[agent.hostname]}", :accept_all_exit_codes => true) }
+      agents.each {|agent| on(agent, "rm -r '#{agent_tmp_dirs[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)}
     end
     # note - master teardown is registered by #mk_tmp_environment_with_teardown
   end
@@ -69,10 +72,9 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
 
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        fqdn = agent.hostname
-        on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"), :acceptable_exit_codes => 2)
+        on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
 
-        on(agent, "cat #{agent_tmp_dirs[fqdn]}/\uff72\uff67\u30d5\u30eb") do |result|
+        on(agent, "cat '#{agent_tmp_dirs[agent_to_fqdn(agent)]}/\uff72\uff67\u30d5\u30eb'") do |result|
           assert_match("\u2603", result.stdout, "managed UTF-8 file contents '#{result.stdout}' did not match expected value '\u2603'")
         end
       end


### PR DESCRIPTION
On the new Linux Power8 system the "facter fqdn" did not match
the agent.hostname, this caused these tests to fail. This fixes
them to use the real fqdn value whether its the short or long name
(This will also fix other vmpooler systems that have the same issue
with these tests)