### PR TITLE
(PUP-8181) Rescue StopIteration for hash in each and map functions

### DIFF
--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -117,8 +117,11 @@ Puppet::Functions.create_function(:each) do
 
   def foreach_Hash_1(hash)
     enumerator = hash.each_pair
-    hash.size.times do
-      yield(enumerator.next)
+    begin
+      hash.size.times do
+        yield(enumerator.next)
+      end
+    rescue StopIteration
     end
     # produces the receiver
     hash
@@ -126,8 +129,11 @@ Puppet::Functions.create_function(:each) do
 
   def foreach_Hash_2(hash)
     enumerator = hash.each_pair
-    hash.size.times do
-      yield(*enumerator.next)
+    begin
+      hash.size.times do
+        yield(*enumerator.next)
+      end
+    rescue StopIteration
     end
     # produces the receiver
     hash

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -88,11 +88,21 @@ Puppet::Functions.create_function(:map) do
   end
 
   def map_Hash_1(hash)
-    hash.map {|x, y| yield([x, y]) }
+    result = []
+    begin
+      hash.map {|x, y| result << yield([x, y]) }
+    rescue StopIteration
+    end
+    result
   end
 
   def map_Hash_2(hash)
-    hash.map {|x, y| yield(x, y) }
+    result = []
+    begin
+      hash.map {|x, y| result << yield(x, y) }
+    rescue StopIteration
+    end
+    result
   end
 
   def map_Enumerable_1(enumerable)


### PR DESCRIPTION
Without this patch applied, the break() function fails on hash iterations
using each() or map(), with the error "break() from context where this is
illegal". break() is expected to break out of an iteration regardless of
context. This is happening because each() and map() rescue the StopIteration
exception for enumerables, but not for hashes. eval_Program() throws the
illegal context error when it catches the previously unhandled StopIteration
for a hash. This patch fixes the issue by rescuing StopIteration for hashes
in each() and map().

reduce() and slice() were already behaving as expected, while with() and
filter() are not conducive to a break() operation.

My assumption is that the Puppet `each()` and `map()` functions were written without `StopIteration` in mind because there was no valid reason to handle that exception prior to the creation of Puppet `break()`.