### PR TITLE
(PUP-8009) Avoid throwing an exception when gettext config is missing

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -57,19 +57,22 @@ module Puppet::GettextConfig
   # @param path [String] to gettext config file
   # @param file_format [Symbol] translation file format to use, either :po or :mo
   # @return true if initialization succeeded, false otherwise
-  def self.initialize(conf_file_location, file_format)
+  def self.initialize(conf_file_dir, file_format)
     return false if @gettext_disabled || !@gettext_loaded
 
     unless file_format == :po || file_format == :mo
       raise Puppet::Error, "Unsupported translation file format #{file_format}; please use :po or :mo"
     end
 
-    if conf_file_location && Puppet::FileSystem.exist?(conf_file_location)
+    return false if conf_file_dir.nil?
+
+    conf_file = File.join(conf_file_dir, "config.yaml")
+    if Puppet::FileSystem.exist?(conf_file)
       if GettextSetup.method(:initialize).parameters.count == 1
         # For use with old gettext-setup gem versions, will load PO files only
-        GettextSetup.initialize(conf_file_location)
+        GettextSetup.initialize(conf_file_dir)
       else
-        GettextSetup.initialize(conf_file_location, :file_format => file_format)
+        GettextSetup.initialize(conf_file_dir, :file_format => file_format)
       end
       # Only change this once.
       # Because negotiate_locales will only return a non-default locale if

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -225,10 +225,10 @@ describe Puppet::Module do
         mod_dir = "#{@modpath}/#{mod_name}"
         metadata_file = "#{mod_dir}/metadata.json"
         tasks_dir = "#{mod_dir}/tasks"
-        locales_dir = "#{mod_dir}/locales"
+        locale_config = "#{mod_dir}/locales/config.yaml"
         Puppet::FileSystem.stubs(:exist?).with(metadata_file).returns true
         # Skip checking for translation config file
-        Puppet::FileSystem.stubs(:exist?).with(locales_dir).returns false
+        Puppet::FileSystem.stubs(:exist?).with(locale_config).returns false
       end
       mod = PuppetSpec::Modules.create(
         'test_gte_req',
@@ -465,7 +465,7 @@ describe Puppet::Module do
         }
       }
       File.open(config_path, 'w') { |file| file.write(config.to_yaml) }
-      Puppet::FileSystem.stubs(:exist?).with(locale_dir).returns(true)
+      Puppet::FileSystem.stubs(:exist?).with(config_path).returns(true)
 
       mod_obj.initialize_i18n
 


### PR DESCRIPTION
This commit updates the file existence check in the gettext config
module to check for the config.yaml file itself, rather than its
containing directory. This should avoid an exception in GettextSetup
when that file is missing.