### PR TITLE
(PUP-4065) Warn once about illegal environment.conf setting

### DIFF
--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -85,7 +85,7 @@ module TypeFactory
       size_type_or_value.nil? ? PStringType::DEFAULT : PStringType.new(size_type_or_value)
     else
       if Puppet[:strict] != :off
-        Puppet.warn_once(:deprecatation, "TypeFactory#string_multi_args", "Passing more than one argument to TypeFactory#string is deprecated")
+        Puppet.warn_once(:deprecation, "TypeFactory#string_multi_args", "Passing more than one argument to TypeFactory#string is deprecated")
       end
       deprecated_second_argument.size == 1 ? PStringType.new(deprecated_second_argument[0]) : PEnumType.new(*deprecated_second_argument)
     end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1392,7 +1392,7 @@ class PStringType < PScalarType
   def initialize(size_type_or_value, deprecated_multi_args = EMPTY_ARRAY)
     unless deprecated_multi_args.empty?
       if Puppet[:strict] != :off
-        Puppet.warn_once(:deprecatation, "PStringType#initialize_multi_args", "Passing more than one argument to PStringType#initialize is deprecated")
+        Puppet.warn_once(:deprecation, "PStringType#initialize_multi_args", "Passing more than one argument to PStringType#initialize is deprecated")
       end
       size_type_or_value = deprecated_multi_args[0]
     end
@@ -1445,7 +1445,7 @@ class PStringType < PScalarType
   # @api private
   def values
     if Puppet[:strict] != :off
-      Puppet.warn_once(:deprecatation, "PStringType#values", "Method PStringType#values is deprecated. Use #value instead")
+      Puppet.warn_once(:deprecation, "PStringType#values", "Method PStringType#values is deprecated. Use #value instead")
     end
     @value.is_a?(String) ? [@value] : EMPTY_ARRAY
   end

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -138,13 +138,21 @@ class Puppet::Settings::EnvironmentConf
     section_keys = config.sections.keys
     main = config.sections[:main]
     if section_keys.size > 1
-      Puppet.warning("Invalid sections in environment.conf at '#{path_to_conf_file}'. Environment conf may not have sections. The following sections are being ignored: '#{(section_keys - [:main]).join(',')}'")
+      # warn once per config file path
+      Puppet.warn_once(
+        :invalid_settings_section, "EnvironmentConf-section:#{path_to_conf_file}",
+        "Invalid sections in environment.conf at '#{path_to_conf_file}'. Environment conf may not have sections. The following sections are being ignored: '#{(section_keys - [:main]).join(',')}'"
+      )
       valid = false
     end
 
     extraneous_settings = main.settings.map(&:name) - VALID_SETTINGS
     if !extraneous_settings.empty?
-      Puppet.warning("Invalid settings in environment.conf at '#{path_to_conf_file}'. The following unknown setting(s) are being ignored: #{extraneous_settings.join(', ')}")
+      # warn once per config file path
+      Puppet.warn_once(
+        :invalid_settings, "EnvironmentConf-settings:#{path_to_conf_file}",
+        "Invalid settings in environment.conf at '#{path_to_conf_file}'. The following unknown setting(s) are being ignored: #{extraneous_settings.join(', ')}"
+      )
       valid = false
     end
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -211,6 +211,20 @@ static_catalogs=false
       it "logs a warning, but processes the main settings if there are any extraneous settings" do
         content << "dog=arf\n"
         content << "cat=mew\n"
+        loader_from(:filesystem => [envdir, manifestdir, modulepath].flatten,
+                    :directory => envdir) do |loader|
+          expect(loader.get("env1")).to environment(:env1).
+            with_manifest(manifestdir.path).
+            with_modulepath(modulepath.map(&:path)).
+            with_config_version(File.expand_path('/some/script'))
+        end
+
+        expect(@logs.map(&:to_s).join).to match(/Invalid.*at.*\/env1.*unknown setting.*dog, cat/)
+      end
+
+      it "logs a warning, but processes the main settings if there are any ignored sections" do
+        content << "dog=arf\n"
+        content << "cat=mew\n"
         content << "[ignored]\n"
         content << "cow=moo\n"
         loader_from(:filesystem => [envdir, manifestdir, modulepath].flatten,
@@ -221,6 +235,7 @@ static_catalogs=false
             with_config_version(File.expand_path('/some/script'))
         end
 
+        expect(@logs.map(&:to_s).join).to match(/Invalid.*at.*\/env1.*The following sections are being ignored: 'ignored'/)
         expect(@logs.map(&:to_s).join).to match(/Invalid.*at.*\/env1.*unknown setting.*dog, cat/)
       end
 


### PR DESCRIPTION
Before this because an environment.conf file is validated mulitple times there could be many logged warnings for ignored but invalid contents.
This changes the logging of these warning to use `warn_once` - there will now only be one logged message per environment.conf file for extra sections, and one for extraneous settings found.