### PR TITLE
(PUP-7401) Ensure that a type alias for an Iterable type is Iterable

### DIFF
--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -79,6 +79,8 @@ module Puppet::Pops::Types
         o.finite_range? ? IntegerRangeIterator.new(o) : nil
       when PEnumType
         Iterator.new(o, o.values.each)
+      when PTypeAliasType
+        on(o.resolved_type)
       when Range
         min = o.min
         max = o.max

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1304,6 +1304,8 @@ class PIterableType < PTypeWithContainedType
         o >= 0
       when PIntegerType
         o.finite_range?
+      when PTypeAliasType
+        instance?(o.resolved_type, guard)
       else
         false
       end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -116,6 +116,10 @@ describe 'The type calculator' do
     PUnitType::DEFAULT
   end
 
+  def iterable_t(t = nil)
+    TypeFactory.iterable(t)
+  end
+
   def types
     Types
   end
@@ -1573,6 +1577,11 @@ describe 'The type calculator' do
         t2 = parser.parse('Type[PositiveIntegerType]', scope)
         expect(calculator.assignable?(t2, t1)).to be_truthy
       end
+
+      it 'An alias for an Iterable Type is Iterable' do
+        t = type_alias_t('MyType', 'Enum[a,b]').resolve(parser, nil)
+        expect(calculator.assignable?(iterable_t, t)).to be_truthy
+      end
     end
   end
 
@@ -1863,6 +1872,11 @@ describe 'The type calculator' do
         expect(calculator.instance?(t, 15)).to be_truthy
       end
 
+      it 'should consider t an instance of Iterable when aliased type is Iterable' do
+        t = type_alias_t('Alias', 'Enum[a, b]').resolve(parser, nil)
+        expect(calculator.instance?(iterable_t, t)).to be_truthy
+      end
+
       it 'should consider x an instance of the aliased type that uses self recursion' do
         t = type_alias_t('Tree', 'Hash[String,Variant[String,Tree]]')
         loader = Object.new
@@ -2063,6 +2077,11 @@ describe 'The type calculator' do
       [Object, Numeric, Float, String, Regexp, Array, Hash].each do |t|
         expect(calculator.iterable(calculator.type(t))).to eq(nil)
       end
+    end
+
+    it 'should produce an iterable for a type alias of an Iterable type' do
+      t = PTypeAliasType.new('MyAlias', nil, PIntegerType.new(1, 10))
+      expect(calculator.iterable(t).respond_to?(:each)).to eq(true)
     end
   end
 

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -1578,8 +1578,10 @@ describe 'The type calculator' do
         expect(calculator.assignable?(t2, t1)).to be_truthy
       end
 
-      it 'An alias for an Iterable Type is Iterable' do
+      it 'An alias for a Type that describes an Iterable instance is assignable to Iterable' do
         t = type_alias_t('MyType', 'Enum[a,b]').resolve(parser, nil)
+
+        # True because String is iterable and an instance of Enum is a String
         expect(calculator.assignable?(iterable_t, t)).to be_truthy
       end
     end


### PR DESCRIPTION
Before this commit, a type alias for an `Iterable` type such as an
bounded `Integer` type or an `Enum` would not be considered `Iterable`.
This commit ensures that a type alias is iterable when the type that
the alias resolves to is iterable.