### PR TITLE
(PUP-8045) Add support for Fedora 26 to the dnf provider

### DIFF
--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23', '24', '25']
+  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23', '24', '25', '26']
 
   def self.update_command
     # In DNF, update is deprecated for upgrade

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:package).provider(:dnf)
 
 context 'default' do
-  [ 19, 20, 21 ].each do |ver|
+  (19..21).each do |ver|
     it "should not be the default provider on fedora#{ver}" do
       Facter.stubs(:value).with(:osfamily).returns(:redhat)
       Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
@@ -15,7 +15,7 @@ context 'default' do
     end
   end
 
-  [ 22, 23, 24 ].each do |ver|
+  (22..26).each do |ver|
     it "should be the default provider on fedora#{ver}" do
       Facter.stubs(:value).with(:osfamily).returns(:redhat)
       Facter.stubs(:value).with(:operatingsystem).returns(:fedora)


### PR DESCRIPTION
The default package provider should be set to use dnf on Fedora 26.