### PR TITLE
(PUP-7802) Make hiera_xxx functions unaffected by data_binding_terminus

### DIFF
--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -68,7 +68,8 @@ class LookupAdapter < DataAdapter
   end
 
   def lookup_global(key, lookup_invocation, merge_strategy)
-    terminus = Puppet[:data_binding_terminus]
+    # hiera_xxx will always use global_provider regardless of data_binding_terminus setting
+    terminus = lookup_invocation.hiera_xxx_call? ? :hiera : Puppet[:data_binding_terminus]
     case terminus
     when :hiera, 'hiera'
       provider = global_provider(lookup_invocation)

--- a/spec/unit/functions/hiera_spec.rb
+++ b/spec/unit/functions/hiera_spec.rb
@@ -293,6 +293,11 @@ describe 'when calling' do
         expect(func('mod::c')).to eql('mod::c (from module)')
       end
     end
+
+    it 'should not be disabled by data_binding_terminus setting' do
+      Puppet[:data_binding_terminus] = 'none'
+      expect(func('a')).to eql('first a')
+    end
   end
 
   context 'hiera_array' do


### PR DESCRIPTION
Prior to this commit, all global lookups would be affected by the
`data_binding_terminus` setting. This commit ensures that this is no
longer the case when the lookup origins from `hiera`, `hiera_array`,
`hiera_hash`, or `hiera_include` function.

The change is made to ensure backward compatibility with Hiera 3 where
the `hiera_xxx` calls would go directly to the classic Hiera and thus
not be affected by the `data_binding_terminus`.