### PR TITLE
(PUP-7678) Add functions any and all

### DIFF
--- a/lib/puppet/functions/all.rb
+++ b/lib/puppet/functions/all.rb
@@ -89,24 +89,12 @@ Puppet::Functions.create_function(:all) do
   end
 
   def all_Enumerable_1(enumerable)
-    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-      begin
-        loop { return false unless yield(enum.next) }
-      rescue StopIteration
-      end
-    true
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable).all? { |e| yield(e) }
   end
 
   def all_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    index = 0
-    begin
-      loop do
-        return false unless yield(index, enum.next)
-        index += 1
-      end
-    rescue StopIteration
-    end
-    return true
+    enum.each_with_index { |e, i| return false unless yield(i, e) }
+    true
   end
 end

--- a/lib/puppet/functions/all.rb
+++ b/lib/puppet/functions/all.rb
@@ -81,19 +81,11 @@ Puppet::Functions.create_function(:all) do
   end
 
   def all_Hash_1(hash)
-    enumerator = hash.each_pair
-    hash.size.times do
-      return false unless yield(enumerator.next)
-    end
-    true
+    hash.each_pair.all? { |x| yield(x) }
   end
 
   def all_Hash_2(hash)
-    enumerator = hash.each_pair
-    hash.size.times do
-      return false unless yield(*enumerator.next)
-    end
-    true
+    hash.each_pair.all? { |x,y| yield(x,y) }
   end
 
   def all_Enumerable_1(enumerable)

--- a/lib/puppet/functions/all.rb
+++ b/lib/puppet/functions/all.rb
@@ -1,0 +1,120 @@
+# Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+# repeatedly using each value in a data structure until the lambda returns a non "truthy" value which
+# makes the function return `false`, or if the end of the iteration is reached, `true` is returned.
+#
+# This function takes two mandatory arguments, in this order:
+#
+# 1. An array, hash, or other iterable object that the function will iterate over.
+# 2. A lambda, which the function calls for each element in the first argument. It can
+# request one or two parameters.
+#
+# @example Using the `all` function
+#
+# `$data.all |$parameter| { <PUPPET CODE BLOCK> }`
+#
+# or
+#
+# `all($data) |$parameter| { <PUPPET CODE BLOCK> }`
+#
+# @example Using the `all` function with an Array and a one-parameter lambda
+#
+# ~~~ puppet
+# # For the array $data, run a lambda that checks that all values are multiples of 10
+# $data = [10, 20, 30]
+# notice $data.all |$item| { $item % 10 == 0 }
+# ~~~
+#
+# Would notice `true`.
+#
+# When the first argument is a `Hash`, Puppet passes each key and value pair to the lambda
+# as an array in the form `[key, value]`.
+#
+# @example Using the `all` function with a `Hash` and a one-parameter lambda
+#
+# ~~~ puppet
+# # For the hash $data, run a lambda using each item as a key-value array
+# $data = { 'a_0'=> 10, 'b_1' => 20 }
+# notice $data.all |$item| { $item[1] % 10 == 0  }
+# ~~~
+#
+# Would notice `true` if all values in the hash are multiples of 10.
+#
+# When the lambda accepts two arguments, the first argument gets the index in an array
+# or the key from a hash, and the second argument the value.
+#
+#
+# @example Using the `all` function with a hash and a two-parameter lambda
+#
+# ~~~ puppet
+# # Check that all values are a multiple of 10 and keys start with 'abc'
+# $data = {abc_123 => 10, abc_42 => 20, abc_blue => 30}
+# notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
+# ~~~
+#
+# Would notice true.
+#
+# For an general examples that demonstrates iteration, see the Puppet
+# [iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+# documentation.
+#
+# @since 5.2.0
+#
+Puppet::Functions.create_function(:all) do
+  dispatch :all_Hash_2 do
+    param 'Hash[Any, Any]', :hash
+    block_param 'Callable[2,2]', :block
+  end
+
+  dispatch :all_Hash_1 do
+    param 'Hash[Any, Any]', :hash
+    block_param 'Callable[1,1]', :block
+  end
+
+  dispatch :all_Enumerable_2 do
+    param 'Iterable', :enumerable
+    block_param 'Callable[2,2]', :block
+  end
+
+  dispatch :all_Enumerable_1 do
+    param 'Iterable', :enumerable
+    block_param 'Callable[1,1]', :block
+  end
+
+  def all_Hash_1(hash)
+    enumerator = hash.each_pair
+    hash.size.times do
+      return false unless yield(enumerator.next)
+    end
+    true
+  end
+
+  def all_Hash_2(hash)
+    enumerator = hash.each_pair
+    hash.size.times do
+      return false unless yield(*enumerator.next)
+    end
+    true
+  end
+
+  def all_Enumerable_1(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
+      begin
+        loop { return false unless yield(enum.next) }
+      rescue StopIteration
+      end
+    true
+  end
+
+  def all_Enumerable_2(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
+    index = 0
+    begin
+      loop do
+        return false unless yield(index, enum.next)
+        index += 1
+      end
+    rescue StopIteration
+    end
+    return true
+  end
+end

--- a/lib/puppet/functions/any.rb
+++ b/lib/puppet/functions/any.rb
@@ -1,0 +1,126 @@
+# Runs a [lambda](http://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html)
+# repeatedly using each value in a data structure until the lambda returns a "truthy" value which
+# makes the function return `true`, or if the end of the iteration is reached, false is returned.
+#
+# This function takes two mandatory arguments, in this order:
+#
+# 1. An array, hash, or other iterable object that the function will iterate over.
+# 2. A lambda, which the function calls for each element in the first argument. It can
+# request one or two parameters.
+#
+# @example Using the `any` function
+#
+# `$data.any |$parameter| { <PUPPET CODE BLOCK> }`
+#
+# or
+#
+# `any($data) |$parameter| { <PUPPET CODE BLOCK> }`
+#
+# @example Using the `any` function with an Array and a one-parameter lambda
+#
+# ~~~ puppet
+# # For the array $data, run a lambda that checks if an unknown hash contains those keys
+# $data = ["routers", "servers", "workstations"]
+# $looked_up = lookup('somekey', Hash)
+# notice $data.any |$item| { $looked_up[$item] }
+# ~~~
+#
+# Would notice `true` if the looked up hash had a value that is neither `false` nor `undef` for at least
+# one of the keys. That is, it is equivalent to the expression
+# `$lookued_up[routers] || $looked_up[servers] || $looked_up[workstations]`.
+#
+# When the first argument is a `Hash`, Puppet passes each key and value pair to the lambda
+# as an array in the form `[key, value]` and returns the original hash.
+#
+# @example Using the `each` function with a `Hash` and a one-parameter lambda
+#
+# ~~~ puppet
+# # For the hash $data, run a lambda using each item as a key-value array that creates a
+# # resource for each item.
+# $data = {"rtr" => "Router", "svr" => "Server", "wks" => "Workstation"}
+# $looked_up = lookup('somekey', Hash)
+# notice $data.any |$item| { $looked_up[$item[0]] }
+# ~~~
+#
+# Would notice `true` if the looked up hash had a value for one of the wanted key that is
+# neither `false` nor `undef`.
+#
+# When the lambda accepts two arguments, the first argument gets the index in an array
+# or the key from a hash, and the second argument the value.
+#
+#
+# @example Using the `any` function with an array and a two-parameter lambda
+#
+# ~~~ puppet
+# # Check if there is an even numbered index that has a non String value
+# $data = [key1, 1, 2, 2]
+# notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
+# ~~~
+#
+# Would notice true as the index `2` is even and not a `String`
+#
+# For an general examples that demonstrates iteration, see the Puppet
+# [iteration](https://docs.puppetlabs.com/puppet/latest/reference/lang_iteration.html)
+# documentation.
+#
+# @since 5.2.0
+#
+Puppet::Functions.create_function(:any) do
+  dispatch :any_Hash_2 do
+    param 'Hash[Any, Any]', :hash
+    block_param 'Callable[2,2]', :block
+  end
+
+  dispatch :any_Hash_1 do
+    param 'Hash[Any, Any]', :hash
+    block_param 'Callable[1,1]', :block
+  end
+
+  dispatch :any_Enumerable_2 do
+    param 'Iterable', :enumerable
+    block_param 'Callable[2,2]', :block
+  end
+
+  dispatch :any_Enumerable_1 do
+    param 'Iterable', :enumerable
+    block_param 'Callable[1,1]', :block
+  end
+
+  def any_Hash_1(hash)
+    enumerator = hash.each_pair
+    hash.size.times do
+      return true if yield(enumerator.next)
+    end
+    false
+  end
+
+  def any_Hash_2(hash)
+    enumerator = hash.each_pair
+    hash.size.times do
+      return true if yield(*enumerator.next)
+    end
+    false
+  end
+
+  def any_Enumerable_1(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
+      begin
+        loop { return true if yield(enum.next) }
+      rescue StopIteration
+      end
+    false
+  end
+
+  def any_Enumerable_2(enumerable)
+    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
+    index = 0
+    begin
+      loop do
+        return true if yield(index, enum.next)
+        index += 1
+      end
+    rescue StopIteration
+    end
+    return false
+  end
+end

--- a/lib/puppet/functions/any.rb
+++ b/lib/puppet/functions/any.rb
@@ -30,13 +30,12 @@
 # `$lookued_up[routers] || $looked_up[servers] || $looked_up[workstations]`.
 #
 # When the first argument is a `Hash`, Puppet passes each key and value pair to the lambda
-# as an array in the form `[key, value]` and returns the original hash.
+# as an array in the form `[key, value]`.
 #
-# @example Using the `each` function with a `Hash` and a one-parameter lambda
+# @example Using the `any` function with a `Hash` and a one-parameter lambda
 #
 # ~~~ puppet
-# # For the hash $data, run a lambda using each item as a key-value array that creates a
-# # resource for each item.
+# # For the hash $data, run a lambda using each item as a key-value array.
 # $data = {"rtr" => "Router", "svr" => "Server", "wks" => "Workstation"}
 # $looked_up = lookup('somekey', Hash)
 # notice $data.any |$item| { $looked_up[$item[0]] }

--- a/lib/puppet/functions/any.rb
+++ b/lib/puppet/functions/any.rb
@@ -94,24 +94,12 @@ Puppet::Functions.create_function(:any) do
   end
 
   def any_Enumerable_1(enumerable)
-    enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-      begin
-        loop { return true if yield(enum.next) }
-      rescue StopIteration
-      end
-    false
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable).any? { |e| yield(e) }
   end
 
   def any_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    index = 0
-    begin
-      loop do
-        return true if yield(index, enum.next)
-        index += 1
-      end
-    rescue StopIteration
-    end
-    return false
+    enum.each_with_index { |e, i| return true if yield(i, e) }
+    false
   end
 end

--- a/lib/puppet/functions/any.rb
+++ b/lib/puppet/functions/any.rb
@@ -86,19 +86,11 @@ Puppet::Functions.create_function(:any) do
   end
 
   def any_Hash_1(hash)
-    enumerator = hash.each_pair
-    hash.size.times do
-      return true if yield(enumerator.next)
-    end
-    false
+    hash.each_pair.any? { |x| yield(x) }
   end
 
   def any_Hash_2(hash)
-    enumerator = hash.each_pair
-    hash.size.times do
-      return true if yield(*enumerator.next)
-    end
-    false
+    hash.each_pair.any? { |x,y| yield(x, y) }
   end
 
   def any_Enumerable_1(enumerable)

--- a/spec/unit/functions/all_spec.rb
+++ b/spec/unit/functions/all_spec.rb
@@ -1,0 +1,97 @@
+require 'puppet'
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+require 'shared_behaviours/iterative_functions'
+
+describe 'the all method' do
+  include PuppetSpec::Compiler
+
+  context "should be callable as" do
+    it 'all on an array' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [1,2,3]
+        $n = $a.all |$v| { $v > 0 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'all on an array with index' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [0,2,4]
+        $n = $a.all |$i, $v| { $v == $i * 2 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'all on a hash selecting entries' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = {0=>0,1=>2,2=>4}
+        $n = $a.all |$e| { $e[1] == $e[0]*2 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'all on a hash selecting key and value' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = {0=>0,1=>2,2=>4}
+        $n = $a.all |$k,$v| { $v == $k*2 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+  end
+
+  context "produces a boolean" do
+    it 'true when boolean true is found' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.all |$v| { true }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'true when truthy is found' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.all |$v| { 42 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'false when truthy is not found (all undef)' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.all |$v| { undef }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "false")['ensure']).to eq('present')
+    end
+
+    it 'false when truthy is not found (all false)' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.all |$v| { false }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "false")['ensure']).to eq('present')
+    end
+
+  end
+  it_should_behave_like 'all iterative functions argument checks', 'any'
+  it_should_behave_like 'all iterative functions hash handling', 'any'
+
+end

--- a/spec/unit/functions/any_spec.rb
+++ b/spec/unit/functions/any_spec.rb
@@ -1,0 +1,109 @@
+require 'puppet'
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+require 'shared_behaviours/iterative_functions'
+
+describe 'the any method' do
+  include PuppetSpec::Compiler
+
+  context "should be callable as" do
+    it 'any on an array' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [1,2,3]
+        $n = $a.any |$v| { $v == 2 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'any on an array with index' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.any |$i, $v| { $i == 2 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'any on a hash selecting entries' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = {'a'=>'ah','b'=>'be','c'=>'ce'}
+        $n = $a.any |$e| { $e[1] == 'be' }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'any on a hash selecting key and value' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = {'a'=>'ah','b'=>'be','c'=>'ce'}
+        $n = $a.any |$k, $v| { $v == 'be' }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+  end
+
+  context 'stops iteration when result is known' do
+    it 'true when boolean true is found' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [1,2,3]
+        $n = $a.any |$v| { if $v == 1 { true } else { fail("unwanted") } }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+  end
+
+  context "produces a boolean" do
+    it 'true when boolean true is found' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.any |$v| { true }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'true when truthy is found' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.any |$v| { 42 }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "true")['ensure']).to eq('present')
+    end
+
+    it 'false when truthy is not found (all undef)' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.any |$v| { undef }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "false")['ensure']).to eq('present')
+    end
+
+    it 'false when truthy is not found (all false)' do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        $a = [6,6,6]
+        $n = $a.any |$v| { false }
+        file { "$n": ensure => present }
+      MANIFEST
+
+      expect(catalog.resource(:file, "false")['ensure']).to eq('present')
+    end
+
+  end
+  it_should_behave_like 'all iterative functions argument checks', 'any'
+  it_should_behave_like 'all iterative functions hash handling', 'any'
+
+end


### PR DESCRIPTION
This adds the functions `any()` and `all()` (with functionality comparable to Ruby's `any?` and `all?`.