### PR TITLE
(PUP-8439) Change how Timespan and Timestamp interprets one parameter

### DIFF
--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -3,7 +3,7 @@ module Types
   class PAbstractTimeDataType < PScalarType
     # @param from [AbstractTime] lower bound for this type. Nil or :default means unbounded
     # @param to [AbstractTime] upper bound for this type. Nil or :default means unbounded
-    def initialize(from, to)
+    def initialize(from, to = nil)
       @from = convert_arg(from, true)
       @to = convert_arg(to, false)
       raise ArgumentError, "'from' must be less or equal to 'to'. Got (#{@from}, #{@to}" unless @from <= @to
@@ -161,7 +161,7 @@ module Types
         end
 
         def from_fields(days, hours, minutes, seconds, milliseconds = 0, microseconds = 0, nanoseconds = 0)
-          Time::Timespan.from_fields(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
+          Time::Timespan.from_fields(false, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
         end
 
         def from_string_hash(args_hash)

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -210,8 +210,6 @@ module TypeFactory
     case args.size
     when 0
       PTimestampType::DEFAULT
-    when 1
-      PTimestampType.new(args[0], args[0])
     else
       PTimestampType.new(*args)
     end
@@ -221,8 +219,6 @@ module TypeFactory
     case args.size
     when 0
       PTimespanType::DEFAULT
-    when 1
-      PTimespanType.new(args[0], args[0])
     else
       PTimespanType.new(*args)
     end

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -47,9 +47,16 @@ describe 'Timespan type' do
         expect(eval_and_collect_notices(code)).to eq(%w(true true))
       end
 
-      it 'using just one parameter is the same as using that parameter twice' do
+      it 'using just one parameter is the same as using default for the second parameter' do
         code = <<-CODE
-            notice(Timespan['01:00:00'] == Timespan['01:00:00', '01:00:00'])
+            notice(Timespan['01:00:00'] == Timespan['01:00:00', default])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true))
+      end
+
+      it 'if the second parameter is default, it is unlimited' do
+        code = <<-CODE
+            notice(Timespan('12345-23:59:59') =~ Timespan['01:00:00', default])
         CODE
         expect(eval_and_collect_notices(code)).to eq(%w(true))
       end

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -121,7 +121,7 @@ describe 'Timespan type' do
         expect { eval_and_collect_notices(code) }.to raise_error(Puppet::Error, /parameter 'format' variant 1 expects size to be at least 1, got 0/)
       end
 
-      it 'can be created from a integer that represents seconds since epoch' do
+      it 'can be created from a integer that represents seconds' do
         code = <<-CODE
             $o = Timespan(6800)
             notice(Integer($o) == 6800)
@@ -130,7 +130,7 @@ describe 'Timespan type' do
         expect(eval_and_collect_notices(code)).to eq(%w(true true))
       end
 
-      it 'can be created from a float that represents seconds with fraction since epoch' do
+      it 'can be created from a float that represents seconds with fraction' do
         code = <<-CODE
             $o = Timespan(6800.123456789)
             notice(Float($o) == 6800.123456789)

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -53,9 +53,16 @@ describe 'Timestamp type' do
         expect(eval_and_collect_notices(code)).to eq(%w(true true))
       end
 
-      it 'using just one parameter is the same as using that parameter twice' do
+      it 'using just one parameter is the same as using default for the second parameter' do
         code = <<-CODE
-            notice(Timestamp['2015-03-01'] == Timestamp['2015-03-01', '2015-03-01'])
+            notice(Timestamp['2015-03-01'] == Timestamp['2015-03-01', default])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true))
+      end
+
+      it 'if the second parameter is default, it is unlimited' do
+        code = <<-CODE
+            notice(Timestamp('5553-12-31') =~ Timestamp['2015-03-01', default])
         CODE
         expect(eval_and_collect_notices(code)).to eq(%w(true))
       end


### PR DESCRIPTION
Prior to this commit, a `Timespan[x]` and `Timestamp[x]` would be
interpreted as `Timespan[x,x]` and `Timestamp[x,x]` respectively. This
was inconsistent with `Float` and `Integer` whose interpretation of
one parameter is that the second parameter is unlimited.

This commit changes the `Timespan` and `Timestamp` data types so that
they intepret one single parameter the same way as `Float` and
`Integer`, i.e. `T[x] == T[x, <unlimited>]`.
