### PR TITLE
(PUP-7926) Fix capitalization in regexp

### DIFF
--- a/lib/puppet/vendor/pathspec/lib/pathspec.rb
+++ b/lib/puppet/vendor/pathspec/lib/pathspec.rb
@@ -70,7 +70,7 @@ class PathSpec
   end
 
   def drive_letter_to_path(path)
-    path.gsub(/^([a-zA-z]):\//, '/\1/')
+    path.gsub(/^([a-zA-Z]):\//, '/\1/')
   end
 
   # Generate specs from a filename, such as a .gitignore


### PR DESCRIPTION
Avoid overmatching characters between "Z" and "a" (such as _ or ^), should be a-zA-Z, not a-zA-z
Otherwise this is over-matching (matches anything between ASCII A and ASCII z, which is much more than just characters).