### PR TITLE
(maint) Remove AppVeyor OpenSSL update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,16 +49,6 @@ test_script:
       # list current OpenSSL install
       gem list openssl
       ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
-      if ( $(ruby --version) -match "^ruby\s+2\.4" ) {
-        # AppVeyor appears to have OpenSSL headers available already
-        # which msys2 would normally install with:
-        # pacman -S mingw-w64-x86_64-openssl --noconfirm
-        Write-Output "Building OpenSSL gem ~> 2.0.4 to fix Ruby 2.4 / AppVeyor issue"
-        gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc -- --with-openssl-dir=C:\msys64\mingw64 '2>&1'
-        # verify new installation
-        gem list openssl
-        ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
-      }
       bundle install --jobs 4 --retry 2 --without development extra
       Get-Content Gemfile.lock
       ruby -v


### PR DESCRIPTION
 - The fix in place here was temporary due to AppVeyor having available
   an older Ruby 2.4.x that shipped a buggy OpenSSL 2.0.3 with a race
   condition. Without the upgrade to at least OpenSSL 2.0.4, installing
   large gemsets would intermittently fail.

   * Original RubyInstaller discussion at:
   https://github.com/oneclick/rubyinstaller2/issues/68

   * Ruby bug is documented at https://bugs.ruby-lang.org/issues/11033

   * OpenSSL 2.0.4 contains the patch as of 8/8/2017
   https://github.com/ruby/ruby/commit/b08e0ade5baacbc7d4754e9f6afe8d09a3e00bc5#diff-51a5e2412fcf851e37d1883b1ae53de5

   * RubyInstaller 2.4.2-2 picked up the fix and was released 9/15/2017
   https://rubyinstaller.org/2017/09/15/rubyinstaller-2.4.2-2-released.html

   * AppVeyor issue was filed
   https://github.com/appveyor/ci/issues/1790

   AppVeyor began shipping updated Ruby in their 11/18/2017 release:
   https://github.com/appveyor/ci/issues/1892
   https://www.appveyor.com/updates/