### PR TITLE
(PUP-7760) Remove automatic element separator padding

### DIFF
--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -271,7 +271,7 @@ class StringConverter
   DEFAULT_ARRAY_FORMAT.freeze
 
   DEFAULT_HASH_FORMAT                           = Format.new('%h')
-  DEFAULT_HASH_FORMAT.separator                 = ','.freeze
+  DEFAULT_HASH_FORMAT.separator                 = ', '.freeze
   DEFAULT_HASH_FORMAT.separator2                = ' => '.freeze
   DEFAULT_HASH_FORMAT.container_string_formats  = DEFAULT_CONTAINER_FORMATS
   DEFAULT_HASH_FORMAT.freeze
@@ -1024,7 +1024,10 @@ class StringConverter
     string_formats = format.container_string_formats || DEFAULT_CONTAINER_FORMATS
     delims         = format.delimiter_pair(DEFAULT_HASH_DELIMITERS)
 
-    sep = format.alt? ? "#{sep}\n" : "#{sep} "
+    if format.alt? 
+      sep = sep.rstrip unless sep[-1] == "\n"
+      sep = "#{sep}\n"
+    end
 
     cond_break     = ''
     padding        = ''

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -265,8 +265,8 @@ class StringConverter
   }.freeze
 
   DEFAULT_ARRAY_FORMAT                          = Format.new('%a')
-  DEFAULT_ARRAY_FORMAT.separator                = ','.freeze
-  DEFAULT_ARRAY_FORMAT.separator2               = ','.freeze
+  DEFAULT_ARRAY_FORMAT.separator                = ', '.freeze
+  DEFAULT_ARRAY_FORMAT.separator2               = ', '.freeze
   DEFAULT_ARRAY_FORMAT.container_string_formats = DEFAULT_CONTAINER_FORMATS
   DEFAULT_ARRAY_FORMAT.freeze
 
@@ -976,12 +976,13 @@ class StringConverter
           # or, if indenting, and previous was an array or hash, then break and continue on next line
           # indented.
           if (sz_break && !is_a_or_h?(v)) || (format.alt? && i > 0 && is_a_or_h?(val[i-1]) && !is_a_or_h?(v))
+            buf.rstrip! unless buf[-1] == "\n"
             buf << "\n"
             buf << children_indentation.padding
-          elsif !(format.alt? && is_a_or_h?(v))
-            buf << ' '
           end
         end
+        # remove trailing space added by separator if followed by break
+        buf.rstrip! if buf[-1] == ' ' && str_val[0] == "\n"
         buf << str_val
       end
       buf << delims[1]

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -647,6 +647,10 @@ describe 'The string converter' do
         'separator' => ' '
       } => "(1 'hello')",
 
+      {'format' => '%(a',
+        'separator' => ''
+      } => "(1'hello')",
+
       {'format' => '%|a',
         'separator' => ' '
       } => "|1 'hello'|",
@@ -799,6 +803,11 @@ describe 'The string converter' do
        {'format' => '%(h',
          'separator2' => ' '
        } => "(1 'hello', 2 'world')",
+
+       {'format' => '%(h',
+         'separator' => '',
+         'separator2' => ''
+       } => "(1'hello'2'world')",
 
        {'format' => '%(h',
          'separator' => ' >> ',

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -644,15 +644,15 @@ describe 'The string converter' do
       "% a"  => "1, 'hello'",
 
       {'format' => '%(a',
-        'separator' => ''
+        'separator' => ' '
       } => "(1 'hello')",
 
       {'format' => '%|a',
-        'separator' => ''
+        'separator' => ' '
       } => "|1 'hello'|",
 
       {'format' => '%(a',
-        'separator' => '',
+        'separator' => ' ',
         'string_formats' => {Puppet::Pops::Types::PIntegerType::DEFAULT => '%#x'}
       } => "(0x1 'hello')",
     }.each do |fmt, result |
@@ -674,7 +674,7 @@ describe 'The string converter' do
     end
 
     it 'indents elements in alternate mode' do
-      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>"," } }
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>", " } }
       # formatting matters here
       result = [
        "[1, 2, 9, 9,",
@@ -689,7 +689,7 @@ describe 'The string converter' do
     end
 
     it 'treats hashes as nested arrays wrt indentation' do
-      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>"," } }
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>", " } }
       # formatting matters here
       result = [
        "[1, 2, 9, 9,",
@@ -704,7 +704,7 @@ describe 'The string converter' do
     end
 
     it 'indents and breaks when a sequence > given width, in alternate mode' do
-      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#3a', 'separator' =>"," } }
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#3a', 'separator' =>", " } }
       # formatting matters here
       result = [
        "[ 1,",
@@ -722,7 +722,7 @@ describe 'The string converter' do
     end
 
     it 'indents and breaks when a sequence (placed last) > given width, in alternate mode' do
-      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#3a', 'separator' =>"," } }
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#3a', 'separator' =>", " } }
       # formatting matters here
       result = [
        "[ 1,",
@@ -740,7 +740,7 @@ describe 'The string converter' do
     end
 
     it 'indents and breaks nested sequences when one is placed first' do
-      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>"," } }
+      string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>", " } }
       # formatting matters here
       result = [
        "[",
@@ -851,7 +851,7 @@ describe 'The string converter' do
 
       it 'both hash and array renders with breaks and indentation if so specified for both' do
         string_formats = {
-          Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#1a', 'separator' =>"," },
+          Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#1a', 'separator' =>", " },
           Puppet::Pops::Types::PHashType::DEFAULT => { 'format' => '%#h', 'separator' =>"," }
         }
         result = [
@@ -867,7 +867,7 @@ describe 'The string converter' do
 
       it 'hash, but not array is rendered with breaks and indentation if so specified only for the hash' do
         string_formats = {
-          Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%a', 'separator' =>"," },
+          Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%a', 'separator' =>", " },
           Puppet::Pops::Types::PHashType::DEFAULT => { 'format' => '%#h', 'separator' =>"," }
         }
         result = [

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -801,7 +801,7 @@ describe 'The string converter' do
        } => "(1 'hello', 2 'world')",
 
        {'format' => '%(h',
-         'separator' => ' >>',
+         'separator' => ' >> ',
          'separator2' => ' <=> ',
          'string_formats' => {Puppet::Pops::Types::PIntegerType::DEFAULT => '%#x'}
        } => "(0x1 <=> 'hello' >> 0x2 <=> 'world')",


### PR DESCRIPTION
Before this the string converter would pad the given element separator for array and hashes with an extra space when producing the string representation.
This was bad because it made it impossible to have an empty string as a separator.