### PR TITLE
(PUP-8443) Populate topscope environment variable directly from node's environment

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -790,9 +790,16 @@ class Puppet::Parser::Compiler
   # Set the node's parameters into the top-scope as variables.
   def set_node_parameters
     node.parameters.each do |param, value|
+      # We don't want to set @topscope['environment'] from the parameters,
+      # instead we want to get that from the node's environment itself in
+      # case a custom node terminus has done any mucking about with
+      # node.parameters.
+      next if param.to_s == 'environment'
       # Ensure node does not leak Symbol instances in general
       @topscope[param.to_s] = value.is_a?(Symbol) ? value.to_s : value
     end
+    @topscope['environment'] = node.environment.name.to_s
+
     # These might be nil.
     catalog.client_version = node.parameters["clientversion"]
     catalog.server_version = node.parameters["serverversion"]

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -279,6 +279,14 @@ describe Puppet::Parser::Compiler do
       expect(@compiler.topscope['wat']).to eq('this is how the sausage is made')
     end
 
+    it "sets the environment based on node.environment instead of the parameters" do
+      compile_stub(:set_node_parameters)
+      @node.parameters['environment'] = "Not actually #{@node.environment.name}"
+
+      @compiler.compile
+      expect(@compiler.topscope['environment']).to eq('testing')
+    end
+
     it "should set the client and server versions on the catalog" do
       params = {"clientversion" => "2", "serverversion" => "3"}
       @node.stubs(:parameters).returns(params)


### PR DESCRIPTION
Rather than relying on node.parameters to populate the topscope environment variable, we now populate this variable by looking directly at the node's environment. This means that if a node terminus sets the environment on a node, but then later sets the node's parameters to a new
hash (instead of merging the new parameters into the existing one), we will now properly populate the topscope environment with a value that matches the node's environment, instead of having it be nil.