### PR TITLE
(PUP-7834) Replace all calls to YAML.load with YAML.safe_load

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -343,7 +343,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       if fact_file.end_with?("json")
         given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
-        given_facts = YAML.safe_load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = Puppet::Util::Yaml.safe_load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end
 
       unless given_facts.instance_of?(Hash)

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -343,7 +343,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       if fact_file.end_with?("json")
         given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
-        given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = YAML.safe_load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end
 
       unless given_facts.instance_of?(Hash)

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -486,7 +486,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       elsif fact_file.end_with?("json")
         given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
-        given_facts = YAML.safe_load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = Puppet::Util::Yaml.safe_load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end
 
       unless given_facts.instance_of?(Hash)

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -486,7 +486,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       elsif fact_file.end_with?("json")
         given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
-        given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = YAML.safe_load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end
 
       unless given_facts.instance_of?(Hash)

--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -44,7 +44,7 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
     path = options['path']
     context.cached_file_data(path) do |content|
       begin
-        data = YAML.safe_load(content, [Symbol], Puppet::Pops::EMPTY_ARRAY, false, path)
+        data = Puppet::Util::Yaml.safe_load(content, [Symbol], path)
         if data.is_a?(Hash)
           Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
         else

--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -44,7 +44,7 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
     path = options['path']
     context.cached_file_data(path) do |content|
       begin
-        data = YAML.load(content, path)
+        data = YAML.safe_load(content, [Symbol], Puppet::Pops::EMPTY_ARRAY, false, path)
         if data.is_a?(Hash)
           Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
         else

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -21,7 +21,7 @@ Puppet::Functions.create_function(:yaml_data) do
     path = options['path']
     context.cached_file_data(path) do |content|
       begin
-        data = YAML.safe_load(content, [Symbol], Puppet::Pops::EMPTY_ARRAY, false, path)
+        data = Puppet::Util::Yaml.safe_load(content, [Symbol], path)
         if data.is_a?(Hash)
           Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
         else

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -21,7 +21,7 @@ Puppet::Functions.create_function(:yaml_data) do
     path = options['path']
     context.cached_file_data(path) do |content|
       begin
-        data = YAML.load(content, path)
+        data = YAML.safe_load(content, [Symbol], Puppet::Pops::EMPTY_ARRAY, false, path)
         if data.is_a?(Hash)
           Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
         else

--- a/lib/puppet/indirector/catalog/yaml.rb
+++ b/lib/puppet/indirector/catalog/yaml.rb
@@ -9,7 +9,7 @@ class Puppet::Resource::Catalog::Yaml < Puppet::Indirector::Yaml
   # Override these, because yaml doesn't want to convert our self-referential
   # objects.  This is hackish, but eh.
   def from_yaml(text)
-    if config = YAML.safe_load(text)
+    if config = Puppet::Util::Yaml.safe_load(text)
       return config
     end
   end

--- a/lib/puppet/indirector/catalog/yaml.rb
+++ b/lib/puppet/indirector/catalog/yaml.rb
@@ -9,7 +9,7 @@ class Puppet::Resource::Catalog::Yaml < Puppet::Indirector::Yaml
   # Override these, because yaml doesn't want to convert our self-referential
   # objects.  This is hackish, but eh.
   def from_yaml(text)
-    if config = YAML.load(text)
+    if config = YAML.safe_load(text)
       return config
     end
   end

--- a/lib/puppet/indirector/node/exec.rb
+++ b/lib/puppet/indirector/node/exec.rb
@@ -52,7 +52,7 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
 
   # Translate the yaml string into Ruby objects.
   def translate(name, output)
-    YAML.load(output).inject({}) do |hash, data|
+    YAML.safe_load(output, [Symbol]).inject({}) do |hash, data|
       case data[0]
       when String
         hash[data[0].intern] = data[1]

--- a/lib/puppet/indirector/node/exec.rb
+++ b/lib/puppet/indirector/node/exec.rb
@@ -52,7 +52,7 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
 
   # Translate the yaml string into Ruby objects.
   def translate(name, output)
-    YAML.safe_load(output, [Symbol]).inject({}) do |hash, data|
+    Puppet::Util::Yaml.safe_load(output, [Symbol]).inject({}) do |hash, data|
       case data[0]
       when String
         hash[data[0].intern] = data[1]

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -37,12 +37,12 @@ Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
   end
 
   def intern(klass, text)
-    data = YAML.safe_load(text, allowed_yaml_classes)
+    data = Puppet::Util::Yaml.safe_load(text, allowed_yaml_classes)
     data_to_instance(klass, data)
   end
 
   def intern_multiple(klass, text)
-    data = YAML.safe_load(text, allowed_yaml_classes)
+    data = Puppet::Util::Yaml.safe_load(text, allowed_yaml_classes)
     unless data.respond_to?(:collect)
       raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a collection of instances when calling intern_multiple")
     end

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -23,13 +23,26 @@ Puppet::Network::FormatHandler.create_serialized_formats(:msgpack, :weight => 20
 end
 
 Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
+  # Cannot be a constant since this handler is initialized before some of the classes exists
+  def allowed_yaml_classes
+    @allowed_yaml_classes ||= [
+      Puppet::Node::Facts,
+      Puppet::Node,
+      Puppet::Transaction::Report,
+      Puppet::Resource,
+      Puppet::Resource::Catalog,
+      Symbol,
+      Time,
+    ].freeze
+  end
+
   def intern(klass, text)
-    data = YAML.load(text)
+    data = YAML.safe_load(text, allowed_yaml_classes)
     data_to_instance(klass, data)
   end
 
   def intern_multiple(klass, text)
-    data = YAML.load(text)
+    data = YAML.safe_load(text, allowed_yaml_classes)
     unless data.respond_to?(:collect)
       raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a collection of instances when calling intern_multiple")
     end

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -132,7 +132,7 @@ class HieraConfig
       if config_path.exist?
         env_context = EnvironmentContext.adapt(lookup_invocation.scope.compiler.environment)
         loaded_config = env_context.cached_file_data(config_path) do |content|
-          parsed = YAML.safe_load(content, [Symbol], EMPTY_ARRAY, false, config_path)
+          parsed = Puppet::Util::Yaml.safe_load(content, [Symbol], config_path)
 
           # For backward compatibility, we must treat an empty file, or a yaml that doesn't
           # produce a Hash as Hiera version 3 default.

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -132,7 +132,7 @@ class HieraConfig
       if config_path.exist?
         env_context = EnvironmentContext.adapt(lookup_invocation.scope.compiler.environment)
         loaded_config = env_context.cached_file_data(config_path) do |content|
-          parsed = YAML.load(content, config_path)
+          parsed = YAML.safe_load(content, [Symbol], EMPTY_ARRAY, false, config_path)
 
           # For backward compatibility, we must treat an empty file, or a yaml that doesn't
           # produce a Hash as Hiera version 3 default.

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -5,7 +5,7 @@ class Puppet::Util::TagSet < Set
   include Puppet::Network::FormatSupport
 
   def self.from_yaml(yaml)
-    self.new(YAML.safe_load(yaml, [Symbol]))
+    self.new(Puppet::Util::Yaml.safe_load(yaml, [Symbol]))
   end
 
   def to_yaml

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -5,7 +5,7 @@ class Puppet::Util::TagSet < Set
   include Puppet::Network::FormatSupport
 
   def self.from_yaml(yaml)
-    self.new(YAML.load(yaml))
+    self.new(YAML.safe_load(yaml, [Symbol]))
   end
 
   def to_yaml

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -9,10 +9,6 @@ module Puppet::Util::Yaml
 
   class YamlLoadError < Puppet::Error; end
 
-  def self.disallowed_class(cls)
-    raise YamlLoadError, "Tried to load unspecified class: #{cls}"
-  end
-
   if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
     def self.safe_load(yaml, allowed_classes = [], filename = nil)
       YAML.safe_load(yaml, allowed_classes, [], false, filename)

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -13,42 +13,15 @@ module Puppet::Util::Yaml
     raise YamlLoadError, "Tried to load unspecified class: #{cls}"
   end
 
-  def self.safe_load(yaml, allowed_classes = [], filename = nil)
-    @psych_safe_load ||= Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
-    return YAML.safe_load(yaml, allowed_classes, [], false, filename) if @psych_safe_load
-
-    # emulate needed parts of YAML.safe_load for rubies < 2.1.0
-    data = YAML.parse(yaml, filename)
-
-    # safe_load returns false for empty yaml
-    return false unless data.is_a?(Psych::Nodes::Document)
-
-    @known_tags ||= {
-      'encoding' => :skip,
-      'range' => Range,
-      'regexp' => Regexp,
-      'sym' => Symbol,
-      'symbol' => Symbol,
-      'array' => :arg,
-      'hash' => :arg,
-      'struct' => :arg,
-      'object' => :arg,
-    }.freeze
-
-    # raise errors for tags that will cause load of disallowed classes
-    allowed_class_names = allowed_classes.map { |cls| cls.name }
-    data.root.each do |o|
-      next unless o.tag && o.tag =~ /\A!ruby\/([^:]+)(?::(.*))\z/
-      tag = $1
-      arg = $2
-      class_name = @known_tags[tag]
-      disallowed_class(tag) if class_name.nil?
-
-      next if class_name == :skip
-      class_name = arg if class_name == :arg
-      disallowed_class(class_name) unless allowed_class_names.include?(class_name)
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+    def self.safe_load(yaml, allowed_classes = [], filename = nil)
+      YAML.safe_load(yaml, allowed_classes, [], false, filename)
     end
-    data.to_ruby
+  else
+    def self.safe_load(yaml, allowed_classes = [], filename = nil)
+      # Fall back to YAML.load for rubies < 2.1.0
+      YAML.load(yaml, filename)
+    end
   end
 
   def self.load_file(filename, default_value = false, strip_classes = false)

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::Configurer do
 
       summary = nil
       File.open(Puppet[:lastrunfile], "r") do |fd|
-        summary = YAML.load(fd.read)
+        summary = YAML.safe_load(fd.read)
       end
 
       expect(summary).to be_a(Hash)

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::Configurer do
 
       summary = nil
       File.open(Puppet[:lastrunfile], "r") do |fd|
-        summary = YAML.safe_load(fd.read)
+        summary = Puppet::Util::Yaml.safe_load(fd.read)
       end
 
       expect(summary).to be_a(Hash)

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -461,7 +461,7 @@ Searching for "a"
       lookup.options[:render_as] = :yaml
       lookup.command_line.stubs(:args).returns(['a'])
       output = run_lookup(lookup)
-      expect(YAML.safe_load(output, [Symbol])).to eq(expected_yaml_hash)
+      expect(Puppet::Util::Yaml.safe_load(output, [Symbol])).to eq(expected_yaml_hash)
     end
 
     it 'can produce a json explanation' do

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -461,7 +461,7 @@ Searching for "a"
       lookup.options[:render_as] = :yaml
       lookup.command_line.stubs(:args).returns(['a'])
       output = run_lookup(lookup)
-      expect(YAML.load(output)).to eq(expected_yaml_hash)
+      expect(YAML.safe_load(output, [Symbol])).to eq(expected_yaml_hash)
     end
 
     it 'can produce a json explanation' do

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -812,6 +812,12 @@ describe "The lookup function" do
           YAML
         end
 
+        it 'fails lookup and reports a type mismatch', :unless => Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0') do
+          expect { lookup('a') }.to raise_error do |e|
+            expect(e.message).to match(/key 'a'.*data_hash function 'yaml_data'.*using location.*wrong type, expects Puppet::LookupValue, got Runtime/)
+          end
+        end
+
         it 'fails lookup and reports unspecified class', :if => Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0') do
           expect { lookup('a') }.to raise_error do |e|
             expect(e.message).to match(/Tried to load unspecified class: Puppet::Graph::Key/)

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -812,7 +812,7 @@ describe "The lookup function" do
           YAML
         end
 
-        it 'fails lookup and reports unspecified class' do
+        it 'fails lookup and reports unspecified class', :if => Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0') do
           expect { lookup('a') }.to raise_error do |e|
             expect(e.message).to match(/Tried to load unspecified class: Puppet::Graph::Key/)
           end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -812,9 +812,9 @@ describe "The lookup function" do
           YAML
         end
 
-        it 'fails lookup and reports a type mismatch' do
+        it 'fails lookup and reports unspecified class' do
           expect { lookup('a') }.to raise_error do |e|
-            expect(e.message).to match(/key 'a'.*data_hash function 'yaml_data'.*using location.*wrong type, expects Puppet::LookupValue, got Runtime/)
+            expect(e.message).to match(/Tried to load unspecified class: Puppet::Graph::Key/)
           end
         end
       end

--- a/spec/unit/graph/simple_graph_spec.rb
+++ b/spec/unit/graph/simple_graph_spec.rb
@@ -596,7 +596,7 @@ describe Puppet::Graph::SimpleGraph do
           # the serialized objects easily without invoking any
           # yaml_initialize hooks.
           yaml_form.gsub!('!ruby/object:Puppet::', '!hack/object:Puppet::')
-          serialized_object = YAML.load(yaml_form)
+          serialized_object = YAML.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
 
           # Check that the object contains instance variables @edges and
           # @vertices only.  @reversal is also permitted, but we don't
@@ -664,7 +664,7 @@ describe Puppet::Graph::SimpleGraph do
           reference_graph = Puppet::Graph::SimpleGraph.new
           send(graph_to_test, reference_graph)
           yaml_form = graph_to_yaml(reference_graph, which_format)
-          recovered_graph = YAML.load(yaml_form)
+          recovered_graph = YAML.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
 
           # Test that the recovered vertices match the vertices in the
           # reference graph.
@@ -708,7 +708,7 @@ describe Puppet::Graph::SimpleGraph do
       derived.add_edge('a', 'b')
       derived.foo = 1234
       yaml = YAML.dump(derived)
-      recovered_derived = YAML.load(yaml)
+      recovered_derived = YAML.safe_load(yaml, [Puppet::TestDerivedClass])
       expect(recovered_derived.class).to equal(Puppet::TestDerivedClass)
       expect(recovered_derived.edges.length).to eq(1)
       expect(recovered_derived.edges[0].source).to eq('a')

--- a/spec/unit/graph/simple_graph_spec.rb
+++ b/spec/unit/graph/simple_graph_spec.rb
@@ -596,7 +596,7 @@ describe Puppet::Graph::SimpleGraph do
           # the serialized objects easily without invoking any
           # yaml_initialize hooks.
           yaml_form.gsub!('!ruby/object:Puppet::', '!hack/object:Puppet::')
-          serialized_object = YAML.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
+          serialized_object = Puppet::Util::Yaml.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
 
           # Check that the object contains instance variables @edges and
           # @vertices only.  @reversal is also permitted, but we don't
@@ -664,7 +664,7 @@ describe Puppet::Graph::SimpleGraph do
           reference_graph = Puppet::Graph::SimpleGraph.new
           send(graph_to_test, reference_graph)
           yaml_form = graph_to_yaml(reference_graph, which_format)
-          recovered_graph = YAML.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
+          recovered_graph = Puppet::Util::Yaml.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
 
           # Test that the recovered vertices match the vertices in the
           # reference graph.
@@ -708,7 +708,7 @@ describe Puppet::Graph::SimpleGraph do
       derived.add_edge('a', 'b')
       derived.foo = 1234
       yaml = YAML.dump(derived)
-      recovered_derived = YAML.safe_load(yaml, [Puppet::TestDerivedClass])
+      recovered_derived = Puppet::Util::Yaml.safe_load(yaml, [Puppet::TestDerivedClass])
       expect(recovered_derived.class).to equal(Puppet::TestDerivedClass)
       expect(recovered_derived.edges.length).to eq(1)
       expect(recovered_derived.edges[0].source).to eq('a')

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -111,7 +111,7 @@ describe Puppet::Node do
     end
 
     it "a node can roundtrip" do
-      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
+      expect(YAML.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
     end
 
     it "limits the serialization of environment to be just the name" do
@@ -123,7 +123,7 @@ describe Puppet::Node do
   describe "when serializing using yaml and values classes and parameters are missing in deserialized hash" do
     it "a node can roundtrip" do
       @node = Puppet::Node.from_data_hash({'name' => "mynode"})
-      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
+      expect(YAML.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
     end
 
     it "errors if name is nil" do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -111,7 +111,7 @@ describe Puppet::Node do
     end
 
     it "a node can roundtrip" do
-      expect(YAML.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
+      expect(Puppet::Util::Yaml.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
     end
 
     it "limits the serialization of environment to be just the name" do
@@ -123,7 +123,7 @@ describe Puppet::Node do
   describe "when serializing using yaml and values classes and parameters are missing in deserialized hash" do
     it "a node can roundtrip" do
       @node = Puppet::Node.from_data_hash({'name' => "mynode"})
-      expect(YAML.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
+      expect(Puppet::Util::Yaml.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
     end
 
     it "errors if name is nil" do

--- a/spec/unit/provider/cron/crontab_spec.rb
+++ b/spec/unit/provider/cron/crontab_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
 
     ########################################################################
     # Simple input fixtures for testing.
-    samples = YAML.safe_load(File.read(my_fixture('single_line.yaml')), [Symbol])
+    samples = Puppet::Util::Yaml.safe_load(File.read(my_fixture('single_line.yaml')), [Symbol])
 
     samples.each do |name, data|
       it "should parse crontab line #{name} correctly" do

--- a/spec/unit/provider/cron/crontab_spec.rb
+++ b/spec/unit/provider/cron/crontab_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
 
     ########################################################################
     # Simple input fixtures for testing.
-    samples = YAML.load(File.read(my_fixture('single_line.yaml')))
+    samples = YAML.safe_load(File.read(my_fixture('single_line.yaml')), [Symbol])
 
     samples.each do |name, data|
       it "should parse crontab line #{name} correctly" do

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -777,7 +777,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
       @catalog.add_edge("one", "two")
 
       text = YAML.dump(@catalog)
-      @newcatalog = YAML.load(text)
+      @newcatalog = YAML.safe_load(text, [Puppet::Resource::Catalog])
     end
 
     it "should get converted back to a catalog" do

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -777,7 +777,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
       @catalog.add_edge("one", "two")
 
       text = YAML.dump(@catalog)
-      @newcatalog = YAML.safe_load(text, [Puppet::Resource::Catalog])
+      @newcatalog = Puppet::Util::Yaml.safe_load(text, [Puppet::Resource::Catalog])
     end
 
     it "should get converted back to a catalog" do

--- a/spec/unit/util/tag_set_spec.rb
+++ b/spec/unit/util/tag_set_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Util::TagSet do
     array = ['a', :b, 1, 5.4]
     set.merge(array)
 
-    expect(Set.new(YAML.load(set.to_yaml))).to eq(Set.new(array))
+    expect(Set.new(YAML.safe_load(set.to_yaml, [Symbol, Puppet::Util::TagSet]))).to eq(Set.new(array))
   end
 
   it 'deserializes from a yaml array' do

--- a/spec/unit/util/tag_set_spec.rb
+++ b/spec/unit/util/tag_set_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Util::TagSet do
     array = ['a', :b, 1, 5.4]
     set.merge(array)
 
-    expect(Set.new(YAML.safe_load(set.to_yaml, [Symbol, Puppet::Util::TagSet]))).to eq(Set.new(array))
+    expect(Set.new(Puppet::Util::Yaml.safe_load(set.to_yaml, [Symbol, Puppet::Util::TagSet]))).to eq(Set.new(array))
   end
 
   it 'deserializes from a yaml array' do


### PR DESCRIPTION
This commit replaces all calls to the unsafe `YAML.load` method with
calls to `YAML.safe_load` to gain control over exactly what classes that
are permitted to create instances during the load.