### PR TITLE
(PUP-8409) Enable config cmd to print conf file compatible format

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -115,7 +115,7 @@ module Puppet::Environments
     def get_conf(name)
       env = get(name)
       if env
-        Puppet::Settings::EnvironmentConf.static_for(env, 0, Puppet[:static_catalogs], Puppet[:rich_data])
+        Puppet::Settings::EnvironmentConf.static_for(env, Puppet[:environment_timeout], Puppet[:static_catalogs], Puppet[:rich_data])
       else
         nil
       end

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -77,7 +77,7 @@ Puppet::Face.define(:config, '0.0.1') do
 
         to_be_rendered = {}
         args.sort.each do |setting_name|
-          to_be_rendered[setting_name] = values.interpolate(setting_name.to_sym)
+          to_be_rendered[setting_name] = values.print(setting_name.to_sym)
         end
       end
 

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -157,6 +157,11 @@ class Puppet::Settings::BaseSetting
     value
   end
 
+  # Print the value for the user in a config compatible format
+  def print(value)
+    munge(value)
+  end
+
   def set_meta(meta)
     Puppet.notice("#{name} does not support meta data. Ignoring.")
   end

--- a/lib/puppet/settings/ttl_setting.rb
+++ b/lib/puppet/settings/ttl_setting.rb
@@ -25,6 +25,11 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
     self.class.munge(value, @name)
   end
 
+  def print(value)
+    val = munge(value)
+    val == Float::INFINITY ? 'unlimited' : val
+  end
+
   # Convert the value to Numeric, parsing numeric string with units if necessary.
   def self.munge(value, param_name)
     case

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -421,6 +421,13 @@ config_version=$vardir/random/scripts
       expect(loader.get_conf(:doesnotexist)).to be_nil
     end
 
+    it "gets the conf environment_timeout if one is specified" do
+      Puppet[:environment_timeout] = 8675
+      conf = loader.get_conf(:static1)
+
+      expect(conf.environment_timeout).to eq(8675)
+    end
+
     context "that are private" do
       let(:private_env) { Puppet::Node::Environment.create(:private, []) }
       let(:loader) { Puppet::Environments::StaticPrivate.new(private_env) }

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -31,6 +31,21 @@ trace = true
     OUTPUT
   end
 
+  it "prints environment_timeout=unlimited correctly" do
+    Puppet[:environment_timeout] = "unlimited"
+
+    result = subject.print("environment_timeout")
+    expect(render(:print, result)).to eq("unlimited\n")
+  end
+
+  it "prints arrays correctly" do
+    pending "Still doesn't print arrays like they would appear in config"
+    Puppet[:server_list] = %w{server1 server2}
+
+    result = subject.print("server_list")
+    expect(render(:print, result)).to eq("server1, server2\n")
+  end
+
   it "prints the setting from the selected section" do
     Puppet.settings.parse_config(<<-CONF)
     [user]

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -555,7 +555,8 @@ describe Puppet::Settings do
           :two    => { :default => "$one TWO", :desc => "b"},
           :three  => { :default => "$one $two THREE", :desc => "c"},
           :four   => { :default => "$two $three FOUR", :desc => "d"},
-          :five   => { :default => nil, :desc => "e" }
+          :five   => { :default => nil, :desc => "e" },
+          :code   => { :default => "", :desc => "my code"}
       Puppet::FileSystem.stubs(:exist?).returns true
     end
 
@@ -609,6 +610,13 @@ describe Puppet::Settings do
       expect(@settings[:two]).to eq("ONE TWO")
       @settings[:one] = "one"
       expect(@settings[:two]).to eq("one TWO")
+    end
+
+    it "should not interpolate the value of the :code setting" do
+      @code = @settings.setting(:code)
+      @code.expects(:munge).never
+
+      expect(@settings[:code]).to eq("")
     end
 
     it "should have a run_mode that defaults to user" do


### PR DESCRIPTION
When showing a setting with config print, without this change values are returned formatted for internal use.
With this change, returned values are formatted like the conf file expects.