### PR TITLE
(PUP-8140) Add inspect method to Puppet::Face

### DIFF
--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -182,6 +182,7 @@ class Puppet::Interface
   def to_s
     "Puppet::Face[#{name.inspect}, #{version.inspect}]"
   end
+  alias_method :inspect, :to_s
 
   # @return [void]
   def deprecate

--- a/spec/unit/interface_spec.rb
+++ b/spec/unit/interface_spec.rb
@@ -126,6 +126,18 @@ describe Puppet::Interface do
     expect { subject[:foo, '0.0.1'] }.to raise_error Puppet::Error
   end
 
+  describe 'when raising NoMethodErrors' do
+    subject { described_class.new(:foo, '1.0.0') }
+
+    it 'includes the face name in the error message' do
+      expect { subject.boombaz }.to raise_error(NoMethodError, /#{subject.name}/)
+    end
+
+    it 'includes the face version in the error message' do
+      expect { subject.boombaz }.to raise_error(NoMethodError, /#{subject.version}/)
+    end
+  end
+
   it_should_behave_like "things that declare options" do
     def add_options_to(&block)
       subject.new(:with_options, '0.0.1', &block)


### PR DESCRIPTION
Prior to this patch, error messages raised by `Puppet::Face` objects would
print the generic Ruby representation of the object, which is just the
class name plus the object instance id. The instance id is exactly as
useful as a random number when trying to figure out which face or version
of a face was involved in the error. This patch aliases the `inspect` method
of the `Puppet::Face` class to the `to_s` method so that error messages
include both the face name and version number.