### PR TITLE
(PUP-8071) Fix documentation of Binary data type

### DIFF
--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -2,8 +2,15 @@ require 'base64'
 module Puppet::Pops
 module Types
 
-# A Puppet Language Type that exposes the {{SemanticPuppet::Version}} and {{SemanticPuppet::VersionRange}}.
-# The version type is parameterized with version ranges.
+# A Puppet Language Type that represents binary data content (a sequence of 8-bit bytes).
+# Instances of this data type can be created from `String` and `Array[Integer[0,255]]`
+# values. Also see the `binary_file` function for reading binary content from a file.
+#
+# A `Binary` can be converted to `String` and `Array` form - see function `new` for
+# the respective target data type for more information.
+#
+# Instances of this data type serialize as base 64 encoded strings when the serialization
+# format is textual, and as binary content when a serialization format supports this.
 #
 # @api public
 class PBinaryType < PAnyType


### PR DESCRIPTION
Before this, the documentation for the Binary data type was a pasted
copy from SemVer.