### PR TITLE
(PUP-8127) change the error location output to be translationable

### DIFF
--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -44,7 +44,7 @@ notice 42 =~ MyInteger
       tmp_manifest = get_test_file_path(agent, "#{app_type}_broken.pp")
       on(agent, puppet("parser validate #{tmp_manifest}"), :accept_all_exit_codes => true) do |result|
         assert_equal(result.exit_code, 1, 'parser validate did not exit with 1 upon parse failure')
-        expected = /Error: Could not parse for environment production: This Name has no effect\. A value was produced and then forgotten \(one or more preceding expressions may have the wrong form\) at .*_broken\.pp:1:1/
+        expected = /Error: Could not parse for environment production: This Name has no effect\. A value was produced and then forgotten \(one or more preceding expressions may have the wrong form\) \(file: .*_broken\.pp, line: 1, column: 1\)/
         assert_match(expected, result.output, "parser validate did not output correctly: '#{result.output}'. expected: '#{expected.to_s}'") unless agent['locale'] == 'ja'
       end
     end

--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -27,22 +27,12 @@ module Puppet
       @line = line
       @pos = pos
     end
+
     def to_s
       msg = super
       @file = nil if (@file.is_a?(String) && @file.empty?)
-      if @file and @line and @pos
-        "#{msg} at #{@file}:#{@line}:#{@pos}"
-      elsif @file and @line
-        "#{msg} at #{@file}:#{@line}"
-      elsif @line and @pos
-          "#{msg} at line #{@line}:#{@pos}"
-      elsif @line
-        "#{msg} at line #{@line}"
-      elsif @file
-        "#{msg} in #{@file}"
-      else
-        msg
-      end
+      msg += Puppet::Util::Errors.error_location_with_space(@file, @line, @pos)
+      msg
     end
   end
 

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -591,12 +591,12 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     return unless existing_resource = @resource_table[title_key]
 
     # If we've gotten this far, it's a real conflict
-    msg = "Duplicate declaration: #{resource.ref} is already declared"
-
-    msg << " in file #{existing_resource.file}:#{existing_resource.line}" if existing_resource.file and existing_resource.line
-
-    msg << "; cannot redeclare"
-
+    error_location_str = Puppet::Util::Errors.error_location(existing_resource.file, existing_resource.line)
+    msg = if error_location_str.empty?
+            _("Duplicate declaration: %{resource} is already declared; cannot redeclare") % { resource: resource.ref }
+          else
+            _("Duplicate declaration: %{resource} is already declared at %{error_location}; cannot redeclare") % { resource: resource.ref, error_location: error_location_str }
+          end
     raise DuplicateResourceError.new(msg, resource.file, resource.line)
   end
 

--- a/lib/puppet/util/errors.rb
+++ b/lib/puppet/util/errors.rb
@@ -31,20 +31,49 @@ module Puppet::Util::Errors
     error
   end
 
+
+
+  # Return a human-readable string of this object's file, line, and pos attributes,
+  # if set.
+  #
+  # @return [String] description of file, line, and pos
+  def self.error_location(file, line=nil, pos=nil)
+    file = nil if (file.is_a?(String) && file.empty?)
+    if file and line and pos
+      _("(file: %{file}, line: %{line}, column: %{column})") % { file: file, line: line, column: pos }
+    elsif file and line
+      _("(file: %{file}, line: %{line})") % { file: file, line: line }
+    elsif line and pos
+      _("(line: %{line}, column: %{column})") % { line: line, column: pos }
+    elsif line
+      _("(line: %{line})") % { line: line }
+    elsif file
+      _("(file: %{file})") % { file: file }
+    else
+      ''
+    end
+  end
+
+  # Return a human-readable string of this object's file, line, and pos attributes,
+  # with a proceeding space in the output
+  # if set.
+  #
+  # @return [String] description of file, line, and pos
+  def self.error_location_with_space(file, line=nil, pos=nil)
+    error_location_str = error_location(file, line, pos)
+    if error_location_str.empty?
+      ''
+    else
+      ' ' + error_location_str
+    end
+  end
+
   # Return a human-readable string of this object's file and line attributes,
   # if set.
   #
   # @return [String] description of file and line
   def error_context
-    if file and line
-      _(" at %{file}:%{line}") % { file: file, line: line }
-    elsif line
-      _(" at line %{line}") % { line: line }
-    elsif file
-      _(" in %{file}") % { file: file }
-    else
-      ""
-    end
+    Puppet::Util::Errors.error_location_with_space(file, line)
   end
 
   # Wrap a call in such a way that we always throw the right exception and keep

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -395,18 +395,8 @@ class Puppet::Util::Log
     # Issue based messages do not have details in the message. It
     # must be appended here
     unless issue_code.nil?
-      msg = _("Could not parse for environment %{env}: %{msg}") % { env: environment, msg: msg } unless environment.nil?
-      if file && line && pos
-        msg = _("%{msg} at %{file}:%{line}:%{pos}") % { msg: msg, file: file, line: line, pos: pos }
-      elsif file and line
-        msg = _("%{msg}  at %{file}:%{line}") % { msg: msg, file: file, line: line }
-      elsif line && pos
-        msg = _("%{msg}  at line %{line}:%{pos}") % { msg: msg, line: line, pos: pos }
-      elsif line
-        msg = _("%{msg}  at line %{line}") % { msg: msg, line: line }
-      elsif file
-        msg = _("%{msg}  in %{file}") % { msg: msg, file: file }
-      end
+      msg = _("Could not parse for environment %{environment}: %{msg}") % { environment: environment, msg: msg } unless environment.nil?
+      msg += Puppet::Util::Errors.error_location_with_space(file, line, pos)
       msg = _("%{msg} on node %{node}") % { msg: msg, node: node } unless node.nil?
       if @backtrace.is_a?(Array)
         msg += "\n"

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -342,13 +342,13 @@ describe 'collectors' do
           Puppet[:strict] = :warning
           expect_the_message_to_be(['given'], manifest)
           expect(warnings).to include(
-            /Attempt to override an already evaluated resource, defined at line 4, with new values at line 6/)
+            /Attempt to override an already evaluated resource, defined at \(line: 4\), with new values \(line: 6\)/)
         end
 
         it 'and --strict=error, it fails compilation' do
           Puppet[:strict] = :error
           expect { compile_to_catalog(manifest) }.to raise_error(
-            /Attempt to override an already evaluated resource, defined at line 4, with new values at line 6/)
+            /Attempt to override an already evaluated resource, defined at \(line: 4\), with new values \(line: 6\)/)
           expect(warnings).to be_empty
         end
       end

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -47,7 +47,7 @@ describe "Two step scoping for variables" do
           compile_to_catalog("$name = 'never in a 0xF4240 years'", enc_node)
         }.to raise_error(
           Puppet::Error,
-          /Cannot reassign built in \(or already assigned\) variable '\$name' at line 1(\:7)? on node the_node/
+          /Cannot reassign built in \(or already assigned\) variable '\$name' \(line: 1(, column: 7)?\) on node the_node/
         )
     end
 
@@ -58,7 +58,7 @@ describe "Two step scoping for variables" do
           compile_to_catalog("$title = 'never in a 0xF4240 years'", enc_node)
         }.to raise_error(
           Puppet::Error,
-          /Cannot reassign built in \(or already assigned\) variable '\$title' at line 1(\:8)? on node the_node/
+          /Cannot reassign built in \(or already assigned\) variable '\$title' \(line: 1(, column: 8)?\) on node the_node/
         )
     end
 
@@ -695,7 +695,7 @@ describe "Two step scoping for variables" do
         compile_to_catalog("$var = 'top scope'", enc_node)
       }.to raise_error(
         Puppet::Error,
-        /Cannot reassign variable '\$var' at line 1(\:6)? on node the_node/
+        /Cannot reassign variable '\$var' \(line: 1(, column: 6)?\) on node the_node/
       )
     end
 

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -147,7 +147,7 @@ describe Puppet::Face[:epp, :current] do
       dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
       template = File.join(dir, template_name)
       expect(eppface.dump(template, :validate => true)).to eq("")
-      expect(@logs.join).to match(/This Literal Integer has no effect.*\/template1.epp:1:4/)
+      expect(@logs.join).to match(/This Literal Integer has no effect.*\(file: .*\/template1\.epp, line: 1, column: 4\)/)
     end
 
     it "validated content by default" do
@@ -155,7 +155,7 @@ describe Puppet::Face[:epp, :current] do
       dir = dir_containing('templates', { template_name => "<% 1 2 3 %>" })
       template = File.join(dir, template_name)
       expect(eppface.dump(template)).to eq("")
-      expect(@logs.join).to match(/This Literal Integer has no effect.*\/template1.epp:1:4/)
+      expect(@logs.join).to match(/This Literal Integer has no effect.*\(file: .*\/template1\.epp, line: 1, column: 4\)/)
     end
 
     it "informs the user of files that don't exist" do

--- a/spec/unit/functions/break_spec.rb
+++ b/spec/unit/functions/break_spec.rb
@@ -117,7 +117,7 @@ describe 'the break function' do
           }
           include(does_break)
         CODE
-      end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+      end.to raise_error(/break\(\) from context where this is illegal \(file: unknown, line: 3\) on node.*/)
     end
 
     it 'does not provide early exit from a define' do
@@ -134,7 +134,7 @@ describe 'the break function' do
           }
             does_break { 'no_you_cannot': }
         CODE
-      end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+      end.to raise_error(/break\(\) from context where this is illegal \(file: unknown, line: 3\) on node.*/)
     end
 
     it 'can be called when nested in a function to make that function behave as a break' do
@@ -159,7 +159,7 @@ describe 'the break function' do
           $result = with(1) |$x| { with($x) |$x| {break() }}
           notice $result
         CODE
-      end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+      end.to raise_error(/break\(\) from context where this is illegal \(file: unknown, line: 3\) on node.*/)
     end
 
     it 'can not be called from top scope' do
@@ -169,7 +169,7 @@ describe 'the break function' do
           # line 2
           break()
         CODE
-      end.to raise_error(/break\(\) from context where this is illegal at unknown:3 on node.*/)
+      end.to raise_error(/break\(\) from context where this is illegal \(file: unknown, line: 3\) on node.*/)
     end
   end
 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -168,7 +168,7 @@ describe "The lookup function" do
           YAML
 
         it 'fails and reports error' do
-          expect { lookup('a') }.to raise_error("This runtime does not support hiera.yaml version 6 in #{code_dir}/hiera.yaml")
+          expect { lookup('a') }.to raise_error("This runtime does not support hiera.yaml version 6 (file: #{code_dir}/hiera.yaml)")
         end
       end
 
@@ -183,7 +183,7 @@ describe "The lookup function" do
 
         it 'fails and reports error' do
           expect { lookup('a') }.to raise_error(
-            "Backend 'yaml' is defined more than once. First defined at line 3 at #{code_dir}/hiera.yaml:5")
+            "Backend 'yaml' is defined more than once. First defined at line 3 (file: #{code_dir}/hiera.yaml, line: 5)")
         end
       end
 
@@ -194,7 +194,7 @@ describe "The lookup function" do
 
         it 'fails and reports error' do
           expect { lookup('a') }.to raise_error(
-            "hiera.yaml version 4 cannot be used in the global layer in #{code_dir}/hiera.yaml")
+            "hiera.yaml version 4 cannot be used in the global layer (file: #{code_dir}/hiera.yaml)")
         end
       end
 
@@ -213,7 +213,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect { lookup('a') }.to raise_error(
-              "Hierarchy name 'Common' defined more than once. First defined at line 3 at #{code_dir}/hiera.yaml:7")
+              "Hierarchy name 'Common' defined more than once. First defined at line 3 (file: #{code_dir}/hiera.yaml, line: 7)")
           end
         end
 
@@ -228,7 +228,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect { lookup('a') }.to raise_error(
-              "Use \"data_hash: hocon_data\" instead of \"hiera3_backend: hocon\" at #{code_dir}/hiera.yaml:4")
+              "Use \"data_hash: hocon_data\" instead of \"hiera3_backend: hocon\" (file: #{code_dir}/hiera.yaml, line: 4)")
           end
         end
 
@@ -244,7 +244,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect { lookup('a') }.to raise_error(
-              "One of data_hash, lookup_key, data_dig, or hiera3_backend must be defined in hierarchy 'Common' in #{code_dir}/hiera.yaml")
+              "One of data_hash, lookup_key, data_dig, or hiera3_backend must be defined in hierarchy 'Common' (file: #{code_dir}/hiera.yaml)")
           end
         end
 
@@ -262,7 +262,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect { lookup('a') }.to raise_error(
-              "Only one of data_hash, lookup_key, data_dig, or hiera3_backend can be defined in defaults in #{code_dir}/hiera.yaml")
+              "Only one of data_hash, lookup_key, data_dig, or hiera3_backend can be defined in defaults (file: #{code_dir}/hiera.yaml)")
           end
         end
 
@@ -278,7 +278,7 @@ describe "The lookup function" do
           it 'fails and reports error' do
             Puppet[:strict] = :error
             expect { lookup('a') }.to raise_error(
-              "Unable to find 'data_hash' function named 'nonesuch_txt_data' in #{code_dir}/hiera.yaml")
+              "Unable to find 'data_hash' function named 'nonesuch_txt_data' (file: #{code_dir}/hiera.yaml)")
           end
         end
 
@@ -296,7 +296,7 @@ describe "The lookup function" do
           it 'fails and reports error' do
             Puppet[:strict] = :error
             expect { lookup('a') }.to raise_error(
-              "'default_hierarchy' is only allowed in the module layer at #{code_dir}/hiera.yaml:5")
+              "'default_hierarchy' is only allowed in the module layer (file: #{code_dir}/hiera.yaml, line: 5)")
           end
         end
 
@@ -311,7 +311,7 @@ describe "The lookup function" do
 
           it 'fails and reports errors when strict == error' do
             Puppet[:strict] = :error
-            expect { lookup('a') }.to raise_error("Undefined variable '::nonesuch' at #{code_dir}/hiera.yaml:4")
+            expect { lookup('a') }.to raise_error("Undefined variable '::nonesuch' (file: #{code_dir}/hiera.yaml, line: 4)")
           end
         end
 
@@ -325,7 +325,7 @@ describe "The lookup function" do
 
           it 'fails and reports errors when strict == error' do
             Puppet[:strict] = :error
-            expect { lookup('a') }.to raise_error("Interpolation using method syntax is not allowed in this context in #{code_dir}/hiera.yaml")
+            expect { lookup('a') }.to raise_error("Interpolation using method syntax is not allowed in this context (file: #{code_dir}/hiera.yaml)")
           end
         end
       end
@@ -344,7 +344,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect { lookup('a') }.to raise_error(
-              "No data provider is registered for backend 'nonesuch' at #{env_dir}/spec/hiera.yaml:4")
+              "No data provider is registered for backend 'nonesuch' (file: #{env_dir}/spec/hiera.yaml, line: 4)")
           end
         end
 
@@ -365,7 +365,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect { lookup('a') }.to raise_error(
-              "Hierarchy name 'Common' defined more than once. First defined at line 3 at #{env_dir}/spec/hiera.yaml:9")
+              "Hierarchy name 'Common' defined more than once. First defined at line 3 (file: #{env_dir}/spec/hiera.yaml, line: 9)")
           end
         end
       end
@@ -381,7 +381,7 @@ describe "The lookup function" do
 
           it 'fails and reports error' do
             expect { lookup('a') }.to raise_error(
-              "'hiera3_backend' is only allowed in the global layer at #{env_dir}/spec/hiera.yaml:4")
+              "'hiera3_backend' is only allowed in the global layer (file: #{env_dir}/spec/hiera.yaml, line: 4)")
           end
         end
 
@@ -399,7 +399,7 @@ describe "The lookup function" do
           it 'fails and reports error' do
             Puppet[:strict] = :error
             expect { lookup('a') }.to raise_error(
-              "'default_hierarchy' is only allowed in the module layer at #{env_dir}/spec/hiera.yaml:5")
+              "'default_hierarchy' is only allowed in the module layer (file: #{env_dir}/spec/hiera.yaml, line: 5)")
           end
         end
       end

--- a/spec/unit/functions/next_spec.rb
+++ b/spec/unit/functions/next_spec.rb
@@ -88,6 +88,6 @@ describe 'the next function' do
         # line 2
         next()
       CODE
-    end.to raise_error(/next\(\) from context where this is illegal at unknown:3 on node.*/)
+    end.to raise_error(/next\(\) from context where this is illegal \(file: unknown, line: 3\) on node.*/)
   end
 end

--- a/spec/unit/functions/return_spec.rb
+++ b/spec/unit/functions/return_spec.rb
@@ -90,7 +90,7 @@ describe 'the return function' do
         $result = with(1) |$x| { with($x) |$x| {return(100) }}
         notice $result
       CODE
-    end.to raise_error(/return\(\) from context where this is illegal at unknown:3 on node.*/)
+    end.to raise_error(/return\(\) from context where this is illegal \(file: unknown, line: 3\) on node.*/)
   end
 
   it 'can not be called from top scope' do
@@ -100,6 +100,6 @@ describe 'the return function' do
         # line 2
         return()
       CODE
-    end.to raise_error(/return\(\) from context where this is illegal at unknown:3 on node.*/)
+    end.to raise_error(/return\(\) from context where this is illegal \(file: unknown, line: 3\) on node.*/)
   end
 end

--- a/spec/unit/info_service_spec.rb
+++ b/spec/unit/info_service_spec.rb
@@ -332,7 +332,7 @@ describe "Puppet::InfoService" do
        expect(result).to eq({
          "production"=>{
             "#{code_dir}/borked.pp"=>
-              {:error=>"Syntax error at '+' at #{code_dir}/borked.pp:1:30",
+              {:error=>"Syntax error at '+' (file: #{code_dir}/borked.pp, line: 1, column: 30)",
               },
             } # end production env
          })

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -590,7 +590,7 @@ EOS
       it "fails if there are non component resources in the site" do
         expect {
         catalog = compile_to_env_catalog(MANIFEST_WITH_ILLEGAL_RESOURCE).to_resource
-        }.to raise_error(/Only application components can appear inside a site - Notify\[fail me\] is not allowed at line 20/)
+        }.to raise_error(/Only application components can appear inside a site - Notify\[fail me\] is not allowed \(line: 20\)/)
       end
     end
 

--- a/spec/unit/parser/resource/param_spec.rb
+++ b/spec/unit/parser/resource/param_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::Parser::Resource::Param do
     it "includes file/line context in errors" do
       expect {
         Puppet::Parser::Resource::Param.new(:file => 'foo.pp', :line => 42)
-      }.to raise_error(Puppet::Error, /foo.pp:42/)
+      }.to raise_error(Puppet::Error, /\(file: foo.pp, line: 42\)/)
     end
   end
 end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1017,7 +1017,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
 
     it "provides location information on error in unparenthesized call logic" do
-    expect{parser.evaluate_string(scope, "include non_existing_class", __FILE__)}.to raise_error(Puppet::ParseError, /:1:1/)
+    expect{parser.evaluate_string(scope, "include non_existing_class", __FILE__)}.to raise_error(Puppet::ParseError, /line: 1, column: 1/)
     end
 
     it 'defaults can be given in a lambda and used only when arg is missing' do
@@ -1204,7 +1204,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     it "a lex error should be raised for '$foo::::bar'" do
-      expect { parser.evaluate_string(scope, "$foo::::bar") }.to raise_error(Puppet::ParseErrorWithIssue, /Illegal fully qualified name at line 1:7/)
+      expect { parser.evaluate_string(scope, "$foo::::bar") }.to raise_error(Puppet::ParseErrorWithIssue, /Illegal fully qualified name \(line: 1, column: 7\)/)
     end
 
     { '$a = $0'   => nil,
@@ -1394,7 +1394,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       source = "\nimport foo"
       # Error references position 5 at the opening '{'
       # Set file to nil to make it easier to match with line number (no file name in output)
-      expect { parser.evaluate_string(scope, source) }.to raise_error(/'import' has been discontinued.*line 2:1/)
+      expect { parser.evaluate_string(scope, source) }.to raise_error(/'import' has been discontinued.* \(line: 2, column: 1\)/)
     end
   end
 
@@ -1404,15 +1404,15 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       # Error references position 5 at the opening '{'
       # Set file to nil to make it easier to match with line number (no file name in output)
       expect { parser.evaluate_string(scope, source) }.to raise_error(
-        /Illegal Resource Type expression, expected result to be a type name, or untitled Resource.*line 1:2/)
+        /Illegal Resource Type expression, expected result to be a type name, or untitled Resource.* \(line: 1, column: 2\)/)
     end
 
     it 'for non r-value producing <| |>' do
-      expect { parser.parse_string("$a = File <| |>", nil) }.to raise_error(/A Virtual Query does not produce a value at line 1:6/)
+      expect { parser.parse_string("$a = File <| |>", nil) }.to raise_error(/A Virtual Query does not produce a value \(line: 1, column: 6\)/)
     end
 
     it 'for non r-value producing <<| |>>' do
-      expect { parser.parse_string("$a = File <<| |>>", nil) }.to raise_error(/An Exported Query does not produce a value at line 1:6/)
+      expect { parser.parse_string("$a = File <<| |>>", nil) }.to raise_error(/An Exported Query does not produce a value \(line: 1, column: 6\)/)
     end
 
     it 'for non r-value producing define' do
@@ -1433,7 +1433,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       yyy
       SOURCE
       # first char after opening " reported as being in error.
-      expect { parser.parse_string(source) }.to raise_error(/Unclosed quote after '"' followed by 'xx\\nyy\.\.\.' at line 1:7/)
+      expect { parser.parse_string(source) }.to raise_error(/Unclosed quote after '"' followed by 'xx\\nyy\.\.\.' \(line: 1, column: 7\)/)
     end
 
     it 'for multiple errors with a summary exception' do
@@ -1445,7 +1445,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     it 'for a bad hostname' do
       expect {
         parser.parse_string("node 'macbook+owned+by+name' { }", nil)
-      }.to raise_error(/The hostname 'macbook\+owned\+by\+name' contains illegal characters.*at line 1:6/)
+      }.to raise_error(/The hostname 'macbook\+owned\+by\+name' contains illegal characters.* \(line: 1, column: 6\)/)
     end
 
     it 'for a hostname with interpolation' do
@@ -1455,7 +1455,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       SOURCE
       expect {
         parser.parse_string(source, nil)
-      }.to raise_error(/An interpolated expression is not allowed in a hostname of a node at line 2:23/)
+      }.to raise_error(/An interpolated expression is not allowed in a hostname of a node \(line: 2, column: 23\)/)
     end
 
   end

--- a/spec/unit/pops/parser/parse_containers_spec.rb
+++ b/spec/unit/pops/parser/parse_containers_spec.rb
@@ -88,7 +88,7 @@ describe "egrammar parsing containers" do
       it "class 'foo' {} # a string as class name" do
         # A common error is to put quotes around the class name, the parser should provide the error message at the right location
         # See PUP-7471
-        expect { parse("class 'foo' {}") }.to raise_error(/A quoted string is not valid as a name here at line 1:7/)
+        expect { parse("class 'foo' {}") }.to raise_error(/A quoted string is not valid as a name here \(line: 1, column: 7\)/)
       end
 
 

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -401,9 +401,9 @@ describe Puppet::Resource::Catalog, "when compiling" do
           expect(error).to be_a Puppet::Resource::Catalog::DuplicateResourceError
 
           expect(error.message).to match %r[Duplicate declaration: Notify\[duplicate-title\] is already declared]
-          expect(error.message).to match %r[in file /path/to/orig/file:42]
+          expect(error.message).to match %r[at \(file: /path/to/orig/file, line: 42\)]
           expect(error.message).to match %r[cannot redeclare]
-          expect(error.message).to match %r[at /path/to/dupe/file:314]
+          expect(error.message).to match %r[\(file: /path/to/dupe/file, line: 314\)]
         }
       end
     end

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -641,7 +641,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       it "should include the file/line in the error" do
         Puppet::Type.type(:file).any_instance.stubs(:file).returns("example.pp")
         Puppet::Type.type(:file).any_instance.stubs(:line).returns(42)
-        expect { Puppet::Type.type(:file).new(:title => "/foo", :source => "unknown:///") }.to raise_error(Puppet::ResourceError, /example.pp:42/)
+        expect { Puppet::Type.type(:file).new(:title => "/foo", :source => "unknown:///") }.to raise_error(Puppet::ResourceError, /\(file: example\.pp, line: 42\)/)
       end
     end
 
@@ -731,7 +731,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
             :source => "puppet:///",
             :content => "foo"
           )
-        end.to raise_error(Puppet::ResourceError, /Validation.*example.pp:42/)
+        end.to raise_error(Puppet::ResourceError, /Validation.*\(file: example\.pp, line: 42\)/)
       end
     end
   end
@@ -1147,7 +1147,7 @@ describe Puppet::Type::RelationshipMetaparam do
         expect { param.validate_relationship }.to raise_error do |error|
           expect(error).to be_a Puppet::ResourceError
           expect(error.message).to match %r[Class\[Test\]]
-          expect(error.message).to match %r[/hitchhikers/guide/to/the/galaxy:42]
+          expect(error.message).to match %r[\(file: /hitchhikers/guide/to/the/galaxy, line: 42\)]
         end
       end
     end

--- a/spec/unit/util/errors_spec.rb
+++ b/spec/unit/util/errors_spec.rb
@@ -32,6 +32,6 @@ describe Puppet::Util::Errors do
   it "should have a method for converting error context into a string" do
     @tester.file = "/my/file"
     @tester.line = 50
-    expect(@tester.error_context).to eq(" at /my/file:50")
+    expect(@tester.error_context).to eq(" (file: /my/file, line: 50)")
   end
 end

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -249,7 +249,7 @@ describe Puppet::Util::Log do
       end
       expect(logs.size).to eq(1)
       log = logs[0]
-      expect(log.message).to match(/ at \/tmp\/test\.pp:30:15/)
+      expect(log.message).to match(/ \(file: \/tmp\/test\.pp, line: 30, column: 15\)/)
       expect(log.message).to be(log.to_s)
     end
 
@@ -267,8 +267,8 @@ describe Puppet::Util::Log do
       end
       expect(logs.size).to eq(1)
       log = logs[0]
-      expect(log.message).to_not match(/ at \/tmp\/test\.pp:30:15/)
-      expect(log.to_s).to match(/ at \/tmp\/test\.pp:30:15/)
+      expect(log.message).to_not match(/ \(file: \/tmp\/test\.pp, line: 30, column: 15\)/)
+      expect(log.to_s).to match(/ \(file: \/tmp\/test\.pp, line: 30, column: 15\)/)
       expect(log.issue_code).to eq(:SYNTAX_ERROR)
       expect(log.file).to eq('/tmp/test.pp')
       expect(log.line).to eq(30)


### PR DESCRIPTION
Created a common method for making a string of the the location of an error
Changed the error reporting and logging systems to use the common methods
Updated all the unit tests 