### PR TITLE
(PUP-7987) Add ability to set variables in Pal API

### DIFF
--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -82,7 +82,8 @@ module Puppet::Pal
   def self.in_tmp_environment(env_name,
       modulepath:    [],
       settings_hash: {},
-      facts: nil,
+      facts:         nil,
+      variables:     {},
       &block
     )
     assert_non_empty_string(env_name, _("temporary environment name"))
@@ -94,9 +95,10 @@ module Puppet::Pal
     end
 
     env = Puppet::Node::Environment.create(env_name, modulepath)
+
     with_loaded_environment(
       Puppet::Environments::Static.new(env), # The tmp env is the only known env
-      env, facts, &block)
+      env, facts, variables, &block)
   end
 
   # Defines the context in which to perform puppet operations (evaluation, etc)
@@ -124,8 +126,9 @@ module Puppet::Pal
       modulepath:    nil,
       settings_hash: {},
       env_dir:       nil,
-      envpath:      nil,
-      facts: nil,
+      envpath:       nil,
+      facts:         nil,
+      variables:     {},
       &block
     )
     # TRANSLATORS terms in the assertions below are names of terms in code
@@ -168,12 +171,12 @@ module Puppet::Pal
       # A given modulepath should override the default
       env = env.override_with(:modulepath => modulepath) if !modulepath.nil?
     end
-    with_loaded_environment(environments, env, facts, &block)
+    with_loaded_environment(environments, env, facts, variables, &block)
   end
 
   private
 
-  def self.with_loaded_environment(environments, env, facts, &block)
+  def self.with_loaded_environment(environments, env, facts, variables, &block)
     env.each_plugin_directory do |dir|
       $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
     end
@@ -186,7 +189,8 @@ module Puppet::Pal
 
     Puppet.override(
       environments: environments,        # The env being used is the only one...
-      current_node: node                 # to allow it to be picked up instead of created
+      current_node: node,                # to allow it to be picked up instead of created
+      variables: variables
     ) do
       prepare_node_facts(node, facts)
       return block.call(self)
@@ -207,6 +211,15 @@ module Puppet::Pal
       #
       node.add_server_facts({})
     end
+  end
+
+  def self.add_variables(scope, variables)
+    return if variables.nil?
+    unless variables.is_a?(Hash)
+      raise Argument_Error, _("Given variables must be a hash, got %{type}") % { type: variables.class }
+    end
+    return if variables.empty?
+    variables.each_pair {|k,v| scope.setvar(k, v) }
   end
 
   def self.main(manifest = nil, facts = nil, &block)
@@ -252,6 +265,8 @@ module Puppet::Pal
 
           # create the $settings:: variables
           topscope.merge_settings(node.environment.name, false)
+
+          add_variables(topscope, Puppet.lookup(:variables))
 
           compiler.compile(&block)
 

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -218,7 +218,6 @@ module Puppet::Pal
     unless variables.is_a?(Hash)
       raise ArgumentError, _("Given variables must be a hash, got %{type}") % { type: variables.class }
     end
-    return if variables.empty?
 
     rich_data_t = Puppet::Pops::Types::TypeFactory.rich_data
     variables.each_pair do |k,v|

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -85,6 +85,26 @@ describe 'Puppet Pal' do
       expect(result).to eq(40)
     end
 
+    it 'errors if variable name is not compliant with variable name rule' do
+      vars = {'_a::b'=> 10}
+      expect do
+        Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts, variables: vars) do |ctx|
+          manifest = file_containing('testing.pp', "ok")
+          ctx.evaluate_script_manifest(manifest)
+        end
+      end.to raise_error(/has illegal name/)
+    end
+
+    it 'errors if variable value is not RichData compliant' do
+      vars = {'a'=> ArgumentError.new("not rich data")}
+      expect do
+        Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts, variables: vars) do |ctx|
+          manifest = file_containing('testing.pp', "$a")
+          ctx.evaluate_script_manifest(manifest)
+        end
+      end.to raise_error(/has illegal type - got: ArgumentError/)
+    end
+
     it 'can call a plan using call_plan and specify content in a manifest' do
       result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
         manifest = file_containing('aplan.pp', "plan myplan() { 'brilliant' }")
@@ -92,7 +112,6 @@ describe 'Puppet Pal' do
       end
       expect(result).to eq('brilliant')
     end
-
   end
 
   context 'with code in modules and env' do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -76,6 +76,15 @@ describe 'Puppet Pal' do
       expect(result).to eq(10)
     end
 
+    it 'can set variables in any scope' do
+      vars = {'a'=> 10, 'x::y' => 20}
+      result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts, variables: vars) do |ctx|
+        manifest = file_containing('testing.pp', "1+2+3+4+$a+$x::y")
+        ctx.evaluate_script_manifest(manifest)
+      end
+      expect(result).to eq(40)
+    end
+
     it 'can call a plan using call_plan and specify content in a manifest' do
       result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
         manifest = file_containing('aplan.pp', "plan myplan() { 'brilliant' }")
@@ -341,6 +350,15 @@ describe 'Puppet Pal' do
           ctx.evaluate_script_string('run_plan("a::aplan")')
         end
         expect(result).to eq("a::aplan value")
+      end
+
+      it 'can set variables in any scope' do
+        vars = {'a'=> 10, 'x::y' => 20}
+        result = Puppet::Pal.in_environment('pal_env', env_dir: testing_env_dir, facts: node_facts, variables: vars) do |ctx|
+          manifest = file_containing('testing.pp', "1+2+3+4+$a+$x::y")
+          ctx.evaluate_script_manifest(manifest)
+        end
+        expect(result).to eq(40)
       end
 
       it 'errors in a meaningful way when a non existing env name is given' do


### PR DESCRIPTION
This makes it possible to set variables in any scope/name-space when
defining the environment to run in.