### PR TITLE
(PUP-7840) Add a file serving mount point for tasks.

### DIFF
--- a/lib/puppet/file_serving/configuration.rb
+++ b/lib/puppet/file_serving/configuration.rb
@@ -5,6 +5,7 @@ require 'puppet/file_serving/mount/file'
 require 'puppet/file_serving/mount/modules'
 require 'puppet/file_serving/mount/plugins'
 require 'puppet/file_serving/mount/pluginfacts'
+require 'puppet/file_serving/mount/tasks'
 
 class Puppet::FileServing::Configuration
   require 'puppet/file_serving/configuration/parser'
@@ -82,6 +83,8 @@ class Puppet::FileServing::Configuration
     @mounts["plugins"].allow('*') if @mounts["plugins"].empty?
     @mounts["pluginfacts"] ||= Mount::PluginFacts.new("pluginfacts")
     @mounts["pluginfacts"].allow('*') if @mounts["pluginfacts"].empty?
+    @mounts["tasks"] ||= Mount::Tasks.new("tasks")
+    @mounts["tasks"].allow('*') if @mounts["tasks"].empty?
   end
 
   # Read the configuration file.

--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -92,6 +92,8 @@ class Puppet::FileServing::Configuration::Parser
       mount = Mount::Modules.new(name)
     when "plugins"
       mount = Mount::Plugins.new(name)
+    when "tasks"
+      mount = Mount::Tasks.new(name)
     else
       mount = Mount::File.new(name)
     end

--- a/lib/puppet/file_serving/mount/tasks.rb
+++ b/lib/puppet/file_serving/mount/tasks.rb
@@ -1,0 +1,21 @@
+require 'puppet/file_serving/mount'
+
+class Puppet::FileServing::Mount::Tasks < Puppet::FileServing::Mount
+  def find(path, request)
+    raise _("No task specified") if path.to_s.empty?
+    module_name, task_path = path.split("/", 2)
+    return nil unless mod = request.environment.module(module_name)
+
+    mod.task_file(task_path)
+  end
+
+  def search(path, request)
+    if result = find(path, request)
+      [result]
+    end
+  end
+
+  def valid?
+    true
+  end
+end

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -184,6 +184,25 @@ class Puppet::Module
     end
   end
 
+  # This is a re-implementation of the Filetypes singular type method (e.g.
+  # `manifest('my/manifest.pp')`. We don't implement the full filetype "API" for
+  # tasks since tasks don't map 1:1 onto files.
+  def task_file(name)
+    # If 'file' is nil then they're asking for the base path.
+    # This is used for things like fileserving.
+    if name
+      full_path = File.join(tasks_directory, name)
+    else
+      full_path = tasks_directory
+    end
+
+    if Puppet::FileSystem.exist?(full_path)
+      return full_path
+    else
+      return nil
+    end
+  end
+
   def license_file
     return @license_file if defined?(@license_file)
 

--- a/spec/integration/indirector/file_content/file_server_spec.rb
+++ b/spec/integration/indirector/file_content/file_server_spec.rb
@@ -57,6 +57,23 @@ describe Puppet::Indirector::FileContent::FileServer, " when finding files" do
     expect(result.content).to eq("1\r\n")
   end
 
+  it "should find file content of tasks in modules" do
+    path = tmpfile("task_file_content")
+    Dir.mkdir(path)
+
+    modpath = File.join(path, "myothermod")
+    FileUtils.mkdir_p(File.join(modpath, "tasks"))
+    file = File.join(modpath, "tasks", "mytask")
+    File.open(file, "wb") { |f| f.write "I'm a task" }
+
+    env = Puppet::Node::Environment.create(:foo, [path])
+    result = Puppet::FileServing::Content.indirection.find("tasks/myothermod/mytask", :environment => env)
+
+    expect(result).not_to be_nil
+    expect(result).to be_instance_of(Puppet::FileServing::Content)
+    expect(result.content).to eq("I'm a task")
+  end
+
   it "should find file content in files when node name expansions are used" do
     Puppet::FileSystem.stubs(:exist?).returns true
     Puppet::FileSystem.stubs(:exist?).with(Puppet[:fileserverconfig]).returns(true)

--- a/spec/integration/indirector/file_metadata/file_server_spec.rb
+++ b/spec/integration/indirector/file_metadata/file_server_spec.rb
@@ -42,6 +42,16 @@ describe Puppet::Indirector::FileMetadata::FileServer, " when finding files" do
     end
   end
 
+  describe "that are tasks in modules" do
+    with_checksum_types("task_file_content", "mymod/tasks/mytask") do
+      it "should return the correct metadata" do
+        env = Puppet::Node::Environment.create(:foo, [env_path])
+        result = Puppet::FileServing::Metadata.indirection.find("tasks/mymod/mytask", :environment => env, :checksum_type => checksum_type)
+        expect_correct_checksum(result, checksum_type, checksum, Puppet::FileServing::Metadata)
+      end
+    end
+  end
+
   describe "when node name expansions are used" do
     with_checksum_types("file_server_testing", "mynode/myfile") do
       it "should return the correct metadata" do

--- a/spec/unit/file_serving/configuration_spec.rb
+++ b/spec/unit/file_serving/configuration_spec.rb
@@ -83,14 +83,15 @@ describe Puppet::FileServing::Configuration do
       expect(config.mounted?("one")).to be_truthy
     end
 
-    it "should add modules and plugins mounts even if the file does not exist" do
+    it "should add modules, plugins, and tasks mounts even if the file does not exist" do
       Puppet::FileSystem.expects(:exist?).returns false # the file doesn't exist
       config = Puppet::FileServing::Configuration.configuration
       expect(config.mounted?("modules")).to be_truthy
       expect(config.mounted?("plugins")).to be_truthy
+      expect(config.mounted?("tasks")).to be_truthy
     end
 
-    it "should allow all access to modules and plugins if no fileserver.conf exists" do
+    it "should allow all access to modules, plugins, and tasks if no fileserver.conf exists" do
       Puppet::FileSystem.expects(:exist?).returns false # the file doesn't exist
       modules = stub 'modules', :empty? => true
       Puppet::FileServing::Mount::Modules.stubs(:new).returns(modules)
@@ -100,10 +101,14 @@ describe Puppet::FileServing::Configuration do
       Puppet::FileServing::Mount::Plugins.stubs(:new).returns(plugins)
       plugins.expects(:allow).with('*')
 
+      tasks = stub 'tasks', :empty? => true
+      Puppet::FileServing::Mount::Tasks.stubs(:new).returns(tasks)
+      tasks.expects(:allow).with('*')
+
       Puppet::FileServing::Configuration.configuration
     end
 
-    it "should not allow access from all to modules and plugins if the fileserver.conf provided some rules" do
+    it "should not allow access from all to modules, plugins, and tasks if the fileserver.conf provided some rules" do
       Puppet::FileSystem.expects(:exist?).returns false # the file doesn't exist
 
       modules = stub 'modules', :empty? => false
@@ -114,15 +119,20 @@ describe Puppet::FileServing::Configuration do
       Puppet::FileServing::Mount::Plugins.stubs(:new).returns(plugins)
       plugins.expects(:allow).with('*').never
 
+      tasks = stub 'tasks', :empty? => false
+      Puppet::FileServing::Mount::Tasks.stubs(:new).returns(tasks)
+      tasks.expects(:allow).with('*').never
+
       Puppet::FileServing::Configuration.configuration
     end
 
-    it "should add modules and plugins mounts even if they are not returned by the parser" do
+    it "should add modules, plugins, and tasks mounts even if they are not returned by the parser" do
       @parser.expects(:parse).returns("one" => mock("mount"))
       Puppet::FileSystem.expects(:exist?).returns true # the file doesn't exist
       config = Puppet::FileServing::Configuration.configuration
       expect(config.mounted?("modules")).to be_truthy
       expect(config.mounted?("plugins")).to be_truthy
+      expect(config.mounted?("tasks")).to be_truthy
     end
   end
 

--- a/spec/unit/file_serving/mount/modules_spec.rb
+++ b/spec/unit/file_serving/mount/modules_spec.rb
@@ -41,7 +41,7 @@ describe Puppet::FileServing::Mount::Modules do
 
   describe "when searching for files" do
     it "should fail if no module is specified" do
-      expect { @mount.find("", @request) }.to raise_error(/No module specified/)
+      expect { @mount.search("", @request) }.to raise_error(/No module specified/)
     end
 
     it "should use the node's environment to search the module" do

--- a/spec/unit/file_serving/mount/tasks_spec.rb
+++ b/spec/unit/file_serving/mount/tasks_spec.rb
@@ -1,0 +1,72 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/file_serving/mount/tasks'
+
+describe Puppet::FileServing::Mount::Tasks do
+  before do
+    @mount = Puppet::FileServing::Mount::Tasks.new("tasks")
+
+    @environment = stub 'environment', :module => nil
+    @request = stub 'request', :environment => @environment
+  end
+
+  describe "when finding task files" do
+    it "should fail if no task is specified" do
+      expect { @mount.find("", @request) }.to raise_error(/No task specified/)
+    end
+
+    it "should use the request's environment to find the module" do
+      mod_name = 'foo'
+      @environment.expects(:module).with(mod_name)
+
+      @mount.find(mod_name, @request)
+    end
+
+    it "should use the first segment of the request's path as the module name" do
+      @environment.expects(:module).with("foo")
+      @mount.find("foo/bartask", @request)
+    end
+
+    it "should return nil if the module in the path doesn't exist" do
+      @environment.expects(:module).with("foo").returns(nil)
+      expect(@mount.find("foo/bartask", @request)).to be_nil
+    end
+
+    it "should return the file path from the module" do
+      mod = mock('module')
+      mod.expects(:task_file).with("bartask").returns("mocked")
+      @environment.expects(:module).with("foo").returns(mod)
+      expect(@mount.find("foo/bartask", @request)).to eq("mocked")
+    end
+  end
+
+  describe "when searching for task files" do
+    it "should fail if no module is specified" do
+      expect { @mount.search("", @request) }.to raise_error(/No task specified/)
+    end
+
+    it "should use the request's environment to find the module" do
+      mod_name = 'foo'
+      @environment.expects(:module).with(mod_name)
+
+      @mount.search(mod_name, @request)
+    end
+
+    it "should use the first segment of the request's path as the module name" do
+      @environment.expects(:module).with("foo")
+      @mount.search("foo/bartask", @request)
+    end
+
+    it "should return nil if the module in the path doesn't exist" do
+      @environment.expects(:module).with("foo").returns(nil)
+      expect(@mount.search("foo/bartask", @request)).to be_nil
+    end
+
+    it "should return the file path from the module" do
+      mod = mock('module')
+      mod.expects(:task_file).with("bartask").returns("mocked")
+      @environment.expects(:module).with("foo").returns(mod)
+      expect(@mount.search("foo/bartask", @request)).to eq(["mocked"])
+    end
+  end
+end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -588,6 +588,20 @@ describe Puppet::Module do
       expect(mod.tasks.map{|t| t.class}).to eq([Puppet::Module::Task] * 2)
     end
 
+    it "should be able to find individual task files when they exist" do
+      task_exe = 'stateskatetask.stk'
+      mod = PuppetSpec::Modules.create('task_file_smoke', @modpath, {:environment => env,
+                                                                     :tasks => [[task_exe]]})
+
+      expect(mod.task_file(task_exe)).to eq("#{mod.path}/tasks/#{task_exe}")
+    end
+
+    it "should return nil when asked for an individual task file if it does not exist" do
+      mod = PuppetSpec::Modules.create('task_file_neg', @modpath, {:environment => env,
+                                                                   :tasks => []})
+      expect(mod.task_file('nosuchtask')).to be_nil
+    end
+
     describe "does the task finding" do
       before :each do
         Puppet::FileSystem.unstub(:exist?)


### PR DESCRIPTION
Add a new special file serving mount point to serve task file content.
It works very similarly to the modules mount point, except that it only
finds files in the module's `tasks` directory.

Add the new tasks mount point to the set of default mounts for file
serving.