### PR TITLE
(PUP-8298) Add invalid task error

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -884,5 +884,9 @@ module Issues
   UNKNOWN_TASK = issue :UNKNOWN_TASK, :type_name do
     _('Task not found: %{type_name}') % { type_name: type_name }
   end
+
+  INVALID_TASK_NAME = issue :INVALID_TASK_NAME, :name do
+    _('%{name} is not a valid task name') % { name: name }
+  end
 end
 end


### PR DESCRIPTION
Adds invalid task name issue type so that when an invalid task name is called from a plan there's an appropriate error type and message for it.  Relates to BOLT-261.