### PR TITLE
(PUP-8297) Ensure we call SSLSocket#accept once

### DIFF
--- a/lib/puppet/network/http/webrick.rb
+++ b/lib/puppet/network/http/webrick.rb
@@ -17,8 +17,6 @@ class Puppet::Network::HTTP::WEBrick
   def listen(address, port)
     @server = create_server(address, port)
 
-    @server.listeners.each { |l| l.start_immediately = false }
-
     @server.mount('/', Puppet::Network::HTTP::WEBrickREST)
 
     raise "WEBrick server is already listening" if @listening
@@ -29,6 +27,7 @@ class Puppet::Network::HTTP::WEBrick
         if ! IO.select([sock],nil,nil,timeout)
           raise "Client did not send data within %.1f seconds of connecting" % timeout
         end
+        sock.accept
         @server.run(sock)
       end
     end
@@ -100,7 +99,7 @@ class Puppet::Network::HTTP::WEBrick
 
     results[:SSLPrivateKey] = host.key.content
     results[:SSLCertificate] = host.certificate.content
-    results[:SSLStartImmediately] = true
+    results[:SSLStartImmediately] = false
     results[:SSLEnable] = true
     results[:SSLOptions] = OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3
 

--- a/spec/unit/network/http/webrick_spec.rb
+++ b/spec/unit/network/http/webrick_spec.rb
@@ -36,6 +36,7 @@ describe Puppet::Network::HTTP::WEBrick do
                   :ssl_context => mock_ssl_context)
     server.stubs(:start).yields(socket)
     IO.stubs(:select).with([socket], nil, nil, anything).returns(true)
+    socket.stubs(:accept)
     server.stubs(:run).with(socket)
     server
   end
@@ -93,9 +94,11 @@ describe Puppet::Network::HTTP::WEBrick do
       expect(server).to be_listening
     end
 
-    it "is passed an already connected socket" do
-      socket.expects(:accept).never
+    it "is passed a yet to be accepted socket" do
+      socket.expects(:accept)
+
       server.listen(address, port)
+      server.unlisten
     end
 
     describe "when the REST protocol is requested" do
@@ -234,8 +237,8 @@ describe Puppet::Network::HTTP::WEBrick do
       expect(server.setup_ssl[:SSLCACertificateFile]).to eq(ssl_server_ca_auth)
     end
 
-    it "should start ssl immediately" do
-      expect(server.setup_ssl[:SSLStartImmediately]).to be_truthy
+    it "should not start ssl immediately" do
+      expect(server.setup_ssl[:SSLStartImmediately]).to eq(false)
     end
 
     it "should enable ssl" do


### PR DESCRIPTION
Previously, our webrick code set the webrick option SSLStartImmediately to true
and then called `SSLServer#start_immediately = false`, in that order. Ruby
versions 2.3.6/2.4.3 and up will skip the call to SSLSocket#accept if the
SSLStartImmediately option is false. However, older versions will skip the call
if the SSLServer `@start_immediately` instance variable is false[1].

Prior to commit a358d5e, newer ruby versions caused an error because
SSLSocket#accept was called twice on the same socket, once by webrick and again
by us.

Commit a358d5e fixed the newer ruby case, but regressed on the older ruby
case, since SSLSocket#accept was never being called.

This commit eliminates the call to `start_immediately = false`, and sets the
configuration option to false. This works as far back as ruby 1.9.3, while
preserving the intent of the original issue[2].

Paired-with: Jacob Helwig <jacob@puppet.com>

[1] ruby/ruby@2e728d5
[1] https://projects.puppetlabs.com/issues/2637