### PR TITLE
(PUP-8066) Fix failing acceptance tests on FIPS platforms

### DIFF
--- a/acceptance/tests/i18n/modules/puppet_apply.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply.rb
@@ -21,6 +21,14 @@ test_name 'C100567: puppet apply of module should translate messages' do
   agents.each do |agent|
     skip_test('on windows this test only works on a machine with a japanese code page set') if agent['platform'] =~ /windows/ && agent['locale'] != 'ja'
 
+    # REMIND - It was noted that skipping tests on certain platforms sometimes causes
+    # beaker to mark the test as a failed even if the test succeeds on other targets. 
+    # Hence we just print a message and skip w/o telling beaker about it.
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      puts "Module build, loading and installing is not supported on fips enabled platforms"
+      next
+    end
+
     agent_language = enable_locale_language(agent, language)
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }

--- a/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
@@ -18,6 +18,14 @@ test_name 'C100574: puppet apply using a module should translate messages in a l
   language='fi_FI'
 
   agents.each do |agent|
+    # REMIND - It was noted that skipping tests on certain platforms sometimes causes
+    # beaker to mark the test as a failed even if the test succeeds on other targets. 
+    # Hence we just print a message and skip w/o telling beaker about it.
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      puts "Module build, loading and installing is not supported on fips enabled platforms"
+      next
+    end
+
     agent_language = enable_locale_language(agent, language)
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }

--- a/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
@@ -15,6 +15,14 @@ test_name 'C100568: puppet apply of module for an unsupported language should fa
   shell_env_language = { 'LANGUAGE' => unsupported_language, 'LANG' => unsupported_language }
 
   agents.each do |agent|
+    # REMIND - It was noted that skipping tests on certain platforms sometimes causes
+    # beaker to mark the test as a failed even if the test succeeds on other targets. 
+    # Hence we just print a message and skip w/o telling beaker about it.
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      puts "Module build, loading and installing is not supported on fips enabled platforms"
+      next
+    end
+
     step 'install a i18ndemo module' do
       install_i18n_demo_module(agent)
     end

--- a/acceptance/tests/i18n/modules/puppet_describe.rb
+++ b/acceptance/tests/i18n/modules/puppet_describe.rb
@@ -18,6 +18,14 @@ test_name 'C100576: puppet describe with module type translates message' do
   agents.each do |agent|
     skip_test('on windows this test only works on a machine with a japanese code page set') if agent['platform'] =~ /windows/ && agent['locale'] != 'ja'
 
+    # REMIND - It was noted that skipping tests on certain platforms sometimes causes
+    # beaker to mark the test as a failed even if the test succeeds on other targets. 
+    # Hence we just print a message and skip w/o telling beaker about it.
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      puts "Module build, loading and installing is not supported on fips enabled platforms"
+      next
+    end
+
     agent_language = enable_locale_language(agent, language)
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }

--- a/acceptance/tests/i18n/modules/puppet_face.rb
+++ b/acceptance/tests/i18n/modules/puppet_face.rb
@@ -18,6 +18,14 @@ test_name 'C100573: puppet application/face with module translates messages' do
   agents.each do |agent|
     skip_test('on windows this test only works on a machine with a japanese code page set') if agent['platform'] =~ /windows/ && agent['locale'] != 'ja'
 
+    # REMIND - It was noted that skipping tests on certain platforms sometimes causes
+    # beaker to mark the test as a failed even if the test succeeds on other targets. 
+    # Hence we just print a message and skip w/o telling beaker about it.
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      puts "Module build, loading and installing is not supported on fips enabled platforms"
+      next
+    end
+
     agent_language = enable_locale_language(agent, language)
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }

--- a/acceptance/tests/i18n/modules/puppet_facts.rb
+++ b/acceptance/tests/i18n/modules/puppet_facts.rb
@@ -18,6 +18,14 @@ test_name 'C100564: puppet facts translates the fact error message' do
   agents.each do |agent|
     skip_test('on windows this test only works on a machine with a japanese code page set') if agent['platform'] =~ /windows/ && agent['locale'] != 'ja'
 
+    # REMIND - It was noted that skipping tests on certain platforms sometimes causes
+    # beaker to mark the test as a failed even if the test succeeds on other targets. 
+    # Hence we just print a message and skip w/o telling beaker about it.
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      puts "Module build, loading and installing is not supported on fips enabled platforms"
+      next
+    end
+
     agent_language = enable_locale_language(agent, language)
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }

--- a/acceptance/tests/i18n/modules/puppet_resource.rb
+++ b/acceptance/tests/i18n/modules/puppet_resource.rb
@@ -18,6 +18,14 @@ test_name 'C100572: puppet resource with module translates messages' do
   agents.each do |agent|
     skip_test('on windows this test only works on a machine with a japanese code page set') if agent['platform'] =~ /windows/ && agent['locale'] != 'ja'
 
+    # REMIND - It was noted that skipping tests on certain platforms sometimes causes
+    # beaker to mark the test as a failed even if the test succeeds on other targets. 
+    # Hence we just print a message and skip w/o telling beaker about it.
+    if on(agent, facter("fips_enabled")).stdout =~ /true/
+      puts "Module build, loading and installing is not supported on fips enabled platforms"
+      next
+    end
+
     agent_language = enable_locale_language(agent, language)
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }


### PR DESCRIPTION
Following internationalization module tests need to be skipped when running
on FIPS enabled platforms as part of original PUP-8066 work. Module operations
are not supported in FIPS module due to their use of md5.

 -  tests/i18n/modules/puppet_apply.rb
 -  tests/i18n/modules/puppet_apply_module_lang.rb
 -  tests/i18n/modules/puppet_apply_unsupported_lang.rb
 -  tests/i18n/modules/puppet_describe.rb
 -  tests/i18n/modules/puppet_face.rb
 -  tests/i18n/modules/puppet_facts.rb
 -  tests/i18n/modules/puppet_resource.rb