### PR TITLE
(maint) Allow numeric hostnames in hiera_in_templates test

### DIFF
--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -97,7 +97,7 @@ node default {
   \\$msgs = hiera_array('message')
   notify {\\$msgs:}
   class {'#{@module_name}':
-    result_dir => hiera('result_dir')[\\$::hostname],
+    result_dir => hiera('result_dir')[\\"host_\\${::hostname}\\"],
   }
 }
 ",
@@ -281,7 +281,7 @@ def find_tmp_dirs
   agents.each do |agent|
     h = on(agent, facter("hostname")).stdout.chomp
     t = agent.tmpdir("#{@module_name}_results")
-    tmp_dirs += "  #{h}: '#{t}'\n"
+    tmp_dirs += "  host_#{h}: '#{t}'\n"
     host_to_result_dir[h] = t
   end
   result = {


### PR DESCRIPTION
This test creates a hash of hostname -> directory, and stores it in
YAML for hiera to query. If the hostname happens to be purely numeric,
the key in the hash will be a number, rather than a string. Facter
always returns the `hostname` fact as a string. This causes the hash
lookup in the puppet code to fail, and the manifest to fail to
compile.

The fix is to prepend a bit of non-numeric junk to the hostname, so
that the key in hiera is always string.
  