### PR TITLE
(maint) Make crontab provider suitable in specs

### DIFF
--- a/spec/integration/provider/cron/crontab_spec.rb
+++ b/spec/integration/provider/cron/crontab_spec.rb
@@ -10,6 +10,7 @@ describe Puppet::Type.type(:cron).provider(:crontab), '(integration)', :unless =
 
   before :each do
     Puppet::Type.type(:cron).stubs(:defaultprovider).returns described_class
+    described_class.stubs(:suitable?).returns true
     Puppet::FileBucket::Dipper.any_instance.stubs(:backup) # Don't backup to filebucket
 
     # I don't want to execute anything


### PR DESCRIPTION
These tests fail when run on a machine where the crontab file is not
suitable. There's no need for this, so just stub it to always be
suitable.