### PR TITLE
(maint)(PUP-5206) Update spec test so it fails on code before this update.

### DIFF
--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -94,6 +94,7 @@ describe Puppet::Application::Filebucket do
 
       it "should create a client with the default bucket if none passed" do
         Puppet[:clientbucketdir] = path
+        Puppet[:bucketdir] = path + "2"
 
         Puppet::FileBucket::Dipper.expects(:new).with { |h| h[:Path] == path }
 


### PR DESCRIPTION
Spec test did not fail when code change was reverted.
With this spec test update, the code fails before and passes after this update.
