### PR TITLE
(PUP-7818) Uninstall with no source attribute

### DIFF
--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -51,7 +51,6 @@ absent_manifest = <<-MANIFEST
 package { '#{package}':
   ensure   => absent,
   provider => aix,
-  source   => '#{dir}',
 }
 MANIFEST
 


### PR DESCRIPTION
This commit modifies the test to catch regressions of PUP-7818; users
ought to be able to ensure a package is absent without passing a source
attribute.