### PR TITLE
(PUP-7818) Prefetch AIX packages when not all have sources

### DIFF
--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
 
     return unless packages.detect { |name, package| package.should(:ensure) == :latest }
 
-    sources = packages.collect { |name, package| package[:source] }.uniq
+    sources = packages.collect { |name, package| package[:source] }.uniq.compact
 
     updates = {}
     sources.each do |source|

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -104,4 +104,12 @@ mypackage                 1.2.3.3         Already superseded by 1.2.3.4
     @provider.expects(:install).with(false)
     @provider.update
   end
+
+  it "should prefetch when some packages lack sources" do
+    latest = Puppet::Type.type(:package).new(:name => 'mypackage', :ensure => :latest, :source => 'mysource', :provider => :aix)
+    absent = Puppet::Type.type(:package).new(:name => 'otherpackage', :ensure => :absent, :provider => :aix)
+    Process.stubs(:euid).returns(0)
+    provider_class.expects(:execute).returns 'mypackage:mypackage.rte:1.8.6.4::I:T:::::N:A Super Cool Package::::0::\n'
+    provider_class.prefetch({ 'mypackage' => latest, 'otherpackage' => absent })
+  end
 end


### PR DESCRIPTION
Previously, the prefetch for the `aix` package provider assumed
that all resources would have a `source` parameter. While this
parameter is required in order to *install* a package, it is
not needed to remove one, so it's possible some package resources
might lack a value.

This fixes the prefetch to skip any empty source values, allowing
prefetch to succeed when some packages do not have a source.