### PR TITLE
(maint) Fix service_enable_linux.rb test to work with ec2 hosts

### DIFF
--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -15,7 +15,7 @@ package_name = {'el'     => 'httpd',
 
 agents.each do |agent|
   platform = agent.platform.variant
-  osname = on(agent, facter('os.name')).stdout.chomp.to_i
+  osname = on(agent, facter('os.name')).stdout.chomp
   osreleasefull = on(agent, facter('os.release.full')).stdout.chomp.to_f
   majrelease = on(agent, facter('operatingsystemmajrelease')).stdout.chomp.to_i
 


### PR DESCRIPTION
Fixed service_enable_linux.rb test to work with ec2 hosts