### PR TITLE
(PUP-8369) skip test supports_utf8.rb on cisco and solaris

### DIFF
--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -1,6 +1,10 @@
 test_name "C97172: static catalogs support utf8" do
-require 'puppet/acceptance/environment_utils'
-extend Puppet::Acceptance::EnvironmentUtils
+
+  confine :except, :platform => /^cisco_/ # skip the test because some of the machines have LANG=C as the default and we break
+  confine :except, :platform => /^solaris/ # skip the test because some of the machines have LANG=C as the default and we break
+
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
 
   app_type = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)


### PR DESCRIPTION
Skip the test direct_puppet/supports_utf8.rb on cisco and solaris machines
where the LANG=C is set and we fail due to mixed encoding issues