### PR TITLE
(maint) Skip autoload tests on masters

### DIFF
--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -114,6 +114,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
 
     # we should not see any log entries on any of the agent nodes
     agents.each do |agent|
+      next if agent == master
       on(agent, "cat '#{execution_log[agent_to_fqdn(agent)]}'") do |cat_result|
         assert_empty(cat_result.stdout.chomp, "Expected execution log file to be empty on agent node #{agent_to_fqdn(agent)}")
       end
@@ -122,6 +123,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
 
   empty_execution_log_file(master, execution_log[agent_to_fqdn(master)])
   agents.each do |agent|
+    next if agent == master
     empty_execution_log_file(agent, execution_log[agent_to_fqdn(agent)])
 
     # this test is relying on the beaker helper with_puppet_running_on() to restart the server


### PR DESCRIPTION
Some of the tests for autoloading resource types from generated types
ran code on masters when the master was also an agent, which caused test
failures. This commit specifically skips test steps that must only occur
on agents.