### PR TITLE
(PUP-8089) Add a new pluginsync downloader for module translations

### DIFF
--- a/lib/puppet/configurer/downloader_factory.rb
+++ b/lib/puppet/configurer/downloader_factory.rb
@@ -31,4 +31,14 @@ class Puppet::Configurer::DownloaderFactory
       source_permissions
     )
   end
+
+  def create_locales_downloader(environment)
+    locales_downloader = Puppet::Configurer::Downloader.new(
+      "locales",
+      Puppet[:localedest],
+      Puppet[:localesource],
+      Puppet[:pluginsignore] + " config.yaml",
+      environment
+    )
+  end
 end

--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -11,13 +11,13 @@ class Puppet::Configurer::PluginHandler
   # Retrieve facts from the central server.
   def download_plugins(environment)
     plugin_downloader = @factory.create_plugin_downloader(environment)
-
-    result = []
-
     plugin_fact_downloader = @factory.create_plugin_facts_downloader(environment)
+    locales_downloader = @factory.create_locales_downloader(environment)
+    result = []
     result += plugin_fact_downloader.evaluate
-
     result += plugin_downloader.evaluate
+    result += locales_downloader.evaluate
+
     Puppet::Util::Autoload.reload_changed
 
     result

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1708,6 +1708,19 @@ EOT
       :default  => "puppet:///pluginfacts",
       :desc     => "Where to retrieve external facts for pluginsync",
     },
+    :localedest => {
+      :type       => :directory,
+      :default    => "$vardir/locales",
+      :desc       => "Where Puppet should store translation files that it pulls down from the central
+      server.",
+    },
+    :localesource => {
+      :default    => "puppet:///locales",
+      :desc       => "From where to retrieve translation files.  The standard Puppet `file` type
+      is used for retrieval, so anything that is a valid file source can
+      be used here.",
+    },
+
     :pluginsync => {
       :default    => true,
       :type       => :boolean,
@@ -1717,9 +1730,8 @@ EOT
         Puppet.deprecation_warning "Setting 'pluginsync' is deprecated."
       }
     },
-
     :pluginsignore => {
-        :default  => ".svn CVS .git .hg",
+        :default  => ".svn CVS .git .hg *.pot",
         :desc     => "What files to ignore when pulling down plugins.",
     }
   )

--- a/spec/integration/faces/plugin_spec.rb
+++ b/spec/integration/faces/plugin_spec.rb
@@ -28,6 +28,7 @@ describe "Puppet plugin face" do
   before do
     FileUtils.mkdir(File.join(Puppet[:vardir], 'lib'))
     FileUtils.mkdir(File.join(Puppet[:vardir], 'facts.d'))
+    FileUtils.mkdir(File.join(Puppet[:vardir], 'locales'))
     @termini_classes = {}
     INDIRECTED_CLASSES.each do |indirected|
       @termini_classes[indirected] = indirected.indirection.terminus_class

--- a/spec/unit/configurer/downloader_factory_spec.rb
+++ b/spec/unit/configurer/downloader_factory_spec.rb
@@ -14,6 +14,10 @@ describe Puppet::Configurer::DownloaderFactory do
     factory.create_plugin_facts_downloader(environment)
   end
 
+  let(:locales_downloader) do
+    factory.create_locales_downloader(environment)
+  end
+
   def ignores_source_permissions(downloader)
     expect(downloader.file[:source_permissions]).to eq(:ignore)
   end
@@ -91,6 +95,35 @@ describe Puppet::Configurer::DownloaderFactory do
       it "ignores source permissions during external fact pluginsync" do
         ignores_source_permissions(facts_downloader)
       end
+    end
+  end
+
+  context "when creating a plugin downloader for module translations" do
+    it 'is named "locales"' do
+      expect(locales_downloader.name).to eq('locales')
+    end
+
+    it 'downloads files into Puppet[:localedest]' do
+      localedest = File.expand_path("/tmp/ldest")
+      Puppet[:localedest] = localedest
+
+      expect(locales_downloader.file[:path]).to eq(localedest)
+    end
+
+    it 'downloads files from Puppet[:localesource]' do
+      Puppet[:localesource] = 'puppet:///myotherlocales'
+
+      expect(locales_downloader.file[:source]).to eq([Puppet[:localesource]])
+    end
+
+    it 'ignores files from Puppet[:pluginsignore], plus config.yaml' do
+      Puppet[:pluginsignore] = 'lignore'
+
+      expect(locales_downloader.file[:ignore]).to eq(['lignore', 'config.yaml'])
+    end
+
+    it "ignores source permissions" do
+      ignores_source_permissions(locales_downloader)
     end
   end
 end

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -14,23 +14,27 @@ describe Puppet::Configurer::PluginHandler do
     Puppet.expects(:err).never
   end
 
-  it "downloads plugins and facts" do
+  it "downloads plugins, facts, and locales" do
     plugin_downloader = stub('plugin-downloader', :evaluate => [])
     facts_downloader = stub('facts-downloader', :evaluate => [])
+    locales_downloader = stub('locales-downloader', :evaluate => [])
 
     factory.expects(:create_plugin_downloader).returns(plugin_downloader)
     factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
+    factory.expects(:create_locales_downloader).returns(locales_downloader)
 
     pluginhandler.download_plugins(environment)
   end
 
-  it "returns downloaded plugin and fact filenames" do
+  it "returns downloaded plugin, fact, and locale filenames" do
     plugin_downloader = stub('plugin-downloader', :evaluate => %w[/a])
     facts_downloader = stub('facts-downloader', :evaluate => %w[/b])
+    locales_downloader = stub('locales-downloader', :evaluate => %w[/c])
 
     factory.expects(:create_plugin_downloader).returns(plugin_downloader)
     factory.expects(:create_plugin_facts_downloader).returns(facts_downloader)
+    factory.expects(:create_locales_downloader).returns(locales_downloader)
 
-    expect(pluginhandler.download_plugins(environment)).to match_array(%w[/a /b])
+    expect(pluginhandler.download_plugins(environment)).to match_array(%w[/a /b /c])
   end
 end

--- a/spec/unit/face/plugin_spec.rb
+++ b/spec/unit/face/plugin_spec.rb
@@ -12,24 +12,24 @@ describe Puppet::Face[:plugin, :current] do
   end
 
   context "download" do
-    it "downloads plugins and external facts" do
-      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).twice.returns([])
+    it "downloads plugins, external facts, and locales" do
+      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).times(3).returns([])
 
       pluginface.download
     end
 
     it "renders 'No plugins downloaded' if nothing was downloaded" do
-      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).twice.returns([])
+      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).times(3).returns([])
 
       result = pluginface.download
       expect(render(result)).to eq('No plugins downloaded.')
     end
 
     it "renders comma separate list of downloaded file names" do
-      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).twice.returns(%w[/a]).then.returns(%w[/b])
+      Puppet::Configurer::Downloader.any_instance.expects(:evaluate).times(3).returns(%w[/a]).then.returns(%w[/b]).then.returns(%w[/c])
 
       result = pluginface.download
-      expect(render(result)).to eq('Downloaded these plugins: /a, /b')
+      expect(render(result)).to eq('Downloaded these plugins: /a, /b, /c')
     end
   end
 end


### PR DESCRIPTION
This commit adds a new downloader to pluginsync, responsible for syncing
the locales directories of modules. Without this, translation files are
not synced from the master to the agent, and module translations will
not be displayed during agent runs.