### PR TITLE
(PUP-8490) Remove inactive maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -34,33 +34,14 @@
       "name": "Ethan J. Brown"
     },
     {
-      "github": "HAIL9000",
-      "email": "hailee@puppet.com",
-      "name": "Hailee Kenney"
-    },
-    {
       "github": "er0ck",
       "email": "eric.thompson@puppet.com",
       "name": "Eric Thompson"
     },
     {
-      "github": "johnduarte",
-      "email": "john.duarte@puppet.com",
-      "name": "John Duarte"
-    },
-    {
-      "github": "adrienthebo",
-      "name": "Adrien Thebo"
-    },
-    {
       "github": "jtappa",
       "email": "jorie@puppet.com",
       "name": "Jorie Tappa"
-    },
-    {
-      "github": "MosesMendoza",
-      "email": "moses@puppet.com",
-      "name": "Moses Mendoza"
     }
   ]
 }


### PR DESCRIPTION
Several folks in the MAINTAINERS file no longer actively contribute to Puppet
or have commiters rights. This commit removes them from the MAINAINTERS file.

Signed-off-by: Moses Mendoza <mendoza.moses@gmail.com>