### PR TITLE
(docs)(DOCUMENT-820) Fix function ref headings.

### DIFF
--- a/lib/puppet/parser/functions/new.rb
+++ b/lib/puppet/parser/functions/new.rb
@@ -56,16 +56,14 @@ Would fail with an assertion error (since value is less than 0).
 The following sections show the arguments and conversion rules
 per data type built into the Puppet Type System.
 
-Conversion to Optional[T] and NotUndef[T]
------------------------------------------
+### Conversion to Optional[T] and NotUndef[T]
 
 Conversion to these data types is the same as a conversion to the type argument `T`.
 In the case of `Optional[T]` it is accepted that the argument to convert may be `undef`.
 It is however not acceptable to give other arguments (than `undef`) that cannot be
 converted to `T`.
 
-Conversion to Integer
----------------------
+### Conversion to Integer
 
 A new `Integer` can be created from `Integer`, `Float`, `Boolean`, and `String` values.
 For conversion from `String` it is possible to specify the radix (base).
@@ -113,8 +111,7 @@ $a_number = Integer(true)          # results in 1
 $a_number = Integer(-38, 10, true) # results in 38
 ```
 
-Conversion to Float
--------------------
+### Conversion to Float
 
 A new `Float` can be created from `Integer`, `Float`, `Boolean`, and `String` values.
 For conversion from `String` both float and integer formats are supported.
@@ -126,15 +123,13 @@ function Float.new(
 )
 ```
 
-
 * For an integer, the floating point fraction of `.0` is added to the value.
 * A `Boolean` `true` is converted to 1.0, and a `false` to 0.0
 * In `String` format, integer prefixes for hex and binary are understood (but not octal since
   floating point in string format may start with a '0').
 * When `abs` is set to `true`, the result will be an absolute floating point value.
 
-Conversion to Numeric
----------------------
+### Conversion to Numeric
 
 A new `Integer` or `Float` can be created from `Integer`, `Float`, `Boolean` and
 `String` values.
@@ -163,8 +158,7 @@ $a_number = Numeric(-42.3, true) # results in 42.3
 $a_number = Numeric(-42, true)   # results in 42
 ```
 
-Conversion to Timespan
--------------------
+### Conversion to Timespan
 
 A new `Timespan` can be created from `Integer`, `Float`, `String`, and `Hash` values. Several variants of the constructor are provided.
 
@@ -281,8 +275,7 @@ $duration = Timespan('10:03.5', '%M:%S.%L') # 10 minutes, 3 seconds, and 5 milli
 $duration = Timespan('10:03.5', '%M:%S.%N') # 10 minutes, 3 seconds, and 5 nano-seconds
 ```
 
-Conversion to Timestamp
--------------------
+### Conversion to Timestamp
 
 A new `Timestamp` can be created from `Integer`, `Float`, `String`, and `Hash` values. Several variants of the constructor are provided.
 
@@ -475,8 +468,7 @@ $ts = Timestamp('2016-08-24T12:13:14', default, 'PST')   # 2016-08-24 20:13:14.0
 
 ```
 
-Conversion to String
---------------------
+### Conversion to String
 
 Conversion to `String` is the most comprehensive conversion as there are many
 use cases where a string representation is wanted. The defaults for the many options
@@ -519,7 +511,7 @@ included in a string format.
 Note that all data type supports the formats `s` and `p` with the meaning "default string representation" and
 "default programmatic string representation" (which for example means that a String is quoted in 'p' format).
 
-### Signatures of String conversion
+#### Signatures of String conversion
 
 ```puppet
 type Format = Pattern[/^%([\s\+\-#0\[\{<\(\|]*)([1-9][0-9]*)?(?:\.([0-9]+))?([a-zA-Z])/]
@@ -577,7 +569,7 @@ $str = String([1,2,3], $formats) # produces '(0x1, 0x2, 0x3)'
 The given formats are merged with the default formats, and matching of values to convert against format is based on
 the specificity of the mapped type; for example, different formats can be used for short and long arrays.
 
-### Integer to String
+#### Integer to String
 
 | Format  | Integer Formats
 | ------  | ---------------
@@ -592,7 +584,7 @@ the specificity of the mapped type; for example, different formats can be used f
 
 Defaults to `d`.
 
-### Float to String
+#### Float to String
 
 | Format  | Float formats
 | ------  | -------------
@@ -606,7 +598,7 @@ Defaults to `d`.
 
 Defaults to `p`.
 
-### String to String
+#### String to String
 
 | Format | String
 | ------ | ------
@@ -620,7 +612,7 @@ Defaults to `p`.
 
 Defaults to `s` at top level and `p` inside array or hash.
 
-### Boolean to String
+#### Boolean to String
 
 | Format    | Boolean Formats
 | ----      | -------------------
@@ -631,14 +623,14 @@ Defaults to `s` at top level and `p` inside array or hash.
 | s         | String 'true' / 'false'.
 | p         | String 'true' / 'false'.
 
-### Regexp to String
+#### Regexp to String
 
 | Format    | Regexp Formats
 | ----      | --------------
 | s         | No delimiters, quoted if alternative flag `#` is used.
 | p         | Delimiters `/ /`.
 
-### Undef to String
+#### Undef to String
 
 | Format    | Undef formats
 | ------    | -------------
@@ -651,7 +643,7 @@ Defaults to `s` at top level and `p` inside array or hash.
 | V         | String 'N/A'.
 | u         | String 'undef', or 'undefined' if alternative `#` flag is used.
 
-### Default value to String
+#### Default value to String
 
 | Format    | Default formats
 | ------    | ---------------
@@ -659,7 +651,7 @@ Defaults to `s` at top level and `p` inside array or hash.
 | s         | Same as d.
 | p         | Same as d.
 
-### Binary value to String
+#### Binary value to String
 
 | Format    | Default formats
 | ------    | ---------------
@@ -676,7 +668,7 @@ Defaults to `s` at top level and `p` inside array or hash.
   as hex escaped characters on the form `\\xHH` where `H` is a hex digit.
 * The width and precision values are applied to the text part only in `%p` format.
 
-### Array & Tuple to String
+#### Array & Tuple to String
 
 | Format    | Array/Tuple Formats
 | ------    | -------------
@@ -691,7 +683,7 @@ The alternate form flag `#` will cause indentation of nested array or hash conta
 it is taken as the maximum allowed length of a sequence of elements (not including delimiters). If this max length
 is exceeded, each element will be indented.
 
-### Hash & Struct to String
+#### Hash & Struct to String
 
 | Format    | Hash/Struct Formats
 | ------    | -------------
@@ -705,14 +697,14 @@ more information about options.
 
 The alternate form flag `#` will format each hash key/value entry indented on a separate line.
 
-### Type to String
+#### Type to String
 
 | Format    | Array/Tuple Formats
 | ------    | -------------
 | s         | The same as `p`, quoted if alternative flag `#` is used.
 | p         | Outputs the type in string form as specified by the Puppet Language.
 
-### Flags
+#### Flags
 
 | Flag     | Effect
 | ------   | ------
@@ -723,8 +715,7 @@ The alternate form flag `#` will format each hash key/value entry indented on a 
 | 0        | Pad with 0 instead of space for widths larger than value.
 | <[({\|   | Defines an enclosing pair <> [] () {} or \| \| when used with a container type.
 
-Conversion to Boolean
----
+### Conversion to Boolean
 
 Accepts a single value as argument:
 
@@ -735,8 +726,7 @@ Accepts a single value as argument:
   * `false` if 'false', 'no', 'n' (case independent compare)
 * Boolean is already boolean and is simply returned
 
-Conversion to Array and Tuple
----
+### Conversion to Array and Tuple
 
 When given a single value as argument:
 
@@ -761,8 +751,7 @@ $arr = Array($value, true)
 Conversion to a `Tuple` works exactly as conversion to an `Array`, only that the constructed array is
 asserted against the given tuple type.
 
-Conversion to Hash and Struct
----
+### Conversion to Hash and Struct
 
 Accepts a single value as argument:
 
@@ -775,8 +764,8 @@ Accepts a single value as argument:
 Conversion to a `Struct` works exactly as conversion to a `Hash`, only that the constructed hash is
 asserted against the given struct type.
 
-Conversion to a Regexp
----
+### Conversion to a Regexp
+
 A `String` can be converted into a `Regexp`
 
 **Example**: Converting a String into a Regexp
@@ -788,8 +777,7 @@ if('foo.com' =~ $r) {
 }
 ```
 
-Creating a SemVer
----
+### Creating a SemVer
 
 A SemVer object represents a single [Semantic Version](http://semver.org/).
 It can be created from a String, individual values for its parts, or a hash specifying the value per part.
@@ -838,8 +826,7 @@ notice(SemVer('2.3.4') =~ $t) # false
 notice(SemVer('3.4.5') =~ $t) # true
 ```
 
-Creating a SemVerRange
----
+### Creating a SemVerRange
 
 A `SemVerRange` object represents a range of `SemVer`. It can be created from
 a `String`, or from two `SemVer` instances, where either end can be given as
@@ -873,10 +860,9 @@ function SemVerRange.new(
 )
 ```
 
-For examples of `SemVerRange` use see "Creating a SemVer"
+For examples of `SemVerRange` use, see "Creating a SemVer".
 
-Creating a Binary
----
+### Creating a Binary
 
 A `Binary` object represents a sequence of bytes and it can be created from a String in Base64 format,
 an Array containing byte values. A Binary can also be created from a Hash containing the value to convert to
@@ -895,7 +881,6 @@ function Binary.new(
   String $base64_str,
   Optional[Base64Format] $format
 )
-
 
 function Binary.new(
   Array[ByteInteger] $byte_array


### PR DESCRIPTION
Function reference docs generate a second-level heading for each
function. Having second-level headings inside a function's description
causes issues with the generated docs' hierarchy.

Drop Markdown heading levels to 3rd or lower for all sections.