### PR TITLE
(PUP-8010) Add iterable features to the ExecutionResult data type

### DIFF
--- a/lib/puppet/functions/all.rb
+++ b/lib/puppet/functions/all.rb
@@ -94,7 +94,11 @@ Puppet::Functions.create_function(:all) do
 
   def all_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    enum.each_with_index { |e, i| return false unless yield(i, e) }
-    true
+    if enum.hash_style?
+      enum.all? { |entry| yield(*entry) }
+    else
+      enum.each_with_index { |e, i| return false unless yield(i, e) }
+      true
+    end
   end
 end

--- a/lib/puppet/functions/any.rb
+++ b/lib/puppet/functions/any.rb
@@ -99,7 +99,11 @@ Puppet::Functions.create_function(:any) do
 
   def any_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    enum.each_with_index { |e, i| return true if yield(i, e) }
-    false
+    if enum.hash_style?
+      enum.any? { |entry| yield(*entry) }
+    else
+      enum.each_with_index { |e, i| return true if yield(i, e) }
+      false
+    end
   end
 end

--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -145,13 +145,17 @@ Puppet::Functions.create_function(:each) do
 
   def foreach_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    index = 0
-    begin
-      loop do
-        yield(index, enum.next)
-        index += 1
+    if enum.hash_style?
+      enum.each { |entry| yield(*entry) }
+    else
+      begin
+        index = 0
+        loop do
+          yield(index, enum.next)
+          index += 1
+        end
+      rescue StopIteration
       end
-    rescue StopIteration
     end
     # produces the receiver
     enumerable

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -119,19 +119,25 @@ Puppet::Functions.create_function(:filter) do
   end
 
   def filter_Enumerable_2(enumerable)
-    result = []
-    index = 0
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    begin
-      loop do
-        it = enum.next
-        if yield(index, it) == true
-          result << it
+    if enum.hash_style?
+      result = {}
+      enum.each { |k, v| result[k] = v if yield(k, v) == true }
+      result
+    else
+      result = []
+      begin
+        index = 0
+        loop do
+          it = enum.next
+          if yield(index, it) == true
+            result << it
+          end
+          index += 1
         end
-        index += 1
+      rescue StopIteration
       end
-    rescue StopIteration
+      result
     end
-    result
   end
 end

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -107,16 +107,20 @@ Puppet::Functions.create_function(:map) do
   end
 
   def map_Enumerable_2(enumerable)
-    result = []
-    index = 0
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    begin
-      loop do
-        result << yield(index, enum.next)
-        index = index +1
+    if enum.hash_style?
+      enum.map { |entry| yield(*entry) }
+    else
+      result = []
+      begin
+        index = 0
+        loop do
+          result << yield(index, enum.next)
+          index = index +1
+        end
+      rescue StopIteration
       end
-    rescue StopIteration
+      result
     end
-    result
   end
 end

--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -2,6 +2,8 @@ module Puppet::Pops
 module Types
   class ExecutionResult
     include PuppetObject
+    include Iterable
+    include IteratorProducer
 
     TYPE_RESULT_HASH = TypeFactory.hash_kv(PStringType::NON_EMPTY, TypeFactory.struct({
       TypeFactory.optional('value') => TypeFactory.data,
@@ -52,7 +54,11 @@ module Types
     def error_nodes
       result = {}
       @result_hash.each_pair { |k, v| result[k] = v if v.is_a?(PErrorType::Error) }
-      return self.class.new(result)
+      self.class.new(result)
+    end
+
+    def iterator
+      Iterable.on(@result_hash)
     end
 
     def names

--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -41,11 +41,11 @@ module Types
     end
 
     def count
-      return @result_hash.size
+      @result_hash.size
     end
 
     def empty
-      return @result_hash.empty?
+      @result_hash.empty?
     end
     alias_method :empty?, :empty
 
@@ -56,7 +56,7 @@ module Types
     end
 
     def names
-      return @result_hash.keys
+      @result_hash.keys
     end
 
     def ok
@@ -67,19 +67,19 @@ module Types
     def ok_nodes
       result = {}
       @result_hash.each_pair { |k, v| result[k] = v unless v.is_a?(PErrorType::Error) }
-      return self.class.new(result)
+      self.class.new(result)
     end
 
     def value(node_uri)
-      return @result_hash[node_uri]
+      @result_hash[node_uri]
     end
 
     def values
-      return @result_hash.values
+      @result_hash.values
     end
 
     def _pcore_init_hash
-      return @result_hash
+      @result_hash
     end
 
     private

--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -8,7 +8,7 @@ module Types
     TYPE_RESULT_HASH = TypeFactory.hash_kv(PStringType::NON_EMPTY, TypeFactory.struct({
       TypeFactory.optional('value') => TypeFactory.data,
       TypeFactory.optional('error') => TypeFactory.struct({
-        'message' => PStringType::NON_EMPTY,
+        'msg' => PStringType::NON_EMPTY,
         TypeFactory.optional('kind') => PStringType::NON_EMPTY,
         TypeFactory.optional('issue_code') => PStringType::NON_EMPTY,
         TypeFactory.optional('details') => TypeFactory.hash_of_data,
@@ -103,7 +103,7 @@ module Types
       if error.nil?
         value
       else
-        PErrorType::Error.new(error['message'], error['kind'], error['issue_code'] || PErrorType::DEFAULT_ISSUE_CODE, value, error['details'])
+        PErrorType::Error.new(error['msg'], error['kind'], error['issue_code'] || PErrorType::DEFAULT_ISSUE_CODE, value, error['details'])
       end
     end
   end

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -59,10 +59,10 @@ module Puppet::Pops::Types
       when Hash
         # Each element is a two element [key, value] tuple.
         if o.empty?
-          Iterator.new(PHashType::DEFAULT_KEY_PAIR_TUPLE, o.each)
+          HashIterator.new(PHashType::DEFAULT_KEY_PAIR_TUPLE, o.each)
         else
           tc = TypeCalculator.singleton
-          Iterator.new(PTupleType.new([
+          HashIterator.new(PTupleType.new([
             PVariantType.maybe_create(o.keys.map {|e| tc.infer_set(e) }),
             PVariantType.maybe_create(o.values.map {|e| tc.infer_set(e) })], PHashType::KEY_PAIR_TUPLE_SIZE), o.each_pair)
         end
@@ -146,6 +146,10 @@ module Puppet::Pops::Types
       super
     end
 
+    def hash_style?
+      false
+    end
+
     def unbounded?
       true
     end
@@ -215,6 +219,14 @@ module Puppet::Pops::Types
 
     def unbounded?
       Iterable.unbounded?(@enumeration)
+    end
+  end
+
+  # Special iterator used when iterating over hashes. Returns `true` for `#hash_style?` so that
+  # it is possible to differentiate between two element arrays and key => value associations
+  class HashIterator < Iterator
+    def hash_style?
+      true
     end
   end
 

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -1,4 +1,12 @@
 module Puppet::Pops::Types
+
+  # Implemented by classes that can produce an iterator to iterate over their contents
+  module IteratorProducer
+    def iterator
+      raise ArgumentError, 'iterator() is not implemented'
+    end
+  end
+
   # The runtime Iterable type for an Iterable
   module Iterable
     # Produces an `Iterable` for one of the following types with the following characterstics:
@@ -45,6 +53,8 @@ module Puppet::Pops::Types
     # @api public
     def self.on(o)
       case o
+      when IteratorProducer
+        o.iterator
       when Iterable
         o
       when String

--- a/spec/unit/pops/types/execution_result_spec.rb
+++ b/spec/unit/pops/types/execution_result_spec.rb
@@ -56,7 +56,7 @@ describe 'ExecutionResult' do
 
       it 'can be created with an error' do
         code = <<-CODE
-            $o = ExecutionResult('example.com' => {error => { 'message' => 'nope', 'issue_code' => 'BAD'}})
+            $o = ExecutionResult('example.com' => {error => { 'msg' => 'nope', 'issue_code' => 'BAD'}})
             notice($o)
             notice($o.empty)
             notice($o.ok)
@@ -80,7 +80,7 @@ describe 'ExecutionResult' do
 
       it 'can be created with an error and a partial result' do
         code = <<-CODE
-            $o = ExecutionResult('example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'})
+            $o = ExecutionResult('example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'})
             notice($o)
         CODE
         expect(eval_and_collect_notices(code)).to eq([
@@ -91,7 +91,7 @@ describe 'ExecutionResult' do
       it 'can be created with an errors and ok values' do
         code = <<-CODE
             $o = ExecutionResult(
-              'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+              'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
               'beta.example.com' => {value => 'total success'})
             notice($o)
             notice($o.empty)
@@ -121,8 +121,8 @@ describe 'ExecutionResult' do
           it 'can do #all' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.all |$e| { $e[1] =~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['true'])
@@ -131,8 +131,8 @@ describe 'ExecutionResult' do
           it 'can do #any' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.any |$e| { $e[1] !~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['false'])
@@ -141,7 +141,7 @@ describe 'ExecutionResult' do
           it 'can do #each' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                   'beta.example.com' => {value => 'total success'})
                 $o.each |$e| { notice("Node ${e[0]} returned ${e[1]}") }
             CODE
@@ -154,7 +154,7 @@ describe 'ExecutionResult' do
           it 'can do #filter' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               $o.filter |$e| { $e[0] =~ /^beta/ }.each |$e| { notice($e[1]) }
             CODE
@@ -166,7 +166,7 @@ describe 'ExecutionResult' do
           it 'can do #map' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               notice($o.map |$e| { $e[1] })
             CODE
@@ -180,8 +180,8 @@ describe 'ExecutionResult' do
           it 'can do #all' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.all |$k, $v| { $v =~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['true'])
@@ -190,8 +190,8 @@ describe 'ExecutionResult' do
           it 'can do #any' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.any |$k, $v| { $v !~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['false'])
@@ -200,7 +200,7 @@ describe 'ExecutionResult' do
           it 'can do #each' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                   'beta.example.com' => {value => 'total success'})
                 $o.each |$k, $v| { notice("Node $k returned $v") }
             CODE
@@ -213,7 +213,7 @@ describe 'ExecutionResult' do
           it 'can do #filter' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               $o.filter |$k, $v| { $k =~ /^beta/ }.each |$k, $v| { notice($v) }
             CODE
@@ -225,7 +225,7 @@ describe 'ExecutionResult' do
           it 'can do #map' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               notice($o.map |$k, $v| { $v })
             CODE


### PR DESCRIPTION
This PR contains a series of commits to enable:
1. Hash-like iterable features for non Hash objects
2. A new API to be used by classes that want to present themselves as `Iterable`
3. Iterable features on the `ExecutionResult` object.