### PR TITLE
(PUP-7907) Make loading of tasks conditional on --tasks feature flag

### DIFF
--- a/lib/puppet/loaders.rb
+++ b/lib/puppet/loaders.rb
@@ -14,7 +14,6 @@ module Puppet
       require 'puppet/pops/loader/runtime3_type_loader'
       require 'puppet/pops/loader/ruby_function_instantiator'
       require 'puppet/pops/loader/puppet_function_instantiator'
-      require 'puppet/pops/loader/task_instantiator'
       require 'puppet/pops/loader/type_definition_instantiator'
       require 'puppet/pops/loader/puppet_resource_type_impl_instantiator'
       require 'puppet/pops/loader/loader_paths'

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -30,7 +30,7 @@ module LoaderPaths
       result << PlanPathPP.new(loader)
     when :type
       result << TypePathPP.new(loader) if loader.loadables.include?(:type_pp)
-      result << TaskPath.new(loader) if loader.loadables.include?(:task)
+      result << TaskPath.new(loader) if Puppet[:tasks] && loader.loadables.include?(:task)
     when :resource_type_pp
       result << ResourceTypeImplPP.new(loader) if loader.loadables.include?(:resource_type_pp)
     else
@@ -218,6 +218,7 @@ module LoaderPaths
     end
 
     def instantiator
+      require_relative 'task_instantiator'
       TaskInstantiator
     end
   end

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -38,6 +38,10 @@ module Pcore
     add_alias('Pcore::MemberName', TYPE_MEMBER_NAME, loader)
     add_alias('Pcore::TypeName', TYPE_QUALIFIED_REFERENCE, loader)
     add_alias('Pcore::QRef', TYPE_QUALIFIED_REFERENCE, loader)
+
+    if Puppet[:tasks]
+      require_relative 'types/task'
+    end
     Types::TypedModelObject.register_ptypes(loader, ir)
 
     @type = create_object_type(loader, ir, Pcore, 'Pcore', nil)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -58,9 +58,12 @@ class TypedModelObject < Object
     types = [
       Annotation.register_ptype(loader, ir),
       RubyMethod.register_ptype(loader, ir),
-      Task.register_ptype(loader, ir),
-      GenericTask.register_ptype(loader, ir)
     ]
+    if Puppet[:tasks]
+      types << Task.register_ptype(loader, ir)
+      types << GenericTask.register_ptype(loader, ir)
+    end
+
     Types.constants.each do |c|
       next if c == :PType || c == :PHostClassType
       cls = Types.const_get(c)
@@ -3509,7 +3512,6 @@ require_relative 'p_timespan_type'
 require_relative 'p_timestamp_type'
 require_relative 'p_binary_type'
 require_relative 'p_init_type'
-require_relative 'task'
 require_relative 'type_set_reference'
 require_relative 'implementation_registry'
 require_relative 'tree_iterators'


### PR DESCRIPTION
This commit ensures that the `Task` and `GenericTask` types are created
and the `Tasks` loader and instantiator activated, only when the `tasks`
feature is enabled.