### PR TITLE
(PUP-7824) Fix bad problem with unanchored end in string format regexp

### DIFF
--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -541,7 +541,7 @@ class StringConverter
 
   def validate_container_input(fmt)
     if (fmt.keys - FMT_KEYS).size > 0
-      raise ArgumentError, "only #{FMT_KEYS}.map {|k| "'#{k}'"}.join(', ')} are allowed in a container format, got #{fmt}"
+      raise ArgumentError, "only #{FMT_KEYS.map {|k| "'#{k}'"}.join(', ')} are allowed in a container format, got #{fmt}"
     end
     result                          = Format.new(fmt['format'])
     result.separator                = fmt['separator']

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -85,7 +85,8 @@ class StringConverter
 
     attr_reader :orig_fmt
 
-    FMT_PATTERN = /^%([\s\+\-#0\[\{<\(\|]*)([1-9][0-9]*)?(?:\.([0-9]+))?([a-zA-Z])/
+    FMT_PATTERN_STR = '^%([\s\[+#0{<(|-]*)([1-9][0-9]*)?(?:\.([0-9]+))?([a-zA-Z])$'
+    FMT_PATTERN = Regexp.compile(FMT_PATTERN_STR)
     DELIMITERS  = [ '[', '{', '(', '<', '|',]
     DELIMITER_MAP = {
       '[' => ['[', ']'],

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1485,9 +1485,9 @@ class PStringType < PScalarDataType
   def self.new_function(type)
     @new_function ||= Puppet::Functions.create_loaded_function(:new_string, type.loader) do
       local_types do
-        type 'Format = Pattern[/^%([\s\+\-#0\[\{<\(\|]*)([1-9][0-9]*)?(?:\.([0-9]+))?([a-zA-Z])/]'
+        type "Format = Pattern[/#{StringConverter::Format::FMT_PATTERN_STR}/]"
         type 'ContainerFormat = Struct[{
-          Optional[format]         => String,
+          Optional[format]         => Format,
           Optional[separator]      => String,
           Optional[separator2]     => String,
           Optional[string_formats] => Hash[Type, Format]

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -87,6 +87,12 @@ describe 'The string converter' do
       end.to raise_error(/Only one of the delimiters/)
     end
 
+    it "Is an error to have trailing characters after the format" do
+      expect do
+        fmt = format.new("%dv")
+      end.to raise_error(/The format '%dv' is not a valid format/)
+    end
+
     it "Is an error to specify the same flag more than once" do
       expect do
         fmt = format.new("%[[d")


### PR DESCRIPTION
The regexp used for checking format specifiers for the string formatter
was not anchored at the end. Also, the regexp was duplicated. It was
specified once in string_formatter.rb and then again in as a parameter
type in types.rb.

This commit adds the anchor and removes the duplification.