### PR TITLE
(PUP-5426) Consider an IniFile::SettingsLine to be "different" from another if their line numbers differ

### DIFF
--- a/lib/puppet/settings/ini_file.rb
+++ b/lib/puppet/settings/ini_file.rb
@@ -169,6 +169,10 @@ class Puppet::Settings::IniFile
       fh.write(value)
       fh.puts(suffix)
     end
+
+    def ==(other)
+      super(other) && self.line_number == other.line_number
+    end
   end
 
   SectionLine = Struct.new(:prefix, :name, :suffix) do

--- a/spec/unit/settings/ini_file_spec.rb
+++ b/spec/unit/settings/ini_file_spec.rb
@@ -236,6 +236,27 @@ updated = new
     CONFIG
   end
 
+  it "adds a new setting to the appropriate section, when it would be added behind a setting with an identical value in a preceeding section" do
+    config_fh = a_config_file_containing(<<-CONFIG)
+    [different]
+    name = some value
+    [section]
+    name = some value
+    CONFIG
+
+    Puppet::Settings::IniFile.update(config_fh) do |config|
+      config.set("section", "new", "new value")
+    end
+
+    expect(config_fh.string).to eq <<-CONFIG
+    [different]
+    name = some value
+    [section]
+    name = some value
+new = new value
+    CONFIG
+  end
+
   def a_config_file_containing(text)
     # set_encoding required for Ruby 1.9.3 as ASCII is the default
     StringIO.new(text).set_encoding(Encoding::UTF_8)


### PR DESCRIPTION
Previously, when we were trying to add a new setting to a section, if the last setting in the section was identical (same prefix, name, infix, value, and suffix) to a setting in another section that came first in the file, we'd get confused about which one we should be adding the new setting after, and add it after the one that appeared first in the file.

We now take the line number of the `SettingLine` into consideration when testing equality (`==`), which means that `Array#index` will no longer give us the index of the first `SettingLine` with the same prefix/name/infix/value/suffix combination as the one we're looking for, and will give us the index of the one that is at the same line number.