### PR TITLE
(PUP-8237) Make Puppet::Pal::ScriptCompiler available to functions

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -706,8 +706,20 @@ module Puppet::Functions
   #
   # @api private
   class InternalDispatchBuilder < DispatcherBuilder
-    def scope_param()
-      @injections << :scope
+    # Inject parameter for `Puppet::Parser::Scope`
+    def scope_param
+      inject(:scope)
+    end
+
+    # Inject parameter for `Puppet::Pal::ScriptCompiler`
+    def script_compiler_param
+      inject(:pal_script_compiler)
+    end
+
+    private
+
+    def inject(injection_name)
+      @injections << injection_name
       # mark what should be picked for this position when dispatching
       @weaving << [@injections.size()-1]
     end

--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -657,30 +657,7 @@ module Puppet::Functions
   #
   # This is a private, internal, system for creating functions. It supports
   # everything that the public function definition system supports as well as a
-  # few extra features.
-  #
-  # Injection Support
-  # ===
-  # The Function API supports injection of data and services. It is possible to
-  # make injection that takes effect when the function is loaded (for services
-  # and runtime configuration that does not change depending on how/from where
-  # in what context the function is called. It is also possible to inject and
-  # weave argument values into a call.
-  #
-  # Injection of attributes
-  # ---
-  # Injection of attributes is performed by one of the methods `attr_injected`,
-  # and `attr_injected_producer`.  The injected attributes are available via
-  # accessor method calls.
-  #
-  # @example using injected attributes
-  #   Puppet::Functions.create_function('test') do
-  #     attr_injected String, :larger, 'message_larger'
-  #     attr_injected String, :smaller, 'message_smaller'
-  #     def test(a, b)
-  #       a > b ? larger() : smaller()
-  #     end
-  #   end
+  # few extra features such as injection of well known parameters.
   #
   # @api private
   class InternalFunction < Function
@@ -704,26 +681,22 @@ module Puppet::Functions
     end
   end
 
-  # @note WARNING: This style of creating functions is not public. It is a system
-  #   under development that will be used for creating "system" functions.
-  #
   # Injection and Weaving of parameters
   # ---
-  # It is possible to inject and weave parameters into a call. These extra
-  # parameters are not part of the parameters passed from the Puppet logic, and
-  # they can not be overridden by parameters given as arguments in the call.
-  # They are invisible to the Puppet Language.
+  # It is possible to inject and weave a set of well known parameters into a call.
+  # These extra parameters are not part of the parameters passed from the Puppet
+  # logic, and  they can not be overridden by parameters given as arguments in the
+  # call. They are invisible to the Puppet Language.
   #
   # @example using injected parameters
   #   Puppet::Functions.create_function('test') do
   #     dispatch :test do
   #       param 'Scalar', 'a'
   #       param 'Scalar', 'b'
-  #       injected_param 'String', 'larger', 'message_larger'
-  #       injected_param 'String', 'smaller', 'message_smaller'
+  #       scope_param
   #     end
-  #     def test(a, b, larger, smaller)
-  #       a > b ? larger : smaller
+  #     def test(a, b, scope)
+  #       a > b ? scope['a'] : scope['b']
   #     end
   #   end
   #
@@ -731,54 +704,10 @@ module Puppet::Functions
   #
   #     test(10, 20)
   #
-  # Using injected value as default
-  # ---
-  # Default value assignment is handled by using the regular Ruby mechanism (a
-  # value is assigned to the variable).  The dispatch simply indicates that the
-  # value is optional. If the default value should be injected, it can be
-  # handled different ways depending on what is desired:
-  #
-  # * by calling the accessor method for an injected Function class attribute.
-  #   This is suitable if the value is constant across all instantiations of the
-  #   function, and across all calls.
-  # * by injecting a parameter into the call
-  #   to the left of the parameter, and then assigning that as the default value.
-  # * One of the above forms, but using an injected producer instead of a
-  #   directly injected value.
-  #
-  # @example method with injected default values
-  #   Puppet::Functions.create_function('test') do
-  #     dispatch :test do
-  #       injected_param String, 'b_default', 'b_default_value_key'
-  #       param 'Scalar', 'a'
-  #       param 'Scalar', 'b'
-  #     end
-  #     def test(b_default, a, b = b_default)
-  #       # ...
-  #     end
-  #   end
-  #
   # @api private
   class InternalDispatchBuilder < DispatcherBuilder
     def scope_param()
-      @injections << [:scope, 'scope', '', :dispatcher_internal]
-      # mark what should be picked for this position when dispatching
-      @weaving << [@injections.size()-1]
-    end
-    # TODO: is param name really needed? Perhaps for error messages? (it is unused now)
-    #
-    # @api private
-    def injected_param(type, name, injection_name = '')
-      @injections << [type, name, injection_name]
-      # mark what should be picked for this position when dispatching
-      @weaving << [@injections.size() -1]
-    end
-
-    # TODO: is param name really needed? Perhaps for error messages? (it is unused now)
-    #
-    # @api private
-    def injected_producer_param(type, name, injection_name = '')
-      @injections << [type, name, injection_name, :producer]
+      @injections << :scope
       # mark what should be picked for this position when dispatching
       @weaving << [@injections.size()-1]
     end

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -77,8 +77,10 @@ class Dispatch < Evaluator::CallableSignature
             case injection_name
             when :scope
               scope
+            when :pal_script_compiler
+              Puppet.lookup(:pal_script_compiler)
             else
-              raise_error ArgumentError, "Unknown injection #{injection_name}"
+              raise ArgumentError, "Unknown injection #{injection_name}"
             end
         else
           # Careful so no new nil arguments are added since they would override default

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -72,14 +72,13 @@ class Dispatch < Evaluator::CallableSignature
       new_args = []
       @weaving.each do |knit|
         if knit.is_a?(Array)
-          injection_data = @injections[knit[0]]
+          injection_name = @injections[knit[0]]
           new_args <<
-            case injection_data[3]
-            when :dispatcher_internal
-              # currently only supports :scope injection
+            case injection_name
+            when :scope
               scope
             else
-              raise_error ArgumentError, "Unknown injection #{injection_data[3]}"
+              raise_error ArgumentError, "Unknown injection #{injection_name}"
             end
         else
           # Careful so no new nil arguments are added since they would override default


### PR DESCRIPTION
This commit makes the `Puppet::Pal::ScriptCompiler` available using a
`Puppet::Context` override. The compiler is available using the symbol
`:pal_script_compiler`.

A new special parameter type named `script_compiler_param` is also added
to the Ruby function dispatcher builder for `InternalFunction`. Usage is
similar to `scope_param` but it injects the script compiler instead of
injecting the scope.