### PR TITLE
(PUP-6364) Fix `ensure => latest` on AIX

### DIFF
--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
           if updates.key?(current[:name])
             previous = updates[current[:name]]
 
-            updates[ current[:name] ] = current unless Puppet::Util::Package.versioncmp(previous[:version], current[:version]) == 1
+            updates[current[:name]] = current unless Puppet::Util::Package.versioncmp(previous[:version], current[:version]) == 1
 
           else
             updates[current[:name]] = current
@@ -62,8 +62,8 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
     end
 
     packages.each do |name, package|
-      if info = updates[package[:name]]
-        package.provider.latest_info = info[0]
+      if updates.key?(name)
+        package.provider.latest_info = updates[name]
       end
     end
   end


### PR DESCRIPTION
Previously, the latest version of a package in AIX was not
being returned when `ensure => latest` was used. In the calculation
of the latest version of the package, `latest_info` was being assigned
to `nil` rather than the package itself, most likely because the method
was written to handle an Array but the data type is a Hash.

The fix is to assign `latest_info` to the package, rather than the 0th
index of the package.