### PR TITLE
(PUP-7804) Do not use server setting when failover fails

### DIFF
--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -207,7 +207,7 @@ class Puppet::Indirector::Request
       if primary_server = Puppet.settings[:server_list][0]
         bound_server = primary_server[0]
       else
-        bound_server = nil
+        bound_server = Puppet.settings[:server]
       end
     end
 
@@ -217,11 +217,11 @@ class Puppet::Indirector::Request
       if primary_server = Puppet.settings[:server_list][0]
         bound_port = primary_server[1]
       else
-        bound_port = nil
+        bound_port = Puppet.settings[:masterport]
       end
     end
-    self.server = default_server || bound_server || Puppet.settings[:server]
-    self.port   = default_port || bound_port || Puppet.settings[:masterport]
+    self.server = default_server || bound_server
+    self.port   = default_port || bound_port
 
     Puppet.debug "No more servers left, falling back to #{self.server}:#{self.port}" if Puppet.settings[:use_srv_records]
 


### PR DESCRIPTION
Previously, when failover was attempted but unsuccessful, the
agent would default to using the `server` setting. This is
incorrect, since that setting might be at its default value,
or be set to the same value as one of the server_list entries.

Instead, we should not attempt to connect to any server if failover
was not successful. This allows the agent to "fail fast", instead of
timing out trying to connect to an incorrect server.