### PR TITLE
(maint) Do not exit loop early when loading module translations

### DIFF
--- a/lib/puppet/gettext/module_translations.rb
+++ b/lib/puppet/gettext/module_translations.rb
@@ -9,7 +9,7 @@ module Puppet::ModuleTranslations
   #        load translations
   def self.load_from_modulepath(modules)
     modules.each do |mod|
-      return unless mod.forge_name && mod.has_translations?(Puppet::GettextConfig.current_locale)
+      next unless mod.forge_name && mod.has_translations?(Puppet::GettextConfig.current_locale)
 
       module_name = mod.forge_name.gsub('/', '-')
       if Puppet::GettextConfig.load_translations(module_name, mod.locale_directory, :po)

--- a/spec/unit/gettext/module_loading_spec.rb
+++ b/spec/unit/gettext/module_loading_spec.rb
@@ -19,18 +19,21 @@ describe Puppet::ModuleTranslations do
       :environment => mock("environment"))
     }
 
-    it "should attempt to load translations for each module that has them" do
-      module_a.expects(:has_translations?).returns(true)
-      Puppet::GettextConfig.expects(:load_translations).with("foo-mod_a", File.join(modpath, "mod_a", "locales"), :po).returns(true)
+    let(:module_b) { PuppetSpec::Modules.create(
+      "mod_b",
+      modpath,
+      :metadata => {
+        :author => 'foo'
+      },
+      :environment => mock("environment"))
+    }
 
-      Puppet::ModuleTranslations.load_from_modulepath([module_a])
-    end
-
-    it "should not attempt to load translations for modules that don't have them" do
+    it "should attempt to load translations only for modules that have them" do
       module_a.expects(:has_translations?).returns(false)
-      Puppet::GettextConfig.expects(:load_translations).never
+      module_b.expects(:has_translations?).returns(true)
+      Puppet::GettextConfig.expects(:load_translations).with("foo-mod_b", File.join(modpath, "mod_b", "locales"), :po).returns(true)
 
-      Puppet::ModuleTranslations.load_from_modulepath([module_a])
+      Puppet::ModuleTranslations.load_from_modulepath([module_a, module_b])
     end
   end
 


### PR DESCRIPTION
This commit fixes a bug where, when loading module translations, if a
module was encountered for which no tranlsations could be loaded, the
loop exited instead of continuing to iterate over the remainder of the
list.