### PR TITLE
(maint) Skipping tests for ec2 hosts

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -3,8 +3,8 @@ test_name "ticket 1073: common package name in two different providers should be
   confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
   confine :except, :platform => /centos-4|el-4/ # PUP-5227
   # Skipping tests if facter finds this is an ec2 host, PUP-7774
-  hosts.each do |host|
-    skip_test('Skipping EC2 Hosts') if fact_on(host, 'ec2_metadata')
+  agents.each do |agent|
+    skip_test('Skipping EC2 Hosts') if fact_on(agent, 'ec2_metadata')
   end
 
   tag 'audit:medium',

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -3,8 +3,8 @@ test_name "test the yum package provider" do
   confine :to, {:platform => /(?:centos|el-|fedora)/}, agents
   confine :except, :platform => /centos-4|el-4/ # PUP-5227
   # Skipping tests if facter finds this is an ec2 host, PUP-7774
-  hosts.each do |host|
-    skip_test('Skipping EC2 Hosts') if fact_on(host, 'ec2_metadata')
+  agents.each do |agent|
+    skip_test('Skipping EC2 Hosts') if fact_on(agent, 'ec2_metadata')
   end
 
   tag 'audit:medium',


### PR DESCRIPTION
Skipping tests for ec2 hosts now correctly iterates over the agents rather then hosts.