### PR TITLE
(PUP-8078) Ensure that attribute access works for PObjectTypeExtension

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -942,7 +942,7 @@ class EvaluatorImpl
 
     obj = receiver[0]
     receiver_type = Types::TypeCalculator.infer(obj)
-    if receiver_type.is_a?(Types::PObjectType)
+    if receiver_type.is_a?(Types::PObjectType) || receiver_type.is_a?(Types::PObjectTypeExtension)
       member = receiver_type[name]
       unless member.nil?
         args = unfold([], o.arguments || [], scope)

--- a/lib/puppet/pops/types/p_object_type_extension.rb
+++ b/lib/puppet/pops/types/p_object_type_extension.rb
@@ -26,6 +26,10 @@ class PObjectTypeExtension < PAnyType
     impl_class.new(base_type, init_parameters)
   end
 
+  def [](name)
+    @base_type[name]
+  end
+
   # @api private
   def initialize(base_type, init_parameters)
     pts = base_type.type_parameters(true)

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -1363,6 +1363,23 @@ describe 'The Object Type' do
         notice(type($x) == MyType['hello', 'world'])
         PUPPET
       end
+
+      it 'Attributes of instance of parameterized type can be accessed using function calls' do
+        expect(eval_and_collect_notices(<<-PUPPET, node)).to eql(['hello', 'world'])
+        type MyType = Object[
+          type_parameters => {
+            p1 => Variant[Undef,String,Regexp,Type[Enum],Type[Pattern]],
+            p2 => Variant[Undef,String,Regexp,Type[Enum],Type[Pattern]],
+          },
+          attributes => {
+            p1 => String,
+            p2 => String
+          }]
+        $x = MyType('hello', 'world')
+        notice($x.p1)
+        notice($x.p2)
+        PUPPET
+      end
     end
   end
 


### PR DESCRIPTION
An `Object` instance, when inferred to a parameterized type (and hence
to an `PObjectTypeExtension` instead of an `PObjectType` does not
make its attributes accessible using functions in Puppet. This is
because the evaluator triggers on the `PObjectType`.

This commit fixes this glitch by also checking for the class
`PObjectTypeExtension`.