### PR TITLE
(PUP-8407) Only load gettext-setup when executing gettext rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,9 +110,11 @@ task(:commits) do
   end
 end
 
-begin
-  spec = Gem::Specification.find_by_name 'gettext-setup'
-  load "#{spec.gem_dir}/lib/tasks/gettext.rake"
-  GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))
-rescue LoadError
+if Rake.application.top_level_tasks.grep(/^gettext:/).any?
+  begin
+    spec = Gem::Specification.find_by_name 'gettext-setup'
+    load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+    GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))
+  rescue LoadError
+  end
 end


### PR DESCRIPTION
Previously running the puppet benchmarks failed with an error "no
implicit conversion of nil into String" when trying to load module
translations.

The issue occurs because puppet initializes FastGettext's default locale
in a way that avoids the "available locales" machinery, by setting
default_available_locales to nil.

Later puppet's Rakefile calls `GettextSetup.initialize`, which
incorrectly sets default_available_locales to an empty array[1]. It
later tries to set the default_locale[2] to 'en'. However, since the
empty array doesn't include 'en', FastGettext.best_locale_in('en')
returns nil[3], and that becomes the default locale.

Since we only need the gettext-setup gem when generating puppet.pot
files in CI, only load it if the currently executing rake task starts
with gettext.

[1] https://github.com/puppetlabs/gettext-setup-gem/blob/88fe9ef4f3c436ff76db6799a0c6e33cd2bbed25/lib/gettext-setup/gettext_setup.rb#L14
[2] https://github.com/puppetlabs/gettext-setup-gem/blob/88fe9ef4f3c436ff76db6799a0c6e33cd2bbed25/lib/gettext-setup/gettext_setup.rb#L40
[3] https://github.com/grosser/fast_gettext/blob/d4092023984badf91596f81ce81a3c7405ac003e/lib/fast_gettext/storage.rb#L130-L137