### PR TITLE
(PUP-8404) add more debuging to ssh_authorized_key

### DIFF
--- a/lib/puppet/provider/ssh_authorized_key/parsed.rb
+++ b/lib/puppet/provider/ssh_authorized_key/parsed.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:ssh_authorized_key).provide(
 
     Puppet::Util::SUIDManager.asuser(@resource.should(:user)) do
         unless Puppet::FileSystem.exist?(dir = File.dirname(target))
-          Puppet.debug "Creating #{dir}"
+          Puppet.debug "Creating #{dir} as #{@resource.should(:user)}"
           Dir.mkdir(dir, dir_perm)
         end
 


### PR DESCRIPTION
The fact that `ssh_authorized_key` calls `mkdir` as the target user (as opposed to the user running puppet) is not directly clear and may lead to non-obvious permission errors. Increasing the debug output to indicate this might make the pitfall a bit more clear.