### PR TITLE
(PUP-7996) Ensure that --tasks disables the Runtime3Loader

### DIFF
--- a/lib/puppet/functions/run_task.rb
+++ b/lib/puppet/functions/run_task.rb
@@ -39,6 +39,9 @@ Puppet::Functions.create_function(:run_task) do
 
   def run_named_task(task_name, nodes, task_args = nil)
     task_type = Puppet.lookup(:loaders).private_environment_loader.load(:type, task_name)
+    if task_type.nil?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::UNKNOWN_TASK, :type_name => task_name)
+    end
     use_args = task_args.nil? ? {} : task_args
     task_instance = call_function('new', task_type, use_args)
     run_task_instance(task_instance, nodes)

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -880,5 +880,9 @@ module Issues
   TASK_MISSING_BOLT = issue :TASK_MISSING_BOLT, :action do
     _("The 'bolt' library is required to %{action}") % { action: action }
   end
+
+  UNKNOWN_TASK = issue :UNKNOWN_TASK, :type_name do
+    _('Task not found: %{type_name}') % { type_name: type_name }
+  end
 end
 end

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -74,8 +74,8 @@ class StaticLoader < Loader
   attr_reader :loaded
   def initialize
     @loaded = {}
+    @runtime_3_initialized = false
     create_built_in_types
-    create_resource_type_references
     register_aliases
   end
 
@@ -114,6 +114,14 @@ class StaticLoader < Loader
 
   def loaded_entry(typed_name, check_dependencies = false)
     @loaded[typed_name]
+  end
+
+  def runtime_3_init
+    unless @runtime_3_initialized
+      @runtime_3_initialized = true
+      create_resource_type_references
+    end
+    nil
   end
 
   private

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -348,15 +348,20 @@ class Loaders
     env_conf = Puppet.lookup(:environments).get_conf(environment.name)
     env_path = env_conf.nil? || !env_conf.is_a?(Puppet::Settings::EnvironmentConf) ? nil : env_conf.path_to_env
 
-    # Create the 3.x resource type loader
-    @runtime3_type_loader = add_loader_by_name(Loader::Runtime3TypeLoader.new(puppet_system_loader, self, environment, env_conf.nil? ? nil : env_path))
-
-    if env_path.nil?
-      # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?
-      loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, Loader::ENVIRONMENT))
+    if Puppet[:tasks]
+      loader = Loader::ModuleLoaders.environment_loader_from(puppet_system_loader, self, env_path)
     else
-      # View the environment as a module to allow loading from it - this module is always called 'environment'
-      loader = Loader::ModuleLoaders.environment_loader_from(@runtime3_type_loader, self, env_path)
+      # Create the 3.x resource type loader
+      static_loader.runtime_3_init
+      @runtime3_type_loader = add_loader_by_name(Loader::Runtime3TypeLoader.new(puppet_system_loader, self, environment, env_conf.nil? ? nil : env_path))
+
+      if env_path.nil?
+        # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?
+        loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, Loader::ENVIRONMENT))
+      else
+        # View the environment as a module to allow loading from it - this module is always called 'environment'
+        loader = Loader::ModuleLoaders.environment_loader_from(@runtime3_type_loader, self, env_path)
+      end
     end
 
     # An environment has a module path even if it has a null loader

--- a/spec/unit/functions/run_task_spec.rb
+++ b/spec/unit/functions/run_task_spec.rb
@@ -188,7 +188,6 @@ describe 'the run_task function' do
       end
 
       it 'with name of puppet runtime type - reports an unknown task error' do
-        pending 'Fix for PUP-7996'
         expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/Task not found: package/)
           run_task(package, [])
         CODE
@@ -211,8 +210,6 @@ describe 'the run_task function' do
         }
 
         it 'the call does not load init.pp' do
-          pending 'Fix for PUP-7996'
-
           executor = mock('executor')
           Bolt::Executor.expects(:from_uris).never
           executor.expects(:run_task).never

--- a/spec/unit/functions/run_task_spec.rb
+++ b/spec/unit/functions/run_task_spec.rb
@@ -186,7 +186,13 @@ describe 'the run_task function' do
           run_task('test::nonesuch', [])
         CODE
       end
-    end
 
+      it 'with name of puppet runtime type - reports an unknown task error' do
+        pending 'Fix for PUP-7996'
+        expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/Task not found: package/)
+          run_task(package, [])
+        CODE
+      end
+    end
   end
 end

--- a/spec/unit/functions/run_task_spec.rb
+++ b/spec/unit/functions/run_task_spec.rb
@@ -193,6 +193,36 @@ describe 'the run_task function' do
           run_task(package, [])
         CODE
       end
+
+      context 'on a module that contains manifests/init.pp' do
+        let(:env_dir_files) {
+          {
+            'modules' => {
+              'test' => {
+                'manifests' => {
+                  'init.pp' => 'class test ? this is not valid puppet ?'
+                },
+                'tasks' => {
+                  'echo.sh' => 'echo -n "$PT_message"',
+                }
+              }
+            }
+          }
+        }
+
+        it 'the call does not load init.pp' do
+          pending 'Fix for PUP-7996'
+
+          executor = mock('executor')
+          Bolt::Executor.expects(:from_uris).never
+          executor.expects(:run_task).never
+
+          expect(eval_and_collect_notices(<<-CODE, node)).to eql(['ok'])
+          run_task('test::echo', [])
+          notice ok
+          CODE
+        end
+      end
     end
   end
 end

--- a/spec/unit/functions/run_task_spec.rb
+++ b/spec/unit/functions/run_task_spec.rb
@@ -180,6 +180,12 @@ describe 'the run_task function' do
           notice type($a)
         CODE
       end
+
+      it 'with non existing task - reports an unknown task error' do
+        expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/Task not found: test::nonesuch/)
+          run_task('test::nonesuch', [])
+        CODE
+      end
     end
 
   end

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -3,17 +3,22 @@ require 'puppet/pops'
 require 'puppet/loaders'
 
 describe 'the static loader' do
+  let(:loader) do
+    loader = Puppet::Pops::Loader::StaticLoader.new()
+    loader.runtime_3_init
+    loader
+  end
+
   it 'has no parent' do
-    expect(Puppet::Pops::Loader::StaticLoader.new.parent).to be(nil)
+    expect(loader.parent).to be(nil)
   end
 
   it 'identifies itself in string form' do
-    expect(Puppet::Pops::Loader::StaticLoader.new.to_s).to be_eql('(StaticLoader)')
+    expect(loader.to_s).to be_eql('(StaticLoader)')
   end
 
   it 'support the Loader API' do
     # it may produce things later, this is just to test that calls work as they should - now all lookups are nil.
-    loader = Puppet::Pops::Loader::StaticLoader.new()
     a_typed_name = typed_name(:function, 'foo')
     expect(loader[a_typed_name]).to be(nil)
     expect(loader.load_typed(a_typed_name)).to be(nil)
@@ -21,8 +26,6 @@ describe 'the static loader' do
   end
 
   context 'provides access to resource types built into puppet' do
-    let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
-
     %w{
       Auegas
       Component
@@ -82,11 +85,16 @@ describe 'the static loader' do
   end
 
   context 'provides access to app-management specific resource types built into puppet' do
-
-    let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
-
     it "such that Node is available" do
       expect(loader.load(:type, 'node')).to be_the_type(resource_type('Node'))
+    end
+  end
+
+  context 'without init_runtime3 initialization' do
+    let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
+
+    it 'does not provide access to resource types built into puppet' do
+      expect(loader.load(:type, 'file')).to be_nil
     end
   end
 


### PR DESCRIPTION
This commit ensures that the `StaticLoader` doesn't add any built in
resource types and that the `Runtime3Loader` doesn't get created and
added to the chain of loaders.

The change is necessary to:
a) Prevent that the names of built in puppet types collide with task
   names.
b) Prevent that files residing under a modules 'manifests' folder are
   loaded.
