### PR TITLE
(PUP-8363) Do not use system_uptime fact on windows

### DIFF
--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -45,10 +45,15 @@ tag 'audit:medium',
 
 echo -n "custom_time=$(date +%s%N)"
   FILE
-  create_remote_file(master, "#{fq_tmp_environmentpath}/modules/custom_time/facts.d/custom_time.ps1", <<-FILE)
-  echo "custom_time=$(get-date -format HHmmssffffff)"
-  FILE
+
   on(master, "chmod -R 0777 #{fq_tmp_environmentpath}/")
+
+  windows_fact_location = "#{fq_tmp_environmentpath}/modules/custom_time/facts.d/custom_time.ps1"
+  create_remote_file(master, windows_fact_location, <<-FILE)
+echo "custom_time=$(get-date -format HHmmssffffff)"
+FILE
+
+  on(master, "chmod -R 0666 #{windows_fact_location}")
 
 
   step "run agent in #{tmp_environment}, ensure it increments the customtime with each run" do

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -15,62 +15,78 @@ tag 'audit:medium',
   CONF
   # the module function loading logic is different from inside a single manifest
   #   we exercise both here
-  on(master, "mkdir -p #{fq_tmp_environmentpath}/modules/uptime/{manifests,functions}")
-  create_remote_file(master, "#{fq_tmp_environmentpath}/modules/uptime/manifests/init.pp", <<-FILE)
-    class uptime {
-      notify { 'current uptime':
-        message => uptime::my_system_uptime()
+  on(master, "mkdir -p #{fq_tmp_environmentpath}/modules/custom_time/{manifests,functions,facts.d}")
+  create_remote_file(master, "#{fq_tmp_environmentpath}/modules/custom_time/manifests/init.pp", <<-FILE)
+    class custom_time {
+      $t = custom_time::my_system_time()
+
+      notify { 'custom time':
+        message => "module_${t}_module",
       }
     }
   FILE
-  create_remote_file(master, "#{fq_tmp_environmentpath}/modules/uptime/functions/my_system_uptime.pp", <<-FILE)
-    function uptime::my_system_uptime() {
-      $facts['system_uptime']
+  create_remote_file(master, "#{fq_tmp_environmentpath}/modules/custom_time/functions/my_system_time.pp", <<-FILE)
+    function custom_time::my_system_time() {
+      $facts['custom_time']
     }
   FILE
   create_sitepp(master, tmp_environment, <<-SITE)
     function bar() {
-      $facts['system_uptime']['seconds']
+      $facts['custom_time']
     }
     class foo::bar {
       notify { "local_${bar()}_local": }
     }
     include foo::bar
-    include uptime
+    include custom_time
   SITE
+  create_remote_file(master, "#{fq_tmp_environmentpath}/modules/custom_time/facts.d/custom_time.sh", <<-FILE)
+#!/bin/bash
+
+echo -n "custom_time=$(date +%s%N)"
+  FILE
+  create_remote_file(master, "#{fq_tmp_environmentpath}/modules/custom_time/facts.d/custom_time.ps1", <<-FILE)
+  echo "custom_time=$(get-date -format HHmmssffffff)"
+  FILE
   on(master, "chmod -R 0777 #{fq_tmp_environmentpath}/")
 
-  step "run agent in #{tmp_environment}, ensure it increments the uptime with each run" do
+
+  step "run agent in #{tmp_environment}, ensure it increments the customtime with each run" do
     with_puppet_running_on(master,{}) do
-      uptime = nil
-      module_uptime = nil
-      local_uptime_pattern = 'local_(\d+)_local'
+      local_custom_time_pattern = 'local_(\d+)_local'
+      module_custom_time_pattern = 'module_(\d+)_module'
       agents.each do |agent|
+        # ensure our custom facts have been synced
+        on(agent,
+           puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+           :accept_all_exit_codes => true)
+
+        local_custom_time1 = module_custom_time1 = nil
+        local_custom_time2 = module_custom_time2 = nil
+
         on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
-           :accept_all_exit_codes => true) do |result|
-          assert_equal(2, result.exit_code, 'wrong exit_code')
-          assert_match(/Notice: #{local_uptime_pattern}/, result.stdout, 'first uptime was not as expected')
-          assert_match(/"seconds"=>\d+,/, result.stdout, 'first module uptime was not as expected')
-          uptime = Integer(result.stdout.match(/Notice: #{local_uptime_pattern}/)[1])
-          module_uptime = Integer(result.stdout.match(/"seconds"=>(\d+),/)[1])
+           :accept_all_exit_codes => [2]) do |result|
+          assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'first custom time was not as expected')
+          assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'first module uptime was not as expected')
+
+          local_custom_time1 = Integer(result.stdout.match(/Notice: #{local_custom_time_pattern}/)[1])
+          module_custom_time1 = Integer(result.stdout.match(/Notice: #{module_custom_time_pattern}/)[1])
         end
-        if agent.platform =~ /solaris|aix/
-          sleep 61  # See FACT-1497;
-        else
-          sleep 1
-        end
+
+        sleep 1
+
         on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
-           :accept_all_exit_codes => true) do |result|
-          assert_equal(2, result.exit_code, 'wrong exit_code')
-          assert_match(/Notice: #{local_uptime_pattern}/, result.stdout, 'second uptime was not as expected')
-          assert_match(/"seconds"=>\d+,/, result.stdout, 'second module uptime was not as expected')
-          uptime2 = Integer(result.stdout.match(/Notice: #{local_uptime_pattern}/)[1])
-          module_uptime2 = Integer(result.stdout.match(/"seconds"=>(\d+),/)[1])
-          assert(uptime2 > uptime, 'uptime did not change')
-          assert(module_uptime2 > module_uptime, 'module based uptime did not change')
+           :accept_all_exit_codes => [2]) do |result|
+          assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'second custom time was not as expected')
+          assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'second module uptime was not as expected')
+
+          local_custom_time2 = Integer(result.stdout.match(/Notice: #{local_custom_time_pattern}/)[1])
+          module_custom_time2 = Integer(result.stdout.match(/Notice: #{module_custom_time_pattern}/)[1])
         end
+
+        assert(local_custom_time2 > local_custom_time1, 'local custom time did not change as expected if at all')
+        assert(module_custom_time2 > module_custom_time1, 'module custom time did not change as expected if at all')
       end
     end
   end
-
 end


### PR DESCRIPTION
Previously, we used the system_uptime fact as a form of randomness when
testing that topscope variables (ie, return values from pure puppet functions
that do not enter ruby land) were refreshed when environment_timeout was
unlimited.

Unfortunately, facter's system_uptime may not return a valid value on
Windows (see FACT-1504 for details).

To avoid using Ruby on the server, while still having a constantly
changing variable, we continue to use the agents under test to provide a
value (fact) but now move from using system_uptime to an external fact.