### PR TITLE
(PUP-8259) Make loader discovery report errors instead of failing

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -884,5 +884,9 @@ module Issues
   UNKNOWN_TASK = issue :UNKNOWN_TASK, :type_name do
     _('Task not found: %{type_name}') % { type_name: type_name }
   end
+
+  LOADER_FAILURE = issue :LOADER_FAILURE, :type do
+    _('Failed to load: %{type_name}') % { type: type }
+  end
 end
 end

--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -20,12 +20,12 @@ class BaseLoader < Loader
     @last_result = nil      # the value of the last name (optimization)
   end
 
-  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+  def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
     result = []
     @named_values.each_pair do |key, entry|
       result << key unless entry.nil? || entry.value.nil? || key.type != type || (block_given? && !yield(key))
     end
-    result.concat(parent.discover(type, name_authority, &block))
+    result.concat(parent.discover(type, error_collector, name_authority, &block))
     result.uniq!
     result
   end

--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -23,9 +23,9 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
     @dependency_loaders = dependency_loaders
   end
 
-  def discover(type, name_authority = Puppet::Pops::Pcore::RUNTIME_NAME_AUTHORITY, &block)
+  def discover(type, error_collector = nil, name_authority = Puppet::Pops::Pcore::RUNTIME_NAME_AUTHORITY, &block)
     result = []
-    @dependency_loaders.each { |loader| result.concat(loader.discover(type, name_authority, &block)) }
+    @dependency_loaders.each { |loader| result.concat(loader.discover(type, error_collector, name_authority, &block)) }
     result.concat(super)
     result
   end

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -40,13 +40,18 @@ class Loader
   # found values for which the given block returns true. All found entries will be returned if no
   # block is given.
   #
+  # Errors that occur function discovery will either be logged as warnings or collected by the optional
+  # `error_collector` array. When provided, it will receive {Puppet::DataTypes::Error} instances describing
+  # each error in detail and no warnings will be logged.
+  #
   # @param type [Symbol] the type of values to search for
+  # @param error_collector [Array<Puppet::DataTypes::Error>] an optional array that will receive errors during load
   # @param name_authority [String] the name authority, defaults to the pcore runtime
   # @yield [typed_name] optional block to filter the results
   # @yieldparam [TypedName] typed_name the typed name of a found entry
   # @yieldreturn [Boolean] `true` to keep the entry, `false` to discard it.
   # @return [Array<TypedName>] the list of names of discovered values
-  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+  def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
     return EMPTY_ARRAY
   end
 

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -13,9 +13,9 @@ class Runtime3TypeLoader < BaseLoader
     @resource_3x_loader = env_path.nil? ? nil : ModuleLoaders.pcore_resource_type_loader_from(parent_loader, loaders, env_path)
   end
 
-  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+  def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
     # TODO: Use generated index of all known types (requires separate utility).
-    parent.discover(type, name_authority, &block)
+    parent.discover(type, error_collector, name_authority, &block)
   end
 
   def to_s()

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -78,7 +78,7 @@ class StaticLoader < Loader
     create_built_in_types
   end
 
-  def discover(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+  def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
     # Static loader only contains runtime types
     return EMPTY_ARRAY unless type == :type && name_authority == name_authority = Pcore::RUNTIME_NAME_AUTHORITY
 

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -77,28 +77,19 @@ module Pal
     # The returned array has more information than just the leaf name - the typical thing is to just get
     # the name as showing the following example.
     #
-    # @example getting the names of all functions
-    #   compiler.list_functions.map {|tn| tn.name }
-    #
-    # @param filter_regex [Regexp] an optional regexp that filters based on name (matching names are included in the result)
-    # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
-    #
-    def list_functions(filter_regex = nil)
-      list_loadable_kind(:function, filter_regex)
-    end
-
-    # Returns an array of TypedName objects for all functions, optionally filtered by a regular expression.
-    # The returned array has more information than just the leaf name - the typical thing is to just get
-    # the name as showing the following example.
+    # Errors that occur during function discovery will either be logged as warnings or collected by the optional
+    # `error_collector` array. When provided, it will receive {Puppet::DataTypes::Error} instances describing
+    # each error in detail and no warnings will be logged.
     #
     # @example getting the names of all functions
     #   compiler.list_functions.map {|tn| tn.name }
     #
     # @param filter_regex [Regexp] an optional regexp that filters based on name (matching names are included in the result)
+    # @param error_collector [Array<Puppet::DataTypes::Error>] an optional array that will receive errors during load
     # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
     #
-    def list_functions(filter_regex = nil)
-      list_loadable_kind(:function, filter_regex)
+    def list_functions(filter_regex = nil, error_collector = nil)
+      list_loadable_kind(:function, filter_regex, error_collector)
     end
 
     # Evaluates a string of puppet language code in top scope.
@@ -228,12 +219,12 @@ module Pal
 
     protected
 
-    def list_loadable_kind(kind, filter_regex = nil)
+    def list_loadable_kind(kind, filter_regex = nil, error_collector = nil)
       loader = internal_compiler.loaders.private_environment_loader
       if filter_regex.nil?
-        loader.discover(kind)
+        loader.discover(kind, error_collector)
       else
-        loader.discover(kind) {|f| f.name =~ filter_regex }
+        loader.discover(kind, error_collector) {|f| f.name =~ filter_regex }
       end
     end
 
@@ -262,14 +253,19 @@ module Pal
     # The returned array has more information than just the leaf name - the typical thing is to just get
     # the name as showing the following example.
     #
+    # Errors that occur during plan discovery will either be logged as warnings or collected by the optional
+    # `error_collector` array. When provided, it will receive {Puppet::DataTypes::Error} instances describing
+    # each error in detail and no warnings will be logged.
+    #
     # @example getting the names of all plans
     #   compiler.list_plans.map {|tn| tn.name }
     #
     # @param filter_regex [Regexp] an optional regexp that filters based on name (matching names are included in the result)
+    # @param error_collector [Array<Puppet::DataTypes::Error>] an optional array that will receive errors during load
     # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
     #
-    def list_plans(filter_regex = nil)
-      list_loadable_kind(:plan, filter_regex)
+    def list_plans(filter_regex = nil, error_collector = nil)
+      list_loadable_kind(:plan, filter_regex, error_collector)
     end
 
     # Returns the signature callable of the given task (the arguments it accepts, and the data type it returns)
@@ -292,11 +288,16 @@ module Pal
     # @example getting the names of all tasks
     #   compiler.list_tasks.map {|tn| tn.name }
     #
+    # Errors that occur during task discovery will either be logged as warnings or collected by the optional
+    # `error_collector` array. When provided, it will receive {Puppet::DataTypes::Error} instances describing
+    # each error in detail and no warnings will be logged.
+    #
     # @param filter_regex [Regexp] an optional regexp that filters based on name (matching names are included in the result)
+    # @param error_collector [Array<Puppet::DataTypes::Error>] an optional array that will receive errors during load
     # @return [Array<Puppet::Pops::Loader::TypedName>] an array of typed names
     #
-    def list_tasks(filter_regex = nil)
-      list_loadable_kind(:task, filter_regex)
+    def list_tasks(filter_regex = nil, error_collector = nil)
+      list_loadable_kind(:task, filter_regex, error_collector)
     end
   end
 


### PR DESCRIPTION
Before this commit, a function, type, plan, or task declaration that
contained errors would cause the loader discovery to raise an exception.
This is now changed so that the discovery will either raise warnings or
collect errors in an `error_collector` array that can be passed as an
optional argument. If the `error_collector` is provided, errors will not
be logged but instead converted into `Puppet::DataType::Error` instances
and added to the collector.