### PR TITLE
(PUP-7910) Make catalog functions illegal when tasks are on

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -78,6 +78,23 @@ module Puppet
       msg = "#{msg} on node #{node}" if node
       msg
     end
+
+    def self.from_issue_and_stack(issue, args = {})
+      stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+      if stacktrace.size > 0
+        filename, line = stacktrace[0]
+      else
+        file = nil
+        line = nil
+      end
+      self.new(
+            issue.format(args),
+            filename,
+            line,
+            nil,
+            nil,
+            issue.issue_code)
+    end
   end
 
   # An error that already contains location information in the message text

--- a/lib/puppet/functions/contain.rb
+++ b/lib/puppet/functions/contain.rb
@@ -13,6 +13,12 @@ Puppet::Functions.create_function(:contain, Puppet::Functions::InternalFunction)
   end
 
   def contain(scope, *classes)
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:operation => 'contain'})
+    end
+
     # Make call patterns uniform and protected against nested arrays, also make
     # names absolute if so desired.
     classes = scope.transform_and_assert_classnames(classes.flatten)

--- a/lib/puppet/functions/include.rb
+++ b/lib/puppet/functions/include.rb
@@ -11,6 +11,12 @@ Puppet::Functions.create_function(:include, Puppet::Functions::InternalFunction)
   end
 
   def include(scope, *classes)
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:operation => 'include'})
+    end
+
     classes = scope.transform_and_assert_classnames(classes.flatten)
     result = classes.map {|name| Puppet::Pops::Types::TypeFactory.host_class(name) }
     scope.compiler.evaluate_classes(classes, scope, false)

--- a/lib/puppet/functions/require.rb
+++ b/lib/puppet/functions/require.rb
@@ -11,6 +11,12 @@ Puppet::Functions.create_function(:require, Puppet::Functions::InternalFunction)
   end
 
   def require_impl(scope, *classes)
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:operation => 'require'})
+    end
+
     # Make call patterns uniform and protected against nested arrays, also make
     # names absolute if so desired.
     classes = scope.transform_and_assert_classnames(classes.flatten)

--- a/lib/puppet/parser/functions/create_resources.rb
+++ b/lib/puppet/parser/functions/create_resources.rb
@@ -47,6 +47,12 @@ Puppet::Parser::Functions::newfunction(:create_resources, :arity => -3, :doc => 
     final value of a parameter (just as when setting a parameter to `undef` in a puppet language
     resource declaration).
   ENDHEREDOC
+  if Puppet[:tasks]
+    raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+      Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING,
+      {:operation => 'create_resources'})
+  end
+
   raise ArgumentError, (_("create_resources(): wrong number of arguments (%{count}; must be 2 or 3)") % { count: args.length }) if args.length > 3
   raise ArgumentError, (_('create_resources(): second argument must be a hash')) unless args[1].is_a?(Hash)
   if args.length == 3

--- a/lib/puppet/parser/functions/inline_template.rb
+++ b/lib/puppet/parser/functions/inline_template.rb
@@ -4,6 +4,12 @@ Puppet::Parser::Functions::newfunction(:inline_template, :type => :rvalue, :arit
   more information. Note that if multiple template strings are specified, their
   output is all concatenated and returned as the output of the function.") do |vals|
 
+  if Puppet[:tasks]
+    raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+      Puppet::Pops::Issues::FEATURE_NOT_SUPPORTED_WHEN_SCRIPTING,
+      {:feature => 'ERB inline_template'})
+  end
+
   require 'erb'
 
     vals.collect do |string|

--- a/lib/puppet/parser/functions/realize.rb
+++ b/lib/puppet/parser/functions/realize.rb
@@ -7,6 +7,12 @@ Puppet::Parser::Functions::newfunction(:realize, :arity => -2, :doc => "Make a v
     and, of course, is a bit shorter.  You must pass the object using a
     reference; e.g.: `realize User[luke]`." ) do |vals|
 
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:operation => 'realize'})
+    end
+
     vals = [vals] unless vals.is_a?(Array)
 
     coll = Puppet::Pops::Evaluator::Collectors::FixedSetCollector.new(self, vals.flatten)

--- a/lib/puppet/parser/functions/tag.rb
+++ b/lib/puppet/parser/functions/tag.rb
@@ -2,5 +2,11 @@
 Puppet::Parser::Functions::newfunction(:tag, :arity => -2, :doc => "Add the specified tags to the containing class
   or definition.  All contained objects will then acquire that tag, also.
   ") do |vals|
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:operation => 'tag'})
+    end
+
     self.resource.tag(*vals)
 end

--- a/lib/puppet/parser/functions/tagged.rb
+++ b/lib/puppet/parser/functions/tagged.rb
@@ -3,6 +3,12 @@ Puppet::Parser::Functions::newfunction(:tagged, :type => :rvalue, :arity => -2, 
   tells you whether the current container is tagged with the specified tags.
   The tags are ANDed, so that all of the specified tags must be included for
   the function to return true.") do |vals|
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:operation => 'tagged'})
+    end
+
     configtags = compiler.catalog.tags
     resourcetags = resource.tags
 

--- a/lib/puppet/parser/functions/template.rb
+++ b/lib/puppet/parser/functions/template.rb
@@ -12,6 +12,11 @@ Puppet::Parser::Functions::newfunction(:template, :type => :rvalue, :arity => -2
   * An absolute path, which can load a template file from anywhere on disk.
   * Multiple arguments, which will evaluate all of the specified templates and
   return their outputs concatenated into a single string.") do |vals|
+    if Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::FEATURE_NOT_SUPPORTED_WHEN_SCRIPTING,
+        {:feature => 'ERB template'})
+    end
     vals.collect do |file|
       # Use a wrapper, so the template can't get access to the full
       # Scope object.

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -856,5 +856,14 @@ module Issues
   SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING = issue :SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING, :path, :klass, :value do
     _("%{path} contains a hash with %{klass} key. It will be converted to the String '%{value}'") % { path: path, klass: label.a_an(klass), value: value }
   end
+
+  FEATURE_NOT_SUPPORTED_WHEN_SCRIPTING = issue :NOT_SUPPORTED_WHEN_SCRIPTING, :feature do
+    _("The feature '%{feature}' is only available when compiling a catalog") % { feature: feature }
+  end
+
+  CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING = issue :CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING, :operation do
+    _("The catalog operation '%{operation}' is only available when compiling a catalog") % { operration: operation }
+  end
+
 end
 end

--- a/spec/unit/functions/contain_spec.rb
+++ b/spec/unit/functions/contain_spec.rb
@@ -295,4 +295,5 @@ describe 'The "contain" function' do
 
   it_should_behave_like 'all functions transforming relative to absolute names', :contain
   it_should_behave_like 'an inclusion function, regardless of the type of class reference,', :contain
+  it_should_behave_like 'an inclusion function, when --tasks is on,', :contain
 end

--- a/spec/unit/functions/include_spec.rb
+++ b/spec/unit/functions/include_spec.rb
@@ -171,5 +171,6 @@ describe 'The "include" function' do
 
   it_should_behave_like 'all functions transforming relative to absolute names', :include
   it_should_behave_like 'an inclusion function, regardless of the type of class reference,', :include
+  it_should_behave_like 'an inclusion function, when --tasks is on,', :include
 
 end

--- a/spec/unit/functions/require_spec.rb
+++ b/spec/unit/functions/require_spec.rb
@@ -80,4 +80,6 @@ describe 'The "require" function' do
 
   it_should_behave_like 'all functions transforming relative to absolute names', :require
   it_should_behave_like 'an inclusion function, regardless of the type of class reference,', :require
+  it_should_behave_like 'an inclusion function, when --tasks is on,', :require
+
 end

--- a/spec/unit/functions/shared.rb
+++ b/spec/unit/functions/shared.rb
@@ -83,3 +83,15 @@ shared_examples_for 'an inclusion function, regardless of the type of class refe
     end
 
 end
+
+shared_examples_for 'an inclusion function, when --tasks is on,' do |function|
+  it "is not available when --tasks is on" do
+    Puppet[:tasks] = true
+    expect do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        #{function}(bar)
+      MANIFEST
+    end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+  end
+end
+

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -324,6 +324,15 @@ describe 'function for dynamically creating resources' do
         compile_to_catalog('include foo')
       }.to raise_error(Puppet::Error, /Syntax error at.*/)
     end
+
+    it 'is not available when --tasks is on' do
+      Puppet[:tasks] = true
+      expect do
+        catalog = compile_to_catalog(<<-MANIFEST)
+          create_resources('class', {'bar'=>{}}, {'one' => 'two'})
+        MANIFEST
+      end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+    end
   end
 
   def collect_notices(code)

--- a/spec/unit/parser/functions/inline_template_spec.rb
+++ b/spec/unit/parser/functions/inline_template_spec.rb
@@ -28,6 +28,13 @@ describe "the inline_template function" do
     expect(inline_template("string was: <%= @string %>")).to eq("string was: this is a variable")
   end
 
+  it 'is not available when --tasks is on' do
+    Puppet[:tasks] = true
+    expect {
+      inline_template("<%= lookupvar('myvar') %>")
+    }.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+  end
+
   def inline_template(*templates)
     scope.function_inline_template(templates)
   end

--- a/spec/unit/parser/functions/realize_spec.rb
+++ b/spec/unit/parser/functions/realize_spec.rb
@@ -58,4 +58,13 @@ describe "the realize function" do
       realize([])
     EOM
   end
+
+  it 'is not available when --tasks is on' do
+    Puppet[:tasks] = true
+    expect do
+      catalog = compile_to_catalog(<<-MANIFEST)
+        realize([])
+      MANIFEST
+    end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+  end
 end

--- a/spec/unit/parser/functions/tag_spec.rb
+++ b/spec/unit/parser/functions/tag_spec.rb
@@ -25,4 +25,11 @@ describe "the 'tag' function" do
     expect(resource).to be_tagged("one")
     expect(resource).to be_tagged("two")
   end
+
+  it 'is not available when --tasks is on' do
+    Puppet[:tasks] = true
+    expect do
+      @scope.function_tag(['one', 'two'])
+    end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+  end
 end

--- a/spec/unit/parser/functions/tagged_spec.rb
+++ b/spec/unit/parser/functions/tagged_spec.rb
@@ -1,0 +1,25 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe "the 'tagged' function" do
+  before :all do
+    Puppet::Parser::Functions.autoloader.loadall
+  end
+
+  before :each do
+    node     = Puppet::Node.new('localhost')
+    compiler = Puppet::Parser::Compiler.new(node)
+    @scope   = Puppet::Parser::Scope.new(compiler)
+  end
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function(:tagged)).to eq("function_tagged")
+  end
+
+  it 'is not available when --tasks is on' do
+    Puppet[:tasks] = true
+    expect do
+      @scope.function_tagged(['one', 'two'])
+    end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+  end
+end

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -81,6 +81,14 @@ describe "the template function" do
     }.to raise_error(Puppet::ParseError, /undefined method `lookupvar'/)
   end
 
+  it 'is not available when --tasks is on' do
+    Puppet[:tasks] = true
+    expect {
+      eval_template("<%= lookupvar('myvar') %>")
+    }.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
+
+  end
+
   def eval_template(content)
     Puppet::FileSystem.stubs(:read_preserve_line_endings).with("template").returns(content)
     Puppet::Parser::Files.stubs(:find_template).returns("template")


### PR DESCRIPTION
This makes all of the functions performing catalog operation illegal when --tasks is on.

THIS PR IS BASED ON PUP-7909 WHICH SHOULD BE MERGED FIRST.