### PR TITLE
(PUP-8438) Pin FFI to 1.9.18

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -37,7 +37,8 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       # Pinning versions that require native extensions
-      ffi: '~> 1.9.6'
+      # ffi is pinned due to PUP-8438
+      ffi: '<= 1.9.18'
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-eventlog: '= 0.6.5'
@@ -48,7 +49,8 @@ gem_platform_dependencies:
       minitar: '~> 0.6.1'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.6'
+      # ffi is pinned due to PUP-8438
+      ffi: '<= 1.9.18'
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-eventlog: '= 0.6.5'


### PR DESCRIPTION
 - On Feb 6, 2018, the FFI maintainers released a FFI 1.9.19, then a
   1.9.20, failing to produce all the various platform specific gems
   that had been published. Both of these versions were yanked, and
   a 1.9.21 was released with all the platform specific gem versions.

   However, there are a few problems with 1.9.21:

    * The Windows gem has inexplicably doubled in size, even though
      the changes to the FFI code should have been minor
    * There are a number of problems compiling the gem now, on
      platforms where it previously worked (CentOS as noted by the
      Bolt team + about 10 tickets on the FFI GitHub issue tracker
      for a variety of other problems)

   For Puppet, this isn't strictly a problem at the moment as Windows
   doesn't need to compile gems, but it feels safest at the moment pin
   to known working.

   FFI 1.9.21+ will be needed when Ruby 2.5 support is added, but for
   now, there are no fixes that Puppet needs in the newest versions,
   and it's unclear why the gem doubled. It's safest to pin to the
   old version until the new FFI maintainers have their process
   smoothed out, etc.

 - Also note that this only impacts gems and gem-based workflows. The
   MSI package pins to 1.9.18 in the puppet-agent project already at
   https://github.com/puppetlabs/puppet-agent/blob/master/configs/components/rubygem-ffi.rb#L2