### PR TITLE
(PUP-7961) Avoid gem install conflict of this branch and other puppet…

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -12,7 +12,7 @@
 # to build the Puppet gem package.
 
 Gem::Specification.new do |s|
-  s.name = "puppet"
+  s.name = "puppet-bolt"
   version = "5.2.0"
   mdata = version.match(/(\d+\.\d+\.\d+)/)
   s.version = mdata ? mdata[1] : version
@@ -23,12 +23,9 @@ Gem::Specification.new do |s|
   s.date = "2012-08-17"
   s.description = "Puppet, an automated configuration management tool"
   s.email = "puppet@puppetlabs.com"
-  s.executables = ["puppet"]
-  s.files = ["bin/puppet"]
   s.homepage = "https://puppetlabs.com"
   s.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
   s.require_paths = ["lib"]
-  s.rubyforge_project = "puppet"
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
   s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,5 +1,5 @@
 ---
-project: 'puppet'
+project: 'puppet-bolt'
 author: 'Puppet Labs'
 email: 'info@puppetlabs.com'
 homepage: 'https://github.com/puppetlabs/puppet'
@@ -7,12 +7,11 @@ summary: 'Puppet, an automated configuration management tool'
 description: 'Puppet, an automated configuration management tool'
 version_file: 'lib/puppet/version.rb'
 # files and gem_files are space separated lists
-files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
+files: '[A-Z]* install.rb lib conf man examples ext tasks spec locales'
 # The gem specification bits only work on Puppet >= 3.0rc, NOT 2.7.x and earlier
-gem_files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
+gem_files: '[A-Z]* install.rb lib libbolt conf man examples ext tasks spec locales'
 gem_test_files: 'spec/**/*'
-gem_executables: 'puppet'
-gem_default_executables: 'puppet'
+gem_require_path: 'libbolt'
 gem_forge_project: 'puppet'
 gem_required_ruby_version: '>= 1.9.3'
 gem_required_rubygems_version: '> 1.3.1'

--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 
 module Puppet
-  PUPPETVERSION = '5.2.0'
+  PUPPETVERSION = '5.2.0-bolt'
 
   ##
   # version is a public API method intended to always provide a fast and

--- a/libbolt/puppet_bolt.rb
+++ b/libbolt/puppet_bolt.rb
@@ -1,0 +1,1 @@
+$:.unshift(File::expand_path("../lib", File::dirname(__FILE__)))


### PR DESCRIPTION
… installs

We need to make sure that when this branch gets installed via a Ruby gem,
that we do not interfere with any other Puppet installations that the user
might already have. We do this by not mentioning 'lib/' in the require_path
of our gemspec. This effectively hides everything in 'lib/' from gem and
will keep ruby from ever satisfying a require of 'puppet/<somewhere>' with
files from this gem.

Code that consciously wants to load this gem, needs to instead require
'puppet_bolt'. That manipulates $LOAD_PATH so that 'lib/' does become
available. After that, any 'require "puppet/<somewhere>"' will resolve to a
file from this gem.

Note that there are two ways to build a Puppet gem: 'gem build' (driven by
.gemspec) will continue to produce a puppet gem; that gem is used by Travis
and Appveyor, and we do not change it to make sure those tests still
run. For release, we use 'rake package:gem' which is driven off
ext/project_data.yaml. We only modify that file.