### PR TITLE
(PUP-8297) Don't accept already connected socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ script:
 notifications:
   email: false
 rvm:
-  - 2.3.1
-  - 2.2.4
+  - 2.3.6
+  - 2.2.9
   - 2.1.9
   - 2.0.0
   - 1.9.3
@@ -19,17 +19,17 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.3.1
+    - rvm: 2.3.6
       env: "CHECK=rubocop"
-    - rvm: 2.2.4
+    - rvm: 2.2.9
       env: "CHECK=rubocop"
     - rvm: 2.0.0
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
-    - rvm: 2.3.1
+    - rvm: 2.3.6
       env: "CHECK=commits"
-    - rvm: 2.2.4
+    - rvm: 2.2.9
       env: "CHECK=commits"
     - rvm: 2.0.0
       env: "CHECK=commits"

--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -29,7 +29,6 @@ class Puppet::Network::HTTP::WEBrick
         if ! IO.select([sock],nil,nil,timeout)
           raise "Client did not send data within %.1f seconds of connecting" % timeout
         end
-        sock.accept
         @server.run(sock)
       end
     end

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -26,15 +26,19 @@ describe Puppet::Network::HTTP::WEBrick do
     stub('ssl_context', :ciphers= => nil)
   end
 
+  let(:socket) { mock('socket') }
   let(:mock_webrick) do
-    stub('webrick',
-         :[] => {},
-         :listeners => [],
-         :status => :Running,
-         :mount => nil,
-         :start => nil,
-         :shutdown => nil,
-         :ssl_context => mock_ssl_context)
+    server = stub('webrick',
+                  :[] => {},
+                  :listeners => [],
+                  :status => :Running,
+                  :mount => nil,
+                  :shutdown => nil,
+                  :ssl_context => mock_ssl_context)
+    server.stubs(:start).yields(socket)
+    IO.stubs(:select).with([socket], nil, nil, anything).returns(true)
+    server.stubs(:run).with(socket)
+    server
   end
 
   before :each do

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -92,6 +92,11 @@ describe Puppet::Network::HTTP::WEBrick do
       expect(server).to be_listening
     end
 
+    it "is passed an already connected socket" do
+      socket.expects(:accept).never
+      server.listen(address, port)
+    end
+
     describe "when the REST protocol is requested" do
       it "should register the REST handler at /" do
         # We don't care about the options here.


### PR DESCRIPTION
Ruby 2.3.6 and 2.4.3 changed webrick to use nonblocking I/O when accepting client connections[1,2]. This exposed a bug in puppet's webrick handler due to us calling the blocking version of accept on the already connected socket, resulting in:

    SSL_accept returned=1 errno=0 state=unknown state: unexpected record

Remove the call to accept, since it's no longer needed, add tests and bump our travis CI matrix, including 2.3.6 which has the new ruby behavior.

[1] https://bugs.ruby-lang.org/issues/14005
[2] https://github.com/ruby/ruby/commit/1beda2970b1c17daf34c15a1ee1c551b29080bdd