### PR TITLE
(maint) Update link to acceptance test docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Setting up and running tests
 
 * [Quickstart Guide](quickstart.md)
 * [RSpec Tutorial](rspec_tutorial.md)
-* [Running acceptance tests](acceptance_tests.md)
+* [Running acceptance tests](../acceptance/README.md)
 
 Developer References
 


### PR DESCRIPTION
In `docs/index.md`, update the link to the documentation on how to run
the acceptance tests.