### PR TITLE
(maint) Add equality operator for ExecutionResult

### DIFF
--- a/lib/puppet/pops/types/execution_result.rb
+++ b/lib/puppet/pops/types/execution_result.rb
@@ -104,6 +104,14 @@ module Types
       @result_hash
     end
 
+    def eql?(o)
+      self.class == o.class && self.result_hash == o.result_hash
+    end
+
+    def ==(o)
+      eql?(o)
+    end
+
     private
 
     def convert_errors(result_hash)

--- a/spec/unit/pops/types/execution_result_spec.rb
+++ b/spec/unit/pops/types/execution_result_spec.rb
@@ -30,6 +30,24 @@ describe 'ExecutionResult' do
         ])
       end
 
+      it 'is equal to other objects with the same hash' do
+        code = <<-CODE
+            $o1 = ExecutionResult('example.com' => {value => 'hello'})
+            $o2 = ExecutionResult('example.com' => {value => 'hello'})
+            notice($o1 == $o2)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true))
+      end
+
+      it 'is not equal to other objects with a different hash' do
+        code = <<-CODE
+            $o1 = ExecutionResult({})
+            $o2 = ExecutionResult('example.com' => {value => 'hello'})
+            notice($o1 == $o2)
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(false))
+      end
+
       it 'can be created with a value' do
         code = <<-CODE
             $o = ExecutionResult('example.com' => {value => 'hello'})


### PR DESCRIPTION
Makes it easier to test functions that return ExecutionResults.