### PR TITLE
(PUP-8015) Add a `puppet ssl` face for generating csrs without needing to connect to a master

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -1,0 +1,19 @@
+require 'puppet/application/face_base'
+
+class Puppet::Application::Ssl < Puppet::Application::FaceBase
+  def app_defaults
+    super.merge({
+      :catalog_terminus => :rest,
+      :catalog_cache_terminus => :json,
+      :node_terminus => :rest,
+      :facts_terminus => :facter,
+    })
+  end
+
+  def setup
+    super
+    Puppet::SSL::Host.ca_location = :none
+    Puppet.settings.preferred_run_mode = "agent"
+    Puppet.settings.use(:ssl)
+  end
+end

--- a/lib/puppet/face/ssl.rb
+++ b/lib/puppet/face/ssl.rb
@@ -1,0 +1,91 @@
+require 'puppet/face'
+require 'puppet/ssl'
+
+module PuppetX
+  module Puppetlabs
+    module Ssl
+      def verify_signed_cert!(hostcert)
+        if !hostcert.nil?
+          Puppet.notice "Found a certificate for #{Puppet[:certname]}"
+        else
+          Puppet.err "No signed certificate found for #{Puppet[:certname]}"
+          exit(1)
+        end
+      end
+
+      def verify_ssl_files_match!(hostcert, hostkey)
+        if hostcert.content.check_private_key(hostkey.content)
+          Puppet.notice "Private key matches certificate"
+        else
+          Puppet.err "Signed certificate does not match host private key"
+          exit(1)
+        end
+      end
+
+      def verify_node_definition_reachable!
+        Puppet::Node.indirection.find(Puppet[:node_name_value],
+                                      environment: Puppet::Node::Environment.remote('production'),
+                                      ignore_cache: true,
+                                      fail_on_404: true)
+        Puppet.notice("Contacted Puppet master for node definition")
+      rescue => e
+        Puppet.err "Unable to reach Puppet master: #{e.message}"
+        exit(1)
+      end
+    end
+  end
+end
+
+Puppet::Face.define(:ssl, '0.1.0') do
+  copyright "Puppet Inc.", 2017
+  license   _("Apache 2 license; see COPYING")
+  summary "Initialize the Puppet agent"
+
+  action(:generate_csr) do
+    summary "Initialize the agent key pair and save a CSR"
+
+    when_invoked do |opts|
+      Puppet::SSL::Oids.register_puppet_oids
+      Puppet::SSL::Oids.load_custom_oid_file(Puppet[:trusted_oid_mapping_file])
+
+      Puppet::SSL::Host.localhost
+    end
+  end
+
+  action(:purge) do
+    summary "Purge all agent SSL files"
+    when_invoked do |opts|
+      Puppet.notice("Purging CA CRL")
+      Puppet::SSL::CertificateRevocationList.indirection.destroy('ca')
+
+      Puppet.notice("Purging agent certificate")
+      Puppet::SSL::Certificate.indirection.destroy(Puppet[:certname])
+      Puppet.notice("Purging agent certificate request")
+      Puppet::SSL::CertificateRequest.indirection.destroy(Puppet[:certname])
+      Puppet.notice("Purging agent key pair")
+      Puppet::SSL::Key.indirection.destroy(Puppet[:certname])
+
+      nil
+    end
+  end
+
+  action(:verify) do
+    summary "Verify that the Puppet agent has a signed certificate"
+
+    when_invoked do |opts|
+      extend PuppetX::Puppetlabs::Ssl
+      hostcert = Puppet::SSL::Certificate.indirection.find(Puppet[:certname])
+      hostkey = Puppet::SSL::Key.indirection.find(Puppet[:certname])
+
+      verify_signed_cert!(hostcert)
+      verify_ssl_files_match!(hostcert, hostkey)
+      verify_node_definition_reachable!
+
+      hostcert
+    end
+
+    when_rendering :console do |cert|
+      cert.content.to_s if cert
+    end
+  end
+end

--- a/spec/unit/face/ssl_spec.rb
+++ b/spec/unit/face/ssl_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+
+require 'puppet/face'
+
+describe Puppet::Face[:ssl, '0.1.0'] do
+  include PuppetSpec::Files
+
+  let(:ssl) { Puppet::Face[:ssl, '0.1.0'] }
+  let(:certificate) { Puppet::Face[:certificate, '0.0.1'] }
+  let(:hostname) { Puppet[:certname] }
+  let(:options) { {:ca_location => 'local'} }
+  let(:different_hostname) { hostname + 'different' }
+
+  before :each do
+    Puppet::SSL::Host.reset
+    Puppet[:confdir] = tmpdir('conf')
+    Puppet::SSL::CertificateAuthority.stubs(:ca?).returns true
+
+    Puppet::SSL::Host.ca_location = :local
+
+    # We can't cache the CA between tests, because each one has its own SSL dir.
+    ca = Puppet::SSL::CertificateAuthority.new
+    Puppet::SSL::CertificateAuthority.stubs(:new).returns ca
+    Puppet::SSL::CertificateAuthority.stubs(:instance).returns ca
+  end
+
+  context "generate-csr" do
+    it "initializes agent key pair and saves a CSR" do
+      # Because we're the CA, calling `puppet ssl generate-csr` will autosign
+      # the certificate request
+      expect { ssl.generate_csr()  }.to_not raise_error
+      expect { ssl.verify()  }.to_not raise_error
+    end
+  end
+
+  context "verify" do
+    it "verifies an agent has a signed cert" do
+      certificate.generate(hostname, options)
+      certificate.sign(hostname, options)
+      expect { ssl.verify() }.to_not raise_error
+    end
+  end
+
+  context "purge" do
+    it "purges correctly" do
+      certificate.generate(different_hostname, options)
+      certificate.sign(different_hostname, options)
+      expect { ssl.verify() }.to raise_error(SystemExit)
+
+      expect { ssl.purge() }.to_not raise_error
+
+      certificate.generate(hostname, options)
+      certificate.sign(hostname, options)
+      expect { ssl.verify() }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This commit moves the puppet-agent-bootstrap code created by Adrien
Thebo (https://github.com/adrienthebo/puppet-agent-bootstrap/) to the
puppetlabs github space, and adds rspec tests to go along with the
bootstrap changes.