### PR TITLE
(PUP-8285) Check if file exists using the configured bucket

### DIFF
--- a/lib/puppet/file_bucket/dipper.rb
+++ b/lib/puppet/file_bucket/dipper.rb
@@ -46,7 +46,7 @@ class Puppet::FileBucket::Dipper
 
       # Make a HEAD request for the file so that we don't waste time
       # uploading it if it already exists in the bucket.
-      unless Puppet::FileBucket::File.indirection.head(file_bucket_path)
+      unless Puppet::FileBucket::File.indirection.head(file_bucket_path, :bucket_path => @local_path)
         Puppet::FileBucket::File.indirection.save(file_bucket_file, dest_path)
       end
 

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -311,7 +311,9 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
 
         file = make_tmp_file(plaintext)
 
-        Puppet::FileBucket::File.indirection.expects(:head).returns true
+        Puppet::FileBucket::File.indirection.expects(:head).with(
+          regexp_matches(%r{#{digest_algorithm}/#{checksum}}), :bucket_path => "/my/bucket"
+        ).returns true
         Puppet::FileBucket::File.indirection.expects(:save).never
         expect(@dipper.backup(file)).to eq(checksum)
       end


### PR DESCRIPTION
Previously, if you used a non-default bucket directory, the backup
command would only backup the file if it didn't exist in the default
bucket. This was a result of not passing the `bucket_path` request
option in the call to `Puppet::FileBucket::File.indirection.head`.

The same change is not need when calling `save` because in that case we
have an instance of Puppet::FileBucket::File that we want to save, and
it is already configured with the correct bucket_path.