### PR TITLE
(PUP-8444) fix puppet man parsing

### DIFF
--- a/spec/unit/face/man_spec.rb
+++ b/spec/unit/face/man_spec.rb
@@ -1,0 +1,22 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/face'
+
+describe Puppet::Face[:man, '0.0.1'] do
+  it 'has a man action' do
+    expect(subject).to be_action(:man)
+  end
+
+  it 'has a default action of man' do
+    expect(subject.get_action('man')).to be_default
+  end
+
+  it 'accepts a call with no arguments' do
+    expect { subject.man() }.to have_printed(/USAGE: puppet man <action>/)
+  end
+
+  it 'raises an ArgumentError when given to many arguments' do
+    subject.stubs(:print_man_help)
+    expect { subject.man(:man, 'cert', 'extra') }.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
Properly print a default help for "puppet man"
Validate the command line arguments
Added a few basic tests (since we're going to deprecate man)