### PR TITLE
PUP-413 Update def query for pip packages

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -79,7 +79,7 @@ Puppet::Type.type(:package).provide :pip,
   # it is not installed or `pip` itself is not available.
   def query
     self.class.instances.each do |provider_pip|
-      return provider_pip.properties if @resource[:name].downcase == provider_pip.name.downcase
+      return provider_pip.properties if @resource[:name].gsub(/[-]/, '_').downcase == provider_pip.name.gsub(/[-]/, '_').downcase
     end
     return nil
   end


### PR DESCRIPTION
PUP-413
https://tickets.puppetlabs.com/browse/ASK-413
Currently, I have 4 pip packages on infinite install, due to the hyphen character being in the package name instead of an underscore in the package name.  
During install of the package, the name uses an underscore.  
After the package is installed, the package name returns with a hyphen instead of an underscore.
  
Examples I have come across include:
smart_open
int_date
cx_Oracle
pandas_oracle

I am sure there are more out there...

The python documentation states that "All comparisons of distribution names MUST be case insensitive, and MUST consider hyphens and underscores to be equivalent." source: https://www.python.org/dev/peps/pep-0426/#name

My update attempts to resolve this problem by gsubing all hyphens for underscores in the @resource:name and provider_pip.name to make hyphens and underscores equivalent.