### PR TITLE
(PUP-7818) Catch regressions of PUP-7818

### DIFF
--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -37,6 +37,10 @@ package { '#{package}':
   provider => aix,
   source   => '#{dir}',
 }
+
+package { 'nonexistant_example_package.rte':
+  ensure => absent,
+}
 MANIFEST
 
 version2_manifest = <<-MANIFEST


### PR DESCRIPTION
This commit modifies the test to catch regressions of PUP-7818; users
ought to be able to ensure a package is absent without passing a source
attribute. PUP-7818 required at least two packages in a manifest to
reproduce.