### PR TITLE
(PUP-7863) Make Default part of the RichData variant

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -64,7 +64,7 @@ class StaticLoader < Loader
   BUILTIN_ALIASES = {
     'Data' => 'Variant[ScalarData,Undef,Hash[String,Data],Array[Data]]',
     'RichDataKey' => 'Variant[String,Numeric]',
-    'RichData' => 'Variant[Scalar,SemVerRange,Binary,Sensitive,Type,TypeSet,Undef,Hash[RichDataKey,RichData],Array[RichData]]',
+    'RichData' => 'Variant[Scalar,SemVerRange,Binary,Sensitive,Type,TypeSet,Undef,Default,Hash[RichDataKey,RichData],Array[RichData]]',
 
     # Backward compatible aliases.
     'Puppet::LookupKey' => 'RichDataKey',

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -664,7 +664,9 @@ class PDefaultType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    o == :default
+    # Ensure that Symbol.== is called here instead of something unknown
+    # that is implemented on o
+    :default == o
   end
 
   DEFAULT = PDefaultType.new

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -180,6 +180,7 @@ shared_context 'types_setup' do
     result << Puppet::Pops::Types::PArrayType.new(tf.rich_data)
     result << Puppet::Pops::Types::PHashType.new(tf.rich_data_key, tf.rich_data)
     result << Puppet::Pops::Types::PUndefType
+    result << Puppet::Pops::Types::PDefaultType
     result << Puppet::Pops::Types::PTupleType.new([tf.rich_data])
     result
   end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1775,11 +1775,12 @@ describe 'The type calculator' do
       expect(calculator.instance?(PAnyType::DEFAULT, :default)).to eq(true)
     end
 
-    it 'should not consider "default" to be an instance of anything but Default, NotUndef, and Any' do
+    it 'should not consider "default" to be an instance of anything but Default, Init, NotUndef, and Any' do
       types_to_test = all_types - [
         PAnyType,
         PNotUndefType,
         PDefaultType,
+        PInitType,
         ]
 
       types_to_test.each {|t| expect(calculator.instance?(t::DEFAULT, :default)).to eq(false) }


### PR DESCRIPTION
This commit adds the `Default` type to the `RichData` variant.

Since `default` now an instance of `RichData` it is also an instance of
an unparameterized `Init` type which called for an adjustment on the
test that checks what default is an instance of.