### PR TITLE
(docs) Replace 3 tildes (+lang) with 3 backticks

### DIFF
--- a/lib/puppet/functions/all.rb
+++ b/lib/puppet/functions/all.rb
@@ -18,11 +18,11 @@
 #
 # @example Using the `all` function with an Array and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, run a lambda that checks that all values are multiples of 10
 # $data = [10, 20, 30]
 # notice $data.all |$item| { $item % 10 == 0 }
-# ~~~
+# ```
 #
 # Would notice `true`.
 #
@@ -31,11 +31,11 @@
 #
 # @example Using the `all` function with a `Hash` and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, run a lambda using each item as a key-value array
 # $data = { 'a_0'=> 10, 'b_1' => 20 }
 # notice $data.all |$item| { $item[1] % 10 == 0  }
-# ~~~
+# ```
 #
 # Would notice `true` if all values in the hash are multiples of 10.
 #
@@ -45,11 +45,11 @@
 #
 # @example Using the `all` function with a hash and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # Check that all values are a multiple of 10 and keys start with 'abc'
 # $data = {abc_123 => 10, abc_42 => 20, abc_blue => 30}
 # notice $data.all |$key, $value| { $value % 10 == 0  and $key =~ /^abc/ }
-# ~~~
+# ```
 #
 # Would notice true.
 #

--- a/lib/puppet/functions/annotate.rb
+++ b/lib/puppet/functions/annotate.rb
@@ -5,11 +5,11 @@
 #
 # @example Using `annotate` with two arguments
 #
-# ~~~ puppet
+# ```puppet
 # $annotation = Mod::NickNameAdapter.annotate(o)
 #
 # $annotation = annotate(Mod::NickNameAdapter.annotate, o)
-# ~~~
+# ```
 #
 # With three arguments, an `Annotation` type, an object, and a block, the function returns the
 # annotation for the object of the given type, or annotates it with a new annotation initialized
@@ -18,11 +18,11 @@
 #
 # @example Using `annotate` with two arguments and a block
 #
-# ~~~ puppet
+# ```puppet
 # $annotation = Mod::NickNameAdapter.annotate(o) || { { 'nick_name' => 'Buddy' } }
 #
 # $annotation = annotate(Mod::NickNameAdapter.annotate, o) || { { 'nick_name' => 'Buddy' } }
-# ~~~
+# ```
 #
 # With three arguments, an `Annotation` type, an object, and an `Hash`, the function will annotate
 # the given object with a new annotation of the given type that is initialized from the given hash.
@@ -30,11 +30,11 @@
 #
 # @example Using `annotate` with three arguments where third argument is a Hash
 #
-# ~~~ puppet
+# ```puppet
 # $annotation = Mod::NickNameAdapter.annotate(o, { 'nick_name' => 'Buddy' })
 #
 # $annotation = annotate(Mod::NickNameAdapter.annotate, o, { 'nick_name' => 'Buddy' })
-# ~~~
+# ```
 #
 # With three arguments, an `Annotation` type, an object, and an the string `clear`, the function will
 # clear the annotation of the given type in the given object. The old annotation is returned if
@@ -42,11 +42,11 @@
 #
 # @example Using `annotate` with three arguments where third argument is the string 'clear'
 #
-# ~~~ puppet
+# ```puppet
 # $annotation = Mod::NickNameAdapter.annotate(o, clear)
 #
 # $annotation = annotate(Mod::NickNameAdapter.annotate, o, clear)
-# ~~~
+# ```
 #
 # With three arguments, the type `Pcore`, an object, and a Hash of hashes keyed by `Annotation` types,
 # the function will annotate the given object with all types used as keys in the given hash. Each annotation
@@ -54,12 +54,12 @@
 #
 # @example Add multiple annotations to a new instance of `Mod::Person` using the `Pcore` type.
 #
-# ~~~ puppet
+# ```puppet
 #   $person = Pcore.annotate(Mod::Person({'name' => 'William'}), {
 #     Mod::NickNameAdapter >= { 'nick_name' => 'Bill' },
 #     Mod::HobbiesAdapter => { 'hobbies' => ['Ham Radio', 'Philatelist'] }
 #   })
-# ~~~
+# ```
 #
 # @since 5.0.0
 #

--- a/lib/puppet/functions/any.rb
+++ b/lib/puppet/functions/any.rb
@@ -18,12 +18,12 @@
 #
 # @example Using the `any` function with an Array and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, run a lambda that checks if an unknown hash contains those keys
 # $data = ["routers", "servers", "workstations"]
 # $looked_up = lookup('somekey', Hash)
 # notice $data.any |$item| { $looked_up[$item] }
-# ~~~
+# ```
 #
 # Would notice `true` if the looked up hash had a value that is neither `false` nor `undef` for at least
 # one of the keys. That is, it is equivalent to the expression
@@ -34,12 +34,12 @@
 #
 # @example Using the `any` function with a `Hash` and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, run a lambda using each item as a key-value array.
 # $data = {"rtr" => "Router", "svr" => "Server", "wks" => "Workstation"}
 # $looked_up = lookup('somekey', Hash)
 # notice $data.any |$item| { $looked_up[$item[0]] }
-# ~~~
+# ```
 #
 # Would notice `true` if the looked up hash had a value for one of the wanted key that is
 # neither `false` nor `undef`.
@@ -50,11 +50,11 @@
 #
 # @example Using the `any` function with an array and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # Check if there is an even numbered index that has a non String value
 # $data = [key1, 1, 2, 2]
 # notice $data.any |$index, $value| { $index % 2 == 0 and $value !~ String }
-# ~~~
+# ```
 #
 # Would notice true as the index `2` is even and not a `String`
 #

--- a/lib/puppet/functions/assert_type.rb
+++ b/lib/puppet/functions/assert_type.rb
@@ -10,7 +10,7 @@
 #
 # @example Using `assert_type`
 #
-# ~~~ puppet
+# ```puppet
 # $raw_username = 'Amy Berry'
 #
 # # Assert that $raw_username is a non-empty string and assign it to $valid_username.
@@ -19,7 +19,7 @@
 # # $valid_username contains "Amy Berry".
 # # If $raw_username was an empty string or a different data type, the Puppet run would
 # # fail with an "Expected type does not match actual" error.
-# ~~~
+# ```
 #
 # You can use an optional lambda to provide enhanced feedback. The lambda takes two
 # mandatory parameters, in this order:
@@ -29,7 +29,7 @@
 #
 # @example Using `assert_type` with a warning and default value
 #
-# ~~~ puppet
+# ```puppet
 # $raw_username = 'Amy Berry'
 #
 # # Assert that $raw_username is a non-empty string and assign it to $valid_username.
@@ -43,7 +43,7 @@
 # # If $raw_username was an empty string, the Puppet run would set $valid_username to
 # # "anonymous" and output a warning: "The username should be 'String[1, default]', not
 # # 'String[0, 0]'. Using 'anonymous'."
-# ~~~
+# ```
 #
 # For more information about data types, see the
 # [documentation](https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html).

--- a/lib/puppet/functions/call.rb
+++ b/lib/puppet/functions/call.rb
@@ -8,20 +8,20 @@
 #
 # @example Using the `call` function
 #
-# ~~~ puppet
+# ```puppet
 # $a = 'notice'
 # call($a, 'message')
-# ~~~
+# ```
 #
 # @example Using the `call` function with a lambda
 #
-# ~~~ puppet
+# ```puppet
 # $a = 'each'
 # $b = [1,2,3]
 # call($a, $b) |$item| {
 #  notify { $item: }
 # }
-# ~~~
+# ```
 #
 # The `call` function can be used to call either Ruby functions or Puppet language
 # functions.

--- a/lib/puppet/functions/convert_to.rb
+++ b/lib/puppet/functions/convert_to.rb
@@ -7,14 +7,14 @@
 #
 # @example 'convert_to' instead of 'new'
 #
-# ~~~ puppet
+# ```puppet
 #   # using new operator - that is "calling the type" with operator ()
 #   Hash(Array("abc").map |$i,$v| { [$i, $v] })
 #
 #   # using 'convert_to'
 #   "abc".convert_to(Array).map |$i,$v| { [$i, $v] }.convert_to(Hash)
 #
-# ~~~
+# ```
 #
 # @since 5.4.0
 #

--- a/lib/puppet/functions/defined.rb
+++ b/lib/puppet/functions/defined.rb
@@ -12,7 +12,7 @@
 #
 # **Examples**: Different types of `defined` function matches
 #
-# ~~~ puppet
+# ```puppet
 # # Matching resource types
 # defined("file")
 # defined("customtype")
@@ -26,14 +26,14 @@
 #
 # # Matching declared resources
 # defined(File['/tmp/file'])
-# ~~~
+# ```
 #
 # Puppet depends on the configuration's evaluation order when checking whether a resource
 # is declared.
 #
 # @example Importance of evaluation order when using `defined`
 #
-# ~~~ puppet
+# ```puppet
 # # Assign values to $is_defined_before and $is_defined_after using identical `defined`
 # # functions.
 #
@@ -46,7 +46,7 @@
 # $is_defined_after = defined(File['/tmp/file'])
 #
 # # $is_defined_before returns false, but $is_defined_after returns true.
-# ~~~
+# ```
 #
 # This order requirement only refers to evaluation order. The order of resources in the
 # configuration graph (e.g. with `before` or `require`) does not affect the `defined`
@@ -64,7 +64,7 @@
 #
 # @example Matching multiple resources and resources by different types with `defined`
 #
-# ~~~ puppet
+# ```puppet
 # file { "/tmp/file1":
 #   ensure => file,
 # }
@@ -90,7 +90,7 @@
 # defined(Resource['exec','/tmp/file2'])
 # defined(File['/tmp/file3'])
 # defined('$tmp_file2')
-# ~~~
+# ```
 #
 # @since 2.7.0
 # @since 3.6.0 variable reference and future parser types

--- a/lib/puppet/functions/each.rb
+++ b/lib/puppet/functions/each.rb
@@ -20,7 +20,7 @@
 #
 # @example Using the `each` function with an array and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, run a lambda that creates a resource for each item.
 # $data = ["routers", "servers", "workstations"]
 # $data.each |$item| {
@@ -30,14 +30,14 @@
 # }
 # # Puppet creates one resource for each of the three items in $data. Each resource is
 # # named after the item's value and uses the item's value in a parameter.
-# ~~~
+# ```
 #
 # When the first argument is a hash, Puppet passes each key and value pair to the lambda
 # as an array in the form `[key, value]` and returns the original hash.
 #
 # @example Using the `each` function with a hash and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, run a lambda using each item as a key-value array that creates a
 # # resource for each item.
 # $data = {"rtr" => "Router", "svr" => "Server", "wks" => "Workstation"}
@@ -48,7 +48,7 @@
 # }
 # # Puppet creates one resource for each of the three items in $data, each named after the
 # # item's key and containing a parameter using the item's value.
-# ~~~
+# ```
 #
 # When the first argument is an array and the lambda has two parameters, Puppet passes the
 # array's indexes (enumerated from 0) in the first parameter and its values in the second
@@ -56,7 +56,7 @@
 #
 # @example Using the `each` function with an array and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, run a lambda using each item's index and value that creates a
 # # resource for each item.
 # $data = ["routers", "servers", "workstations"]
@@ -67,14 +67,14 @@
 # }
 # # Puppet creates one resource for each of the three items in $data, each named after the
 # # item's value and containing a parameter using the item's index.
-# ~~~
+# ```
 #
 # When the first argument is a hash, Puppet passes its keys to the first parameter and its
 # values to the second parameter.
 #
 # @example Using the `each` function with a hash and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, run a lambda using each item's key and value to create a resource
 # # for each item.
 # $data = {"rtr" => "Router", "svr" => "Server", "wks" => "Workstation"}
@@ -85,7 +85,7 @@
 # }
 # # Puppet creates one resource for each of the three items in $data, each named after the
 # # item's key and containing a parameter using the item's value.
-# ~~~
+# ```
 #
 # For an example that demonstrates how to create multiple `file` resources using `each`,
 # see the Puppet

--- a/lib/puppet/functions/filter.rb
+++ b/lib/puppet/functions/filter.rb
@@ -21,19 +21,19 @@
 #
 # @example Using the `filter` function with an array and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, return an array containing the values that end with "berry"
 # $data = ["orange", "blueberry", "raspberry"]
 # $filtered_data = $data.filter |$items| { $items =~ /berry$/ }
 # # $filtered_data = [blueberry, raspberry]
-# ~~~
+# ```
 #
 # When the first argument is a hash, Puppet passes each key and value pair to the lambda
 # as an array in the form `[key, value]` and returns a hash containing the results.
 #
 # @example Using the `filter` function with a hash and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, return a hash containing all values of keys that end with "berry"
 # $data = { "orange" => 0, "blueberry" => 1, "raspberry" => 2 }
 # $filtered_data = $data.filter |$items| { $items[0] =~ /berry$/ }
@@ -45,26 +45,26 @@
 #
 # @example Using the `filter` function with an array and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, return an array of all keys that both end with "berry" and have
 # # an even-numbered index
 # $data = ["orange", "blueberry", "raspberry"]
 # $filtered_data = $data.filter |$indexes, $values| { $indexes % 2 == 0 and $values =~ /berry$/ }
 # # $filtered_data = [raspberry]
-# ~~~
+# ```
 #
 # When the first argument is a hash, Puppet passes its keys to the first parameter and its
 # values to the second parameter.
 #
 # @example Using the `filter` function with a hash and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, return a hash of all keys that both end with "berry" and have 
 # # values less than or equal to 1
 # $data = { "orange" => 0, "blueberry" => 1, "raspberry" => 2 }
 # $filtered_data = $data.filter |$keys, $values| { $keys =~ /berry$/ and $values <= 1 }
 # # $filtered_data = {blueberry => 1}
-# ~~~
+# ```
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/hiera.rb
+++ b/lib/puppet/functions/hiera.rb
@@ -25,7 +25,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera`
 #
-# ~~~ yaml
+# ```yaml
 # # Assuming hiera.yaml
 # # :hierarchy:
 # #   - web01.example.com
@@ -44,16 +44,16 @@ require 'hiera/puppet_function'
 #   regular:
 #     - "Iris Jackson"
 #     - "Kelly Lambert"
-# ~~~
+# ```
 #
-# ~~~ puppet
+# ```puppet
 # # Assuming we are not web01.example.com:
 #
 # $users = hiera('users', undef)
 #
 # # $users contains {admins  => ["Edith Franklin", "Ginny Hamilton"],
 # #                  regular => ["Iris Jackson", "Kelly Lambert"]}
-# ~~~
+# ```
 #
 # You can optionally generate the default value with a
 # [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
@@ -61,7 +61,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera` with a lambda
 #
-# ~~~ puppet
+# ```puppet
 # # Assuming the same Hiera data as the previous example:
 #
 # $users = hiera('users') | $key | { "Key \'${key}\' not found" }
@@ -70,7 +70,7 @@ require 'hiera/puppet_function'
 # #                  regular => ["Iris Jackson", "Kelly Lambert"]}
 # # If hiera couldn't match its key, it would return the lambda result,
 # # "Key 'users' not found".
-# ~~~
+# ```
 #
 # The returned value's data type depends on the types of the results. In the example 
 # above, Hiera matches the 'users' key and returns it as a hash.

--- a/lib/puppet/functions/hiera_array.rb
+++ b/lib/puppet/functions/hiera_array.rb
@@ -24,7 +24,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera_array`
 #
-# ~~~ yaml
+# ```yaml
 # # Assuming hiera.yaml
 # # :hierarchy:
 # #   - web01.example.com
@@ -37,13 +37,13 @@ require 'hiera/puppet_function'
 #
 # # Assuming web01.example.com.yaml:
 # # users: 'abarry = admin'
-# ~~~
+# ```
 #
-# ~~~ puppet
+# ```puppet
 # $allusers = hiera_array('users', undef)
 #
 # # $allusers contains ["cdouglas = regular", "efranklin = regular", "abarry = admin"].
-# ~~~
+# ```
 #
 # You can optionally generate the default value with a
 # [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
@@ -51,7 +51,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera_array` with a lambda
 #
-# ~~~ puppet
+# ```puppet
 # # Assuming the same Hiera data as the previous example:
 #
 # $allusers = hiera_array('users') | $key | { "Key \'${key}\' not found" }
@@ -59,7 +59,7 @@ require 'hiera/puppet_function'
 # # $allusers contains ["cdouglas = regular", "efranklin = regular", "abarry = admin"].
 # # If hiera_array couldn't match its key, it would return the lambda result,
 # # "Key 'users' not found".
-# ~~~
+# ```
 #
 # `hiera_array` expects that all values returned will be strings or arrays. If any matched
 # value is a hash, Puppet raises a type mismatch error.

--- a/lib/puppet/functions/hiera_hash.rb
+++ b/lib/puppet/functions/hiera_hash.rb
@@ -29,7 +29,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera_hash`
 #
-# ~~~ yaml
+# ```yaml
 # # Assuming hiera.yaml
 # # :hierarchy:
 # #   - web01.example.com
@@ -44,16 +44,16 @@ require 'hiera/puppet_function'
 # # users:
 # #   administrators:
 # #     'aberry': 'Amy Berry'
-# ~~~
+# ```
 #
-# ~~~ puppet
+# ```puppet
 # # Assuming we are not web01.example.com:
 #
 # $allusers = hiera_hash('users', undef)
 #
 # # $allusers contains {regular => {"cdouglas" => "Carrie Douglas"},
 # #                     administrators => {"aberry" => "Amy Berry"}}
-# ~~~
+# ```
 #
 # You can optionally generate the default value with a
 # [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
@@ -61,7 +61,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera_hash` with a lambda
 #
-# ~~~ puppet
+# ```puppet
 # # Assuming the same Hiera data as the previous example:
 #
 # $allusers = hiera_hash('users') | $key | { "Key \'${key}\' not found" }
@@ -70,7 +70,7 @@ require 'hiera/puppet_function'
 # #                     administrators => {"aberry" => "Amy Berry"}}
 # # If hiera_hash couldn't match its key, it would return the lambda result,
 # # "Key 'users' not found".
-# ~~~
+# ```
 #
 # `hiera_hash` expects that all values returned will be hashes. If any of the values
 # found in the data sources are strings or arrays, Puppet raises a type mismatch error.

--- a/lib/puppet/functions/hiera_include.rb
+++ b/lib/puppet/functions/hiera_include.rb
@@ -11,10 +11,10 @@ require 'hiera/puppet_function'
 #
 # @example Using `lookup` and `include` instead of of the deprecated `hiera_include`
 # 
-# ~~~puppet
+# ```puppet
 # # In site.pp, outside of any node definitions and below any top-scope variables:
 # lookup('classes', Array[String], 'unique').include
-# ~~~
+# ```
 #
 # The `hiera_include` function requires:
 #
@@ -43,7 +43,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera_include`
 #
-# ~~~ yaml
+# ```yaml
 # # Assuming hiera.yaml
 # # :hierarchy:
 # #   - web01.example.com
@@ -56,14 +56,14 @@ require 'hiera/puppet_function'
 # # Assuming common.yaml:
 # # classes:
 # #   - apache
-# ~~~
+# ```
 #
-# ~~~ puppet
+# ```puppet
 # # In site.pp, outside of any node definitions and below any top-scope variables:
 # hiera_include('classes', undef)
 #
 # # Puppet assigns the apache and apache::mod::php classes to the web01.example.com node.
-# ~~~
+# ```
 #
 # You can optionally generate the default value with a
 # [lambda](https://docs.puppetlabs.com/puppet/latest/reference/lang_lambdas.html) that
@@ -71,7 +71,7 @@ require 'hiera/puppet_function'
 #
 # @example Using `hiera_include` with a lambda
 #
-# ~~~ puppet
+# ```puppet
 # # Assuming the same Hiera data as the previous example:
 #
 # # In site.pp, outside of any node definitions and below any top-scope variables:
@@ -80,7 +80,7 @@ require 'hiera/puppet_function'
 # # Puppet assigns the apache and apache::mod::php classes to the web01.example.com node.
 # # If hiera_include couldn't match its key, it would return the lambda result,
 # # "Key 'classes' not found".
-# ~~~
+# ```
 #
 # See
 # [the 'Using the lookup function' documentation](https://docs.puppet.com/puppet/latest/hiera_use_function.html) for how to perform lookup of data.

--- a/lib/puppet/functions/inline_epp.rb
+++ b/lib/puppet/functions/inline_epp.rb
@@ -35,13 +35,13 @@
 # For example, to evaluate an inline EPP template using a heredoc, call the
 # `inline_epp` function like this:
 #
-# ~~~ puppet
+# ```puppet
 # # Outputs 'Hello given argument planet!'
 # inline_epp(@(END), { x => 'given argument' })
 # <%- | $x, $y = planet | -%>
 # Hello <%= $x %> <%= $y %>!
 # END
-# ~~~
+# ```
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -20,24 +20,24 @@
 #
 # @example Using the `map` function with an array and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, return an array containing each value multiplied by 10
 # $data = [1,2,3]
 # $transformed_data = $data.map |$items| { $items * 10 }
 # # $transformed_data contains [10,20,30]
-# ~~~
+# ```
 #
 # When the first argument is a hash, Puppet passes each key and value pair to the lambda
 # as an array in the form `[key, value]`.
 #
 # @example Using the `map` function with a hash and a one-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, return an array containing the keys
 # $data = {'a'=>1,'b'=>2,'c'=>3}
 # $transformed_data = $data.map |$items| { $items[0] }
 # # $transformed_data contains ['a','b','c']
-# ~~~
+# ```
 #
 # When the first argument is an array and the lambda has two parameters, Puppet passes the
 # array's indexes (enumerated from 0) in the first parameter and its values in the second
@@ -45,24 +45,24 @@
 #
 # @example Using the `map` function with an array and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the array $data, return an array containing the indexes
 # $data = [1,2,3]
 # $transformed_data = $data.map |$index,$value| { $index }
 # # $transformed_data contains [0,1,2]
-# ~~~
+# ```
 #
 # When the first argument is a hash, Puppet passes its keys to the first parameter and its
 # values to the second parameter.
 #
 # @example Using the `map` function with a hash and a two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # For the hash $data, return an array containing each value
 # $data = {'a'=>1,'b'=>2,'c'=>3}
 # $transformed_data = $data.map |$key,$value| { $value }
 # # $transformed_data contains [1,2,3]
-# ~~~
+# ```
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/match.rb
+++ b/lib/puppet/functions/match.rb
@@ -13,24 +13,24 @@
 #
 # @example Matching a regular expression in a string
 #
-# ~~~ ruby
+# ```ruby
 # $matches = "abc123".match(/[a-z]+[1-9]+/)
 # # $matches contains [abc123]
-# ~~~
+# ```
 #
 # @example Matching a regular expressions with grouping captures in a string
 #
-# ~~~ ruby
+# ```ruby
 # $matches = "abc123".match(/([a-z]+)([1-9]+)/)
 # # $matches contains [abc123, abc, 123]
-# ~~~
+# ```
 #
 # @example Matching a regular expression with grouping captures in an array of strings
 #
-# ~~~ ruby
+# ```ruby
 # $matches = ["abc123","def456"].match(/([a-z]+)([1-9]+)/)
 # # $matches contains [[abc123, abc, 123], [def456, def, 456]]
-# ~~~
+# ```
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/reduce.rb
+++ b/lib/puppet/functions/reduce.rb
@@ -47,7 +47,7 @@
 #
 # @example Using the `reduce` function
 #
-# ~~~ puppet
+# ```puppet
 # # Reduce the array $data, returning the sum of all values in the array.
 # $data = [1, 2, 3]
 # $sum = $data.reduce |$memo, $value| { $memo + $value }
@@ -68,11 +68,11 @@
 #   [$string, $number]
 # }
 # # $combine contains [abc, 6]
-# ~~~
+# ```
 #
 # @example Using the `reduce` function with a start memo and two-parameter lambda
 #
-# ~~~ puppet
+# ```puppet
 # # Reduce the array $data, returning the sum of all values in the array and starting
 # # with $memo set to an arbitrary value instead of $data's first value.
 # $data = [1, 2, 3]
@@ -92,11 +92,11 @@
 # # At the start of the lambda's first iteration, $memo contains [d, 4] and $value
 # # contains [a, 1].
 # # $combine contains [dabc, 10]
-# ~~~
+# ```
 #
 # @example Using the `reduce` function to reduce a hash of hashes
 #
-# ~~~ puppet
+# ```puppet
 # # Reduce a hash of hashes $data, merging defaults into the inner hashes.
 # $data = {
 #   'connection1' => {
@@ -123,7 +123,7 @@
 # # the first [key, value] tuple. The key in $data is, therefore, given by $x[0]. In
 # # subsequent rounds, $memo retains the value returned by the expression, i.e.
 # # $memo + { $x[0] => $defaults + $data[$x[0]] }.
-# ~~~
+# ```
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/tree_each.rb
+++ b/lib/puppet/functions/tree_each.rb
@@ -42,9 +42,9 @@
 #
 # @example depth- or breadth-first order
 #
-# ~~~ puppet
+# ```puppet
 # [1, [2, 3], 4]
-# ~~~
+# ```
 # 
 # Results in:
 # 
@@ -67,29 +67,29 @@
 #
 # @example A flattened iteration over a tree excluding Collections
 #
-# ~~~ puppet
+# ```puppet
 # $data = [1, 2, [3, [4, 5]]]
 # $data.tree_each({include_containers => false}) |$v| { notice "$v" }
-# ~~~
+# ```
 #
 # This would call the lambda 5 times with with the following values in sequence: `1`, `2`, `3`, `4`, `5`
 #
 # @example A flattened iteration over a tree (including containers by default)
 #
-# ~~~ puppet
+# ```puppet
 # $data = [1, 2, [3, [4, 5]]]
 # $data.tree_each |$v| { notice "$v" }
-# ~~~
+# ```
 #
 # This would call the lambda 7 times with the following values in sequence:
 # `1`, `2`, `[3, [4, 5]]`, `3`, `[4, 5]`, `4`, `5`
 #
 # @example A flattened iteration over a tree (including only non root containers)
 #
-# ~~~ puppet
+# ```puppet
 # $data = [1, 2, [3, [4, 5]]]
 # $data.tree_each({include_values => false, include_root => false}) |$v| { notice "$v" }
-# ~~~
+# ```
 #
 # This would call the lambda 2 times with the following values in sequence:
 # `[3, [4, 5]]`, `[4, 5]`
@@ -101,10 +101,10 @@
 #
 # @example Only `Array` as container type
 #
-# ~~~ puppet
+# ```puppet
 # $data = [1, {a => 'hello', b => [100, 200]}, [3, [4, 5]]]
 # $data.tree_each({container_type => Array, include_containers => false} |$v| { notice "$v" }
-# ~~~
+# ```
 # 
 # Would call the lambda 5 times with `1`, `{a => 'hello', b => [100, 200]}`, `3`, `4`, `5`
 #
@@ -120,7 +120,7 @@
 #
 # @example pruning a tree
 # 
-# ~~~ puppet
+# ```puppet
 # # A tree of some complexity (here very simple for readability)
 # $tree = [
 #  { name => 'user1', status => 'inactive', id => '10'},
@@ -130,7 +130,7 @@
 #  $value = $v[1]
 #  $value =~ Hash and $value[status] == active
 # }
-# ~~~
+# ```
 #
 # Would notice `[[[1], {name => user2, status => active, id => 20}]]`, which can then be processed
 # further as each filtered result appears as a `Tuple` with `[path, value]`.

--- a/lib/puppet/functions/unique.rb
+++ b/lib/puppet/functions/unique.rb
@@ -11,21 +11,21 @@
 #
 # @example Using unique with a String
 #
-# ~~~puppet
+# ```puppet
 # # will produce 'abc'
 # "abcaabb".unique
-# ~~~
+# ```
 #
 # @example Using unique with an Array
 #
-# ~~~puppet
+# ```puppet
 # # will produce ['a', 'b', 'c']
 # ['a', 'b', 'c', 'a', 'a', 'b'].unique
-# ~~~
+# ```
 #
 # @example Using unique with a Hash
 #
-# ~~~puppet
+# ```puppet
 # # will produce { ['a', 'b'] => [10], ['c'] => [20]}
 # {'a' => 10, 'b' => 10, 'c' => 20}.unique
 #
@@ -34,18 +34,18 @@
 #
 # # will produce { 'b' => 10, 'c' => 20 } (use last key with first value)
 # Hash.new({'a' => 10, 'b' => 10, 'c' => 20}.unique.map |$k, $v| { [ $k[-1] , $v[0]] })
-# ~~~
+# ```
 #
 # @example Using unique with an Iterable
 #
-# ~~~
+# ```
 # # will produce [3, 2, 1]
 # [1,2,2,3,3].reverse_each.unique
-# ~~~
+# ```
 #
 # @example Using unique with a lambda
 #
-# ~~~puppet
+# ```puppet
 # # will produce [['sam', 'smith'], ['sue', 'smith']]
 # [['sam', 'smith'], ['sam', 'brown'], ['sue', 'smith']].unique |$x| { $x[0] }
 #
@@ -57,7 +57,7 @@
 #
 # # will produce {[a] => [10], [b, c, d, e] => [11, 12, 100]}
 # {a => 10, b => 11, c => 12, d => 100, e => 11}.unique |$v| { if $v > 10 { big } else { $v } } 
-# ~~~
+# ```
 #
 # Note that for `Hash` the result is slightly different than for the other data types. For those the result contains the
 # *first-found* unique value, but for `Hash` it contains associations from a set of keys to the set of values clustered by the
@@ -70,7 +70,7 @@
 #
 # @example turning a string or array into a hash with index keys
 #
-# ~~~puppet
+# ```puppet
 # # Array ['a', 'b', 'c'] to Hash with index results in
 # # {0 => 'a', 1 => 'b', 2 => 'c'}
 # Hash(['a', 'b', 'c'].map |$i, $v| { [$i, $v]})
@@ -79,7 +79,7 @@
 # # {0 => 'a', 1 => 'b', 2 => 'c'}
 # Hash(Array("abc").map |$i,$v| { [$i, $v]})
 # "abc".to(Array).map |$i,$v| { [$i, $v]}.to(Hash)
-# ~~~
+# ```
 #
 # @since Puppet 5.0.0
 #

--- a/lib/puppet/functions/unwrap.rb
+++ b/lib/puppet/functions/unwrap.rb
@@ -1,17 +1,17 @@
 # Unwraps a Sensitive value and returns the wrapped object.
 #
-# ~~~puppet
+# ```puppet
 # $plaintext = 'hunter2'
 # $pw = Sensitive.new($plaintext)
 # notice("Wrapped object is $pw") #=> Prints "Wrapped object is Sensitive [value redacted]"
 # $unwrapped = $pw.unwrap
 # notice("Unwrapped object is $unwrapped") #=> Prints "Unwrapped object is hunter2"
-# ~~~
+# ```
 #
 # You can optionally pass a block to unwrap in order to limit the scope where the
 # unwrapped value is visible.
 #
-# ~~~puppet
+# ```puppet
 # $pw = Sensitive.new('hunter2')
 # notice("Wrapped object is $pw") #=> Prints "Wrapped object is Sensitive [value redacted]"
 # $pw.unwrap |$unwrapped| {
@@ -19,7 +19,7 @@
 #   Sensitive.new($conf)
 # } #=> Returns a new Sensitive object containing an interpolated config file
 # # $unwrapped is now out of scope
-# ~~~
+# ```
 #
 # @since 4.0.0
 #

--- a/lib/puppet/functions/with.rb
+++ b/lib/puppet/functions/with.rb
@@ -6,7 +6,7 @@
 #
 # @example Using `with`
 #
-# ~~~ puppet
+# ```puppet
 # # Concatenate three strings into a single string formatted as a list.
 # $fruit = with("apples", "oranges", "bananas") |$x, $y, $z| { 
 #   "${x}, ${y}, and ${z}" 
@@ -14,7 +14,7 @@
 # $check_var = $x
 # # $fruit contains "apples, oranges, and bananas"
 # # $check_var is undefined, as the value of $x is local to the lambda.
-# ~~~
+# ```
 #
 # @since 4.0.0
 #


### PR DESCRIPTION
Before this, function documentation was written with three tildes and
the language name (or no language).
This is now changed in all 4.x functions as the three tildes syntax is
not standard markdown.