### PR TITLE
(PUP-8227) puppet apply/resource should not overwrite transactionstore

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -93,7 +93,7 @@ class Puppet::Transaction
 
     perform_pre_run_checks
 
-    persistence.load if catalog.host_config?
+    persistence.load if persistence.enabled?(catalog)
 
     Puppet.info _("Applying configuration version '%{version}'") % { version: catalog.version } if catalog.version
 
@@ -145,7 +145,7 @@ class Puppet::Transaction
         end
       end
 
-      persistence.save if catalog.host_config?
+      persistence.save if persistence.enabled?(catalog)
     end
 
     # Graph cycles are returned as an array of arrays

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -89,4 +89,11 @@ class Puppet::Transaction::Persistence
   def save
     Puppet::Util::Yaml.dump(@new_data, Puppet[:transactionstorefile])
   end
+
+  # Use the catalog and run_mode to determine if persistence should be enabled or not
+  # @param [Puppet::Resource::Catalog] catalog catalog being processed
+  # @return [boolean] true if persistence is enabled
+  def enabled?(catalog)
+    catalog.host_config? && Puppet.run_mode.name == :agent
+  end
 end

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 require 'puppet_spec/files'
 
 describe Puppet::Transaction::Report do
+  before :each do
+    # Enable persistence during tests
+    Puppet::Transaction::Persistence.any_instance.stubs(:enabled?).returns(true)
+  end
+
   describe "when using the indirector" do
     after do
       Puppet.settings.stubs(:use)

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -175,4 +175,46 @@ describe Puppet::Transaction::Persistence do
       expect(persistence.get_system_value(resource, property)).to eq(value)
     end
   end
+
+  describe "when checking if persistence is enabled" do
+    let(:mock_catalog) do
+      mock
+    end
+
+    before :each do
+      @persistence = Puppet::Transaction::Persistence.new
+    end
+
+    before :all do
+      @preferred_run_mode = Puppet.settings.preferred_run_mode
+    end
+
+    after :all do
+      Puppet.settings.preferred_run_mode = @preferred_run_mode
+    end
+
+    it "should not be enabled when not running in agent mode" do
+      Puppet.settings.preferred_run_mode = :user
+      mock_catalog.stubs(:host_config?).returns(true)
+      expect(@persistence.enabled?(mock_catalog)).to be false
+    end
+
+    it "should not be enabled when the catalog is not the host catalog" do
+      Puppet.settings.preferred_run_mode = :agent
+      mock_catalog.stubs(:host_config?).returns(false)
+      expect(@persistence.enabled?(mock_catalog)).to be false
+    end
+
+    it "should not be enabled outside of agent mode and the catalog is not the host catalog" do
+      Puppet.settings.preferred_run_mode = :user
+      mock_catalog.stubs(:host_config?).returns(false)
+      expect(@persistence.enabled?(mock_catalog)).to be false
+    end
+
+    it "should be enabled in agent mode and when the catalog is the host catalog" do
+      Puppet.settings.preferred_run_mode = :agent
+      mock_catalog.stubs(:host_config?).returns(true)
+      expect(@persistence.enabled?(mock_catalog)).to be true
+    end
+  end
 end

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -134,6 +134,11 @@ describe Puppet::Transaction do
     end
 
     describe "when evaluating a skipped resource for corrective change it" do
+      before :each do
+        # Enable persistence during tests
+        Puppet::Transaction::Persistence.any_instance.stubs(:enabled?).returns(true)
+      end
+
       it "should persist in the transactionstore" do
         Puppet[:transactionstorefile] = tmpfile('persistence_test')
 


### PR DESCRIPTION
In the past enforcing change using "puppet apply" or "puppet resource"
would cause the transactionstore.yaml file to be overwritten. This
happened because persistence was enabled regardless of how
puppet was being run.

This commit adds the `enabled?` method to Transaction::Persistence which
now checks how puppet is being run to determine if persistence should be
enabled, which means we no longer overwrite transactionstore.yaml
during a "puppet apply" or "puppet resource" run.