### PR TITLE
(PUP-8098) adding 'acltype' as a valid property for a ZFS file system

### DIFF
--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -57,8 +57,9 @@ Puppet::Type.type(:zfs).provide(:zfs) do
   # https://docs.oracle.com/cd/E19963-01/html/821-1448/gbscy.html
   # shareiscsi (added in build 120) was removed from S11 build 136
   # aclmode was removed from S11 in build 139 but it may have been added back
+  # acltype is for ZFS on Linux, and allows disabling or enabling POSIX ACLs
   # http://webcache.googleusercontent.com/search?q=cache:-p74K0DVsdwJ:developers.slashdot.org/story/11/11/09/2343258/solaris-11-released+&cd=13
-  [:aclmode, :shareiscsi].each do |field|
+  [:aclmode, :acltype, :shareiscsi].each do |field|
     # The zfs commands use the property value '-' to indicate that the
     # property is not set. We make use of this value to indicate that the
     # property is not set since it is not available. Conversely, if these

--- a/lib/puppet/type/zfs.rb
+++ b/lib/puppet/type/zfs.rb
@@ -20,6 +20,10 @@ parent zfs instances, the zfs resource will autorequire them."
       desc "The aclmode property. Valid values are `discard`, `groupmask`, `passthrough`."
     end
 
+    newproperty(:acltype) do
+      desc "The acltype propery. Valid values are 'noacl' and 'posixacl'. Only supported on Linux."
+    end
+
     newproperty(:atime) do
       desc "The atime property. Valid values are `on`, `off`."
     end

--- a/spec/unit/provider/zfs/zfs_spec.rb
+++ b/spec/unit/provider/zfs/zfs_spec.rb
@@ -139,7 +139,28 @@ describe Puppet::Type.type(:zfs).provider(:zfs) do
         provider.send("zoned=", "value")
       end
     end
+  end
+  describe "acltype" do
+    context "when available" do
+      it "should get 'acltype' property" do
+        provider.expects(:zfs).with(:get, '-H', '-o', 'value', :acltype, name).returns("value\n")
+        expect(provider.send("acltype")).to eq('value')
+      end
+      it "should set acltype=value" do
+        provider.expects(:zfs).with(:set, "acltype=value", name)
+        provider.send("acltype=", "value")
+      end
+    end
 
-
+    context "when not available" do
+      it "should get '-' for the acltype property" do
+        provider.expects(:zfs).with(:get, '-H', '-o', 'value', :acltype, name).raises(RuntimeError, 'not valid')
+        expect(provider.send("acltype")).to eq('-')
+      end
+      it "should not error out when trying to set acltype" do
+        provider.expects(:zfs).with(:set, "acltype=value", name).raises(RuntimeError, 'not valid')
+        expect{provider.send("acltype=", "value")}.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds property 'acltype' to the accepted list of ZFS properties.