### PR TITLE
(PUP-8066) Fix failing acceptance tests on FIPS platforms

### DIFF
--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -11,6 +11,12 @@ defaultversion = '0.1.0'
 buildpath = "#{modname}/pkg/#{modname}-#{defaultversion}"
 
 agents.each do |agent|
+
+  if on(agent, facter("fips_enabled")).stdout =~ /true/
+    puts "Module build, loading and installing is not supported on fips enabled platforms"
+    next
+  end
+
   tmpdir = agent.tmpdir('pmtbuildsymlink')
 
   teardown do


### PR DESCRIPTION
The following test had got left out to be adjusted/skipped when running
on FIPS enabled platform as part of original PUP-8066 work.

  - acceptance/tests/module/build/build_should_not_allow_symlinks.rb