### PR TITLE
(PUP-7890) Add discovery to the Puppet Loader system

### DIFF
--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -20,6 +20,16 @@ class BaseLoader < Loader
     @last_result = nil      # the value of the last name (optimization)
   end
 
+  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+    result = []
+    @named_values.each_pair do |key, entry|
+      result << key unless entry.nil? || entry.value.nil? || key.type != type || (block_given? && !yield(key))
+    end
+    result.concat(parent.discover(type, name_authority, &block))
+    result.uniq!
+    result
+  end
+
   # @api public
   #
   def load_typed(typed_name)

--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -23,6 +23,13 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
     @dependency_loaders = dependency_loaders
   end
 
+  def discover(type, name_authority = Puppet::Pops::Pcore::RUNTIME_NAME_AUTHORITY, &block)
+    result = []
+    @dependency_loaders.each { |loader| result.concat(loader.discover(type, name_authority, &block)) }
+    result.concat(super)
+    result
+  end
+
   # Finds name in a loader this loader depends on / can see
   #
   def find(typed_name)

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -36,6 +36,20 @@ class Loader
     @loader_name = loader_name.freeze
   end
 
+  # Search all places where this loader would find values of a given type and return a list the
+  # found values for which the given block returns true. All found entries will be returned if no
+  # block is given.
+  #
+  # @param type [Symbol] the type of values to search for
+  # @param name_authority [String] the name authority, defaults to the pcore runtime
+  # @yield [typed_name] optional block to filter the results
+  # @yieldparam [TypedName] typed_name the typed name of a found entry
+  # @yieldreturn [Boolean] `true` to keep the entry, `false` to discard it.
+  # @return [Array<TypedName>] the list of names of discovered values
+  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+    return EMPTY_ARRAY
+  end
+
   # Produces the value associated with the given name if already loaded, or available for loading
   # by this loader, one of its parents, or other loaders visible to this loader.
   # This is the method an external party should use to "get" the named element.

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -13,6 +13,11 @@ class Runtime3TypeLoader < BaseLoader
     @resource_3x_loader = env_path.nil? ? nil : ModuleLoaders.pcore_resource_type_loader_from(parent_loader, loaders, env_path)
   end
 
+  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+    # TODO: Use generated index of all known types (requires separate utility).
+    parent.discover(type, name_authority, &block)
+  end
+
   def to_s()
     "(Runtime3TypeLoader '#{loader_name()}')"
   end

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -79,6 +79,14 @@ class StaticLoader < Loader
     register_aliases
   end
 
+  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+    # Static loader only contains runtime types
+    return EMPTY_ARRAY unless type == :type && name_authority == name_authority = Pcore::RUNTIME_NAME_AUTHORITY
+
+    typed_names = type == :type && name_authority == Pcore::RUNTIME_NAME_AUTHORITY ? @loaded.keys : EMPTY_ARRAY
+    block_given? ? typed_names.select { |tn| yield(tn) } : typed_names
+  end
+
   def load_typed(typed_name)
     load_constant(typed_name)
   end

--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -153,34 +153,34 @@ describe 'The Loader' do
         context 'with multiple modules' do
           let(:metadata_json_a) {
               {
-                'name': 'example/a',
-                'version': '0.1.0',
-                'source': 'git@github.com/example/example-a.git',
-                'dependencies': [{'name' => 'c', 'version_range' => '>=0.1.0'}],
-                'author': 'Bob the Builder',
-                'license': 'Apache-2.0'
+                'name' => 'example/a',
+                'version' => '0.1.0',
+                'source' => 'git@github.com/example/example-a.git',
+                'dependencies' => [{'name' => 'c', 'version_range' => '>=0.1.0'}],
+                'author' => 'Bob the Builder',
+                'license' => 'Apache-2.0'
               }
           }
 
           let(:metadata_json_b) {
             {
-              'name': 'example/b',
-              'version': '0.1.0',
-              'source': 'git@github.com/example/example-b.git',
-              'dependencies': [{'name' => 'c', 'version_range' => '>=0.1.0'}],
-              'author': 'Bob the Builder',
-              'license': 'Apache-2.0'
+              'name' => 'example/b',
+              'version' => '0.1.0',
+              'source' => 'git@github.com/example/example-b.git',
+              'dependencies' => [{'name' => 'c', 'version_range' => '>=0.1.0'}],
+              'author' => 'Bob the Builder',
+              'license' => 'Apache-2.0'
             }
           }
 
           let(:metadata_json_c) {
             {
-              'name': 'example/c',
-              'version': '0.1.0',
-              'source': 'git@github.com/example/example-c.git',
-              'dependencies': [],
-              'author': 'Bob the Builder',
-              'license': 'Apache-2.0'
+              'name' => 'example/c',
+              'version' => '0.1.0',
+              'source' => 'git@github.com/example/example-c.git',
+              'dependencies' => [],
+              'author' => 'Bob the Builder',
+              'license' => 'Apache-2.0'
             }
           }
 

--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -1,0 +1,288 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+require 'puppet_spec/compiler'
+
+require 'puppet/pops'
+require 'puppet/loaders'
+
+module Puppet::Pops
+module Loader
+describe 'The Loader' do
+  include PuppetSpec::Compiler
+  include PuppetSpec::Files
+
+  let(:testing_env) do
+    {
+      'testing' => {
+        'functions' => functions,
+        'lib' => { 'puppet' => lib_puppet },
+        'manifests' => manifests,
+        'modules' => modules,
+        'plans' => plans,
+        'tasks' => tasks,
+        'types' => types,
+      }
+    }
+  end
+
+  let(:functions) { {} }
+  let(:manifests) { {} }
+  let(:modules) { {} }
+  let(:plans) { {} }
+  let(:lib_puppet) { {} }
+  let(:tasks) { {} }
+  let(:types) { {} }
+
+  let(:environments_dir) { Puppet[:environmentpath] }
+
+  let(:testing_env_dir) do
+    dir_contained_in(environments_dir, testing_env)
+    env_dir = File.join(environments_dir, 'testing')
+    PuppetSpec::Files.record_tmp(env_dir)
+    env_dir
+  end
+
+  let(:modules_dir) { File.join(testing_env_dir, 'modules') }
+  let(:env) { Puppet::Node::Environment.create(:testing, [modules_dir]) }
+  let(:node) { Puppet::Node.new('test', :environment => env) }
+  let(:loader) { Loaders.find_loader(nil) }
+
+  before(:each) { Puppet.push_context(:loaders => Loaders.new(env)) }
+  after(:each) { Puppet.pop_context }
+
+  context 'when doing discovery' do
+    context 'of things' do
+      it 'finds statically basic types' do
+        expect(loader.discover(:type)).to include(tn(:type, 'integer'))
+      end
+
+      it 'finds statically loaded types' do
+        expect(loader.discover(:type)).to include(tn(:type, 'file'))
+      end
+
+      it 'finds statically loaded Object types' do
+        expect(loader.discover(:type)).to include(tn(:type, 'puppet::ast::accessexpression'))
+      end
+
+      context 'in environment' do
+        let(:types) {
+          {
+            'global.pp' => <<-PUPPET.unindent,
+              type Global = Integer
+              PUPPET
+            'environment' => {
+              'env.pp' => <<-PUPPET.unindent,
+                type Environment::Env = String
+                PUPPET
+            }
+          }
+        }
+
+        let(:tasks) {
+          {
+            'globtask' => '',
+            'environment' => {
+              'envtask' => ''
+            }
+          }
+        }
+
+        let(:functions) {
+          {
+            'globfunc.pp' => 'function globfunc() {}',
+            'environment' => {
+              'envfunc.pp' => 'function environment::envfunc() {}'
+            }
+          }
+        }
+
+        let(:lib_puppet) {
+          {
+            'functions' => {
+              'globrubyfunc.rb' => 'Puppet::Functions.create_function(:globrubyfunc) { def globrubyfunc; end }',
+              'environment' => {
+                'envrubyfunc.rb' => "Puppet::Functions.create_function(:'environment::envrubyfunc') { def envrubyfunc; end }",
+              }
+            }
+          }
+        }
+
+        it 'finds global types in environment' do
+          expect(loader.discover(:type)).to include(tn(:type, 'global'))
+        end
+
+        it 'finds global functions in environment' do
+          expect(loader.discover(:function)).to include(tn(:function, 'lookup'))
+        end
+
+        it 'finds types prefixed with Environment in environment' do
+          expect(loader.discover(:type)).to include(tn(:type, 'environment::env'))
+        end
+
+        it 'finds global tasks in environment' do
+          expect(loader.discover(:type)).to include(tn(:type, 'globtask'))
+        end
+
+        it 'finds tasks prefixed with Environment in environment' do
+          expect(loader.discover(:type)).to include(tn(:type, 'environment::envtask'))
+        end
+
+        it 'finds global functions in environment' do
+          expect(loader.discover(:function)).to include(tn(:function, 'globfunc'))
+        end
+
+        it 'finds functions prefixed with Environment in environment' do
+          expect(loader.discover(:function)).to include(tn(:function, 'environment::envfunc'))
+        end
+
+        it 'finds global ruby functions in environment' do
+          expect(loader.discover(:function)).to include(tn(:function, 'globrubyfunc'))
+        end
+
+        it 'finds ruby functions prefixed with Environment in environment' do
+          expect(loader.discover(:function)).to include(tn(:function, 'environment::envrubyfunc'))
+        end
+
+        it 'can filter the list of discovered entries using a block' do
+          expect(loader.discover(:function) { |t| t.name =~ /rubyfunc\z/ }).to contain_exactly(
+            tn(:function, 'environment::envrubyfunc'),
+            tn(:function, 'globrubyfunc')
+          )
+        end
+
+        context 'with multiple modules' do
+          let(:modules) {
+            {
+              'a' => {
+                'functions' => a_functions,
+                'lib' => { 'puppet' => a_lib_puppet },
+                'plans' => a_plans,
+                'tasks' => a_tasks,
+                'types' => a_types,
+              },
+              'b' => {
+                'functions' => b_functions,
+                'lib' => { 'puppet' => b_lib_puppet },
+                'plans' => b_plans,
+                'tasks' => b_tasks,
+                'types' => b_types,
+              },
+            }
+          }
+
+          let(:a_plans) {
+            {
+              'aplan.pp' => <<-PUPPET.unindent,
+                plan a::aplan() {}
+                PUPPET
+            }
+          }
+
+          let(:a_types) {
+            {
+              'atype.pp' => <<-PUPPET.unindent,
+                type A::Atype = Integer
+                PUPPET
+            }
+          }
+
+          let(:a_tasks) {
+            {
+              'atask' => '',
+            }
+          }
+
+          let(:a_functions) {
+            {
+              'afunc.pp' => 'function a::afunc() {}',
+            }
+          }
+
+          let(:a_lib_puppet) {
+            {
+              'functions' => {
+                'a' => {
+                  'arubyfunc.rb' => "Puppet::Functions.create_function(:'a::arubyfunc') { def arubyfunc; end }",
+                }
+              }
+            }
+          }
+
+          let(:b_plans) {
+            {
+              'aplan.pp' => <<-PUPPET.unindent,
+                plan b::aplan() {}
+                PUPPET
+            }
+          }
+
+          let(:b_types) {
+            {
+              'atype.pp' => <<-PUPPET.unindent,
+                type B::Atype = Integer
+                PUPPET
+            }
+          }
+
+          let(:b_tasks) {
+            {
+              'atask' => '',
+            }
+          }
+
+          let(:b_functions) {
+            {
+              'afunc.pp' => 'function b::afunc() {}',
+            }
+          }
+
+          let(:b_lib_puppet) {
+            {
+              'functions' => {
+                'b' => {
+                  'arubyfunc.rb' => "Puppet::Functions.create_function(:'b::arubyfunc') { def arubyfunc; end }",
+                }
+              }
+            }
+          }
+
+          it 'private loader finds plans in all modules' do
+            expect(loader.private_loader.discover(:plan) { |t| t.name =~ /^.::.*\z/ }).to(
+              contain_exactly(tn(:plan, 'a::aplan'), tn(:plan, 'b::aplan')))
+          end
+
+          it 'module loader finds plans only in itself' do
+            expect(Loaders.find_loader('a').discover(:plan)).to(
+              contain_exactly(tn(:plan, 'a::aplan')))
+          end
+
+          it 'private loader finds types in all modules' do
+            expect(loader.private_loader.discover(:type) { |t| t.name =~ /^.::.*\z/ }).to(
+              contain_exactly(tn(:type, 'a::atype'), tn(:type, 'b::atype'), tn(:type, 'a::atask'), tn(:type, 'b::atask')))
+          end
+
+          it 'module loader finds types only in itself' do
+            expect(Loaders.find_loader('a').discover(:type) { |t| t.name =~ /^.::.*\z/ }).to(
+              contain_exactly(tn(:type, 'a::atype'), tn(:type, 'a::atask')))
+          end
+
+          it 'private loader finds functions in all modules' do
+            expect(loader.private_loader.discover(:function) { |t| t.name =~ /^.::.*\z/ }).to(
+              contain_exactly(tn(:function, 'a::afunc'), tn(:function, 'b::afunc'), tn(:function, 'a::arubyfunc'), tn(:function, 'b::arubyfunc')))
+          end
+
+          it 'module loader finds functions only in itself' do
+            expect(Loaders.find_loader('a').discover(:function) { |t| t.name =~ /^.::.*\z/ }).to(
+              contain_exactly(tn(:function, 'a::afunc'), tn(:function, 'a::arubyfunc')))
+          end
+        end
+      end
+    end
+  end
+
+  def tn(type, name)
+    TypedName.new(type, name)
+  end
+end
+end
+end


### PR DESCRIPTION
This commit adds a `#discover` method to all pcore loaders. This new
method can be used to discover all entities that the loader has access
to. The type of entity to search for must be provided. A filter can
also be provided in the form of a block.

Current limitations:
- All entities that are discovered will be loaded. This has pros and
  cons. The pro is that once loaded, the type will be cached in memory.
  The con is that loading and keeping all entities in memory might be
  resource demanding.
- Resource types are currently not loaded.

A solution for both limitations would be to provide a utility program
that would execute separate from the puppet runtime to maintain an
index of everything that can be loaded.