### PR TITLE
Add pip3.exe for windows to work properly

### DIFF
--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -15,6 +15,9 @@ Puppet::Type.type(:package).provide :pip3,
   has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
 
   def self.cmd
-    ["pip3"]
+    if Puppet.features.microsoft_windows?
+      ["pip3.exe"]
+    else
+      ["pip3"]
   end
 end


### PR DESCRIPTION
Using this provider in windows fails because can't locate pip3. pip3.exe needs to be specified.