### PR TITLE
(PUP-8411) Fix typo in impl of processing namevar patterns

### DIFF
--- a/lib/puppet/pops/resource/resource_type_impl.rb
+++ b/lib/puppet/pops/resource/resource_type_impl.rb
@@ -149,7 +149,7 @@ class ResourceTypeImpl
         # Here it is silently ignored.
         nil
       when 1
-        if @title_pattners_hash.nil?
+        if @title_patterns_hash.nil?
           [ [ /(.*)/m, [ [@key_attributes.first] ] ] ]
         else
           # TechDebt: The case of having one namevar and an empty title patterns is unspecified behavior in puppet.

--- a/spec/integration/parser/pcore_resource_spec.rb
+++ b/spec/integration/parser/pcore_resource_spec.rb
@@ -219,7 +219,7 @@ describe 'when pcore described resources types are in use' do
       generate_and_in_a_compilers_context do |compiler|
         t1 = find_resource_type(compiler.topscope, 'test1')
         expect(t1.title_patterns.size).to be(1)
-        expect(t1.title_patterns[0][0]).to eql(/(.*)/m)
+        expect(t1.title_patterns[0][0]).to eql(/(?m-ix:(.*))/)
       end
     end
 


### PR DESCRIPTION
Before this, there was a typo in the logic in resource_type_impl.rb
that made it always use the default name pattern of "entire string".
This meant that if the generated type used a different pattern it would
not be used.