### PR TITLE
(PUP-7840) Document `tasks` file content mount

### DIFF
--- a/api/docs/http_file_content.md
+++ b/api/docs/http_file_content.md
@@ -16,6 +16,7 @@ The endpoint path includes a `:mount_point` which can be one of the following ty
 * `modules/<MODULE>` --- a semi-magical mount point which allows access to the `files` subdirectory of `<MODULE>` --- see [the docs on file serving](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
 * `plugins` --- a highly magical mount point which merges the `lib`  directory of every module together. Used for syncing plugins; not intended for general consumption. Per-module sub-paths can not be specified.
 * `pluginfacts` --- a highly magical mount point which merges the `facts.d` directory of every module together. Used for syncing external facts; not intended for general consumption. Per-module sub-paths can not be specified.
+* `tasks/<MODULE>` --- a semi-magical mount point which allows access to files in the `tasks` subdirectory of `<MODULE>` --- see the [the docs on file serving](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
 
 `:name` is the path to the file within the `:mount_point` that is requested.
 

--- a/api/docs/http_file_metadata.md
+++ b/api/docs/http_file_metadata.md
@@ -17,6 +17,7 @@ The endpoint path includes a `:mount` which can be one of the following types:
 * `modules/<MODULE>` --- a semi-magical mount point which allows access to the `files` subdirectory of `<MODULE>` --- see [the docs on file serving](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
 * `plugins` --- a highly magical mount point which merges the `lib`  directory of every module together. Used for syncing plugins; not intended for general consumption. Per-module sub-paths can not be specified.
 * `pluginfacts` --- a highly magical mount point which merges the `facts.d` directory of every module together. Used for syncing external facts; not intended for general consumption. Per-module sub-paths can not be specified.
+* `tasks/<MODULE>` --- a semi-magical mount point which allows access to files in the `tasks` subdirectory of `<MODULE>` --- see the [the docs on file serving](https://docs.puppet.com/puppet/latest/reference/file_serving.html).
 
 Note: PSON responses in the examples below are pretty-printed for readability.
 


### PR DESCRIPTION
Add descriptions of the new special `tasks` mount point to the API
documentation on the v3 file_content and file_metadata endpoints. The
mount point behaves analagously to the `modules` endpoint, so the
description mirrors that one's.