### PR TITLE
(PUP-8347) use error_location for network device config file

### DIFF
--- a/lib/puppet/util/network_device/config.rb
+++ b/lib/puppet/util/network_device/config.rb
@@ -39,34 +39,41 @@ class Puppet::Util::NetworkDevice::Config
     begin
       devices = {}
       device = nil
-      File.open(@file) { |f|
-        count = 1
-        f.each { |line|
+      File.open(@file) do |f|
+        file_line_count = 1
+        f.each do |line|
           case line
           when /^\s*#/ # skip comments
-            count += 1
+            file_line_count += 1
             next
           when /^\s*$/  # skip blank lines
-            count += 1
+            file_line_count += 1
             next
           when /^\[([\w.-]+)\]\s*$/ # [device.fqdn]
             name = $1
             name.chomp!
-            raise Puppet::Error, _("Duplicate device found at line %{count}, already found at %{line}") % { count: count, line: device.line } if devices.include?(name)
+            if devices.include?(name)
+              file_error_location = Puppet::Util::Errors.error_location(nil, file_line_count)
+              device_error_location = Puppet::Util::Errors.error_location(nil, device.line)
+              raise Puppet::Error, _("Duplicate device found at %{file_error_location}, already found at %{device_error_location}") %
+                  { file_error_location: file_error_location, device_error_location: device_error_location }
+            end
             device = OpenStruct.new
             device.name = name
-            device.line = count
+            device.line = file_line_count
             device.options = { :debug => false }
             Puppet.debug "found device: #{device.name} at #{device.line}"
             devices[name] = device
           when /^\s*(type|url|debug)(\s+(.+)\s*)*$/
-            parse_directive(device, $1, $3, count)
+            parse_directive(device, $1, $3, file_line_count)
           else
-            raise Puppet::Error, _("Invalid line %{count}: %{line}") % { count: count, line: line }
+            error_location_str = Puppet::Util::Errors.error_location(nil, file_line_count)
+            raise Puppet::Error, _("Invalid entry at %{error_location}: %{file_text}") %
+                { error_location: error_location_str, file_text: line }
           end
-          count += 1
-        }
-      }
+          file_line_count += 1
+        end
+      end
     rescue Errno::EACCES => detail
       Puppet.err _("Configuration error: Cannot read %{file}; cannot serve") % { file: @file }
       #raise Puppet::Error, "Cannot read #{@config}"
@@ -91,7 +98,8 @@ class Puppet::Util::NetworkDevice::Config
     when "debug"
       device.options[:debug] = true
     else
-      raise Puppet::Error, _("Invalid argument '%{var}' at line %{count}") % { var: var, count: count }
+      error_location_str = Puppet::Util::Errors.error_location(nil, count)
+      raise Puppet::Error, _("Invalid argument '%{var}' at %{error_location}") % { var: var, error_location: error_location_str }
     end
   end
 


### PR DESCRIPTION
Use the error_location() to tell the error location when processing
the network device config file
I refactored the code to be more understandable