### PR TITLE
(PUP-8124) Resolve qualified names in class parameter scope

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -611,6 +611,7 @@ class Puppet::Parser::Scope
       begin
         qs = qualified_scope(class_name)
         unless qs.nil?
+          return qs.get_local_variable(leaf_name) if qs.has_local_variable?(leaf_name)
           iscope = qs.inherited_scope
           return lookup_qualified_variable("#{iscope.source.name}::#{leaf_name}", options) unless iscope.nil?
         end
@@ -621,6 +622,16 @@ class Puppet::Parser::Scope
     end
     # report with leading '::' by using empty class_name
     return handle_not_found('', fqn, options)
+  end
+
+  # @api private
+  def has_local_variable?(name)
+    @ephemeral.last.include?(name)
+  end
+
+  # @api private
+  def get_local_variable(name)
+    @ephemeral.last[name]
   end
 
   def handle_not_found(class_name, variable_name, position, reason = nil)

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -316,6 +316,19 @@ describe "Two step scoping for variables" do
       end
     end
 
+    it 'resolves a qualified name in class parameter scope' do
+      expect_the_message_to_be('Does it work? Yes!') do <<-PUPPET
+        class a ( 
+          $var1 = 'Does it work?',
+          $var2 = "${a::var1} Yes!"
+        ) { 
+          notify { 'something': message => $var2 }
+        }
+        include a
+        PUPPET
+      end
+    end
+
     it "finds values in its inherited scope when the inherited class is qualified to the top" do
       expect_the_message_to_be('foo_msg') do <<-MANIFEST
             node default {


### PR DESCRIPTION
A regression introduced in PUP-5635 caused the evaluator to omit the
parameter scope when evaluating parameter default expressions and
resolving qualified names of variables. As a result, a reference to a
parameter to the left of the one declaring the default expression,
declared using the qualified name of the class holding the parameter
list, would be unresolved.

This commit ensures that resolution of qualified names will include the
parameter scope when the name appoints the current class.