### PR TITLE
(PUP-8011) Make all functions that call Bolt return an ExecutionResult

### DIFF
--- a/lib/puppet/functions/all.rb
+++ b/lib/puppet/functions/all.rb
@@ -94,7 +94,11 @@ Puppet::Functions.create_function(:all) do
 
   def all_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    enum.each_with_index { |e, i| return false unless yield(i, e) }
-    true
+    if enum.hash_style?
+      enum.all? { |entry| yield(*entry) }
+    else
+      enum.each_with_index { |e, i| return false unless yield(i, e) }
+      true
+    end
   end
 end

--- a/lib/puppet/functions/any.rb
+++ b/lib/puppet/functions/any.rb
@@ -99,7 +99,11 @@ Puppet::Functions.create_function(:any) do
 
   def any_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    enum.each_with_index { |e, i| return true if yield(i, e) }
-    false
+    if enum.hash_style?
+      enum.any? { |entry| yield(*entry) }
+    else
+      enum.each_with_index { |e, i| return true if yield(i, e) }
+      false
+    end
   end
 end

--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -145,13 +145,17 @@ Puppet::Functions.create_function(:each) do
 
   def foreach_Enumerable_2(enumerable)
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    index = 0
-    begin
-      loop do
-        yield(index, enum.next)
-        index += 1
+    if enum.hash_style?
+      enum.each { |entry| yield(*entry) }
+    else
+      begin
+        index = 0
+        loop do
+          yield(index, enum.next)
+          index += 1
+        end
+      rescue StopIteration
       end
-    rescue StopIteration
     end
     # produces the receiver
     enumerable

--- a/lib/puppet/functions/file_upload.rb
+++ b/lib/puppet/functions/file_upload.rb
@@ -40,11 +40,9 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
     hosts = nodes.flatten
     if hosts.empty?
       call_function('debug', "Simulating file upload of '#{found}' - no hosts given - no action taken")
-      []
+      Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
     else
-      Bolt::Executor.from_uris(hosts).file_upload(found, destination).map do |_, result|
-        result.success? ? result.output_string : result.exit_code
-      end
+      Puppet::Pops::Types::ExecutionResult.from_bolt(Bolt::Executor.from_uris(hosts).file_upload(found, destination))
     end
   end
 end

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -119,19 +119,25 @@ Puppet::Functions.create_function(:filter) do
   end
 
   def filter_Enumerable_2(enumerable)
-    result = []
-    index = 0
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    begin
-      loop do
-        it = enum.next
-        if yield(index, it) == true
-          result << it
+    if enum.hash_style?
+      result = {}
+      enum.each { |k, v| result[k] = v if yield(k, v) == true }
+      result
+    else
+      result = []
+      begin
+        index = 0
+        loop do
+          it = enum.next
+          if yield(index, it) == true
+            result << it
+          end
+          index += 1
         end
-        index += 1
+      rescue StopIteration
       end
-    rescue StopIteration
+      result
     end
-    result
   end
 end

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -107,16 +107,20 @@ Puppet::Functions.create_function(:map) do
   end
 
   def map_Enumerable_2(enumerable)
-    result = []
-    index = 0
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
-    begin
-      loop do
-        result << yield(index, enum.next)
-        index = index +1
+    if enum.hash_style?
+      enum.map { |entry| yield(*entry) }
+    else
+      result = []
+      begin
+        index = 0
+        loop do
+          result << yield(index, enum.next)
+          index = index +1
+        end
+      rescue StopIteration
       end
-    rescue StopIteration
+      result
     end
-    result
   end
 end

--- a/lib/puppet/functions/run_command.rb
+++ b/lib/puppet/functions/run_command.rb
@@ -33,12 +33,9 @@ Puppet::Functions.create_function(:run_command) do
     hosts = nodes.flatten
     if hosts.empty?
       call_function('debug', "Simulating run_command('#{command}') - no hosts given - no action taken")
-      []
+      Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
     else
-      # TODO, rewrite once proper handling of returned values is fully specified
-      Bolt::Executor.from_uris(hosts).run_command(command).map do |_, result|
-        result.success? ? result.output_string : result.exit_code
-      end
+      Puppet::Pops::Types::ExecutionResult.from_bolt(Bolt::Executor.from_uris(hosts).run_command(command))
     end
   end
 end

--- a/lib/puppet/functions/run_script.rb
+++ b/lib/puppet/functions/run_script.rb
@@ -42,11 +42,9 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     hosts = nodes.flatten
     if hosts.empty?
       call_function('debug', "Simulating run_script of '#{found}' - no hosts given - no action taken")
-      []
+      Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
     else
-      Bolt::Executor.from_uris(hosts).run_script(found).map do |_, result|
-        result.success? ? result.output_string : result.exit_code
-      end
+      Puppet::Pops::Types::ExecutionResult.from_bolt(Bolt::Executor.from_uris(hosts).run_script(found))
     end
   end
 end

--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -2,6 +2,8 @@ module Puppet::Pops
 module Types
   class ExecutionResult
     include PuppetObject
+    include Iterable
+    include IteratorProducer
 
     TYPE_RESULT_HASH = TypeFactory.hash_kv(PStringType::NON_EMPTY, TypeFactory.struct({
       TypeFactory.optional('value') => TypeFactory.data,
@@ -52,7 +54,11 @@ module Types
     def error_nodes
       result = {}
       @result_hash.each_pair { |k, v| result[k] = v if v.is_a?(PErrorType::Error) }
-      return self.class.new(result)
+      self.class.new(result)
+    end
+
+    def iterator
+      Iterable.on(@result_hash)
     end
 
     def names

--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -41,11 +41,11 @@ module Types
     end
 
     def count
-      return @result_hash.size
+      @result_hash.size
     end
 
     def empty
-      return @result_hash.empty?
+      @result_hash.empty?
     end
     alias_method :empty?, :empty
 
@@ -56,7 +56,7 @@ module Types
     end
 
     def names
-      return @result_hash.keys
+      @result_hash.keys
     end
 
     def ok
@@ -67,19 +67,19 @@ module Types
     def ok_nodes
       result = {}
       @result_hash.each_pair { |k, v| result[k] = v unless v.is_a?(PErrorType::Error) }
-      return self.class.new(result)
+      self.class.new(result)
     end
 
     def value(node_uri)
-      return @result_hash[node_uri]
+      @result_hash[node_uri]
     end
 
     def values
-      return @result_hash.values
+      @result_hash.values
     end
 
     def _pcore_init_hash
-      return @result_hash
+      @result_hash
     end
 
     private

--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -36,6 +36,14 @@ module Types
       @type
     end
 
+    # Creates a pure Data hash from a result hash returned from the Bolt::Executor
+    # @return [Hash{String => Data}] The data hash
+    def self.from_bolt(result_hash)
+      data_result = {}
+      result_hash.each_pair { |k, v| data_result[k.uri] = v.to_h }
+      self.new(data_result)
+    end
+
     attr_reader :result_hash
 
     def initialize(result_hash)
@@ -106,6 +114,8 @@ module Types
         PErrorType::Error.new(error['msg'], error['kind'], error['issue_code'] || PErrorType::DEFAULT_ISSUE_CODE, value, error['details'])
       end
     end
+
+    EMPTY_RESULT = ExecutionResult.new(EMPTY_HASH)
   end
 end
 end

--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -8,7 +8,7 @@ module Types
     TYPE_RESULT_HASH = TypeFactory.hash_kv(PStringType::NON_EMPTY, TypeFactory.struct({
       TypeFactory.optional('value') => TypeFactory.data,
       TypeFactory.optional('error') => TypeFactory.struct({
-        'message' => PStringType::NON_EMPTY,
+        'msg' => PStringType::NON_EMPTY,
         TypeFactory.optional('kind') => PStringType::NON_EMPTY,
         TypeFactory.optional('issue_code') => PStringType::NON_EMPTY,
         TypeFactory.optional('details') => TypeFactory.hash_of_data,
@@ -103,7 +103,7 @@ module Types
       if error.nil?
         value
       else
-        PErrorType::Error.new(error['message'], error['kind'], error['issue_code'] || PErrorType::DEFAULT_ISSUE_CODE, value, error['details'])
+        PErrorType::Error.new(error['msg'], error['kind'], error['issue_code'] || PErrorType::DEFAULT_ISSUE_CODE, value, error['details'])
       end
     end
   end

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -59,10 +59,10 @@ module Puppet::Pops::Types
       when Hash
         # Each element is a two element [key, value] tuple.
         if o.empty?
-          Iterator.new(PHashType::DEFAULT_KEY_PAIR_TUPLE, o.each)
+          HashIterator.new(PHashType::DEFAULT_KEY_PAIR_TUPLE, o.each)
         else
           tc = TypeCalculator.singleton
-          Iterator.new(PTupleType.new([
+          HashIterator.new(PTupleType.new([
             PVariantType.maybe_create(o.keys.map {|e| tc.infer_set(e) }),
             PVariantType.maybe_create(o.values.map {|e| tc.infer_set(e) })], PHashType::KEY_PAIR_TUPLE_SIZE), o.each_pair)
         end
@@ -146,6 +146,10 @@ module Puppet::Pops::Types
       super
     end
 
+    def hash_style?
+      false
+    end
+
     def unbounded?
       true
     end
@@ -215,6 +219,14 @@ module Puppet::Pops::Types
 
     def unbounded?
       Iterable.unbounded?(@enumeration)
+    end
+  end
+
+  # Special iterator used when iterating over hashes. Returns `true` for `#hash_style?` so that
+  # it is possible to differentiate between two element arrays and key => value associations
+  class HashIterator < Iterator
+    def hash_style?
+      true
     end
   end
 

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -1,4 +1,12 @@
 module Puppet::Pops::Types
+
+  # Implemented by classes that can produce an iterator to iterate over their contents
+  module IteratorProducer
+    def iterator
+      raise ArgumentError, 'iterator() is not implemented'
+    end
+  end
+
   # The runtime Iterable type for an Iterable
   module Iterable
     # Produces an `Iterable` for one of the following types with the following characterstics:
@@ -45,6 +53,8 @@ module Puppet::Pops::Types
     # @api public
     def self.on(o)
       case o
+      when IteratorProducer
+        o.iterator
       when Iterable
         o
       when String

--- a/spec/unit/functions/file_upload_spec.rb
+++ b/spec/unit/functions/file_upload_spec.rb
@@ -54,7 +54,7 @@ describe 'the file_upload function' do
     let(:hosts) { [hostname] }
     let(:host) { stub(uri: hostname) }
     let(:message) { 'uploaded' }
-    let(:result) { stub(output_string: message, success?: true) }
+    let(:result) { { value: message } }
     let(:full_dir_path) { File.join(env_dir, 'modules', 'test', 'files', 'uploads' ) }
     let(:full_path) { File.join(full_dir_path, 'index.html') }
     let(:destination) { '/var/www/html' }
@@ -69,7 +69,7 @@ describe 'the file_upload function' do
       Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
       executor.expects(:file_upload).with(full_path, destination).returns({ host => result })
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
         $a = file_upload('test/uploads/index.html', '#{destination}', '#{hostname}')
         notice $a
       CODE
@@ -80,7 +80,7 @@ describe 'the file_upload function' do
       Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
       executor.expects(:file_upload).with(full_dir_path, destination).returns({ host => result })
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
         $a = file_upload('test/uploads', '#{destination}', '#{hostname}')
         notice $a
       CODE
@@ -91,14 +91,14 @@ describe 'the file_upload function' do
       let(:hosts) { [hostname, hostname2] }
       let(:host2) { stub(uri: hostname2) }
       let(:message2) { 'received' }
-      let(:result2) { stub(output_string: message2, success?: true) }
+      let(:result2) { { value: message2 } }
 
       it 'with propagates multiple hosts and returns multiple results' do
         executor = mock('executor')
         Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
         executor.expects(:file_upload).with(full_path, destination).returns({ host => result, host2 => result2 })
 
-        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}, #{message2}]"])
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}, '#{hostname2}' => {value => '#{message2}'}})"])
           $a = file_upload('test/uploads/index.html', '#{destination}', '#{hostname}', '#{hostname2}')
           notice $a
         CODE
@@ -110,7 +110,7 @@ describe 'the file_upload function' do
       Bolt::Executor.expects(:from_uris).never
       executor.expects(:file_upload).never
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['[]'])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['ExecutionResult({})'])
         $a = file_upload('test/uploads/index.html', '#{destination}')
         notice $a
       CODE

--- a/spec/unit/functions/run_command_spec.rb
+++ b/spec/unit/functions/run_command_spec.rb
@@ -32,7 +32,7 @@ describe 'the run_command function' do
     let(:hosts) { [hostname] }
     let(:host) { stub(uri: hostname) }
     let(:command) { 'hostname' }
-    let(:result) { stub(output_string: hostname, success?: true) }
+    let(:result) { { value: hostname } }
     before(:each) do
       Puppet.features.stubs(:bolt?).returns(true)
       module ::Bolt; end
@@ -44,7 +44,7 @@ describe 'the run_command function' do
       Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
       executor.expects(:run_command).with(command).returns({ host => result })
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{hostname}]"])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}})"])
         $a = run_command('#{command}', '#{hostname}')
         notice $a
       CODE
@@ -54,14 +54,14 @@ describe 'the run_command function' do
       let(:hostname2) { 'test.testing.com' }
       let(:hosts) { [hostname, hostname2] }
       let(:host2) { stub(uri: hostname2) }
-      let(:result2) { stub(output_string: hostname2, success?: true) }
+      let(:result2) { { value: hostname2 } }
 
       it 'with propagates multiple hosts and returns multiple results' do
         executor = mock('executor')
         Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
         executor.expects(:run_command).with(command).returns({ host => result, host2 => result2 })
 
-        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{hostname}, #{hostname2}]"])
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}, '#{hostname2}' => {value => '#{hostname2}'}})"])
           $a = run_command('#{command}', '#{hostname}', '#{hostname2}')
           notice $a
         CODE
@@ -73,7 +73,7 @@ describe 'the run_command function' do
       Bolt::Executor.expects(:from_uris).never
       executor.expects(:run_command).never
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['[]'])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['ExecutionResult({})'])
         $a = run_command('#{command}')
         notice $a
       CODE

--- a/spec/unit/functions/run_script_spec.rb
+++ b/spec/unit/functions/run_script_spec.rb
@@ -52,7 +52,7 @@ describe 'the run_script function' do
     let(:hostname) { 'test.example.com' }
     let(:hosts) { [hostname] }
     let(:host) { stub(uri: hostname) }
-    let(:result) { stub(output_string: hostname, success?: true) }
+    let(:result) { { value: hostname } }
     let(:full_dir_path) { File.join(env_dir, 'modules', 'test', 'files', 'uploads' ) }
     let(:full_path) { File.join(full_dir_path, 'hostname.sh') }
     before(:each) do
@@ -66,7 +66,7 @@ describe 'the run_script function' do
       Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
       executor.expects(:run_script).with(full_path).returns({ host => result })
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{hostname}]"])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}})"])
         $a = run_script('test/uploads/hostname.sh', '#{hostname}')
         notice $a
       CODE
@@ -76,14 +76,14 @@ describe 'the run_script function' do
       let(:hostname2) { 'test.testing.com' }
       let(:hosts) { [hostname, hostname2] }
       let(:host2) { stub(uri: hostname2) }
-      let(:result2) { stub(output_string: hostname2, success?: true) }
+      let(:result2) { { value: hostname2 } }
 
       it 'with propagated multiple hosts and returns multiple results' do
         executor = mock('executor')
         Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
         executor.expects(:run_script).with(full_path).returns({ host => result, host2 => result2 })
 
-        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{hostname}, #{hostname2}]"])
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}, '#{hostname2}' => {value => '#{hostname2}'}})"])
           $a = run_script('test/uploads/hostname.sh', '#{hostname}', '#{hostname2}')
           notice $a
         CODE
@@ -95,7 +95,7 @@ describe 'the run_script function' do
       Bolt::Executor.expects(:from_uris).never
       executor.expects(:run_script).never
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['[]'])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(['ExecutionResult({})'])
         $a = run_script('test/uploads/hostname.sh')
         notice $a
       CODE

--- a/spec/unit/functions/run_task_spec.rb
+++ b/spec/unit/functions/run_task_spec.rb
@@ -52,7 +52,7 @@ describe 'the run_task function' do
     let(:hosts) { [hostname] }
     let(:host) { stub(uri: hostname) }
     let(:host2) { stub(uri: hostname2) }
-    let(:result) { stub(output_string: message, success?: true) }
+    let(:result) { { value: message } }
     before(:each) do
       Puppet.features.stubs(:bolt?).returns(true)
       module ::Bolt; end
@@ -66,7 +66,7 @@ describe 'the run_task function' do
       Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
       executor.expects(:run_task).with(executable, 'both', {'message' => 'the message'}).returns({ host => result })
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
         $a = run_task(Test::Echo({message => "#{message}"}), "#{hostname}")
         notice $a
       CODE
@@ -79,7 +79,7 @@ describe 'the run_task function' do
       Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
       executor.expects(:run_task).with(executable, 'environment', {'message' => 'the message'}).returns({ host => result })
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
         $a = run_task(Test::Meta({message => "#{message}"}), "#{hostname}")
         notice $a
       CODE
@@ -93,7 +93,7 @@ describe 'the run_task function' do
       executor.expects(:run_task).with(executable, 'environment', {'message' => 'the message'}).returns(
         { host => result, host2 => result })
 
-      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}, #{message}]"])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}, '#{hostname2}' => {value => '#{message}'}})"])
         $a = run_task(Test::Meta({message => "#{message}"}), "#{hostname}", [["#{hostname2}"]],[])
         notice $a
       CODE
@@ -108,7 +108,7 @@ describe 'the run_task function' do
           Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
           executor.expects(:run_task).with(executable, 'environment', {'message' => 'the message'}).returns({ host => result })
 
-          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
             $a = run_task(Test::Meta, "#{hostname}", {message => "#{message}"})
             notice $a
           CODE
@@ -121,7 +121,7 @@ describe 'the run_task function' do
           Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
           executor.expects(:run_task).with(executable, 'both', {}).returns({ host => result })
 
-          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
             $a = run_task(Test::Yes, "#{hostname}")
             notice $a
           CODE
@@ -134,9 +134,9 @@ describe 'the run_task function' do
           Bolt::Executor.expects(:from_uris).never
           executor.expects(:run_task).never
 
-          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["Undef"])
+          expect(eval_and_collect_notices(<<-CODE, node)).to eql(['ExecutionResult({})'])
             $a = run_task(Test::Yes, [])
-            notice type($a)
+            notice $a
           CODE
         end
       end
@@ -149,7 +149,7 @@ describe 'the run_task function' do
         Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
         executor.expects(:run_task).with(executable, 'environment', {'message' => 'the message'}).returns({ host => result })
 
-        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
           $a = run_task('test::meta', "#{hostname}", {message => "#{message}"})
           notice $a
         CODE
@@ -162,7 +162,7 @@ describe 'the run_task function' do
         Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
         executor.expects(:run_task).with(executable, 'both', {}).returns({ host => result })
 
-        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
           $a = run_task('test::yes', "#{hostname}")
           notice $a
         CODE
@@ -175,9 +175,9 @@ describe 'the run_task function' do
         Bolt::Executor.expects(:from_uris).never
         executor.expects(:run_task).never
 
-        expect(eval_and_collect_notices(<<-CODE, node)).to eql(["Undef"])
+        expect(eval_and_collect_notices(<<-CODE, node)).to eql(['ExecutionResult({})'])
           $a = run_task('test::yes', [])
-          notice type($a)
+          notice $a
         CODE
       end
 
@@ -241,7 +241,7 @@ describe 'the run_task function' do
           Bolt::Executor.expects(:from_uris).with(hosts).returns(executor)
           executor.expects(:run_task).with(executable, 'both', {}).returns({ host => result })
 
-          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["[#{message}]"])
+          expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{message}'}})"])
           $a = run_task('test', "#{hostname}")
           notice $a
           CODE

--- a/spec/unit/pops/types/execution_result_spec.rb
+++ b/spec/unit/pops/types/execution_result_spec.rb
@@ -56,7 +56,7 @@ describe 'ExecutionResult' do
 
       it 'can be created with an error' do
         code = <<-CODE
-            $o = ExecutionResult('example.com' => {error => { 'message' => 'nope', 'issue_code' => 'BAD'}})
+            $o = ExecutionResult('example.com' => {error => { 'msg' => 'nope', 'issue_code' => 'BAD'}})
             notice($o)
             notice($o.empty)
             notice($o.ok)
@@ -80,7 +80,7 @@ describe 'ExecutionResult' do
 
       it 'can be created with an error and a partial result' do
         code = <<-CODE
-            $o = ExecutionResult('example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'})
+            $o = ExecutionResult('example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'})
             notice($o)
         CODE
         expect(eval_and_collect_notices(code)).to eq([
@@ -91,7 +91,7 @@ describe 'ExecutionResult' do
       it 'can be created with an errors and ok values' do
         code = <<-CODE
             $o = ExecutionResult(
-              'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+              'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
               'beta.example.com' => {value => 'total success'})
             notice($o)
             notice($o.empty)
@@ -121,8 +121,8 @@ describe 'ExecutionResult' do
           it 'can do #all' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.all |$e| { $e[1] =~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['true'])
@@ -131,8 +131,8 @@ describe 'ExecutionResult' do
           it 'can do #any' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.any |$e| { $e[1] !~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['false'])
@@ -141,7 +141,7 @@ describe 'ExecutionResult' do
           it 'can do #each' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                   'beta.example.com' => {value => 'total success'})
                 $o.each |$e| { notice("Node ${e[0]} returned ${e[1]}") }
             CODE
@@ -154,7 +154,7 @@ describe 'ExecutionResult' do
           it 'can do #filter' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               $o.filter |$e| { $e[0] =~ /^beta/ }.each |$e| { notice($e[1]) }
             CODE
@@ -166,7 +166,7 @@ describe 'ExecutionResult' do
           it 'can do #map' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               notice($o.map |$e| { $e[1] })
             CODE
@@ -180,8 +180,8 @@ describe 'ExecutionResult' do
           it 'can do #all' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.all |$k, $v| { $v =~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['true'])
@@ -190,8 +190,8 @@ describe 'ExecutionResult' do
           it 'can do #any' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
-                  'beta.example.com' => {error => { 'message' => 'bad'}})
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'beta.example.com' => {error => { 'msg' => 'bad'}})
                 notice($o.any |$k, $v| { $v !~ Error })
             CODE
             expect(eval_and_collect_notices(code)).to eq(['false'])
@@ -200,7 +200,7 @@ describe 'ExecutionResult' do
           it 'can do #each' do
             code = <<-CODE
                 $o = ExecutionResult(
-                  'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                  'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                   'beta.example.com' => {value => 'total success'})
                 $o.each |$k, $v| { notice("Node $k returned $v") }
             CODE
@@ -213,7 +213,7 @@ describe 'ExecutionResult' do
           it 'can do #filter' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               $o.filter |$k, $v| { $k =~ /^beta/ }.each |$k, $v| { notice($v) }
             CODE
@@ -225,7 +225,7 @@ describe 'ExecutionResult' do
           it 'can do #map' do
             code = <<-CODE
               $o = ExecutionResult(
-                'alpha.example.com' => {error => { 'message' => 'nope'}, value => 'almost there, almost th...argh'},
+                'alpha.example.com' => {error => { 'msg' => 'nope'}, value => 'almost there, almost th...argh'},
                 'beta.example.com' => {value => 'total success'})
               notice($o.map |$k, $v| { $v })
             CODE


### PR DESCRIPTION
This commit changes the return value of `#file_upload`, `#run_command`,
`#run_script` and `#run_task` so that they always return an instance of
`ExecutionResult`.