### PR TITLE
(PUP-8471) Prevent TypeSet loader from being replaced

### DIFF
--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -23,6 +23,10 @@ class PTypeSetType < PMetaType
       @type_set.name_authority
     end
 
+    def model_loader
+      @type_set.loader
+    end
+
     def find(typed_name)
       if typed_name.type == :type && typed_name.name_authority == @type_set.name_authority
         type = @type_set[typed_name.name]

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -290,7 +290,14 @@ class TypeParser
 
   # @api private
   def loader_from_context(ast, context)
-    Adapters::LoaderAdapter.loader_for_model_object(ast, nil, context)
+    model_loader = Adapters::LoaderAdapter.loader_for_model_object(ast, nil, context)
+    if context.is_a?(PTypeSetType::TypeSetLoader)
+      # Only swap a given TypeSetLoader for another loader when the other loader is different
+      # from the one associated with the TypeSet expression
+      context.model_loader.equal?(model_loader.parent) ? context : model_loader
+    else
+      model_loader
+    end
   end
 
   # @api private

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -534,6 +534,20 @@ describe 'loaders' do
               },
               'metadata.json' => sprintf(metadata_json, 'c', '')
             },
+            'd' => {
+              'types' => {
+                'init_typeset.pp' => <<-PUPPET.unindent,
+                  type D = TypeSet[{
+                    pcore_version => '1.0.0',
+                    types => {
+                      P => Object[{}],
+                      O => Object[{ parent => P }]
+                    }
+                  }]
+                  PUPPET
+              },
+              'metadata.json' => sprintf(metadata_json, 'd', '')
+            }
           }
         }
       end
@@ -623,6 +637,14 @@ describe 'loaders' do
         type = p.parse('C::D::Y', l)
         expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
         expect(type.resolved_type).to be_a(Puppet::Pops::Types::PFloatType)
+      end
+
+      it 'loads an object type from a typeset that references another type defined in the same typeset' do
+        l = Puppet::Pops::Loaders.find_loader('d').private_loader
+        p = Puppet::Pops::Types::TypeParser.singleton
+        type = p.parse('D::O', l)
+        expect(type).to be_a(Puppet::Pops::Types::PObjectType)
+        expect(type.resolved_parent).to be_a(Puppet::Pops::Types::PObjectType)
       end
     end
   end


### PR DESCRIPTION
Before this commit, the TypeSet loader that provides internal access
to the types defined locally in the set was replaced by the loader
that is associated with the file containing the type set source. This
replacement happened in the TypeParser when resolving the types
contained in the TypeSet. This commit prevents that replacement from
taking place.