### PR TITLE
(PUP-8119) Add case insensitive flag to the Enum data type

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -146,8 +146,14 @@ class AccessOperator
 
   def access_PEnumType(o, scope, keys)
     keys.flatten!
+    last = keys.last
+    case_insensitive = false
+    if last == true || last == false
+      keys = keys[0...-1]
+      case_insensitive = last
+    end
     assert_keys(keys, o, 1, Float::INFINITY, String)
-    Types::TypeFactory.enum(*keys)
+    Types::PEnumType.new(keys, case_insensitive)
   end
 
   def access_PVariantType(o, scope, keys)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -127,7 +127,13 @@ module TypeFactory
   # @api public
   #
   def self.enum(*values)
-    PEnumType.new(values)
+    last = values.last
+    case_insensitive = false
+    if last == true || last == false
+      case_insensitive = last
+      values = values[0...-1]
+    end
+    PEnumType.new(values, case_insensitive)
   end
 
   # Produces the Variant type, optionally with the "one of" types

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -213,7 +213,13 @@ class TypeFormatter
 
   # @api private
   def string_PEnumType(t)
-    append_array('Enum', t.values.empty?) { append_strings(t.values) }
+    append_array('Enum', t.values.empty?) do
+      append_strings(t.values)
+      if t.case_insensitive?
+        @bld << COMMA_SEP
+        append_string(true)
+      end
+    end
   end
 
   # @api private

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -341,10 +341,16 @@ class TypeParser
       TypeFactory.regexp(parameters[0])
 
     when 'enum'
-      # 1..m parameters being strings
+      # 1..m parameters being string
+      last = parameters.last
+      case_insensitive = false
+      if last == true || last == false
+        parameters = parameters[0...-1]
+        case_insensitive = last
+      end
       raise_invalid_parameters_error('Enum', '1 or more', parameters.size) unless parameters.size >= 1
       parameters.each { |p|  raise Puppet::ParseError, 'Enum parameters must be identifiers or strings' unless p.is_a?(String) }
-      TypeFactory.enum(*parameters)
+      PEnumType.new(parameters, case_insensitive)
 
     when 'pattern'
       # 1..m parameters being strings or regular expressions

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1052,6 +1052,32 @@ describe 'The type calculator' do
       end
     end
 
+    context 'for Enum, such that' do
+      it 'Enum is assignable to an Enum with all contained options' do
+        expect(enum_t('a', 'b')).to be_assignable_to(enum_t('a', 'b', 'c'))
+      end
+
+      it 'Enum is not assignable to an Enum with fewer contained options' do
+        expect(enum_t('a', 'b')).not_to be_assignable_to(enum_t('a'))
+      end
+
+      it 'case insensitive Enum is not assignable to case sensitive Enum' do
+        expect(enum_t('a', 'b', true)).not_to be_assignable_to(enum_t('a', 'b'))
+      end
+
+      it 'case sensitive Enum is assignable to case insensitive Enum' do
+        expect(enum_t('a', 'b')).to be_assignable_to(enum_t('a', 'b', true))
+      end
+
+      it 'case sensitive Enum is not assignable to case sensitive Enum using different case' do
+        expect(enum_t('a', 'b')).not_to be_assignable_to(enum_t('A', 'B'))
+      end
+
+      it 'case sensitive Enum is assignable to case insensitive Enum using different case' do
+        expect(enum_t('a', 'b')).to be_assignable_to(enum_t('A', 'B', true))
+      end
+    end
+
     context 'for Hash, such that' do
       it 'Hash is not assignable to any other Collection type' do
         t = PHashType::DEFAULT

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -290,6 +290,16 @@ FORMATTED
       expect(s.string(t)).to eq("Enum['a', 'b', 'c']")
     end
 
+    it "should yield 'Enum[s,...]' for a PEnumType[s,...,false]" do
+      t = f.enum('a', 'b', 'c', false)
+      expect(s.string(t)).to eq("Enum['a', 'b', 'c']")
+    end
+
+    it "should yield 'Enum[s,...,true]' for a PEnumType[s,...,true]" do
+      t = f.enum('a', 'b', 'c', true)
+      expect(s.string(t)).to eq("Enum['a', 'b', 'c', true]")
+    end
+
     it "should yield 'Pattern[/pat/,...]' for a PPatternType['pat',...]" do
       t = f.pattern('a')
       t2 = f.pattern('a', 'b', 'c')


### PR DESCRIPTION
This commit adds the ability to declare a boolean case insensitive flag
as the last argument to an `Enum` data type. The default, when no such
flag is given, is that the `Enum` is case sensitive.