### PR TITLE
(PUP-8377) update puppet_apply_unsupported_lang.rb to run on solaris

### DIFF
--- a/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
@@ -1,7 +1,5 @@
 test_name 'C100568: puppet apply of module for an unsupported language should fall back to english' do
 
-  confine :except, :platform => /^solaris-10/ # PUP-8377
-
   tag 'audit:medium',
       'audit:acceptance'
 


### PR DESCRIPTION
We've updated the i18ndemo module to always raise instead of checking for
openssl which was failing on solaris10. It now passes when run on Solaris10 hosts