### PR TITLE
(PUP-8008) Avoid double-encoding Forge API pagination URIs

### DIFF
--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -90,7 +90,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
   # @see SemanticPuppet::Dependency::Source#fetch
   def fetch(input)
     name = input.tr('/', '-')
-    uri = "/v3/releases?module=#{name}"
+    uri = "/v3/releases?module=#{name}&sort_by=version"
     if Puppet[:module_groups]
       uri += "&module_groups=#{Puppet[:module_groups].gsub('+', ' ')}"
     end

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -113,8 +113,14 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     return releases
   end
 
-  def make_http_request(*args)
-    @repository.make_http_request(*args)
+  def make_http_request(uri, *args)
+    # Change plus to space so it can be encoded properly
+    uri = uri.gsub('+', ' ')
+
+    # Avoid double encoding
+    uri = URI.decode(uri)
+
+    @repository.make_http_request(uri, *args)
   end
 
   class ModuleRelease < SemanticPuppet::Dependency::ModuleRelease

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -44,8 +44,8 @@ class Puppet::Forge
 
     # Return a Net::HTTPResponse read for this +path+.
     def make_http_request(path, io = nil)
-      Puppet.debug "HTTP GET #{@host}#{path}"
       request = get_request_object(@uri.path.chomp('/')+path)
+      Puppet.debug "HTTP GET #{@host}#{request.path}"
       return read_response(request, io)
     end
 

--- a/spec/unit/forge/forge_spec.rb
+++ b/spec/unit/forge/forge_spec.rb
@@ -20,7 +20,10 @@ describe Puppet::Forge do
   # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
   # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
   let (:mixed_utf8_query_param) { "foo + A\u06FF\u16A0\u{2070E}" } # Aۿᚠ
-  let (:mixed_utf8_query_param_encoded) { "foo%20%2B%20A%DB%BF%E1%9A%A0%F0%A0%9C%8E"}
+
+  # literal plus characters in the URI are converted to spaces prior to encoding
+  let (:mixed_utf8_query_param_encoded) { "foo%20%20%20A%DB%BF%E1%9A%A0%F0%A0%9C%8E"}
+
   let (:empty_json) { '{ "results": [], "pagination" : { "next" : null } }' }
   let (:ok_response) { stub('response', :code => '200', :body => empty_json) }
 

--- a/spec/unit/forge/forge_spec.rb
+++ b/spec/unit/forge/forge_spec.rb
@@ -65,7 +65,7 @@ describe Puppet::Forge do
 
         # ignores Puppet::Forge::Repository#read_response, provides response to fetch
         performs_an_http_request(ok_response) do |http|
-          encoded_uri = "/v3/releases?module=#{module_name}&module_groups=base%20pe"
+          encoded_uri = "/v3/releases?module=#{module_name}&sort_by=version&module_groups=base%20pe"
           http.expects(:request).with(responds_with(:path, encoded_uri))
         end
 
@@ -77,7 +77,7 @@ describe Puppet::Forge do
 
         # ignores Puppet::Forge::Repository#read_response, provides response to fetch
         performs_an_http_request(ok_response) do |http|
-          encoded_uri = "/v3/releases?module=puppetlabs-#{mixed_utf8_query_param_encoded}"
+          encoded_uri = "/v3/releases?module=puppetlabs-#{mixed_utf8_query_param_encoded}&sort_by=version"
           http.expects(:request).with(responds_with(:path, encoded_uri))
         end
 

--- a/spec/unit/forge_spec.rb
+++ b/spec/unit/forge_spec.rb
@@ -131,6 +131,59 @@ describe Puppet::Forge do
     end
   end
 
+  context "when multiple module_groups are defined" do
+    let(:release_response) do
+      releases = JSON.parse(http_response)
+      releases['results'] = []
+      JSON.dump(releases)
+    end
+
+    context "with space seperator" do
+      before :each do
+        repository_responds_with(stub(:body => release_response, :code => '200')).with {|uri| uri =~ /module_groups=foo bar/}
+        Puppet[:module_groups] = "foo bar"
+      end
+
+      it "passes module_groups with search" do
+        forge.search('bacula')
+      end
+
+      it "passes module_groups with fetch" do
+        forge.fetch('puppetlabs-bacula')
+      end
+    end
+
+    context "with plus seperator" do
+      before :each do
+        repository_responds_with(stub(:body => release_response, :code => '200')).with {|uri| uri =~ /module_groups=foo bar/}
+        Puppet[:module_groups] = "foo+bar"
+      end
+
+      it "passes module_groups with search" do
+        forge.search('bacula')
+      end
+
+      it "passes module_groups with fetch" do
+        forge.fetch('puppetlabs-bacula')
+      end
+    end
+
+    context "with already encoded space seperator" do
+      before :each do
+        repository_responds_with(stub(:body => release_response, :code => '200')).with {|uri| uri =~ /module_groups=foo bar/}
+        Puppet[:module_groups] = "foo%20bar"
+      end
+
+      it "passes module_groups with search" do
+        forge.search('bacula')
+      end
+
+      it "passes module_groups with fetch" do
+        forge.fetch('puppetlabs-bacula')
+      end
+    end
+  end
+
   context "when the connection to the forge fails" do
     before :each do
       repository_responds_with(stub(:body => '{}', :code => '404', :message => "not found"))


### PR DESCRIPTION
This should resolve the issue with PMT following the pagination links returned by the Forge API.