### PR TITLE
(PUP-6739) Puppet config should not error out if an environment does …

### DIFF
--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -28,8 +28,11 @@ results = use_an_environment(env, 'bad environmentpath', master_opts, testdir, p
 
 expectations = {
   :puppet_config => {
-    :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
+    :exit_code => 0,
+    :matches => [%r{basemodulepath = /etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules},
+                 %r{modulepath =},
+                 %r{manifest =},
+                 %r{config_version =}],
   },
   :puppet_module_install => {
     :exit_code => 1,

--- a/acceptance/tests/environment/environment_scenario-non_existent.rb
+++ b/acceptance/tests/environment/environment_scenario-non_existent.rb
@@ -28,8 +28,11 @@ results = use_an_environment(env, "non existent environment", *general)
 
 expectations = {
   :puppet_config => {
-    :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{testdir}}],
+    :exit_code => 0,
+    :matches => [%r{basemodulepath = /etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules},
+                 %r{modulepath =},
+                 %r{manifest =},
+                 %r{config_version =}],
   },
   :puppet_module_install => {
     :exit_code => 1,


### PR DESCRIPTION
…not exist locally

This commit updates tests that had been missed when this change was
first introduced.