### PR TITLE
(PUP-8361) Add 'ronn' to the development/test group in the Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ group(:development, :test) do
   gem 'rdoc', "~> 4.1", :platforms => [:ruby]
   gem 'yard'
 
+  # ronn is used for generating manpages.
+  gem 'ronn', '~> 0.7.3', :platforms => [:ruby]
+
   # webmock requires addressable as as of 2.5.0 addressable started
   # requiring the public_suffix gem which requires Ruby 2
   gem 'addressable', '< 2.5.0'


### PR DESCRIPTION
`ronn` is used for generating manpages.