### PR TITLE
(PUP-3963) [#puppethack] Improve module name invalid character warning

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -456,7 +456,11 @@ class Puppet::Module
 
   def assert_validity
     if !Puppet::Module.is_module_directory_name?(@name) && !Puppet::Module.is_module_namespaced_name?(@name)
-      raise InvalidName, "Invalid module name #{@name}; module names must be alphanumeric (plus '-'), not '#{@name}'"
+      raise InvalidName, _(<<-ERROR_STRING).chomp % { name: @name }
+        Invalid module name '%{name}'; module names must match either:
+        An installed module name (ex. modulename) matching the expression /^[a-z][a-z0-9_]*$/ -or-
+        A namespaced module name (ex. author-modulename) matching the expression /^[a-zA-Z0-9]+[-][a-z][a-z0-9_]*$/
+      ERROR_STRING
     end
   end
 end


### PR DESCRIPTION
(PUP-3963) Error message gives wrong advice for allowed module names
Improved the error message concerning an invalid module name to accurately reflect the documentation by removing the hyphen as a valid character, specifying letters must be lowercase and underscores are acceptable, and noting that the name must start with a lowercase letter.