### PR TITLE
(PUP-8109) puppet device cannot create certs when run as root

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1325,6 +1325,8 @@ EOT
         :default  => "$vardir/devices",
         :type     => :directory,
         :mode     => "0750",
+        :owner    => "service",
+        :group    => "service",
         :desc     => "The root directory of devices' $vardir.",
     },
     :deviceconfig => {


### PR DESCRIPTION
This is a backport of the same fix from 5.4.0 #6026 

Prior to this commit, puppet device could not write to the privatekeydir
and certdir for devices.

drwxr-x---.  3 root      root        18 Jun 28 22:55 devices

With this commit, the $vardir/devices directory’s owner and and group are set
to the service user, so that the service user can traverse the directory.

drwxr-x---.  3 pe-puppet pe-puppet   18 Jun 28 22:55 devices