### PR TITLE
(PUP-8144) Make it clear that | between strategies means 'or'

### DIFF
--- a/lib/puppet/functions/lookup.rb
+++ b/lib/puppet/functions/lookup.rb
@@ -91,8 +91,8 @@
 # merged hash. If the same key exists in multiple source hashes, Puppet will
 # recursively merge hash or array values (with duplicate values removed from
 # arrays). For conflicting scalar values, the highest-priority value will win.
-# * `{'strategy' => 'first|unique|hash'}` --- Same as the string versions of these
-# merge behaviors.
+# * `{'strategy' => 'first'}`, `{'strategy' => 'unique'}`,
+# or `{'strategy' => 'hash'}` --- Same as the string versions of these merge behaviors.
 # * `{'strategy' => 'deep', <DEEP OPTION> => <VALUE>, ...}` --- Same as `'deep'`,
 # but can adjust the merge with additional options. The available options are:
 #     * `'knockout_prefix'` (string or undef) --- A string prefix to indicate a


### PR DESCRIPTION
Before this, it was possible to misinterpret `{strategy =>
'first|hash|deep'}` as making it possible to set a combined strategy.
This is made clearer by showing three separate entries, one per strategy.