### PR TITLE
(PUP-7349) Generated tidy resources should have the same noop-ness

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -222,7 +222,14 @@ Puppet::Type.newtype(:tidy) do
   # Make a file resource to remove a given file.
   def mkfile(path)
     # Force deletion, so directories actually get deleted.
-    Puppet::Type.type(:file).new :path => path, :backup => self[:backup], :ensure => :absent, :force => true
+    parameters = {
+      :path => path, :backup => self[:backup],
+      :ensure => :absent, :force => true
+    }
+
+    parameters[:noop] = self[:noop] unless self[:noop].nil?
+
+    Puppet::Type.type(:file).new(parameters)
   end
 
   def retrieve

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -440,6 +440,20 @@ describe tidy do
       result = @tidy.generate.inject({}) { |hash, res| hash[res[:path]] = res; hash }
       expect(result[@basepath + '/a'][:require].collect{|a| a.name[('File//a/' + @basepath).length..-1]}.join()).to eq('321')
     end
+
+    it "generates resources whose noop parameter matches the managed resource's noop parameter" do
+      @tidy[:recurse] = true
+      @tidy[:noop] = true
+
+      fileset = mock 'fileset'
+      Puppet::FileServing::Fileset.expects(:new).with(@basepath, :recurse => true).returns fileset
+      fileset.expects(:files).returns %w{. a a/2 a/1 a/3}
+      @tidy.stubs(:tidy?).returns true
+
+      result = @tidy.generate.inject({}) { |hash, res| hash[res[:path]] = res; hash }
+
+      expect(result.values).to all(be_noop)
+    end
   end
 
   def lstat_is(path, stat)


### PR DESCRIPTION
If tidy resource's noop metaparameter is true or false, but not nil,
then generate file resources with the same noop-ness. If the noop
metaparameter is not set, but the Puppet noop setting is, then just
let puppet handle it.