### PR TITLE
(Maint) Fix Augeas typo

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -6,7 +6,7 @@ module Loader
 class StaticLoader < Loader
 
   BUILTIN_TYPE_NAMES = %w{
-      Auegas
+      Augeas
       Component
       Computer
       Cron
@@ -113,7 +113,7 @@ class StaticLoader < Loader
     # These types are in all environments.
     #
     %w{
-      Auegas
+      Augeas
       Component
       Computer
       Cron

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -24,7 +24,7 @@ describe 'the static loader' do
     let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
 
     %w{
-      Auegas
+      Augeas
       Component
       Computer
       Cron


### PR DESCRIPTION
The Augeas type in static loader was misspelled.

I'm not sure how much this would break things. It doesn't seem that there were many complaints, so I'm assuming this would fall back to the older type system possibly and still function? Ping @hlindberg or @thallgren to help me understand the behavior here.