### PR TITLE
(PUP-2169) Invalidate SELinux matchpathcon cache

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -49,6 +49,7 @@ module Puppet::Util::SELinux
     end
 
     retval = Selinux.matchpathcon(file, mode)
+    Selinux.matchpathcon_fini
     if retval == -1
       return nil
     end

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -126,6 +126,7 @@ describe Puppet::Util::SELinux do
       Puppet::FileSystem.expects(:lstat).with('/foo').returns(fstat)
       self.expects(:find_fs).with("/foo").returns "ext3"
       Selinux.expects(:matchpathcon).with("/foo", 0).returns [0, "user_u:role_r:type_t:s0"]
+      Selinux.expects(:matchpathcon_fini)
 
       expect(get_selinux_default_context("/foo")).to eq("user_u:role_r:type_t:s0")
     end
@@ -134,6 +135,7 @@ describe Puppet::Util::SELinux do
       self.stubs(:selinux_support?).returns true
       self.stubs(:selinux_label_support?).returns true
       Selinux.stubs(:matchpathcon).with("/root/chuj", 0).returns(-1)
+      Selinux.expects(:matchpathcon_fini)
       self.stubs(:file_lstat).with("/root/chuj").raises(Errno::EACCES, "/root/chuj")
 
       expect(get_selinux_default_context("/root/chuj")).to be_nil
@@ -143,6 +145,7 @@ describe Puppet::Util::SELinux do
       self.stubs(:selinux_support?).returns true
       self.stubs(:selinux_label_support?).returns true
       Selinux.stubs(:matchpathcon).with("/root/chuj", 0).returns(-1)
+      Selinux.expects(:matchpathcon_fini)
       self.stubs(:file_lstat).with("/root/chuj").raises(Errno::ENOENT, "/root/chuj")
 
       expect(get_selinux_default_context("/root/chuj")).to be_nil
@@ -154,6 +157,7 @@ describe Puppet::Util::SELinux do
       Puppet::FileSystem.expects(:lstat).with('/foo').returns(fstat)
       self.expects(:find_fs).with("/foo").returns "ext3"
       Selinux.expects(:matchpathcon).with("/foo", 0).returns -1
+      Selinux.expects(:matchpathcon_fini)
 
       expect(get_selinux_default_context("/foo")).to be_nil
     end


### PR DESCRIPTION
The `file` resource has 4 selinux parameters (`selrange`, `selrole`,
`seltype`, `seluser`).  When not set, these default to "the value
returned by matchpathcon for the file".  When puppet is run as a
service, the first call to matchpathcon correctly returns the default
SELinux security context for the specified file.  But on subsequent
runs, matchpathcon returns a cached value.  This is a problem if the
default context has changed since the puppet service was first started.
This leads to puppet doing things like reverting file contexts that were
set when an RPM was installed (there are several RPMs which bundle
SELinux modules and run `restorecon` on file paths when installed).

This bad behaviour is easy to replicate.  eg create a very simple puppet
module 'selinux-test' and apply that to a test node through PE or
Foreman etc.
```puppet
 # selinux-test/init.pp
class selinux-test {
  file { '/selinux-test':
    ensure => file,
  }
}
```

Set a very short runinterval...
```
puppet config set --section agent runinterval 30
```

Wait for puppet to create `/selinux-test` with whatever the default
context type is for this path (`etc_runtime_t`).

```
[root@testhost ~]# ls -Z /selinux-test
-rw-r--r--. root root system_u:object_r:etc_runtime_t:s0 /selinux-test
```

Change the default context type for this file using `fcontext`
```
semanage fcontext -a -t tmp_t /selinux-test
```

Wait another 30 seconds, tailing the puppet agent log and notice how
puppet does *not* update the file.

Use `restorecon` to relabel the file manually.
```
[root@testhost ~]# restorecon /selinux-test
[root@testhost ~]# ls -Z /selinux-test
-rw-r--r--. root root system_u:object_r:tmp_t:s0 /selinux-test
```

Wait for puppet to unhelpfully revert the seltype back to
`etc_runtime_t`.

Restart the puppet service and note how puppet now changes the seltype
back to `tmp_t`.

The fix is really simple.  Just call `matchpathcon_fini` after the call
to `matchpathcon`.  The code never explicitly called
`matchpathcon_init`, but this was done automatically by the call to
`matchpathcon`.

From the man page...
> If matchpathcon_init() has not already been called, then this function
> will call it upon its first invocation with a NULL path, defaulting to
> the active file contexts configuration.

And on `matchpathcon_fini()`...
> matchpathcon_fini() frees the memory allocated by a prior call to
> matchpathcon_init.() This function can be used to free and reset the
> internal state between multiple matchpathcon_init() calls

I was initially concerned that calling `matchpathcon_fini` after *each*
call to `matchpathcon` might be awful for performance.  I did some
testing, and even though it is much slower, it's still so fast as to not
be an issue (over 500 calls to `matchpathcon` with `matchpathcon_fini`
in less than a second).
```
[root@testhost ~]# cat test.rb
require 'selinux'
require 'benchmark'
list_of_files = Dir['/etc/**/*.*']
puts "Testing with all #{list_of_files.size} files under /etc"
time = Benchmark.realtime do
        list_of_files.each do |file|
                Selinux.matchpathcon('file',0)
                Selinux.matchpathcon_fini
        end
end
puts "Time elapsed #{time*1000} milliseconds"
time = Benchmark.realtime do
        list_of_files.each do |file|
                Selinux.matchpathcon('file',0)
        end
end
puts "Time elapsed #{time*1000} milliseconds"
[root@testhost ~]# /opt/puppetlabs/puppet/bin/ruby test.rb
Testing with all 507 files under /etc
Time elapsed 881.8768259999999 milliseconds
Time elapsed 12.083007 milliseconds
```