### PR TITLE
(PUP-8378) Provide graceful errors for any md5 runtime use attempts w…

### DIFF
--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -1,4 +1,5 @@
 require 'puppet/face'
+require 'puppet/settings'
 require 'puppet/settings/ini_file'
 
 Puppet::Face.define(:config, '0.0.1') do
@@ -117,6 +118,21 @@ section by using the `--section` flag. For example,
 `puppet config --section user set environment foo`. For more information, see
 https://puppet.com/docs/puppet/latest/configuration.html#environment
         EOM
+      end
+
+      # REMIND - we want to be able to make this check more specific to account
+      # for master node which is in fips mode then the fips restrictions
+      # should be based only when the setting is going to be agent specific
+      # and/or applicable to agent.
+      # It would depend on whether the digest_algorithm and supported_checksum_types
+      # settings are consumed by server.
+      if name == 'digest_algorithm'
+        Puppet::Settings.validate_digest_algorithm(value)
+      end
+
+      if name == 'supported_checksum_types'
+        values = value.split(/\s*,\s*/)
+        Puppet::Settings.validate_checksum_types(values)
       end
 
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)

--- a/lib/puppet/type/file/checksum.rb
+++ b/lib/puppet/type/file/checksum.rb
@@ -41,4 +41,10 @@ Puppet::Type.type(:file).newparam(:checksum) do
   def digest_algorithm
     value || Puppet[:digest_algorithm].to_sym
   end
+
+  validate do |value|
+    if Puppet::Util::Platform.fips_enabled? && value =~ /^md5/
+      raise ArgumentError, "MD5 is not supported in FIPS mode"
+    end
+  end
 end

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -70,6 +70,16 @@ describe "Defaults" do
       it "should be sha256" do
         expect(Puppet.default_digest_alg).to eq('sha256')
       end
+      it 'should raise an error on a prohibited digest_algorithm in fips mode' do
+        expect { Puppet.settings[:digest_algorithm] = 'md5' }.to raise_exception ArgumentError, 'MD5 digest is prohited in fips mode. Valid values are ["sha256", "sha384", "sha512", "sha224"].'
+      end
+      it 'should not raise an error on setting a valid list of checksum types when in fips mode' do
+        Puppet.settings[:digest_algorithm] = 'sha384'
+        expect(Puppet.settings[:digest_algorithm]).to eq('sha384')
+      end
+      it 'should raise an error on an invalid digest_algorithm' do
+        expect { Puppet.settings[:digest_algorithm] = 'foo' }.to raise_exception ArgumentError, 'Unrecognized digest_algorithm foo is not supported. Valid values are ["sha256", "sha384", "sha512", "sha224"].'
+      end
     end
   end
 
@@ -119,6 +129,13 @@ describe "Defaults" do
       it "should exclude md5" do
         expect(Puppet.default_checksum_types).to eq(['sha256', 'sha384', 'sha512', 'sha224'])
       end
+      it 'should raise an error on a prohibited checksum type in fips mode' do
+        expect { Puppet.settings[:supported_checksum_types] = ['md5', 'foo'] }.to raise_exception ArgumentError, '["md5", "md5lite"] checksum types are prohibited in FIPS mode. Valid values are ["sha256", "sha256lite", "sha384", "sha512", "sha224", "sha1", "sha1lite", "mtime", "ctime"].'
+      end
+      it 'should not raise an error on setting a valid list of checksum types when in fips mode' do
+        Puppet.settings[:supported_checksum_types] = ['sha256', 'sha384', 'mtime']
+        expect(Puppet.settings[:supported_checksum_types]).to eq(['sha256', 'sha384', 'mtime'])
+      end
     end
   end
 
@@ -135,6 +152,7 @@ describe "Defaults" do
       Puppet.settings[:supported_checksum_types] = ['sha256', 'md5lite', 'mtime']
       expect(Puppet.settings[:supported_checksum_types]).to eq(['sha256', 'md5lite', 'mtime'])
     end
+
   end
 
   describe 'server vs server_list' do


### PR DESCRIPTION
…hen in fips mode

In FIPS mode attempts to use md5 at runtime need to be disallowed while providing a graceful
error. This can happen when md5 checksum is explicitly specified in a file resource within
a manifest. User may also attempt to set the configuration settings of digest_algorithm and
supported_checksum_types with FIPS disallowed values.
This is related to PUP-8141.