### PR TITLE
(PUP-7619) Add a 'convert_to' convenience function

### DIFF
--- a/lib/puppet/functions/convert_to.rb
+++ b/lib/puppet/functions/convert_to.rb
@@ -1,0 +1,32 @@
+# The `convert_to(value, type)` is a convenience function does the same as `new(type, value)`.
+# The difference in the argument ordering allows it to be used in chained style for
+# improved readability "left to right".
+#
+# When the function is given a lambda, it is called with the converted value, and the function
+# returns what the lambda returns, otherwise the converted value.
+#
+# @example 'convert_to' instead of 'new'
+#
+# ~~~ puppet
+#   # using new operator - that is "calling the type" with operator ()
+#   Hash(Array("abc").map |$i,$v| { [$i, $v] })
+#
+#   # using 'convert_to'
+#   "abc".convert_to(Array).map |$i,$v| { [$i, $v] }.convert_to(Hash)
+#
+# ~~~
+#
+# @since 5.4.0
+#
+Puppet::Functions.create_function(:convert_to) do
+  dispatch :convert_to do
+    param 'Any', :value
+    param 'Type', :type
+    optional_block_param 'Callable[1,1]', :block
+  end
+
+  def convert_to(value, type, &block)
+    result = call_function('new', type, value)
+    block_given? ? yield(result) : result
+  end
+end

--- a/spec/unit/functions/convert_to_spec.rb
+++ b/spec/unit/functions/convert_to_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the convert_to function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'converts and returns the converted when no lambda is given' do
+    expect(compile_to_catalog('notify{ "testing-${[a,1].convert_to(Hash) =~ Hash}": }')).to have_resource('Notify[testing-true]')
+  end
+
+  it 'converts given value to instance of type and calls a lambda with converted value' do
+    expect(compile_to_catalog('"1".convert_to(Integer) |$x| { notify { "testing-${x.type(generalized)}": } }')).to have_resource('Notify[testing-Integer]')
+  end
+
+  it 'returns the lambda return when lambda is given' do
+    expect(compile_to_catalog('notify{ "testing-${[a,1].convert_to(Hash) |$x| { yay }}": }')).to have_resource('Notify[testing-yay]')
+  end
+
+end


### PR DESCRIPTION
This adds a 'convert_to(value, type)' function that can be used to make
chained creation/operations more readable than having to use `new`
(which has the type first), or directly calling the type using `()`.
The `convert_to` also accepts a one-arg lambda to complete the
conversion operation.