### PR TITLE
(maint) Skip autoload tests on masters

### DIFF
--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -114,6 +114,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
 
     # we should not see any log entries on any of the agent nodes
     agents.each do |agent|
+      next if agent == master
       on(agent, "cat '#{execution_log[agent_to_fqdn(agent)]}'") do |cat_result|
         assert_empty(cat_result.stdout.chomp, "Expected execution log file to be empty on agent node #{agent_to_fqdn(agent)}")
       end
@@ -122,6 +123,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
 
   empty_execution_log_file(master, execution_log[agent_to_fqdn(master)])
   agents.each do |agent|
+    next if agent == master
     empty_execution_log_file(agent, execution_log[agent_to_fqdn(agent)])
 
     # this test is relying on the beaker helper with_puppet_running_on() to restart the server


### PR DESCRIPTION
The tests for autoloading resource types from generated types made the
assumption that Puppet masters are not Puppet agents. This assumption
depends on the beaker configuration used, and in many cases a master is
also classified as an agent. In this particular test the log files for
the agents must be empty while the log files for the master must be
populated, or vice versa.

Since the existing tests already have special cases for the master, this
commit resolves the issue by excluding the master from agent tests.