### PR TITLE
(PA-7959) Fix apache2 dependent package list in service test

### DIFF
--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -60,7 +60,7 @@ agents.each do |agent|
 
   teardown do
     if platform == 'sles'
-      on agent, 'zypper remove -y apache2 apache2-prefork apache2-worker libapr1 libapr-util1'
+      on agent, 'zypper remove -y apache2 apache2-prefork libapr1 libapr-util1'
     else
       apply_manifest_on(agent, manifest_uninstall_package)
     end


### PR DESCRIPTION
On SLES, the apache2-worker package is not a dependency of apache2, and
so doesn't get installed at the start of this test. Our new Power8
platform is based on SLES 12 SP2 and now causes zypper to return a
non-zero error when you explicitly try to uninstall a package that is
not already installed, which fails this test without this fix.