### PR TITLE
(PUP-8191) Don't initialize gettext for modules without relevant translations

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -98,6 +98,13 @@ module Puppet::GettextConfig
   end
 
   # @api private
+  # Delete all text domains.
+  def self.delete_all_text_domains
+    FastGettext.translation_repositories.clear
+    FastGettext.default_text_domain = nil
+  end
+
+  # @api private
   # Deletes the text domain with the given name
   # @param [String] domain_name the name of the domain to delete
   def self.delete_text_domain(domain_name)

--- a/lib/puppet/gettext/module_translations.rb
+++ b/lib/puppet/gettext/module_translations.rb
@@ -9,7 +9,7 @@ module Puppet::ModuleTranslations
   #        load translations
   def self.load_from_modulepath(modules)
     modules.each do |mod|
-      return unless mod.forge_name
+      return unless mod.forge_name && mod.has_translations?(Puppet::GettextConfig.current_locale)
 
       module_name = mod.forge_name.gsub('/', '-')
       if Puppet::GettextConfig.load_translations(module_name, mod.locale_directory, :po)

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -305,6 +305,16 @@ class Puppet::Module
     subpath("locales")
   end
 
+  # Returns true if the module has translation files for the
+  # given locale.
+  # @param [String] locale the two-letter language code to check
+  #        for translations
+  # @return true if the module has a directory for the locale, false
+  #         false otherwise
+  def has_translations?(locale)
+    return Puppet::FileSystem.exist?(File.join(locale_directory, locale))
+  end
+
   def has_external_facts?
     File.directory?(plugin_fact_directory)
   end

--- a/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet.rb
+++ b/lib/puppet/vendor/semantic_puppet/lib/semantic_puppet.rb
@@ -1,5 +1,9 @@
 module SemanticPuppet
-  Puppet::GettextConfig.load_translations('semantic_puppet', File.absolute_path('../locales', File.dirname(__FILE__)), :po)
+  locales_path = File.absolute_path('../locales', File.dirname(__FILE__))
+  # Only create a translation repository of the relevant translations exist
+  if Puppet::FileSystem.exist?(File.join(locales_path, Puppet::GettextConfig.current_locale))
+    Puppet::GettextConfig.load_translations('semantic_puppet', locales_path, :po)
+  end
 
   autoload :Version, 'semantic_puppet/version'
   autoload :VersionRange, 'semantic_puppet/version_range'

--- a/locales/en/puppet.po
+++ b/locales/en/puppet.po
@@ -1,0 +1,19 @@
+# English translations for Puppet automation framework package.
+# Copyright (C) 2017 Puppet, Inc.
+# This file is distributed under the same license as the Puppet automation framework package.
+# Automatically generated, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Puppet automation framework 5.3.3-51-gc11ddbe\n"
+"\n"
+"Report-Msgid-Bugs-To: https://tickets.puppetlabs.com\n"
+"POT-Creation-Date: 2017-11-17 12:09+0000\n"
+"PO-Revision-Date: 2017-11-17 12:09+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"

--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 describe Puppet::GettextConfig do
   require 'puppet_spec/files'
   include PuppetSpec::Files
+  include Puppet::GettextConfig
 
   let(:local_path) do
     local_path ||= Puppet::GettextConfig::LOCAL_PATH
@@ -19,6 +20,11 @@ describe Puppet::GettextConfig do
 
   before(:each) do
     Puppet::GettextConfig.stubs(:gettext_loaded?).returns true
+  end
+
+  after(:each) do
+    Puppet::GettextConfig.set_locale('en')
+    Puppet::GettextConfig.delete_all_text_domains
   end
 
   describe 'setting and getting the locale' do
@@ -83,10 +89,31 @@ describe Puppet::GettextConfig do
     end
 
     it 'should copy default translations when creating a non-default text domain' do
-      Puppet::GettextConfig.expects(:copy_default_translations).with('test')
-
       Puppet::GettextConfig.reset_text_domain('test')
       expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
+    end
+  end
+
+  describe "deleting text domains" do
+    it 'can delete a text domain by name' do
+      Puppet::GettextConfig.reset_text_domain('test')
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
+      Puppet::GettextConfig.delete_text_domain(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN)
+      expect(Puppet::GettextConfig.loaded_text_domains).not_to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN)
+    end
+
+    it 'can delete all non-default text domains' do
+      Puppet::GettextConfig.reset_text_domain('test')
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
+      Puppet::GettextConfig.delete_environment_text_domains
+      expect(Puppet::GettextConfig.loaded_text_domains).not_to include('test')
+    end
+
+    it 'can delete all text domains' do
+      Puppet::GettextConfig.reset_text_domain('test')
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
+      Puppet::GettextConfig.delete_all_text_domains
+      expect(Puppet::GettextConfig.loaded_text_domains).to be_empty
     end
   end
 end

--- a/spec/unit/gettext/module_loading_spec.rb
+++ b/spec/unit/gettext/module_loading_spec.rb
@@ -19,8 +19,16 @@ describe Puppet::ModuleTranslations do
       :environment => mock("environment"))
     }
 
-    it 'should attempt to load translations for each module given' do
+    it "should attempt to load translations for each module that has them" do
+      module_a.expects(:has_translations?).returns(true)
       Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(modpath, "mod_a", "locales"), :po).returns(true)
+
+      Puppet::ModuleTranslations.load_from_modulepath([module_a])
+    end
+
+    it "should not attempt to load translations for modules that don't have them" do
+      module_a.expects(:has_translations?).returns(false)
+      Puppet::GettextConfig.expects(:load_translations).never
 
       Puppet::ModuleTranslations.load_from_modulepath([module_a])
     end


### PR DESCRIPTION
This commit ensures that a module's locales directory contains a set of
translation files for the selected locale before creating the
translation repository for that module. Since translation files are
lazily loaded by FastGettext, it will create the repo first and look for
the files later. If it can't find them, it will create and read an
empty MO file as a placeholder. To avoid this extra work, we now do that
check up front.