### PR TITLE
(PUP-7398) Deprecates puppet module generate.

### DIFF
--- a/lib/puppet/face/help/action.erb
+++ b/lib/puppet/face/help/action.erb
@@ -1,4 +1,7 @@
 <%# encoding: UTF-8%>
+<% if action.deprecated? -%>
+  <%= "Warning: 'puppet #{action.face.name} #{action.name}' is deprecated and will be removed in a future release." %>
+<% end %>
 <% if action.synopsis -%>
 USAGE: <%= action.synopsis %>
 

--- a/lib/puppet/face/module/generate.rb
+++ b/lib/puppet/face/module/generate.rb
@@ -129,6 +129,8 @@ Puppet::Face.define(:module, '1.0.0') do
       puts _("Finished; module generated in %{path}.") % { path: path }
       result.join("\n")
     end
+
+    deprecate
   end
 end
 
@@ -136,6 +138,9 @@ module Puppet::ModuleTool::Generate
   module_function
 
   def generate(metadata, skip_interview = false)
+    #TRANSLATORS 'puppet module generate' is the name of the puppet command and 'Puppet Development Kit' is the name of the software package replacing this action and should not be translated. 
+    Puppet.deprecation_warning _("`puppet module generate` is deprecated and will be removed in a future release. This action has been replaced by Puppet Development Kit. For more information visit https://puppet.com/docs/pdk/latest/pdk.html.")
+
     interview(metadata) unless skip_interview
     destination = duplicate_skeleton(metadata)
     all_files = destination.basename + '**/*'

--- a/lib/puppet/interface/action.rb
+++ b/lib/puppet/interface/action.rb
@@ -149,6 +149,17 @@ class Puppet::Interface::Action
     @render_as = value.to_sym
   end
 
+  # @api private
+  # @return [void]
+  def deprecate
+    @deprecated = true
+  end
+
+  # @api private
+  # @return [Boolean]
+  def deprecated?
+    @deprecated
+  end
 
   ########################################################################
   # Initially, this was defined to allow the @action.invoke pattern, which is

--- a/lib/puppet/interface/action_builder.rb
+++ b/lib/puppet/interface/action_builder.rb
@@ -17,6 +17,14 @@ class Puppet::Interface::ActionBuilder
     new(face, name, &block).action
   end
 
+  # Deprecates the action
+  # @return [void]
+  # @api private
+  # @dsl Faces
+  def deprecate
+    @action.deprecate
+  end
+
   # Ideally the method we're defining here would be added to the action, and a
   # method on the face would defer to it, but we can't get scope correct, so
   # we stick with this. --daniel 2011-03-24

--- a/spec/unit/interface/action_spec.rb
+++ b/spec/unit/interface/action_spec.rb
@@ -644,4 +644,37 @@ describe Puppet::Interface::Action do
       expect(subject.get_default_action).to eq(action)
     end
   end
+
+  context "when deprecating a face action" do
+    let :face do
+      Puppet::Interface.new(:foo, '1.0.0') do
+        action :bar do
+          option "--bar"
+          when_invoked do |options| options end
+        end
+      end
+    end
+
+    let :action do face.get_action :bar end
+
+    describe "#deprecate" do
+      it "should set the deprecated value to true" do
+        expect(action).not_to be_deprecated
+        action.deprecate
+        expect(action).to be_deprecated
+      end
+    end
+
+    describe "#deprecated?" do
+      it "should return a nil (falsey) value by default" do
+        expect(action.deprecated?).to be_falsey
+      end
+
+      it "should return true if the action has been deprecated" do
+        expect(action).not_to be_deprecated
+        action.deprecate
+        expect(action).to be_deprecated
+      end
+    end
+  end
 end


### PR DESCRIPTION
PR includes:
- Helper methods to allow deprecation of individual face actions.
- Deprecation warning to the help page and cli output of `puppet module generate`. The warning also informs the user that the action has been replaced by PDK and where to get PDK.