### PR TITLE
(PUP-8096) Preserve transactionstore when tags are applied

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -262,6 +262,7 @@ class Puppet::Transaction
       resource_status(resource).skipped = true
       resource.debug("Resource is being skipped, unscheduling all events")
       event_manager.dequeue_all_events_for_resource(resource)
+      persistence.copy_skipped(resource.ref)
     else
       resource_status(resource).scheduled = true
       apply(resource, ancestor)

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -40,6 +40,14 @@ class Puppet::Transaction::Persistence
     @new_data["resources"][resource_name]["parameters"][param_name]["system_value"] = value
   end
 
+  def copy_skipped(resource_name)
+    @old_data["resources"] ||= {}
+    old_value = @old_data["resources"][resource_name]
+    if !old_value.nil?
+      @new_data["resources"][resource_name] = old_value
+    end
+  end
+
   # Load data from the persistence store on disk.
   def load
     filename = Puppet[:transactionstorefile]


### PR DESCRIPTION
The transactionstore.yaml file used to calculate corrective change is updated on each agent run with the set of applied resources. When the --tags option is provided, only the state of the resources matching the tags were stored, with the state for other resources discarded. That means corrective change is not correctly determined on future runs for those resources excluded by the tags.

This commit updates the transactionstore when resources are skipped to preserve the last seen value.