### PR TITLE
(PUP-7864) Add Puppet Type Loader for Tasks

### DIFF
--- a/lib/puppet/loaders.rb
+++ b/lib/puppet/loaders.rb
@@ -14,6 +14,7 @@ module Puppet
       require 'puppet/pops/loader/runtime3_type_loader'
       require 'puppet/pops/loader/ruby_function_instantiator'
       require 'puppet/pops/loader/puppet_function_instantiator'
+      require 'puppet/pops/loader/task_instantiator'
       require 'puppet/pops/loader/type_definition_instantiator'
       require 'puppet/pops/loader/puppet_resource_type_impl_instantiator'
       require 'puppet/pops/loader/loader_paths'

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -29,7 +29,7 @@ class Loader
   attr_reader :loader_name
 
   # Describes the kinds of things that loaders can load
-  LOADABLE_KINDS = [:func_4x, :func_4xpp, :type_pp, :resource_type_pp, :plan].freeze
+  LOADABLE_KINDS = [:func_4x, :func_4xpp, :type_pp, :resource_type_pp, :plan, :task].freeze
 
   # @param [String] name the name of the loader. Must be unique among all loaders maintained by a {Loader} instance
   def initialize(loader_name)

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -64,6 +64,10 @@ module LoaderPaths
       @generic_path = (the_root_path.nil? ? relative_path : File.join(the_root_path, relative_path))
     end
 
+    def match_many?
+      false
+    end
+
     def root_path
       @loader.path
     end

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -30,6 +30,7 @@ module LoaderPaths
       result << PlanPathPP.new(loader)
     when :type
       result << TypePathPP.new(loader) if loader.loadables.include?(:type_pp)
+      result << TaskPath.new(loader) if loader.loadables.include?(:task)
     when :resource_type_pp
       result << ResourceTypeImplPP.new(loader) if loader.loadables.include?(:resource_type_pp)
     else
@@ -168,6 +169,37 @@ module LoaderPaths
 
     def instantiator
       TypeDefinitionInstantiator
+    end
+  end
+
+  class TaskPath < SmartPath
+    TASKS_PATH = 'tasks'.freeze
+
+    def extension
+      EMPTY_STRING
+    end
+
+    def match_many?
+      true
+    end
+
+    def relative_path
+      TASKS_PATH
+    end
+
+    def effective_path(typed_name, start_index_in_name)
+      # Puppet name to path always skips the name-space as that is part of the generic path
+      # i.e. <module>/mymodule/tasks/foo is the function mymodule::foo
+      parts = typed_name.name_parts
+      if start_index_in_name > 0
+        return nil if start_index_in_name >= parts.size
+        parts = parts[start_index_in_name..-1]
+      end
+      "#{File.join(generic_path, parts)}"
+    end
+
+    def instantiator
+      TaskInstantiator
     end
   end
 

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -6,7 +6,10 @@
 #
 # TODO: Currently only supports loading of functions (2 kinds)
 #
-module Puppet::Pops::Loader::LoaderPaths
+module Puppet::Pops
+module Loader
+module LoaderPaths
+
   # Returns an array of SmartPath, each instantiated with a reference to the given loader (for root path resolution
   # and existence checks). The smart paths in the array appear in precedence order. The returned array may be
   # mutated.
@@ -54,10 +57,10 @@ module Puppet::Pops::Loader::LoaderPaths
       @loader = loader
     end
 
-    def generic_path()
+    def generic_path
       return @generic_path unless @generic_path.nil?
 
-      the_root_path = root_path() # @loader.path
+      the_root_path = root_path # @loader.path
       @generic_path = (the_root_path.nil? ? relative_path : File.join(the_root_path, relative_path))
     end
 
@@ -71,11 +74,11 @@ module Puppet::Pops::Loader::LoaderPaths
       "#{File.join(generic_path, typed_name.name_parts)}#{extension}"
     end
 
-    def relative_path()
+    def relative_path
       raise NotImplementedError.new
     end
 
-    def instantiator()
+    def instantiator
       raise NotImplementedError.new
     end
   end
@@ -127,8 +130,8 @@ module Puppet::Pops::Loader::LoaderPaths
       FUNCTION_PATH_4X
     end
 
-    def instantiator()
-      Puppet::Pops::Loader::RubyFunctionInstantiator
+    def instantiator
+      RubyFunctionInstantiator
     end
   end
 
@@ -139,8 +142,8 @@ module Puppet::Pops::Loader::LoaderPaths
       FUNCTION_PATH_3X
     end
 
-    def instantiator()
-      Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
+    def instantiator
+      RubyLegacyFunctionInstantiator
     end
   end
 
@@ -152,8 +155,8 @@ module Puppet::Pops::Loader::LoaderPaths
       FUNCTION_PATH_PP
     end
 
-    def instantiator()
-      Puppet::Pops::Loader::PuppetFunctionInstantiator
+    def instantiator
+      PuppetFunctionInstantiator
     end
   end
 
@@ -164,8 +167,8 @@ module Puppet::Pops::Loader::LoaderPaths
       TYPE_PATH_PP
     end
 
-    def instantiator()
-      Puppet::Pops::Loader::TypeDefinitionInstantiator
+    def instantiator
+      TypeDefinitionInstantiator
     end
   end
 
@@ -180,8 +183,8 @@ module Puppet::Pops::Loader::LoaderPaths
       @loader.path
     end
 
-    def instantiator()
-      Puppet::Pops::Loader::PuppetResourceTypeImplInstantiator
+    def instantiator
+      PuppetResourceTypeImplInstantiator
     end
 
     # The effect paths for resource type impl is the full name
@@ -229,7 +232,7 @@ module Puppet::Pops::Loader::LoaderPaths
       unless effective_paths = smart_paths[type]
         # type not yet processed, does the various directories for the type exist ?
         # Get the relative dirs for the type
-        paths_for_type = Puppet::Pops::Loader::LoaderPaths.relative_paths_for_type(type, loader)
+        paths_for_type = LoaderPaths.relative_paths_for_type(type, loader)
         # Check which directories exist in the loader's content/index
         effective_paths = smart_paths[type] = paths_for_type.select { |sp| loader.meaningful_to_search?(sp) }
       end
@@ -237,3 +240,6 @@ module Puppet::Pops::Loader::LoaderPaths
     end
   end
 end
+end
+end
+

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -106,10 +106,6 @@ module LoaderPaths
       EXTENSION
     end
 
-    def root_path
-      Puppet::FileSystem.dir_string(@loader.path)
-    end
-
     # Duplication of extension information, but avoids one call
     def effective_path(typed_name, start_index_in_name)
       # Puppet name to path always skips the name-space as that is part of the generic path
@@ -124,7 +120,7 @@ module LoaderPaths
   end
 
   class FunctionPath4x < RubySmartPath
-    FUNCTION_PATH_4X = File.join('puppet', 'functions')
+    FUNCTION_PATH_4X = File.join('lib', 'puppet', 'functions').freeze
 
     def relative_path
       FUNCTION_PATH_4X
@@ -136,7 +132,7 @@ module LoaderPaths
   end
 
   class FunctionPath3x < RubySmartPath
-    FUNCTION_PATH_3X = File.join('puppet', 'parser', 'functions')
+    FUNCTION_PATH_3X = File.join('lib', 'puppet', 'parser', 'functions').freeze
 
     def relative_path
       FUNCTION_PATH_3X
@@ -148,8 +144,7 @@ module LoaderPaths
   end
 
   class FunctionPathPP < PuppetSmartPath
-    # Navigate to directory where 'lib' is, then down again
-    FUNCTION_PATH_PP = File.join('functions')
+    FUNCTION_PATH_PP = 'functions'.freeze
 
     def relative_path
       FUNCTION_PATH_PP
@@ -161,7 +156,7 @@ module LoaderPaths
   end
 
   class TypePathPP < PuppetSmartPath
-    TYPE_PATH_PP = File.join('types')
+    TYPE_PATH_PP = 'types'.freeze
 
     def relative_path
       TYPE_PATH_PP
@@ -173,7 +168,7 @@ module LoaderPaths
   end
 
   class ResourceTypeImplPP < PuppetSmartPath
-    RESOURCE_TYPES_PATH_PP = File.join('.resource_types')
+    RESOURCE_TYPES_PATH_PP = '.resource_types'.freeze
 
     def relative_path
       RESOURCE_TYPES_PATH_PP

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -27,7 +27,7 @@ module ModuleLoaders
     # to search up the path from this source file's __FILE__ location until it finds the base of
     # puppet.
     #
-    puppet_lib = File.join(File.dirname(__FILE__), '../../..')
+    puppet_lib = File.join(File.dirname(__FILE__), '../../../..')
     ModuleLoaders::FileBased.new(parent_loader,
                                                        loaders,
                                                        nil,
@@ -41,7 +41,7 @@ module ModuleLoaders
     ModuleLoaders::FileBased.new(parent_loader,
       loaders,
       ENVIRONMENT,
-      File.join(env_path, 'lib'),
+      env_path,
       ENVIRONMENT
     )
   end
@@ -50,7 +50,7 @@ module ModuleLoaders
     ModuleLoaders::FileBased.new(parent_loader,
                                                        loaders,
                                                        module_name,
-                                                       File.join(module_path, 'lib'),
+                                                       module_path,
                                                        module_name
                                                        )
   end

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -1,0 +1,117 @@
+# The TypeDefinitionInstantiator instantiates a type alias or a type definition
+#
+module Puppet::Pops
+module Loader
+class TaskInstantiator
+  def self.create(loader, typed_name, source_refs)
+    ensure_initialized
+    name = typed_name.name
+    metadata = nil
+    task_source = nil
+    source_refs.each do |source_ref|
+      if source_ref.end_with?('.json')
+        metadata = source_ref
+      elsif task_source.nil?
+        task_source = source_ref
+      else
+        raise ArgumentError, _('Only one file can exists besides the .json file for task %{name} in directory %{directory}') %
+          { name: name, directory: File.dirname(source_refs[0]) }
+      end
+    end
+
+    if task_source.nil?
+      raise ArgumentError, _('No source besides task metadata was found in directory %{directory} for task %{name}') %
+        { name: name, directory: File.dirname(source_refs[0]) }
+    end
+    create_task_type(loader, typed_name, task_source, metadata)
+  end
+
+  def self.create_task_type(loader, typed_name, task_source, metadata)
+    if metadata.nil?
+      create_task_type_from_hash(loader, typed_name, task_source, EMPTY_HASH)
+    else
+      json_text = loader.get_contents(metadata)
+      begin
+        hash = JSON.parse(json_text) || EMPTY_HASH
+        Types::TypeAsserter.assert_instance_of(nil, @type_hash_t, hash) { _('The metadata for task %{name}') % { name: typed_name.name } }
+        create_task_type_from_hash(loader, typed_name, task_source, hash)
+      rescue JSON::ParserError => ex
+        raise Puppet::ParseError.new(ex.message, metadata)
+      rescue Types::TypeAssertionError => ex
+        # Not strictly a parser error but from the users perspective, the file content didn't parse properly. The
+        # ParserError also conveys file info (even though line is unknown)
+        raise Puppet::ParseError.new(ex.message, metadata)
+      end
+    end
+  end
+
+  def self.ensure_initialized
+    return if @initialized
+    @initialized = true
+
+    tf = Types::TypeFactory
+    params_t = tf.hash_kv(
+      Types::Task::PARAMETER_NAME_PATTERN,
+      tf.struct(
+        tf.optional('description') => tf.string,
+        tf.optional('type') => Types::PStringType::NON_EMPTY
+      )
+    )
+
+    @type_hash_t = tf.struct(
+      tf.optional('description') => tf.string,
+      tf.optional('puppet_task_version') => tf.string,
+      tf.optional('supports_noop') => tf.boolean,
+      tf.optional('input_method') => tf.enum('stdin', 'environment'),
+      'parameters' => params_t,
+      tf.optional('output') => params_t
+    )
+  end
+
+  def self.create_task_type_from_hash(loader, typed_name, task_source, hash)
+    attributes = {}
+    constants = {}
+    parameters_entry_found = false
+    hash.each_pair do |key, value|
+      if 'parameters' == key
+        parameters_entry_found = true
+        value.each_pair do |param_name, param_decl|
+          attributes[param_name] = create_attribute(loader, param_decl)
+        end
+      else
+        constants[key] = value
+      end
+    end
+
+    if parameters_entry_found
+      parent_type = 'Task'
+    else
+      # No entry means any parameters
+      attributes = EMPTY_HASH
+      parent_type = 'GenericTask'
+    end
+
+    constants['executable'] = Pathname(task_source).relative_path_from(Pathname(loader.path) + 'tasks').to_s
+
+    Types::TypeFactory.object(
+      {
+        'name' => Types::TypeFormatter.singleton.capitalize_segments(typed_name.name),
+        'parent' => Types::TypeParser.singleton.parse(parent_type, loader),
+        'attributes' => attributes,
+        'constants' => constants
+      }, loader)
+  end
+
+  def self.create_attribute(loader, param_decl)
+    result = {}
+    type = Types::TypeParser.singleton.parse(param_decl['type'] || 'Data', loader)
+
+    # Treat OptionalType as optional attribute entry, i.e. provide a default of undef
+    result['value'] = nil if type.is_a?(Types::POptionalType)
+
+    result['type'] = type
+    result
+  end
+end
+end
+end

--- a/lib/puppet/pops/loader/type_definition_instantiator.rb
+++ b/lib/puppet/pops/loader/type_definition_instantiator.rb
@@ -88,6 +88,10 @@ class TypeDefinitionInstantiator
   def self.named_definition(te)
     te.is_a?(Model::AccessExpression) && (left = te.left_expr).is_a?(Model::QualifiedReference) ? left.cased_value : nil
   end
+
+  def several_paths?
+    false
+  end
 end
 end
 end

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -607,7 +607,13 @@ class PObjectType < PMetaType
     end
 
     constants = init_hash[KEY_CONSTANTS]
-    attr_specs = init_hash[KEY_ATTRIBUTES] || {}
+    attr_specs = init_hash[KEY_ATTRIBUTES]
+    if attr_specs.nil?
+      attr_specs = {}
+    else
+      # attr_specs might be frozen
+      attr_specs = Hash[attr_specs]
+    end
     unless constants.nil? || constants.empty?
       constants.each do |key, value|
         raise Puppet::ParseError, "attribute #{label}[#{key}] is defined as both a constant and an attribute" if attr_specs.include?(key)

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -379,11 +379,13 @@ class PObjectType < PMetaType
   # @overload initialize(init_hash)
   #   Used when the object is created by the {TypeFactory}. The init_hash must be fully resolved.
   #   @param _pcore_init_hash [Hash{String=>Object}] The hash describing the Object features
+  #   @param loader [Loaders::Loader,nil] the loader that loaded the type
   #
   # @api private
   def initialize(_pcore_init_hash, init_hash_expression = nil)
     if _pcore_init_hash.is_a?(Hash)
       _pcore_init_from_hash(_pcore_init_hash)
+      @loader = init_hash_expression unless init_hash_expression.nil?
     else
       @attributes = EMPTY_HASH
       @functions = EMPTY_HASH

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -189,56 +189,56 @@ class RubyGenerator < TypeFormatter
       eq_names = obj.equality
     end
 
-    unless obj.parent.is_a?(PObjectType) && obj_attrs.empty?
-      # Output type safe hash constructor
-      bld << "\n  def self.from_hash(init_hash)\n"
-      bld << '    from_asserted_hash(' << namespace_relative(segments, TypeAsserter.name) << '.assert_instance_of('
-      bld << "'" << obj.label << " initializer', _pcore_type.init_hash_type, init_hash))\n  end\n\n  def self.from_asserted_hash(init_hash)\n    new"
-      unless non_opt.empty? && opt.empty?
-        bld << "(\n"
-        non_opt.each { |ip| bld << "      init_hash['" << ip.name << "'],\n" }
-        opt.each do |ip|
-          if ip.value.nil?
-            bld << "      init_hash['" << ip.name << "'],\n"
-          else
-            bld << "      init_hash.fetch('" << ip.name << "') { "
-            default_string(bld, ip)
-            bld << " },\n"
-          end
-        end
-        bld.chomp!(",\n")
-        bld << ')'
-      end
-      bld << "\n  end\n"
-
-      # Output type safe constructor
-      bld << "\n  def self.create"
-      if init_params.empty?
-        bld << "\n    new"
-      else
-        bld << '('
-        non_opt.each { |ip| bld << ip.name << ', ' }
-        opt.each do |ip|
-          bld << ip.name << ' = '
+    # Output type safe hash constructor
+    bld << "\n  def self.from_hash(init_hash)\n"
+    bld << '    from_asserted_hash(' << namespace_relative(segments, TypeAsserter.name) << '.assert_instance_of('
+    bld << "'" << obj.label << " initializer', _pcore_type.init_hash_type, init_hash))\n  end\n\n  def self.from_asserted_hash(init_hash)\n    new"
+    unless non_opt.empty? && opt.empty?
+      bld << "(\n"
+      non_opt.each { |ip| bld << "      init_hash['" << ip.name << "'],\n" }
+      opt.each do |ip|
+        if ip.value.nil?
+          bld << "      init_hash['" << ip.name << "'],\n"
+        else
+          bld << "      init_hash.fetch('" << ip.name << "') { "
           default_string(bld, ip)
-          bld << ', '
+          bld << " },\n"
         end
-        bld.chomp!(', ')
-        bld << ")\n"
-        bld << '    ta = ' << namespace_relative(segments, TypeAsserter.name) << "\n"
-        bld << "    attrs = _pcore_type.attributes(true)\n"
-        init_params.each do |a|
-          bld << "    ta.assert_instance_of('" << a.container.name << '[' << a.name << ']'
-          bld << "', attrs['" << a.name << "'].type, " << a.name << ")\n"
-        end
-        bld << '    new('
-        non_opt.each { |a| bld << a.name << ', ' }
-        opt.each { |a| bld << a.name << ', ' }
-        bld.chomp!(', ')
-        bld << ')'
       end
-      bld << "\n  end\n"
+      bld.chomp!(",\n")
+      bld << ')'
+    end
+    bld << "\n  end\n"
 
+    # Output type safe constructor
+    bld << "\n  def self.create"
+    if init_params.empty?
+      bld << "\n    new"
+    else
+      bld << '('
+      non_opt.each { |ip| bld << ip.name << ', ' }
+      opt.each do |ip|
+        bld << ip.name << ' = '
+        default_string(bld, ip)
+        bld << ', '
+      end
+      bld.chomp!(', ')
+      bld << ")\n"
+      bld << '    ta = ' << namespace_relative(segments, TypeAsserter.name) << "\n"
+      bld << "    attrs = _pcore_type.attributes(true)\n"
+      init_params.each do |a|
+        bld << "    ta.assert_instance_of('" << a.container.name << '[' << a.name << ']'
+        bld << "', attrs['" << a.name << "'].type, " << a.name << ")\n"
+      end
+      bld << '    new('
+      non_opt.each { |a| bld << a.name << ', ' }
+      opt.each { |a| bld << a.name << ', ' }
+      bld.chomp!(', ')
+      bld << ')'
+    end
+    bld << "\n  end\n"
+
+    unless obj.parent.is_a?(PObjectType) && obj_attrs.empty?
       # Output attr_readers
       unless obj_attrs.empty?
         bld << "\n"

--- a/lib/puppet/pops/types/task.rb
+++ b/lib/puppet/pops/types/task.rb
@@ -1,0 +1,92 @@
+require 'json'
+
+module Puppet::Pops
+module Types
+  # Ruby implementation of the Task Pcore type. It is the super type of a custom task that either has parameters
+  # or explicitly declared that it has zero parameters (by providing an empty parameters clause).
+  class Task
+    include PuppetObject
+
+    # Pattern used for task parameter names
+    PARAMETER_NAME_PATTERN = PPatternType.new([PRegexpType.new(/\A[a-z][a-z0-9_]*\z/)])
+
+    # Register the Task type with the Pcore loader and implementation registry
+    def self.register_ptype(loader, ir)
+      @type = Pcore::create_object_type(loader, ir, self, 'Task', nil, {
+        'supports_noop' => {
+          'type' => PBooleanType::DEFAULT,
+          'value' => false,
+          'kind' => 'constant'
+        },
+        'input_method' => {
+          'type' => PStringType::DEFAULT,
+          'value' => 'stdin',
+          'kind' => 'constant'
+        },
+        'executable' => {
+          'type' => PStringType::DEFAULT,
+          'kind' => 'constant',
+          'value' => ''
+        },
+        'task_json' => {
+          'type' => PStringType::DEFAULT,
+          'kind' => 'derived'
+        },
+      })
+    end
+
+    def self._pcore_type
+      @type
+    end
+
+    # Calculates the full path of the executable file. It is required that the type was loaded
+    # using a file based loader
+    # @return [String] The full path to the executable.
+    def executable_path
+      loader = _pcore_type.loader
+      unless loader.is_a?(Loader::ModuleLoaders::FileBased)
+        raise Puppet::Error,
+          _('Absolute path of executable %{file} for task %{task} cannot be determined. This type was not loaded by a file based loader') %
+          { :filename => executable, :task => _pcore_type.name }
+      end
+      File.join(loader.path, 'tasks', executable)
+    end
+
+    # Returns the parameters of this instance represented as a JSON string
+    # @return [String] the JSON string representation of all parameter values
+    def task_json
+      # Convert this instance into Data and strip off the __pcore_type__ key. It's not
+      # needed when executing the task
+      rich_json = Serialization::ToDataConverter.convert(self, :rich_data => true)
+      rich_json.delete('__pcore_type__')
+      rich_json.to_json
+    end
+  end
+
+  # Ruby implementation of the GenericTask. It is a specialization of the Task Pcore type used as the super type
+  # of custom task that lacks a 'parameters' definition (or lacks metadata altogether). This task accepts any
+  # parameters and keeps them in an 'args' hash.
+  class GenericTask < Task
+    # Register the GenericTask type with the Pcore loader and implementation registry
+    def self.register_ptype(loader, ir)
+      @type = Pcore::create_object_type(loader, ir, self, 'GenericTask', 'Task', {
+        'args' => PHashType.new(PARAMETER_NAME_PATTERN, PTypeReferenceType.new('Data'))
+      })
+    end
+
+    def self._pcore_type
+      @type
+    end
+
+    attr_reader :args
+
+    def initialize(args_hash)
+      @args = args_hash
+    end
+
+    def task_json
+      @args.to_json
+    end
+  end
+end
+end

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -190,8 +190,8 @@ module TypeFactory
   # @param hash [{String=>Object}] the hash of feature groups
   # @return [PObjectType] the created type
   #
-  def self.object(hash = nil)
-    hash.nil? || hash.empty? ? PObjectType::DEFAULT : PObjectType.new(hash)
+  def self.object(hash = nil, loader = nil)
+    hash.nil? || hash.empty? ? PObjectType::DEFAULT : PObjectType.new(hash, loader)
   end
 
   def self.type_set(hash = nil)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -57,7 +57,9 @@ class TypedModelObject < Object
   def self.register_ptypes(loader, ir)
     types = [
       Annotation.register_ptype(loader, ir),
-      RubyMethod.register_ptype(loader, ir)
+      RubyMethod.register_ptype(loader, ir),
+      Task.register_ptype(loader, ir),
+      GenericTask.register_ptype(loader, ir)
     ]
     Types.constants.each do |c|
       next if c == :PType || c == :PHostClassType
@@ -3507,6 +3509,7 @@ require_relative 'p_timespan_type'
 require_relative 'p_timestamp_type'
 require_relative 'p_binary_type'
 require_relative 'p_init_type'
+require_relative 'task'
 require_relative 'type_set_reference'
 require_relative 'implementation_registry'
 require_relative 'tree_iterators'

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+module Puppet::Pops
+module Types
+describe 'The Task Type' do
+  include PuppetSpec::Compiler
+
+  it 'can present itself as json' do
+    code = <<-PUPPET.unindent
+    
+      type Service::Action = Enum[
+        # Start the service
+        'start',
+        # Stop the service,
+        'stop',
+        # Restart the service
+        'restart',
+        # Ensure that the service is enabled
+        'enable',
+        # Disable the service
+        'disable',
+        # Report the current status of the service
+        'Status'
+      ]
+
+      # @summary Manage and inspect the state of services
+      # @parameter action The operation (start, stop, restart, enable, disable, status) to perform on the service
+      # @parameter service The name of the service to install
+      # @parameter provider The provider to use to manage or inspect the service, defaults to the system service manager
+      type Service::Init = Task {
+        constants => {
+          supports_noop => true,
+          input_format => 'stdin:json'
+        },
+        attributes => {
+          action => Service::Action,
+          service => String[1],
+          provider => {
+            type => String[1],
+            value => 'system'
+          }
+        }
+      }
+      notice(Service::Init('restart', 'httpd').task_json())
+    PUPPET
+    expect(eval_and_collect_notices(code)[0]).to eql('{"action":"restart","service":"httpd"}')
+  end
+end
+end
+end
+


### PR DESCRIPTION
This commit adds a loader that finds files under the 'tasks' folder
in a module root directory. The loader will expect to find exactly one
file that matches the expected task name and has an optional or
arbitrary file extension that is different from '.json'. That file may
optionally be accompanied by file that has the same name and a '.json'
extension. The json latter is then the metadata that describes the task
type.