### PR TITLE
(PUP-8204) Add an EmptyLoader to be used by static environment

### DIFF
--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -413,12 +413,9 @@ module ModuleLoaders
     # @return [Array<String>] found paths
     def relative_paths(smart_path)
       root = smart_path.generic_path
-      ext = smart_path.extension
-      ext = nil if ext.empty?
       found = []
       @path_index.each do |path|
-        next unless (ext.nil? || path.end_with?(ext)) && path.start_with?(root)
-        found << Pathname(path).relative_path_from(Pathname(root)).to_s
+        found << Pathname(path).relative_path_from(Pathname(root)).to_s if smart_path.valid_path?(path)
       end
       found
     end

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -38,12 +38,16 @@ module ModuleLoaders
   end
 
   def self.environment_loader_from(parent_loader, loaders, env_path)
-    ModuleLoaders::FileBased.new(parent_loader,
-      loaders,
-      ENVIRONMENT,
-      env_path,
-      ENVIRONMENT
-    )
+    if env_path.nil? || env_path.empty?
+      EmptyLoader.new(parent_loader, ENVIRONMENT)
+    else
+      FileBased.new(parent_loader,
+        loaders,
+        ENVIRONMENT,
+        env_path,
+        ENVIRONMENT
+      )
+    end
   end
 
   def self.module_loader_from(parent_loader, loaders, module_name, module_path)
@@ -62,6 +66,20 @@ module ModuleLoaders
       environment_path,
       'pcore_resource_types'
     )
+  end
+
+  class EmptyLoader < BaseLoader
+    def find(typed_name)
+      return nil
+    end
+
+    def private_loader
+      @private_loader ||= self
+    end
+
+    def private_loader=(loader)
+      @private_loader = loader
+    end
   end
 
   class AbstractPathBasedModuleLoader < BaseLoader
@@ -91,6 +109,8 @@ module ModuleLoaders
     #
     def initialize(parent_loader, loaders, module_name, path, loader_name, loadables)
       super parent_loader, loader_name
+
+      raise ArgumentError, 'path based loader cannot be instantiated without a path' if path.nil? || path.empty?
 
       @module_name = module_name
       @path = path

--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -389,7 +389,19 @@ describe 'The Loader' do
               expect(Loaders.find_loader('c').discover(:type) { |t| t.name =~ /(?:foo|fee|fum)\z/ }).to(
                 contain_exactly(tn(:type, 'c::foo')))
             end
+
+            context 'and an environment without directory' do
+              let(:environments_dir) { tmpdir('loader_spec') }
+              let(:env) { Puppet::Node::Environment.create(:none_such, [modules_dir]) }
+
+              it 'an EmptyLoader is used and module loader finds types' do
+                Puppet::Pops::Loader::ModuleLoaders::EmptyLoader.any_instance.expects(:find).at_least_once.returns(nil)
+                expect(Loaders.find_loader('a').discover(:type) { |t| t.name =~ /^.::.*\z/ }).to(
+                  contain_exactly(tn(:type, 'a::atype'), tn(:type, 'a::atask')))
+              end
+            end
           end
+
           context 'with no explicit dependencies' do
 
             let(:modules) {


### PR DESCRIPTION
This PR adds a new `EmptyLoader` to be used as the environment loader for environments that does not have a valid path such as the tmp_environment created by `Puppet::Pal`.
The PR also contains a commit that addresses a bug where a file could not coexist with it's metadata. The fix was a slight refactoring of the code checking what paths that are valid for a specific `SmartPath`.