### PR TITLE
(PUP-8378) Reject MD5 related digest algorithms in FIPS mode

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -957,8 +957,9 @@ EOT
         valid   = ['md5', 'md5lite', 'sha256', 'sha256lite', 'sha384', 'sha512', 'sha224', 'sha1', 'sha1lite', 'mtime', 'ctime']
         invalid = values.reject {|alg| valid.include?(alg)}
         if not invalid.empty?
-          raise ArgumentError, _("Unrecognized checksum types %{invalid} are not supported.") % { invalid: invalid } +
-              ' ' + _("Valid values are %{values}.") % { values: valid }
+
+          raise ArgumentError, _("Unrecognized checksum types %{invalid} are not supported.") % { invalid: invalid.join(', ') } +
+              ' ' + _("Valid values are %{values}.") % { values: valid.join(', ') }
         end
       end
     }

--- a/lib/puppet/type/file/checksum.rb
+++ b/lib/puppet/type/file/checksum.rb
@@ -15,6 +15,12 @@ Puppet::Type.type(:file).newparam(:checksum) do
     Puppet[:digest_algorithm].to_sym
   end
 
+  validate do |value|
+    if Puppet::Util::Platform.fips_enabled? && (value == :md5 || value == :md5lite)
+      raise ArgumentError, _("MD5 is not supported in FIPS mode")
+    end
+  end
+
   def sum(content)
     content = content.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? content.binary_buffer : content
     type = digest_algorithm()

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -42,37 +42,6 @@ describe "Defaults" do
     end
   end
 
-  describe ".default_digest_alg" do
-    describe "on windows platform" do
-      before(:each) do
-        Puppet::Util::Platform.stubs(:windows?).returns true
-      end
-      it "should be md5" do
-        expect(Puppet.default_digest_alg).to eq('md5')
-      end
-    end
-
-    describe "on non-windows not fips platform" do
-      before(:each) do
-        Puppet::Util::Platform.stubs(:windows?).returns false
-        Puppet::Util::Platform.stubs(:fips_enabled?).returns false
-      end
-      it "should be md5" do
-        expect(Puppet.default_digest_alg).to eq('md5')
-      end
-    end
-
-    describe "on non-windows fips-enabled platform" do
-      before(:each) do
-        Puppet::Util::Platform.stubs(:windows?).returns false
-        Puppet::Util::Platform.stubs(:fips_enabled?).returns true
-      end
-      it "should be sha256" do
-        expect(Puppet.default_digest_alg).to eq('sha256')
-      end
-    end
-  end
-
   describe 'strict' do
     it 'should accept the valid value :off' do
       expect {Puppet.settings[:strict] = 'off'}.to_not raise_exception
@@ -91,49 +60,42 @@ describe "Defaults" do
     end
   end
 
-  describe 'supported_checksum_types in fips mode testing' do
-    describe "on windows platform" do
-      before(:each) do
-        Puppet::Util::Platform.stubs(:windows?).returns true
-      end
-      it "should return all checksums" do
-        expect(Puppet.default_checksum_types).to eq(['md5', 'sha256', 'sha384', 'sha512', 'sha224'])
-      end
+  describe '.default_digest_alg' do
+    it 'defaults to md5 when FIPS is not enabled' do
+      Puppet::Util::Platform.stubs(:fips_enabled?).returns false
+      expect(Puppet.default_digest_alg).to eq('md5')
     end
 
-    describe "on non-windows non fips platform" do
-      before(:each) do
-        Puppet::Util::Platform.stubs(:windows?).returns false
-        Puppet::Util::Platform.stubs(:fips_enabled?).returns false
-      end
-      it "should return all checksums" do
-        expect(Puppet.default_checksum_types).to eq(['md5', 'sha256', 'sha384', 'sha512', 'sha224'])
-      end
-    end
-
-    describe "on non-windows fips-enabled platform" do
-      before(:each) do
-        Puppet::Util::Platform.stubs(:windows?).returns false
-        Puppet::Util::Platform.stubs(:fips_enabled?).returns true
-      end
-      it "should exclude md5" do
-        expect(Puppet.default_checksum_types).to eq(['sha256', 'sha384', 'sha512', 'sha224'])
-      end
+    it 'defaults to sha256 when FIPS is enabled' do
+      Puppet::Util::Platform.stubs(:fips_enabled?).returns true
+      expect(Puppet.default_digest_alg).to eq('sha256')
     end
   end
 
-  describe 'supported_checksum_types' do
-    it 'should default to md5,sha256,sha512,sha384,sha224' do
-      expect(Puppet.settings[:supported_checksum_types]).to eq(['md5', 'sha256', 'sha384', 'sha512', 'sha224'])
+  describe '.supported_checksum_types' do
+    it 'defaults to md5, sha256, sha384, sha512, sha224 when FIPS is not enabled' do
+      Puppet::Util::Platform.stubs(:fips_enabled?).returns false
+      expect(Puppet.default_checksum_types).to eq(%w[md5 sha256 sha384 sha512 sha224])
+    end
+
+    it 'defaults to sha256, sha384, sha512, sha224 when FIPS is enabled' do
+      Puppet::Util::Platform.stubs(:fips_enabled?).returns true
+      expect(Puppet.default_checksum_types).to eq(%w[sha256 sha384 sha512 sha224])
+    end
+  end
+
+  describe 'Puppet[:supported_checksum_types]' do
+    it 'defaults to md5, sha256, sha512, sha384, sha224' do
+      expect(Puppet.settings[:supported_checksum_types]).to eq(%w[md5 sha256 sha384 sha512 sha224])
     end
 
     it 'should raise an error on an unsupported checksum type' do
-      expect { Puppet.settings[:supported_checksum_types] = ['md5', 'foo'] }.to raise_exception ArgumentError, 'Unrecognized checksum types ["foo"] are not supported. Valid values are ["md5", "md5lite", "sha256", "sha256lite", "sha384", "sha512", "sha224", "sha1", "sha1lite", "mtime", "ctime"].'
+      expect { Puppet.settings[:supported_checksum_types] = %w[md5 foo] }.to raise_exception ArgumentError, 'Unrecognized checksum types ["foo"] are not supported. Valid values are ["md5", "md5lite", "sha256", "sha256lite", "sha384", "sha512", "sha224", "sha1", "sha1lite", "mtime", "ctime"].'
     end
 
     it 'should not raise an error on setting a valid list of checksum types' do
-      Puppet.settings[:supported_checksum_types] = ['sha256', 'md5lite', 'mtime']
-      expect(Puppet.settings[:supported_checksum_types]).to eq(['sha256', 'md5lite', 'mtime'])
+      Puppet.settings[:supported_checksum_types] = %w[sha256 md5lite mtime]
+      expect(Puppet.settings[:supported_checksum_types]).to eq(%w[sha256 md5lite mtime])
     end
   end
 

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -90,7 +90,7 @@ describe "Defaults" do
     end
 
     it 'should raise an error on an unsupported checksum type' do
-      expect { Puppet.settings[:supported_checksum_types] = %w[md5 foo] }.to raise_exception ArgumentError, 'Unrecognized checksum types ["foo"] are not supported. Valid values are ["md5", "md5lite", "sha256", "sha256lite", "sha384", "sha512", "sha224", "sha1", "sha1lite", "mtime", "ctime"].'
+      expect { Puppet.settings[:supported_checksum_types] = %w[md5 foo] }.to raise_exception ArgumentError, 'Unrecognized checksum types foo are not supported. Valid values are md5, md5lite, sha256, sha256lite, sha384, sha512, sha224, sha1, sha1lite, mtime, ctime.'
     end
 
     it 'should not raise an error on setting a valid list of checksum types' do

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -60,27 +60,27 @@ describe "Defaults" do
     end
   end
 
-  describe '.default_digest_alg' do
+  describe '.default_digest_algorithm' do
     it 'defaults to md5 when FIPS is not enabled' do
       Puppet::Util::Platform.stubs(:fips_enabled?).returns false
-      expect(Puppet.default_digest_alg).to eq('md5')
+      expect(Puppet.default_digest_algorithm).to eq('md5')
     end
 
     it 'defaults to sha256 when FIPS is enabled' do
       Puppet::Util::Platform.stubs(:fips_enabled?).returns true
-      expect(Puppet.default_digest_alg).to eq('sha256')
+      expect(Puppet.default_digest_algorithm).to eq('sha256')
     end
   end
 
   describe '.supported_checksum_types' do
     it 'defaults to md5, sha256, sha384, sha512, sha224 when FIPS is not enabled' do
       Puppet::Util::Platform.stubs(:fips_enabled?).returns false
-      expect(Puppet.default_checksum_types).to eq(%w[md5 sha256 sha384 sha512 sha224])
+      expect(Puppet.default_file_checksum_types).to eq(%w[md5 sha256 sha384 sha512 sha224])
     end
 
     it 'defaults to sha256, sha384, sha512, sha224 when FIPS is enabled' do
       Puppet::Util::Platform.stubs(:fips_enabled?).returns true
-      expect(Puppet.default_checksum_types).to eq(%w[sha256 sha384 sha512 sha224])
+      expect(Puppet.default_file_checksum_types).to eq(%w[sha256 sha384 sha512 sha224])
     end
   end
 
@@ -90,12 +90,23 @@ describe "Defaults" do
     end
 
     it 'should raise an error on an unsupported checksum type' do
-      expect { Puppet.settings[:supported_checksum_types] = %w[md5 foo] }.to raise_exception ArgumentError, 'Unrecognized checksum types foo are not supported. Valid values are md5, md5lite, sha256, sha256lite, sha384, sha512, sha224, sha1, sha1lite, mtime, ctime.'
+      expect {
+        Puppet.settings[:supported_checksum_types] = %w[md5 foo]
+      }.to raise_exception ArgumentError,
+                           /Invalid value 'foo' for parameter supported_checksum_types. Allowed values are/
     end
 
     it 'should not raise an error on setting a valid list of checksum types' do
       Puppet.settings[:supported_checksum_types] = %w[sha256 md5lite mtime]
       expect(Puppet.settings[:supported_checksum_types]).to eq(%w[sha256 md5lite mtime])
+    end
+
+    it 'raises when setting md5 in FIPS mode' do
+      Puppet::Util::Platform.stubs(:fips_enabled?).returns true
+      expect {
+        Puppet.settings[:supported_checksum_types] = %w[md5]
+      }.to raise_error(ArgumentError,
+                       /Invalid value 'md5' for parameter supported_checksum_types. Allowed values are 'sha256'/)
     end
   end
 

--- a/spec/unit/type/file/checksum_spec.rb
+++ b/spec/unit/type/file/checksum_spec.rb
@@ -94,4 +94,12 @@ describe checksum do
     Puppet.settings[:supported_checksum_types] = values
     expect(Puppet.settings[:supported_checksum_types]).to eq(values)
   end
+
+  it 'rejects md5 checksums in FIPS mode' do
+    Puppet::Util::Platform.stubs(:fips_enabled?).returns true
+    expect {
+      @resource[:checksum] = :md5
+    }.to raise_error(Puppet::ResourceError,
+                     /Parameter checksum failed.* MD5 is not supported in FIPS mode/)
+  end
 end


### PR DESCRIPTION
FIPS enabled agents will segfault if they attempt MD5 related operations. The `digest_algorithm` is used for filebucketing, and is the default checksum type for file resources. The `supported_checksum_types` setting is used when requesting a catalog, so that the server has an opportunity to inline file metadata in the static catalog.

This PR does not attempt to prevent the user from setting `md5` in puppet settings, as that is a more general problem in puppet.

Supersedes PR #6581