### PR TITLE
(PUP-7825) Fix problems with regexp string representation

### DIFF
--- a/lib/puppet/generate/models/type/property.rb
+++ b/lib/puppet/generate/models/type/property.rb
@@ -40,7 +40,7 @@ module Puppet
             values = property.value_collection.instance_variable_get('@values') || {}
             values.each do |_, value|
               if value.regex?
-                regexes << "/#{value.name.source.gsub(/\//, '\/')}/"
+                regexes << Puppet::Pops::Types::StringConverter.convert(value.name, '%p')
                 next
               end
 

--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -70,6 +70,6 @@ class Puppet::Parser::AST::Regex < Puppet::Parser::AST::Leaf
   end
 
   def to_s
-    "/#{@value.source}/"
+    Puppet::Pops::Types::PRegexpType.regexp_to_s_with_delimiters(@value)
   end
 end

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -1095,7 +1095,7 @@ class EvaluatorImpl
   end
 
   def string_Regexp(o, scope)
-    "/#{o.source}/"
+    Types::PRegexpType.regexp_to_s_with_delimiters(o)
   end
 
   def string_PAnyType(o, scope)

--- a/lib/puppet/pops/model/model_tree_dumper.rb
+++ b/lib/puppet/pops/model/model_tree_dumper.rb
@@ -160,7 +160,7 @@ class Puppet::Pops::Model::ModelTreeDumper < Puppet::Pops::Model::TreeDumper
   end
 
   def dump_LiteralRegularExpression o
-    "/#{o.value.source}/"
+    Puppet::Pops::Types::StringConverter.convert(o.value, '%p')
   end
 
   def dump_Nop o

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -901,12 +901,10 @@ class StringConverter
     f = get_format(val_type, format_map)
     case f.format
     when :p
-      rx_s = val.options == 0 ? val.source : val.to_s
-      rx_s = rx_s.gsub(/\//, '\/') unless Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-      str_regexp = "/#{rx_s}/"
+      str_regexp = PRegexpType.regexp_to_s_with_delimiters(val)
       f.orig_fmt == '%p' ? str_regexp : Kernel.format(f.orig_fmt.gsub('p', 's'), str_regexp)
     when :s
-      str_regexp = val.options == 0 ? val.source : val.to_s
+      str_regexp = PRegexpType.regexp_to_s(val)
       str_regexp = puppet_quote(str_regexp) if f.alt?
       f.orig_fmt == '%s' ? str_regexp : Kernel.format(f.orig_fmt, str_regexp)
     else

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -550,7 +550,7 @@ class TypeCalculator
 
   # @api private
   def infer_Regexp(o)
-    PRegexpType.new(o.source)
+    PRegexpType.new(o)
   end
 
   # @api private

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -545,7 +545,7 @@ class TypeFormatter
   def string_Numeric(t)      ; @bld << t.to_s    ; end
 
   # @api private
-  def string_Regexp(t)       ; @bld << t.inspect; end
+  def string_Regexp(t)       ; @bld << PRegexpType.regexp_to_s_with_delimiters(t); end
 
   # @api private
   def string_String(t)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1592,10 +1592,41 @@ class PRegexpType < PScalarType
 
   attr_reader :pattern
 
+  # @param regexp [Regexp] the regular expression
+  # @return [String] the Regexp as a slash delimited string with slashes escaped
+  def self.regexp_to_s_with_delimiters(regexp)
+    regexp.options == 0 ? regexp.inspect : "/#{regexp.to_s}/"
+  end
+
+  # @param regexp [Regexp] the regular expression
+  # @return [String] the Regexp as a string without escaped slash
+  def self.regexp_to_s(regexp)
+    append_flags_group(regexp.source, regexp.options)
+  end
+
+  def self.append_flags_group(rx_string, options)
+    if options == 0
+      rx_string
+    else
+      bld = '(?'
+      bld << 'i' if (options & Regexp::IGNORECASE) != 0
+      bld << 'm' if (options & Regexp::MULTILINE) != 0
+      bld << 'x' if (options & Regexp::EXTENDED) != 0
+      unless options == (Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED)
+        bld << '-'
+        bld << 'i' if (options & Regexp::IGNORECASE) == 0
+        bld << 'm' if (options & Regexp::MULTILINE) == 0
+        bld << 'x' if (options & Regexp::EXTENDED) == 0
+      end
+      bld << ':' << rx_string << ')'
+      bld.freeze
+    end
+  end
+
   def initialize(pattern)
     if pattern.is_a?(Regexp)
       @regexp = pattern
-      @pattern = pattern.options == 0 ? pattern.source : pattern.to_s
+      @pattern = PRegexpType.regexp_to_s(pattern)
     else
       @pattern = pattern
     end
@@ -1614,7 +1645,7 @@ class PRegexpType < PScalarType
   end
 
   def instance?(o, guard=nil)
-    o.is_a?(Regexp) && (@pattern.nil? || @pattern == (o.options == 0 ? o.source : o.to_s))
+    o.is_a?(Regexp) && @pattern.nil? || regexp == o
   end
 
   DEFAULT = PRegexpType.new(nil)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1601,7 +1601,30 @@ class PRegexpType < PScalarType
   # @param regexp [Regexp] the regular expression
   # @return [String] the Regexp as a string without escaped slash
   def self.regexp_to_s(regexp)
-    append_flags_group(regexp.source, regexp.options)
+    # Rubies < 2.0.0 retains escaped delimiters in the source string.
+    @source_retains_escaped_slash ||= Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+    source = regexp.source
+    if @source_retains_escaped_slash && source.include?('\\')
+      # Restore corrupt string in rubies <2.0.0, i.e. turn '\/' into '/' but
+      # don't touch valid escapes such as '\s', '\{' etc.
+      escaped = false
+      bld = ''
+      source.each_codepoint do |codepoint|
+        if escaped
+          bld << 0x5c unless codepoint == 0x2f # '/'
+          bld << codepoint
+          escaped = false
+        elsif codepoint == 0x5c # '\'
+          escaped = true
+        elsif codepoint <= 0x7f
+          bld << codepoint
+        else
+          bld << [codepoint].pack('U')
+        end
+      end
+      source = bld
+    end
+    append_flags_group(source, regexp.options)
   end
 
   def self.append_flags_group(rx_string, options)

--- a/spec/unit/parser/ast/leaf_spec.rb
+++ b/spec/unit/parser/ast/leaf_spec.rb
@@ -60,13 +60,12 @@ describe Puppet::Parser::AST::Regex do
     end
   end
 
-  it "should return the regex source with to_s" do
+  it 'should return the PRegexpType#regexp_to_s_with_delimiters with to_s' do
     regex = stub 'regex'
     Regexp.stubs(:new).returns(regex)
 
-    val = Puppet::Parser::AST::Regex.new :value => "/ab/"
-
-    regex.expects(:source)
+    val = Puppet::Parser::AST::Regex.new :value => '/ab/'
+    Puppet::Pops::Types::PRegexpType.expects(:regexp_to_s_with_delimiters)
 
     val.to_s
   end

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -1000,6 +1000,11 @@ describe 'The string converter' do
           expect(converter.convert(/foo\/bar/m, string_formats)).to eq('(?m-ix:foo/bar)')
         end
 
+        it 'the format %s produces \'(?m-ix:foo\/bar)\' for expression /foo\\\/bar/m' do
+          string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%s'}
+          expect(converter.convert(/foo\\\/bar/m, string_formats)).to eq('(?m-ix:foo\\\\/bar)')
+        end
+
         it 'the format %p produces \'(?m-ix:foo\/bar)\' for expression /foo\/bar/m' do
           string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
           expect(converter.convert(/foo\/bar/m, string_formats)).to eq('/(?m-ix:foo\/bar)/')

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -993,6 +993,25 @@ describe 'The string converter' do
         string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
         expect(converter.convert(/foo\/bar/, string_formats)).to eq('/foo\/bar/')
       end
+
+      context 'and slashes' do
+        it 'the format %s produces \'(?m-ix:foo/bar)\' for expression /foo\/bar/m' do
+          pending 'Fix for PUP-7825'
+          string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%s'}
+          expect(converter.convert(/foo\/bar/m, string_formats)).to eq('(?m-ix:foo/bar)')
+        end
+
+        it 'the format %p produces \'(?m-ix:foo\/bar)\' for expression /foo\/bar/m' do
+          pending 'Fix for PUP-7825'
+          string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
+          expect(converter.convert(/foo\/bar/m, string_formats)).to eq('/(?m-ix:foo\/bar)/')
+        end
+
+        it 'the format %p produces \'(?m-ix:foo\/bar)\' for expression /(?m-ix:foo\/bar)/' do
+          string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
+          expect(converter.convert(/(?m-ix:foo\/bar)/, string_formats)).to eq('/(?m-ix:foo\/bar)/')
+        end
+      end
     end
 
     it 'errors when format is not recognized' do

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -996,13 +996,11 @@ describe 'The string converter' do
 
       context 'and slashes' do
         it 'the format %s produces \'(?m-ix:foo/bar)\' for expression /foo\/bar/m' do
-          pending 'Fix for PUP-7825'
           string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%s'}
           expect(converter.convert(/foo\/bar/m, string_formats)).to eq('(?m-ix:foo/bar)')
         end
 
         it 'the format %p produces \'(?m-ix:foo\/bar)\' for expression /foo\/bar/m' do
-          pending 'Fix for PUP-7825'
           string_formats = { Puppet::Pops::Types::PRegexpType::DEFAULT => '%p'}
           expect(converter.convert(/foo\/bar/m, string_formats)).to eq('/(?m-ix:foo\/bar)/')
         end


### PR DESCRIPTION
This commit adds a new method called `#regexp_to_s_with_delimiters` to
the PRegexpType and ensures that it is used throughout to get consistent
string format of regexps.