### PR TITLE
(PUP-8039) Only warn once when module loading code can't find gettext

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -77,7 +77,7 @@ class Puppet::Module
         Puppet.warning _("GettextSetup initialization for %{module_name} failed with: %{error_message}") % { module_name: name, error_message: e.message }
       end
     else
-      Puppet.warning _("GettextSetup is not available, skipping GettextSetup initialization for %{module_name}.") % { module_name: name }
+      Puppet.warn_once("gettext_unavailable", "gettext_unavailable", "GettextSetup is not available, skipping GettextSetup initialization for modules.")
     end
   end
 


### PR DESCRIPTION
Previously, Puppet would issue a warning about gettext being unavailable
each time a module was loaded. This commit updates that warning to only
be issued once.