### PR TITLE
(maint) push_application_context should have a default

### DIFF
--- a/lib/puppet/application_support.rb
+++ b/lib/puppet/application_support.rb
@@ -14,10 +14,11 @@ module Puppet
     # before being set in a pushed Puppet Context.
     #
     # @param run_mode [Puppet::Util::RunMode] Puppet's current Run Mode.
-    # @param environment_mode [Puppet::Util::EnvironmentMode] Puppet's current Environment Mode.
+    # @param environment_mode [Symbol] optional, Puppet's
+    #   current Environment Mode. Defaults to :local
     # @return [void]
     # @api private
-    def self.push_application_context(run_mode, environment_mode)
+    def self.push_application_context(run_mode, environment_mode = :local)
       Puppet.push_context(Puppet.base_context(Puppet.settings), "Update for application settings (#{run_mode})")
       # This use of configured environment is correct, this is used to establish
       # the defaults for an application that does not override, or where an override


### PR DESCRIPTION
This method is used outside of just puppet, so in order to maintain
backward compatibility, we need to allow the method to be used with only
one argument. This commits adds in a default for `environment_mode`, so
that projects like puppetserver can still use the method.