### PR TITLE
(PUP-8481) Load the major part of pcore types statically instead of per environment

### DIFF
--- a/lib/puppet/datatypes.rb
+++ b/lib/puppet/datatypes.rb
@@ -169,7 +169,7 @@ module Puppet::DataTypes
             end
           end
         else
-          Puppet::Pops::Loaders.implementation_registry.register_implementation(created_type, @implementation_class, loader)
+          Puppet::Pops::Loaders.implementation_registry.register_implementation(created_type, @implementation_class)
         end
         created_type.implementation_class = @implementation_class
       elsif !@implementation.nil?

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -27,11 +27,11 @@ class TaskInstantiator
 
   def self.create_task(loader, name, task_source, metadata)
     if metadata.nil?
-      create_task_from_hash(loader, name, task_source, EMPTY_HASH)
+      create_task_from_hash(name, task_source, EMPTY_HASH)
     else
       json_text = loader.get_contents(metadata)
       begin
-        create_task_from_hash(loader, name, task_source, JSON.parse(json_text) || EMPTY_HASH)
+        create_task_from_hash(name, task_source, JSON.parse(json_text) || EMPTY_HASH)
       rescue JSON::ParserError => ex
         raise Puppet::ParseError.new(ex.message, metadata)
       rescue Types::TypeAssertionError => ex
@@ -43,7 +43,7 @@ class TaskInstantiator
     end
   end
 
-  def self.create_task_from_hash(loader, name, task_source, hash)
+  def self.create_task_from_hash(name, task_source, hash)
     arguments = {
       'name' => name,
       'executable' => task_source
@@ -54,7 +54,7 @@ class TaskInstantiator
         value.each_pair do |k, v|
           pd = v.dup
           t = v['type']
-          pd['type'] = t.nil? ? Types::TypeFactory.data : Types::TypeParser.singleton.parse(t, loader)
+          pd['type'] = t.nil? ? Types::TypeFactory.data : Types::TypeParser.singleton.parse(t)
           ps[k] = pd
         end
         value = ps

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -57,7 +57,7 @@ class Loaders
 
     # 3. The implementation registry maintains mappings between Puppet types and Runtime types for
     #    the current environment
-    @implementation_registry = Types::ImplementationRegistry.new(@private_environment_loader)
+    @implementation_registry = Types::ImplementationRegistry.new
     Pcore.init(@puppet_system_loader, @implementation_registry, for_agent)
 
     # 4. module loaders are set up from the create_environment_loader, they register themselves
@@ -337,7 +337,7 @@ class Loaders
     tf = Types::TypeParser.singleton
     lhs = tf.interpret(type_mapping.type_expr, loader)
     rhs = tf.interpret_any(type_mapping.mapping_expr, loader)
-    implementation_registry.register_type_mapping(lhs, rhs, loader)
+    implementation_registry.register_type_mapping(lhs, rhs)
     nil
   end
 

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -31,14 +31,7 @@ module Pcore
     instance
   end
 
-  def self.init(loader, ir, for_agent)
-    add_alias('Pcore::URI_RX', TYPE_URI_RX, loader)
-    add_type(TYPE_URI_ALIAS, loader)
-    add_alias('Pcore::SimpleTypeName', TYPE_SIMPLE_TYPE_NAME, loader)
-    add_alias('Pcore::MemberName', TYPE_MEMBER_NAME, loader)
-    add_alias('Pcore::TypeName', TYPE_QUALIFIED_REFERENCE, loader)
-    add_alias('Pcore::QRef', TYPE_QUALIFIED_REFERENCE, loader)
-
+  def self.init_env(loader)
     if Puppet[:tasks]
       add_object_type('Task', <<-PUPPET, loader)
         {
@@ -83,6 +76,15 @@ module Pcore
         }
       PUPPET
     end
+  end
+
+  def self.init(loader, ir)
+    add_alias('Pcore::URI_RX', TYPE_URI_RX, loader)
+    add_type(TYPE_URI_ALIAS, loader)
+    add_alias('Pcore::SimpleTypeName', TYPE_SIMPLE_TYPE_NAME, loader)
+    add_alias('Pcore::MemberName', TYPE_MEMBER_NAME, loader)
+    add_alias('Pcore::TypeName', TYPE_QUALIFIED_REFERENCE, loader)
+    add_alias('Pcore::QRef', TYPE_QUALIFIED_REFERENCE, loader)
     Types::TypedModelObject.register_ptypes(loader, ir)
 
     @type = create_object_type(loader, ir, Pcore, 'Pcore', nil)
@@ -90,11 +92,9 @@ module Pcore
     ir.register_implementation_namespace('Pcore', 'Puppet::Pops::Pcore')
     ir.register_implementation_namespace('Puppet::AST', 'Puppet::Pops::Model')
     ir.register_implementation('Puppet::AST::Locator', 'Puppet::Pops::Parser::Locator::Locator19')
-    unless for_agent
-      Resource.register_ptypes(loader, ir)
-      Lookup::Context.register_ptype(loader, ir);
-      Lookup::DataProvider.register_types(loader)
-    end
+    Resource.register_ptypes(loader, ir)
+    Lookup::Context.register_ptype(loader, ir);
+    Lookup::DataProvider.register_types(loader)
   end
 
   # Create and register a new `Object` type in the Puppet Type System and map it to an implementation class

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -87,9 +87,9 @@ module Pcore
 
     @type = create_object_type(loader, ir, Pcore, 'Pcore', nil)
 
-    ir.register_implementation_namespace('Pcore', 'Puppet::Pops::Pcore', loader)
-    ir.register_implementation_namespace('Puppet::AST', 'Puppet::Pops::Model', loader)
-    ir.register_implementation('Puppet::AST::Locator', 'Puppet::Pops::Parser::Locator::Locator19', loader)
+    ir.register_implementation_namespace('Pcore', 'Puppet::Pops::Pcore')
+    ir.register_implementation_namespace('Puppet::AST', 'Puppet::Pops::Model')
+    ir.register_implementation('Puppet::AST::Locator', 'Puppet::Pops::Parser::Locator::Locator19')
     unless for_agent
       Resource.register_ptypes(loader, ir)
       Lookup::Context.register_ptype(loader, ir);
@@ -116,7 +116,7 @@ module Pcore
     init_hash[Types::KEY_ATTRIBUTES] = attributes_hash unless attributes_hash.empty?
     init_hash[Types::KEY_FUNCTIONS] = functions_hash unless functions_hash.empty?
     init_hash[Types::KEY_EQUALITY] = equality unless equality.nil?
-    ir.register_implementation(type_name, impl_class, loader)
+    ir.register_implementation(type_name, impl_class)
     add_type(Types::PObjectType.new(type_name, init_hash), loader)
   end
 

--- a/lib/puppet/pops/types/implementation_registry.rb
+++ b/lib/puppet/pops/types/implementation_registry.rb
@@ -10,7 +10,9 @@ module Types
 
     # Create a new instance. This method is normally only called once
     #
-    def initialize
+    # @param parent [ImplementationRegistry, nil] the parent of this registry
+    def initialize(parent = nil)
+      @parent = parent
       @type_names_per_implementation = {}
       @implementations_per_type_name = {}
       @type_name_substitutions = []
@@ -76,7 +78,8 @@ module Types
     # @return [String,nil] the name of the implementation module, or `nil` if no mapping was found
     def module_name_for_type(type)
       type = type.name if type.is_a?(PAnyType)
-      find_mapping(type, @implementations_per_type_name, @type_name_substitutions)
+      name = @parent.module_name_for_type(type) unless @parent.nil?
+      name.nil? ? find_mapping(type, @implementations_per_type_name, @type_name_substitutions) : name
     end
 
     # Find the module that corresponds to the given type or type name
@@ -95,7 +98,8 @@ module Types
     # @return [String,nil] the name of the type, or `nil` if no mapping was found
     def type_name_for_module(impl_module)
       impl_module = impl_module.name if impl_module.is_a?(Module)
-      find_mapping(impl_module, @type_names_per_implementation, @impl_name_substitutions)
+      name = @parent.type_name_for_module(impl_module) unless @parent.nil?
+      name.nil? ? find_mapping(impl_module, @type_names_per_implementation, @impl_name_substitutions) : name
     end
 
     # Find the name for, and then load, the type  that corresponds to the given runtime module or module name

--- a/lib/puppet/pops/types/implementation_registry.rb
+++ b/lib/puppet/pops/types/implementation_registry.rb
@@ -8,20 +8,13 @@ module Types
   class ImplementationRegistry
     TYPE_REGEXP_SUBST = TypeFactory.tuple([PRegexpType::DEFAULT, PStringType::NON_EMPTY])
 
-    def self.singleton
-      @singleton ||= new(Loaders.static_loader)
-    end
-
     # Create a new instance. This method is normally only called once
     #
-    # The initializer will create mappings for well known types that can be loaded using the static loader
-    #
-    def initialize(static_loader)
+    def initialize
       @type_names_per_implementation = {}
       @implementations_per_type_name = {}
       @type_name_substitutions = []
       @impl_name_substitutions = []
-      TypeParser.type_map.values.each { |type| register_implementation(type.simple_name, type.class.name, static_loader) }
     end
 
     # Register a bidirectional type mapping.
@@ -29,20 +22,18 @@ module Types
     # @overload register_type_mapping(runtime_type, puppet_type)
     #   @param runtime_type [PRuntimeType] type that represents the runtime module or class to map to a puppet type
     #   @param puppet_type [PAnyType] type that will be mapped to the runtime module or class
-    #   @param loader [Loader::Loader] the loader to use when resolving names
     # @overload register_type_mapping(runtime_type, pattern_replacement)
     #   @param runtime_type [PRuntimeType] type containing the pattern and replacement to map the runtime type to a puppet type
     #   @param puppet_type [Array(Regexp,String)] the pattern and replacement to map a puppet type to a runtime type
-    #   @param loader [Loader::Loader] the loader to use when resolving names
-    def register_type_mapping(runtime_type, puppet_type_or_pattern, loader)
+    def register_type_mapping(runtime_type, puppet_type_or_pattern, _ = nil)
       TypeAsserter.assert_assignable('First argument of type mapping', PRuntimeType::RUBY, runtime_type)
       expr = runtime_type.name_or_pattern
       if expr.is_a?(Array)
         TypeAsserter.assert_instance_of('Second argument of type mapping', TYPE_REGEXP_SUBST, puppet_type_or_pattern)
-        register_implementation_regexp(puppet_type_or_pattern, expr, loader)
+        register_implementation_regexp(puppet_type_or_pattern, expr)
       else
         TypeAsserter.assert_instance_of('Second argument of type mapping', PTypeType::DEFAULT, puppet_type_or_pattern)
-        register_implementation(puppet_type_or_pattern, expr, loader)
+        register_implementation(puppet_type_or_pattern, expr)
       end
     end
 
@@ -50,23 +41,20 @@ module Types
     #
     # @param type_namespace [String] the namespace for the puppet types
     # @param impl_namespace [String] the namespace for the implementations
-    # @param loader [Loader::Loader] the loader to use when resolving names
-    def register_implementation_namespace(type_namespace, impl_namespace, loader)
+    def register_implementation_namespace(type_namespace, impl_namespace, _ = nil)
       ns = TypeFormatter::NAME_SEGMENT_SEPARATOR
       register_implementation_regexp(
         [/\A#{type_namespace}#{ns}(\w+)\z/, "#{impl_namespace}#{ns}\\1"],
-        [/\A#{impl_namespace}#{ns}(\w+)\z/, "#{type_namespace}#{ns}\\1"],
-        loader)
+        [/\A#{impl_namespace}#{ns}(\w+)\z/, "#{type_namespace}#{ns}\\1"])
     end
 
     # Register a bidirectional regexp mapping
     #
     # @param type_name_subst [Array(Regexp,String)] regexp and replacement mapping type names to runtime names
     # @param impl_name_subst [Array(Regexp,String)] regexp and replacement mapping runtime names to type names
-    # @param loader [Loader::Loader] the loader to use when resolving names
-    def register_implementation_regexp(type_name_subst, impl_name_subst, loader)
-      @type_name_substitutions << [type_name_subst, loader]
-      @impl_name_substitutions << [impl_name_subst, loader]
+    def register_implementation_regexp(type_name_subst, impl_name_subst, _ = nil)
+      @type_name_substitutions << type_name_subst
+      @impl_name_substitutions << impl_name_subst
       nil
     end
 
@@ -74,12 +62,11 @@ module Types
     #
     # @param type [PAnyType,String] the type or type name
     # @param impl_module[Module,String] the module or module name
-    # @param loader [Loader::Loader] the loader to use when resolving names
-    def register_implementation(type, impl_module, loader)
+    def register_implementation(type, impl_module, _ = nil)
       type = type.name if type.is_a?(PAnyType)
       impl_module = impl_module.name if impl_module.is_a?(Module)
-      @type_names_per_implementation[impl_module] = [type, loader]
-      @implementations_per_type_name[type] = [impl_module, loader]
+      @type_names_per_implementation[impl_module] = type
+      @implementations_per_type_name[type] = impl_module
       nil
     end
 
@@ -97,15 +84,15 @@ module Types
     # @param type [PAnyType,String] the name of the type
     # @return [Module,nil] the name of the implementation module, or `nil` if no mapping was found
     def module_for_type(type)
-      name_and_loader = module_name_for_type(type)
+      name = module_name_for_type(type)
       # TODO Shouldn't ClassLoader be module specific?
-      name_and_loader.nil? ? nil : ClassLoader.provide(name_and_loader[0])
+      name.nil? ? nil : ClassLoader.provide(name)
     end
 
     # Find the type name and loader that corresponds to the given runtime module or module name
     #
     # @param impl_module [Module,String] the implementation class or class name
-    # @return [Array(String,Loader::Loader),nil] the name and loader of the type, or `nil` if no mapping was found
+    # @return [String,nil] the name of the type, or `nil` if no mapping was found
     def type_name_for_module(impl_module)
       impl_module = impl_module.name if impl_module.is_a?(Module)
       find_mapping(impl_module, @type_names_per_implementation, @impl_name_substitutions)
@@ -118,20 +105,22 @@ module Types
     # @param impl_module [Module,String] the implementation class or class name
     # @return [PAnyType,nil] the type, or `nil` if no mapping was found
     def type_for_module(impl_module)
-      name_and_loader = type_name_for_module(impl_module)
-      if name_and_loader.nil?
+      name = type_name_for_module(impl_module)
+      if name.nil?
         nil
       else
-        TypeParser.singleton.parse(*name_and_loader)
+        TypeParser.singleton.parse(name)
       end
     end
+
+    private
 
     def find_mapping(name, names, substitutions)
       found = names[name]
       if found.nil?
         substitutions.each do |subst|
-          substituted = name.sub(*subst[0])
-          return [substituted, subst[1]] unless substituted == name
+          substituted = name.sub(*subst)
+          return substituted unless substituted == name
         end
       end
       found

--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -532,14 +532,13 @@ class PObjectType < PMetaType
   def implementation_class(create = true)
     if @implementation_class.nil? && create
       ir = Loaders.implementation_registry
-      impl_name = ir.nil? ? nil : ir.module_name_for_type(self)
-      if impl_name.nil?
+      class_name = ir.nil? ? nil : ir.module_name_for_type(self)
+      if class_name.nil?
         # Use generator to create a default implementation
         @implementation_class = RubyGenerator.new.create_class(self)
         @implementation_class.class_eval(&@implementation_override) if instance_variable_defined?(:@implementation_override)
       else
         # Can the mapping be loaded?
-        class_name = impl_name[0]
         @implementation_class = ClassLoader.provide(class_name)
 
         raise Puppet::Error, "Unable to load class #{class_name}" if @implementation_class.nil?

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -158,7 +158,7 @@ class RubyGenerator < TypeFormatter
       ir = Loaders.implementation_registry
       impl_name = ir.module_name_for_type(type)
       raise Puppet::Error, "Unable to create an instance of #{type.name}. No mapping exists to runtime object" if impl_name.nil?
-      impl_name[0]
+      impl_name
     end
   end
 
@@ -179,9 +179,8 @@ class RubyGenerator < TypeFormatter
     unless obj.parent.nil?
       if impl_subst.empty?
         ir = Loaders.implementation_registry
-        parent_impl = ir.module_name_for_type(obj.parent)
-        raise Puppet::Error, "Unable to create an instance of #{obj.parent.name}. No mapping exists to runtime object" if parent_impl.nil?
-        parent_name = parent_impl[0]
+        parent_name = ir.module_name_for_type(obj.parent)
+        raise Puppet::Error, "Unable to create an instance of #{obj.parent.name}. No mapping exists to runtime object" if parent_name.nil?
       else
         parent_name = obj.parent.name.gsub(*impl_subst)
       end

--- a/spec/unit/pops/types/ruby_generator_spec.rb
+++ b/spec/unit/pops/types/ruby_generator_spec.rb
@@ -430,10 +430,9 @@ describe 'Puppet Ruby Generator' do
             first_type = parser.parse('MyModule::FirstGenerated')
             second_type = parser.parse('MyModule::SecondGenerated')
 
-            loader = Loaders.find_loader(nil)
             Loaders.implementation_registry.register_type_mapping(
               PRuntimeType.new(:ruby, [/^PuppetSpec::RubyGenerator::(\w+)$/, 'MyModule::\1']),
-              [/^MyModule::(\w+)$/, 'PuppetSpec::RubyGenerator::\1'], loader)
+              [/^MyModule::(\w+)$/, 'PuppetSpec::RubyGenerator::\1'])
 
             module_def = generator.module_definition([first_type, second_type], 'Generated stuff')
           end
@@ -742,14 +741,13 @@ describe 'Puppet Ruby Generator' do
             typeset1 = parser.parse('MyModule')
             typeset2 = parser.parse('OtherModule')
 
-            loader = Loaders.find_loader(nil)
             Loaders.implementation_registry.register_type_mapping(
               PRuntimeType.new(:ruby, [/^PuppetSpec::RubyGenerator::My::(\w+)$/, 'MyModule::\1']),
-              [/^MyModule::(\w+)$/, 'PuppetSpec::RubyGenerator::My::\1'], loader)
+              [/^MyModule::(\w+)$/, 'PuppetSpec::RubyGenerator::My::\1'])
 
             Loaders.implementation_registry.register_type_mapping(
               PRuntimeType.new(:ruby, [/^PuppetSpec::RubyGenerator::Other::(\w+)$/, 'OtherModule::\1']),
-              [/^OtherModule::(\w+)$/, 'PuppetSpec::RubyGenerator::Other::\1'], loader)
+              [/^OtherModule::(\w+)$/, 'PuppetSpec::RubyGenerator::Other::\1'])
 
             module_def = generator.module_definition_from_typeset(typeset1)
             module_def2 = generator.module_definition_from_typeset(typeset2)


### PR DESCRIPTION
This PR contains the commits necessary to make the `ImplementationRegistry` parented and to split the `Pcore` initialization into a static part and an environment initialization part.