### PR TITLE
(PUP-8219) Don't log no-op Tidy runs

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -260,8 +260,10 @@ Puppet::Type.newtype(:tidy) do
     end
     found_files = files.find_all { |path| tidy?(path) }.collect { |path| mkfile(path) }
     result = found_files.each { |file| debug "Tidying #{file.ref}" }.sort { |a,b| b[:path] <=> a[:path] }
-    #TRANSLATORS "Tidy" is a program name and should not be translated
-    notice _("Tidying %{count} files") % { count: found_files.size }
+    if found_files.size > 0
+      #TRANSLATORS "Tidy" is a program name and should not be translated
+      notice _("Tidying %{count} files") % { count: found_files.size }
+    end
 
     # No need to worry about relationships if we don't have rmdirs; there won't be
     # any directories.


### PR DESCRIPTION
As mentioned in PR #3693 Tidy shouldn't output anything in the Puppet logs when no objects are cleaned up, i.e. when everything is already tidy.

This change adds the missing `if` statement to avoid the `Tidying 0 files` log message.