### PR TITLE
(maint) Pass through text domain when loading translations

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -89,7 +89,7 @@ module Puppet::GettextConfig
                                 report_warning: false)
     FastGettext.default_text_domain = DEFAULT_TEXT_DOMAIN
 
-    load_translations('puppet', puppet_locale_path, translation_mode(puppet_locale_path))
+    load_translations('puppet', puppet_locale_path, translation_mode(puppet_locale_path), DEFAULT_TEXT_DOMAIN)
   end
 
   # @api private
@@ -191,7 +191,7 @@ module Puppet::GettextConfig
   # @param [String] locale_dir the path to the directory containing translations
   # @param [Symbol] file_format translation file format to use, either :po or :mo
   # @return true if initialization succeeded, false otherwise
-  def self.load_translations(project_name, locale_dir, file_format)
+  def self.load_translations(project_name, locale_dir, file_format, text_domain = FastGettext.text_domain)
     if project_name.nil? || project_name.empty?
       raise Puppet::Error, "A project name must be specified in order to initialize translations."
     end
@@ -204,7 +204,7 @@ module Puppet::GettextConfig
       raise Puppet::Error, "Unsupported translation file format #{file_format}; please use :po or :mo"
     end
 
-    add_repository_to_domain(project_name, locale_dir, file_format)
+    add_repository_to_domain(project_name, locale_dir, file_format, text_domain)
     return true
   end
 
@@ -214,10 +214,10 @@ module Puppet::GettextConfig
   # @param [String] project_name the name of the project for which to load translations
   # @param [String] locale_dir the path to the directory containing translations
   # @param [Symbol] file_format the fomat of the translations files, :po or :mo
-  def self.add_repository_to_domain(project_name, locale_dir, file_format)
+  def self.add_repository_to_domain(project_name, locale_dir, file_format, text_domain = FastGettext.text_domain)
     return if @gettext_disabled || !gettext_loaded?
 
-    current_chain = FastGettext.translation_repositories[FastGettext.text_domain].chain
+    current_chain = FastGettext.translation_repositories[text_domain].chain
 
     repository = FastGettext::TranslationRepository.build(project_name,
                                                           path: locale_dir,

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -108,6 +108,7 @@ module Puppet::GettextConfig
   def self.delete_all_text_domains
     FastGettext.translation_repositories.clear
     FastGettext.default_text_domain = nil
+    FastGettext.text_domain = nil
   end
 
   # @api private
@@ -117,6 +118,9 @@ module Puppet::GettextConfig
     return if @gettext_disabled || !gettext_loaded?
 
     FastGettext.translation_repositories.delete(domain_name)
+    if FastGettext.text_domain == domain_name
+      FastGettext.text_domain = nil
+    end
   end
 
   # @api private
@@ -130,6 +134,7 @@ module Puppet::GettextConfig
 
       FastGettext.translation_repositories.delete(key)
     end
+    FastGettext.text_domain = nil
   end
 
   # @api private

--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -67,7 +67,7 @@ describe Puppet::GettextConfig do
 
     context 'when given a valid locale file location' do
       it 'should return true' do
-        Puppet::GettextConfig.expects(:add_repository_to_domain).with('puppet', local_path, :po)
+        Puppet::GettextConfig.expects(:add_repository_to_domain).with('puppet', local_path, :po, anything)
 
         expect(Puppet::GettextConfig.load_translations('puppet', local_path, :po)).to be true
       end
@@ -81,8 +81,14 @@ describe Puppet::GettextConfig do
   end
 
   describe "setting up text domains" do
+    it 'can create the default text domain after another is set' do
+      Puppet::GettextConfig.delete_all_text_domains
+      FastGettext.text_domain = 'other'
+      Puppet::GettextConfig.create_default_text_domain
+    end
+
     it 'should add puppet translations to the default text domain' do
-      Puppet::GettextConfig.expects(:load_translations).with('puppet', local_path, :po).returns(true)
+      Puppet::GettextConfig.expects(:load_translations).with('puppet', local_path, :po, Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN).returns(true)
 
       Puppet::GettextConfig.create_default_text_domain
       expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN)


### PR DESCRIPTION
If this isn't passed through the tests can fail sometimes depending on
the order in which they're run. I don't think this is ever a problem in
production but adding an argument with a default makes it a little more
robust.