### PR TITLE
(PUP-6739) Encourage users to limit where they set environment

### DIFF
--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -106,6 +106,19 @@ Puppet::Face.define(:config, '0.0.1') do
     EOT
 
     when_invoked do |name, value, options|
+      if name == 'environment' && options[:section] == 'main'
+        Puppet.warning _(<<-EOM).chomp
+The environment should be set in either the `[user]`, `[agent]`, or `[master]`
+section. Variables set in the `[agent]` section are used when running
+`puppet agent`. Variables set in the `[user]` section are used when running
+various other puppet subcommands, like `puppet apply` and `puppet module`; these
+require the defined environment directory to exist locally. Set the config
+section by using the `--section` flag. For example,
+`puppet config --section user set environment foo`. For more information, see
+https://puppet.com/docs/puppet/latest/configuration.html#environment
+        EOM
+      end
+
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)
       Puppet::FileSystem.touch(path)
       Puppet::FileSystem.open(path, nil, 'r+:UTF-8') do |file|


### PR DESCRIPTION
This commits adds in a warning to encourage users to set the environment
in a subsection of puppet.conf rather than globally. This is because the
environment setting has different meaning depending on which context it
is being used in. It can either refer to the environment defined locally
on the filesystem or the environment that it is requesting from the
master. These different uses can lead to issues when the user has set
environment globally to an environment that only exists on the master
and not the agent. In this case, puppet subcommands that interpret
environment to refer to the environment as defined locally will fail
because that environment does not exist on the local filesystem. This
can be very frustrating and unintuitive to users.