### PR TITLE
(MAINT) Fix tests for puppetserver pipelines

### DIFF
--- a/acceptance/tests/cycle_detection.rb
+++ b/acceptance/tests/cycle_detection.rb
@@ -9,11 +9,12 @@ manifest = <<EOT
 notify { "a1": require => Notify["a2"] }
 notify { "a2": require => Notify["a1"] }
 EOT
-
-apply_manifest_on(agents, manifest, :acceptable_exit_codes => [1]) do
-  unless agent['locale'] == 'ja'
-    assert_match(/Found 1 dependency cycle/, stderr,
-                 "found and reported the cycle correctly")
+agents.each do |host|
+  apply_manifest_on(host, manifest, :acceptable_exit_codes => [1]) do
+    unless host['locale'] == 'ja'
+      assert_match(/Found 1 dependency cycle/, stderr,
+                   "found and reported the cycle correctly")
+    end
   end
 end
 
@@ -26,9 +27,11 @@ notify { "b1": require => Notify["b2"] }
 notify { "b2": require => Notify["b1"] }
 EOT
 
-apply_manifest_on(agents, manifest, :acceptable_exit_codes => [1]) do
-  unless agent['locale'] == 'ja'
-    assert_match(/Found 2 dependency cycles/, stderr,
-                 "found and reported the cycle correctly")
+agents.each do |host|
+  apply_manifest_on(host, manifest, :acceptable_exit_codes => [1]) do
+    unless host['locale'] == 'ja'
+      assert_match(/Found 2 dependency cycles/, stderr,
+                   "found and reported the cycle correctly")
+    end
   end
 end

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -54,9 +54,11 @@ expectations = {
   },
 }
 
-unless agent['locale'] == 'ja'
-  expectations[:puppet_agent][:matches] = [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
-                                          %r{Could not retrieve catalog; skipping run}]
+agents.each do |host|
+  unless host['locale'] == 'ja'
+    expectations[:puppet_agent][:matches] = [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
+                                             %r{Could not retrieve catalog; skipping run}]
+  end
 end
 
 assert_review(review_results(results,expectations))

--- a/acceptance/tests/ticket_4233_resource_with_a_newline.rb
+++ b/acceptance/tests/ticket_4233_resource_with_a_newline.rb
@@ -16,6 +16,6 @@ tag 'audit:low',      # basic parser functionality
 agents.each do |host|
   resource = host.echo('-e "\nHello World\n"')
   apply_manifest_on(host, "exec { '#{resource}': }") do
-    assert_match(/Hello World.*success/, stdout) unless agent['locale'] == 'ja'
+    assert_match(/Hello World.*success/, stdout) unless host['locale'] == 'ja'
   end
 end

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -44,7 +44,9 @@ user { '#{username}':
 }
 MANIFEST
 
-apply_manifest_on(hosts_to_test, adduser_manifest )
-apply_manifest_on(hosts_to_test, changepass_manifest ) do |result|
-  assert_match( /current_value \[old password hash redacted\], should be \[new password hash redacted\]/ , "#{result.host}: #{result.stdout}" ) unless agent['locale'] == 'ja'
+hosts_to_test.each do |host|
+  apply_manifest_on(host, adduser_manifest )
+  apply_manifest_on(host, changepass_manifest ) do |result|
+    assert_match( /current_value \[old password hash redacted\], should be \[new password hash redacted\]/ , "#{result.host}: #{result.stdout}" ) unless host['locale'] == 'ja'
+  end
 end

--- a/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
+++ b/acceptance/tests/ticket_6928_puppet_master_parse_fails.rb
@@ -9,9 +9,11 @@ step "Master: create valid, invalid formatted manifests"
 create_remote_file(master, '/tmp/good.pp', %w{notify{good:}} )
 create_remote_file(master, '/tmp/bad.pp', 'notify{bad:')
 
-step "Master: use --parseonly on an invalid manifest, should return 1 and issue deprecation warning"
-on master, puppet_master( %w{--parseonly /tmp/bad.pp} ), :acceptable_exit_codes => [ 1 ]
-  assert_match(/--parseonly has been removed. Please use \'puppet parser validate <manifest>\'/, stdout, "Deprecation warning not issued for --parseonly on #{master}" ) unless agent['locale'] == 'ja'
+agents.each do |host|
+  step "Master: use --parseonly on an invalid manifest, should return 1 and issue deprecation warning"
+  on master, puppet_master( %w{--parseonly /tmp/bad.pp} ), :acceptable_exit_codes => [ 1 ]
+  assert_match(/--parseonly has been removed. Please use \'puppet parser validate <manifest>\'/, stdout, "Deprecation warning not issued for --parseonly on #{master}" ) unless host['locale'] == 'ja'
+end
 
 step "Agents: create valid, invalid formatted manifests"
 agents.each do |host|
@@ -23,7 +25,7 @@ agents.each do |host|
 
   step "Agents: use --parseonly on an invalid manifest, should return 1 and issue deprecation warning"
   on(host, puppet('apply', '--parseonly', bad), :acceptable_exit_codes => [ 1 ]) do
-    assert_match(/--parseonly has been removed. Please use \'puppet parser validate <manifest>\'/, stdout, "Deprecation warning not issued for --parseonly on #{host}" ) unless agent['locale'] == 'ja'
+    assert_match(/--parseonly has been removed. Please use \'puppet parser validate <manifest>\'/, stdout, "Deprecation warning not issued for --parseonly on #{host}" ) unless host['locale'] == 'ja'
   end
 
   step "Test Face for 'parser validate' with good manifest -- should pass"
@@ -31,6 +33,6 @@ agents.each do |host|
 
   step "Test Faces for 'parser validate' with bad manifest -- should fail"
   on(host, puppet('parser', 'validate', bad), :acceptable_exit_codes => [ 1 ]) do
-    assert_match(/Error: Could not parse for environment production/, stderr, "Bad manifest detection failed on #{host}" ) unless agent['locale'] == 'ja'
+    assert_match(/Error: Could not parse for environment production/, stderr, "Bad manifest detection failed on #{host}" ) unless host['locale'] == 'ja'
   end
 end


### PR DESCRIPTION
Currently the puppetserver CI jobs which run the puppet agent tests are failing

When puppetserver runs the puppet tests it uses a beaker config which creates
multiple machines with agent roles. This causes the 'agent' beaker variable to
be a list of hashes instead of a hash. Tests which access the agent array as if
it's a hash throw errors

This commit modifies the offending tests to work under both conditions