### PR TITLE
(PUP-7973) gem package provider should match exactly

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       gem_list_command << "--source" << options[:source]
     end
     if name = options[:justme]
-      gem_list_command << "^" + name + "$"
+      gem_list_command << '\A' + name + '\z'
     end
 
     begin

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -186,7 +186,7 @@ context 'installing myresource' do
     describe "listing gems" do
       describe "searching for a single package" do
         it "searches for an exact match" do
-          provider_class.expects(:execute).with(includes('^bundler$'), {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns(File.read(my_fixture('gem-list-single-package')))
+          provider_class.expects(:execute).with(includes('\Abundler\z'), {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns(File.read(my_fixture('gem-list-single-package')))
           expected = {:name => 'bundler', :ensure => %w[1.6.2], :provider => :gem}
           expect(provider_class.gemlist({:justme => 'bundler'})).to eq(expected)
         end


### PR DESCRIPTION
The `^` is apparently ignored in windows, but `\A` works.