### PR TITLE
(PUP-3321) puppet config should be able to alter an empty setting

### DIFF
--- a/lib/puppet/settings/ini_file.rb
+++ b/lib/puppet/settings/ini_file.rb
@@ -12,7 +12,7 @@ class Puppet::Settings::IniFile
   def self.parse(config_fh)
     config = new([DefaultSection.new])
     config_fh.each_line do |line|
-      case line
+      case line.chomp
       when /^(\s*)\[([[:word:]]+)\](\s*)$/
         config.append(SectionLine.new($1, $2, $3))
       when /^(\s*)([[:word:]]+)(\s*=\s*)(.*?)(\s*)$/

--- a/spec/unit/settings/ini_file_spec.rb
+++ b/spec/unit/settings/ini_file_spec.rb
@@ -109,6 +109,46 @@ name = value
     CONFIG
   end
 
+  it "updates existing empty settings" do
+    config_fh = a_config_file_containing(<<-CONFIG)
+    # this is the preceding comment
+     [section]
+    name = 
+    # this is the trailing comment
+    CONFIG
+
+    Puppet::Settings::IniFile.update(config_fh) do |config|
+      config.set("section", "name", "changed value")
+    end
+
+    expect(config_fh.string).to eq <<-CONFIG
+    # this is the preceding comment
+     [section]
+    name = changed value
+    # this is the trailing comment
+    CONFIG
+  end
+
+  it "can set empty settings" do
+    config_fh = a_config_file_containing(<<-CONFIG)
+    # this is the preceding comment
+     [section]
+    name = original value
+    # this is the trailing comment
+    CONFIG
+
+    Puppet::Settings::IniFile.update(config_fh) do |config|
+      config.set("section", "name", "")
+    end
+
+    expect(config_fh.string).to eq <<-CONFIG
+    # this is the preceding comment
+     [section]
+    name = 
+    # this is the trailing comment
+    CONFIG
+  end
+
   it "updates existing UTF-8 name / values in place" do
     config_fh = a_config_file_containing(<<-CONFIG)
     # this is the preceding comment


### PR DESCRIPTION
`puppet config` should be able to update an empty setting on the same line, without adding more excess lines.

Previously, if you tried to add a value to an existing setting that had no value, it would place it on the following line. There was a new line being added in the infix instead of the suffix when the file is written, so even if you had previously set the value to `''`, a newline would already be there, and would cause a Parse Error, but still edit the file. So each time you did this, it would add more new lines and error, never actually editing the setting value on the same line as the setting name. This solution strips any existing newlines on the setting before attempting to set the value.