### PR TITLE
Merge up 4.10.x to 5.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ group(:development, :test) do
   gem 'rdoc', "~> 4.1", :platforms => [:ruby]
   gem 'yard'
 
+  # ronn is used for generating manpages.
+  gem 'ronn', '~> 0.7.3', :platforms => [:ruby]
+
   # webmock requires addressable as as of 2.5.0 addressable started
   # requiring the public_suffix gem which requires Ruby 2
   gem 'addressable', '< 2.5.0'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ which also includes orchestration features, a web console, and professional supp
 [The PE documentation is available here.](https://puppet.com/docs/pe/latest)
 
 To install an open source release of Puppet,
-[see the installation guide on the docs site.](http://puppet.com/docs/puppet/4.10/install_pre.html)
+[see the installation guide on the docs site.](http://puppet.com/docs/puppet/5.3/install_pre.html)
 
 If you need to run Puppet from source as a tester or developer,
 [see the running from source guide on the docs site.](https://docs.puppet.com/puppet/3.8/from_source.html)

--- a/README.md
+++ b/README.md
@@ -12,41 +12,41 @@ Documentation
 -------------
 
 Documentation for Puppet and related projects can be found online at the
-[Puppet Docs site](https://docs.puppetlabs.com).
+[Puppet Docs site](https://puppet.com/docs).
 
 HTTP API
 --------
-[HTTP API Index](https://docs.puppetlabs.com/puppet/latest/reference/http_api/http_api_index.html)
+[HTTP API Index](https://puppet.com/docs/puppet/4.10/http_api/http_api_index.html)
 
 Installation
 ------------
 
-The best way to run Puppet is with [Puppet Enterprise](https://puppetlabs.com/puppet/puppet-enterprise),
+The best way to run Puppet is with [Puppet Enterprise](https://puppet.com/puppet/puppet-enterprise),
 which also includes orchestration features, a web console, and professional support.
-[The PE documentation is available here.](https://docs.puppetlabs.com/pe/latest)
+[The PE documentation is available here.](https://puppet.com/docs/pe/latest)
 
 To install an open source release of Puppet,
-[see the installation guide on the docs site.](https://docs.puppetlabs.com/puppet/latest/reference/install_pre.html)
+[see the installation guide on the docs site.](http://puppet.com/docs/puppet/4.10/install_pre.html)
 
 If you need to run Puppet from source as a tester or developer,
-[see the running from source guide on the docs site.](https://docs.puppetlabs.com/guides/from_source.html)
+[see the running from source guide on the docs site.](https://docs.puppet.com/puppet/3.8/from_source.html)
 
 Developing and Contributing
 ------
 
 We'd love to get contributions from you! For a quick guide to getting your
 system setup for developing take a look at our [Quickstart
-Guide](docs/quickstart.md). Once you are up and running, take a look at the
-[Contribution Documents](CONTRIBUTING.md) to see how to get your changes merged
+Guide](https://github.com/puppetlabs/puppet/blob/master/docs/quickstart.md). Once you are up and running, take a look at the
+[Contribution Documents](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md) to see how to get your changes merged
 in.
 
 For more complete docs on developing with puppet you can take a look at the
-rest of the [developer documents](docs/index.md).
+rest of the [developer documents](https://github.com/puppetlabs/puppet/blob/master/docs/index.md).
 
 License
 -------
 
-See [LICENSE](LICENSE) file.
+See [LICENSE](https://github.com/puppetlabs/puppet/blob/master/LICENSE) file.
 
 Support
 -------
@@ -71,4 +71,4 @@ a best effort to backport that fix onto the latest Puppet 3 release.
 Long-term support, including security patches and bug fixes, is available for
 commercial customers. Please see the following page for more details:
 
-[Puppet Enterprise Support Lifecycle](https://puppetlabs.com/misc/puppet-enterprise-lifecycle)
+[Puppet Enterprise Support Lifecycle](https://puppet.com/misc/puppet-enterprise-lifecycle)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation for Puppet and related projects can be found online at the
 
 HTTP API
 --------
-[HTTP API Index](https://puppet.com/docs/puppet/4.10/http_api/http_api_index.html)
+[HTTP API Index](https://puppet.com/docs/puppet/5.3/http_api/http_api_index.html)
 
 Installation
 ------------

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -13,7 +13,7 @@ extend Puppet::Acceptance::EnvironmentUtils
 
   tmp_file = {}
   agents.each do |agent|
-    if agent.platform =~ /^(eos-4-i386|cumulus-2\.5|osx|sles-10|)/
+    if agent.platform =~ /^(eos-4-i386|cumulus-2\.5|osx|sles-10)/
       # skip_test doesn't work in with_puppet_running_on blocks (tableflip)
       #   so we can't easily use expect_failure here
       skip_test 'PUP-6217'


### PR DESCRIPTION
Resolves a conflict in a README docs link, and updates the link to point to 5.3.