### PR TITLE
(PUP-7908) Remove use of 'main' class for ScriptCompiler

### DIFF
--- a/lib/puppet/parser/script_compiler.rb
+++ b/lib/puppet/parser/script_compiler.rb
@@ -105,13 +105,7 @@ class Puppet::Parser::ScriptCompiler
 
   # Find and evaluate the top level code.
   def evaluate_main
-    evaluator = Puppet::Pops::Parser::EvaluatingParser.singleton.evaluator
-
-    # Evaluate all programs and return the result of the last evaluation
-    result = nil
-    @loaders.perform_initial_import.each do |program|
-      result = evaluator.evaluate(program, @topscope)
-    end
-    result
+    program = @loaders.load_main_manifest
+    return program.nil? ? nil : Puppet::Pops::Parser::EvaluatingParser.singleton.evaluator.evaluate(program, @topscope)
   end
 end

--- a/lib/puppet/parser/script_compiler.rb
+++ b/lib/puppet/parser/script_compiler.rb
@@ -103,19 +103,15 @@ class Puppet::Parser::ScriptCompiler
 
   private
 
-  # Find and evaluate the main class object.
-  # TODO: this is really strange, but needed for the time being since the parser creates the main class
-  #
+  # Find and evaluate the top level code.
   def evaluate_main
-    krt = environment.known_resource_types
-    @main = krt.find_hostclass('')
+    evaluator = Puppet::Pops::Parser::EvaluatingParser.singleton.evaluator
 
-    # short circuit the chain of evaluation done via the resource_type (the "main" class), and its code
-    # via pops bridge to get to an evaluator.
-    # 
-    # TODO: set up with modified evaluator.
-    #
-    code = @main.code.program_model
-    Puppet::Pops::Parser::EvaluatingParser.new().evaluate(@topscope, code)
+    # Evaluate all programs and return the result of the last evaluation
+    result = nil
+    @loaders.perform_initial_import.each do |program|
+      result = evaluator.evaluate(program, @topscope)
+    end
+    result
   end
 end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -229,7 +229,7 @@ class Loaders
     @loaders_by_name[name] = loader
   end
 
-  # Reparse the manifests for the given environment
+  # Load the main manifest for the given environment
   #
   # There are two sources that can be used for the initial parse:
   #
@@ -238,28 +238,27 @@ class Loaders
   #     Puppet applications to read in a manifest and pass it to the
   #     environment as a side effect. This is attempted first.
   #   2. The contents of the environment's +manifest+ attribute: Puppet will
-  #     try to load the environment manifest.
+  #     try to load the environment manifest. The manifest must be a file.
   #
-  # @return [Array<Model::Program>] The parsed model objects
-  def perform_initial_import
+  # @return [Model::Program] The manifest parsed into a model object
+  def load_main_manifest
     parser = Parser::EvaluatingParser.singleton
     parsed_code = Puppet[:code]
     if parsed_code != ""
-      [parser.parse_string(parsed_code, 'unknown-source-location')]
+      parser.parse_string(parsed_code, 'unknown-source-location')
     else
       file = @environment.manifest
 
       # if the manifest file is a reference to a directory, parse and combine
       # all .pp files in that directory
       if file == Puppet::Node::Environment::NO_MANIFEST
-        []
+        nil
       elsif File.directory?(file)
-        files = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*.pp')).glob.sort
-        files.map do | file_to_parse |
-          parser.parse_file(file_to_parse)
-        end
+        raise Puppet::Error, "manifest of environment '#{@environment.name}' appoints directory '#{file}'. It must be a file"
+      elsif File.exists?(file)
+        parser.parse_file(file)
       else
-        [parser.parse_file(file)]
+        raise Puppet::Error, "manifest of environment '#{@environment.name}' appoints '#{file}'. It does not exist"
       end
     end
   rescue Puppet::ParseErrorWithIssue => detail

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -266,7 +266,7 @@ class Loaders
     detail.environment = @environment.name
     raise
   rescue => detail
-    msg = _('Could not parse for environment %{env}: %{detail}') % { env: self, detail: detail }
+    msg = _('Could not parse for environment %{env}: %{detail}') % { env: @environment, detail: detail }
     error = Puppet::Error.new(msg)
     error.set_backtrace(detail.backtrace)
     raise error

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -229,6 +229,49 @@ class Loaders
     @loaders_by_name[name] = loader
   end
 
+  # Reparse the manifests for the given environment
+  #
+  # There are two sources that can be used for the initial parse:
+  #
+  #   1. The value of `Puppet[:code]`: Puppet can take a string from
+  #     its settings and parse that as a manifest. This is used by various
+  #     Puppet applications to read in a manifest and pass it to the
+  #     environment as a side effect. This is attempted first.
+  #   2. The contents of the environment's +manifest+ attribute: Puppet will
+  #     try to load the environment manifest.
+  #
+  # @return [Array<Model::Program>] The parsed model objects
+  def perform_initial_import
+    parser = Parser::EvaluatingParser.singleton
+    parsed_code = Puppet[:code]
+    if parsed_code != ""
+      [parser.parse_string(parsed_code, 'unknown-source-location')]
+    else
+      file = @environment.manifest
+
+      # if the manifest file is a reference to a directory, parse and combine
+      # all .pp files in that directory
+      if file == Puppet::Node::Environment::NO_MANIFEST
+        []
+      elsif File.directory?(file)
+        files = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*.pp')).glob.sort
+        files.map do | file_to_parse |
+          parser.parse_file(file_to_parse)
+        end
+      else
+        [parser.parse_file(file)]
+      end
+    end
+  rescue Puppet::ParseErrorWithIssue => detail
+    detail.environment = @environment.name
+    raise
+  rescue => detail
+    msg = _('Could not parse for environment %{env}: %{detail}') % { env: self, detail: detail }
+    error = Puppet::Error.new(msg)
+    error.set_backtrace(detail.backtrace)
+    raise error
+  end
+
   private
 
   def create_puppet_system_loader()

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'puppet/pops'
 require 'puppet_spec/compiler'
+require 'puppet/parser/script_compiler'
 
 module Puppet::Pops
 module Types
@@ -38,7 +39,7 @@ describe 'The Task Type' do
     before(:each) { Puppet[:tasks] = true }
 
     context 'tasks' do
-      let(:compiler) { Puppet::Parser::Compiler.new(node) }
+      let(:compiler) { Puppet::Parser::ScriptCompiler.new(env, node.name) }
 
       let(:modules) do
         { 'testmodule' => testmodule }


### PR DESCRIPTION
This commit changes the `ScriptCompiler#evaluate_main` so that it no
longer creates a class with an empty name (a.k.a. 'main').

The method `Environment#perform_initial_import` was moved to the
`Loaders` class and rewritten to no longer create wrappers for the
version 3 AST. Instead, it directly returns an array of Program
instanses.

The `ScriptCompiler#evaluate_main` calls the new method on the `Loaders`
instance to obtain the programs to evaluate. It then evaluates them in
sequence and returns the result of the last evaluation.

The new behavior is tested by the integration test for the
`ScriptCompiler` and also by the `Task` unit test which was rewritten
to use the `ScriptCompiler`.