### PR TITLE
(PUP-8117) Make it possible to parameterize Boolean data type

### DIFF
--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -144,6 +144,12 @@ class AccessOperator
     end
   end
 
+  def access_PBooleanType(o, scope, keys)
+    keys.flatten!
+    assert_keys(keys, o, 1, 1, TrueClass, FalseClass)
+    Types::TypeFactory.boolean(keys[0])
+  end
+
   def access_PEnumType(o, scope, keys)
     keys.flatten!
     assert_keys(keys, o, 1, Float::INFINITY, String)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -227,8 +227,8 @@ module TypeFactory
   # Produces the Boolean type
   # @api public
   #
-  def self.boolean
-    PBooleanType::DEFAULT
+  def self.boolean(value = nil)
+    value.nil? ? PBooleanType::DEFAULT : (value ? PBooleanType::TRUE : PBooleanType::FALSE)
   end
 
   # Produces the Any type

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -149,7 +149,9 @@ class TypeFormatter
   def string_PDefaultType(_) ; @bld << 'Default' ; end
 
   # @api private
-  def string_PBooleanType(_) ; @bld << 'Boolean' ; end
+  def string_PBooleanType(t)
+    append_array('Boolean', t.value.nil?) { append_string(t.value) }
+  end
 
   # @api private
   def string_PScalarType(_)  ; @bld << 'Scalar'  ; end

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -408,7 +408,7 @@ class TypeParser
     when 'boolean'
       raise_invalid_parameters_error('Boolean', '1', parameters.size) unless parameters.size == 1
       p = parameters[0]
-      raise Puppet::ParseError, 'Boolean parameter must a true or false' unless p == true || p == false
+      raise Puppet::ParseError, 'Boolean parameter must be true or false' unless p == true || p == false
       TypeFactory.boolean(p)
 
     when 'integer'

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -405,6 +405,12 @@ class TypeParser
       raise_invalid_type_specification_error(ast) unless h.is_a?(Hash)
       TypeFactory.struct(h)
 
+    when 'boolean'
+      raise_invalid_parameters_error('Boolean', '1', parameters.size) unless parameters.size == 1
+      p = parameters[0]
+      raise Puppet::ParseError, 'Boolean parameter must a true or false' unless p == true || p == false
+      TypeFactory.boolean(p)
+
     when 'integer'
       if parameters.size == 1
         case parameters[0]
@@ -497,7 +503,7 @@ class TypeParser
       assert_type(ast, param) unless param.is_a?(String)
       TypeFactory.optional(param)
 
-    when 'any', 'data', 'catalogentry', 'boolean', 'scalar', 'undef', 'numeric', 'default', 'semverrange'
+    when 'any', 'data', 'catalogentry', 'scalar', 'undef', 'numeric', 'default', 'semverrange'
       raise_unparameterized_type_error(qref)
 
     when 'notundef'

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1780,8 +1780,26 @@ class PBooleanType < PScalarDataType
     create_ptype(loader, ir, 'ScalarDataType')
   end
 
+  attr_reader :value
+
+  def initialize(value = nil)
+    @value = value
+  end
+
+  def eql?(o)
+    o.is_a?(PBooleanType) && @value == o.value
+  end
+
+  def generalize
+    PBooleanType::DEFAULT
+  end
+
+  def hash
+    31 ^ @value.hash
+  end
+
   def instance?(o, guard = nil)
-    o == true || o == false
+    (o == true || o == false) && (@value.nil? || value == o)
   end
 
   def self.new_function(type)
@@ -1813,13 +1831,15 @@ class PBooleanType < PScalarDataType
   end
 
   DEFAULT = PBooleanType.new
+  TRUE = PBooleanType.new(true)
+  FALSE = PBooleanType.new(false)
 
   protected
 
   # @api private
   #
   def _assignable?(o, guard)
-    o.is_a?(PBooleanType)
+    o.is_a?(PBooleanType) && (@value.nil? || @value == o.value)
   end
 end
 

--- a/spec/unit/pops/types/type_formatter_spec.rb
+++ b/spec/unit/pops/types/type_formatter_spec.rb
@@ -99,6 +99,14 @@ FORMATTED
       expect(s.string(f.boolean)).to eq('Boolean')
     end
 
+    it "should yield 'Boolean[true]' for PBooleanType parameterized with true" do
+      expect(s.string(f.boolean(true))).to eq('Boolean[true]')
+    end
+
+    it "should yield 'Boolean[false]' for PBooleanType parameterized with false" do
+      expect(s.string(f.boolean(false))).to eq('Boolean[false]')
+    end
+
     it "should yield 'Data' for the Data type" do
       expect(s.string(f.data)).to eq('Data')
     end

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -36,7 +36,7 @@ describe TypeParser do
   end
 
   [
-    'Any', 'Data', 'CatalogEntry', 'Boolean', 'Scalar', 'Undef', 'Numeric', 'Default'
+    'Any', 'Data', 'CatalogEntry', 'Scalar', 'Undef', 'Numeric', 'Default'
   ].each do |name|
     it "does not support parameterizing unparameterized type <#{name}>" do
       expect { parser.parse("#{name}[Integer]") }.to raise_unparameterized_error_for(name)
@@ -77,6 +77,14 @@ describe TypeParser do
 
   it "interprets a parameterized Hash[t] as a Hash of Scalar to t" do
     expect(parser.parse("Hash[Scalar, Integer]")).to be_the_type(types.hash_of(types.integer))
+  end
+
+  it 'interprets an Boolean with a true parameter to represent boolean true' do
+    expect(parser.parse('Boolean[true]')).to be_the_type(types.boolean(true))
+  end
+
+  it 'interprets an Boolean with a false parameter to represent boolean false' do
+    expect(parser.parse('Boolean[false]')).to be_the_type(types.boolean(false))
   end
 
   it 'interprets an Integer with one parameter to have unbounded upper range' do

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -87,6 +87,10 @@ describe TypeParser do
     expect(parser.parse('Boolean[false]')).to be_the_type(types.boolean(false))
   end
 
+  it 'does not accept non-boolean parameters' do
+    expect{parser.parse('Boolean["false"]')}.to raise_error(/Boolean parameter must be true or false/)
+  end
+
   it 'interprets an Integer with one parameter to have unbounded upper range' do
     expect(parser.parse('Integer[0]')).to eq(parser.parse('Integer[0,default]'))
   end

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -153,6 +153,40 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Boolean type' do
+    it 'parameterized type is assignable to base type' do
+      code = <<-CODE
+        notice(Boolean[true] < Boolean)
+        notice(Boolean[false] < Boolean)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true', 'true'])
+    end
+
+    it 'boolean literals are instances of the base type' do
+      code = <<-CODE
+        notice(true =~ Boolean)
+        notice(false =~ Boolean)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true', 'true'])
+    end
+
+    it 'boolean literals are instances of type parameterized with the same literal' do
+      code = <<-CODE
+        notice(true =~ Boolean[true])
+        notice(false =~ Boolean[false])
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true', 'true'])
+    end
+
+    it 'boolean literals are not instances of type parameterized with a different literal' do
+      code = <<-CODE
+        notice(true =~ Boolean[false])
+        notice(false =~ Boolean[true])
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['false', 'false'])
+    end
+  end
+
   context 'Enum type' do
     it 'sorts its entries' do
       code = <<-CODE


### PR DESCRIPTION
This commit makes it possible to parameterized the `Boolean` data type
using a boolean value. When set, the resulting type will only represent
that value.