### PR TITLE
(PUP-7912) feature switch run task/plan

### DIFF
--- a/lib/puppet/functions/run_plan.rb
+++ b/lib/puppet/functions/run_plan.rb
@@ -18,6 +18,12 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
   end
 
   def run_plan(scope, plan_name, named_args = {})
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        {:operation => 'run_plan'})
+    end
+
     loaders = closure_scope.compiler.loaders
     # The perspective of the environment is wanted here (for now) to not have to require modules
     # to have dependencies defined in meta data.

--- a/lib/puppet/functions/run_task.rb
+++ b/lib/puppet/functions/run_task.rb
@@ -9,6 +9,12 @@ Puppet::Functions.create_function(:run_task) do
   end
 
   def mocked_run_task(task, *hosts)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        {:operation => 'run_task'})
+    end
+
     call_function('notice', "Simulating run of task #{task._pcore_type.name} on hosts: [" + hosts.join(', ') + "]")
     hosts.map do |hostname|
       exit_code = task.respond_to?(:simulated_exit_code) ? task.exit_code : 0

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -865,5 +865,8 @@ module Issues
     _("The catalog operation '%{operation}' is only available when compiling a catalog") % { operration: operation }
   end
 
+  TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING = issue :TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, :operation do
+    _("The task operation '%{operation}' is not available when compiling a catalog") % { operation: operation }
+  end
 end
 end

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -862,7 +862,7 @@ module Issues
   end
 
   CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING = issue :CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING, :operation do
-    _("The catalog operation '%{operation}' is only available when compiling a catalog") % { operration: operation }
+    _("The catalog operation '%{operation}' is only available when compiling a catalog") % { operation: operation }
   end
 
   TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING = issue :TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, :operation do

--- a/spec/unit/functions/run_plan_spec.rb
+++ b/spec/unit/functions/run_plan_spec.rb
@@ -8,6 +8,9 @@ describe 'the run_plan function' do
   include PuppetSpec::Compiler
   include PuppetSpec::Files
   include Matchers::Resource
+  before(:each) do
+    Puppet[:tasks] = true
+  end
 
   context "when invoked" do
     let(:env_name) { 'testenv' }


### PR DESCRIPTION
This makes it illegal to call run_task and run_plan when --tasks is not on (i.e. when compiling a catalog).
This PR also contains a fix of a spelling error causes the error message for one issue added in PUP-7910 to not appear correctly.