### PR TITLE
[WIP] PUP-7474: Always generate the subjectAltNames per RFC2818

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -387,7 +387,8 @@ class Puppet::SSL::CertificateAuthority
     unless csr.subject_alt_names.empty?
       # If you alt names are allowed, they are required. Otherwise they are
       # disallowed. Self-signed certs are implicitly trusted, however.
-      unless options[:allow_dns_alt_names]
+      # Per RFC2818 states you should have the CN in alt names
+      unless options[:allow_dns_alt_names] || csr.subject_alt_names == ["DNS:#{hostname}"]
         raise CertificateSigningError.new(hostname), _("CSR '%{csr}' contains subject alternative names (%{alt_names}), which are disallowed. Use `puppet cert --allow-dns-alt-names sign %{csr}` to sign this request.") % { csr: csr.name, alt_names: csr.subject_alt_names.join(', ') }
       end
 

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -89,6 +89,13 @@ DOC
     csr.subject = OpenSSL::X509::Name.new([["CN", common_name]])
     csr.public_key = key.public_key
 
+    # RFC28128: Ensure the CN is also in the SAN
+    if options[:dns_alt_names]
+      options[:dns_alt_names] += ", #{common_name}"
+    else
+      options[:dns_alt_names] = common_name
+    end
+
     if options[:csr_attributes]
       add_csr_attributes(csr, options[:csr_attributes])
     end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -174,6 +174,11 @@ DOC
       end
     end
 
+    # RFC2818: Ensure the CN is also in the SAN
+    alt_names = (options[:dns_alt_names] || '').split(/\s*,\s*/)
+    alt_names << name unless alt_names.include?(name) # TODO: lower case comparison
+    options[:dns_alt_names] = alt_names.join(', ')
+
     csr_attributes = Puppet::SSL::CertificateRequestAttributes.new(Puppet[:csr_attributes])
     if csr_attributes.load
       options[:csr_attributes] = csr_attributes.custom_attributes

--- a/spec/unit/face/certificate_spec.rb
+++ b/spec/unit/face/certificate_spec.rb
@@ -123,7 +123,7 @@ describe Puppet::Face[:certificate, '0.0.1'] do
 
         subject.generate(hostname, options)
 
-        expect(csr.subject_alt_names).to be_empty
+        expect(csr.subject_alt_names).to match_array(%W[DNS:#{hostname}])
       end
 
       it "should add the provided dns_alt_names if they are specified" do

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -1138,9 +1138,9 @@ describe "CertificateAuthority.generate" do
         expect( cert.name ).to eq(cn)
       end
 
-      it "should not have any subject_alt_names by default" do
+      it "should have the name in subject_alt_names by default" do
         cert = ca.generate(cn)
-        expect( cert.subject_alt_names ).to be_empty
+        expect( cert.subject_alt_names ).to match_array(["DNS:#{cn}"])
       end
 
       it "should have subject_alt_names if passed dns_alt_names" do

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -125,9 +125,9 @@ describe Puppet::SSL::CertificateRequest do
           end).not_to be
         end
 
-        it "should return no subjectAltNames" do
+        it "should return the CN in subjectAltNames" do
           request.generate(key)
-          expect(request.subject_alt_names).to be_empty
+          expect(request.subject_alt_names).to match_array(["DNS:myname"])
         end
       end
     end
@@ -145,9 +145,9 @@ describe Puppet::SSL::CertificateRequest do
           end).not_to be
         end
 
-        it "should return no subjectAltNames" do
+        it "should return the CN in subjectAltNames" do
           request.generate(key)
-          expect(request.subject_alt_names).to be_empty
+          expect(request.subject_alt_names).to match_array(["DNS:myname"])
         end
       end
     end


### PR DESCRIPTION
This ensures the there is always a subjectAltNames in a CSR with the common name. The allow_dns_alt_names option is changed to ignore the CN matching the subjectAltNames.

Currently it's untested hence the WIP flag.