### PR TITLE
(PUP-6241) Only expect incorrect File exception on JRuby 1.7

### DIFF
--- a/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
+++ b/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
@@ -1,5 +1,7 @@
 test_name "C97899 - Agent run should fail if environment is unreadable" do
   skip_test 'requires a puppetserver master for managing the environment' if hosts_with_role(hosts, 'master').length == 0 or not @options[:is_puppetserver]
+  jruby_version = on(master, 'puppetserver ruby --version').stdout
+  skip_test 'This is only valid on JRuby 1.7' unless jruby_version =~ /^jruby 1\.7/
 
   testdir = ''
   env_path = ''


### PR DESCRIPTION
Previously, our tests for an environment bug on JRuby 1.7 would execute
on any Puppet Server instance.

Since we have a regular JRuby 9k version of our Puppet Server jobs this
means this test, which expects a bug that only exists in JRuby 1.7
fails.

This patch updates the acceptance test to skip if Puppet Server is using
JRuby 9k.