### PR TITLE
(PUP-7883) Make node_terminus=ldap working with jruby/puppetserver

### DIFF
--- a/lib/puppet/indirector/node/ldap.rb
+++ b/lib/puppet/indirector/node/ldap.rb
@@ -93,7 +93,7 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
     result[:stacked] = get_stacked_values_from_entry(entry)
     result[:parameters] = get_parameters_from_entry(entry)
 
-    result[:environment] = result[:parameters]["environment"] if result[:parameters]["environment"]
+    result[:environment] = result[:parameters][:environment] if result[:parameters][:environment]
 
     result[:stacked_parameters] = {}
 

--- a/lib/puppet/indirector/node/ldap.rb
+++ b/lib/puppet/indirector/node/ldap.rb
@@ -229,10 +229,11 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
   # @see https://github.com/jruby/jruby-ldap/pull/5
   #
   # @param entry [LDAP::Entry] The LDAP::Entry object to convert to a hash
-  # @return [Hash] The hash of the provided LDAP::Entry object
+  # @return [Hash] The hash of the provided LDAP::Entry object with keys
+  #   downcased (puppet variables need to start with lowercase char)
   def ldap_entry_to_hash(entry)
      h = {}
-     entry.get_attributes.each { |a| h[a.to_sym] = entry[a] }
+     entry.get_attributes.each { |a| h[a.downcase.to_sym] = entry[a] }
      h[:dn] = [entry.dn]
      h
   end

--- a/lib/puppet/indirector/node/ldap.rb
+++ b/lib/puppet/indirector/node/ldap.rb
@@ -93,7 +93,8 @@ class Puppet::Node::Ldap < Puppet::Indirector::Ldap
     result[:stacked] = get_stacked_values_from_entry(entry)
     result[:parameters] = get_parameters_from_entry(entry)
 
-    result[:environment] = result[:parameters][:environment] if result[:parameters][:environment]
+    # delete from parameters to prevent "Already declered variable $environment" error
+    result[:environment] = result[:parameters].delete(:environment) if result[:parameters][:environment]
 
     result[:stacked_parameters] = {}
 

--- a/spec/unit/indirector/node/ldap_spec.rb
+++ b/spec/unit/indirector/node/ldap_spec.rb
@@ -18,13 +18,15 @@ describe Puppet::Node::Ldap do
     let(:request) { Puppet::Indirector::Request.new(:node, :find, nodename, nil, :environment => environment) }
 
     it "should convert the hostname into a search filter" do
-      entry = stub 'entry', :dn => 'cn=mynode.domain.com,ou=hosts,dc=madstop,dc=com', :vals => %w{}, :to_hash => {}
+      node_indirection.stubs(:ldap_entry_to_hash).returns({})
+      entry = stub 'entry', :dn => 'cn=mynode.domain.com,ou=hosts,dc=madstop,dc=com', :vals => %w{}
       node_indirection.expects(:ldapsearch).with("(&(objectclass=puppetClient)(cn=#{nodename}))").yields entry
       node_indirection.name2hash(nodename)
     end
 
     it "should convert any found entry into a hash" do
-      entry = stub 'entry', :dn => 'cn=mynode.domain.com,ou=hosts,dc=madstop,dc=com', :vals => %w{}, :to_hash => {}
+      node_indirection.stubs(:ldap_entry_to_hash).returns({})
+      entry = stub 'entry', :dn => 'cn=mynode.domain.com,ou=hosts,dc=madstop,dc=com', :vals => %w{}
       node_indirection.expects(:ldapsearch).with("(&(objectclass=puppetClient)(cn=#{nodename}))").yields entry
       myhash = {"myhash" => true}
       node_indirection.expects(:entry2hash).with(entry).returns myhash
@@ -34,7 +36,8 @@ describe Puppet::Node::Ldap do
     # This heavily tests our entry2hash method, so we don't have to stub out the stupid entry information any more.
     describe "when an ldap entry is found" do
       before do
-        @entry = stub 'entry', :dn => 'cn=mynode,ou=hosts,dc=madstop,dc=com', :vals => %w{}, :to_hash => {}
+        @entry = stub 'entry', :dn => 'cn=mynode,ou=hosts,dc=madstop,dc=com', :vals => %w{}
+        node_indirection.stubs(:ldap_entry_to_hash).returns({})
         node_indirection.stubs(:ldapsearch).yields @entry
       end
 
@@ -56,7 +59,7 @@ describe Puppet::Node::Ldap do
       end
 
       it "should deduplicate class values" do
-        @entry.stubs(:to_hash).returns({})
+        node_indirection.stubs(:ldap_entry_to_hash).returns({})
         node_indirection.stubs(:class_attributes).returns(%w{one two})
         @entry.stubs(:vals).with("one").returns(%w{a b})
         @entry.stubs(:vals).with("two").returns(%w{b c})
@@ -64,7 +67,7 @@ describe Puppet::Node::Ldap do
       end
 
       it "should add the entry's environment to the hash" do
-        @entry.stubs(:to_hash).returns("environment" => %w{production})
+        node_indirection.stubs(:ldap_entry_to_hash).returns(:environment => %w{production})
         expect(node_indirection.entry2hash(@entry)[:environment]).to eq("production")
       end
 
@@ -77,37 +80,37 @@ describe Puppet::Node::Ldap do
 
       it "should not add the stacked parameter as a normal parameter" do
         @entry.stubs(:vals).with("puppetvar").returns(%w{one=two three=four})
-        @entry.stubs(:to_hash).returns("puppetvar" => %w{one=two three=four})
+        node_indirection.stubs(:ldap_entry_to_hash).returns("puppetvar" => %w{one=two three=four})
         expect(node_indirection.entry2hash(@entry)[:parameters]["puppetvar"]).to be_nil
       end
 
       it "should add all other attributes as parameters in the hash" do
-        @entry.stubs(:to_hash).returns("foo" => %w{one two})
+        node_indirection.stubs(:ldap_entry_to_hash).returns("foo" => %w{one two})
         expect(node_indirection.entry2hash(@entry)[:parameters]["foo"]).to eq(%w{one two})
       end
 
       it "should return single-value parameters as strings, not arrays" do
-        @entry.stubs(:to_hash).returns("foo" => %w{one})
+        node_indirection.stubs(:ldap_entry_to_hash).returns("foo" => %w{one})
         expect(node_indirection.entry2hash(@entry)[:parameters]["foo"]).to eq("one")
       end
 
       it "should convert 'true' values to the boolean 'true'" do
-        @entry.stubs(:to_hash).returns({"one" => ["true"]})
+        node_indirection.stubs(:ldap_entry_to_hash).returns({"one" => ["true"]})
         expect(node_indirection.entry2hash(@entry)[:parameters]["one"]).to eq(true)
       end
 
       it "should convert 'false' values to the boolean 'false'" do
-        @entry.stubs(:to_hash).returns({"one" => ["false"]})
+        node_indirection.stubs(:ldap_entry_to_hash).returns({"one" => ["false"]})
         expect(node_indirection.entry2hash(@entry)[:parameters]["one"]).to eq(false)
       end
 
       it "should convert 'true' values to the boolean 'true' inside an array" do
-        @entry.stubs(:to_hash).returns({"one" => ["true", "other"]})
+        node_indirection.stubs(:ldap_entry_to_hash).returns({"one" => ["true", "other"]})
         expect(node_indirection.entry2hash(@entry)[:parameters]["one"]).to eq([true, "other"])
       end
 
       it "should convert 'false' values to the boolean 'false' inside an array" do
-        @entry.stubs(:to_hash).returns({"one" => ["false", "other"]})
+        node_indirection.stubs(:ldap_entry_to_hash).returns({"one" => ["false", "other"]})
         expect(node_indirection.entry2hash(@entry)[:parameters]["one"]).to eq([false, "other"])
       end
 


### PR DESCRIPTION
* the environment parameter from ldap was accessed with a string instead of a symbol
* jruby-ldap does not provide a to_hash method - add a ldap_entry_to_hash() method
* remove environment from parameters  hash to prevent duplicate declaration error
* downcase key in ldap_entry_to_hash for consistent key names
