### PR TITLE
(DOCUMENT-729) Add context to static_catalogs setting.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -156,7 +156,9 @@ module Puppet
     :static_catalogs => {
       :default    => true,
       :type       => :boolean,
-      :desc       => "Whether to compile a static catalog."
+      :desc       => "Whether to compile a [static catalog](https://docs.puppet.com/puppet/latest/static_catalogs.html#enabling-or-disabling-static-catalogs),
+        which occurs only on a Puppet Server master when the `code-id-command` and
+        `code-content-command` settings are configured in its `puppetserver.conf` file.",
     },
     :strict_environment_mode => {
       :default    => false,


### PR DESCRIPTION
Clarify how the `static_catalogs` setting behaves in the configuration reference, and link to context about what static catalogs are and how they work.