### PR TITLE
(PUP-5206) Use clientbucketdir instead of bucketdir

### DIFF
--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -43,20 +43,20 @@ agents.each do |agent|
   step "Backup file into the filebucket"
   on agent, puppet_filebucket("backup --local #{target}")
 
-  bucketdir="not set"
-  on agent, puppet_filebucket("--configprint bucketdir") do
-    bucketdir = stdout.chomp
-  end
+  step "Modify file to force apply to retrieve file from local clientbucket"
+  on agent, "echo 'This is the modified file contents' > #{target}"
+
+  dir = on(agent, puppet_filebucket("--configprint clientbucketdir")).stdout.chomp
 
   manifest = %Q|
     filebucket { 'local':
-      path => '#{bucketdir}',
+      path => '#{dir}',
     }
 
     file { '#{target}':
+      ensure  => present,
       content => '{md5}18571d3a04b2bb7ccfdbb2c44c72caa9',
-      ensure => present,
-      backup => local,
+      backup  => local,
     }
   |
 

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -249,7 +249,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
     require 'puppet/file_bucket/dipper'
     begin
       if options[:local] or options[:bucket]
-        path = options[:bucket] || Puppet[:bucketdir]
+        path = options[:bucket] || Puppet[:clientbucketdir]
         @client = Puppet::FileBucket::Dipper.new(:Path => path)
       else
         @client = Puppet::FileBucket::Dipper.new(:Server => Puppet[:server])

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -93,7 +93,7 @@ describe Puppet::Application::Filebucket do
       end
 
       it "should create a client with the default bucket if none passed" do
-        Puppet[:bucketdir] = path
+        Puppet[:clientbucketdir] = path
 
         Puppet::FileBucket::Dipper.expects(:new).with { |h| h[:Path] == path }
 


### PR DESCRIPTION
Previously, using the --local option would use the server's
filebucket instead of the actual local filebucket. This changes behavior
to use the clientbucketdir instead of bucketdir.