### PR TITLE
(PUP-7308) Propagate class tags to admissible whits

### DIFF
--- a/lib/puppet/graph/relationship_graph.rb
+++ b/lib/puppet/graph/relationship_graph.rb
@@ -244,7 +244,12 @@ class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
     containers.each { |x|
       admissible[x] = whit_class.new(:name => "admissible_#{x.ref}", :catalog => catalog)
       completed[x]  = whit_class.new(:name => "completed_#{x.ref}",  :catalog => catalog)
+
+      # This copies the original container's tags over to the two anchor whits.
+      # Without this, tags are not propagated to the container's resources.
       admissible[x].set_tags(x)
+      completed[x].set_tags(x)
+
       priority = @prioritizer.priority_of(x)
       add_vertex(admissible[x], priority)
       add_vertex(completed[x], priority)

--- a/lib/puppet/graph/relationship_graph.rb
+++ b/lib/puppet/graph/relationship_graph.rb
@@ -244,6 +244,7 @@ class Puppet::Graph::RelationshipGraph < Puppet::Graph::SimpleGraph
     containers.each { |x|
       admissible[x] = whit_class.new(:name => "admissible_#{x.ref}", :catalog => catalog)
       completed[x]  = whit_class.new(:name => "completed_#{x.ref}",  :catalog => catalog)
+      admissible[x].set_tags(x)
       priority = @prioritizer.priority_of(x)
       add_vertex(admissible[x], priority)
       add_vertex(completed[x], priority)

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -19,11 +19,11 @@ describe Puppet::Transaction do
   end
 
   def touch_path
-    Puppet.features.microsoft_windows? ? "#{ENV['windir']}/system32" : "/usr/bin:/bin"
+    Puppet.features.microsoft_windows? ? "#{ENV['windir']}\\system32" : "/usr/bin:/bin"
   end
 
   def usr_bin_touch(path)
-    Puppet.features.microsoft_windows? ? "#{ENV['windir']}/system32/cmd.exe /c \"type NUL >> \"#{path}\"\"" : "/usr/bin/touch #{path}"
+    Puppet.features.microsoft_windows? ? "#{ENV['windir']}\\system32\\cmd.exe /c \"type NUL >> \"#{path}\"\"" : "/usr/bin/touch #{path}"
   end
 
   def touch(path)

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -1,10 +1,12 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
+require 'puppet_spec/compiler'
 
 require 'puppet/transaction'
 
 describe Puppet::Transaction do
   include PuppetSpec::Files
+  include PuppetSpec::Compiler
 
   before do
     Puppet::Util::Storage.stubs(:store)
@@ -337,6 +339,37 @@ describe Puppet::Transaction do
         expect(Puppet::FileSystem.exist?(file1)).to be_truthy
         expect(Puppet::FileSystem.exist?(file2)).to be_truthy
       end
+    end
+
+    it "should propagate events correctly from a tagged container when running with tags" do
+      file1 = tmpfile("original_tag")
+      file2 = tmpfile("tag_propagation")
+      command1 = usr_bin_touch(file1)
+      command2 = usr_bin_touch(file2)
+      manifest = <<-"MANIFEST"
+        class foo {
+          exec { 'notify test':
+            command     => '#{command1}',
+            refreshonly => true,
+          }
+        }
+
+        class test {
+          include foo
+
+          exec { 'test':
+            command => '#{command2}',
+            notify  => Class['foo'],
+          }
+        }
+
+        include test
+      MANIFEST
+
+      Puppet[:tags] = 'test'
+      apply_compiled_manifest(manifest)
+      expect(Puppet::FileSystem.exist?(file1)).to be_truthy
+      expect(Puppet::FileSystem.exist?(file2)).to be_truthy
     end
   end
 

--- a/spec/unit/graph/relationship_graph_spec.rb
+++ b/spec/unit/graph/relationship_graph_spec.rb
@@ -295,7 +295,7 @@ describe Puppet::Graph::RelationshipGraph do
           completed_sentinel_of("class[A]"))
     end
 
-    it "admissible sentinels should inherit the same tags" do
+    it "admissible and completed sentinels should inherit the same tags" do
       relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
         class a {
 	  tag "test_tag"
@@ -305,6 +305,8 @@ describe Puppet::Graph::RelationshipGraph do
       MANIFEST
 
       expect(vertex_called(relationship_graph, admissible_sentinel_of("class[A]")).tagged?("test_tag")).
+      to eq(true)
+      expect(vertex_called(relationship_graph, completed_sentinel_of("class[A]")).tagged?("test_tag")).
       to eq(true)
     end
 

--- a/spec/unit/graph/relationship_graph_spec.rb
+++ b/spec/unit/graph/relationship_graph_spec.rb
@@ -295,6 +295,19 @@ describe Puppet::Graph::RelationshipGraph do
           completed_sentinel_of("class[A]"))
     end
 
+    it "admissible sentinels should inherit the same tags" do
+      relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
+        class a {
+	  tag "test_tag"
+        }
+
+        include a
+      MANIFEST
+
+      expect(vertex_called(relationship_graph, admissible_sentinel_of("class[A]")).tagged?("test_tag")).
+      to eq(true)
+    end
+
     it "should remove all Component objects from the dependency graph" do
       relationship_graph = compile_to_relationship_graph(<<-MANIFEST)
         class a {


### PR DESCRIPTION
Without this patch applied, the admissible whit does not have the same
tags as the initial class. When sending a refresh event to a class and
running puppet with a specific tag, if that class loses it's tags,
then the agent unschedules all the refresh events (because it thinks
the class does not have the tag in question).

This patch copies tags from the initial class resource to the
admissible whit that it gets replaced with.