### PR TITLE
(PUP-8467) Fix ambiguous operator in functions/map.rb

### DIFF
--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -123,7 +123,7 @@ Puppet::Functions.create_function(:map) do
     begin
       loop do
         result << yield(index, enum.next)
-        index = index +1
+        index = index + 1
       end
     rescue StopIteration
     end


### PR DESCRIPTION
Previously, we had an ambiguous operator that would always cause
warnings when running with JRuby 9k.

These warning are suspected of causing unwanted interactions with
production logging systems and should be removed regardless.

This removes the ambiguous operator usage.