### PR TITLE
(PUP-7967) Add file_upload function

### DIFF
--- a/lib/puppet/functions/file_upload.rb
+++ b/lib/puppet/functions/file_upload.rb
@@ -1,0 +1,50 @@
+# Uploads the given file or directory to the given set of nodes and returns the result from each upload.
+#
+# * This function does nothing if the list of nodes is empty.
+# * It is possible to run on the node 'localhost'
+# * A node is a String with a node's hostname or a URI that also describes how to connect and run the task on that node
+#   including "user" and "password" parts of a URI.
+# * The returned value contains information about the result per node. TODO: needs mapping to a runtime Pcore Object to be useful
+#
+#
+# Since > 5.4.0 TODO: Update when version is known
+#
+Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunction) do
+  local_types do
+    type 'NodeOrNodes = Variant[String[1], Array[NodeOrNodes]]'
+  end
+
+  dispatch :file_upload do
+    scope_param
+    param 'String[1]', :source
+    param 'String[1]', :destination
+    repeated_param 'NodeOrNodes', :nodes
+  end
+
+  def file_upload(scope, source, destination, *nodes)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        {:operation => 'file_upload'})
+    end
+
+    unless Puppet.features.bolt?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT, :action => _('do file uploads'))
+    end
+
+    found = Puppet::Parser::Files.find_file(source, scope.compiler.environment)
+    unless found && Puppet::FileSystem.exist?(found)
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::NO_SUCH_FILE_OR_DIRECTORY, {:file => source})
+    end
+
+    hosts = nodes.flatten
+    if hosts.empty?
+      call_function('debug', "Simulating file upload of '#{found}' - no hosts given - no action taken")
+      []
+    else
+      Bolt::Executor.from_uris(hosts).file_upload(found, destination).map do |_, result|
+        result.success? ? result.output_string : result.exit_code
+      end
+    end
+  end
+end

--- a/lib/puppet/functions/run_task.rb
+++ b/lib/puppet/functions/run_task.rb
@@ -6,7 +6,7 @@
 #   including "user" and "password" parts of a URI.
 # * The returned value contains information about the result per node. TODO: needs mapping to a runtime Pcore Object to be useful
 #
-# 
+#
 # Since > 5.4.0 TODO: Update when version is known
 #
 Puppet::Functions.create_function(:run_task) do
@@ -53,7 +53,7 @@ Puppet::Functions.create_function(:run_task) do
     end
 
     unless Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT)
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT, :action => _('run a task'))
     end
 
     if hosts.empty?

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -749,6 +749,10 @@ module Issues
     _("Illegal %{format} Byte Order mark at beginning of input: %{bom} - remove these from the puppet source") % { format: format_name, bom: bytes }
   end
 
+  NO_SUCH_FILE_OR_DIRECTORY = hard_issue :NO_SUCH_FILE_OR_DIRECTORY, :file do
+    _('No such file or directory: %{file}') % { file: file }
+  end
+
   NUMERIC_OVERFLOW = hard_issue :NUMERIC_OVERFLOW, :value do
     if value > 0
       _("%{expression} resulted in a value outside of Puppet Integer max range, got '%{value}'") % { expression: label.a_an_uc(semantic), value: ("%#+x" % value) }
@@ -869,8 +873,8 @@ module Issues
     _("The task operation '%{operation}' is not available when compiling a catalog") % { operation: operation }
   end
 
-  TASK_MISSING_BOLT = issue :TASK_MISSING_BOLT do
-    _("The 'bolt' library is required to run a task")
+  TASK_MISSING_BOLT = issue :TASK_MISSING_BOLT, :action do
+    _("The 'bolt' library is required to %{action}") % { action: action }
   end
 end
 end

--- a/spec/unit/functions/file_upload_spec.rb
+++ b/spec/unit/functions/file_upload_spec.rb
@@ -1,0 +1,147 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet/loaders'
+require 'puppet_spec/compiler'
+
+describe 'the file_upload function' do
+  include PuppetSpec::Compiler
+  include PuppetSpec::Files
+
+  let(:tasks_enabled) { true }
+  let(:env_name) { 'testenv' }
+  let(:environments_dir) { Puppet[:environmentpath] }
+  let(:env_dir) { File.join(environments_dir, env_name) }
+  let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, 'modules')]) }
+  let(:node) { Puppet::Node.new("test", :environment => env) }
+  let(:env_dir_files) {
+    {
+      'modules' => {
+        'test' => {
+          'files' => {
+            'uploads' => {
+              'index.html' => <<-HTML.unindent
+                <html>
+                  <body>Hello World</body>
+                </html>
+                HTML
+            }
+          }
+        }
+      }
+    }
+  }
+
+  before(:each) do
+    Puppet[:tasks] = tasks_enabled
+    loaders = Puppet::Pops::Loaders.new(env)
+    Puppet.push_context({:loaders => loaders}, "test-examples")
+  end
+
+  after(:each) do
+    Puppet::Pops::Loaders.clear
+    Puppet::pop_context()
+  end
+
+  let(:populated_env_dir) do
+    dir_contained_in(environments_dir, env_name => env_dir_files)
+    PuppetSpec::Files.record_tmp(env_dir)
+    env_dir
+  end
+  let(:func) { Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'file_upload') }
+
+  context 'it calls bolt executor file_upload' do
+    let(:hostname) { 'test.example.com' }
+    let(:hosts) { [hostname] }
+    let(:host) { stub(uri: hostname) }
+    let(:message) { 'uploaded' }
+    let(:result) { stub(output_string: message, success?: true) }
+    let(:full_dir_path) { File.join(env_dir, 'modules', 'test', 'files', 'uploads' ) }
+    let(:full_path) { File.join(full_dir_path, 'index.html') }
+    let(:destination) { '/var/www/html' }
+    before(:each) do
+      Puppet.features.stubs(:bolt?).returns(true)
+      module ::Bolt; end
+      class ::Bolt::Executor; end
+    end
+
+    it 'with fully resolved path of file and destination' do
+      executor = mock('executor')
+      Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
+      executor.expects(:file_upload).with(full_path, destination).returns({ host => result })
+
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+        $a = file_upload('test/uploads/index.html', '#{destination}', '#{hostname}')
+        notice $a
+      CODE
+    end
+
+    it 'with fully resolved path of directory and destination' do
+      executor = mock('executor')
+      Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
+      executor.expects(:file_upload).with(full_dir_path, destination).returns({ host => result })
+
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+        $a = file_upload('test/uploads', '#{destination}', '#{hostname}')
+        notice $a
+      CODE
+    end
+
+    context 'with multiple destinations' do
+      let(:hostname2) { 'test.testing.com' }
+      let(:hosts) { [hostname, hostname2] }
+      let(:host2) { stub(uri: hostname2) }
+      let(:message2) { 'received' }
+      let(:result2) { stub(output_string: message2, success?: true) }
+
+      it 'with propagates multiple hosts and returns multiple results' do
+        executor = mock('executor')
+        Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
+        executor.expects(:file_upload).with(full_path, destination).returns({ host => result, host2 => result2 })
+
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}, #{message2}]"])
+          $a = file_upload('test/uploads/index.html', '#{destination}', '#{hostname}', '#{hostname2}')
+          notice $a
+        CODE
+      end
+    end
+
+    it 'without nodes - does not invoke bolt' do
+      executor = mock('executor')
+      Bolt::Executor.expects(:from_uris).never
+      executor.expects(:file_upload).never
+
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['[]'])
+        $a = file_upload('test/uploads/index.html', '#{destination}')
+        notice $a
+      CODE
+    end
+
+    it 'errors when file is not found' do
+      executor = mock('executor')
+      Bolt::Executor.expects(:from_uris).never
+      executor.expects(:file_upload).never
+
+      expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/No such file or directory: .*nonesuch\.html/)
+        file_upload('test/uploads/nonesuch.html', '/some/place')
+      CODE
+    end
+  end
+
+  context 'without bolt feature present' do
+    it 'fails and reports that bolt library is required' do
+      expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/The 'bolt' library is required to do file uploads/)
+          file_upload('test/uploads/nonesuch.html', '/some/place')
+      CODE
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that file_upload is not available' do
+      expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/The task operation 'file_upload' is not available/)
+          file_upload('test/uploads/nonesuch.html', '/some/place')
+      CODE
+    end
+  end
+end


### PR DESCRIPTION
Adds a `file_upload` function that can upload a file or directory
to a set of nodes by calling the `Bolt::Executor#file_upload`. The
function requires that --tasks is enabled and that the `bolt` feature
is present.