### PR TITLE
(PUP-7994) Add check to run_task that task is found before calling new

### DIFF
--- a/lib/puppet/functions/run_task.rb
+++ b/lib/puppet/functions/run_task.rb
@@ -39,6 +39,9 @@ Puppet::Functions.create_function(:run_task) do
 
   def run_named_task(task_name, nodes, task_args = nil)
     task_type = Puppet.lookup(:loaders).private_environment_loader.load(:type, task_name)
+    if task_type.nil?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::UNKNOWN_TASK, :type_name => task_name)
+    end
     use_args = task_args.nil? ? {} : task_args
     task_instance = call_function('new', task_type, use_args)
     run_task_instance(task_instance, nodes)

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -880,5 +880,9 @@ module Issues
   TASK_MISSING_BOLT = issue :TASK_MISSING_BOLT, :action do
     _("The 'bolt' library is required to %{action}") % { action: action }
   end
+
+  UNKNOWN_TASK = issue :UNKNOWN_TASK, :type_name do
+    _('Task not found: %{type_name}') % { type_name: type_name }
+  end
 end
 end

--- a/spec/unit/functions/run_task_spec.rb
+++ b/spec/unit/functions/run_task_spec.rb
@@ -180,6 +180,12 @@ describe 'the run_task function' do
           notice type($a)
         CODE
       end
+
+      it 'with non existing task - reports an unknown task error' do
+        expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/Task not found: test::nonesuch/)
+          run_task('test::nonesuch', [])
+        CODE
+      end
     end
 
   end


### PR DESCRIPTION
This commit adds a check to the run_task function so that verifies that
the loader actually finds the given task when the task is given as
a string