### PR TITLE
PUP-7905) Add a --tasks feature flagged expression validator

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -387,12 +387,6 @@ module Issues
     _("Expressions of type %{expression} are not supported in this version of Puppet") % { expression: label.a_an(semantic) }
   end
 
-  # Issues when expressions that are not implemented or activated when running with --tasks
-  #
-  UNSUPPORTED_TASKS_EXPRESSION = issue :UNSUPPORTED_TASKS_EXPRESSION do
-    _("Expressions of type %{expression} are not supported when running with --tasks") % { expression: label.a_an(semantic) }
-  end
-
   ILLEGAL_RELATIONSHIP_OPERAND_TYPE = issue :ILLEGAL_RELATIONSHIP_OPERAND_TYPE, :operand do
     _("Illegal relationship operand, can not form a relationship with %{expression}. A Catalog type is required.") % { expression: label.a_an(operand) }
   end

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -387,6 +387,12 @@ module Issues
     _("Expressions of type %{expression} are not supported in this version of Puppet") % { expression: label.a_an(semantic) }
   end
 
+  # Issues when expressions that are not implemented or activated when running with --tasks
+  #
+  UNSUPPORTED_TASKS_EXPRESSION = issue :UNSUPPORTED_TASKS_EXPRESSION do
+    _("Expressions of type %{expression} are not supported when running with --tasks") % { expression: label.a_an(semantic) }
+  end
+
   ILLEGAL_RELATIONSHIP_OPERAND_TYPE = issue :ILLEGAL_RELATIONSHIP_OPERAND_TYPE, :operand do
     _("Illegal relationship operand, can not form a relationship with %{expression}. A Catalog type is required.") % { expression: label.a_an(operand) }
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -15,19 +15,25 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   attr_reader :acceptor
   attr_reader :migration_checker
 
+  def self.check_visitor
+    # Class instance variable rather than Class variable because methods visited
+    # may be overridden in subclass
+    @check_visitor ||= Visitor.new(nil, 'check', 0, 0)
+  end
+
   # Initializes the validator with a diagnostics producer. This object must respond to
   # `:will_accept?` and `:accept`.
   #
   def initialize(diagnostics_producer)
     super()
-    @@check_visitor       ||= Visitor.new(nil, "check", 0, 0)
     @@rvalue_visitor      ||= Visitor.new(nil, "rvalue", 0, 0)
     @@hostname_visitor    ||= Visitor.new(nil, "hostname", 1, 2)
     @@assignment_visitor  ||= Visitor.new(nil, "assign", 0, 1)
     @@query_visitor       ||= Visitor.new(nil, "query", 0, 0)
     @@relation_visitor    ||= Visitor.new(nil, "relation", 0, 0)
-    @@idem_visitor        ||= Visitor.new(self, "idem", 0, 0)
+    @@idem_visitor        ||= Visitor.new(nil, "idem", 0, 0)
 
+    @check_visitor = self.class.check_visitor
     @acceptor = diagnostics_producer
 
     # Use null migration checker unless given in context
@@ -51,7 +57,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   # Performs regular validity check
   def check(o)
-    @@check_visitor.visit_this_0(self, o)
+    @check_visitor.visit_this_0(self, o)
   end
 
   # Performs check if this is a vaid hostname expression

--- a/lib/puppet/pops/validation/tasks_checker.rb
+++ b/lib/puppet/pops/validation/tasks_checker.rb
@@ -1,0 +1,60 @@
+module Puppet::Pops
+module Validation
+
+# Validator that limits the set of allowed expressions to not include catalog related operations
+# @api private
+class TasksChecker < Checker4_0
+  def check_Application(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_CapabilityMapping(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_CollectExpression(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_HostClassDefinition(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_NodeDefinition(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_RelationshipExpression(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_ResourceDefaultsExpression(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_ResourceExpression(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_ResourceOverrideExpression(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_ResourceTypeDefinition(o)
+    illegalTasksExpression(o)
+  end
+
+  def check_SiteDefinition(o)
+    illegalTasksExpression(o)
+  end
+
+  def illegalTasksExpression(o)
+    acceptor.accept(Issues::UNSUPPORTED_TASKS_EXPRESSION, o)
+  end
+
+  def resource_without_title?(o)
+    false
+  end
+end
+end
+end

--- a/lib/puppet/pops/validation/tasks_checker.rb
+++ b/lib/puppet/pops/validation/tasks_checker.rb
@@ -49,7 +49,7 @@ class TasksChecker < Checker4_0
   end
 
   def illegalTasksExpression(o)
-    acceptor.accept(Issues::UNSUPPORTED_TASKS_EXPRESSION, o)
+    acceptor.accept(Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING, o)
   end
 
   def resource_without_title?(o)

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -7,7 +7,12 @@ class ValidatorFactory_4_0 < Factory
 
   # Produces the checker to use
   def checker diagnostic_producer
-    Checker4_0.new(diagnostic_producer)
+    if Puppet[:tasks]
+      require_relative 'tasks_checker'
+      TasksChecker.new(diagnostic_producer)
+    else
+      Checker4_0.new(diagnostic_producer)
+    end
   end
 
   # Produces the label provider to use

--- a/spec/unit/functions/run_plan_spec.rb
+++ b/spec/unit/functions/run_plan_spec.rb
@@ -38,25 +38,25 @@ describe 'the run_plan function' do
 
     context 'can be called as' do
       it 'run_plan(name) referencing a plan defined in the manifest' do
-        expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[worked1]')
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(['worked1'])
             plan run_me() { "worked1" }
             $a = run_plan('run_me')
-            notify { $a: }
+            notice $a
           CODE
       end
 
       it 'run_plan(name) referencing an autoloaded plan in a module' do
-        expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[worked2]')
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(['worked2'])
             $a = run_plan('test::run_me')
-            notify { $a: }
+            notice $a
           CODE
       end
 
       it 'run_plan(name, hash) where hash is mapping argname to value' do
-        expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[worked3]')
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(['worked3'])
             plan run_me($x) { $x }
             $a = run_plan('run_me', {x=>'worked3'})
-            notify { $a: }
+            notice $a
           CODE
       end
     end
@@ -65,7 +65,7 @@ describe 'the run_plan function' do
       it 'failing with error for non-existent plan name' do
         expect { compile_to_catalog(<<-CODE) }.to raise_error(Puppet::Error, /Unknown plan/)
           $a = run_plan('not_a_plan_name')
-          notify { $a: }
+          notice $a
         CODE
       end
 

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -159,67 +159,67 @@ describe "validating 4x" do
     it 'produces an error for application' do
       acceptor = validate(parse('application test {}'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for capability mapping' do
       acceptor = validate(parse('Foo produces Sql {}'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for collect expressions' do
       acceptor = validate(parse("User <| title == 'admin' |>"))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for class expressions' do
       acceptor = validate(parse('class test {}'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for node expressions' do
       acceptor = validate(parse('node default {}'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for relationship expressions' do
       acceptor = validate(parse('$x -> $y'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for resource expressions' do
       acceptor = validate(parse('notify { nope: }'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for resource default expressions' do
       acceptor = validate(parse("File { mode => '0644' }"))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for resource override expressions' do
       acceptor = validate(parse("File['/tmp/foo'] { mode => '0644' }"))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for resource definitions' do
       acceptor = validate(parse('define foo($a) {}'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
     it 'produces an error for site definitions' do
       acceptor = validate(parse('site {}'))
       expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
   end
 

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -153,6 +153,76 @@ describe "validating 4x" do
     end
   end
 
+  context 'with --tasks set' do
+    before(:each) { Puppet[:tasks] = true }
+
+    it 'produces an error for application' do
+      acceptor = validate(parse('application test {}'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for capability mapping' do
+      acceptor = validate(parse('Foo produces Sql {}'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for collect expressions' do
+      acceptor = validate(parse("User <| title == 'admin' |>"))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for class expressions' do
+      acceptor = validate(parse('class test {}'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for node expressions' do
+      acceptor = validate(parse('node default {}'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for relationship expressions' do
+      acceptor = validate(parse('$x -> $y'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for resource expressions' do
+      acceptor = validate(parse('notify { nope: }'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for resource default expressions' do
+      acceptor = validate(parse("File { mode => '0644' }"))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for resource override expressions' do
+      acceptor = validate(parse("File['/tmp/foo'] { mode => '0644' }"))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for resource definitions' do
+      acceptor = validate(parse('define foo($a) {}'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+
+    it 'produces an error for site definitions' do
+      acceptor = validate(parse('site {}'))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::UNSUPPORTED_TASKS_EXPRESSION)
+    end
+  end
+
   context 'for non productive expressions' do
     [ '1',
       '3.14',

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -168,8 +168,14 @@ describe "validating 4x" do
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end
 
-    it 'produces an error for collect expressions' do
+    it 'produces an error for collect expressions with virtual query' do
       acceptor = validate(parse("User <| title == 'admin' |>"))
+      expect(acceptor.error_count).to eql(1)
+      expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
+    end
+
+    it 'produces an error for collect expressions with exported query' do
+      acceptor = validate(parse("User <<| title == 'admin' |>>"))
       expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CATALOG_OPERATION_NOT_SUPPORTED_WHEN_SCRIPTING)
     end


### PR DESCRIPTION
This commit adds a new `TasksChecker` validator and ensures that it
is used instead of the `Checker4_0` validator when the --taskss feature
is enabled.