### PR TITLE
(PUP-8255) 'default' in gem package provider confuses puppet

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
     if desc =~ /^(\S+)\s+\((.+)\)/
       gem_name = $1
-      versions = $2.split(/,\s*/)
+      versions = $2.sub('default: ', '').split(/,\s*/)
       {
         :name     => gem_name,
         :ensure   => versions.map{|v| v.split[0]},

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -165,6 +165,16 @@ context 'installing myresource' do
         ])
       end
 
+      it "should not list 'default: ' text from rubygems''" do
+        provider_class.expects(:execute).with(%w{/my/gem list --local}, anything).returns <<-HEREDOC.gsub(/        /, '')
+        bundler (1.16.1, default: 1.16.0, 1.15.1)
+        HEREDOC
+
+        expect(provider_class.instances.map {|p| p.properties}).to eq([
+          {:name => 'bundler', :ensure => ["1.16.1", "1.16.0", "1.15.1"], :provider => :gem}
+        ])
+      end
+
       it "should not fail when an unmatched line is returned" do
         provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).
           returns(File.read(my_fixture('line-with-1.8.5-warning')))


### PR DESCRIPTION
In rubygems 2.7, `gem list` now shows 'default: ' next to the default version of a gem. Puppet tries to include this text as a part of that gem's version number, and it breaks things during a Puppet run.

This simply strips out that string in the gem package provider, leaving only the version number.