### PR TITLE
(maint) Skipping test if facter finds this is an ec2 host

### DIFF
--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -2,7 +2,10 @@ test_name "test the yum package provider" do
 
   confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
   confine :except, :platform => /centos-4|el-4/ # PUP-5227
-  confine :except, :hypervisor => /ec2/
+  # Skipping tests if facter finds this is an ec2 host, PUP-7774
+  hosts.each do |host|
+    skip_test('Skipping EC2 Hosts') if fact_on(host, 'ec2_metadata')
+  end
 
   tag 'audit:medium',
       'audit:acceptance' # Could be done at the integration (or unit) layer though


### PR DESCRIPTION
We were skipping tests when the hypervisor was ec2. I have added support in QENG-5106
to use abs as a hypervisor. This change will now skip tests for any ec2 host
whether created with the ec2 hypervisor or abs hypervisor.