### PR TITLE
(PUP-8436) Exclude *.pot files only during locales sync

### DIFF
--- a/lib/puppet/configurer/downloader_factory.rb
+++ b/lib/puppet/configurer/downloader_factory.rb
@@ -37,7 +37,7 @@ class Puppet::Configurer::DownloaderFactory
       "locales",
       Puppet[:localedest],
       Puppet[:localesource],
-      Puppet[:pluginsignore] + " config.yaml",
+      Puppet[:pluginsignore] + " *.pot config.yaml",
       environment
     )
   end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1791,7 +1791,7 @@ EOT
       }
     },
     :pluginsignore => {
-        :default  => ".svn CVS .git .hg *.pot",
+        :default  => ".svn CVS .git .hg",
         :desc     => "What files to ignore when pulling down plugins.",
     }
   )

--- a/spec/unit/configurer/downloader_factory_spec.rb
+++ b/spec/unit/configurer/downloader_factory_spec.rb
@@ -119,7 +119,7 @@ describe Puppet::Configurer::DownloaderFactory do
     it 'ignores files from Puppet[:pluginsignore], plus config.yaml' do
       Puppet[:pluginsignore] = 'lignore'
 
-      expect(locales_downloader.file[:ignore]).to eq(['lignore', 'config.yaml'])
+      expect(locales_downloader.file[:ignore]).to eq(['lignore', '*.pot', 'config.yaml'])
     end
 
     it "ignores source permissions" do


### PR DESCRIPTION
Previously, *.pot files were excluded from all pluginsync related mounts
(plugins, pluginfacts, locales). Since fact files can be named anything,
and only need to be executable, this could have prevented a necessary
fact from being downloaded to an agent.

Move the *.pot exclusion so it only affects the 'locales' mount.