### PR TITLE
(DOC-3310) Fix and expand splay docs.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1591,23 +1591,33 @@ EOT
     :splaylimit => {
       :default    => "$runinterval",
       :type       => :duration,
-      :desc       => "The maximum time to delay before runs.  Defaults to being the same as the
-        run interval. #{AS_DURATION}",
+      :desc       => "The maximum time to delay before an agent's first run when
+        `splay` is enabled. Defaults to the agent's `$runinterval`. The
+        `splay` interval is random and recalculated each time the agent is started or
+        restarted. #{AS_DURATION}",
     },
     :splay => {
       :default    => false,
       :type       => :boolean,
-      :desc       => "Whether to sleep for a pseudo-random (but consistent) amount of time before
-        a run.
+      :desc       => "Whether to sleep for a random amount of time, ranging from
+        immediately up to its `$splaylimit`, before performing its first agent run
+        after a service restart. After this period, the agent runs periodically
+        on its `$runinterval`.
 
-        For example, without `splay` enabled, your agent checks in every 30
-        minutes at :01 and :31 past the hour. After enabling `splay`, the agent
-        will wait the pseudorandom sleep time, say eight minutes, and then check
-        in every 30 minutes, at :09 and :39 after the hour. If you restart the
-        same agent at 12:45 PM, it will wait its eight minutes, and check in at
-        12:52 PM, and every 30 minutes after that, at 1:22 PM, 1:52 PM, and so
-        on. Other agents will have different sleep times, and so will check in
-        at different times even if they are all restarted at the same time.",
+        For example, assume a default 30-minute `$runinterval`, `splay` set to its
+        default of `false`, and an agent starting at :00 past the hour. The agent
+        would check in every 30 minutes at :01 and :31 past the hour.
+
+        With `splay` enabled, it waits any amount of time up to its `$splaylimit`
+        before its first run. For example, it might randomly wait 8 minutes,
+        then start its first run at :08 past the hour. With the `$runinterval`
+        at its default 30 minutes, its next run will be at :38 past the hour.
+
+        If you restart an agent's puppet service with `splay` enabled, it
+        recalculates its splay period and delays its first agent run after
+        restarting for this new period. If you simultaneously restart a group of
+        puppet agents with `splay` enabled, their checkins to your puppet masters
+        can be distributed more evenly.",
     },
     :clientbucketdir => {
       :default  => "$vardir/clientbucket",

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -48,7 +48,7 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
 end
 
 config.header = <<EOT
-## Configuration Settings
+## Configuration settings
 
 * Each of these settings can be specified in `puppet.conf` or on the
   command line.
@@ -67,6 +67,8 @@ config.header = <<EOT
   combined with other units, and defaults to seconds when omitted. Examples are
   '3600' which is equivalent to '1h' (one hour), and '1825d' which is equivalent
   to '5y' (5 years).
+* If you use the `splay` setting, note that the period that it waits changes
+  each time the Puppet agent is restarted.
 * Settings that take a single file or directory can optionally set the owner,
   group, and mode for their value: `rundir = $vardir/run { owner = puppet,
   group = puppet, mode = 644 }`
@@ -75,7 +77,7 @@ config.header = <<EOT
 
 See the [configuration guide][confguide] for more details.
 
-[confguide]: https://docs.puppetlabs.com/puppet/latest/reference/config_about_settings.html
+[confguide]: https://puppet.com/docs/puppet/latest/config_about_settings.html
 
 * * *
 


### PR DESCRIPTION
- Removes language suggesting splay period is consistent across agent restarts.
- Adds example of how splay works.
- Adds a bullet point noting that splay doesn't persist across restarts.