### PR TITLE
(PUP-8170) Add parsing to PAL API

### DIFF
--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -105,6 +105,21 @@ module Pal
       internal_evaluator.evaluate(topscope, ast)
     end
 
+    # Produces a literal value if the AST obtained from `parse_string` or `parse_file` does not require any actual evaluation.
+    # This method is useful if obtaining an AST that represents literal values; string, integer, float, boolean, regexp, array, hash;
+    # for example from having read this from the command line or as values in some file.
+    #
+    # @param ast [Puppet::Pops::Model::PopsObject] typically the returned `Program` from the parse methods, but can be any `Expression`
+    # @returns [Object] whatever the literal value the ast evaluates to
+    #
+    def evaluate_literal(ast)
+      catch :not_literal do
+        return Puppet::Pops::Evaluator::LiteralEvaluator.new().literal(ast)
+      end
+      # TRANSLATORS, the 'ast' is the name of a parameter, do not translate
+      raise ArgumentError, _("The given 'ast' does not represent a literal value")
+    end
+
     # Parses and validates a puppet language string and returns an instance of Puppet::Pops::Model::Program on success.
     # If the content is not valid an error is raised.
     #

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -97,6 +97,41 @@ module Pal
       internal_evaluator.evaluate_file(topscope, file)
     end
 
+    # Evaluates an AST obtained from `parse_string` or `parse_file` in topscope.
+    # @param ast [Puppet::Pops::Model::PopsObject] typically the returned `Program` from the parse methods, but can be any `Expression`
+    # @returns [Object] whatever the ast evaluates to
+    #
+    def evaluate_ast(ast)
+      internal_evaluator.evaluate(topscope, ast)
+    end
+
+    # Parses and validates a puppet language string and returns an instance of Puppet::Pops::Model::Program on success.
+    # If the content is not valid an error is raised.
+    #
+    # @param code_string [String] a puppet language string to parse and validate
+    # @param source_file [String] an optional reference to a file or other location in angled brackets
+    # @return [Puppet::Pops::Model::Program] returns a `Program` instance on success
+    #
+    def parse_string(code_string, source_file = nil)
+      unless code_string.is_a?(String)
+        raise ArgumentError, _("The argument 'code_string' must be a String, got %{type}") % { type: code_string.class }
+      end
+      internal_evaluator.parse_string(code_string, source_file)
+    end
+
+    # Parses and validates a puppet language file and returns an instance of Puppet::Pops::Model::Program on success.
+    # If the content is not valid an error is raised.
+    #
+    # @param file [String] a file with puppet language content to parse and validate
+    # @return [Puppet::Pops::Model::Program] returns a `Program` instance on success
+    #
+    def parse_file(file)
+      unless file.is_a?(String)
+        raise ArgumentError, _("The argument 'file' must be a String, got %{type}") % { type: puppet_code.class }
+      end
+      internal_evaluator.parse_file(file)
+    end
+
     # Parses a puppet data type given in String format and returns that type, or raises an error.
     # A type is needed in calls to `new` to create an instance of the data type, or to perform type checking
     # of values - typically using `type.instance?(obj)` to check if `obj` is an instance of the type.

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -101,7 +101,7 @@ module Pal
     # @param ast [Puppet::Pops::Model::PopsObject] typically the returned `Program` from the parse methods, but can be any `Expression`
     # @returns [Object] whatever the ast evaluates to
     #
-    def evaluate_ast(ast)
+    def evaluate(ast)
       internal_evaluator.evaluate(topscope, ast)
     end
 

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -304,21 +304,21 @@ describe 'Puppet Pal' do
         }.to raise_error(Puppet::Error)
       end
 
-      it 'it can evaluate the parsed AST' do
+      it 'the "evaluate" method evaluates the parsed AST' do
         result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
-          ctx.with_script_compiler { |c| c.evaluate_ast(c.parse_string('10 + 20')) }
+          ctx.with_script_compiler { |c| c.evaluate(c.parse_string('10 + 20')) }
         end
         expect(result).to eq(30)
       end
 
-      it '"evaluate_literal" can evaluate AST being a representation of a literal value' do
+      it 'the "evaluate_literal" method evaluates AST being a representation of a literal value' do
         result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
           ctx.with_script_compiler { |c| c.evaluate_literal(c.parse_string('{10 => "hello"}')) }
         end
         expect(result).to eq({10 => 'hello'})
       end
 
-      it '"evaluate_literal" errors if ast is not representing a literal value' do
+      it 'the "evaluate_literal" method errors if ast is not representing a literal value' do
         expect do
           Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
             ctx.with_script_compiler { |c| c.evaluate_literal(c.parse_string('{10+1 => "hello"}')) }

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -257,6 +257,62 @@ describe 'Puppet Pal' do
       end
     end
 
+    context 'supports parsing such that' do
+      it '"parse_string" parses a puppet language string' do
+        result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+          ctx.with_script_compiler { |c| c.parse_string('$a = 10') }
+        end
+        expect(result.class).to eq(Puppet::Pops::Model::Program)
+      end
+
+      {  nil      => Puppet::Error,
+        '0xWAT'   => Puppet::ParseErrorWithIssue, 
+        '$0 = 1'  => Puppet::ParseErrorWithIssue, 
+        'else 32' => Puppet::ParseErrorWithIssue,
+      }.each_pair do |input, error_class|
+        it "'parse_string' raises an error for invalid input: '#{input}'" do
+          expect {
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+            ctx.with_script_compiler { |c| c.parse_string(input) }
+          end
+          }.to raise_error(error_class)
+        end
+      end
+
+      it '"parse_file" parses a puppet language string' do
+        result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+          manifest = file_containing('main.pp', "$a = 10")
+          ctx.with_script_compiler { |c| c.parse_file(manifest) }
+        end
+        expect(result.class).to eq(Puppet::Pops::Model::Program)
+      end
+
+      it "'parse_file' raises an error for invalid input: 'else 32'" do
+        expect {
+        Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+          manifest = file_containing('main.pp', "else 32")
+          ctx.with_script_compiler { |c| c.parse_file(manifest) }
+        end
+        }.to raise_error(Puppet::ParseErrorWithIssue)
+      end
+
+      it "'parse_file' raises an error for invalid input, file is not a string" do
+        expect {
+        Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+          ctx.with_script_compiler { |c| c.parse_file(42) }
+        end
+        }.to raise_error(Puppet::Error)
+      end
+
+      it 'it can evaluate the parsed AST' do
+        result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+          ctx.with_script_compiler { |c| c.evaluate_ast(c.parse_string('10 + 20')) }
+        end
+        expect(result).to eq(30)
+      end
+
+    end
+
     # Note: When function run_plan moves to bolt, so should this test
     it 'can call run_plan function to run a plan' do
       result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -311,6 +311,21 @@ describe 'Puppet Pal' do
         expect(result).to eq(30)
       end
 
+      it '"evaluate_literal" can evaluate AST being a representation of a literal value' do
+        result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+          ctx.with_script_compiler { |c| c.evaluate_literal(c.parse_string('{10 => "hello"}')) }
+        end
+        expect(result).to eq({10 => 'hello'})
+      end
+
+      it '"evaluate_literal" errors if ast is not representing a literal value' do
+        expect do
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do | ctx|
+            ctx.with_script_compiler { |c| c.evaluate_literal(c.parse_string('{10+1 => "hello"}')) }
+          end
+        end.to raise_error(/does not represent a literal value/)
+      end
+
     end
 
     # Note: When function run_plan moves to bolt, so should this test


### PR DESCRIPTION
This makes it possible to just parse puppet language and get AST back. The returned AST is validated.
The AST can then either be evaluated using `evaluate(ast)` or `evaluate_literal(ast)`.