### PR TITLE
(PUP-7885) Ensure that Enum data type only accepts string parameters

### DIFF
--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -342,6 +342,7 @@ class TypeParser
     when 'enum'
       # 1..m parameters being strings
       raise_invalid_parameters_error('Enum', '1 or more', parameters.size) unless parameters.size >= 1
+      parameters.each { |p|  raise Puppet::ParseError, 'Enum parameters must be identifiers or strings' unless p.is_a?(String) }
       TypeFactory.enum(*parameters)
 
     when 'pattern'

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -376,6 +376,26 @@ describe TypeParser do
     expect(t.type_string).to eql('Nonesuch[{a=>undef,b=>true,c=>false,d=>default,e=>"string",f=>0,g=>1.0,h=>[1,2,3]}]')
   end
 
+  it 'parses a parameterized Enum using identifiers' do
+    t = parser.parse('Enum[a, b]')
+    expect(t).to be_a(PEnumType)
+    expect(t.to_s).to eql("Enum['a', 'b']")
+  end
+
+  it 'parses a parameterized Enum using strings' do
+    t = parser.parse("Enum['a', 'b']")
+    expect(t).to be_a(PEnumType)
+    expect(t.to_s).to eql("Enum['a', 'b']")
+  end
+
+  it 'rejects a parameterized Enum using type refs' do
+    expect { parser.parse('Enum[A, B]') }.to raise_error(/Enum parameters must be identifiers or strings/)
+  end
+
+  it 'rejects a parameterized Enum using integers' do
+    expect { parser.parse('Enum[1, 2]') }.to raise_error(/Enum parameters must be identifiers or strings/)
+  end
+
   matcher :be_the_type do |type|
     calc = TypeCalculator.new
 


### PR DESCRIPTION
A parameterized `Enum` must only accept parameters of type string
(or identifier, since it's converted to a string) but prior to this
commit it was possible to use arbitrary parameters such as integers if
the string was parsed/evaluated by the internal TypeParser. This commit
adds the check needed to prevent this from happening.