### PR TITLE
(PUP-7909) ERB not supported with task feature

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -78,6 +78,23 @@ module Puppet
       msg = "#{msg} on node #{node}" if node
       msg
     end
+
+    def self.from_issue_and_stack(issue, args = {})
+      stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+      if stacktrace.size > 0
+        filename, line = stacktrace[0]
+      else
+        file = nil
+        line = nil
+      end
+      self.new(
+            issue.format(args),
+            filename,
+            line,
+            nil,
+            nil,
+            issue.issue_code)
+    end
   end
 
   # An error that already contains location information in the message text

--- a/lib/puppet/parser/functions/inline_template.rb
+++ b/lib/puppet/parser/functions/inline_template.rb
@@ -4,6 +4,12 @@ Puppet::Parser::Functions::newfunction(:inline_template, :type => :rvalue, :arit
   more information. Note that if multiple template strings are specified, their
   output is all concatenated and returned as the output of the function.") do |vals|
 
+  if Puppet[:tasks]
+    raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+      Puppet::Pops::Issues::FEATURE_NOT_SUPPORTED_WHEN_SCRIPTING,
+      {:feature => 'ERB inline_template'})
+  end
+
   require 'erb'
 
     vals.collect do |string|

--- a/lib/puppet/parser/functions/template.rb
+++ b/lib/puppet/parser/functions/template.rb
@@ -12,6 +12,11 @@ Puppet::Parser::Functions::newfunction(:template, :type => :rvalue, :arity => -2
   * An absolute path, which can load a template file from anywhere on disk.
   * Multiple arguments, which will evaluate all of the specified templates and
   return their outputs concatenated into a single string.") do |vals|
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::FEATURE_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:feature => 'ERB template'})
+    end
     vals.collect do |file|
       # Use a wrapper, so the template can't get access to the full
       # Scope object.

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -856,5 +856,14 @@ module Issues
   SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING = issue :SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING, :path, :klass, :value do
     _("%{path} contains a hash with %{klass} key. It will be converted to the String '%{value}'") % { path: path, klass: label.a_an(klass), value: value }
   end
+
+  FEATURE_NOT_SUPPORTED_WHEN_SCRIPTING = issue :NOT_SUPPORTED_WHEN_SCRIPTING, :feature do
+    _("The feature '%{feature}' is only available when compiling a catalog") % { feature: feature }
+  end
+
+  CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING = issue :CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING, :operation do
+    _("The catalog operation '%{operation}' is only available when compiling a catalog") % { operration: operation }
+  end
+
 end
 end

--- a/spec/unit/parser/functions/inline_template_spec.rb
+++ b/spec/unit/parser/functions/inline_template_spec.rb
@@ -28,6 +28,13 @@ describe "the inline_template function" do
     expect(inline_template("string was: <%= @string %>")).to eq("string was: this is a variable")
   end
 
+  it 'is not available when --tasks is on' do
+    Puppet[:tasks] = true
+    expect {
+      inline_template("<%= lookupvar('myvar') %>")
+    }.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+  end
+
   def inline_template(*templates)
     scope.function_inline_template(templates)
   end

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -81,6 +81,14 @@ describe "the template function" do
     }.to raise_error(Puppet::ParseError, /undefined method `lookupvar'/)
   end
 
+  it 'is not available when --tasks is on' do
+    Puppet[:tasks] = true
+    expect {
+      eval_template("<%= lookupvar('myvar') %>")
+    }.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+
+  end
+
   def eval_template(content)
     Puppet::FileSystem.stubs(:read_preserve_line_endings).with("template").returns(content)
     Puppet::Parser::Files.stubs(:find_template).returns("template")


### PR DESCRIPTION
This adds a feature switch so that `template` and `inline_template` are not supported when running with --tasks turned on.
