### PR TITLE
(PUP-8100) add locales mountpoint.

### DIFF
--- a/lib/puppet/file_serving/configuration.rb
+++ b/lib/puppet/file_serving/configuration.rb
@@ -4,6 +4,7 @@ require 'puppet/file_serving/mount'
 require 'puppet/file_serving/mount/file'
 require 'puppet/file_serving/mount/modules'
 require 'puppet/file_serving/mount/plugins'
+require 'puppet/file_serving/mount/locales'
 require 'puppet/file_serving/mount/pluginfacts'
 require 'puppet/file_serving/mount/tasks'
 
@@ -81,6 +82,8 @@ class Puppet::FileServing::Configuration
     @mounts["modules"].allow('*') if @mounts["modules"].empty?
     @mounts["plugins"] ||= Mount::Plugins.new("plugins")
     @mounts["plugins"].allow('*') if @mounts["plugins"].empty?
+    @mounts["locales"] ||= Mount::Locales.new("locales")
+    @mounts["locales"].allow('*') if @mounts["locales"].empty?
     @mounts["pluginfacts"] ||= Mount::PluginFacts.new("pluginfacts")
     @mounts["pluginfacts"].allow('*') if @mounts["pluginfacts"].empty?
     @mounts["tasks"] ||= Mount::Tasks.new("tasks")

--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -94,6 +94,8 @@ class Puppet::FileServing::Configuration::Parser
       mount = Mount::Plugins.new(name)
     when "tasks"
       mount = Mount::Tasks.new(name)
+    when "locales"
+      mount = Mount::Locales.new(name)
     else
       mount = Mount::File.new(name)
     end

--- a/lib/puppet/file_serving/mount/locales.rb
+++ b/lib/puppet/file_serving/mount/locales.rb
@@ -1,0 +1,35 @@
+require 'puppet/file_serving/mount'
+
+# Find files in the modules' locales directories.
+# This is a very strange mount because it merges
+# many directories into one.
+class Puppet::FileServing::Mount::Locales < Puppet::FileServing::Mount
+  # Return an instance of the appropriate class.
+  def find(relative_path, request)
+    return nil unless mod = request.environment.modules.find { |m|  m.locale(relative_path) }
+
+    path = mod.locale(relative_path)
+
+    path
+  end
+
+  def search(relative_path, request)
+    # We currently only support one kind of search on locales - return
+    # them all.
+    Puppet.debug("Warning: calling Locales.search with empty module path.") if request.environment.modules.empty?
+    paths = request.environment.modules.find_all { |mod| mod.locales? }.collect { |mod| mod.locale_directory }
+    if paths.empty?
+      # If the modulepath is valid then we still need to return a valid root
+      # directory for the search, but make sure nothing inside it is
+      # returned.
+      request.options[:recurse] = false
+      request.environment.modulepath.empty? ? nil : request.environment.modulepath
+    else
+      paths
+    end
+  end
+
+  def valid?
+    true
+  end
+end

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -23,6 +23,7 @@ class Puppet::Module
     "templates" => "templates",
     "plugins" => "lib",
     "pluginfacts" => "facts.d",
+    "locales" => "locales",
   }
 
   # Find and return the +module+ that +path+ belongs to. If +path+ is
@@ -302,6 +303,11 @@ class Puppet::Module
     subpath("facts.d")
   end
 
+  #@return [String]
+  def locale_directory
+    subpath("locales")
+  end
+
   def has_external_facts?
     File.directory?(plugin_fact_directory)
   end
@@ -428,12 +434,10 @@ class Puppet::Module
     module_name = @forge_name ? @forge_name.gsub("/", "-") : name
     return if Puppet::GettextConfig.translations_loaded?(module_name)
 
-    locales_path = File.absolute_path('locales', path)
-
-    if Puppet::GettextConfig.load_translations(module_name, locales_path, :po)
+    if Puppet::GettextConfig.load_translations(module_name, locale_directory, :po)
       Puppet.debug "i18n initialized for #{module_name}"
     elsif Puppet::GettextConfig.gettext_loaded?
-      Puppet.debug "Could not find translation files for #{module_name} at #{locales_path}. Skipping i18n initialization."
+      Puppet.debug "Could not find translation files for #{module_name} at #{locale_directory}. Skipping i18n initialization."
     else
       Puppet.debug "No gettext library found, skipping i18n initialization."
     end

--- a/spec/unit/file_serving/mount/locales_spec.rb
+++ b/spec/unit/file_serving/mount/locales_spec.rb
@@ -1,0 +1,73 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/file_serving/mount/locales'
+
+describe Puppet::FileServing::Mount::Locales do
+  before do
+    @mount = Puppet::FileServing::Mount::Locales.new("locales")
+
+    @environment = stub 'environment', :module => nil
+    @options = { :recurse => true }
+    @request = stub 'request', :environment => @environment, :options => @options
+  end
+
+  describe  "when finding files" do
+    it "should use the provided environment to find the modules" do
+      @environment.expects(:modules).returns []
+
+      @mount.find("foo", @request)
+    end
+
+    it "should return nil if no module can be found with a matching locale" do
+      mod = mock 'module'
+      mod.stubs(:locale).with("foo/bar").returns nil
+
+      @environment.stubs(:modules).returns [mod]
+      expect(@mount.find("foo/bar", @request)).to be_nil
+    end
+
+    it "should return the file path from the module" do
+      mod = mock 'module'
+      mod.stubs(:locale).with("foo/bar").returns "eh"
+
+      @environment.stubs(:modules).returns [mod]
+      expect(@mount.find("foo/bar", @request)).to eq("eh")
+    end
+  end
+
+  describe "when searching for files" do
+    it "should use the node's environment to find the modules" do
+      @environment.expects(:modules).at_least_once.returns []
+      @environment.stubs(:modulepath).returns ["/tmp/modules"]
+
+      @mount.search("foo", @request)
+    end
+
+    it "should return modulepath if no modules can be found that have locales" do
+      mod = mock 'module'
+      mod.stubs(:locales?).returns false
+
+      @environment.stubs(:modules).returns []
+      @environment.stubs(:modulepath).returns ["/"]
+      @options.expects(:[]=).with(:recurse, false)
+      expect(@mount.search("foo/bar", @request)).to eq(["/"])
+    end
+
+    it "should return nil if no modules can be found that have locales and modulepath is invalid" do
+      mod = mock 'module'
+      mod.stubs(:locales?).returns false
+
+      @environment.stubs(:modules).returns []
+      @environment.stubs(:modulepath).returns []
+      expect(@mount.search("foo/bar", @request)).to be_nil
+    end
+
+    it "should return the locale paths for each module that has locales" do
+      one = stub 'module', :locales? => true, :locale_directory => "/one"
+      two = stub 'module', :locales? => true, :locale_directory => "/two"
+
+      @environment.stubs(:modules).returns [one, two]
+      expect(@mount.search("foo/bar", @request)).to eq(%w{/one /two})
+    end
+  end
+end


### PR DESCRIPTION
locales is a new default mountpoint desiged to serve modules' translations from their locales directories, in order to download those files from the master to the agent during pluginsync