### PR TITLE
Clean up & enable Lint/Void Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,9 +144,8 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: true
 
-# DISABLED - TODO
 Lint/Void:
-  Enabled: false
+  Enabled: true
 
 Layout/AccessModifierIndentation:
   Enabled: false

--- a/ext/regexp_nodes/regexp_nodes.rb
+++ b/ext/regexp_nodes/regexp_nodes.rb
@@ -89,7 +89,6 @@ class ExternalNode
   # parameters
   def initialize(hostname, classdir = 'classes/', parameterdir = 'parameters/', environmentdir = 'environment/')
     # instance variables that contain the lists of classes and parameters
-    @hostname
     @classes = Set.new
     @parameters = Hash.new("unknown")  # sets a default value of "unknown"
     @environment = "production"
@@ -134,13 +133,13 @@ class ExternalNode
     patternlist = []
 
     begin
-      open(filepath).each { |l|
+      open(filepath).each do |l|
         l.chomp!
 
         next if l =~ /^$/
         next if l =~ /^#/
 
-		if l =~ /^\s*(\S+)/
+        if l =~ /^\s*(\S+)/
           m = Regexp.last_match
           log("found a non-comment line, transforming [#{l}] into [#{m[1]}]")
           l.gsub!(l,m[1])
@@ -151,7 +150,7 @@ class ExternalNode
         pattern = %r{#{l}}
         patternlist <<  pattern
         log("appending [#{pattern}] to patternlist for [#{filepath}]")
-      }
+      end
     rescue StandardError
       log("Problem reading #{filepath}: #{$!}",:err)
       exit(1)

--- a/lib/puppet/external/dot.rb
+++ b/lib/puppet/external/dot.rb
@@ -181,9 +181,6 @@ module DOT
   # node element
 
   class DOTNode < DOTElement
-
-    @ports
-
     def initialize (params = {}, option_list = NODE_OPTS)
       super(params, option_list)
       @ports = params['ports'] ? params['ports'] : []
@@ -235,10 +232,6 @@ module DOT
   # notation.
 
   class DOTSubgraph < DOTElement
-
-    @nodes
-    @dot_string
-
     def initialize (params = {}, option_list = GRAPH_OPTS)
       super(params, option_list)
       @nodes      = params['nodes'] ? params['nodes'] : []

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -49,7 +49,6 @@ module Issues
         # Evaluate the message block in the msg data's binding
         msgdata.format(hash, &message_block)
       rescue StandardError => e
-        MessageData
         raise RuntimeError, _("Error while reporting issue: %{code}. %{message}") % { code: issue_code, message: e.message }, caller
       end
     end

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -25,8 +25,9 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
 
   def setupservice
       if resource[:manifest]
-        [command(:svcs), "-l", @resource[:name]]
-        if $CHILD_STATUS.exitstatus == 1
+        begin
+          svcs("-l", @resource[:name])
+        rescue Puppet::ExecutionFailure
           Puppet.notice "Importing #{@resource[:manifest]} for #{@resource[:name]}"
           svccfg :import, resource[:manifest]
         end

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -151,6 +151,7 @@ describe provider_class, :if => Puppet.features.posix? do
     end
 
     it "should import the manifest if service is missing" do
+      @provider.expects(:svcs).with('-l', '/system/myservice').raises(Puppet::ExecutionFailure, "Exited 1")
       @provider.expects(:svccfg).with(:import, "/tmp/myservice.xml")
       @provider.expects(:texecute).with(:start, ["/usr/sbin/svcadm", :enable, '-rs', "/system/myservice"], true)
       @provider.expects(:wait).with('online')
@@ -159,6 +160,7 @@ describe provider_class, :if => Puppet.features.posix? do
     end
 
     it "should handle failures if importing a manifest" do
+      @provider.expects(:svcs).with('-l', '/system/myservice').raises(Puppet::ExecutionFailure, "Exited 1")
       @provider.expects(:svccfg).raises(Puppet::ExecutionFailure.new("can't svccfg import"))
       expect { @provider.start }.to raise_error(Puppet::Error, "Cannot config /system/myservice to enable it: can't svccfg import")
     end


### PR DESCRIPTION
Turns out that the SMF provider was never actually running `svcs -l <name>` to see if a service was enabled and was instead creating an array that would immediately get thrown away as it was used in void context. We now run the svcs command, and check that it didn't raise a Puppet::ExecutionFailure due to exiting with anything other than a `0` return value.

There were also a handful of other violations that are cleaned up in a separate commit from the SMF change.
