### PR TITLE
(PUP-8068) Lookup bolt executor

### DIFF
--- a/lib/puppet/application/script.rb
+++ b/lib/puppet/application/script.rb
@@ -113,7 +113,13 @@ Copyright (c) 2017 Puppet Inc., LLC Licensed under the Apache 2.0 License
   end
 
   def run_command
-    main
+    if Puppet.features.bolt?
+      Puppet.override(:bolt_executor => Bolt::Executor.new) do
+        main
+      end
+    else
+      raise _("Bolt must be installed to use the script application")
+    end
   end
 
   def main

--- a/lib/puppet/functions/run_command.rb
+++ b/lib/puppet/functions/run_command.rb
@@ -26,7 +26,8 @@ Puppet::Functions.create_function(:run_command) do
         {:operation => 'run_command'})
     end
 
-    unless Puppet.features.bolt?
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    unless executor && Puppet.features.bolt?
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT, :action => _('run a command'))
     end
 
@@ -35,7 +36,9 @@ Puppet::Functions.create_function(:run_command) do
       call_function('debug', "Simulating run_command('#{command}') - no hosts given - no action taken")
       Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
     else
-      Puppet::Pops::Types::ExecutionResult.from_bolt(Bolt::Executor.from_uris(hosts).run_command(command))
+      Puppet::Pops::Types::ExecutionResult.from_bolt(
+        executor.run_command(executor.from_uris(hosts), command)
+      )
     end
   end
 end

--- a/lib/puppet/functions/run_script.rb
+++ b/lib/puppet/functions/run_script.rb
@@ -27,7 +27,8 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
         {:operation => 'run_script'})
     end
 
-    unless Puppet.features.bolt?
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    unless executor && Puppet.features.bolt?
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT, :action => _('run a script'))
     end
 
@@ -44,7 +45,9 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
       call_function('debug', "Simulating run_script of '#{found}' - no hosts given - no action taken")
       Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
     else
-      Puppet::Pops::Types::ExecutionResult.from_bolt(Bolt::Executor.from_uris(hosts).run_script(found))
+      Puppet::Pops::Types::ExecutionResult.from_bolt(
+        executor.run_script(executor.from_uris(hosts), found)
+      )
     end
   end
 end

--- a/lib/puppet/functions/run_task.rb
+++ b/lib/puppet/functions/run_task.rb
@@ -55,7 +55,8 @@ Puppet::Functions.create_function(:run_task) do
         {:operation => 'run_task'})
     end
 
-    unless Puppet.features.bolt?
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    unless executor && Puppet.features.bolt?
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT, :action => _('run a task'))
     end
 
@@ -67,7 +68,11 @@ Puppet::Functions.create_function(:run_task) do
       input_method = task._pcore_type['input_method'].value
 
       arguments = task.task_args
-      Puppet::Pops::Types::ExecutionResult.from_bolt(Bolt::Executor.from_uris(hosts).run_task(task.executable_path, input_method, arguments))
+      Puppet::Pops::Types::ExecutionResult.from_bolt(
+        executor.run_task(
+          executor.from_uris(hosts), task.executable_path, input_method, arguments
+        )
+      )
     end
   end
 end


### PR DESCRIPTION
Lookup the bolt executor from puppet's context system instead of relying on the
Bolt::Executor.from_uris factory method. The latter did not preserve options set
on the bolt command line, e.g. default user, password, tty, etc. which prevented
plans for working in some situations.