### PR TITLE
(PUP-1916) Allow cert clean when node has a CSR

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -264,7 +264,10 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       hosts = command_line.args.collect { |h| h.downcase }
     end
     begin
-      apply(@ca, :revoke, options.merge(:to => hosts)) if subcommand == :destroy
+      if subcommand == :destroy
+        signed_hosts = hosts - @ca.waiting?
+        apply(@ca, :revoke, options.merge(:to => signed_hosts))
+      end
       apply(@ca, subcommand, options.merge(:to => hosts, :digest => @digest))
     rescue => detail
       Puppet.log_exception(detail)

--- a/spec/unit/application/cert_spec.rb
+++ b/spec/unit/application/cert_spec.rb
@@ -139,7 +139,7 @@ describe Puppet::Application::Cert => true do
   describe "when running" do
     before :each do
       @cert_app.all = false
-      @ca = stub_everything 'ca'
+      @ca = stub_everything( 'ca', :waiting? => ['unsigned-node'] )
       @cert_app.ca = @ca
       @cert_app.command_line.stubs(:args).returns([])
       @iface = stub_everything 'iface'
@@ -183,6 +183,33 @@ describe Puppet::Application::Cert => true do
 
       Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to| cert_mode == :revoke }
       Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to| cert_mode == :destroy }
+
+      @cert_app.main
+    end
+
+    it "should not revoke cert if node does not have a signed certificate" do
+      @cert_app.subcommand = :destroy
+      @cert_app.command_line.stubs(:args).returns(["unsigned-node"])
+
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to| cert_mode == :destroy
+        to[:to] == ["unsigned-node"]
+      }
+
+      @cert_app.main
+    end
+
+    it "should only revoke signed certificate and destroy certificate signing requests" do
+      @cert_app.subcommand = :destroy
+      @cert_app.command_line.stubs(:args).returns(["host","unsigned-node"])
+
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to|
+        cert_mode == :revoke
+        to[:to] == ["host"]
+      }
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to|
+        cert_mode == :destroy
+        to[:to] == ["host","unsigned-node"]
+      }
 
       @cert_app.main
     end


### PR DESCRIPTION
Prior to this commit, running `puppet cert clean` against a
certname that does not have a signed cert but has a CSR would
cause a failure because we tried to revoke the cert when
of course you cannot revoke an unsigned cert.

After this commit, we check to make sure the certname passed into
puppet cert clean is not currently waiting to be signed.  If the
cert is waiting to be signed then we do not try to revoke it and
move along to destroying which clears the CSR.

If you pass a certname that has no signed cert and no CSR then
cert clean will fail in the same way that it did before.

# Previous Behavior: 

```
[root@split-master ~]# puppet cert list --all
  "split-puppetdb-2.puppetdebug.vlan"      (SHA256) 42:3F:8E:C5:68:13:AB:2F:74:6D:2A:D7:83:B4:DB:C9:BB:19:39:C7:97:36:EB:97:55:B3:6D:E0:EF:60:91:5B
+ "pe-internal-mcollective-servers"        (SHA256) 6E:8C:76:50:EB:3D:B6:61:3E:87:6F:0B:72:1B:B1:98:7F:B5:63:70:2A:E8:FB:AC:4A:A0:5F:37:22:90:2C:32
+ "pe-internal-peadmin-mcollective-client" (SHA256) 4D:CA:14:DF:61:BC:37:5D:E7:FF:BB:D9:E4:E6:FD:08:24:F8:B5:80:DE:91:22:0C:FD:DF:BA:D6:7B:C0:74:0C
+ "pe-postgres-node.puppetdebug.vlan"      (SHA256) BB:BC:1C:56:D1:87:76:FD:05:9C:E8:4E:8B:C3:B6:1F:CE:66:AB:84:57:73:BD:90:49:11:17:C8:10:BA:EA:90
+ "split-console.puppetdebug.vlan"         (SHA256) 34:97:7D:5B:97:FC:8C:B3:6D:6B:92:13:48:74:0A:19:5B:D0:CE:22:74:65:26:54:41:FB:61:CA:92:9D:D9:E5
+ "split-master.puppetdebug.vlan"          (SHA256) F6:A0:B4:43:14:06:24:C8:8D:65:14:83:67:37:4E:60:E3:BF:14:39:D6:F5:1B:23:62:CE:C1:FE:51:11:4C:D3 (alt names: "DNS:puppet", "DNS:split-master.puppetdebug.vlan")
+ "split-puppetdb.puppetdebug.vlan"        (SHA256) 9A:D7:78:92:86:BC:16:1E:73:CE:37:9C:D4:AD:E6:4B:3C:05:D5:A0:70:FB:71:8A:57:D6:9E:3A:F7:C6:50:28
[root@split-master ~]# puppet cert clean split-puppetdb-2.puppetdebug.vlan
Error: Could not find a serial number for split-puppetdb-2.puppetdebug.vlan
```

# New Behavior:

```
[root@master201732-centos ~]# puppet agent -t --certname test_cert
Info: Creating a new SSL key for test_cert
Info: csr_attributes file loading from /etc/puppetlabs/puppet/csr_attributes.yaml
Info: Creating a new SSL certificate request for test_cert
Info: Certificate Request fingerprint (SHA256): 85:69:89:64:42:22:D0:86:EC:8B:A1:DE:64:3E:52:CC:E2:72:7E:5D:F9:4A:BC:8B:96:B4:AB:A6:B9:B4:F0:7A
Exiting; no certificate found and waitforcert is disabled
[root@master201732-centos ~]# puppet cert list test_cert
  "test_cert" (SHA256) 85:69:89:64:42:22:D0:86:EC:8B:A1:DE:64:3E:52:CC:E2:72:7E:5D:F9:4A:BC:8B:96:B4:AB:A6:B9:B4:F0:7A
[root@master201732-centos ~]# puppet cert clean test_cert
Notice: Removing file Puppet::SSL::CertificateRequest test_cert at '/etc/puppetlabs/puppet/ssl/ca/requests/test_cert.pem'
Notice: Removing file Puppet::SSL::CertificateRequest test_cert at '/etc/puppetlabs/puppet/ssl/certificate_requests/test_cert.pem'
Notice: Removing file Puppet::SSL::Key test_cert at '/etc/puppetlabs/puppet/ssl/private_keys/test_cert.pem'
```