### PR TITLE
(maint) Enable Lint/UselessAccessModifier Rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,9 +137,8 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Enabled: false
 
-# DISABLED - TODO
 Lint/UselessAccessModifier:
-  Enabled: false
+  Enabled: true
 
 Lint/UselessAssignment:
   Enabled: true

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -74,8 +74,6 @@ class Puppet::FileBucket::File
     self.new(contents)
   end
 
-  private
-
   class StringContents
     def initialize(content)
       @contents = content;

--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -650,8 +650,6 @@ module Puppet::Functions
     end
   end
 
-  private
-
   # @note WARNING: This style of creating functions is not public. It is a system
   #   under development that will be used for creating "system" functions.
   #

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -38,8 +38,6 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     result
   end
 
-  private
-
   def self.setup_search_paths(request)
     # Add any per-module fact directories to facter's search path
     dirs = request.environment.modulepath.collect do |dir|

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -72,8 +72,6 @@ class Puppet::Module
       self.module == other.module
     end
 
-    private
-
     def self.new_with_files(pup_module, name, tasks_files)
       files = tasks_files.map do |filename|
         File.join(pup_module.tasks_directory, File.basename(filename))
@@ -82,9 +80,11 @@ class Puppet::Module
       metadata_files, exe_files = files.partition { |f| is_tasks_metadata_filename?(f) }
       Puppet::Module::Task.new(pup_module, name, exe_files, metadata_files.first)
     end
+    private_class_method :new_with_files
 
     def self.task_name_from_path(path)
       return File.basename(path, '.*')
     end
+    private_class_method :task_name_from_path
   end
 end

--- a/lib/puppet/network/resolver.rb
+++ b/lib/puppet/network/resolver.rb
@@ -40,8 +40,6 @@ module Puppet::Network::Resolver
     end
   end
 
-  private
-
   def self.each_priority(records)
     pri_hash = records.inject({}) do |groups, element|
       groups[element.priority] ||= []
@@ -53,6 +51,7 @@ module Puppet::Network::Resolver
       yield key, pri_hash[key]
     end
   end
+  private_class_method :each_priority
 
   def self.find_weighted_server(records)
     return nil if records.nil? || records.empty?

--- a/lib/puppet/pops/evaluator/epp_evaluator.rb
+++ b/lib/puppet/pops/evaluator/epp_evaluator.rb
@@ -53,8 +53,6 @@ class Puppet::Pops::Evaluator::EppEvaluator
     evaluate(parser, 'epp', scope, true, result, template_args)
   end
 
-  private
-
   def self.evaluate(parser, func_name, scope, use_global_scope_only, parse_result, template_args)
     template_args, template_args_set = handle_template_args(func_name, template_args)
 
@@ -104,6 +102,7 @@ class Puppet::Pops::Evaluator::EppEvaluator
       parser.closure(body, scope).call_by_name(template_args, enforce_parameters)
     end
   end
+  private_class_method :evaluate
 
   def self.handle_template_args(func_name, template_args)
     if template_args.nil?
@@ -117,4 +116,5 @@ class Puppet::Pops::Evaluator::EppEvaluator
       [template_args, true]
     end
   end
+  private_class_method :handle_template_args
 end

--- a/lib/puppet/pops/evaluator/runtime3_resource_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_resource_support.rb
@@ -89,8 +89,6 @@ module Runtime3ResourceSupport
     scope.environment.known_resource_types.find_hostclass(class_name)
   end
 
-  private
-
   def self.find_builtin_resource_type(scope, type_name)
     if type_name.include?(':')
       # Skip the search for built in types as they are always in global namespace
@@ -106,11 +104,13 @@ module Runtime3ResourceSupport
     # horrible - should be loaded by a "last loader" in 4.x loaders instead.
     Puppet::Type.type(type_name)
   end
+  private_class_method :find_builtin_resource_type
 
   def self.find_defined_resource_type(scope, type_name)
     krt = scope.environment.known_resource_types
     krt.find_definition(type_name) || krt.application(type_name)
   end
+  private_class_method :find_defined_resource_type
 
 end
 end

--- a/lib/puppet/pops/loader/ruby_data_type_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_data_type_instantiator.rb
@@ -29,12 +29,11 @@ class Puppet::Pops::Loader::RubyDataTypeInstantiator
     created
   end
 
-  private
-
   # Produces a binding where the given loader is bound as a local variable (loader_injected_arg). This variable can be used in loaded
   # ruby code - e.g. to call Puppet::Function.create_loaded_function(:name, loader,...)
   #
   def self.get_binding(loader_injected_arg)
     binding
   end
+  private_class_method :get_binding
 end

--- a/lib/puppet/pops/loader/ruby_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_function_instantiator.rb
@@ -35,12 +35,11 @@ class Puppet::Pops::Loader::RubyFunctionInstantiator
     created.new(nil, loader_for_function)
   end
 
-  private
-
   # Produces a binding where the given loader is bound as a local variable (loader_injected_arg). This variable can be used in loaded
   # ruby code - e.g. to call Puppet::Function.create_loaded_function(:name, loader,...)
   #
   def self.get_binding(loader_injected_arg)
     binding
   end
+  private_class_method :get_binding
 end

--- a/lib/puppet/pops/parser/locator.rb
+++ b/lib/puppet/pops/parser/locator.rb
@@ -155,8 +155,6 @@ class Locator
     end
   end
 
-  private
-
   class AbstractLocator < Locator
     attr_accessor :line_index
     attr_accessor :string

--- a/lib/puppet/pops/types/class_loader.rb
+++ b/lib/puppet/pops/types/class_loader.rb
@@ -32,8 +32,6 @@ class ClassLoader
     end
   end
 
-  private
-
   def self.provide_from_type(type)
     case type
     when PRuntimeType
@@ -72,6 +70,7 @@ class ClassLoader
       nil
     end
   end
+  private_class_method :provide_from_type
 
   def self.provide_from_string(name)
     name_path = name.split(TypeFormatter::NAME_SEGMENT_SEPARATOR)
@@ -97,6 +96,7 @@ class ClassLoader
     return nil unless result.is_a?(Module)
     result
   end
+  private_class_method :provide_from_string
 
   def self.find_class(name_path)
     name_path.reduce(Object) do |ns, name|
@@ -107,6 +107,7 @@ class ClassLoader
       end
     end
   end
+  private_class_method :find_class
 
   def self.paths_for_name(fq_named_parts)
     # search two entries, one where all parts are decamelized, and one with names just downcased
@@ -115,6 +116,7 @@ class ClassLoader
     #
     [fq_named_parts.map {|part| de_camel(part)}.join('/'), fq_named_parts.join('/').downcase ]
   end
+  private_class_method :paths_for_name
 
   def self.de_camel(fq_name)
     fq_name.to_s.gsub(/::/, '/').
@@ -123,6 +125,7 @@ class ClassLoader
     tr("-", "_").
     downcase
   end
+  private_class_method :de_camel
 
 end
 end

--- a/lib/puppet/pops/types/class_loader.rb
+++ b/lib/puppet/pops/types/class_loader.rb
@@ -66,7 +66,7 @@ class ClassLoader
     when PPatternType  ; String
     when PEnumType     ; String
     when PFloatType    ; Float
-    when PUndefType      ; NilClass
+    when PUndefType    ; NilClass
     when PCallableType ; Proc
     else
       nil

--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -110,8 +110,6 @@ module Puppet::Resource::CapabilityFinder
     end
   end
 
-  private
-
   # Find a distinct copy of the given capability resource by searching for only
   # resources matching the given code_id. Returns `nil` if no code_id is
   # supplied or if there isn't exactly one matching resource.
@@ -132,6 +130,7 @@ module Puppet::Resource::CapabilityFinder
       end
     end
   end
+  private_class_method :disambiguate_by_code_id
 
   def self.instantiate_resource(resource_hash)
     real_type = resource_hash['type']
@@ -147,4 +146,5 @@ module Puppet::Resource::CapabilityFinder
     end
     return resource
   end
+  private_class_method :instantiate_resource
 end

--- a/lib/puppet/ssl/certificate_factory.rb
+++ b/lib/puppet/ssl/certificate_factory.rb
@@ -54,8 +54,6 @@ module Puppet::SSL::CertificateFactory
     return cert
   end
 
-  private
-
   # Add X509v3 extensions to the given certificate.
   #
   # @param cert [OpenSSL::X509::Certificate] The certificate to add the
@@ -114,6 +112,7 @@ module Puppet::SSL::CertificateFactory
       generate_extension(ef, oid, *val)
     end
   end
+  private_class_method :add_extensions_to
 
   # Woot! We're a CA.
   def self.build_ca_extensions
@@ -216,4 +215,5 @@ module Puppet::SSL::CertificateFactory
       OpenSSL::X509::Extension.new(oid, OpenSSL::ASN1::UTF8String.new(val).to_der, crit)
     end
   end
+  private_class_method :generate_extension
 end

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -238,8 +238,6 @@ DOC
     end
   end
 
-  private
-
   PRIVATE_EXTENSIONS = [
     'subjectAltName', '2.5.29.17',
   ]

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -2233,8 +2233,6 @@ end
 
   # class methods dealing with Type management
 
-  public
-
   # The Type class attribute accessors
   class << self
     # @return [String] the name of the resource type; e.g., "File"
@@ -2343,8 +2341,6 @@ end
 
   # instance methods related to instance intrinsics
   # e.g., initialize and name
-
-  public
 
   # @return [Hash] hash of parameters originally defined
   # @api private

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -366,11 +366,7 @@ module Util
   end
   module_function :uri_to_path
 
-  private
-
   RFC_3986_URI_REGEX = /^(?<scheme>([^:\/?#]+):)?(?<authority>\/\/([^\/?#]*))?(?<path>[^?#]*)(\?(?<query>[^#]*))?(#(?<fragment>.*))?$/
-
-  public
 
   # Percent-encodes a URI query parameter per RFC3986 - https://tools.ietf.org/html/rfc3986
   #

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -164,8 +164,6 @@ class Puppet::Util::Log
     end
   end
 
-  private
-  # produces UTF-8 strings or dumps strings when they cannot be re-encoded
   def Log.coerce_string(str)
     return Puppet::Util::CharacterEncoding.convert_to_utf_8(str) if str.valid_encoding?
 
@@ -175,8 +173,7 @@ class Puppet::Util::Log
     message += '\n' + _("Backtrace:\n%{backtrace}") % { backtrace: caller[0..10].join("\n") }
     message
   end
-
-  public
+  private_class_method :coerce_string
 
   # Route the actual message. FIXME There are lots of things this method
   # should do, like caching and a bit more.  It's worth noting that there's

--- a/lib/puppet/util/warnings.rb
+++ b/lib/puppet/util/warnings.rb
@@ -20,8 +20,6 @@ module Puppet::Util::Warnings
     nil
   end
 
-  protected
-
   def self.maybe_log(message, klass)
     @stampwarnings ||= {}
     @stampwarnings[klass] ||= []

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -393,8 +393,6 @@ module Puppet::Util::Windows::File
   end
   module_function :lstat
 
-  private
-
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364571(v=vs.85).aspx
   FSCTL_GET_REPARSE_POINT = 0x900a8
 
@@ -410,6 +408,7 @@ module Puppet::Util::Windows::File
 
     path
   end
+  private_class_method :resolve_symlink
 
   # these reparse point types are the only ones Puppet currently understands
   # so rather than raising an exception in readlink, prefer to not consider
@@ -426,6 +425,7 @@ module Puppet::Util::Windows::File
 
     symlink
   end
+  private_class_method :symlink_reparse_point?
 
   ffi_convention :stdcall
 

--- a/lib/puppet/util/windows/taskscheduler.rb
+++ b/lib/puppet/util/windows/taskscheduler.rb
@@ -12,8 +12,6 @@ module Win32
     # The error class raised if any task scheduler specific calls fail.
     class Error < Puppet::Util::Windows::Error; end
 
-    private
-
     class << self
       attr_accessor :com_initialized
     end
@@ -91,8 +89,6 @@ module Win32
     SCHED_E_NO_SECURITY_SERVICES          = -2147216622 # 0x80041312
     # No mapping between account names and security IDs was done.
     ERROR_NONE_MAPPED                     = -2147023564 # 0x80070534  WIN32 Error CODE 1332 (0x534)
-
-    public
 
     # :startdoc:
 
@@ -935,8 +931,6 @@ module Win32
       new_hash
     end
 
-    private
-
     def reset_current_task
       # Ensure that COM reference is decremented properly
       @pITask.Release if @pITask && ! @pITask.null?
@@ -1052,11 +1046,8 @@ module Win32
 
     module COM
       extend FFI::Library
-      private
 
       com = Puppet::Util::Windows::COM
-
-      public
 
       # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381811(v=vs.85).aspx
       ITaskScheduler = com::Interface[com::IUnknown,

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -680,8 +680,6 @@ module Pal
     in_environment_context(environments, env, facts, variables, &block)
   end
 
-  private
-
   # Prepares the puppet context with pal information - and delegates to the block
   # No set up is performed at this step - it is delayed until it is known what the
   # operation is going to be (for example - using a ScriptCompiler).
@@ -701,6 +699,7 @@ module Pal
       return block.call(self)
     end
   end
+  private_class_method :in_environment_context
 
   # Prepares the node for use by giving it node_facts (if given)
   # If a hash of facts values is given, then the operation of creating a node with facts is much
@@ -717,6 +716,7 @@ module Pal
       node.add_server_facts({})
     end
   end
+  private_class_method :prepare_node_facts
 
   def self.add_variables(scope, variables)
     return if variables.nil?
@@ -737,6 +737,7 @@ module Pal
       scope.setvar(k, v)
     end
   end
+  private_class_method :add_variables
 
   # The main routine for script compiler
   # Picks up information from the puppet context and configures a script compiler which is given to
@@ -837,6 +838,7 @@ module Pal
       end
     end
   end
+  private_class_method :main
 
   T_STRING = Puppet::Pops::Types::PStringType::NON_EMPTY
   T_STRING_ARRAY = Puppet::Pops::Types::TypeFactory.array_of(T_STRING)
@@ -857,18 +859,21 @@ module Pal
   def self.assert_optionally_empty_array(a, what, allow_nil=false)
     assert_type(T_STRING_ARRAY, a, what, allow_nil)
   end
+  private_class_method :assert_optionally_empty_array
 
   def self.assert_mutually_exclusive(a, b, a_term, b_term)
     if a && b
       raise ArgumentError, _("Cannot use '%{a_term}' and '%{b_term}' at the same time") % { a_term: a_term, b_term: b_term }
     end
   end
+  private_class_method :assert_mutually_exclusive
 
   def self.assert_block_given(block)
     if block.nil?
       raise ArgumentError, _("A block must be given")
     end
   end
+  private_class_method :assert_block_given
 end
 end
 


### PR DESCRIPTION
The Lint/UselessAccessModifier can let us know when we think we've marked something as public/protected/private, but haven't. Some examples of common reasons for things being not-actually private are Ruby syntax, or Ruby not actually supporting the thing in question being private at all.

We have a large number of violations of the Lint/UselessAccessModifier cop for a few different reasons:
  * Trying to mark constants private. Ruby doesn't do this.
  * Trying to mark classes private. Ruby doesn't do this.
  * Trying to mark class methods defined using `def self.foo` private. This doesn't work by placing the definition below `private`, and needs to be done by calling `private_class_method :foo` after the method definition.
  * Marking the following methods as public when the methods were already in a public context.
  * Trying to mark class methods as protected. Ruby doesn't do this, as it's effectively the same as a private class method.

In all cases where we were trying to mark a method as private, but not actually doing so, the method is now marked as private as long as it didn't break any tests.

In cases where we were redundantly marking things as public, or where making it private would have broken tests, the method is left as public.

In cases where we were trying to mark things as private and Ruby doesn't support having them as private, the decoration has been removed.