### PR TITLE
(PUP-8442) Params should allow default of `false`

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -831,10 +831,11 @@ class Type
 
     return unless parameter = newattr(klass.name)
 
-    if value = parameter.default and ! value.nil?
-      parameter.value = value
-    else
+    value = parameter.default
+    if value.nil?
       @parameters.delete(parameter.name)
+    else
+      parameter.value = value
     end
   end
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -677,7 +677,6 @@ module Puppet
 
       defaultto :false
 
-      # Use Symbols instead of booleans until PUP-1967 is resolved.
       newvalues(:true, :false)
 
       validate do |value|

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -215,8 +215,7 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
       create = sequence('create')
       group.expects(:commit).in_sequence(create)
-      # due to PUP-1967, defaultto false will set the default to nil
-      group.expects(:set_members).with(['user1', 'user2'], nil).in_sequence(create)
+      group.expects(:set_members).with(['user1', 'user2'], false).in_sequence(create)
 
       provider.create
     end

--- a/spec/unit/type/augeas_spec.rb
+++ b/spec/unit/type/augeas_spec.rb
@@ -82,6 +82,10 @@ describe augeas do
     it "should be false for type_check" do
       expect(augeas.new(:name => :type_check)[:type_check]).to eq(:false)
     end
+
+    it "should be false for :force" do
+      expect(augeas.new(:name => :type_check)[:force]).to eq(false)
+    end
   end
 
   describe "provider interaction" do

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -191,6 +191,12 @@ describe Puppet::Type.type(:file) do
     end
   end
 
+  describe "the force parameter" do
+    it "should default to false" do
+      expect(file[:force]).to eq(false)
+    end
+  end
+
   describe ".instances" do
     it "should return an empty array" do
       expect(described_class.instances).to eq([])

--- a/spec/unit/type/group_spec.rb
+++ b/spec/unit/type/group_spec.rb
@@ -19,6 +19,12 @@ describe Puppet::Type.type(:group) do
   end
 
   describe "when validating attributes" do
+    [:auth_membership, :allowdupe, :system].each do |default_param|
+      it "should set the default for #{default_param} to false" do
+        expect(@class.new(:name => "foo")[default_param]).to eq(false)
+      end
+    end
+
     [:name, :allowdupe].each do |param|
       it "should have a #{param} parameter" do
         expect(@class.attrtype(param)).to eq(:param)

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -52,13 +52,20 @@ describe Puppet::Type.type(:user) do
     expect(described_class.provider_feature(:manages_shell)).not_to be_nil
   end
 
-  context "managehome" do
+  context "defaults" do
     let (:provider) { @provider_class.new(:name => 'foo', :ensure => :absent) }
     let (:instance) { described_class.new(:name => 'foo', :provider => provider) }
 
-    it "defaults to false" do
-      expect(instance[:managehome]).to be_falsey
+    [:system, :allowdupe, :managehome].each do |default_param|
+      it "defaults #{default_param} to false" do
+        expect(instance[default_param]).to eq(false)
+      end
     end
+  end
+
+  context "managehome" do
+    let (:provider) { @provider_class.new(:name => 'foo', :ensure => :absent) }
+    let (:instance) { described_class.new(:name => 'foo', :provider => provider) }
 
     it "can be set to false" do
       instance[:managehome] = 'false'

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -78,6 +78,12 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
     expect(params).not_to be_include(nil)
   end
 
+  it "can return any `false` values when retrieving all set parameters" do
+    resource = Puppet::Type.type(:mount).new(:name => "foo", :fstype => "bar", :pass => 1, :ensure => :present, :tag => 'foo', :remounts => false)
+    params = resource.parameters_with_value
+    expect(params).to be_include(resource.parameter(:remounts))
+  end
+
   it "can return an iterator for all set parameters" do
     resource = Puppet::Type.type(:notify).new(:name=>'foo',:message=>'bar',:tag=>'baz',:require=> "File['foo']")
     params = [:name, :message, :withpath, :loglevel, :tag, :require]
@@ -92,6 +98,10 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
 
   it "should do nothing for attributes that have no defaults and no specified value" do
     expect(Puppet::Type.type(:mount).new(:name => "foo").parameter(:noop)).to be_nil
+  end
+
+  it "should set attributes that have a default value of false and no user specified value" do
+    expect(Puppet::Type.type(:group).new(:name => "foo")[:system]).to eq(false)
   end
 
   it "should have a method for adding tags" do
@@ -733,6 +743,59 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
           )
         end.to raise_error(Puppet::ResourceError, /Validation.*\(file: example\.pp, line: 42\)/)
       end
+    end
+  end
+
+  describe "#set_default" do
+    let(:test_defaults_type) do
+      Puppet::Type.newtype(:default_test) do
+        newparam(:name) { isnamevar }
+        newparam(:default_to_false) { defaultto false }
+        newparam(:default_to_true) { defaultto true }
+        newparam(:default_to_string) { defaultto 'foo' }
+        newparam(:default_to_symbol) { defaultto :false }
+        newparam(:default_to_empty_array) { defaultto [] }
+        newparam(:default_to_array) { defaultto ['foo', 'baz'] }
+        newparam(:default_to_empty_hash) { defaultto ({}) }
+        newparam(:default_to_hash) { defaultto ({'foo' => 'baz'}) }
+        newparam(:no_default)
+      end
+    end
+
+    it "populates a parameter when the default is false" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_false]).to be false
+    end
+
+    it "populates a parameter when the default is true" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_true]).to be true
+    end
+
+    it "populates a parameter when the default is a string" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_string]).to eq 'foo'
+    end
+
+    it "populates a parameter when the default is a symbol" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_symbol]).to eq :false
+    end
+
+    it "populates a parameter when the default is an empty array" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_empty_array]).to match_array([])
+    end
+
+    it "populates a parameter when the default is an array" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_array]).to match_array(['foo', 'baz'])
+    end
+
+    it "populates a parameter when the default is an empty array" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_empty_hash]).to eq ({})
+    end
+
+    it "populates a parameter when the default is a hash" do
+      expect(test_defaults_type.new(:name => 'bar')[:default_to_hash]).to eq ({'foo' => 'baz'})
+    end
+
+    it "does not populates a parameter when there is no default" do
+      expect(test_defaults_type.new(:name => 'bar')[:no_default]).to be_nil
     end
   end
 


### PR DESCRIPTION
Prior to this commit, parameters that had a default of false set
wouldn't populate properly. This is because in ruby, both `nil` and
`false` are considered to be 'falsey'. In effect, `defaultto false` was
treated the same as having no default value specified. This is not
ideal, considering there are cases where we treat a param set to `false`
differently then we would if that param were set to `nil`.

This commit fixes the bit in the code that short circuits when default
is set to `false`. Parameters with a default of `false` will not return
nil anymore.

This commit also fixes up some test cases that had worked around this
expectation, either by checking for 'falsiness', or not checking the
default value at all.