### PR TITLE
(maint) Remove -R flag from pkg version

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   end
 
   def self.get_version_list
-    pkg(['version', '-voRL='])
+    pkg(['version', '-voL='])
   end
 
   def self.get_latest_version(origin, version_list)


### PR DESCRIPTION
According to pkg-version(8):

```
     When -R is used, package repository catalogues will be automatically
     updated whenever pkg version is run by a user ID with write access to the
     package database, unless disabled by the -U flag or setting
     REPO_AUTOUPDATE to NO in pkg.conf(5).
[...]
     -R, --remote
                 Use repository catalogue for determining if a package is out
                 of date.  This is the default if neither the ports index nor
                 the ports tree exists.
```

So basically, when passing `-R`, we **force** a catalog refresh, that will *fail* if no remote package repository is configured (e.g. the user install software through ports and has disabled the default FreeBSD package repository).

By removing the `-R` flag, the behavior will not change on systems where remote repositories are configured (because it's the default behavior in such a situation), and the provider will stop failing when no remote repository is configured.