### PR TITLE
(MAINT) Remove Travis before_install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: ruby
 sudo: false
-# Travis Ruby 1.9.3 stack is defaulting to version 1.7.6 of bundler
-# which is incompatible with the Rubygems 2.6.13 security release.
-#
-# TODO: Remove when Travis updates its default:
-#   https://github.com/travis-ci/travis-ci/issues/8357
-before_install:
-  - gem install bundler --version 1.15.4
 bundler_args: --without development extra
 script:
   - "bundle exec rake $CHECK"


### PR DESCRIPTION
Prior to this commit the Travis config included a `before_install`
step which installed bundler at `1.15.4` to resolve an issue with
compatibility in the matrices for Ruby `1.9.3`. However, during
research for MODULES-6339 it was discovered that Travis now keeps
their matrices updated with the latest compatible bundler install.

For all of the builds in this matrix Travis is currently using
bundler `1.16.0` and the builds pass successfully.

This maintenance commit removes the pinned-version install of
bundler and instead returns to relying on Travis to build and
maintain images with compatible versions. This also follows the
advice in the comment in the config file on this step.