### PR TITLE
(PUP-8232) Add back 'puppet facts upload' face and update

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -81,6 +81,7 @@ These endpoints accept payload formats formatted as JSON or PSON (MIME types of
 `application/json` and `text/pson`, respectively) except for `File Content` and
 `File Bucket File` which always use `application/octet-stream`.
 
+* [Facts](./http_facts.md)
 * [Catalog](./http_catalog.md)
 * [Node](./http_node.md)
 * [File Bucket File](./http_file_bucket_file.md)

--- a/api/docs/http_facts.md
+++ b/api/docs/http_facts.md
@@ -1,0 +1,144 @@
+Facts
+=============
+
+The `facts` endpoint allows getting or setting the facts for the specified node name.  The `facts_search` endpoint
+allows retrieving a list of node names containing the specified facts.
+
+Find
+----
+
+Get facts for a node.
+
+    GET /:environment/facts/:nodename
+
+### Supported HTTP Methods
+
+GET
+
+### Supported Response Formats
+
+PSON
+
+### Parameters
+
+None
+
+### Example Response
+
+* Note: list of facts was shortened for readability.
+* Note: pson was formatted for readability.
+
+#### Facts found
+
+    GET /env/facts/elmo.mydomain.com
+
+    HTTP 200 OK
+    Content-Type: text/pson
+
+    {
+      "name": "elmo.mydomain.com",
+      "values": {
+        "architecture": "x86_64",
+        "kernel": "Darwin",
+        "domain": "local",
+        "macaddress": "70:11:24:8c:33:a9",
+        "osfamily": "Darwin",
+        "operatingsystem": "Darwin",
+        "facterversion": "1.7.2",
+        "fqdn": "elmo.mydomain.com",
+      },
+      "timestamp": "2013-09-09 15:49:27 -0700",
+      "expiration": "2013-09-09 16:19:27 -0700"
+    }
+
+Save
+----
+
+Store facts for a node.  The request body should contain pson-formatted facts.
+
+    PUT /:environment/facts/:nodename
+
+### Supported HTTP Methods
+
+PUT
+
+### Supported Format
+
+Accept: pson, text/pson
+
+### Parameters
+
+None
+
+### Example Response
+
+* Note: list of facts was shortened for readability.
+* Note: pson was formatted for readability.
+
+#### Facts found
+
+    PUT /env/facts/elmo.mydomain.com
+
+    Content-Type: text/pson
+
+    {
+      "name": "elmo.mydomain.com",
+      "values": {
+        "architecture": "x86_64",
+        "kernel": "Darwin",
+        "domain": "local",
+        "macaddress": "70:11:24:8c:33:a9",
+        "osfamily": "Darwin",
+        "operatingsystem": "Darwin",
+        "facterversion": "1.7.2",
+        "fqdn": "elmo.mydomain.com",
+      },
+      "timestamp": "2013-09-09 15:49:27 -0700",
+      "expiration": "2013-09-09 16:19:27 -0700"
+    }
+
+    HTTP/1.1 200 OK
+    Content-Type: text/pson
+
+    "/etc/puppet/var/yaml/facts/joebob.local.yaml"
+
+Search
+----
+
+Get the list of nodes matching the facts_search parameters
+
+    GET /:environment/facts_search/search
+
+### Supported HTTP Methods
+
+GET
+
+### Supported Format
+
+Accept: pson, text/pson
+
+### Parameters
+
+For the parameters, see http://docs.puppetlabs.com/guides/rest_api.html#facts-search.
+
+### Response
+
+The response is an array of node names.  The array is square-bracket delimited; the node names are quoted and
+comma separated.
+
+### Example Response
+
+#### Facts found
+
+    GET /env/facts_search/search?facts.processorcount.ge=2
+
+    HTTP 200 OK
+    Content-Type: text/pson
+
+    ["elmo.mydomain.com","kermit.mydomain.com"]
+
+Schema
+------
+
+The representation of facts, whether returned from a GET or contained in a PUT body, should adhere to the
+{file:api/schemas/facts.json api/schemas/facts.json} schema.

--- a/api/docs/http_facts.md
+++ b/api/docs/http_facts.md
@@ -1,85 +1,34 @@
 Facts
-=============
+=====
 
-The `facts` endpoint allows getting or setting the facts for the specified node name.  The `facts_search` endpoint
-allows retrieving a list of node names containing the specified facts.
-
-Find
-----
-
-Get facts for a node.
-
-    GET /:environment/facts/:nodename
-
-### Supported HTTP Methods
-
-GET
-
-### Supported Response Formats
-
-PSON
-
-### Parameters
-
-None
-
-### Example Response
-
-* Note: list of facts was shortened for readability.
-* Note: pson was formatted for readability.
-
-#### Facts found
-
-    GET /env/facts/elmo.mydomain.com
-
-    HTTP 200 OK
-    Content-Type: text/pson
-
-    {
-      "name": "elmo.mydomain.com",
-      "values": {
-        "architecture": "x86_64",
-        "kernel": "Darwin",
-        "domain": "local",
-        "macaddress": "70:11:24:8c:33:a9",
-        "osfamily": "Darwin",
-        "operatingsystem": "Darwin",
-        "facterversion": "1.7.2",
-        "fqdn": "elmo.mydomain.com",
-      },
-      "timestamp": "2013-09-09 15:49:27 -0700",
-      "expiration": "2013-09-09 16:19:27 -0700"
-    }
+The `facts` endpoint allows setting the facts for the specified node name.
 
 Save
 ----
 
-Store facts for a node.  The request body should contain pson-formatted facts.
+Store facts for a node. The request body should contain JSON-formatted facts.
 
-    PUT /:environment/facts/:nodename
+    PUT /puppet/v3/facts/:nodename?environment=:environment
 
 ### Supported HTTP Methods
 
 PUT
 
-### Supported Format
+### Supported Format(s)
 
-Accept: pson, text/pson
+`application/json`, `text/pson`
 
 ### Parameters
 
 None
 
-### Example Response
+### Example
 
 * Note: list of facts was shortened for readability.
-* Note: pson was formatted for readability.
+* Note: JSON was formatted for readability.
 
-#### Facts found
-
-    PUT /env/facts/elmo.mydomain.com
-
-    Content-Type: text/pson
+    PUT /puppet/v3/facts/elmo.mydomain.com?environment=env
+    Content-Type: application/json
 
     {
       "name": "elmo.mydomain.com",
@@ -98,47 +47,10 @@ None
     }
 
     HTTP/1.1 200 OK
-    Content-Type: text/pson
-
-    "/etc/puppet/var/yaml/facts/joebob.local.yaml"
-
-Search
-----
-
-Get the list of nodes matching the facts_search parameters
-
-    GET /:environment/facts_search/search
-
-### Supported HTTP Methods
-
-GET
-
-### Supported Format
-
-Accept: pson, text/pson
-
-### Parameters
-
-For the parameters, see http://docs.puppetlabs.com/guides/rest_api.html#facts-search.
-
-### Response
-
-The response is an array of node names.  The array is square-bracket delimited; the node names are quoted and
-comma separated.
-
-### Example Response
-
-#### Facts found
-
-    GET /env/facts_search/search?facts.processorcount.ge=2
-
-    HTTP 200 OK
-    Content-Type: text/pson
-
-    ["elmo.mydomain.com","kermit.mydomain.com"]
+    Content-Type: application/json
 
 Schema
 ------
 
-The representation of facts, whether returned from a GET or contained in a PUT body, should adhere to the
-{file:api/schemas/facts.json api/schemas/facts.json} schema.
+The representation of facts contained in a PUT body, should adhere to
+[the facts schema.](../schemas/facts.json)

--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -100,6 +100,11 @@ path ~ ^/puppet/v3/report/([^/]+)$
 method save
 allow $1
 
+# allow all nodes to update their own facts
+path ~ ^/puppet/v3/facts/([^/]+)$
+method save
+allow $1
+
 # Allow all nodes to access all file services; this is necessary for
 # pluginsync, file serving from modules, and file serving from custom
 # mount points (see fileserver.conf). Note that the `/file` prefix matches

--- a/lib/puppet/application/facts.rb
+++ b/lib/puppet/application/facts.rb
@@ -1,4 +1,9 @@
 require 'puppet/application/indirection_base'
 
 class Puppet::Application::Facts < Puppet::Application::IndirectionBase
+  # Allows `puppet facts` actions to be run against environments that
+  # don't exist locally, such as using the `--environment` flag to make a REST
+  # request to a specific environment on a master. There is no way to set this
+  # behavior per-action, so it must be set for the face as a whole.
+  environment_mode :not_required
 end

--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -35,4 +35,35 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
 
   deactivate_action(:destroy)
   deactivate_action(:search)
+
+  action(:upload) do
+    summary "Upload local facts to the puppet master."
+    description <<-'EOT'
+      Reads facts from the local system using the `facter` terminus, then
+      saves the returned facts using the rest terminus.
+    EOT
+    returns "Nothing."
+    notes <<-'EOT'
+      This action requires that the puppet master's `auth.conf` file
+      allow save access to the `facts` REST terminus. Puppet agent does
+      not use this facility, and it is turned off by default. See
+      <http://docs.puppetlabs.com/guides/rest_auth_conf.html> for more details.
+    EOT
+    examples <<-'EOT'
+      Upload facts:
+
+      $ puppet facts upload
+    EOT
+
+    render_as :yaml
+
+    when_invoked do |options|
+      Puppet::Node::Facts.indirection.terminus_class = :facter
+      facts = Puppet::Node::Facts.indirection.find(Puppet[:certname])
+      Puppet::Node::Facts.indirection.terminus_class = :rest
+      Puppet::Node::Facts.indirection.save(facts)
+      Puppet.notice "Uploaded facts for '#{Puppet[:certname]}'"
+      nil
+    end
+  end
 end

--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -45,10 +45,15 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
     returns "Nothing."
     notes <<-'EOT'
       This action requires that the puppet master's `auth.conf` file
-      allow save access to the `facts` REST terminus. Puppet agent does
-      not use this facility, and it is turned off by default. See
+      allow `PUT` or `save` access to the `/puppet/v3/facts` API endpoint.
+
+      For details on configuring Puppet Server's `auth.conf`, see:
+
       <https://puppet.com/docs/puppetserver/latest/config_file_auth.html>
-      for more details.
+
+      For legacy Rack-based Puppet Masters, see:
+
+      <https://puppet.com/docs/puppet/latest/config_file_auth.html>
     EOT
     examples <<-'EOT'
       Upload facts:

--- a/lib/puppet/indirector/facts/rest.rb
+++ b/lib/puppet/indirector/facts/rest.rb
@@ -1,0 +1,8 @@
+require 'puppet/node/facts'
+require 'puppet/indirector/rest'
+
+class Puppet::Node::Facts::Rest < Puppet::Indirector::REST
+  desc "Find and save facts about nodes over HTTP via REST."
+  use_server_setting(:inventory_server)
+  use_port_setting(:inventory_port)
+end

--- a/lib/puppet/indirector/facts/rest.rb
+++ b/lib/puppet/indirector/facts/rest.rb
@@ -3,6 +3,19 @@ require 'puppet/indirector/rest'
 
 class Puppet::Node::Facts::Rest < Puppet::Indirector::REST
   desc "Find and save facts about nodes over HTTP via REST."
-  use_server_setting(:inventory_server)
-  use_port_setting(:inventory_port)
+
+  def save(request)
+    raise ArgumentError, _("PUT does not accept options") unless request.options.empty?
+
+    response = do_request(request) do |req|
+      http_put(req, IndirectedRoutes.request_to_uri(req), req.instance.render, headers.merge({ "Content-Type" => req.instance.mime }))
+    end
+
+    if is_http_200?(response)
+      content_type, body = parse_response(response)
+      deserialize_save(content_type, body)
+    else
+      raise convert_to_http_error(response)
+    end
+  end
 end

--- a/lib/puppet/indirector/facts/yaml.rb
+++ b/lib/puppet/indirector/facts/yaml.rb
@@ -5,10 +5,6 @@ class Puppet::Node::Facts::Yaml < Puppet::Indirector::Yaml
   desc "Store client facts as flat files, serialized using YAML, or
     return deserialized facts from disk."
 
-  def allow_remote_requests?
-    false
-  end
-
   def search(request)
     node_names = []
     Dir.glob(yaml_dir_path).each do |file|

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -265,6 +265,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     # NOTE These specific hooks for paths are ridiculous, but it's a *many*-line
     # fix to not need this, and our goal is to move away from the complication
     # that leads to the fix being too long.
+    return :singular if indirection == "facts"
     return :singular if indirection == "status"
     return :singular if indirection == "certificate_status"
 

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -1,19 +1,62 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/face'
+require 'puppet/indirector/facts/facter'
+require 'puppet/indirector/facts/rest'
 
 describe Puppet::Face[:facts, '0.0.1'] do
-  it "should define an 'upload' action" do
-    subject.should be_action(:upload)
-  end
-
-  describe "when uploading" do
-    it "should set the terminus_class to :facter"
-    it "should set the cache_class to :rest"
-    it "should find the current certname"
-  end
-
   describe "#find" do
     it { is_expected.to be_action :find }
+  end
+
+  describe '#upload' do
+    let(:model) { Puppet::Node::Facts }
+    let(:test_data) { model.new('puppet.node.test', {test_fact: 'test value'}) }
+    let(:facter_terminus) { model.indirection.terminus(:facter) }
+    let(:rest_terminus) { model.indirection.terminus(:rest) }
+
+    before(:each) do
+      Puppet.settings.parse_config(<<-CONF)
+[main]
+server=puppet.server.invalid
+certname=puppet.node.invalid
+[agent]
+server=puppet.server.test
+node_name_value=puppet.node.test
+CONF
+
+      # Faces start in :user run mode
+      Puppet.settings.preferred_run_mode = :user
+
+      facter_terminus.stubs(:find).with(instance_of(Puppet::Indirector::Request)).returns(test_data)
+      rest_terminus.stubs(:save).with(instance_of(Puppet::Indirector::Request)).returns(nil)
+    end
+
+    it { is_expected.to be_action :upload }
+
+    it "finds facts from terminus_class :facter" do
+      facter_terminus.expects(:find).with(instance_of(Puppet::Indirector::Request)).returns(test_data)
+
+      subject.upload
+    end
+
+    it "saves facts to terminus_class :rest" do
+      rest_terminus.expects(:save).with(instance_of(Puppet::Indirector::Request)).returns(nil)
+
+      subject.upload
+    end
+
+    it "uses settings from the agent section of puppet.conf" do
+      facter_terminus.expects(:find).with(responds_with(:key, 'puppet.node.test')).returns(test_data)
+
+      subject.upload
+    end
+
+    it "logs the name of the server that received the upload" do
+      subject.upload
+
+      expect(@logs).to be_any {|log| log.level == :notice &&
+                               log.message =~ /Uploading facts for '.*' to: 'puppet\.server\.test'/}
+    end
   end
 end

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -3,6 +3,16 @@ require 'spec_helper'
 require 'puppet/face'
 
 describe Puppet::Face[:facts, '0.0.1'] do
+  it "should define an 'upload' action" do
+    subject.should be_action(:upload)
+  end
+
+  describe "when uploading" do
+    it "should set the terminus_class to :facter"
+    it "should set the cache_class to :rest"
+    it "should find the current certname"
+  end
+
   describe "#find" do
     it { is_expected.to be_action :find }
   end

--- a/spec/unit/indirector/facts/rest_spec.rb
+++ b/spec/unit/indirector/facts/rest_spec.rb
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet/indirector/facts/rest'
+
+describe Puppet::Node::Facts::Rest do
+  it "should be a sublcass of Puppet::Indirector::REST" do
+    Puppet::Node::Facts::Rest.superclass.should equal(Puppet::Indirector::REST)
+  end
+end

--- a/spec/unit/indirector/facts/rest_spec.rb
+++ b/spec/unit/indirector/facts/rest_spec.rb
@@ -5,6 +5,41 @@ require 'puppet/indirector/facts/rest'
 
 describe Puppet::Node::Facts::Rest do
   it "should be a sublcass of Puppet::Indirector::REST" do
-    Puppet::Node::Facts::Rest.superclass.should equal(Puppet::Indirector::REST)
+    expect(Puppet::Node::Facts::Rest.superclass).to equal(Puppet::Indirector::REST)
+  end
+
+  let(:model) { Puppet::Node::Facts }
+  before(:each) { model.indirection.terminus_class = :rest }
+
+  def mock_response(code, body, content_type='text/plain', encoding=nil)
+    obj = stub('http response', :code => code.to_s, :body => body)
+    obj.stubs(:[]).with('content-type').returns(content_type)
+    obj.stubs(:[]).with('content-encoding').returns(encoding)
+    obj.stubs(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).returns(Puppet.version)
+    obj
+  end
+
+  describe '#save' do
+    subject { model.indirection.terminus(:rest) }
+
+    let(:connection) { stub('mock http connection', :verify_callback= => nil) }
+    let(:node_name) { 'puppet.node.test' }
+    let(:data) { model.new(node_name, {test_fact: 'test value'}) }
+    let(:request) { Puppet::Indirector::Request.new(:facts, :save, node_name, data) }
+
+    before :each do
+      subject.stubs(:network).returns(connection)
+    end
+
+    context 'when a 404 response is received' do
+      let(:response) { mock_response(404, '{}', 'test/json') }
+
+      before(:each) { connection.expects(:put).returns response }
+
+      it 'riases with HTTP 404' do
+        expect{ subject.save(request) }.to raise_error(Net::HTTPError,
+                                                       /Error 404 on SERVER/)
+      end
+    end
   end
 end

--- a/spec/unit/indirector/facts/yaml_spec.rb
+++ b/spec/unit/indirector/facts/yaml_spec.rb
@@ -23,6 +23,12 @@ describe Puppet::Node::Facts::Yaml do
     expect(Puppet::Node::Facts::Yaml.name).to eq(:yaml)
   end
 
+  it "should allow network requests" do
+    # Doesn't allow yaml as a network format, but allows `puppet facts upload`
+    # to update the YAML cache on a master.
+    expect(Puppet::Node::Facts::Yaml.new.allow_remote_requests?).to be(true)
+  end
+
   describe "#search" do
     def assert_search_matches(matching, nonmatching, query)
       request = Puppet::Indirector::Request.new(:inventory, :search, nil, nil, query)

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -106,6 +106,10 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(handler.uri2indirection("GET", "#{master_url_prefix}/nodes/bar", params)[1]).to eq(:search)
     end
 
+    it "should choose 'save' as the indirection method if the http method is a PUT and the indirection name is facts" do
+      expect(handler.uri2indirection("PUT", "#{master_url_prefix}/facts/puppet.node.test", params)[0].name).to eq(:facts)
+    end
+
     it "should change indirection name to 'status' if the http method is a GET and the indirection name is statuses" do
       expect(handler.uri2indirection("GET", "#{master_url_prefix}/statuses/bar", params)[0].name).to eq(:status)
     end


### PR DESCRIPTION
This changeset reverts pieces of [PUP-2560](https://tickets.puppetlabs.com/browse/PUP-2560) in order to re-add the ability to upload facts outside of a catalog request. Specifically, this patch re-adds the following functionality:

  - The `puppet facts upload` command.

  - The Puppet::Node::Facts::Rest terminus for saving facts to Puppet Servers.

  - The ability to handle requests for the `/puppet/v3/facts` endpoint.