### PR TITLE
(maint) Suppress fuzzy translation warning

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -63,7 +63,10 @@ module Puppet::GettextConfig
   def self.reset_text_domain(domain_name)
     return if @gettext_disabled || !gettext_loaded?
 
-    FastGettext.add_text_domain(domain_name, type: :chain, chain: [])
+    FastGettext.add_text_domain(domain_name,
+                                type: :chain,
+                                chain: [],
+                                report_warning: false)
     copy_default_translations(domain_name)
     FastGettext.text_domain = domain_name
   end
@@ -80,7 +83,10 @@ module Puppet::GettextConfig
   def self.create_default_text_domain
     return if @gettext_disabled || !gettext_loaded?
 
-    FastGettext.add_text_domain(DEFAULT_TEXT_DOMAIN, type: :chain, chain: [])
+    FastGettext.add_text_domain(DEFAULT_TEXT_DOMAIN,
+                                type: :chain,
+                                chain: [],
+                                report_warning: false)
     FastGettext.default_text_domain = DEFAULT_TEXT_DOMAIN
 
     load_translations('puppet', puppet_locale_path, translation_mode(puppet_locale_path))
@@ -209,7 +215,7 @@ module Puppet::GettextConfig
     repository = FastGettext::TranslationRepository.build(project_name,
                                                           path: locale_dir,
                                                           type: file_format,
-                                                          ignore_fuzzy: false)
+                                                          report_warning: false)
     current_chain << repository
   end
 


### PR DESCRIPTION
When an English string changes slightly, the FastGettext will
attempt to choose a translation that seems similar, update its English
key, and mark the translation as "fuzzy", to inform the translator that
review is needed. By default, FastGettext will issue a warning when a
fuzzy translation is used at runtime. This warning comes out of FastGettext
directly, circumventing our logging framework, and so is impossible for
a user to turn off, and in some cases impossible for them to fix.
Therefore, this commit passes a flag to FastGettext to suppress the
warning.