### PR TITLE
(PUP-7672) zoned property is called jailed on FreeBSD. 

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -70,7 +70,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
    :mountpoint, :nbmand,  :primarycache, :quota, :readonly,
    :recordsize, :refquota, :refreservation, :reservation,
    :secondarycache, :setuid, :sharenfs, :sharesmb,
-   :snapdir, :version, :volsize, :vscan, :xattr, :zoned].each do |field|
+   :snapdir, :version, :volsize, :vscan, :xattr].each do |field|
     define_method(field) do
       zfs(:get, "-H", "-o", "value", field, @resource[:name]).strip
     end
@@ -78,6 +78,22 @@ Puppet::Type.type(:zfs).provide(:zfs) do
     define_method(field.to_s + "=") do |should|
       zfs(:set, "#{field}=#{should}", @resource[:name])
     end
+  end
+
+  # On FreeBSD zoned is called jailed
+  container = case Facter.value(:operatingsystem)
+    when "FreeBSD"
+      "jailed"
+    else
+      "zoned"
+  end
+
+  define_method(:zoned) do
+    zfs(:get, "-H", "-o", "value", container, @resource[:name]).strip
+  end
+
+  define_method("zoned=") do |should|
+    zfs(:set, "#{container}=#{should}", @resource[:name])
   end
 
 end

--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -83,9 +83,9 @@ Puppet::Type.type(:zfs).provide(:zfs) do
   # On FreeBSD zoned is called jailed
   container = case Facter.value(:operatingsystem)
     when "FreeBSD"
-      "jailed"
+      :jailed
     else
-      "zoned"
+      :zoned
   end
 
   define_method(:zoned) do

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -89,7 +89,7 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
      :mountpoint, :nbmand,  :primarycache, :quota, :readonly,
      :recordsize, :refquota, :refreservation, :reservation,
      :secondarycache, :setuid, :shareiscsi, :sharenfs, :sharesmb,
-     :snapdir, :version, :volsize, :vscan, :xattr, :zoned].each do |prop|
+     :snapdir, :version, :volsize, :vscan, :xattr].each do |prop|
       it "should get #{prop}" do
         provider.expects(:zfs).with(:get, '-H', '-o', 'value', prop, name).returns("value\n")
 
@@ -101,6 +101,25 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
 
         provider.send("#{prop}=", "value")
       end
+    end
+  end
+  describe "zoned" do
+    container = case Facter.value(:operatingsystem)
+      when "FreeBSD"
+        :jailed
+      else
+        :zoned
+    end
+    it "should get zoned" do
+      provider.expects(:zfs).with(:get, '-H', '-o', 'value', container, name).returns("value\n")
+
+      expect(provider.send("zoned")).to eq('value')
+    end
+
+    it "should set zoned=value" do
+      provider.expects(:zfs).with(:set, "#{container}=value", name)
+
+      provider.send("zoned=", "value")
     end
   end
 end


### PR DESCRIPTION
It makes zfs fail on FreeBSD systems.

See : https://tickets.puppetlabs.com/browse/PUP-7672

Even if Solaris zones don't exist on Linux, the property was preserved on this system.
Don't know exactly on NetBSD.
This patch handle zoned property properly on both SunOS, Linux and FreeBSD.