### PR TITLE
(PUP-7807) Add mount options on AIX remount

### DIFF
--- a/lib/puppet/provider/mount.rb
+++ b/lib/puppet/provider/mount.rb
@@ -27,7 +27,11 @@ module Puppet::Provider::Mount
     #TRANSLATORS refers to remounting a file system
     info _("Remounting")
     if resource[:remounts] == :true
-      mountcmd "-o", "remount", resource[:name]
+      if Facter.value(:kernel) == 'AIX' && self.options && !self.options.empty?
+        mountcmd "-o", self.options + ",remount", resource[:name]
+      else
+        mountcmd "-o", "remount", resource[:name]
+      end
     elsif ["FreeBSD", "DragonFly", "OpenBSD"].include?(Facter.value(:operatingsystem))
       if self.options && !self.options.empty?
         options = self.options + ",update"


### PR DESCRIPTION
Prior to this commit, the mount resource on AIX would not remount NFS
shares with the mount options specified. Since AIX did not read the NFS
options from the `/etc/filesystems`, the share would be remounted
without options.

This commit adds a simple check to ensure all AIX remounts are done with
the specified options including JFS2.