### PR TITLE
(PUP-6043) Change syntax error "at end of file" to "end of input"

### DIFF
--- a/lib/puppet/pops/parser/parser_support.rb
+++ b/lib/puppet/pops/parser/parser_support.rb
@@ -91,7 +91,7 @@ class Parser
   #
   def on_error(token,value,stack)
     if token == 0 # denotes end of file
-      value_at = 'end of file'
+      value_at = 'end of input'
     else
       value_at = "'#{value[:value]}'"
     end

--- a/spec/unit/face/parser_spec.rb
+++ b/spec/unit/face/parser_spec.rb
@@ -72,7 +72,7 @@ describe Puppet::Face[:parser, :current] do
           expect { parser.validate(manifest) }.to exit_with(1)
         end
 
-        expect(@logs.join).to match(/environment special.*Syntax error at end of file/)
+        expect(@logs.join).to match(/environment special.*Syntax error at end of input/)
       end
 
     end
@@ -117,7 +117,7 @@ describe Puppet::Face[:parser, :current] do
       output = parser.dump({ :e => '{ invalid =>' })
 
       expect(output).to eq("")
-      expect(@logs[0].message).to eq("Syntax error at end of file")
+      expect(@logs[0].message).to eq("Syntax error at end of input")
       expect(@logs[0].level).to eq(:err)
     end
 


### PR DESCRIPTION
This changes the error message produced when there is a syntax error
because the parser hits the end of its input. When this happens the
parser does not know if the text it is parsing is from a file or from a
string, or from the command line.

Since users found it confusing that the error speaks of "end of file"
when there is no file involved, the best is thought to be naming it "end
of input" as that works for all of the various ways input may be given.