### PR TITLE
(PUP-7862) Ensure variant assignability to Data and RichData

### DIFF
--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -361,6 +361,13 @@ module TypeFactory
     @rich_data_t ||= TypeParser.singleton.parse('RichData', Loaders.static_loader)
   end
 
+  # Produces the RichData type
+  # @api public
+  #
+  def self.rich_data_key
+    @rich_data_key_t ||= TypeParser.singleton.parse('RichDataKey', Loaders.static_loader)
+  end
+
   # Creates an instance of the Undef type
   # @api public
   def self.undef

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -93,6 +93,7 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PFloatType,
       Puppet::Pops::Types::PBooleanType,
       Puppet::Pops::Types::PEnumType,
+      Puppet::Pops::Types::PPatternType,
     ]
   end
   def scalar_data_types
@@ -161,16 +162,29 @@ shared_context 'types_setup' do
   end
 
   def self.data_compatible_types
+    tf = Puppet::Pops::Types::TypeFactory
     result = scalar_data_types
-    result << Puppet::Pops::Types::PArrayType.new(Puppet::Pops::Types::PScalarDataType::DEFAULT)
-    result << Puppet::Pops::Types::PHashType.new(Puppet::Pops::Types::PStringType::DEFAULT, Puppet::Pops::Types::PScalarDataType::DEFAULT)
+    result << Puppet::Pops::Types::PArrayType.new(tf.data)
+    result << Puppet::Pops::Types::PHashType.new(Puppet::Pops::Types::PStringType::DEFAULT, tf.data)
     result << Puppet::Pops::Types::PUndefType
-    result << Puppet::Pops::Types::PNotUndefType.new(Puppet::Pops::Types::PScalarDataType::DEFAULT)
-    result << Puppet::Pops::Types::PTupleType.new([Puppet::Pops::Types::PScalarDataType::DEFAULT])
+    result << Puppet::Pops::Types::PTupleType.new([tf.data])
     result
   end
   def data_compatible_types
     self.class.data_compatible_types
+  end
+
+  def self.rich_data_compatible_types
+    tf = Puppet::Pops::Types::TypeFactory
+    result = scalar_types
+    result << Puppet::Pops::Types::PArrayType.new(tf.rich_data)
+    result << Puppet::Pops::Types::PHashType.new(tf.rich_data_key, tf.rich_data)
+    result << Puppet::Pops::Types::PUndefType
+    result << Puppet::Pops::Types::PTupleType.new([tf.rich_data])
+    result
+  end
+  def rich_data_compatible_types
+    self.class.rich_data_compatible_types
   end
 
   def self.type_from_class(c)

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -862,19 +862,50 @@ describe 'The type calculator' do
     context 'for Data, such that' do
       let(:data) { TypeFactory.data }
       data_compatible_types.map { |t2| type_from_class(t2) }.each do |tc|
-        it "#{tc.name} is assignable to Data" do
+        it "it is assignable from #{tc.name}" do
           expect(tc).to be_assignable_to(data)
         end
       end
 
-      it 'Data is not assignable to any of its subtypes' do
+      data_compatible_types.map { |t2| type_from_class(t2) }.each do |tc|
+        it "it is assignable from Optional[#{tc.name}]" do
+          expect(optional_t(tc)).to be_assignable_to(data)
+        end
+      end
+
+      it 'it is not assignable to any of its subtypes' do
         types_to_test = data_compatible_types
         types_to_test.each {|t2| expect(data).not_to be_assignable_to(type_from_class(t2)) }
       end
 
-      it 'Data is not assignable to any disjunct type' do
-        tested_types = all_types - [PAnyType, POptionalType, PInitType] - scalar_types
+      it 'it is not assignable to any disjunct type' do
+        tested_types = all_types - [PAnyType, POptionalType, PInitType] - scalar_data_types
         tested_types.each {|t2| expect(data).not_to be_assignable_to(t2::DEFAULT) }
+      end
+    end
+
+    context 'for Rich Data, such that' do
+      let(:rich_data) { TypeFactory.rich_data }
+      rich_data_compatible_types.map { |t2| type_from_class(t2) }.each do |tc|
+        it "it is assignable from #{tc.name}" do
+          expect(tc).to be_assignable_to(rich_data)
+        end
+      end
+
+      rich_data_compatible_types.map { |t2| type_from_class(t2) }.each do |tc|
+        it "it is assignable from Optional[#{tc.name}]" do
+          expect(optional_t(tc)).to be_assignable_to(rich_data)
+        end
+      end
+
+      it 'it is not assignable to any of its subtypes' do
+        types_to_test = rich_data_compatible_types
+        types_to_test.each {|t2| expect(rich_data).not_to be_assignable_to(type_from_class(t2)) }
+      end
+
+      it 'it is not assignable to any disjunct type' do
+        tested_types = all_types - [PAnyType, POptionalType, PInitType] - scalar_types
+        tested_types.each {|t2| expect(rich_data).not_to be_assignable_to(t2::DEFAULT) }
       end
     end
 


### PR DESCRIPTION
Before this commit, only subclasses to `PScalarDataType` were considered
assignable the `ScalarData` type. This commit ensures that all variants
containing assignable types (i.e. `Optional`, `NotUndef`, or `Variant`)
are assignable (with the exception of `NotUndef[Undef]`, which isn't
assignable to anything).

The `Scalar` datatype which experienced the same problem, is also fixed
by this commit.