### PR TITLE
(PUP-8432) Remove gettext-setup as a runtime gem dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   # PUP-7115 - return to a gem dependency in Puppet 5
   # s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])
   # i18n support (gettext-setup and dependencies)
-  s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.1")
+  s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.2")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   # hocon is an optional hiera backend shipped in puppet-agent packages
   s.add_runtime_dependency(%q<hocon>, "~> 1.0")

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -17,11 +17,11 @@ gem_forge_project: 'puppet'
 gem_required_ruby_version: '>= 1.9.3'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
-  facter: ['> 2.0', '< 4']
+  facter: ['> 2.0.1', '< 4']
   hiera: ['>= 3.2.1', '< 4']
   # PUP-7115 - return to a gem dependency in Puppet 5
   # semantic_puppet: ['>= 0.1.3', '< 2']
-  gettext-setup: ['>= 0.10', '< 1']
+  fast_gettext: '~> 1.1.2'
   locale: '~> 2.1'
 gem_rdoc_options:
   - --title


### PR DESCRIPTION
Puppet uses ext/project_data.yaml as the source for its gem dependencies
when it is packaged as a gem. Remove gettext-setup as that is only
needed when generating the pot files containing strings to be localized.

This is a follow up to commit 53aa50aa.