### PR TITLE
(PUP-7893) Update aix tests to use jfs2 for mounting on 5.3

### DIFF
--- a/acceptance/lib/puppet/acceptance/mount_utils.rb
+++ b/acceptance/lib/puppet/acceptance/mount_utils.rb
@@ -23,12 +23,7 @@ module Puppet
       def filesystem_type(host)
         case host['platform']
         when /aix/
-          maj_version = on(host, facter('operatingsystemmajrelease')).stdout.chomp.to_i
-          if maj_version >= 6100
-            'jfs2'
-          else
-            'jfs'
-          end
+          'jfs2'
         when /el-|centos|fedora|sles|debian|ubuntu|cumulus/
           'ext3'
         else


### PR DESCRIPTION
AIX 5.3 images have been updated to use jfs2, so we need to update our tests
to use jfs2 when doing tests with mounts