### PR TITLE
(PUP-7988) Add stop sssd pre-suite to aio testing

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -6,6 +6,7 @@
     'setup/aio/pre-suite/020_InstallCumulusModules.rb',
     'setup/aio/pre-suite/021_InstallAristaModule.rb',
     'setup/common/pre-suite/025_StopFirewall.rb',
+    'setup/common/pre-suite/030_StopSssd.rb',
     'setup/common/pre-suite/040_ValidateSignCert.rb',
     'setup/aio/pre-suite/045_EnsureMasterStarted.rb',
   ],


### PR DESCRIPTION
This commit adds the beaker pre-suite to ensure that the `sssd`
service is stopped to the options for the `ci:test:aio` rake task.