### PR TITLE
(PUP-7046) Update dnf provider to support future Fedora releases

### DIFF
--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => ['22', '23', '24', '25']
+  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => (22..30).to_a
 
   def self.update_command
     # In DNF, update is deprecated for upgrade


### PR DESCRIPTION
The dnf provider is hard coded to work with Fedora 22-25.  This update
converts the release list into a range which will work Fedora through
version 30.