### PR TITLE
(PUP-8347) use error_location in file_server config parsing

### DIFF
--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -13,9 +13,9 @@ class Puppet::FileServing::Configuration::Parser
     @mounts = {}
     @count = 0
 
-    File.open(@file) { |f|
+    File.open(@file) do |f|
       mount = nil
-      f.each_line { |line|
+      f.each_line do |line|
         # Have the count increment at the top, in case we throw exceptions.
         @count += 1
 
@@ -37,13 +37,17 @@ class Puppet::FileServing::Configuration::Parser
           when "deny"
             deny(mount, value)
           else
-            raise ArgumentError.new(_("Invalid argument '%{var}' in %{file}, line %{line_num}") % { var: var, file: @file.filename, line_num: @count })
+            error_location_str = Puppet::Util::Errors.error_location(@file.filename, @count)
+            raise ArgumentError.new(_("Invalid argument '%{var}' at %{error_location}") %
+                                        { var: var, error_location: error_location_str })
           end
         else
-          raise ArgumentError.new(_("Invalid line '%{line}' at %{file}, line %{line_num}") % { line: line.chomp, file: @file.filename, line_num: @count })
+          error_location_str = Puppet::Util::Errors.error_location(@file.filename, @count)
+          raise ArgumentError.new(_("Invalid entry at %{error_location}: '%{file_text}'") %
+                                      { file_text: line.chomp, error_location: error_location_str })
         end
-      }
-    }
+      end
+    end
 
     validate
 
@@ -67,7 +71,9 @@ class Puppet::FileServing::Configuration::Parser
         mount.info _("allowing %{val} access") % { val: val }
         mount.allow(val)
       rescue Puppet::AuthStoreError => detail
-        raise ArgumentError.new(_("%{detail} in %{file}, line %{line_num}") % { detail: detail.to_s, file: @file, line_num: @count })
+        error_location_str = Puppet::Util::Errors.error_location(@file, @count)
+        raise ArgumentError.new("%{detail} %{error_location}" %
+                                    { detail: detail.to_s, error_location: error_location_str })
       end
     }
   end
@@ -79,14 +85,20 @@ class Puppet::FileServing::Configuration::Parser
         mount.info _("denying %{val} access") % { val: val }
         mount.deny(val)
       rescue Puppet::AuthStoreError => detail
-        raise ArgumentError.new(_("%{detail} in %{file}, line %{line_num}") % { detail: detail.to_s, file: @file, line_num: @count })
+        error_location_str = Puppet::Util::Errors.error_location(@file, @count)
+        raise ArgumentError.new("%{detail} %{error_location}" %
+                                    { detail: detail.to_s, error_location: error_location_str  })
       end
     }
   end
 
   # Create a new mount.
   def newmount(name)
-    raise ArgumentError.new(_("%{mount} is already mounted at %{name} in %{file}, line %{line_num}") % { mount: @mounts[name], name: name, file: @file, line_num: @count }) if @mounts.include?(name)
+    if @mounts.include?(name)
+      error_location_str = Puppet::Util::Errors.error_location(@file, @count)
+      raise ArgumentError.new(_("%{mount} is already mounted at %{name} at %{error_location}") %
+                                  { mount: @mounts[name], name: name, error_location: error_location_str })
+    end
     case name
     when "modules"
       mount = Mount::Modules.new(name)

--- a/spec/unit/file_serving/configuration/parser_spec.rb
+++ b/spec/unit/file_serving/configuration/parser_spec.rb
@@ -78,7 +78,7 @@ describe Puppet::FileServing::Configuration::Parser do
     it "should return comprehensible error message, if invalid line detected" do
       write_config_file "[one]\n\n\x01path /etc/puppetlabs/puppet/files\n\x01allow *\n"
 
-      expect { @parser.parse }.to raise_error(ArgumentError, /Invalid line.*in.*, line 3/)
+      expect { @parser.parse }.to raise_error(ArgumentError, /Invalid entry at \(file: .*, line: 3\): .*/)
     end
   end
 
@@ -130,7 +130,7 @@ describe Puppet::FileServing::Configuration::Parser do
     it "should return comprehensible error message, if failed on invalid attribute" do
       write_config_file "[one]\ndo something\n"
 
-      expect { @parser.parse }.to raise_error(ArgumentError, /Invalid argument 'do' in .*, line 2/)
+      expect { @parser.parse }.to raise_error(ArgumentError, /Invalid argument 'do' at \(file: .*, line: 2\)/)
     end
   end
 


### PR DESCRIPTION
Use error_location() in the file_server config file parser code