### PR TITLE
(PUP-8183) Update puppet device documentation for --user

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -138,8 +138,7 @@ you can specify '--server <servername>' as an argument.
   valid JSON.
 
 * --user:
-  The user to run as. '--user=root' is required, even when run as root,
-  for runs that create device certificates or keys.
+  The user to run as.
 
 * --verbose:
   Turn on verbose reporting.


### PR DESCRIPTION
Prior to the commits for PUP-1391 and PUP-8108 it was neccessary
for `--user=root` be set when `puppet device` was creating certs.

This commit updates the `puppet device` man page to reflect this is
 no longer needed.