### PR TITLE
(PUP-8137) Make run_script accept arguments

### DIFF
--- a/spec/unit/functions/run_script_spec.rb
+++ b/spec/unit/functions/run_script_spec.rb
@@ -69,7 +69,7 @@ describe 'the run_script function' do
     it 'with fully resolved path of file' do
       executor.expects(:from_uris).with(hosts).returns([host])
       result.expects(:to_h).returns(result)
-      executor.expects(:run_script).with([host], full_path).returns({ host => result })
+      executor.expects(:run_script).with([host], full_path, []).returns({ host => result })
 
       expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}})"])
         $a = run_script('test/uploads/hostname.sh', '#{hostname}')
@@ -80,10 +80,32 @@ describe 'the run_script function' do
     it 'with host given as Target' do
       executor.expects(:from_uris).with(hosts).returns([host])
       result.expects(:to_h).returns(result)
-      executor.expects(:run_script).with([host], full_path).returns({ host => result })
+      executor.expects(:run_script).with([host], full_path, []).returns({ host => result })
 
       expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}})"])
         $a = run_script('test/uploads/hostname.sh', Target('#{hostname}'))
+        notice $a
+      CODE
+    end
+
+    it 'with given arguments as a hash of {arguments => [value]}' do
+      executor.expects(:from_uris).with(hosts).returns([host])
+      result.expects(:to_h).returns(result)
+      executor.expects(:run_script).with([host], full_path, ['hello', 'world']).returns({ host => result })
+
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}})"])
+        $a = run_script('test/uploads/hostname.sh', Target('#{hostname}'), arguments => ['hello', 'world'])
+        notice $a
+      CODE
+    end
+
+    it 'with given arguments as a hash of {arguments => []}' do
+      executor.expects(:from_uris).with(hosts).returns([host])
+      result.expects(:to_h).returns(result)
+      executor.expects(:run_script).with([host], full_path, []).returns({ host => result })
+
+      expect(eval_and_collect_notices(<<-CODE, node)).to eql(["ExecutionResult({'#{hostname}' => {value => '#{hostname}'}})"])
+        $a = run_script('test/uploads/hostname.sh', Target('#{hostname}'), arguments => [])
         notice $a
       CODE
     end
@@ -97,7 +119,7 @@ describe 'the run_script function' do
 
       it 'with propagated multiple hosts and returns multiple results' do
         executor.expects(:from_uris).with(hosts).returns(nodes)
-        executor.expects(:run_script).with(nodes, full_path).returns({ host => result, host2 => result2 })
+        executor.expects(:run_script).with(nodes, full_path, []).returns({ host => result, host2 => result2 })
         result.expects(:to_h).returns(result)
         result2.expects(:to_h).returns(result2)
 


### PR DESCRIPTION
Before this the run_script function did not accept arguments and did not
call bolt executor correctly.

Now, the run_script function accept a hash with a single key 'arguments'
that can be set to an array of strings to give as arguments to the
script. This solution was decided to make the run_script and run_task
functions similar in signature. It would otherwise be difficult to
support the list of targets in the same manner.