### PR TITLE
(PUP-7858) Isolate and externalize all `puppet help` summary texts

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -474,5 +474,12 @@ class Application
   def help
     _("No help available for puppet %{app_name}") % { app_name: name }
   end
+
+  # The description used in top level `puppet help` output
+  # If left empty in implementations, we will attempt to extract
+  # the summary from the help text itself.
+  def summary
+    ""
+  end
 end
 end

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -75,10 +75,14 @@ class Puppet::Application::Agent < Puppet::Application
     options[:job_id] = arg
   end
 
-  def help
-    <<-'HELP'
+  def summary
+    _("The puppet agent daemon")
+  end
 
-puppet-agent(8) -- The puppet agent daemon
+  def help
+    <<-HELP
+
+puppet-agent(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -31,10 +31,14 @@ class Puppet::Application::Apply < Puppet::Application
     exit 1
   end
 
-  def help
-    <<-'HELP'
+  def summary
+    _("Apply Puppet manifests locally")
+  end
 
-puppet-apply(8) -- Apply Puppet manifests locally
+  def help
+    <<-HELP
+
+puppet-apply(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -99,10 +99,14 @@ class Puppet::Application::Cert < Puppet::Application
     options[:yes] = true
   end
 
-  def help
-    <<-'HELP'
+  def summary
+    _("Manage certificates and requests")
+  end
 
-puppet-cert(8) -- Manage certificates and requests
+  def help
+    <<-HELP
+
+puppet-cert(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -178,10 +178,14 @@ class Puppet::Application::Describe < Puppet::Application
   option("--list", "-l")
   option("--meta","-m")
 
-  def help
-    <<-'HELP'
+  def summary
+    _("Display help about resource types")
+  end
 
-puppet-describe(8) -- Display help about resource types
+  def help
+    <<-HELP
+
+puppet-describe(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -62,10 +62,14 @@ class Puppet::Application::Device < Puppet::Application
     options[:target] = arg.to_s
   end
 
-    def help
-      <<-'HELP'
+  def summary
+    _("Manage remote network devices")
+  end
 
-puppet-device(8) -- Manage remote network devices
+  def help
+      <<-HELP
+
+puppet-device(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -48,10 +48,14 @@ class Puppet::Application::Doc < Puppet::Application
     options[:references] << arg.intern
   end
 
-  def help
-    <<-'HELP'
+  def summary
+    _("Generate Puppet references")
+  end
 
-puppet-doc(8) -- Generate Puppet references
+  def help
+    <<-HELP
+
+puppet-doc(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -12,10 +12,14 @@ class Puppet::Application::Filebucket < Puppet::Application
 
   attr :args
 
-  def help
-    <<-'HELP'
+  def summary
+    _("Store and retrieve files in a filebucket")
+  end
 
-puppet-filebucket(8) -- Store and retrieve files in a filebucket
+  def help
+    <<-HELP
+
+puppet-filebucket(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -95,10 +95,14 @@ class Puppet::Application::Lookup < Puppet::Application
     setup_terminuses
   end
 
-  def help
-    <<-'HELP'
+  def summary
+    _("Interactive Hiera lookup")
+  end
 
-puppet-lookup(8) -- Interactive Hiera lookup
+  def help
+    <<-HELP
+
+puppet-lookup(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -25,10 +25,14 @@ class Puppet::Application::Master < Puppet::Application
     exit 1
   end
 
-  def help
-    <<-'HELP'
+  def summary
+    _("The puppet master daemon")
+  end
 
-puppet-master(8) -- The puppet master daemon
+  def help
+    <<-HELP
+
+puppet-master(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -28,10 +28,14 @@ class Puppet::Application::Resource < Puppet::Application
     @extra_params << arg.to_sym
   end
 
-  def help
-    <<-'HELP'
+  def summary
+    _("The resource abstraction layer shell")
+  end
 
-puppet-resource(8) -- The resource abstraction layer shell
+  def help
+    <<-HELP
+
+puppet-resource(8) -- #{summary}
 ========
 
 SYNOPSIS

--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -4,7 +4,7 @@ Puppet::Indirector::Face.define(:catalog, '0.0.1') do
   copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
-  summary "Compile, save, view, and convert catalogs."
+  summary _("Compile, save, view, and convert catalogs.")
   description <<-'EOT'
     This subcommand deals with catalogs, which are compiled per-node artifacts
     generated from a set of Puppet manifests. By default, it interacts with the

--- a/lib/puppet/face/certificate_request.rb
+++ b/lib/puppet/face/certificate_request.rb
@@ -4,7 +4,7 @@ Puppet::Indirector::Face.define(:certificate_request, '0.0.1') do
   copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
-  summary "Manage certificate requests."
+  summary _("Manage certificate requests.")
   description <<-EOT
     This subcommand retrieves and submits certificate signing requests (CSRs).
   EOT

--- a/lib/puppet/face/certificate_revocation_list.rb
+++ b/lib/puppet/face/certificate_revocation_list.rb
@@ -4,7 +4,7 @@ Puppet::Indirector::Face.define(:certificate_revocation_list, '0.0.1') do
   copyright "Puppet Inc.", 2011
   license   "Apache 2 license; see COPYING"
 
-  summary "Manage the list of revoked certificates."
+  summary _("Manage the list of revoked certificates.")
   description <<-EOT
     This subcommand is primarily for retrieving the certificate revocation
     list from the CA.

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -103,13 +103,13 @@ describe Puppet::Face[:help, '0.0.1'] do
     end
 
     it "returns an 'unavailable' summary if the 'agent' application fails to generate help" do
-      Puppet::Application['agent'].class.any_instance.stubs(:help).raises(ArgumentError, "whoops")
+      Puppet::Application['agent'].class.any_instance.stubs(:summary).raises(ArgumentError, "whoops")
 
       expect(subject).to match(/agent\s+! Subcommand unavailable due to error\. Check error logs\./)
     end
 
     it "returns an 'unavailable' summary if the legacy application raises a LoadError" do
-      Puppet::Application['agent'].class.any_instance.stubs(:help).raises(LoadError, "cannot load such file -- yard")
+      Puppet::Application['agent'].class.any_instance.stubs(:summary).raises(LoadError, "cannot load such file -- yard")
 
       expect(subject).to match(/agent\s+! Subcommand unavailable due to error\. Check error logs\./)
     end


### PR DESCRIPTION
Some summary texts for subcommands appearing in `puppet help` missed
being translated. For some of these, that was because the string was
embedded in a larger help text (which was not intended for translation)
and extracted on the fly. This commit isolates all of these summary
texts and makes them available via a `summary` method. This allows them
to be marked for translation.

The summary method return an empty string by default. If users of puppet
have created their own applications without summaries, the `help`
command will still attempt to extract the summary text from the help
body.