### PR TITLE
(PUP-9096) Preserve transactionstore when tags are applied

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -262,6 +262,7 @@ class Puppet::Transaction
       resource_status(resource).skipped = true
       resource.debug("Resource is being skipped, unscheduling all events")
       event_manager.dequeue_all_events_for_resource(resource)
+      persistence.copy_skipped(resource.ref)
     else
       resource_status(resource).scheduled = true
       apply(resource, ancestor)

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -22,14 +22,9 @@ class Puppet::Transaction::Persistence
   # @param [String] param_name name of the parameter
   # @return [Object,nil] the system_value
   def get_system_value(resource_name, param_name)
-    if !@old_data["resources"].nil? &&
-       !@old_data["resources"][resource_name].nil? &&
-       !@old_data["resources"][resource_name]["parameters"].nil? &&
-       !@old_data["resources"][resource_name]["parameters"][param_name].nil?
-      @old_data["resources"][resource_name]["parameters"][param_name]["system_value"]
-    else
-      nil
-    end
+    @old_data["resources"][resource_name]["parameters"][param_name]["system_value"]
+  rescue 
+    nil
   end
 
   def set_system_value(resource_name, param_name, value)
@@ -38,6 +33,14 @@ class Puppet::Transaction::Persistence
     @new_data["resources"][resource_name]["parameters"] ||= {}
     @new_data["resources"][resource_name]["parameters"][param_name] ||= {}
     @new_data["resources"][resource_name]["parameters"][param_name]["system_value"] = value
+  end
+
+  def copy_skipped(resource_name)
+    @old_data["resources"] ||= {}
+    old_value = @old_data["resources"][resource_name]
+    if !old_value.nil?
+      @new_data["resources"][resource_name] = old_value
+    end
   end
 
   # Load data from the persistence store on disk.

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -4,6 +4,7 @@ require 'matchers/include_in_order'
 require 'puppet_spec/compiler'
 
 require 'puppet/transaction'
+require 'puppet/transaction/persistence'
 require 'fileutils'
 
 describe Puppet::Transaction do
@@ -129,6 +130,27 @@ describe Puppet::Transaction do
         transaction.expects(:skip?).with(resource).returns true
         transaction.event_manager.expects(:dequeue_all_events_for_resource).with(resource)
         transaction.evaluate
+      end
+    end
+
+    describe "when evaluating a skipped resource for corrective change it" do
+      it "should persist in the transactionstore" do  
+        Puppet[:transactionstorefile] = tmpfile('persistence_test')
+       
+        resource = Puppet::Type.type(:notify).new :title => "foobar"
+        transaction = transaction_with_resource(resource)
+        transaction.evaluate
+        expect(transaction.resource_status(resource)).to be_changed
+
+        transaction = transaction_with_resource(resource)
+        transaction.expects(:skip?).with(resource).returns true
+        transaction.event_manager.expects(:process_events).with(resource).never
+        transaction.evaluate
+        expect(transaction.resource_status(resource)).to be_skipped
+
+        persistence = Puppet::Transaction::Persistence.new
+        persistence.load
+        expect(persistence.get_system_value(resource.ref, "message")).to eq(["foobar"])
       end
     end
   end


### PR DESCRIPTION
The transactionstore.yaml file used to calculate corrective change is updated on each agent run with the set of applied resources. When the `--tags` option is provided, only the state of the resources matching the tags was preserved with all other state list. That means corrective change is not correctly determined on future runs for those resources excluded by the tags.

This commit updates the transactionstore when resources are skipped to preserve the last seen value.