### PR TITLE
(PUP-8374) pass our custom_environment to user and group commands

### DIFF
--- a/lib/puppet/provider/nameservice.rb
+++ b/lib/puppet/provider/nameservice.rb
@@ -174,7 +174,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     begin
       execute(self.addcmd, {:failonfail => true, :combine => true, :custom_environment => @custom_environment})
       if feature?(:manages_password_age) && (cmd = passcmd)
-        execute(cmd)
+        execute(cmd, { :custom_environment => @custom_environment })
       end
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, _("Could not create %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
@@ -189,7 +189,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     end
 
     begin
-      execute(self.deletecmd)
+      execute(self.deletecmd, { :custom_environment => @custom_environment })
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, _("Could not delete %{resource} %{name}: %{detail}") % { resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
     end
@@ -301,7 +301,7 @@ class Puppet::Provider::NameService < Puppet::Provider
     cmd = modifycmd(param, munge(param, value))
     raise Puppet::DevError, _("Nameservice command must be an array") unless cmd.is_a?(Array)
     begin
-      execute(cmd)
+      execute(cmd, { :custom_environment => @custom_environment })
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, _("Could not set %{param} on %{resource}[%{name}]: %{detail}") % { param: param, resource: @resource.class.name, name: @resource.name, detail: detail }, detail.backtrace
     end

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -78,13 +78,13 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
       end
 
       it "should use groupmod" do
-        provider.expects(:execute).with(['/usr/sbin/groupmod', '-g', 150, 'mygroup'])
+        provider.expects(:execute).with(['/usr/sbin/groupmod', '-g', 150, 'mygroup'], has_entry(:custom_environment, {}))
         provider.gid = 150
       end
 
       it "should pass -o to groupmod" do
         resource[:allowdupe] = :true
-        provider.expects(:execute).with(['/usr/sbin/groupmod', '-g', 150, '-o', 'mygroup'])
+        provider.expects(:execute).with(['/usr/sbin/groupmod', '-g', 150, '-o', 'mygroup'], has_entry(:custom_environment, {}))
         provider.gid = 150
       end
     end
@@ -95,13 +95,13 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
       end
 
       it "should use lgroupmod instead of groupmod" do
-        provider.expects(:execute).with(['/usr/sbin/lgroupmod', '-g', 150, 'mygroup'])
+        provider.expects(:execute).with(['/usr/sbin/lgroupmod', '-g', 150, 'mygroup'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.gid = 150
       end
 
       it "should NOT pass -o to lgroupmod" do
         resource[:allowdupe] = :true
-        provider.expects(:execute).with(['/usr/sbin/lgroupmod', '-g', 150, 'mygroup'])
+        provider.expects(:execute).with(['/usr/sbin/lgroupmod', '-g', 150, 'mygroup'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.gid = 150
       end
       it "should raise an exception for duplicate GID if allowdupe is not set and duplicate GIDs exist" do
@@ -116,7 +116,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
   describe "#gid=" do
     it "should add -o when allowdupe is enabled and the gid is being modified" do
       resource[:allowdupe] = :true
-      provider.expects(:execute).with(['/usr/sbin/groupmod', '-g', 150, '-o', 'mygroup'])
+      provider.expects(:execute).with(['/usr/sbin/groupmod', '-g', 150, '-o', 'mygroup'], has_entry(:custom_environment, {}))
       provider.gid = 150
     end
   end
@@ -132,7 +132,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
       end
 
       it "should use groupdel" do
-        provider.expects(:execute).with(['/usr/sbin/groupdel', 'mygroup'])
+        provider.expects(:execute).with(['/usr/sbin/groupdel', 'mygroup'], has_entry(:custom_environment, {}))
         provider.delete
       end
     end
@@ -143,7 +143,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
       end
 
       it "should use lgroupdel instead of groupdel" do
-        provider.expects(:execute).with(['/usr/sbin/lgroupdel', 'mygroup'])
+        provider.expects(:execute).with(['/usr/sbin/lgroupdel', 'mygroup'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.delete
       end
     end

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -54,7 +54,7 @@ describe provider_class do
     it "should run pw with no additional flags" do
       provider.expects(:exists?).returns true
       expect(provider.deletecmd).to eq([provider_class.command(:pw), "groupdel", "testgroup"])
-      provider.expects(:execute).with([provider_class.command(:pw), "groupdel", "testgroup"])
+      provider.expects(:execute).with([provider_class.command(:pw), "groupdel", "testgroup"], has_entry(:custom_environment, {}))
       provider.delete
     end
   end
@@ -62,19 +62,19 @@ describe provider_class do
   describe "when modifying groups" do
     it "should run pw with the correct arguments" do
       expect(provider.modifycmd("gid", 12345)).to eq([provider_class.command(:pw), "groupmod", "testgroup", "-g", 12345])
-      provider.expects(:execute).with([provider_class.command(:pw), "groupmod", "testgroup", "-g", 12345])
+      provider.expects(:execute).with([provider_class.command(:pw), "groupmod", "testgroup", "-g", 12345], has_entry(:custom_environment, {}))
       provider.gid = 12345
     end
 
     it "should use -M with the correct argument when the members property is changed" do
       resource[:members] = "user1"
-      provider.expects(:execute).with(all_of(includes("-M"), includes("user2")))
+      provider.expects(:execute).with(all_of(includes("-M"), includes("user2")), has_entry(:custom_environment, {}))
       provider.members = "user2"
     end
 
     it "should use -M with all the given users when the members property is changed with an array" do
       resource[:members] = ["user1", "user2"]
-      provider.expects(:execute).with(all_of(includes("-M"), includes("user3,user4")))
+      provider.expects(:execute).with(all_of(includes("-M"), includes("user3,user4")), has_entry(:custom_environment, {}))
       provider.members = ["user3", "user4"]
     end
   end

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -393,20 +393,20 @@ describe Puppet::Provider::NameService do
 
     it "should execute the modify command on valid values" do
       provider.expects(:modifycmd).with(:foo, 100).returns ['/bin/modify', '-f', '100' ]
-      provider.expects(:execute).with ['/bin/modify', '-f', '100']
+      provider.expects(:execute).with(['/bin/modify', '-f', '100'], has_entry(:custom_environment, {}))
       provider.set(:foo, 100)
     end
 
     it "should munge the value first" do
       described_class.options(:foo, :munge => proc { |x| x*2}, :unmunge => proc {|x| x/2})
-      provider.expects(:modifycmd).with(:foo, 200).returns ['/bin/modify', '-f', '200' ]
-      provider.expects(:execute).with ['/bin/modify', '-f', '200']
+      provider.expects(:modifycmd).with(:foo, 200).returns(['/bin/modify', '-f', '200' ])
+      provider.expects(:execute).with(['/bin/modify', '-f', '200'], has_entry(:custom_environment, {}))
       provider.set(:foo, 100)
     end
 
     it "should fail if the modify command fails" do
-      provider.expects(:modifycmd).with(:foo, 100).returns ['/bin/modify', '-f', '100' ]
-      provider.expects(:execute).with(['/bin/modify', '-f', '100']).raises(Puppet::ExecutionFailure, "Execution of '/bin/modify' returned 1: some_failure")
+      provider.expects(:modifycmd).with(:foo, 100).returns(['/bin/modify', '-f', '100' ])
+      provider.expects(:execute).with(['/bin/modify', '-f', '100'], kind_of(Hash)).raises(Puppet::ExecutionFailure, "Execution of '/bin/modify' returned 1: some_failure")
       expect { provider.set(:foo, 100) }.to raise_error Puppet::Error, /Could not set foo/
     end
   end

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -59,14 +59,14 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     it "should add modprpw to modifycmd if Trusted System" do
       resource.stubs(:allowdupe?).returns true
       provider.expects(:exec_getprpw).with('root','-m uid').returns('uid=0')
-      provider.expects(:execute).with(['/usr/sam/lbin/usermod.sam', '-u', 1000, '-o', 'testuser', '-F', ';', '/usr/lbin/modprpw', '-v', '-l', 'testuser'])
+      provider.expects(:execute).with(['/usr/sam/lbin/usermod.sam', '-u', 1000, '-o', 'testuser', '-F', ';', '/usr/lbin/modprpw', '-v', '-l', 'testuser'], has_entry(:custom_environment, {}))
       provider.uid = 1000
     end
 
     it "should not add modprpw if not Trusted System" do
       resource.stubs(:allowdupe?).returns true
       provider.expects(:exec_getprpw).with('root','-m uid').returns('System is not trusted')
-      provider.expects(:execute).with(['/usr/sam/lbin/usermod.sam', '-u', 1000, '-o', 'testuser', '-F'])
+      provider.expects(:execute).with(['/usr/sam/lbin/usermod.sam', '-u', 1000, '-o', 'testuser', '-F'], has_entry(:custom_environment, {}))
       provider.uid = 1000
     end
   end

--- a/spec/unit/provider/user/openbsd_spec.rb
+++ b/spec/unit/provider/user/openbsd_spec.rb
@@ -33,13 +33,13 @@ describe Puppet::Type.type(:user).provider(:openbsd) do
   describe "#expiry=" do
     it "should pass expiry to usermod as MM/DD/YY" do
       resource[:expiry] = '2014-11-05'
-      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', 'November 05 2014', 'myuser'])
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', 'November 05 2014', 'myuser'], has_entry(:custom_environment, {}))
       provider.expiry = '2014-11-05'
     end
 
     it "should use -e with an empty string when the expiry property is removed" do
       resource[:expiry] = :absent
-      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '', 'myuser'])
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '', 'myuser'], has_entry(:custom_environment, {}))
       provider.expiry = :absent
     end
   end

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -109,7 +109,7 @@ describe provider_class do
       provider = resource.provider
       provider.expects(:exists?).returns true
       expect(provider.deletecmd).to eq([provider_class.command(:pw), "userdel", "testuser"])
-      provider.expects(:execute).with([provider_class.command(:pw), "userdel", "testuser"])
+      provider.expects(:execute).with([provider_class.command(:pw), "userdel", "testuser"], has_entry(:custom_environment, {}))
       provider.delete
     end
 
@@ -120,7 +120,7 @@ describe provider_class do
       provider = resource.provider
       provider.expects(:exists?).returns true
       resource[:managehome] = false
-      provider.expects(:execute).with(Not(includes("-r")))
+      provider.expects(:execute).with(Not(includes("-r")), has_entry(:custom_environment, {}))
       provider.delete
     end
 
@@ -128,7 +128,7 @@ describe provider_class do
       provider = resource.provider
       provider.expects(:exists?).returns true
       resource[:managehome] = true
-      provider.expects(:execute).with(includes("-r"))
+      provider.expects(:execute).with(includes("-r"), has_entry(:custom_environment, {}))
       provider.delete
     end
   end
@@ -140,56 +140,56 @@ describe provider_class do
 
     it "should run pw with the correct arguments" do
       expect(provider.modifycmd("uid", 12345)).to eq([provider_class.command(:pw), "usermod", "testuser", "-u", 12345])
-      provider.expects(:execute).with([provider_class.command(:pw), "usermod", "testuser", "-u", 12345])
+      provider.expects(:execute).with([provider_class.command(:pw), "usermod", "testuser", "-u", 12345], has_entry(:custom_environment, {}))
       provider.uid = 12345
     end
 
     it "should use -c with the correct argument when the comment property is changed" do
       resource[:comment] = "Testuser Name"
-      provider.expects(:execute).with(all_of(includes("-c"), includes("Testuser New Name")))
+      provider.expects(:execute).with(all_of(includes("-c"), includes("Testuser New Name")), has_entry(:custom_environment, {}))
       provider.comment = "Testuser New Name"
     end
 
     it "should use -e with the correct argument when the expiry property is changed" do
       resource[:expiry] = "2010-02-19"
-      provider.expects(:execute).with(all_of(includes("-e"), includes("19-02-2011")))
+      provider.expects(:execute).with(all_of(includes("-e"), includes("19-02-2011")), has_entry(:custom_environment, {}))
       provider.expiry = "2011-02-19"
     end
 
     it "should use -e with the correct argument when the expiry property is removed" do
       resource[:expiry] = :absent
-      provider.expects(:execute).with(all_of(includes("-e"), includes("00-00-0000")))
+      provider.expects(:execute).with(all_of(includes("-e"), includes("00-00-0000")), has_entry(:custom_environment, {}))
       provider.expiry = :absent
     end
 
     it "should use -g with the correct argument when the gid property is changed" do
       resource[:gid] = 12345
-      provider.expects(:execute).with(all_of(includes("-g"), includes(54321)))
+      provider.expects(:execute).with(all_of(includes("-g"), includes(54321)), has_entry(:custom_environment, {}))
       provider.gid = 54321
     end
 
     it "should use -G with the correct argument when the groups property is changed" do
       resource[:groups] = "group1"
-      provider.expects(:execute).with(all_of(includes("-G"), includes("group2")))
+      provider.expects(:execute).with(all_of(includes("-G"), includes("group2")), has_entry(:custom_environment, {}))
       provider.groups = "group2"
     end
 
     it "should use -G with all the given groups when the groups property is changed with an array" do
       resource[:groups] = ["group1", "group2"]
-      provider.expects(:execute).with(all_of(includes("-G"), includes("group3,group4")))
+      provider.expects(:execute).with(all_of(includes("-G"), includes("group3,group4")), has_entry(:custom_environment, {}))
       provider.groups = "group3,group4"
     end
 
     it "should use -d with the correct argument when the home property is changed" do
       resource[:home] = "/home/testuser"
-      provider.expects(:execute).with(all_of(includes("-d"), includes("/newhome/testuser")))
+      provider.expects(:execute).with(all_of(includes("-d"), includes("/newhome/testuser")), has_entry(:custom_environment, {}))
       provider.home = "/newhome/testuser"
     end
 
     it "should use -m and -d with the correct argument when the home property is changed and managehome is enabled" do
       resource[:home] = "/home/testuser"
       resource[:managehome] = true
-      provider.expects(:execute).with(all_of(includes("-d"), includes("/newhome/testuser"), includes("-m")))
+      provider.expects(:execute).with(all_of(includes("-d"), includes("/newhome/testuser"), includes("-m")), has_entry(:custom_environment, {}))
       provider.home = "/newhome/testuser"
     end
 
@@ -201,13 +201,13 @@ describe provider_class do
 
     it "should use -s with the correct argument when the shell property is changed" do
       resource[:shell] = "/bin/sh"
-      provider.expects(:execute).with(all_of(includes("-s"), includes("/bin/tcsh")))
+      provider.expects(:execute).with(all_of(includes("-s"), includes("/bin/tcsh")), has_entry(:custom_environment, {}))
       provider.shell = "/bin/tcsh"
     end
 
     it "should use -u with the correct argument when the uid property is changed" do
       resource[:uid] = 12345
-      provider.expects(:execute).with(all_of(includes("-u"), includes(54321)))
+      provider.expects(:execute).with(all_of(includes("-u"), includes(54321)), has_entry(:custom_environment, {}))
       provider.uid = 54321
     end
   end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -99,7 +99,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       resource[:password_max_age] = 10
       resource[:password_warn_days] = 15
       provider.expects(:execute).with(includes('/usr/sbin/useradd'), kind_of(Hash))
-      provider.expects(:execute).with(['/usr/bin/chage', '-m', 5, '-M', 10, '-W', 15, 'myuser'])
+      provider.expects(:execute).with(['/usr/bin/chage', '-m', 5, '-M', 10, '-W', 15, 'myuser'], has_entry(:custom_environment, {}))
       provider.create
     end
 
@@ -128,7 +128,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       it "should not use -G for luseradd and should call lusermod with -G after luseradd when groups property is set" do
         resource[:groups] = ['group1', 'group2']
         provider.expects(:execute).with(Not(includes("-G")), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
-        provider.expects(:execute).with(includes('/usr/sbin/lusermod'))
+        provider.expects(:execute).with(includes('/usr/sbin/lusermod'), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.create
       end
 
@@ -141,7 +141,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       it "should not use -e with luseradd, should call lusermod with -e after luseradd when expiry is set" do
         resource[:expiry] = '2038-01-24'
         provider.expects(:execute).with(all_of(includes('/usr/sbin/luseradd'), Not(includes('-e'))), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
-        provider.expects(:execute).with(all_of(includes('/usr/sbin/lusermod'), includes('-e')))
+        provider.expects(:execute).with(all_of(includes('/usr/sbin/lusermod'), includes('-e')), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.create
       end
 
@@ -150,8 +150,8 @@ describe Puppet::Type.type(:user).provider(:useradd) do
         resource[:password_min_age] = 5
         resource[:password_max_age] = 10
         resource[:password_warn_days] = 15
-        provider.expects(:execute).with(includes('/usr/sbin/luseradd'), kind_of(Hash))
-        provider.expects(:execute).with(['/usr/sbin/lchage', '-m', 5, '-M', 10, '-W', 15, 'myuser'])
+        provider.expects(:execute).with(includes('/usr/sbin/luseradd'), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
+        provider.expects(:execute).with(['/usr/sbin/lchage', '-m', 5, '-M', 10, '-W', 15, 'myuser'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.create
       end
     end
@@ -175,28 +175,28 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       end
 
       it "should use usermod" do
-        provider.expects(:execute).with(['/usr/sbin/usermod', '-u', 150, 'myuser'])
+        provider.expects(:execute).with(['/usr/sbin/usermod', '-u', 150, 'myuser'], has_entry(:custom_environment, {}))
         provider.uid = 150
       end
 
       it "should use -o when allowdupe=true" do
         resource[:allowdupe] = :true
-        provider.expects(:execute).with(includes('-o'))
+        provider.expects(:execute).with(includes('-o'), has_entry(:custom_environment, {}))
         provider.uid = 505
       end
 
       it 'should use chage for password_min_age' do
-        provider.expects(:execute).with(['/usr/bin/chage', '-m', 100, 'myuser'])
+        provider.expects(:execute).with(['/usr/bin/chage', '-m', 100, 'myuser'], has_entry(:custom_environment, {}))
         provider.password_min_age = 100
       end
 
       it 'should use chage for password_max_age' do
-        provider.expects(:execute).with(['/usr/bin/chage', '-M', 101, 'myuser'])
+        provider.expects(:execute).with(['/usr/bin/chage', '-M', 101, 'myuser'], has_entry(:custom_environment, {}))
         provider.password_max_age = 101
       end
 
       it 'should use chage for password_warn_days' do
-        provider.expects(:execute).with(['/usr/bin/chage', '-W', 99, 'myuser'])
+        provider.expects(:execute).with(['/usr/bin/chage', '-W', 99, 'myuser'], has_entry(:custom_environment, {}))
         provider.password_warn_days = 99
       end
     end
@@ -208,13 +208,13 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       end
 
       it "should use lusermod and not usermod" do
-        provider.expects(:execute).with(['/usr/sbin/lusermod', '-u', 150, 'myuser'])
+        provider.expects(:execute).with(['/usr/sbin/lusermod', '-u', 150, 'myuser'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.uid = 150
       end
 
       it "should NOT use -o when allowdupe=true" do
         resource[:allowdupe] = :true
-        provider.expects(:execute).with(Not(includes('-o')))
+        provider.expects(:execute).with(Not(includes('-o')), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.uid = 505
       end
 
@@ -225,17 +225,17 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       end
 
       it 'should use lchage for password_warn_days' do
-        provider.expects(:execute).with(['/usr/sbin/lchage', '-W', 99, 'myuser'])
+        provider.expects(:execute).with(['/usr/sbin/lchage', '-W', 99, 'myuser'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.password_warn_days = 99
       end
 
       it 'should use lchage for password_min_age' do
-        provider.expects(:execute).with(['/usr/sbin/lchage', '-m', 100, 'myuser'])
+        provider.expects(:execute).with(['/usr/sbin/lchage', '-m', 100, 'myuser'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.password_min_age = 100
       end
 
       it 'should use lchage for password_max_age' do
-        provider.expects(:execute).with(['/usr/sbin/lchage', '-M', 101, 'myuser'])
+        provider.expects(:execute).with(['/usr/sbin/lchage', '-M', 101, 'myuser'], has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.password_max_age = 101
       end
     end
@@ -244,7 +244,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
   describe "#uid=" do
     it "should add -o when allowdupe is enabled and the uid is being modified" do
       resource[:allowdupe] = :true
-      provider.expects(:execute).with(['/usr/sbin/usermod', '-u', 150, '-o', 'myuser'])
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-u', 150, '-o', 'myuser'], has_entry(:custom_environment, {}))
       provider.uid = 150
     end
   end
@@ -253,20 +253,20 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     it "should pass expiry to usermod as MM/DD/YY when on Solaris" do
       Facter.expects(:value).with(:operatingsystem).returns 'Solaris'
       resource[:expiry] = '2012-10-31'
-      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '10/31/2012', 'myuser'])
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '10/31/2012', 'myuser'], has_entry(:custom_environment, {}))
       provider.expiry = '2012-10-31'
     end
 
     it "should pass expiry to usermod as YYYY-MM-DD when not on Solaris" do
       Facter.expects(:value).with(:operatingsystem).returns 'not_solaris'
       resource[:expiry] = '2012-10-31'
-      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '2012-10-31', 'myuser'])
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '2012-10-31', 'myuser'], has_entry(:custom_environment, {}))
       provider.expiry = '2012-10-31'
     end
 
     it "should use -e with an empty string when the expiry property is removed" do
       resource[:expiry] = :absent
-      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '', 'myuser'])
+      provider.expects(:execute).with(['/usr/sbin/usermod', '-e', '', 'myuser'], has_entry(:custom_environment, {}))
       provider.expiry = :absent
     end
   end
@@ -313,7 +313,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
   describe "#check_manage_home" do
     it "should return an array with -m flag if home is managed" do
       resource[:managehome] = :true
-      provider.expects(:execute).with(includes('-m'), kind_of(Hash))
+      provider.expects(:execute).with(includes('-m'), has_entry(:custom_environment, {}))
       provider.create
     end
 
@@ -321,7 +321,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       resource[:managehome] = :true
       resource[:ensure] = :absent
       provider.stubs(:exists?).returns(true)
-      provider.expects(:execute).with(includes('-r'))
+      provider.expects(:execute).with(includes('-r'), has_entry(:custom_environment, {}))
       provider.delete
     end
 
@@ -608,7 +608,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
          resource[:forcelocal] = false
       end
       it "should use userdel to delete users" do
-        provider.expects(:execute).with(includes('/usr/sbin/userdel'))
+        provider.expects(:execute).with(includes('/usr/sbin/userdel'), has_entry(:custom_environment, {}))
         provider.delete
       end
     end
@@ -618,7 +618,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
          resource[:forcelocal] = true
       end
       it "should use luserdel to delete users" do
-        provider.expects(:execute).with(includes('/usr/sbin/luserdel'))
+        provider.expects(:execute).with(includes('/usr/sbin/luserdel'), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.delete
       end
     end


### PR DESCRIPTION
We pass the customer_environment when we create a user or group, but not
when we modify or delete it. We should be more consistent