### PR TITLE
(PUP-8393) Fix problem transforming tree iterators to Array

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -330,7 +330,7 @@ class EvaluatorImpl
       candidate
     when Hash
       candidate.to_a
-    when Puppet::Pops::Types::Iterator
+    when Puppet::Pops::Types::Iterable
       candidate.to_a
     else
       # turns anything else into an array (so result can be unfolded)

--- a/lib/puppet/pops/types/tree_iterators.rb
+++ b/lib/puppet/pops/types/tree_iterators.rb
@@ -67,12 +67,16 @@ class TreeIterator
     false
   end
 
-  def to_array
+  def to_a
     result = []
     loop do
       result << self.next
     end
     result
+  end
+
+  def to_array
+    to_a
   end
 
   def reverse_each(&block)


### PR DESCRIPTION
Before this, it was not possible to turn the iterators returned by the
function `tree_each` into an Array unless this was done as a `filter` or
`map` operations.
This was caused by two undetected problems:
* the iterator should have implemented `to_a`
* the splat/unfold operator checked for instance of `Iterator` instead
of `Iterable`.