### PR TITLE
(PUP-5987) Specify that logdest accepts an absolute file path.

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -90,7 +90,7 @@ USAGE
 -----
 puppet agent [--certname <NAME>] [-D|--daemonize|--no-daemonize]
   [-d|--debug] [--detailed-exitcodes] [--digest <DIGEST>] [--disable [MESSAGE]] [--enable]
-  [--fingerprint] [-h|--help] [-l|--logdest syslog|eventlog|<FILE>|console]
+  [--fingerprint] [-h|--help] [-l|--logdest syslog|eventlog|<ABS FILEPATH>|console]
   [--masterport <PORT>] [--noop] [-o|--onetime] [-t|--test]
   [-v|--verbose] [-V|--version] [-w|--waitforcert <SECONDS>]
 

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -46,7 +46,7 @@ USAGE
 -----
 puppet apply [-h|--help] [-V|--version] [-d|--debug] [-v|--verbose]
   [-e|--execute] [--detailed-exitcodes] [-L|--loadclasses]
-  [-l|--logdest syslog|eventlog|<FILE>|console] [--noop]
+  [-l|--logdest syslog|eventlog|<ABS FILEPATH>|console] [--noop]
   [--catalog <catalog>] [--write-catalog-summary] <file>
 
 


### PR DESCRIPTION
CLI help content suggests the `--logdest` flag can take a file as a destination. It requires an absolute file path. Specify this in the CLI help content.

This content is also used to generate some docs site content.