### PR TITLE
(PUP-8106) Make the `mount` type autorequire its `file` mountpoint

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -16,6 +16,9 @@ module Puppet
       that is, other mount points higher up in the filesystem --- the child
       mount will autorequire them.
 
+      **Autorequires:** If Puppet is managing a `File` resource for the mount
+      point of a mount resource, the mount will autorequire it.
+
       **Autobefores:**  If Puppet is managing any child file paths of a mount
       point, the mount resource will autobefore them."
 
@@ -298,6 +301,12 @@ module Puppet
         dependencies.unshift parent.to_s
       end
       dependencies[0..-2]
+    end
+
+    # Ensure that the mountpoint is created first
+    autorequire(:file) do
+      dependencies = []
+      dependencies.unshift @parameters[:name].value
     end
 
     # Autobefore the mount point's child file paths

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -589,24 +589,32 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
 
     it "adds the parent autorequire and the file autorequire for a mount with one parent" do
       parent_relationship = var_mount.autorequire[0]
+      mountpoint_relationship = var_mount.autorequire[1]
 
-      expect(var_mount.autorequire).to have_exactly(1).item
+      expect(var_mount.autorequire).to have_exactly(2).items
 
       expect(parent_relationship.source).to eq root_mount
       expect(parent_relationship.target).to eq var_mount
+      expect(mountpoint_relationship.source).to eq var_file
+      expect(mountpoint_relationship.target).to eq var_mount
     end
 
     it "adds both parent autorequires and the file autorequire for a mount with two parents" do
       grandparent_relationship = log_mount.autorequire[0]
       parent_relationship = log_mount.autorequire[1]
+      mountpoint_relationship = log_mount.autorequire[2]
 
-      expect(log_mount.autorequire).to have_exactly(2).items
+      expect(log_mount.autorequire).to have_exactly(3).items
 
       expect(grandparent_relationship.source).to eq root_mount
       expect(grandparent_relationship.target).to eq log_mount
 
       expect(parent_relationship.source).to eq var_mount
       expect(parent_relationship.target).to eq log_mount
+
+      expect(mountpoint_relationship.source).to eq log_file
+      expect(mountpoint_relationship.target).to eq log_mount
+
     end
 
     it "adds the child autobefore for a mount with one file child" do


### PR DESCRIPTION
Without this patch, the `mount` type might try to mount a filesystem
before its mountpoint is created.