### PR TITLE
(PUP-7951) correct size comparison in filebucket

### DIFF
--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -218,7 +218,7 @@ module Puppet::FileBucketFile
     #   and content as that in the bucket_file
     # @api private
     def verify_identical_file(contents_file, bucket_file)
-      (bucket_file.size == Puppet::FileSystem.size(contents_file)) &&
+      (bucket_file.to_binary.bytesize == Puppet::FileSystem.size(contents_file)) &&
         (bucket_file.stream() {|s| Puppet::FileSystem.compare_stream(contents_file, s) })
     end
 

--- a/spec/integration/file_bucket/file_spec.rb
+++ b/spec/integration/file_bucket/file_spec.rb
@@ -43,12 +43,27 @@ describe Puppet::FileBucket::File do
   end
 
   describe "saving binary files" do
-    let(:binary) { "\xD1\xF2\r\n\x81NuSc\x00".force_encoding(Encoding::ASCII_8BIT) }
+    context "given multiple backups of identical files" do
+      it "does not error given content with binary external encoding" do
+        binary = "\xD1\xF2\r\n\x81NuSc\x00".force_encoding(Encoding::ASCII_8BIT)
+        bucket_file = Puppet::FileBucket::File.new(binary)
+        Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
+        Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
+      end
 
-    it "does not error when the same contents are saved twice" do
-      bucket_file = Puppet::FileBucket::File.new(binary)
-      Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
-      Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
+      it "also does not error if the content is reported with UTF-8 external encoding" do
+        # PUP-7951 - ensure accurate size comparison across encodings If binary
+        # content arrives as a string with UTF-8 default external encoding, its
+        # character count might be different than the same bytes with binary
+        # external encoding. Ensure our equality comparison does not fail due to this.
+        # As would be the case with our friend snowman:
+        # Unicode snowman \u2603 - \xE2 \x98 \x83
+        # character size 1, if interpreted as UTF-8, 3 "characters" if interpreted as binary
+        utf8 = "\u2603".force_encoding(Encoding::UTF_8)
+        bucket_file = Puppet::FileBucket::File.new(utf8)
+        Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
+        Puppet::FileBucket::File.indirection.save(bucket_file, bucket_file.name)
+      end
     end
   end
 end


### PR DESCRIPTION
Puppet::Indirector::FileBucketFile::File#verify_identical_file is used to
validate that an incoming file to back up is identical to an existing backup we
believe to matches it. As a part of this comparison, we attempt to compare the
size of the content of the incoming IO object to the size of the existing
backup on disk, before doing a more resource-intensive byte-by-byte comparison.

Prior to this commit, we would call Puppet::FileBucket::File#size on the
incoming object, and compare it to the Puppet::FileSystem#size of the existing
backup. The former can actually call String#size or Puppet::FileSystem#size, as
the contents of a Puppet::FileBucket::File are represented either as a
StringContents or FileContents depending on the class of content supplied at
initialization. The latter is fine, but the former falls prey to inaccurate
comparison due to mismatched encoding.

Because we never explicitly force the external encoding on the incoming string
when initialize the StringContents or access it thereafter, it's possible for
it to be interpreted with a default external encoding of UTF-8. This is fine,
because we only care about reading/writing/comparing files on disk and whenever
we read or write the content on disk, it's treated explicitly as binary.
However, the ruby String#size method we use for the in-memory side of the size
comparison returns the *number of characters* in a string, and a string with a
variable-byte encoding like UTF-8 can be interpreted as have a different number
of characters than a BINARY encoded string, or a UTF-16 string, even if they
all have identical byte contents.

Rather than using #size, this commit updates the comparison to use
String#bytesize for the left side (incoming bucket file object in memory). To
get the string value, we first call #to_binary, which for the StringContents
object just returns a reference to the @contents object.  This is safe to call
on the FileContents implementation as well, as #to_binary there delegates to
Puppet::FileSystem#binread, which returns a string object.  On the other side
of the comparison (existing backup on disk), we're guaranteed correct units,
because Puppet::FileSystem#size calls ruby Pathname#size under the hood - which
returns the `st_size` field of the struct returned by the unix stat() function.
According to the man pages, this field is the "Total size, in bytes" of the
file[1].

[1] http://man7.org/linux/man-pages/man2/stat.2.html

Signed-off-by: Moses Mendoza <moses@puppet.com>