### PR TITLE
(PUP-8419) Do not "pre-cache" the Node's environment when creating from a data hash

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -28,9 +28,10 @@ class Puppet::Node
     @classes    = data['classes']    || []
     @parameters = data['parameters'] || {}
     env_name = data['environment'] || @parameters[ENVIRONMENT]
-    env_name = env_name.intern unless env_name.nil?
-    @environment_name = env_name
-    self.environment = env_name
+    unless env_name.nil?
+      @parameters[ENVIRONMENT] = env_name
+      @environment_name = env_name.intern
+    end
   end
 
   def self.from_data_hash(data)

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -205,6 +205,15 @@ describe Puppet::Node do
         expect(Puppet::Node).to read_json_attribute('environment_name').from(@node.to_json).as(:bar)
       end
     end
+
+    it "does not immediately populate the environment instance" do
+      node = described_class.from_data_hash("name" => "foo", "environment" => "production")
+
+      expect(node.environment_name).to eq(:production)
+      expect(node).not_to be_has_environment_instance
+      node.environment
+      expect(node).to be_has_environment_instance
+    end
   end
 end
 


### PR DESCRIPTION
Previously we would effectively pre-load the cache of what a node's environment is when initializing from a data hash, but this could be problematic outside of the context of a compilation master.

The biggest problem is that in the context of a compilation master, we have much stronger constraints around what constitutes a valid environment, such as the environment having a corresponding directory on disk (which are enforced by using the #get! version of retrieving an environment object). In pretty much all other contexts, the only real constraint we have around an environment is "it's a string that the compilation master gave us". This would be much less of a problem if we had separate `Node` objects for use in compilation master context & all other contexts, as we could directly use a `Puppet::Node::Environment::Remote` in the "all other contexts" version of `Node`, instead of relying on a `Puppet::Node::Environment::Remote` being passed in from outside.

Enforcing the stricter compilation master constraints around environments in all other contexts would lead to spurious warnings, and extra catalog retrievals from the agent-side code blowing up before it has a chance to set the `Remote` version of an `Environment`.

In order to maintain the previously set environment lookup precedence, we need to make sure that the environment parameter is set to be the environment name as that has the highest precedence if we end up falling back to the lookup chain in the environment getter method. We didn't need to do this when we were pre-loading the cache, as we were explicitly setting the environment using the environment name (if there was one).