### PR TITLE
(PUP-8212) Fix strange behavior of empty Variant data type

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -129,8 +129,11 @@ class PAnyType < TypedModelObject
         assignable?(o.resolved_type, guard)
       end
     when PVariantType
-      # Assignable if all contained types are assignable
-      o.types.all? { |vt| assignable?(vt, guard) }
+      # Assignable if all contained types are assignable, or if this is exactly Any
+      return true if self.class == PAnyType
+      # An empty variant may be assignable to NotUndef[T] if T is assignable to empty variant
+      return _assignable?(o, guard) if is_a?(PNotUndefType) && o.types.empty?
+      !o.types.empty? && o.types.all? { |vt| assignable?(vt, guard) }
     when POptionalType
       # Assignable if undef and contained type is assignable
       assignable?(PUndefType::DEFAULT) && (o.type.nil? || assignable?(o.type))
@@ -649,7 +652,12 @@ class PUnitType < PAnyType
 
   DEFAULT = PUnitType.new
 
+  def assignable?(o, guard=nil)
+    true
+  end
+
   protected
+
   # @api private
   def _assignable?(o, guard)
     true
@@ -3013,6 +3021,20 @@ class PVariantType < PAnyType
   end
 
   DEFAULT = PVariantType.new(EMPTY_ARRAY)
+
+  def assignable?(o, guard = nil)
+    # an empty Variant does not match Undef (it is void - not even undef)
+    if o.is_a?(PUndefType) && types.empty?
+      return false
+    end
+
+    return super unless o.is_a?(PVariantType)
+    # If empty, all Variant types match irrespective of the types they hold (including being empty)
+    return true if types.empty?
+    # Since this variant is not empty, an empty Variant cannot match, because it matches nothing
+    # otherwise all types in o must be assignable to this
+    !o.types.empty? && o.types.all? { |vt| super(vt, guard) }
+  end
 
   protected
 

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -1,6 +1,7 @@
 shared_context 'types_setup' do
 
   # Do not include the special type Unit in this list
+  # Do not include the type Variant in this list as it needs to be parameterized to be meaningful
   def self.all_types
     [ Puppet::Pops::Types::PAnyType,
       Puppet::Pops::Types::PUndefType,
@@ -23,7 +24,6 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PResourceType,
       Puppet::Pops::Types::PPatternType,
       Puppet::Pops::Types::PEnumType,
-      Puppet::Pops::Types::PVariantType,
       Puppet::Pops::Types::PStructType,
       Puppet::Pops::Types::PTupleType,
       Puppet::Pops::Types::PCallableType,
@@ -46,6 +46,9 @@ shared_context 'types_setup' do
     self.class.all_types
   end
 
+  # Do not include the Variant type in this list - while it is abstract it is also special in that
+  # it must be parameterized to be meaningful.
+  #
   def self.abstract_types
     [ Puppet::Pops::Types::PAnyType,
       Puppet::Pops::Types::PCallableType,
@@ -63,7 +66,6 @@ shared_context 'types_setup' do
       Puppet::Pops::Types::PPatternType,
       Puppet::Pops::Types::PScalarType,
       Puppet::Pops::Types::PScalarDataType,
-      Puppet::Pops::Types::PVariantType,
       Puppet::Pops::Types::PUndefType,
       Puppet::Pops::Types::PTypeReferenceType,
       Puppet::Pops::Types::PTypeAliasType,


### PR DESCRIPTION
This changes the (broken) type algebra for empty Variant type such that
it is only assignable to empty Variant, Any, NotUndef[Variant], and
Unit, and that any Variant is assignable to an empty Variant.

This modifies the setup in `types_setup` by removing Variant type from
`all_types` - this because it is not meaninful to test all other data
types against empty Variant with one and the same rule. Instead, there
are now explicit tests for empty Variant.