### PR TITLE
(PUP-5556) sprintf named arguments needs symbols

### DIFF
--- a/lib/puppet/parser/functions/sprintf.rb
+++ b/lib/puppet/parser/functions/sprintf.rb
@@ -29,7 +29,8 @@ Puppet::Parser::Functions::newfunction(
   :arity => -2,
   :doc => "Perform printf-style formatting of text.
 
-      The first parameter is format string describing how the rest of the parameters should be formatted.  See the documentation for the `Kernel::sprintf` function in Ruby for all the details."
+  The first parameter is format string describing how the rest of the parameters should be formatted.
+  See the documentation for the `Kernel::sprintf` function in Ruby for all the details."
 ) do |args|
   fmt = args.shift
   return sprintf(fmt, *args)

--- a/lib/puppet/parser/functions/sprintf.rb
+++ b/lib/puppet/parser/functions/sprintf.rb
@@ -32,6 +32,7 @@ Puppet::Parser::Functions::newfunction(
   The first parameter is format string describing how the rest of the parameters should be formatted.
   See the documentation for the `Kernel::sprintf` function in Ruby for all the details."
 ) do |args|
-  fmt = args.shift
+  fmt = args[0]
+  args = args[1..-1]
   return sprintf(fmt, *args)
 end

--- a/lib/puppet/parser/functions/sprintf.rb
+++ b/lib/puppet/parser/functions/sprintf.rb
@@ -34,5 +34,17 @@ Puppet::Parser::Functions::newfunction(
 ) do |args|
   fmt = args[0]
   args = args[1..-1]
-  return sprintf(fmt, *args)
+  begin
+    return sprintf(fmt, *args)
+  rescue KeyError => e
+    if args.size == 1 && args[0].is_a?(Hash)
+      # map the single hash argument such that all top level string keys are symbols
+      # as that allows named arguments to be used in the format string.
+      #
+      result = {}
+      args[0].each_pair { |k,v| result[k.is_a?(String) ? k.to_sym : k] = v }
+      return sprintf(fmt, result)
+    end
+    raise e
+  end
 end

--- a/spec/unit/parser/functions/sprintf_spec.rb
+++ b/spec/unit/parser/functions/sprintf_spec.rb
@@ -44,4 +44,8 @@ describe "the sprintf function" do
     expect(result).to(eql("<overlong:  027   0XBEEF (foo     )>"))
   end
 
+  it 'does not attempt to mutate its arguments' do
+    args = ['%d', 1].freeze
+    result = @scope.function_sprintf(args)
+  end
 end

--- a/spec/unit/parser/functions/sprintf_spec.rb
+++ b/spec/unit/parser/functions/sprintf_spec.rb
@@ -46,6 +46,23 @@ describe "the sprintf function" do
 
   it 'does not attempt to mutate its arguments' do
     args = ['%d', 1].freeze
-    result = @scope.function_sprintf(args)
+    expect { @scope.function_sprintf(args) }.to_not raise_error
   end
+
+  it 'support named arguments in a hash with string keys' do
+    result = @scope.function_sprintf(["%<foo>d : %<bar>f", {'foo' => 1, 'bar' => 2}])
+    expect(result).to eq("1 : 2.000000")
+  end
+
+  it 'raises a key error if a key is not present' do
+    expect do
+      @scope.function_sprintf(["%<foo>d : %<zanzibar>f", {'foo' => 1, 'bar' => 2}])
+    end.to raise_error(KeyError, /key<zanzibar> not found/)
+  end
+
+  it 'a hash with string keys that is output formats as strings' do
+    result = @scope.function_sprintf(["%s", {'foo' => 1, 'bar' => 2}])
+    expect(result).to eq("{\"foo\"=>1, \"bar\"=>2}")
+  end
+
 end

--- a/spec/unit/parser/functions/sprintf_spec.rb
+++ b/spec/unit/parser/functions/sprintf_spec.rb
@@ -65,4 +65,9 @@ describe "the sprintf function" do
     expect(result).to eq("{\"foo\"=>1, \"bar\"=>2}")
   end
 
+  it 'named arguments hash with non string keys are tolerated' do
+    result = @scope.function_sprintf(["%<foo>d : %<bar>f", {'foo' => 1, 'bar' => 2, 1 => 2, [1] => 2, false => true, {} => {}}])
+    expect(result).to eq("1 : 2.000000")
+  end
+
 end


### PR DESCRIPTION
This makes named arguments in a sprintf work. The problem is that it requires symbols and we don't have those. We also don't want to always change a hash with string keys into a hash with symbol keys because if the hash is output with a %s format it will output symbols.

The approach taken is to only transform if needed (on the KeyError that is raised when it does not find the keys). Thus, this is also future proof if Ruby should change and allow string keys (then it would work on the first attempt).