### PR TITLE
(PUP-8475) Change capability component to QREF instead of QNAME

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -460,10 +460,10 @@ class Puppet::Parser::Compiler
       component_ref = args['component']
       kind = args['kind']
 
-      # That component_ref is either a QNAME or a Class['literal'|QREF] is asserted during validation so no
+      # That component_ref is either a QREF or a Class['literal'|QREF] is asserted during validation so no
       # need to check that here
-      if component_ref.is_a?(Puppet::Pops::Model::QualifiedName)
-        component_name = component_ref.value
+      if component_ref.is_a?(Puppet::Pops::Model::QualifiedReference)
+        component_name = component_ref.cased_value
         component_type = 'type'
         component = krt.find_definition(component_name)
       else

--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -530,7 +530,7 @@ application_expression
 capability_mapping
   : classname capability_kw classname LBRACE  attribute_operations endcomma RBRACE {
     result = Factory.CAPABILITY_MAPPING(val[1][:value],
-                                        Factory.QNAME(classname(val[0][:value])),
+                                        Factory.QREF(classname(val[0][:value])),
                                         classname(val[2][:value]), val[4])
     loc result, val[0], val[6]
     add_mapping(result)

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -2543,7 +2543,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 524)
 module_eval(<<'.,.,', 'egrammar.ra', 531)
   def _reduce_154(val, _values, result)
         result = Factory.CAPABILITY_MAPPING(val[1][:value],
-                                        Factory.QNAME(classname(val[0][:value])),
+                                        Factory.QREF(classname(val[0][:value])),
                                         classname(val[2][:value]), val[4])
     loc result, val[0], val[6]
     add_mapping(result)
@@ -3310,6 +3310,6 @@ def _reduce_none(val, _values, result)
 end
 
       end   # class Parser
-    end   # module Parser
-  end   # module Pops
-end   # module Puppet
+      end   # module Parser
+    end   # module Pops
+  end   # module Puppet

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -292,8 +292,8 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   def check_CapabilityMapping(o)
     ok =
     case o.component
-    when Model::QualifiedName
-      name = o.component.value
+    when Model::QualifiedReference
+      name = o.component.cased_value
       acceptor.accept(Issues::ILLEGAL_CLASSREF, o.component, {:name=>name}) unless name =~ Patterns::CLASSREF_EXT
       true
     when Model::AccessExpression

--- a/spec/unit/pops/parser/parse_capabilities_spec.rb
+++ b/spec/unit/pops/parser/parse_capabilities_spec.rb
@@ -9,13 +9,13 @@ describe "egrammar parsing of capability mappings" do
   context "when parsing 'produces'" do
     it "the ast contains produces and attributes" do
       prog = "Foo produces Sql { name => value }"
-      ast = "(produces Foo Sql ((name => value)))"
+      ast = "(produces foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 
     it "optional end comma is allowed" do
       prog = "Foo produces Sql { name => value, }"
-      ast = "(produces Foo Sql ((name => value)))"
+      ast = "(produces foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
   end
@@ -23,13 +23,13 @@ describe "egrammar parsing of capability mappings" do
   context "when parsing 'consumes'" do
     it "the ast contains consumes and attributes" do
       prog = "Foo consumes Sql { name => value }"
-      ast = "(consumes Foo Sql ((name => value)))"
+      ast = "(consumes foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 
     it "optional end comma is allowed" do
       prog = "Foo consumes Sql { name => value, }"
-      ast = "(consumes Foo Sql ((name => value)))"
+      ast = "(consumes foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 


### PR DESCRIPTION
The component of a capability is a type reference but the parser created
a QNAME for it which was then validated using a QREF pattern. This
commit changes this so that the parser instead creates a QREF.