### PR TITLE
(PUP-8090) Do not reference the Locale gem outside of GettextConfig

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -42,7 +42,7 @@ module Puppet
   require 'puppet/environments'
 
   class << self
-    Puppet::GettextConfig.set_locale(Locale.current.language)
+    Puppet::GettextConfig.setup_locale
     Puppet::GettextConfig.create_default_text_domain
 
     include Puppet::Util

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -214,6 +214,14 @@ module Puppet::GettextConfig
   end
 
   # @api private
+  # Sets FastGettext's locale to the current system locale
+  def self.setup_locale
+    return if @gettext_disabled || !gettext_loaded?
+
+    set_locale(Locale.current.language)
+  end
+
+  # @api private
   # Sets the language in which to display strings.
   # @param [String] locale the language portion of a locale string (e.g. "ja")
   def self.set_locale(locale)


### PR DESCRIPTION
The GettextConfig module controls all access to the FastGettext and
Locale libraries. A previous commit accidentally introduced a reference
to the Locale library outside of this module, which caused errors during
puppetserver unit testing, when the gem was not installed. This commit
moves all references to Locale behind the guards set up in the
GettextConfig module.