### PR TITLE
(PUP-8009 & PUP-7769) Optimize gettext initialization and add settings toggle

### DIFF
--- a/acceptance/tests/i18n/check_puppet_run_message.rb
+++ b/acceptance/tests/i18n/check_puppet_run_message.rb
@@ -5,8 +5,6 @@ test_name 'C100559: puppet agent run output with a supported language should be 
   confine :except, :platform => /^solaris/ # translation not supported
   confine :except, :platform => /^aix/     # QENG-5283 needed for this to work
 
-  pending_test 'PUP-8009'
-
   tag 'audit:medium',
       'audit:acceptance'
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -126,6 +126,19 @@ module Puppet
         munge(value)
         value.to_sym
       end
+    },
+    :disable_i18n => {
+      :default => false,
+      :type    => :boolean,
+      :desc    => "If true, turns off all translations of Puppet and module
+        log messages, which affects error, warning, and info log messages,
+        as well as any translations in the report and CLI.",
+      :hook    => proc do |value|
+        if value
+          require 'puppet/gettext/stubs'
+          Puppet::GettextConfig.disable_gettext
+        end
+      end
     }
   )
 

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -98,7 +98,7 @@ class Puppet::Module
     @absolute_path_to_manifests = Puppet::FileSystem::PathPattern.absolute(manifests)
 
     # i18n initialization for modules
-    initialize_i18n
+    initialize_i18n unless Puppet[:disable_i18n]
   end
 
   # @deprecated The puppetversion module metadata field is no longer used.
@@ -430,11 +430,10 @@ class Puppet::Module
 
     if Puppet::GettextConfig.initialize(locales_path, :po)
       Puppet.debug "#{module_name} initialized for i18n: #{GettextSetup.translation_repositories[module_name]}"
-    else
-      if Puppet::GettextConfig.gettext_found?
+    else if Puppet::GettextConfig.gettext_loaded?
         config_path = File.absolute_path('config.yaml', locales_path)
         Puppet.debug "Could not find locales configuration file for #{module_name} at #{config_path}. Skipping i18n initialization."
-      else
+    else
         Puppet.debug "No gettext library found, skipping i18n initialization."
       end
     end
@@ -443,7 +442,7 @@ class Puppet::Module
   private
 
   def i18n_initialized?(module_name)
-    if Puppet::GettextConfig.gettext_found?
+    if Puppet::GettextConfig.gettext_loaded?
       GettextSetup.translation_repositories.has_key? module_name
     else
       # GettextSetup not yet initialized or not found

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -428,22 +428,25 @@ class Puppet::Module
 
     locales_path = File.absolute_path('locales', path)
 
-    begin
-      Puppet::GettextConfig.initialize(locales_path, :po)
+    if Puppet::GettextConfig.initialize(locales_path, :po)
       Puppet.debug "#{module_name} initialized for i18n: #{GettextSetup.translation_repositories[module_name]}"
-    rescue
-      config_path = File.absolute_path('config.yaml', locales_path)
-      Puppet.debug "Could not find locales configuration file for #{module_name} at #{config_path}. Skipping i18n initialization."
+    else
+      if Puppet::GettextConfig.gettext_found?
+        config_path = File.absolute_path('config.yaml', locales_path)
+        Puppet.debug "Could not find locales configuration file for #{module_name} at #{config_path}. Skipping i18n initialization."
+      else
+        Puppet.debug "No gettext library found, skipping i18n initialization."
+      end
     end
   end
 
   private
 
   def i18n_initialized?(module_name)
-    begin
+    if Puppet::GettextConfig.gettext_found?
       GettextSetup.translation_repositories.has_key? module_name
-    rescue NameError
-      # GettextSetup not yet initialized
+    else
+      # GettextSetup not yet initialized or not found
       false
     end
   end

--- a/spec/unit/gettext_config_spec.rb
+++ b/spec/unit/gettext_config_spec.rb
@@ -44,14 +44,12 @@ describe Puppet::GettextConfig do
 
     context 'when given a valid config file location' do
       it 'should return true' do
-        pending 'PUP-8009'
         expect(Puppet::GettextConfig.initialize(local_path, :po)).to be true
       end
     end
 
     context 'when given a bad file format' do
       it 'should raise an exception' do
-        pending 'PUP-8009'
         expect { Puppet::GettextConfig.initialize(local_path, :bad_format) }.to raise_error(Puppet::Error)
       end
     end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -452,7 +452,6 @@ describe Puppet::Module do
     let(:mod_obj) { PuppetSpec::Modules.create( modname, modpath, :metadata => { :dependencies => [] }, :env => env ) }
 
     it "is expected to initialize an un-initialized module" do
-      pending 'PUP-8009'
       expect(GettextSetup.translation_repositories.has_key? modname).to be false
 
       FileUtils.mkdir_p("#{mod_obj.path}/locales")

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -225,7 +225,10 @@ describe Puppet::Module do
         mod_dir = "#{@modpath}/#{mod_name}"
         metadata_file = "#{mod_dir}/metadata.json"
         tasks_dir = "#{mod_dir}/tasks"
+        locales_dir = "#{mod_dir}/locales"
         Puppet::FileSystem.stubs(:exist?).with(metadata_file).returns true
+        # Skip checking for translation config file
+        Puppet::FileSystem.stubs(:exist?).with(locales_dir).returns false
       end
       mod = PuppetSpec::Modules.create(
         'test_gte_req',
@@ -448,19 +451,21 @@ describe Puppet::Module do
     let(:modpath) { tmpdir('modpath') }
     let(:modname) { 'puppetlabs-i18n'}
     let(:modroot) { "#{modpath}/#{modname}/" }
-    let(:config_path) { "#{modroot}/locales/config.yaml" }
+    let(:locale_dir) { "#{modroot}locales" }
+    let(:config_path) { "#{locale_dir}/config.yaml" }
     let(:mod_obj) { PuppetSpec::Modules.create( modname, modpath, :metadata => { :dependencies => [] }, :env => env ) }
 
     it "is expected to initialize an un-initialized module" do
       expect(GettextSetup.translation_repositories.has_key? modname).to be false
 
-      FileUtils.mkdir_p("#{mod_obj.path}/locales")
+      FileUtils.mkdir_p(locale_dir)
       config = {
         "gettext" => {
           "project_name" => modname
         }
       }
       File.open(config_path, 'w') { |file| file.write(config.to_yaml) }
+      Puppet::FileSystem.stubs(:exist?).with(locale_dir).returns(true)
 
       mod_obj.initialize_i18n
 


### PR DESCRIPTION
A recent refactor of the gettext initialization code caused the require
for gettext-setup and locale to be called repeatedly during module
loading. This commit updates the gettext configuration module to only
require those gems once, and prevent unnecessary searching of the load
path.

This PR also adds a setting that allows gettext to be disabled entirely.