### PR TITLE
(PUP-8343) let rich data params through to resources

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -330,8 +330,7 @@ module Runtime3Support
   end
 
   def convert(value, scope, undef_value)
-    converter = scope.environment.rich_data? ? Runtime3Converter.instance : Runtime3FunctionArgumentConverter.instance
-    converter.convert(value, scope, undef_value)
+    Runtime3Converter.instance.convert(value, scope, undef_value)
   end
 
   def create_resources(o, scope, virtual, exported, type_name, resource_titles, evaluated_parameters)

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -188,15 +188,19 @@ module Serialization
     end
 
     def unknown_key_to_string_with_warning(value)
-      str = value.to_s
+      str = unknown_to_string(value)
       serialization_issue(Issues::SERIALIZATION_UNKNOWN_KEY_CONVERTED_TO_STRING, :path => path_to_s, :klass => value.class, :value => str)
       str
     end
 
     def unknown_to_string_with_warning(value)
-      str = value.to_s
+      str = unknown_to_string(value)
       serialization_issue(Issues::SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING, :path => path_to_s, :klass => value.class, :value => str)
       str
+    end
+
+    def unknown_to_string(value)
+      value.is_a?(Regexp) ? value.inspect : value.to_s
     end
 
     def non_string_keyed_hash_to_data(hash)

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -200,7 +200,7 @@ module Serialization
     end
 
     def unknown_to_string(value)
-      value.is_a?(Regexp) ? value.inspect : value.to_s
+      value.is_a?(Regexp) ? Puppet::Pops::Types::PRegexpType.regexp_to_s_with_delimiters(value) : value.to_s
     end
 
     def non_string_keyed_hash_to_data(hash)

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -898,13 +898,22 @@ describe Puppet::Parser::Compiler do
         end.to raise_error(/Class\[Foo\]: parameter 'x' expects an Integer value, got Undef/)
       end
 
-      it 'denies a regexp (rich data) argument given to String parameter (even if later encoding of it is a string)' do
+      it 'denies a regexp (rich data) argument given to class String parameter (even if later encoding of it is a string)' do
         expect do
           catalog = compile_to_catalog(<<-MANIFEST)
             class foo(String $x) { }
             class { 'foo':  x => /I am a regexp and I don't want to be a String/}
           MANIFEST
         end.to raise_error(/Class\[Foo\]: parameter 'x' expects a String value, got Regexp/)
+      end
+
+      it 'denies a regexp (rich data) argument given to define String parameter (even if later encoding of it is a string)' do
+        expect do
+          catalog = compile_to_catalog(<<-MANIFEST)
+            define foo(String $x) { }
+            foo { 'foo':  x => /I am a regexp and I don't want to be a String/}
+          MANIFEST
+        end.to raise_error(/Foo\[foo\]: parameter 'x' expects a String value, got Regexp/)
       end
 
       it 'accepts a Resource as a Type' do

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -898,6 +898,15 @@ describe Puppet::Parser::Compiler do
         end.to raise_error(/Class\[Foo\]: parameter 'x' expects an Integer value, got Undef/)
       end
 
+      it 'denies a regexp (rich data) argument given to String parameter (even if later encoding of it is a string)' do
+        expect do
+          catalog = compile_to_catalog(<<-MANIFEST)
+            class foo(String $x) { }
+            class { 'foo':  x => /I am a regexp and I don't want to be a String/}
+          MANIFEST
+        end.to raise_error(/Class\[Foo\]: parameter 'x' expects a String value, got Regexp/)
+      end
+
       it 'accepts a Resource as a Type' do
         catalog = compile_to_catalog(<<-MANIFEST)
           define bar($text) { }


### PR DESCRIPTION
Before this given rich-data (not all data types though) were transformed to String when given as arguments to classes and defines.
This was not good because it works against the purpose of type checking.
