### PR TITLE
(PUP-7875) Correct the documentation of run_task localhost, no hosts

### DIFF
--- a/lib/puppet/functions/run_task.rb
+++ b/lib/puppet/functions/run_task.rb
@@ -1,4 +1,10 @@
-# Runs a given instance of a `Task` on the given set of hosts, or localhost if no hosts are given and returns the result from each
+# Runs a given instance of a `Task` on the given set of nodes and returns the result from each.
+#
+# * This function does nothing if the list of nodes is empty.
+# * It is possible to run on the node 'localhost'
+# * A node is a String with a node's hostname or a URI that also describes how to connect and run the task on that node
+#   including "user" and "password" parts of a URI.
+# * The returned value contains information about the result per node. TODO: needs mapping to a runtime Pcore Object to be useful
 #
 # Since > 5.2.0 TODO: Update when version is known
 #
@@ -13,6 +19,11 @@ Puppet::Functions.create_function(:run_task) do
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
         {:operation => 'run_task'})
+    end
+
+    if hosts.empty?
+      call_function('notice', "Simulating run of task #{task._pcore_type.name} - no hosts given - no action taken")
+      return nil
     end
 
     call_function('notice', "Simulating run of task #{task._pcore_type.name} on hosts: [" + hosts.join(', ') + "]")


### PR DESCRIPTION
This corrects the documentation of run_task() function wrt running on
local host and that an empty host list results in no action (should not
log).

(The current simple simulation does however log if list is empty for
testing purposes).