### PR TITLE
(PUP-4918) `rotate` instead of `reload` for logrotate

### DIFF
--- a/ext/redhat/logrotate
+++ b/ext/redhat/logrotate
@@ -15,7 +15,7 @@
   nocreate
   sharedscripts
   postrotate
-   ([ -x /etc/init.d/puppet ] && /etc/init.d/puppet reload > /dev/null 2>&1) ||
+   ([ -x /etc/init.d/puppet ] && /etc/init.d/puppet rotate > /dev/null 2>&1) ||
     ([ -x /usr/bin/systemctl ] && /usr/bin/systemctl kill -s USR2 puppet.service > /dev/null 2>&1) || true
   endscript
 }


### PR DESCRIPTION
This PR contains the content of https://github.com/puppetlabs/puppet/pull/5708, with the commit message amended per contributing guidelines.

From that PR:
> ext/redhat/logrotate: really avoid 'service puppet reload' in favor of 'service
puppet rotate' with the correct signal
>
> It looks like there was an intention to introduce this fix in
793d713503d27600b4c64e4e0c331d6d7365e3c4
'(PUP-4918) Updated logrotate and init scripts',
where the "rotate" command was added to
ext/redhat/client.init specifically for this purpose.
>
> This doesn't apply to ext/debian/puppet.logrotate because
ext/debian/puppet.init lacks a special command with this signal.