### PR TITLE
(PUP-6274) Raise Error if included classname is undef or empty string

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -1068,7 +1068,10 @@ class Puppet::Parser::Scope
   def transform_and_assert_classnames(names)
     names.map do |name|
       case name
+      when NilClass
+        raise ArgumentError, _("Cannot use undef as a class name")
       when String
+        raise ArgumentError, _("Cannot use empty string as a class name") if name.empty?
         name.sub(/^([^:]{1,2})/, '::\1')
 
       when Puppet::Resource

--- a/spec/unit/functions/include_spec.rb
+++ b/spec/unit/functions/include_spec.rb
@@ -98,6 +98,20 @@ describe 'The "include" function' do
     }.to raise_error(Puppet::Error)
   end
 
+    { "''"      => 'empty string', 
+      'undef'   => 'undef',
+      "['']"    => 'empty string',
+      "[undef]" => 'undef'
+    }.each_pair do |value, name_kind|
+      it "raises an error if class is #{name_kind}" do
+        expect {
+          catalog = compile_to_catalog(<<-MANIFEST)
+            include #{value}
+          MANIFEST
+        }.to raise_error(/Cannot use #{name_kind}/)
+      end
+    end
+
   it "does not contained the included class in the current class" do
     catalog = compile_to_catalog(<<-MANIFEST)
       class not_contained {


### PR DESCRIPTION
Before this, undef and empty string given to include would not lead to
an error because the Class[main] is known internally as '' which is also
what undef becomes in the 3.x API.

There is no legit case where the class '' should be allowed in the
puppet language.

This commit raises an error if include is given an empty string or
undef/nil.

(The ticket said to also move the `include` to 4.x API, but that was already done - hence the name of the branch - just ignore that).