### PR TITLE
(PUP-8056) Add by-name initializer to the Error data type

### DIFF
--- a/lib/puppet/pops/types/p_error_type.rb
+++ b/lib/puppet/pops/types/p_error_type.rb
@@ -12,6 +12,10 @@ class PErrorType < PAnyType
       return PErrorType::DEFAULT
     end
 
+    def self.from_hash(hash)
+      self.new(hash['message'], hash['kind'], hash['issue_code'] || DEFAULT_ISSUE_CODE, hash['partial_result'], hash['details'])
+    end
+
     def initialize(message, kind = nil, issue_code = DEFAULT_ISSUE_CODE, partial_result = nil, details = nil)
       @issue_code = issue_code
       @kind = kind
@@ -61,6 +65,14 @@ class PErrorType < PAnyType
         optional_param 'Optional[String[1]]', :issue_code
         optional_param 'Data', :partial_result
         optional_param 'Optional[DataHash]', :details
+      end
+
+      dispatch :from_hash do
+        param 'Struct[message => String[1], Optional[kind] => String[1], Optional[issue_code] => String[1], Optional[partial_result] => Data, Optional[details] => DataHash]', :hash
+      end
+
+      def from_hash(hash)
+        Error.from_hash(hash)
       end
 
       def create(message, kind = nil, issue_code = nil, partial_result = nil, details = nil)

--- a/spec/unit/pops/types/p_error_type_spec.rb
+++ b/spec/unit/pops/types/p_error_type_spec.rb
@@ -102,6 +102,18 @@ describe 'Error type' do
         ])
       end
 
+      it 'can be created from a hash' do
+        code = <<-CODE
+            $o = Error(message => 'Sorry, not implemented', kind => 'puppet/error', issue_code => 'NOT_IMPLEMENTED')
+            notice($o)
+            notice(type($o))
+        CODE
+        expect(eval_and_collect_notices(code)).to eq([
+          "Error({'message' => 'Sorry, not implemented', 'kind' => 'puppet/error', 'issue_code' => 'NOT_IMPLEMENTED'})",
+          "Error['puppet/error', 'NOT_IMPLEMENTED']"
+        ])
+      end
+
       it 'is an instance of its type' do
         code = <<-CODE
             $o = Error('bad tings happened', 'puppet/error')


### PR DESCRIPTION
This commit adds a dispatcher to the `Error` data type that takes a hash
as an argument so that `Error` instances can be created from named
arguments.