### PR TITLE
(PUP-6964) Make modules see all other modules

### DIFF
--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -339,17 +339,13 @@ class Loaders
       !@private_loader.nil?
     end
 
-    def restrict_to_dependencies?
-      @puppet_module.has_metadata?
-    end
-
-    def unmet_dependencies?
-      @puppet_module.unmet_dependencies.any?
-    end
-
-    def dependency_names
-      @puppet_module.dependencies_as_modules.collect(&:name)
-    end
+#    def unmet_dependencies?
+#      @puppet_module.unmet_dependencies.any?
+#    end
+#
+#    def dependency_names
+#      @puppet_module.dependencies_as_modules.collect(&:name)
+#    end
   end
 
   # Resolves module loaders - resolution of model dependencies is done by Puppet::Module
@@ -378,41 +374,14 @@ class Loaders
       if module_data.resolved?
         nil
       else
-        module_data.private_loader =
-          if module_data.restrict_to_dependencies?
-            create_loader_with_only_dependencies_visible(module_data)
-          else
-            create_loader_with_all_modules_visible(module_data)
-          end
+        module_data.private_loader = create_loader_with_all_modules_visible(module_data)
       end
     end
 
     private
 
     def create_loader_with_all_modules_visible(from_module_data)
-      Puppet.debug{"ModuleLoader: module '#{from_module_data.name}' has unknown dependencies - it will have all other modules visible"}
-
       @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", all_module_loaders()))
-    end
-
-    def create_loader_with_only_dependencies_visible(from_module_data)
-      if from_module_data.unmet_dependencies?
-        if Puppet[:strict] != :off
-          msg = "ModuleLoader: module '#{from_module_data.name}' has unresolved dependencies" \
-              " - it will only see those that are resolved." \
-              " Use 'puppet module list --tree' to see information about modules"
-          case Puppet[:strict]
-          when :error
-              raise LoaderError.new(msg)
-          when :warning
-            Puppet.warn_once(:unresolved_module_dependencies,
-                             "unresolved_dependencies_for_module_#{from_module_data.name}",
-                             msg)
-          end
-        end
-      end
-      dependency_loaders = from_module_data.dependency_names.collect { |name| @index[name].public_loader }
-      @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", dependency_loaders))
     end
   end
 end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -338,14 +338,6 @@ class Loaders
     def resolved?
       !@private_loader.nil?
     end
-
-#    def unmet_dependencies?
-#      @puppet_module.unmet_dependencies.any?
-#    end
-#
-#    def dependency_names
-#      @puppet_module.dependencies_as_modules.collect(&:name)
-#    end
   end
 
   # Resolves module loaders - resolution of model dependencies is done by Puppet::Module

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -246,21 +246,15 @@ describe 'loaders' do
           expect(resource['message']).to eq(desc[:expects])
         end
 
-        it "can call #{desc[:called]} from #{desc[:from]} when no metadata is present" do
-          Puppet::Module.any_instance.expects('has_metadata?').at_least_once.returns(false)
+        it "can call #{desc[:called]} from #{desc[:from]} when dependency is not present in metadata.json" do
+          File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ ]).to_pson
+          File.stubs(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
+          File.stubs(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
           Puppet[:code] = "$case_number = #{case_number}\ninclude ::user"
           catalog = compiler.compile
           resource = catalog.resource('Notify', "case_#{case_number}")
           expect(resource).not_to be_nil
           expect(resource['message']).to eq(desc[:expects])
-        end
-
-        it "can not call #{desc[:called]} from #{desc[:from]} if dependency is missing in existing metadata.json" do
-          File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => []).to_pson
-          File.stubs(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
-          File.stubs(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
-          Puppet[:code] = "$case_number = #{case_number}\ninclude ::user"
-          expect { catalog = compiler.compile }.to raise_error(Puppet::Error, /Unknown function/)
         end
       end
     end
@@ -276,15 +270,15 @@ describe 'loaders' do
     end
 
     it "a type can reference an autoloaded type alias from another module when no metadata is present" do
-      Puppet::Module.any_instance.expects('has_metadata?').at_least_once.returns(false)
+      # Puppet::Module.any_instance.expects('has_metadata?').at_least_once.returns(false)
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
         assert_type(Usee::Zero, 0)
         notice(ok)
       CODE
     end
 
-    it "a type can reference a type alias from another module when other module has it declared in init.pp" do
-      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+    it "a type can reference a type alias from another module when other module has it declared in init.pp without required dependency" do
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ ]).to_pson
       File.stubs(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
       File.stubs(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
@@ -294,8 +288,8 @@ describe 'loaders' do
       CODE
     end
 
-    it "an autoloaded type can reference an autoloaded type alias from another module when dependency is present in metadata.json" do
-      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+    it "an autoloaded type can reference an autoloaded type alias from another module" do
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ ]).to_pson
       File.stubs(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
       File.stubs(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
@@ -305,7 +299,7 @@ describe 'loaders' do
     end
 
     it "an autoloaded type can reference an autoloaded type alias from another module when other module has it declared in init.pp" do
-      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ { 'name' => 'test-usee'} ]).to_pson
+      File.stubs(:read).with(user_metadata_path, {:encoding => 'utf-8'}).returns user_metadata.merge('dependencies' => [ ]).to_pson
       File.stubs(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
       File.stubs(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
       expect(eval_and_collect_notices(<<-CODE, node)).to eq(['ok'])
@@ -551,22 +545,22 @@ describe 'loaders' do
         expect(type).to be_a(Puppet::Pops::Types::PIntegerType)
       end
 
-      it 'will not resolve implicit transitive dependencies, a -> c' do
+      it 'will resolve implicit transitive dependencies, a -> c' do
         type = Puppet::Pops::Types::TypeParser.singleton.parse('A::N', Puppet::Pops::Loaders.find_loader('a'))
         expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
         expect(type.name).to eql('A::N')
         type = type.resolved_type
-        expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
-        expect(type.type_string).to eql('C::C')
+        expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+        expect(type.name).to eql('C::C')
       end
 
-      it 'will not resolve reverse dependencies, b -> a' do
+      it 'will resolve reverse dependencies, b -> a' do
         type = Puppet::Pops::Types::TypeParser.singleton.parse('B::X', Puppet::Pops::Loaders.find_loader('b'))
         expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
         expect(type.name).to eql('B::X')
         type = type.resolved_type
-        expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
-        expect(type.type_string).to eql('A::A')
+        expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+        expect(type.name).to eql('A::A')
       end
 
       it 'does not resolve init_typeset when more qualified type is found in typeset' do


### PR DESCRIPTION
It is an unwanted complications that a module must have a metadata.json with dependencies on other modules in order to be able to use them.
This PR removes that requirement - after this all modules see all other module's functions and types.