### PR TITLE
(PUP-6854) degrade missing label warning to debug

### DIFF
--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -141,7 +141,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
         if job.has_key?("Label")
           @label_to_path_map[job["Label"]] = filepath
         else
-          Puppet.warning("The #{filepath} plist does not contain a 'label' key; " +
+          Puppet.debug("The #{filepath} plist does not contain a 'label' key; " +
                        "Puppet is skipping it")
           next
         end

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -292,7 +292,8 @@ describe Puppet::Type.type(:service).provider(:launchd) do
         provider.expects(:launchd_paths).returns(['/Library/LaunchAgents'])
         provider.expects(:return_globbed_list_of_file_paths).with('/Library/LaunchAgents').returns([busted_plist_path])
         plistlib.expects(:read_plist_file).with(busted_plist_path).returns(plist_without_label)
-        Puppet.expects(:warning).with("The #{busted_plist_path} plist does not contain a 'label' key; Puppet is skipping it")
+        Puppet.expects(:debug).with("Reading launchd plist #{busted_plist_path}")
+        Puppet.expects(:debug).with("The #{busted_plist_path} plist does not contain a 'label' key; Puppet is skipping it")
         provider.make_label_to_path_map
       end
     end


### PR DESCRIPTION
On macOS puppet throws the infamous warning:

```
Warning: The /System/Library/LaunchDaemons/com.apple.jetsamproperties.Mac.plist plist does not contain a 'label' key; Puppet is skipping it
```

I switched the warning to a debug message, just as @MosesMendoza recommended in #5730.