### PR TITLE
(PUP-8356) Base fips specific behaviors without using facts

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1,3 +1,5 @@
+require 'puppet/util/platform'
+
 module Puppet
 
   def self.default_diffargs
@@ -9,7 +11,7 @@ module Puppet
   end
 
   def self.default_digest_alg
-    if Facter.value(:fips_enabled) == true
+    if Puppet::Util::Platform.fips_enabled?
       "sha256"
     else
       "md5"
@@ -17,7 +19,7 @@ module Puppet
   end
 
   def self.default_checksum_types 
-    if Facter.value(:fips_enabled) == true
+    if Puppet::Util::Platform.fips_enabled?
       ['sha256', 'sha384', 'sha512', 'sha224']
     else
       ['md5', 'sha256', 'sha384', 'sha512', 'sha224']

--- a/lib/puppet/util/platform.rb
+++ b/lib/puppet/util/platform.rb
@@ -1,6 +1,9 @@
 module Puppet
   module Util
     module Platform
+
+      FIPS_STATUS_FILE = "/proc/sys/crypto/fips_enabled".freeze
+
       def windows?
         # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
         # library uses that to test what platform it's on. In some places we
@@ -17,6 +20,16 @@ module Puppet
         %w{/usr/sbin /sbin}
       end
       module_function :default_paths
+
+      @fips_enabled = !windows? &&
+                       File.exist?(FIPS_STATUS_FILE) &&  
+                       File.read(FIPS_STATUS_FILE, 1) == '1'
+
+      def fips_enabled?
+        @fips_enabled
+      end
+      module_function :fips_enabled?
+
     end
   end
 end


### PR DESCRIPTION
We need to adjust some settings based on whether fips mode is enabled
or not for FIPS compliance. Till now the later was done using a fact (PUP-8141).
However that created a dependency in puppetserver which cannot load facts in certain configurations like dev testing and running from sources.
This change implements fips mode detection using a local method instead of facter.