### PR TITLE
(PUP-6977) Add a module_directory(names...) function

### DIFF
--- a/lib/puppet/functions/module_directory.rb
+++ b/lib/puppet/functions/module_directory.rb
@@ -1,0 +1,41 @@
+# Finds an existing module and returns the path to its root directory.
+#
+# The argument to this function should be a module name String
+# For example, the reference `mysql` will search for the
+# directory `<MODULES DIRECTORY>/mysql` and return the first
+# found on the modulepath.
+#
+# This function can also accept:
+#
+# * Multiple String arguments, which will return the path of the **first** module
+#  found, skipping non existing modules.
+# * An array of module names, which will return the path of the **first** module
+#  found from the given names in the array, skipping non existing modules.
+#
+# The function returns `undef` if none of the given modules were found
+#
+# @since 5.4.0
+#
+Puppet::Functions.create_function(:module_directory, Puppet::Functions::InternalFunction) do
+  dispatch :module_directory do
+    scope_param
+    repeated_param 'String', :names
+  end
+
+  dispatch :module_directory_array do
+    scope_param
+    repeated_param 'Array[String]', :names
+  end
+
+  def module_directory_array(scope, names)
+    module_directory(scope, *names)
+  end
+
+  def module_directory(scope, *names)
+    names.each do |module_name|
+      found = scope.compiler.environment.module(module_name)
+      return found.path if found
+    end
+    nil
+  end
+end

--- a/spec/unit/functions/module_directory_spec.rb
+++ b/spec/unit/functions/module_directory_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+require 'puppet_spec/files'
+
+describe 'the module_directory function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+  include PuppetSpec::Files
+
+  it 'returns first found module from one or more given names' do
+    mod = mock 'module'
+    mod.stubs(:path).returns('expected_path')
+    Puppet[:code] = "notify { module_directory('one', 'two'):}"
+    node = Puppet::Node.new('localhost')
+    compiler = Puppet::Parser::Compiler.new(node)
+    compiler.environment.stubs(:module).with('one').returns(nil)
+    compiler.environment.stubs(:module).with('two').returns(mod)
+    expect(compiler.compile()).to have_resource("Notify[expected_path]")
+  end
+
+  it 'returns first found module from one or more given names in an array' do
+    mod = mock 'module'
+    mod.stubs(:path).returns('expected_path')
+    Puppet[:code] = "notify { module_directory(['one', 'two']):}"
+    node = Puppet::Node.new('localhost')
+    compiler = Puppet::Parser::Compiler.new(node)
+    compiler.environment.stubs(:module).with('one').returns(nil)
+    compiler.environment.stubs(:module).with('two').returns(mod)
+    expect(compiler.compile()).to have_resource("Notify[expected_path]")
+  end
+
+  it 'returns undef when none of the modules were found' do
+    mod = mock 'module'
+    mod.stubs(:path).returns('expected_path')
+    Puppet[:code] = "notify { String(type(module_directory('one', 'two'))):}"
+    node = Puppet::Node.new('localhost')
+    compiler = Puppet::Parser::Compiler.new(node)
+    compiler.environment.stubs(:module).with('one').returns(nil)
+    compiler.environment.stubs(:module).with('two').returns(nil)
+    expect(compiler.compile()).to have_resource("Notify[Undef]")
+  end
+end


### PR DESCRIPTION
This adds the function module_directory() that returns the first found
module's root directory path given one or more module names directly or
in an array.