### PR TITLE
(PUP-7835) Refactor how TypeMismatchDescriber tracks expected type

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -92,51 +92,6 @@ module Types
     end
   end
 
-  # Module to handle present/past tense.
-  #
-  # All method names prefixed with "it_" to avoid conflict with Mocha expectations. Adding a method
-  # named 'expects' just doesn't work.
-  #
-  # @deprecated Will be removed in Puppet 5
-  # @api private
-  module TenseVariants
-    def it_expects(tense)
-      case tense
-      when :present
-        'expects'
-      else
-        'expected'
-      end
-    end
-
-    def it_does_not_expect(tense)
-      case tense
-      when :present
-        'does not expect'
-      else
-        'did not expect'
-      end
-    end
-
-    def it_has_no(tense)
-      case tense
-      when :present
-        'has no'
-      else
-        'did not have a'
-      end
-    end
-
-    def it_references(tense)
-      case tense
-        when :present
-          'references'
-        else
-          'referenced'
-      end
-    end
-  end
-
   # @api private
   class Mismatch
     attr_reader :path

--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -293,11 +293,6 @@ module Types
       super(path)
       @expected = (expected.is_a?(Array) ? PVariantType.maybe_create(expected) : expected).normalize
       @actual = actual.normalize
-      @optional = false
-    end
-
-    def set_optional
-      @optional = true
     end
 
     def ==(o)
@@ -306,12 +301,6 @@ module Types
 
     def hash
       [canonical_path, expected, actual].hash
-    end
-
-    def swap_expected(expected)
-      copy = self.clone
-      copy.instance_variable_set(:@expected, expected)
-      copy
     end
   end
 
@@ -328,15 +317,12 @@ module Types
       e = expected
       a = actual
       multi = false
-      if @optional
-        if e.is_a?(PVariantType)
-          e = e.types
-          e = [PUndefType::DEFAULT] + e unless e.include?(PUndefType::DEFAULT)
-        else
-          er = all_resolved(e)
-          e = [PUndefType::DEFAULT, e] unless er.is_a?(PVariantType) && er.types.include?(PUndefType::DEFAULT)
-        end
-      elsif e.is_a?(PVariantType)
+      if e.is_a?(POptionalType)
+        e = e.optional_type
+        optional = true
+      end
+
+      if e.is_a?(PVariantType)
         e = e.types
       end
 
@@ -348,6 +334,7 @@ module Types
           e = e.map { |t| t.simple_name }.uniq
           a = a.simple_name
         end
+        e.insert(0, 'Undef') if optional
         case e.size
         when 1
           e = e[0]
@@ -365,6 +352,10 @@ module Types
         else
           e = e.simple_name
           a = a.simple_name
+        end
+        if optional
+          e = "Undef or #{e}"
+          multi = true
         end
       end
       if multi
@@ -473,7 +464,13 @@ module Types
   # @api private
   class PatternMismatch < TypeMismatch
     def message(variant, position)
-      "#{variant}#{position} expects a match for #{expected.to_alias_expanded_s}, got #{actual_string}"
+      e = expected
+      value_pfx = ''
+      if e.is_a?(POptionalType)
+        e = e.optional_type
+        value_pfx = 'an undef value or '
+      end
+      "#{variant}#{position} expects #{value_pfx}a match for #{e.to_alias_expanded_s}, got #{actual_string}"
     end
 
     def actual_string
@@ -747,14 +744,23 @@ module Types
       end
     end
 
-    def describe_PVariantType(expected, actual, path)
+    def describe_PVariantType(expected, original, actual, path)
       variant_descriptions = []
-      expected.types.each_with_index do |vt, index|
+      types = expected.types
+      types = [PUndefType::DEFAULT] + types if original.is_a?(POptionalType)
+      types.each_with_index do |vt, index|
         d = describe(vt, actual, path + [VariantPathElement.new(index)])
         return EMPTY_ARRAY if d.empty?
         variant_descriptions << d
       end
-      merge_descriptions(path.length, SizeMismatch, variant_descriptions)
+      descriptions = merge_descriptions(path.length, SizeMismatch, variant_descriptions)
+      if original.is_a?(PTypeAliasType) && descriptions.size == 1
+        # All variants failed in this alias so we report it as a mismatch on the alias
+        # rather than reporting individual failures of the variants
+        [TypeMismatch.new(path, original, actual)]
+      else
+        descriptions
+      end
     end
 
     def merge_descriptions(varying_path_position, size_mismatch_class, variant_descriptions)
@@ -778,33 +784,24 @@ module Types
       descriptions.size == 1 ? [descriptions[0].chop_path(varying_path_position)] : descriptions
     end
 
-    def describe_POptionalType(expected, actual, path)
+    def describe_POptionalType(expected, original, actual, path)
       return EMPTY_ARRAY if actual.is_a?(PUndefType)
-      descriptions = describe(expected.optional_type, actual, path)
-      descriptions.each { |description| description.set_optional }
-      descriptions
+      internal_describe(expected.optional_type, original.is_a?(PTypeAliasType) ? original : expected, actual, path)
     end
 
-    def describe_PEnumType(expected, actual, path)
-      [PatternMismatch.new(path, expected, actual)]
+    def describe_PEnumType(expected, original, actual, path)
+      [PatternMismatch.new(path, original, actual)]
     end
 
-    def describe_PPatternType(expected, actual, path)
-      [PatternMismatch.new(path, expected, actual)]
+    def describe_PPatternType(expected, original, actual, path)
+      [PatternMismatch.new(path, original, actual)]
     end
 
-    def describe_PTypeAliasType(expected, actual, path)
-      resolved_type = expected.resolved_type
-      describe(resolved_type, actual, path).map do |description|
-        if description.is_a?(ExpectedActualMismatch) && description.path.length == path.length
-          description.swap_expected(expected)
-        else
-          description
-        end
-      end
+    def describe_PTypeAliasType(expected, original, actual, path)
+      internal_describe(expected.resolved_type.normalize, expected, actual, path)
     end
 
-    def describe_PArrayType(expected, actual, path)
+    def describe_PArrayType(expected, original, actual, path)
       descriptions = []
       element_type = expected.element_type || PAnyType::DEFAULT
       if actual.is_a?(PTupleType)
@@ -822,17 +819,17 @@ module Types
         expected_size = expected.size_type
         actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
         if expected_size.nil? || expected_size.assignable?(actual_size)
-          descriptions << TypeMismatch.new(path, expected, PArrayType.new(actual.element_type))
+          descriptions << TypeMismatch.new(path, original, PArrayType.new(actual.element_type))
         else
           descriptions << SizeMismatch.new(path, expected_size, actual_size)
         end
       else
-        descriptions << TypeMismatch.new(path, expected, actual)
+        descriptions << TypeMismatch.new(path, original, actual)
       end
       descriptions
     end
 
-    def describe_PHashType(expected, actual, path)
+    def describe_PHashType(expected, original, actual, path)
       descriptions = []
       key_type = expected.key_type || PAnyType::DEFAULT
       value_type = expected.value_type || PAnyType::DEFAULT
@@ -852,17 +849,17 @@ module Types
         expected_size = expected.size_type
         actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
         if expected_size.nil? || expected_size.assignable?(actual_size)
-          descriptions << TypeMismatch.new(path, expected, PHashType.new(actual.key_type, actual.value_type))
+          descriptions << TypeMismatch.new(path, original, PHashType.new(actual.key_type, actual.value_type))
         else
           descriptions << SizeMismatch.new(path, expected_size, actual_size)
         end
       else
-        descriptions << TypeMismatch.new(path, expected, actual)
+        descriptions << TypeMismatch.new(path, original, actual)
       end
       descriptions
     end
 
-    def describe_PStructType(expected, actual, path)
+    def describe_PStructType(expected, original, actual, path)
       elements = expected.elements
       descriptions = []
       if actual.is_a?(PStructType)
@@ -882,25 +879,25 @@ module Types
         actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
         expected_size = PIntegerType.new(elements.count { |e| !e.key_type.assignable?(PUndefType::DEFAULT) }, elements.size)
         if expected_size.assignable?(actual_size)
-          descriptions << TypeMismatch.new(path, expected, PHashType.new(actual.key_type, actual.value_type))
+          descriptions << TypeMismatch.new(path, original, PHashType.new(actual.key_type, actual.value_type))
         else
           descriptions << SizeMismatch.new(path, expected_size, actual_size)
         end
       else
-        descriptions << TypeMismatch.new(path, expected, actual)
+        descriptions << TypeMismatch.new(path, original, actual)
       end
       descriptions
     end
 
-    def describe_PTupleType(expected, actual, path)
-      describe_tuple(expected, actual, path, SizeMismatch)
+    def describe_PTupleType(expected, original, actual, path)
+      describe_tuple(expected, original, actual, path, SizeMismatch)
     end
 
     def describe_argument_tuple(expected, actual, path)
-      describe_tuple(expected, actual, path, CountMismatch)
+      describe_tuple(expected, expected, actual, path, CountMismatch)
     end
 
-    def describe_tuple(expected, actual, path, size_mismatch_class)
+    def describe_tuple(expected, original, actual, path, size_mismatch_class)
       return EMPTY_ARRAY if expected == actual || expected.types.empty? && (actual.is_a?(PArrayType))
       expected_size = expected.size_type || TypeFactory.range(*expected.size_range)
 
@@ -928,7 +925,7 @@ module Types
           # Array of anything can not be assigned (unless tuple is tuple of anything) - this case
           # was handled at the top of this method.
           #
-          [TypeMismatch.new(path, expected, actual)]
+          [TypeMismatch.new(path, original, actual)]
         else
           expected_size = expected.size_type || TypeFactory.range(*expected.size_range)
           actual_size = actual.size_type || PCollectionType::DEFAULT_SIZE
@@ -943,11 +940,11 @@ module Types
           end
         end
       else
-        [TypeMismatch.new(path, expected, actual)]
+        [TypeMismatch.new(path, original, actual)]
       end
     end
 
-    def describe_PCallableType(expected, actual, path)
+    def describe_PCallableType(expected, original, actual, path)
       if actual.is_a?(PCallableType)
         # nil param_types means, any other Callable is assignable
         if expected.param_types.nil? && expected.return_type.nil?
@@ -977,12 +974,12 @@ module Types
           end
         end
       else
-        [TypeMismatch.new(path, expected, actual)]
+        [TypeMismatch.new(path, original, actual)]
       end
     end
 
-    def describe_PAnyType(expected, actual, path)
-      expected.assignable?(actual) ? EMPTY_ARRAY : [TypeMismatch.new(path, expected, actual)]
+    def describe_PAnyType(expected, original, actual, path)
+      expected.assignable?(actual) ? EMPTY_ARRAY : [TypeMismatch.new(path, original, actual)]
     end
 
     class UnresolvedTypeFinder
@@ -1008,33 +1005,37 @@ module Types
       if unresolved
         [UnresolvedTypeReference.new(path, unresolved)]
       else
-        expected = expected.normalize
-        case expected
-        when PVariantType
-          describe_PVariantType(expected, actual, path)
-        when PStructType
-          describe_PStructType(expected, actual, path)
-        when PHashType
-          describe_PHashType(expected, actual, path)
-        when PTupleType
-          describe_PTupleType(expected, actual, path)
-        when PArrayType
-          describe_PArrayType(expected, actual, path)
-        when PCallableType
-          describe_PCallableType(expected, actual, path)
-        when POptionalType
-          describe_POptionalType(expected, actual, path)
-        when PPatternType
-          describe_PPatternType(expected, actual, path)
-        when PEnumType
-          describe_PEnumType(expected, actual, path)
-        when PTypeAliasType
-          describe_PTypeAliasType(expected, actual, path)
-        else
-          describe_PAnyType(expected, actual, path)
-        end
+        internal_describe(expected.normalize, expected, actual, path)
       end
     end
+
+    def internal_describe(expected, original, actual, path)
+      case expected
+      when PVariantType
+        describe_PVariantType(expected, original, actual, path)
+      when PStructType
+        describe_PStructType(expected, original, actual, path)
+      when PHashType
+        describe_PHashType(expected, original, actual, path)
+      when PTupleType
+        describe_PTupleType(expected, original, actual, path)
+      when PArrayType
+        describe_PArrayType(expected, original, actual, path)
+      when PCallableType
+        describe_PCallableType(expected, original, actual, path)
+      when POptionalType
+        describe_POptionalType(expected, original, actual, path)
+      when PPatternType
+        describe_PPatternType(expected, original, actual, path)
+      when PEnumType
+        describe_PEnumType(expected, original, actual, path)
+      when PTypeAliasType
+        describe_PTypeAliasType(expected, original, actual, path)
+      else
+        describe_PAnyType(expected, original, actual, path)
+      end
+    end
+    private :internal_describe
 
     # Produces a string for the signature(s)
     #

--- a/spec/unit/functions/regsubst_spec.rb
+++ b/spec/unit/functions/regsubst_spec.rb
@@ -30,7 +30,7 @@ describe 'the regsubst function' do
     end
 
     it 'should raise an Error if given a bad flag' do
-      expect { regsubst('foo', 'bar', 'gazonk', 'X') }.to raise_error(/parameter 'flags' expects a match for Pattern\[\/\^\[GEIM\]\*\$\/\], got 'X'/)
+      expect { regsubst('foo', 'bar', 'gazonk', 'X') }.to raise_error(/parameter 'flags' expects an undef value or a match for Pattern\[\/\^\[GEIM\]\*\$\/\], got 'X'/)
     end
 
     it 'should raise an Error if given a bad encoding' do

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -223,6 +223,18 @@ describe 'the type mismatch describer' do
       expect(subject.describe_signatures('function', [dispatch], args_tuple)).to eq("'function' block return expects a String value, got Integer")
     end
   end
+
+  it "reports struct mismatch correctly when hash doesn't contain required keys" do
+    code = <<-PUPPET
+      type Test::Options = Struct[{
+        var => String
+      }]
+      class test(String $var, Test::Options $opts) {}
+      class { 'test': var => 'hello', opts => {} }
+    PUPPET
+    expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
+      /Class\[Test\]: parameter 'opts' expects size to be 1, got 0/))
+  end
 end
 end
 end


### PR DESCRIPTION
The `TypeMismatchDescriber` contained some less ideal logic that made
attempts to revert the effect or using normalized types or types
extracted from an `Optional` or a `TypeAlias`. This commit removes that
code and adds a parameter to get track of the original instead which
results in a simpler and more reliable solution.