### PR TITLE
(PUP-8470) Use usermod to manage group membership when user forcelocal is true

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -188,7 +188,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
 
   def modifycmd(param, value)
     if @resource.forcelocal?
-      cmd = [command(property_manages_password_age?(param) ? :localpassword : :localmodify)]
+      if param == :groups
+        cmd = [command(:modify)]
+      else
+        cmd = [command(property_manages_password_age?(param) ? :localpassword : :localmodify)]
+      end
       @custom_environment = Puppet::Util::Libuser.getenv
     else
       cmd = [command(property_manages_password_age?(param) ? :password : :modify)]

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -125,10 +125,10 @@ describe Puppet::Type.type(:user).provider(:useradd) do
         expect { provider.create }.to raise_error(Puppet::Error, "UID 505 already exists, use allowdupe to force user creation")
       end
 
-      it "should not use -G for luseradd and should call lusermod with -G after luseradd when groups property is set" do
+      it "should not use -G for luseradd and should call usermod with -G after luseradd when groups property is set" do
         resource[:groups] = ['group1', 'group2']
-        provider.expects(:execute).with(Not(includes("-G")), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
-        provider.expects(:execute).with(includes('/usr/sbin/lusermod'), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
+        provider.expects(:execute).with(all_of(includes('/usr/sbin/luseradd'), Not(includes('-G'))), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
+        provider.expects(:execute).with(all_of(includes('/usr/sbin/usermod'), includes('-G')), has_entry(:custom_environment, has_key('LIBUSER_CONF')))
         provider.create
       end
 


### PR DESCRIPTION
When forcelocal is true and groups are defined for a user, use usermod since
lusermod does not support -G.