### PR TITLE
(PUP-7472) Make binding to '*' work on non-Linux platforms

### DIFF
--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -54,6 +54,7 @@ class Puppet::Network::HTTP::WEBrick
 
   # @api private
   def create_server(address, port)
+    address = nil if address == '*'
     arguments = {:BindAddress => address, :Port => port, :DoNotReverseLookup => true}
     arguments.merge!(setup_logger)
     arguments.merge!(setup_ssl)


### PR DESCRIPTION
It appears that binding to '\*' is platform-specific on Ruby, but
binding to 'nil' works everywhere. Since Puppet settings aren't
nillable, we keep '\*' as the setting value, but munge that to 'nil'
in the HTTP setup code.