### PR TITLE
(PUP-8082) Add warnings to PMT for deprecated modules

### DIFF
--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -49,8 +49,10 @@ Puppet::Face.define(:module, '1.0.0') do
       terminal_width = [Puppet::Util::Terminal.width, min_width].max
 
       columns = results[:answers].inject(min_widths) do |hash, result|
+        deprecated_buffer = result['deprecated_at'].nil? ? 0 : 11 # ' DEPRECATED'.length
+
         {
-          'full_name' => [ hash['full_name'], result['full_name'].length          ].max,
+          'full_name' => [ hash['full_name'], result['full_name'].length + deprecated_buffer ].max,
           'desc'      => [ hash['desc'],      result['desc'].length               ].max,
           'author'    => [ hash['author'],    "@#{result['author']}".length       ].max,
           'tag_list'  => [ hash['tag_list'],  result['tag_list'].join(' ').length ].max,
@@ -86,6 +88,7 @@ Puppet::Face.define(:module, '1.0.0') do
       format % [ headers['full_name'], headers['desc'], headers['author'], headers['tag_list'] ] +
       results[:answers].map do |match|
         name, desc, author, keywords = %w{full_name desc author tag_list}.map { |k| match[k] }
+        name += " #{colorize(:red, 'DEPRECATED')}" unless match['deprecated_at'].nil?
         desc = desc[0...(columns['desc'] - 3)] + '...' if desc.length > columns['desc']
         highlight[format % [ name.sub('/', '-'), desc, "@#{author}", [keywords].flatten.join(' ') ]]
       end.join

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -166,6 +166,8 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     def prepare
       return @unpacked_into if @unpacked_into
 
+      Puppet.warning "#{@metadata['name']} has been deprecated by its author! View module on Puppet Forge for more info." if deprecated?
+
       download(@data['file_uri'], tmpfile)
       validate_checksum(tmpfile, @data['file_md5'])
       unpack(tmpfile, tmpdir)
@@ -208,6 +210,10 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       rescue Puppet::ExecutionFailure => e
         raise RuntimeError, _("Could not extract contents of module archive: %{message}") % { message: e.message }
       end
+    end
+
+    def deprecated?
+      @data['module'] && (@data['module']['deprecated_at'] != nil)
     end
   end
 

--- a/spec/unit/face/module/search_spec.rb
+++ b/spec/unit/face/module/search_spec.rb
@@ -64,6 +64,17 @@ describe "puppet module search" do
       expect(subject.render(results, ['apache', {}])).to match(/tag2/)
     end
 
+    it 'should mark deprecated modules in search results' do
+      results = {
+        :result => :success,
+        :answers => [
+          {'full_name' => 'puppetlabs-corosync', 'deprecated_at' => Time.new, 'author' => 'Author', 'desc' => 'Summary', 'tag_list' => ['tag1', 'tag2'] },
+        ]
+      }
+
+      expect(subject.render(results, ['apache', {}])).to match(/puppetlabs-corosync.*DEPRECATED/i)
+    end
+
     it 'should elide really long descriptions' do
       results = {
         :result => :success,

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -215,4 +215,74 @@ describe Puppet::Forge::ModuleRelease do
 
     it_behaves_like 'a module release'
   end
+
+  context 'deprecated forge module' do
+    let(:release_json) do %Q{
+    {
+      "uri": "/#{api_version}/releases/#{module_full_name_versioned}",
+      "module": {
+        "uri": "/#{api_version}/modules/#{module_full_name}",
+        "name": "#{module_name}",
+        "deprecated_at": "2017-10-10 10:21:32 -0700",
+        "owner": {
+          "uri": "/#{api_version}/users/#{module_author}",
+          "username": "#{module_author}",
+          "gravatar_id": "fdd009b7c1ec96e088b389f773e87aec"
+        }
+      },
+      "version": "#{module_version}",
+      "metadata": {
+        "types": [ ],
+        "license": "Apache 2.0",
+        "checksums": { },
+        "version": "#{module_version}",
+        "description": "Standard Library for Puppet Modules",
+        "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+        "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+        "summary": "Puppet Module Standard Library",
+        "dependencies": [
+
+        ],
+        "author": "#{module_author}",
+        "name": "#{module_full_name}"
+      },
+      "tags": [
+        "puppetlabs",
+        "library",
+        "stdlib",
+        "standard",
+        "stages"
+      ],
+      "file_uri": "/#{api_version}/files/#{module_full_name_versioned}.tar.gz",
+      "file_size": 67586,
+      "file_md5": "#{module_md5}",
+      "downloads": 610751,
+      "readme": "",
+      "changelog": "",
+      "license": "",
+      "created_at": "2013-05-13 08:31:19 -0700",
+      "updated_at": "2013-05-13 08:31:19 -0700",
+      "deleted_at": null
+    }
+    }
+    end
+
+    it_behaves_like 'a module release'
+
+    describe '#prepare' do
+      before :each do
+        release.stubs(:tmpfile).returns(mock_file)
+        release.stubs(:tmpdir).returns(mock_dir)
+        release.stubs(:download)
+        release.stubs(:validate_checksum)
+        release.stubs(:unpack)
+      end
+
+      it 'should emit warning about module deprecation' do
+        Puppet.expects(:warning).with(regexp_matches(/#{Regexp.escape(module_full_name)}.*deprecated/i))
+
+        release.prepare
+      end
+    end
+  end
 end


### PR DESCRIPTION
Updates `puppet module search` to clearly indicate any deprecated
modules in the returned search results. Updates `puppet module
install` and `puppet module update` to emit a warning if a deprecated
module is being installed.