### PR TITLE
(PUP-8080) fix issues with new i18n tests

### DIFF
--- a/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
@@ -42,7 +42,7 @@ test_name 'C100566: puppet agent with module should translate messages when usin
 
   agents.each do |agent|
     skip_test('on windows this test only works on a machine with a japanese code page set') if agent['platform'] =~ /windows/ && agent['locale'] != 'ja'
-    skip_test('PUP-8368') if agent['platform'] =~ /windows/ && agent['locale'] =~ 'ja'
+    skip_test('PUP-8368') if agent['platform'] =~ /windows/ && agent['locale'] =~ /ja/
 
     agent_language = enable_locale_language(agent, language)
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?

--- a/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
@@ -1,5 +1,7 @@
 test_name 'C100568: puppet apply of module for an unsupported language should fall back to english' do
 
+  confine :except, :platform => /^solaris-10/ # PUP-8377
+
   tag 'audit:medium',
       'audit:acceptance'
 


### PR DESCRIPTION
The windows ja skip test check should have been a regex
Skip the unsupported lang tests on solaris 10 for now - Filed PUP-8377