### PR TITLE
(DOCS) Update error message [#puppethack]

### DIFF
--- a/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
+++ b/acceptance/tests/ssl/puppet_cert_generate_and_autosign.rb
@@ -67,7 +67,7 @@ test_name "Puppet cert generate behavior (#6112)" do
   def fail_to_generate_cert_on_agent_that_is_not_ca(host, cn, autosign)
     return if master.is_pe?
     on(host, puppet('cert', 'generate', cn, '--autosign', autosign), :acceptable_exit_codes => [23])
-    assert_match(/Error: The certificate retrieved from the master does not match the agent's private key./, stderr, "Should not be able to generate a certificate on an agent that is not also the CA, with autosign #{autosign}.")
+    assert_match(/Error: The certificate retrieved from the master does not match the agent's private key. Did you forget to run as root\?/, stderr, "Should not be able to generate a certificate on an agent that is not also the CA, with autosign #{autosign}.")
   end
 
   def generate_and_clean_cert_with_dns_alt_names(host, cn, autosign)

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -211,7 +211,7 @@ DOC
     raise Puppet::Error, _("No private key with which to validate certificate with fingerprint: %{fingerprint}") % { fingerprint: certificate.fingerprint } unless key
     unless certificate.content.check_private_key(key.content)
       raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: certificate.fingerprint, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
-The certificate retrieved from the master does not match the agent's private key.
+The certificate retrieved from the master does not match the agent's private key. Did you forget to run as root?
 Certificate fingerprint: %{fingerprint}
 To fix this, remove the certificate from both the master and the agent and then start a puppet run, which will automatically regenerate a certificate.
 On the master:


### PR DESCRIPTION
When a user runs Puppet not as root, the error message starts them down
a certificate rabbit hole. This commit adds a friendly reminder and updates the associated acceptance test.