### PR TITLE
(PUP-7857) Guard reference to GettextSetup

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -440,7 +440,12 @@ class Puppet::Module
   private
 
   def i18n_initialized?(module_name)
-    GettextSetup.translation_repositories.has_key? module_name
+    begin
+      GettextSetup.translation_repositories.has_key? module_name
+    rescue NameError
+      # GettextSetup not yet initialized
+      false
+    end
   end
 
   def wanted_manifests_from(pattern)


### PR DESCRIPTION
With the recent refactor of GettextSetup configuration, a check to make
sure that gem had already been loaded when initializing a module was
also removed. This ensures that we don't try to call the module's
methods before requiring it.