### PR TITLE
(PUP-7864) Fix issues with GenericTask and add tests

### DIFF
--- a/lib/puppet/pops/types/puppet_object.rb
+++ b/lib/puppet/pops/types/puppet_object.rb
@@ -21,6 +21,10 @@ module PuppetObject
   def _pcore_init_hash
     EMPTY_HASH
   end
+
+  def to_s
+    TypeFormatter.string(self)
+  end
 end
 end
 end

--- a/lib/puppet/pops/types/puppet_object.rb
+++ b/lib/puppet/pops/types/puppet_object.rb
@@ -19,7 +19,7 @@ module PuppetObject
   end
 
   def _pcore_init_hash
-    EMPTY_HASH
+    {}
   end
 
   def to_s

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -298,9 +298,7 @@ class RubyGenerator < TypeFormatter
       end
     end
 
-    if obj_attrs.empty?
-      bld << "\n  def _pcore_init_hash\n    {}\n  end\n" unless obj.parent.is_a?(PObjectType)
-    else
+    unless obj_attrs.empty? && obj.parent.nil?
       bld << "\n  def _pcore_init_hash\n"
       bld << '    result = '
       bld << (obj.parent.nil? ? '{}' : 'super')

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -347,12 +347,6 @@ class RubyGenerator < TypeFormatter
       bld << "    path.pop\n  end\n"
     end
 
-    unless obj.parent.is_a?(PObjectType)
-      bld << "\n  def to_s\n"
-      bld << '    ' << namespace_relative(segments, TypeFormatter.name) << ".string(self)\n"
-      bld << "  end\n"
-    end
-
     # Output function placeholders
     obj.functions(false).each_value do |func|
       code_annotation = RubyMethod.annotate(func)

--- a/lib/puppet/pops/types/task.rb
+++ b/lib/puppet/pops/types/task.rb
@@ -91,6 +91,12 @@ module Types
     def task_json
       @args.to_json
     end
+
+    # Special to_s needed to cloak the 'attr' attribute and instead present
+    # the hash
+    def to_s
+      "#{_pcore_type.name}(#{TypeFormatter.string(@args)})"
+    end
   end
 end
 end

--- a/lib/puppet/pops/types/task.rb
+++ b/lib/puppet/pops/types/task.rb
@@ -80,8 +80,12 @@ module Types
 
     attr_reader :args
 
-    def initialize(args_hash)
-      @args = args_hash
+    def _pcore_init_hash
+      { 'args' => args }
+    end
+
+    def initialize(args)
+      @args = args
     end
 
     def task_json

--- a/spec/unit/pops/loaders/module_loaders_spec.rb
+++ b/spec/unit/pops/loaders/module_loaders_spec.rb
@@ -58,184 +58,6 @@ describe 'FileBased module loader' do
     expect(function.is_a?(Puppet::Functions::Function)).to eq(true)
   end
 
-  context 'when loading tasks' do
-    let(:testmodule) { {} }
-    let(:modules_dir) { dir_containing('modules', { 'testmodule' => testmodule }) }
-    let(:loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [modules_dir])) }
-
-    before {
-      Puppet.push_context(:loaders => loaders)
-    }
-
-    after {
-      Puppet.pop_context
-    }
-
-    context 'without metadata' do
-      let(:testmodule) {
-        {
-          'tasks' => {
-            'hello' => <<-RUBY
-            require 'json'
-            args = JSON.parse(STDIN.read)
-            puts({message: args['message']}.to_json)
-            exit 0
-          RUBY
-          }
-        }
-      }
-
-      it 'loads task as a GenericTask subtype' do
-        module_loader = loaders.find_loader('testmodule')
-        task_t = module_loader.load(:type, 'testmodule::hello')
-        expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
-        expect(task_t.name).to eq('Testmodule::Hello')
-        expect(task_t.parent.name).to eq('GenericTask')
-
-        task = task_t.create('foo' => 'the foo', 'fee' => 311, 'fum' => false)
-        expect(task).to be_a(Puppet::Pops::Types::Task)
-        expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello")
-        expect(task.task_json).to eql('{"foo":"the foo","fee":311,"fum":false}')
-      end
-    end
-
-    context 'with metadata' do
-      let(:testmodule) {
-        {
-          'tasks' => {
-            'hello.rb' => <<-RUBY,
-            require 'json'
-            args = JSON.parse(STDIN.read)
-            puts({message: args['message']}.to_json)
-            exit 0
-          RUBY
-          'hello.json' => <<-JSON
-            {
-              "supports_noop": true,
-              "parameters": {
-                 "message": {
-                   "type": "String"
-                 },
-                 "font": {
-                   "type": "Optional[String]"
-                 }
-            }}
-          JSON
-          }
-        }
-      }
-
-      it 'loads a task with parameters as a Task subtype' do
-        module_loader = loaders.find_loader('testmodule')
-        task_t = module_loader.load(:type, 'testmodule::hello')
-        expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
-        expect(task_t.name).to eq('Testmodule::Hello')
-        expect(task_t.parent.name).to eq('Task')
-
-        expect(task_t['message']).to be_a(Puppet::Pops::Types::PObjectType::PAttribute)
-        expect(task_t['message'].type).to be_a(Puppet::Pops::Types::PStringType)
-        expect(task_t['supports_noop']).to be_a(Puppet::Pops::Types::PObjectType::PAttribute)
-        expect(task_t['supports_noop'].type).to be_a(Puppet::Pops::Types::PBooleanType)
-        expect(task_t['supports_noop'].kind).to eql('constant')
-        expect(task_t['supports_noop'].value).to eql(true)
-
-        task = task_t.create('a message')
-        expect(task).to be_a(Puppet::Pops::Types::Task)
-        expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello.rb")
-        expect(task.task_json).to eql('{"message":"a message"}')
-      end
-
-      context 'that has a malformed top-level entry' do
-        let(:testmodule) {
-          {
-            'tasks' => {
-              'hello' => 'echo hello',
-              'hello.json' => <<-JSON
-                {
-                  "supports_nop": true,
-                  "parameters": {
-                     "message": { "type": "String" }
-                  }
-                }
-                JSON
-            }
-          }
-        }
-
-        it 'loads a task with parameters as a Task subtype' do
-          module_loader = loaders.find_loader('testmodule')
-          expect{module_loader.load(:type, 'testmodule::hello')}.to raise_error(
-            /The metadata for task testmodule::hello has wrong type, unrecognized key 'supports_nop'/)
-        end
-      end
-
-      context 'that has a malformed parameter name' do
-        let(:testmodule) {
-          {
-            'tasks' => {
-              'hello' => 'echo hello',
-              'hello.json' => <<-JSON
-                {
-                  "supports_noop": true,
-                  "parameters": {
-                     "Message": { "type": "String" }
-                  }
-                }
-            JSON
-            }
-          }
-        }
-
-        it 'loads a task with parameters as a Task subtype' do
-          module_loader = loaders.find_loader('testmodule')
-          expect{module_loader.load(:type, 'testmodule::hello')}.to raise_error(
-            /entry 'parameters' key of entry 'Message' expects a match for Pattern\[\/\\A\[a-z\]\[a-z0-9_\]\*\\z\/\], got 'Message'/)
-        end
-      end
-    end
-
-    context 'with defined type' do
-      let(:testmodule) {
-        {
-          'tasks' => {
-            'hello.rb' => <<-RUBY,
-            require 'json'
-            args = JSON.parse(STDIN.read)
-            puts({message: args['message']}.to_json)
-            exit 0
-          RUBY
-          },
-          'types' => {
-            'hello.pp' => <<-PUPPET
-            type Testmodule::Hello = Task {
-              constants => {
-                supports_noop => true,
-                executable => 'hello.rb'
-              },
-              attributes => {
-                message => String,
-                font => {
-                  type => Optional[String],
-                  value => undef
-                }
-              }
-            }
-          PUPPET
-          }
-        }
-      }
-
-      it 'loads a task defined as a Type' do
-        module_loader = loaders.find_loader('testmodule')
-        task_t = module_loader.load(:type, 'testmodule::hello').resolve(module_loader)
-        expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
-        expect(task_t.name).to eq('Testmodule::Hello')
-        task = task_t.create('a message')
-        expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello.rb")
-      end
-    end
-  end
-
   it 'system loader has itself as private loader' do
     module_loader = loaders.puppet_system_loader
     expect(module_loader.private_loader).to be(module_loader)
@@ -272,43 +94,19 @@ describe 'FileBased module loader' do
     Puppet::Pops::Loader::TypedName.new(type, name)
   end
 
-  context 'module function and class using a module type alias' do
+  context 'when loading' do
     include PuppetSpec::Compiler
-
-    let(:modules) do
-      {
-        'mod' => {
-          'functions' => {
-            'afunc.pp' => <<-PUPPET.unindent
-              function mod::afunc(Mod::Analias $v) {
-                notice($v)
-              }
-          PUPPET
-          },
-          'types' => {
-            'analias.pp' => <<-PUPPET.unindent
-               type Mod::Analias = Enum[a,b]
-               PUPPET
-          },
-          'manifests' => {
-            'init.pp' => <<-PUPPET.unindent
-              class mod(Mod::Analias $v) {
-                notify { $v: }
-              }
-              PUPPET
-          }
-        }
-      }
-    end
 
     let(:testing_env) do
       {
         'testing' => {
-          'modules' => modules
+          'modules' => modules,
+          'manifests' => manifests
         }
       }
     end
 
+    let(:manifests) { {} }
     let(:environments_dir) { Puppet[:environmentpath] }
 
     let(:testing_env_dir) do
@@ -318,17 +116,295 @@ describe 'FileBased module loader' do
       env_dir
     end
 
-    let(:env) { Puppet::Node::Environment.create(:testing, [File.join(testing_env_dir, 'modules')]) }
+    let(:modules_dir) { File.join(testing_env_dir, 'modules') }
+    let(:env) { Puppet::Node::Environment.create(:testing, [modules_dir]) }
     let(:node) { Puppet::Node.new('test', :environment => env) }
+    let(:logs) { [] }
+    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+    let(:notices) { logs.select { |log| log.level == :notice }.map { |log| log.message } }
 
-    # The call to mod:afunc will load the function, and as a consequence, make an attempt to load
-    # the parameter type Mod::Analias. That load in turn, will trigger the Runtime3TypeLoader which
-    # will load the manifests in Mod. The init.pp manifest also references the Mod::Analias parameter
-    # which results in a recursive call to the same loader. This test asserts that this recursive
-    # call is handled OK.
-    # See PUP-7391 for more info.
-    it 'should handle a recursive load' do
-      expect(eval_and_collect_notices("mod::afunc('b')", node)).to eql(['b'])
+    context 'tasks' do
+      let(:compiler) { Puppet::Parser::Compiler.new(node) }
+
+      let(:modules) do
+        { 'testmodule' => testmodule }
+      end
+
+      def compile(code = nil)
+        Puppet[:code] = code
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          compiler.compile do |catalog|
+            yield if block_given?
+            catalog
+          end
+        end
+      end
+
+      context 'without metadata' do
+        let(:testmodule) {
+          {
+            'tasks' => {
+              'hello' => <<-RUBY
+            require 'json'
+            args = JSON.parse(STDIN.read)
+            puts({message: args['message']}.to_json)
+            exit 0
+            RUBY
+            }
+          }
+        }
+
+        it 'loads task as a GenericTask subtype' do
+          compile do
+            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+            task_t = module_loader.load(:type, 'testmodule::hello')
+            expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
+            expect(task_t.name).to eq('Testmodule::Hello')
+            expect(task_t.parent.name).to eq('GenericTask')
+
+            task = task_t.create('foo' => 'the foo', 'fee' => 311, 'fum' => false)
+            expect(task).to be_a(Puppet::Pops::Types::Task)
+            expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello")
+            expect(task.task_json).to eql('{"foo":"the foo","fee":311,"fum":false}')
+          end
+        end
+
+        it 'evaluator loads and notices an empty GenericTask' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({})"])
+        end
+
+        it 'evaluator loads and notices a GenericTask with parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({foo => 'the foo', fee => 311, fum => false}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'foo' => 'the foo', 'fee' => 311, 'fum' => false})"])
+       end
+      end
+
+      context 'with metadata' do
+        let(:testmodule) {
+          {
+            'tasks' => {
+              'hello.rb' => <<-RUBY,
+            require 'json'
+            args = JSON.parse(STDIN.read)
+            puts({message: args['message']}.to_json)
+            exit 0
+            RUBY
+            'hello.json' => <<-JSON
+            {
+              "supports_noop": true,
+              "parameters": {
+                 "message": {
+                   "type": "String"
+                 },
+                 "font": {
+                   "type": "Optional[String]"
+                 }
+            }}
+            JSON
+            }
+          }
+        }
+
+        it 'loads a task with parameters as a Task subtype' do
+          compile do
+            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+            task_t = module_loader.load(:type, 'testmodule::hello')
+            expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
+            expect(task_t.name).to eq('Testmodule::Hello')
+            expect(task_t.parent.name).to eq('Task')
+
+            expect(task_t['message']).to be_a(Puppet::Pops::Types::PObjectType::PAttribute)
+            expect(task_t['message'].type).to be_a(Puppet::Pops::Types::PStringType)
+            expect(task_t['supports_noop']).to be_a(Puppet::Pops::Types::PObjectType::PAttribute)
+            expect(task_t['supports_noop'].type).to be_a(Puppet::Pops::Types::PBooleanType)
+            expect(task_t['supports_noop'].kind).to eql('constant')
+            expect(task_t['supports_noop'].value).to eql(true)
+
+            task = task_t.create('a message')
+            expect(task).to be_a(Puppet::Pops::Types::Task)
+            expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello.rb")
+            expect(task.task_json).to eql('{"message":"a message"}')
+          end
+        end
+
+        it 'evaluator loads and notices a Task with positional parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello('a message'))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message'})"])
+        end
+
+        it 'evaluator loads and notices a Task with positional parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello('a message', 'helvetica'))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message', 'font' => 'helvetica'})"])
+        end
+
+        it 'evaluator fails on invalid number of parameters' do
+          expect { compile(<<-PUPPET.unindent) }.to raise_error(/expects between 1 and 2 arguments, got 3/)
+            notice(Testmodule::Hello('a message', 'helvetica', 'bold'))
+          PUPPET
+        end
+
+        it 'evaluator loads and notices a Task with named parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({message => 'a message'}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message'})"])
+        end
+
+        it 'evaluator fails on invalid parameter names' do
+          expect { compile(<<-PUPPET.unindent) }.to raise_error(/expects a value for key 'message'.*unrecognized key 'echo'/m)
+            notice(Testmodule::Hello({echo => 'a message'}))
+          PUPPET
+        end
+
+        context 'that has a malformed top-level entry' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'hello' => 'echo hello',
+                'hello.json' => <<-JSON
+                {
+                  "supports_nop": true,
+                  "parameters": {
+                     "message": { "type": "String" }
+                  }
+                }
+              JSON
+              }
+            }
+          }
+
+          it 'loads a task with parameters as a Task subtype' do
+            compile do
+              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+              expect{module_loader.load(:type, 'testmodule::hello')}.to raise_error(
+                /The metadata for task testmodule::hello has wrong type, unrecognized key 'supports_nop'/)
+            end
+          end
+        end
+
+        context 'that has a malformed parameter name' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'hello' => 'echo hello',
+                'hello.json' => <<-JSON
+                {
+                  "supports_noop": true,
+                  "parameters": {
+                     "Message": { "type": "String" }
+                  }
+                }
+              JSON
+              }
+            }
+          }
+
+          it 'loads a task with parameters as a Task subtype' do
+            compile do
+              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+              expect{module_loader.load(:type, 'testmodule::hello')}.to raise_error(
+                /entry 'parameters' key of entry 'Message' expects a match for Pattern\[\/\\A\[a-z\]\[a-z0-9_\]\*\\z\/\], got 'Message'/)
+            end
+          end
+        end
+      end
+
+      context 'with defined type' do
+        let(:testmodule) {
+          {
+            'tasks' => {
+              'hello.rb' => <<-RUBY,
+            require 'json'
+            args = JSON.parse(STDIN.read)
+            puts({message: args['message']}.to_json)
+            exit 0
+            RUBY
+            },
+            'types' => {
+              'hello.pp' => <<-PUPPET
+            type Testmodule::Hello = Task {
+              constants => {
+                supports_noop => true,
+                executable => 'hello.rb'
+              },
+              attributes => {
+                message => String,
+                font => {
+                  type => Optional[String],
+                  value => undef
+                }
+              }
+            }
+            PUPPET
+            }
+          }
+        }
+
+        it 'loads a task defined as a Type' do
+          compile do
+            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+            task_t = module_loader.load(:type, 'testmodule::hello').resolve(module_loader)
+            expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
+            expect(task_t.name).to eq('Testmodule::Hello')
+            task = task_t.create('a message')
+            expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello.rb")
+          end
+        end
+
+        it 'evaluator loads and notices a Task with named parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({message => 'a message'}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message'})"])
+        end
+      end
+    end
+
+    context 'module function and class using a module type alias' do
+      let(:modules) do
+        {
+          'mod' => {
+            'functions' => {
+              'afunc.pp' => <<-PUPPET.unindent
+                function mod::afunc(Mod::Analias $v) {
+                  notice($v)
+                }
+            PUPPET
+            },
+            'types' => {
+              'analias.pp' => <<-PUPPET.unindent
+                 type Mod::Analias = Enum[a,b]
+                 PUPPET
+            },
+            'manifests' => {
+              'init.pp' => <<-PUPPET.unindent
+                class mod(Mod::Analias $v) {
+                  notify { $v: }
+                }
+                PUPPET
+            }
+          }
+        }
+      end
+
+      # The call to mod:afunc will load the function, and as a consequence, make an attempt to load
+      # the parameter type Mod::Analias. That load in turn, will trigger the Runtime3TypeLoader which
+      # will load the manifests in Mod. The init.pp manifest also references the Mod::Analias parameter
+      # which results in a recursive call to the same loader. This test asserts that this recursive
+      # call is handled OK.
+      # See PUP-7391 for more info.
+      it 'should handle a recursive load' do
+        expect(eval_and_collect_notices("mod::afunc('b')", node)).to eql(['b'])
+      end
     end
   end
 end

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -6,6 +6,281 @@ module Puppet::Pops
 module Types
 describe 'The Task Type' do
   include PuppetSpec::Compiler
+  include PuppetSpec::Files
+
+  context 'when loading' do
+    let(:testing_env) do
+      {
+        'testing' => {
+          'modules' => modules,
+          'manifests' => manifests
+        }
+      }
+    end
+
+    let(:manifests) { {} }
+    let(:environments_dir) { Puppet[:environmentpath] }
+
+    let(:testing_env_dir) do
+      dir_contained_in(environments_dir, testing_env)
+      env_dir = File.join(environments_dir, 'testing')
+      PuppetSpec::Files.record_tmp(env_dir)
+      env_dir
+    end
+
+    let(:modules_dir) { File.join(testing_env_dir, 'modules') }
+    let(:env) { Puppet::Node::Environment.create(:testing, [modules_dir]) }
+    let(:node) { Puppet::Node.new('test', :environment => env) }
+    let(:logs) { [] }
+    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+    let(:notices) { logs.select { |log| log.level == :notice }.map { |log| log.message } }
+
+    context 'tasks' do
+      let(:compiler) { Puppet::Parser::Compiler.new(node) }
+
+      let(:modules) do
+        { 'testmodule' => testmodule }
+      end
+
+      def compile(code = nil)
+        Puppet[:code] = code
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          compiler.compile do |catalog|
+            yield if block_given?
+            catalog
+          end
+        end
+      end
+
+      context 'without metadata' do
+        let(:testmodule) {
+          {
+            'tasks' => {
+              'hello' => <<-RUBY
+            require 'json'
+            args = JSON.parse(STDIN.read)
+            puts({message: args['message']}.to_json)
+            exit 0
+            RUBY
+            }
+          }
+        }
+
+        it 'loads task as a GenericTask subtype' do
+          compile do
+            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+            task_t = module_loader.load(:type, 'testmodule::hello')
+            expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
+            expect(task_t.name).to eq('Testmodule::Hello')
+            expect(task_t.parent.name).to eq('GenericTask')
+
+            task = task_t.create('foo' => 'the foo', 'fee' => 311, 'fum' => false)
+            expect(task).to be_a(Puppet::Pops::Types::Task)
+            expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello")
+            expect(task.task_json).to eql('{"foo":"the foo","fee":311,"fum":false}')
+          end
+        end
+
+        it 'evaluator loads and notices an empty GenericTask' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({})"])
+        end
+
+        it 'evaluator loads and notices a GenericTask with parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({foo => 'the foo', fee => 311, fum => false}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'foo' => 'the foo', 'fee' => 311, 'fum' => false})"])
+        end
+      end
+
+      context 'with metadata' do
+        let(:testmodule) {
+          {
+            'tasks' => {
+              'hello.rb' => <<-RUBY,
+            require 'json'
+            args = JSON.parse(STDIN.read)
+            puts({message: args['message']}.to_json)
+            exit 0
+            RUBY
+            'hello.json' => <<-JSON
+            {
+              "supports_noop": true,
+              "parameters": {
+                 "message": {
+                   "type": "String"
+                 },
+                 "font": {
+                   "type": "Optional[String]"
+                 }
+            }}
+            JSON
+            }
+          }
+        }
+
+        it 'loads a task with parameters as a Task subtype' do
+          compile do
+            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+            task_t = module_loader.load(:type, 'testmodule::hello')
+            expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
+            expect(task_t.name).to eq('Testmodule::Hello')
+            expect(task_t.parent.name).to eq('Task')
+
+            expect(task_t['message']).to be_a(Puppet::Pops::Types::PObjectType::PAttribute)
+            expect(task_t['message'].type).to be_a(Puppet::Pops::Types::PStringType)
+            expect(task_t['supports_noop']).to be_a(Puppet::Pops::Types::PObjectType::PAttribute)
+            expect(task_t['supports_noop'].type).to be_a(Puppet::Pops::Types::PBooleanType)
+            expect(task_t['supports_noop'].kind).to eql('constant')
+            expect(task_t['supports_noop'].value).to eql(true)
+
+            task = task_t.create('a message')
+            expect(task).to be_a(Puppet::Pops::Types::Task)
+            expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello.rb")
+            expect(task.task_json).to eql('{"message":"a message"}')
+          end
+        end
+
+        it 'evaluator loads and notices a Task with positional parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello('a message'))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message'})"])
+        end
+
+        it 'evaluator loads and notices a Task with positional parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello('a message', 'helvetica'))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message', 'font' => 'helvetica'})"])
+        end
+
+        it 'evaluator fails on invalid number of parameters' do
+          expect { compile(<<-PUPPET.unindent) }.to raise_error(/expects between 1 and 2 arguments, got 3/)
+            notice(Testmodule::Hello('a message', 'helvetica', 'bold'))
+          PUPPET
+        end
+
+        it 'evaluator loads and notices a Task with named parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({message => 'a message'}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message'})"])
+        end
+
+        it 'evaluator fails on invalid parameter names' do
+          expect { compile(<<-PUPPET.unindent) }.to raise_error(/expects a value for key 'message'.*unrecognized key 'echo'/m)
+            notice(Testmodule::Hello({echo => 'a message'}))
+          PUPPET
+        end
+
+        context 'that has a malformed top-level entry' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'hello' => 'echo hello',
+                'hello.json' => <<-JSON
+                {
+                  "supports_nop": true,
+                  "parameters": {
+                     "message": { "type": "String" }
+                  }
+                }
+              JSON
+              }
+            }
+          }
+
+          it 'loads a task with parameters as a Task subtype' do
+            compile do
+              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+              expect{module_loader.load(:type, 'testmodule::hello')}.to raise_error(
+                /The metadata for task testmodule::hello has wrong type, unrecognized key 'supports_nop'/)
+            end
+          end
+        end
+
+        context 'that has a malformed parameter name' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'hello' => 'echo hello',
+                'hello.json' => <<-JSON
+                {
+                  "supports_noop": true,
+                  "parameters": {
+                     "Message": { "type": "String" }
+                  }
+                }
+              JSON
+              }
+            }
+          }
+
+          it 'loads a task with parameters as a Task subtype' do
+            compile do
+              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+              expect{module_loader.load(:type, 'testmodule::hello')}.to raise_error(
+                /entry 'parameters' key of entry 'Message' expects a match for Pattern\[\/\\A\[a-z\]\[a-z0-9_\]\*\\z\/\], got 'Message'/)
+            end
+          end
+        end
+      end
+
+      context 'with defined type' do
+        let(:testmodule) {
+          {
+            'tasks' => {
+              'hello.rb' => <<-RUBY,
+            require 'json'
+            args = JSON.parse(STDIN.read)
+            puts({message: args['message']}.to_json)
+            exit 0
+            RUBY
+            },
+            'types' => {
+              'hello.pp' => <<-PUPPET
+            type Testmodule::Hello = Task {
+              constants => {
+                supports_noop => true,
+                executable => 'hello.rb'
+              },
+              attributes => {
+                message => String,
+                font => {
+                  type => Optional[String],
+                  value => undef
+                }
+              }
+            }
+            PUPPET
+            }
+          }
+        }
+
+        it 'loads a task defined as a Type' do
+          compile do
+            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
+            task_t = module_loader.load(:type, 'testmodule::hello').resolve(module_loader)
+            expect(task_t).to be_a(Puppet::Pops::Types::PObjectType)
+            expect(task_t.name).to eq('Testmodule::Hello')
+            task = task_t.create('a message')
+            expect(task.executable_path).to eql("#{modules_dir}/testmodule/tasks/hello.rb")
+          end
+        end
+
+        it 'evaluator loads and notices a Task with named parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello({message => 'a message'}))
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({'message' => 'a message'})"])
+        end
+      end
+    end
+  end
 
   it 'can present itself as json' do
     code = <<-PUPPET.unindent


### PR DESCRIPTION
This PR fixes several issues with the GenericTask class and adds tests that uses the puppet evaluator to produce and notice the string form of created tasks.

See individual commits for details.