### PR TITLE
(PUP-8235) Shorten paths to file in module in Scope.to_s

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -884,11 +884,12 @@ class Puppet::Parser::Scope
     path = detail[0]
     env_path = nil
     env_path = environment.configuration.path_to_env unless (environment.nil? || environment.configuration.nil?)
-    if env_path && path && path.start_with?(env_path)
+    # check module paths first since they may be in the environment (i.e. they are longer)
+    if module_path = environment.full_modulepath.detect {|m_path| path.start_with?(m_path) }
+      path = "<module>" + path[module_path.length..-1]
+    elsif env_path && path && path.start_with?(env_path)
       path = "<env>" + path[env_path.length..-1]
     end
-    # TODO: also shorten module paths to <module>/name/...
-
     # Make the output appear as "Scope(path, line)"
     "Scope(#{[path, detail[1]].join(', ')})" 
   end

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -42,6 +42,25 @@ describe Puppet::Parser::Scope do
     expect(@scope.inspect).to eq("Scope(foo::bar)")
   end
 
+  it "should generate a path if there is one on the puppet stack" do
+    result = Puppet::Pops::PuppetStack.stack('/tmp/kansas.pp', 42, @scope, 'inspect', [])
+    expect(result).to eq("Scope(/tmp/kansas.pp, 42)")
+  end
+
+  it "should generate an <env> shortened path if path points into the environment" do
+    env_path = @scope.environment.configuration.path_to_env
+    mocked_path = File.join(env_path, 'oz.pp')
+    result = Puppet::Pops::PuppetStack.stack(mocked_path, 42, @scope, 'inspect', [])
+
+    expect(result).to eq("Scope(<env>/oz.pp, 42)")
+  end
+
+  it "should generate a <module> shortened path if path points into a module" do
+    mocked_path = File.join(@scope.environment.full_modulepath[0], 'mymodule', 'oz.pp')
+    result = Puppet::Pops::PuppetStack.stack(mocked_path, 42, @scope, 'inspect', [])
+    expect(result).to eq("Scope(<module>/mymodule/oz.pp, 42)")
+  end
+
   it "should return a scope for use in a test harness" do
     expect(create_test_scope_for_node("node_name_foo")).to be_a_kind_of(Puppet::Parser::Scope)
   end


### PR DESCRIPTION
This fixes a TODO for shortening the path to a module when Scope.to_s
does not have a resource and the path on top of the puppet stack is to a
.pp file in a module.

Earlier only paths into the environment got this treatment and paths to
files in modules were output in full.