### PR TITLE
(PUP-7916) Prevent that Object can be parented by an unresolved type

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -397,6 +397,7 @@ class PObjectType < PMetaType
       assignable?(o._pcore_type, guard)
     else
       name = o.class.name
+      return false if name.nil? # anonymous class that doesn't implement PuppetObject is not an instance
       ir = Loaders.implementation_registry
       type = ir.nil? ? nil : ir.type_for_module(name)
       !type.nil? && assignable?(type, guard)

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -601,6 +601,7 @@ class PObjectType < PMetaType
     unless @parent.nil?
       check_self_recursion(self)
       rp = resolved_parent
+      raise Puppet::ParseError, _("reference to unresolved type '%{name}'") % { :name => rp.type_string } if rp.is_a?(PTypeReferenceType)
       if rp.is_a?(PObjectType)
         parent_object_type = rp
         parent_members = rp.members(true)

--- a/lib/puppet/pops/types/puppet_object.rb
+++ b/lib/puppet/pops/types/puppet_object.rb
@@ -19,7 +19,7 @@ module PuppetObject
   end
 
   def _pcore_init_hash
-    EMPTY_HASH
+    {}
   end
 end
 end

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -163,7 +163,7 @@ class RubyGenerator < TypeFormatter
   end
 
   def class_body(obj, segments, bld)
-    if obj.parent.nil?
+    unless obj.parent.is_a?(PObjectType)
       bld << "\n  include " << namespace_relative(segments, Puppet::Pops::Types::PuppetObject.name) << "\n\n" # marker interface
       bld << "  def self.ref(type_string)\n"
       bld << '    ' << namespace_relative(segments, Puppet::Pops::Types::PTypeReferenceType.name) << ".new(type_string)\n"

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -512,6 +512,7 @@ class TypeCalculator
       o._pcore_type
     else
       name = o.class.name
+      return PRuntimeType.new(:ruby, nil) if name.nil? # anonymous class that doesn't implement PuppetObject is impossible to infer
       ir = Loaders.implementation_registry
       type = ir.nil? ? nil : ir.type_for_module(name)
       type.nil? ? PRuntimeType.new(:ruby, name) : type

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -440,6 +440,7 @@ describe 'the 4x function api' do
       let(:parser) {  Puppet::Pops::Parser::EvaluatingParser.new }
       let(:node) { 'node.example.com' }
       let(:scope) { s = create_test_scope_for_node(node); s }
+      let(:loader) { Puppet::Pops::Loaders.find_loader(nil) }
 
       it 'function with required block can be called' do
         # construct ruby function to call
@@ -455,9 +456,9 @@ describe 'the 4x function api' do
           end
         end
         # add the function to the loader (as if it had been loaded from somewhere)
-        the_loader = loader()
+        the_loader = loader
         f = fc.new({}, the_loader)
-        loader.add_function('testing::test', f)
+        loader.set_entry(Puppet::Pops::Loader::TypedName.new(:function, 'testing::test'), f)
         # evaluate a puppet call
         source = "testing::test(10) |$x| { $x+1 }"
         program = parser.parse_string(source, __FILE__)

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -920,6 +920,14 @@ describe 'The Object Type' do
         /attribute MySecondObject\[a\] attempts to override final attribute MyObject\[a\]/)
     end
 
+    it 'a type cannot be created using an unresolved parent' do
+      code = <<-CODE
+      notice(Object[{ name => 'MyObject', parent => Type('NoneSuch'), attributes => { a => String}}].new('hello'))
+      CODE
+      expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error,
+        /reference to unresolved type 'NoneSuch'/)
+    end
+
     context 'type alias using bracket-less (implicit Object) form' do
       let(:logs) { [] }
       let(:notices) { logs.select { |log| log.level == :notice }.map { |log| log.message } }
@@ -970,7 +978,7 @@ describe 'The Object Type' do
         Puppet[:strict] = 'warning'
         compile(<<-CODE)
           type MyObject = { name => 'MyFirstObject', attributes => { a => String }}
-          type MySecondObject = { parent => MyOtherType, attributes => { b => String }}
+          type MySecondObject = { parent => MyObject, attributes => { b => String }}
           notice(MySecondObject =~ Type)
         CODE
         expect(warnings).to be_empty
@@ -981,7 +989,7 @@ describe 'The Object Type' do
         Puppet[:strict] = 'warning'
         compile(<<-CODE)
           type MyObject = { name => 'MyFirstObject', attributes => { a => String }}
-          type MySecondObject = Object { parent => MyOtherType, attributes => { b => String }}
+          type MySecondObject = Object { parent => MyObject, attributes => { b => String }}
           notice(MySecondObject =~ Type)
         CODE
         expect(warnings).to be_empty

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -523,6 +523,19 @@ describe 'The type calculator' do
         end
       end
     end
+
+    it 'infers an instance of an anonymous class to Runtime[ruby]' do
+      cls = Class.new do
+        attr_reader :name
+        def initialize(name)
+          @name = name
+        end
+      end
+      t = calculator.infer(cls.new('test'))
+      expect(t.class).to eql(PRuntimeType)
+      expect(t.runtime).to eql(:ruby)
+      expect(t.name_or_pattern).to eql(nil)
+    end
   end
 
   context 'patterns' do


### PR DESCRIPTION
This commit adds a check to the `PObjectType#_pcore_init_from_hash`
that prevents a type from being created unless the parent is resolved.

Some tests broke as a consequence of this new check. Those tests were
in error and hence corrected.
