### PR TITLE
(PUP-6452) Allow defaultfor to accept regex

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -291,16 +291,8 @@ class Puppet::Provider
   end
 
   def self.fact_match(fact, values)
-    values = [values] unless values.is_a? Array
-    values.map! { |v| v.to_s.downcase.intern }
-
-    if fval = Facter.value(fact).to_s and fval != ""
-      fval = fval.to_s.downcase.intern
-
-      values.include?(fval)
-    else
-      false
-    end
+    fact_val = Facter.value(fact).to_s.downcase
+    fact_val != "" and [*values].any? { |v| v === fact_val }
   end
 
   def self.feature_match(value)

--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -290,9 +290,27 @@ class Puppet::Provider
     end
   end
 
+  # Compare a fact value against one or more supplied value
+  # @param [Symbol] fact a fact to query to match against one of the given values
+  # @param [Array, Regexp, String] values one or more values to compare to the
+  #   value of the given fact
+  # @return [Boolean] whether or not the fact value matches one of the supplied
+  #   values. Given one or more Regexp instances, fact is compared via the basic
+  #   pattern-matching operator.
   def self.fact_match(fact, values)
     fact_val = Facter.value(fact).to_s.downcase
-    fact_val != "" and [*values].any? { |v| v === fact_val }
+    if fact_val.empty?
+      return false
+    else
+      values = [values] unless values.is_a?(Array)
+      values.any? do |value|
+        if value.is_a?(Regexp)
+          fact_val =~ value
+        else
+          fact_val.intern == value.to_s.downcase.intern
+        end
+      end
+    end
   end
 
   def self.feature_match(value)


### PR DESCRIPTION
This PR is the content of https://github.com/puppetlabs/puppet/pull/5069 with one additional commit added containing a refactor that achieves the original goal. See https://github.com/puppetlabs/puppet/pull/5069 for context. From that PR:

> - Allows easier matching for defaults. For example, Fedora 22+ uses DNF. It's easier to just give a regex of 22-29 rather than add a new one each time
> 
> Code is rough right now, but working according to the specs! 😄 
