### PR TITLE
(docs)(DOCUMENT-730) Restore AIX mount option docs.

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -173,8 +173,12 @@ module Puppet
 
     newproperty(:options) do
       desc "A single string containing options for the mount, as they would
-        appear in fstab. For many platforms this is a comma delimited string.
-        Consult the fstab(5) man page for system-specific details."
+        appear in fstab on Linux. For many platforms this is a comma-delimited
+        string. Consult the fstab(5) man page for system-specific details.
+        AIX options other than dev, nodename, or vfs can be defined here. If
+        specified, AIX options of account, boot, check, free, mount, size,
+        type, vol, log, and quota must be ordered alphabetically at the end of
+        the list."
 
       validate do |value|
         raise Puppet::Error, _("options must not contain whitespace: %{value}") % { value: value } if value =~ /\s/


### PR DESCRIPTION
AIX options for the mount type were added in Puppet 3.x in #3769, along with documentation explaining those options. The options are part of Puppet 4 onward, but the documentation wasn't brought forward.

Restore the AIX documentation to the mount type's options.