### PR TITLE
(PUP-8271) Make loader discovery find 'init' for plans and tasks

### DIFF
--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -254,11 +254,15 @@ module LoaderPaths
       # Remove extension regardless of what it is. A task name cannot contain dots
       relative_path = relative_path.sub(/\.[^\/]*\z/, '')
 
-      relative_path.split('/').each do |segment|
-        n << '::' if n.size > 0
-        n << segment
+      if relative_path == 'init' && !(module_name.nil? || module_name.empty?)
+        TypedName.new(type, module_name, name_authority)
+      else
+        relative_path.split('/').each do |segment|
+          n << '::' if n.size > 0
+          n << segment
+        end
+        TypedName.new(type, n, name_authority)
       end
-      TypedName.new(type, n, name_authority)
     end
 
     def instantiator
@@ -315,6 +319,24 @@ module LoaderPaths
 
     def instantiator()
       Puppet::Pops::Loader::PuppetPlanInstantiator
+    end
+
+    def typed_name(type, name_authority, relative_path, module_name)
+      if relative_path == 'init.pp' && !(module_name.nil? || module_name.empty?)
+        TypedName.new(type, module_name, name_authority)
+      else
+        n = ''
+        n << module_name unless module_name.nil?
+        unless extension.empty?
+          # Remove extension
+          relative_path = relative_path[0..-(extension.length+1)]
+        end
+        relative_path.split('/').each do |segment|
+          n << '::' if n.size > 0
+          n << segment
+        end
+        TypedName.new(type, n, name_authority)
+      end
     end
   end
 

--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -265,6 +265,9 @@ describe 'The Loader' do
 
           let(:b_plans) {
             {
+              'init.pp' => <<-PUPPET.unindent,
+                plan b() {}
+                PUPPET
               'aplan.pp' => <<-PUPPET.unindent,
                 plan b::aplan() {}
                 PUPPET
@@ -281,6 +284,13 @@ describe 'The Loader' do
 
           let(:b_tasks) {
             {
+              'init.json' => <<-JSON.unindent,
+                {
+                  "description": "test task b",
+                  "parameters": {}
+                }
+                JSON
+              'init.sh' => "# doing exactly nothing\n",
               'atask' => "# doing exactly nothing\n",
               'atask.json' => <<-JSON.unindent,
                 {
@@ -368,8 +378,8 @@ describe 'The Loader' do
             let(:tasks_feature) { true }
 
             it 'private loader finds plans in all modules' do
-              expect(loader.private_loader.discover(:plan) { |t| t.name =~ /^.::.*\z/ }).to(
-                contain_exactly(tn(:plan, 'a::aplan'), tn(:plan, 'b::aplan')))
+              expect(loader.private_loader.discover(:plan) { |t| t.name =~ /^.(?:::.*)?\z/ }).to(
+                contain_exactly(tn(:plan, 'b'), tn(:plan, 'a::aplan'), tn(:plan, 'b::aplan')))
             end
 
             it 'module loader finds plans only in itself' do
@@ -383,8 +393,8 @@ describe 'The Loader' do
             end
 
             it 'private loader finds tasks in all modules' do
-              expect(loader.private_loader.discover(:task) { |t| t.name =~ /^.::.*\z/ }).to(
-                contain_exactly(tn(:task, 'a::atask'), tn(:task, 'b::atask'), tn(:task, 'c::foo')))
+              expect(loader.private_loader.discover(:task) { |t| t.name =~ /^.(?:::.*)?\z/ }).to(
+                contain_exactly(tn(:task, 'a::atask'), tn(:task, 'b::atask'), tn(:task, 'b'), tn(:task, 'c::foo')))
             end
 
             it 'module loader finds types only in itself' do


### PR DESCRIPTION
Before this commit, the discovery mechanism would incorrectly consider a
file named plans/init.pp to denote a plan named `<module-name>::init`.
The same thing was true files under tasks with names starting with
'init'.

This commit ensures that the `SmartPath` used for Plans and Tasks is
aware of the 'init' semantics when producing the `TypedName` for the
actual Plan or Target, thus avoiding errors about a name mismatch when
the corresponding entity is loaded.