### PR TITLE
(docs) Update the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,18 +22,17 @@ be added in modules. Exceptions would be things like new cross-OS providers
 and updates to existing core types.
 
 If you are unsure of whether your contribution should be implemented as a
-module or part of Puppet Core, you may visit
-[#puppet-dev on Freenode IRC](https://freenode.net) or ask on the
-[puppet-dev mailing list](https://groups.google.com/forum/#!forum/puppet-dev)
-for advice.
+module or part of Puppet Core, you may visit [#puppet-dev on slack](https://puppetcommunity.slack.com/), or ask on
+the [puppet-dev mailing list](https://groups.google.com/forum/#!forum/puppet-dev) for advice.
 
 ## Getting Started
 
 * Make sure you have a [Jira account](https://tickets.puppetlabs.com)
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a ticket for your issue, assuming one does not already exist.
-  * Clearly describe the issue including steps to reproduce when it is a bug.
+* Submit a Jira ticket for your issue if one does not already exist.
+  * Clearly describe the issue including steps to reproduce when it is a bug
   * Make sure you fill in the earliest version that you know has the issue.
+  * A ticket is not necessary for [trivial changes](https://docs.puppet.com/community/trivial_patch_exemption.html)
 * Fork the repository on GitHub
 
 ## Making Changes
@@ -45,7 +44,7 @@ for advice.
   * To quickly create a topic branch based on master; `git checkout -b
     fix/master/my_contribution master`. Please avoid working directly on the
     `master` branch.
-* Make commits of logical units.
+* Make commits of logical and atomic units.
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are in the proper format.
 
@@ -64,19 +63,20 @@ for advice.
 ````
 
 * Make sure you have added the necessary tests for your changes.
-* Run _all_ the tests to assure nothing else was accidentally broken.
+* Run _all_ the tests to assure nothing else was accidentally broken. First
+  install all the test dependencies with `bundle install --path .bundle`. Then
+  either run all the tests serially with `bundle exec rspec spec` or in parallel
+  with `bundle exec rake parallel:spec[process_count]`
 
 ## Making Trivial Changes
 
-### Documentation
-
-For changes of a trivial nature to comments and documentation, it is not
-always necessary to create a new ticket in Jira. In this case, it is
-appropriate to start the first line of a commit with '(doc)' instead of
-a ticket number.
+For [changes of a trivial nature](https://docs.puppet.com/community/trivial_patch_exemption.html), it is not always necessary to create a new
+ticket in Jira. In this case, it is appropriate to start the first line of a
+commit with one of  `(docs)`, `(maint)`, or `(packaging)` instead of a ticket
+number.
 
 ````
-    (doc) Add documentation commit example to CONTRIBUTING
+    (docs) Add documentation commit example to CONTRIBUTING
 
     There is no example for contributing a documentation commit
     to the Puppet repository. This is a problem because the contributor


### PR DESCRIPTION
This commit updates CONTRIBUTING.md to include more up to date
information on our contribution guidelines.

This includes more details around running tests and more guidance around
the definition of a trivial contribution.