### PR TITLE
(PUP-4963) Puppet module build fails on FIPS enabled system

### DIFF
--- a/lib/puppet/face/module/build.rb
+++ b/lib/puppet/face/module/build.rb
@@ -4,6 +4,7 @@ Puppet::Face.define(:module, '1.0.0') do
     description <<-EOT
       Prepares a local module for release on the Puppet Forge by building a
       ready-to-upload archive file.
+      Note: Module build uses MD5 checksums, which are prohibited on FIPS enabled systems.
 
       This action uses the metadata.json file in the module directory to set metadata
       used by the Forge. See <https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html> for more

--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -8,6 +8,7 @@ Puppet::Face.define(:module, '1.0.0') do
     summary _("Install a module from the Puppet Forge or a release archive.")
     description <<-EOT
       Installs a module from the Puppet Forge or from a release archive file.
+      Note: Module install uses MD5 checksums, which are prohibited on FIPS enabled systems.
 
       The specified module will be installed into the directory
       specified with the `--target-dir` option, which defaults to the first

--- a/lib/puppet/face/module/uninstall.rb
+++ b/lib/puppet/face/module/uninstall.rb
@@ -4,6 +4,7 @@ Puppet::Face.define(:module, '1.0.0') do
     description <<-EOT
       Uninstalls a puppet module from the modulepath (or a specific
       target directory).
+      Note: Module uninstall uses MD5 checksums, which are prohibited on FIPS enabled systems.
     EOT
 
     returns _("Hash of module objects representing uninstalled modules and related errors.")

--- a/lib/puppet/face/module/upgrade.rb
+++ b/lib/puppet/face/module/upgrade.rb
@@ -5,6 +5,7 @@ Puppet::Face.define(:module, '1.0.0') do
     summary _("Upgrade a puppet module.")
     description <<-EOT
       Upgrades a puppet module.
+      Note: Module upgrade uses MD5 checksums, which are prohibited on FIPS enabled systems.
     EOT
 
     returns "Hash"

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -2,6 +2,7 @@ require 'fileutils'
 require 'json'
 require 'puppet/file_system'
 require 'pathspec'
+require 'facter'
 
 module Puppet::ModuleTool
   module Applications
@@ -14,6 +15,9 @@ module Puppet::ModuleTool
       end
 
       def run
+        # Disallow anything that invokes md5 to avoid un-friendly termination due to FIPS
+        raise _("Module building is prohibited in FIPS mode.") if Facter.value(:fips_enabled)
+
         load_metadata!
         create_directory
         copy_contents

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -52,6 +52,9 @@ module Puppet::ModuleTool
       end
 
       def run
+        # Disallow anything that invokes md5 to avoid un-friendly termination due to FIPS
+        raise _("Module install is prohibited in FIPS mode.") if Facter.value(:fips_enabled)
+
         name = @name.tr('/', '-')
         version = options[:version] || '>= 0.0.0'
 

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -16,6 +16,9 @@ module Puppet::ModuleTool
       end
 
       def run
+        # Disallow anything that invokes md5 to avoid un-friendly termination due to FIPS
+        raise _("Module uninstall is prohibited in FIPS mode.") if Facter.value(:fips_enabled)
+
         results = {
           :module_name       => @name,
           :requested_version => @version,

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -27,6 +27,9 @@ module Puppet::ModuleTool
       end
 
       def run
+        # Disallow anything that invokes md5 to avoid un-friendly termination due to FIPS
+        raise _("Module upgrade is prohibited in FIPS mode.") if Facter.value(:fips_enabled)
+
         name = @name.tr('/', '-')
         version = options[:version] || '>= 0.0.0'
 

--- a/spec/unit/module_tool/applications/builder_spec.rb
+++ b/spec/unit/module_tool/applications/builder_spec.rb
@@ -429,4 +429,11 @@ symlinkfile
 
     it_behaves_like "a packagable module"
   end
+
+  context 'when in FIPS mode...' do
+    it 'module builder refuses to run' do
+      Facter.stubs(:value).with(:fips_enabled).returns(true)
+      expect { builder.run }.to raise_error(/Module building is prohibited in FIPS mode/)
+    end 
+  end
 end

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -366,6 +366,14 @@ describe Puppet::ModuleTool::Applications::Installer do
         end
       end
     end
+
+    context 'when in FIPS mode...' do
+      it 'module installer refuses to run' do
+        Facter.stubs(:value).with(:fips_enabled).returns(true)
+        expect {application.run}.to raise_error(/Module install is prohibited in FIPS mode./)
+      end 
+    end
+
   end
 
 end

--- a/spec/unit/module_tool/applications/uninstaller_spec.rb
+++ b/spec/unit/module_tool/applications/uninstaller_spec.rb
@@ -162,4 +162,12 @@ describe Puppet::ModuleTool::Applications::Uninstaller do
       end
     end
   end
+
+  context 'when in FIPS mode...' do
+    it 'module uninstaller refuses to run' do
+      Facter.stubs(:value).with(:fips_enabled).returns(true)
+      expect {application.run}.to raise_error(/Module uninstall is prohibited in FIPS mode/)
+    end 
+  end
+
 end

--- a/spec/unit/module_tool/applications/upgrader_spec.rb
+++ b/spec/unit/module_tool/applications/upgrader_spec.rb
@@ -327,5 +327,11 @@ describe Puppet::ModuleTool::Applications::Upgrader do
         end
       end
     end
+    context 'when in FIPS mode...' do
+      it 'module unpgrader refuses to run' do
+        Facter.stubs(:value).with(:fips_enabled).returns(true)
+        expect { application.run }.to raise_error(/Module upgrade is prohibited in FIPS mode/)
+      end 
+    end
   end
 end


### PR DESCRIPTION
We now disallow the module tool operations of install, uninstall, and upgrade
besides building to be able to provide an appropriate error message instead
of the operations getting aborted due to FIPS preventing use of any
unapproved algorithms/operations like MD5.
Module checksums use MD5 and cannot be changed easily without requiring a
large number of design changes throughout.