### PR TITLE
(PUP-7829) Ensure that Variant parameters are types

### DIFF
--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -221,7 +221,7 @@ An exception is raised when no format was able to parse the given string.
 
 ```puppet
 function Timespan.new(
-  String $string, Variant[String[2],Array[String[2]], 1] $format = <default format>)
+  String $string, Variant[String[2],Array[String[2], 1]] $format = <default format>)
 )
 ```
 
@@ -231,7 +231,7 @@ the arguments may also be passed as a `Hash`:
 function Timespan.new(
   Struct[{
     string => String[1],
-    Optional[format] => Variant[String[2],Array[String[2]], 1]
+    Optional[format] => Variant[String[2],Array[String[2], 1]]
   }] $hash
 )
 ```
@@ -316,7 +316,7 @@ An exception is raised when no format was able to parse the given string.
 ```puppet
 function Timestamp.new(
   String $string,
-  Variant[String[2],Array[String[2]], 1] $format = <default format>,
+  Variant[String[2],Array[String[2], 1]] $format = <default format>,
   String $timezone = default)
 )
 ```
@@ -327,7 +327,7 @@ the arguments may also be passed as a `Hash`:
 function Timestamp.new(
   Struct[{
     string => String[1],
-    Optional[format] => Variant[String[2],Array[String[2]], 1],
+    Optional[format] => Variant[String[2],Array[String[2], 1]],
     Optional[timezone] => String[1]
   }] $hash
 )
@@ -889,8 +889,8 @@ The signatures are:
 ```puppet
 type SemVerRangeString = String[1]
 type SemVerRangeHash = Struct[{
-  min                   => Variant[default, SemVer],
-  Optional[max]         => Variant[default, SemVer],
+  min                   => Variant[Default, SemVer],
+  Optional[max]         => Variant[Default, SemVer],
   Optional[exclude_max] => Boolean
 }]
 
@@ -899,8 +899,8 @@ function SemVerRange.new(
 )
 
 function SemVerRange.new(
-  Variant[default,SemVer] $min
-  Variant[default,SemVer] $max
+  Variant[Default,SemVer] $min
+  Variant[Default,SemVer] $max
   Optional[Boolean]       $exclude_max = undef
 )
 

--- a/lib/puppet/pops/types/p_sem_ver_range_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_range_type.rb
@@ -111,7 +111,7 @@ class PSemVerRangeType < PAnyType
     @new_function ||= Puppet::Functions.create_loaded_function(:new_VersionRange, type.loader) do
       local_types do
         type 'SemVerRangeString = String[1]'
-        type 'SemVerRangeHash = Struct[{min=>Variant[default,SemVer],Optional[max]=>Variant[default,SemVer],Optional[exclude_max]=>Boolean}]'
+        type 'SemVerRangeHash = Struct[{min=>Variant[Default,SemVer],Optional[max]=>Variant[Default,SemVer],Optional[exclude_max]=>Boolean}]'
       end
 
       # Constructs a VersionRange from a String with a format specified by
@@ -136,8 +136,8 @@ class PSemVerRangeType < PAnyType
       # default.
       #
       dispatch :from_versions do
-        param 'Variant[default,SemVer]', :min
-        param 'Variant[default,SemVer]', :max
+        param 'Variant[Default,SemVer]', :min
+        param 'Variant[Default,SemVer]', :max
         optional_param 'Boolean', :exclude_max
       end
 

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -106,7 +106,7 @@ module Types
     def self.new_function(type)
       @new_function ||= Puppet::Functions.create_loaded_function(:new_timespan, type.loader) do
         local_types do
-          type 'Formats = Variant[String[2],Array[String[2]], 1]'
+          type 'Formats = Variant[String[2],Array[String[2], 1]]'
         end
 
         dispatch :from_seconds do

--- a/lib/puppet/pops/types/p_timestamp_type.rb
+++ b/lib/puppet/pops/types/p_timestamp_type.rb
@@ -11,7 +11,7 @@ module Types
     def self.new_function(type)
       @new_function ||= Puppet::Functions.create_loaded_function(:new_timestamp, type.loader) do
         local_types do
-          type 'Formats = Variant[String[2],Array[String[2]], 1]'
+          type 'Formats = Variant[String[2],Array[String[2], 1]]'
         end
 
         dispatch :now do

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -796,7 +796,7 @@ module Types
     def describe_PTypeAliasType(expected, actual, path)
       resolved_type = expected.resolved_type
       describe(resolved_type, actual, path).map do |description|
-        if description.is_a?(ExpectedActualMismatch)
+        if description.is_a?(ExpectedActualMismatch) && description.path.length == path.length
           description.swap_expected(expected)
         else
           description

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -348,6 +348,7 @@ class TypeParser
     when 'variant'
       # 1..m parameters being strings or regular expressions
       raise_invalid_parameters_error('Variant', '1 or more', parameters.size) unless parameters.size >= 1
+      parameters.each { |p| assert_type(ast, p) }
       TypeFactory.variant(*parameters)
 
     when 'tuple'

--- a/spec/unit/pops/evaluator/access_ops_spec.rb
+++ b/spec/unit/pops/evaluator/access_ops_spec.rb
@@ -539,6 +539,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl/AccessOperator' do
       expect(evaluate(type_expr)).to eql(tf.callable([String], Integer))
     end
 
+    # Variant Type
+    it 'does not allow Variant declarations with non-type arguments' do
+      type_expr = fqr('Variant').access_at(fqr('Integer'), 'not a type')
+      expect { evaluate(type_expr) }.to raise_error(/Cannot use String where Any-Type is expected/)
+    end
   end
 
   matcher :be_the_type do |type|

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -108,7 +108,6 @@ describe 'Timespan type' do
       end
 
       it 'it cannot be created using an empty formats array' do
-        pending 'Fix for PUP-7829'
         code = <<-CODE
             notice(Timespan('1d11h23m13s', []))
         CODE

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -107,6 +107,14 @@ describe 'Timespan type' do
           %w(1-11:23:13.0 0-11:23:13.0 1-11:23:00.0 1-11:00:00.0 0-11:23:00.0 0-00:23:13.0 1-00:00:00.0 0-11:00:00.0 0-00:23:00.0 0-00:00:13.0))
       end
 
+      it 'it cannot be created using an empty formats array' do
+        pending 'Fix for PUP-7829'
+        code = <<-CODE
+            notice(Timespan('1d11h23m13s', []))
+        CODE
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /parameter 'format' variant 1 expects size to be at least 1, got 0/)
+      end
+
       it 'can be created from a integer that represents seconds since epoch' do
         code = <<-CODE
             $o = Timespan(6800)

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -163,6 +163,14 @@ describe 'Timestamp type' do
           ['2016-08-28T12:15:00.000000000 UTC', '2016-07-24T01:20:00.000000000 UTC', '2016-06-21T18:23:15.000000000 UTC'])
       end
 
+      it 'it cannot be created using an empty formats array' do
+        pending 'Fix for PUP-7829'
+        code = <<-CODE
+            notice(Timestamp('2015-03-01T11:12:13', []))
+        CODE
+        expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /parameter 'format' variant 1 expects size to be at least 1, got 0/)
+      end
+
       it 'can be created from a string, array of formats, and a timezone' do
         code = <<-CODE
             $fmts = [

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -164,7 +164,6 @@ describe 'Timestamp type' do
       end
 
       it 'it cannot be created using an empty formats array' do
-        pending 'Fix for PUP-7829'
         code = <<-CODE
             notice(Timestamp('2015-03-01T11:12:13', []))
         CODE

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -31,7 +31,6 @@ describe TypeParser do
   end
 
   it "rejects an unknown type parameter in a variant" do
-    pending 'Fix for PUP-7829'
     expect { parser.parse("Variant[Integer,'not a type']") }.to raise_error(Puppet::ParseError,
       /The expression <Variant\[Integer,'not a type'\]> is not a valid type specification/)
   end

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -30,6 +30,12 @@ describe TypeParser do
       /The expression <Array\[notAType\]> is not a valid type specification/)
   end
 
+  it "rejects an unknown type parameter in a variant" do
+    pending 'Fix for PUP-7829'
+    expect { parser.parse("Variant[Integer,'not a type']") }.to raise_error(Puppet::ParseError,
+      /The expression <Variant\[Integer,'not a type'\]> is not a valid type specification/)
+  end
+
   [
     'Any', 'Data', 'CatalogEntry', 'Boolean', 'Scalar', 'Undef', 'Numeric', 'Default'
   ].each do |name|


### PR DESCRIPTION
The `TypeParser` did not check that the parameters used when creating
a `Variant` type were types. Consequently, some variants created
internally in dispatchers used for the function `new` on `Timespan`
and `SemVerRange`, were incorrect. The faulty declarations were also
copied into the corresponding documentation of the `new` method.

Incidentally, the code did work anyway since the type, when created
from the `TypeParser`, will do a `#to_type` on the argument, thus
converting the keyword `default`, or an integer value into it's type.