### PR TITLE
(PUP-3368) fix parsing of unicode in nagios resources on ruby >= 2.1.0

### DIFF
--- a/lib/puppet/external/nagios/grammar.ry
+++ b/lib/puppet/external/nagios/grammar.ry
@@ -52,7 +52,7 @@ require 'strscan'
 class ::Nagios::Parser::SyntaxError < RuntimeError; end
 
 def parse(src)
-  if src.respond_to?("force_encoding") then
+  if (RUBY_VERSION < '2.1.0') && src.respond_to?("force_encoding") then
     src.force_encoding("ASCII-8BIT")
   end
   @ss = StringScanner.new(src)

--- a/lib/puppet/external/nagios/parser.rb
+++ b/lib/puppet/external/nagios/parser.rb
@@ -14,7 +14,7 @@ require 'strscan'
 class ::Nagios::Parser::SyntaxError < RuntimeError; end
 
 def parse(src)
-  if src.respond_to?("force_encoding") then
+  if (RUBY_VERSION < '2.1.0') && src.respond_to?("force_encoding") then
     src.force_encoding("ASCII-8BIT")
   end
   @ss = StringScanner.new(src)


### PR DESCRIPTION
As reported in other places - e.g. (PUP-4633), with ruby >= 2.1.0
we don't need to enforce encoding anymore. This adds the same fix
also to the Nagios parser and adds a test that takes the example
from the bug report, which fails when running on 2.4.1.