### PR TITLE
(PUP-7645) Load translations from PO file when running as a gem

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -1,0 +1,70 @@
+require 'puppet/util/platform'
+
+module Puppet::GettextConfig
+  LOCAL_PATH = File.absolute_path('../../../locales', File.dirname(__FILE__))
+  POSIX_PATH = File.absolute_path('../../../../../share/locale', File.dirname(__FILE__))
+  WINDOWS_PATH = File.absolute_path('../../../../../../../puppet/share/locale', File.dirname(__FILE__))
+
+  # Search for puppet gettext config files
+  # @return [String] path to the config, or nil if not found
+  def self.puppet_locale_path
+    if File.exist?(LOCAL_PATH)
+      return LOCAL_PATH
+    elsif Puppet::Util::Platform.windows? && File.exist?(WINDOWS_PATH)
+      return WINDOWS_PATH
+    elsif !Puppet::Util::Platform.windows? && File.exist?(POSIX_PATH)
+      return POSIX_PATH
+    else
+      nil
+    end
+  end
+
+  # Determine which translation file format to use
+  # @param conf_path [String] the path to the gettext config file
+  # @return [Symbol] :mo if in a package structure, :po otherwise
+  def self.translation_mode(conf_path)
+    if WINDOWS_PATH == conf_path || POSIX_PATH == conf_path
+      return :mo
+    else
+      return :po
+    end
+  end
+
+  # Attempt to initialize the gettext-setup gem
+  # @param path [String] to gettext config file
+  # @param file_format [Symbol] translation file format to use, either :po or :mo
+  # @return true if initialization succeeded, false otherwise
+  def self.initialize(conf_file_location, file_format)
+    unless file_format == :po || file_format == :mo
+      raise Puppet::Error, "Unsupported translation file format #{file_format}; please use :po or :mo"
+    end
+
+    begin
+      require 'gettext-setup'
+      require 'locale'
+
+      if conf_file_location && File.exists?(conf_file_location)
+        if GettextSetup.method(:initialize).parameters.count == 1
+          # For use with old gettext-setup gem versions, will load PO files only
+          GettextSetup.initialize(conf_file_location)
+        else
+          GettextSetup.initialize(conf_file_location, :file_format => file_format)
+        end
+        # Only change this once.
+        # Because negotiate_locales will only return a non-default locale if
+        # the system locale matches a translation set actually available for the
+        # given gettext project, we don't want this to get set back to default if
+        # we load a module that doesn't have translations, but Puppet does have
+        # translations for the user's locale.
+        if FastGettext.locale == GettextSetup.default_locale
+          FastGettext.locale = GettextSetup.negotiate_locale(Locale.current.language)
+        end
+        true
+      else
+        false
+      end
+    rescue LoadError
+      false
+    end
+  end
+end

--- a/lib/puppet/gettext/stubs.rb
+++ b/lib/puppet/gettext/stubs.rb
@@ -1,0 +1,11 @@
+# These stub the translation methods noramlly brought in
+# by FastGettext. Used when Gettext could not be properly
+# initialized.
+def _(msg)
+  msg
+end
+
+def n_(*args, &block)
+  plural = args[2] == 1 ? args[0] : args[1]
+  block ? block.call : plural
+end

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -97,15 +97,7 @@ class Puppet::Module
     @absolute_path_to_manifests = Puppet::FileSystem::PathPattern.absolute(manifests)
 
     # i18n initialization for modules
-    if Puppet::GETTEXT_AVAILABLE
-      begin
-        initialize_i18n
-      rescue Exception => e
-        Puppet.warning _("GettextSetup initialization for %{module_name} failed with: %{error_message}") % { module_name: name, error_message: e.message }
-      end
-    else
-      Puppet.warning _("GettextSetup is not available, skipping GettextSetup initialization for %{module_name}.") % { module_name: name }
-    end
+    initialize_i18n
   end
 
   # @deprecated The puppetversion module metadata field is no longer used.
@@ -403,7 +395,7 @@ class Puppet::Module
     locales_path = File.absolute_path('locales', path)
 
     begin
-      GettextSetup.initialize(locales_path)
+      Puppet::GettextConfig.initialize(locales_path, :po)
       Puppet.debug "#{module_name} initialized for i18n: #{GettextSetup.translation_repositories[module_name]}"
     rescue
       config_path = File.absolute_path('config.yaml', locales_path)

--- a/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet.rb
+++ b/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet.rb
@@ -1,7 +1,5 @@
 module SemanticPuppet
-  if Puppet::GETTEXT_AVAILABLE
-    GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
-  end
+  Puppet::GettextConfig.initialize(File.absolute_path('../locales', File.dirname(__FILE__)), :po)
 
   autoload :Version, 'semantic_puppet/version'
   autoload :VersionRange, 'semantic_puppet/version_range'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,19 +8,18 @@ $LOAD_PATH.unshift File.join(dir, 'lib')
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear
 
-# Stub out gettext's `_` method, which attempts to load translations.
-# Several of our mocks (mostly around file system interaction) are broken by
-# FastGettext's implementation of this method.
-def _(msg)
-  msg
-end
-
 begin
   require 'rubygems'
 rescue LoadError
 end
 
 require 'puppet'
+
+# Stub out gettext's `_` and `n_()` methods, which attempt to load translations.
+# Several of our mocks (mostly around file system interaction) are broken by
+# FastGettext's implementation of these methods.
+require 'puppet/gettext/stubs'
+
 gem 'rspec', '>=3.1.0'
 require 'rspec/expectations'
 require 'rspec/its'

--- a/spec/unit/gettext_config_spec.rb
+++ b/spec/unit/gettext_config_spec.rb
@@ -1,0 +1,57 @@
+require 'puppet/gettext/config'
+require 'spec_helper'
+
+describe Puppet::GettextConfig do
+  require 'puppet_spec/files'
+  include PuppetSpec::Files
+
+  let(:local_path) do
+    local_path ||= Puppet::GettextConfig::LOCAL_PATH
+  end
+
+  let(:windows_path) do
+    windows_path ||= Puppet::GettextConfig::WINDOWS_PATH
+  end
+
+  let(:posix_path) do
+    windows_path ||= Puppet::GettextConfig::POSIX_PATH
+  end
+
+  describe 'translation mode selection' do
+    it 'should select PO mode when given a local config path' do
+      expect(Puppet::GettextConfig.translation_mode(local_path)).to eq(:po)
+    end
+
+    it 'should select PO mode when given a non-package config path' do
+      expect(Puppet::GettextConfig.translation_mode('../fake/path')).to eq(:po)
+    end
+
+    it 'should select MO mode when given a Windows package config path' do
+      expect(Puppet::GettextConfig.translation_mode(windows_path)).to eq(:mo)
+    end
+
+    it 'should select MO mode when given a POSIX package config path' do
+      expect(Puppet::GettextConfig.translation_mode(posix_path)).to eq(:mo)
+    end
+  end
+
+  describe 'initialization' do
+    context 'when given a nil config path' do
+      it 'should return false' do
+        expect(Puppet::GettextConfig.initialize(nil, :po)).to be false
+      end
+    end
+
+    context 'when given a valid config file location' do
+      it 'should return true' do
+        expect(Puppet::GettextConfig.initialize(local_path, :po)).to be true
+      end
+    end
+
+    context 'when given a bad file format' do
+      it 'should raise an exception' do
+        expect { Puppet::GettextConfig.initialize(local_path, :bad_format) }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Normally, Puppet loads translations from a binary MO file, to match what
the C++ projects do. However, since we do not check these MO files into
source control, instead building them as part of the agent package build,
they are not available when running from source or when running as a
gem. The only functionality change in this refactor causes Puppet to
load PO files when its gettext config files are found locally, rather
than in the puppet-agent package structure.

Besides that, this commit significantly refactors the way gettext-setup is
initialized to encapsulated the complicated logic around finding config
files and choosing translation file format.