### PR TITLE
(PUP-6162) Improve function local type errors

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -623,11 +623,12 @@ module Puppet::Functions
       # Get location to use in case of error - this produces ruby filename and where call to 'type' occurred
       # but strips off the rest of the internal "where" as it is not meaningful to user.
       #
-      rb_location = caller[0].gsub(/:in.*$/, '')
+      rb_location = caller[0]
 
       begin
         result = parser.parse_string("type #{assignment_string}", nil)
       rescue StandardError => e
+        rb_location = rb_location.gsub(/:in.*$/, '')
         # Create a meaningful location for parse errors - show both what went wrong with the parsing
         # and in which ruby file it was found.
         raise ArgumentError, _("Parsing of 'type \"%{assignment_string}\"' failed with message: <%{message}>.\n" +
@@ -638,6 +639,7 @@ module Puppet::Functions
         }
       end
       unless result.body.kind_of?(Puppet::Pops::Model::TypeAlias)
+        rb_location = rb_location.gsub(/:in.*$/, '')
         raise ArgumentError, _("Expected a type alias assignment on the form 'AliasType = T', got '%{assignment_string}'.\n"+
         "Called from <%{ruby_file_location}>") % {
           assignment_string: assignment_string,

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -470,6 +470,48 @@ describe 'the 4x function api' do
       end
     end
 
+    context 'reports meaningful errors' do
+      let(:parser) {  Puppet::Pops::Parser::EvaluatingParser.new }
+
+      it 'syntax error in local type is reported with puppet source, puppet location, and ruby file containing function' do
+        the_loader = loader()
+        here = get_binding(the_loader)
+        expect do
+          fc = eval(<<-CODE, here)
+            Puppet::Functions.create_function('testing::test') do
+              local_types do
+                type 'MyType += Array[Integer]'
+              end
+              dispatch :test do
+                param 'MyType', :x
+              end
+              def test(x)
+                x
+              end
+            end
+          CODE
+        end.to raise_error(/MyType \+\= Array.*<Syntax error at '\+\=' at line 1:[0-9]+>.*functions4_spec\.rb.*/m)
+        # Note that raised error reports this spec file as the function source since the function is defined here
+      end
+
+      it 'syntax error in param type is reported with puppet source, puppet location, and ruby file containing function' do
+        the_loader = loader()
+        here = get_binding(the_loader)
+        expect do
+          fc = eval(<<-CODE, here)
+            Puppet::Functions.create_function('testing::test') do
+              dispatch :test do
+                param 'Array[1+=1]', :x
+              end
+              def test(x)
+                x
+              end
+            end
+          CODE
+        end.to raise_error(/Parsing of type string '"Array\[1\+=1\]"' failed with message: <Syntax error at '\]' at line 1:[0-9]+/m)
+      end
+
+    end
     context 'can use a loader when parsing types in function dispatch, and' do
       let(:parser) {  Puppet::Pops::Parser::EvaluatingParser.new }
 

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -56,7 +56,7 @@ describe 'the 4x function api' do
   it 'refuses to create functions that are not based on the Function class' do
     expect do
       Puppet::Functions.create_function('testing', Object) {}
-    end.to raise_error(ArgumentError, 'Functions must be based on Puppet::Pops::Functions::Function. Got Object')
+    end.to raise_error(ArgumentError, /function 'testing'.*Functions must be based on Puppet::Pops::Functions::Function. Got Object/)
   end
 
   it 'refuses to create functions with parameters that are not named with a symbol' do
@@ -212,15 +212,18 @@ describe 'the 4x function api' do
     end
 
     it 'a function can not be created with parameters declared after a repeated parameter' do
-      expect { create_function_with_param_after_repeated }.to raise_error(ArgumentError, 'Parameters cannot be added after a repeated parameter')
+      expect { create_function_with_param_after_repeated }.to raise_error(ArgumentError, 
+        /function 't1'.*Parameters cannot be added after a repeated parameter/)
     end
 
     it 'a function can not be created with required parameters declared after optional ones' do
-      expect { create_function_with_rq_after_opt }.to raise_error(ArgumentError, 'A required parameter cannot be added after an optional parameter')
+      expect { create_function_with_rq_after_opt }.to raise_error(ArgumentError, 
+        /function 't1'.*A required parameter cannot be added after an optional parameter/)
     end
 
     it 'a function can not be created with required repeated parameters declared after optional ones' do
-      expect { create_function_with_rq_repeated_after_opt }.to raise_error(ArgumentError, 'A required repeated parameter cannot be added after an optional parameter')
+      expect { create_function_with_rq_repeated_after_opt }.to raise_error(ArgumentError,
+        /function 't1'.*A required repeated parameter cannot be added after an optional parameter/)
     end
 
     it 'an error is raised with reference to multiple methods when called with mis-matched arguments' do


### PR DESCRIPTION
Before this, errors in `local_types` or in one of the methods that define a parameter type in a 4.x functions raised an unactionable error.
Now the error messages output as much information as they have about the type string being in error, what the error was, and where it came from (as much as it knows).