### PR TITLE
(PUP-7875) Add a mocking version of run_task

### DIFF
--- a/lib/puppet/functions/run_task.rb
+++ b/lib/puppet/functions/run_task.rb
@@ -1,0 +1,26 @@
+# Runs a given instance of a `Task` on the given set of hosts, or localhost if no hosts are given and returns the result from each
+#
+# Since > 5.2.0 TODO: Update when version is known
+#
+Puppet::Functions.create_function(:run_task) do
+  dispatch :mocked_run_task do
+    param 'Object', :task
+    repeated_param 'String', :hosts
+  end
+
+  def mocked_run_task(task, *hosts)
+    call_function('notice', "Simulating run of task #{task._pcore_type.name} on hosts: [" + hosts.join(', ') + "]")
+    hosts.map do |hostname|
+      exit_code = task.respond_to?(:simulated_exit_code) ? task.exit_code : 0
+      result =
+      if exit_code == 0
+        result = task.respond_to?(:simluated_result) ? task.simulated_result : '<simulated result>'
+      else
+        exit_code
+      end
+      call_function('notice', "Simulating run of task #{task._pcore_type.name} on '#{hostname}' with result '#{result}'")
+      result
+    end
+  end
+end
+


### PR DESCRIPTION
This adds a mocking version of run_task where it is possible to simulate
running of a task by giving it an Object instance that has the
attributes simulated_exit_code and simulated_result. All other
attributes are ignored.

The function logs information at notice level.

This behavior will be replaced when there are real Task instances.