### PR TITLE
(PUP-7425) Refactor Gemfile / .gemspec for Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+gemspec
+
 def location_for(place, fake_version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/
     [fake_version, { :git => $1, :branch => $2, :require => false }].compact
@@ -22,16 +24,17 @@ platforms :ruby do
   #gem 'ruby-augeas', :group => :development
 end
 
-gem "puppet", :path => File.dirname(__FILE__), :require => false
-gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 2.0', '< 4'])
-gem "hiera", *location_for(ENV['HIERA_LOCATION'] || ['>= 3.2.1', '< 4'])
+# override .gemspec deps - may issue warning depending on Bundler version
+gem "facter", *location_for(ENV['FACTER_LOCATION']) if ENV.has_key?('FACTER_LOCATION')
+gem "hiera", *location_for(ENV['HIERA_LOCATION']) if ENV.has_key?('HIERA_LOCATION')
 # PUP-7115 - return to a gem dependency in Puppet 5
 # gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ['>= 0.1.3', '< 2'])
-# i18n support (gettext-setup and dependencies)
-gem 'gettext-setup', '>= 0.10', '< 1.0', :require => false
-gem 'locale', '~> 2.1', :require => false
 
 group(:development, :test) do
+  # rake is in .gemspec as a development dependency but cannot
+  # be removed here *yet* due to TravisCI / AppVeyor which call:
+  # bundle install --without development
+  # PUP-7433 describes work necessary to restructure this
   gem "rake", "10.1.1", :require => false
   gem "rspec", "~> 3.1", :require => false
   gem "rspec-its", "~> 1.1", :require => false
@@ -77,28 +80,6 @@ group(:extra) do
   gem "msgpack", :require => false
 end
 
-require 'yaml'
-data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
-bundle_platforms = data['bundle_platforms']
-x64_platform = Gem::Platform.local.cpu == 'x64'
-data['gem_platform_dependencies'].each_pair do |gem_platform, info|
-  next if gem_platform == 'x86-mingw32' && x64_platform
-  next if gem_platform == 'x64-mingw32' && !x64_platform
-  if bundle_deps = info['gem_runtime_dependencies']
-    bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
-    if bundle_platform == "all"
-      bundle_deps.each_pair do |name, version|
-        gem(name, version, :require => false)
-      end
-    else
-      platform(bundle_platform.intern) do
-        bundle_deps.each_pair do |name, version|
-          gem(name, version, :require => false)
-        end
-      end
-    end
-  end
-end
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)


### PR DESCRIPTION
 - This commit was originally in 19f78a20b70660b30fff8c0c49e8b9a9b3c99b40
   but due to a bad merge-up at 8dd78d37f049b4bb81f6146e4fa8af39b88a6130
   was not correctly carried over.

   As a result, the current branch thinks it has these changes, but
   none of the Puppet 5 branches / tags have the following fixes:

 - Without platform-specific gem dependencies marked as such inside the
   .gemspec, this can cause issues with a bundler based workflow that
   uses `bundle install --system --binstubs c:\ruby\bin` on Windows
   machines *even if* the given Ruby version already satisfies all of
   the Puppet platform-specific dependencies. This is due to how a
   Gem is installed by Bundler when it refers to a git repo and its
   .gemspec is rewritten by Bundler as its installed.

 - Note that all runtime dependencies are now present in the .gemspec
   and that any development dependencies are still defined in the
   Gemfile itself.

   The .gemspec is included in a `bundle install` by calling the
   `gemspec` method inside the Gemfile.  This is the intended inclusion
   mechanism for Bundler.

   The Gemfile continues to allow a few gem overrides with the
   environment variables:

   FACTER_LOCATION
   HIERA_LOCATION

   These overrides are only activated when the relevant environment
   variables are defined.