### PR TITLE
(maint) Disable sssd service on SUTs

### DIFF
--- a/acceptance/setup/common/pre-suite/030_StopSssd.rb
+++ b/acceptance/setup/common/pre-suite/030_StopSssd.rb
@@ -1,0 +1,9 @@
+test_name "Stop sssd" do
+  # The sssd service causes local users/groups to be cached,
+  # which can cause unexpected results when tests are trying
+  # to restore state. We ensure that it is not running to
+  # prevent such caching from occurring.
+  hosts.each do |host|
+    on(host, puppet('resource', 'service', 'sssd', 'ensure=stopped'), :accept_all_exit_codes => true)
+  end
+end

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -185,7 +185,7 @@ agents.each do |agent|
   on(agent, puppet("resource group symgroup ensure=present"))
 
   teardown do
-    on(agent, puppet("resource user symuser ensure=absent")) unless agent['platform'] =~ /fedora-2[6-9]/
+    on(agent, puppet("resource user symuser ensure=absent"))
     on(agent, puppet("resource group symgroup ensure=absent"))
   end
 


### PR DESCRIPTION
Thanks to @geoffnichols the root cause of the user/group test conflict on Fedora 26 has been identified as caching caused by the sssd service. This PR adds a pre-suite to stop the service and reverts the previous commit that skipped the user teardown on Fedora 26.