### PR TITLE
(PUP-7979) Add run_command function

### DIFF
--- a/lib/puppet/functions/run_command.rb
+++ b/lib/puppet/functions/run_command.rb
@@ -1,0 +1,44 @@
+# Runs a command on the given set of nodes and returns the result from each command execution.
+#
+# * This function does nothing if the list of nodes is empty.
+# * It is possible to run on the node 'localhost'
+# * A node is a String with a node's hostname or a URI that also describes how to connect and run the task on that node
+#   including "user" and "password" parts of a URI.
+# * The returned value contains information about the result per node. TODO: needs mapping to a runtime Pcore Object to be useful
+#
+#
+# Since > 5.4.0 TODO: Update when version is known
+#
+Puppet::Functions.create_function(:run_command) do
+  local_types do
+    type 'NodeOrNodes = Variant[String[1], Array[NodeOrNodes]]'
+  end
+
+  dispatch :run_command do
+    param 'String[1]', :command
+    repeated_param 'NodeOrNodes', :nodes
+  end
+
+  def run_command(command, *nodes)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        {:operation => 'run_command'})
+    end
+
+    unless Puppet.features.bolt?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT, :action => _('run a command'))
+    end
+
+    hosts = nodes.flatten
+    if hosts.empty?
+      call_function('debug', "Simulating run_command('#{command}') - no hosts given - no action taken")
+      []
+    else
+      # TODO, rewrite once proper handling of returned values is fully specified
+      Bolt::Executor.from_uris(hosts).execute(command).map do |_, result|
+        result.success? ? result.output_string : result.exit_code
+      end
+    end
+  end
+end

--- a/spec/unit/functions/run_command_spec.rb
+++ b/spec/unit/functions/run_command_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet/loaders'
+require 'puppet_spec/compiler'
+
+describe 'the run_command function' do
+  include PuppetSpec::Compiler
+  include PuppetSpec::Files
+
+  let(:tasks_enabled) { true }
+  let(:env_name) { 'testenv' }
+  let(:environments_dir) { Puppet[:environmentpath] }
+  let(:env_dir) { File.join(environments_dir, env_name) }
+  let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(env_dir, 'modules')]) }
+  let(:node) { Puppet::Node.new("test", :environment => env) }
+
+  before(:each) do
+    Puppet[:tasks] = tasks_enabled
+    loaders = Puppet::Pops::Loaders.new(env)
+    Puppet.push_context({:loaders => loaders}, "test-examples")
+  end
+
+  after(:each) do
+    Puppet::Pops::Loaders.clear
+    Puppet::pop_context()
+  end
+
+  let(:func) { Puppet.lookup(:loaders).puppet_system_loader.load(:function, 'run_command') }
+
+  context 'it calls bolt executor execute' do
+    let(:hostname) { 'test.example.com' }
+    let(:hosts) { [hostname] }
+    let(:host) { stub(uri: hostname) }
+    let(:command) { 'hostname' }
+    let(:result) { stub(output_string: hostname, success?: true) }
+    before(:each) do
+      Puppet.features.stubs(:bolt?).returns(true)
+      module ::Bolt; end
+      class ::Bolt::Executor; end
+    end
+
+    it 'with given command and host' do
+      executor = mock('executor')
+      Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
+      executor.expects(:execute).with(command).returns({ host => result })
+
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{hostname}]"])
+        $a = run_command('#{command}', '#{hostname}')
+        notice $a
+      CODE
+    end
+
+    context 'with multiple hosts' do
+      let(:hostname2) { 'test.testing.com' }
+      let(:hosts) { [hostname, hostname2] }
+      let(:host2) { stub(uri: hostname2) }
+      let(:result2) { stub(output_string: hostname2, success?: true) }
+
+      it 'with propagates multiple hosts and returns multiple results' do
+        executor = mock('executor')
+        Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
+        executor.expects(:execute).with(command).returns({ host => result, host2 => result2 })
+
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{hostname}, #{hostname2}]"])
+          $a = run_command('#{command}', '#{hostname}', '#{hostname2}')
+          notice $a
+        CODE
+      end
+    end
+
+    it 'without nodes - does not invoke bolt' do
+      executor = mock('executor')
+      Bolt::Executor.expects(:from_uris).never
+      executor.expects(:execute).never
+
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['[]'])
+        $a = run_command('#{command}')
+        notice $a
+      CODE
+    end
+  end
+
+  context 'without bolt feature present' do
+    it 'fails and reports that bolt library is required' do
+      expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/The 'bolt' library is required to run a command/)
+          run_command('echo hello')
+      CODE
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that run_command is not available' do
+      expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/The task operation 'run_command' is not available/)
+          run_command('echo hello')
+      CODE
+    end
+  end
+end


### PR DESCRIPTION
Adds a `run_command` function that can run a command on a set of nodes
by calling the `Bolt::Executor#execute`. The function requires that
--tasks is enabled and that the `bolt` feature is present.