### PR TITLE
(PUP-8463) Remove "ambiguous first argument", and "assigned but unused variable" warnings

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -301,10 +301,13 @@ module Runtime3Support
   def call_function(name, args, o, scope, &block)
     file, line = extract_file_line(o)
     loader = Adapters::LoaderAdapter.loader_for_model_object(o, file)
-    if loader && func = loader.load(:function, name)
+    # 'ruby -wc' thinks that _func is unused, because the only reference to it
+    # is inside of the Kernel.eval string below. By prefixing it with the
+    # underscore, we let Ruby know to not worry about whether it's unused or not.
+    if loader && _func = loader.load(:function, name)
       Puppet::Util::Profiler.profile(name, [:functions, name]) do
         # Add stack frame when calling. See Puppet::Pops::PuppetStack
-        return Kernel.eval('func.call(scope, *args, &block)', Kernel.binding, file || '', line)
+        return Kernel.eval('_func.call(scope, *args, &block)', Kernel.binding, file || '', line)
       end
     end
     # Call via 3x API if function exists there

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -95,7 +95,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
             Puppet.debug "Success: curl transferred [#{name}] (via: curl #{args.join(" ")})"
         rescue Puppet::ExecutionFailure
           Puppet.debug "curl #{args.join(" ")} did not transfer [#{name}].  Falling back to local file." # This used to fall back to open-uri. -NF
-            cached_source = source
+          cached_source = source
         end
       end
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -411,7 +411,7 @@ module Puppet
            a zero-padded YYYY-MM-DD format -- for example, 2010-02-19."
 
       newvalues :absent
-      newvalues /^\d{4}-\d{2}-\d{2}$/
+      newvalues(/^\d{4}-\d{2}-\d{2}$/)
 
       validate do |value|
         if value.intern != :absent and value !~ /^\d{4}-\d{2}-\d{2}$/

--- a/lib/puppet/util/network_device/cisco/facts.rb
+++ b/lib/puppet/util/network_device/cisco/facts.rb
@@ -63,7 +63,7 @@ class Puppet::Util::NetworkDevice::Cisco::Facts
   end
 
   def uptime_to_seconds(uptime)
-    captures = (uptime.match /^(?:(\d+) years?,)?\s*(?:(\d+) weeks?,)?\s*(?:(\d+) days?,)?\s*(?:(\d+) hours?,)?\s*(\d+) minutes?$/).captures
+    captures = (uptime.match(/^(?:(\d+) years?,)?\s*(?:(\d+) weeks?,)?\s*(?:(\d+) days?,)?\s*(?:(\d+) hours?,)?\s*(\d+) minutes?$/)).captures
     captures.zip([31536000, 604800, 86400, 3600, 60]).inject(0) do |total, (x,y)|
       total + (x.nil? ? 0 : x.to_i * y)
     end

--- a/spec/fixtures/unit/pops/binder/bindings_composer/ok/modules/awesome2/lib/puppet_x/awesome2/echo_scheme_handler.rb
+++ b/spec/fixtures/unit/pops/binder/bindings_composer/ok/modules/awesome2/lib/puppet_x/awesome2/echo_scheme_handler.rb
@@ -11,7 +11,7 @@ module PuppetX
         factory = ::Puppet::Pops::Binder::BindingsFactory
         bindings = factory.named_bindings("echo")
         bindings.bind.name(uri.path.gsub(/\//, '::')).to("echo: #{uri.path.gsub(/\//, ' ').strip!}")
-        result = factory.contributed_bindings("echo", bindings.model) ### , nil)
+        factory.contributed_bindings("echo", bindings.model) ### , nil)
       end
     end
   end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -493,7 +493,7 @@ class amod::bad_type {
 
       it 'will log a warning that a value of unknown type is converted into a string' do
         logs = []
-        json = Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
           compile_to_catalog('include amod::bad_type', node).to_json
         end
         logs = logs.select { |log| log.level == :warning }.map { |log| log.message }

--- a/spec/integration/parser/catalog_spec.rb
+++ b/spec/integration/parser/catalog_spec.rb
@@ -90,7 +90,7 @@ describe "A catalog" do
   end
 
   def master_catalog_for(manifest)
-    master_catalog = Puppet::Resource::Catalog::Compiler.new.filter(compile_to_catalog(manifest, node))
+    Puppet::Resource::Catalog::Compiler.new.filter(compile_to_catalog(manifest, node))
   end
 
   def master_and_agent_catalogs_for(manifest)

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -180,7 +180,7 @@ describe 'collectors' do
     it "does not collect classes" do
       node = Puppet::Node.new('the node')
       expect do
-        catalog = compile_to_catalog(<<-MANIFEST, node)
+        compile_to_catalog(<<-MANIFEST, node)
           class theclass {
             @notify { "testing": message => "good message" }
           }
@@ -192,7 +192,7 @@ describe 'collectors' do
     it "does not collect resources that don't exist" do
       node = Puppet::Node.new('the node')
       expect do
-        catalog = compile_to_catalog(<<-MANIFEST, node)
+        compile_to_catalog(<<-MANIFEST, node)
           class theclass {
             @notify { "testing": message => "good message" }
           }

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -259,7 +259,7 @@ describe Puppet::Parser::Compiler do
     it "should not create duplicate resources when a class is referenced both directly and indirectly by the node classifier (4792)" do
       node = Puppet::Node.new("testnodex")
       node.classes = ['foo', 'bar']
-      catalog = compile_to_catalog(<<-PP, node)
+      compile_to_catalog(<<-PP, node)
         class foo
         {
           notify { foo_notify: }
@@ -401,7 +401,7 @@ describe Puppet::Parser::Compiler do
 
       it "should not favor local name scope" do
         expect {
-          catalog = compile_to_catalog(<<-PP)
+          compile_to_catalog(<<-PP)
             class experiment {
               class baz {
               }
@@ -683,7 +683,7 @@ describe Puppet::Parser::Compiler do
 
       it 'an initial underscore in not ok if elsewhere than last segment' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             class a { $_a = 10}
             include a
             notify { 'test': message => $_a::_a }
@@ -769,7 +769,7 @@ describe Puppet::Parser::Compiler do
 
       it 'accepts anything when parameters are untyped' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
           define foo($a, $b, $c) { }
           foo { 'test': a => String, b=>10, c=>undef }
           MANIFEST
@@ -778,7 +778,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies non type compliant arguments' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             define foo(Integer $x) { }
             foo { 'test': x =>'say friend' }
           MANIFEST
@@ -787,7 +787,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies undef for a non-optional type' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             define foo(Integer $x) { }
             foo { 'test': x => undef }
           MANIFEST
@@ -796,7 +796,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies non type compliant default argument' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             define foo(Integer $x = 'pow') { }
             foo { 'test':  }
           MANIFEST
@@ -805,7 +805,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies undef as the default for a non-optional type' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             define foo(Integer $x = undef) { }
             foo { 'test':  }
           MANIFEST
@@ -826,7 +826,7 @@ describe Puppet::Parser::Compiler do
 
       it 'uses infer_set when reporting type mismatch' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             define foo(Struct[{b => Integer, d=>String}] $a) { }
             foo{ bar: a => {b => 5, c => 'stuff'}}
           MANIFEST
@@ -855,7 +855,7 @@ describe Puppet::Parser::Compiler do
 
       it 'accepts anything when parameters are untyped' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             class foo($a, $b, $c) { }
             class { 'foo': a => String, b=>10, c=>undef }
           MANIFEST
@@ -864,7 +864,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies non type compliant arguments' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             class foo(Integer $x) { }
             class { 'foo': x =>'say friend' }
           MANIFEST
@@ -873,7 +873,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies undef for a non-optional type' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             class foo(Integer $x) { }
             class { 'foo': x => undef }
           MANIFEST
@@ -882,7 +882,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies non type compliant default argument' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             class foo(Integer $x = 'pow') { }
             class { 'foo':  }
           MANIFEST
@@ -891,7 +891,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies undef as the default for a non-optional type' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             class foo(Integer $x = undef) { }
             class { 'foo':  }
           MANIFEST
@@ -900,7 +900,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies a regexp (rich data) argument given to class String parameter (even if later encoding of it is a string)' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             class foo(String $x) { }
             class { 'foo':  x => /I am a regexp and I don't want to be a String/}
           MANIFEST
@@ -909,7 +909,7 @@ describe Puppet::Parser::Compiler do
 
       it 'denies a regexp (rich data) argument given to define String parameter (even if later encoding of it is a string)' do
         expect do
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             define foo(String $x) { }
             foo { 'foo':  x => /I am a regexp and I don't want to be a String/}
           MANIFEST
@@ -1162,7 +1162,7 @@ describe Puppet::Parser::Compiler do
     it 'errors when an alias cannot be found when relationship is formed with -> operator' do
       node = Puppet::Node.new("testnodex")
       expect {
-        catalog = compile_to_catalog(<<-PP, node)
+        compile_to_catalog(<<-PP, node)
           notify { 'actual_2':  }
           notify { 'actual_1': alias => 'alias_1' }
           Notify[actual_2] -> Notify[alias_2]
@@ -1190,7 +1190,6 @@ describe Puppet::Parser::Compiler do
         include foo
         include bar
       MANIFEST
-      package = catalog.resource('Package', 'pip')
       expect(catalog.resource('Package', 'pip')[:require].to_s).to eql('Package[python]')
     end
 

--- a/spec/integration/parser/pcore_resource_spec.rb
+++ b/spec/integration/parser/pcore_resource_spec.rb
@@ -227,7 +227,7 @@ describe 'when pcore described resources types are in use' do
       pending "assertion of parameter types not yet implemented"
       genface.types
       expect {
-      catalog = compile_to_catalog(<<-MANIFEST)
+      compile_to_catalog(<<-MANIFEST)
         test2 { 'b':
           color => 'white is not a color'
         }
@@ -237,7 +237,7 @@ describe 'when pcore described resources types are in use' do
   end
 
   def find_resource_type(scope, name)
-    t1 = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, name)
+    Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, name)
   end
 
   def generate_and_in_a_compilers_context(&block)

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -20,7 +20,7 @@ describe "Two step scoping for variables" do
   describe "using unsupported operators" do
     it "issues an error for +=" do
       expect do
-        catalog = compile_to_catalog(<<-MANIFEST)
+        compile_to_catalog(<<-MANIFEST)
               $var = ["top_msg"]
               node default {
                 $var += ["override"]
@@ -31,7 +31,7 @@ describe "Two step scoping for variables" do
 
     it "issues an error for -=" do
       expect do
-        catalog = compile_to_catalog(<<-MANIFEST)
+        compile_to_catalog(<<-MANIFEST)
               $var = ["top_msg"]
               node default {
                 $var -= ["top_msg"]

--- a/spec/integration/ssl/certificate_authority_spec.rb
+++ b/spec/integration/ssl/certificate_authority_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::SSL::CertificateAuthority, :unless => Puppet.features.microsoft
 
   describe "when signing certificates" do
     it "should save the signed certificate" do
-      host = certificate_request_for("luke.madstop.com")
+      certificate_request_for("luke.madstop.com")
 
       ca.sign("luke.madstop.com")
 
@@ -44,8 +44,8 @@ describe Puppet::SSL::CertificateAuthority, :unless => Puppet.features.microsoft
     end
 
     it "should be able to sign multiple certificates" do
-      host = certificate_request_for("luke.madstop.com")
-      other = certificate_request_for("other.madstop.com")
+      certificate_request_for("luke.madstop.com")
+      certificate_request_for("other.madstop.com")
 
       ca.sign("luke.madstop.com")
       ca.sign("other.madstop.com")
@@ -55,7 +55,7 @@ describe Puppet::SSL::CertificateAuthority, :unless => Puppet.features.microsoft
     end
 
     it "should save the signed certificate to the :signeddir" do
-      host = certificate_request_for("luke.madstop.com")
+      certificate_request_for("luke.madstop.com")
 
       ca.sign("luke.madstop.com")
 
@@ -64,16 +64,16 @@ describe Puppet::SSL::CertificateAuthority, :unless => Puppet.features.microsoft
     end
 
     it "should save valid certificates" do
-      host = certificate_request_for("luke.madstop.com")
+      certificate_request_for("luke.madstop.com")
 
       ca.sign("luke.madstop.com")
 
-      unless ssl = Puppet::Util::which('openssl')
+      unless Puppet::Util::which('openssl')
         pending "No ssl available"
       else
         ca_cert = Puppet[:cacert]
         client_cert = File.join(Puppet[:signeddir], "luke.madstop.com.pem")
-        output = %x{openssl verify -CAfile #{ca_cert} #{client_cert}}
+        %x{openssl verify -CAfile #{ca_cert} #{client_cert}}
         expect($CHILD_STATUS).to eq(0)
       end
     end

--- a/spec/integration/ssl/certificate_revocation_list_spec.rb
+++ b/spec/integration/ssl/certificate_revocation_list_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::SSL::CertificateRevocationList do
   }
 
   it "should be able to read in written out CRLs with no revoked certificates" do
-    ca = Puppet::SSL::CertificateAuthority.new
+    Puppet::SSL::CertificateAuthority.new
 
     raise "CRL not created" unless Puppet::FileSystem.exist?(Puppet[:hostcrl])
 

--- a/spec/integration/ssl/key_spec.rb
+++ b/spec/integration/ssl/key_spec.rb
@@ -84,7 +84,7 @@ describe Puppet::SSL::Key do
       # note incorrect password is an error
       expect do
         Puppet::FileSystem.open(pem_path, nil, 'r:ASCII') do |f|
-          reloaded_key = OpenSSL::PKey::RSA.new(f.read, 'invalid_password')
+          OpenSSL::PKey::RSA.new(f.read, 'invalid_password')
         end
       end.to raise_error(OpenSSL::PKey::RSAError)
 

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -87,7 +87,7 @@ describe Puppet::Transaction::Report do
     end
 
     def get_cc_count(report)
-      cc = report.metrics["resources"].values.each do |v|
+      report.metrics["resources"].values.each do |v|
         if v[0] == "corrective_change"
           return v[2]
         end

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -146,7 +146,6 @@ describe Puppet::Transaction do
   # Verify that one component requiring another causes the contained
   # resources in the requiring component to get refreshed.
   it "should propagate events from a contained resource through its container to its dependent container's contained resources" do
-    transaction = nil
     file = Puppet::Type.type(:file).new :path => tmpfile("event_propagation"), :ensure => :present
     execfile = File.join(tmpdir("exec_event"), "exectestingness2")
     exec = Puppet::Type.type(:exec).new :command => touch(execfile), :path => ENV['PATH']

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -542,8 +542,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         File.open(dest1, "w") { |f| f.puts "whatever" }
         Puppet::FileSystem.symlink(dest1, link)
 
-        d = filebucket_digest.call(File.read(file[:path]))
-
         catalog.apply
 
         expect(Puppet::FileSystem.readlink(link)).to eq(dest2)
@@ -1031,8 +1029,8 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
     before do
       source = tmpdir("generating_in_catalog_source")
 
-      s1 = file_in_dir_with_contents(source, "one", "uno")
-      s2 = file_in_dir_with_contents(source, "two", "dos")
+      file_in_dir_with_contents(source, "one", "uno")
+      file_in_dir_with_contents(source, "two", "dos")
 
       @file = described_class.new(
         :name => path,

--- a/spec/integration/type_spec.rb
+++ b/spec/integration/type_spec.rb
@@ -21,8 +21,7 @@ describe Puppet::Type do
 
   it "should not lose its provider parameter when it is reloaded" do
     type = Puppet::Type.newtype(:reload_test_type)
-
-    provider = type.provide(:test_provider)
+    type.provide(:test_provider)
 
     # reload it
     type = Puppet::Type.newtype(:reload_test_type)

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
 
   let (:current_user_sid) { Puppet::Util::Windows::ADSI::User.current_user_sid }
   let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }
-  let (:null_sid_bytes) { bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+  let (:null_sid_bytes) { [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
   let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
   let (:computer_sid) { Puppet::Util::Windows::SID.name_to_sid_object(Puppet::Util::Windows::ADSI.computer_name) }
   # BUILTIN is localized on German Windows, but not French

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -734,11 +734,11 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
       let (:explorer) { File.join(Dir::WINDOWS, "explorer.exe") }
 
       it "should get the owner" do
-        expect(winsec.get_owner(explorer)).to match /^S-1-5-/
+        expect(winsec.get_owner(explorer)).to match(/^S-1-5-/)
       end
 
       it "should get the group" do
-        expect(winsec.get_group(explorer)).to match /^S-1-5-/
+        expect(winsec.get_group(explorer)).to match(/^S-1-5-/)
       end
 
       it "should get the mode" do

--- a/spec/shared_behaviours/file_server_terminus.rb
+++ b/spec/shared_behaviours/file_server_terminus.rb
@@ -34,8 +34,6 @@ shared_examples_for "Puppet::Indirector::FileServerTerminus" do
     @modules.stubs(:find).returns(nil)
     @terminus.indirection.stubs(:terminus).with(:modules).returns(@modules)
 
-    path = File.join(@path, "myfile")
-
     expect(@terminus.find(@request)).to be_instance_of(@test_class)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ require 'rspec/collection_matchers'
 
 # So everyone else doesn't have to include this base constant.
 module PuppetSpec
-  FIXTURE_DIR = File.join(dir = File.expand_path(File.dirname(__FILE__)), "fixtures") unless defined?(FIXTURE_DIR)
+  FIXTURE_DIR = File.join(File.expand_path(File.dirname(__FILE__)), "fixtures") unless defined?(FIXTURE_DIR)
 end
 
 require 'pathname'

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -201,7 +201,7 @@ describe "when using a hiera data provider" do
     it 'will report config path (original and resolved), data path (original and resolved), and interpolation (before and after)' do
       compile('hiera_misc', '$target_scope = "with scope"') do |compiler|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(compiler.topscope, {}, {}, true)
-        value = Puppet::Pops::Lookup.lookup('km_scope', nil, nil, nil, nil, lookup_invocation)
+        Puppet::Pops::Lookup.lookup('km_scope', nil, nil, nil, nil, lookup_invocation)
         expect(lookup_invocation.explainer.explain).to include(<<-EOS)
       Path "#{environmentpath}/hiera_misc/data/common.yaml"
         Original path: "common.yaml"
@@ -216,7 +216,7 @@ describe "when using a hiera data provider" do
     it 'will report that merge options was found in the lookup_options hash' do
       compile('hiera_misc', '$target_scope = "with scope"') do |compiler|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(compiler.topscope, {}, {}, true)
-        value = Puppet::Pops::Lookup.lookup('one::loptsm_test::hash', nil, nil, nil, nil, lookup_invocation)
+        Puppet::Pops::Lookup.lookup('one::loptsm_test::hash', nil, nil, nil, nil, lookup_invocation)
         expect(lookup_invocation.explainer.explain).to include("Using merge options from \"lookup_options\" hash")
       end
     end
@@ -224,7 +224,7 @@ describe "when using a hiera data provider" do
     it 'will report lookup_options details in combination with details of found value' do
       compile('hiera_misc', '$target_scope = "with scope"') do |compiler|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(compiler.topscope, {}, {}, Puppet::Pops::Lookup::Explainer.new(true))
-        value = Puppet::Pops::Lookup.lookup('one::loptsm_test::hash', nil, nil, nil, nil, lookup_invocation)
+        Puppet::Pops::Lookup.lookup('one::loptsm_test::hash', nil, nil, nil, nil, lookup_invocation)
         expect(lookup_invocation.explainer.explain).to eq(<<EOS)
 Searching for "lookup_options"
   Global Data Provider (hiera configuration version 5)
@@ -314,7 +314,7 @@ EOS
     it 'will report config path (original and resolved), data path (original and resolved), and interpolation (before and after)' do
       compile('hiera_misc', '$target_scope = "with scope"') do |compiler|
         lookup_invocation = Puppet::Pops::Lookup::Invocation.new(compiler.topscope, {}, {}, Puppet::Pops::Lookup::Explainer.new(true, true))
-        value = Puppet::Pops::Lookup.lookup('one::loptsm_test::hash', nil, nil, nil, nil, lookup_invocation)
+        Puppet::Pops::Lookup.lookup('one::loptsm_test::hash', nil, nil, nil, nil, lookup_invocation)
         expect(lookup_invocation.explainer.explain).to eq(<<EOS)
 Merge strategy hash
   Global Data Provider (hiera configuration version 5)

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -307,7 +307,6 @@ describe Puppet::Face[:epp, :current] do
       end
 
       it "renders multiple files separated by headers by default" do
-        modules_dir = File.join(dir, 'environments', 'production', 'modules')
         # chomp the last newline, it is put there by heredoc
         expect(eppface.render('m1/greetings.epp', 'm2/goodbye.epp')).to eq(<<-EOT.chomp)
 --- m1/greetings.epp
@@ -318,7 +317,6 @@ goodbye world
       end
 
       it "outputs multiple files verbatim when --no-headers is given" do
-        modules_dir = File.join(dir, 'environments', 'production', 'modules')
         expect(eppface.render('m1/greetings.epp', 'm2/goodbye.epp', :header => false)).to eq("hello worldgoodbye world")
       end
     end

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -152,7 +152,7 @@ describe Puppet::Face[:help, '0.0.1'] do
     it "appends a deprecation warning for deprecated faces" do
       # Stub the module face as deprecated
       Puppet::Face[:module, :current].expects(:deprecated?).returns(true)
-      result = Puppet::Face[:help, :current].all_application_summaries.each do |appname,summary|
+      Puppet::Face[:help, :current].all_application_summaries.each do |appname,summary|
         expect(summary).to match(/Deprecated/) if appname == 'module'
       end
     end

--- a/spec/unit/face/module/list_spec.rb
+++ b/spec/unit/face/module/list_spec.rb
@@ -83,7 +83,6 @@ describe "puppet module list" do
   it "prefers a given modulepath over the modulepath from the given environment" do
     foomod = PuppetSpec::Modules.create('foo', @modpath1)
     barmod = PuppetSpec::Modules.create('bar', @modpath2)
-    env = Puppet::Node::Environment.create(:myenv, ['/tmp/notused'])
 
     modules = Puppet::Face[:module, :current].list(:environment => 'myenv', :modulepath => "#{@modpath1}#{File::PATH_SEPARATOR}#{@modpath2}")[:modules_by_path]
 

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -153,9 +153,6 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
 
         @dipper = Puppet::FileBucket::Dipper.new(:Path => file_bucket)
 
-        onehour=60*60
-        twohours=onehour*2
-
         #First File
         file1 = make_tmp_file(plaintext)
         real_path = Pathname.new(file1).realpath
@@ -182,7 +179,6 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
         checksum = digest(plaintext)
         expect(digest(plaintext)).to eq(checksum)
         expect(@dipper.backup(file3)).to eq(checksum)
-        date = Time.now
         expected_list3 = /#{checksum} \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} #{real_path}\n/
 
         result = @dipper.list(nil, nil)

--- a/spec/unit/file_serving/content_spec.rb
+++ b/spec/unit/file_serving/content_spec.rb
@@ -25,7 +25,6 @@ describe Puppet::FileServing::Content do
   it "should not retrieve and store its contents when its attributes are collected" do
     content = Puppet::FileServing::Content.new(path)
 
-    result = "foo"
     File.expects(:read).with(path).never
     content.collect
 

--- a/spec/unit/file_serving/fileset_spec.rb
+++ b/spec/unit/file_serving/fileset_spec.rb
@@ -277,7 +277,6 @@ describe Puppet::FileServing::Fileset do
     it "works when paths have regexp significant characters" do
       @path = make_absolute("/my/path/rV1x2DafFr0R6tGG+1bbk++++TM")
       stat = stub('dir_stat', :directory? => true)
-      stub_file = stub(@path, :stat => stat, :lstat => stat)
       Puppet::FileSystem.expects(:lstat).with(@path).returns stub(@path, :stat => stat, :lstat => stat)
       @fileset = Puppet::FileServing::Fileset.new(@path)
       mock_dir_structure(@path)

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -495,7 +495,6 @@ describe Puppet::FileServing::Metadata, " when pointing to a link", :if => Puppe
         path = "/base/path/my/file"
         @file = Puppet::FileServing::Metadata.new(path, :links => :manage)
         stat = stub("stat", :uid => 1, :gid => 2, :ftype => "link", :mode => 0755)
-        stub_file = stub(:readlink => "/some/other/path", :lstat => stat)
         Puppet::FileSystem.expects(:lstat).with(path).at_least_once.returns stat
         Puppet::FileSystem.expects(:readlink).with(path).at_least_once.returns "/some/other/path"
         @file.stubs("#{digest_algorithm}_file".intern).returns(checksum) # Remove these when :managed links are no longer checksumed.

--- a/spec/unit/file_serving/terminus_selector_spec.rb
+++ b/spec/unit/file_serving/terminus_selector_spec.rb
@@ -56,8 +56,6 @@ describe Puppet::FileServing::TerminusSelector do
       end
 
       it "should choose :file_server when default_file_terminus is file_server and no server is specified on the request" do
-        modules = mock 'modules'
-
         @request.expects(:protocol).returns "puppet"
         @request.expects(:server).returns nil
         Puppet[:default_file_terminus] = 'file_server'

--- a/spec/unit/forge_spec.rb
+++ b/spec/unit/forge_spec.rb
@@ -270,8 +270,7 @@ describe Puppet::Forge do
     end
 
     it "ignores modules with unparseable dependencies" do
-      expect { result = forge.fetch('puppetlabs/bacula') }.to_not raise_error
-      expect { result.to be_empty }
+      expect(forge.fetch('puppetlabs/bacula')).to be_empty
     end
   end
 end

--- a/spec/unit/functions/epp_spec.rb
+++ b/spec/unit/functions/epp_spec.rb
@@ -164,6 +164,6 @@ describe "the epp function" do
   end
 
   def epp_function()
-    epp_func = scope.compiler.loaders.public_environment_loader.load(:function, 'epp')
+    scope.compiler.loaders.public_environment_loader.load(:function, 'epp')
   end
 end

--- a/spec/unit/functions/include_spec.rb
+++ b/spec/unit/functions/include_spec.rb
@@ -92,7 +92,7 @@ describe 'The "include" function' do
 
   it "raises an error if class does not exist" do
     expect {
-      catalog = compile_to_catalog(<<-MANIFEST)
+      compile_to_catalog(<<-MANIFEST)
         include the_god_in_your_religion
       MANIFEST
     }.to raise_error(Puppet::Error)
@@ -105,7 +105,7 @@ describe 'The "include" function' do
     }.each_pair do |value, name_kind|
       it "raises an error if class is #{name_kind}" do
         expect {
-          catalog = compile_to_catalog(<<-MANIFEST)
+          compile_to_catalog(<<-MANIFEST)
             include #{value}
           MANIFEST
         }.to raise_error(/Cannot use #{name_kind}/)

--- a/spec/unit/functions/inline_epp_spec.rb
+++ b/spec/unit/functions/inline_epp_spec.rb
@@ -83,7 +83,7 @@ describe "the inline_epp function" do
   end
 
   def epp_function()
-    epp_func = scope.compiler.loaders.public_environment_loader.load(:function, 'inline_epp')
+    scope.compiler.loaders.public_environment_loader.load(:function, 'inline_epp')
   end
 
 end

--- a/spec/unit/functions/shared.rb
+++ b/spec/unit/functions/shared.rb
@@ -88,7 +88,7 @@ shared_examples_for 'an inclusion function, when --tasks is on,' do |function|
   it "is not available when --tasks is on" do
     Puppet[:tasks] = true
     expect do
-      catalog = compile_to_catalog(<<-MANIFEST)
+      compile_to_catalog(<<-MANIFEST)
         #{function}(bar)
       MANIFEST
     end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)

--- a/spec/unit/functions/versioncmp_spec.rb
+++ b/spec/unit/functions/versioncmp_spec.rb
@@ -31,6 +31,6 @@ describe "the versioncmp function" do
   it "should call Puppet::Util::Package.versioncmp (included in scope)" do
     Puppet::Util::Package.expects(:versioncmp).with('1.2', '1.3').returns(-1)
 
-    expect(versioncmp('1.2', '1.3')).to eq -1
+    expect(versioncmp('1.2', '1.3')).to eq(-1)
   end
 end

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -96,7 +96,6 @@ describe 'the 4x function api' do
     # TODO: Bogus parameters, not yet used
     func = f.new(:closure_scope, :loader)
     expect(func.is_a?(Puppet::Functions::Function)).to be_truthy
-    signature = 'Any x, Any y'
     expect do
       func.call({}, 10)
     end.to raise_error(ArgumentError, "'min' expects 2 arguments, got 1")
@@ -107,7 +106,6 @@ describe 'the 4x function api' do
     # TODO: Bogus parameters, not yet used
     func = f.new(:closure_scope, :loader)
     expect(func.is_a?(Puppet::Functions::Function)).to be_truthy
-    signature = 'Any x, Any y'
     expect do
       func.call({}, 10, 10, 10)
     end.to raise_error(ArgumentError, "'min' expects 2 arguments, got 3")
@@ -122,7 +120,7 @@ describe 'the 4x function api' do
 
   it 'an error is raised if simple function-name and method are not matched' do
     expect do
-      f = create_badly_named_method_function_class()
+      create_badly_named_method_function_class()
     end.to raise_error(ArgumentError, /Function Creation Error, cannot create a default dispatcher for function 'mix', no method with this name found/)
   end
 
@@ -477,7 +475,7 @@ describe 'the 4x function api' do
         the_loader = loader()
         here = get_binding(the_loader)
         expect do
-          fc = eval(<<-CODE, here)
+          eval(<<-CODE, here)
             Puppet::Functions.create_function('testing::test') do
               local_types do
                 type 'MyType += Array[Integer]'
@@ -498,7 +496,7 @@ describe 'the 4x function api' do
         the_loader = loader()
         here = get_binding(the_loader)
         expect do
-          fc = eval(<<-CODE, here)
+          eval(<<-CODE, here)
             Puppet::Functions.create_function('testing::test') do
               dispatch :test do
                 param 'Array[1+=1]', :x
@@ -647,7 +645,7 @@ describe 'the 4x function api' do
 
 
   def create_noargs_function_class
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       def test()
         10
       end
@@ -655,7 +653,7 @@ describe 'the 4x function api' do
   end
 
   def create_min_function_class
-    f = Puppet::Functions.create_function('min') do
+    Puppet::Functions.create_function('min') do
       def min(x,y)
         x <= y ? x : y
       end
@@ -663,7 +661,7 @@ describe 'the 4x function api' do
   end
 
   def create_max_function_class
-    f = Puppet::Functions.create_function('max') do
+    Puppet::Functions.create_function('max') do
       def max(x,y)
         x >= y ? x : y
       end
@@ -671,7 +669,7 @@ describe 'the 4x function api' do
   end
 
   def create_badly_named_method_function_class
-    f = Puppet::Functions.create_function('mix') do
+    Puppet::Functions.create_function('mix') do
       def mix_up(x,y)
         x <= y ? x : y
       end
@@ -679,7 +677,7 @@ describe 'the 4x function api' do
   end
 
   def create_min_function_class_using_dispatch
-    f = Puppet::Functions.create_function('min') do
+    Puppet::Functions.create_function('min') do
         dispatch :min do
           param 'Numeric', :a
           param 'Numeric', :b
@@ -691,7 +689,7 @@ describe 'the 4x function api' do
   end
 
   def create_min_function_class_disptaching_to_two_methods
-    f = Puppet::Functions.create_function('min') do
+    Puppet::Functions.create_function('min') do
       dispatch :min do
         param 'Numeric', :a
         param 'Numeric', :b
@@ -714,7 +712,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_optionals_and_repeated
-    f = Puppet::Functions.create_function('min') do
+    Puppet::Functions.create_function('min') do
       def min(x,y,a=1, b=1, *c)
         x <= y ? x : y
       end
@@ -722,7 +720,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_optionals_and_repeated_via_dispatch
-    f = Puppet::Functions.create_function('min') do
+    Puppet::Functions.create_function('min') do
       dispatch :min do
         param 'Numeric', :x
         param 'Numeric', :y
@@ -737,7 +735,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_optionals_and_repeated_via_multiple_dispatch
-    f = Puppet::Functions.create_function('min') do
+    Puppet::Functions.create_function('min') do
       dispatch :min do
         param 'Numeric', :x
         param 'Numeric', :y
@@ -757,7 +755,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_required_repeated_via_dispatch
-    f = Puppet::Functions.create_function('min') do
+    Puppet::Functions.create_function('min') do
       dispatch :min do
         param 'Numeric', :x
         param 'Numeric', :y
@@ -770,7 +768,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_repeated
-    f = Puppet::Functions.create_function('count_args') do
+    Puppet::Functions.create_function('count_args') do
       dispatch :count_args do
         repeated_param 'Any', :c
       end
@@ -781,7 +779,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_optional_repeated
-    f = Puppet::Functions.create_function('count_args') do
+    Puppet::Functions.create_function('count_args') do
       dispatch :count_args do
         optional_repeated_param 'Any', :c
       end
@@ -792,7 +790,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_required_repeated
-    f = Puppet::Functions.create_function('count_args') do
+    Puppet::Functions.create_function('count_args') do
       dispatch :count_args do
         required_repeated_param 'Any', :c
       end
@@ -803,7 +801,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_inexact_dispatch
-    f = Puppet::Functions.create_function('t1') do
+    Puppet::Functions.create_function('t1') do
       dispatch :t1 do
         param 'Numeric', :x
         param 'Numeric', :y
@@ -821,7 +819,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_rq_after_opt
-    f = Puppet::Functions.create_function('t1') do
+    Puppet::Functions.create_function('t1') do
       dispatch :t1 do
         optional_param 'Numeric', :x
         param 'Numeric', :y
@@ -833,7 +831,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_rq_repeated_after_opt
-    f = Puppet::Functions.create_function('t1') do
+    Puppet::Functions.create_function('t1') do
       dispatch :t1 do
         optional_param 'Numeric', :x
         required_repeated_param 'Numeric', :y
@@ -845,7 +843,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_param_after_repeated
-    f = Puppet::Functions.create_function('t1') do
+    Puppet::Functions.create_function('t1') do
       dispatch :t1 do
         repeated_param 'Numeric', :x
         param 'Numeric', :y
@@ -857,7 +855,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_param_injection_regular
-    f = Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
+    Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
       attr_injected Puppet::Pops::Types::TypeFactory.type_of(FunctionAPISpecModule::TestDuck), :test_attr
       attr_injected Puppet::Pops::Types::TypeFactory.string(), :test_attr2, "a_string"
       attr_injected_producer Puppet::Pops::Types::TypeFactory.integer(), :serial, "an_int"
@@ -877,7 +875,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_required_block_all_defaults
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       dispatch :test do
         param 'Integer', :x
         # use defaults, any callable, name is 'block'
@@ -890,7 +888,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_scope_required_block_all_defaults
-    f = Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
+    Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
       dispatch :test do
         scope_param
         param 'Integer', :x
@@ -904,7 +902,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_required_block_default_type
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       dispatch :test do
         param 'Integer', :x
         # use defaults, any callable, name is 'block'
@@ -917,7 +915,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_scope_param_required_repeat
-    f = Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
+    Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
       dispatch :test do
         scope_param
         param 'Any', :extra
@@ -930,7 +928,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_required_block_given_type
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       dispatch :test do
         param 'Integer', :x
         required_block_param
@@ -942,7 +940,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_required_block_fully_specified
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       dispatch :test do
         param 'Integer', :x
         # use defaults, any callable, name is 'block'
@@ -955,7 +953,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_optional_block_all_defaults
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       dispatch :test do
         param 'Integer', :x
         # use defaults, any callable, name is 'block'
@@ -968,7 +966,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_no_parameter_dispatch
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       dispatch :test_no_args do
       end
       dispatch :test_one_arg do
@@ -984,7 +982,7 @@ describe 'the 4x function api' do
   end
 
   def create_function_with_mismatch_handler
-    f = Puppet::Functions.create_function('test') do
+    Puppet::Functions.create_function('test') do
       dispatch :test do
         param 'Integer', :x
       end

--- a/spec/unit/graph/title_hash_prioritizer_spec.rb
+++ b/spec/unit/graph/title_hash_prioritizer_spec.rb
@@ -38,8 +38,9 @@ describe Puppet::Graph::TitleHashPrioritizer do
     resource = resource(:notify, "title")
     different_resource = resource(:notify, "title")
 
-    generated = prioritizer.generate_priority_for(resource)
+    prioritizer.generate_priority_for(resource)
 
+    expect(prioritizer.priority_of(resource)).not_to be_nil
     expect(prioritizer.priority_of(different_resource)).to be_nil
   end
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -89,7 +89,6 @@ describe Puppet::Resource::Catalog::Compiler do
 
     it "should pass the found node to the compiler for compiling" do
       Puppet::Node.indirection.expects(:find).with(node_name, anything).returns(node)
-      config = mock 'config'
       Puppet::Parser::Compiler.expects(:compile).with(node, anything)
       compiler.find(@request)
     end
@@ -287,21 +286,12 @@ describe Puppet::Resource::Catalog::Compiler do
       it "accepts PSON facts from older agents" do
         request = a_legacy_request_that_contains(@facts)
 
-        options = {
-          :environment => request.environment,
-          :transaction_uuid => request.options[:transaction_uuid],
-        }
         facts = compiler.extract_facts_from_request(request)
         expect(facts).to eq(@facts)
       end
 
       it "rejects YAML facts" do
         request = a_legacy_request_that_contains(@facts, :yaml)
-
-        options = {
-          :environment => request.environment,
-          :transaction_uuid => request.options[:transaction_uuid],
-        }
 
         expect {
           compiler.extract_facts_from_request(request)
@@ -311,11 +301,6 @@ describe Puppet::Resource::Catalog::Compiler do
       it "rejects unknown fact formats" do
         request = a_request_that_contains(@facts)
         request.options[:facts_format] = 'unknown-format'
-
-        options = {
-          :environment => request.environment,
-          :transaction_uuid => request.options[:transaction_uuid],
-        }
 
         expect {
           compiler.extract_facts_from_request(request)

--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -96,7 +96,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
               if Puppet::Util::Platform.windows? && (['sha512', 'sha384'].include? digest_algorithm)
                 skip "PUP-8257: Skip file bucket test on windows for #{digest_algorithm} due to long path names"
               else
-                checksum = save_bucket_file(plaintext, "/foo/bar")
+                save_bucket_file(plaintext, "/foo/bar")
   
                 dir_path = "#{Puppet[:bucketdir]}/#{bucket_dir}"
                 contents_file = "#{dir_path}/contents"
@@ -139,7 +139,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
             if Puppet::Util::Platform.windows? && (['sha512', 'sha384'].include? digest_algorithm)
               skip "PUP-8257: Skip file bucket test on windows for #{digest_algorithm} due to long path names"
             else
-              checksum = save_bucket_file(plaintext, "")
+              save_bucket_file(plaintext, "")
   
               dir_path = "#{Puppet[:bucketdir]}/#{bucket_dir}"
               expect(Puppet::FileSystem.binread("#{dir_path}/contents")).to eq(plaintext)

--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -788,7 +788,7 @@ describe Puppet::Indirector::Indirection do
 
     it "should not create a terminus instance until one is actually needed" do
       Puppet::Indirector.expects(:terminus).never
-      indirection = Puppet::Indirector::Indirection.new(mock('model'), :lazytest)
+      Puppet::Indirector::Indirection.new(mock('model'), :lazytest)
     end
 
     after do

--- a/spec/unit/indirector/node/ldap_spec.rb
+++ b/spec/unit/indirector/node/ldap_spec.rb
@@ -46,11 +46,11 @@ describe Puppet::Node::Ldap do
       end
 
       it "should add the entry's common name to the hash if fqdn if false" do
-        expect(node_indirection.entry2hash(@entry,fqdn = false)[:name]).to eq("mynode")
+        expect(node_indirection.entry2hash(@entry, false)[:name]).to eq("mynode")
       end
 
       it "should add the entry's fqdn name to the hash if fqdn if true" do
-        expect(node_indirection.entry2hash(@entry,fqdn = true)[:name]).to eq("mynode.madstop.com")
+        expect(node_indirection.entry2hash(@entry, true)[:name]).to eq("mynode.madstop.com")
       end
 
       it "should add all of the entry's classes to the hash" do

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -260,8 +260,6 @@ describe Puppet::Indirector::Request do
   end
 
   it "should use the current environment when none is provided" do
-    configured = Puppet::Node::Environment.create(:foo, [])
-
     Puppet[:environment] = "foo"
 
     expect(Puppet::Indirector::Request.new(:myind, :find, "my key", nil).environment).to eq(Puppet.lookup(:current_environment))

--- a/spec/unit/indirector_spec.rb
+++ b/spec/unit/indirector_spec.rb
@@ -113,7 +113,6 @@ describe Puppet::Indirector, "when registering an indirection" do
   end
 
   it "should pass any provided options to the indirection during initialization" do
-    klass = mock 'terminus class'
     Puppet::Indirector::Indirection.expects(:new).with(@thingie, :first, {:some => :options, :indirected_class => 'Thingie'})
     @indirection = @thingie.indirects :first, :some => :options
   end

--- a/spec/unit/info_service_spec.rb
+++ b/spec/unit/info_service_spec.rb
@@ -20,7 +20,7 @@ describe "Puppet::InfoService" do
     context 'tasks_per_environment method' do
       it "returns task data for the tasks in an environment" do
         Puppet.override(:environments => env_loader) do
-          mod = PuppetSpec::Modules.create(mod_name, modpath, {:environment => env, :tasks => [['thingtask']]})
+          PuppetSpec::Modules.create(mod_name, modpath, {:environment => env, :tasks => [['thingtask']]})
           expect(Puppet::InfoService.tasks_per_environment(env_name)).to eq([{:name => task_name, :module => {:name => mod_name}}])
         end
       end

--- a/spec/unit/interface/action_manager_spec.rb
+++ b/spec/unit/interface/action_manager_spec.rb
@@ -232,7 +232,7 @@ describe Puppet::Interface::ActionManager do
           when_invoked do |options| true end
           default
         }
-      }.to raise_error /cannot both be default/
+      }.to raise_error(/cannot both be default/)
     end
   end
 

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -169,7 +169,6 @@ describe Puppet::Module do
     end
 
     it "should list modules that are missing" do
-      metadata_file = "#{@modpath}/needy/metadata.json"
       mod = PuppetSpec::Modules.create(
         'needy',
         @modpath,
@@ -194,7 +193,6 @@ describe Puppet::Module do
     end
 
     it "should list modules that are missing and have invalid names" do
-      metadata_file = "#{@modpath}/needy/metadata.json"
       mod = PuppetSpec::Modules.create(
         'needy',
         @modpath,
@@ -224,8 +222,6 @@ describe Puppet::Module do
       ['test_gte_req', 'test_specific_req', 'foobar'].each do |mod_name|
         mod_dir = "#{@modpath}/#{mod_name}"
         metadata_file = "#{mod_dir}/metadata.json"
-        tasks_dir = "#{mod_dir}/tasks"
-        locale_dir = "#{mod_dir}/locales"
         Puppet::FileSystem.stubs(:exist?).with(metadata_file).returns true
       end
       mod = PuppetSpec::Modules.create(
@@ -305,7 +301,6 @@ describe Puppet::Module do
     it "should consider a dependency without a semantic version to be unmet" do
       env = Puppet::Node::Environment.create(:testing, [@modpath])
 
-      metadata_file = "#{@modpath}/foobar/metadata.json"
       mod = PuppetSpec::Modules.create(
         'foobar',
         @modpath,

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -128,7 +128,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
 
     it "should not URI unescape the indirection key" do
       escaped = Puppet::Util.uri_encode("foo bar")
-      indirection, _, key, _ = handler.uri2indirection("GET", "#{master_url_prefix}/node/#{escaped}", params)
+      _, _, key, _ = handler.uri2indirection("GET", "#{master_url_prefix}/node/#{escaped}", params)
       expect(key).to eq(escaped)
     end
 
@@ -136,7 +136,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       key_escaped = Puppet::Util.uri_encode("foo bar")
       uri_escaped = "#{master_url_prefix}/node/#{key_escaped}"
       handler.expects(:check_authorization).with(anything, uri_escaped, anything)
-      indirection, _, _, _ = handler.uri2indirection("GET", uri_escaped, params)
+      _, _, _, _ = handler.uri2indirection("GET", uri_escaped, params)
     end
 
     it "should not pass through an environment to check_authorization and fail if the environment is unknown" do

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -344,7 +344,7 @@ describe Puppet::Network::HTTP::Connection do
 
       ::Kernel.expects(:sleep).with(30)
 
-      result = subject.get('/foo')
+      subject.get('/foo')
     end
   end
 

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -52,9 +52,10 @@ describe Puppet::Network::HTTP::Handler do
 
     it "raises an error if multiple routes with the same path regex are registered" do
       expect do
-        handler = PuppetSpec::Handler.new(
+        PuppetSpec::Handler.new(
           Puppet::Network::HTTP::Route.path(%r{^/foo}).get(respond("ignored")),
-          Puppet::Network::HTTP::Route.path(%r{^/foo}).post(respond("also ignored")))
+          Puppet::Network::HTTP::Route.path(%r{^/foo}).post(respond("also ignored"))
+        )
       end.to raise_error(ArgumentError)
     end
 

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -353,7 +353,7 @@ describe Puppet::Node::Environment do
           end
 
           it "does not find modules with same name by the wrong author" do
-            mod = PuppetSpec::Modules.create(
+            PuppetSpec::Modules.create(
               'baz',
               first_modulepath,
               :metadata => {:author => 'sneakylabs'},

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -58,7 +58,7 @@ describe Puppet::Node do
     end
 
     it "can round-trip through json" do
-      facts = Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
+      Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar',
                               :classes => ['erth', 'aiu'],
@@ -72,7 +72,7 @@ describe Puppet::Node do
     end
 
     it "validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
-      facts = Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
+      Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar',
                               :classes => ['erth', 'aiu'],
@@ -82,7 +82,7 @@ describe Puppet::Node do
     end
 
     it "when missing optional parameters validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
-      facts = Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
+      Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar'
                              )

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -235,7 +235,6 @@ describe Puppet::Parser::Compiler do
     end
 
     it "should set the parent scope of the new scope to its topscope if the parent passed in is nil" do
-      scope = mock 'scope'
       newscope = @compiler.newscope(nil)
 
       expect(newscope.parent).to equal(@compiler.topscope)
@@ -725,7 +724,7 @@ describe Puppet::Parser::Compiler do
     end
 
     it "should ensure class is in catalog without params" do
-      @node.classes = klasses = {'foo'=>nil}
+      @node.classes = {'foo'=>nil}
       foo = Puppet::Resource::Type.new(:hostclass, 'foo')
       @compiler.environment.known_resource_types.add foo
       catalog = @compiler.compile

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -497,7 +497,7 @@ EOS
     end
 
     it "ignores usage of hiera_include() at topscope for classification" do
-      Puppet.expects(:debug).with(regexp_matches /Ignoring hiera_include/)
+      Puppet.expects(:debug).with(regexp_matches(/Ignoring hiera_include/))
 
       expect {
         catalog = compile_to_env_catalog(<<-EOC).to_resource

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -490,9 +490,9 @@ EOS
   describe "in the environment catalog" do
     it "does not fail if there is no site expression" do
       expect {
-      catalog = compile_to_env_catalog(<<-EOC).to_resource
-        notify { 'ignore me':}
-      EOC
+        compile_to_env_catalog(<<-EOC).to_resource
+          notify { 'ignore me':}
+        EOC
       }.to_not raise_error()
     end
 
@@ -500,9 +500,9 @@ EOS
       Puppet.expects(:debug).with(regexp_matches(/Ignoring hiera_include/))
 
       expect {
-        catalog = compile_to_env_catalog(<<-EOC).to_resource
-        hiera_include('classes')
-        site { }
+        compile_to_env_catalog(<<-EOC).to_resource
+          hiera_include('classes')
+          site { }
         EOC
       }.to_not raise_error()
 
@@ -598,7 +598,7 @@ EOS
 
       it "fails if there are non component resources in the site" do
         expect {
-        catalog = compile_to_env_catalog(MANIFEST_WITH_ILLEGAL_RESOURCE).to_resource
+          compile_to_env_catalog(MANIFEST_WITH_ILLEGAL_RESOURCE).to_resource
         }.to raise_error(/Only application components can appear inside a site - Notify\[fail me\] is not allowed \(line: 20\)/)
       end
     end

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -328,7 +328,7 @@ describe 'function for dynamically creating resources' do
     it 'is not available when --tasks is on' do
       Puppet[:tasks] = true
       expect do
-        catalog = compile_to_catalog(<<-MANIFEST)
+        compile_to_catalog(<<-MANIFEST)
           create_resources('class', {'bar'=>{}}, {'one' => 'two'})
         MANIFEST
       end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)

--- a/spec/unit/parser/functions/fail_spec.rb
+++ b/spec/unit/parser/functions/fail_spec.rb
@@ -23,6 +23,6 @@ describe "the 'fail' parser function" do
   end
 
   it "should join arguments into a string in the error" do
-    expect { scope.function_fail(["hello", "world"]) }.to raise_error /hello world/
+    expect { scope.function_fail(["hello", "world"]) }.to raise_error(/hello world/)
   end
 end

--- a/spec/unit/parser/functions/realize_spec.rb
+++ b/spec/unit/parser/functions/realize_spec.rb
@@ -62,7 +62,7 @@ describe "the realize function" do
   it 'is not available when --tasks is on' do
     Puppet[:tasks] = true
     expect do
-      catalog = compile_to_catalog(<<-MANIFEST)
+      compile_to_catalog(<<-MANIFEST)
         realize([])
       MANIFEST
     end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)

--- a/spec/unit/parser/resource_spec.rb
+++ b/spec/unit/parser/resource_spec.rb
@@ -177,7 +177,6 @@ describe Puppet::Parser::Resource do
     end
 
     it "should add edges from the class resources to the parent's stage if no stage is specified" do
-      main      = @compiler.catalog.resource(:stage, :main)
       foo_stage = Puppet::Parser::Resource.new(:stage, :foo_stage, :scope => @scope, :catalog => @catalog)
       @compiler.add_resource(@scope, foo_stage)
       @compiler.environment.known_resource_types.add Puppet::Resource::Type.new(:hostclass, "foo", {})

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -294,13 +294,13 @@ describe Puppet::Parser::Scope do
       end
 
       it "should return nil for qualified variables that cannot be found in other classes" do
-        other_scope = create_class_scope("other::deep::klass")
+        create_class_scope("other::deep::klass")
 
         expect(@scope["other::deep::klass::var"]).to be_nil
       end
 
       it "should warn and return nil for qualified variables whose classes have not been evaluated" do
-        klass = newclass("other::deep::klass")
+        newclass("other::deep::klass")
         Puppet.expects(:warn_once)
         expect(@scope["other::deep::klass::var"]).to be_nil
       end
@@ -316,7 +316,7 @@ describe Puppet::Parser::Scope do
 
       it "should return nil when asked for a non-string qualified variable from a class that has not been evaluated" do
         @scope.stubs(:warning)
-        klass = newclass("other::deep::klass")
+        newclass("other::deep::klass")
         expect(@scope["other::deep::klass::var"]).to be_nil
       end
     end

--- a/spec/unit/parser/type_loader_spec.rb
+++ b/spec/unit/parser/type_loader_spec.rb
@@ -161,7 +161,7 @@ describe Puppet::Parser::TypeLoader do
     end
 
     it "should skip modules that don't have manifests" do
-      module1 = mk_module(modulebase1, "one")
+      mk_module(modulebase1, "one")
       module2 = mk_module(modulebase2, "two")
       mk_manifests(modulebase2, module2, %w{c d})
 

--- a/spec/unit/pops/adaptable_spec.rb
+++ b/spec/unit/pops/adaptable_spec.rb
@@ -42,7 +42,6 @@ describe Puppet::Pops::Adaptable::Adapter do
 
   it "should return the correct adapter if there are several" do
     d = Duck.new
-    other = OtherAdapter.adapt(d)
     a = ValueAdapter.adapt(d)
     a.value = 10
     b = ValueAdapter.adapt(d)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1146,7 +1146,6 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       source = '"value is ${{a=>1,b=>2}} yo"'
       # This test requires testing against two options because a hash to string
       # produces a result that is unordered
-      hashstr = {'a' => 1, 'b' => 2}.to_s
       alt_results = ["value is {a => 1, b => 2} yo", "value is {b => 2, a => 1} yo" ]
       populate
       parse_result = parser.evaluate_string(scope, source, __FILE__)
@@ -1494,8 +1493,6 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
   end
 
   matcher :have_relationship do |expected|
-    calc = Puppet::Pops::Types::TypeCalculator.new
-
     match do |compiler|
       op_name = {'->' => :relationship, '~>' => :subscription}
       compiler.relationships.any? do | relation |

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -31,22 +31,18 @@ describe 'when converting to 3.x' do
   end
 
   it 'converts the symbol :undef to the undef value' do
-    v = SemanticPuppet::Version.parse('1.0.0')
     expect(converter.convert(:undef, {}, 'undef value')).to eql('undef value')
   end
 
   it 'converts the nil to the undef value' do
-    v = SemanticPuppet::Version.parse('1.0.0')
     expect(converter.convert(nil, {}, 'undef value')).to eql('undef value')
   end
 
   it 'does not convert a symbol nested in an array' do
-    v = SemanticPuppet::Version.parse('1.0.0')
     expect(converter.convert({'foo' => :undef}, {}, 'undef value')).to eql({'foo' => :undef})
   end
 
   it 'converts nil to :undef when nested in an array' do
-    v = SemanticPuppet::Version.parse('1.0.0')
     expect(converter.convert({'foo' => nil}, {}, 'undef value')).to eql({'foo' => :undef})
   end
 

--- a/spec/unit/pops/factory_rspec_helper.rb
+++ b/spec/unit/pops/factory_rspec_helper.rb
@@ -59,7 +59,7 @@ module FactoryRspecHelper
   end
 
   def unindent x
-    (x.gsub /^#{x[/\A\s*/]}/, '').chomp
+    x.gsub(/^#{x[/\A\s*/]}/, '').chomp
   end
   factory ||= Puppet::Pops::Model::Factory
 end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -271,7 +271,7 @@ describe 'loaders' do
           File.stubs(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
           File.stubs(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
           Puppet[:code] = "$case_number = #{case_number}\ninclude ::user"
-          expect { catalog = compiler.compile }.to raise_error(Puppet::Error, /Unknown function/)
+          expect { compiler.compile }.to raise_error(Puppet::Error, /Unknown function/)
         end
       end
     end

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -91,7 +91,7 @@ describe 'the static loader' do
   end
 
   context 'without init_runtime3 initialization' do
-    let(:loader) { loader = Puppet::Pops::Loader::StaticLoader.new() }
+    let(:loader) { Puppet::Pops::Loader::StaticLoader.new() }
 
     it 'does not provide access to resource types built into puppet' do
       expect(loader.load(:type, 'file')).to be_nil

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -7,13 +7,13 @@ module EgrammarLexer2Spec
   def tokens_scanned_from(s)
     lexer = Puppet::Pops::Parser::Lexer2.new
     lexer.string = s
-    tokens = lexer.fullscan[0..-2]
+    lexer.fullscan[0..-2]
   end
 
   def epp_tokens_scanned_from(s)
     lexer = Puppet::Pops::Parser::Lexer2.new
     lexer.string = s
-    tokens = lexer.fullscan_epp[0..-2]
+    lexer.fullscan_epp[0..-2]
   end
 end
 
@@ -893,7 +893,7 @@ describe Puppet::Pops::Parser::Lexer2 do
         manifest = file_containing('manifest.pp', manifest_code)
 
         expect {
-          lexed_file = described_class.new.lex_file(manifest)
+          described_class.new.lex_file(manifest)
         }.to raise_error(Puppet::ParseErrorWithIssue,
           'Illegal UTF-8 Byte Order mark at beginning of input: [EF BB BF] - remove these from the puppet source')
     end

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -761,7 +761,7 @@ describe 'The Object Type' do
 
   context 'when using the initialization hash' do
     it 'produced hash that contains features using short form (type instead of detailed hash when only type is declared)' do
-      obj = t = parse_object('MyObject', <<-OBJECT)
+      obj = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Integer }
         }
@@ -770,7 +770,7 @@ describe 'The Object Type' do
     end
 
     it 'produced hash that does not include default for equality_include_type' do
-      obj = t = parse_object('MyObject', <<-OBJECT)
+      obj = parse_object('MyObject', <<-OBJECT)
         attributes => { a => Integer },
         equality_include_type => true
       OBJECT
@@ -778,7 +778,7 @@ describe 'The Object Type' do
     end
 
     it 'constants are presented in a separate hash if they use a generic type' do
-      obj = t = parse_object('MyObject', <<-OBJECT)
+      obj = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Integer, value => 23, kind => constant },
         },
@@ -787,7 +787,7 @@ describe 'The Object Type' do
     end
 
     it 'constants are not presented in a separate hash unless they use a generic type' do
-      obj = t = parse_object('MyObject', <<-OBJECT)
+      obj = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Integer[0, 30], value => 23, kind => constant },
         },
@@ -796,7 +796,7 @@ describe 'The Object Type' do
     end
 
     it 'can create an equal copy from produced hash' do
-      obj = t = parse_object('MyObject', <<-OBJECT)
+      obj = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Struct[{x => Integer, y => Integer}], value => {x => 4, y => 9}, kind => constant },
           b => Integer

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -418,7 +418,7 @@ module Puppet::Pops
             pcore_version => '1.0.0',
             types => { Car => Object[{}] }
         OBJECT
-        tt = parse_type_set('Transports', <<-OBJECT)
+        parse_type_set('Transports', <<-OBJECT)
             version => '1.0.0',
             pcore_version => '1.0.0',
             references => {

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -291,8 +291,6 @@ describe 'Puppet Ruby Generator' do
         end)
       end
 
-      after(:each) { typeset = nil }
-
       context 'the generated class' do
         it 'inherits the PuppetObject module' do
           expect(first < PuppetObject).to be_truthy
@@ -740,7 +738,6 @@ describe 'Puppet Ruby Generator' do
         # Ideally, this would be in a before(:all) but that is impossible since lots of Puppet
         # environment specific settings are configured by the spec_helper in before(:each)
         if module_def.nil?
-          typeset = nil
           eval_and_collect_notices(source) do
             typeset1 = parser.parse('MyModule')
             typeset2 = parser.parse('OtherModule')

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -83,19 +83,19 @@ describe 'The string converter' do
 
     it "Is an error to specify different delimiters at the same time" do
       expect do
-        fmt = format.new("%[{d")
+        format.new("%[{d")
       end.to raise_error(/Only one of the delimiters/)
     end
 
     it "Is an error to have trailing characters after the format" do
       expect do
-        fmt = format.new("%dv")
+        format.new("%dv")
       end.to raise_error(/The format '%dv' is not a valid format/)
     end
 
     it "Is an error to specify the same flag more than once" do
       expect do
-        fmt = format.new("%[[d")
+        format.new("%[[d")
       end.to raise_error(/The same flag can only be used once/)
     end
   end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -67,7 +67,7 @@ describe 'The type calculator' do
   end
 
   def empty_array_t
-  empty_array = array_t(unit_t, range_t(0,0))
+    array_t(unit_t, range_t(0,0))
   end
 
   def hash_t(k,v,s = nil)

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -294,7 +294,7 @@ describe Puppet::Property do
     end
 
     it "should validate that all required features are present for regexes" do
-      value = subclass.newvalue(/./, :required_features => [:a, :b])
+      subclass.newvalue(/./, :required_features => [:a, :b])
 
       resource.provider.expects(:satisfies?).with([:a, :b]).returns true
 
@@ -302,7 +302,7 @@ describe Puppet::Property do
     end
 
     it "should support specifying an individual required feature" do
-      value = subclass.newvalue(/./, :required_features => :a)
+      subclass.newvalue(/./, :required_features => :a)
 
       resource.provider.expects(:satisfies?).returns true
 

--- a/spec/unit/provider/aixobject_spec.rb
+++ b/spec/unit/provider/aixobject_spec.rb
@@ -10,7 +10,7 @@ describe Puppet::Provider::AixObject do
   end
 
   let(:provider) do
-    provider = Puppet::Provider::AixObject.new resource
+    Puppet::Provider::AixObject.new resource
   end
 
   describe "base provider methods" do

--- a/spec/unit/provider/exec/posix_spec.rb
+++ b/spec/unit/provider/exec/posix_spec.rb
@@ -140,14 +140,14 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
         Puppet::Util::POSIX::LOCALE_ENV_VARS.each { |var| orig_env[var] = ENV[var] if ENV[var] }
 
         orig_env.keys.each do |var|
-          output, status = provider.run(command % var)
+          output, _ = provider.run(command % var)
           expect(output.strip).to eq(orig_env[var])
         end
 
         # now, once more... but with our sentinel values
         Puppet::Util.withenv(locale_sentinel_env) do
           Puppet::Util::POSIX::LOCALE_ENV_VARS.each do |var|
-            output, status = provider.run(command % var)
+            output, _ = provider.run(command % var)
             expect(output.strip).to eq(locale_sentinel_env[var])
           end
         end
@@ -155,9 +155,9 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
 
       it "should respect locale overrides in user's 'environment' configuration" do
         provider.resource[:environment] = ['LANG=C', 'LC_ALL=C']
-        output, status = provider.run(command % 'LANG')
+        output, _ = provider.run(command % 'LANG')
         expect(output.strip).to eq('C')
-        output, status = provider.run(command % 'LC_ALL')
+        output, _ = provider.run(command % 'LC_ALL')
         expect(output.strip).to eq('C')
       end
     end
@@ -180,7 +180,7 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
             expect(ENV[var]).to eq(user_sentinel_env[var])
 
             # run an "exec" via the provider and ensure that it unsets the vars
-            output, status = provider.run(command % var)
+            output, _ = provider.run(command % var)
             expect(output.strip).to eq("")
 
             # ensure that after the exec, our temporary env is still intact
@@ -199,7 +199,7 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
         # loop over the posix user-related environment variables
         Puppet::Util::POSIX::USER_ENV_VARS.each do |var|
           # run an 'exec' to get the value of each variable
-          output, status = provider.run(command % var)
+          output, _ = provider.run(command % var)
           # ensure that it matches our expected sentinel value
           expect(output.strip).to eq(sentinel_value)
         end

--- a/spec/unit/provider/ldap_spec.rb
+++ b/spec/unit/provider/ldap_spec.rb
@@ -72,7 +72,6 @@ describe Puppet::Provider::Ldap do
 
     describe "resources that do not exist" do
       it "should create a provider with :ensure => :absent" do
-        result = mock 'result'
         @manager.expects(:find).with("one").returns nil
 
         @class.expects(:new).with(:ensure => :absent).returns "myprovider"

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:package).provider(:rpm)
 
 describe provider_class do
-
   let (:packages) do
     <<-RPM_OUTPUT
     'cracklib-dicts 0 2.8.9 3.3 x86_64
@@ -58,7 +57,7 @@ describe provider_class do
       it "includes all the modern flags" do
         Puppet::Util::Execution.expects(:execpipe).with("/bin/rpm -qa --nosignature --nodigest --qf '#{nevra_format}'").yields(packages)
 
-        installed_packages = provider_class.instances
+        provider_class.instances
       end
     end
 
@@ -67,7 +66,7 @@ describe provider_class do
       it "excludes the --nosignature flag" do
         Puppet::Util::Execution.expects(:execpipe).with("/bin/rpm -qa  --nodigest --qf '#{nevra_format}'").yields(packages)
 
-        installed_packages = provider_class.instances
+        provider_class.instances
       end
     end
 
@@ -76,7 +75,7 @@ describe provider_class do
       it "excludes the --nodigest flag" do
         Puppet::Util::Execution.expects(:execpipe).with("/bin/rpm -qa   --qf '#{nevra_format}'").yields(packages)
 
-        installed_packages = provider_class.instances
+        provider_class.instances
       end
     end
 

--- a/spec/unit/provider/parsedfile_spec.rb
+++ b/spec/unit/provider/parsedfile_spec.rb
@@ -212,7 +212,7 @@ describe "A very basic provider based on ParsedFile" do
     end
 
     it "should move the native header to the top" do
-      expect(provider.to_file(input_records)).not_to match /\A#{provider.header}/
+      expect(provider.to_file(input_records)).not_to match(/\A#{provider.header}/)
     end
 
     context "and dropping native headers found in input" do

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -3,8 +3,6 @@ require 'spec_helper'
 require 'rbconfig'
 require 'fileutils'
 
-provider_class = Puppet::Type.type(:service).provider(:init)
-
 describe "base service provider" do
   include PuppetSpec::Files
 

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -234,11 +234,11 @@ describe Puppet::Type.type(:service).provider(:upstart) do
 
   describe "inheritance" do
     let :resource do
-      resource = Puppet::Type.type(:service).new(:name => "foo", :provider => :upstart)
+      Puppet::Type.type(:service).new(:name => "foo", :provider => :upstart)
     end
 
     let :provider do
-      provider = provider_class.new(resource)
+      provider_class.new(resource)
     end
 
     describe "when upstart job" do

--- a/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
+++ b/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
@@ -188,13 +188,11 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
       end
 
       it "should absolutely not chown the directory to the user" do
-        uid = Puppet::Util.uid("random_bob")
         File.expects(:chown).never
         @provider.flush
       end
 
       it "should absolutely not chown the key file to the user" do
-        uid = Puppet::Util.uid("random_bob")
         File.expects(:chown).never
         @provider.flush
       end
@@ -233,7 +231,6 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
       it "should absolutely not chown the directory to the user if it creates it" do
         Puppet::FileSystem.stubs(:exist?).with(@dir).returns false
         Dir.stubs(:mkdir).with(@dir,0700)
-        uid = Puppet::Util.uid("nobody")
         File.expects(:chown).never
         @provider.flush
       end
@@ -246,7 +243,6 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
       end
 
       it "should absolutely not chown the key file to the user" do
-        uid = Puppet::Util.uid("nobody")
         File.expects(:chown).never
         @provider.flush
       end

--- a/spec/unit/provider/sshkey/parsed_spec.rb
+++ b/spec/unit/provider/sshkey/parsed_spec.rb
@@ -1,8 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:sshkey).provider(:parsed)
-
 describe "sshkey parsed provider" do
   let :type do Puppet::Type.type(:sshkey) end
   let :provider do type.provider(:parsed) end

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -839,7 +839,7 @@ describe 'Puppet Pal' do
 
       it 'a given "modulepath" overrides the default' do
         expect do
-          result = Puppet::Pal.in_environment('pal_env', env_dir: testing_env_dir, modulepath: [], facts: node_facts) do |ctx|
+          Puppet::Pal.in_environment('pal_env', env_dir: testing_env_dir, modulepath: [], facts: node_facts) do |ctx|
             ctx.with_script_compiler {|c| c.evaluate_string('a::afunc()') }
           end
         end.to raise_error(/Unknown function: 'a::afunc'/)
@@ -917,7 +917,7 @@ describe 'Puppet Pal' do
       it 'a given "modulepath" overrides the default' do
         testing_env_dir # creates the structure
         expect do
-          result = Puppet::Pal.in_environment('pal_env', envpath: environments_dir, modulepath: [], facts: node_facts) do |ctx|
+          Puppet::Pal.in_environment('pal_env', envpath: environments_dir, modulepath: [], facts: node_facts) do |ctx|
             ctx.with_script_compiler { |c| c.evaluate_string('a::afunc()') }
           end
         end.to raise_error(/Unknown function: 'a::afunc'/)
@@ -940,7 +940,6 @@ describe 'Puppet Pal' do
 
       it 'the envpath can have multiple entries - that are searched for the given env' do
         testing_env_dir # creates the structure
-        several_dirs = "/tmp/nowhere/to/be/found:#{environments_dir}"
         result = Puppet::Pal.in_environment('pal_env', envpath: environments_dir, facts: node_facts) do |ctx|
           ctx.with_script_compiler {|c| c.evaluate_string('a::afunc()') }
         end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -438,7 +438,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
     it "should optionally support an initialization block and should finalize after such blocks" do
       @one.expects :finish
       @two.expects :finish
-      config = Puppet::Resource::Catalog.new("host") do |conf|
+      Puppet::Resource::Catalog.new("host") do |conf|
         conf.add_resource @one
         conf.add_resource @two
       end

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -524,7 +524,6 @@ describe Puppet::Resource::Type do
       subscope = stub 'subscope', :compiler => @compiler
       @scope.expects(:newscope).with(:source => @type, :resource => @resource).returns subscope
 
-      elevel = 876
       subscope.expects(:with_guarded_scope).yields
       subscope.expects(:ephemeral_from).with(match, nil, nil).returns subscope
       code.expects(:safeevaluate).with(subscope)
@@ -778,7 +777,7 @@ describe Puppet::Resource::Type do
 
   describe "when merging code from another instance" do
     def code(str)
-      factory = Puppet::Pops::Model::Factory.literal(str)
+      Puppet::Pops::Model::Factory.literal(str)
     end
 
     it "should fail unless it is a class" do
@@ -811,7 +810,7 @@ describe Puppet::Resource::Type do
     it "should copy the other class's parent if it has not parent" do
       dest = Puppet::Resource::Type.new(:hostclass, "bar")
 
-      parent = Puppet::Resource::Type.new(:hostclass, "parent")
+      Puppet::Resource::Type.new(:hostclass, "parent")
       source = Puppet::Resource::Type.new(:hostclass, "foo", :parent => "parent")
       dest.merge(source)
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -104,7 +104,6 @@ describe Puppet::Settings do
     end
 
     it "should fail if the app defaults hash is missing any required values" do
-      incomplete_default_values = default_values.reject { |key, _| key == :confdir }
       expect {
         @settings.initialize_app_defaults(default_values.reject { |key, _| key == :confdir })
       }.to raise_error(Puppet::Settings::SettingsError)
@@ -658,7 +657,6 @@ describe Puppet::Settings do
 
     it "should not return values outside of its search path" do
       text = "[other]\none = oval\n"
-      file = "/some/file"
       @settings.stubs(:read_file).returns(text)
       @settings.send(:parse_config_files)
       expect(@settings[:one]).to eq("ONE")
@@ -938,7 +936,6 @@ describe Puppet::Settings do
     end
 
     it "does not require the value for a setting without a hook to resolve during global setup" do
-      hook_invoked = false
       @settings.define_settings :section, :can_cause_problems  => {:desc => '' }
 
       @settings.define_settings(:main,

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -46,7 +46,6 @@ describe Puppet::SSL::CertificateAuthority do
         Puppet[:ca] = false
         Puppet.run_mode.stubs(:master?).returns true
 
-        ca = mock('ca')
         Puppet::SSL::CertificateAuthority.expects(:new).never
         expect(Puppet::SSL::CertificateAuthority.instance).to be_nil
       end
@@ -57,7 +56,6 @@ describe Puppet::SSL::CertificateAuthority do
         Puppet[:ca] = true
         Puppet.run_mode.stubs(:master?).returns false
 
-        ca = mock('ca')
         Puppet::SSL::CertificateAuthority.expects(:new).never
         expect(Puppet::SSL::CertificateAuthority.instance).to be_nil
       end
@@ -392,7 +390,7 @@ describe Puppet::SSL::CertificateAuthority do
         Puppet::SSL::CertificateFactory.expects(:build).with do |*args|
           args[2] == @cacert.content
         end.returns @cert.content
-        signed = @ca.sign(@name)
+        @ca.sign(@name)
       end
 
       it "should pass the next serial as the serial number" do
@@ -986,8 +984,6 @@ describe Puppet::SSL::CertificateAuthority do
       end
 
       it "should get the serial number from inventory if no local certificate exists" do
-        real_cert = stub 'real_cert', :serial => 15
-        cert = stub 'cert', :content => real_cert
         Puppet::SSL::Certificate.indirection.expects(:find).with("host").returns nil
 
         @ca.inventory.expects(:serials).with("host").returns [16]
@@ -997,8 +993,6 @@ describe Puppet::SSL::CertificateAuthority do
       end
 
       it "should revoke all serials matching a name" do
-        real_cert = stub 'real_cert', :serial => 15
-        cert = stub 'cert', :content => real_cert
         Puppet::SSL::Certificate.indirection.expects(:find).with("host").returns nil
 
         @ca.inventory.expects(:serials).with("host").returns [16, 20, 25]
@@ -1010,8 +1004,6 @@ describe Puppet::SSL::CertificateAuthority do
       end
 
       it "should raise an error if no certificate match" do
-        real_cert = stub 'real_cert', :serial => 15
-        cert = stub 'cert', :content => real_cert
         Puppet::SSL::Certificate.indirection.expects(:find).with("host").returns nil
 
         @ca.inventory.expects(:serials).with("host").returns []

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -374,14 +374,13 @@ describe Puppet::SSL::CertificateRequest do
     end
 
     it "should raise an error if neither SHA256/SHA1/SHA512/SHA384/SHA224 are available" do
-      csr = OpenSSL::X509::Request.new
       OpenSSL::Digest.expects(:const_defined?).with("SHA256").returns(false)
       OpenSSL::Digest.expects(:const_defined?).with("SHA1").returns(false)
       OpenSSL::Digest.expects(:const_defined?).with("SHA512").returns(false)
       OpenSSL::Digest.expects(:const_defined?).with("SHA384").returns(false)
       OpenSSL::Digest.expects(:const_defined?).with("SHA224").returns(false)
       expect {
-        signer = Puppet::SSL::CertificateSigner.new
+        Puppet::SSL::CertificateSigner.new
       }.to raise_error(Puppet::Error)
     end
   end

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::Transaction do
 
       report.expects(:add_times).with(:config_retrieval, 5)
 
-      transaction = Puppet::Transaction.new(catalog, report, nil)
+      Puppet::Transaction.new(catalog, report, nil)
     end
   end
 

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -22,7 +22,6 @@ describe Puppet::Type.type(:exec) do
 
     exec = Puppet::Type.type(:exec).new(args)
 
-    status = stub "process", :exitstatus => exitstatus
     Puppet::Util::Execution.expects(:execute).times(tries).
       with() { |*args|
         args[0] == command &&

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -75,7 +75,6 @@ require 'spec_helper'
     end
 
     it "should be able to set a new context" do
-      stat = stub 'stat', :ftype => "foo"
       @sel.should = %w{newone}
       @sel.expects(:set_selinux_context).with(@path, ["newone"], param)
       @sel.sync

--- a/spec/unit/type/nagios_spec.rb
+++ b/spec/unit/type/nagios_spec.rb
@@ -100,7 +100,7 @@ EOL
   it "should parse without error" do
     parser =  Nagios::Parser.new
     expect {
-      results = parser.parse(NONESCAPED_SEMICOLON_COMMENT)
+      parser.parse(NONESCAPED_SEMICOLON_COMMENT)
     }.to_not raise_error
   end
 
@@ -117,14 +117,14 @@ EOL
   it "should raise an error when an incorrect object definition is present" do
     parser =  Nagios::Parser.new
     expect {
-      results = parser.parse(UNKNOWN_NAGIOS_OBJECT_DEFINITION)
+      parser.parse(UNKNOWN_NAGIOS_OBJECT_DEFINITION)
     }.to raise_error Nagios::Base::UnknownNagiosType
   end
 
   it "should raise an error when syntax is not correct" do
     parser =  Nagios::Parser.new
     expect {
-      results = parser.parse(MISSING_CLOSING_CURLY_BRACKET)
+      parser.parse(MISSING_CLOSING_CURLY_BRACKET)
     }.to raise_error Nagios::Parser::SyntaxError
   end
 
@@ -132,7 +132,7 @@ EOL
     it "should not throw an exception" do
       parser =  Nagios::Parser.new
       expect {
-        results = parser.parse(ESCAPED_SEMICOLON)
+        parser.parse(ESCAPED_SEMICOLON)
       }.to_not raise_error
     end
 
@@ -154,7 +154,7 @@ EOL
     it "should not throw an exception" do
       parser =  Nagios::Parser.new
       expect {
-        results = parser.parse(POUND_SIGN_HASH_SYMBOL_NOT_IN_FIRST_COLUMN)
+        parser.parse(POUND_SIGN_HASH_SYMBOL_NOT_IN_FIRST_COLUMN)
       }.to_not raise_error
     end
 
@@ -177,7 +177,7 @@ EOL
     it "should not throw an exception" do
       parser =  Nagios::Parser.new
       expect {
-        results = parser.parse(ANOTHER_ESCAPED_SEMICOLON)
+        parser.parse(ANOTHER_ESCAPED_SEMICOLON)
       }.to_not raise_error
     end
 

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -413,7 +413,7 @@ describe Puppet::Type.type(:user) do
       testuser = described_class.new(:name => "testuser", :roles => ['testrole'] )
       testrole = described_class.new(:name => "testrole")
 
-      config = Puppet::Resource::Catalog.new :testing do |conf|
+      Puppet::Resource::Catalog.new :testing do |conf|
         [testuser, testrole].each { |resource| conf.add_resource resource }
       end
       Puppet::Type::User::ProviderDirectoryservice.stubs(:get_macosx_version_major).returns "10.5"

--- a/spec/unit/type/zfs_spec.rb
+++ b/spec/unit/type/zfs_spec.rb
@@ -35,7 +35,7 @@ describe zfs do
     foo_bar_baz_zfs = Puppet::Type.type(:zfs).new(:name => "foo/bar/baz")
     foo_bar_baz_buz_zfs = Puppet::Type.type(:zfs).new(:name => "foo/bar/baz/buz")
 
-    config = Puppet::Resource::Catalog.new :testing do |conf|
+    Puppet::Resource::Catalog.new :testing do |conf|
       [foo_pool, foo_bar_zfs, foo_bar_baz_zfs, foo_bar_baz_buz_zfs].each { |resource| conf.add_resource resource }
     end
 

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -353,7 +353,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it "should be registered as a provider of the child type" do
-        child_provider = @type.provide(:child_provider, :parent => @parent_provider)
+        @type.provide(:child_provider, :parent => @parent_provider)
         expect(@type.providers).to include(:child_provider)
         expect(@parent_type.providers).not_to include(:child_provider)
       end
@@ -379,14 +379,14 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
 
   context "autorelations" do
     before :each do
-      type = Puppet::Type.newtype(:autorelation_one) do
+      Puppet::Type.newtype(:autorelation_one) do
         newparam(:name) { isnamevar }
       end
     end
 
     describe "when building autorelations" do
       it "should be able to autorequire resources" do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autorequire(:autorelation_one) { ['foo'] }
         end
@@ -404,7 +404,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it 'should not fail autorequire contains undef entries' do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autorequire(:autorelation_one) { [nil, 'foo'] }
         end
@@ -422,7 +422,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it "should be able to autosubscribe resources" do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autosubscribe(:autorelation_one) { ['foo'] }
         end
@@ -440,7 +440,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it 'should not fail if autosubscribe contains undef entries' do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autosubscribe(:autorelation_one) { [nil, 'foo'] }
         end
@@ -458,7 +458,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it "should be able to autobefore resources" do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autobefore(:autorelation_one) { ['foo'] }
         end
@@ -476,7 +476,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it "should not fail when autobefore contains undef entries" do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autobefore(:autorelation_one) { [nil, 'foo'] }
         end
@@ -494,7 +494,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it "should be able to autonotify resources" do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autonotify(:autorelation_one) { ['foo'] }
         end
@@ -512,7 +512,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
       end
 
       it 'should not fail if autonotify contains undef entries' do
-        type = Puppet::Type.newtype(:autorelation_two) do
+        Puppet::Type.newtype(:autorelation_two) do
           newparam(:name) { isnamevar }
           autonotify(:autorelation_one) { [nil, 'foo'] }
         end
@@ -1312,7 +1312,6 @@ describe Puppet::Type.metaparamclass(:audit) do
 
     it "should handle proprieties correctly" do
       # Order of assignment is significant in this test.
-      props = {}
       [:one, :two, :three].each {|prop| type.newproperty(prop) {} }
       instance = type.new(:name => "test")
 
@@ -1335,9 +1334,9 @@ describe Puppet::Type.metaparamclass(:audit) do
       type.feature :feature1, "one"
       type.feature :feature2, "two"
 
-      none = type.newproperty(:none) {}
-      one  = type.newproperty(:one, :required_features => :feature1) {}
-      two  = type.newproperty(:two, :required_features => [:feature1, :feature2]) {}
+      type.newproperty(:none) {}
+      type.newproperty(:one, :required_features => :feature1) {}
+      type.newproperty(:two, :required_features => [:feature1, :feature2]) {}
 
       nope  = type.provide(:nope)  {}
       maybe = type.provide(:maybe) { has_features :feature1 }

--- a/spec/unit/util/docs_spec.rb
+++ b/spec/unit/util/docs_spec.rb
@@ -69,7 +69,7 @@ EOT
     it "has no side effects on original input string" do
       input       = "First line \n        second line \n        \n            indented line \n        \n        last line\n\n"
       clean_input = "First line \n        second line \n        \n            indented line \n        \n        last line\n\n"
-      not_used = Puppet::Util::Docs.scrub(input)
+      Puppet::Util::Docs.scrub(input)
       expect(input).to eq clean_input
     end
 

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -711,7 +711,6 @@ describe Puppet::Util::Execution do
         it "should not raise an error if the file is open" do
           stdout = Puppet::FileSystem::Uniquefile.new('test')
           Puppet::FileSystem::Uniquefile.stubs(:new).returns(stdout)
-          file = File.new(stdout.path, 'r')
 
           Puppet::Util::Execution.execute('test command')
         end

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -532,7 +532,7 @@ describe Puppet::Util::Log do
       it "should not try to copy over file, version, line, or tag information" do
         source = mock
         source.expects(:file).never
-        log = Puppet::Util::Log.new(:level => "notice", :message => :foo, :source => source)
+        Puppet::Util::Log.new(:level => "notice", :message => :foo, :source => source)
       end
     end
   end

--- a/spec/unit/util/network_device/cisco/device_spec.rb
+++ b/spec/unit/util/network_device/cisco/device_spec.rb
@@ -51,12 +51,12 @@ if Puppet.features.telnet?
 
       it "should find the debug mode from the options" do
         Puppet::Util::NetworkDevice::Transport::Telnet.expects(:new).with(true).returns(@transport)
-        cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23", :debug => true)
+        Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23", :debug => true)
       end
 
       it "should set the debug mode to nil by default" do
         Puppet::Util::NetworkDevice::Transport::Telnet.expects(:new).with(nil).returns(@transport)
-        cisco = Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23")
+        Puppet::Util::NetworkDevice::Cisco::Device.new("telnet://user:password@localhost:23")
       end
     end
 

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -109,7 +109,7 @@ describe Puppet::Util::SELinux do
 
     it "should return nil if lgetfilecon fails" do
       self.expects(:selinux_support?).returns true
-      Selinux.expects(:lgetfilecon).with("/foo").returns -1
+      Selinux.expects(:lgetfilecon).with("/foo").returns(-1)
       expect(get_selinux_current_context("/foo")).to be_nil
     end
   end
@@ -153,7 +153,7 @@ describe Puppet::Util::SELinux do
       fstat = stub 'File::Stat', :mode => 0
       Puppet::FileSystem.expects(:lstat).with('/foo').returns(fstat)
       self.expects(:find_fs).with("/foo").returns "ext3"
-      Selinux.expects(:matchpathcon).with("/foo", 0).returns -1
+      Selinux.expects(:matchpathcon).with("/foo", 0).returns(-1)
 
       expect(get_selinux_default_context("/foo")).to be_nil
     end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -680,7 +680,7 @@ describe Puppet::Util do
       Kernel.expects(:fork).returns(pid).yields
 
       Puppet::Util.safe_posix_fork do
-        message = "Fork this!"
+        "Fork this!"
       end
     end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -837,7 +837,7 @@ describe Puppet::Util do
     end
 
     it "should fail if no block is given" do
-      expect { subject.replace_file(target.path, 0600) }.to raise_error /block/
+      expect { subject.replace_file(target.path, 0600) }.to raise_error(/block/)
     end
 
     it "should replace a file when invoked" do

--- a/spec/watchr.rb
+++ b/spec/watchr.rb
@@ -65,7 +65,6 @@ end
 def run_test(command)
   clear
   result = run_comp(command).split("\n").last
-  status = result.include?('0 failures, 0 errors') ? :pass : :fail
   growl result.split("\n").last rescue nil
 end
 


### PR DESCRIPTION
Part 4 of an unbounded series. In this episode, we remove the instances of the following warnings:
* "ambiguous first argument; put parentheses or a space"
* "assigned but unused variable"