### PR TITLE
(docs)(DOCUMENT-652) fixes metaparameter log level order

### DIFF
--- a/lib/puppet/functions/lookup.rb
+++ b/lib/puppet/functions/lookup.rb
@@ -96,7 +96,8 @@
 # * `{'strategy' => 'deep', <DEEP OPTION> => <VALUE>, ...}` --- Same as `'deep'`,
 # but can adjust the merge with additional options. The available options are:
 #     * `'knockout_prefix'` (string or undef) --- A string prefix to indicate a
-#     value should be _removed_ from the final result. Defaults to `undef`, which
+#     value should be _removed_ from the final result. If a value is exactly equal
+#     to the prefix, it will knockout the entire element.Defaults to `undef`, which
 #     disables this feature.
 #     * `'sort_merged_arrays'` (boolean) --- Whether to sort all arrays that are
 #     merged together. Defaults to `false`.

--- a/lib/puppet/functions/lookup.rb
+++ b/lib/puppet/functions/lookup.rb
@@ -97,7 +97,7 @@
 # but can adjust the merge with additional options. The available options are:
 #     * `'knockout_prefix'` (string or undef) --- A string prefix to indicate a
 #     value should be _removed_ from the final result. If a value is exactly equal
-#     to the prefix, it will knockout the entire element.Defaults to `undef`, which
+#     to the prefix, it will knockout the entire element. Defaults to `undef`, which
 #     disables this feature.
 #     * `'sort_merged_arrays'` (boolean) --- Whether to sort all arrays that are
 #     merged together. Defaults to `false`.

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1358,9 +1358,9 @@ class Type
 
       The order of the log levels, in decreasing priority, is:
 
-      * `crit`
       * `emerg`
       * `alert`
+      * `crit`
       * `err`
       * `warning`
       * `notice`


### PR DESCRIPTION
Also fixes missing details on lookup merge option "knockout_prefix"; tiny doc fixes.