### PR TITLE
(PUP-7401) Include type parameter in type mismatch report

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -343,8 +343,8 @@ module Types
           a = detailed_actual_to_s(e, a)
           e = e.map { |t| t.to_alias_expanded_s }
         else
-          e = e.map { |t| t.simple_name }.uniq
-          a = a.simple_name
+          e = e.map { |t| short_name(t) }.uniq
+          a = short_name(a)
         end
         case e.size
         when 1
@@ -361,8 +361,8 @@ module Types
           a = detailed_actual_to_s(e, a)
           e = e.to_alias_expanded_s
         else
-          e = e.simple_name
-          a = a.simple_name
+          e = short_name(e)
+          a = short_name(a)
         end
       end
       if multi
@@ -377,6 +377,16 @@ module Types
     end
 
     private
+
+    def short_name(t)
+      # Ensure that Optional, NotUndef, Sensitive, and Type are reported with included
+      # type parameter.
+      if t.is_a?(PTypeWithContainedType) && !(t.type.nil? || t.type.class == PAnyType)
+        "#{t.name}[#{t.type.name}]"
+      else
+        t.name
+      end
+    end
 
     # Answers the question if `e` is a specialized type of `a`
     # @param e [PAnyType] the expected type
@@ -477,7 +487,7 @@ module Types
 
     def actual_string
       a = actual
-      a.is_a?(PStringType) && !a.value.nil? ? "'#{a.value}'" : a.simple_name
+      a.is_a?(PStringType) && !a.value.nil? ? "'#{a.value}'" : short_name(a)
     end
   end
 

--- a/spec/unit/functions/defined_spec.rb
+++ b/spec/unit/functions/defined_spec.rb
@@ -268,11 +268,11 @@ describe "the 'defined' function" do
   end
 
   it 'raises error if referencing undef' do
-    expect{func.call(@scope, nil)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String or Type, got Undef/)
+    expect{func.call(@scope, nil)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String, Type\[CatalogEntry\], or Type\[Type\], got Undef/)
   end
 
   it 'raises error if referencing a number' do
-    expect{func.call(@scope, 42)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String or Type, got Integer/)
+    expect{func.call(@scope, 42)}.to raise_error(ArgumentError, /'defined' parameter 'vals' expects a value of type String, Type\[CatalogEntry\], or Type\[Type\], got Integer/)
   end
 
   it 'is false if referencing empty string' do

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -168,6 +168,15 @@ describe 'the type mismatch describer' do
       /parameter 'arg' expects a match for Enum\['a', 'b'\], got Sensitive/))
   end
 
+  it "will report the parameter of Type[<type alias>] using the alias name" do
+    code = <<-CODE
+      type Custom = String[1]
+      Custom.each |$x| { notice($x) }
+    CODE
+    expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
+      /expects an Iterable value, got Type\[Custom\]/))
+  end
+
   context 'when reporting a mismatch between' do
     let(:parser) { TypeParser.singleton }
     let(:subject) { TypeMismatchDescriber.singleton }


### PR DESCRIPTION
Before this commit, a type mismtach involving the the types `Optional`,
`NotUndef`, `Sensitive`, and `Type` would be reported without the type
parameter when the base type differered between actual and expected
type. The resulting output was often somewhat cryptic since it's almost
always desirable to know the the contained type.

This commit ensures that the aformentioned types are always reported
with their included type.