### PR TITLE
(PUP-7968) [#puppethack] Add a default to present for the ensure param

### DIFF
--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -37,7 +37,7 @@ module Puppet
         provider.delete
       end
 
-    defaultto :present
+      defaultto :present
 
     end
 

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -36,6 +36,9 @@ module Puppet
       newvalue(:absent) do
         provider.delete
       end
+
+    defaultto :present
+
     end
 
     newproperty(:gid) do

--- a/spec/unit/type/group_spec.rb
+++ b/spec/unit/type/group_spec.rb
@@ -10,6 +10,14 @@ describe Puppet::Type.type(:group) do
     expect(@class.provider_feature(:system_groups)).not_to be_nil
   end
 
+  it 'should default to `present`' do
+    expect(@class.new(:name => "foo")[:ensure]).to eq(:present)
+  end
+
+  it 'should set ensure to whatever is passed in' do
+    expect(@class.new(:name => "foo", :ensure => 'absent')[:ensure]).to eq(:absent)
+  end
+
   describe "when validating attributes" do
     [:name, :allowdupe].each do |param|
       it "should have a #{param} parameter" do


### PR DESCRIPTION
(PUP-7968) [#puppethack] Add a default to present for the ensure param

Before this commit, the group resource didn't have a default `ensure => present`, which was inconsistent with other resources such as package (assumes you want to install the package and defaults to `ensure => installed`)