### PR TITLE
(PUP-8090) Load module translations from modulepath and vardir

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -42,11 +42,8 @@ module Puppet
   require 'puppet/environments'
 
   class << self
-    Puppet::GettextConfig.create_text_domain('production')
-    locale_dir = Puppet::GettextConfig.puppet_locale_path
-    if Puppet::GettextConfig.load_translations('puppet', locale_dir, Puppet::GettextConfig.translation_mode(locale_dir))
-      Puppet::GettextConfig.set_locale(Locale.current.language)
-    end
+    Puppet::GettextConfig.set_locale(Locale.current.language)
+    Puppet::GettextConfig.create_default_text_domain
 
     include Puppet::Util
     attr_reader :features

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -117,10 +117,8 @@ class Puppet::Configurer
       remote_environment_for_plugins = Puppet::Node::Environment.remote(@environment)
       download_plugins(remote_environment_for_plugins)
 
-      if !Puppet[:disable_i18n]
-        Puppet::GettextConfig.reset_text_domain('agent')
-        Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
-      end
+      Puppet::GettextConfig.reset_text_domain('agent')
+      Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
     end
 
     facts_hash = {}

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -116,6 +116,11 @@ class Puppet::Configurer
     if options[:pluginsync]
       remote_environment_for_plugins = Puppet::Node::Environment.remote(@environment)
       download_plugins(remote_environment_for_plugins)
+
+      if !Puppet[:disable_i18n]
+        Puppet::GettextConfig.reset_text_domain('agent')
+        Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
+      end
     end
 
     facts_hash = {}
@@ -293,11 +298,10 @@ class Puppet::Configurer
       end
 
       current_environment = Puppet.lookup(:current_environment)
-      local_node_environment =
       if current_environment.name == @environment.intern
-        current_environment
+        local_node_environment = current_environment
       else
-        Puppet::Node::Environment.create(@environment,
+        local_node_environment = Puppet::Node::Environment.create(@environment,
                                          current_environment.modulepath,
                                          current_environment.manifest,
                                          current_environment.config_version)

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -365,6 +365,7 @@ module Puppet::Environments
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear(name)
       @cache.delete(name)
+      Puppet::GettextConfig.delete_text_domain(name)
     end
 
     # Clears all cached environments.
@@ -374,6 +375,7 @@ module Puppet::Environments
       @cache = {}
       @expirations.clear
       @next_expiration = END_OF_TIME
+      Puppet::GettextConfig.delete_environment_text_domains
     end
 
     # Clears all environments that have expired, either by exceeding their time to live, or

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -47,6 +47,17 @@ module Puppet::GettextConfig
   end
 
   # @api private
+  # Returns the currently selected locale from FastGettext,
+  # or 'en' of gettext has not been loaded
+  def self.current_locale
+    if gettext_loaded?
+      return FastGettext.default_locale
+    else
+      return 'en'
+    end
+  end
+
+  # @api private
   # Creates a new empty text domain with the given name, replacing
   # any existing domain with that name, then switches to using
   # that domain. Also clears the cache of loaded translations.
@@ -126,7 +137,6 @@ module Puppet::GettextConfig
   def self.add_repository_to_domain(project_name, locale_dir, file_format)
     # check if we've already loaded these transltaions
     current_chain = FastGettext.translation_repositories[FastGettext.text_domain].chain
-    return current_chain if @loaded_repositories[project_name]
 
     repository = FastGettext::TranslationRepository.build(project_name,
                                                           path: locale_dir,

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -8,7 +8,6 @@ module Puppet::GettextConfig
 
   # Load gettext helpers and track whether they're available.
   # Used instead of features because we initialize gettext before features is available.
-  # Stubbing gettext if unavailable is handled in puppet.rb.
   begin
     require 'fast_gettext'
     require 'locale'
@@ -34,21 +33,9 @@ module Puppet::GettextConfig
   end
 
   # @api private
-  # Whether translations have been loaded for a given project
-  # @param project_name [String] the project whose translations we are querying
-  # @return [Boolean] true if translations have been loaded for the project
-  def self.translations_loaded?(project_name)
-    return false unless gettext_loaded?
-    if @loaded_repositories[project_name]
-      return true
-    else
-      return false
-    end
-  end
-
-  # @api private
   # Returns the currently selected locale from FastGettext,
   # or 'en' of gettext has not been loaded
+  # @return [String] the active locale
   def self.current_locale
     if gettext_loaded?
       return FastGettext.default_locale
@@ -58,18 +45,54 @@ module Puppet::GettextConfig
   end
 
   # @api private
-  # Creates a new empty text domain with the given name, replacing
-  # any existing domain with that name, then switches to using
-  # that domain. Also clears the cache of loaded translations.
-  # @param domain_name [String] the name of the domain to create
-  def self.create_text_domain(domain_name)
+  # Clears the translation repository for the given text domain,
+  # creating it if it doesn't exist, then adds default translations
+  # and switches to using this domain.
+  # @param [String] domain_name the name of the domain to create
+  def self.reset_text_domain(domain_name)
     return unless gettext_loaded?
-    # Clear the cache of loaded translation repositories
-    @loaded_repositories = {}
+
     FastGettext.add_text_domain(domain_name, type: :chain, chain: [])
-    #TODO remove this when we start managing domains per environment
-    FastGettext.default_text_domain = domain_name
+    copy_default_translations(domain_name)
     FastGettext.text_domain = domain_name
+  end
+
+  # @api private
+  # Creates a default text domain containing the translations for
+  # Puppet as the start of chain. When semantic_puppet gets initialized,
+  # its translations are added to this chain. This is used as a cache
+  # so that all non-module translations only need to be loaded once as
+  # we create and reset environment-specific text domains.
+  #
+  # @return true if Puppet translations were successfully loaded, false
+  # otherwise
+  def self.create_default_text_domain
+    return unless gettext_loaded?
+
+    FastGettext.add_text_domain('puppet', type: :chain, chain: [])
+    FastGettext.default_text_domain = 'puppet'
+
+    load_translations('puppet', puppet_locale_path, translation_mode(puppet_locale_path))
+  end
+
+  # @api private
+  # Adds translations from the default text domain to the specified
+  # text domain. Creates the default text domain if one does not exist
+  # (this will load Puppet's translations).
+  #
+  # Since we are currently (Nov 2017) vendoring semantic_puppet, in normal
+  # flows these translations will be copied along with Puppet's.
+  #
+  # @param [String] domain_name the name of the domain to add translations to
+  def self.copy_default_translations(domain_name)
+    return unless gettext_loaded?
+
+    if FastGettext.default_text_domain.nil?
+      create_default_text_domain
+    end
+
+    puppet_translations = FastGettext.translation_repositories[FastGettext.default_text_domain].chain
+    FastGettext.translation_repositories[domain_name].chain.push(*puppet_translations)
   end
 
   # @api private
@@ -89,7 +112,7 @@ module Puppet::GettextConfig
 
   # @api private
   # Determine which translation file format to use
-  # @param conf_path [String] the path to the gettext config file
+  # @param [String] conf_path the path to the gettext config file
   # @return [Symbol] :mo if in a package structure, :po otherwise
   def self.translation_mode(conf_path)
     if WINDOWS_PATH == conf_path || POSIX_PATH == conf_path
@@ -107,21 +130,21 @@ module Puppet::GettextConfig
 
   # @api private
   # Attempt to load tranlstions for the given project.
-  # @param project_name [String] the project whose translations we want to load
-  # @param locale_dir [String] the path to the directory containing translations
-  # @param file_format [Symbol] translation file format to use, either :po or :mo
+  # @param [String] project_name the project whose translations we want to load
+  # @param [String] locale_dir the path to the directory containing translations
+  # @param [Symbol] file_format translation file format to use, either :po or :mo
   # @return true if initialization succeeded, false otherwise
   def self.load_translations(project_name, locale_dir, file_format)
+    if project_name.nil? || project_name.empty?
+      raise Puppet::Error, "A project name must be specified in order to initialize translations."
+    end
+
     return false if @gettext_disabled || !@gettext_loaded
 
     return false unless locale_dir && Puppet::FileSystem.exist?(locale_dir)
 
     unless file_format == :po || file_format == :mo
       raise Puppet::Error, "Unsupported translation file format #{file_format}; please use :po or :mo"
-    end
-
-    if project_name.nil? || project_name.empty?
-      raise Puppet::Error, "A project name must be specified in order to initialize translations."
     end
 
     add_repository_to_domain(project_name, locale_dir, file_format)
@@ -131,24 +154,22 @@ module Puppet::GettextConfig
   # @api private
   # Add the translations for this project to the domain's repository chain
   # chain for the currently selected text domain, if needed.
-  # @param project_name [String] the name of the project for which to load translations
-  # @param locale_dir [String] the path to the directory containing translations
-  # @param file_format [Symbol] the fomat of the translations files, :po or :mo
+  # @param [String] project_name the name of the project for which to load translations
+  # @param [String] locale_dir the path to the directory containing translations
+  # @param [Symbol] file_format the fomat of the translations files, :po or :mo
   def self.add_repository_to_domain(project_name, locale_dir, file_format)
-    # check if we've already loaded these transltaions
     current_chain = FastGettext.translation_repositories[FastGettext.text_domain].chain
 
     repository = FastGettext::TranslationRepository.build(project_name,
                                                           path: locale_dir,
                                                           type: file_format,
                                                           ignore_fuzzy: false)
-    @loaded_repositories[project_name] = true
     current_chain << repository
   end
 
   # @api private
   # Sets the language in which to display strings.
-  # @param locale [String] the language portion of a locale string (e.g. "ja")
+  # @param [String] locale the language portion of a locale string (e.g. "ja")
   def self.set_locale(locale)
     return if !gettext_loaded?
     # make sure we're not using the `available_locales` machinery

--- a/lib/puppet/gettext/module_translations.rb
+++ b/lib/puppet/gettext/module_translations.rb
@@ -17,8 +17,7 @@ module Puppet::ModuleTranslations
       elsif Puppet::GettextConfig.gettext_loaded?
         Puppet.debug "Could not find translation files for #{module_name} at #{mod.locale_directory}. Skipping translation initialization."
       else
-        #TRANSLATORS 'gettext' is the name of a program and should not be translated
-        Puppet.warn_once("gettext_unavailable", "gettext_unavailable", _("No gettext library found, skipping translation initialization."))
+        Puppet.warn_once("gettext_unavailable", "gettext_unavailable", "No gettext library found, skipping translation initialization.")
       end
     end
   end
@@ -36,8 +35,7 @@ module Puppet::ModuleTranslations
       elsif Puppet::GettextConfig.gettext_loaded?
         Puppet.debug "Could not load translations for #{module_name}."
       else
-        #TRANSLATORS 'gettext' is the name of a program and should not be translated
-        Puppet.warn_once("gettext_unavailable", "gettext_unavailable", _("No gettext library found, skipping translation initialization."))
+        Puppet.warn_once("gettext_unavailable", "gettext_unavailable", "No gettext library found, skipping translation initialization.")
       end
     end
   end

--- a/lib/puppet/gettext/module_translations.rb
+++ b/lib/puppet/gettext/module_translations.rb
@@ -1,0 +1,30 @@
+require 'puppet/gettext/config'
+
+module Puppet::ModuleTranslations
+  def self.from_modulepath(modules)
+    modules.each do |mod|
+      return unless mod.forge_name
+
+      module_name = mod.forge_name.gsub('/', '-')
+      if Puppet::GettextConfig.load_translations(module_name, mod.locale_directory, :po)
+        Puppet.debug "Loaded translations for #{module_name}."
+      elsif Puppet::GettextConfig.gettext_loaded?
+        Puppet.debug "Could not find translation files for #{module_name} at #{mod.locale_directory}. Skipping i18n initialization."
+      else
+        Puppet.warn_once(:gettext_missing, "No gettext library found, skipping i18n initialization.")
+      end
+    end
+  end
+
+  def self.from_vardir(vardir)
+    locale = Puppet::GettextConfig.current_locale
+    Dir.glob("#{vardir}/locales/#{locale}/*.po") do |f|
+      module_name = File.basename(f, ".po")
+      if Puppet::GettextConfig.load_translations(module_name, File.join(vardir, "locales"), :po)
+        Puppet.debug "Loaded translations for #{module_name}."
+      else
+        Puppet.debug "Could not load translations for #{module_name}."
+      end
+    end
+  end
+end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -49,12 +49,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     node = node_from_request(facts, request)
     node.trusted_data = Puppet.lookup(:trusted_information) { Puppet::Context::TrustedInformation.local(node) }.to_h
 
-    if node.environment
-      # TODO Do we want to end up resetting this every time? Do we expect any changes
-      # to the available translations to be loaded each time, and is that worth the extra work?
-      Puppet::GettextConfig.reset_text_domain(node.environment.name)
-      Puppet::ModuleTranslations.load_from_modulepath(node.environment.modules)
-    end
+    node.environment.use_text_domain if node.environment
 
     if catalog = compile(node, request.options)
       return catalog

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -49,6 +49,13 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     node = node_from_request(facts, request)
     node.trusted_data = Puppet.lookup(:trusted_information) { Puppet::Context::TrustedInformation.local(node) }.to_h
 
+    if node.environment
+      # TODO Do we want to end up resetting this every time? Do we expect any changes
+      # to the available translations to be loaded each time, and is that worth the extra work?
+      Puppet::GettextConfig.reset_text_domain(node.environment.name)
+      Puppet::ModuleTranslations.load_from_modulepath(node.environment.modules)
+    end
+
     if catalog = compile(node, request.options)
       return catalog
     else

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -97,9 +97,6 @@ class Puppet::Module
     load_metadata
 
     @absolute_path_to_manifests = Puppet::FileSystem::PathPattern.absolute(manifests)
-
-    # i18n initialization for modules
-    initialize_i18n unless Puppet[:disable_i18n]
   end
 
   # @deprecated The puppetversion module metadata field is no longer used.
@@ -426,21 +423,6 @@ class Puppet::Module
 
   def strict_semver?
     @strict_semver
-  end
-
-  def initialize_i18n
-    # this name takes the form "namespace-module", and should match the name of
-    # the PO file containing the translations.
-    module_name = @forge_name ? @forge_name.gsub("/", "-") : name
-    return if Puppet::GettextConfig.translations_loaded?(module_name)
-
-    if Puppet::GettextConfig.load_translations(module_name, locale_directory, :po)
-      Puppet.debug "i18n initialized for #{module_name}"
-    elsif Puppet::GettextConfig.gettext_loaded?
-      Puppet.debug "Could not find translation files for #{module_name} at #{locale_directory}. Skipping i18n initialization."
-    else
-      Puppet.debug "No gettext library found, skipping i18n initialization."
-    end
   end
 
   private

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -433,6 +433,20 @@ class Puppet::Node::Environment
     deps
   end
 
+  # Loads module translations for the current environment once for
+  # the lifetime of the environment.
+  def use_text_domain
+    return if Puppet[:disable_i18n]
+
+    if @text_domain.nil?
+      @text_domain = @name
+      Puppet::GettextConfig.reset_text_domain(@text_domain)
+      Puppet::ModuleTranslations.load_from_modulepath(modules)
+    else
+      Puppet::GettextConfig.use_text_domain(@text_domain)
+    end
+  end
+
   # Checks if a reparse is required (cache of files is stale).
   #
   def check_for_reparse

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -123,11 +123,9 @@ module Puppet
                 $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
               end
 
-              if !Puppet[:disable_i18n]
-                Puppet::GettextConfig.reset_text_domain('cli')
-                Puppet::ModuleTranslations.load_from_modulepath(configured_environment.modules)
-                Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
-              end
+              Puppet::GettextConfig.reset_text_domain('cli')
+              Puppet::ModuleTranslations.load_from_modulepath(configured_environment.modules)
+              Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
 
               # Puppet requires Facter, which initializes its lookup paths. Reset Facter to
               # pickup the new $LOAD_PATH.

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -14,6 +14,7 @@ require 'puppet/util'
 require "puppet/util/rubygems"
 require "puppet/util/limits"
 require 'puppet/util/colors'
+require 'puppet/gettext/module_translations'
 
 module Puppet
   module Util
@@ -120,6 +121,11 @@ module Puppet
             if configured_environment = Puppet.lookup(:environments).get(Puppet[:environment])
               configured_environment.each_plugin_directory do |dir|
                 $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
+              end
+
+              if !Puppet[:disable_i18n]
+                Puppet::ModuleTranslations.from_modulepath(configured_environment.modules)
+                Puppet::ModuleTranslations.from_vardir(Puppet[:vardir])
               end
 
               # Puppet requires Facter, which initializes its lookup paths. Reset Facter to

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -124,8 +124,9 @@ module Puppet
               end
 
               if !Puppet[:disable_i18n]
-                Puppet::ModuleTranslations.from_modulepath(configured_environment.modules)
-                Puppet::ModuleTranslations.from_vardir(Puppet[:vardir])
+                Puppet::GettextConfig.reset_text_domain('cli')
+                Puppet::ModuleTranslations.load_from_modulepath(configured_environment.modules)
+                Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
               end
 
               # Puppet requires Facter, which initializes its lookup paths. Reset Facter to

--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -17,9 +17,13 @@ describe Puppet::GettextConfig do
     windows_path ||= Puppet::GettextConfig::POSIX_PATH
   end
 
+  before(:each) do
+    Puppet::GettextConfig.stubs(:gettext_loaded?).returns true
+  end
+
   describe 'setting and getting the locale' do
     it 'should return "en" when gettext is unavailable' do
-      Puppet::GettextConfig.expects(:gettext_loaded?).returns(false)
+      Puppet::GettextConfig.stubs(:gettext_loaded?).returns(false)
 
       expect(Puppet::GettextConfig.current_locale).to eq('en')
     end
@@ -49,14 +53,16 @@ describe Puppet::GettextConfig do
   end
 
   describe 'loading translations' do
-    context 'when given a nil config path' do
+    context 'when given a nil locale path' do
       it 'should return false' do
         expect(Puppet::GettextConfig.load_translations('puppet', nil, :po)).to be false
       end
     end
 
-    context 'when given a valid config file location' do
+    context 'when given a valid locale file location' do
       it 'should return true' do
+        Puppet::GettextConfig.expects(:add_repository_to_domain).with('puppet', local_path, :po)
+
         expect(Puppet::GettextConfig.load_translations('puppet', local_path, :po)).to be true
       end
     end
@@ -73,12 +79,14 @@ describe Puppet::GettextConfig do
       Puppet::GettextConfig.expects(:load_translations).with('puppet', local_path, :po).returns(true)
 
       Puppet::GettextConfig.create_default_text_domain
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN)
     end
 
     it 'should copy default translations when creating a non-default text domain' do
       Puppet::GettextConfig.expects(:copy_default_translations).with('test')
 
       Puppet::GettextConfig.reset_text_domain('test')
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
     end
   end
 end

--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -17,6 +17,17 @@ describe Puppet::GettextConfig do
     windows_path ||= Puppet::GettextConfig::POSIX_PATH
   end
 
+  describe 'setting and getting the locale' do
+    it 'should return "en" by default' do
+      expect(Puppet::GettextConfig.current_locale).to eq('en')
+    end
+
+    it 'should allow the locale to be set' do
+      Puppet::GettextConfig.set_locale('ja')
+      expect(Puppet::GettextConfig.current_locale).to eq('ja')
+    end
+  end
+
   describe 'translation mode selection' do
     it 'should select PO mode when given a local config path' do
       expect(Puppet::GettextConfig.translation_mode(local_path)).to eq(:po)

--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -18,13 +18,15 @@ describe Puppet::GettextConfig do
   end
 
   describe 'setting and getting the locale' do
-    it 'should return "en" by default' do
+    it 'should return "en" when gettext is unavailable' do
+      Puppet::GettextConfig.expects(:gettext_loaded?).returns(false)
+
       expect(Puppet::GettextConfig.current_locale).to eq('en')
     end
 
     it 'should allow the locale to be set' do
-      Puppet::GettextConfig.set_locale('ja')
-      expect(Puppet::GettextConfig.current_locale).to eq('ja')
+      Puppet::GettextConfig.set_locale('hu')
+      expect(Puppet::GettextConfig.current_locale).to eq('hu')
     end
   end
 
@@ -63,6 +65,20 @@ describe Puppet::GettextConfig do
       it 'should raise an exception' do
         expect { Puppet::GettextConfig.load_translations('puppet', local_path, :bad_format) }.to raise_error(Puppet::Error)
       end
+    end
+  end
+
+  describe "setting up text domains" do
+    it 'should add puppet translations to the default text domain' do
+      Puppet::GettextConfig.expects(:load_translations).with('puppet', local_path, :po).returns(true)
+
+      Puppet::GettextConfig.create_default_text_domain
+    end
+
+    it 'should copy default translations when creating a non-default text domain' do
+      Puppet::GettextConfig.expects(:copy_default_translations).with('test')
+
+      Puppet::GettextConfig.reset_text_domain('test')
     end
   end
 end

--- a/spec/unit/gettext/module_loading_spec.rb
+++ b/spec/unit/gettext/module_loading_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::ModuleTranslations do
       it 'should attempt to load translations for each module given' do
         Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(modpath, "mod_a", "locales"), :po).returns(true)
 
-        Puppet::ModuleTranslations.from_modulepath([module_a])
+        Puppet::ModuleTranslations.load_from_modulepath([module_a])
       end
   end
 
@@ -35,7 +35,7 @@ describe Puppet::ModuleTranslations do
       Puppet::GettextConfig.expects(:current_locale).returns("ja")
       Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(vardir, "locales"), :po).returns(true)
 
-      Puppet::ModuleTranslations.from_vardir(vardir)
+      Puppet::ModuleTranslations.load_from_vardir(vardir)
     end
   end
 end

--- a/spec/unit/gettext/module_loading_spec.rb
+++ b/spec/unit/gettext/module_loading_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'puppet_spec/modules'
+require 'puppet_spec/files'
+
+require 'puppet/gettext/module_translations'
+
+describe Puppet::ModuleTranslations do
+  include PuppetSpec::Files
+
+  describe "loading translations from the module path" do
+    let(:modpath) { tmpdir('modpath') }
+
+    let(:module_a) { PuppetSpec::Modules.create(
+      "mod_a",
+      modpath,
+      :metadata => {
+        :author => 'foo'
+      },
+      :environment => mock("environment")) }
+
+      it 'should attempt to load translations for each module given' do
+        Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(modpath, "mod_a", "locales"), :po).returns(true)
+
+        Puppet::ModuleTranslations.from_modulepath([module_a])
+      end
+  end
+
+  describe "loading translations from $vardir" do
+    let(:vardir) {
+      dir_containing("vardir",
+        { "locales" => { "ja" => { "foo-mod_a.po" => "" } } })
+    }
+
+    it "should attempt to load translations for the current locale" do
+      Puppet::GettextConfig.expects(:current_locale).returns("ja")
+      Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(vardir, "locales"), :po).returns(true)
+
+      Puppet::ModuleTranslations.from_vardir(vardir)
+    end
+  end
+end

--- a/spec/unit/gettext/module_loading_spec.rb
+++ b/spec/unit/gettext/module_loading_spec.rb
@@ -16,13 +16,14 @@ describe Puppet::ModuleTranslations do
       :metadata => {
         :author => 'foo'
       },
-      :environment => mock("environment")) }
+      :environment => mock("environment"))
+    }
 
-      it 'should attempt to load translations for each module given' do
-        Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(modpath, "mod_a", "locales"), :po).returns(true)
+    it 'should attempt to load translations for each module given' do
+      Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(modpath, "mod_a", "locales"), :po).returns(true)
 
-        Puppet::ModuleTranslations.load_from_modulepath([module_a])
-      end
+      Puppet::ModuleTranslations.load_from_modulepath([module_a])
+    end
   end
 
   describe "loading translations from $vardir" do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -227,8 +227,6 @@ describe Puppet::Module do
         tasks_dir = "#{mod_dir}/tasks"
         locale_dir = "#{mod_dir}/locales"
         Puppet::FileSystem.stubs(:exist?).with(metadata_file).returns true
-        # Skip checking for translation config file
-        Puppet::FileSystem.stubs(:exist?).with(locale_dir).returns false
       end
       mod = PuppetSpec::Modules.create(
         'test_gte_req',
@@ -445,31 +443,6 @@ describe Puppet::Module do
     end
   end
 
-
-  describe "initialize_i18n" do
-
-    let(:modpath) { tmpdir('modpath') }
-    let(:modname) { 'i18n' }
-    let(:modroot) { "#{modpath}/#{modname}/" }
-    let(:locale_dir) { "#{modroot}locales" }
-    let(:mod_obj) { PuppetSpec::Modules.create( modname, modpath, :metadata => { :dependencies => [] }, :env => env ) }
-
-    it "is expected to initialize an un-initialized module" do
-      expect(Puppet::GettextConfig.translations_loaded?("puppetlabs-#{modname}")).to be false
-
-      FileUtils.mkdir_p(locale_dir)
-      Puppet::FileSystem.stubs(:exist?).with(locale_dir).returns(true)
-
-      mod_obj.initialize_i18n
-
-      expect(Puppet::GettextConfig.translations_loaded?("puppetlabs-#{modname}")).to be true
-    end
-
-    it "is expected return nil if module is intiailized" do
-      expect(mod_obj.initialize_i18n).to be nil
-    end
-  end
-
   describe "when managing supported platforms" do
     it "should support specifying a supported platform" do
       mod.supports "solaris"
@@ -612,7 +585,6 @@ describe Puppet::Module do
 
       it "after the module is initialized" do
         Puppet::FileSystem.expects(:exist?).with(mod_tasks_dir).never
-        Puppet::GettextConfig.expects(:load_translations).returns(false)
         Puppet::Module::Task.expects(:tasks_in_module).never
         Puppet::Module.new(mod_name, @modpath, env)
       end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -492,4 +492,20 @@ describe Puppet::Node::Environment do
     end
   end
 
+  describe "managing module translations" do
+    it "creates a new text domain the first time we try to use the text domain" do
+      Puppet::GettextConfig.expects(:reset_text_domain).with(env.name)
+      Puppet::ModuleTranslations.expects(:load_from_modulepath)
+
+      env.use_text_domain
+    end
+
+    it "uses the existing text domain once it has been created" do
+      env.use_text_domain
+
+      Puppet::GettextConfig.expects(:use_text_domain).with(env.name)
+      env.use_text_domain
+    end
+  end
+
 end


### PR DESCRIPTION
These commits change the way module translations are loaded. Previously, module translations were only loaded from the module's directory when a new module object was created. This didn't work agent-side, where module files are loaded from `$vardir` instead of from the modulepath, and it also caused some unnecessary loading of translations.

The first commit causes all available module translations to be loaded from both the module path and `$vardir` when a puppet subcommand is run from the command line.

The second commit causes module translations to be loaded from `$vardir` on the agent whenever pluginsync occurs, before facts are loaded, to ensure that any messages in facts get translated.