### PR TITLE
(PUP-7992) Avoid translating keyword `new`

### DIFF
--- a/lib/puppet/agent/locker.rb
+++ b/lib/puppet/agent/locker.rb
@@ -29,7 +29,7 @@ module Puppet::Agent::Locker
 
   # @deprecated
   def running?
-    Puppet.deprecation_warning _(<<-ENDHEREDOC)
+    Puppet.deprecation_warning <<-ENDHEREDOC
 Puppet::Agent::Locker.running? is deprecated as it is inherently unsafe.
 The only safe way to know if the lock is locked is to try lock and perform some
 action and then handle the LockError that may result.

--- a/lib/puppet/face/catalog/select.rb
+++ b/lib/puppet/face/catalog/select.rb
@@ -3,7 +3,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
   action :select do
     summary _("Retrieve a catalog and filter it for resources of a given type.")
     arguments _("<host> <resource_type>")
-    returns _(<<-'EOT')
+    returns <<-'EOT'
       A list of resource references ("Type[title]"). When used from the API,
       returns an array of Puppet::Resource objects excised from a catalog.
     EOT

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -14,7 +14,7 @@ Puppet::Face.define(:help, '0.0.1') do
     summary _("Display help about Puppet subcommands and their actions.")
     arguments _("[<subcommand>] [<action>]")
     returns _("Short help text for the specified subcommand or action.")
-    examples _(<<-'EOT')
+    examples <<-'EOT'
       Get help for an action:
 
       $ puppet help
@@ -78,7 +78,7 @@ Puppet::Face.define(:help, '0.0.1') do
   def render_application_help(applicationname)
     return Puppet::Application[applicationname].help
   rescue StandardError, LoadError => detail
-    msg = _(<<-MSG) % { applicationname: applicationname, detail: detail.message }
+    msg = <<-MSG % { applicationname: applicationname, detail: detail.message }
 Could not load help for the application %{applicationname}.
 Please check the error logs for more information.
 
@@ -91,7 +91,7 @@ MSG
     face, action = load_face_help(facename, actionname, version)
     return template_for(face, action).result(binding)
   rescue StandardError, LoadError => detail
-    msg = _(<<-MSG) % { facename: facename, detail: detail.message }
+    msg = <<-MSG % { facename: facename, detail: detail.message }
 Could not load help for the face %{facename}.
 Please check the error logs for more information.
 

--- a/lib/puppet/face/man.rb
+++ b/lib/puppet/face/man.rb
@@ -25,7 +25,7 @@ Puppet::Face.define(:man, '0.0.1') do
   action(:man) do
     summary _("Display the manual page for a Puppet subcommand.")
     arguments _("<subcommand>")
-    returns _(<<-'EOT')
+    returns <<-'EOT'
       The man data, in Markdown format, suitable for consumption by Ronn.
 
       RENDERING ISSUES: To skip fancy formatting and output the raw Markdown

--- a/lib/puppet/face/node.rb
+++ b/lib/puppet/face/node.rb
@@ -17,7 +17,7 @@ Puppet::Indirector::Face.define(:node, '0.0.1') do
   find = get_action(:find)
   find.summary _("Retrieve a node object.")
   find.arguments _("<host>")
-  find.returns _(<<-'EOT')
+  find.returns <<-'EOT'
     A hash containing the node's `classes`, `environment`, `expiration`, `name`,
     `parameters` (its facts, combined with any ENC-set parameters), and `time`.
     When used from the Ruby API: a Puppet::Node object.

--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -24,7 +24,7 @@ Puppet::Face.define(:plugin, '0.0.1') do
       downloaded in this way will be used in all subsequent Puppet activity.
       This action modifies files on disk.
     EOT
-    returns _(<<-'EOT')
+    returns <<-'EOT'
       A list of the files downloaded, or a confirmation that no files were
       downloaded. When used from the Ruby API, this action returns an array of
       the files downloaded, which will be empty if none were retrieved.

--- a/lib/puppet/face/status.rb
+++ b/lib/puppet/face/status.rb
@@ -13,7 +13,7 @@ Puppet::Indirector::Face.define(:status, '0.0.1') do
   find = get_action(:find)
   find.default = true
   find.summary _("Check status of puppet master server.")
-  find.returns _(<<-'EOT')
+  find.returns <<-'EOT'
     A "true" response or a low-level connection error. When used from the Ruby
     API: returns a Puppet::Status object.
   EOT

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -32,7 +32,7 @@ module Puppet::Forge::Errors
     #
     # @return [String] the multiline version of the error message
     def multiline
-      _(<<-EOS).chomp % { uri: @uri }
+      <<-EOS.chomp % { uri: @uri }
 Could not connect via HTTPS to %{uri}
   Unable to verify the SSL certificate
     The certificate may not be signed by a valid CA
@@ -59,7 +59,7 @@ Could not connect via HTTPS to %{uri}
     #
     # @return [String] the multiline version of the error message
     def multiline
-      _(<<-EOS).chomp % { uri: @uri, detail: @detail }
+      <<-EOS.chomp % { uri: @uri, detail: @detail }
 Could not connect to %{uri}
   There was a network communications problem
     The error we caught said '%{detail}'
@@ -99,7 +99,7 @@ Could not connect to %{uri}
     #
     # @return [String] the multiline version of the error message
     def multiline
-      message = _(<<-EOS).chomp % { uri: @uri, response: @response }
+      message = <<-EOS.chomp % { uri: @uri, response: @response }
 Request to Puppet Forge failed.
   The server being queried was %{uri}
   The HTTP response we received was '%{response}'

--- a/lib/puppet/module_tool/errors/installer.rb
+++ b/lib/puppet/module_tool/errors/installer.rb
@@ -50,7 +50,7 @@ module Puppet::ModuleTool::Errors
     end
 
     def multiline
-      _(<<-MSG).strip % { module_name: @requested_module, version: @requested_version, dir: @directory }
+      <<-MSG.strip % { module_name: @requested_module, version: @requested_version, dir: @directory }
 Could not install module '%{module_name}' (%{version})
   Path '%{dir}' exists but is not a directory.
   A potential solution is to rename the path and then
@@ -68,7 +68,7 @@ Could not install module '%{module_name}' (%{version})
     end
 
     def multiline
-      _(<<-MSG).strip % { module_name: @requested_module, version: @requested_version, dir: @directory }
+      <<-MSG.strip % { module_name: @requested_module, version: @requested_version, dir: @directory }
 Could not install module '%{module_name}' (%{version})
   Permission is denied when trying to create directory '%{dir}'.
   A potential solution is to check the ownership and permissions of
@@ -85,7 +85,7 @@ Could not install module '%{module_name}' (%{version})
     end
 
     def multiline
-      _(<<-MSG).strip % { path: @entry_path.inspect, dir: @directory.inspect }
+      <<-MSG.strip % { path: @entry_path.inspect, dir: @directory.inspect }
 Could not install package with an invalid path.
   Package attempted to install file into
   %{path} under %{dir}.

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -319,7 +319,7 @@ class Puppet::Parser::Compiler
       raise Puppet::Error, _("Invalid node mapping in %{app}: Mapping must be a hash") % { app: app.ref } unless mapping.is_a?(Hash)
       all_mapped = Set.new
       mapping.each do |k,v|
-        raise Puppet::Error, _("Invalid node mapping in %{app}: Key %{k} is not a Node") % { app: app.ref, k: k } unless k.is_a?(Puppet::Resource) && k.type == _('Node')
+        raise Puppet::Error, _("Invalid node mapping in %{app}: Key %{k} is not a Node") % { app: app.ref, k: k } unless k.is_a?(Puppet::Resource) && k.type == 'Node'
         v = [v] unless v.is_a?(Array)
         v.each do |res|
           raise Puppet::Error, _("Invalid node mapping in %{app}: Value %{res} is not a resource") % { app: app.ref, res: res } unless res.is_a?(Puppet::Resource)

--- a/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
@@ -41,7 +41,7 @@ class PuppetResourceTypeImplInstantiator
           functor_expr.left_expr.is_a?(Model::QualifiedReference) &&
           functor_expr.left_expr.cased_value == rname &&
           functor_expr.right_expr.is_a?(Model::QualifiedName) &&
-          functor_expr.right_expr.value == _('new')
+          functor_expr.right_expr.value == 'new'
       else
         false
       end

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -585,7 +585,7 @@ class HieraConfigV5 < HieraConfig
 
   def create_configured_data_providers(lookup_invocation, parent_data_provider, use_default_hierarchy)
     defaults = @config[KEY_DEFAULTS] || EMPTY_HASH
-    datadir = defaults[KEY_DATADIR] || _('data')
+    datadir = defaults[KEY_DATADIR] || 'data'
 
     # Hashes enumerate their values in the order that the corresponding keys were inserted so it's safe to use
     # a hash for the data_providers.

--- a/lib/puppet/ssl/certificate_revocation_list.rb
+++ b/lib/puppet/ssl/certificate_revocation_list.rb
@@ -39,7 +39,7 @@ DOC
   # The name doesn't actually matter; there's only one CRL.
   # We just need the name so our Indirector stuff all works more easily.
   def initialize(fakename)
-    @name = _("crl")
+    @name = "crl"
   end
 
   # Revoke the certificate with serial number SERIAL issued by this

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -210,7 +210,7 @@ DOC
     raise Puppet::Error, _("No certificate to validate.") unless certificate
     raise Puppet::Error, _("No private key with which to validate certificate with fingerprint: %{fingerprint}") % { fingerprint: certificate.fingerprint } unless key
     unless certificate.content.check_private_key(key.content)
-      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: certificate.fingerprint, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
+      raise Puppet::Error, <<ERROR_STRING % { fingerprint: certificate.fingerprint, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
 The certificate retrieved from the master does not match the agent's private key.
 Certificate fingerprint: %{fingerprint}
 To fix this, remove the certificate from both the master and the agent and then start a puppet run, which will automatically regenerate a certificate.
@@ -235,7 +235,7 @@ ERROR_STRING
     if !existing_request.nil? &&
       (key.content.public_key.to_s != existing_request.content.public_key.to_s)
 
-      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: existing_request.fingerprint, csr_public_key: existing_request.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
+      raise Puppet::Error, <<ERROR_STRING % { fingerprint: existing_request.fingerprint, csr_public_key: existing_request.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
 The CSR retrieved from the master does not match the agent's public key.
 CSR fingerprint: %{fingerprint}
 CSR public key: %{csr_public_key}


### PR DESCRIPTION
Avoid translating the keyword `new`, used as part of reading pcore
types. Translating it meant that reading pcore would fail on non-english
locales.