### PR TITLE
(PUP-7844) Return -1 for exit_status for interrupted runs

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -377,9 +377,15 @@ class Puppet::Transaction::Report
   #
   def exit_status
     status = 0
-    status |= 2 if @metrics["changes"]["total"] > 0
-    status |= 4 if @metrics["resources"]["failed"] > 0
-    status |= 4 if @metrics["resources"]["failed_to_restart"] > 0
+    if @metrics["changes"] && @metrics["changes"]["total"] &&
+        @metrics["resources"] && @metrics["resources"]["failed"] &&
+        @metrics["resources"]["failed_to_restart"]
+      status |= 2 if @metrics["changes"]["total"] > 0
+      status |= 4 if @metrics["resources"]["failed"] > 0
+      status |= 4 if @metrics["resources"]["failed_to_restart"] > 0
+    else
+      status = -1
+    end
     status
   end
 

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -189,6 +189,11 @@ describe Puppet::Transaction::Report do
   end
 
   describe "when computing exit status" do
+    it "should produce -1 if no metrics are present" do
+      report = Puppet::Transaction::Report.new("apply")
+      expect(report.exit_status).to eq(-1)
+    end
+
     it "should produce 2 if changes are present" do
       report = Puppet::Transaction::Report.new("apply")
       report.add_metric("changes", {"total" => 1})


### PR DESCRIPTION
If a puppet run is interrupted, the local puppet report in
last_run_report will be incomplete, which will mean that the metrics
instance variable will portentially be the empty hash. Because the
lookups in `exit_status` against `metrics` is not safe, it could raise
an exception. This commit updates the `exit_status` method to check to
make sure `metrics` has the expected keys and if not to return -1
instead of raising an exception.