### PR TITLE
(PUP-7815) Add Task class, TaskInfoService class

### DIFF
--- a/lib/puppet/info_service.rb
+++ b/lib/puppet/info_service.rb
@@ -1,7 +1,17 @@
 
 module Puppet::InfoService
   require 'puppet/info_service/class_information_service'
+  require 'puppet/info_service/task_information_service'
+
   def self.classes_per_environment(env_file_hash)
     Puppet::InfoService::ClassInformationService.new.classes_per_environment(env_file_hash)
+  end
+
+  def self.tasks_per_environment(environment_name)
+    Puppet::InfoService::TaskInformationService.tasks_per_environment(environment_name)
+  end
+
+  def self.task_data(environment_name, module_name, task_name)
+    Puppet::InfoService::TaskInformationService.task_data(environment_name, module_name, task_name)
   end
 end

--- a/lib/puppet/info_service/task_information_service.rb
+++ b/lib/puppet/info_service/task_information_service.rb
@@ -1,0 +1,32 @@
+class Puppet::InfoService::TaskInformationService
+  require 'puppet/module'
+
+  def self.tasks_per_environment(environment_name)
+    # get the actual environment object, raise error if the named env doesn't exist
+    env = Puppet.lookup(:environments).get!(environment_name)
+    env.modules.map do |mod|
+      mod.tasks.map do |task|
+        {:module => {:name => task.module.name}, :name => task.name}
+      end
+    end.flatten
+  end
+
+  def self.task_data(environment_name, module_name, task_name)
+    # raise EnvironmentNotFound if applicable
+    Puppet.lookup(:environments).get!(environment_name)
+
+    pup_module = Puppet::Module.find(module_name, environment_name)
+    if pup_module.nil?
+      raise Puppet::Module::MissingModule, _("Module %{module_name} not found in environment %{environment_name}.") %
+                                            {module_name: module_name, environment_name: environment_name}
+    end
+
+    task = pup_module.tasks.find { |t| t.name == task_name }
+    if task.nil?
+      raise Puppet::Module::Task::TaskNotFound, _("Task %{task_name} not found in module %{module_name}.") %
+                                                 {task_name: task_name, module_name: module_name}
+    end
+
+    {:metadata_file => task.metadata_file, :files => task.files}
+  end
+end

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -1,4 +1,5 @@
 require 'puppet/util/logging'
+require 'puppet/module/task'
 require 'json'
 require 'semantic_puppet/gem_version'
 
@@ -79,7 +80,7 @@ class Puppet::Module
     end
   end
 
-  attr_reader :name, :environment, :path, :metadata
+  attr_reader :name, :environment, :path, :metadata, :tasks
   attr_writer :environment
 
   attr_accessor :dependencies, :forge_name
@@ -171,6 +172,16 @@ class Puppet::Module
 
   def tasks_directory
     subpath("tasks")
+  end
+
+  def tasks
+    return @tasks if instance_variable_defined?(:@tasks)
+
+    if Puppet::FileSystem.exist?(tasks_directory)
+      @tasks = Puppet::Module::Task.tasks_in_module(self)
+    else
+      @tasks = []
+    end
   end
 
   def license_file

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -169,6 +169,10 @@ class Puppet::Module
     end
   end
 
+  def tasks_directory
+    subpath("tasks")
+  end
+
   def license_file
     return @license_file if defined?(@license_file)
 

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -1,0 +1,90 @@
+require 'json'
+require 'puppet/util/logging'
+
+class Puppet::Module
+  class Task
+    class Error < Puppet::Error; end
+    class InvalidName < Error; end
+    class InvalidFile < Error; end
+    class TaskNotFound < Error; end
+
+    FORBIDDEN_EXTENSIONS = %w{.conf .md}
+
+    def self.is_task_name?(name)
+      return true if name =~ /^[a-z][a-z0-9_]*$/
+      return false
+    end
+
+    # Determine whether a file has a legal name for either a task's executable or metadata file.
+    def self.is_tasks_filename?(path)
+      name_less_extension = File.basename(path, '.*')
+      return false if not is_task_name?(name_less_extension)
+      FORBIDDEN_EXTENSIONS.each do |ext|
+        return false if path.end_with?(ext)
+      end
+      return true
+    end
+
+    def self.is_tasks_metadata_filename?(name)
+      is_tasks_filename?(name) && name.end_with?('.json')
+    end
+
+    def self.is_tasks_executable_filename?(name)
+      is_tasks_filename?(name) && !name.end_with?('.json')
+    end
+
+    def self.tasks_in_module(pup_module)
+      Dir.glob(File.join(pup_module.tasks_directory, '*'))
+        .keep_if { |f| is_tasks_filename?(f) }
+        .group_by { |f| task_name_from_path(f) }
+        .map { |task, files| new_with_files(pup_module, task, files) }
+    end
+
+    attr_reader :name, :module, :metadata_file, :files
+
+    def initialize(pup_module, task_name, files, metadata_file = nil)
+      if !Puppet::Module::Task.is_task_name?(task_name)
+        raise InvalidName, _("Task names must start with a lowercase letter and be composed of only lowercase letters, numbers, and underscores")
+      end
+
+      all_files = metadata_file.nil? ? files : files + [metadata_file]
+      all_files.each do |f|
+        if !f.start_with?(pup_module.tasks_directory)
+          msg = _("The file '%{path}' is not located in the %{module_name} module's tasks directory") %
+                       {path: f.to_s, module_name: pup_module.name}
+
+          # we can include some extra context for the log message:
+          Puppet.err(msg + " (#{pup_module.tasks_directory})")
+          raise InvalidFile, msg
+        end
+      end
+
+      name = task_name == "init" ? pup_module.name : "#{pup_module.name}::#{task_name}"
+
+      @module = pup_module
+      @name = name
+      @metadata_file = metadata_file if metadata_file
+      @files = files
+    end
+
+    def ==(other)
+      self.name == other.name &&
+      self.module == other.module
+    end
+
+    private
+
+    def self.new_with_files(pup_module, name, tasks_files)
+      files = tasks_files.map do |filename|
+        File.join(pup_module.tasks_directory, File.basename(filename))
+      end
+
+      metadata_files, exe_files = files.partition { |f| is_tasks_metadata_filename?(f) }
+      Puppet::Module::Task.new(pup_module, name, exe_files, metadata_files.first)
+    end
+
+    def self.task_name_from_path(path)
+      return File.basename(path, '.*')
+    end
+  end
+end

--- a/spec/lib/puppet_spec/modules.rb
+++ b/spec/lib/puppet_spec/modules.rb
@@ -20,6 +20,16 @@ module PuppetSpec::Modules
         end
       end
 
+      if tasks = options[:tasks]
+        tasks_dir = File.join(module_dir, 'tasks')
+        FileUtils.mkdir_p(tasks_dir)
+        tasks.each do |task_files|
+          task_files.each do |task_file|
+            FileUtils.touch(File.join(tasks_dir, task_file))
+          end
+        end
+      end
+
       Puppet::Module.new(name, module_dir, environment)
     end
 

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -553,6 +553,10 @@ describe Puppet::Module do
   it "should return the path to the plugin directory" do
     expect(mod.plugin_directory).to eq(File.join(path, "lib"))
   end
+
+  it "should return the path to the tasks directory" do
+    expect(mod.tasks_directory).to eq(File.join(path, "tasks"))
+  end
 end
 
 describe Puppet::Module, "when finding matching manifests" do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -222,7 +222,9 @@ describe Puppet::Module do
       env = Puppet::Node::Environment.create(:testing, [@modpath])
 
       ['test_gte_req', 'test_specific_req', 'foobar'].each do |mod_name|
-        metadata_file = "#{@modpath}/#{mod_name}/metadata.json"
+        mod_dir = "#{@modpath}/#{mod_name}"
+        metadata_file = "#{mod_dir}/metadata.json"
+        tasks_dir = "#{mod_dir}/tasks"
         Puppet::FileSystem.stubs(:exist?).with(metadata_file).returns true
       end
       mod = PuppetSpec::Modules.create(
@@ -556,6 +558,66 @@ describe Puppet::Module do
 
   it "should return the path to the tasks directory" do
     expect(mod.tasks_directory).to eq(File.join(path, "tasks"))
+  end
+
+  describe "when finding tasks" do
+    before do
+      Puppet::FileSystem.unstub(:exist?)
+      @modpath = tmpdir('modpath')
+      Puppet.settings[:modulepath] = @modpath
+    end
+
+    it "should have an empty array for the tasks when the tasks directory does not exist" do
+      mod = PuppetSpec::Modules.create('tasks_test_nodir', @modpath, :environment => env)
+      expect(mod.tasks).to eq([])
+    end
+
+    it "should have an empty array for the tasks when the tasks directory does exist and is empty" do
+      mod = PuppetSpec::Modules.create('tasks_test_empty', @modpath, {:environment => env,
+                                                                      :tasks => []})
+      expect(mod.tasks).to eq([])
+    end
+
+    it "should list the expected tasks when the required files exist" do
+      fake_tasks = [['task1'], ['task2.sh', 'task2.json']]
+      mod = PuppetSpec::Modules.create('tasks_smoke', @modpath, {:environment => env,
+                                                                 :tasks => fake_tasks})
+
+      expect(mod.tasks.count).to eq(2)
+      expect(mod.tasks.map{|t| t.name}.sort).to eq(['tasks_smoke::task1', 'tasks_smoke::task2'])
+      expect(mod.tasks.map{|t| t.class}).to eq([Puppet::Module::Task] * 2)
+    end
+
+    describe "does the task finding" do
+      before :each do
+        Puppet::FileSystem.unstub(:exist?)
+        Puppet::Module::Task.unstub(:tasks_in_module)
+      end
+
+      let(:mod_name) { 'tasks_test_lazy' }
+      let(:mod_tasks_dir) { File.join(@modpath, mod_name, 'tasks') }
+
+      it "after the module is initialized" do
+        Puppet::FileSystem.expects(:exist?).with(mod_tasks_dir).never
+        Puppet::Module::Task.expects(:tasks_in_module).never
+        Puppet::Module.new(mod_name, @modpath, env)
+      end
+
+      it "when the tasks method is called" do
+        Puppet::Module::Task.expects(:tasks_in_module)
+        mod = PuppetSpec::Modules.create(mod_name, @modpath, {:environment => env,
+                                                              :tasks => [['itascanstaccatotask']]})
+        mod.tasks
+      end
+
+      it "only once for the lifetime of the module object" do
+        Dir.expects(:glob).with("#{mod_tasks_dir}/*").once.returns ['allalaskataskattacktactics']
+        mod = PuppetSpec::Modules.create(mod_name, @modpath, {:environment => env,
+                                                              :tasks => []})
+        mod.tasks
+        mod.tasks
+      end
+    end
   end
 end
 

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -1,0 +1,102 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet_spec/files'
+require 'puppet_spec/modules'
+require 'puppet/module/task'
+
+describe Puppet::Module::Task do
+  include PuppetSpec::Files
+
+  let(:modpath) { tmpdir('task_modpath') }
+  let(:mymodpath) { File.join(modpath, 'mymod') }
+  let(:mymod) { Puppet::Module.new('mymod', mymodpath, nil) }
+  let(:tasks_path) { File.join(mymodpath, 'tasks') }
+  let(:tasks_glob) { File.join(mymodpath, 'tasks', '*') }
+
+  it "cannot construct tasks with illegal names" do
+    expect { Puppet::Module::Task.new(mymod, "iLegal", []) }
+      .to raise_error(Puppet::Module::Task::InvalidName,
+                      "Task names must start with a lowercase letter and be composed of only lowercase letters, numbers, and underscores")
+  end
+
+  it "cannot construct tasks whose files are outside of their module's tasks directory" do
+    outside_file = "/var/root/secret_tasks/classified"
+    expect { Puppet::Module::Task.new(mymod, "fail", [outside_file]) }
+      .to raise_error(Puppet::Module::Task::InvalidFile,
+                     "The file '#{outside_file}' is not located in the mymod module's tasks directory")
+  end
+
+  it "constructs tasks as expected when every task has a metadata file with the same name (besides extension)" do
+    Dir.expects(:glob).with(tasks_glob).returns(%w{task1.json task1 task2.json task2.exe task3.json task3.sh})
+    tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+    expect(tasks.count).to eq(3)
+    expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1 mymod::task2 mymod::task3})
+    expect(tasks.map{|t| t.metadata_file}).to eq(["#{tasks_path}/task1.json",
+                                                  "#{tasks_path}/task2.json",
+                                                  "#{tasks_path}/task3.json"])
+    expect(tasks.map{|t| t.files}).to eq([["#{tasks_path}/task1"],
+                                          ["#{tasks_path}/task2.exe"],
+                                          ["#{tasks_path}/task3.sh"]])
+
+    tasks.map{|t| t.metadata_file}.each do |metadata_file|
+      expect(metadata_file).to eq(File.absolute_path(metadata_file))
+    end
+
+    tasks.map{|t| t.files}.each do |task_files|
+      task_file = task_files[0]
+      expect(task_file).to eq(File.absolute_path(task_file))
+    end
+  end
+
+  it "constructs tasks as expected when some tasks don't have a metadata file" do
+    Dir.expects(:glob).with(tasks_glob).returns(%w{task1 task2.exe task3.json task3.sh})
+    tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+    expect(tasks.count).to eq(3)
+    expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1 mymod::task2 mymod::task3})
+    expect(tasks.map{|t| t.metadata_file}).to eq([nil, nil, "#{tasks_path}/task3.json"])
+    expect(tasks.map{|t| t.files}).to eq([["#{tasks_path}/task1"],
+                                          ["#{tasks_path}/task2.exe"],
+                                          ["#{tasks_path}/task3.sh"]])
+  end
+
+  it "constructs tasks as expected when a task has multiple executable files" do
+    Dir.expects(:glob).with(tasks_glob).returns(%w{task1.elf task1.exe task1.json task2.ps1 task2.sh})
+    tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+    expect(tasks.count).to eq(2)
+    expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1 mymod::task2})
+    expect(tasks.map{|t| t.metadata_file}).to eq(["#{tasks_path}/task1.json", nil])
+    expect(tasks.map{|t| t.files}).to eq([["#{tasks_path}/task1.elf", "#{tasks_path}/task1.exe"],
+                                          ["#{tasks_path}/task2.ps1", "#{tasks_path}/task2.sh"]])
+  end
+
+  it "finds files whose names (besides extensions) are valid task names" do
+    Dir.expects(:glob).with(tasks_glob).returns(%w{task task_1 xx_t_a_s_k_2_xx})
+    tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+    expect(tasks.count).to eq(3)
+    expect(tasks.map{|t| t.name}).to eq(%w{mymod::task mymod::task_1 mymod::xx_t_a_s_k_2_xx})
+  end
+
+  it "ignores files that have names (besides extensions) that are not valid task names" do
+    Dir.expects(:glob).with(tasks_glob).returns(%w{.nottask.exe .wat !runme _task 2task2furious def_a_task_PSYCH Fake_task not-a-task realtask})
+    tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+    expect(tasks.count).to eq(1)
+    expect(tasks.map{|t| t.name}).to eq(%w{mymod::realtask})
+  end
+
+  it "ignores files that have names ending in .conf and .md" do
+    Dir.expects(:glob).with(tasks_glob).returns(%w{ginuwine_task task.conf readme.md other_task.md})
+    tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+    expect(tasks.count).to eq(1)
+    expect(tasks.map{|t| t.name}).to eq(%w{mymod::ginuwine_task})
+  end
+
+  it "gives the 'init' task a name that is just the module's name" do
+    expect(Puppet::Module::Task.new(mymod, 'init', ["#{tasks_path}/init.sh"]).name).to eq('mymod')
+  end
+end


### PR DESCRIPTION
Supercedes #6100

Add a new class to represent tasks contained in modules. There's not much functionality in it yet: it can find valid task files in a module's tasks directory and construct tasks composed of them, where the tasks
can't do anything but tell you their name, their payload files, their metadata file (if they have one), and the module they belong to, all via attribute reader instance methods. There are no other instance methods,
but there are a few public class methods for validating task names and file names.

When modules are created, they check to see if their tasks directory exists. If so, they use the Puppet::Module::Task class to create a Task object for every task that exists in their task directory.

Also adds two new methods to the InformationService module, both of which are implemented in the new TaskInfoService class. `tasks_per_environment` returns very basic information (module and task name) for every task in a given environment. `task_data` returns the file paths relevant to a named task in a given environment and module.