### PR TITLE
(maint) AppVeyor Ruby 2.4 openssl gem install fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,15 +46,19 @@ test_script:
       $Env:PATH = "C:\${Env:PLATFORM}\bin;${Env:PATH}"
       $Env:LOG_SPEC_ORDER = 'true'
       Get-ChildItem Env: | % { Write-Output "$($_.Key): $($_.Value)"  }
+      # list current OpenSSL install
+      gem list openssl
+      ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
       if ( $(ruby --version) -match "^ruby\s+2\.4" ) {
         # AppVeyor appears to have OpenSSL headers available already
         # which msys2 would normally install with:
         # pacman -S mingw-w64-x86_64-openssl --noconfirm
         Write-Output "Building OpenSSL gem ~> 2.0.4 to fix Ruby 2.4 / AppVeyor issue"
-        gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc -- --with-openssl-dir=C:\msys64\mingw64
+        gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc -- --with-openssl-dir=C:\msys64\mingw64 '2>&1'
+        # verify new installation
+        gem list openssl
+        ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
       }
-      gem list openssl
-      ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"' 
       bundle install --jobs 4 --retry 2 --without development extra
       Get-Content Gemfile.lock
       ruby -v


### PR DESCRIPTION
 - AppVeyor appears to have fixed their OpenSSL issue, as performing
   a gem install now seems to be skipped given the message:

```
 gem : warning: mingw-w64-x86_64-openssl-1.0.2.k-1 is up to date -- skipping
 At line:11 char:3
 +   gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc -- --wit ...
 +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : NotSpecified: (warning: mingw-...ate -- skipping:String) [], RemoteException
     + FullyQualifiedErrorId : NativeCommandError
```

 - Update the code to first perform a version check before attempting
   to install