### PR TITLE
(QENG-5106) Skipping tests for ec2 hosts

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -2,7 +2,10 @@ test_name "ticket 1073: common package name in two different providers should be
 
   confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
   confine :except, :platform => /centos-4|el-4/ # PUP-5227
-  confine :except, :hypervisor => 'ec2' # PUP-7774
+  # Skipping tests if facter finds this is an ec2 host, PUP-7774
+  hosts.each do |host|
+    skip_test('Skipping EC2 Hosts') if fact_on(host, 'ec2_metadata')
+  end
 
   tag 'audit:medium',
       'audit:acceptance' # Uses a provider that depends on AIO packaging


### PR DESCRIPTION
We were skipping tests when the hypervisor was ec2.  I have added support in QENG-5106 to use abs as a hypervisor.  This change will now skip tests for any ec2 host whether created with the ec2 hypervisor or abs hypervisor.