### PR TITLE
(WIP) (MAINT) Test Travis bundler fail theory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 # TODO: Remove when Travis updates its default:
 #   https://github.com/travis-ci/travis-ci/issues/8357
 before_install:
-  - gem install bundler --version 1.15.4
 bundler_args: --without development extra
 script:
   - "bundle exec rake $CHECK"


### PR DESCRIPTION
As discussed in MODULES-6339, there are some ongoing problems
with Travis, bundler, and ruby versions. This commit is
an experiment to see what versions of bundler come with
which images and to determine whether or not we can remove
the update line or if we should pin to a particular version.