### PR TITLE
(maint) remove teardown for symbolic_modes test

### DIFF
--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -185,7 +185,7 @@ agents.each do |agent|
   on(agent, puppet("resource group symgroup ensure=present"))
 
   teardown do
-    on(agent, puppet("resource user symuser ensure=absent"))
+    on(agent, puppet("resource user symuser ensure=absent")) unless agent['platform'] =~ /fedora-2[6-9]/
     on(agent, puppet("resource group symgroup ensure=absent"))
   end
 


### PR DESCRIPTION
The teardown that removes the user and group used in the test
is leaving something behind on Fedora 26. Nothing obvious, since
all of the expected resources seem to be removed. However, on
Fedora 26 the gid value conflicts with the one created in the
resource/group/should_create test.