### PR TITLE
(PUP-8249) Remove gettext-setup as a runtime dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   # PUP-7115 - return to a gem dependency in Puppet 5
   # s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])
   # i18n support (gettext-setup and dependencies)
-  s.add_runtime_dependency(%q<gettext-setup>, [">= 0.10", "< 1"])
+  s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.1")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   # hocon is an optional hiera backend shipped in puppet-agent packages
   s.add_runtime_dependency(%q<hocon>, "~> 1.0")

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,8 @@ group(:development) do
   if RUBY_PLATFORM != 'java'
     gem 'ruby-prof', '>= 0.16.0', :require => false
   end
+
+  gem 'gettext-setup', '~> 0.28', :require => false
 end
 
 group(:extra) do


### PR DESCRIPTION
We no longer rely on gettext-setup at runtime, instead using
fast_gettext directly. This commit adds fast_gettext to the gemspec and
moves gettext-setup to the Gemfile, so it can be pulled in for its rake
tasks used when manipulating translation files at build time.