### PR TITLE
(PUP-8472) Allow Object data type short form in TypeSet

### DIFF
--- a/lib/puppet/pops/issue_reporter.rb
+++ b/lib/puppet/pops/issue_reporter.rb
@@ -86,6 +86,21 @@ class IssueReporter
     [prefix, message].join(' ')
   end
 
+  def self.warning(semantic, issue, args)
+    Puppet::Util::Log.create({
+      :level => :warning,
+      :message => issue.format(args),
+      :issue_code => issue.issue_code,
+      :file => semantic.file,
+      :line => semantic.line,
+      :pos => semantic.pos,
+    })
+  end
+
+  def self.error(exception_class, semantic, issue, args)
+    raise exception_class.new(issue.format(args), semantic.file, semantic.line, semantic.pos, nil, issue.issue_code)
+  end
+
   def self.create_exception(exception_class, emit_message, formatter, diagnostic)
     file = diagnostic.file
     file = (file.is_a?(String) && file.empty?) ? nil : file

--- a/lib/puppet/pops/loader/type_definition_instantiator.rb
+++ b/lib/puppet/pops/loader/type_definition_instantiator.rb
@@ -73,7 +73,9 @@ class TypeDefinitionInstantiator
     case type_name
     when 'Object'
       # No need for an alias. The Object type itself will receive the name instead
-      type_expr = type_expr.keys.empty? ? nil : type_expr.keys[0] unless type_expr.is_a?(Hash)
+      unless type_expr.is_a?(Model::LiteralHash)
+        type_expr = type_expr.keys.empty? ? nil : type_expr.keys[0] unless type_expr.is_a?(Hash)
+      end
       Types::PObjectType.new(name, type_expr)
     when 'TypeSet'
       # No need for an alias. The Object type itself will receive the name instead
@@ -86,6 +88,7 @@ class TypeDefinitionInstantiator
 
   # @api private
   def self.named_definition(te)
+    return 'Object' if te.is_a?(Model::LiteralHash)
     te.is_a?(Model::AccessExpression) && (left = te.left_expr).is_a?(Model::QualifiedReference) ? left.cased_value : nil
   end
 

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -453,10 +453,12 @@ class Factory
       #
       parent = type_expr['key']
       hash = type_expr['value']
-      unless parent['cased_value'] == 'Object'
+      pn = parent['cased_value']
+      unless pn == 'Object' || pn == 'TypeSet'
         hash['entries'] << Factory.KEY_ENTRY(Factory.QNAME('parent'), parent)
+        parent = Factory.QREF('Object')
       end
-      type_expr = Factory.QREF('Object').access([hash])
+      type_expr = parent.access([hash])
     elsif type_expr.model_class <= LiteralHash
       # LiteralHash is used for the form:
       #

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -52,7 +52,7 @@ class PTypeSetType < PMetaType
     TypeFactory.optional(KEY_NAME_AUTHORITY) => Pcore::TYPE_URI,
     TypeFactory.optional(KEY_NAME) => Pcore::TYPE_QUALIFIED_REFERENCE,
     TypeFactory.optional(KEY_VERSION) => TYPE_STRING_OR_VERSION,
-    TypeFactory.optional(KEY_TYPES) => TypeFactory.hash_kv(Pcore::TYPE_SIMPLE_TYPE_NAME, PTypeType::DEFAULT, PCollectionType::NOT_EMPTY_SIZE),
+    TypeFactory.optional(KEY_TYPES) => TypeFactory.hash_kv(Pcore::TYPE_SIMPLE_TYPE_NAME, PVariantType.new([PTypeType::DEFAULT, PObjectType::TYPE_OBJECT_I12N]), PCollectionType::NOT_EMPTY_SIZE),
     TypeFactory.optional(KEY_REFERENCES) => TypeFactory.hash_kv(Pcore::TYPE_SIMPLE_TYPE_NAME, TYPE_TYPE_REFERENCE_I12N, PCollectionType::NOT_EMPTY_SIZE),
     TypeFactory.optional(KEY_ANNOTATIONS) => TYPE_ANNOTATIONS,
   })
@@ -292,6 +292,25 @@ class PTypeSetType < PMetaType
       types.each do |type_name, value|
         full_name = "#{@name}::#{type_name}".freeze
         typed_name = Loader::TypedName.new(:type, full_name, name_auth)
+        if value.is_a?(Model::ResourceDefaultsExpression)
+          # This is actually a <Parent> { <key-value entries> } notation. Convert to a literal hash that contains the parent
+          n = value.type_ref
+          name = n.cased_value
+          entries = []
+          unless name == 'Object' or name == 'TypeSet'
+            if value.operations.any? { |op| op.attribute_name == KEY_PARENT }
+              case Puppet[:strict]
+              when :warning
+                IssueReporter.warning(value, Issues::DUPLICATE_KEY, :key => KEY_PARENT)
+              when :error
+                IssueReporter.error(Puppet::ParseErrorWithIssue, value, Issues::DUPLICATE_KEY, :key => KEY_PARENT)
+              end
+            end
+            entries << Model::KeyedEntry.new(n.locator, n.offset, n.length, KEY_PARENT, n)
+          end
+          value.operations.each { |op| entries << Model::KeyedEntry.new(op.locator, op.offset, op.length, op.attribute_name, op.value_expr) }
+          value = Model::LiteralHash.new(value.locator, value.offset, value.length, entries)
+        end
         type = Loader::TypeDefinitionInstantiator.create_type(full_name, value, name_auth)
         loader.set_entry(typed_name, type, value.locator.to_uri(value))
         types[type_name] = type

--- a/spec/unit/pops/types/p_type_set_type_spec.rb
+++ b/spec/unit/pops/types/p_type_set_type_spec.rb
@@ -314,7 +314,7 @@ module Puppet::Pops
           OBJECT
         end
 
-        it 'can declare a type and Object type' do
+        it 'can declare an Object type using Object[{}]' do
           expect { parse_type_set('TheSet', <<-OBJECT) }.not_to raise_error
             version => '1.0.0',
             pcore_version => '1.0.0',
@@ -409,6 +409,110 @@ module Puppet::Pops
                 }
               }
           OBJECT
+        end
+
+        context 'allows bracket-less form' do
+          let(:logs) { [] }
+          let(:notices) { logs.select { |log| log.level == :notice }.map { |log| log.message } }
+          let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+          let(:node) { Puppet::Node.new('example.com') }
+          let(:compiler) { Puppet::Parser::Compiler.new(node) }
+
+          def compile(code)
+            Puppet[:code] = code
+            Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) { compiler.compile }
+          end
+
+          it 'on the TypeSet declaration itself' do
+            compile(<<-PUPPET)
+              type TS = TypeSet { pcore_version => '1.0.0' }
+              notice(TS =~ Type[TypeSet])
+            PUPPET
+            expect(warnings).to be_empty
+            expect(notices).to eql(['true'])
+          end
+
+          it 'without prefix on declared types (implies Object)' do
+            compile(<<-PUPPET)
+              type TS = TypeSet {
+                pcore_version => '1.0.0',
+                types => {
+                  MyObject => { attributes => { a => Integer} }
+                }
+              }
+              notice(TS =~ Type[TypeSet])
+              notice(TS::MyObject =~ Type)
+              notice(TS::MyObject(3))
+            PUPPET
+            expect(warnings).to be_empty
+            expect(notices).to eql(['true', 'true', "TS::MyObject({'a' => 3})"])
+          end
+
+          it "prefixed with QREF 'Object' on declared types" do
+            compile(<<-PUPPET)
+              type TS = TypeSet {
+                pcore_version => '1.0.0',
+                types => {
+                  MyObject => Object { attributes => { a => Integer} }
+                }
+              }
+              notice(TS =~ Type[TypeSet])
+              notice(TS::MyObject =~ Type)
+              notice(TS::MyObject(3))
+            PUPPET
+            expect(warnings).to be_empty
+            expect(notices).to eql(['true', 'true', "TS::MyObject({'a' => 3})"])
+          end
+
+          it 'prefixed with QREF to declare parent on declared types' do
+            compile(<<-PUPPET)
+              type TS = TypeSet {
+                pcore_version => '1.0.0',
+                types => {
+                  MyObject => { attributes => { a => String }},
+                  MySecondObject => MyObject { attributes => { b => String }}
+                }
+              }
+              notice(TS =~ Type[TypeSet])
+              notice(TS::MySecondObject =~ Type)
+              notice(TS::MySecondObject < TS::MyObject)
+              notice(TS::MyObject('hi'))
+              notice(TS::MySecondObject('hello', 'world'))
+            PUPPET
+            expect(warnings).to be_empty
+            expect(notices).to eql(
+              ['true', 'true', 'true', "TS::MyObject({'a' => 'hi'})", "TS::MySecondObject({'a' => 'hello', 'b' => 'world'})"])
+          end
+
+          it 'and warns when parent is specified both before and inside the hash if strict == warning' do
+            Puppet[:strict] = 'warning'
+            compile(<<-PUPPET)
+              type TS = TypeSet {
+                pcore_version => '1.0.0',
+                types => {
+                  MyObject => { attributes => { a => String }},
+                  MySecondObject => MyObject { parent => MyObject, attributes => { b => String }}
+                }
+              }
+              notice(TS =~ Type[TypeSet])
+            PUPPET
+            expect(warnings).to eql(["The key 'parent' is declared more than once"])
+            expect(notices).to eql(['true'])
+          end
+
+          it 'and errors when parent is specified both before and inside the hash if strict == error' do
+            Puppet[:strict] = 'error'
+            expect{ compile(<<-PUPPET) }.to raise_error(/The key 'parent' is declared more than once/)
+              type TS = TypeSet {
+                pcore_version => '1.0.0',
+                types => {
+                  MyObject => { attributes => { a => String }},
+                  MySecondObject => MyObject { parent => MyObject, attributes => { b => String }}
+                }
+              }
+              notice(TS =~ Type[TypeSet])
+            PUPPET
+          end
         end
       end
 


### PR DESCRIPTION
This commit improves the TypeSet resolver so that it accepts the
bracket less forms of Object type definitions inside the TypeSet.