### PR TITLE
(PUP-8028) Ensure that directories are ignored by the file based loader

### DIFF
--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -93,6 +93,10 @@ module LoaderPaths
       TypedName.new(type, n, name_authority)
     end
 
+    def valid_name?(typed_name)
+      true
+    end
+
     def relative_path
       raise NotImplementedError.new
     end
@@ -220,6 +224,11 @@ module LoaderPaths
     def instantiator
       require_relative 'task_instantiator'
       TaskInstantiator
+    end
+
+    def valid_name?(typed_name)
+      # TODO: Remove when PE has proper namespace handling
+      typed_name.name_parts.size <= 2
     end
   end
 

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -388,6 +388,12 @@ module ModuleLoaders
 
     def add_to_index(smart_path)
       found = Dir.glob(File.join(smart_path.generic_path, '**', "*#{smart_path.extension}"))
+
+      # The reason for not always rejecting directories here is performance (avoid extra stat calls). The
+      # false positives (directories with a matching extension) is an error in any case and will be caught
+      # later.
+      found = found.reject { |file_name| File.directory?(file_name) } if smart_path.extension.empty?
+
       @path_index.merge(found)
       found
     end

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -113,6 +113,7 @@ module ModuleLoaders
         smart_paths.effective_paths(type).each do |sp|
           relative_paths(sp).each do |rp|
             tp = sp.typed_name(type, name_authority, rp, global ? nil : @module_name)
+            next unless sp.valid_name?(tp)
             load_typed(tp) unless block_given? && !block.yield(tp)
           end
         end
@@ -333,6 +334,7 @@ module ModuleLoaders
     def find_existing_path(typed_name)
       is_global = global?
       smart_paths.effective_paths(typed_name.type).each do |sp|
+        next unless sp.valid_name?(typed_name)
         origin = sp.effective_path(typed_name, is_global ? 0 : 1)
         unless origin.nil?
           if sp.match_many?

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -255,6 +255,24 @@ describe 'The Task Type' do
           PUPPET
         end
 
+        context 'using more than two segments in the name' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'hello' => {
+                  'foo.sh' => 'echo hello'
+                }
+              }
+            }
+          }
+
+          it 'task is not found' do
+            expect{compile(<<-PUPPET.unindent)}.to raise_error(/Resource type not found: Testmodule::Hello::Foo/)
+              notice(Testmodule::Hello::Foo(message => 'a message'))
+            PUPPET
+          end
+        end
+
         context 'without --tasks' do
           before(:each) { Puppet[:tasks] = false }
 

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -180,6 +180,62 @@ describe 'The Task Type' do
           expect(notices).to eql(["Testmodule::Hello({'message' => 'a message', 'font' => 'helvetica'})"])
         end
 
+        context 'with adjacent directory for init task' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'init' => {
+                  'foo.sh' => 'echo hello'
+                },
+                'init.sh' => 'echo hello',
+                'init.json' => <<-JSON
+                {
+                  "supports_noop": true,
+                  "parameters": {
+                     "message": { "type": "String" }
+                  }
+                }
+              JSON
+              }
+            }
+          }
+
+          it 'evaluator loads and notices a Task with positional parameters' do
+            compile(<<-PUPPET.unindent)
+            notice(Testmodule('a message'))
+            PUPPET
+            expect(notices).to eql(["Testmodule({'message' => 'a message'})"])
+          end
+        end
+
+        context 'with adjacent directory for named task' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'hello' => {
+                  'foo.sh' => 'echo hello'
+                },
+                'hello.sh' => 'echo hello',
+                'hello.json' => <<-JSON
+                {
+                  "supports_noop": true,
+                  "parameters": {
+                     "message": { "type": "String" }
+                  }
+                }
+              JSON
+              }
+            }
+          }
+
+          it 'evaluator loads and notices a Task with positional parameters' do
+            compile(<<-PUPPET.unindent)
+            notice(Testmodule::Hello('a message'))
+            PUPPET
+            expect(notices).to eql(["Testmodule::Hello({'message' => 'a message'})"])
+          end
+        end
+
         it 'evaluator fails on invalid number of parameters' do
           expect { compile(<<-PUPPET.unindent) }.to raise_error(/expects between 1 and 2 arguments, got 3/)
             notice(Testmodule::Hello('a message', 'helvetica', 'bold'))


### PR DESCRIPTION
This commit changes the file based loader so that rejecs the directory
entries that are returned by the ruby `Dir#glob` method in case the
glob is executed without any known extension (as is the case when doing
a glob to find tasks).

The change fixes the problem where a directory would be interpreted as
a task, or interfere with a task using the same name (but different
extension) as the directory.