### PR TITLE
(PUP-8313) raise DevError decorate strings part 3

### DIFF
--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -23,7 +23,8 @@ module Puppet::Resource::CapabilityFinder
   # @return [Puppet::Resource,nil] The found capability resource or `nil` if it could not be found
   def self.find(environment, code_id, cap)
     unless Puppet::Util.const_defined?('Puppetdb')
-      raise Puppet::DevError, 'PuppetDB is not available'
+      #TRANSLATOR PuppetDB is a product name and should not be translated
+      raise Puppet::DevError, _('PuppetDB is not available')
     end
 
     resources = search(nil, nil, cap)
@@ -40,10 +41,11 @@ module Puppet::Resource::CapabilityFinder
     elsif code_id_resource = disambiguate_by_code_id(environment, code_id, cap)
       resource_hash = code_id_resource
     else
-      raise Puppet::DevError,
-        "Unexpected response from PuppetDB when looking up #{cap}:\n" \
-        "expected exactly one resource but got #{resources.size};\n" \
-        "returned data is:\n#{resources.inspect}"
+      #TRANSLATOR PuppetDB is a product name and should not be translated
+      message = _("Unexpected response from PuppetDB when looking up %{capability}:") % { capability: cap }
+      message += "\n" + _("expected exactly one resource but got %{count};") % { count: resources.size }
+      message += "\n" + _("returned data is:\n%{resources}") % { resources: resources.inspect }
+      raise Puppet::DevError, message
     end
 
     if resource_hash
@@ -72,7 +74,8 @@ module Puppet::Resource::CapabilityFinder
             ['=', 'code_id', code_id]]]]
     end
 
-    Puppet.notice _("Looking up capability %{cap} in PuppetDB: %{query_terms}") % { cap: cap, query_terms: query_terms }
+    #TRANSLATOR PuppetDB is a product name and should not be translated
+    Puppet.notice _("Looking up capability %{capability} in PuppetDB: %{query_terms}") % { capability: cap, query_terms: query_terms }
 
     query_puppetdb(query_terms)
   end
@@ -95,15 +98,15 @@ module Puppet::Resource::CapabilityFinder
       # The format of the response body is documented at
       #   https://docs.puppetlabs.com/puppetdb/3.0/api/query/v4/resources.html#response-format
       unless result.is_a?(Array)
-        raise Puppet::DevError,
-        "Unexpected response from PuppetDB when looking up #{cap}: " \
-          "expected an Array but got #{result.inspect}"
+        #TRANSLATOR PuppetDB is a product name and should not be translated
+        raise Puppet::DevError, _("Unexpected response from PuppetDB when looking up %{capability}: expected an Array but got %{result}") %
+            { capability: cap, result: result.inspect }
       end
 
       result
     rescue JSON::JSONError => e
-      raise Puppet::DevError,
-        "Invalid JSON from PuppetDB when looking up #{cap}\n#{e}"
+      #TRANSLATOR PuppetDB is a product name and should not be translated
+      raise Puppet::DevError, _("Invalid JSON from PuppetDB when looking up %{capability}\n%{detail}") % { capability: cap, detail: e }
     end
   end
 

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -572,7 +572,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
                      when "random"
                        Puppet::Graph::RandomPrioritizer.new
                      else
-                       raise Puppet::DevError, "Unknown ordering type #{Puppet[:ordering]}"
+                       raise Puppet::DevError, _("Unknown ordering type %{ordering}") % { ordering: Puppet[:ordering] }
                      end
   end
 
@@ -643,11 +643,11 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
       next if block_given? and yield edge.target
 
       unless source = map[edge.source.ref]
-        raise Puppet::DevError, "Could not find resource #{edge.source.ref} when converting #{message} resources"
+        raise Puppet::DevError, _("Could not find resource %{resource} when converting %{message} resources") % { resource: edge.source.ref, message: message }
       end
 
       unless target = map[edge.target.ref]
-        raise Puppet::DevError, "Could not find resource #{edge.target.ref} when converting #{message} resources"
+        raise Puppet::DevError, _("Could not find resource %{resource} when converting %{message} resources") % { resource: edge.target.ref, message: message }
       end
 
       result.add_edge(source, target, edge.label)

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -420,10 +420,10 @@ class Puppet::Resource::Type
     name_to_type_hash.each do |name, t|
       # catch internal errors
       unless @arguments.include?(name)
-        raise Puppet::DevError, "Parameter '#{name}' is given a type, but is not a valid parameter."
+        raise Puppet::DevError, _("Parameter '%{name}' is given a type, but is not a valid parameter.") % { name: name }
       end
       unless t.is_a? Puppet::Pops::Types::PAnyType
-        raise Puppet::DevError, "Parameter '#{name}' is given a type that is not a Puppet Type, got #{t.class}"
+        raise Puppet::DevError, _("Parameter '%{name}' is given a type that is not a Puppet Type, got %{class_name}") % { name: name, class_name: t.class }
       end
       @argument_types[name] = t
     end
@@ -463,7 +463,7 @@ class Puppet::Resource::Type
   end
 
   def parent_scope(scope, klass)
-    scope.class_scope(klass) || raise(Puppet::DevError, "Could not find scope for #{klass.name}")
+    scope.class_scope(klass) || raise(Puppet::DevError, _("Could not find scope for %{class_name}") % { class_name: klass.name })
   end
 
   def set_name_and_namespace(name)

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -256,7 +256,7 @@ class Puppet::Settings
   end
 
   def initialize_global_settings(args = [])
-    raise Puppet::DevError, "Attempting to initialize global default settings more than once!" if global_defaults_initialized?
+    raise Puppet::DevError, _("Attempting to initialize global default settings more than once!") if global_defaults_initialized?
 
     # The first two phases of the lifecycle of a puppet application are:
     # 1) Parse the command line options and handle any of them that are
@@ -830,7 +830,7 @@ class Puppet::Settings
     when :environment
       ValuesFromEnvironmentConf.new(source.name)
     else
-      raise(Puppet::DevError, "Unknown searchpath case: #{source.type} for the #{source} settings path element.")
+      raise Puppet::DevError, _("Unknown searchpath case: %{source_type} for the %{source} settings path element.") % { source_type: source.type, source: source}
     end
   end
 

--- a/lib/puppet/ssl/base.rb
+++ b/lib/puppet/ssl/base.rb
@@ -24,7 +24,7 @@ class Puppet::SSL::Base
   end
 
   def self.wrapped_class
-    raise(Puppet::DevError, "#{self} has not declared what class it wraps") unless defined?(@wrapped_class)
+    raise(Puppet::DevError, _("%{name} has not declared what class it wraps") % { name: self }) unless defined?(@wrapped_class)
     @wrapped_class
   end
 
@@ -40,7 +40,7 @@ class Puppet::SSL::Base
   end
 
   def generate
-    raise Puppet::DevError, "#{self.class} did not override 'generate'"
+    raise Puppet::DevError, _("%{class_name} did not override 'generate'") % { class_name: self.class }
   end
 
   def initialize(name)

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -425,7 +425,7 @@ class Type
     when 1;
       [ [ /(.*)/m, [ [key_attributes.first] ] ] ]
     else
-      raise Puppet::DevError,"you must specify title patterns when there are two or more key attributes"
+      raise Puppet::DevError, _("you must specify title patterns when there are two or more key attributes")
     end
   end
 
@@ -500,11 +500,10 @@ class Type
     # This is here for types that might still have the old method of defining
     # a parent class.
     unless options.is_a? Hash
-      raise Puppet::DevError,
-        "Options must be a hash, not #{options.inspect}"
+      raise Puppet::DevError, _("Options must be a hash, not %{type}") % { type: options.inspect }
     end
 
-    raise Puppet::DevError, "Class #{self.name} already has a property named #{name}" if @validproperties.include?(name)
+    raise Puppet::DevError, _("Class %{class_name} already has a property named %{property}") % { class_name: self.name, property: name } if @validproperties.include?(name)
 
     if parent = options[:parent]
       options.delete(:parent)
@@ -590,7 +589,7 @@ class Type
 
   # @return [Boolean] Returns true if the given name is the name of an existing parameter
   def self.validparameter?(name)
-    raise Puppet::DevError, "Class #{self} has not defined parameters" unless defined?(@parameters)
+    raise Puppet::DevError, _("Class %{class_name} has not defined parameters") % { class_name: self } unless defined?(@parameters)
     !!(@paramhash.include?(name) or @@metaparamhash.include?(name))
   end
 
@@ -697,7 +696,7 @@ class Type
     if @parameters.has_key?(attr)
       @parameters.delete(attr)
     else
-      raise Puppet::DevError.new("Undefined attribute '#{attr}' in #{self}")
+      raise Puppet::DevError.new(_("Undefined attribute '%{attribute}' in %{name}") % { attribute: attr, name: self})
     end
   end
 
@@ -1019,8 +1018,8 @@ class Type
 
     if property = @parameters[:ensure]
       unless is.include? property
-        raise Puppet::DevError,
-          "The is value is not in the is array for '#{property.name}'"
+        #TRANSLATORS 'is' is a variable name and should not be translated
+        raise Puppet::DevError, _("The 'is' value is not in the 'is' array for '%{name}'") % { name: property.name }
       end
       ensureis = is[property]
       if property.safe_insync?(ensureis) and property.should == :absent
@@ -1030,8 +1029,8 @@ class Type
 
     properties.each { |prop|
       unless is.include? prop
-        raise Puppet::DevError,
-          "The is value is not in the is array for '#{prop.name}'"
+        #TRANSLATORS 'is' is a variable name and should not be translated
+        raise Puppet::DevError, _("The 'is' value is not in the 'is' array for '%{name}'") % { name: prop.name }
       end
 
       propis = is[prop]
@@ -1157,7 +1156,7 @@ class Type
   # Either requires providers or must be overridden.
   # @raise [Puppet::DevError] when there are no providers and the implementation has not overridden this method.
   def self.instances
-    raise Puppet::DevError, "#{self.name} has no providers and has not overridden 'instances'" if provider_hash.empty?
+    raise Puppet::DevError, _("%{name} has no providers and has not overridden 'instances'") % { name: self.name } if provider_hash.empty?
 
     # Put the default provider first, then the rest of the suitable providers.
     provider_instances = {}
@@ -1841,8 +1840,7 @@ end
         if provider = self.provider(pname)
           provider
         else
-          raise Puppet::DevError,
-            "Could not find parent provider #{pname} of #{name}"
+          raise Puppet::DevError, _("Could not find parent provider %{parent} of %{name}") % { parent: pname, name: name }
         end
       end
     else
@@ -2118,7 +2116,7 @@ end
   #
   def autorelation(rel_type, rel_catalog = nil)
     rel_catalog ||= catalog
-    raise(Puppet::DevError, "You cannot add relationships without a catalog") unless rel_catalog
+    raise Puppet::DevError, _("You cannot add relationships without a catalog") unless rel_catalog
 
     reqs = []
 
@@ -2484,7 +2482,7 @@ end
       rescue ArgumentError, Puppet::Error, TypeError
         raise
       rescue => detail
-        error = Puppet::DevError.new( "Could not set #{attr} on #{self.class.name}: #{detail}")
+        error = Puppet::DevError.new(_("Could not set %{attribute} on %{class_name}: %{detail}") % { attribute: attr, class_name: self.class.name, detail: detail })
         error.set_backtrace(detail.backtrace)
         raise error
       end

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -128,7 +128,7 @@ module Puppet
     # Look up (if necessary) and return local content.
     def content
       return @content if @content
-      raise Puppet::DevError, "No source for content was stored with the metadata" unless metadata.source
+      raise Puppet::DevError, _("No source for content was stored with the metadata") unless metadata.source
 
       unless tmp = Puppet::FileServing::Content.indirection.find(metadata.source, :environment => resource.catalog.environment_instance, :links => resource[:links])
         self.fail "Could not find any content at %s" % metadata.source

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -54,7 +54,7 @@ module Puppet
 
       def sync
         if self.should == :absent
-          raise Puppet::DevError, "GID cannot be deleted"
+          raise Puppet::DevError, _("GID cannot be deleted")
         else
           provider.gid = self.should
         end

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -112,7 +112,7 @@ module Puppet
         # Determine if there are any out-of-sync properties.
         oos = @resource.send(:properties).find_all do |prop|
           unless currentvalues.include?(prop)
-            raise Puppet::DevError, "Parent has property %s but it doesn't appear in the current values", [prop.name]
+            raise Puppet::DevError, _("Parent has property %{name} but it doesn't appear in the current values") % { name: prop.name }
           end
           if prop.name == :ensure
             false

--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -127,7 +127,7 @@ Puppet::Type.newtype(:resources) do
   def resource_type
     unless defined?(@resource_type)
       unless type = Puppet::Type.type(self[:name])
-        raise Puppet::DevError, "Could not find resource type"
+        raise Puppet::DevError, _("Could not find resource type")
       end
       @resource_type = type
     end

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -115,7 +115,7 @@ end
       # everything between it and us.
       self.class.state_sequence(self.retrieve, self.should).each do |state|
         method = state[direction]
-        raise Puppet::DevError, "Cannot move #{direction} from #{st[:name]}" unless method
+        raise Puppet::DevError, _("Cannot move %{direction} from %{name}") % { direction: direction, name: st[:name] } unless method
         provider_sync_send(method)
       end
 

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -219,10 +219,11 @@ module Util
                args.pop
              end
 
-    raise Puppet::DevError, "Failed to provide level to :benchmark" unless level
+    #TRANSLATORS 'benchmark' is a method name and should not be translated
+    raise Puppet::DevError, _("Failed to provide level to benchmark") unless level
 
     unless level == :none or object.respond_to? level
-      raise Puppet::DevError, "Benchmarked object does not respond to #{level}"
+      raise Puppet::DevError, _("Benchmarked object does not respond to %{value}") % { value: level }
     end
 
     # Only benchmark if our log level is high enough
@@ -306,7 +307,7 @@ module Util
             when :posix
               AbsolutePathPosix
             else
-              raise Puppet::DevError, "unknown platform #{platform} in absolute_path"
+              raise Puppet::DevError, _("unknown platform %{platform} in absolute_path") % { platform: platform }
             end
 
     !! (path =~ regex)
@@ -562,11 +563,11 @@ module Util
   DEFAULT_WINDOWS_MODE = nil
 
   def replace_file(file, default_mode, &block)
-    raise Puppet::DevError, "replace_file requires a block" unless block_given?
+    raise Puppet::DevError, _("replace_file requires a block") unless block_given?
 
     if default_mode
       unless valid_symbolic_mode?(default_mode)
-        raise Puppet::DevError, "replace_file default_mode: #{default_mode} is invalid"
+        raise Puppet::DevError, _("replace_file default_mode: %{default_mode} is invalid") % { default_mode: default_mode }
       end
 
       mode = symbolic_mode_to_int(normalize_symbolic_mode(default_mode))

--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -151,8 +151,7 @@ module Puppet::Util::FileParsing
     if record.respond_to?(:process)
       if ret = record.send(:process, line.dup)
         unless ret.is_a?(Hash)
-          raise Puppet::DevError,
-            "Process record type #{record.name} returned non-hash"
+          raise Puppet::DevError, _("Process record type %{record_name} returned non-hash") % { record_name: record.name }
         end
       else
         return nil
@@ -236,7 +235,7 @@ module Puppet::Util::FileParsing
 
   # Handle parsing a single line.
   def parse_line(line)
-    raise Puppet::DevError, "No record types defined; cannot parse lines" unless records?
+    raise Puppet::DevError, _("No record types defined; cannot parse lines") unless records?
 
     @record_order.each do |record|
       # These are basically either text or record lines.
@@ -247,8 +246,7 @@ module Puppet::Util::FileParsing
           return result
         end
       else
-        raise Puppet::DevError,
-          "Somehow got invalid line type #{record.type}"
+        raise Puppet::DevError, _("Somehow got invalid line type %{record_type}") % { record_type: record.type }
       end
     end
 

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -63,7 +63,8 @@ class Puppet::Util::Log
     destinations.keys.each { |dest|
       close(dest)
     }
-    raise Puppet::DevError.new("Log.close_all failed to close #{@destinations.keys.inspect}") if !@destinations.empty?
+    #TRANSLATORS "Log.close_all" is a method name and should not be translated
+    raise Puppet::DevError.new(_("Log.close_all failed to close %{destinations}") % { destinations: @destinations.keys.inspect }) if !@destinations.empty?
   end
 
   # Flush any log destinations that support such operations.
@@ -82,8 +83,8 @@ class Puppet::Util::Log
   # Create a new log message.  The primary role of this method is to
   # avoid creating log messages below the loglevel.
   def Log.create(hash)
-    raise Puppet::DevError, "Logs require a level" unless hash.include?(:level)
-    raise Puppet::DevError, "Invalid log level #{hash[:level]}" unless @levels.index(hash[:level])
+    raise Puppet::DevError, _("Logs require a level") unless hash.include?(:level)
+    raise Puppet::DevError, _("Invalid log level %{level}") % { level: hash[:level] } unless @levels.index(hash[:level])
     @levels.index(hash[:level]) >= @loglevel ? Puppet::Util::Log.new(hash) : nil
   end
 
@@ -105,7 +106,7 @@ class Puppet::Util::Log
   def Log.level=(level)
     level = level.intern unless level.is_a?(Symbol)
 
-    raise Puppet::DevError, "Invalid loglevel #{level}" unless @levels.include?(level)
+    raise Puppet::DevError, _("Invalid loglevel %{level}") % { level: level } unless @levels.include?(level)
 
     @loglevel = @levels.index(level)
 
@@ -132,7 +133,7 @@ class Puppet::Util::Log
       return
     end
 
-    raise Puppet::DevError, "Unknown destination type #{dest}" unless type
+    raise Puppet::DevError, _("Unknown destination type %{dest}") % { dest: dest} unless type
 
     begin
       if type.instance_method(:initialize).arity == 1

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -146,7 +146,8 @@ module Logging
     key = options[:key]
     file = options[:file]
     line = options[:line]
-    raise(Puppet::DevError, "Need either :file and :line, or :key") if (key.nil?) && (file.nil? || line.nil?)
+    #TRANSLATORS the literals ":file", ":line", and ":key" should not be translated
+    raise Puppet::DevError, _("Need either :file and :line, or :key") if (key.nil?) && (file.nil? || line.nil?)
 
     key ||= "#{file}:#{line}"
     issue_deprecation_warning(message, key, file, line, false)

--- a/lib/puppet/util/nagios_maker.rb
+++ b/lib/puppet/util/nagios_maker.rb
@@ -9,7 +9,7 @@ module Puppet::Util::NagiosMaker
     name = name.to_sym
     full_name = ("nagios_#{name}").to_sym
 
-    raise(Puppet::DevError, "No nagios type for #{name}") unless nagtype = Nagios::Base.type(name)
+    raise Puppet::DevError, _("No nagios type for %{name}") % { name: name } unless nagtype = Nagios::Base.type(name)
 
     type = Puppet::Type.newtype(full_name) do
 

--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -17,7 +17,7 @@ module Puppet::Util::POSIX
   # method search_posix_field in the gid and uid methods if a sanity check
   # fails
   def get_posix_field(space, field, id)
-    raise Puppet::DevError, "Did not get id from caller" unless id
+    raise Puppet::DevError, _("Did not get id from caller") unless id
 
     if id.is_a?(Integer)
       if id > Puppet[:maximum_uid].to_i

--- a/lib/puppet/util/provider_features.rb
+++ b/lib/puppet/util/provider_features.rb
@@ -63,7 +63,7 @@ module Puppet::Util::ProviderFeatures
   # @todo How methods that determine if the feature is present are specified.
   def feature(name, docs, hash = {})
     @features ||= {}
-    raise(Puppet::DevError, "Feature #{name} is already defined") if @features.include?(name)
+    raise Puppet::DevError, _("Feature %{name} is already defined") % { name: name } if @features.include?(name)
     begin
       obj = ProviderFeature.new(name, docs, hash)
       @features[obj.name] = obj

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -240,7 +240,7 @@ module Puppet::Util::SELinux
     # while we try and figure out what file-system the target lives on.
     path = Pathname(path).cleanpath
     unless path.absolute?
-      raise Puppet::DevError, "got a relative path in SELinux find_fs: #{path}"
+      raise Puppet::DevError, _("got a relative path in SELinux find_fs: %{path}") % { path: path }
     end
 
     # Now, walk up the tree until we find a match for that path in the hash.


### PR DESCRIPTION
Decorate strings when we raise a DevError error so that we'll
have translations for the error (Part 3 of 3)
Coding fix in lib/puppet/type/mount.rb
Added quotes in lib/puppet/type.rb to make this message readable
   "The 'is' value is not in the 'is' array for '%{name}'"