### PR TITLE
(PUP-7806) Allow epp CLI to set fully qualified variables

### DIFF
--- a/lib/puppet/pops/evaluator/epp_evaluator.rb
+++ b/lib/puppet/pops/evaluator/epp_evaluator.rb
@@ -71,6 +71,19 @@ class Puppet::Pops::Evaluator::EppEvaluator
       enforce_parameters = true
     end
 
+    # filter out all qualified names and set them in qualified_variables
+    # only pass unqualified (filtered) variable names to the the template
+    filtered_args = {}
+    template_args.each_pair do |k, v|
+      if k =~ /::/
+        k = k[2..-1] if k.start_with?('::')
+        scope[k] = v
+      else
+        filtered_args[k] = v
+      end
+    end
+    template_args = filtered_args
+
     # inline_epp() logic sees all local variables, epp() all global
     if use_global_scope_only
       scope.with_global_scope do |global_scope|

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -201,8 +201,12 @@ describe Puppet::Face[:epp, :current] do
       expect(eppface.render(:e => 'hello <%= $x %>', :values => '{x => "mr X"}')).to eq("hello mr X")
     end
 
-    it "adds values given in a puppet hash given on command line with --values" do
-      expect(eppface.render(:e => 'hello <%= $x %>', :values => '{x => "mr X"}')).to eq("hello mr X")
+    it "adds fully qualified values given in a puppet hash given on command line with --values" do
+      expect(eppface.render(:e => 'hello <%= $mr::x %>', :values => '{mr::x => "mr X"}')).to eq("hello mr X")
+    end
+
+    it "adds fully qualified values with leading :: given in a puppet hash given on command line with --values" do
+      expect(eppface.render(:e => 'hello <%= $::mr %>', :values => '{"::mr" => "mr X"}')).to eq("hello mr X")
     end
 
     it "adds values given in a puppet hash produced by a .pp file given with --values_file" do

--- a/spec/unit/functions/epp_spec.rb
+++ b/spec/unit/functions/epp_spec.rb
@@ -13,6 +13,11 @@ describe "the epp function" do
       expect(eval_template("all your base <%= $what %> to us")).to eq("all your base are belong to us")
     end
 
+    it "looks up a fully qualified value from the scope" do
+      scope["what::is"] = "are belong"
+      expect(eval_template("all your base <%= $what::is %> to us")).to eq("all your base are belong to us")
+    end
+
     it "get nil accessing a variable that does not exist" do
       expect(eval_template("<%= $kryptonite == undef %>")).to eq("true")
     end


### PR DESCRIPTION
Before this it was not possible to give names of fully qualified
variables on the command line to `puppet epp --values` as those were
simply ignored.

Now, all variable names with '::' are set as fully qualified names and
thus available to epp templates when referenced the same way.