### PR TITLE
(PUP-8288) Report exceptions during transactions as failed status.

### DIFF
--- a/lib/puppet/application/inspect.rb
+++ b/lib/puppet/application/inspect.rb
@@ -170,6 +170,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
       finishtime = Time.now
       @report.add_times("inspect", finishtime - inspect_starttime)
+
+      @report.transaction_completed = true
       @report.finalize_report
 
       begin

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -171,6 +171,9 @@ class Puppet::Transaction
       report.resources_failed_to_generate = true
     end
 
+    # mark the end of transaction evaluate.
+    report.transaction_completed = true
+
     Puppet.debug "Finishing transaction #{object_id}"
   end
 

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -132,6 +132,10 @@ class Puppet::Transaction::Report
   #
   attr_accessor :resources_failed_to_generate
 
+  # @return [Boolean] true if the transaction completed it's evaluate
+  #
+  attr_accessor :transaction_completed
+
   def self.from_data_hash(data)
     obj = self.allocate
     obj.initialize_from_hash(data)
@@ -172,7 +176,9 @@ class Puppet::Transaction::Report
 
   # @api private
   def compute_status(resource_metrics, change_metric)
-    if resources_failed_to_generate || (resource_metrics["failed"] || 0) > 0
+    if resources_failed_to_generate ||
+       !transaction_completed ||
+       (resource_metrics["failed"] || 0) > 0
       'failed'
     elsif change_metric > 0
       'changed'
@@ -227,6 +233,7 @@ class Puppet::Transaction::Report
     @noop = Puppet[:noop]
     @noop_pending = false
     @corrective_change = false
+    @transaction_completed = false
   end
 
   # @api private

--- a/spec/unit/application/inspect_spec.rb
+++ b/spec/unit/application/inspect_spec.rb
@@ -70,6 +70,17 @@ describe Puppet::Application::Inspect do
       @inspect.run_command
     end
 
+    it "should not fail if no resource failed" do
+      Puppet::Resource::Catalog::Json.any_instance.stubs(:find).returns(Puppet::Resource::Catalog.new)
+      Puppet::Transaction::Report::Rest.any_instance.expects(:save).with do |request|
+        @report = request.instance
+      end
+
+      @inspect.run_command
+
+      expect(@report.status).to eq("unchanged")
+    end
+
     with_digest_algorithms do
       it "should audit the specified properties" do
         catalog = Puppet::Resource::Catalog.new

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -653,6 +653,16 @@ describe Puppet::Resource::Catalog, "when compiling" do
       @catalog.apply(:ignoreschedules => true)
     end
 
+    it "should detect transaction failure and report it" do
+      @transaction.stubs(:evaluate).raises(RuntimeError, 'transaction failed.')
+      report = Puppet::Transaction::Report.new('apply')
+
+      expect { @catalog.apply(:report => report) }.to raise_error(RuntimeError)
+      report.finalize_report
+
+      expect(report.status).to eq('failed')
+    end
+
     describe "host catalogs" do
 
       # super() doesn't work in the setup method for some reason


### PR DESCRIPTION
Without this patch, exceptions during a transaction that are not caught will not be marked as failed.

Users and tools that use exit status information are not catching these failures due to the incorrect information.

This patch creates a flag that must be positively changed at the end of the transaction flow to allow the transaction to be marked with success.