### PR TITLE
(PUP-7848) Fix problem with VAR pattern and longer segments

### DIFF
--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -48,7 +48,8 @@ module Puppet::Pops::Patterns
 
   # VAR_NAME matches the name part of a variable (The $ character is not included)
   # Note, that only the final segment may start with an underscore.
-  VAR_NAME = %r{\A(?:((::)?[a-z]\w*)*(?:(::)?_\w*)?)\z}
+  # Note, regexp sensitive to backtracking - hence its complexity
+  VAR_NAME = %r{\A(?:::){0,1}(?:(?:[a-z_]\w*)|(?:(?:(?:(?!_)[a-z]\w*))::)+(?:[a-z_]\w*))\z}
 
   # PARAM_NAME matches the name part of a parameter (The $ character is not included)
   PARAM_NAME = %r{\A[a-z_]\w*\z}

--- a/lib/puppet/pops/patterns.rb
+++ b/lib/puppet/pops/patterns.rb
@@ -48,8 +48,8 @@ module Puppet::Pops::Patterns
 
   # VAR_NAME matches the name part of a variable (The $ character is not included)
   # Note, that only the final segment may start with an underscore.
-  # Note, regexp sensitive to backtracking - hence its complexity
-  VAR_NAME = %r{\A(?:::){0,1}(?:(?:[a-z_]\w*)|(?:(?:(?:(?!_)[a-z]\w*))::)+(?:[a-z_]\w*))\z}
+  # Note, regexp sensitive to backtracking
+  VAR_NAME = %r{\A(?:::)?(?:[a-z]\w*::)*[a-z_]\w*\z}
 
   # PARAM_NAME matches the name part of a parameter (The $ character is not included)
   PARAM_NAME = %r{\A[a-z_]\w*\z}

--- a/spec/unit/functions/epp_spec.rb
+++ b/spec/unit/functions/epp_spec.rb
@@ -18,8 +18,13 @@ describe "the epp function" do
     end
 
     it "gets error accessing a variable that is malformed" do
-      expect { eval_template("<%= $kryptonite::USER %>")}.to raise_error(
-        /Illegal variable name, The given name 'kryptonite::USER' does not conform to the naming rule/)
+      expect { eval_template("<%= $kryptonite::bbbbbbbbbbbb::cccccccc::ddd::USER %>")}.to raise_error(
+        /Illegal variable name, The given name 'kryptonite::bbbbbbbbbbbb::cccccccc::ddd::USER' does not conform to the naming rule/)
+    end
+
+    it "gets error accessing a variable that is malformed as reported in PUP-7848" do
+      expect { eval_template("USER='<%= $hg_oais::archivematica::requirements::automation_tools::USER %>'")}.to raise_error(
+        /Illegal variable name, The given name 'hg_oais::archivematica::requirements::automation_tools::USER' does not conform to the naming rule/)
     end
 
     it "get nil accessing a variable that is undef" do

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -625,6 +625,16 @@ describe "validating 4x" do
     end
   end
 
+  context 'uses a var pattern that is performant' do
+    it 'such that illegal VAR_NAME is not too slow' do
+      t = Time.now.nsec
+      result = '$hg_oais::archivematica::requirements::automation_tools::USER' =~ Puppet::Pops::Patterns::VAR_NAME
+      t2 = Time.now.nsec
+      expect(result).to be(nil)
+      expect(t2-t).to be < 1000000 # one ms as a check for very slow operation, is in fact at ~< 10 microsecond 
+    end
+  end
+
   def parse(source)
     Puppet::Pops::Parser::Parser.new().parse_string(source)
   end


### PR DESCRIPTION
This is yet another fix of the same problem as earlier believed to be
fixed. When input such as $aaaaa::bbbbb::ccccc::UPPER was encountered
the regexp matcher for variable/name ended up taking an enormous amount
of time. The initial regexp triggered this problem on very short
sequences. The updated worked for short sequences, but not for longer
(also took a very long time to complete).

The regexp is now updated with a more complex negative lookahead of '_'
as the problem is to prevent that a segment other than the last starts
with '_'.

Tests are updated to have longer sequences, and also includes the
original reported name.