### PR TITLE
Amazon Linux fixes

### DIFF
--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -16,7 +16,6 @@ package_name = {'el'     => 'httpd',
 agents.each do |agent|
   platform = agent.platform.variant
   osname = on(agent, facter('os.name')).stdout.chomp
-  osreleasefull = on(agent, facter('os.release.full')).stdout.chomp.to_f
   majrelease = on(agent, facter('operatingsystemmajrelease')).stdout.chomp.to_i
 
   init_script_systemd = "/usr/lib/systemd/system/#{package_name[platform]}.service"
@@ -61,14 +60,13 @@ agents.each do |agent|
   apply_manifest_on(agent, manifest_install_package, :catch_failures => true)
 
   step "ensure enabling service creates the start & kill symlinks"
-  # amazon linux is based on el: 2017.09 and earlier is based on el-6
-  # (sysV) and 2017.12 and later is based on el-7 (systemd). In beaker
-  # we still use the el platform name, hence the use of facts below
-  # when checking for amazon linux.
-  is_sysV = ((platform == 'centos' || platform == 'el') && majrelease < 7) ||
-              (osname == 'Amazon' && osreleasefull < 2017.12) ||
-              platform == 'debian' || platform == 'ubuntu' ||
-             (platform == 'sles'                        && majrelease < 12)
+  # amazon linux is based on el: v1 uses a 4-digit year for its majrelease
+  # and is based on el-6 (sysV). v2 returns a single-digit version for its
+  # majrelease and is based on el-7 (systemd).
+  is_sysV = ((platform == 'centos' || platform == 'el') && osname != 'Amazon' && majrelease < 7) ||
+             (osname == 'Amazon' && majrelease > 2010) ||
+             platform == 'debian' || platform == 'ubuntu' ||
+             (platform == 'sles' && majrelease < 12)
   apply_manifest_on(agent, manifest_service_disabled, :catch_failures => true)
   apply_manifest_on(agent, manifest_service_enabled, :catch_failures => true) do
     if is_sysV

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
-  defaultfor :operatingsystem => :amazon, :operatingsystemrelease => ["2017.12"]
+  defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   confine :any => [
     Facter.value(:operatingsystem) == 'Ubuntu',
     (Facter.value(:osfamily) == 'RedHat' and Facter.value(:operatingsystemrelease) =~ /^6\./),
-    (Facter.value(:operatingsystem) == 'Amazon' and Facter.value(:operatingsystemrelease).to_f < 2017.12),
+    (Facter.value(:operatingsystem) == 'Amazon' and Facter.value(:operatingsystemmajrelease) =~ /\d{4}/),
     Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -58,11 +58,10 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     end
   end
 
-  it "should be the default provider on Amazon Linux 2017.12" do
+  it "should be the default provider on Amazon Linux 2.0" do
     Facter.stubs(:value).with(:osfamily).returns(:redhat)
     Facter.stubs(:value).with(:operatingsystem).returns(:amazon)
-    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("2017")
-    Facter.stubs(:value).with(:operatingsystemrelease).returns("2017.12")
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("2")
     expect(described_class).to be_default
   end
 
@@ -70,7 +69,6 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     Facter.stubs(:value).with(:osfamily).returns(:redhat)
     Facter.stubs(:value).with(:operatingsystem).returns(:amazon)
     Facter.stubs(:value).with(:operatingsystemmajrelease).returns("2017")
-    Facter.stubs(:value).with(:operatingsystemrelease).returns("2017.09")
     expect(described_class).not_to be_default
   end
 


### PR DESCRIPTION
Previously I had mistakenly thought that Amazon Linux v2 returned a year-based version string from facter, but that's only the case for Amazon Linux v1. v2 returns "2.0" instead.