### PR TITLE
(PUP-7997) Add ability to declare plan or task named after module

### DIFF
--- a/spec/unit/functions/run_plan_spec.rb
+++ b/spec/unit/functions/run_plan_spec.rb
@@ -61,6 +61,27 @@ describe 'the run_plan function' do
       end
     end
 
+    context 'using the name of the module' do
+      let(:env_dir_files) {
+        {
+          'modules' => {
+            'test' => {
+              'plans' => {
+                'init.pp' => 'plan test() { "worked3" }'
+              }
+            }
+          }
+        }
+      }
+
+      it 'the plans/init.pp is found and called' do
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(['worked3'])
+            $a = run_plan('test')
+            notice $a
+        CODE
+      end
+    end
+
     context 'handles exceptions by' do
       it 'failing with error for non-existent plan name' do
         expect { compile_to_catalog(<<-CODE) }.to raise_error(Puppet::Error, /Unknown plan/)

--- a/spec/unit/functions/run_task_spec.rb
+++ b/spec/unit/functions/run_task_spec.rb
@@ -220,6 +220,33 @@ describe 'the run_task function' do
           CODE
         end
       end
+
+      context 'on a module that contains tasks/init.sh' do
+        let(:env_dir_files) {
+          {
+            'modules' => {
+              'test' => {
+                'tasks' => {
+                  'init.sh' => 'echo -n "$PT_message"',
+                }
+              }
+            }
+          }
+        }
+
+        it 'finds task named after the module' do
+          executor = mock('executor')
+          executable = File.join(env_dir, 'modules/test/tasks/init.sh')
+
+          Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
+          executor.expects(:run_task).with(executable, 'both', {}).returns({ host => result })
+
+          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+          $a = run_task('test', "#{hostname}")
+          notice $a
+          CODE
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This commit will make the loader search for files named 'init' (with
appropriate extensions) under the 'plans' and 'tasks' directory. If such
a file is found, it's assumed to contain a plan or task that has the
same name as the module that contained the 'plans' or 'tasks' directory.