### PR TITLE
(PUP-8114) Make enabled state check accurate for SLES 11 boot services in redhat service provider

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -33,8 +33,9 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
     end
 
     # For Suse OS family, chkconfig returns 0 even if the service is disabled or non-existent
-    # Therefore, check the output for '<name>  on' to see if it is enabled
-    return :false unless Facter.value(:osfamily) != 'Suse' || output =~ /^#{name}\s+on$/
+    # Therefore, check the output for '<name>  on' (or '<name>  B for boot services)
+    # to see if it is enabled
+    return :false unless Facter.value(:osfamily) != 'Suse' || output =~ /^#{name}\s+(on|B)$/
 
     :true
   end

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -88,6 +88,11 @@ describe provider_class, :if => Puppet.features.posix? do
       expect(@provider.enabled?).to eq(:true)
     end
 
+    it "should check for B" do
+      provider_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  B"
+      expect(@provider.enabled?).to eq(:true)
+    end
+
     it "should check for off" do
       provider_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  off"
       expect(@provider.enabled?).to eq(:false)


### PR DESCRIPTION
(PUP-8114) Make enabled state check accurate for SLES 11 boot services in redhat service provider

Without this patch applied, the redhat service provider is not idempotent
in enabling SLES 11 boot services. These are special Sys V services beginning
with the string 'boot.'. When `chkconfig` is run against them, they print
'<name>  B' instead of '<name>  on', so the existing regex does not match them.
Thus the redhat provider always sees them as disabled, and tries to enable
them on each agent run.

This patch adds the '<name>  B' condition to the regex.

```
$ chkconfig boot.kdump
boot.kdump  B
```

Before:
```
$ puppet agent -t --debug 2>&1 | grep -i kdump | grep -i enable
Notice: /Stage[main]/Kdump/Service[kdump]/enable: enable changed 'false' to 'true'
```

After: 
```
$ puppet agent -t --debug 2>&1 | grep -i kdump | grep -i enable
```