### PR TITLE
(PUP-7507) Ensure that --facts are propagated to top scope and facts

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -323,7 +323,6 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
     fact_file = options[:fact_file]
 
     if fact_file
-      original_facts = node.parameters
       if fact_file.end_with?("json")
         given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
@@ -333,8 +332,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       unless given_facts.instance_of?(Hash)
         raise "Incorrect formatted data in #{fact_file} given via the --facts flag"
       end
-
-      node.parameters = original_facts.merge(given_facts)
+      node.add_extra_facts(given_facts)
     end
 
     Puppet[:code] = 'undef' unless options[:compile]

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -137,6 +137,16 @@ class Puppet::Node
     @parameters[ENVIRONMENT] ||= self.environment.name.to_s
   end
 
+  # Add extra facts, such as facts given to lookup on the command line The
+  # extra facts will override existing ones.
+  # @param extra_facts [Hash{String=>Object}] the facts to tadd
+  # @api private
+  def add_extra_facts(extra_facts)
+    @facts.add_extra_values(extra_facts)
+    @parameters.merge!(extra_facts)
+    nil
+  end
+
   def add_server_facts(facts)
     # Append the current environment to the list of server facts
     @server_facts = facts.merge({ "environment" => self.environment.name.to_s})

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -59,6 +59,15 @@ class Puppet::Node::Facts
     end
   end
 
+  # Add extra values, such as facts given to lookup on the command line. The
+  # extra values will override existing values.
+  # @param extra_values [Hash{String=>Object}] the values to add
+  # @api private
+  def add_extra_values(extra_values)
+    @values.merge!(extra_values)
+    nil
+  end
+
   # Sanitize fact values by converting everything not a string, Boolean
   # numeric, array or hash into strings.
   def sanitize

--- a/spec/fixtures/unit/application/environments/production/data/common.yaml
+++ b/spec/fixtures/unit/application/environments/production/data/common.yaml
@@ -18,5 +18,7 @@ f.one:
 
 ab: "%{hiera('a')} and %{hiera('b')}"
 
+g: "This is%{facts.cx} in facts hash"
+
 lookup_options:
   a: first

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -498,6 +498,8 @@ Searching for "a"
     end
 
     context 'the global scope' do
+      include PuppetSpec::Files
+
       it "is unaffected by global variables unless '--compile' is used" do
         lookup.options[:node] = node
         lookup.command_line.stubs(:args).returns(['c'])
@@ -509,6 +511,34 @@ Searching for "a"
         lookup.options[:compile] = true
         lookup.command_line.stubs(:args).returns(['c'])
         expect(run_lookup(lookup)).to eql("--- This is C from site.pp\n...")
+      end
+
+      it 'receives extra facts in top scope' do
+        file_path = tmpdir('lookup_spec')
+        filename = File.join(file_path, "facts.yaml")
+        File.open(filename, "w+") { |f| f.write(<<-YAML.unindent) }
+          ---
+          cx: ' C from facts'
+          YAML
+
+        lookup.options[:node] = node
+        lookup.options[:fact_file] = filename
+        lookup.command_line.stubs(:args).returns(['c'])
+        expect(run_lookup(lookup)).to eql("--- This is C from facts\n...")
+      end
+
+      it 'receives extra facts in the facts hash' do
+        file_path = tmpdir('lookup_spec')
+        filename = File.join(file_path, "facts.yaml")
+        File.open(filename, "w+") { |f| f.write(<<-YAML.unindent) }
+          ---
+          cx: ' G from facts'
+        YAML
+
+        lookup.options[:node] = node
+        lookup.options[:fact_file] = filename
+        lookup.command_line.stubs(:args).returns(['g'])
+        expect(run_lookup(lookup)).to eql("--- This is G from facts in facts hash\n...")
       end
     end
 


### PR DESCRIPTION
Prior to this commit, the content of a yaml or json file passed to the
lookup CLI with the --facts option was just added to the node parameters
hash (which in essence means that they were just added to top scope).
This commit ensures that they are added to the contained facts instance
in the node and and hence, made available also when the dotted name
'facts.xxx' is used.