### PR TITLE
(PUP-8133) Lookup bolt executor for file_upload function

### DIFF
--- a/lib/puppet/functions/file_upload.rb
+++ b/lib/puppet/functions/file_upload.rb
@@ -28,7 +28,8 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
         {:operation => 'file_upload'})
     end
 
-    unless Puppet.features.bolt?
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    unless executor && Puppet.features.bolt?
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(Puppet::Pops::Issues::TASK_MISSING_BOLT, :action => _('do file uploads'))
     end
 
@@ -42,7 +43,9 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
       call_function('debug', "Simulating file upload of '#{found}' - no hosts given - no action taken")
       Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
     else
-      Puppet::Pops::Types::ExecutionResult.from_bolt(Bolt::Executor.from_uris(hosts).file_upload(found, destination))
+      Puppet::Pops::Types::ExecutionResult.from_bolt(
+        executor.file_upload(executor.from_uris(hosts), found, destination)
+      )
     end
   end
 end

--- a/spec/unit/functions/run_command_spec.rb
+++ b/spec/unit/functions/run_command_spec.rb
@@ -87,6 +87,7 @@ describe 'the run_command function' do
 
   context 'without bolt feature present' do
     it 'fails and reports that bolt library is required' do
+      Puppet.features.stubs(:bolt?).returns(false)
       expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/The 'bolt' library is required to run a command/)
           run_command('echo hello')
       CODE

--- a/spec/unit/functions/run_script_spec.rb
+++ b/spec/unit/functions/run_script_spec.rb
@@ -128,6 +128,7 @@ describe 'the run_script function' do
 
   context 'without bolt feature present' do
     it 'fails and reports that bolt library is required' do
+      Puppet.features.stubs(:bolt?).returns(false)
       expect{eval_and_collect_notices(<<-CODE, node)}.to raise_error(/The 'bolt' library is required to run a script/)
           run_script('test/uploads/nonesuch.sh')
       CODE


### PR DESCRIPTION
Commit b6a166974 changed how bolt related run_* functions lookup the executor,
but I forgot to apply the same change to the file_upload function.

/cc @hlindberg @thallgren 