### PR TITLE
(PUP-8134) Allow tasks to specify that parameters are "sensitive"

### DIFF
--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -54,7 +54,8 @@ class TaskInstantiator
       Types::Task::PARAMETER_NAME_PATTERN,
       tf.struct(
         tf.optional('description') => tf.string,
-        tf.optional('type') => Types::PStringType::NON_EMPTY
+        tf.optional('type') => Types::PStringType::NON_EMPTY,
+        tf.optional('sensitive') => tf.boolean
       )
     )
 

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -133,7 +133,8 @@ describe 'The Task Type' do
               "supports_noop": true,
               "parameters": {
                  "message": {
-                   "type": "String"
+                   "type": "String",
+                   "sensitive": false
                  },
                  "font": {
                    "type": "Optional[String]"
@@ -456,7 +457,7 @@ describe 'The Task Type' do
       type Service::Init = Task {
         constants => {
           supports_noop => true,
-          input_format => 'stdin:json'
+          input_method => 'stdin'
         },
         attributes => {
           action => Service::Action,


### PR DESCRIPTION
This commit adds the task metadata field "sensitive" to the whitelist of
metadata fields. This field can be used to specify that a parameter
value should be redacted from logs, etc.

This does not include any behavior change to actually redact data, just
to allow those tasks to be run.