### PR TITLE
(PUP-8040) Fix error if fast_gettext isn't loaded

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -38,6 +38,7 @@ module Puppet::GettextConfig
   # @param project_name [String] the project whose translations we are querying
   # @return [Boolean] true if translations have been loaded for the project
   def self.translations_loaded?(project_name)
+    return false unless gettext_loaded?
     if @loaded_repositories[project_name]
       return true
     else


### PR DESCRIPTION
if fast_gettext wasn't loaded, initializing modules would result in an
exception because loaded_repositories was never set. This was found in
puppetserver unit tests. It's unlikely to affect other places as
gettext-setup - and thus fast_gettext - are runtime dependencies in the
gemspec.