### PR TITLE
(maint) Eliminate redundant sort_by

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -665,7 +665,7 @@ Performance/DoubleStartEndWith:
   Enabled: false
 
 Performance/RedundantSortBy:
-  Enabled: false
+  Enabled: true
 
 Performance/TimesMap:
   Enabled: false

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -75,7 +75,7 @@ Puppet::Face.define(:config, '0.0.1') do
         if args.length == 1
           puts values.interpolate(args[0].to_sym)
         else
-          args.sort_by { |key| key }.each do |setting_name|
+          args.sort.each do |setting_name|
             puts "#{setting_name} = #{values.interpolate(setting_name.to_sym)}"
           end
         end

--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -150,7 +150,7 @@ Puppet::Face.define(:module, '1.0.0') do
     error_display_order = [:non_semantic_version, :version_mismatch, :missing]
     error_display_order.each do |type|
       unless @unmet_deps[type].empty?
-        @unmet_deps[type].keys.sort_by {|dep| dep }.each do |dep|
+        @unmet_deps[type].keys.sort.each do |dep|
           name    = dep.gsub('/', '-')
           errors  = @unmet_deps[type][dep][:errors]
           version = @unmet_deps[type][dep][:version]


### PR DESCRIPTION
When sorting an array, just call `sort` instead of `sort_by` with a
block returning each element. Also enable the rubocop check for this.

See https://github.com/bbatsov/rubocop/blob/master/manual/cops_performance.md#performanceredundantsortby

Follow up from PR #6372