### PR TITLE
Revert "Merge pull request #6603 from kris-bosland/fix/master/pup-2868"

### DIFF
--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -2,8 +2,6 @@ require 'puppet/face'
 require 'puppet/settings/ini_file'
 
 Puppet::Face.define(:config, '0.0.1') do
-  extend Puppet::Util::Colors
-
   copyright "Puppet Inc.", 2011
   license   _("Apache 2 license; see COPYING")
 
@@ -14,7 +12,7 @@ Puppet::Face.define(:config, '0.0.1') do
     see https://docs.puppetlabs.com/puppet/latest/reference/configuration.html."
 
   option "--section " + _("SECTION_NAME") do
-    default_to { :main } #Setting a non-string object as default here, so we can detect later if the default was used...
+    default_to { "main" }
     summary _("The section of the configuration file to interact with.")
     description <<-EOT
       The section of the puppet.conf configuration file to interact with.
@@ -59,12 +57,6 @@ Puppet::Face.define(:config, '0.0.1') do
     when_invoked do |*args|
       options = args.pop
 
-      @default_section = false
-
-      if options[:section].is_a? Symbol
-        @default_section = true
-      end
-
       args = Puppet.settings.to_a.collect(&:first) if args.empty? || args == ['all']
 
       values_from_the_selected_section =
@@ -79,21 +71,7 @@ Puppet::Face.define(:config, '0.0.1') do
                      _("New environment loaders generated from the requested section.")) do
         # And now we can lookup values that include those from environments configured from
         # the requested section
-
-        if @default_section
-          messages = []
-          messages << _("No section specified; defaulting to '%{section_name}'.") %
-            { section_name: options[:section] }
-          #TRANSLATORS '--section' is a command line option and should not be translated
-          messages << _("Set the config section by using the `--section` flag.")
-          #TRANSLATORS `puppet config --section user print foo` is a command line example and should not be translated
-          messages << _("For example, `puppet config --section user print foo`.")
-          messages << _("For more information, see https://puppet.com/docs/puppet/latest/configuration.html")
-          Puppet.warning(messages.join("\n"))
-        end
-
         values = Puppet.settings.values(Puppet[:environment].to_sym, options[:section].to_sym)
-        report_section_and_environment(options[:section], Puppet.settings[:environment])
         if args.length == 1
           puts values.interpolate(args[0].to_sym)
         else
@@ -128,21 +106,17 @@ Puppet::Face.define(:config, '0.0.1') do
     EOT
 
     when_invoked do |name, value, options|
-      if name == 'environment' && options[:section].to_s == 'main'
-        messages = []
-        #TRANSLATORS `[user]`, `[agent]`, and `[master]` are section names and should not be translated
-        messages << _("The environment should be set in either the `[user]`, `[agent]`, or `[master]` section.")
-        #TRANSLATORS `[agent]` is a section name and `puppet agent` is a command line example and should not be translated
-        messages << _("Variables set in the `[agent]` section are used when running `puppet agent`.")
-        #TRANSLATORS `[user]` is a section name and `puppet apply` and `puppet module` are command line examples and should not be translated
-        messages << _("Variables set in the `[user]` section are used when running various other puppet subcommands, "\
-          "like `puppet apply` and `puppet module`;\n  these require the defined environment directory to exist locally.")
-        #TRANSLATORS '--section' is a command line option and should not be translated
-        messages << _("Set the config section by using the `--section` flag.")
-        #TRANSLATORS `puppet config --section user set environment foo` is a command line example and should not be translated
-        messages << _("For example, `puppet config --section user set environment foo`.")
-        messages << _("For more information, see https://puppet.com/docs/puppet/latest/configuration.html#environment")
-        Puppet.warning(messages.join("\n"))
+      if name == 'environment' && options[:section] == 'main'
+        Puppet.warning _(<<-EOM).chomp
+The environment should be set in either the `[user]`, `[agent]`, or `[master]`
+section. Variables set in the `[agent]` section are used when running
+`puppet agent`. Variables set in the `[user]` section are used when running
+various other puppet subcommands, like `puppet apply` and `puppet module`; these
+require the defined environment directory to exist locally. Set the config
+section by using the `--section` flag. For example,
+`puppet config --section user set environment foo`. For more information, see
+https://puppet.com/docs/puppet/latest/configuration.html#environment
+        EOM
       end
 
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)
@@ -177,6 +151,8 @@ Puppet::Face.define(:config, '0.0.1') do
     EOT
 
     when_invoked do |name, options|
+      options[:section] = options[:section].to_s # If value was left as default - set to default string
+
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)
       if Puppet::FileSystem.exist?(path)
         Puppet::FileSystem.open(path, nil, 'r+:UTF-8') do |file|
@@ -197,10 +173,5 @@ Puppet::Face.define(:config, '0.0.1') do
       end
       nil
     end
-  end
-
-  def report_section_and_environment(section_name, environment)
-        $stderr.puts colorize( :hyellow, _("Resolving settings from section '%{section_name}' in environment '%{environment}'") %
-            { section_name: section_name, environment: environment })
   end
 end

--- a/lib/puppet/settings/ini_file.rb
+++ b/lib/puppet/settings/ini_file.rb
@@ -68,7 +68,6 @@ class Puppet::Settings::IniFile
   end
 
   def lines_in(section_name)
-    section_name = section_name.to_s
     section_lines = []
     current_section_name = DEFAULT_SECTION_NAME
     @lines.each do |line|

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -32,42 +32,14 @@ trace = true
     expect { subject.print("syslogfacility", :section => "user") }.to have_printed('file')
   end
 
-  it "does not print a warning when a section is given" do
-    Puppet.settings.parse_config(<<-CONF)
-    [user]
-    syslogfacility = file
-    CONF
-
-    Puppet.expects(:warning).never
-    subject.expects(:report_section_and_environment).with('user', 'production')
-
-    expect { subject.print("syslogfacility", :section => "user") }.to have_printed('file')
-    end
-
-  it "does print a warning when a section is not given" do
-    Puppet.settings.parse_config(<<-CONF)
-    [main]
-    syslogfacility = elif
-    [user]
-    syslogfacility = file
-    CONF
-
-    Puppet.expects(:warning).once
-    subject.expects(:report_section_and_environment).with(:main, 'production')
-
-    expect { subject.print("syslogfacility") }.to have_printed('elif')
-  end
-
-  it "prints out all of the settings when no arguments are given" do
+  it "defaults to all when no arguments are given" do
     subject.expects(:puts).times(Puppet.settings.to_a.length)
-    subject.expects(:report_section_and_environment)
 
     subject.print
   end
 
   it "prints out all of the settings when asked for 'all'" do
     subject.expects(:puts).times(Puppet.settings.to_a.length)
-    subject.expects(:report_section_and_environment)
 
     subject.print('all')
   end
@@ -98,7 +70,7 @@ trace = true
       manipulator = Puppet::Settings::IniFile::Manipulator.new(config)
       Puppet::Settings::IniFile::Manipulator.stubs(:new).returns(manipulator)
 
-      manipulator.expects(:set).with(:main, "foo", "bar")
+      manipulator.expects(:set).with("main", "foo", "bar")
       subject.set('foo', 'bar')
     end
 

--- a/spec/unit/settings/ini_file_spec.rb
+++ b/spec/unit/settings/ini_file_spec.rb
@@ -276,22 +276,6 @@ updated = new
     CONFIG
   end
 
-  it "finds settings when given a symbol for section" do
-    config_fh = a_config_file_containing(<<-CONFIG)
-      [section]
-      name = original value
-      CONFIG
-
-    Puppet::Settings::IniFile.update(config_fh) do |config|
-      config.set(:section, "name", "changed value")
-    end
-
-    expect(config_fh.string).to eq <<-CONFIG
-      [section]
-      name = changed value
-      CONFIG
-  end
-
   it "adds a new setting to the appropriate section, when it would be added behind a setting with an identical value in a preceeding section" do
     config_fh = a_config_file_containing(<<-CONFIG)
     [different]


### PR DESCRIPTION
This reverts commit e9bf54fd34387fc6bd9ddc81f97cc9d270e2aa8b, reversing
changes made to 81c7c762ebd4759d727791f718961147d7c64c57.

Reverting this because each time `puppet config set` is called without a
section, it creates a duplicate [main] section. This arises because the
default section in code is :main (symbol), but the default section read
from the inifile is 'main' (string).