### PR TITLE
(maint) Remove unnecessary binary json test

### DIFF
--- a/spec/unit/indirector/json_spec.rb
+++ b/spec/unit/indirector/json_spec.rb
@@ -198,16 +198,5 @@ describe Puppet::Indirector::JSON do
       create_file('foo.json~', 'foo-backup')
       expect(subject.search(request('f*')).map(&:value)).to eq(['foo-json'])
     end
-
-    it "raises if the content contains binary" do
-      binary = "\xC0\xFF".force_encoding(Encoding::BINARY)
-
-      File.binwrite(subject.path('foo.json', ''), "foo-json")
-      File.binwrite(subject.path("foo#{binary}.bin", ''), "foo-binary")
-
-      expect {
-        subject.search(request('*'))
-      }.to raise_error Puppet::Error, /Could not parse JSON data/
-    end
   end
 end


### PR DESCRIPTION
This test was attempting to verify that the json terminus would error
in the face of files on disk with binary names. It doesn't actually do
that, and is also broken on High Sierra with APFS

Since this is not a particular valuable thing to test, instead of
attempting to repair the test it is simply being removed.