### PR TITLE
(PUP-7957) Use SHA256 when signing CRLs

### DIFF
--- a/lib/puppet/ssl/certificate_revocation_list.rb
+++ b/lib/puppet/ssl/certificate_revocation_list.rb
@@ -1,5 +1,6 @@
 require 'puppet/ssl/base'
 require 'puppet/indirector'
+require 'puppet/ssl/certificate_signer'
 
 # Manage the CRL.
 class Puppet::SSL::CertificateRevocationList < Puppet::SSL::Base
@@ -105,6 +106,6 @@ private
   end
 
   def sign_with(cakey)
-    @content.sign(cakey, OpenSSL::Digest::SHA1.new)
+    Puppet::SSL::CertificateSigner.new.sign(@content, cakey)
   end
 end

--- a/lib/puppet/ssl/certificate_signer.rb
+++ b/lib/puppet/ssl/certificate_signer.rb
@@ -4,6 +4,11 @@
 #
 # @api private
 class Puppet::SSL::CertificateSigner
+
+  # @!attribute [r] digest
+  #   @return [OpenSSL::Digest]
+  attr_reader :digest
+
   def initialize
     if OpenSSL::Digest.const_defined?('SHA256')
       @digest = OpenSSL::Digest::SHA256

--- a/spec/unit/ssl/certificate_revocation_list_spec.rb
+++ b/spec/unit/ssl/certificate_revocation_list_spec.rb
@@ -156,7 +156,8 @@ describe Puppet::SSL::CertificateRevocationList do
     end
 
     it "should sign the CRL with the CA's private key and a digest instance" do
-      @crl.content.expects(:sign).with { |key, digest| key == @key and digest.is_a?(OpenSSL::Digest::SHA1) }
+      digest = Puppet::SSL::CertificateSigner.new.digest
+      @crl.content.expects(:sign).with { |key, signer| key == @key and signer.is_a?(digest) }
       @crl.revoke(1, @key)
     end
 


### PR DESCRIPTION
SHA1 is being phased out in favor of SHA256 and greater owing to the
increasing feasibility of attacks on the algorithm; this commit updates
the CRL signing code to use the same digest algorithm used when signing
certificates.