### PR TITLE
(PUP-8448) Only revoke certificates in puppet cert clean if any have already been signed

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -265,6 +265,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
     end
     begin
       if subcommand == :destroy
+        raise _("Refusing to destroy all certs, provide an explicit list of certs to destroy") if hosts == :all
+
         signed_hosts = hosts - @ca.waiting?
         apply(@ca, :revoke, options.merge(:to => signed_hosts)) unless signed_hosts.empty?
       end

--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -266,7 +266,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
     begin
       if subcommand == :destroy
         signed_hosts = hosts - @ca.waiting?
-        apply(@ca, :revoke, options.merge(:to => signed_hosts))
+        apply(@ca, :revoke, options.merge(:to => signed_hosts)) unless signed_hosts.empty?
       end
       apply(@ca, subcommand, options.merge(:to => hosts, :digest => @digest))
     rescue => detail

--- a/spec/unit/application/cert_spec.rb
+++ b/spec/unit/application/cert_spec.rb
@@ -191,9 +191,9 @@ describe Puppet::Application::Cert => true do
       @cert_app.subcommand = :destroy
       @cert_app.command_line.stubs(:args).returns(["unsigned-node"])
 
-      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to| cert_mode == :destroy
-        to[:to] == ["unsigned-node"]
-      }
+      Puppet::SSL::CertificateAuthority::Interface.unstub(:new)
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).with(:revoke, anything).never
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).with(:destroy, {:to => ['unsigned-node'], :digest => nil}).returns(@iface)
 
       @cert_app.main
     end

--- a/spec/unit/application/cert_spec.rb
+++ b/spec/unit/application/cert_spec.rb
@@ -213,6 +213,18 @@ describe Puppet::Application::Cert => true do
 
       @cert_app.main
     end
+
+    it "should refuse to destroy all certificates" do
+      @cert_app.subcommand = :destroy
+      @cert_app.all = true
+
+      Puppet::SSL::CertificateAuthority::Interface.unstub(:new)
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).never
+
+      Puppet.expects(:log_exception).with {|e| e.message == "Refusing to destroy all certs, provide an explicit list of certs to destroy"}
+
+      expect { @cert_app.main }.to exit_with(24)
+    end
   end
 
   describe "when identifying subcommands" do


### PR DESCRIPTION
Previously, we would pass an empty list of hosts to the `Puppet::SSL::CertificateAuthority::Interface` when asking it to revoke the certificates if all of the certificates we were asked to clean were
unsigned. This broke the CA's expectations, and would cause it to raise an exception. We now only ask the CA to revoke the list of certificates if there is at least one signed certificate in the list of certificates to clean.

This also fixes a spec that was attempting to test for this exact scenario, but wasn't quite stubbing/expecting the method calls on `Puppet::SSL::CertificateAuthority::Interface` correctly to detect the issue.