### PR TITLE
(PUP-7946) Add support for existing env in Pal API

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -138,6 +138,23 @@ module Puppet::Environments
     end
   end
 
+  class StaticDirectory < Static
+    # Accepts a single environment in the given directory having the given name (not required to be reflected as the name
+    # of the directory)
+    # 
+    def initialize(env_name, env_dir, environment)
+      super(environment)
+      @env_dir = env_dir
+      @env_name = env_name
+    end
+
+    # @!macro loader_get_conf
+    def get_conf(name)
+      return nil unless name == @env_name
+      Puppet::Settings::EnvironmentConf.load_from(@env_dir, '')
+    end
+  end
+
   # Reads environments from a directory on disk. Each environment is
   # represented as a sub-directory. The environment's manifest setting is the
   # `manifest` directory of the environment directory. The environment's

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -87,7 +87,10 @@ module Puppet::Pal
     assert_non_empty_string(env_name, _("temporary environment name"))
     # TRANSLATORS: do not translate variable name string in these assertions
     assert_optionally_empty_array(modulepath, 'modulepath')
-    return unless block_given?
+
+    unless block_given?
+      raise ArgumentError, _("A block must be given to 'in_tmp_environment'") # TRANSLATORS 'in_tmp_environment' is a name, do not translate
+    end
 
     env = Puppet::Node::Environment.create(env_name, modulepath)
     node = Puppet::Node.new(Puppet[:node_name_value], :environment => env)
@@ -133,7 +136,9 @@ module Puppet::Pal
     assert_optionally_empty_array(modulepath, 'modulepath', true) 
     assert_mutually_exclusive(env_dir, envpath, 'env_dir', 'envpath')
 
-    return unless block_given?
+    unless block_given?
+      raise ArgumentError, _("A block must be given to 'in_environment'") # TRANSLATORS 'in_environment' is a name, do not translate
+    end
 
     if env_dir
       unless Puppet::FileSystem.exist?(env_dir)

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -114,6 +114,8 @@ module Puppet::Pal
   # @param env_name [String] the name of an existing environment
   # @param modulepath [Array<String>] an array of directory paths containing Puppet modules, overrides the modulepath of an existing env
   # @param settings_hash [Hash] a hash of settings - currently not used for anything, defaults to empty hash
+  # @param env_dir [String] a reference to a directory being the named environment (mutually exclusive with `envpath`)
+  # @param envpath [String] a path of directories in which there are environments to search for `env_name` (mutually exclusive with `env_dir`)
   # @param facts [Hash] optional map of fact name to fact value - if not given will initialize the facts (which is a slow operation)
   # @return [Object] returns what the given block returns
   # @yieldparam [Puppet::Pal] context, a context that responds to Puppet::Pal methods
@@ -125,15 +127,23 @@ module Puppet::Pal
       envpath:      nil,
       facts: nil
     )
-    assert_non_empty_string(env_name, _("environment name"))
-    assert_optionally_empty_array(modulepath, 'modulepath', true) # TRANSLATORS 'modulepath' is a term on the command line
+    # TRANSLATORS terms in the assertions below are names of terms in code
+    assert_non_empty_string(env_name, 'env_name')
+    assert_optionally_empty_array(modulepath, 'modulepath', true) 
+    assert_mutually_exclusive(env_dir, envpath, 'env_dir', 'envpath')
+
     return unless block_given?
+
+    # a nil modulepath for env_dir means it should use its ./modules directory
+    if !env_dir.nil? && modulepath.nil?
+      modulepath = [Puppet::FileSystem.expand_path(File.join(env_dir, 'modules'))]
+    end
 
     env = Puppet::Node::Environment.create(env_name, modulepath)
     node = Puppet::Node.new(Puppet[:node_name_value], :environment => env)
 
     Puppet.override(
-      environments: Puppet::Environments::StaticDir.new(env_name, env_dir, env), # The env being used is the only one...
+      environments: Puppet::Environments::StaticDirectory.new(env_name, env_dir, env), # The env being used is the only one...
       current_node: node                                   # to allow it to be picked up instead of created
       ) do
       prepare_node_facts(node, facts)

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -249,20 +249,19 @@ module Puppet::Pal
     end
   end
 
+  T_STRING = Puppet::Pops::Types::PStringType::NON_EMPTY
+  T_STRING_ARRAY = Puppet::Pops::Types::TypeFactory.array_of(T_STRING)
+
+  def self.assert_type(type, value, what, allow_nil=false)
+    Puppet::Pops::Types::TypeAsserter.assert_instance_of(nil, type, value, allow_nil) { _('Puppet Pal: %{what}') % {what: what} }
+  end
+
   def self.assert_non_empty_string(s, what, allow_nil=false)
-    unless s.is_a?(String) && s.length > 0 || (allow_nil && s.nil?)
-      if s.is_a?(String)
-        raise ArgumentError(_("Puppet Pal: %{what} must be a non empty string, got ''") % {what: what})
-      else
-        raise ArgumentError(_("Puppet Pal: %{what} must be a non empty string, got value of type '%{type}'") % {what: what, type: s.class})
-      end
-    end
+    assert_type(T_STRING, s, what, allow_nil)
   end
 
   def self.assert_optionally_empty_array(a, what, allow_nil=false)
-    unless a.is_a?(Array) || (allow_nil && a.nil?)
-      raise ArgumentError(_("Puppet Pal: %{what} must be an Array (it may be empty), got '%{type}'") % {what: what, type: a.class})
-    end
+    assert_type(T_STRING_ARRAY, a, what, allow_nil)
   end
 
   def self.assert_mutually_exclusive(a, b, a_term, b_term)

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -360,11 +360,10 @@ describe 'Puppet Pal' do
         testing_env_dir # creates the structure
         expect do
           Puppet::Pal.in_environment('blah_env', env_dir: testing_env_dir, envpath: environments_dir, facts: node_facts) do |ctx|
-            ctx.evaluate_script_string('run_plan("a::aplan")')
+            ctx.evaluate_script_string('irrelevant')
           end
         end.to raise_error(/Cannot use 'env_dir' and 'envpath' at the same time/)
       end
-
     end
 
     context 'configured as existing given envpath such that' do
@@ -393,6 +392,15 @@ describe 'Puppet Pal' do
         expect(result).to eq("a::aplan value")
       end
 
+      it 'the envpath can have multiple entries - that are searched for the given env' do
+        testing_env_dir # creates the structure
+        several_dirs = "/tmp/nowhere/to/be/found:#{environments_dir}"
+        result = Puppet::Pal.in_environment('pal_env', envpath: environments_dir, facts: node_facts) do |ctx|
+          ctx.evaluate_script_string('run_plan("a::aplan")')
+        end
+        expect(result).to eq("a::aplan value")
+      end
+
       it 'errors in a meaningful way when a non existing env name is given' do
         testing_env_dir # creates the structure
         expect do
@@ -407,6 +415,22 @@ describe 'Puppet Pal' do
           Puppet::Pal.in_environment('blah_env', envpath: environments_dir, facts: node_facts)
         end.to raise_error(/A block must be given to 'in_environment/)
       end
+
+      it 'errors if envpath is something other than a string' do
+        testing_env_dir # creates the structure
+        expect do
+          Puppet::Pal.in_environment('blah_env', envpath: '', facts: node_facts) do |ctx|
+            ctx.evaluate_script_string('irrelevant')
+          end
+        end.to raise_error(/envpath has wrong type/)
+
+        expect do
+          Puppet::Pal.in_environment('blah_env', envpath: [environments_dir], facts: node_facts) do |ctx|
+            ctx.evaluate_script_string('irrelevant')
+          end
+        end.to raise_error(/envpath has wrong type/)
+      end
+
     end
 
     it 'sets the facts if they are not given' do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -251,9 +251,21 @@ describe 'Puppet Pal' do
       it 'errors if a block is not given to in_tmp_environment' do
         expect do
           Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
         end.to raise_error(/A block must be given to 'in_tmp_environment/)
       end
 
+      it 'errors if an env_name is given and is not a String[1]' do |ctx|
+        expect do
+          Puppet::Pal.in_tmp_environment('', modulepath: modulepath, facts: node_facts)
+            ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/temporary environment name has wrong type/)
+
+        expect do
+          Puppet::Pal.in_tmp_environment(32, modulepath: modulepath, facts: node_facts)
+            ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/temporary environment name has wrong type/)
+      end
     end
 
     context 'configured as existing given environment directory such that' do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -266,6 +266,28 @@ describe 'Puppet Pal' do
             ctx.evaluate_script_string('a::afunc()')
         end.to raise_error(/temporary environment name has wrong type/)
       end
+
+      it 'errors if modulepath is something other than an array of strings, empty, or nil' do
+        expect do
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: {'a' => 'hm'}, facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
+
+        expect do
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: 32, facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
+
+        expect do
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: 'dir1;dir2', facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
+
+        expect do
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: [''], facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
+      end
     end
 
     context 'configured as existing given environment directory such that' do
@@ -310,6 +332,28 @@ describe 'Puppet Pal' do
           Puppet::Pal.in_environment(32, env_dir: testing_env_dir, facts: node_facts)
             ctx.evaluate_script_string('a::afunc()')
         end.to raise_error(/env_name has wrong type/)
+      end
+
+      it 'errors if modulepath is something other than an array of strings, empty, or nil' do
+        expect do
+          Puppet::Pal.in_environment('pal_env', env_dir: testing_env_dir, modulepath: {'a' => 'hm'}, facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
+
+        expect do
+          Puppet::Pal.in_environment('pal_env', env_dir: testing_env_dir, modulepath: 32, facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
+
+        expect do
+          Puppet::Pal.in_environment('pal_env', env_dir: testing_env_dir, modulepath: 'dir1;dir2', facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
+
+        expect do
+          Puppet::Pal.in_environment('pal_env', env_dir: testing_env_dir, modulepath: [''], facts: node_facts)
+          ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/modulepath has wrong type/)
       end
 
     end

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -247,6 +247,13 @@ describe 'Puppet Pal' do
         end
         expect(result).to eq("a::aplan value")
       end
+
+      it 'errors if a block is not given to in_tmp_environment' do
+        expect do
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts)
+        end.to raise_error(/A block must be given to 'in_tmp_environment/)
+      end
+
     end
 
     context 'configured as existing given environment directory such that' do
@@ -318,6 +325,11 @@ describe 'Puppet Pal' do
         end.to raise_error(/No directory found for the environment 'blah_env' on the path '.*'/)
       end
 
+      it 'errors if a block is not given to in_environment' do
+        expect do
+          Puppet::Pal.in_environment('blah_env', envpath: environments_dir, facts: node_facts)
+        end.to raise_error(/A block must be given to 'in_environment/)
+      end
     end
 
     it 'sets the facts if they are not given' do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -300,6 +300,18 @@ describe 'Puppet Pal' do
         end.to raise_error(/The environment directory '.*' does not exist/)
       end
 
+      it 'errors if an env_name is given and is not a String[1]' do |ctx|
+        expect do
+          Puppet::Pal.in_environment('', env_dir: testing_env_dir, facts: node_facts)
+            ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/env_name has wrong type/)
+
+        expect do
+          Puppet::Pal.in_environment(32, env_dir: testing_env_dir, facts: node_facts)
+            ctx.evaluate_script_string('a::afunc()')
+        end.to raise_error(/env_name has wrong type/)
+      end
+
     end
 
     context 'configured as existing given envpath such that' do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -356,6 +356,15 @@ describe 'Puppet Pal' do
         end.to raise_error(/modulepath has wrong type/)
       end
 
+      it 'errors if env_dir and envpath are both given' do
+        testing_env_dir # creates the structure
+        expect do
+          Puppet::Pal.in_environment('blah_env', env_dir: testing_env_dir, envpath: environments_dir, facts: node_facts) do |ctx|
+            ctx.evaluate_script_string('run_plan("a::aplan")')
+          end
+        end.to raise_error(/Cannot use 'env_dir' and 'envpath' at the same time/)
+      end
+
     end
 
     context 'configured as existing given envpath such that' do


### PR DESCRIPTION
This makes it possible to specify the use of an environment:
* by name and a directory where this environment is (name and directory name does not have to match)
* by name that is found on an environment path in a directory on that path having the name of the wanted env