### PR TITLE
(maint) Fix reference to title patterns hash

### DIFF
--- a/lib/puppet/pops/resource/resource_type_impl.rb
+++ b/lib/puppet/pops/resource/resource_type_impl.rb
@@ -149,7 +149,7 @@ class ResourceTypeImpl
         # Here it is silently ignored.
         nil
       when 1
-        if @title_pattners_hash.nil?
+        if @title_patterns_hash.nil?
           [ [ /(.*)/m, [ [@key_attributes.first] ] ] ]
         else
           # TechDebt: The case of having one namevar and an empty title patterns is unspecified behavior in puppet.


### PR DESCRIPTION
This makes the 'a generated type returns [[/(.*)/m, <first attr>]] as default title_pattern when there is a namevar but no pattern specified' test fail. I believe the test is in error because the branch it expects the code to take is always taken because of the spelling mistake. I don't understand the test or associated code enough. Someone should amend one of them and add a test for the other branch.