### PR TITLE
(PUP-7902) Ensure that empty heredoc lines are not trimmed

### DIFF
--- a/lib/puppet/pops/parser/heredoc_support.rb
+++ b/lib/puppet/pops/parser/heredoc_support.rb
@@ -133,7 +133,7 @@ module HeredocSupport
       lines = lines.collect {|s| s.gsub(leading_pattern, '') }
     end
     result = lines.join('')
-    result.gsub!(/\r?\n$/, '') if remove_break
+    result.gsub!(/\r?\n\z/m, '') if remove_break
     result
   end
 

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -488,6 +488,21 @@ describe 'Lexer2' do
       )
     end
 
+    it 'strips only one newline at the end when using trim option' do
+      code = <<-CODE.unindent
+        @(END)
+        Line 1
+        Line 2
+        
+        -END
+      CODE
+      expect(tokens_scanned_from(code)).to match_tokens2(
+        [:HEREDOC, ''],
+        [:SUBLOCATE, ["Line 1\n", "Line 2\n", "\n"]],
+        [:STRING, "Line 1\nLine 2\n"],
+      )
+    end
+
     context 'with bad syntax' do
       def expect_issue(code, issue)
         expect { tokens_scanned_from(code) }.to raise_error(Puppet::ParseErrorWithIssue) { |e|

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -474,7 +474,6 @@ describe 'Lexer2' do
     end
 
     it 'strips only last newline when using trim option' do
-      pending 'fix for PUP-7902'
       code = <<-CODE.unindent
         @(END)
         Line 1

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -473,6 +473,22 @@ describe 'Lexer2' do
         )
     end
 
+    it 'strips only last newline when using trim option' do
+      pending 'fix for PUP-7902'
+      code = <<-CODE.unindent
+        @(END)
+        Line 1
+        
+        Line 2
+        -END
+        CODE
+      expect(tokens_scanned_from(code)).to match_tokens2(
+        [:HEREDOC, ''],
+        [:SUBLOCATE, ["Line 1\n", "\n", "Line 2\n"]],
+        [:STRING, "Line 1\n\nLine 2"],
+      )
+    end
+
     context 'with bad syntax' do
       def expect_issue(code, issue)
         expect { tokens_scanned_from(code) }.to raise_error(Puppet::ParseErrorWithIssue) { |e|


### PR DESCRIPTION
Before this commit, the regexp that was used to trim off the last
newline (or cr-nl) was not a multi-line regexp and used the '$' (end of
line) which resulted in that all empty lines where removed. This commit
changes the regexp into a multiline that uses \z (end of string), thus
ensuring that only the last occurrence is removed.