### PR TITLE
(PUP-3713) Fix zfs type volume with volsize param

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -15,7 +15,11 @@ Puppet::Type.type(:zfs).provide(:zfs) do
     Puppet::Type.type(:zfs).validproperties.each do |property|
       next if property == :ensure
       if value = @resource[property] and value != ""
-        properties << "-o" << "#{property}=#{value}"
+        if property == :volsize
+          properties << "-V" << "#{value}"
+        else
+          properties << "-o" << "#{property}=#{value}"
+        end
       end
     end
     properties

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -49,7 +49,7 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
     end
 
     Puppet::Type.type(:zfs).validproperties.each do |prop|
-      next if prop == :ensure
+      next if [:ensure, :volsize].include?(prop)
       it "should include property #{prop}" do
         resource[prop] = prop
 
@@ -57,6 +57,12 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
 
         provider.create
       end
+    end
+
+    it "should use -V for the volsize property" do
+      resource[:volsize] = "10"
+      provider.expects(:zfs).with(:create, '-V', "10", name)
+      provider.create
     end
   end
 


### PR DESCRIPTION
This is the content of #4990, with commit message adjusted and an additional test that adjusts the spec to account for this change.

From #4990:
> Zfs of type "volume" (not filesystem) must be created with the -V option and the volsize param is only used in this case.
> So puppet should not specify -o volsize=N but -V N . 
> 
> It has already been asked the 11/26/2014 and updated twice in 2015 : https://tickets.puppetlabs.com/browse/PUP-3713
> 
> Thx
