### PR TITLE
(PUP-8099) Use fully qualified paths of VDevs in zpool provider.

### DIFF
--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:zpool).provide(:zpool) do
   def get_pool_data
     # https://docs.oracle.com/cd/E19082-01/817-2271/gbcve/index.html
     # we could also use zpool iostat -v mypool for a (little bit) cleaner output
-    out = execute("zpool status #{@resource[:pool]}", :failonfail => false, :combine => false)
+    out = execute("zpool status -P #{@resource[:pool]}", :failonfail => false, :combine => false)
     zpool_data = out.lines.select { |line| line.index("\t") == 0 }.collect { |l| l.strip.split("\s")[0] }
     zpool_data.shift
     zpool_data


### PR DESCRIPTION
Adds the -P parameter to "zpool status" to get back fully qualified device paths of VDevs.