### PR TITLE
(PUP-8040) Do not use thread local locale

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -42,11 +42,10 @@ module Puppet
   require 'puppet/environments'
 
   class << self
-    gettext_config_file = Puppet::GettextConfig.puppet_locale_path
-    unless Puppet::GettextConfig.initialize(gettext_config_file, Puppet::GettextConfig.translation_mode(gettext_config_file))
-      # Stub out gettext's `_` and `n_()` methods, which attempt to load translations,
-      # with versions that do nothing
-      require 'puppet/gettext/stubs'
+    Puppet::GettextConfig.create_text_domain('production')
+    locale_dir = Puppet::GettextConfig.puppet_locale_path
+    if Puppet::GettextConfig.load_translations('puppet', locale_dir, Puppet::GettextConfig.translation_mode(locale_dir))
+      Puppet::GettextConfig.set_locale(Locale.current.language)
     end
 
     include Puppet::Util

--- a/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet.rb
+++ b/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet.rb
@@ -1,5 +1,5 @@
 module SemanticPuppet
-  Puppet::GettextConfig.initialize(File.absolute_path('../locales', File.dirname(__FILE__)), :po)
+  Puppet::GettextConfig.load_translations('semantic_puppet', File.absolute_path('../locales', File.dirname(__FILE__)), :po)
 
   autoload :Version, 'semantic_puppet/version'
   autoload :VersionRange, 'semantic_puppet/version_range'

--- a/spec/unit/gettext_config_spec.rb
+++ b/spec/unit/gettext_config_spec.rb
@@ -35,22 +35,22 @@ describe Puppet::GettextConfig do
     end
   end
 
-  describe 'initialization' do
+  describe 'loading translations' do
     context 'when given a nil config path' do
       it 'should return false' do
-        expect(Puppet::GettextConfig.initialize(nil, :po)).to be false
+        expect(Puppet::GettextConfig.load_translations('puppet', nil, :po)).to be false
       end
     end
 
     context 'when given a valid config file location' do
       it 'should return true' do
-        expect(Puppet::GettextConfig.initialize(local_path, :po)).to be true
+        expect(Puppet::GettextConfig.load_translations('puppet', local_path, :po)).to be true
       end
     end
 
     context 'when given a bad file format' do
       it 'should raise an exception' do
-        expect { Puppet::GettextConfig.initialize(local_path, :bad_format) }.to raise_error(Puppet::Error)
+        expect { Puppet::GettextConfig.load_translations('puppet', local_path, :bad_format) }.to raise_error(Puppet::Error)
       end
     end
   end


### PR DESCRIPTION
This commit majorly refactors the way we load tranlsations, to avoid
using the gettext-setup gem altogether. This allows us to set the locale
globally, rather than thread-locally, and also paves the way for
maintaining a different text domain for each environment.