### PR TITLE
(PUP-7845) Implement leaf certificate revocation checking

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -267,6 +267,7 @@ module Puppet
         Puppet::Network::HTTP::NoCachePool.new
       },
       :ssl_host => proc { Puppet::SSL::Host.localhost },
+      :certificate_revocation => proc { Puppet[:certificate_revocation] },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins }
     }
   end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -854,11 +854,23 @@ EOT
         This is distinct from the certificate authority's CRL."
     },
     :certificate_revocation => {
-        :default  => true,
-        :type     => :boolean,
-        :desc     => "Whether certificate revocation should be supported by downloading a
-          Certificate Revocation List (CRL)
-          to all clients.  If enabled, CA chaining will almost definitely not work.",
+        :default  => 'chain',
+        :type     => :certificate_revocation,
+        :desc     => <<EOT
+Whether certificate revocation checking should be enabled, and what level of checking should be performed.
+
+When certificate_revocation is set to 'true' or 'chain', Puppet will download the CA CRL and will perform revocation
+checking against each certificate in the chain. When Puppet is using a single root certificate and has no intermediates
+this will perform revocation checking with the root CA certificate. Puppet is unable to load multiple CRLs so if
+intermediate CAs are in use full chain revocation checking will fail.
+
+When certificate_revocation is set to 'leaf', Puppet will download the CA CRL and will verify the leaf certificate
+against that CRL. CRLs will not be fetched or checked for the rest of the certificates in the chain. If you are using
+an intermediate CA certificate and want to enable certificate revocation checking, this setting must be set to 'leaf'.
+
+When certificate_revocation is set to 'false', Puppet will disable all certificate revocation checking and will not
+attempt to download the CRL.
+EOT
     },
     :digest_algorithm => {
         :default  => 'md5',

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -860,9 +860,13 @@ EOT
 Whether certificate revocation checking should be enabled, and what level of checking should be performed.
 
 When certificate_revocation is set to 'true' or 'chain', Puppet will download the CA CRL and will perform revocation
-checking against each certificate in the chain. When Puppet is using a single root certificate and has no intermediates
-this will perform revocation checking with the root CA certificate. Puppet is unable to load multiple CRLs so if
-intermediate CAs are in use full chain revocation checking will fail.
+checking against each certificate in the chain.
+
+Puppet is unable to load multiple CRLs, so if certificate_revocation is set to 'chain' and Puppet attempts to verify
+a certificate signed by a root CA the behavior is equivalent to the 'leaf' setting, and if Puppet attempts to verify
+a certificate signed by an intermediate CA then verification will fail as Puppet will be unable to load the multiple
+CRLs required for full chain checking. As such the 'chain' setting is limited in functionality and is meant as a stand
+in pending the implementation of full chain checking.
 
 When certificate_revocation is set to 'leaf', Puppet will download the CA CRL and will verify the leaf certificate
 against that CRL. CRLs will not be fetched or checked for the rest of the certificates in the chain. If you are using

--- a/lib/puppet/indirector/certificate_revocation_list/rest.rb
+++ b/lib/puppet/indirector/certificate_revocation_list/rest.rb
@@ -7,4 +7,16 @@ class Puppet::SSL::CertificateRevocationList::Rest < Puppet::Indirector::REST
   use_server_setting(:ca_server)
   use_port_setting(:ca_port)
   use_srv_service(:ca)
+
+  def find(request)
+    if !Puppet::FileSystem.exist?(Puppet[:hostcrl])
+      msg =  "Disable certificate revocation checking when fetching the CRL and no CRL is present"
+      overrides = {certificate_revocation: false}
+      Puppet.override(overrides, msg) do
+        super
+      end
+    else
+      super
+    end
+  end
 end

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -228,8 +228,13 @@ module Puppet::Network::HTTP
         raise Puppet::Error, msg, error.backtrace
       elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert.content, site.host)
         valid_certnames = [peer_cert.name, *peer_cert.subject_alt_names].uniq
-        certnames_msg = valid_certnames.length > 1 ? _("one of %{certnames}") % { certnames: valid_certnames.join(', ') } : valid_certnames.first
-        msg = _("Server hostname '%{host}' did not match server certificate; expected %{msg}") % { host: site.host, msg: certnames_msg }
+        if valid_certnames.size > 1
+          expected_certnames = _("expected one of %{certnames}") % { certnames: valid_certnames.join(', ') }
+        else
+          expected_certnames = _("expected %{certname}") % { certname: valid_certnames.first }
+        end
+
+        msg = _("Server hostname '%{host}' did not match server certificate; %{expected_certnames}") % { host: site.host, expected_certnames: expected_certnames }
         raise Puppet::Error, msg, error.backtrace
       else
         raise

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -228,8 +228,8 @@ module Puppet::Network::HTTP
         raise Puppet::Error, msg, error.backtrace
       elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert.content, site.host)
         valid_certnames = [peer_cert.name, *peer_cert.subject_alt_names].uniq
-        msg = valid_certnames.length > 1 ? _("one of %{certnames}") % { certnames: valid_certnames.join(', ') } : valid_certnames.first
-        msg += _("Server hostname '%{host}' did not match server certificate; expected %{msg}") % { host: site.host, msg: msg }
+        certnames_msg = valid_certnames.length > 1 ? _("one of %{certnames}") % { certnames: valid_certnames.join(', ') } : valid_certnames.first
+        msg = _("Server hostname '%{host}' did not match server certificate; expected %{msg}") % { host: site.host, msg: certnames_msg }
         raise Puppet::Error, msg, error.backtrace
       else
         raise

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -30,6 +30,7 @@ class Puppet::Settings
   require 'puppet/settings/value_translator'
   require 'puppet/settings/environment_conf'
   require 'puppet/settings/server_list_setting'
+  require 'puppet/settings/certificate_revocation_setting'
 
   # local reference for convenience
   PuppetOptionParser = Puppet::Util::CommandLine::PuppetOptionParser
@@ -670,7 +671,8 @@ class Puppet::Settings
       :symbolic_enum   => SymbolicEnumSetting,
       :priority   => PrioritySetting,
       :autosign   => AutosignSetting,
-      :server_list => ServerListSetting
+      :server_list => ServerListSetting,
+      :certificate_revocation => CertificateRevocationSetting
   }
 
   # Create a new setting.  The value is passed in because it's used to determine

--- a/lib/puppet/settings/certificate_revocation_setting.rb
+++ b/lib/puppet/settings/certificate_revocation_setting.rb
@@ -1,0 +1,21 @@
+require 'puppet/settings/base_setting'
+
+class Puppet::Settings::CertificateRevocationSetting < Puppet::Settings::BaseSetting
+
+  def type
+    :certificate_revocation
+  end
+
+  def munge(value)
+    case value
+    when 'chain', 'true', TrueClass
+      :chain
+    when 'leaf'
+      :leaf
+    when 'false', FalseClass, NilClass
+      false
+    else
+      raise Puppet::Settings::ValidationError, _("Invalid certificate revocation value %{value}: must be one of 'true', 'chain', 'leaf', or 'false'") % { value: value }
+    end
+  end
+end

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -446,7 +446,7 @@ class Puppet::SSL::CertificateAuthority
     store.add_file(Puppet[:cacert])
     store.add_crl(crl.content) if self.crl
     store.purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT
-    if Puppet.settings[:certificate_revocation]
+    if Puppet.lookup(:certificate_revocation)
       store.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL | OpenSSL::X509::V_FLAG_CRL_CHECK
     end
     store

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -380,10 +380,10 @@ ERROR_STRING
     store.add_file(Puppet[:localcacert])
 
     # If we're doing revocation and there's a CRL, add it to our store.
-    if Puppet.settings[:certificate_revocation]
+    if Puppet.lookup(:certificate_revocation)
       if crl = Puppet::SSL::CertificateRevocationList.indirection.find(CA_NAME)
         flags = OpenSSL::X509::V_FLAG_CRL_CHECK
-        if Puppet.settings[:certificate_revocation] == :chain
+        if Puppet.lookup(:certificate_revocation) == :chain
           flags |= OpenSSL::X509::V_FLAG_CRL_CHECK_ALL
         end
 

--- a/spec/unit/indirector/certificate_revocation_list/rest_spec.rb
+++ b/spec/unit/indirector/certificate_revocation_list/rest_spec.rb
@@ -23,4 +23,12 @@ describe Puppet::SSL::CertificateRevocationList::Rest do
   it "should use the :ca SRV service" do
     expect(Puppet::SSL::CertificateRevocationList::Rest.srv_service).to eq(:ca)
   end
+
+  it "temporarily disables revocation checking when finding a CRL and no CRL is available" do
+    Puppet::FileSystem.expects(:exist?).with(Puppet[:hostcrl]).returns false
+    Puppet.override({:certificate_revocation => :chain}) do
+      Puppet.expects(:override).with({:certificate_revocation => false}, anything)
+      subject.find(nil)
+    end
+  end
 end

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -137,7 +137,7 @@ describe Puppet::Network::HTTP::Connection do
       expect do
         connection.get('request')
       end.to raise_error(Puppet::Error) do |error|
-        error.message =~ /Server hostname 'my_server' did not match server certificate; expected one of (.+)/
+        error.message =~ /\AServer hostname 'my_server' did not match server certificate; expected one of (.+)/
         expect($1.split(', ')).to match_array(%w[DNS:foo DNS:bar DNS:baz DNS:not_my_server not_my_server])
       end
     end

--- a/spec/unit/settings/certificate_revocation_setting_spec.rb
+++ b/spec/unit/settings/certificate_revocation_setting_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+require 'puppet/settings'
+require 'puppet/settings/certificate_revocation_setting'
+
+describe Puppet::Settings::CertificateRevocationSetting do
+  subject { described_class.new(:settings => stub('settings'), :desc => "test") }
+
+  it "is of type :certificate_revocation" do
+    expect(subject.type).to eq :certificate_revocation
+  end
+
+  describe "munging the value" do
+    ['true', true, 'chain'].each do |setting|
+      it "munges #{setting.inspect} to :chain" do
+        expect(subject.munge(setting)).to eq :chain
+      end
+    end
+
+    it "munges 'leaf' to :leaf" do
+      expect(subject.munge("leaf")).to eq :leaf
+    end
+
+    ['false', false, nil].each do |setting|
+      it "munges #{setting.inspect} to false" do
+        expect(subject.munge(setting)).to eq false
+      end
+    end
+
+    it "raises an error when given an unexpected object type" do
+        expect {
+          subject.munge(1)
+        }.to raise_error(Puppet::Settings::ValidationError, "Invalid certificate revocation value 1: must be one of 'true', 'chain', 'leaf', or 'false'")
+    end
+  end
+end
+

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -714,9 +714,27 @@ describe Puppet::SSL::Host do
         Puppet::SSL::CertificateRevocationList.indirection.stubs(:find).returns @crl
       end
 
-      describe "and 'certificate_revocation' is true" do
+      [true, 'chain'].each do |crl_setting|
+        describe "and 'certificate_revocation' is #{crl_setting}" do
+          before do
+            Puppet[:certificate_revocation] = crl_setting
+          end
+
+          it "should add the CRL" do
+            @store.expects(:add_crl).with "real_crl"
+            @host.ssl_store
+          end
+
+          it "should set the flags to OpenSSL::X509::V_FLAG_CRL_CHECK_ALL|OpenSSL::X509::V_FLAG_CRL_CHECK" do
+            @store.expects(:flags=).with(OpenSSL::X509::V_FLAG_CRL_CHECK_ALL|OpenSSL::X509::V_FLAG_CRL_CHECK)
+            @host.ssl_store
+          end
+        end
+      end
+
+      describe "and 'certificate_revocation' is leaf" do
         before do
-          Puppet[:certificate_revocation] = true
+          Puppet[:certificate_revocation] = 'leaf'
         end
 
         it "should add the CRL" do
@@ -724,8 +742,8 @@ describe Puppet::SSL::Host do
           @host.ssl_store
         end
 
-        it "should set the flags to OpenSSL::X509::V_FLAG_CRL_CHECK_ALL|OpenSSL::X509::V_FLAG_CRL_CHECK" do
-          @store.expects(:flags=).with OpenSSL::X509::V_FLAG_CRL_CHECK_ALL|OpenSSL::X509::V_FLAG_CRL_CHECK
+        it "should set the flags to OpenSSL::X509::V_FLAG_CRL_CHECK" do
+          @store.expects(:flags=).with(OpenSSL::X509::V_FLAG_CRL_CHECK)
           @host.ssl_store
         end
       end


### PR DESCRIPTION
Puppet has always performed chain revocation checking when revocation
checking was enabled, but has never been able to load more than a single
CRL. Because of this Puppet could only be used with a root CA if
revocation checking was desired, and if intermediate CAs were in used
revocation had to be entirely disabled.

This commit sidesteps the issue of loading multiple CRLs by allowing
certificate revocation checking to be performed on the leaf certificate
only. This allows users to revoke certificates with an intermediate CA
that Puppet is managing, which is a definite improvement over not
allowing any revocation checking at all.

For the sake of compatibility certificate_revocation still defaults to
full chain checking; users must opt in to leaf revocation checking.