### PR TITLE
(PUP-8463) Remove the last lingering warnings

### DIFF
--- a/lib/puppet/functions/map.rb
+++ b/lib/puppet/functions/map.rb
@@ -125,7 +125,7 @@ Puppet::Functions.create_function(:map) do
         index = 0
         loop do
           result << yield(index, enum.next)
-          index = index +1
+          index = index + 1
         end
       rescue StopIteration
       end

--- a/spec/unit/pops/factory_spec.rb
+++ b/spec/unit/pops/factory_spec.rb
@@ -191,7 +191,7 @@ describe Puppet::Pops::Model::Factory do
     it "should handle 'just a string'" do
       model = string('blah blah').model
       expect(model.class).to eq(Puppet::Pops::Model::ConcatenatedString)
-      model.segments.size == 1
+      expect(model.segments.size).to eq(1)
       expect(model.segments[0].class).to eq(Puppet::Pops::Model::LiteralString)
       expect(model.segments[0].value).to eq("blah blah")
     end
@@ -199,7 +199,7 @@ describe Puppet::Pops::Model::Factory do
     it "should handle one expression in the middle" do
       model = string('blah blah', TEXT(literal(1)+literal(2)), 'blah blah').model
       expect(model.class).to eq(Puppet::Pops::Model::ConcatenatedString)
-      model.segments.size == 3
+      expect(model.segments.size).to eq(3)
       expect(model.segments[0].class).to eq(Puppet::Pops::Model::LiteralString)
       expect(model.segments[0].value).to eq("blah blah")
       expect(model.segments[1].class).to eq(Puppet::Pops::Model::TextExpression)
@@ -211,7 +211,7 @@ describe Puppet::Pops::Model::Factory do
     it "should handle one expression at the end" do
       model = string('blah blah', TEXT(literal(1)+literal(2))).model
       expect(model.class).to eq(Puppet::Pops::Model::ConcatenatedString)
-      model.segments.size == 2
+      expect(model.segments.size).to eq(2)
       expect(model.segments[0].class).to eq(Puppet::Pops::Model::LiteralString)
       expect(model.segments[0].value).to eq("blah blah")
       expect(model.segments[1].class).to eq(Puppet::Pops::Model::TextExpression)
@@ -221,7 +221,7 @@ describe Puppet::Pops::Model::Factory do
     it "should handle only one expression" do
       model = string(TEXT(literal(1)+literal(2))).model
       expect(model.class).to eq(Puppet::Pops::Model::ConcatenatedString)
-      model.segments.size == 1
+      expect(model.segments.size).to eq(1)
       expect(model.segments[0].class).to eq(Puppet::Pops::Model::TextExpression)
       expect(model.segments[0].expr.class).to eq(Puppet::Pops::Model::ArithmeticExpression)
     end
@@ -229,7 +229,7 @@ describe Puppet::Pops::Model::Factory do
     it "should handle several expressions" do
       model = string(TEXT(literal(1)+literal(2)), TEXT(literal(1)+literal(2))).model
       expect(model.class).to eq(Puppet::Pops::Model::ConcatenatedString)
-      model.segments.size == 2
+      expect(model.segments.size).to eq(2)
       expect(model.segments[0].class).to eq(Puppet::Pops::Model::TextExpression)
       expect(model.segments[0].expr.class).to eq(Puppet::Pops::Model::ArithmeticExpression)
       expect(model.segments[1].class).to eq(Puppet::Pops::Model::TextExpression)

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -867,8 +867,8 @@ describe Puppet::Pops::Parser::Lexer2 do
   # Section 3.2.1.3 of Ruby spec guarantees that \u strings are encoded as UTF-8
   # Runes (may show up as garbage if font is not available): ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
   let (:rune_utf8) {
-    "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2"
-    "\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA"
+    "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2" +
+    "\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA" +
     "\u16B3\u16A2\u16D7"
   }
 


### PR DESCRIPTION
The only remaining warnings after this are in an auto-generated file, vendored code from `semantic_puppet`, and spec fixtures that intentionally have errors in them. 🎉