### PR TITLE
(PUP-8463) Warning cleanup

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -564,7 +564,7 @@ module Puppet::Functions
       @block_name = nil
       @return_type = nil
       @argument_mismatch_hander = argument_mismatch_handler
-      self.instance_eval &block
+      self.instance_eval(&block)
       callable_t = create_callable(@types, @block_type, @return_type, @min, @max)
       @dispatcher.add(Puppet::Pops::Functions::Dispatch.new(callable_t, meth_name, @names, @max == :default, @block_name, @injections, @weaving, @argument_mismatch_hander))
     end

--- a/lib/puppet/indirector/certificate_status/file.rb
+++ b/lib/puppet/indirector/certificate_status/file.rb
@@ -70,7 +70,7 @@ class Puppet::Indirector::CertificateStatus::File < Puppet::Indirector::Code
       klass.indirection.search(request.key, request.options)
     end.flatten.collect do |result|
       result.name
-    end.uniq.collect &Puppet::SSL::Host.method(:new)
+    end.uniq.collect(&Puppet::SSL::Host.method(:new))
   end
 
   def find(request)

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -64,7 +64,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       true
     end
 
-    Facter.search *dirs
+    Facter.search(*dirs)
   end
 
   def self.setup_external_search_paths(request)

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -71,7 +71,7 @@ module Issues
 
     def format(hash, &block)
       @data = hash
-      instance_eval &block
+      instance_eval(&block)
     end
 
     # Obtains the label provider given as a key `:label` in the hash passed to #format. The label provider is

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -209,9 +209,9 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     cmd << resource_name
 
     if self.class.yaourt?
-      yaourt *cmd
+      yaourt(*cmd)
     else
-      pacman *cmd
+      pacman(*cmd)
     end
   end
 
@@ -258,9 +258,9 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     cmd << "-Sy" << resource_name
 
     if self.class.yaourt?
-      yaourt *cmd
+      yaourt(*cmd)
     else
-      pacman *cmd
+      pacman(*cmd)
     end
   end
 

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -117,7 +117,7 @@ Puppet::Type.type(:package).provide :pip,
         args << @resource[:name]
       end
     end
-    lazy_pip *args
+    lazy_pip(*args)
   end
 
   # Uninstall a package.  Uninstall won't work reliably on Debian/Ubuntu
@@ -135,7 +135,7 @@ Puppet::Type.type(:package).provide :pip,
   # try to teach it and if even that fails, raise the error.
   private
   def lazy_pip(*args)
-    pip *args
+    pip(*args)
   rescue NoMethodError => e
     # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
     # The path to pip needs to be looked up again in the subsequent request. Using the preferred approach as noted
@@ -145,7 +145,7 @@ Puppet::Type.type(:package).provide :pip,
     # to search for them using the PATH variable.
     if pathname = self.class.cmd.map { |c| which(c) }.find { |c| c != nil }
       self.class.commands :pip => File.basename(pathname)
-      pip *args
+      pip(*args)
     else
       raise e, "Could not locate command #{self.class.cmd.join(' and ')}.", e.backtrace
     end

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -91,7 +91,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
           args << "--proxy" << http_proxy_host
         end
       begin
-        curl *args
+        curl(*args)
           Puppet.debug "Success: curl transferred [#{name}] (via: curl #{args.join(" ")})"
         rescue Puppet::ExecutionFailure
           Puppet.debug "curl #{args.join(" ")} did not transfer [#{name}].  Falling back to local file." # This used to fall back to open-uri. -NF

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -152,9 +152,9 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     # get passed to pkgutil via one or more -t options
     if resource[:source]
       sources = [resource[:source]].flatten
-      pkguti *[sources.map{|src| [ "-t", src ]}, *args].flatten
+      pkguti(*[sources.map{|src| [ "-t", src ]}, *args].flatten)
     else
-      pkguti *args.flatten
+      pkguti(*args.flatten)
     end
   end
 

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
       search_output = nil
       Puppet::Util.withenv :EIX_LIMIT => limit, :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format, :INSTALLEDVERSIONS => installed_versions_format, :STABLEVERSIONS => installable_versions_format do
-        search_output = eix *(self.eix_search_arguments + ['--installed'])
+        search_output = eix(*(self.eix_search_arguments + ['--installed']))
       end
 
       packages = []
@@ -74,7 +74,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     cmd << '--update' if [:latest].include?(should)
     cmd += install_options if @resource[:install_options]
     cmd << name
-    emerge *cmd
+    emerge(*cmd)
   end
 
   def uninstall
@@ -89,10 +89,10 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     cmd << name
     if [:purged].include?(should)
       Puppet::Util.withenv :CONFIG_PROTECT => "-*" do
-        emerge *cmd
+        emerge(*cmd)
       end
     else
-      emerge *cmd
+      emerge(*cmd)
     end
   end
 
@@ -111,7 +111,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     @atom ||= begin
       package_info = {}
       # do the search
-      search_output = qatom_bin *([@resource[:name], '--format', output_format])
+      search_output = qatom_bin(*([@resource[:name], '--format', output_format]))
       # verify if the search found anything
       match = result_format.match(search_output)
       if match
@@ -146,7 +146,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
   def self.get_sets
     @sets ||= begin
-      @sets = emerge *(['--list-sets'])
+      @sets = emerge(*(['--list-sets']))
     end
   end
 
@@ -180,7 +180,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
 
       search_output = nil
       Puppet::Util.withenv :EIX_LIMIT => limit, :LASTVERSION => version_format, :LASTSLOTVERSIONS => slot_versions_format, :INSTALLEDVERSIONS => installed_versions_format, :STABLEVERSIONS => installable_versions_format do
-        search_output = eix *(self.class.eix_search_arguments + ['--exact',search_field,search_value])
+        search_output = eix(*(self.class.eix_search_arguments + ['--exact',search_field,search_value]))
       end
 
       packages = []

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -102,7 +102,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
     options << '--name' unless major < 1 || @resource.allow_virtual? || should
     options << wanted
 
-    zypper *options
+    zypper(*options)
 
     unless self.query
       raise Puppet::ExecutionFailure.new(
@@ -138,7 +138,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
 
       options << @resource[:name]
 
-      zypper *options
+      zypper(*options)
     end
 
   end

--- a/lib/puppet/provider/zfs/zfs.rb
+++ b/lib/puppet/provider/zfs/zfs.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:zfs).provide(:zfs) do
   end
 
   def create
-    zfs *([:create] + add_properties + [@resource[:name]])
+    zfs(*([:create] + add_properties + [@resource[:name]]))
   end
 
   def destroy

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -31,7 +31,7 @@ module Puppet
 
       # Boolean status types set while evaluating `@real_resource`.
       STATES = [:skipped, :failed, :failed_to_restart, :restarted, :changed, :out_of_sync, :scheduled, :corrective_change]
-      attr_accessor *STATES
+      attr_accessor(*STATES)
 
       # @!attribute [r] source_description
       #   @return [String] The textual description of the path to `@real_resource`

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -12,7 +12,7 @@ class Puppet::Transaction::Event
   include Puppet::Network::FormatSupport
 
   ATTRIBUTES = [:name, :resource, :property, :previous_value, :desired_value, :historical_value, :status, :message, :file, :line, :source_description, :audited, :invalidate_refreshes, :redacted, :corrective_change]
-  attr_accessor *ATTRIBUTES
+  attr_accessor(*ATTRIBUTES)
   attr_accessor :time
   attr_reader :default_log_level
 

--- a/lib/puppet/util/windows/com.rb
+++ b/lib/puppet/util/windows/com.rb
@@ -76,8 +76,9 @@ module Puppet::Util::Windows::COM
           vtable_hash = Hash[(ifaces.map { |iface| iface::VTBL::SPEC.to_a } << spec.to_a).flatten(1)]
           const_set(:SPEC, vtable_hash)
 
-          layout \
+          layout(
             *self::SPEC.map { |name, signature| [name, callback(*signature)] }.flatten
+          )
         end
 
         const_set(:VTBL, vtable)

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -292,13 +292,14 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
             Puppet::FileSystem.symlink(link_target, link)
           end
 
-          it "should not set the executable bit on the link nor the target" do
+          it "should not set the executable bit on the link target" do
             catalog.add_resource described_class.new(:path => link, :ensure => :link, :mode => '0666', :target => link_target, :links => :manage)
 
             catalog.apply
 
-            (Puppet::FileSystem.stat(link).mode & 07777) == 0666
-            (Puppet::FileSystem.lstat(link_target).mode & 07777) == 0444
+            expected_target_permissions = Puppet::Util::Platform.windows? ? 0700 : 0444
+
+            expect(Puppet::FileSystem.stat(link_target).mode & 07777).to eq(expected_target_permissions)
           end
 
           it "should ignore dangling symlinks (#6856)" do

--- a/spec/shared_behaviours/things_that_declare_options.rb
+++ b/spec/shared_behaviours/things_that_declare_options.rb
@@ -87,8 +87,8 @@ shared_examples_for "things that declare options" do
     it "should detect conflicts between #{base.inspect} and #{conflict.inspect}" do
       expect {
         add_options_to do
-          option *base
-          option *conflict
+          option(*base)
+          option(*conflict)
         end
       }.to raise_error ArgumentError, /conflicts with existing option/
     end

--- a/spec/unit/interface/action_spec.rb
+++ b/spec/unit/interface/action_spec.rb
@@ -246,7 +246,7 @@ describe Puppet::Interface::Action do
         face = Puppet::Interface.new(:with_options, '0.0.1') do
           action(:foo) do
             when_invoked do |options| true end
-            self.instance_eval &block
+            self.instance_eval(&block)
           end
         end
         face.get_action(:foo)

--- a/spec/unit/provider/cron/crontab_spec.rb
+++ b/spec/unit/provider/cron/crontab_spec.rb
@@ -59,7 +59,7 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
 
     it "should parse all sample records at once" do
       subject.parse(text).zip(records).each do |round|
-        compare_crontab_record *round
+        compare_crontab_record(*round)
       end
     end
 
@@ -95,7 +95,7 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
 
           it "should parse the records from the text" do
             subject.parse(text).zip(records).each do |round|
-              compare_crontab_record *round
+              compare_crontab_record(*round)
             end
           end
         end
@@ -103,7 +103,7 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
 
       it "should parse the whole set of records from the text" do
         subject.parse(all_text).zip(all_records).each do |round|
-          compare_crontab_record *round
+          compare_crontab_record(*round)
         end
       end
 

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -160,7 +160,7 @@ describe Puppet::Provider::NameService do
     it "should return a list of users if resource_type is user" do
       described_class.resource_type = Puppet::Type.type(:user)
       Puppet::Etc.expects(:setpwent)
-      Puppet::Etc.stubs(:getpwent).returns *users
+      Puppet::Etc.stubs(:getpwent).returns(*users)
       Puppet::Etc.expects(:endpwent)
       expect(described_class.listbyname).to eq(%w{root foo})
     end
@@ -172,7 +172,7 @@ describe Puppet::Provider::NameService do
       # the same name on disk, but each name is stored on disk in a different
       # encoding
       it "should return names with invalid byte sequences replaced with '?'" do
-        Etc.stubs(:getpwent).returns *utf_8_mixed_users
+        Etc.stubs(:getpwent).returns(*utf_8_mixed_users)
         expect(invalid_utf_8_jose).to_not be_valid_encoding
         result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::UTF_8) do
           described_class.listbyname
@@ -181,7 +181,7 @@ describe Puppet::Provider::NameService do
       end
 
       it "should return names in their original encoding/bytes if they would not be valid UTF-8" do
-        Etc.stubs(:getpwent).returns *latin_1_mixed_users
+        Etc.stubs(:getpwent).returns(*latin_1_mixed_users)
         result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::ISO_8859_1) do
           described_class.listbyname
         end
@@ -192,7 +192,7 @@ describe Puppet::Provider::NameService do
     it "should return a list of groups if resource_type is group", :unless => Puppet.features.microsoft_windows? do
       described_class.resource_type = Puppet::Type.type(:group)
       Puppet::Etc.expects(:setgrent)
-      Puppet::Etc.stubs(:getgrent).returns *groups
+      Puppet::Etc.stubs(:getgrent).returns(*groups)
       Puppet::Etc.expects(:endgrent)
       expect(described_class.listbyname).to eq(%w{root bin})
     end
@@ -201,7 +201,7 @@ describe Puppet::Provider::NameService do
       yield_results = []
       described_class.resource_type = Puppet::Type.type(:user)
       Puppet::Etc.expects(:setpwent)
-      Puppet::Etc.stubs(:getpwent).returns *users
+      Puppet::Etc.stubs(:getpwent).returns(*users)
       Puppet::Etc.expects(:endpwent)
       described_class.listbyname {|x| yield_results << x }
       expect(yield_results).to eq(%w{root foo})

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -160,7 +160,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
     before do
       @original = Puppet::Resource::Catalog.new("mynode")
       @original.tag(*%w{one two three})
-      @original.add_class *%w{four five six}
+      @original.add_class(*%w{four five six})
 
       @top            = Puppet::Resource.new :class, 'top'
       @topobject      = Puppet::Resource.new :file, @basepath+'/topobject'
@@ -233,7 +233,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
     before :each do
       @original = Puppet::Resource::Catalog.new("mynode")
       @original.tag(*%w{one two three})
-      @original.add_class *%w{four five six}
+      @original.add_class(*%w{four five six})
 
       @r1 = stub_everything 'r1', :ref => "File[/a]"
       @r1.stubs(:respond_to?).with(:ref).returns(true)

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -518,7 +518,7 @@ describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows
     def run_in_catalog(*resources)
       Puppet::Util::Storage.stubs(:store)
       catalog = Puppet::Resource::Catalog.new
-      catalog.add_resource *resources
+      catalog.add_resource(*resources)
       catalog.apply
     end
 


### PR DESCRIPTION
`find lib spec -type f -name \*.rb | xargs -n1 ruby -wc > /dev/null` gives a rather large number of warnings. This only addresses a small number of those warnings. Specifically:

* `&` being interpreted as an argument prefix (typically because of a lack of parenthesis around function arguments).
* `*` being interpreted as an argument prefix (typically because of a lack of parenthesis around function artuments).
* Use of `==` in a void context. Typically this means there was a `&&` missing somewhere.

The specific "`==` in void" case that this addresses is because it was originally meant to be an rspec `.should` when it was created, but the `.should` was accidentally left off (which means we never noticed that the test wasn't ever passing).