### PR TITLE
(PUP-7855) Ensure proper Data conversion the special default value

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -510,6 +510,7 @@ module Runtime3Support
       p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
       p[Issues::CLASS_NOT_VIRTUALIZABLE]      = Puppet[:strict] == :off ? :warning : Puppet[:strict]
       p[Issues::NUMERIC_COERCION]             = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
+      p[Issues::SERIALIZATION_DEFAULT_CONVERTED_TO_STRING] = Puppet[:strict] == :off ? :warning : Puppet[:strict]
       p[Issues::SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING] = Puppet[:strict] == :off ? :warning : Puppet[:strict]
       p[Issues::SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING] = Puppet[:strict] == :off ? :warning : Puppet[:strict]
     end

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -843,6 +843,10 @@ module Issues
     _('Endless recursion detected when attempting to serialize value of class %{type_name}') % { :type_name => type_name }
   end
 
+  SERIALIZATION_DEFAULT_CONVERTED_TO_STRING = issue :SERIALIZATION_DEFAULT_CONVERTED_TO_STRING, :path, :klass, :value do
+    _("%{path} contains the special value default. It will be converted to the String 'default'") % { path: path }
+  end
+
   SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING = issue :SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING, :path, :klass, :value do
     _("%{path} contains %{klass} value. It will be converted to the String '%{value}'") % { path: path, klass: label.a_an(klass), value: value }
   end

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -71,11 +71,20 @@ module Serialization
     def to_data(value)
       if value.nil? || Types::PScalarDataType::DEFAULT.instance?(value)
         value
-      elsif value.is_a?(Symbol)
-        if value == :default
+      elsif :default == value
+        if @rich_data
           { PCORE_TYPE_KEY => PCORE_TYPE_DEFAULT }
         else
-          @symbol_as_string ? value.to_s : { PCORE_TYPE_KEY => PCORE_TYPE_SYMBOL, PCORE_VALUE_KEY => value.to_s }
+          serialization_issue(Issues::SERIALIZATION_DEFAULT_CONVERTED_TO_STRING, :path => path_to_s)
+          'default'
+        end
+      elsif value.is_a?(Symbol)
+        if @symbol_as_string
+          value.to_s
+        elsif @rich_data
+          { PCORE_TYPE_KEY => PCORE_TYPE_SYMBOL, PCORE_VALUE_KEY => value.to_s }
+        else
+          unknown_to_string_with_warning(value)
         end
       elsif value.instance_of?(Array)
         process(value) do

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -490,7 +490,6 @@ module Serialization
       end
 
       it 'A Hash with default values will have the values converted to string with a warning' do
-        pending 'Fix for PUP-7855'
         val = { 'key' => :default  }
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
           write(val)


### PR DESCRIPTION
Before this commit, the `ToDataConversion` would convert the special
`default` value using rich data semantics even when `rich_data` was
set to false. This commit ensures that a) this only happens when rich
data is enabled, and b) when it happens, a proper warning is logged.

A new issue was added to avoid logging info about the symbol `:default`
and instead mention the "special value default" (the use of the symbol
is an an internal concern of the ruby implementation).