### PR TITLE
(PUP-3323) Support `source` in yum provider

### DIFF
--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -103,6 +103,13 @@ test_name "test the yum package provider" do
       end
       verify_absent agents, 'not_a_package'
     end
+
+    step 'Installing a known package using source succeeds' do
+      verify_absent agents, 'guid'
+      apply_manifest_on(agent, "package { 'guid': ensure => installed, source=>'/tmp/rpmrepo/RPMS/noarch/guid-1.0-1.noarch.rpm' }") do |result|
+        assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
+      end
+    end
   end
 
   ### Epoch tests ###

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -175,12 +175,12 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
         operation = :install
       end
       should = nil
-    when true, :present, :installed 
+    when true, :present, :installed
       # if we have been given a source and we were not asked for a specific
       # version feed it to yum directly
       if @resource[:source]
         wanted = @resource[:source]
-        self.debug "Downloading directly from #{wanted}"
+        self.debug "Installing directly from #{wanted}"
       end
       should = nil
     when false,:absent

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -175,7 +175,15 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
         operation = :install
       end
       should = nil
-    when true, false, Symbol
+    when true, :present, :installed 
+      # if we have been given a source and we were not asked for a specific
+      # version feed it to yum directly
+      if @resource[:source]
+        wanted = @resource[:source]
+        self.debug "Downloading directly from #{wanted}"
+      end
+      should = nil
+    when false,:absent
       # pass
       should = nil
     else

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -187,13 +187,20 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       # pass
       should = nil
     else
-      # Add the package version
-      wanted += "-#{should}"
-      if wanted.scan(ARCH_REGEX)
-        self.debug "Detected Arch argument in package! - Moving arch to end of version string"
-        wanted.gsub!(/(.+)(#{ARCH_REGEX})(.+)/,'\1\3\2')
+      if @resource[:source]
+        # An explicit source was supplied, which means we're ensuring a specific
+        # version, and also supplying the path to a package that supplies that
+        # version.
+        wanted = @resource[:source]
+        self.debug "Installing directly from #{wanted}"
+      else
+        # No explicit source was specified, so add the package version
+        wanted += "-#{should}"
+        if wanted.scan(ARCH_REGEX)
+          self.debug "Detected Arch argument in package! - Moving arch to end of version string"
+          wanted.gsub!(/(.+)(#{ARCH_REGEX})(.+)/,'\1\3\2')
+        end
       end
-
       current_package = self.query
       if current_package
         if rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(current_package[:ensure])) < 0


### PR DESCRIPTION
This PR contains the content from #5986, with an additional couple commits that complete the functionality for the ensure => version case.

From that PR:
> If the source parameter is set when using the yum package provider, then use it with yum directly. This has the advantage of bringing in a package's dependencies while allowing direct installation from the internet without already setting up a repository

#5986 sufficiently covered the ensure present case, ie
```
package { "foo":
  ensure => present,
  source => "http://foo.com/foo-1.1.0.rpm",
}
```
will work correctly.

This PR completes this with the ensure => version case, ie
```
package { "foo":
  ensure => "1.2.0",
  source => "http://foo.com/foo-1.2.0.rpm",
}
```

This PR also adds spec tests to yum_spec.rb for the functionality.