### PR TITLE
(PUP-8463) Remove "shadowing outer local variable" and "character class has duplicated range" warnings

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -245,7 +245,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
             $stderr.puts _("%{file} is not readable") % { file: file }
             exit(63)
           end
-          node.classes = Puppet::FileSystem.read(file, :encoding => 'utf-8').split(/[\s\n]+/)
+          node.classes = Puppet::FileSystem.read(file, :encoding => 'utf-8').split(/[\s]+/)
         end
       end
 

--- a/lib/puppet/settings/config_file.rb
+++ b/lib/puppet/settings/config_file.rb
@@ -131,7 +131,7 @@ private
     value = string.sub(/\{\s*([^}]+)\s*\}/) do
       params = $1
       params.split(/\s*,\s*/).each do |str|
-        if str =~ /^\s*(\w+)\s*=\s*([\w\d]+)\s*$/
+        if str =~ /^\s*(\w+)\s*=\s*([\w]+)\s*$/
           param, value = $1.intern, $2
           result[param] = value
           unless [:owner, :mode, :group].include?(param)

--- a/lib/puppet/type/host.rb
+++ b/lib/puppet/type/host.rb
@@ -80,7 +80,7 @@ module Puppet
 
       validate do |value|
         value.split('.').each do |hostpart|
-          unless hostpart =~ /^([\d\w]+|[\d\w][\d\w\-]+[\d\w])$/
+          unless hostpart =~ /^([\w]+|[\w][\w\-]+[\w])$/
             raise Puppet::Error, _("Invalid host name")
           end
         end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -470,13 +470,13 @@ class amod::bad_type {
         catalog = compile_to_catalog(execute, node)
         apply = Puppet::Application[:apply]
         apply.options[:catalog] = file_containing('manifest', catalog.to_json)
-        apply.expects(:apply_catalog).with do |catalog|
-          catalog.resource(:notify, 'rx')['message'].is_a?(String)
-          catalog.resource(:notify, 'bin')['message'].is_a?(String)
-          catalog.resource(:notify, 'ver')['message'].is_a?(String)
-          catalog.resource(:notify, 'vrange')['message'].is_a?(String)
-          catalog.resource(:notify, 'tspan')['message'].is_a?(String)
-          catalog.resource(:notify, 'tstamp')['message'].is_a?(String)
+        apply.expects(:apply_catalog).with do |cat|
+          cat.resource(:notify, 'rx')['message'].is_a?(String)
+          cat.resource(:notify, 'bin')['message'].is_a?(String)
+          cat.resource(:notify, 'ver')['message'].is_a?(String)
+          cat.resource(:notify, 'vrange')['message'].is_a?(String)
+          cat.resource(:notify, 'tspan')['message'].is_a?(String)
+          cat.resource(:notify, 'tstamp')['message'].is_a?(String)
         end
         apply.run
       end
@@ -509,13 +509,13 @@ class amod::bad_type {
         catalog = compile_to_catalog(execute, node)
         apply = Puppet::Application[:apply]
         apply.options[:catalog] = file_containing('manifest', catalog.to_json)
-        apply.expects(:apply_catalog).with do |catalog|
-          catalog.resource(:notify, 'rx')['message'].is_a?(Regexp)
-          catalog.resource(:notify, 'bin')['message'].is_a?(Puppet::Pops::Types::PBinaryType::Binary)
-          catalog.resource(:notify, 'ver')['message'].is_a?(SemanticPuppet::Version)
-          catalog.resource(:notify, 'vrange')['message'].is_a?(SemanticPuppet::VersionRange)
-          catalog.resource(:notify, 'tspan')['message'].is_a?(Puppet::Pops::Time::Timespan)
-          catalog.resource(:notify, 'tstamp')['message'].is_a?(Puppet::Pops::Time::Timestamp)
+        apply.expects(:apply_catalog).with do |cat|
+          cat.resource(:notify, 'rx')['message'].is_a?(Regexp)
+          cat.resource(:notify, 'bin')['message'].is_a?(Puppet::Pops::Types::PBinaryType::Binary)
+          cat.resource(:notify, 'ver')['message'].is_a?(SemanticPuppet::Version)
+          cat.resource(:notify, 'vrange')['message'].is_a?(SemanticPuppet::VersionRange)
+          cat.resource(:notify, 'tspan')['message'].is_a?(Puppet::Pops::Time::Timespan)
+          cat.resource(:notify, 'tstamp')['message'].is_a?(Puppet::Pops::Time::Timestamp)
         end
         apply.run
       end

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -298,8 +298,8 @@ describe Puppet::Transaction::Report do
                                                            :content => "mystuff1"),
                               Puppet::Type.type(:file).new(:title => file,
                                                            :content => "mystuff2")) do
-          File.open(file, 'w') do |file|
-            file.write "some content"
+          File.open(file, 'w') do |f|
+            f.write "some content"
           end
         end
 

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -661,13 +661,13 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       catalog.apply
 
       expect(@dirs).not_to be_empty
-      @dirs.each do |path|
-        expect(get_mode(path) & 007777).to eq(0755)
+      @dirs.each do |dir|
+        expect(get_mode(dir) & 007777).to eq(0755)
       end
 
       expect(@files).not_to be_empty
-      @files.each do |path|
-        expect(get_mode(path) & 007777).to eq(0644)
+      @files.each do |dir|
+        expect(get_mode(dir) & 007777).to eq(0644)
       end
     end
 

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -42,7 +42,7 @@ describe 'the assert_type function' do
   end
 
   it 'can be called with a callable that receives a specific type' do
-    expected, actual, actual2 = func.call({}, 'Optional[String]', 1) { |expected, actual| [expected, actual, actual] }
+    expected, actual, actual2 = func.call({}, 'Optional[String]', 1) { |expctd, actul| [expctd, actul, actul] }
     expect(expected.to_s).to eql('Optional[String]')
     expect(actual.to_s).to eql('Integer[1, 1]')
     expect(actual2.to_s).to eql('Integer[1, 1]')

--- a/spec/unit/functions/lookup_fixture_spec.rb
+++ b/spec/unit/functions/lookup_fixture_spec.rb
@@ -47,7 +47,7 @@ describe 'The lookup function' do
   def compile_and_get_notifications(code)
     Puppet[:code] = code
     node.environment.check_for_reparse
-    catalog = block_given? ? compiler.compile { |catalog| yield(compiler.topscope); catalog } : compiler.compile
+    catalog = block_given? ? compiler.compile { |cat| yield(compiler.topscope); cat } : compiler.compile
     catalog.resources.map(&:ref).select { |r| r.start_with?('Notify[') }.map { |r| r[7..-2] }
   end
 

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -194,7 +194,7 @@ describe 'loaders' do
 
     def compile_and_get_notifications(code)
       Puppet[:code] = code
-      catalog = block_given? ? compiler.compile { |catalog| yield(compiler.topscope); catalog } : compiler.compile
+      catalog = block_given? ? compiler.compile { |c| yield(compiler.topscope); c } : compiler.compile
       catalog.resources.map(&:ref).select { |r| r.start_with?('Notify[') }.map { |r| r[7..-2] }
     end
 

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -17,8 +17,8 @@ describe "base service provider" do
 
   if Puppet.features.microsoft_windows?
     # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+    cmd = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(cmd, {:failonfail => false})
   end
 
   context "basic operations" do

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -9,8 +9,8 @@ describe Puppet::Type.type(:service).provider(:init) do
 
   if Puppet.features.microsoft_windows?
     # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+    cmd = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(cmd, {:failonfail => false})
   end
 
   before do

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -6,8 +6,8 @@ describe Puppet::Type.type(:service).provider(:openrc) do
 
   if Puppet.features.microsoft_windows?
     # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+    cmd = "cmd.exe /c \"exit 0\""
+    Puppet::Util::Execution.execute(cmd, {:failonfail => false})
   end
 
   before :each do

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -23,9 +23,9 @@ describe provider_class, :if => Puppet.features.posix? do
     Facter.stubs(:value).with(:osfamily).returns 'RedHat'
   end
 
-  osfamily = [ 'RedHat' ]
+  osfamilies = [ 'RedHat' ]
 
-  osfamily.each do |osfamily|
+  osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
       Facter.expects(:value).with(:osfamily).returns(osfamily)
       expect(provider_class.default?).to be_truthy

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -21,9 +21,9 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     described_class.new(:name => 'sshd.service')
   end
 
-  osfamily = [ 'archlinux', 'coreos' ]
+  osfamilies = [ 'archlinux', 'coreos' ]
 
-  osfamily.each do |osfamily|
+  osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
       Facter.stubs(:value).with(:osfamily).returns(osfamily)
       expect(described_class).to be_default

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -14,8 +14,8 @@ describe Puppet::Type.type(:service).provider(:upstart) do
   end
 
   def given_contents_of(file, content)
-    File.open(file, 'w') do |file|
-      file.write(content)
+    File.open(file, 'w') do |f|
+      f.write(content)
     end
   end
 
@@ -245,9 +245,9 @@ describe Puppet::Type.type(:service).provider(:upstart) do
       before(:each) do
         provider.stubs(:is_upstart?).returns(true)
       end
-      ["start", "stop"].each do |command|
-        it "should return the #{command}cmd of its parent provider" do
-          expect(provider.send("#{command}cmd".to_sym)).to eq([provider.command(command.to_sym), resource.name])
+      ["start", "stop"].each do |action|
+        it "should return the #{action}cmd of its parent provider" do
+          expect(provider.send("#{action}cmd".to_sym)).to eq([provider.command(action.to_sym), resource.name])
         end
       end
       it "should return nil for the statuscmd" do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -691,7 +691,7 @@ describe 'Puppet Pal' do
         end.to raise_error(/A block must be given to 'in_tmp_environment/)
       end
 
-      it 'errors if an env_name is given and is not a String[1]' do |ctx|
+      it 'errors if an env_name is given and is not a String[1]' do
         expect do
           Puppet::Pal.in_tmp_environment('', modulepath: modulepath, facts: node_facts) { |ctx| }
         end.to raise_error(/temporary environment name has wrong type/)
@@ -874,7 +874,7 @@ describe 'Puppet Pal' do
         end.to raise_error(/The environment directory '.*' does not exist/)
       end
 
-      it 'errors if an env_name is given and is not a String[1]' do |ctx|
+      it 'errors if an env_name is given and is not a String[1]' do
         expect do
           Puppet::Pal.in_environment('', env_dir: testing_env_dir, facts: node_facts)  { |ctx| }
         end.to raise_error(/env_name has wrong type/)

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Type.type(:exec) do
     output = Puppet::Util::Execution::ProcessOutput.new(output, exitstatus)
     tries  = rest[:tries] || 1
 
-    args = {
+    type_args = {
       :name      => command,
       :path      => @example_path,
       :logoutput => false,
@@ -20,14 +20,13 @@ describe Puppet::Type.type(:exec) do
       :returns   => 0
     }.merge(rest)
 
-    exec = Puppet::Type.type(:exec).new(args)
+    exec = Puppet::Type.type(:exec).new(type_args)
 
-    Puppet::Util::Execution.expects(:execute).times(tries).
-      with() { |*args|
-        args[0] == command &&
-        args[1][:override_locale] == false &&
-        args[1].has_key?(:custom_environment)
-      }.returns(output)
+    Puppet::Util::Execution.expects(:execute).times(tries).with() do |*args|
+      args[0] == command &&
+      args[1][:override_locale] == false &&
+      args[1].has_key?(:custom_environment)
+    end.returns(output)
 
     return exec
   end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -390,8 +390,9 @@ describe Puppet::Type.type(:file) do
   describe "#mark_children_for_purging" do
     it "should set each child's ensure to absent" do
       paths = %w[foo bar baz]
-      children = paths.inject({}) do |children,child|
-        children.merge child => described_class.new(:path => File.join(path, child), :ensure => :present)
+      children = {}
+      paths.each do |child|
+        children[child] = described_class.new(:path => File.join(path, child), :ensure => :present)
       end
 
       file.mark_children_for_purging(children)

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -276,7 +276,7 @@ describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
 
     it "should have documentation for the 'provider' parameter if there are providers" do
       @type.provide(:test_provider)
-      expect(@type.paramdoc(:provider)).to match(/`provider_test_type`[\s\r]+resource/)
+      expect(@type.paramdoc(:provider)).to match(/`provider_test_type`[\s]+resource/)
     end
 
     it "should not have documentation for the 'provider' parameter if there are no providers" do


### PR DESCRIPTION
We had a few regexes that had redundant character classes in them, and a large number of cases where we were using the same variable name in an inner scope as a variable in an outer scope, which would mask the outer variable.

While the variable masking wasn't causing any issues in these cases, it can often be the source of confusion.

This does not fix the variable masking in `lib/puppet/vendor/semantic_puppet/lib/semantic_puppet/dependency/module_release.rb` as that is vendored code from another repo, and because fixing the variable masking in that file causes the test suite to use 100+GB of RAM, so we'll need to do some investigation as to what's going on there.