### PR TITLE
(PUP-8268) aio setup should use new install method

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,8 +12,9 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.10')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.30')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 0.10")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -1,27 +1,16 @@
 require 'puppet/acceptance/common_utils'
 require 'puppet/acceptance/install_utils'
 
+require 'beaker-puppet'
 extend Puppet::Acceptance::InstallUtils
+extend BeakerPuppet::Install::Puppet5
 
 test_name "Install Packages"
 
 step "Install puppet-agent..." do
-  opts = {
-    :puppet_collection    => 'PC1',
-    :puppet_agent_sha     => ENV['SHA'],
-    # SUITE_VERSION is necessary for Beaker to build a package download
-    # url which is built upon a `git describe` for a SHA.
-    # Beaker currently cannot find or calculate this value based on
-    # the SHA, and thus it must be passed at invocation time.
-    # The one exception is when SHA is a tag like `1.8.0` and
-    # SUITE_VERSION will be equivalent.
-    # RE-8333 may make this unnecessary in the future
-    :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
-  }
-  agents.each do |agent|
-    next if agent == master # Avoid SERVER-528
-    install_puppet_agent_dev_repo_on(agent, opts)
-  end
+  dev_builds_url  = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
+  sha = ENV['SHA']
+  install_from_build_data_url('puppet-agent', "#{dev_builds_url}/puppet-agent/#{sha}/artifacts/#{sha}.yaml", hosts)
 end
 
 MASTER_PACKAGES = {
@@ -83,13 +72,13 @@ step "Install puppetserver..." do
     if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
       server_version = 'latest'
       server_download_url = "http://nightlies.puppet.com"
+      install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
+      master.install_package('puppetserver')
     else
       server_version = ENV['SERVER_VERSION']
-      server_download_url = "http://builds.delivery.puppetlabs.net"
+      dev_builds_url = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
+      install_from_build_data_url('puppetserver', "#{dev_builds_url}/puppetserver/#{server_version}/artifacts/#{server_version}.yaml", master)
     end
-    install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
-    install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
-    master.install_package('puppetserver')
   end
 end
 


### PR DESCRIPTION
This commit updates the aio setup steps to install puppet and
puppetserver with new methods added to beaker. These install the
packages based on data gathered from a yaml file, rather than trying to
figure out what the path to the artifact or repo file is.

This commit does not attempt to make the same change for the EC2 install
(as it's dependent on external infrastructure and the new install
methods rely on internal-only infrastructure). Nor does this commit
attempt to update the puppetserver nightly install. Nightlies is going
to change soon, so it is not worth updating those methods currently.

This commit also updates beaker and beaker-hostgenerator versions. This
change depends on code available in these newer releases. It also adds
beaker-puppet to the Gemfile, as we should be explicit about this
dependency since we are using methods that are specific to
beaker-puppet.