### PR TITLE
(maint) Skip yum package test on ec2

### DIFF
--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -2,6 +2,7 @@ test_name "test the yum package provider"
 
 confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
 confine :except, :platform => /centos-4|el-4/ # PUP-5227
+confine :except, :hypervisor => /ec2/
 
 require 'puppet/acceptance/rpm_util'
 extend Puppet::Acceptance::RpmUtils


### PR DESCRIPTION
The guid package used by the yum package test is not present in the
repos on targeted Amazon Linux instances in EC2. Therefore, this
test should be skipped when being tested in that environment.