### PR TITLE
(PUP-8474) Make ModelTreeDumper dump QREFs using cased value

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -460,10 +460,10 @@ class Puppet::Parser::Compiler
       component_ref = args['component']
       kind = args['kind']
 
-      # That component_ref is either a QNAME or a Class['literal'|QREF] is asserted during validation so no
+      # That component_ref is either a QREF or a Class['literal'|QREF] is asserted during validation so no
       # need to check that here
-      if component_ref.is_a?(Puppet::Pops::Model::QualifiedName)
-        component_name = component_ref.value
+      if component_ref.is_a?(Puppet::Pops::Model::QualifiedReference)
+        component_name = component_ref.cased_value
         component_type = 'type'
         component = krt.find_definition(component_name)
       else

--- a/lib/puppet/pops/model/model_tree_dumper.rb
+++ b/lib/puppet/pops/model/model_tree_dumper.rb
@@ -28,6 +28,10 @@ class Puppet::Pops::Model::ModelTreeDumper < Puppet::Pops::Model::TreeDumper
     o.value.to_s
   end
 
+  def dump_QualifiedReference o
+    o.cased_value.to_s
+  end
+
   def dump_Factory o
     o['locator'] ||= Puppet::Pops::Parser::Locator.locator("<not from source>", nil)
     do_dump(o.model)

--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -530,7 +530,7 @@ application_expression
 capability_mapping
   : classname capability_kw classname LBRACE  attribute_operations endcomma RBRACE {
     result = Factory.CAPABILITY_MAPPING(val[1][:value],
-                                        Factory.QNAME(classname(val[0][:value])),
+                                        Factory.QREF(classname(val[0][:value])),
                                         classname(val[2][:value]), val[4])
     loc result, val[0], val[6]
     add_mapping(result)

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -2543,7 +2543,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 524)
 module_eval(<<'.,.,', 'egrammar.ra', 531)
   def _reduce_154(val, _values, result)
         result = Factory.CAPABILITY_MAPPING(val[1][:value],
-                                        Factory.QNAME(classname(val[0][:value])),
+                                        Factory.QREF(classname(val[0][:value])),
                                         classname(val[2][:value]), val[4])
     loc result, val[0], val[6]
     add_mapping(result)
@@ -3310,6 +3310,6 @@ def _reduce_none(val, _values, result)
 end
 
       end   # class Parser
-    end   # module Parser
-  end   # module Pops
-end   # module Puppet
+      end   # module Parser
+    end   # module Pops
+  end   # module Puppet

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -292,8 +292,8 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   def check_CapabilityMapping(o)
     ok =
     case o.component
-    when Model::QualifiedName
-      name = o.component.value
+    when Model::QualifiedReference
+      name = o.component.cased_value
       acceptor.accept(Issues::ILLEGAL_CLASSREF, o.component, {:name=>name}) unless name =~ Patterns::CLASSREF_EXT
       true
     when Model::AccessExpression

--- a/spec/unit/pops/parser/parse_basic_expressions_spec.rb
+++ b/spec/unit/pops/parser/parse_basic_expressions_spec.rb
@@ -234,7 +234,7 @@ describe "egrammar parsing basic expressions" do
 
   context 'When parsing type aliases' do
     it 'type A = B' do
-      expect(dump(parse('type A = B'))).to eq('(type-alias A b)')
+      expect(dump(parse('type A = B'))).to eq('(type-alias A B)')
     end
 
     it 'type A = B[]' do
@@ -246,19 +246,19 @@ describe "egrammar parsing basic expressions" do
     end
 
     it 'type A = B[C]' do
-      expect(dump(parse('type A = B[C]'))).to eq('(type-alias A (slice b c))')
+      expect(dump(parse('type A = B[C]'))).to eq('(type-alias A (slice B C))')
     end
 
     it 'type A = B[C,]' do
-      expect(dump(parse('type A = B[C,]'))).to eq('(type-alias A (slice b c))')
+      expect(dump(parse('type A = B[C,]'))).to eq('(type-alias A (slice B C))')
     end
 
     it 'type A = B[C,D]' do
-      expect(dump(parse('type A = B[C,D]'))).to eq('(type-alias A (slice b (c d)))')
+      expect(dump(parse('type A = B[C,D]'))).to eq('(type-alias A (slice B (C D)))')
     end
 
     it 'type A = B[C,D,]' do
-      expect(dump(parse('type A = B[C,D,]'))).to eq('(type-alias A (slice b (c d)))')
+      expect(dump(parse('type A = B[C,D,]'))).to eq('(type-alias A (slice B (C D)))')
     end
   end
 

--- a/spec/unit/pops/parser/parse_calls_spec.rb
+++ b/spec/unit/pops/parser/parse_calls_spec.rb
@@ -138,7 +138,7 @@ describe "egrammar parsing function calls" do
     end
 
     it 'notice Hash.assert_type(a => 42)' do
-      expect(dump(parse('notice Hash.assert_type(a => 42)'))).to eq('(invoke notice (call-method (. hash assert_type) ({} (a 42))))')
+      expect(dump(parse('notice Hash.assert_type(a => 42)'))).to eq('(invoke notice (call-method (. Hash assert_type) ({} (a 42))))')
     end
 
     it "notice 42.type(detailed)" do

--- a/spec/unit/pops/parser/parse_capabilities_spec.rb
+++ b/spec/unit/pops/parser/parse_capabilities_spec.rb
@@ -9,13 +9,13 @@ describe "egrammar parsing of capability mappings" do
   context "when parsing 'produces'" do
     it "the ast contains produces and attributes" do
       prog = "Foo produces Sql { name => value }"
-      ast = "(produces foo Sql ((name => value)))"
+      ast = "(produces Foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 
     it "optional end comma is allowed" do
       prog = "Foo produces Sql { name => value, }"
-      ast = "(produces foo Sql ((name => value)))"
+      ast = "(produces Foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
   end
@@ -23,13 +23,13 @@ describe "egrammar parsing of capability mappings" do
   context "when parsing 'consumes'" do
     it "the ast contains consumes and attributes" do
       prog = "Foo consumes Sql { name => value }"
-      ast = "(consumes foo Sql ((name => value)))"
+      ast = "(consumes Foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 
     it "optional end comma is allowed" do
       prog = "Foo consumes Sql { name => value, }"
-      ast = "(consumes foo Sql ((name => value)))"
+      ast = "(consumes Foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 

--- a/spec/unit/pops/parser/parse_capabilities_spec.rb
+++ b/spec/unit/pops/parser/parse_capabilities_spec.rb
@@ -9,13 +9,13 @@ describe "egrammar parsing of capability mappings" do
   context "when parsing 'produces'" do
     it "the ast contains produces and attributes" do
       prog = "Foo produces Sql { name => value }"
-      ast = "(produces Foo Sql ((name => value)))"
+      ast = "(produces foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 
     it "optional end comma is allowed" do
       prog = "Foo produces Sql { name => value, }"
-      ast = "(produces Foo Sql ((name => value)))"
+      ast = "(produces foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
   end
@@ -23,13 +23,13 @@ describe "egrammar parsing of capability mappings" do
   context "when parsing 'consumes'" do
     it "the ast contains consumes and attributes" do
       prog = "Foo consumes Sql { name => value }"
-      ast = "(consumes Foo Sql ((name => value)))"
+      ast = "(consumes foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 
     it "optional end comma is allowed" do
       prog = "Foo consumes Sql { name => value, }"
-      ast = "(consumes Foo Sql ((name => value)))"
+      ast = "(consumes foo Sql ((name => value)))"
       expect(dump(parse(prog))).to eq(ast)
     end
 

--- a/spec/unit/pops/parser/parse_functions_spec.rb
+++ b/spec/unit/pops/parser/parse_functions_spec.rb
@@ -13,7 +13,7 @@ describe 'egrammar parsing function definitions' do
 
   context 'with return type' do
     it 'function foo() >> Integer { 1 }' do
-      expect(dump(parse('function foo() >> Integer { 1 }'))).to eq("(function foo (return_type integer) (block\n  1\n))")
+      expect(dump(parse('function foo() >> Integer { 1 }'))).to eq("(function foo (return_type Integer) (block\n  1\n))")
     end
   end
 end

--- a/spec/unit/pops/parser/parse_lambda_spec.rb
+++ b/spec/unit/pops/parser/parse_lambda_spec.rb
@@ -13,7 +13,7 @@ describe 'egrammar parsing lambda definitions' do
 
   context 'with return type' do
     it 'f() |$x| >> Integer { 1 }' do
-      expect(dump(parse('f() |$x| >> Integer { 1 }'))).to eq("(invoke f (lambda (parameters x) (return_type integer) (block\n  1\n)))")
+      expect(dump(parse('f() |$x| >> Integer { 1 }'))).to eq("(invoke f (lambda (parameters x) (return_type Integer) (block\n  1\n)))")
     end
   end
 end

--- a/spec/unit/pops/parser/parse_resource_spec.rb
+++ b/spec/unit/pops/parser/parse_resource_spec.rb
@@ -12,14 +12,14 @@ describe "egrammar parsing resource declarations" do
     ["File", "file"].each do |word|
       it "#{word} { 'title': }" do
         expect(dump(parse("#{word} { 'title': }"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title'))"
         ].join("\n"))
       end
 
       it "#{word} { 'title': path => '/somewhere', mode => '0777'}" do
         expect(dump(parse("#{word} { 'title': path => '/somewhere', mode => '0777'}"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title'",
           "    (path => '/somewhere')",
           "    (mode => '0777')))"
@@ -28,7 +28,7 @@ describe "egrammar parsing resource declarations" do
 
       it "#{word} { 'title': path => '/somewhere', }" do
         expect(dump(parse("#{word} { 'title': path => '/somewhere', }"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title'",
           "    (path => '/somewhere')))"
         ].join("\n"))
@@ -36,21 +36,21 @@ describe "egrammar parsing resource declarations" do
 
       it "#{word} { 'title': , }" do
         expect(dump(parse("#{word} { 'title': , }"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title'))"
         ].join("\n"))
       end
 
       it "#{word} { 'title': ; }" do
         expect(dump(parse("#{word} { 'title': ; }"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title'))"
         ].join("\n"))
       end
 
       it "#{word} { 'title': ; 'other_title': }" do
         expect(dump(parse("#{word} { 'title': ; 'other_title': }"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title')",
           "  ('other_title'))"
         ].join("\n"))
@@ -59,7 +59,7 @@ describe "egrammar parsing resource declarations" do
       # PUP-2898, trailing ';'
       it "#{word} { 'title': ; 'other_title': ; }" do
         expect(dump(parse("#{word} { 'title': ; 'other_title': ; }"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title')",
           "  ('other_title'))"
         ].join("\n"))
@@ -67,7 +67,7 @@ describe "egrammar parsing resource declarations" do
 
       it "#{word} { 'title1': path => 'x'; 'title2': path => 'y'}" do
         expect(dump(parse("#{word} { 'title1': path => 'x'; 'title2': path => 'y'}"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  ('title1'",
           "    (path => 'x'))",
           "  ('title2'",
@@ -77,7 +77,7 @@ describe "egrammar parsing resource declarations" do
 
       it "#{word} { title: * => {mode => '0777'} }" do
         expect(dump(parse("#{word} { title: * => {mode => '0777'}}"))).to eq([
-          "(resource file",
+          "(resource #{word}",
           "  (title",
           "    (* => ({} (mode '0777')))))"
         ].join("\n"))
@@ -87,19 +87,19 @@ describe "egrammar parsing resource declarations" do
 
   context "When parsing (type based) resource defaults" do
     it "File {  }" do
-      expect(dump(parse("File { }"))).to eq("(resource-defaults file)")
+      expect(dump(parse("File { }"))).to eq("(resource-defaults File)")
     end
 
     it "File { mode => '0777' }" do
       expect(dump(parse("File { mode => '0777'}"))).to eq([
-        "(resource-defaults file",
+        "(resource-defaults File",
         "  (mode => '0777'))"
       ].join("\n"))
     end
 
     it "File { * => {mode => '0777'} } (even if validated to be illegal)" do
       expect(dump(parse("File { * => {mode => '0777'}}"))).to eq([
-        "(resource-defaults file",
+        "(resource-defaults File",
         "  (* => ({} (mode '0777'))))"
       ].join("\n"))
     end
@@ -107,12 +107,12 @@ describe "egrammar parsing resource declarations" do
 
   context "When parsing resource override" do
     it "File['x'] {  }" do
-      expect(dump(parse("File['x'] { }"))).to eq("(override (slice file 'x'))")
+      expect(dump(parse("File['x'] { }"))).to eq("(override (slice File 'x'))")
     end
 
     it "File['x'] { x => 1 }" do
       expect(dump(parse("File['x'] { x => 1}"))).to eq([
-        "(override (slice file 'x')",
+        "(override (slice File 'x')",
         "  (x => 1))"
         ].join("\n"))
     end
@@ -120,14 +120,14 @@ describe "egrammar parsing resource declarations" do
 
     it "File['x', 'y'] { x => 1 }" do
       expect(dump(parse("File['x', 'y'] { x => 1}"))).to eq([
-        "(override (slice file ('x' 'y'))",
+        "(override (slice File ('x' 'y'))",
         "  (x => 1))"
         ].join("\n"))
     end
 
     it "File['x'] { x => 1, y => 2 }" do
       expect(dump(parse("File['x'] { x => 1, y=> 2}"))).to eq([
-        "(override (slice file 'x')",
+        "(override (slice File 'x')",
         "  (x => 1)",
         "  (y => 2))"
         ].join("\n"))
@@ -135,14 +135,14 @@ describe "egrammar parsing resource declarations" do
 
     it "File['x'] { x +> 1 }" do
       expect(dump(parse("File['x'] { x +> 1}"))).to eq([
-        "(override (slice file 'x')",
+        "(override (slice File 'x')",
         "  (x +> 1))"
         ].join("\n"))
     end
 
     it "File['x'] { * => {mode => '0777'} } (even if validated to be illegal)" do
       expect(dump(parse("File['x'] { * => {mode => '0777'}}"))).to eq([
-        "(override (slice file 'x')",
+        "(override (slice File 'x')",
         "  (* => ({} (mode '0777'))))"
       ].join("\n"))
     end
@@ -173,28 +173,28 @@ describe "egrammar parsing resource declarations" do
 
     it "parses global defaults with @ (even if validated to be illegal)" do
       expect(dump(parse("@File { mode => '0777' }"))).to eq([
-        "(virtual-resource-defaults file",
+        "(virtual-resource-defaults File",
         "  (mode => '0777'))"
         ].join("\n"))
     end
 
     it "parses global defaults with @@ (even if validated to be illegal)" do
       expect(dump(parse("@@File { mode => '0777' }"))).to eq([
-        "(exported-resource-defaults file",
+        "(exported-resource-defaults File",
         "  (mode => '0777'))"
         ].join("\n"))
     end
 
     it "parses override with @ (even if validated to be illegal)" do
       expect(dump(parse("@File[foo] { mode => '0777' }"))).to eq([
-        "(virtual-override (slice file foo)",
+        "(virtual-override (slice File foo)",
         "  (mode => '0777'))"
         ].join("\n"))
     end
 
     it "parses override combined with @@ (even if validated to be illegal)" do
       expect(dump(parse("@@File[foo] { mode => '0777' }"))).to eq([
-        "(exported-override (slice file foo)",
+        "(exported-override (slice File foo)",
         "  (mode => '0777'))"
         ].join("\n"))
     end
@@ -253,19 +253,19 @@ describe "egrammar parsing resource declarations" do
 
   context "When parsing Relationships" do
     it "File[a] -> File[b]" do
-      expect(dump(parse("File[a] -> File[b]"))).to eq("(-> (slice file a) (slice file b))")
+      expect(dump(parse("File[a] -> File[b]"))).to eq("(-> (slice File a) (slice File b))")
     end
 
     it "File[a] <- File[b]" do
-      expect(dump(parse("File[a] <- File[b]"))).to eq("(<- (slice file a) (slice file b))")
+      expect(dump(parse("File[a] <- File[b]"))).to eq("(<- (slice File a) (slice File b))")
     end
 
     it "File[a] ~> File[b]" do
-      expect(dump(parse("File[a] ~> File[b]"))).to eq("(~> (slice file a) (slice file b))")
+      expect(dump(parse("File[a] ~> File[b]"))).to eq("(~> (slice File a) (slice File b))")
     end
 
     it "File[a] <~ File[b]" do
-      expect(dump(parse("File[a] <~ File[b]"))).to eq("(<~ (slice file a) (slice file b))")
+      expect(dump(parse("File[a] <~ File[b]"))).to eq("(<~ (slice File a) (slice File b))")
     end
 
     it "Should chain relationships" do
@@ -276,13 +276,13 @@ describe "egrammar parsing resource declarations" do
 
     it "Should chain relationships" do
       expect(dump(parse("File[a] -> File[b] ~> File[c] <- File[d] <~ File[e]"))).to eq(
-      "(<~ (<- (~> (-> (slice file a) (slice file b)) (slice file c)) (slice file d)) (slice file e))"
+      "(<~ (<- (~> (-> (slice File a) (slice File b)) (slice File c)) (slice File d)) (slice File e))"
       )
     end
 
     it "should create relationships between collects" do
       expect(dump(parse("File <| mode == 0644 |> -> File <| mode == 0755 |>"))).to eq(
-      "(-> (collect file\n  (<| |> (== mode 0644))) (collect file\n  (<| |> (== mode 0755))))"
+      "(-> (collect File\n  (<| |> (== mode 0644))) (collect File\n  (<| |> (== mode 0755))))"
       )
     end
   end
@@ -290,38 +290,38 @@ describe "egrammar parsing resource declarations" do
   context "When parsing collection" do
     context "of virtual resources" do
       it "File <| |>" do
-        expect(dump(parse("File <| |>"))).to eq("(collect file\n  (<| |>))")
+        expect(dump(parse("File <| |>"))).to eq("(collect File\n  (<| |>))")
       end
     end
 
     context "of exported resources" do
       it "File <<| |>>" do
-        expect(dump(parse("File <<| |>>"))).to eq("(collect file\n  (<<| |>>))")
+        expect(dump(parse("File <<| |>>"))).to eq("(collect File\n  (<<| |>>))")
       end
     end
 
     context "queries are parsed with correct precedence" do
       it "File <| tag == 'foo' |>" do
-        expect(dump(parse("File <| tag == 'foo' |>"))).to eq("(collect file\n  (<| |> (== tag 'foo')))")
+        expect(dump(parse("File <| tag == 'foo' |>"))).to eq("(collect File\n  (<| |> (== tag 'foo')))")
       end
 
       it "File <| tag == 'foo' and mode != '0777' |>" do
-        expect(dump(parse("File <| tag == 'foo' and mode != '0777' |>"))).to eq("(collect file\n  (<| |> (&& (== tag 'foo') (!= mode '0777'))))")
+        expect(dump(parse("File <| tag == 'foo' and mode != '0777' |>"))).to eq("(collect File\n  (<| |> (&& (== tag 'foo') (!= mode '0777'))))")
       end
 
       it "File <| tag == 'foo' or mode != '0777' |>" do
-        expect(dump(parse("File <| tag == 'foo' or mode != '0777' |>"))).to eq("(collect file\n  (<| |> (|| (== tag 'foo') (!= mode '0777'))))")
+        expect(dump(parse("File <| tag == 'foo' or mode != '0777' |>"))).to eq("(collect File\n  (<| |> (|| (== tag 'foo') (!= mode '0777'))))")
       end
 
       it "File <| tag == 'foo' or tag == 'bar' and mode != '0777' |>" do
         expect(dump(parse("File <| tag == 'foo' or tag == 'bar' and mode != '0777' |>"))).to eq(
-        "(collect file\n  (<| |> (|| (== tag 'foo') (&& (== tag 'bar') (!= mode '0777')))))"
+        "(collect File\n  (<| |> (|| (== tag 'foo') (&& (== tag 'bar') (!= mode '0777')))))"
         )
       end
 
       it "File <| (tag == 'foo' or tag == 'bar') and mode != '0777' |>" do
         expect(dump(parse("File <| (tag == 'foo' or tag == 'bar') and mode != '0777' |>"))).to eq(
-        "(collect file\n  (<| |> (&& (|| (== tag 'foo') (== tag 'bar')) (!= mode '0777'))))"
+        "(collect File\n  (<| |> (&& (|| (== tag 'foo') (== tag 'bar')) (!= mode '0777'))))"
         )
       end
     end


### PR DESCRIPTION
Prior to this commit, the ModelTreeDumper would dump both QNAME and
QREF using their 'value' and thereby render them indistinguishable
in the output since that attribute is always downcased. This commit
changes the dumper so that it uses the 'cased_value' when dumping a
QREF.

NOTE! PR #6656 must be merged before this one or the parse_capability_spec test will fail.