### PR TITLE
(docs) Provide instructions on running puppet unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,10 @@ for advice.
       why this is a problem, and how the patch fixes the problem when applied.
   ```
 * Make sure you have added the necessary tests for your changes.
-* Run _all_ the tests to assure nothing else was accidentally broken.
+* Run _all_ the tests to assure nothing else was accidentally broken. First
+  install all the test dependencies with `bundle install --path .bundle`. Then
+  either run all the tests serially with `bundle exec rspec spec` or in parallel
+  with `bundle exec rake parallel:spec[process_count]`
 
 ## Writing Translatable Code
 


### PR DESCRIPTION
This commits adds in a few details on exactly how to run all the tests.
Prior to this commit, we simply had a mandate that users run tests
before opening pull requests. This commit details how to do that. Users
are only expected to ensure the unit tests are passing prior to opening
a pull request.