### PR TITLE
(PUP-8138) Ensure that the inferred type of a boolean retains value

### DIFF
--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -614,12 +614,12 @@ class TypeCalculator
 
   # @api private
   def infer_TrueClass(o)
-    PBooleanType::DEFAULT
+    PBooleanType::TRUE
   end
 
   # @api private
   def infer_FalseClass(o)
-    PBooleanType::DEFAULT
+    PBooleanType::FALSE
   end
 
   # @api private

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -239,7 +239,7 @@ describe Puppet::Face[:epp, :current] do
 
     it 'initializes the 4x loader' do
       expect(eppface.render({ :e => <<-EPP.unindent })).to eql("\nString\n\nInteger\n\nBoolean\n")
-        <% $data = [type('a',generalized), type(2,generalized), type(true)] -%>
+        <% $data = [type('a',generalized), type(2,generalized), type(true,generalized)] -%>
         <% $data.each |$value| { %>
         <%= $value %>
         <% } -%>

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -152,12 +152,12 @@ describe 'The type calculator' do
       expect(t.value).to eq('foo')
     end
 
-    it 'boolean true translates to PBooleanType' do
-      expect(calculator.infer(true).class).to eq(PBooleanType)
+    it 'boolean true translates to PBooleanType::TRUE' do
+      expect(calculator.infer(true)).to eq(PBooleanType::TRUE)
     end
 
-    it 'boolean false translates to PBooleanType' do
-      expect(calculator.infer(false).class).to eq(PBooleanType)
+    it 'boolean false translates to PBooleanType::FALSE' do
+      expect(calculator.infer(false)).to eq(PBooleanType::FALSE)
     end
 
     it 'regexp translates to PRegexpType' do


### PR DESCRIPTION
Before this commit, `true` and `false` would be inferred to `Boolean`
without parameters. This commit ensures that the value is retained so
that the inferred type is `Boolean[true]` or Boolean[`false`].