### PR TITLE
(PUP-8258) Use Catalog cache in noop mode, but do not write to it

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -411,9 +411,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
     # we want the last report to be persisted locally
     Puppet::Transaction::Report.indirection.cache_class = :yaml
 
-    if Puppet[:noop]
-      Puppet::Resource::Catalog.indirection.cache_class = nil
-    elsif Puppet[:catalog_cache_terminus]
+    if Puppet[:catalog_cache_terminus]
       Puppet::Resource::Catalog.indirection.cache_class = Puppet[:catalog_cache_terminus]
     end
 

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -316,9 +316,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
     Puppet.settings.use :main, :agent, :ssl
 
 
-    if Puppet[:noop]
-      Puppet::Resource::Catalog.indirection.cache_class = nil
-    elsif Puppet[:catalog_cache_terminus]
+    if Puppet[:catalog_cache_terminus]
       Puppet::Resource::Catalog.indirection.cache_class = Puppet[:catalog_cache_terminus]
     end
 

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -419,8 +419,13 @@ class Puppet::Configurer
   def retrieve_catalog_from_cache(query_options)
     result = nil
     @duration = thinmark do
-      result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value],
-        query_options.merge(:ignore_terminus => true, :environment => Puppet::Node::Environment.remote(@environment)))
+      result = Puppet::Resource::Catalog.indirection.find(
+        Puppet[:node_name_value],
+        query_options.merge(
+          :ignore_terminus => true,
+          :environment     => Puppet::Node::Environment.remote(@environment)
+        )
+      )
     end
     result
   rescue => detail
@@ -431,8 +436,16 @@ class Puppet::Configurer
   def retrieve_new_catalog(query_options)
     result = nil
     @duration = thinmark do
-      result = Puppet::Resource::Catalog.indirection.find(Puppet[:node_name_value],
-        query_options.merge(:ignore_cache => true, :environment => Puppet::Node::Environment.remote(@environment), :fail_on_404 => true))
+      result = Puppet::Resource::Catalog.indirection.find(
+        Puppet[:node_name_value],
+        query_options.merge(
+          :ignore_cache      => true,
+          # We never want to update the cached Catalog if we're running in noop mode.
+          :ignore_cache_save => Puppet[:noop],
+          :environment       => Puppet::Node::Environment.remote(@environment),
+          :fail_on_404       => true
+        )
+      )
     end
     result
   rescue StandardError => detail

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -297,7 +297,7 @@ module Puppet::Environments
     end
 
     # Returns the end of time (the next Mesoamerican Long Count cycle-end after 2012 (5125+2012) = 7137,
-    # of for a 32 bit machine using Ruby < 1.9.3, the year 2038.
+    # or for a 32 bit machine using Ruby < 1.9.3, the year 2038.
     def self.end_of_time
       begin
         Time.gm(7137)

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -161,7 +161,7 @@ class Puppet::Indirector::Indirection
   def expire(key, options={})
     request = request(:expire, key, nil, options)
 
-    return nil unless cache?
+    return nil unless cache? && !request.ignore_cache_save?
 
     return nil unless instance = cache.find(request(:find, key, nil, options))
 
@@ -194,7 +194,7 @@ class Puppet::Indirector::Indirection
       result = terminus.find(request)
       if not result.nil?
         result.expiration ||= self.expiration if result.respond_to?(:expiration)
-        if cache?
+        if cache? && !request.ignore_cache_save?
           Puppet.info "Caching #{self.name} for #{request.key}"
           begin
             cache.save request(:save, key, result, options)
@@ -285,7 +285,7 @@ class Puppet::Indirector::Indirection
     result = terminus.save(request)
 
     # If caching is enabled, save our document there
-    cache.save(request) if cache?
+    cache.save(request) if cache? && !request.ignore_cache_save?
 
     result
   end

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -10,7 +10,7 @@ require 'puppet/util/psych_support'
 class Puppet::Indirector::Request
   include Puppet::Util::PsychSupport
 
-  attr_accessor :key, :method, :options, :instance, :node, :ip, :authenticated, :ignore_cache, :ignore_terminus
+  attr_accessor :key, :method, :options, :instance, :node, :ip, :authenticated, :ignore_cache, :ignore_cache_save, :ignore_terminus
 
   attr_accessor :server, :port, :uri, :protocol
 
@@ -18,7 +18,7 @@ class Puppet::Indirector::Request
 
   # trusted_information is specifically left out because we can't serialize it
   # and keep it "trusted"
-  OPTION_ATTRIBUTES = [:ip, :node, :authenticated, :ignore_terminus, :ignore_cache, :instance, :environment]
+  OPTION_ATTRIBUTES = [:ip, :node, :authenticated, :ignore_terminus, :ignore_cache, :ignore_cache_save, :instance, :environment]
 
   # Is this an authenticated request?
   def authenticated?
@@ -56,6 +56,10 @@ class Puppet::Indirector::Request
   # not be any better.
   def ignore_cache?
     ignore_cache
+  end
+
+  def ignore_cache_save?
+    ignore_cache_save
   end
 
   def ignore_terminus?

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -350,15 +350,6 @@ describe Puppet::Application::Agent do
       @puppetd.setup
     end
 
-    it "should set catalog cache class to nil during a noop run" do
-      Puppet[:catalog_cache_terminus] = "json"
-      Puppet[:noop] = true
-      Puppet::Resource::Catalog.indirection.expects(:cache_class=).with(nil)
-
-      @puppetd.initialize_app_defaults
-      @puppetd.setup
-    end
-
     it "should default facts_terminus setting to 'facter'" do
       @puppetd.initialize_app_defaults
       expect(Puppet[:facts_terminus]).to eq(:facter)

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -478,13 +478,4 @@ describe Puppet::Application::Apply do
     @apply.initialize_app_defaults
     @apply.setup
   end
-
-  it "should set catalog cache class to nil during a noop run" do
-    Puppet[:catalog_cache_terminus] = "json"
-    Puppet[:noop] = true
-    Puppet::Resource::Catalog.indirection.expects(:cache_class=).with(nil)
-
-    @apply.initialize_app_defaults
-    @apply.setup
-  end
 end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -860,6 +860,20 @@ describe Puppet::Configurer do
       @agent.retrieve_catalog({})
       expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
     end
+
+    it "should not update the cached catalog in noop mode" do
+      Puppet[:noop] = true
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:ignore_cache => true, :ignore_cache_save => true)).returns(@catalog)
+
+      @agent.retrieve_catalog({})
+    end
+
+    it "should update the cached catalog when not in noop mode" do
+      Puppet[:noop] = false
+      Puppet::Resource::Catalog.indirection.expects(:find).with(anything, has_entries(:ignore_cache => true, :ignore_cache_save => false)).returns(@catalog)
+
+      @agent.retrieve_catalog({})
+    end
   end
 
   describe "when converting the catalog" do


### PR DESCRIPTION
When running apply & agent in noop mode, we do want to be able to retrieve previously cached catalogs according to the "normal" cache lookup rules, but we should never write the retrieved catalog back to the cache.

Since ignore_cache only affects retrieving from the cache, we can't use it to turn off saving to the cache. Also, we do want to be able to look up from the cache so even if it did turn off cache saving, we wouldn't want to use it.

Now, we can explicitly specify that we do not wish to save to the `cache_class` for the terminus by specifying `ignore_cache_save`, and we set that depending on the value of `noop`.