### PR TITLE
(PUP-7864) Remove the need to provide {} for empty GenericTasks

### DIFF
--- a/lib/puppet/pops/types/task.rb
+++ b/lib/puppet/pops/types/task.rb
@@ -70,7 +70,10 @@ module Types
     # Register the GenericTask type with the Pcore loader and implementation registry
     def self.register_ptype(loader, ir)
       @type = Pcore::create_object_type(loader, ir, self, 'GenericTask', 'Task', {
-        'args' => PHashType.new(PARAMETER_NAME_PATTERN, PTypeReferenceType.new('Data'))
+        'args' => {
+          'type' => PHashType.new(PARAMETER_NAME_PATTERN, PTypeReferenceType.new('Data')),
+          'value' => EMPTY_HASH
+        }
       })
     end
 
@@ -84,7 +87,7 @@ module Types
       { 'args' => args }
     end
 
-    def initialize(args)
+    def initialize(args = EMPTY_HASH)
       @args = args
     end
 

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -81,7 +81,14 @@ describe 'The Task Type' do
           end
         end
 
-        it 'evaluator loads and notices an empty GenericTask' do
+        it 'evaluator loads and notices an empty GenericTask without parameters' do
+          compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello())
+          PUPPET
+          expect(notices).to eql(["Testmodule::Hello({})"])
+        end
+
+        it 'evaluator loads and notices an empty GenericTask using {}' do
           compile(<<-PUPPET.unindent)
             notice(Testmodule::Hello({}))
           PUPPET


### PR DESCRIPTION
This commit changes the signature of the GenericTask constructor so that
an instance can be creatd without providing any parameters. Prior to
this commit, it was necessary to provide {} as a parameter.