### PR TITLE
Revert "(PUP-8106) Make the `mount` type autorequire its `file` mount…

### DIFF
--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -16,9 +16,6 @@ module Puppet
       that is, other mount points higher up in the filesystem --- the child
       mount will autorequire them.
 
-      **Autorequires:** If Puppet is managing a `File` resource for the mount
-      point of a mount resource, the mount will autorequire it.
-
       **Autobefores:**  If Puppet is managing any child file paths of a mount
       point, the mount resource will autobefore them."
 
@@ -301,12 +298,6 @@ module Puppet
         dependencies.unshift parent.to_s
       end
       dependencies[0..-2]
-    end
-
-    # Ensure that the mountpoint is created first
-    autorequire(:file) do
-      dependencies = []
-      dependencies.unshift @parameters[:name].value
     end
 
     # Autobefore the mount point's child file paths

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -589,32 +589,24 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
 
     it "adds the parent autorequire and the file autorequire for a mount with one parent" do
       parent_relationship = var_mount.autorequire[0]
-      mountpoint_relationship = var_mount.autorequire[1]
 
-      expect(var_mount.autorequire).to have_exactly(2).items
+      expect(var_mount.autorequire).to have_exactly(1).item
 
       expect(parent_relationship.source).to eq root_mount
       expect(parent_relationship.target).to eq var_mount
-      expect(mountpoint_relationship.source).to eq var_file
-      expect(mountpoint_relationship.target).to eq var_mount
     end
 
     it "adds both parent autorequires and the file autorequire for a mount with two parents" do
       grandparent_relationship = log_mount.autorequire[0]
       parent_relationship = log_mount.autorequire[1]
-      mountpoint_relationship = log_mount.autorequire[2]
 
-      expect(log_mount.autorequire).to have_exactly(3).items
+      expect(log_mount.autorequire).to have_exactly(2).items
 
       expect(grandparent_relationship.source).to eq root_mount
       expect(grandparent_relationship.target).to eq log_mount
 
       expect(parent_relationship.source).to eq var_mount
       expect(parent_relationship.target).to eq log_mount
-
-      expect(mountpoint_relationship.source).to eq log_file
-      expect(mountpoint_relationship.target).to eq log_mount
-
     end
 
     it "adds the child autobefore for a mount with one file child" do


### PR DESCRIPTION
…point"

This reverts commit 73210132efe54494ecd4ab3d4d39df25d52d87e9.

This commit reintroduces a bug fixed with PUP-6397. When the mount type
autorequires its mount point, it creates a dependency loop. More
information can be found in PUP-6397.