### PR TITLE
(PUP-8357) Correctly match files for tasks

### DIFF
--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -251,8 +251,8 @@ module LoaderPaths
       n = ''
       n << module_name unless module_name.nil?
 
-      # Remove extension regardless of what it is. A task name cannot contain dots
-      relative_path = relative_path.sub(/\.[^\/]*\z/, '')
+      # Remove the file extension, defined as everything after the *last* dot.
+      relative_path = relative_path.sub(%r{\.[^/.]*\z}, '')
 
       if relative_path == 'init' && !(module_name.nil? || module_name.empty?)
         TypedName.new(type, module_name, name_authority)

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -424,8 +424,13 @@ module ModuleLoaders
     end
 
     def existing_paths(effective_path)
-      # Select all paths starting with effective_path but reject any path that continues into a subdirectory
-      @path_index.select { |path| path.start_with?(effective_path) }.reject { |path| path[effective_path.size..-1].include?('/')}
+      dirname = File.dirname(effective_path)
+      basename = File.basename(effective_path)
+      # Select all paths matching `effective_path` up until an optional file extension
+      @path_index.select do |path|
+        File.basename(path, '.*') == basename &&
+          File.dirname(path) == dirname
+      end
     end
 
     def meaningful_to_search?(smart_path)


### PR DESCRIPTION
Previously, the existing_paths method for the FileBased loader was using
naive string matching to determine which files were associated with a
particular task. This resulted in the wrong set of files being found for
a task, in the case where the name of one task was a prefix of the name
of an adjacent task. For example, task `foo` would match both `foo.py`
and `foobar.py`. The desired behavior is that filenames need to match
all the way up to the file extension, in order to be associated with a
particular task.

This commit changes the existing_paths method to compare basenames
exactly, excluding file extensions.