### PR TITLE
(PUP-8216) Relax URI type constraint in hiera.yaml

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -566,8 +566,8 @@ class HieraConfigV5 < HieraConfig
     tf = Types::TypeFactory
     nes_t = Types::PStringType::NON_EMPTY
 
-    # Need alias here to avoid ridiculously long regexp burp in case of validation errors.
-    uri_t = Pcore::TYPE_URI_ALIAS
+    # Validated using Ruby URI implementation
+    uri_t = Types::PStringType::NON_EMPTY
 
     # The option name must start with a letter and end with a letter or digit. May contain underscore and dash.
     option_name_t = tf.pattern(/\A[A-Za-z](:?[0-9A-Za-z_-]*[0-9A-Za-z])?\z/)

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1102,13 +1102,23 @@ describe "The lookup function" do
               glob_c: value glob_a
               YAML
             'b.yaml' => <<-YAML.unindent
-              glob_b:
-                c: value glob_b.c
-                d: value glob_b.d
+              glob_d:
+                a: value glob_d.a
+                b: value glob_d.b
             YAML
 
           }
         }
+      end
+
+      it 'finds environment data using globs' do
+        expect(lookup('glob_a')).to eql('value glob_a')
+        expect(warnings).to be_empty
+      end
+
+      it 'finds environment data using interpolated globs' do
+        expect(lookup('glob_d.a')).to eql('value glob_d.a')
+        expect(warnings).to be_empty
       end
     end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1128,11 +1128,12 @@ describe "The lookup function" do
         ---
         version: 5
         hierarchy:
-          - name: Globs
+          - name: Uris
             uris:
               - "http://test.example.com"
               - "/some/arbitrary/path"
               - "urn:with:opaque:path"
+              - "dothis%20-f%20bar"
             data_hash: mod::uri_test_func
         YAML
       end
@@ -1155,7 +1156,8 @@ describe "The lookup function" do
       end
 
       it 'The uris are propagated in the options hash' do
-        expect(lookup('uri', 'merge' => 'unique')).to eql(["http://test.example.com", "/some/arbitrary/path", "urn:with:opaque:path"])
+        expect(lookup('uri', 'merge' => 'unique')).to eql(
+          %w(http://test.example.com /some/arbitrary/path urn:with:opaque:path dothis%20-f%20bar))
         expect(warnings).to be_empty
       end
 
@@ -1165,8 +1167,8 @@ describe "The lookup function" do
         ---
         version: 5
         hierarchy:
-          - name: Globs
-            uri: "}#!@"
+          - name: Uris
+            uri: "dothis -f bar"
             data_hash: mod::uri_test_func
           YAML
         end


### PR DESCRIPTION
This commit removes the requirement that an uri in the hiera.yaml must
match a URI pattern. The only requirement now is that a URI can be
created from the given string.