### PR TITLE
(PUP-8244) Resolve Lint/UselessAssignment errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,9 +141,8 @@ Lint/UnusedMethodArgument:
 Lint/UselessAccessModifier:
   Enabled: false
 
-# DISABLED - TODO
 Lint/UselessAssignment:
-  Enabled: false
+  Enabled: true
 
 # DISABLED - TODO
 Lint/Void:

--- a/benchmarks/hiera_include/benchmarker.rb
+++ b/benchmarks/hiera_include/benchmarker.rb
@@ -37,7 +37,6 @@ class Benchmarker
     dummy_class_manifest = File.join(manifests_dir, 'foo.pp')
     hiera_yaml = File.join(@target, 'hiera.yaml')
     datadir = File.join(@target, 'data')
-    localdir = File.dirname(File.realpath(__FILE__))
     common_yaml = File.join(datadir, 'common.yaml')
     groups_yaml = File.join(datadir, 'groups.yaml')
 

--- a/benchmarks/hiera_include_one/benchmarker.rb
+++ b/benchmarks/hiera_include_one/benchmarker.rb
@@ -35,7 +35,6 @@ class Benchmarker
     dummy_class_manifest = File.join(manifests_dir, 'foo.pp')
     hiera_yaml = File.join(@target, 'hiera.yaml')
     datadir = File.join(@target, 'data')
-    localdir = File.dirname(File.realpath(__FILE__))
     common_yaml = File.join(datadir, 'common.yaml')
     groups_yaml = File.join(datadir, 'groups.yaml')
 

--- a/ext/cert_inspector
+++ b/ext/cert_inspector
@@ -97,7 +97,7 @@ class X509Collector
         next unless public_key_info = extract_public_key_info(path, meaning)
         public_key, priority, name = public_key_info
         pem = public_key.to_s
-        existing_priority, existing_name, existing_public_key = key_data[pem]
+        existing_priority, _, _ = key_data[pem]
         next if existing_priority and existing_priority < priority
         key_data[pem] = priority, name, public_key
       rescue
@@ -106,7 +106,7 @@ class X509Collector
     end
     name_to_key_hash = {}
     key_data.each do |pem, data|
-      priority, name, public_key = data
+      _, name, public_key = data
       if name_to_key_hash[name]
         suffix_num = 2
         while name_to_key_hash[name + " (#{suffix_num})"]

--- a/ext/puppet-test
+++ b/ext/puppet-test
@@ -381,7 +381,6 @@ $args = {}
 $options = {:repeat => 1, :fork => 0, :pause => false, :nodes => []}
 
 begin
-    explicit_waitforcert = false
     result.each { |opt,arg|
         case opt
             # First check to see if the argument is a valid setting;
@@ -396,7 +395,7 @@ begin
             when "--fork"
                 begin
                     $options[:fork] = Integer(arg)
-                rescue => detail
+                rescue
                     $stderr.puts "The argument to 'fork' must be an integer"
                     exit(14)
                 end

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -142,7 +142,7 @@ class WindowsDaemon < Win32::Daemon
         :event_id    => id,     # 0x01 or 0x02, 0x03 etc.
         :data        => message # "the message"
       )
-    rescue Exception => e
+    rescue Exception
       # Ignore all errors
     ensure
       if (!eventlog.nil?)

--- a/install.rb
+++ b/install.rb
@@ -482,7 +482,6 @@ EOS
         FileUtils.install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)
 
         tmp_file2.unlink
-        installed_wrapper = true
       end
     end
   end
@@ -495,8 +494,8 @@ FileUtils.cd File.dirname(__FILE__) do
   # Set these values to what you want installed.
   configs = glob(%w{conf/auth.conf conf/puppet.conf conf/hiera.yaml})
   bins  = glob(%w{bin/*})
-  rdoc  = glob(%w{bin/* lib/**/*.rb README* }).reject { |e| e=~ /\.(bat|cmd)$/ }
-  ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }
+  #rdoc  = glob(%w{bin/* lib/**/*.rb README* }).reject { |e| e=~ /\.(bat|cmd)$/ }
+  #ri    = glob(%w{bin/*.rb lib/**/*.rb}).reject { |e| e=~ /\.(bat|cmd)$/ }
   man   = glob(%w{man/man[0-9]/*})
   libs  = glob(%w{lib/**/*})
   locales = glob(%w{locales/**/*})

--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -37,7 +37,6 @@ class Formatter
   def scrub(text)
     # For text with no carriage returns, there's nothing to do.
     return text if text !~ /\n/
-    indent = nil
 
     # If we can match an indentation, then just remove that same level of
     # indent from every line.

--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -84,7 +84,7 @@ module Puppet
       if stacktrace.size > 0
         filename, line = stacktrace[0]
       else
-        file = nil
+        filename = nil
         line = nil
       end
       self.new(

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -63,7 +63,7 @@ Puppet::Face.define(:epp, '0.0.1') do
     when_invoked do |*args|
       options = args.pop
       # pass a dummy node, as facts are not needed for validation
-      options[:node] = node = Puppet::Node.new("testnode", :facts => Puppet::Node::Facts.new("facts", {}))
+      options[:node] = Puppet::Node.new("testnode", :facts => Puppet::Node::Facts.new("facts", {}))
       compiler = create_compiler(options)
 
       status = true # no validation error yet
@@ -145,7 +145,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       require 'puppet/pops'
       options = args.pop
       # pass a dummy node, as facts are not needed for dump
-      options[:node] = node = Puppet::Node.new("testnode", :facts => Puppet::Node::Facts.new("facts", {}))
+      options[:node] = Puppet::Node.new("testnode", :facts => Puppet::Node::Facts.new("facts", {}))
       options[:header] = options[:header].nil? ? true : options[:header]
       options[:validate] = options[:validate].nil? ? true : options[:validate]
 
@@ -176,7 +176,7 @@ Puppet::Face.define(:epp, '0.0.1') do
         end
 
         show_filename = templates.count > 1
-        dumps = templates.each do |file|
+        templates.each do |file|
           buffer.print dump_parse(Puppet::FileSystem.read(file, :encoding => 'utf-8'), file, options, show_filename)
         end
 

--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -44,7 +44,7 @@ Puppet::Face.define(:module, '1.0.0') do
       min_widths = Hash[ *headers.map { |k,v| [k, v.length] }.flatten ]
       min_widths['full_name'] = min_widths['author'] = 12
 
-      min_width = min_widths.inject(0) { |sum,pair| sum += pair.last } + (padding.length * (headers.length - 1))
+      min_width = min_widths.inject(0) { |sum,pair| sum + pair.last } + (padding.length * (headers.length - 1))
 
       terminal_width = [Puppet::Util::Terminal.width, min_width].max
 

--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -99,7 +99,6 @@ Puppet::Face.define(:parser, '0.0.1') do
           raise Puppet::Error, _("No input to parse given on command line or stdin")
         end
       else
-        missing_files = []
         files = args
         available_files = files.select do |file|
           Puppet::FileSystem.exist?(file)

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -83,7 +83,7 @@ Puppet.features.add(:manages_symlinks) do
           attach_function :CreateSymbolicLinkW, [:lpwstr, :lpwstr, :dword], :boolean
 
           true
-        rescue LoadError => err
+        rescue LoadError
           Puppet.debug("CreateSymbolicLink is not available")
           false
         end

--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -17,7 +17,6 @@ class Puppet::FileBucket::Dipper
     # Emulate the XMLRPC client
     server      = hash[:Server]
     port        = hash[:Port] || Puppet[:masterport]
-    environment = Puppet[:environment]
 
     if hash.include?(:Path)
       @local_path = hash[:Path]

--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -154,7 +154,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
   def tmpdir
     tmp = '.'
     if $SAFE > 0
-      tmp = @@systmpdir
+      @@systmpdir
     else
       for dir in [ Puppet::Util.get_env('TMPDIR'), Puppet::Util.get_env('TMP'), Puppet::Util.get_env('TEMP'), @@systmpdir, '/tmp']
         if dir and stat = File.stat(dir) and stat.directory? and stat.writable?

--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -144,7 +144,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
   def try_convert_to_hash(h)
     begin
       h.to_hash
-    rescue NoMethodError => e
+    rescue NoMethodError
       nil
     end
   end

--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -105,7 +105,6 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
   end
 
   def is_defined(scope, *vals)
-    env = scope.environment
     vals.any? do |val|
       case val
       when String
@@ -120,7 +119,6 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
             Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_main_class(scope)
           else
             # Find a resource type, definition or class definition
-            krt = scope.environment.known_resource_types
             Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type_or_class(scope, val)
           end
         end
@@ -150,7 +148,6 @@ Puppet::Functions.create_function(:'defined', Puppet::Functions::InternalFunctio
           #
           raise  ArgumentError, _('The given class type is a reference to all classes') if val.type.class_name.nil?
           Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_hostclass(scope, val.type.class_name)
-          #scope.environment.known_resource_types.find_hostclass(val.type.class_name)
         end
       else
         raise ArgumentError, _("Invalid argument of type '%{value_class}' to 'defined'") % { value_class: val.class }

--- a/lib/puppet/functions/find_file.rb
+++ b/lib/puppet/functions/find_file.rb
@@ -19,7 +19,6 @@ Puppet::Functions.create_function(:find_file, Puppet::Functions::InternalFunctio
   end
 
   def find_file(scope, *args)
-    path = nil
     args.each do |file|
       found = Puppet::Parser::Files.find_file(file, scope.compiler.environment)
       if found && Puppet::FileSystem.exist?(found)

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -107,7 +107,6 @@ Puppet::Functions.create_function(:map) do
 
   def map_Enumerable_1(enumerable)
     result = []
-    index = 0
     enum = Puppet::Pops::Types::Iterable.asserted_iterable(self, enumerable)
     begin
       loop { result << yield(enum.next) }

--- a/lib/puppet/functions/regsubst.rb
+++ b/lib/puppet/functions/regsubst.rb
@@ -66,7 +66,7 @@ Puppet::Functions.create_function(:regsubst) do
 
   def regsubst_regexp(target, pattern, replacement, flags = nil)
     pattern = (pattern.pattern || '') if pattern.is_a?(Puppet::Pops::Types::PRegexpType)
-    inner_regsubst(target, pattern, replacement, operation = flags == 'G' ? :gsub : :sub)
+    inner_regsubst(target, pattern, replacement, flags == 'G' ? :gsub : :sub)
   end
 
   def inner_regsubst(target, re, replacement, op)

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -178,7 +178,6 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     # TODO: get property/parameter defaults if entries are nil in the resource
     # For now they're hard-coded to match the File type.
 
-    file_metadata = {}
     list_of_resources.each do |resource|
       sources = [resource[:source]].flatten.compact
       next unless inlineable?(resource, sources)

--- a/lib/puppet/indirector/file_server.rb
+++ b/lib/puppet/indirector/file_server.rb
@@ -11,7 +11,7 @@ class Puppet::Indirector::FileServer < Puppet::Indirector::Terminus
   def authorized?(request)
     return false unless [:find, :search].include?(request.method)
 
-    mount, file_path = configuration.split_path(request)
+    mount, _ = configuration.split_path(request)
 
     # If we're not serving this mount, then access is denied.
     return false unless mount

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -160,8 +160,6 @@ class Puppet::Indirector::Indirection
   # remove it, we expire it and write it back out to disk.  This way people
   # can still use the expired object if they want.
   def expire(key, options={})
-    request = request(:expire, key, nil, options)
-
     return nil unless cache?
 
     return nil unless instance = cache.find(request(:find, key, nil, options))

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -183,7 +183,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
       # While this way of handling the issue is not perfect, there is at least an error
       # that makes a user aware of the reason for the failure.
       #
-      content_type, body = parse_response(response)
+      _, body = parse_response(response)
       msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(uri_with_query_string, 100), body: body }
       raise Puppet::Error, msg
     else
@@ -315,8 +315,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   # uncompress_body)
   def parse_response(response)
     if response['content-type']
-      [ response['content-type'].gsub(/\s*;.*$/,''),
-        body = uncompress_body(response) ]
+      [ response['content-type'].gsub(/\s*;.*$/,''), uncompress_body(response) ]
     else
       raise _("No content type in http response; cannot parse")
     end

--- a/lib/puppet/info_service/class_information_service.rb
+++ b/lib/puppet/info_service/class_information_service.rb
@@ -59,7 +59,7 @@ class Puppet::InfoService::ClassInformationService
       {:classes =>
         parse_result.definitions.select {|d| d.is_a?(Puppet::Pops::Model::HostClassDefinition)}.map do |d|
           {:name   => d.name,
-           :params => params = d.parameters.map {|p| extract_param(p) }
+           :params => d.parameters.map {|p| extract_param(p) }
           }
         end
       }

--- a/lib/puppet/interface/option_manager.rb
+++ b/lib/puppet/interface/option_manager.rb
@@ -23,7 +23,7 @@ module Puppet::Interface::OptionManager
 
   # @api private
   def walk_inheritance_tree(start, sym)
-    result = (start ||= [])
+    result = (start || [])
     if self.is_a?(Class) and superclass.respond_to?(sym)
       result = superclass.send(sym) + result
     elsif self.class.respond_to?(sym)

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -333,7 +333,7 @@ class Puppet::Module
   def dependencies_as_modules
     dependent_modules = []
     dependencies and dependencies.each do |dep|
-      author, dep_name = dep["name"].split('/')
+      _, dep_name = dep["name"].split('/')
       found_module = environment.module(dep_name)
       dependent_modules << found_module if found_module
     end

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -76,7 +76,7 @@ module Puppet::ModuleTool
       # @api private
       def module_name
         metadata = JSON.parse((root_dir + 'metadata.json').read)
-        name = metadata['name'][/-(.*)/, 1]
+        metadata['name'][/-(.*)/, 1]
       end
 
       # @api private

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -60,7 +60,7 @@ module Puppet::ModuleTool
         name = mod.forge_name.tr('/', '-')
         begin
           version = SemanticPuppet::Version.parse(mod.version)
-        rescue SemanticPuppet::Version::ValidationFailure => e
+        rescue SemanticPuppet::Version::ValidationFailure
           Puppet.warning _("%{module_name} (%{path}) has an invalid version number (%{version}). The version has been set to 0.0.0. If you are the maintainer for this module, please update the metadata.json with a valid Semantic Version (http://semver.org).") % { module_name: mod.name, path: mod.path, version: mod.version }
           version = SemanticPuppet::Version.parse("0.0.0")
         end

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -200,7 +200,6 @@ module Puppet::ModuleTool
     #
     # @param value [Object] The value to be tested
     def validate_data_provider(value)
-      err = nil
       if value.is_a?(String)
         unless value =~ /^[a-zA-Z][a-zA-Z0-9_]*$/
           if value =~ /^[a-zA-Z]/

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -191,7 +191,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       begin
         yield format
         true
-      rescue Puppet::Network::FormatHandler::FormatError => e
+      rescue Puppet::Network::FormatHandler::FormatError
         false
       end
     end

--- a/lib/puppet/network/rights.rb
+++ b/lib/puppet/network/rights.rb
@@ -34,7 +34,7 @@ class Rights
 
   def is_forbidden_and_why?(name, args = {})
     res = :nomatch
-    right = @rights.find do |acl|
+    @rights.find do |acl|
       found = false
       # an acl can return :dunno, which means "I'm not qualified to answer your question,
       # please ask someone else". This is used when for instance an acl matches, but not for the

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -30,7 +30,7 @@ class Puppet::Node
     env_name = data['environment']
     env_name = env_name.intern unless env_name.nil?
     @environment_name = env_name
-    environment = env_name
+    environment = env_name # rubocop:disable Lint/UselessAssignment
   end
 
   def self.from_data_hash(data)

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -295,7 +295,7 @@ class Puppet::Node::Environment
   # @param forge_name [String] The module name
   # @return [Puppet::Module, nil] The module if found, else nil
   def module_by_forge_name(forge_name)
-    author, modname = forge_name.split('/')
+    _, modname = forge_name.split('/')
     found_mod = self.module(modname)
     found_mod and found_mod.forge_name == forge_name ?
       found_mod :

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -198,7 +198,6 @@ module Puppet::Parser::Functions
   def self.function(name, environment = Puppet.lookup(:current_environment))
     name = name.intern
 
-    func = nil
     unless func = get_function(name, environment)
       autoloader.load(name, environment)
       func = get_function(name, environment)

--- a/lib/puppet/parser/functions/scanf.rb
+++ b/lib/puppet/parser/functions/scanf.rb
@@ -34,5 +34,5 @@ DOC
 ) do |args|
   data = args[0]
   format = args[1]
-  result = data.scanf(format)
+  data.scanf(format)
 end

--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -70,7 +70,7 @@ class Puppet::Parser::TypeLoader
           Puppet.debug {"Automatically imported #{fqname} from #{filename} into #{environment}"}
           return result
         end
-      rescue TypeLoaderError => detail
+      rescue TypeLoaderError
         # I'm not convinced we should just drop these errors, but this
         # preserves existing behaviours.
       end

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -318,7 +318,7 @@ class Closure < CallableSignature
     closure_scope = enclosing_scope
 
     parameters.each do |param|
-      arg_type, param_range = create_param_type(param, closure_scope)
+      arg_type, _ = create_param_type(param, closure_scope)
       key_type = type_factory.string(param.name.to_s)
       key_type = type_factory.optional(key_type) unless param.value.nil?
       members[key_type] = arg_type

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -442,9 +442,9 @@ class EvaluatorImpl
           end
         end
         result = left.send(operator, right)
-      rescue NoMethodError => e
+      rescue NoMethodError
         fail(Issues::OPERATOR_NOT_APPLICABLE, left_o, {:operator => operator, :left_value => left})
-      rescue ZeroDivisionError => e
+      rescue ZeroDivisionError
         fail(Issues::DIV_BY_ZERO, bin_expr.right_expr)
       end
       case result

--- a/lib/puppet/pops/functions/function.rb
+++ b/lib/puppet/pops/functions/function.rb
@@ -49,13 +49,13 @@ class Puppet::Pops::Functions::Function
     rescue Puppet::Pops::Evaluator::Next => jumper
       begin
         throw :next, jumper.value
-      rescue Puppet::Parser::Scope::UNCAUGHT_THROW_EXCEPTION => uncaught
+      rescue Puppet::Parser::Scope::UNCAUGHT_THROW_EXCEPTION
         raise Puppet::ParseError.new("next() from context where this is illegal", jumper.file, jumper.line)
       end
     rescue Puppet::Pops::Evaluator::Return => jumper
       begin
         throw :return, jumper
-      rescue Puppet::Parser::Scope::UNCAUGHT_THROW_EXCEPTION => uncaught
+      rescue Puppet::Parser::Scope::UNCAUGHT_THROW_EXCEPTION
         raise Puppet::ParseError.new("return() from context where this is illegal", jumper.file, jumper.line)
       end
     end

--- a/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_resource_type_impl_instantiator.rb
@@ -20,14 +20,14 @@ class PuppetResourceTypeImplInstantiator
     # parse and validate
     model = parser.parse_string(pp_code_string, source_ref)
     statements = if model.is_a?(Model::Program)
-      if model.body.is_a?(Model::BlockExpression)
-        statements = model.body.statements
-      else
-        statements = [model.body]
-      end
-    else
-      statements = EMPTY_ARRAY
-    end
+                   if model.body.is_a?(Model::BlockExpression)
+                     model.body.statements
+                   else
+                     [model.body]
+                   end
+                 else
+                   EMPTY_ARRAY
+                 end
     statements = statements.reject { |s| s.is_a?(Model::Nop) }
     if statements.empty?
       raise ArgumentError, _("The code loaded from %{source_ref} does not create the resource type '%{type_name}' - it is empty") % { source_ref: source_ref, type_name: typed_name.name }

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -97,7 +97,7 @@ class Loaders
   end
 
   def register_implementations(obj_classes, name_authority)
-    self.class.register_implementations_with_loader(obj_classes, name_authority, loader = @private_environment_loader)
+    self.class.register_implementations_with_loader(obj_classes, name_authority, @private_environment_loader)
   end
 
   # Register implementations using the global static loader

--- a/lib/puppet/pops/lookup/data_dig_function_provider.rb
+++ b/lib/puppet/pops/lookup/data_dig_function_provider.rb
@@ -71,7 +71,7 @@ class V3BackendFunctionProvider < DataDigFunctionProvider
     # A merge_behavior retrieved from hiera.yaml must not be converted here. Instead, passing the symbol :hash
     # tells the V3 backend to pick it up from the config.
     resolution_type = lookup_invocation.hiera_v3_merge_behavior? ? :hash : convert_merge(merge)
-    @backend.lookup(key.to_s, lookup_invocation.scope, lookup_invocation.hiera_v3_location_overrides, resolution_type, context = {:recurse_guard => nil})
+    @backend.lookup(key.to_s, lookup_invocation.scope, lookup_invocation.hiera_v3_location_overrides, resolution_type, {:recurse_guard => nil})
   end
 
   def full_name

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -48,7 +48,6 @@ class LookupAdapter < DataAdapter
 
     key = LookupKey.new(key)
     lookup_invocation.lookup(key, key.module_name) do
-      merge_explained = false
       if lookup_invocation.only_explain_options?
         catch(:no_such_key) { do_lookup(LookupKey::LOOKUP_OPTIONS, lookup_invocation, HASH) }
         nil

--- a/lib/puppet/pops/model/model_tree_dumper.rb
+++ b/lib/puppet/pops/model/model_tree_dumper.rb
@@ -209,7 +209,7 @@ class Puppet::Pops::Model::ModelTreeDumper < Puppet::Pops::Model::TreeDumper
   end
 
   def dump_HeredocExpression(o)
-    result = ["@(#{o.syntax})", :indent, :break, do_dump(o.text_expr), :dedent, :break]
+    ["@(#{o.syntax})", :indent, :break, do_dump(o.text_expr), :dedent, :break]
   end
 
   def dump_HostClassDefinition o

--- a/lib/puppet/pops/parser/code_merger.rb
+++ b/lib/puppet/pops/parser/code_merger.rb
@@ -15,10 +15,10 @@ class Puppet::Pops::Parser::CodeMerger
       case parsed_class.code
       when Puppet::Parser::AST::BlockExpression
         # the BlockExpression wraps a single 4x instruction that is most likely wrapped in a Factory
-        memo += parsed_class.code.children.map {|c| c.is_a?(Puppet::Pops::Model::Factory) ? c.model : c }
+        memo + parsed_class.code.children.map {|c| c.is_a?(Puppet::Pops::Model::Factory) ? c.model : c }
       when Puppet::Pops::Model::Factory
         # If it is a 4x instruction wrapped in a Factory
-        memo += parsed_class.code.model
+        memo + parsed_class.code.model
       else
         # It is the instruction directly
         memo << parsed_class.code

--- a/lib/puppet/pops/parser/epp_support.rb
+++ b/lib/puppet/pops/parser/epp_support.rb
@@ -201,8 +201,6 @@ module EppSupport
           if s.end_with? "<%"
             @mode = :error
             @issue = Issues::EPP_UNBALANCED_EXPRESSION
-          else
-            mode = :epp
           end
           return s
 

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -80,7 +80,7 @@ class EvaluatingParser
   end
 
   def convert_to_3x(object, scope)
-    val = evaluator.convert(object, scope, nil)
+    evaluator.convert(object, scope, nil)
   end
 
   def validate(parse_result)

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -535,7 +535,6 @@ class Lexer2
             scn.pos = before
             invalid_number = scn.peek(after - before) unless invalid_number
           end
-          length = scn.pos - before
           assert_numeric(invalid_number, before)
           scn.pos = before + 1
           lex_error(Issues::ILLEGAL_NUMBER, {:value => invalid_number})
@@ -545,7 +544,6 @@ class Lexer2
     ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
       'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '_'].each do |c|
       @selector[c] = lambda do
-
         scn = @scanner
         before = scn.pos
         value = scn.scan(PATTERN_BARE_WORD)

--- a/lib/puppet/pops/parser/parser_support.rb
+++ b/lib/puppet/pops/parser/parser_support.rb
@@ -121,7 +121,7 @@ class Parser
       file = lexer.file
     end
     file = nil unless file.is_a?(String) && !file.empty?
-    raise Puppet::ParseErrorWithIssue.new(error, file, line, pos, nil, issue_code = Issues::SYNTAX_ERROR.issue_code)
+    raise Puppet::ParseErrorWithIssue.new(error, file, line, pos, nil, Issues::SYNTAX_ERROR.issue_code)
   end
 
   # Parses a String of pp DSL code.
@@ -219,7 +219,7 @@ class Parser
     # Create a synthetic NOOP token at EOF offset with 0 size. The lexer does not produce an EOF token that is
     # visible to the grammar rules. Creating this token is mainly to reuse the positioning logic as it
     # expects a token decorated with location information.
-    token_sym, token = @lexer.emit_completed([:NOOP,'',0], locator.string.bytesize)
+    _, token = @lexer.emit_completed([:NOOP,'',0], locator.string.bytesize)
     loc(no_op, token)
     # Program with a Noop
     program = Factory.PROGRAM(no_op, [], locator)

--- a/lib/puppet/pops/parser/slurp_support.rb
+++ b/lib/puppet/pops/parser/slurp_support.rb
@@ -45,9 +45,6 @@ module SlurpSupport
    # Copy from old lexer - can do much better
    def slurp_uqstring
      scn = @scanner
-     last = scn.matched
-     ignore = true
-
      str = slurp(scn, @lexing_context[:uq_slurp_pattern], @lexing_context[:escapes], :ignore_invalid_escapes)
 
      # Terminator may be a single char '$', two characters '${', or empty string '' at the end of intput.

--- a/lib/puppet/pops/serialization/object.rb
+++ b/lib/puppet/pops/serialization/object.rb
@@ -43,7 +43,7 @@ class ObjectWriter
 
   def write(type, value, serializer)
     impl_class = value.class
-    (names, types, required_count) = type.parameter_info(impl_class)
+    (names, _, required_count) = type.parameter_info(impl_class)
     args = names.map { |name| value.send(name) }
 
     # Pop optional arguments that are default

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -252,7 +252,7 @@ module Serialization
           end
         else
           process(value) do
-            (names, types, required_count) = pcore_type.parameter_info(value.class)
+            (names, _, required_count) = pcore_type.parameter_info(value.class)
             args = names.map { |name| value.send(name) }
 
             # Pop optional arguments that are default

--- a/lib/puppet/pops/time/timespan.rb
+++ b/lib/puppet/pops/time/timespan.rb
@@ -259,7 +259,7 @@ module Time
           add_unless_zero(result, KEY_NANOSECONDS, n % 1000)
           n /= 1000
           add_unless_zero(result, KEY_MICROSECONDS, n % 1000)
-          add_unless_zero(result, KEY_MILLISECONDS, n /= 1000)
+          add_unless_zero(result, KEY_MILLISECONDS, n / 1000)
         end
         result[KEY_NEGATIVE] = true if negative?
       end

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -471,7 +471,6 @@ class PObjectType < PMetaType
     # @api private
   def create_new_function
     impl_class = implementation_class
-    class_name = impl_class.name || "Anonymous Ruby class for #{name}"
 
     (param_names, param_types, required_param_count) = parameter_info(impl_class)
 

--- a/lib/puppet/pops/types/p_sem_ver_range_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_range_type.rb
@@ -107,7 +107,6 @@ class PSemVerRangeType < PAnyType
   end
 
   def self.new_function(type)
-    range_expr = "\\A#{range_pattern}\\Z"
     @new_function ||= Puppet::Functions.create_loaded_function(:new_VersionRange, type.loader) do
       local_types do
         type 'SemVerRangeString = String[1]'

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -227,7 +227,6 @@ class PTypeSetType < PMetaType
   def name_for(t, default_name)
     key = @types.key(t)
     if key.nil?
-      qname = t.name
       if @references.empty?
         default_name
       else

--- a/lib/puppet/pops/types/p_uri_type.rb
+++ b/lib/puppet/pops/types/p_uri_type.rb
@@ -151,7 +151,6 @@ class PURIType < PAnyType
   def _assignable?(o, guard = nil)
     return false unless o.class == self.class
     return true if @parameters.nil?
-    params = @parameters
     o_params = o.parameters || EMPTY_HASH
 
     eval = Parser::EvaluatingParser.singleton.evaluator

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -715,7 +715,7 @@ class StringConverter
     when :c
       char = [val].pack("U")
       char = f.alt? ? "\"#{char}\"" : char
-      char = Kernel.format(f.orig_fmt.gsub('c','s'), char)
+      Kernel.format(f.orig_fmt.gsub('c','s'), char)
 
     when :s
       fmt = f.alt? ? 'p' : 's'

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -2059,7 +2059,6 @@ class PStructType < PAnyType
     if self == DEFAULT
       PIterableType.new(PHashType::DEFAULT_KEY_PAIR_TUPLE)
     else
-      tc = TypeCalculator.singleton
       PIterableType.new(
         PTupleType.new([
           PVariantType.maybe_create(@elements.map {|se| se.key_type }),

--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -364,7 +364,7 @@ class Puppet::Property < Puppet::Parameter
     begin
       @should = should
       insync?(is)
-    rescue => detail
+    rescue
       # Certain operations may fail, but we don't want to fail the transaction if we can
       # avoid it
       msg = "Unknown failure using insync_values? on type: #{self.resource.ref} / property: #{self.name} to compare values #{should} and #{is}"

--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -168,7 +168,6 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       glob_avail = !aug.match("/augeas/version/pathx/functions/glob").empty?
       opt_ctx = resource[:context].match("^/files/[^'\"\\[\\]]+$") if resource[:context]
 
-      restricted = false
       if resource[:incl]
         aug.set("/augeas/load/Xfm/lens", resource[:lens])
         aug.set("/augeas/load/Xfm/incl", resource[:incl])
@@ -220,7 +219,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
     #validate and tear apart the command
     fail (_("Invalid command: %{cmd}") % { cmd: cmd_array.join(" ") }) if cmd_array.length < 4
-    cmd = cmd_array.shift
+    _ = cmd_array.shift
     path = cmd_array.shift
     comparator = cmd_array.shift
     arg = cmd_array.join(" ")
@@ -251,7 +250,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
     #validate and tear apart the command
     fail(_("Invalid command: %{cmd}") % { cmd: cmd_array.join(" ") }) if cmd_array.length < 3
-    cmd = cmd_array.shift
+    _ = cmd_array.shift
     path = cmd_array.shift
 
     # Need to break apart the clause
@@ -299,7 +298,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
 
     #validate and tear apart the command
     fail(_("Invalid command: %{cmd}") % { cmd: cmd_array.join(" ") }) if cmd_array.length < 3
-    cmd = cmd_array.shift
+    _ = cmd_array.shift
     path = cmd_array.shift
 
     # Need to break apart the clause

--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -6,8 +6,6 @@ class Puppet::Provider::Exec < Puppet::Provider
 
   def run(command, check = false)
     output = nil
-    status = nil
-    dir = nil
     sensitive = resource.parameters[:command].sensitive
 
     checkexe(command)

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -430,7 +430,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
         cmd = [:dseditgroup, "-o", "edit", "-n", ".", "-d", member, @resource[:name]]
         begin
           execute(cmd)
-        rescue Puppet::ExecutionFailure => detail
+        rescue Puppet::ExecutionFailure
           # TODO: We're falling back to removing the member using dscl due to rdar://8481241
           # This bug causes dseditgroup to fail to remove a member if that member doesn't exist
           cmd = [:dscl, ".", "-delete", "/Groups/#{@resource.name}", "GroupMembership", member]

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -401,10 +401,10 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       next if property == :ensure
       value = @resource.should(property)
       if property == :gid and value.nil?
-        value = self.class.next_system_id(id_type='gid')
+        value = self.class.next_system_id('gid')
       end
       if property == :uid and value.nil?
-        value = self.class.next_system_id(id_type='uid')
+        value = self.class.next_system_id('uid')
       end
       if value != "" and not value.nil?
         if property == :members

--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -98,7 +98,6 @@ Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Packag
   end
 
   def install
-    source = nil
     unless source = @resource[:source]
       self.fail _("Mac OS X PKG DMGs must specify a package source.")
     end

--- a/lib/puppet/provider/package/apple.rb
+++ b/lib/puppet/provider/package/apple.rb
@@ -37,7 +37,6 @@ Puppet::Type.type(:package).provide :apple, :parent => Puppet::Provider::Package
   end
 
   def install
-    source = nil
     unless source = @resource[:source]
       self.fail _("Mac OS X packages must specify a package source")
     end

--- a/lib/puppet/provider/package/macports.rb
+++ b/lib/puppet/provider/package/macports.rb
@@ -61,9 +61,9 @@ Puppet::Type.type(:package).provide :macports, :parent => Puppet::Provider::Pack
   def install
     should = @resource.should(:ensure)
     if [:latest, :installed, :present].include?(should)
-      output = port("-q", :install, @resource[:name])
+      port("-q", :install, @resource[:name])
     else
-      output = port("-q", :install, @resource[:name], "@#{should}")
+      port("-q", :install, @resource[:name], "@#{should}")
     end
     # MacPorts now correctly exits non-zero with appropriate errors in
     # situations where a port cannot be found or installed.

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -140,7 +140,6 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
   end
 
   def install
-    source = nil
     unless source = @resource[:source]
       raise Puppet::Error.new(_("Mac OS X PKG DMGs must specify a package source."))
     end

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -109,7 +109,6 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     result_format = self.qatom_result_format
     result_fields = self.qatom_result_fields
     @atom ||= begin
-      search_output = nil
       package_info = {}
       # do the search
       search_output = qatom_bin *([@resource[:name], '--format', output_format])

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -126,7 +126,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
 
   def uninstall
     #extract version numbers and convert to integers
-    major, minor, patch = zypper_version.scan(/\d+/).map{ |x| x.to_i }
+    major, minor, _ = zypper_version.scan(/\d+/).map{ |x| x.to_i }
 
     if major < 1
       super
@@ -137,7 +137,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
       end
 
       options << @resource[:name]
-    	
+
       zypper *options
     end
 

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -426,7 +426,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
       day = 32 if day == 'last'
 
       integer_day = Integer(day)
-      self.fail "Day must be specified as an integer in the range 1-31, or as 'last'" unless integer_day = day.to_f and integer_day.between?(1,32)
+      self.fail "Day must be specified as an integer in the range 1-31, or as 'last'" unless integer_day.between?(1,32)
 
       bitfield |= 1 << integer_day - 1
     end

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -308,7 +308,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
       trigger['type']['days_of_week'] = if puppet_trigger['day_of_week']
                                           bitfield_from_days_of_week(puppet_trigger['day_of_week'])
                                         else
-                                          scheduler_days_of_week.inject(0) {|day_flags,day| day_flags |= day}
+                                          scheduler_days_of_week.inject(0) {|day_flags,day| day_flags | day}
                                         end
     when 'monthly'
       trigger['type'] = {

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -72,6 +72,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     excludes += %w{cryptdisks-udev}
     excludes += %w{statd-mounting}
     excludes += %w{gssd-mounting}
+    excludes
   end
 
   # List all services of this type.

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -238,7 +238,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   # directly.
   def start
     return ucommand(:start) if resource[:start]
-    job_path, job_plist = plist_from_label(resource[:name])
+    job_path, _ = plist_from_label(resource[:name])
     did_enable_job = false
     cmds = []
     cmds << :launchctl << :load
@@ -261,7 +261,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
 
   def stop
     return ucommand(:stop) if resource[:stop]
-    job_path, job_plist = plist_from_label(resource[:name])
+    job_path, _ = plist_from_label(resource[:name])
     did_disable_job = false
     cmds = []
     cmds << :launchctl << :unload
@@ -297,7 +297,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
     job_plist_disabled = nil
     overrides_disabled = nil
 
-    job_path, job_plist = plist_from_label(resource[:name])
+    _, job_plist = plist_from_label(resource[:name])
     job_plist_disabled = job_plist["Disabled"] if job_plist.has_key?("Disabled")
 
     if FileTest.file?(self.class.launchd_overrides) and overrides = self.class.read_plist(self.class.launchd_overrides)

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -286,7 +286,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   def managed_attribute_keys(hash)
     managed_attributes ||= @resource.original_parameters[:attributes] || hash.keys.map{|k| k.to_s}
     managed_attributes = [managed_attributes] unless managed_attributes.is_a?(Array)
-    managed_attributes.map {|attr| key, value = attr.split("="); key.strip.to_sym}
+    managed_attributes.map {|attr| key, _ = attr.split("="); key.strip.to_sym}
   end
 
   def should_include?(key, managed_keys)

--- a/lib/puppet/provider/user/openbsd.rb
+++ b/lib/puppet/provider/user/openbsd.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:user).provide :openbsd, :parent => :useradd do
           # sp_loginclass field.
           begin
             return unmunge(shadow_property, ent.send(method))
-          rescue => detail
+          rescue
             Puppet.warning "ruby-shadow doesn't support #{method}"
           end
         end

--- a/lib/puppet/provider/user/pw.rb
+++ b/lib/puppet/provider/user/pw.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::
   # use pw to update password hash
   def password=(cryptopw)
     Puppet.debug "change password for user '#{@resource[:name]}' method called with hash '#{cryptopw}'"
-    stdin, stdout, stderr = Open3.popen3("pw user mod #{@resource[:name]} -H 0")
+    stdin, _, _ = Open3.popen3("pw user mod #{@resource[:name]} -H 0")
     stdin.puts(cryptopw)
     stdin.close
     Puppet.debug "finished password for user '#{@resource[:name]}' method called with hash '#{cryptopw}'"

--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -76,8 +76,8 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
     # Use directories in reposdir if they are set instead of default
     if reposdir
       # Follow the code from the yum/config.py
-      dirs = reposdir.gsub!("\n", ' ')
-      dirs = reposdir.gsub!(',', ' ')
+      reposdir.gsub!("\n", ' ')
+      reposdir.gsub!(',', ' ')
       dirs = reposdir.split
     end
     dirs.select! { |dir| Puppet::FileSystem.exist?(dir) }
@@ -202,8 +202,6 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
   # @return [void]
   def create
     @property_hash[:ensure] = :present
-
-    new_section = current_section
 
     # We fetch a list of properties from the type, then iterate
     # over them, avoiding ensure.  We're relying on .should to

--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
 
   def self.instances
     zfs(:list, '-H').split("\n").collect do |line|
-      name,used,avail,refer,mountpoint = line.split(/\s+/)
+      name, _used, _avail, _refer, _mountpoint = line.split(/\s+/)
       new({:name => name, :ensure => :present})
     end
   end

--- a/lib/puppet/provider/zpool/zpool.rb
+++ b/lib/puppet/provider/zpool/zpool.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:zpool).provide(:zpool) do
   #NAME    SIZE  ALLOC   FREE    CAP  HEALTH  ALTROOT
   def self.instances
     zpool(:list, '-H').split("\n").collect do |line|
-      name, size, alloc, free, cap, health, altroot = line.split(/\s+/)
+      name, _size, _alloc, _free, _cap, _health, _altroot = line.split(/\s+/)
       new({:name => name, :ensure => :present})
     end
   end

--- a/lib/puppet/reference/type.rb
+++ b/lib/puppet/reference/type.rb
@@ -79,7 +79,6 @@ Puppet::Util::Reference.newreference :type, :doc => "All Puppet resource types a
 
       raise _("Could not retrieve property %{sname} on type %{type_name}") % { sname: sname, type_name: type.name } unless property
 
-      doc = nil
       unless doc = property.doc
         $stderr.puts _("No docs for %{type}[%{sname}]") % { type: type, sname: sname }
         next

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -255,7 +255,6 @@ class Puppet::Resource
           "Did you mean (#{(type[:type] || type["type"]).inspect}, #{(type[:title] || type["title"]).inspect }) ?"
       end
 
-      environment = attributes[:environment]
       # In order to avoid an expensive search of 'known_resource_types" and
       # to obey/preserve the implementation of the resource's type - if the
       # given type is a resource type implementation (one of):
@@ -277,7 +276,7 @@ class Puppet::Resource
       end
       @exported = false
 
-      # Set things like strictness first.
+      # Set things like environment, strictness first.
       attributes.each do |attr, value|
         next if attr == :parameters
         send(attr.to_s + "=", value)

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -144,7 +144,6 @@ module Puppet
       # Puppet::Transaction::Event failure with the given message.
       # @param message [String] the reason for a status failure
       def fail_with_event(message)
-        failed = true
         add_event(@real_resource.event(:name => :resource_error, :status => "failure", :message => message))
       end
 

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -442,9 +442,9 @@ class Puppet::Resource::Type
   def convert_from_ast(name)
     value = name.value
     if value.is_a?(Puppet::Parser::AST::Regex)
-      name = value.value
+      value.value
     else
-      name = value
+      value
     end
   end
 
@@ -476,7 +476,7 @@ class Puppet::Resource::Type
       # Note we're doing something somewhat weird here -- we're setting
       # the class's namespace to its fully qualified name.  This means
       # anything inside that class starts looking in that namespace first.
-      @namespace, ignored_shortname = @type == :hostclass ? [@name, ''] : namesplit(@name)
+      @namespace, _ = @type == :hostclass ? [@name, ''] : namesplit(@name)
     end
   end
 

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -58,7 +58,7 @@ class Puppet::Resource::TypeCollection
 
   def add(instance)
     # return a merged instance, or the given
-    result = catch(:merged) {
+    catch(:merged) {
       send("add_#{instance.type}", instance)
       instance.resource_type_collection = self
       instance

--- a/lib/puppet/settings/environment_conf.rb
+++ b/lib/puppet/settings/environment_conf.rb
@@ -22,7 +22,6 @@ class Puppet::Settings::EnvironmentConf
   def self.load_from(path_to_env, global_module_path)
     path_to_env = File.expand_path(path_to_env)
     conf_file = File.join(path_to_env, 'environment.conf')
-    config = nil
 
     begin
       config = Puppet.settings.parse_file(conf_file)

--- a/lib/puppet/syntax_checkers/base64.rb
+++ b/lib/puppet/syntax_checkers/base64.rb
@@ -23,7 +23,7 @@ class Puppet::SyntaxCheckers::Base64 < Puppet::Plugins::SyntaxCheckers::SyntaxCh
       # Do a strict decode64 on text with all whitespace stripped since the non strict version
       # simply skips all non base64 characters
       Base64.strict_decode64(cleaned_text)
-    rescue => e
+    rescue
       msg = if (cleaned_text.bytes.to_a.size * 8) % 6 != 0
               _("Base64 syntax checker: Cannot parse invalid Base64 string - padding is not correct")
             else

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1336,9 +1336,9 @@ class Type
 
     def properties_to_audit(list)
       if !list.kind_of?(Array) && list.to_sym == :all
-        list = all_properties
+        all_properties
       else
-        list = Array(list).collect { |p| p.to_sym }
+        Array(list).collect { |p| p.to_sym }
       end
     end
   end

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -828,11 +828,11 @@ Puppet::Type.newtype(:file) do
 
     @stat = begin
       Puppet::FileSystem.send(method, self[:path])
-    rescue Errno::ENOENT => error
+    rescue Errno::ENOENT
       nil
-    rescue Errno::ENOTDIR => error
+    rescue Errno::ENOTDIR
       nil
-    rescue Errno::EACCES => error
+    rescue Errno::EACCES
       warning _("Could not stat; permission denied")
       nil
     end

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -326,10 +326,10 @@ Puppet::Type.newtype(:tidy) do
   def stat(path)
     begin
       Puppet::FileSystem.lstat(path)
-    rescue Errno::ENOENT => error
+    rescue Errno::ENOENT
       info _("File does not exist")
       return nil
-    rescue Errno::EACCES => error
+    rescue Errno::EACCES
       #TRANSLATORS "stat" is a program name and should not be translated
       warning _("Could not stat; permission denied")
       return nil

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -767,7 +767,7 @@ module Puppet
         # the name is stored in the 4th capture of the regex
         name = $4
         if name.empty?
-          key = $3.delete("\n")
+          $3.delete("\n")
           # If no comment is specified for this key, generate a unique internal
           # name. This uses the same rules as
           # provider/ssh_authorized_key/parsed (PUP-3357)

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -42,7 +42,7 @@ class Puppet::Util::FileType
           else
             return ""
           end
-        rescue Puppet::Error => detail
+        rescue Puppet::Error
           raise
         rescue => detail
           message = _("%{klass} could not read %{path}: %{detail}") % { klass: self.class, path: @path, detail: detail }
@@ -58,7 +58,7 @@ class Puppet::Util::FileType
           val = real_write(text)
           @synced = Time.now
           return val
-        rescue Puppet::Error => detail
+        rescue Puppet::Error
           raise
         rescue => detail
           message = _("%{klass} could not write %{path}: %{detail}") % { klass: self.class, path: @path, detail: detail }

--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -36,7 +36,7 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
     file_contents = super
     return nil if file_contents.nil? or file_contents.empty?
     JSON.parse(file_contents)
-  rescue JSON::ParserError => e
+  rescue JSON::ParserError
     Puppet.warning _("Unable to read lockfile data from %{path}: not in JSON") % { path: @file_path }
     nil
   end

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -124,7 +124,7 @@ class Puppet::Util::Log
       return
     end
 
-    name, type = @desttypes.find do |name, klass|
+    _, type = @desttypes.find do |name, klass|
       klass.match?(dest)
     end
 

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -125,7 +125,6 @@ Puppet::Util::Log.newdesttype :logstash_event do
     # logstash_event format is documented at
     # https://logstash.jira.com/browse/LOGSTASH-675
 
-    data = {}
     data = msg.to_hash
     data['version'] = 1
     data['@timestamp'] = data['time']

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -69,7 +69,7 @@ if Puppet::Util::Platform.windows?
         Puppet::Util::Windows::RootCerts.instance.to_a.uniq { |cert| cert.to_der }.each do |x509|
           begin
             add_cert(x509)
-          rescue OpenSSL::X509::StoreError => e
+          rescue OpenSSL::X509::StoreError
             warn "Failed to add #{x509.subject.to_s}"
           end
         end

--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -67,10 +67,10 @@ class Puppet::Util::NetworkDevice::Config
           count += 1
         }
       }
-    rescue Errno::EACCES => detail
+    rescue Errno::EACCES
       Puppet.err _("Configuration error: Cannot read %{file}; cannot serve") % { file: @file }
       #raise Puppet::Error, "Cannot read #{@config}"
-    rescue Errno::ENOENT => detail
+    rescue Errno::ENOENT
       Puppet.err _("Configuration error: '%{file}' does not exit; cannot serve") % { file: @file }
     end
 

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -122,11 +122,11 @@ module Puppet::Util::Plist
 
     def to_format(format)
       if format.to_sym == :xml
-        plist_format = CFPropertyList::List::FORMAT_XML
+        CFPropertyList::List::FORMAT_XML
       elsif format.to_sym == :binary
-        plist_format = CFPropertyList::List::FORMAT_BINARY
+        CFPropertyList::List::FORMAT_BINARY
       elsif format.to_sym == :plain
-        plist_format = CFPropertyList::List::FORMAT_PLAIN
+        CFPropertyList::List::FORMAT_PLAIN
       else
         raise FormatError.new "Unknown plist format #{format}"
       end

--- a/lib/puppet/util/rdoc/generators/puppet_generator.rb
+++ b/lib/puppet/util/rdoc/generators/puppet_generator.rb
@@ -896,7 +896,7 @@ module Generators
 
     def find_symbol(symbol, method=nil)
       res = @context.parent.find_symbol(symbol, method)
-      res &&= res.viewer
+      res && res.viewer
     end
 
   end

--- a/lib/puppet/util/rdoc/parser/puppet_parser_rdoc2.rb
+++ b/lib/puppet/util/rdoc/parser/puppet_parser_rdoc2.rb
@@ -8,7 +8,7 @@ module RDoc
     include PuppetParserCore
 
     def create_rdoc_preprocess
-      preprocess = Markup::PreProcess.new(@input_file_name, @options.rdoc_include)
+      Markup::PreProcess.new(@input_file_name, @options.rdoc_include)
     end
   end
 end

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -44,7 +44,7 @@ module Puppet::Util::Windows
       index = 0
       subkey = nil
 
-      subkey_max_len, value_max_len = reg_query_info_key_max_lengths(key)
+      subkey_max_len, _ = reg_query_info_key_max_lengths(key)
 
       begin
         subkey, filetime = reg_enum_key(key, index, subkey_max_len)
@@ -69,7 +69,7 @@ module Puppet::Util::Windows
       index = 0
       subkey = nil
 
-      subkey_max_len, value_max_len = reg_query_info_key_max_lengths(key)
+      _, value_max_len = reg_query_info_key_max_lengths(key)
 
       begin
         subkey, type, data = reg_enum_value(key, index, value_max_len)

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -71,7 +71,6 @@ module Puppet::Util::Windows
       raw_sid_bytes = nil
       begin
         string_to_sid_ptr(name) do |sid_ptr|
-          valid = ! sid_ptr.nil? && ! sid_ptr.null?
           raw_sid_bytes = sid_ptr.read_array_of_uchar(get_length_sid(sid_ptr))
         end
       rescue
@@ -105,7 +104,6 @@ module Puppet::Util::Windows
       sid_bytes = []
       begin
         string_to_sid_ptr(value) do |ptr|
-          valid = ! ptr.nil? && ! ptr.null?
           sid_bytes = ptr.read_array_of_uchar(get_length_sid(ptr))
         end
       rescue Puppet::Util::Windows::Error => e

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -826,7 +826,7 @@ module Pal
             end
           end
 
-        rescue Puppet::ParseErrorWithIssue, Puppet::Error => detail
+        rescue Puppet::ParseErrorWithIssue, Puppet::Error
           # already logged and handled by the compiler for these two cases
           raise
 


### PR DESCRIPTION
This resolves a number of errors detected with the UselessAssignment rubocop check. Important to note ruby's assignment behavior: https://docs.ruby-lang.org/en/2.0.0/syntax/assignment_rdoc.html

>When using method assignment you must always have a receiver. If you do not have a receiver Ruby assumes you are assigning to a local variable.

So if you're calling the accessor within the class, you must use `self.foo = ...` or reference the instance variable directly `@foo = ...`. Whereas `foo = ...` creates a useless assignment and doesn't do what you'd expect.