### PR TITLE
(PUP-8639) fix tests/direct_puppet/supports_utf8.rb to run

### DIFF
--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -7,7 +7,7 @@ extend Puppet::Acceptance::EnvironmentUtils
 
   tmp_file = {}
   agents.each do |agent|
-    if agent.platform =~ /^(eos-4-i386|cumulus-2\.5|osx|sles-10|)/
+    if agent.platform =~ /^(eos-4-i386|cumulus-2\.5|osx|sles-10)/
       # skip_test doesn't work in with_puppet_running_on blocks (tableflip)
       #   so we can't easily use expect_failure here
       skip_test 'PUP-6217'


### PR DESCRIPTION
The test included a skip which was pattern matching on ..."|sles-10|)/"
which is an empty string which would match anything and the test would
always be skipped.