### PR TITLE
(PUP-8046) Fix problem with Ruby generator and Ruby keywords

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -228,10 +228,10 @@ class PObjectType < PMetaType
       # TODO: Assumes Ruby implementation for now
       if(callable_type.is_a?(PVariantType))
         callable_type.types.map do |ct|
-          Functions::Dispatch.new(ct, name, [], false, ct.block_type.nil? ? nil : 'block')
+          Functions::Dispatch.new(ct, RubyGenerator.protect_reserved_name(name), [], false, ct.block_type.nil? ? nil : 'block')
         end
       else
-        [Functions::Dispatch.new(callable_type, name, [], false, callable_type.block_type.nil? ? nil : 'block')]
+        [Functions::Dispatch.new(callable_type, RubyGenerator.protect_reserved_name(name), [], false, callable_type.block_type.nil? ? nil : 'block')]
       end
     end
 
@@ -544,7 +544,13 @@ class PObjectType < PMetaType
     init_non_opt_count = 0
     init_param_names = init.parameters.map do |p|
       init_non_opt_count += 1 if :req == p[0]
-      p[1].to_s
+      n = p[1].to_s
+      r = RubyGenerator.unprotect_reserved_name(n)
+      unless r.equal?(n)
+        # assert that the protected name wasn't a real name (names can start with underscore)
+        n = r unless param_names.index(r).nil?
+      end
+      n
     end
 
     if init_param_names != param_names

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -15,6 +15,198 @@ describe 'Puppet Ruby Generator' do
   let!(:parser) { TypeParser.singleton }
   let(:generator) { RubyGenerator.new }
 
+  context 'when generating classes for Objects having attribute names that are Ruby reserved words' do
+    let (:source) { <<-PUPPET }
+      type MyObject = Object[{
+        attributes => {
+          alias => String,
+          begin => String,
+          break => String,
+          def => String,
+          do => String,
+          end => String,
+          ensure => String,
+          for => String,
+          module => String,
+          next => String,
+          nil => String,
+          not => String,
+          redo => String,
+          rescue => String,
+          retry => String,
+          return => String,
+          self => String,
+          super => String,
+          then => String,
+          until => String,
+          when => String,
+          while => String,
+          yield => String,
+        },
+      }]
+      $x = MyObject({
+        alias => 'value of alias',
+        begin => 'value of begin',
+        break => 'value of break',
+        def => 'value of def',
+        do => 'value of do',
+        end => 'value of end',
+        ensure => 'value of ensure',
+        for => 'value of for',
+        module => 'value of module',
+        next => 'value of next',
+        nil => 'value of nil',
+        not => 'value of not',
+        redo => 'value of redo',
+        rescue => 'value of rescue',
+        retry => 'value of retry',
+        return => 'value of return',
+        self => 'value of self',
+        super => 'value of super',
+        then => 'value of then',
+        until => 'value of until',
+        when => 'value of when',
+        while => 'value of while',
+        yield => 'value of yield',
+      })
+      notice($x.alias)
+      notice($x.begin)
+      notice($x.break)
+      notice($x.def)
+      notice($x.do)
+      notice($x.end)
+      notice($x.ensure)
+      notice($x.for)
+      notice($x.module)
+      notice($x.next)
+      notice($x.nil)
+      notice($x.not)
+      notice($x.redo)
+      notice($x.rescue)
+      notice($x.retry)
+      notice($x.return)
+      notice($x.self)
+      notice($x.super)
+      notice($x.then)
+      notice($x.until)
+      notice($x.when)
+      notice($x.while)
+      notice($x.yield)
+    PUPPET
+
+    it 'can create an instance and access all attributes' do
+      expect(eval_and_collect_notices(source)).to eql([
+        'value of alias',
+        'value of begin',
+        'value of break',
+        'value of def',
+        'value of do',
+        'value of end',
+        'value of ensure',
+        'value of for',
+        'value of module',
+        'value of next',
+        'value of nil',
+        'value of not',
+        'value of redo',
+        'value of rescue',
+        'value of retry',
+        'value of return',
+        'value of self',
+        'value of super',
+        'value of then',
+        'value of until',
+        'value of when',
+        'value of while',
+        'value of yield',
+      ])
+    end
+  end
+
+  context 'when generating classes for Objects having function names that are Ruby reserved words' do
+    let (:source) { <<-PUPPET }
+      type MyObject = Object[{
+        functions => {
+          alias  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of alias'" }}},
+          begin  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of begin'" }}},
+          break  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of break'" }}},
+          def    => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of def'" }}},
+          do     => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of do'" }}},
+          end    => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of end'" }}},
+          ensure => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of ensure'" }}},
+          for    => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of for'" }}},
+          module => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of module'" }}},
+          next   => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of next'" }}},
+          nil    => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of nil'" }}},
+          not    => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of not'" }}},
+          redo   => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of redo'" }}},
+          rescue => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of rescue'" }}},
+          retry  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of retry'" }}},
+          return => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of return'" }}},
+          self   => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of self'" }}},
+          super  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of super'" }}},
+          then   => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of then'" }}},
+          until  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of until'" }}},
+          when   => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of when'" }}},
+          while  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of while'" }}},
+          yield  => { type => Callable[[0,0],String], annotations => {RubyMethod => { 'body' => "'value of yield'" }}},
+        },
+      }]
+      $x = MyObject()
+      notice($x.alias)
+      notice($x.begin)
+      notice($x.break)
+      notice($x.def)
+      notice($x.do)
+      notice($x.end)
+      notice($x.ensure)
+      notice($x.for)
+      notice($x.module)
+      notice($x.next)
+      notice($x.nil)
+      notice($x.not)
+      notice($x.redo)
+      notice($x.rescue)
+      notice($x.retry)
+      notice($x.return)
+      notice($x.self)
+      notice($x.super)
+      notice($x.then)
+      notice($x.until)
+      notice($x.when)
+      notice($x.while)
+      notice($x.yield)
+    PUPPET
+
+    it 'can create an instance and call all functions' do
+      expect(eval_and_collect_notices(source)).to eql([
+        'value of alias',
+        'value of begin',
+        'value of break',
+        'value of def',
+        'value of do',
+        'value of end',
+        'value of ensure',
+        'value of for',
+        'value of module',
+        'value of next',
+        'value of nil',
+        'value of not',
+        'value of redo',
+        'value of rescue',
+        'value of retry',
+        'value of return',
+        'value of self',
+        'value of super',
+        'value of then',
+        'value of until',
+        'value of when',
+        'value of while',
+        'value of yield',
+      ])
+    end
+  end
+
   context 'when generating from Object types' do
     def source
       <<-CODE


### PR DESCRIPTION
When generating Ruby code from an `Object` data type containing
attributes or functions with names that are Ruby keywords, those names
were used verbatim in the generated code. This made it impossible to use
attribute or function names such as `ensure`.

This commit alters the generator so that all names that are reserved in
Ruby get prefixed with an underscore letter in the generated Ruby code.
The change is invisible from the Puppet code.