### PR TITLE
(packaging) Update beaker and install methods

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,9 +12,9 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.10')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.24')
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.3")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -72,7 +72,7 @@ In order to run the tests on hosts provisioned from packages produced by Deliver
 
 Typically if you are investigating a failure, you will have a SHA from a failed jenkins run which should correspond to a successful pipeline run, and you should not need to run the pipeline manually.
 
-A finished pipeline will have repository information available at http://builds.puppetlabs.lan/puppet-agent/  So you can also browse this list and select a recent sha which has repo_configs/ available.
+A finished pipeline will have repository information available at http://builds.delivery.puppetlabs.net/puppet-agent/  So you can also browse this list and select a recent sha which has repo_configs/ available.
 
 The ci:test:aio task depends on having a local installation of `wget`. When executing the `ci:test:aio` task, you must set the `SHA` and the `SUITE_VERSION` to identify a puppet-agent package version to test.
 

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -120,65 +120,53 @@ module Puppet
       def install_repos_on(host, project, sha, repo_configs_dir)
         platform = host['platform'].with_version_codename
         platform_configs_dir = File.join(repo_configs_dir,platform)
-        tld     = sha == 'nightly' ? 'nightlies.puppetlabs.com' : 'builds.puppetlabs.lan'
-        project = sha == 'nightly' ? project + '-latest'        :  project
-        sha     = sha == 'nightly' ? nil                        :  sha
+        dev_builds_url  = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
+        tld             = sha == 'nightly' ? 'http://nightlies.puppetlabs.com'  :  dev_builds_url
+        project         = sha == 'nightly' ? project + '-latest'                :  project
+        sha             = sha == 'nightly' ? nil                                :  sha
 
-        case platform
-        when /^(fedora|el|centos)-(\d+)-(.+)$/
-          variant = (($1 == 'centos') ? 'el' : $1)
-          fedora_prefix = ((variant == 'fedora') ? 'f' : '')
-          version = $2
-          arch = $3
+        if sha == 'nightly'
+          case platform
+          when /^(fedora|el|centos)-(\d+)-(.+)$/
+            variant = (($1 == 'centos') ? 'el' : $1)
+            fedora_prefix = ((variant == 'fedora') ? 'f' : '')
+            version = $2
+            arch = $3
 
-          repo_filename = "pl-%s%s-%s-%s%s-%s.repo" % [
-            project,
-            sha ? '-' + sha : '',
-            variant,
-            fedora_prefix,
-            version,
-            arch
-          ]
-          repo_url = "http://%s/%s/%s/repo_configs/rpm/%s" % [tld, project, sha, repo_filename]
+            repo_filename = "pl-%s%s-%s-%s%s-%s.repo" % [
+              project,
+              sha ? '-' + sha : '',
+              variant,
+              fedora_prefix,
+              version,
+              arch
+            ]
+            repo_url = "%s/%s/%s/repo_configs/rpm/%s" % [tld, project, sha, repo_filename]
 
-          on host, "curl -o /etc/yum.repos.d/#{repo_filename} #{repo_url}"
-        when /^(debian|ubuntu|cumulus)-([^-]+)-(.+)$/
-          variant = $1
-          version = $2
-          arch = $3
+            on host, "curl -o /etc/yum.repos.d/#{repo_filename} #{repo_url}"
+          when /^(debian|ubuntu|cumulus)-([^-]+)-(.+)$/
+            variant = $1
+            version = $2
+            arch = $3
 
-          if variant =~ /cumulus/ then
-            version = variant
-          end
+            if variant =~ /cumulus/ then
+              version = variant
+            end
 
-          list_filename = "pl-%s%s-%s.list" % [
-            project,
-            sha ? '-' + sha : '',
-            version
-          ]
-          list_url = "http://%s/%s/%s/repo_configs/deb/%s" % [tld, project, sha, list_filename]
+            list_filename = "pl-%s%s-%s.list" % [
+              project,
+              sha ? '-' + sha : '',
+              version
+            ]
+            list_url = "%s/%s/%s/repo_configs/deb/%s" % [tld, project, sha, list_filename]
 
-          on host, "curl -o /etc/apt/sources.list.d/#{list_filename} #{list_url}"
-          on host, "apt-get update"
-        else
-          if project == 'puppet-agent'
-            opts = {
-              :puppet_collection => 'PC1',
-              :puppet_agent_sha => ENV['SHA'],
-              # SUITE_VERSION is necessary for Beaker to build a package download
-              # url which is built upon a `git describe` for a SHA.
-              # Beaker currently cannot find or calculate this value based on
-              # the SHA, and thus it must be passed at invocation time.
-              # The one exception is when SHA is a tag like `1.8.0` and
-              # SUITE_VERSION will be equivalent.
-              # RE-8333 may make this unnecessary in the future
-              :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
-            }
-            # this installs puppet-agent on windows (msi), osx (dmg) and eos (swix)
-            install_puppet_agent_dev_repo_on(agent, opts)
+            on host, "curl -o /etc/apt/sources.list.d/#{list_filename} #{list_url}"
+            on host, "apt-get update"
           else
             fail_test("No repository installation step for #{platform} yet...")
           end
+        else
+          install_from_build_data_url(project, "#{tld}/#{project}/#{sha}/artifacts/#{sha}.yaml", host)
         end
       end
 

--- a/acceptance/lib/puppet/acceptance/install_utils_spec.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils_spec.rb
@@ -104,14 +104,14 @@ describe 'InstallUtils' do
     end
 
     it "calls wget with the right amount of cut dirs for url that ends in '/'" do
-      url = 'http://builds.puppetlabs.lan/puppet/7807591405af849da2ad6534c66bd2d4efff604f/repos/el/6/devel/x86_64/'
+      url = 'http://builds.delivery.puppetlabs.net/puppet/7807591405af849da2ad6534c66bd2d4efff604f/repos/el/6/devel/x86_64/'
       testcase.expects(:`).with("wget -nv -P dir --reject \"index.html*\",\"*.gif\" --cut-dirs=6 -np -nH --no-check-certificate -r #{url} 2>&1").returns("log")
 
       expect( testcase.fetch_remote_dir(url, 'dir')).to eql('dir/x86_64')
     end
 
     it "calls wget with the right amount of cut dirs for url that doesn't end in '/'" do
-      url = 'http://builds.puppetlabs.lan/puppet/7807591405af849da2ad6534c66bd2d4efff604f/repos/apt/wheezy'
+      url = 'http://builds.delivery.puppetlabs.net/puppet/7807591405af849da2ad6534c66bd2d4efff604f/repos/apt/wheezy'
       testcase.expects(:`).with("wget -nv -P dir --reject \"index.html*\",\"*.gif\" --cut-dirs=4 -np -nH --no-check-certificate -r #{url}/ 2>&1").returns("log")
 
       expect( testcase.fetch_remote_dir(url, 'dir')).to eql('dir/wheezy')
@@ -176,11 +176,11 @@ describe 'InstallUtils' do
           "puppetlabs-release-el-6.noarch.rpm",
         ],
         :repo => [
-          "http://builds.puppetlabs.lan/puppet/abcdef10/repo_configs/rpm/",
+          "http://builds.delivery.puppetlabs.net/puppet/abcdef10/repo_configs/rpm/",
           "pl-puppet-abcdef10-el-6-i386.repo",
         ],
         :repo_dir => [
-          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/el/6/products/i386/",
+          "http://builds.delivery.puppetlabs.net/puppet/abcdef10/repos/el/6/products/i386/",
           "i386",
         ],
       },
@@ -195,11 +195,11 @@ describe 'InstallUtils' do
           "puppetlabs-release-fedora-20.noarch.rpm",
         ],
         :repo => [
-          "http://builds.puppetlabs.lan/puppet/abcdef10/repo_configs/rpm/",
+          "http://builds.delivery.puppetlabs.net/puppet/abcdef10/repo_configs/rpm/",
           "pl-puppet-abcdef10-fedora-f20-x86_64.repo",
         ],
         :repo_dir => [
-          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/fedora/f20/products/x86_64/",
+          "http://builds.delivery.puppetlabs.net/puppet/abcdef10/repos/fedora/f20/products/x86_64/",
           "x86_64",
         ],
       },
@@ -214,11 +214,11 @@ describe 'InstallUtils' do
           "puppetlabs-release-el-5.noarch.rpm",
         ],
         :repo => [
-          "http://builds.puppetlabs.lan/puppet/abcdef10/repo_configs/rpm/",
+          "http://builds.delivery.puppetlabs.net/puppet/abcdef10/repo_configs/rpm/",
           "pl-puppet-abcdef10-el-5-x86_64.repo",
         ],
         :repo_dir => [
-          "http://builds.puppetlabs.lan/puppet/abcdef10/repos/el/5/products/x86_64/",
+          "http://builds.delivery.puppetlabs.net/puppet/abcdef10/repos/el/5/products/x86_64/",
           "x86_64",
         ],
       },
@@ -237,13 +237,13 @@ describe 'InstallUtils' do
 
       list = "pl-puppet-#{sha}-precise.list"
       testcase.expects(:fetch).with(
-        "http://builds.puppetlabs.lan/puppet/#{sha}/repo_configs/deb/",
+        "http://builds.delivery.puppetlabs.net/puppet/#{sha}/repo_configs/deb/",
         list,
         platform_configs_dir
       ).returns("#{platform_configs_dir}/#{list}")
 
       testcase.expects(:fetch_remote_dir).with(
-        "http://builds.puppetlabs.lan/puppet/#{sha}/repos/apt/precise",
+        "http://builds.delivery.puppetlabs.net/puppet/#{sha}/repos/apt/precise",
         platform_configs_dir
       ).returns("#{platform_configs_dir}/precise")
 

--- a/acceptance/setup/gem/pre-suite/010_GemInstall.rb
+++ b/acceptance/setup/gem/pre-suite/010_GemInstall.rb
@@ -4,7 +4,7 @@ require 'puppet/acceptance/common_utils'
 
 agents.each do |agent|
   sha = ENV['SHA']
-  base_url = "http://builds.puppetlabs.lan/puppet/#{sha}/artifacts"
+  base_url = "http://builds.delivery.puppetlabs.net/puppet/#{sha}/artifacts"
 
   ruby_command = Puppet::Acceptance::CommandUtils.ruby_command(agent)
   gem_command = Puppet::Acceptance::CommandUtils.gem_command(agent)

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,5 +1,5 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 packager: 'puppetlabs'
 gpg_key: '7F438280EF8D349F'


### PR DESCRIPTION
The latest beaker release includes new install utilities that enable
less reliance on correctly guessing the path to artifacts staged on
builds.delivery.puppetlabs.net. This commit updates the puppet tests to
use these new install utilities.