### PR TITLE
(docs) Reword description to clarify truncated text

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -400,10 +400,9 @@ module Puppet
     end
 
     newproperty(:expiry, :required_features => :manages_expiry) do
-      desc "The expiry date for this user. Must be provided in
-           a zero-padded YYYY-MM-DD format --- e.g. 2010-02-19.
-           If you want to ensure the user account never expires,
-           you can pass the special value `absent`."
+      desc "The expiry date for this user. Provide as either the special
+           value `absent` to ensure that the account never expires, or as
+           a zero-padded YYYY-MM-DD format -- for example, 2010-02-19."
 
       newvalues :absent
       newvalues /^\d{4}-\d{2}-\d{2}$/


### PR DESCRIPTION
If you read the docs page describing the user resource, the summary for
the `expiry` parameter says `The expiry date for this user. Must be
provided...`, which might lead a user to believe that the parameter is
required.

This rewords the description so that the truncated version is clearly
not implying a required parameter.

I think there's a high chance that PUP-7663 originated as the user
mistakingly believing that they had to provide a value. (it's also
possible that they've specified defaults in `login.defs` and are trying
to override it for a specific user account.)