### PR TITLE
(PUP-8143) Pass "child" to ctrun on Solaris instead of "none"

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -171,7 +171,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
 
   def texecute(type, command, fof = true, squelch = false, combine = true)
     if type == :start && Facter.value(:osfamily) == "Solaris"
-        command =  ["/usr/bin/ctrun -l none", command].flatten.join(" ")
+        command =  ["/usr/bin/ctrun -l child", command].flatten.join(" ")
     end
     super(type, command, fof, squelch, combine)
   end

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -240,7 +240,7 @@ describe Puppet::Type.type(:service).provider(:init) do
     describe "when starting a service on Solaris" do
       it "should use ctrun" do
         Facter.stubs(:value).with(:osfamily).returns 'Solaris'
-        provider.expects(:execute).with('/usr/bin/ctrun -l none /service/path/myservice start', {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).returns("")
+        provider.expects(:execute).with('/usr/bin/ctrun -l child /service/path/myservice start', {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).returns("")
         $CHILD_STATUS.stubs(:exitstatus).returns(0)
         provider.start
       end


### PR DESCRIPTION
In Puppet 5, some Solaris services were failing to start because Puppet
was abandoning them before making sure that they started correctly. This
caused Puppet to report that the service had started, when it actually
had not. Passing "child" to the ctrun command causes Puppet to manage
the service start more closely, while still retaining the contract
behavior for which ctrun was added (see PUP-2455).