### PR TITLE
(MAINT) Update Beaker Host Generator Gem

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -13,7 +13,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.10')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false


### PR DESCRIPTION
The latest version of Beaker Host Generator is 1.1.3, which was excluded
by the current Gemfile rule. Update to fix, especially since
Windows-2012r2-core and Windows-2016-core have been introduced.

Submitting this as a trivial MAINT PR