### PR TITLE
(PUP-7326) Handle Windows unresolvable SIDs

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -37,7 +37,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
   def members_to_s(users)
     return '' if users.nil? or !users.kind_of?(Array)
     users = users.map do |user_name|
-      sid = Puppet::Util::Windows::SID.name_to_sid_object(user_name)
+      sid = Puppet::Util::Windows::SID.name_to_principal(user_name)
       if !sid
         resource.debug("#{user_name} (unresolvable to SID)")
         next user_name
@@ -55,7 +55,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
   end
 
   def member_valid?(user_name)
-    ! Puppet::Util::Windows::SID.name_to_sid_object(user_name).nil?
+    ! Puppet::Util::Windows::SID.name_to_principal(user_name).nil?
   end
 
   def group

--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -23,12 +23,9 @@ Puppet::Type.type(:group).provide :windows_adsi do
     # Cannot use munge of the group property to canonicalize @should
     # since the default array_matching comparison is not commutative
 
+    current_sids = current.map(&:sid)
     # dupes automatically weeded out when hashes built
-    current_users = Hash[ current.map { |u| [ u.sid, u ] } ]
-    specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
-
-    current_sids = current_users.keys.to_a
-    specified_sids = specified_users.keys.to_a
+    specified_sids = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should).keys.to_a
 
     if @resource[:auth_membership]
       current_sids.sort == specified_sids.sort

--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
     # since the default array_matching comparison is not commutative
 
     # dupes automatically weeded out when hashes built
-    current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
+    current_users = Hash[ current.map { |u| [ u.sid, u ] } ]
     specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
 
     current_sids = current_users.keys.to_a

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
   def groups_to_s(groups)
     return '' if groups.nil? || !groups.kind_of?(Array)
     groups = groups.map do |group_name|
-      sid = Puppet::Util::Windows::SID.name_to_sid_object(group_name)
+      sid = Puppet::Util::Windows::SID.name_to_principal(group_name)
       if sid.account =~ /\\/
         account, _ = Puppet::Util::Windows::ADSI::Group.parse_name(sid.account)
       else

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -139,10 +139,12 @@ module Puppet::Util::Windows::ADSI
       return account, domain
     end
 
+    # returns Puppet::Util::Windows::SID::Principal[]
+    # may contain objects that represent unresolvable SIDs
     def get_sids(adsi_child_collection)
       sids = []
       adsi_child_collection.each do |m|
-        sids << Puppet::Util::Windows::SID.octet_string_to_sid_object(m.objectSID)
+        sids << Puppet::Util::Windows::SID.ads_to_sid_object(m)
       end
 
       sids
@@ -463,13 +465,13 @@ module Puppet::Util::Windows::ADSI
       end
     end
 
+    # returns Puppet::Util::Windows::SID::Principal[]
+    # may contain objects that represent unresolvable SIDs
+    # qualified account names are returned by calling #domain_account
     def members
-      member_sids.map(&:domain_account)
-    end
-
-    def member_sids
       self.class.get_sids(native_group.Members)
     end
+    alias member_sids members
 
     def set_members(desired_members, inclusive = true)
       return if desired_members.nil?

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -66,7 +66,7 @@ module Puppet::Util::Windows::ADSI
       return sid_uri(sid) if sid.kind_of?(Puppet::Util::Windows::SID::Principal)
 
       begin
-        sid = Puppet::Util::Windows::SID.name_to_sid_object(sid)
+        sid = Puppet::Util::Windows::SID.name_to_principal(sid)
         sid_uri(sid)
       rescue Puppet::Util::Windows::Error, Puppet::Error
         nil
@@ -114,7 +114,7 @@ module Puppet::Util::Windows::ADSI
         Puppet::Util::Windows::SID.sid_to_name('S-1-5-32').upcase,
         # localized version of NT AUTHORITY (can't use S-1-5)
         # for instance AUTORITE NT on French Windows
-        Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM').domain.upcase
+        Puppet::Util::Windows::SID.name_to_principal('SYSTEM').domain.upcase
       ]
     end
 
@@ -144,7 +144,7 @@ module Puppet::Util::Windows::ADSI
     def get_sids(adsi_child_collection)
       sids = []
       adsi_child_collection.each do |m|
-        sids << Puppet::Util::Windows::SID.ads_to_sid_object(m)
+        sids << Puppet::Util::Windows::SID.ads_to_principal(m)
       end
 
       sids
@@ -154,7 +154,7 @@ module Puppet::Util::Windows::ADSI
       return {} if names.nil? || names.empty?
 
       sids = names.map do |name|
-        sid = Puppet::Util::Windows::SID.name_to_sid_object(name)
+        sid = Puppet::Util::Windows::SID.name_to_principal(name)
         raise Puppet::Error.new( "Could not resolve name: #{name}" ) if !sid
         [sid.sid, sid]
       end
@@ -185,7 +185,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def sid
-      @sid ||= Puppet::Util::Windows::SID.octet_string_to_sid_object(native_user.objectSID)
+      @sid ||= Puppet::Util::Windows::SID.octet_string_to_principal(native_user.objectSID)
     end
 
     def uri
@@ -338,12 +338,12 @@ module Puppet::Util::Windows::ADSI
     end
 
     def self.current_user_sid
-      Puppet::Util::Windows::SID.name_to_sid_object(current_user_name)
+      Puppet::Util::Windows::SID.name_to_principal(current_user_name)
     end
 
     def self.exists?(name_or_sid)
       well_known = false
-      if (sid = Puppet::Util::Windows::SID.name_to_sid_object(name_or_sid))
+      if (sid = Puppet::Util::Windows::SID.name_to_principal(name_or_sid))
         return true if sid.account_type == :SidTypeUser
 
         # 'well known group' is special as it can be a group like Everyone OR a user like SYSTEM
@@ -433,7 +433,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def sid
-      @sid ||= Puppet::Util::Windows::SID.octet_string_to_sid_object(native_group.objectSID)
+      @sid ||= Puppet::Util::Windows::SID.octet_string_to_principal(native_group.objectSID)
     end
 
     def commit
@@ -505,7 +505,7 @@ module Puppet::Util::Windows::ADSI
 
     def self.exists?(name_or_sid)
       well_known = false
-      if (sid = Puppet::Util::Windows::SID.name_to_sid_object(name_or_sid))
+      if (sid = Puppet::Util::Windows::SID.name_to_principal(name_or_sid))
         return true if sid.account_type == :SidTypeGroup
 
         # 'well known group' is special as it can be a group like Everyone OR a user like SYSTEM

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -32,9 +32,10 @@ module Puppet::Util::Windows::SID
         @sid_bytes == compare.sid_bytes
     end
 
-    # added for backward compatibility
+    # returns authority qualified account name
+    # prefer to compare Principal instances with == operator or by #sid
     def to_s
-      @sid
+      @domain_account
     end
 
     # = 8 + max sub identifiers (15) * 4

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -52,18 +52,18 @@ module Puppet::Util::Windows
     # 'BUILTIN\Administrators', or 'S-1-5-32-544', and will return the
     # SID. Returns nil if the account doesn't exist.
     def name_to_sid(name)
-      sid = name_to_sid_object(name)
+      sid = name_to_principal(name)
 
       sid ? sid.sid : nil
     end
     module_function :name_to_sid
 
-    # Convert an account name, e.g. 'Administrators' into a SID object,
+    # Convert an account name, e.g. 'Administrators' into a Principal::SID object,
     # e.g. 'S-1-5-32-544'. The name can be specified as 'Administrators',
     # 'BUILTIN\Administrators', or 'S-1-5-32-544', and will return the
     # SID object. Returns nil if the account doesn't exist.
     # This method returns a SID::Principal with the account, domain, SID, etc
-    def name_to_sid_object(name)
+    def name_to_principal(name)
       # Apparently, we accept a symbol..
       name = name.to_s.strip if name
 
@@ -81,34 +81,36 @@ module Puppet::Util::Windows
     rescue
       nil
     end
-    module_function :name_to_sid_object
+    module_function :name_to_principal
+    class << self; alias name_to_sid_object name_to_principal; end
 
-    # Converts an octet string array of bytes to a SID object,
+    # Converts an octet string array of bytes to a SID::Principal object,
     # e.g. [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] is the representation for
     # S-1-5-18, the local 'SYSTEM' account.
     # Raises an Error for nil or non-array input.
     # This method returns a SID::Principal with the account, domain, SID, etc
-    def octet_string_to_sid_object(bytes)
+    def octet_string_to_principal(bytes)
       if !bytes || !bytes.respond_to?('pack') || bytes.empty?
         raise Puppet::Util::Windows::Error.new("Octet string must be an array of bytes")
       end
 
       Principal.lookup_account_sid(bytes)
     end
-    module_function :octet_string_to_sid_object
+    module_function :octet_string_to_principal
+    class << self; alias octet_string_to_sid_object octet_string_to_principal; end
 
-    # Converts a COM instance of IAdsUser or IAdsGroup to a SID object,
+    # Converts a COM instance of IAdsUser or IAdsGroup to a SID::Principal object,
     # Raises an Error for nil or an object without an objectSID / Name property.
     # This method returns a SID::Principal with the account, domain, SID, etc
     # This method will return instances even when the SID is unresolvable, as
     # may be the case when domain users have been added to local groups, but
     # removed from the domain
-    def ads_to_sid_object(ads_object)
+    def ads_to_principal(ads_object)
       if !ads_object || !ads_object.respond_to?(:ole_respond_to?) ||
         !ads_object.ole_respond_to?(:objectSID) || !ads_object.ole_respond_to?(:Name)
         raise Puppet::Error.new("ads_object must be an IAdsUser or IAdsGroup instance")
       end
-      octet_string_to_sid_object(ads_object.objectSID)
+      octet_string_to_principal(ads_object.objectSID)
     rescue Puppet::Util::Windows::Error => e
       # SID could not be mapped but is a valid SID representation that matches Name
       unresolvable = e.code == ERROR_NONE_MAPPED &&
@@ -126,7 +128,7 @@ module Puppet::Util::Windows
         # Indicates that the type of object could not be determined. For example, no object with that SID exists.
         :SidTypeUnknown)
     end
-    module_function :ads_to_sid_object
+    module_function :ads_to_principal
 
     # Convert a SID string, e.g. "S-1-5-32-544" to a name,
     # e.g. 'BUILTIN\Administrators'. Returns nil if an account

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -97,6 +97,37 @@ module Puppet::Util::Windows
     end
     module_function :octet_string_to_sid_object
 
+    # Converts a COM instance of IAdsUser or IAdsGroup to a SID object,
+    # Raises an Error for nil or an object without an objectSID / Name property.
+    # This method returns a SID::Principal with the account, domain, SID, etc
+    # This method will return instances even when the SID is unresolvable, as
+    # may be the case when domain users have been added to local groups, but
+    # removed from the domain
+    def ads_to_sid_object(ads_object)
+      if !ads_object || !ads_object.respond_to?(:ole_respond_to?) ||
+        !ads_object.ole_respond_to?(:objectSID) || !ads_object.ole_respond_to?(:Name)
+        raise Puppet::Error.new("ads_object must be an IAdsUser or IAdsGroup instance")
+      end
+      octet_string_to_sid_object(ads_object.objectSID)
+    rescue Puppet::Util::Windows::Error => e
+      # SID could not be mapped but is a valid SID representation that matches Name
+      unresolvable = e.code == ERROR_NONE_MAPPED &&
+        valid_sid?(ads_object.Name) &&
+        octet_string_to_sid_string(ads_object.objectSID) == ads_object.Name
+
+      raise if !unresolvable
+
+      Principal.new(
+        ads_object.Name + " (unresolvable)", # account
+        ads_object.objectSID, # sid_bytes
+        ads_object.Name, # sid string
+        nil, #domain
+        # https://msdn.microsoft.com/en-us/library/cc245534.aspx?f=255&MSPPError=-2147217396
+        # Indicates that the type of object could not be determined. For example, no object with that SID exists.
+        :SidTypeUnknown)
+    end
+    module_function :ads_to_sid_object
+
     # Convert a SID string, e.g. "S-1-5-32-544" to a name,
     # e.g. 'BUILTIN\Administrators'. Returns nil if an account
     # for that SID does not exist.
@@ -192,6 +223,19 @@ module Puppet::Util::Windows
       GetLengthSid(sid_ptr)
     end
     module_function :get_length_sid
+
+    private
+
+    def self.octet_string_to_sid_string(sid_bytes)
+      sid_string = nil
+
+      FFI::MemoryPointer.new(:byte, sid_bytes.length) do |sid_ptr|
+        sid_ptr.write_array_of_uchar(sid_bytes)
+        sid_string = Puppet::Util::Windows::SID.sid_ptr_to_string(sid_ptr)
+      end
+
+      sid_string
+    end
 
     ffi_convention :stdcall
 

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -134,11 +134,10 @@ describe Puppet::Util::Windows::ADSI::Group,
 
     it 'should return a list of Principal objects even with unresolvable SIDs' do
       members = [
-        # SYSTEM account is legitimate
-        # Use sid_to_name to get localized names of SIDs - BUILTIN, SYSTEM, NT AUTHORITY, Everyone are all localized
+        # NULL SID is not localized
         stub('WIN32OLE', {
-          :objectSID => [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0],
-          :Name => Puppet::Util::Windows::SID.sid_to_name('S-1-5-18'),
+          :objectSID => [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          :Name => 'NULL SID',
           :ole_respond_to? => true,
         }),
         # unresolvable SID is a different story altogether
@@ -157,8 +156,8 @@ describe Puppet::Util::Windows::ADSI::Group,
       admins.native_group
       admins.native_group.stubs(:Members).returns(members)
 
-      # well-known SYSTEM
-      expect(admins.members[0].sid).to eq('S-1-5-18')
+      # well-known NULL SID
+      expect(admins.members[0].sid).to eq('S-1-0-0')
       expect(admins.members[0].account_type).to eq(:SidTypeWellKnownGroup)
 
       # unresolvable SID

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -87,7 +87,7 @@ describe Puppet::Util::Windows::ADSI::Group,
 
       # select a virtual account that requires an authority to be able to resolve to SID
       # the Dhcp service is chosen for no particular reason aside from it's a service available on all Windows versions
-      dhcp_virtualaccount = Puppet::Util::Windows::SID.name_to_sid_object('NT SERVICE\Dhcp')
+      dhcp_virtualaccount = Puppet::Util::Windows::SID.name_to_principal('NT SERVICE\Dhcp')
 
       # adding :SidTypeGroup as a group member will cause error in IAdsUser::Add
       # adding :SidTypeDomain (such as S-1-5-80 / NT SERVICE or computer name) won't error

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -23,6 +23,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq('')
       expect(principal.domain_account).to eq('NULL SID')
       expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
+      expect(principal.to_s).to eq('NULL SID')
     end
 
     it "should create an instance from a well-known account prefixed with NT AUTHORITY" do
@@ -39,6 +40,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
         expect(principal.account).to eq('SYSTEM')
         expect(principal.domain).to eq('NT AUTHORITY')
         expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
+        expect(principal.to_s).to eq('NT AUTHORITY\\SYSTEM')
       end
 
       # Windows API LookupAccountSid behaves differently if current user is SYSTEM
@@ -87,6 +89,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq(domain)
       expect(principal.domain_account).to eq(qualified_name)
       expect(principal.account_type).to eq(:SidTypeAlias)
+      expect(principal.to_s).to eq(qualified_name)
     end
 
     it "should raise an error when trying to lookup an account that doesn't exist" do
@@ -106,6 +109,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account).to eq(builtin_localized)
       expect(principal.domain).to eq(builtin_localized)
       expect(principal.domain_account).to eq(builtin_localized)
+      expect(principal.to_s).to eq(builtin_localized)
     end
 
     it "should return a BUILTIN domain principal for BUILTIN account names" do
@@ -115,6 +119,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account).to eq(builtin_localized)
       expect(principal.domain).to eq(builtin_localized)
       expect(principal.domain_account).to eq(builtin_localized)
+      expect(principal.to_s).to eq(builtin_localized)
     end
 
   end
@@ -135,6 +140,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq(computer_sid.domain)
       expect(principal.domain_account).to eq(guest_name)
       expect(principal.account_type).to eq(:SidTypeUser)
+      expect(principal.to_s).to eq(guest_name)
     end
 
     it "should create an instance from a well-known group SID" do
@@ -145,6 +151,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq('')
       expect(principal.domain_account).to eq('NULL SID')
       expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
+      expect(principal.to_s).to eq('NULL SID')
     end
 
     it "should create an instance from a well-known BUILTIN Alias SID" do
@@ -160,6 +167,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq(domain)
       expect(principal.domain_account).to eq(qualified_name)
       expect(principal.account_type).to eq(:SidTypeAlias)
+      expect(principal.to_s).to eq(qualified_name)
     end
 
     it "should raise an error when trying to lookup nil" do
@@ -214,6 +222,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account).to eq(builtin_localized)
       expect(principal.domain).to eq(builtin_localized)
       expect(principal.domain_account).to eq(builtin_localized)
+      expect(principal.to_s).to eq(builtin_localized)
     end
   end
 

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
   let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }
   let (:null_sid_bytes) { bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
   let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
-  let (:computer_sid) { Puppet::Util::Windows::SID.name_to_sid_object(Puppet::Util::Windows::ADSI.computer_name) }
+  let (:computer_sid) { Puppet::Util::Windows::SID.name_to_principal(Puppet::Util::Windows::ADSI.computer_name) }
   # BUILTIN is localized on German Windows, but not French
   # looking this up like this dilutes the values of the tests as we're comparing two mechanisms
   # for returning the same values, rather than to a known good

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -48,15 +48,28 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
     describe "#members_insync?" do
       it "should return true for same lists of members" do
-        expect(provider.members_insync?(['user1', 'user2'], ['user1', 'user2'])).to be_truthy
+        current = [
+          Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+        ]
+        expect(provider.members_insync?(current, ['user1', 'user2'])).to be_truthy
       end
 
       it "should return true for same lists of unordered members" do
-        expect(provider.members_insync?(['user1', 'user2'], ['user2', 'user1'])).to be_truthy
+        current = [
+          Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+        ]
+        expect(provider.members_insync?(current, ['user2', 'user1'])).to be_truthy
       end
 
       it "should return true for same lists of members irrespective of duplicates" do
-        expect(provider.members_insync?(['user1', 'user2', 'user2'], ['user2', 'user1', 'user1'])).to be_truthy
+        current = [
+          Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+        ]
+        expect(provider.members_insync?(current, ['user2', 'user1', 'user1'])).to be_truthy
       end
 
       it "should return true when current and should members are empty lists" do
@@ -77,7 +90,12 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return true when current and should contain the same users in a different order" do
-          expect(provider.members_insync?(['user1', 'user2', 'user3'], ['user3', 'user1', 'user2'])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user3'),
+          ]
+          expect(provider.members_insync?(current, ['user3', 'user1', 'user2'])).to be_truthy
         end
 
         it "should return false when current is nil" do
@@ -85,15 +103,24 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return false when should is nil" do
-          expect(provider.members_insync?(['user1'], nil)).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          ]
+          expect(provider.members_insync?(current, nil)).to be_falsey
         end
 
         it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          ]
+          expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return false when current contains members and should is empty" do
-          expect(provider.members_insync?(['user1'], [])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_falsey
         end
 
         it "should return false when current is empty and should contains members" do
@@ -101,11 +128,19 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return false when should user(s) are not the only items in the current" do
-          expect(provider.members_insync?(['user1', 'user2'], ['user1'])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          ]
+          expect(provider.members_insync?(current, ['user1'])).to be_falsey
         end
 
         it "should return false when current user(s) is not empty and should is an empty list" do
-          expect(provider.members_insync?(['user1','user2'], [])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_falsey
         end
       end
 
@@ -120,15 +155,24 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return true when should is nil" do
-          expect(provider.members_insync?(['user1'], nil)).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          ]
+          expect(provider.members_insync?(current, nil)).to be_truthy
         end
 
         it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          ]
+          expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return true when current contains members and should is empty" do
-          expect(provider.members_insync?(['user1'], [])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_truthy
         end
 
         it "should return false when current is empty and should contains members" do
@@ -136,15 +180,28 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return true when current user(s) contains at least the should list" do
-          expect(provider.members_insync?(['user1','user2'], ['user1'])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          ]
+          expect(provider.members_insync?(current, ['user1'])).to be_truthy
         end
 
         it "should return true when current user(s) is not empty and should is an empty list" do
-          expect(provider.members_insync?(['user1','user2'], [])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_truthy
         end
 
         it "should return true when current user(s) contains at least the should list, even unordered" do
-          expect(provider.members_insync?(['user3','user1','user2'], ['user2','user1'])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_sid_object('user3'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          ]
+          expect(provider.members_insync?(current, ['user2','user1'])).to be_truthy
         end
       end
     end

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -40,34 +40,34 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
     let(:invalid_user) { SecureRandom.uuid }
 
     before :each do
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user1').returns(user1)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user2').returns(user2)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user3').returns(user3)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with(invalid_user).returns(nil)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('user1').returns(user1)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('user2').returns(user2)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('user3').returns(user3)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with(invalid_user).returns(nil)
     end
 
     describe "#members_insync?" do
       it "should return true for same lists of members" do
         current = [
-          Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          Puppet::Util::Windows::SID.name_to_principal('user1'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
         ]
         expect(provider.members_insync?(current, ['user1', 'user2'])).to be_truthy
       end
 
       it "should return true for same lists of unordered members" do
         current = [
-          Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          Puppet::Util::Windows::SID.name_to_principal('user1'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
         ]
         expect(provider.members_insync?(current, ['user2', 'user1'])).to be_truthy
       end
 
       it "should return true for same lists of members irrespective of duplicates" do
         current = [
-          Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
-          Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+          Puppet::Util::Windows::SID.name_to_principal('user1'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
         ]
         expect(provider.members_insync?(current, ['user2', 'user1', 'user1'])).to be_truthy
       end
@@ -91,9 +91,9 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return true when current and should contain the same users in a different order" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user3'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
+            Puppet::Util::Windows::SID.name_to_principal('user3'),
           ]
           expect(provider.members_insync?(current, ['user3', 'user1', 'user2'])).to be_truthy
         end
@@ -104,21 +104,21 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return false when should is nil" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
           ]
           expect(provider.members_insync?(current, nil)).to be_falsey
         end
 
         it "should return false when current contains different users than should" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
           ]
           expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return false when current contains members and should is empty" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
           ]
           expect(provider.members_insync?(current, [])).to be_falsey
         end
@@ -129,16 +129,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return false when should user(s) are not the only items in the current" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
           ]
           expect(provider.members_insync?(current, ['user1'])).to be_falsey
         end
 
         it "should return false when current user(s) is not empty and should is an empty list" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
           ]
           expect(provider.members_insync?(current, [])).to be_falsey
         end
@@ -156,21 +156,21 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return true when should is nil" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
           ]
           expect(provider.members_insync?(current, nil)).to be_truthy
         end
 
         it "should return false when current contains different users than should" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
           ]
           expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return true when current contains members and should is empty" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
           ]
           expect(provider.members_insync?(current, [])).to be_truthy
         end
@@ -181,25 +181,25 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return true when current user(s) contains at least the should list" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
           ]
           expect(provider.members_insync?(current, ['user1'])).to be_truthy
         end
 
         it "should return true when current user(s) is not empty and should is an empty list" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
           ]
           expect(provider.members_insync?(current, [])).to be_truthy
         end
 
         it "should return true when current user(s) contains at least the should list, even unordered" do
           current = [
-            Puppet::Util::Windows::SID.name_to_sid_object('user3'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user1'),
-            Puppet::Util::Windows::SID.name_to_sid_object('user2'),
+            Puppet::Util::Windows::SID.name_to_principal('user3'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
           ]
           expect(provider.members_insync?(current, ['user2','user1'])).to be_truthy
         end
@@ -253,8 +253,8 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
       provider.group.stubs(:member_sids).returns(member_sids[0..1])
 
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(member_sids[1])
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user3').returns(member_sids[2])
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with('user2').returns(member_sids[1])
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with('user3').returns(member_sids[2])
 
       provider.group.expects(:remove_member_sids).with(member_sids[0])
       provider.group.expects(:add_member_sids).with(member_sids[2])
@@ -304,7 +304,7 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
   end
 
   it "should be able to test whether a group exists" do
-    Puppet::Util::Windows::SID.stubs(:name_to_sid_object).returns(nil)
+    Puppet::Util::Windows::SID.stubs(:name_to_principal).returns(nil)
     Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection', :Class => 'Group')
     expect(provider).to be_exists
 

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -81,9 +81,9 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     let(:group3) { stub(:account => 'group3', :domain => '.', :sid => 'group3sid') }
 
     before :each do
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group1').returns(group1)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group2').returns(group2)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group3').returns(group3)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('group1').returns(group1)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('group2').returns(group2)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('group3').returns(group3)
     end
 
     it "should return true for same lists of members" do
@@ -267,7 +267,7 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
   end
 
   it 'should be able to test whether a user exists' do
-    Puppet::Util::Windows::SID.stubs(:name_to_sid_object).returns(nil)
+    Puppet::Util::Windows::SID.stubs(:name_to_principal).returns(nil)
     Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection', :Class => 'User')
     expect(provider).to be_exists
 

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -106,14 +106,14 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
     end
 
     it "should be able to check the existence of a user" do
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with(username).returns nil
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with(username).returns nil
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://./#{username},user").returns connection
       connection.expects(:Class).returns('User')
       expect(Puppet::Util::Windows::ADSI::User.exists?(username)).to be_truthy
     end
 
     it "should be able to check the existence of a domain user" do
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with("#{domain}\\#{username}").returns nil
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with("#{domain}\\#{username}").returns nil
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://#{domain}/#{username},user").returns connection
       connection.expects(:Class).returns('User')
       expect(Puppet::Util::Windows::ADSI::User.exists?(domain_username)).to be_truthy
@@ -213,7 +213,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       end
 
       it "should generate the correct URI" do
-        Puppet::Util::Windows::SID.stubs(:octet_string_to_sid_object).returns(sid)
+        Puppet::Util::Windows::SID.stubs(:octet_string_to_principal).returns(sid)
         expect(user.uri).to eq("WinNT://testcomputername/#{username},user")
       end
 
@@ -276,8 +276,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       let(:someone_sid){ stub(:account => 'someone', :domain => 'testcomputername')}
 
       describe "should be able to use SID objects" do
-        let(:system)     { Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM') }
-        let(:invalid)    { Puppet::Util::Windows::SID.name_to_sid_object('foobar') }
+        let(:system)     { Puppet::Util::Windows::SID.name_to_principal('SYSTEM') }
+        let(:invalid)    { Puppet::Util::Windows::SID.name_to_principal('foobar') }
 
         it "to add a member" do
           adsi_group.expects(:Add).with("WinNT://S-1-5-18")
@@ -307,8 +307,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
         adsi_group.expects(:Members).returns(users)
 
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with('user1').returns(stub(:domain_account => 'HOSTNAME\user1'))
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with('user2').returns(stub(:domain_account => 'HOSTNAME\user2'))
+        Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with('user1').returns(stub(:domain_account => 'HOSTNAME\user1'))
+        Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with('user2').returns(stub(:domain_account => 'HOSTNAME\user2'))
 
         expect(group.members.map(&:domain_account)).to match(['HOSTNAME\user1', 'HOSTNAME\user2'])
       end
@@ -323,11 +323,11 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           ]
 
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(sids[1])
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('DOMAIN2\user3').returns(sids[2])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('user2').returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('DOMAIN2\user3').returns(sids[2])
 
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[0]).returns("WinNT://DOMAIN/user1,user")
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[2]).returns("WinNT://DOMAIN2/user3,user")
@@ -350,11 +350,11 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           ]
 
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(sids[1])
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('DOMAIN2\user3').returns(sids[2])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('user2').returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('DOMAIN2\user3').returns(sids[2])
 
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[2]).returns("WinNT://DOMAIN2/user3,user")
 
@@ -385,8 +385,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           ]
 
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[0]).returns("WinNT://DOMAIN/user1,user")
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[1]).returns("WinNT://testcomputername/user2,user")
@@ -407,8 +407,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
               stub(:account => 'user2', :domain => 'testcomputername', :sid => 2 ),
           ]
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
           members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i], :ole_respond_to? => true)}
           adsi_group.expects(:Members).returns members
@@ -431,7 +431,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
         adsi_group.expects(:objectSID).returns([0])
         Socket.expects(:gethostname).returns('TESTcomputerNAME')
         computer_sid = stub(:account => groupname,:domain => 'testcomputername')
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(computer_sid)
+        Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(computer_sid)
         expect(group.uri).to eq("WinNT://./#{groupname},group")
       end
     end
@@ -461,7 +461,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
     end
 
     it "should be able to confirm the existence of a group" do
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with(groupname).returns nil
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with(groupname).returns nil
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://./#{groupname},group").returns connection
       connection.expects(:Class).returns('Group')
 
@@ -503,7 +503,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       Puppet::Util::Windows::ADSI.expects(:execquery).with('select name from win32_group where localaccount = "TRUE"').returns(wmi_groups)
 
       native_group = stub('IADsGroup')
-      Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([]).returns(stub(:domain_account => '.\Administrator'))
+      Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([]).returns(stub(:domain_account => '.\Administrator'))
       native_group.expects(:Members).returns([stub(:Name => 'Administrator', :objectSID => [], :ole_respond_to? => true)])
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://./#{name},group").returns(native_group)
 

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -13,10 +13,10 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
   let(:null_sid)     { 'S-1-0-0' }
   let(:unknown_name) { 'chewbacca' }
 
-  context "#octet_string_to_sid_object" do
+  context "#octet_string_to_principal" do
     it "should properly convert an array of bytes for a well-known non-localized SID" do
       bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-      converted = subject.octet_string_to_sid_object(bytes)
+      converted = subject.octet_string_to_principal(bytes)
 
       expect(converted).to be_an_instance_of Puppet::Util::Windows::SID::Principal
       expect(converted.sid_bytes).to eq(bytes)
@@ -28,13 +28,13 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
 
     it "should raise an error for non-array input" do
       expect {
-        subject.octet_string_to_sid_object(invalid_sid)
+        subject.octet_string_to_principal(invalid_sid)
       }.to raise_error(Puppet::Error, /Octet string must be an array of bytes/)
     end
 
     it "should raise an error for an empty byte array" do
       expect {
-        subject.octet_string_to_sid_object([])
+        subject.octet_string_to_principal([])
       }.to raise_error(Puppet::Error, /Octet string must be an array of bytes/)
     end
 
@@ -42,7 +42,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       expect {
         # S-1-1-1 which is not a valid account
         valid_octet_invalid_user =[1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
-        subject.octet_string_to_sid_object(valid_octet_invalid_user)
+        subject.octet_string_to_principal(valid_octet_invalid_user)
       }.to raise_error do |error|
         expect(error).to be_a(Puppet::Util::Windows::Error)
         expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
@@ -52,7 +52,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
     it "should raise an error for a malformed byte array" do
       expect {
         invalid_octet = [2]
-        subject.octet_string_to_sid_object(invalid_octet)
+        subject.octet_string_to_principal(invalid_octet)
       }.to raise_error do |error|
         expect(error).to be_a(Puppet::Util::Windows::Error)
         expect(error.code).to eq(87) # ERROR_INVALID_PARAMETER
@@ -72,12 +72,12 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
     end
 
     it "should return a SID for a passed user or group name" do
-      subject.expects(:name_to_sid_object).with('testers').returns stub(:sid => 'S-1-5-32-547')
+      subject.expects(:name_to_principal).with('testers').returns stub(:sid => 'S-1-5-32-547')
       expect(subject.name_to_sid('testers')).to eq('S-1-5-32-547')
     end
 
     it "should return a SID for a passed fully-qualified user or group name" do
-      subject.expects(:name_to_sid_object).with('MACHINE\testers').returns stub(:sid => 'S-1-5-32-547')
+      subject.expects(:name_to_principal).with('MACHINE\testers').returns stub(:sid => 'S-1-5-32-547')
       expect(subject.name_to_sid('MACHINE\testers')).to eq('S-1-5-32-547')
     end
 
@@ -128,57 +128,57 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
     end
   end
 
-  context "#name_to_sid_object" do
+  context "#name_to_principal" do
     it "should return nil if the account does not exist" do
-      expect(subject.name_to_sid_object(unknown_name)).to be_nil
+      expect(subject.name_to_principal(unknown_name)).to be_nil
     end
 
     it "should return a Puppet::Util::Windows::SID::Principal instance for any valid sid" do
-      expect(subject.name_to_sid_object(sid)).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
+      expect(subject.name_to_principal(sid)).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
     end
 
     it "should accept unqualified account name" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really Syst\u00E8me
-      expect(subject.name_to_sid_object('SYSTEM').sid).to eq(sid)
+      expect(subject.name_to_principal('SYSTEM').sid).to eq(sid)
     end
 
     it "should be case-insensitive" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really Syst\u00E8me
-      expect(subject.name_to_sid_object('SYSTEM')).to eq(subject.name_to_sid_object('system'))
+      expect(subject.name_to_principal('SYSTEM')).to eq(subject.name_to_principal('system'))
     end
 
     it "should be leading and trailing whitespace-insensitive" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really Syst\u00E8me
-      expect(subject.name_to_sid_object('SYSTEM')).to eq(subject.name_to_sid_object(' SYSTEM '))
+      expect(subject.name_to_principal('SYSTEM')).to eq(subject.name_to_principal(' SYSTEM '))
     end
 
     it "should accept domain qualified account names" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really AUTORITE NT\\Syst\u00E8me
-      expect(subject.name_to_sid_object('NT AUTHORITY\SYSTEM').sid).to eq(sid)
+      expect(subject.name_to_principal('NT AUTHORITY\SYSTEM').sid).to eq(sid)
     end
   end
 
-  context "#ads_to_sid_object" do
+  context "#ads_to_principal" do
     it "should raise an error for non-WIN32OLE input" do
       expect {
-        subject.ads_to_sid_object(stub('WIN32OLE', { :Name => 'foo' }))
+        subject.ads_to_principal(stub('WIN32OLE', { :Name => 'foo' }))
       }.to raise_error(Puppet::Error, /ads_object must be an IAdsUser or IAdsGroup instance/)
     end
 
     it "should raise an error for an empty byte array in the objectSID property" do
       expect {
-        subject.ads_to_sid_object(stub('WIN32OLE', { :objectSID => [], :Name => '', :ole_respond_to? => true }))
+        subject.ads_to_principal(stub('WIN32OLE', { :objectSID => [], :Name => '', :ole_respond_to? => true }))
       }.to raise_error(Puppet::Error, /Octet string must be an array of bytes/)
     end
 
     it "should raise an error for a malformed byte array" do
       expect {
         invalid_octet = [2]
-        subject.ads_to_sid_object(stub('WIN32OLE', { :objectSID => invalid_octet, :Name => '', :ole_respond_to? => true }))
+        subject.ads_to_principal(stub('WIN32OLE', { :objectSID => invalid_octet, :Name => '', :ole_respond_to? => true }))
       }.to raise_error do |error|
         expect(error).to be_a(Puppet::Util::Windows::Error)
         expect(error.code).to eq(87) # ERROR_INVALID_PARAMETER
@@ -189,7 +189,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       expect {
         # S-1-1-1 is a valid SID that will not resolve
         valid_octet_invalid_user = [1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
-        subject.ads_to_sid_object(stub('WIN32OLE', { :objectSID => valid_octet_invalid_user, :Name => unknown_name, :ole_respond_to? => true }))
+        subject.ads_to_principal(stub('WIN32OLE', { :objectSID => valid_octet_invalid_user, :Name => unknown_name, :ole_respond_to? => true }))
       }.to raise_error do |error|
         expect(error).to be_a(Puppet::Util::Windows::Error)
         expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
@@ -200,7 +200,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       # S-1-1-1 is a valid SID that will not resolve
       valid_octet_invalid_user = [1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
       unresolvable_user = stub('WIN32OLE', { :objectSID => valid_octet_invalid_user, :Name => 'S-1-1-1', :ole_respond_to? => true })
-      principal = subject.ads_to_sid_object(unresolvable_user)
+      principal = subject.ads_to_principal(unresolvable_user)
 
       expect(principal).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
       expect(principal.account).to eq('S-1-1-1 (unresolvable)')
@@ -214,13 +214,13 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
     it "should return a Puppet::Util::Windows::SID::Principal instance for any valid sid" do
       system_bytes = [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0]
       adsuser = stub('WIN32OLE', { :objectSID => system_bytes, :Name => 'SYSTEM', :ole_respond_to? => true })
-      expect(subject.ads_to_sid_object(adsuser)).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
+      expect(subject.ads_to_principal(adsuser)).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
     end
 
     it "should properly convert an array of bytes for a well-known non-localized SID, ignoring the Name from the WIN32OLE object" do
       bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       adsuser = stub('WIN32OLE', { :objectSID => bytes, :Name => unknown_name, :ole_respond_to? => true })
-      converted = subject.ads_to_sid_object(adsuser)
+      converted = subject.ads_to_principal(adsuser)
 
       expect(converted).to be_an_instance_of Puppet::Util::Windows::SID::Principal
       expect(converted.sid_bytes).to eq(bytes)


### PR DESCRIPTION
(PUP-7326) Handle Windows unresolvable SIDs

 - bef10f187f10b5083e73c888d1b4f663ce3a67d9 improved the handling of
   account names within local groups that refer to domain or virtual
   accounts. Prior to that change, Puppet could not manage groups
   with virtual accounts, failed to properly disambiguate accounts
   with the same name that came from different authorities (for
   example local Administrator from NT AUTHORITY vs domain), and
   would produce output from `puppet resource` that didn't include
   the authority.

   Puppet has always emitted errors when managing groups with
   unresolvable SIDs (typically domain accounts that have been deleted
   but that are still present in local groups), but the previous 
   change degraded the behavior of `puppet resource` so that instead
   of producing output like the following when an unresolved SID is
   present:

```puppet
   group { 'Bar':
     ensure  => 'present',
     gid     => 'S-1-5-21-969762586-3490402988-3896818487-1004',
     members => ['SYSTEM', 'Administrator', 'Administrator', 'BM', 'S-1-5-21-3661721861-956923663-2119435483-1116'],
   }
```

   It would instead immediately produce an error like:

```
   Error: Could not run: Failed to call LookupAccountSidW:  No mapping between account names and security IDs was done.
```

   The output is now correct:

```puppet
   group { 'Bar':
     ensure  => 'present',
     gid     => 'S-1-5-21-969762586-3490402988-3896818487-1004',
     members => ['NT AUTHORITY\SYSTEM', 'DFSDEMO\Administrator', 'DFS-DEMO-CLIENT\Administrator', 'DFSDEMO\BM', 'S-1-5-21-3661721861-956923663-2119435483-1116 (unresolvable)'],
   }
```

   The previous change introduced the authority prefixes, but also
   encountered difficulties with unresolvable SIDs, earlier in the
   provider lifecycle.

 - With auth_membership => true, unresolvable SIDs will be removed as
   expected from groups that have them. When auth_membership => false
   unresolvable SIDs will be preserved in local groups.

 - Introduces a breaking internal change by returning Windows Group
   :members property to the Windows ADSI group provider as an array of
   SID::Principal objects rather than an array of string as
   DOMAIN\USER qualified account names.

   While breaking the internal API is generally undesirable, the only
   callers should be Puppet itself.

   This was the simplest path to preserving orphaned / unresolvable
   SIDs that may be part of a local group, but that no longer exist
   in the upstream domain controller, without introducing a number of
   new code paths with special case error-handling.

 - Introduces an additional breaking internal change by changing
   Puppet::Util::Windows::SID::Principal#to_s to return a string in
   DOMAIN\USER format rather than in S-1-XXX style string format.
   This was necessary for `puppet resource` to produce manifests with
   friendly account names rather than SIDs.

   6a3d8215385be5b659db8b4792680273db47da69 initially added this
   method for 3rd party backward compatiblity when the class
   Win32::Security::SID was removed as part of 4.3.2. At the time, all
   internal callsites were modified to use #sid accessor of 
   Puppet::Util::Windows::SID::Principal instead of to_s in the prior
   commit at 42fceb295c4f37ca99b5d0d283b30970745dfadb

 - Note that it is unnecessary to implement the same safeguards
   against the user provider, as it should not be possible to have
   unresolvable SIDs for the groups a user is a member of. Local users
   cannot be added to domain groups.
