### PR TITLE
(PUP-7920) Pin bundler to 1.15.4 for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: ruby
 sudo: false
+# Travis Ruby 1.9.3 stack is defaulting to version 1.7.6 of bundler
+# which is incompatible with the Rubygems 2.6.13 security release.
+#
+# TODO: Remove when Travis updates its default:
+#   https://github.com/travis-ci/travis-ci/issues/8357
+before_install:
+  - gem install bundler --version 1.15.4
 bundler_args: --without development extra
 script:
   - "bundle exec rake $CHECK"


### PR DESCRIPTION
All other Travis 2.y Ruby stacks are using Bundler 1.15.4, but 1.9.3 is still
stuck on 1.7.6 for some reason. Bundler 1.7.6 is incompatible with the recent
Rubgems 2.6.13 security release, so this patch updates the Ruby 1.9.3 test
to use Bundler 1.15.4.