### PR TITLE
(maint) Remove 'possibly useless use of == in void context' warnings

### DIFF
--- a/spec/unit/application/cert_spec.rb
+++ b/spec/unit/application/cert_spec.rb
@@ -191,9 +191,10 @@ describe Puppet::Application::Cert => true do
       @cert_app.subcommand = :destroy
       @cert_app.command_line.stubs(:args).returns(["unsigned-node"])
 
-      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to| cert_mode == :destroy
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with do |cert_mode,to|
+        cert_mode == :destroy &&
         to[:to] == ["unsigned-node"]
-      }
+      end
 
       @cert_app.main
     end
@@ -202,14 +203,14 @@ describe Puppet::Application::Cert => true do
       @cert_app.subcommand = :destroy
       @cert_app.command_line.stubs(:args).returns(["host","unsigned-node"])
 
-      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to|
-        cert_mode == :revoke
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with do |cert_mode,to|
+        cert_mode == :revoke &&
         to[:to] == ["host"]
-      }
-      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with { |cert_mode,to|
-        cert_mode == :destroy
+      end
+      Puppet::SSL::CertificateAuthority::Interface.expects(:new).returns(@iface).with do |cert_mode,to|
+        cert_mode == :destroy &&
         to[:to] == ["host","unsigned-node"]
-      }
+      end
 
       @cert_app.main
     end


### PR DESCRIPTION
`ruby -wc` let us know that we had some chained logic in a spec file that wasn't actually chaining. Because of this, we were only using the last test in the chain, instead of and'ing all of the tests together.