### PR TITLE
(maint) Match Bolt executor run_script signature

### DIFF
--- a/lib/puppet/functions/run_script.rb
+++ b/lib/puppet/functions/run_script.rb
@@ -46,7 +46,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
       Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
     else
       Puppet::Pops::Types::ExecutionResult.from_bolt(
-        executor.run_script(executor.from_uris(hosts), found)
+        executor.run_script(executor.from_uris(hosts), found, [])
       )
     end
   end

--- a/spec/unit/functions/run_script_spec.rb
+++ b/spec/unit/functions/run_script_spec.rb
@@ -69,7 +69,7 @@ describe 'the run_script function' do
     it 'with fully resolved path of file' do
       executor.expects(:from_uris).with(hosts).returns([host])
       result.expects(:to_h).returns(result)
-      executor.expects(:run_script).with([host], full_path).returns({ host => result })
+      executor.expects(:run_script).with([host], full_path, []).returns({ host => result })
 
       expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}})"])
         $a = run_script('test/uploads/hostname.sh', '#{hostname}')
@@ -86,7 +86,7 @@ describe 'the run_script function' do
 
       it 'with propagated multiple hosts and returns multiple results' do
         executor.expects(:from_uris).with(hosts).returns(nodes)
-        executor.expects(:run_script).with(nodes, full_path).returns({ host => result, host2 => result2 })
+        executor.expects(:run_script).with(nodes, full_path, []).returns({ host => result, host2 => result2 })
         result.expects(:to_h).returns(result)
         result2.expects(:to_h).returns(result2)
 


### PR DESCRIPTION
 - While the Puppet run_script function should later be updated to
   include passing arguments, for now we can pass an emtpy arguments
   array for the sake of being able to properly call Bolt.

   As it stands, without this change, users attempting to use
   run_script in plans like the following:

   plan sample::script_test(String $nodes) {
     run_script(split($nodes, ','), "sample/uploads/test.ps1")
   }

   Will receive an error like:

   Error: Evaluation Error: Error while evaluating a Function Call, wrong number of arguments (given 2, expected 3) at /Users/Iristyle/source/bolt/spec/fixtures/modules/sample/plans/script_test.pp:2:3 on node niihau.delivery.puppetlabs.net