### PR TITLE
(PUP-8420) Uncompress http file source response body

### DIFF
--- a/lib/puppet/indirector/file_content/http.rb
+++ b/lib/puppet/indirector/file_content/http.rb
@@ -1,15 +1,17 @@
 require 'puppet/file_serving/metadata'
 require 'puppet/indirector/generic_http'
+require 'puppet/network/http'
 
 class Puppet::Indirector::FileContent::Http < Puppet::Indirector::GenericHttp
   desc "Retrieve file contents from a remote HTTP server."
 
   include Puppet::FileServing::TerminusHelper
+  include Puppet::Network::HTTP::Compression.module
 
   @http_method = :get
 
   def find(request)
     response = super
-    model.from_binary(response.body)
+    model.from_binary(uncompress_body(response))
   end
 end

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -157,8 +157,10 @@ module Puppet::Util::HttpProxy
     proxy
   end
 
-  # Retrieve a document through HTTP(s), following redirects if necessary.
-  # 
+  # Retrieve a document through HTTP(s), following redirects if necessary. The
+  # returned response body may be compressed, and it is the caller's
+  # responsibility to decompress it based on the 'content-encoding' header.
+  #
   # Based on the the client implementation in the HTTP pool.
   #
   # @see Puppet::Network::HTTP::Connection#request_with_redirects


### PR DESCRIPTION
Prior to commit a5f9d599, puppet agent and apply could both download compressed
file sources using http, however, they followed different code paths to
accomplish the same thing. In the agent case, the `source` parameter's
`each_chunk_from` method calls `HttpProxy.request_with_redirects` with a block,
which had the side-effect of setting the `Accept-Encoding` header explicitly.
This tells Ruby that we accept compressed responses, and more importantly, we
want to decompress the response body, if necessary.

In the apply case, the `each_chunk_from` method calls
`HttpProxy.request_with_redirects` without a block. Although we don't add an
`Accept-Encoding` header, Ruby does[1] (surprise!) and it automagically
decompresses the response body, if neceessary[2].

Commit a5f9d599 changed `request_with_redirects` method to always set the
`Accept-Encoding` header, which broke the apply case, as it wasn't prepared to
handle compressed responses. The user facing outcome was puppet apply saved the
compressed file to disk.

This commit allows puppet apply to download compressed file content when using
http(s) file sources. The puppet agent case is unchanged since it already
handles compressed response bodies.

PUP-8338 is filed to consolidate on a single method for agent and apply.

[1] https://github.com/ruby/ruby/blob/v2_1_9/lib/net/http/generic_request.rb#L32-L42
[2] https://github.com/ruby/ruby/blob/v2_1_9/lib/net/http/generic_request.rb#L57-L60