### PR TITLE
(PUP-7768) Enable use of heredoc in a type description

### DIFF
--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -99,11 +99,6 @@ class TypeParser
   end
 
   # @api private
-  def interpret_QualifiedReference(o, context)
-    o.cased_value
-  end
-
-  # @api private
   def interpret_LiteralBoolean(o, context)
     o.value
   end

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -85,6 +85,15 @@ class TypeParser
   end
 
   # @api private
+  def interpret_HeredocExpression(o, context)
+    interpret_any(o.text_expr, context)
+  end
+
+  def interpret_SubLocatedExpression(o, context)
+    interpret_any(o.expr, context)
+  end
+
+  # @api private
   def interpret_QualifiedName(o, context)
     o.value
   end

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -91,6 +91,20 @@ describe 'The Object Type' do
       expect(attr.value?).to be_truthy
     end
 
+    it 'attribute value can be defined using heredoc?' do
+      pending 'Fix for PUP-7768'
+      tp = parse_object('MyObject', <<-OBJECT.unindent)
+        attributes => {
+          a => { type => String, value => @(END) }
+            The value is some
+            multiline text
+            |-END
+        }
+      OBJECT
+      attr = tp['a']
+      expect(attr.value).to eql("The value is some\nmultiline text")
+    end
+
     it 'attribute without defined value responds false to value?' do
       tp = parse_object('MyObject', <<-OBJECT)
         attributes => {

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -92,7 +92,6 @@ describe 'The Object Type' do
     end
 
     it 'attribute value can be defined using heredoc?' do
-      pending 'Fix for PUP-7768'
       tp = parse_object('MyObject', <<-OBJECT.unindent)
         attributes => {
           a => { type => String, value => @(END) }


### PR DESCRIPTION
Prior to this commit, the `TypeParser` would raise an exception when it
encountered a `HeredocExpression`. As a consequence, no strings could
be entered as heredoc in a type description.

This commit adds the methods necessary to make the `TypeParser`
understand literal heredoc. Interpolations are not allowed (goes for
both heredoc and double quoted strings).