### PR TITLE
(PUP-7880) Ensure log message attributes are UTF-8

### DIFF
--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -184,6 +184,7 @@ class Puppet::Util::Log
     return if @levels.index(msg.level) < @loglevel
 
     msg.message = coerce_string(msg.message)
+    msg.source = coerce_string(msg.source)
 
     queuemessage(msg) if @destinations.length == 0
 

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -163,6 +163,19 @@ class Puppet::Util::Log
     end
   end
 
+  private
+  # produces UTF-8 strings or dumps strings when they cannot be re-encoded
+  def Log.coerce_string(str)
+    return Puppet::Util::CharacterEncoding.convert_to_utf_8(str) if str.valid_encoding?
+
+    annotated_string = _("Received a Log attribute with invalid encoding:")
+    annotated_string << Puppet::Util::CharacterEncoding.convert_to_utf_8(str.dump) << "\n"
+    # We only select the last 10 callers in the stack to avoid being spammy
+    annotated_string << _("Backtrace:") << "\n" << caller[0..10].join("\n")
+  end
+
+  public
+
   # Route the actual message. FIXME There are lots of things this method
   # should do, like caching and a bit more.  It's worth noting that there's
   # a potential for a loop here, if the machine somehow gets the destination set as
@@ -170,16 +183,7 @@ class Puppet::Util::Log
   def Log.newmessage(msg)
     return if @levels.index(msg.level) < @loglevel
 
-    if msg.message.valid_encoding?
-      message = Puppet::Util::CharacterEncoding.convert_to_utf_8(msg.message)
-    else
-      message = _("Received a log message with invalid encoding:")
-      message << Puppet::Util::CharacterEncoding.convert_to_utf_8(msg.message.dump) << "\n"
-      # We only select the last 10 callers in the stack to avoid being spammy
-      message << _("Backtrace:") << "\n" << caller[0..10].join("\n")
-    end
-
-    msg.message = message
+    msg.message = coerce_string(msg.message)
 
     queuemessage(msg) if @destinations.length == 0
 

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -32,11 +32,11 @@ describe Puppet::Util::Log do
     end
 
     it "includes a backtrace in the log" do
-      expect(logs.last.message).to match(/Backtrace:\n.*in `initialize'/ )
+      expect(logs.last.message).to match(/Backtrace:\n.*in `newmessage'\n.*in `initialize'/ )
     end
 
     it "warns that message included invalid encoding" do
-      expect(logs.last.message).to match(/Received a log message with invalid encoding/)
+      expect(logs.last.message).to match(/Received a Log attribute with invalid encoding/)
     end
 
     it "includes the 'dump' of the invalid message" do


### PR DESCRIPTION
 - Log message objects contain attributes other than the string
   message itself, which may be concatenated to form the actual string
   to write when the handle method of each instance of
   Puppet::Util::Log::Destination is executed.

   For instance, the :console destination and :file destination may
   concatenate the @source and @message of a Log message.

 - While Puppet began coercing log messages to UTF-8 as part of
   c47be2d3b3d002f02cbed6edee8dfee119152b46 it didn't also coerce the
   source.

   In many circumstances, Ruby is happy to concatenate UTF-8 strings
   with strings of other encodings that only use 7-bit ASCII characters
   that are consistent amongst all encodings.

   However, it is also possible under certain circumstances to
   generate a @source and @message that are of different encodings
   that cannot be concatenated.

   In such cases, attempts to log will result in Puppet crashing with
   an error like:

   Error: Failed to apply catalog: incompatible character encodings: IBM437 and UTF-8

 - Such a failure occurs when running the following manifest through
   Cygwin:

```puppet
     file { "c:/temp":
       ensure => directory
     }

     file { "c:/temp/unicode_dir_ㅀㅅㅶㅅㅲㅂㅄㅉㅑㅧㅩㅙㅘ":
       ensure  => directory,
       require => File['c:/temp']
     }

     user { "bob":
       ensure     => present,
       groups     => 'Users',
       managehome => true,
       password   => "L0v3Pupp3t!"
     }

     acl { "c:/temp/unicode_dir_ㅀㅅㅶㅅㅲㅂㅄㅉㅑㅧㅩㅙㅘ":
       permissions => [
         { identity => 'bob', rights => ['full']  },
       ],
     }
```

 - Log destinations *should* have already had their messages groomed
   so that both the @source and @message attributes are uniformly
   in UTF-8, so that specific log implementations like :console and
   :file don't have to be aware of any additional string coercing
   behavior.

 - Add tests demonstrating the problem, noting that the :console
   log destination is being used specifically as it has special
   behavior when calling `handle` for generating actual messages.