### PR TITLE
(PUP-6739) Certain apps shouldn't fail if env is not local

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -281,6 +281,23 @@ class Application
       @run_mode = Puppet::Util::RunMode[ mode_name || Puppet.settings.preferred_run_mode ]
     end
 
+    # Sets environment_mode name
+    # @param mode_name [Symbol] The name of the environment mode to run in. May
+    #   be one of :local, :remote, or :not_required. This impacts where the
+    #   application looks for its specified environment. If :not_required or
+    #   :remote are set, the application will not fail if the environment does
+    #   not exist on the local filesystem.
+    def environment_mode(mode_name)
+      raise Puppet::Error, _("Invalid environment mode '%{mode_name}'") % { mode_name: mode_name } unless [:local, :remote, :not_required].include?(mode_name)
+      @environment_mode = mode_name
+    end
+
+    # Gets environment_mode name. If none is set with `environment_mode=`,
+    # default to :local.
+    def get_environment_mode
+      @environment_mode || :local
+    end
+
     # This is for testing only
     def clear_everything_for_tests
       @run_mode = @banner = @run_status = @option_parser_commands = nil
@@ -343,7 +360,7 @@ class Application
       initialize_app_defaults
     end
 
-    Puppet::ApplicationSupport.push_application_context(self.class.run_mode)
+    Puppet::ApplicationSupport.push_application_context(self.class.run_mode, self.class.get_environment_mode)
 
     exit_on_fail("initialize")                                   { preinit }
     exit_on_fail("parse application options")                    { parse_options }

--- a/lib/puppet/application/config.rb
+++ b/lib/puppet/application/config.rb
@@ -1,4 +1,5 @@
 require 'puppet/application/face_base'
 
 class Puppet::Application::Config < Puppet::Application::FaceBase
+  environment_mode :not_required
 end

--- a/lib/puppet/application/help.rb
+++ b/lib/puppet/application/help.rb
@@ -1,4 +1,5 @@
 require 'puppet/application/face_base'
 
 class Puppet::Application::Help < Puppet::Application::FaceBase
+  environment_mode :not_required
 end

--- a/lib/puppet/application_support.rb
+++ b/lib/puppet/application_support.rb
@@ -14,9 +14,10 @@ module Puppet
     # before being set in a pushed Puppet Context.
     #
     # @param run_mode [Puppet::Util::RunMode] Puppet's current Run Mode.
+    # @param environment_mode [Puppet::Util::EnvironmentMode] Puppet's current Environment Mode.
     # @return [void]
     # @api private
-    def self.push_application_context(run_mode)
+    def self.push_application_context(run_mode, environment_mode)
       Puppet.push_context(Puppet.base_context(Puppet.settings), "Update for application settings (#{run_mode})")
       # This use of configured environment is correct, this is used to establish
       # the defaults for an application that does not override, or where an override
@@ -25,6 +26,9 @@ module Puppet
       configured_environment_name = Puppet[:environment]
       if run_mode.name == :agent
         configured_environment = Puppet::Node::Environment.remote(configured_environment_name)
+      elsif environment_mode == :not_required
+        configured_environment =
+          Puppet.lookup(:environments).get(configured_environment_name) || Puppet::Node::Environment.remote(configured_environment_name)
       else
         configured_environment = Puppet.lookup(:environments).get!(configured_environment_name)
       end

--- a/spec/unit/application/config_spec.rb
+++ b/spec/unit/application/config_spec.rb
@@ -6,4 +6,8 @@ describe Puppet::Application::Config do
   it "should be a subclass of Puppet::Application::FaceBase" do
     expect(Puppet::Application::Config.superclass).to equal(Puppet::Application::FaceBase)
   end
+
+  it "should set `environment_mode` to :not_required" do
+    expect(Puppet::Application::Config.get_environment_mode).to equal(:not_required)
+  end
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -105,6 +105,24 @@ describe Puppet::Application do
     end
   end
 
+  describe ".environment_mode" do
+    it "should default to :local" do
+      expect(@appclass.get_environment_mode).to eq(:local)
+    end
+
+    it "should set and get a value" do
+      @appclass.environment_mode :remote
+      expect(@appclass.get_environment_mode).to eq(:remote)
+    end
+
+    it "should error if given a random symbol" do
+      expect{@appclass.environment_mode :foo}.to raise_error(/Invalid environment mode/)
+    end
+
+    it "should error if given a string" do
+      expect{@appclass.environment_mode 'local'}.to raise_error(/Invalid environment mode/)
+    end
+  end
 
 
   # These tests may look a little weird and repetative in its current state;

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -139,7 +139,6 @@ basemodulepath = #{File.expand_path("/some/base")}
     end
 
     it "prints the default configured env settings for an env that does not exist" do
-      pending "This case no longer exists because Application will through an error before we even get here because of the non-existent environment"
       Puppet[:environment] = 'doesnotexist'
 
       FS.overlay(
@@ -150,7 +149,7 @@ basemodulepath = #{File.expand_path("/some/base")}
         args = "environmentpath","manifest","modulepath","environment","basemodulepath"
         expect { subject.print(*add_section_option(args, section)) }.to have_printed(<<-OUTPUT)
 environmentpath = #{File.expand_path("/dev/null/environments")}
-manifest = no_manifest
+manifest = 
 modulepath = 
 environment = doesnotexist
 basemodulepath = #{File.expand_path("/some/base")}


### PR DESCRIPTION
Prior to this commit, we had a number of users running into an issue
where if they set the environment in either the toplevel or [main] of
puppet.conf, and that environment did not have a corresponding directory
in the local file system, commands like `puppet config` and `puppet
help` would bail out. This commit adds in the ability to specify
environment requirements on the application level. Commands like `puppet
config` and `puppet help` shouldn't require the environment to exist
locally.

This issue mainly surfaces because the concept of environment is used in
multiple contexts. The use case this change is meant to address is when
a user has set environment to refer to an environment that only exists
on the master. Under this scenario, `puppet agent` can check into the
master to request that specified environment. Although this change does
allow the user to continue to abuse how and where environment is set,
this is a common enough behavior we should have this buffer. This is
also useful if the user has accidentally mistyped their environment. If
this is the case, the user can still use `puppet config set` to update
that setting to the correct one.

This does not impact applications that should depend on the environment
existing locally, such as `puppet apply` and `puppet module`.