### PR TITLE
(PUP-8231) Domain prefix Windows group members

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -464,12 +464,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def members
-      # WIN32OLE objects aren't enumerable, so no map
-      members = []
-      # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
-      # values are returned as UTF-8
-      native_group.Members.each {|m| members << m.Name}
-      members
+      member_sids.map(&:domain_account)
     end
 
     def member_sids

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -81,6 +81,57 @@ describe Puppet::Util::Windows::ADSI::Group,
   end
 
   describe '.members' do
+    it 'should return a list of members resolvable with Puppet::Util::Windows::ADSI::Group.name_sid_hash' do
+      temp_groupname = "g#{SecureRandom.uuid}"
+      temp_username  = "u#{SecureRandom.uuid}"[0..12]
+
+      # select a virtual account that requires an authority to be able to resolve to SID
+      # the Dhcp service is chosen for no particular reason aside from it's a service available on all Windows versions
+      dhcp_virtualaccount = Puppet::Util::Windows::SID.name_to_sid_object('NT SERVICE\Dhcp')
+
+      # adding :SidTypeGroup as a group member will cause error in IAdsUser::Add
+      # adding :SidTypeDomain (such as S-1-5-80 / NT SERVICE or computer name) won't error
+      #   but also won't be returned as a group member
+      # uncertain how to obtain :SidTypeComputer (perhaps AD? the local machine is :SidTypeDomain)
+      users = [
+        # Use sid_to_name to get localized names of SIDs - BUILTIN, SYSTEM, NT AUTHORITY, Everyone are all localized
+        # :SidTypeWellKnownGroup
+        # SYSTEM is prefixed with the NT Authority authority, resolveable with or without authority
+        { :sid => 'S-1-5-18', :name => Puppet::Util::Windows::SID.sid_to_name('S-1-5-18') },
+        # Everyone is not prefixed with an authority, resolveable with or without NT AUTHORITY authority
+        { :sid => 'S-1-1-0', :name => Puppet::Util::Windows::SID.sid_to_name('S-1-1-0') },
+        # Dhcp service account is prefixed with NT SERVICE authority, requires authority to resolve SID
+        # behavior is similar to IIS APPPOOL\DefaultAppPool
+        { :sid => dhcp_virtualaccount.sid, :name => dhcp_virtualaccount.domain_account },
+
+        # :SidTypeAlias with authority component
+        # Administrators group is prefixed with BUILTIN authority, can be resolved with or without authority
+        { :sid => 'S-1-5-32-544', :name => Puppet::Util::Windows::SID.sid_to_name('S-1-5-32-544') },
+      ]
+
+      begin
+        # :SidTypeUser as user on localhost, can be resolved with or without authority prefix
+        user = Puppet::Util::Windows::ADSI::User.create(temp_username)
+        user.commit()
+        users.push({ :sid => user.sid.sid, :name => Puppet::Util::Windows::ADSI.computer_name + '\\' + temp_username })
+
+        # create a test group and add above 5 members by SID
+        group = described_class.create(temp_groupname)
+        group.commit()
+        group.set_members(users.map { |u| u[:sid]} )
+
+        # most importantly make sure that all name are convertible to SIDs
+        expect { described_class.name_sid_hash(group.members) }.to_not raise_error
+
+        # also verify the names returned are as expected
+        expected_usernames = users.map { |u| u[:name] }
+        expect(group.members).to eq(expected_usernames)
+      ensure
+        described_class.delete(temp_groupname) if described_class.exists?(temp_groupname)
+        Puppet::Util::Windows::ADSI::User.delete(temp_username) if Puppet::Util::Windows::ADSI::User.exists?(temp_username)
+      end
+    end
+
     it 'should return a list of members with UTF-8 names' do
       begin
         original_codepage = Encoding.default_external


### PR DESCRIPTION
(PUP-8231) Support Windows virtual accounts in groups

 - When retrieiving a groups members, Puppet has historically returned
   the "Name" property of each `IAdsUser` COM component instance when
   enumerating the members of a group.

   For instance, given a group with members:

```
   NT AUTHORITY\SYSTEM (Well known SID S-1-5-18)
   %HOSTNAME%\Administrator
   Everyone (well known SID S-1-1-0)
   IIS APPPOOL\DefaultAppPool
```

   The list of members that the ADSI provider would return is:

```
   SYSTEM
   Administrator
   Everyone
   DefaultAppPool
```

   This is problematic.

   The first three accounts will properly resolve via
   `Puppet::Util::Windows::ADSI::Group.name_sid_hash`, which uses
   `Puppet::Util::Windows::SID.name_to_sid_object` to translate names to
   canonical SIDs. The last account `DefaultAppPool`, which is a
   :SidTypeWellKnownGroup, has lost a vital piece of information to be
   able to lookup that account name. With `IIS APPPOOL`, the account
   information cannot be retrieved.

   This is remedied by returning the names in authority prefixed form,
   which Puppet already understands. This changes the above resolution
   of members to:

```
   NT AUTHORITY\SYSTEM
   %HOSTNAME%\Administrator
   Everyone
   IIS APPPOOL\DefaultAppPool
```

 - Puppet already properly handles resolving all of the above string
   formats with `Puppet::Util::Windows::SID.name_to_sid_object` and
   therefore no longer fails when an existing group contains virtual
   accounts like those from `IIS APPPOOL`, those from `NT SERVICE`, those
   from `NT VIRTUAL MACHINE`, or those from `Windows Manager`.

   This is particularly problematic when attempting to use groups to
   manage disk permissions for `IIS APPPOOL` virtual accounts, which
   is reasonably common security practice when managing IIS.

 - An alternative implementation could have parsed the `AdsPath`
   property from `IAdsUser`, but in addition to having to parse a path
   like `WinNT://GROUP/USER`, there is already logic present in the
   `Puppet::Util::Windows::SID::Principal` class to properly prefix
   an authority when it's necessary to resolve an account / omit the
   authority when it can't be used in `WinNT` style monikers.

   It seems prudent to leverage existing work to create and use string
   representations for accounts that Puppet will understand.

 - This does change the behavior of `puppet resource group Foo` to
   provide authority information that was previously omitted, for
   instance:

```puppet
   group { 'g45991a14-ee2d-48f6-925c-6ea809a5f994':
     ensure  => 'present',
     gid     => 'S-1-5-21-271343509-1886877197-423808128-4735',
     members => ['SYSTEM', 'Everyone', 'Dhcp', 'Administrators', 'uf6547db8-959', 'DefaultAppPool'],
   }   
```

   Becomes:

```puppet
   group { 'g45991a14-ee2d-48f6-925c-6ea809a5f994':
     ensure  => 'present',
     gid     => 'S-1-5-21-271343509-1886877197-423808128-4735',
     members => ['NT AUTHORITY\SYSTEM', 'Everyone', 'NT SERVICE\Dhcp', 'BUILTIN\Administrators', 'VAGRANT-2008R2\uf6547db8-959', 'IIS APPPOOL\DefaultAppPool'],
   }
```