### PR TITLE
(PUP-8262) Revert changes which made non-existent SMF services return :absent instead of :stopped

### DIFF
--- a/acceptance/tests/resource/service/smf_should_be_idempotent.rb
+++ b/acceptance/tests/resource/service/smf_should_be_idempotent.rb
@@ -1,4 +1,4 @@
-test_name "SMF: basic tests"
+test_name "SMF: should be idempotent"
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'
@@ -15,26 +15,19 @@ end
 agents.each do |agent|
   clean agent, :service => 'tstapp'
   manifest, method = setup agent, :service => 'tstapp'
-  step "SMF: clean slate"
-  apply_manifest_on(agent, 'service {tstapp : ensure=>stopped}') do
-    assert_match( /.*/, result.stdout, "err: #{agent}")
-  end
 
-  step "SMF: ensure it is created with a manifest"
+  step "SMF: ensre it is created with a manifest"
   apply_manifest_on(agent, 'service {tstapp : ensure=>running, manifest=>"%s"}' % manifest) do
     assert_match( / ensure changed 'stopped'.* to 'running'/, result.stdout, "err: #{agent}")
-  end
-  step "SMF: verify it with puppet"
-  on(agent, puppet("resource service tstapp")) do
-    assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
   end
 
   step "SMF: verify with svcs that the service is online"
   on agent, "svcs -l application/tstapp" do
     assert_match( /state\s+online/, result.stdout, "err: #{agent}")
   end
-  step "SMF: stop the service"
-  apply_manifest_on(agent, 'service {tstapp : ensure=>stopped}') do
-    assert_match( /changed 'running'.* to 'stopped'/, result.stdout, "err: #{agent}")
+
+  step "SMF: ensre it is not created again"
+  apply_manifest_on(agent, 'service {tstapp : ensure=>running, manifest=>"%s"}' % manifest) do
+    assert_no_match( /changed/, result.stdout, "err: #{agent}")
   end
 end

--- a/acceptance/tests/resource/service/smf_should_create.rb
+++ b/acceptance/tests/resource/service/smf_should_create.rb
@@ -1,4 +1,4 @@
-test_name "SMF: basic tests"
+test_name "SMF: should create a service given a manifest"
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'
@@ -13,28 +13,14 @@ end
 
 
 agents.each do |agent|
-  clean agent, :service => 'tstapp'
   manifest, method = setup agent, :service => 'tstapp'
-  step "SMF: clean slate"
-  apply_manifest_on(agent, 'service {tstapp : ensure=>stopped}') do
-    assert_match( /.*/, result.stdout, "err: #{agent}")
-  end
-
   step "SMF: ensure it is created with a manifest"
   apply_manifest_on(agent, 'service {tstapp : ensure=>running, manifest=>"%s"}' % manifest) do
     assert_match( / ensure changed 'stopped'.* to 'running'/, result.stdout, "err: #{agent}")
-  end
-  step "SMF: verify it with puppet"
-  on(agent, puppet("resource service tstapp")) do
-    assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
   end
 
   step "SMF: verify with svcs that the service is online"
   on agent, "svcs -l application/tstapp" do
     assert_match( /state\s+online/, result.stdout, "err: #{agent}")
-  end
-  step "SMF: stop the service"
-  apply_manifest_on(agent, 'service {tstapp : ensure=>stopped}') do
-    assert_match( /changed 'running'.* to 'stopped'/, result.stdout, "err: #{agent}")
   end
 end

--- a/acceptance/tests/resource/service/smf_should_query.rb
+++ b/acceptance/tests/resource/service/smf_should_query.rb
@@ -1,0 +1,29 @@
+test_name "SMF: should query instances"
+confine :to, :platform => 'solaris'
+
+require 'puppet/acceptance/solaris_util'
+extend Puppet::Acceptance::SMFUtils
+
+teardown do
+  step "SMF: cleanup"
+  agents.each do |agent|
+    clean agent, :service => 'tstapp'
+  end
+end
+
+
+agents.each do |agent|
+  manifest, method = setup agent, :service => 'tstapp'
+  step "SMF: ensre it is created with a manifest"
+  apply_manifest_on(agent, 'service {tstapp : ensure=>running, manifest=>"%s"}' % manifest) do
+    assert_match( / ensure changed 'stopped'.* to 'running'/, result.stdout, "err: #{agent}")
+  end
+  step "SMF: query the resource"
+  on(agent, puppet("resource service tstapp")) do
+    assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
+  end
+  step "SMF: query all the instances"
+  on(agent, puppet("resource service")) do
+    assert_match( /tstapp/, result.stdout, "err: #{agent}")
+  end
+end

--- a/acceptance/tests/resource/service/smf_should_stop.rb
+++ b/acceptance/tests/resource/service/smf_should_stop.rb
@@ -1,4 +1,4 @@
-test_name "SMF: basic tests"
+test_name "SMF: should stop a given service"
 confine :to, :platform => 'solaris'
 
 require 'puppet/acceptance/solaris_util'
@@ -13,28 +13,19 @@ end
 
 
 agents.each do |agent|
-  clean agent, :service => 'tstapp'
   manifest, method = setup agent, :service => 'tstapp'
-  step "SMF: clean slate"
-  apply_manifest_on(agent, 'service {tstapp : ensure=>stopped}') do
-    assert_match( /.*/, result.stdout, "err: #{agent}")
-  end
-
-  step "SMF: ensure it is created with a manifest"
+  step "SMF: ensre it is created with a manifest"
   apply_manifest_on(agent, 'service {tstapp : ensure=>running, manifest=>"%s"}' % manifest) do
     assert_match( / ensure changed 'stopped'.* to 'running'/, result.stdout, "err: #{agent}")
   end
-  step "SMF: verify it with puppet"
-  on(agent, puppet("resource service tstapp")) do
-    assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
-  end
 
-  step "SMF: verify with svcs that the service is online"
-  on agent, "svcs -l application/tstapp" do
-    assert_match( /state\s+online/, result.stdout, "err: #{agent}")
-  end
   step "SMF: stop the service"
   apply_manifest_on(agent, 'service {tstapp : ensure=>stopped}') do
     assert_match( /changed 'running'.* to 'stopped'/, result.stdout, "err: #{agent}")
+  end
+
+  step "SMF: verify with svcs that the service is not online"
+  on agent, "svcs -l application/tstapp", :acceptable_exit_codes => [0,1] do
+    assert_no_match( /state\s+online/, result.stdout, "err: #{agent}")
   end
 end

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -107,8 +107,6 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
   end
 
   def stop
-    # Don't try to stop non-existing services (PUP-8167)
-    return if self.status == :absent
     # Wait for the service to actually stop before returning.
     super
     self.wait('offline', 'disabled', 'uninitialized')
@@ -137,8 +135,8 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
       states = service_states
       state = states[1] == "-" ? states[0] : states[1]
     rescue Puppet::ExecutionFailure
-      debug "Could not get status on service #{self.name} #{$!}"
-      return :absent
+      info "Could not get status on service #{self.name}"
+      return :stopped
     end
 
     case state

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -18,8 +18,6 @@ describe provider_class, :if => Puppet.features.posix? do
 
     FileTest.stubs(:file?).with('/usr/sbin/svcadm').returns true
     FileTest.stubs(:executable?).with('/usr/sbin/svcadm').returns true
-    FileTest.stubs(:file?).with('/usr/sbin/svccfg').returns true
-    FileTest.stubs(:executable?).with('/usr/sbin/svccfg').returns true
     FileTest.stubs(:file?).with('/usr/bin/svcs').returns true
     FileTest.stubs(:executable?).with('/usr/bin/svcs').returns true
     Facter.stubs(:value).with(:operatingsystem).returns('Solaris')
@@ -76,9 +74,9 @@ describe provider_class, :if => Puppet.features.posix? do
       @provider.expects(:svcs).with('-H', '-o', 'state,nstate', "/system/myservice").returns("online\t-")
       @provider.status
     end
-    it "should return absent if svcs can't find the service" do
+    it "should return stopped if svcs can't find the service" do
       @provider.stubs(:svcs).raises(Puppet::ExecutionFailure.new("no svc found"))
-      expect(@provider.status).to eq(:absent)
+      expect(@provider.status).to eq(:stopped)
     end
     it "should return running if online in svcs output" do
       @provider.stubs(:svcs).returns("online\t-")
@@ -166,14 +164,12 @@ describe provider_class, :if => Puppet.features.posix? do
 
   describe "when stopping" do
     it "should execute external command 'svcadm disable /system/myservice'" do
-      @provider.stubs(:status).returns :running
       @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, '-s', "/system/myservice"], true)
       @provider.expects(:wait).with('offline', 'disabled', 'uninitialized')
       @provider.stop
     end
 
     it "should error if timeout occurs while stopping the service" do
-      @provider.stubs(:status).returns :running
       @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, '-s', "/system/myservice"], true)
       Timeout.expects(:timeout).with(60).raises(Timeout::Error)
       expect { @provider.stop }.to raise_error Puppet::Error, ('Timed out waiting for /system/myservice to transition states')


### PR DESCRIPTION
The changes made as a result of PUP-6860 and PUP-6797 made non-existent services from the SMF (Solaris service) provider return a state of :absent instead of :stopped. This diverts from what pretty much all of our other service providers do. Customers in the field are reporting PE upgrade errors due to this changed behavior (See PE-22951). 

I'll also note that after Moses made these changes to address PUP-6797, his thinking appears to have evolved, because he later made changes to the AIX service provider that again ensured that non-existent services report :stopped. See:

https://github.com/puppetlabs/puppet/pull/5632

For these reasons I think reverting the commits related to PUP-6860 and PUP-6797 is the way to address the problems customers are having upgrading agents on Solaris.