### PR TITLE
(PUP-7848) Modify var name regexp to avoid infinite recursion

### DIFF
--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -48,7 +48,7 @@ module Puppet::Pops::Patterns
 
   # VAR_NAME matches the name part of a variable (The $ character is not included)
   # Note, that only the final segment may start with an underscore.
-  VAR_NAME = %r{\A(?:(::)?[a-z]\w*)*(?:(::)?[a-z_]\w*)\z}
+  VAR_NAME = %r{\A(?:((::)?[a-z]\w*)*(?:(::)?_\w*)?)\z}
 
   # PARAM_NAME matches the name part of a parameter (The $ character is not included)
   PARAM_NAME = %r{\A[a-z_]\w*\z}

--- a/spec/unit/functions/epp_spec.rb
+++ b/spec/unit/functions/epp_spec.rb
@@ -17,6 +17,11 @@ describe "the epp function" do
       expect(eval_template("<%= $kryptonite == undef %>")).to eq("true")
     end
 
+    it "gets error accessing a variable that is malformed" do
+      expect { eval_template("<%= $kryptonite::USER %>")}.to raise_error(
+        /Illegal variable name, The given name 'kryptonite::USER' does not conform to the naming rule/)
+    end
+
     it "get nil accessing a variable that is undef" do
       scope['undef_var'] = nil
       expect(eval_template("<%= $undef_var == undef %>")).to eq("true")


### PR DESCRIPTION
The VAR_NAME regular expression caused an infinite left recursion due to
an ambiguity in this regular expression. This manifested itself when the
trailing part of a FQN did not match the trailing part of the regexp.
For example `$foo::bar::WRONG`

This commit changes the regexp so that left recursion is not needed.