### PR TITLE
(PUP-8202) Add list kind to pal api

### DIFF
--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -92,7 +92,9 @@ class TaskInstantiator
       parent_type = 'GenericTask'
     end
 
-    constants['executable'] = Pathname(task_source).relative_path_from(Pathname(loader.path) + 'tasks').to_s
+    if loader.path.nil?
+      return nil
+    end
 
     Types::TypeFactory.object(
       {

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -95,6 +95,7 @@ class TaskInstantiator
     if loader.path.nil?
       return nil
     end
+    constants['executable'] = Pathname(task_source).relative_path_from(Pathname(loader.path) + 'tasks').to_s
 
     Types::TypeFactory.object(
       {

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -84,12 +84,7 @@ module Pal
     # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
     #
     def list_functions(filter_regex = nil)
-      loader = internal_compiler.loaders.private_environment_loader
-      if filter_regex.nil?
-        loader.discover(:function)
-      else
-        loader.discover(:function) {|f| f.name =~ filter_regex }
-      end
+      list_loadable_kind(:function, filter_regex)
     end
 
     # Evaluates a string of puppet language code in top scope.
@@ -217,6 +212,17 @@ module Pal
       call_function('new', t, *arguments)
     end
 
+    protected
+
+    def list_loadable_kind(kind, filter_regex = nil)
+      loader = internal_compiler.loaders.private_environment_loader
+      if filter_regex.nil?
+        loader.discover(kind)
+      else
+        loader.discover(kind) {|f| f.name =~ filter_regex }
+      end
+    end
+
     private
 
     def topscope
@@ -237,6 +243,21 @@ module Pal
       # Could not find plan
       nil
     end
+
+    # Returns an array of TypedName objects for all plans, optionally filtered by a regular expression.
+    # The returned array has more information than just the leaf name - the typical thing is to just get
+    # the name as showing the following example.
+    #
+    # @example getting the names of all plans
+    #   compiler.list_plans.map {|tn| tn.name }
+    #
+    # @param filter_regex [Regexp] an optional regexp that filters based on name (matching names are included in the result)
+    # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
+    #
+    def list_plans(filter_regex = nil)
+      list_loadable_kind(:plan, filter_regex)
+    end
+
   end
 
   # A FunctionSignature is returned from `function_signature`. Its purpose is to answer questions about the function's parameters

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -73,6 +73,25 @@ module Pal
       nil
     end
 
+    # Returns an array of TypedName objects for all functions, optionally filtered by a regular expression.
+    # The returned array has more information than just the leaf name - the typical thing is to just get
+    # the name as showing the following example.
+    #
+    # @example getting the names of all functions
+    #   compiler.list_functions.map {|tn| tn.name }
+    #
+    # @param filter_regex [Regexp] an optional regexp that filters based on name (matching names are included in the result)
+    # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
+    #
+    def list_functions(filter_regex = nil)
+      loader = internal_compiler.loaders.private_environment_loader
+      if filter_regex.nil?
+        loader.discover(:function)
+      else
+        loader.discover(:function) {|f| f.name =~ filter_regex }
+      end
+    end
+
     # Evaluates a string of puppet language code in top scope.
     # A "source_file" reference to a source can be given - if not an actual file name, by convention the name should
     # be bracketed with < > to indicate it is something symbolic; for example `<commandline>` if the string was given on the

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -67,10 +67,24 @@ module Pal
     def function_signature(function_name)
       loader = internal_compiler.loaders.private_environment_loader
       if func = loader.load(:function, function_name)
-        return FunctionSignature.new(func)
+        return FunctionSignature.new(func.class)
       end
       # Could not find function
       nil
+    end
+
+    # Returns an array of TypedName objects for all functions, optionally filtered by a regular expression.
+    # The returned array has more information than just the leaf name - the typical thing is to just get
+    # the name as showing the following example.
+    #
+    # @example getting the names of all functions
+    #   compiler.list_functions.map {|tn| tn.name }
+    #
+    # @param filter_regex [Regexp] an optional regexp that filters based on name (matching names are included in the result)
+    # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
+    #
+    def list_functions(filter_regex = nil)
+      list_loadable_kind(:function, filter_regex)
     end
 
     # Returns an array of TypedName objects for all functions, optionally filtered by a regular expression.
@@ -258,6 +272,19 @@ module Pal
       list_loadable_kind(:plan, filter_regex)
     end
 
+    # Returns the signature callable of the given plan (the arguments it accepts, and the data type it returns)
+    # @param plan_name [String] the name of the plan to get the signature of
+    # @return [Puppet::Pops::Types::PCallableType, nil] returns a callable data type, or nil if plan is not found
+    #
+    def task_signature(task_name)
+      loader = internal_compiler.loaders.private_environment_loader
+      if task_type = loader.load(:type, task_name)
+        return TaskSignature.new(task_type)
+      end
+      # Could not find plan
+      nil
+    end
+
     # Returns an array of TypedName objects for all plans, optionally filtered by a regular expression.
     # The returned array has more information than just the leaf name - the typical thing is to just get
     # the name as showing the following example.
@@ -298,7 +325,6 @@ module Pal
       end
       task_types
     end
-
   end
 
   # A FunctionSignature is returned from `function_signature`. Its purpose is to answer questions about the function's parameters
@@ -311,8 +337,8 @@ module Pal
   #
   class FunctionSignature
     # @api private
-    def initialize(function_instance)
-      @func = function_instance
+    def initialize(function_class)
+      @func = function_class
     end
 
     # Returns true if the function can be called with the given arguments and false otherwise.
@@ -327,13 +353,13 @@ module Pal
     # @api public
     #
     def callable_with?(args, callable=nil)
-      signatures = @func.class.dispatcher.to_type
+      signatures = @func.dispatcher.to_type
       callables = signatures.is_a?(Puppet::Pops::Types::PVariantType) ? signatures.types : [signatures]
 
       return true if callables.any? {|t| t.callable_with?(args) }
       return false unless block_given?
       args_type = Puppet::Pops::Types::TypeCalculator.singleton.infer_set(callable.nil? ? args : args + [callable])
-      error_message = Puppet::Pops::Types::TypeMismatchDescriber.describe_signatures(@func.class.name, @func.class.signatures, args_type)
+      error_message = Puppet::Pops::Types::TypeMismatchDescriber.describe_signatures(@func.name, @func.signatures, args_type)
       yield error_message
       false
     end
@@ -344,8 +370,27 @@ module Pal
     # @api public
     #
     def callables
-      signatures = @func.class.dispatcher.to_type
+      signatures = @func.dispatcher.to_type
       signatures.is_a?(Puppet::Pops::Types::PVariantType) ? signatures.types : [signatures]
+    end
+  end
+
+  # A TaskSignature is returned from `task_signature`. Its purpose is to answer questions about the task's parameters
+  # and if it can be run/called with a hash of named parameters.
+  #
+  class TaskSignature
+    def initialize(task_type)
+      @task_type = task_type
+    end
+
+    # Returns whether or not the given arguments are acceptable when running the task
+    # @param args_hash [Hash] a hash mapping parameter names to argument values
+    # @yieldparam [String] a formatted error message if a type mismatch occurs that explains the mismatch
+    # @return [Boolean] if the given arguments are acceptable when running the task
+    #
+    def runnable_with?(args_hash)
+      @new_signature ||= FunctionSignature.new(@task_type.new_function)
+      @new_signature.callable_with?(args_hash)
     end
   end
 

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -710,6 +710,28 @@ describe 'Puppet Pal' do
           expect(result).to eq(true)
         end
       end
+
+      context 'supports tasks such that' do
+        it '"list_tasks" returns an array with all tasks that can be loaded' do
+          testing_env_dir # creates the structure
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
+            ctx.with_script_compiler {|c| c.list_tasks() }
+          end
+          expect(result.is_a?(Array)).to eq(true)
+          expect(result.all? {|s| s.is_a?(Puppet::Pops::Loader::TypedName) }).to eq(true)
+          expect(result.map {|tn| tn.name}).to eq(['a::atask', 'b::atask'])
+        end
+
+        it '"list_tasks" filters on name based on a given regexp' do
+          testing_env_dir # creates the structure
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
+            ctx.with_script_compiler {|c| c.list_tasks(/^a::/) }
+          end
+          expect(result.is_a?(Array)).to eq(true)
+          expect(result.all? {|s| s.is_a?(Puppet::Pops::Loader::TypedName) }).to eq(true)
+          expect(result.map {|tn| tn.name}).to eq(['a::atask'])
+        end
+      end
     end
 
     context 'configured as an existing given environment directory such that' do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -290,6 +290,7 @@ describe 'Puppet Pal' do
           # there are two functions currently that have 'epp' in their name
           expect(result.count).to eq(2)
         end
+
       end
 
       context 'supports plans such that' do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -270,6 +270,26 @@ describe 'Puppet Pal' do
           expect(result.all? {|c| c.is_a?(Puppet::Pops::Types::PCallableType)}).to eq(true)
         end
 
+        it '"list_functions" returns an array with all function names that can be loaded' do
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
+            ctx.with_script_compiler {|c| c.list_functions() }
+          end
+          expect(result.is_a?(Array)).to eq(true)
+          expect(result.all? {|s| s.is_a?(Puppet::Pops::Loader::TypedName) }).to eq(true)
+          # there are certainly more than 30 functions in puppet - (56 when writing this, but some refactoring
+          # may take place, so don't want an exact number here - jsut make sure it found "all of them"
+          expect(result.count).to be > 30
+        end
+
+        it '"list_functions" filters on name based on a given regexp' do
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
+            ctx.with_script_compiler {|c| c.list_functions(/epp/) }
+          end
+          expect(result.is_a?(Array)).to eq(true)
+          expect(result.all? {|s| s.is_a?(Puppet::Pops::Loader::TypedName) }).to eq(true)
+          # there are two functions currently that have 'epp' in their name
+          expect(result.count).to eq(2)
+        end
       end
 
       context 'supports plans such that' do


### PR DESCRIPTION
This adds `list_functions`, `list_plans` and `list_tasks` to the PAL API. It also adds a `TaskSignature` that is obtained from the new method `task_signature`.
The `TaskSignature` can answer if a hash of arguments is acceptable when running the task.