### PR TITLE
(PUP-8182) Backport PUP-7608 to 4.10.x

### DIFF
--- a/lib/puppet/pops/merge_strategy.rb
+++ b/lib/puppet/pops/merge_strategy.rb
@@ -120,7 +120,7 @@ module Puppet::Pops
       when 0
         throw :no_such_key
       when 1
-        yield(lookup_variants[0])
+        merge_single(yield(lookup_variants[0]))
       else
         lookup_invocation.with(:merge, self) do
           result = lookup_variants.reduce(NOT_FOUND) do |memo, lookup_variant|
@@ -146,6 +146,13 @@ module Puppet::Pops
     # @param value [Object] the value to convert
     # @return [Object] the converted value
     def convert_value(value)
+      value
+    end
+
+    # Applies the merge strategy on a single element. Only applicable for `unique`
+    # @param value [Object] the value to merge with nothing
+    # @return [Object] the merged value
+    def merge_single(value)
       value
     end
 
@@ -280,6 +287,14 @@ module Puppet::Pops
 
     def convert_value(e)
       e.is_a?(Array) ? e.flatten : [e]
+    end
+
+    # If _value_ is an array, then return the result of calling `uniq` on that array. Otherwise,
+    # the argument is returned.
+    # @param value [Object] the value to merge with nothing
+    # @return [Object] the merged value
+    def merge_single(value)
+      value.is_a?(Array) ? value.uniq : value
     end
 
     protected

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -842,6 +842,24 @@ describe "The lookup function" do
           end
         end
       end
+
+      context 'that contains an array with duplicates' do
+        let(:common_yaml) { <<-YAML.unindent }
+          a:
+           - alpha
+           - bravo
+           - charlie
+           - bravo
+          YAML
+
+        it 'retains the duplicates when using default merge strategy' do
+          expect(lookup('a')).to eql(%w(alpha bravo charlie bravo))
+        end
+
+        it 'does deduplification when using merge strategy "unique"' do
+          expect(lookup('a', :merge => 'unique')).to eql(%w(alpha bravo charlie))
+        end
+      end
     end
 
     context 'with lookup_options configured using patterns' do


### PR DESCRIPTION
This PR is a backport of [PR-5931](/puppetlabs/puppet/pull/5931) for [PUP-7608](https://tickets.puppetlabs.com/browse/PUP-7608).