### PR TITLE
(PUP-7821) Handle corrupt windows environment variables

### DIFF
--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -53,10 +53,10 @@ module Puppet::Util::Windows::APITypes
     alias_method :read_word,  :read_uint16
     alias_method :read_array_of_wchar, :read_array_of_uint16
 
-    def read_wide_string(char_length, dst_encoding = Encoding::UTF_8)
+    def read_wide_string(char_length, dst_encoding = Encoding::UTF_8, encode_options = {})
       # char_length is number of wide chars (typically excluding NULLs), *not* bytes
       str = get_bytes(0, char_length * 2).force_encoding('UTF-16LE')
-      str.encode(dst_encoding)
+      str.encode(dst_encoding, str.encoding, encode_options)
     rescue Exception => e
       Puppet.debug "Unable to convert value #{str.dump} to encoding #{dst_encoding} due to #{e.inspect}"
       raise
@@ -66,7 +66,8 @@ module Puppet::Util::Windows::APITypes
     # @param null_terminator [Symbol] Number of number of null wchar characters, *not* bytes, that determine the end of the string
     #   null_terminator = :single_null, then the terminating sequence is two bytes of zero.   This is UNIT16 = 0
     #   null_terminator = :double_null, then the terminating sequence is four bytes of zero.  This is UNIT32 = 0
-    def read_arbitrary_wide_string_up_to(max_char_length = 512, null_terminator = :single_null)
+    # @param encode_options [Hash] Accepts the same option hash that may be passed to String#encode in Ruby
+    def read_arbitrary_wide_string_up_to(max_char_length = 512, null_terminator = :single_null, encode_options = {})
       if null_terminator != :single_null && null_terminator != :double_null
         raise "Unable to read wide strings with #{null_terminator} terminal nulls"
       end
@@ -76,11 +77,11 @@ module Puppet::Util::Windows::APITypes
 
       # Look for a null terminating characters; if found, read up to that null (exclusive)
       (0...max_char_length - terminator_width).each do |i|
-        return read_wide_string(i) if send(reader_method, (i * 2)) == 0
+        return read_wide_string(i, Encoding::UTF_8, encode_options) if send(reader_method, (i * 2)) == 0
       end
 
       # String is longer than the max; read just to the max
-      read_wide_string(max_char_length)
+      read_wide_string(max_char_length, Encoding::UTF_8, encode_options)
     end
 
     def read_win32_local_pointer(&block)

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -57,6 +57,9 @@ module Puppet::Util::Windows::APITypes
       # char_length is number of wide chars (typically excluding NULLs), *not* bytes
       str = get_bytes(0, char_length * 2).force_encoding('UTF-16LE')
       str.encode(dst_encoding)
+    rescue Exception => e
+      Puppet.debug "Unable to convert value #{str.dump} to encoding #{dst_encoding} due to #{e.inspect}"
+      raise
     end
 
     # @param max_char_length [Integer] Maximum number of wide chars to return (typically excluding NULLs), *not* bytes

--- a/spec/integration/util/windows/process_spec.rb
+++ b/spec/integration/util/windows/process_spec.rb
@@ -34,6 +34,51 @@ describe "Puppet::Util::Windows::Process", :if => Puppet.features.microsoft_wind
     end
   end
 
+  describe "when reading environment variables" do
+    after :each do
+      # spec\integration\test\test_helper_spec.rb calls set_environment_strings
+      # after :all and thus needs access to the real APIs once again
+      Puppet::Util::Windows::Process.unstub(:GetEnvironmentStringsW)
+      Puppet::Util::Windows::Process.unstub(:FreeEnvironmentStringsW)
+    end
+
+    it "will ignore only keys or values with corrupt byte sequences" do
+      arraydest = []
+      Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(arraydest))
+
+      env_vars = {}
+
+      # Create a UTF-16LE version of the below null separated environment string
+      # "a=b\x00c=d\x00e=\xDD\xDD\x00f=g\x00\x00"
+      env_var_block =
+        "a=b\x00".encode(Encoding::UTF_16LE) +
+        "c=d\x00".encode(Encoding::UTF_16LE) +
+        'e='.encode(Encoding::UTF_16LE) + "\xDD\xDD".force_encoding(Encoding::UTF_16LE) + "\x00".encode(Encoding::UTF_16LE) +
+        "f=g\x00\x00".encode(Encoding::UTF_16LE)
+
+      env_var_block_bytes = env_var_block.bytes.to_a
+
+      FFI::MemoryPointer.new(:byte, env_var_block_bytes.count) do |ptr|
+        # uchar here is synonymous with byte
+        ptr.put_array_of_uchar(0, env_var_block_bytes)
+
+        # stub the block of memory that the Win32 API would typically return via pointer
+        Puppet::Util::Windows::Process.expects(:GetEnvironmentStringsW).returns(ptr)
+        # stub out the real API call to free memory, else process crashes
+        Puppet::Util::Windows::Process.expects(:FreeEnvironmentStringsW)
+
+        env_vars = Puppet::Util::Windows::Process.get_environment_strings
+      end
+
+      # based on corrupted memory, the e=\xDD\xDD should have been removed from the set
+      expect(env_vars).to eq({'a' => 'b', 'c' => 'd', 'f' => 'g'})
+
+      # and Puppet should emit a warning about it
+      expect(arraydest.last.level).to eq(:warning)
+      expect(arraydest.last.message).to eq("Discarding environment variable e=\uFFFD which contains invalid bytes")
+    end
+  end
+
   describe "when setting environment variables" do
     it "can properly handle env var values with = in them" do
       begin

--- a/spec/unit/util/windows/api_types_spec.rb
+++ b/spec/unit/util/windows/api_types_spec.rb
@@ -4,6 +4,10 @@
 require 'spec_helper'
 
 describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
+  # use 2 bad bytes at end so we have even number of bytes / characters
+  let (:bad_string) { "hello invalid world".encode(Encoding::UTF_16LE) + "\xDD\xDD".force_encoding(Encoding::UTF_16LE) }
+  let (:bad_string_bytes) { bad_string.bytes.to_a }
+
   context "read_wide_string" do
     let (:string) { "foo_bar" }
 
@@ -33,10 +37,6 @@ describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
 
       read_string = nil
 
-      # use 2 bad bytes at end so we have even number of bytes / characters
-      bad_string = "hello invalid world".encode(Encoding::UTF_16LE) + "\xDD\xDD".force_encoding(Encoding::UTF_16LE)
-      bad_string_bytes = bad_string.bytes.to_a
-
       expect {
         FFI::MemoryPointer.new(:byte, bad_string_bytes.count) do |ptr|
           # uchar here is synonymous with byte
@@ -48,6 +48,19 @@ describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
 
       expect(read_string).to be_nil
       expect(arraydest.last.message).to eq("Unable to convert value #{bad_string.dump} to encoding UTF-8 due to #<Encoding::InvalidByteSequenceError: \"\\xDD\\xDD\" on UTF-16LE>")
+    end
+
+    it "should not raise an error when receiving a string containing invalid bytes in the destination encoding, when specifying :invalid => :replace" do
+      read_string = nil
+
+      FFI::MemoryPointer.new(:byte, bad_string_bytes.count) do |ptr|
+        # uchar here is synonymous with byte
+        ptr.put_array_of_uchar(0, bad_string_bytes)
+
+        read_string = ptr.read_wide_string(bad_string.length, Encoding::UTF_8, :invalid => :replace)
+      end
+
+      expect(read_string).to eq("hello invalid world\uFFFD")
     end
   end
 
@@ -90,6 +103,19 @@ describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
       end
 
       expect(read_string.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "should not raise an error when receiving a string containing invalid bytes in the destination encoding, when specifying :invalid => :replace" do
+      read_string = nil
+
+      FFI::MemoryPointer.new(:byte, bad_string_bytes.count) do |ptr|
+        # uchar here is synonymous with byte
+        ptr.put_array_of_uchar(0, bad_string_bytes)
+
+        read_string = ptr.read_arbitrary_wide_string_up_to(ptr.size / 2, :single_null, :invalid => :replace)
+      end
+
+      expect(read_string).to eq("hello invalid world\uFFFD")
     end
   end
 end


### PR DESCRIPTION
- When reading environment variables, request that invalid byte
   sequences be replaced with the Unicode replacement character. This
   will prevent Puppet from crashing hard when reading the block of
   memory representing environment variables and it contains bytes
   that are not valid UTF-16LE.

 - When iterating over the individual key=value pairs representing
   environment variables in get_environment_strings, check the strings
   for the Unicode replacement character \uFFFD. If found, then emit
   a warning and discard the variable as its not particularly useful
   to Puppet.

 - Add test demonstrating bad byte sequences embedded in Windows API
   response are ignored and that Puppet will emit a warning in this
   case.