### PR TITLE
check yum repo file exists before stat

### DIFF
--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -187,11 +187,13 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
 
     target_mode = 0644
     inifile.each_file do |file|
-      current_mode = Puppet::FileSystem.stat(file).mode & 0777
-      unless current_mode == target_mode
-        resource.info _("changing mode of %{file} from %{current_mode} to %{target_mode}") %
-                          { file: file, current_mode: "%03o" % current_mode, target_mode: "%03o" % target_mode }
-        Puppet::FileSystem.chmod(target_mode, file)
+      if Puppet::FileSystem.exist?(file)
+        current_mode = Puppet::FileSystem.stat(file).mode & 0777
+        unless current_mode == target_mode
+          resource.info _("changing mode of %{file} from %{current_mode} to %{target_mode}") %
+                            { file: file, current_mode: "%03o" % current_mode, target_mode: "%03o" % target_mode }
+          Puppet::FileSystem.chmod(target_mode, file)
+        end
       end
     end
   end


### PR DESCRIPTION
If a yum repo file is removed during an agent run (e.g. by a yum plugin or a directory purge), any yumrepo resource changes may fail with a "No such file or directory @ rb_file_stat" error because the repofiles list is not refreshed before store() attempts to stat a file that no longer exists.