### PR TITLE
(PUP-3323) Ensure we don't check gpg

### DIFF
--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -106,7 +106,7 @@ test_name "test the yum package provider" do
 
     step 'Installing a known package using source succeeds' do
       verify_absent agents, 'guid'
-      apply_manifest_on(agent, "package { 'guid': ensure => installed, source=>'/tmp/rpmrepo/RPMS/noarch/guid-1.0-1.noarch.rpm' }") do |result|
+      apply_manifest_on(agent, "package { 'guid': ensure => installed, install_options => '--nogpgcheck', source=>'/tmp/rpmrepo/RPMS/noarch/guid-1.0-1.noarch.rpm' }") do |result|
         assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
       end
     end


### PR DESCRIPTION
When testing the yum utilities, we are creating an empty rpm package so
that we can install from a repo without hitting any external repos.
However, we aren't bothering to sign that empty package. When we go to
do the actual install, yum bails out because the package isn't signed.
This is great, but not in this instance. We don't care that the package
isn't signed, we just want to make sure the install works. This commit
adds in a flag to the install to make sure yum doesn't check the
signature.