### PR TITLE
(PUP-8197) Make parameters optional

### DIFF
--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -64,7 +64,7 @@ class TaskInstantiator
       tf.optional('puppet_task_version') => tf.integer,
       tf.optional('supports_noop') => tf.boolean,
       tf.optional('input_method') => tf.enum('stdin', 'environment'),
-      'parameters' => params_t,
+      tf.optional('parameters') => params_t,
       tf.optional('output') => params_t
     )
   end


### PR DESCRIPTION
The task metadata specification says every field in metadata should have
a reasonable default so they can be omitted. For parameters that's
equivalent to not having metadata, i.e. any input is allowed. Update the
task loader to make parameters an optional property.