### PR TITLE
(PUP-8171) add support for checking parameters of plan

### DIFF
--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -26,8 +26,9 @@ require 'puppet/parser/script_compiler'
 module Puppet
 module Pal
 
-  # @param compiler [Puppet::Pal::Compiler] a configured compiler as obtained in the callback from `with_script_compiler`
-
+  # A configured compiler as obtained in the callback from `with_script_compiler`.
+  # (Later, there may also be a catalog compiler available.)
+  #
   class Compiler
     attr_reader :internal_compiler
     protected :internal_compiler

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -207,10 +207,73 @@ module Pal
     def plan_signature(plan_name)
       loader = internal_compiler.loaders.private_environment_loader
       if func = loader.load(:plan, plan_name)
-        return func.class.dispatcher.to_type
+        return PlanSignature.new(func)
+#        return func.class.dispatcher.to_type
       end
       # Could not find plan
       nil
+    end
+  end
+
+  # A PlanSignature is returned from `plan_signature`. Its purpose is to answer questions about the plans's parameters
+  # and if it can be called with a hash of named parameters.
+  #
+  # @api public
+  #
+  class PlanSignature
+    def initialize(plan_function)
+      @plan_func = plan_function
+    end
+
+    # Returns true or false depending on if the given PlanSignature is callable with a set of named arguments or not
+    # In addition to returning the boolean outcome, if a block is given, it is called with a string of formatted
+    # error messages that describes the difference between what was given and what is expected. The error message may
+    # have multiple lines of text, and each line is indented one space.
+    #
+    # @example Checking if signature is acceptable
+    #
+    #   signature = pal.plan_signature('myplan')
+    #   signature.callable_with?({x => 10}) { |errors| raise ArgumentError("Ooops: given arguments does not match\n#{errors}") }
+    #
+    def callable_with?(args_hash)
+      dispatcher = @plan_func.class.dispatcher.dispatchers[0]
+
+      param_scope = {}
+      # Assign all non-nil values, even those that represent non-existent parameters.
+      args_hash.each { |k, v| param_scope[k] = v unless v.nil? }
+      dispatcher.parameters.each do |p|
+        name = p.name
+        arg = args_hash[name]
+        if arg.nil?
+          # Arg either wasn't given, or it was undef
+          if p.value.nil?
+            # No default. Assign nil if the args_hash included it
+            param_scope[name] = nil if args_hash.include?(name)
+          else
+            # parameter does not have a default value, it will be assigned its default when being called
+            # we assume that the default value is of the correct type and therefore simply skip
+            # checking this
+            # param_scope[name] = param_scope.evaluate(name, p.value, closure_scope, @evaluator)
+          end
+        end
+      end
+
+      errors = Puppet::Pops::Types::TypeMismatchDescriber.singleton.describe_struct_signature(dispatcher.params_struct, param_scope).flatten
+      return true if errors.empty?
+      if block_given?
+        yield errors.map {|e| e.format }.join("\n")
+      end
+      false
+    end
+
+    # Returns a hash mapping all parameter's name to type
+    #
+    def params_hash
+    end
+
+    # Returns a hash mapping all required parameter's name to type
+    #
+    def required_parameters
     end
   end
 

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -200,15 +200,14 @@ module Pal
   end
 
   class ScriptCompiler < Compiler
-    # Returns the signature callable of the given plan (the arguments it accepts, and the data type it returns)
+    # Returns the signature of the given plan name
     # @param plan_name [String] the name of the plan to get the signature of
-    # @return [Puppet::Pops::Types::PCallableType, nil] returns a callable data type, or nil if plan is not found
+    # @return [Puppet::Pal::PlanSignature, nil] returns a PlanSignature, or nil if plan is not found
     #
     def plan_signature(plan_name)
       loader = internal_compiler.loaders.private_environment_loader
       if func = loader.load(:plan, plan_name)
         return PlanSignature.new(func)
-#        return func.class.dispatcher.to_type
       end
       # Could not find plan
       nil

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -265,14 +265,15 @@ module Pal
       false
     end
 
-    # Returns a hash mapping all parameter's name to type
+    # Returns a PStructType describing the parameters as a puppet Struct data type
+    # Note that a `to_s` on the returned structure will result in a human readable Struct datatype as a
+    # description of what a plan expects.
     #
-    def params_hash
-    end
-
-    # Returns a hash mapping all required parameter's name to type
+    # @return [Puppet::Pops::Types::PStructType] a struct data type describing the parameters and their types
     #
-    def required_parameters
+    def params_type
+      dispatcher = @plan_func.class.dispatcher.dispatchers[0]
+      dispatcher.params_struct
     end
   end
 

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -54,20 +54,22 @@ module Pal
       internal_evaluator.evaluator.external_call_function(function_name, args, topscope, &block)
     end
 
-    # Returns an Array[Puppet::Pops::Types::PCallableType] describing the given function's signatures, or empty array if function not found.
+    # Returns an Puppet::Pal::FunctionSignature objects or nil if function is not found
+    # The returned FunctionSignature has information about all overloaded signatures of the function
+    #
+    # @example using function_signature
+    #   # returns true if 'myfunc' is callable with three integer arguments 1, 2, 3
+    #   compiler.function_signature('myfunc').callable_with?([1,2,3])
+    #
     # @param function_name [String] the name of the function to get a signature for
-    # @return [Array<Puppet::Pops::Types::PCallableType>] an array of callable signatures, or an empty array if function not found
+    # @return [Array<Puppet::Pal::FunctionSignature>] an array of callable signatures, or an empty array if function not found
     def function_signature(function_name)
       loader = internal_compiler.loaders.private_environment_loader
       if func = loader.load(:function, function_name)
         return FunctionSignature.new(func)
-#        t = func.class.dispatcher.to_type
-#        return FunctionSignature(t.is_a?(Puppet::Pops::Types::PVariantType) ? t.types : [t])
-        #return t.is_a?(Puppet::Pops::Types::PVariantType) ? t.types : [t]
       end
       # Could not find function
       nil
-#      Puppet::Pops::EMPTY_ARRAY
     end
 
     # Evaluates a string of puppet language code in top scope.

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -239,7 +239,7 @@ describe 'Puppet Pal' do
           expect(result).to eq([true, false])
         end
 
-        it 'a PlanSignature.callable_with? calls a given lambda with any errors' do
+        it 'a PlanSignature.callable_with? calls a given lambda with any errors as a formatted string' do
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
             manifest = file_containing('afunc.pp', "plan myplan(Integer $a, Integer $b) {  } ")
             ctx.with_script_compiler(manifest_file: manifest) do |c|
@@ -254,7 +254,7 @@ describe 'Puppet Pal' do
           expect(result).to eq(" parameter 'a' expects an Integer value, got String\n expects a value for parameter 'b'")
         end
 
-        it 'a PlanSignature.callable_with? does not calla  given lambda if there are no errors' do
+        it 'a PlanSignature.callable_with? does not call a given lambda if there are no errors' do
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
             manifest = file_containing('afunc.pp', "plan myplan(Integer $a) {  } ")
             ctx.with_script_compiler(manifest_file: manifest) do |c|
@@ -272,6 +272,17 @@ describe 'Puppet Pal' do
             ctx.with_script_compiler {|c| c.plan_signature('no_where_to_be_found') }
           end
           expect(result).to be(nil)
+        end
+
+        it '"PlanSignature#params_type" returns a map of all parameters and their types' do
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
+            manifest = file_containing('afunc.pp', "plan myplan(Integer $a, String $b) {  } ")
+            ctx.with_script_compiler(manifest_file: manifest) do |c|
+              c.plan_signature('myplan').params_type
+            end
+          end
+          expect(result.class).to eq(Puppet::Pops::Types::PStructType)
+          expect(result.to_s).to eq("Struct[{'a' => Integer, 'b' => String}]")
         end
       end
 


### PR DESCRIPTION
This adds support for checking arguments to a plan against its parameters. This is implemented by having PAL specific Signature type classes that have a limited set of features compared to returning the more detailed type system descriptions. For Plan that would require modifying PCallableType, or having yet another type for "args by name" in order for that to be useful to the caller of 'plan_signature'. 

Now, plan_signature returns a Puppet::Pal::PlanSignature and it has a simple `callable_with?` method (for args in a hash)
Also added is a Puppet::Pal::FunctionSignature with a simple `callable_with`` method (for args in an array).

More details about the underlying data type is available in the respective signature classes.