### PR TITLE
Don't trigger this error if puppet agent run without NTP

### DIFF
--- a/lib/puppet/interface/documentation.rb
+++ b/lib/puppet/interface/documentation.rb
@@ -307,7 +307,7 @@ class Puppet::Interface
         elsif input > (future = Time.now.year + 2) then
           fault = "after #{future}"
         end
-        if fault and if Time.now.year != 1970 then
+        if fault and Time.now.year != 1970 then
           #TRANSLATORS 'copyright' is an attribute name and should not be translate
           raise ArgumentError, _("copyright with a year %{value} is very strange; did you accidentally add or subtract two years?") %
               { value: fault }

--- a/lib/puppet/interface/documentation.rb
+++ b/lib/puppet/interface/documentation.rb
@@ -307,8 +307,8 @@ class Puppet::Interface
         elsif input > (future = Time.now.year + 2) then
           fault = "after #{future}"
         end
-        if fault then
-          #TRANSLATORS 'copyright' is an attribute name and should not be translated
+        if fault and if Time.now.year != 1970 then
+          #TRANSLATORS 'copyright' is an attribute name and should not be translate
           raise ArgumentError, _("copyright with a year %{value} is very strange; did you accidentally add or subtract two years?") %
               { value: fault }
         end


### PR DESCRIPTION
Hello, I'm trying to run puppet agent on an embedded device without a clock.

This error seems to be related to documentation. Would it be possible to have the error ignored if the year on a system is 1970?

I have outlined the problem on [SO](https://stackoverflow.com/questions/48813154/puppet-start-on-device-with-no-clock/48814347):

> I'm starting puppet agent using upstart on a Debian 14.04 embedded system:
> 
>     description "Puppet Agent"
>     
>     start on started 2klic-gateway
>     stop on runlevel [!2345]
>     
>     respawn
>     
>     pre-start script
>         if [ ! -f /var/lib/sc2klic/system.json ]; then
>             stop ; exit 0
>         fi
>         puppet config set certname "$(hostname)"
>     end script
>     
>     exec /usr/local/bin/puppet agent --no-daemonize
> 
> The device, or at least this version, doesn't have a hardware clock. So the system starts with a date of January 1, 1970.
> 
> When I look in `/var/log/upstart/puppet-agent.log` I see this error over and over again:
> 
>     ESC[1;31mError: Could not parse application options: copyright with a year after 1972 is very strange; did you accidentally add or subtract two years?ESC[0m
> 
> Is it possible to initialize puppet agent without having a correct date?
> 
> *Puppet Agent Version 4.10.1*