### PR TITLE
(PUP-8121) Make #new function signatures more strict

### DIFF
--- a/lib/puppet/functions/new.rb
+++ b/lib/puppet/functions/new.rb
@@ -14,10 +14,7 @@ Puppet::Functions.create_function(:new, Puppet::Functions::InternalFunction) do
 
   def new_instance(scope, t, *args)
     return args[0] if args.size == 1 && !t.is_a?(Puppet::Pops::Types::PInitType) && t.instance?(args[0])
-    result = catch :undefined_value do
-      new_function_for_type(t, scope).call(scope, *args)
-    end
-    assert_type(t, result)
+    result = assert_type(t, new_function_for_type(t, scope).call(scope, *args))
     return block_given? ? yield(result) : result
   end
 

--- a/lib/puppet/pops/types/p_init_type.rb
+++ b/lib/puppet/pops/types/p_init_type.rb
@@ -156,7 +156,7 @@ class PInitType < PTypeWithContainedType
     rescue ArgumentError
       raise ArgumentError, _("Creation of new instance of type '%{type_name}' is not supported") % { type_name: @type.to_s }
     end
-    param_tuples = new_func.dispatcher.dispatchers.map { |closure| closure.type.param_types }
+    param_tuples = new_func.dispatcher.signatures.map { |closure| closure.type.param_types }
 
     # An instance of the contained type is always a match to this type.
     single_types = [@type]

--- a/lib/puppet/pops/types/p_sem_ver_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_type.rb
@@ -60,14 +60,14 @@ class PSemVerType < PScalarType
       local_types do
         type 'PositiveInteger = Integer[0,default]'
         type 'SemVerQualifier = Pattern[/\A(?<part>[0-9A-Za-z-]+)(?:\.\g<part>)*\Z/]'
-        type 'SemVerString = String[1]'
+        type "SemVerPattern = Pattern[/\\A#{SemanticPuppet::Version::REGEX_FULL}\\Z/]"
         type 'SemVerHash = Struct[{major=>PositiveInteger,minor=>PositiveInteger,patch=>PositiveInteger,Optional[prerelease]=>SemVerQualifier,Optional[build]=>SemVerQualifier}]'
       end
 
       # Creates a SemVer from a string as specified by http://semver.org/
       #
       dispatch :from_string do
-        param 'SemVerString', :str
+        param 'SemVerPattern', :str
       end
 
       # Creates a SemVer from integers, prerelease, and build arguments
@@ -86,6 +86,10 @@ class PSemVerType < PScalarType
         param 'SemVerHash', :hash_args
       end
 
+      argument_mismatch :on_error do
+        param 'String', :str
+      end
+
       def from_string(str)
         SemanticPuppet::Version.parse(str)
       end
@@ -96,6 +100,10 @@ class PSemVerType < PScalarType
 
       def from_hash(hash)
         SemanticPuppet::Version.new(hash['major'], hash['minor'], hash['patch'], hash['prerelease'], hash['build'])
+      end
+
+      def on_error(str)
+        "The string '#{str}' cannot be converted to a SemVer"
       end
     end
   end

--- a/lib/puppet/pops/types/p_sem_ver_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_type.rb
@@ -103,7 +103,7 @@ class PSemVerType < PScalarType
       end
 
       def on_error(str)
-        "The string '#{str}' cannot be converted to a SemVer"
+        _("The string '%{str}' cannot be converted to a SemVer") % { str: str }
       end
     end
   end

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -28,7 +28,7 @@ describe 'the new function' do
       $x = Integer.new(undef)
       notify { "one${x}word": }
     MANIFEST
-    )}.to raise_error(Puppet::Error, /expects an Integer value, got Undef/)
+    )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
   end
 
   it 'errors if converted value is not assignable to the type' do
@@ -294,11 +294,11 @@ describe 'the new function' do
         '+ 0XGG'=> :error,
         '- 0XGG'=> :error,
       }.each do |str, result|
-        it "errors when given the non octal value compliant string '#{str}'" do
+        it "errors when given the non hexadecimal value compliant string '#{str}'" do
           expect{compile_to_catalog(<<-"MANIFEST"
             $x = Integer.new("#{str}", 8)
           MANIFEST
-        )}.to raise_error(Puppet::Error, /invalid value/)
+        )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
         end
       end
     end
@@ -321,7 +321,7 @@ describe 'the new function' do
         '0b10'  => :error,
         '0B10'  => :error,
       }.each do |str, result|
-        it "errors when given the non octal value compliant string '#{str}'" do
+        it "errors when given the non binary value compliant string '#{str}'" do
           expect{compile_to_catalog(<<-"MANIFEST"
             $x = Integer.new("#{str}", 10)
           MANIFEST
@@ -352,28 +352,28 @@ describe 'the new function' do
         expect{compile_to_catalog(<<-"MANIFEST"
           $x = Integer.new('10', 3)
         MANIFEST
-      )}.to raise_error(Puppet::Error, /rejected: parameter 'radix'/m)
+      )}.to raise_error(Puppet::Error, /Illegal radix/)
       end
 
       it 'radix is wrong and when given in long form' do
         expect{compile_to_catalog(<<-"MANIFEST"
           $x = Integer.new({from =>'10', radix=>3})
         MANIFEST
-      )}.to raise_error(Puppet::Error, /rejected: parameter 'hash_args' entry 'radix'/m)
+      )}.to raise_error(Puppet::Error, /Illegal radix/)
       end
 
       it 'value is not numeric and given directly' do
         expect{compile_to_catalog(<<-"MANIFEST"
           $x = Integer.new('eleven', 10)
         MANIFEST
-      )}.to raise_error(Puppet::Error, /invalid value/)
+      )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
       end
 
       it 'value is not numeric and given in long form' do
         expect{compile_to_catalog(<<-"MANIFEST"
       $x = Integer.new({from => 'eleven', radix => 10})
         MANIFEST
-      )}.to raise_error(Puppet::Error, /invalid value/)
+      )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
       end
     end
   end
@@ -545,7 +545,7 @@ describe 'the new function' do
       expect{compile_to_catalog(<<-"MANIFEST"
         $x = Boolean.new(undef)
       MANIFEST
-      )}.to raise_error(Puppet::Error, /expects a Boolean value, got Undef/)
+      )}.to raise_error(Puppet::Error, /cannot be converted to Boolean/)
     end
   end
 

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -28,7 +28,7 @@ describe 'the new function' do
       $x = Integer.new(undef)
       notify { "one${x}word": }
     MANIFEST
-    )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
+    )}.to raise_error(Puppet::Error, /of type Undef cannot be converted to Integer/)
   end
 
   it 'errors if converted value is not assignable to the type' do
@@ -298,7 +298,7 @@ describe 'the new function' do
           expect{compile_to_catalog(<<-"MANIFEST"
             $x = Integer.new("#{str}", 8)
           MANIFEST
-        )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
+        )}.to raise_error(Puppet::Error, /The string '#{Regexp.escape(str)}' cannot be converted to Integer/)
         end
       end
     end
@@ -366,14 +366,14 @@ describe 'the new function' do
         expect{compile_to_catalog(<<-"MANIFEST"
           $x = Integer.new('eleven', 10)
         MANIFEST
-      )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
+      )}.to raise_error(Puppet::Error, /The string 'eleven' cannot be converted to Integer/)
       end
 
       it 'value is not numeric and given in long form' do
         expect{compile_to_catalog(<<-"MANIFEST"
       $x = Integer.new({from => 'eleven', radix => 10})
         MANIFEST
-      )}.to raise_error(Puppet::Error, /cannot be converted to Integer/)
+      )}.to raise_error(Puppet::Error, /The string 'eleven' cannot be converted to Integer/)
       end
     end
   end
@@ -538,14 +538,14 @@ describe 'the new function' do
       expect{compile_to_catalog(<<-"MANIFEST"
         $x = Boolean.new('hello')
       MANIFEST
-      )}.to raise_error(Puppet::Error, /cannot be converted to Boolean/)
+      )}.to raise_error(Puppet::Error, /The string 'hello' cannot be converted to Boolean/)
     end
 
     it "does not convert an undef (as may be expected, but is handled as every other undef)" do
       expect{compile_to_catalog(<<-"MANIFEST"
         $x = Boolean.new(undef)
       MANIFEST
-      )}.to raise_error(Puppet::Error, /cannot be converted to Boolean/)
+      )}.to raise_error(Puppet::Error, /of type Undef cannot be converted to Boolean/)
     end
   end
 
@@ -566,8 +566,8 @@ describe 'the new function' do
     end
 
     {
-      true          => /cannot be converted to Array/,
-      42.3          => /cannot be converted to Array/,
+      true          => /of type Boolean cannot be converted to Array/,
+      42.3          => /of type Float cannot be converted to Array/,
     }.each do |input, error_match|
       it "errors when given an non convertible #{input.inspect} when wrap is not given" do
         expect{compile_to_catalog(<<-"MANIFEST"
@@ -650,7 +650,7 @@ describe 'the new function' do
       end
     end
 
-    { true             => /cannot be converted to Hash/,
+    { true             => /Value of type Boolean cannot be converted to Hash/,
       [1,2,3]          => /odd number of arguments for Hash/,
     }.each do |input, error_match|
       it "errors when given an non convertible #{input.inspect}" do

--- a/spec/unit/pops/types/p_init_type_spec.rb
+++ b/spec/unit/pops/types/p_init_type_spec.rb
@@ -279,6 +279,64 @@ describe 'The Init Type' do
       CODE
       expect(eval_and_collect_notices(code)).to eql(["One({'init_one' => 'w'})"])
     end
+
+    context 'computes if x is an instance such that' do
+      %w(true false True False TRUE FALSE Yes No yes no YES NO y n Y N).each do |str|
+        it "string '#{str}' is an instance of Init[Boolean]" do
+          expect(eval_and_collect_notices("notice('#{str}' =~ Init[Boolean])")).to eql(['true'])
+        end
+      end
+
+      it 'arbitrary string is not an instance of Init[Boolean]' do
+        expect(eval_and_collect_notices("notice('blue' =~ Init[Boolean])")).to eql(['false'])
+      end
+
+      %w(0 1 0634 0x3b -0xba 0b1001 +0b1111 23.14 -2.3 2e-21 1.23e18  -0.23e18).each do |str|
+        it "string '#{str}' is an instance of Init[Numeric]" do
+          expect(eval_and_collect_notices("notice('#{str}' =~ Init[Numeric])")).to eql(['true'])
+        end
+      end
+
+      it 'non numeric string is not an instance of Init[Numeric]' do
+        expect(eval_and_collect_notices("notice('blue' =~ Init[Numeric])")).to eql(['false'])
+      end
+
+      %w(0 1 0634 0x3b -0xba 0b1001 +0b1111 23.14 -2.3 2e-21 1.23e18  -0.23e18).each do |str|
+        it "string '#{str}' is an instance of Init[Float]" do
+          expect(eval_and_collect_notices("notice('#{str}' =~ Init[Float])")).to eql(['true'])
+        end
+      end
+
+      it 'non numeric string is not an instance of Init[Float]' do
+        expect(eval_and_collect_notices("notice('blue' =~ Init[Float])")).to eql(['false'])
+      end
+
+      %w(0 1 0634 0x3b -0xba 0b1001 0b1111).each do |str|
+        it "string '#{str}' is an instance of Init[Integer]" do
+          expect(eval_and_collect_notices("notice('#{str}' =~ Init[Integer])")).to eql(['true'])
+        end
+      end
+
+      %w(23.14 -2.3 2e-21 1.23e18  -0.23e18).each do |str|
+        it "valid float string '#{str}' is not an instance of Init[Integer]" do
+          expect(eval_and_collect_notices("notice('#{str}' =~ Init[Integer])")).to eql(['false'])
+        end
+      end
+
+      it 'non numeric string is not an instance of Init[Integer]' do
+        expect(eval_and_collect_notices("notice('blue' =~ Init[Integer])")).to eql(['false'])
+      end
+
+      %w(1.2.3 1.1.1-a3 1.2.3+b3 1.2.3-a3+b3).each do |str|
+        it "string '#{str}' is an instance of Init[SemVer]" do
+          expect(eval_and_collect_notices("notice('#{str}' =~ Init[SemVer])")).to eql(['true'])
+        end
+      end
+
+      it 'non SemVer compliant string is not an instance of Init[SemVer]' do
+        expect(eval_and_collect_notices("notice('blue' =~ Init[SemVer])")).to eql(['false'])
+      end
+    end
   end
 end
 end

--- a/spec/unit/pops/types/p_init_type_spec.rb
+++ b/spec/unit/pops/types/p_init_type_spec.rb
@@ -281,7 +281,7 @@ describe 'The Init Type' do
     end
 
     context 'computes if x is an instance such that' do
-      %w(true false True False TRUE FALSE Yes No yes no YES NO y n Y N).each do |str|
+      %w(true false True False TRUE FALSE tRuE FaLsE Yes No yes no YES NO YeS nO y n Y N).each do |str|
         it "string '#{str}' is an instance of Init[Boolean]" do
           expect(eval_and_collect_notices("notice('#{str}' =~ Init[Boolean])")).to eql(['true'])
         end
@@ -289,6 +289,14 @@ describe 'The Init Type' do
 
       it 'arbitrary string is not an instance of Init[Boolean]' do
         expect(eval_and_collect_notices("notice('blue' =~ Init[Boolean])")).to eql(['false'])
+      end
+
+      it 'empty string is not an instance of Init[Boolean]' do
+        expect(eval_and_collect_notices("notice('' =~ Init[Boolean])")).to eql(['false'])
+      end
+
+      it 'undef string is not an instance of Init[Boolean]' do
+        expect(eval_and_collect_notices("notice(undef =~ Init[Boolean])")).to eql(['false'])
       end
 
       %w(0 1 0634 0x3b -0xba 0b1001 +0b1111 23.14 -2.3 2e-21 1.23e18  -0.23e18).each do |str|
@@ -301,6 +309,14 @@ describe 'The Init Type' do
         expect(eval_and_collect_notices("notice('blue' =~ Init[Numeric])")).to eql(['false'])
       end
 
+      it 'empty string is not an instance of Init[Numeric]' do
+        expect(eval_and_collect_notices("notice('' =~ Init[Numeric])")).to eql(['false'])
+      end
+
+      it 'undef is not an instance of Init[Numeric]' do
+        expect(eval_and_collect_notices("notice(undef =~ Init[Numeric])")).to eql(['false'])
+      end
+
       %w(0 1 0634 0x3b -0xba 0b1001 +0b1111 23.14 -2.3 2e-21 1.23e18  -0.23e18).each do |str|
         it "string '#{str}' is an instance of Init[Float]" do
           expect(eval_and_collect_notices("notice('#{str}' =~ Init[Float])")).to eql(['true'])
@@ -309,6 +325,14 @@ describe 'The Init Type' do
 
       it 'non numeric string is not an instance of Init[Float]' do
         expect(eval_and_collect_notices("notice('blue' =~ Init[Float])")).to eql(['false'])
+      end
+
+      it 'empty string is not an instance of Init[Float]' do
+        expect(eval_and_collect_notices("notice('' =~ Init[Float])")).to eql(['false'])
+      end
+
+      it 'undef is not an instance of Init[Float]' do
+        expect(eval_and_collect_notices("notice(undef =~ Init[Float])")).to eql(['false'])
       end
 
       %w(0 1 0634 0x3b -0xba 0b1001 0b1111).each do |str|
@@ -327,6 +351,14 @@ describe 'The Init Type' do
         expect(eval_and_collect_notices("notice('blue' =~ Init[Integer])")).to eql(['false'])
       end
 
+      it 'empty string is not an instance of Init[Integer]' do
+        expect(eval_and_collect_notices("notice('' =~ Init[Integer])")).to eql(['false'])
+      end
+
+      it 'undef is not an instance of Init[Integer]' do
+        expect(eval_and_collect_notices("notice(undef =~ Init[Integer])")).to eql(['false'])
+      end
+
       %w(1.2.3 1.1.1-a3 1.2.3+b3 1.2.3-a3+b3).each do |str|
         it "string '#{str}' is an instance of Init[SemVer]" do
           expect(eval_and_collect_notices("notice('#{str}' =~ Init[SemVer])")).to eql(['true'])
@@ -335,6 +367,14 @@ describe 'The Init Type' do
 
       it 'non SemVer compliant string is not an instance of Init[SemVer]' do
         expect(eval_and_collect_notices("notice('blue' =~ Init[SemVer])")).to eql(['false'])
+      end
+
+      it 'empty string is not an instance of Init[SemVer]' do
+        expect(eval_and_collect_notices("notice('' =~ Init[SemVer])")).to eql(['false'])
+      end
+
+      it 'undef is not an instance of Init[SemVer]' do
+        expect(eval_and_collect_notices("notice(undef =~ Init[SemVer])")).to eql(['false'])
       end
     end
   end


### PR DESCRIPTION
The `Init` data type bases assignability and instance computation on the
signatures of the #new function for a given type. Before this commit,
those signatures were very relaxed. An `Integer` could for instance be
created from any `String` which gave that "blue" was an instance of
`Init[Integer]`. This commit tightens the constraints.
