### PR TITLE
Update CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,12 @@ for advice.
     `master` branch.
 * Make commits of logical units.
 * Check for unnecessary whitespace with `git diff --check` before committing.
-* Make sure your commit messages are in the proper format.
+* Make sure your commit messages are in the proper format. If the commit
+  addresses an issue filed in the
+  [Puppet Jira project](https://tickets.puppetlabs.com/browse/PUP), start
+  the first line of the commit with the issue number in parentheses.
 
-````
+```
     (PUP-1234) Make the example in CONTRIBUTING imperative and concrete
 
     Without this patch applied the example commit message in the CONTRIBUTING
@@ -61,7 +64,7 @@ for advice.
     The first line is a real life imperative statement with a ticket number
     from our issue tracker.  The body describes the behavior without the patch,
     why this is a problem, and how the patch fixes the problem when applied.
-````
+```
 
 * Make sure you have added the necessary tests for your changes.
 * Run _all_ the tests to assure nothing else was accidentally broken.
@@ -77,7 +80,7 @@ for the translators.
 When adding user-facing strings to your work, follow these guidelines:
 * Use full sentences. Strings built up out of concatenated bits are hard to translate.
 * Use string formatting instead of interpolation.
-    Ex. `_('Creating new user %{name}.') % { name: user.name }`
+  For example: `_('Creating new user %{name}.') % { name: user.name }`
 * Use `n_()` for pluralization. (see gettext gem docs linked above for details)
 
 It is the responsibility of contributors and code reviewers to ensure that all
@@ -89,21 +92,28 @@ user-facing strings are marked in new PRs before merging.
 
 For changes of a trivial nature to comments and documentation, it is not
 always necessary to create a new ticket in Jira. In this case, it is
-appropriate to start the first line of a commit with '(doc)' instead of
+appropriate to start the first line of a commit with `(docs)` instead of
 a ticket number.
 
-````
-    (doc) Add documentation commit example to CONTRIBUTING
+If a Jira ticket exists for the documentation commit, you can include it
+after the `(docs)` token.
+
+```
+    (docs)(DOCUMENT-000) Add docs commit example to CONTRIBUTING
 
     There is no example for contributing a documentation commit
     to the Puppet repository. This is a problem because the contributor
     is left to assume how a commit of this nature may appear.
 
-    The first line is a real life imperative statement with '(doc)' in
-    place of what would have been the ticket number in a
+    The first line is a real life imperative statement with '(docs)' in
+    place of what would have been the PUP project ticket number in a
     non-documentation related commit. The body describes the nature of
     the new documentation or comments added.
-````
+```
+
+For commits that address trivial repository maintenance tasks or packaging
+issues, start the first line of the commit with `(maint)` or `(packaging)`,
+respectively.
 
 ## Submitting Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,12 @@ for advice.
 
 ## Getting Started
 
-* Make sure you have a [Jira account](https://tickets.puppetlabs.com)
-* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Make sure you have a [Jira account](https://tickets.puppetlabs.com).
+* Make sure you have a [GitHub account](https://github.com/signup/free).
 * Submit a ticket for your issue, assuming one does not already exist.
   * Clearly describe the issue including steps to reproduce when it is a bug.
   * Make sure you fill in the earliest version that you know has the issue.
-* Fork the repository on GitHub
+* Fork the repository on GitHub.
 
 ## Making Changes
 
@@ -42,7 +42,7 @@ for advice.
   * This is usually the master branch.
   * Only target release branches if you are certain your fix must be on that
     branch.
-  * To quickly create a topic branch based on master; `git checkout -b
+  * To quickly create a topic branch based on master, run `git checkout -b
     fix/master/my_contribution master`. Please avoid working directly on the
     `master` branch.
 * Make commits of logical units.
@@ -52,20 +52,19 @@ for advice.
   [Puppet Jira project](https://tickets.puppetlabs.com/browse/PUP), start
   the first line of the commit with the issue number in parentheses.
 
-```
-    (PUP-1234) Make the example in CONTRIBUTING imperative and concrete
+  ```
+      (PUP-1234) Make the example in CONTRIBUTING imperative and concrete
 
-    Without this patch applied the example commit message in the CONTRIBUTING
-    document is not a concrete example.  This is a problem because the
-    contributor is left to imagine what the commit message should look like
-    based on a description rather than an example.  This patch fixes the
-    problem by making the example concrete and imperative.
+      Without this patch applied the example commit message in the CONTRIBUTING
+      document is not a concrete example. This is a problem because the
+      contributor is left to imagine what the commit message should look like
+      based on a description rather than an example. This patch fixes the
+      problem by making the example concrete and imperative.
 
-    The first line is a real life imperative statement with a ticket number
-    from our issue tracker.  The body describes the behavior without the patch,
-    why this is a problem, and how the patch fixes the problem when applied.
-```
-
+      The first line is a real-life imperative statement with a ticket number
+      from our issue tracker. The body describes the behavior without the patch,
+      why this is a problem, and how the patch fixes the problem when applied.
+  ```
 * Make sure you have added the necessary tests for your changes.
 * Run _all_ the tests to assure nothing else was accidentally broken.
 
@@ -78,6 +77,7 @@ wrapped in the `_()` translation function, so they can be extracted into files
 for the translators.
 
 When adding user-facing strings to your work, follow these guidelines:
+
 * Use full sentences. Strings built up out of concatenated bits are hard to translate.
 * Use string formatting instead of interpolation.
   For example: `_('Creating new user %{name}.') % { name: user.name }`
@@ -105,7 +105,7 @@ after the `(docs)` token.
     to the Puppet repository. This is a problem because the contributor
     is left to assume how a commit of this nature may appear.
 
-    The first line is a real life imperative statement with '(docs)' in
+    The first line is a real-life imperative statement with '(docs)' in
     place of what would have been the PUP project ticket number in a
     non-documentation related commit. The body describes the nature of
     the new documentation or comments added.
@@ -120,7 +120,8 @@ respectively.
 * Sign the [Contributor License Agreement](http://links.puppet.com/cla).
 * Push your changes to a topic branch in your fork of the repository.
 * Submit a pull request to the repository in the puppetlabs organization.
-* Update your Jira ticket to mark that you have submitted code and are ready for it to be reviewed (Status: Ready for Merge).
+* Update your Jira ticket to mark that you have submitted code and are ready
+  for it to be reviewed (Status: Ready for Merge).
   * Include a link to the pull request in the ticket.
 * The core team looks at Pull Requests on a regular basis in a weekly triage
   meeting that we hold in a public Google Hangout. The hangout is announced in
@@ -132,6 +133,7 @@ respectively.
   weeks we may close the pull request if it isn't showing any activity.
 
 ## Revert Policy
+
 By running tests in advance and by engaging with peer review for prospective
 changes, your contributions have a high probability of becoming long lived
 parts of the the project. After being merged, the code will run through a
@@ -152,10 +154,11 @@ ticket. This test(s) should be used to check future submissions of the code to
 ensure the issue has been resolved.
 
 ### Summary
+
 * Changes resulting in test pipeline failures will be reverted if they cannot
   be resolved within one business day.
 
-# Additional Resources
+## Additional Resources
 
 * [Puppet community guidelines](https://docs.puppet.com/community/community_guidelines.html)
 * [Bug tracker (Jira)](https://tickets.puppetlabs.com)


### PR DESCRIPTION
CONTRIBUTING.md was not updated with changes to commit message guidelines made to the Rakefile in commit 2a6ffedabf07fde2fd5e7d8678bbcc5ab0b25340 and is missing guidelines added in commit 4d5afd5795d580c5e51b68fb81ebaae4a5dec352. This means the Rakefile error message for commit summaries that fail the regex suggests that they should follow guidelines in CONTRIBUTING.md that either don't match the Rakefile error or don't exist in CONTRIBUTING.md.

This PR adds those commit message guidelines to CONTRIBUTING.md.

This PR also edits CONTRIBUTING.md for consistency in punctuation and Markdown formatting.