### PR TITLE
(maint) Merge branch '4.10.x' into 5.2.x

### DIFF
--- a/acceptance/lib/puppet/acceptance/mount_utils.rb
+++ b/acceptance/lib/puppet/acceptance/mount_utils.rb
@@ -23,12 +23,7 @@ module Puppet
       def filesystem_type(host)
         case host['platform']
         when /aix/
-          maj_version = on(host, facter('operatingsystemmajrelease')).stdout.chomp.to_i
-          if maj_version >= 6100
-            'jfs2'
-          else
-            'jfs'
-          end
+          'jfs2'
         when /el-|centos|fedora|sles|debian|ubuntu|cumulus/
           'ext3'
         else

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -40,6 +40,10 @@ package { '#{package}':
   provider => aix,
   source   => '#{dir}',
 }
+
+package { 'nonexistant_example_package.rte':
+  ensure => absent,
+}
 MANIFEST
 
 version2_manifest = <<-MANIFEST

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -74,51 +74,54 @@ puppet-device(8) -- #{summary}
 
 SYNOPSIS
 --------
-Retrieves all configurations from the puppet master and apply
-them to the remote devices configured in /etc/puppetlabs/puppet/device.conf.
+Retrieves catalogs from the Puppet master and applies them to remote devices. 
 
-Currently must be run out periodically, using cron or something similar.
+This subcommand can be run manually; or periodically using cron,
+a scheduled task, or a similar tool.
+
 
 USAGE
 -----
   puppet device [-d|--debug] [--detailed-exitcodes] [--deviceconfig <file>]
                 [-h|--help] [-l|--logdest syslog|<file>|console]
                 [-v|--verbose] [-w|--waitforcert <seconds>]
-                [-t|--target <device>] [-V|--version]
+                [-t|--target <device>] [--user=<user>] [-V|--version]
 
 
 DESCRIPTION
 -----------
-Once the client has a signed certificate for a given remote device, it will
-retrieve its configuration and apply it.
+Devices require a proxy Puppet agent to request certificates, collect facts,
+retrieve and apply catalogs, and store reports.
+
 
 USAGE NOTES
 -----------
-One need a /etc/puppetlabs/puppet/device.conf file with the following content:
+Devices managed by the puppet-device subcommand on a Puppet agent are 
+configured in device.conf, which is located at $confdir/device.conf by default, 
+and is configurable with the $deviceconfig setting. 
 
-[remote.device.fqdn]
-type <type>
-url <url>
+The device.conf file is an INI-like file, with one section per device:
 
-where:
- * type: the current device type (the only value at this time is cisco)
- * url: an url allowing to connect to the device
+[<DEVICE_CERTNAME>]
+type <TYPE>
+url <URL>
+debug
 
-Supported url must conforms to:
- scheme://user:password@hostname/?query
+The section name specifies the certname of the device. 
 
- with:
-  * scheme: either ssh or telnet
-  * user: username, can be omitted depending on the switch/router configuration
-  * password: the connection password
-  * query: this is device specific. Cisco devices supports an enable parameter whose
-  value would be the enable password.
+The values for the type and url properties are specific to each type of device.
+
+The optional debug property specifies transport-level debugging,
+and is limited to telnet and ssh transports.
+
+See https://docs.puppet.com/puppet/latest/config_file_device.html for details.
+
 
 OPTIONS
 -------
-Note that any setting that's valid in the configuration file
-is also a valid long argument.  For example, 'server' is a valid configuration
-parameter, so you can specify '--server <servername>' as an argument.
+Note that any setting that's valid in the configuration file is also a valid 
+long argument. For example, 'server' is a valid configuration parameter, so 
+you can specify '--server <servername>' as an argument.
 
 * --debug:
   Enable full debugging.
@@ -151,6 +154,10 @@ parameter, so you can specify '--server <servername>' as an argument.
   Target a specific device/certificate in the device.conf. Doing so will perform a
   device run against only that device/certificate.
 
+* --user:
+  The user to run as. '--user=root' is required, even when run as root,
+  for runs that create device certificates or keys.
+
 * --verbose:
   Turn on verbose reporting.
 
@@ -159,8 +166,8 @@ parameter, so you can specify '--server <servername>' as an argument.
   and it is enabled by default, with a value of 120 (seconds).  This causes
   +puppet agent+ to connect to the server every 2 minutes and ask it to sign a
   certificate request.  This is useful for the initial setup of a puppet
-  client.  You can turn off waiting for certificates by specifying a time
-  of 0.
+  client.  You can turn off waiting for certificates by specifying a time of 0.
+
 
 EXAMPLE
 -------


### PR DESCRIPTION

    * 4.10.x:
      (PUP-7818) Catch regressions of PUP-7818
      (PUP-7893) Update aix tests to use jfs2 for mounting on 5.3
      (PUP-7825) Remove escapes for slash in #regexp.source for rubies < 2.0.0
      (PUP-7825) Fix problems with regexp string representation
      (PUP-7825) Add test that asserts correct string format of regexps
      (docs)(DOCUMENT-1967) update help for puppet-de