### PR TITLE
(PUP-8050) Add shorter `-E` flag for `--environment`

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -299,7 +299,8 @@ module Puppet
         :desc     => "The environment Puppet is running in.  For clients
           (e.g., `puppet agent`) this determines the environment itself, which
           is used to find modules and much more.  For servers (i.e., `puppet master`)
-          this provides the default environment for nodes we know nothing about."
+          this provides the default environment for nodes we know nothing about.",
+        :short    => "E"
     },
     :environmentpath => {
       :default => "$codedir/environments",


### PR DESCRIPTION
Prior to this commit, users had to spell out `--environment`
on the command line, which was repetitious and long.

This adds a short `-E` flag as a synonym since `-e` is already
in widespread use for inline code with `puppet apply -e ...`

PS I looked through the acceptance and unit tests and didn't see any that specifically tested command line arguments so there wasn't an obvious place to start adding them.

PPS I targeted 4.10.x for this as the oldest branch, happy to retarget if that's wrong.