### PR TITLE
(maint) Remove unguarded reference to GettextSetup

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -30,6 +30,15 @@ module Puppet::GettextConfig
     end
   end
 
+  def self.module_initialized?(module_name)
+    begin
+      GettextSetup.translation_repositories.has_key? module_name
+    rescue NameError
+      # If GettextSetup has not been loaded yet, just return false
+      false
+    end
+  end
+
   # Attempt to initialize the gettext-setup gem
   # @param path [String] to gettext config file
   # @param file_format [Symbol] translation file format to use, either :po or :mo

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -424,24 +424,19 @@ class Puppet::Module
 
   def initialize_i18n
     module_name = @forge_name.gsub("/","-") if @forge_name
-    return if module_name.nil? || i18n_initialized?(module_name)
+    return if module_name.nil? || Puppet::GettextConfig.module_initialized?(module_name)
 
     locales_path = File.absolute_path('locales', path)
 
-    begin
-      Puppet::GettextConfig.initialize(locales_path, :po)
+    if Puppet::GettextConfig.initialize(locales_path, :po)
       Puppet.debug "#{module_name} initialized for i18n: #{GettextSetup.translation_repositories[module_name]}"
-    rescue
+    else
       config_path = File.absolute_path('config.yaml', locales_path)
       Puppet.debug "Could not find locales configuration file for #{module_name} at #{config_path}. Skipping i18n initialization."
     end
   end
 
   private
-
-  def i18n_initialized?(module_name)
-    GettextSetup.translation_repositories.has_key? module_name
-  end
 
   def wanted_manifests_from(pattern)
     begin


### PR DESCRIPTION
With the recent refactor of GettextSetup configuration, a check to make
sure that gem had already been loaded when initializing a module was
also removed. This ensures that we don't try to call the module's
methods before requiring it.