### PR TITLE
(PUP-8400) disable rubocop Style/SafeNavigation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -802,3 +802,6 @@ GetText/DecorateStringFormattingUsingInterpolation:
 
 GetText/DecorateStringFormattingUsingPercent:
   Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false


### PR DESCRIPTION
This operator requires Ruby 2.3.0, which means we can't use it in puppet
      The most interesting addition to Ruby 2.3.0 is the Safe Navigation Operator(&.).