### PR TITLE
(PUP-8347) usr error_location for auth config parsing

### DIFF
--- a/lib/puppet/network/auth_config_parser.rb
+++ b/lib/puppet/network/auth_config_parser.rb
@@ -29,11 +29,14 @@ class AuthConfigParser
       when /^\s*(allow(?:_ip)?|deny(?:_ip)?|method|environment|auth(?:enticated)?)\s+(.+?)(\s*#.*)?$/
         if right.nil?
           #TRANSLATORS "path" is a configuration file entry and should not be translated
-          raise Puppet::ConfigurationError, _("Missing or invalid 'path' before right directive at line %{count} of %{file}") % { count: count, file: @file }
+          raise Puppet::ConfigurationError, _("Missing or invalid 'path' before right directive at %{error_location}") %
+              { error_location: Puppet::Util::Errors.error_location(@file, count) }
         end
         parse_right_directive(right, $1, $2, count)
       else
-        raise Puppet::ConfigurationError, _("Invalid line %{count}: %{line}") % { count: count, line: line }
+        error_location_str = Puppet::Util::Errors.error_location(nil, count)
+        raise Puppet::ConfigurationError, _("Invalid entry at %{error_location}: %{file_text}") %
+            { error_location: error_location_str, file_text: line }
       end
       count += 1
     }
@@ -65,8 +68,9 @@ class AuthConfigParser
     when /auth(?:enticated)?/
       modify_right(right, :restrict_authenticated, value, _("adding authentication %{value}"), count)
     else
-      raise Puppet::ConfigurationError,
-        _("Invalid argument '%{var}' at line %{count}") % { var: var, count: count }
+      error_location_str = Puppet::Util::Errors.error_location(nil, count)
+      raise Puppet::ConfigurationError, _("Invalid argument '%{var}' at %{error_location}") %
+          { var: var, error_location: error_location_str }
     end
   end
 
@@ -77,7 +81,8 @@ class AuthConfigParser
         right.info msg % { value: val }
         right.send(method, val)
       rescue Puppet::AuthStoreError => detail
-        raise Puppet::ConfigurationError, _("%{detail} at line %{count} of %{file}") % { detail: detail, count: count, file: @file }, detail.backtrace
+        error_location_str = Puppet::Util::Errors.error_location(@file, count)
+        raise Puppet::ConfigurationError, "#{detail} #{error_location_str}", detail.backtrace
       end
     end
   end

--- a/spec/integration/network/authconfig_spec.rb
+++ b/spec/integration/network/authconfig_spec.rb
@@ -97,13 +97,13 @@ describe Puppet::Network::AuthConfig do
     it 'should warn about missing path before allow_ip in stanza' do
       expect {
         add_raw_stanza("allow_ip 10.0.0.1\n")
-      }.to raise_error Puppet::ConfigurationError, /Missing or invalid 'path' before right directive at line.*/
+      }.to raise_error Puppet::ConfigurationError, /Missing or invalid 'path' before right directive at \(line: .*\)/
     end
 
     it 'should warn about missing path before allow in stanza' do
       expect {
         add_raw_stanza("allow host.domain.com\n")
-      }.to raise_error Puppet::ConfigurationError, /Missing or invalid 'path' before right directive at line.*/
+      }.to raise_error Puppet::ConfigurationError, /Missing or invalid 'path' before right directive at \(line: .*\)/
     end
 
     it "should support hostname backreferences" do


### PR DESCRIPTION
Use the error_location() method when parsing network auth config files