### PR TITLE
(PUP-8009) Disable gettext

### DIFF
--- a/acceptance/tests/i18n/check_puppet_run_message.rb
+++ b/acceptance/tests/i18n/check_puppet_run_message.rb
@@ -5,6 +5,8 @@ test_name 'C100559: puppet agent run output with a supported language should be 
   confine :except, :platform => /^solaris/ # translation not supported
   confine :except, :platform => /^aix/     # QENG-5283 needed for this to work
 
+  pending 'PUP-8009'
+
   tag 'audit:medium',
       'audit:acceptance'
 

--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -114,6 +114,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
 
     # we should not see any log entries on any of the agent nodes
     agents.each do |agent|
+      next if agent == master
       on(agent, "cat '#{execution_log[agent_to_fqdn(agent)]}'") do |cat_result|
         assert_empty(cat_result.stdout.chomp, "Expected execution log file to be empty on agent node #{agent_to_fqdn(agent)}")
       end
@@ -122,6 +123,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
 
   empty_execution_log_file(master, execution_log[agent_to_fqdn(master)])
   agents.each do |agent|
+    next if agent == master
     empty_execution_log_file(agent, execution_log[agent_to_fqdn(agent)])
 
     # this test is relying on the beaker helper with_puppet_running_on() to restart the server

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -35,36 +35,7 @@ module Puppet::GettextConfig
   # @param file_format [Symbol] translation file format to use, either :po or :mo
   # @return true if initialization succeeded, false otherwise
   def self.initialize(conf_file_location, file_format)
-    unless file_format == :po || file_format == :mo
-      raise Puppet::Error, "Unsupported translation file format #{file_format}; please use :po or :mo"
-    end
-
-    begin
-      require 'gettext-setup'
-      require 'locale'
-
-      if conf_file_location && File.exists?(conf_file_location)
-        if GettextSetup.method(:initialize).parameters.count == 1
-          # For use with old gettext-setup gem versions, will load PO files only
-          GettextSetup.initialize(conf_file_location)
-        else
-          GettextSetup.initialize(conf_file_location, :file_format => file_format)
-        end
-        # Only change this once.
-        # Because negotiate_locales will only return a non-default locale if
-        # the system locale matches a translation set actually available for the
-        # given gettext project, we don't want this to get set back to default if
-        # we load a module that doesn't have translations, but Puppet does have
-        # translations for the user's locale.
-        if FastGettext.locale == GettextSetup.default_locale
-          FastGettext.locale = GettextSetup.negotiate_locale(Locale.current.language)
-        end
-        true
-      else
-        false
-      end
-    rescue LoadError
-      false
-    end
+    # Bypass gettext until we can resolve a performance regression related to it, PUP-8009.
+    return false
   end
 end

--- a/spec/unit/gettext_config_spec.rb
+++ b/spec/unit/gettext_config_spec.rb
@@ -44,12 +44,14 @@ describe Puppet::GettextConfig do
 
     context 'when given a valid config file location' do
       it 'should return true' do
+        pending 'PUP-8009'
         expect(Puppet::GettextConfig.initialize(local_path, :po)).to be true
       end
     end
 
     context 'when given a bad file format' do
       it 'should raise an exception' do
+        pending 'PUP-8009'
         expect { Puppet::GettextConfig.initialize(local_path, :bad_format) }.to raise_error(Puppet::Error)
       end
     end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -452,6 +452,7 @@ describe Puppet::Module do
     let(:mod_obj) { PuppetSpec::Modules.create( modname, modpath, :metadata => { :dependencies => [] }, :env => env ) }
 
     it "is expected to initialize an un-initialized module" do
+      pending 'PUP-8009'
       expect(GettextSetup.translation_repositories.has_key? modname).to be false
 
       FileUtils.mkdir_p("#{mod_obj.path}/locales")


### PR DESCRIPTION
A significant (~30%) performance regression was found when gettext is
enabled. Until we can resolve it, disable gettext with a fix we've
tested. The root cause isn't clear, but appears to be that we configure
gettext too often.