### PR TITLE
Task/master/fips changes

### DIFF
--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -14,6 +14,12 @@ extend Puppet::Acceptance::TempFileUtils
 initialize_temp_dirs
 
 agents.each do |agent|
+    
+  if on(agent, facter("fips_enabled")).stdout =~ /true/
+    puts "Module build, loading and installing not supported on fips enabled platforms"
+    next
+  end
+
   environmentpath = get_test_file_path(agent, 'environments')
   dev_modulepath = "#{environmentpath}/dev/modules"
 

--- a/acceptance/tests/modules/build/build_agent.rb
+++ b/acceptance/tests/modules/build/build_agent.rb
@@ -4,6 +4,12 @@ tag 'audit:medium',
     'audit:acceptance'
 
 agents.each do |agent|
+
+  if on(agent, facter("fips_enabled")).stdout =~ /true/
+    puts "Module build, loading and installing not supported on fips enabled platforms"
+    next
+  end
+
   teardown do
     on agent, 'rm -rf bar'
   end

--- a/acceptance/tests/modules/build/build_should_not_create_changes.rb
+++ b/acceptance/tests/modules/build/build_should_not_create_changes.rb
@@ -9,6 +9,12 @@ defaultversion = '0.1.0'
 buildpath = "#{modname}/pkg/#{modauthor}-#{modname}-#{defaultversion}"
 
 agents.each do |agent|
+
+  if on(agent, facter("fips_enabled")).stdout =~ /true/
+    puts "Module build, loading and installing not supported on fips enabled platforms"
+    next
+  end
+
   teardown do
     on(agent, "rm -rf #{modname}")
   end

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -18,6 +18,12 @@ teardown do
 end
 
 agents.each do |agent|
+
+  if on(agent, facter("fips_enabled")).stdout =~ /true/
+    puts "Module build, loading and installing not supported on fips enabled platforms"
+    next
+  end
+
   step 'setup'
   stub_forge_on(agent)
 

--- a/acceptance/tests/modules/install/with_version.rb
+++ b/acceptance/tests/modules/install/with_version.rb
@@ -18,6 +18,12 @@ teardown do
 end
 
 agents.each do |agent|
+
+  if on(agent, facter("fips_enabled")).stdout =~ /true/
+    puts "Module build, loading and installing not supported on fips enabled platforms"
+    next
+  end
+
   step 'setup'
   stub_forge_on(agent)
 

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -50,8 +50,9 @@ agents.each do |agent|
     {:name => :crit,             :args => '"consider yourself critical"',      :lambda => nil, :expected => 'consider yourself critical', :rvalue => false},
     {:name => :debug,            :args => '"consider yourself bugged"',        :lambda => nil, :expected => '', :rvalue => false}, # no output expected unless run with debug
     {:name => :defined,          :args => 'File["/tmp"]',                      :lambda => nil, :expected => 'false', :rvalue => true},
-    {:name => :digest,           :args => '"Sansa"',                           :lambda => nil, :expected => 'f16491bf0133c6103918b2edcd00cf89', :rvalue => true},
     {:name => :dig,              :args => '[100]',                             :lambda => nil, :expected => '[100]', :rvalue => true},
+    # Expect sha256 hash value for the digest when running on fips enabled system
+    {:name => :digest,           :args => '"Sansa"',                           :lambda => nil, :expected => on(agent, facter("fips_enabled")).stdout =~ /true/ ? '4ebf3a5527313f06c7965749d7764c15cba6fe86da11691ca9bd0ce448563979' : 'f16491bf0133c6103918b2edcd00cf89', :rvalue => true},
     {:name => :emerg,            :args => '"consider yourself emergent"',      :lambda => nil, :expected => 'consider yourself emergent', :rvalue => false},
     {:name => :err,              :args => '"consider yourself in err"',        :lambda => nil, :expected => 'consider yourself in err', :rvalue => false},
     {:name => :file,             :args => '"call_em_all/rickon.txt"',          :lambda => nil, :expected => 'who?', :rvalue => true},
@@ -67,7 +68,8 @@ agents.each do |agent|
     {:name => :inline_template,  :args => '\'empty<%= @x %>space\'',           :lambda => nil, :expected => 'emptyspace', :rvalue => true},
     # test the living life out of this thing in lookup.rb, and it doesn't allow for a default value
     #{:name => :lookup,           :args => 'date,lookup_date',                  :lambda => nil, :expected => '', :rvalue => true},  # well tested elsewhere
-    {:name => :md5,              :args => '"Bran"',                            :lambda => nil, :expected => '723f9ac32ceb881ddf4fb8fc1020cf83', :rvalue => true},
+    # Use fips approved hash when running on fips enabled system
+    {:name => on(agent, facter("fips_enabled")).stdout =~ /true/ ?  :sha256 : :md5,              :args => '"Bran"',                            :lambda => nil, :expected => on(agent, facter("fips_enabled")).stdout =~ /true/ ? '824264f7f73d6026550b52a671c50ad0c4452af66c24f3784e30f515353f2ce0' : '723f9ac32ceb881ddf4fb8fc1020cf83' , :rvalue => true},
     # Integer.new
     {:name => :Integer,          :args => '"100"',                             :lambda => nil, :expected => '100', :rvalue => true},
     {:name => :notice,           :args => '"consider yourself under notice"',  :lambda => nil, :expected => 'consider yourself under notice', :rvalue => false},
@@ -198,9 +200,11 @@ PP
      end
 
    file_path = agent.tmpfile('apply_manifest.pp')
+
    create_remote_file(agent, file_path, manifest_call_each_function_from_array(functions_3x))
+
    trusted_3x = puppet_version =~ /\A3\./ ? '--trusted_node_data ' : ''
-   on(agent, puppet("apply #{trusted_3x} --color=false --modulepath #{testdir}/environments/production/modules/ #{file_path}"),
+   on(agent, puppet("apply #{trusted_3x} --color=false  --modulepath #{testdir}/environments/production/modules/ #{file_path}"),
       :acceptable_exit_codes => 1 ) do |result|
         functions_3x.each do |function|
           # append the function name to the matcher so it's more expressive

--- a/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
+++ b/acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb
@@ -10,9 +10,18 @@ agents.each do |agent|
   step "clean up #{file} for testing"
   on(agent, "rm -f #{file}")
 
-  step "Run the manifest and verify MD5 was printed"
-  apply_manifest_on(agent, manifest) do
-    assert_match(/defined content as '{md5}098f6bcd4621d373cade4e832627b4f6'/, stdout, "#{agent}: didn't find the content MD5 on output")
+  fips_mode = on(agent, facter("fips_enabled")).stdout =~ /true/
+
+  if fips_mode
+    step "Run the manifest and verify SHA256 was printed"
+    apply_manifest_on(agent, manifest) do
+      assert_match(/defined content as '{sha256}9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'/, stdout, "#{agent}: didn't find the content SHA256 on output")
+    end
+  else
+    step "Run the manifest and verify MD5 was printed"
+    apply_manifest_on(agent, manifest) do
+      assert_match(/defined content as '{md5}098f6bcd4621d373cade4e832627b4f6'/, stdout, "#{agent}: didn't find the content MD5 on output")
+    end
   end
 
   step "clean up #{file} after testing"

--- a/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
+++ b/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
@@ -6,7 +6,13 @@ test_name 'C99977 corrupted clientbucket' do
   agents.each do |agent|
     tmpfile = agent.tmpfile('c99977file')
     unmanaged_content = "unmanaged\n"
-    unmanaged_sha = Digest::MD5.hexdigest(unmanaged_content)
+    
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      unmanaged_sha = Digest::SHA256.hexdigest(unmanaged_content)
+    else
+      unmanaged_sha = Digest::MD5.hexdigest(unmanaged_content)
+    end
+
     managed_content = "managed\n"
     manifest = "file { '#{tmpfile}': content => '#{managed_content}', }"
 

--- a/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
+++ b/acceptance/tests/ticket_3961_puppet_ca_should_produce_certs.rb
@@ -32,5 +32,9 @@ agents.each do |agent|
   on agent, "test -f #{scratch}/ssl/certs/#{target}.pem"
 
   step "verify the private key for #{target} exists"
-  on agent, "grep 'BEGIN RSA PRIVATE KEY' #{scratch}/ssl/private_keys/#{target}.pem > /dev/null 2>&1"
+  if on(agent, facter("fips_enabled")).stdout =~ /true/
+    on agent, "grep 'BEGIN PRIVATE KEY' #{scratch}/ssl/private_keys/#{target}.pem > /dev/null 2>&1"
+  else
+    on agent, "grep 'BEGIN RSA PRIVATE KEY' #{scratch}/ssl/private_keys/#{target}.pem > /dev/null 2>&1"
+  end
 end

--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -26,6 +26,13 @@ step "Master: Start Puppet Master" do
   with_puppet_running_on(master, {}) do
     agents.each do |agent|
 
+      if on(agent, facter("fips_enabled")).stdout =~ /true/
+        # We do not want to do a skip_test here as that aborts the tests across all targets
+        # and the whole test gets skipped even if it will succeed on any non-fips platforms
+        puts "Skipping test on platforms in fips mode - (remote) filebucket is not supported"
+        next
+      end
+
       tmpfile = agent.tmpfile('testfile')
       remote_str = "--remote --server #{master}"
       local_str = "--local"

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -19,7 +19,15 @@ agents.each do |agent|
   apply_manifest_on(agent, manifest)
 
   test_name "verify invalid hashes should not change the file"
-  manifest = "file { '#{target}': content => '{md5}notahash' }"
+  
+  fips_mode = on(agent, facter("fips_enabled")).stdout =~ /true/
+
+  if fips_mode
+    manifest = "file { '#{target}': content => '{sha256}notahash' }"
+  else
+    manifest = "file { '#{target}': content => '{md5}notahash' }"
+  end
+
   apply_manifest_on(agent, manifest) do
     assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
   end
@@ -31,8 +39,17 @@ agents.each do |agent|
   end
 
   test_name "verify that an empty file can be retrieved from the filebucket"
-  manifest = "file { '#{target}': content => '{md5}d41d8cd98f00b204e9800998ecf8427e' }"
+  if fips_mode
+    manifest = "file { '#{target}': content => '{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' }"
+  else
+    manifest = "file { '#{target}': content => '{md5}d41d8cd98f00b204e9800998ecf8427e' }"
+  end
+
   apply_manifest_on(agent, manifest) do
-    assert_match(/content changed '\{md5\}552e21cd4cd9918678e3c1a0df491bc3' to '\{md5\}d41d8cd98f00b204e9800998ecf8427e'/, stdout, "#{agent}: shouldn't have overwrote the file")
+    if fips_mode
+      assert_match(/content changed '\{sha256\}b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2' to '\{sha256\}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'/, stdout, "#{agent}: shouldn't have overwrote the file")
+    else
+      assert_match(/content changed '\{md5\}552e21cd4cd9918678e3c1a0df491bc3' to '\{md5\}d41d8cd98f00b204e9800998ecf8427e'/, stdout, "#{agent}: shouldn't have overwrote the file")
+    end
   end
 end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -8,6 +8,22 @@ module Puppet
     end
   end
 
+  def self.default_digest_alg
+    if Facter.value(:fips_enabled) == true
+      "sha256"
+    else
+      "md5"
+    end
+  end
+
+  def self.default_checksum_types 
+    if Facter.value(:fips_enabled) == true
+      ['sha256', 'sha384', 'sha512', 'sha224']
+    else
+      ['md5', 'sha256', 'sha384', 'sha512', 'sha224']
+    end
+  end
+
   ############################################################################################
   # NOTE: For information about the available values for the ":type" property of settings,
   #   see the docs for Settings.define_settings
@@ -915,14 +931,14 @@ attempt to download the CRL.
 EOT
     },
     :digest_algorithm => {
-        :default  => 'md5',
+        :default  => lambda { default_digest_alg },
         :type     => :enum,
         :values => ["md5", "sha256", "sha384", "sha512", "sha224"],
         :desc     => 'Which digest algorithm to use for file resources and the filebucket.
                       Valid values are md5, sha256, sha384, sha512, sha224. Default is md5.',
     },
     :supported_checksum_types => {
-      :default => ['md5', 'sha256', 'sha384', 'sha512', 'sha224'],
+      :default => lambda { default_checksum_types },
       :type    => :array,
       :desc    => 'Checksum types supported by this agent for use in file resources of a
                    static catalog. Values must be comma-separated. Valid types are md5,

--- a/lib/puppet/file_serving/http_metadata.rb
+++ b/lib/puppet/file_serving/http_metadata.rb
@@ -37,7 +37,7 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
   def collect
     # Prefer the checksum_type from the indirector request options
     # but fall back to the alternative otherwise
-    [ @checksum_type, :md5, :mtime ].each do |type|
+    [ @checksum_type, :md5, :sha256, :sha384, :sha512, :sha224, :mtime ].each do |type|
       @checksum_type = type
       @checksum = @checksums[type]
       return if @checksum

--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -1,4 +1,4 @@
-require 'digest/md5'
+require 'digest/sha2'
 
 Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalue, :doc =>
   "Usage: `fqdn_rand(MAX, [SEED])`. MAX is required and must be a positive
@@ -16,6 +16,10 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
   node. (For example, `fqdn_rand(30)`, `fqdn_rand(30, 'expensive job 1')`, and
   `fqdn_rand(30, 'expensive job 2')` will produce totally different numbers.)") do |args|
     max = args.shift.to_i
-    seed = Digest::MD5.hexdigest([self['::fqdn'],max,args].join(':')).hex
+ 
+    # We are consciously not using different hash algs based on fips mode here
+    # since the randomness is not guaranteed to be predictable for a given node
+    # It just needs to be unique for a given node
+    seed = Digest::SHA256.hexdigest([self['::fqdn'],max,args].join(':')).hex
     Puppet::Util.deterministic_rand_int(seed,max)
 end

--- a/lib/puppet/parser/functions/sha256.rb
+++ b/lib/puppet/parser/functions/sha256.rb
@@ -1,0 +1,5 @@
+require 'digest/sha2'
+
+Puppet::Parser::Functions::newfunction(:sha256, :type => :rvalue, :arity => 1, :doc => "Returns a SHA256 hash value from a provided string.") do |args|
+  Digest::SHA256.hexdigest(args[0])
+end

--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -19,12 +19,14 @@ describe "mount provider (integration)", :unless => Puppet.features.microsoft_wi
     @fake_fstab = tmpfile('fstab')
     @current_options = "local"
     @current_device = "/dev/disk1s1"
+    Puppet[:digest_algorithm] = 'md5' 
     Puppet::Type.type(:mount).defaultprovider.stubs(:default_target).returns(@fake_fstab)
     Facter.stubs(:value).with(:hostname).returns('some_host')
     Facter.stubs(:value).with(:domain).returns('some_domain')
     Facter.stubs(:value).with(:kernel).returns('Linux')
     Facter.stubs(:value).with(:operatingsystem).returns('RedHat')
     Facter.stubs(:value).with(:osfamily).returns('RedHat')
+    Facter.stubs(:value).with(:fips_enabled).returns(false)
     Puppet::Util::ExecutionStub.set do |command, options|
       case command[0]
       when %r{/s?bin/mount}

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -42,6 +42,17 @@ describe "Defaults" do
     end
   end
 
+  describe ".default_digest_alg" do
+    describe "on everything else" do
+      before(:each) do
+        Facter.stubs(:value).with(:fips_enabled).returns(false)
+      end
+      it "should be false" do
+        expect(Puppet.default_digest_alg).to eq('md5')
+      end
+    end
+  end
+
   describe 'strict' do
     it 'should accept the valid value :off' do
       expect {Puppet.settings[:strict] = 'off'}.to_not raise_exception


### PR DESCRIPTION
Consists of code and acceptance test changes as two commits corresponding to these tickets: 
 - PUP-8066: Adjust acceptance tests to run in fips/mixed environments.
 - PUP-8141: Replace hard coded instances of md5 in puppet
All changes involve dynamically adjusting behaviors & defaults to stay within fips limits. A FIPS fact is used for making those decisions per FACT-1802. 

Following is needed to be able to use this on platforms running in FIPS mode: Puppet-agent needs to be built against system openssl and the corresponding target platform needs to be in fips mode. Those are separate changes not part of this PR. FIPS mode testing was done on redhat7 by using temporary changes on my forks.  FIPs enabled redhat-7 vmpooler images could be used for testing whenever they become available. 
