### PR TITLE
(maint) Restore attempting to remove files even if backup fails

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -727,7 +727,7 @@ Puppet::Type.newtype(:file) do
       if can_backup?(current_type)
         backup_existing
       else
-        self.fail "Could not back up file of type #{current_type}; will not remove"
+        self.warning "Could not back up file of type #{current_type}"
       end
     end
 

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -907,8 +907,8 @@ describe Puppet::Type.type(:file) do
         file.stubs(:stat).returns stub('stat', :ftype => 'directory')
 
         file.expects(:perform_backup).never
-
-        expect { file.remove_existing(:file) }.to raise_error(Puppet::Error, /Could not back up file of type directory; will not remove/)
+        file.expects(:warning).with("Could not back up file of type directory")
+        expect(file.remove_existing(:file)).to eq(false)
       end
 
       it "should backup directories if backup is true and force is true" do
@@ -935,9 +935,6 @@ describe Puppet::Type.type(:file) do
       file.stat
       file.stubs(:stat).returns stub('stat', :ftype => 'directory')
 
-      file.expects(:remove_directory).never
-      expect { file.remove_existing(:file) }.to raise_error(Puppet::Error, /Could not back up file of type directory; will not remove/)
-      #expect(file.instance_variable_get(:@needs_stat)).to eq(nil)
       expect(file.instance_variable_get(:@stat)).to eq(nil)
     end
 
@@ -976,7 +973,8 @@ describe Puppet::Type.type(:file) do
     it "should fail if the file is not a directory, link, file, fifo, socket, or is unknown" do
       file.stubs(:stat).returns stub('stat', :ftype => 'blockSpecial')
 
-      expect { file.remove_existing(:file) }.to raise_error(Puppet::Error, /Could not back up file of type blockSpecial; will not remove/)
+      file.expects(:warning).with("Could not back up file of type blockSpecial")
+      expect { file.remove_existing(:file) }.to raise_error(Puppet::Error, /Could not remove files of type blockSpecial/)
     end
 
     it "should invalidate the existing stat of the file" do


### PR DESCRIPTION
The fix for PUP-6966 introduced a new error, halting file removal if
backup could not be performed. While ultimately this seems like the
correct behavior, we will need to further investigate the implications
of this logic change. For the time being, this commit changes the
error to a warning, allowing the code to proceed to try to remove the
file even if backup has failed.