### PR TITLE
(PUP-7482) Accept all content types with http file sources

### DIFF
--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -187,10 +187,12 @@ module Puppet::Util::HttpProxy
         next
       end
 
-      if block_given?
-        response = proxy.send("request_#{method}".to_sym, current_uri.path, headers, &block)
-      else
-        response = proxy.send(method, current_uri.path, headers)
+      if method != :head
+        if block_given?
+          response = proxy.send("request_#{method}".to_sym, current_uri.path, headers, &block)
+        else
+          response = proxy.send(method, current_uri.path, headers)
+        end
       end
 
       Puppet.debug("HTTP #{method.to_s.upcase} request to #{current_uri} returned #{response.code} #{response.message}")

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'openssl'
+require 'puppet/network/http'
 
 module Puppet::Util::HttpProxy
   def self.proxy(uri)
@@ -172,7 +173,13 @@ module Puppet::Util::HttpProxy
 
     0.upto(redirect_limit) do |redirection|
       proxy = get_http_object(current_uri)
-      response = proxy.send(:head, current_uri.path)
+
+      headers = { 'Accept' => '*/*', 'User-Agent' => Puppet[:http_user_agent] }
+      if Puppet.features.zlib?
+        headers.merge!({"Accept-Encoding" => Puppet::Network::HTTP::Compression::ACCEPT_ENCODING})
+      end
+
+      response = proxy.send(:head, current_uri.path, headers)
 
       if [301, 302, 307].include?(response.code.to_i)
         # handle the redirection
@@ -181,10 +188,9 @@ module Puppet::Util::HttpProxy
       end
 
       if block_given?
-        headers = {'Accept' => 'binary', 'accept-encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}
         response = proxy.send("request_#{method}".to_sym, current_uri.path, headers, &block)
       else
-        response = proxy.send(method, current_uri.path)
+        response = proxy.send(method, current_uri.path, headers)
       end
 
       Puppet.debug("HTTP #{method.to_s.upcase} request to #{current_uri} returned #{response.code} #{response.message}")

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -213,4 +213,35 @@ describe Puppet::Util::HttpProxy do
       end
     end
   end
+
+  describe '.request_with_redirects' do
+    let(:dest) { URI.parse('http://mydomain.com/some/path') }
+    let(:http_ok) { stub('http ok', :code => 200, :message => 'HTTP OK') }
+
+    it 'generates accept and accept-encoding headers' do
+      Net::HTTP.any_instance.stubs(:head).returns(http_ok)
+      Net::HTTP.any_instance.expects(:get).with do |_, headers|
+        expect(headers)
+          .to match({'Accept' => '*/*',
+                     'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'User-Agent' => /Puppet/})
+      end.returns(http_ok)
+
+      subject.request_with_redirects(dest, :get, 0)
+    end
+
+    it 'generates accept and accept-encoding headers when a block is provided' do
+      Net::HTTP.any_instance.stubs(:head).returns(http_ok)
+      Net::HTTP.any_instance.expects(:request_get).with do |_, headers, &block|
+        expect(headers)
+          .to match({'Accept' => '*/*',
+                     'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'User-Agent' => /Puppet/})
+      end.returns(http_ok)
+
+      subject.request_with_redirects(dest, :get, 0) do
+        # unused
+      end
+    end
+  end
 end

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -243,5 +243,11 @@ describe Puppet::Util::HttpProxy do
         # unused
       end
     end
+
+    it 'only makes a single HEAD request' do
+      Net::HTTP.any_instance.expects(:head).with(anything, anything).returns(http_ok)
+
+      subject.request_with_redirects(dest, :head, 0)
+    end
   end
 end


### PR DESCRIPTION
When retrieving file resources from http/https sources, accept all content types (`Accept: */*`), accept compressed content (`Accept-Encoding: gzip,...,identity`), and send our standard `User-Agent` string. Also eliminate a redundant `HEAD` request when retrieving file metadata.

This changes allow puppet to retrieve file sources that don't accept the `binary` content type, e.g. IIS, or other files whose extension maps to a well-known MIME type, e.g. `image/gif`.