### PR TITLE
(PUP-8488) convert microsoft_windows? to windows? in tests and docs

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -13,17 +13,17 @@ You will need to install Ruby on Windows from [rubyinstaller.org](http://rubyins
 When writing a test that cannot possibly run on Windows, e.g. there is
 no mount type on windows, do the following:
 
-    describe Puppet::MyClass, :unless => Puppet.features.microsoft_windows? do
+    describe Puppet::MyClass, :unless => Puppet::Util::Platform.windows? do
       ..
     end
 
 If the test doesn't currently pass on Windows, e.g. due to on going porting, then use an rspec conditional pending block:
 
-    pending("porting to Windows", :if => Puppet.features.microsoft_windows?) do
+    pending("porting to Windows", :if => Puppet::Util::Platform.windows?) do
       <example1>
     end
 
-    pending("porting to Windows", :if => Puppet.features.microsoft_windows?) do
+    pending("porting to Windows", :if => Puppet::Util::Platform.windows?) do
       <example2>
     end
 

--- a/spec/integration/agent/logging_spec.rb
+++ b/spec/integration/agent/logging_spec.rb
@@ -81,7 +81,7 @@ describe 'agent logging' do
       command_line.execute
     end
 
-    if Puppet.features.microsoft_windows? && argv.include?(DAEMONIZE)
+    if Puppet::Util::Platform.windows? && argv.include?(DAEMONIZE)
 
       it "should exit on a platform which cannot daemonize if the --daemonize flag is set" do
         expect { double_of_bin_puppet_agent_call(argv) }.to raise_error(SystemExit)
@@ -128,7 +128,7 @@ describe 'agent logging' do
     loggers << CONSOLE if verbose_or_debug_set_in_argv(argv)
     loggers << 'console' if log_dest_is_set_to(argv, LOGDEST_CONSOLE)
     loggers << '/dev/null/foo' if log_dest_is_set_to(argv, LOGDEST_FILE)
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       # an explicit call to --logdest syslog on windows is swallowed silently with no
       # logger created (see #suitable() of the syslog Puppet::Util::Log::Destination subclass)
       # however Puppet::Util::Log.newdestination('syslog') does get called...so we have

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -255,7 +255,7 @@ end
     expect(@logs.map(&:to_s)).to include(/{environment =>.*/)
   end
 
-  it "applies a given file even when an ENC is configured", :if => !Puppet.features.microsoft_windows? do
+  it "applies a given file even when an ENC is configured", :if => !Puppet::Util::Platform.windows? do
     manifest = file_containing("manifest.pp", "notice('specific manifest applied')")
     enc = script_containing('enc_script',
       :windows => '@echo classes: []' + "\n" + '@echo environment: special',

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -47,7 +47,7 @@ describe Puppet::Configurer do
       t2 = Time.now.tv_sec
 
       # sticky bit only applies to directories in windows
-      file_mode = Puppet.features.microsoft_windows? ? '666' : '100666'
+      file_mode = Puppet::Util::Platform.windows? ? '666' : '100666'
 
       expect(Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode.to_s(8)).to eq(file_mode)
 

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -115,7 +115,7 @@ describe "Puppet defaults" do
     end
   end
 
-  describe "on a Windows-like platform it", :if => Puppet.features.microsoft_windows? do
+  describe "on a Windows-like platform it", :if => Puppet::Util::Platform.windows? do
     let (:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
 
     it "path should not add anything" do
@@ -196,11 +196,11 @@ describe "Puppet defaults" do
   end
 
   describe "daemonize" do
-    it "should default to true", :unless => Puppet.features.microsoft_windows? do
+    it "should default to true", :unless => Puppet::Util::Platform.windows? do
       expect(Puppet.settings[:daemonize]).to eq(true)
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should default to false" do
         expect(Puppet.settings[:daemonize]).to eq(false)
       end
@@ -212,11 +212,11 @@ describe "Puppet defaults" do
   end
 
   describe "diff" do
-    it "should default to 'diff' on POSIX", :unless => Puppet.features.microsoft_windows? do
+    it "should default to 'diff' on POSIX", :unless => Puppet::Util::Platform.windows? do
       expect(Puppet.settings[:diff]).to eq('diff')
     end
 
-    it "should default to '' on Windows", :if => Puppet.features.microsoft_windows? do
+    it "should default to '' on Windows", :if => Puppet::Util::Platform.windows? do
       expect(Puppet.settings[:diff]).to eq('')
     end
   end

--- a/spec/integration/faces/ca_spec.rb
+++ b/spec/integration/faces/ca_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:ca, '0.1.0'], :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Face[:ca, '0.1.0'], :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   before :each do

--- a/spec/integration/file_system/uniquefile_spec.rb
+++ b/spec/integration/file_system/uniquefile_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Puppet::FileSystem::Uniquefile do
 
-  describe "#open_tmp on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#open_tmp on Windows", :if => Puppet::Util::Platform.windows? do
 
     describe "with UTF8 characters" do
       include PuppetSpec::Files

--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::Node::Facts::Facter do
     it "should resolve external facts" do
       external_fact = File.join(factdir, 'external')
 
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         external_fact += '.bat'
         File.open(external_fact, 'wb') { |file| file.write(<<-EOF)}
         @echo foo=bar

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -141,7 +141,7 @@ describe Puppet::Node::Environment do
       :strict_variables => true
   end
 
-  describe "#extralibs on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#extralibs on Windows", :if => Puppet::Util::Platform.windows? do
 
     describe "with UTF8 characters in PUPPETLIB" do
       let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -211,7 +211,7 @@ describe Puppet::Parser::Compiler do
   describe "the compiler when using 4.x language constructs" do
     include PuppetSpec::Compiler
 
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       it "should be able to determine the configuration version from a local version control repository" do
         pending("Bug #14071 about semantics of Puppet::Util::Execute on Windows")
         # This should always work, because we should always be

--- a/spec/integration/provider/cron/crontab_spec.rb
+++ b/spec/integration/provider/cron/crontab_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'puppet/file_bucket/dipper'
 require 'puppet_spec/compiler'
 
-describe Puppet::Type.type(:cron).provider(:crontab), '(integration)', :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:cron).provider(:crontab), '(integration)', :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 

--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 require 'puppet/file_bucket/dipper'
 
-describe "mount provider (integration)", :unless => Puppet.features.microsoft_windows? do
+describe "mount provider (integration)", :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   family = Facter.value(:osfamily)

--- a/spec/integration/provider/service/windows_spec.rb
+++ b/spec/integration/provider/service/windows_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:windows), '(integration)',
-  :if => Puppet.features.microsoft_windows? do
+  :if => Puppet::Util::Platform.windows? do
 
   require 'puppet/util/windows'
 

--- a/spec/integration/provider/ssh_authorized_key_spec.rb
+++ b/spec/integration/provider/ssh_authorized_key_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'puppet/file_bucket/dipper'
 
-describe Puppet::Type.type(:ssh_authorized_key).provider(:parsed), '(integration)', :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:ssh_authorized_key).provider(:parsed), '(integration)', :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   let :fake_userfile do

--- a/spec/integration/provider/sshkey_spec.rb
+++ b/spec/integration/provider/sshkey_spec.rb
@@ -6,7 +6,7 @@ require 'puppet_spec/files'
 require 'puppet_spec/compiler'
 
 describe Puppet::Type.type(:sshkey).provider(:parsed), '(integration)',
-  :unless => Puppet.features.microsoft_windows? do
+  :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 

--- a/spec/integration/provider/yumrepo_spec.rb
+++ b/spec/integration/provider/yumrepo_spec.rb
@@ -6,7 +6,7 @@ require 'puppet_spec/files'
 require 'puppet_spec/compiler'
 
 describe Puppet::Type.type(:yumrepo).provider(:inifile), '(integration)',
-  :unless => Puppet.features.microsoft_windows? do
+  :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 

--- a/spec/integration/ssl/certificate_authority_spec.rb
+++ b/spec/integration/ssl/certificate_authority_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet/ssl/certificate_authority'
 
-describe Puppet::SSL::CertificateAuthority, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::SSL::CertificateAuthority, :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   let(:ca) { @ca }

--- a/spec/integration/ssl/host_spec.rb
+++ b/spec/integration/ssl/host_spec.rb
@@ -71,7 +71,7 @@ describe Puppet::SSL::Host do
     end
   end
 
-  it "should pass the verification of its own SSL store", :unless => Puppet.features.microsoft_windows? do
+  it "should pass the verification of its own SSL store", :unless => Puppet::Util::Platform.windows? do
     @host.generate
     @ca = Puppet::SSL::CertificateAuthority.new
     @ca.sign(@host.name)

--- a/spec/integration/test/test_helper_spec.rb
+++ b/spec/integration/test/test_helper_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-describe "Windows UTF8 environment variables", :if => Puppet.features.microsoft_windows? do
+describe "Windows UTF8 environment variables", :if => Puppet::Util::Platform.windows? do
   # The Puppet::Util::Windows::Process class is used to manipulate environment variables as it is known to handle UTF8 characters. Where as the implementation of ENV in ruby does not.
   # before and end all are used to inject environment variables before the test helper 'before_each_test' function is called
   # Do not use before and after hooks in these tests as it may have unintended consequences
@@ -16,7 +16,7 @@ describe "Windows UTF8 environment variables", :if => Puppet.features.microsoft_
     # Need to cleanup this environment variable otherwise it contaminates any subsequent tests
     Puppet::Util::Windows::Process.set_environment_variable(@varname, nil)
   }
-  
+
   it "#after_each_test should preserve UTF8 environment variables" do
     envhash = Puppet::Util::Windows::Process.get_environment_strings
     expect(envhash[@varname]).to eq(@rune_utf8)

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -385,7 +385,7 @@ describe Puppet::Transaction::Report do
         expect(get_cc_count(report)).to eq(0)
       end
 
-      it "link with ensure property change present => absent", :unless => Puppet.features.microsoft_windows? do
+      it "link with ensure property change present => absent", :unless => Puppet::Util::Platform.windows? do
         file = tmpfile("test_file")
         FileUtils.symlink(file, tmpfile("test_link"))
 
@@ -440,7 +440,7 @@ describe Puppet::Transaction::Report do
         expect(get_cc_count(report)).to eq(0)
       end
 
-      it "exec with idempotence issue", :unless => Puppet.features.microsoft_windows? do
+      it "exec with idempotence issue", :unless => Puppet::Util::Platform.windows? do
         report = run_catalogs(Puppet::Type.type(:exec).new(:title => "exec1",
                                                            :command => "/bin/echo foo"),
                               Puppet::Type.type(:exec).new(:title => "exec1",
@@ -458,7 +458,7 @@ describe Puppet::Transaction::Report do
         expect(get_cc_count(report)).to eq(1)
       end
 
-      it "exec with no idempotence issue", :unless => Puppet.features.microsoft_windows? do
+      it "exec with no idempotence issue", :unless => Puppet::Util::Platform.windows? do
         report = run_catalogs(Puppet::Type.type(:exec).new(:title => "exec1",
                                                            :command => "echo foo",
                                                            :path => "/bin",

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -19,15 +19,15 @@ describe Puppet::Transaction do
   end
 
   def touch_path
-    Puppet.features.microsoft_windows? ? "#{ENV['windir']}\\system32" : "/usr/bin:/bin"
+    Puppet::Util::Platform.windows? ? "#{ENV['windir']}\\system32" : "/usr/bin:/bin"
   end
 
   def usr_bin_touch(path)
-    Puppet.features.microsoft_windows? ? "#{ENV['windir']}\\system32\\cmd.exe /c \"type NUL >> \"#{path}\"\"" : "/usr/bin/touch #{path}"
+    Puppet::Util::Platform.windows? ? "#{ENV['windir']}\\system32\\cmd.exe /c \"type NUL >> \"#{path}\"\"" : "/usr/bin/touch #{path}"
   end
 
   def touch(path)
-    Puppet.features.microsoft_windows? ? "cmd.exe /c \"type NUL >> \"#{path}\"\"" : "touch #{path}"
+    Puppet::Util::Platform.windows? ? "cmd.exe /c \"type NUL >> \"#{path}\"\"" : "touch #{path}"
   end
 
   it "should not apply generated resources if the parent resource fails" do

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet_spec/files'
 
-if Puppet.features.microsoft_windows?
+if Puppet::Util::Platform.windows?
   require 'puppet/util/windows'
   class WindowsSecurity
     extend Puppet::Util::Windows::Security
@@ -1100,7 +1100,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       uri_path = resource.parameters[:source].uri.path
 
       # note that Windows file:// style URIs get an extra / in front of c:/ like /c:/
-      source_prefix = Puppet.features.microsoft_windows? ? '/' : ''
+      source_prefix = Puppet::Util::Platform.windows? ? '/' : ''
 
       # the URI can be round-tripped through unescape
       expect(URI.unescape(uri_path)).to eq(source_prefix + source)
@@ -1393,7 +1393,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       def expects_sid_granted_full_access_explicitly(path, sid)
         inherited_ace = Puppet::Util::Windows::AccessControlEntry::INHERITED_ACE
 

--- a/spec/integration/type/user_spec.rb
+++ b/spec/integration/type/user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'puppet_spec/files'
 require 'puppet_spec/compiler'
 
-describe Puppet::Type.type(:user), '(integration)', :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:user), '(integration)', :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 

--- a/spec/integration/util/execution_spec.rb
+++ b/spec/integration/util/execution_spec.rb
@@ -4,13 +4,13 @@ describe Puppet::Util::Execution do
   include PuppetSpec::Files
 
   describe "#execpipe" do
-    it "should set LANG to C avoid localized output", :if => !Puppet.features.microsoft_windows? do
+    it "should set LANG to C avoid localized output", :if => !Puppet::Util::Platform.windows? do
       out = ""
       Puppet::Util::Execution.execpipe('echo $LANG'){ |line| out << line.read.chomp }
       expect(out).to eq("C")
     end
 
-    it "should set LC_ALL to C avoid localized output", :if => !Puppet.features.microsoft_windows? do
+    it "should set LC_ALL to C avoid localized output", :if => !Puppet::Util::Platform.windows? do
       out = ""
       Puppet::Util::Execution.execpipe('echo $LC_ALL'){ |line| out << line.read.chomp }
       expect(out).to eq("C")
@@ -25,7 +25,7 @@ describe Puppet::Util::Execution do
     end
   end
 
-  describe "#execute (non-Windows)", :if => !Puppet.features.microsoft_windows? do
+  describe "#execute (non-Windows)", :if => !Puppet::Util::Platform.windows? do
     it "should execute basic shell command" do
       result = Puppet::Util::Execution.execute("ls /tmp", :failonfail => true)
       expect(result.exitstatus).to eq(0)
@@ -33,7 +33,7 @@ describe Puppet::Util::Execution do
     end
   end
 
-  describe "#execute (Windows)", :if => Puppet.features.microsoft_windows? do
+  describe "#execute (Windows)", :if => Puppet::Util::Platform.windows? do
     let(:utf8text) do
       # Japanese Lorem Ipsum snippet
       "utf8testfile" + [227, 131, 171, 227, 131, 147, 227, 131, 179, 227, 131, 132, 227,

--- a/spec/integration/util/rdoc/parser_spec.rb
+++ b/spec/integration/util/rdoc/parser_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/rdoc'
 
-describe "RDoc::Parser", :unless => Puppet.features.microsoft_windows? do
+describe "RDoc::Parser", :unless => Puppet::Util::Platform.windows? do
   require 'puppet_spec/files'
   include PuppetSpec::Files
 

--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -70,7 +70,7 @@ environment=#{rune_utf8}
     expect(settings[:environment]).to eq(rune_utf8)
   end
 
-  it "reparses configuration if configuration file is touched", :if => !Puppet.features.microsoft_windows? do
+  it "reparses configuration if configuration file is touched", :if => !Puppet::Util::Platform.windows? do
     config = tmpfile("config")
     define_settings(:main,
       :config => {

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'puppet/util/windows'
 
 describe Puppet::Util::Windows::ADSI::User,
-  :if => Puppet.features.microsoft_windows? do
+  :if => Puppet::Util::Platform.windows? do
 
   describe ".initialize" do
     it "cannot reference BUILTIN accounts like SYSTEM due to WinNT moniker limitations" do
@@ -59,7 +59,7 @@ describe Puppet::Util::Windows::ADSI::User,
 end
 
 describe Puppet::Util::Windows::ADSI::Group,
-  :if => Puppet.features.microsoft_windows? do
+  :if => Puppet::Util::Platform.windows? do
 
   let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
   let (:administrators_principal) { Puppet::Util::Windows::SID::Principal.lookup_account_sid(administrator_bytes) }

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft_windows? do
+describe Puppet::Util::Windows::SID::Principal, :if => Puppet::Util::Platform.windows? do
 
   let (:current_user_sid) { Puppet::Util::Windows::ADSI::User.current_user_sid }
   let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }

--- a/spec/integration/util/windows/process_spec.rb
+++ b/spec/integration/util/windows/process_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'facter'
 
-describe "Puppet::Util::Windows::Process", :if => Puppet.features.microsoft_windows?  do
+describe "Puppet::Util::Windows::Process", :if => Puppet::Util::Platform.windows?  do
   describe "as an admin" do
     it "should have the SeCreateSymbolicLinkPrivilege necessary to create symlinks on Vista / 2008+",
-      :if => Facter.value(:kernelmajversion).to_f >= 6.0 && Puppet.features.microsoft_windows? do
+      :if => Facter.value(:kernelmajversion).to_f >= 6.0 && Puppet::Util::Platform.windows? do
       # this is a bit of a lame duck test since it requires running user to be admin
       # a better integration test would create a new user with the privilege and verify
       expect(Puppet::Util::Windows::User).to be_admin
@@ -14,7 +14,7 @@ describe "Puppet::Util::Windows::Process", :if => Puppet.features.microsoft_wind
     end
 
     it "should not have the SeCreateSymbolicLinkPrivilege necessary to create symlinks on 2003 and earlier",
-      :if => Facter.value(:kernelmajversion).to_f < 6.0 && Puppet.features.microsoft_windows? do
+      :if => Facter.value(:kernelmajversion).to_f < 6.0 && Puppet::Util::Platform.windows? do
       expect(Puppet::Util::Windows::User).to be_admin
       expect(Puppet::Util::Windows::Process.process_privilege_symlink?).to be_falsey
     end

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 require 'spec_helper'
 
-if Puppet.features.microsoft_windows?
+if Puppet::Util::Platform.windows?
   class WindowsSecurityTester
     require 'puppet/util/windows/security'
     include Puppet::Util::Windows::Security
   end
 end
 
-describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::Security", :if => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   before :all do
@@ -406,7 +406,7 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
         end
       end
 
-      describe "for an administrator", :if => (Puppet.features.root? && Puppet.features.microsoft_windows?) do
+      describe "for an administrator", :if => (Puppet.features.root? && Puppet::Util::Platform.windows?) do
         before :each do
           is_dir = Puppet::FileSystem.directory?(path)
           winsec.set_mode(WindowsSecurityTester::S_IRWXU | WindowsSecurityTester::S_IRWXG, path)

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::User", :if => Puppet::Util::Platform.windows? do
   describe "2003 without UAC" do
     before :each do
       Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(5)

--- a/spec/integration/util_spec.rb
+++ b/spec/integration/util_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Util do
     end
   end
 
-  describe "#replace_file on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#replace_file on Windows", :if => Puppet::Util::Platform.windows? do
     it "replace_file should preserve original ACEs from existing replaced file on Windows" do
 
       file = tmpfile("somefile")
@@ -109,7 +109,7 @@ describe Puppet::Util do
     end
   end
 
-  describe "#which on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#which on Windows", :if => Puppet::Util::Platform.windows? do
     let (:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
     let (:filename) { 'foo.exe' }
     let (:filepath) { File.expand_path('C:\\' + rune_utf8 + '\\' + filename) }

--- a/spec/lib/matchers/json.rb
+++ b/spec/lib/matchers/json.rb
@@ -101,7 +101,7 @@ module JSONMatchers
     end
   end
 
-  if !Puppet.features.microsoft_windows?
+  if !Puppet::Util::Platform.windows?
     require 'json'
     require 'json-schema'
 
@@ -120,7 +120,7 @@ module JSONMatchers
   end
 
   def validate_against(schema_file)
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       pending("Schema checks cannot be done on windows because of json-schema problems")
     else
       schema = JSON.parse(File.read(schema_file))

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -20,7 +20,7 @@ module PuppetSpec::Files
   def make_absolute(path) PuppetSpec::Files.make_absolute(path) end
   def self.make_absolute(path)
     path = File.expand_path(path)
-    path[0] = 'c' if Puppet.features.microsoft_windows?
+    path[0] = 'c' if Puppet::Util::Platform.windows?
     path
   end
 
@@ -46,7 +46,7 @@ module PuppetSpec::Files
   def script_containing(name, contents) PuppetSpec::Files.script_containing(name, contents) end
   def self.script_containing(name, contents)
     file = tmpfile(name)
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       file += '.bat'
       text = contents[:windows]
     else
@@ -93,7 +93,7 @@ module PuppetSpec::Files
 
   def expect_file_mode(file, mode)
     actual_mode = "%o" % Puppet::FileSystem.stat(file).mode
-    target_mode = if Puppet.features.microsoft_windows?
+    target_mode = if Puppet::Util::Platform.windows?
       mode
     else
       "10" + "%04i" % mode.to_i

--- a/spec/shared_behaviours/path_parameters.rb
+++ b/spec/shared_behaviours/path_parameters.rb
@@ -115,7 +115,7 @@ shared_examples_for "all path parameters" do |param, options|
     end
   end
 
-  describe "on a Windows-like platform it", :if => Puppet.features.microsoft_windows? do
+  describe "on a Windows-like platform it", :if => Puppet::Util::Platform.windows?  do
     if array then
       it_should_behave_like "all pathname parameters with arrays", true
     end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -252,7 +252,7 @@ describe Puppet::Agent do
       end
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should never fork" do
         agent = Puppet::Agent.new(AgentTestClient, true)
         expect(agent.should_fork).to be_falsey

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -5,7 +5,7 @@ require 'puppet/application/master'
 require 'puppet/daemon'
 require 'puppet/network/server'
 
-describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Application::Master, :unless => Puppet::Util::Platform.windows? do
   before :each do
     @master = Puppet::Application[:master]
     @daemon = stub_everything 'daemon'

--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -391,7 +391,7 @@ test { one: hostname => "ahost", export => Cap[two] }
   end
 
   context 'and aliased resources' do
-    let(:drive) { Puppet.features.microsoft_windows? ? 'C:' : '' }
+    let(:drive) { Puppet::Util::Platform.windows? ? 'C:' : '' }
     let(:code) { <<-PUPPET }
       $dir='#{drive}/tmp/test'
       $same_dir='#{drive}/tmp/test/'

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -104,7 +104,7 @@ describe Puppet::Configurer::Downloader do
       end
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should omit the owner" do
         file = generate_file_resource(:path => 'C:/path')
 

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -16,7 +16,7 @@ class TestClient
   end
 end
 
-describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Daemon, :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   class RecordingScheduler

--- a/spec/unit/etc_spec.rb
+++ b/spec/unit/etc_spec.rb
@@ -9,7 +9,7 @@ require 'puppet_spec/character_encoding'
 # - We correctly set external encoding values IF they're valid UTF-8 bytes
 # - We do not modify non-UTF-8 values if they're NOT valid UTF-8 bytes
 
-describe Puppet::Etc, :if => !Puppet.features.microsoft_windows? do
+describe Puppet::Etc, :if => !Puppet::Util::Platform.windows? do
   # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
   # 希 Han Character 'rare; hope, expect, strive for'
   # In EUC_KR: \xfd \xf1 - 253 241

--- a/spec/unit/face/certificate_spec.rb
+++ b/spec/unit/face/certificate_spec.rb
@@ -160,7 +160,7 @@ describe Puppet::Face[:certificate, '0.0.1'] do
     let(:host) { Puppet::SSL::Host.new(hostname) }
     let(:hostname) { "foobar" }
 
-    it "should sign the certificate request if one is waiting", :unless => Puppet.features.microsoft_windows? do
+    it "should sign the certificate request if one is waiting", :unless => Puppet::Util::Platform.windows? do
       subject.generate(hostname, options)
 
       subject.sign(hostname, options)
@@ -176,7 +176,7 @@ describe Puppet::Face[:certificate, '0.0.1'] do
       end.to raise_error(ArgumentError, /Could not find certificate request for #{hostname}/)
     end
 
-    describe "when ca_location is local", :unless => Puppet.features.microsoft_windows? do
+    describe "when ca_location is local", :unless => Puppet::Util::Platform.windows? do
       describe "when the request has dns alt names" do
         before :each do
           subject.generate(hostname, options.merge(:dns_alt_names => 'some,alt,names'))

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -73,7 +73,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
   end
 
   describe "when diffing on a local filebucket" do
-    describe "in non-windows environments", :unless => Puppet.features.microsoft_windows? do
+    describe "in non-windows environments", :unless => Puppet::Util::Platform.windows? do
       with_digest_algorithms do
 
         it "should fail in an informative way when one or more checksum doesn't exists" do
@@ -121,7 +121,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
 
         end
       end
-      describe "in windows environment", :if => Puppet.features.microsoft_windows? do
+      describe "in windows environment", :if => Puppet::Util::Platform.windows? do
         it "should fail in an informative way when trying to diff" do
           @dipper = Puppet::FileBucket::Dipper.new(:Path => tmpdir("bucket"))
           wrong_checksum = "DEADBEEF"
@@ -250,7 +250,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
   end
 
   describe "when diffing on a remote filebucket" do
-    describe "in non-windows environments", :unless => Puppet.features.microsoft_windows? do
+    describe "in non-windows environments", :unless => Puppet::Util::Platform.windows? do
       with_digest_algorithms do
         it "should fail in an informative way when one or more checksum doesn't exists" do
           @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port => "31337")
@@ -271,7 +271,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
       end
     end
 
-    describe "in windows environment", :if => Puppet.features.microsoft_windows? do
+    describe "in windows environment", :if => Puppet::Util::Platform.windows? do
       it "should fail in an informative way when trying to diff" do
         @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port => "31337")
         wrong_checksum = "DEADBEEF"

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -241,7 +241,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
     end
   end
 
-  describe "WindowsStat", :if => Puppet.features.microsoft_windows? do
+  describe "WindowsStat", :if => Puppet::Util::Platform.windows? do
     include PuppetSpec::Files
 
     it "should return default owner, group and mode when the given path has an invalid DACL (such as a non-NTFS volume)" do
@@ -388,7 +388,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
     end
   end
 
-  describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+  describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
     let(:owner) {'S-1-1-50'}
     let(:group) {'S-1-1-51'}
 
@@ -499,7 +499,7 @@ describe Puppet::FileServing::Metadata, " when pointing to a link", :if => Puppe
         Puppet::FileSystem.expects(:readlink).with(path).at_least_once.returns "/some/other/path"
         @file.stubs("#{digest_algorithm}_file".intern).returns(checksum) # Remove these when :managed links are no longer checksumed.
 
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           win_stat = stub('win_stat', :owner => 'snarf', :group => 'thundercats',
             :ftype => 'link', :mode => 0755)
           Puppet::FileServing::Metadata::WindowsStat.stubs(:new).returns win_stat
@@ -530,7 +530,7 @@ describe Puppet::FileServing::Metadata, " when pointing to a link", :if => Puppe
         Puppet::FileSystem.expects(:stat).with(path).at_least_once.returns stat
         Puppet::FileSystem.expects(:readlink).never
 
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           win_stat = stub('win_stat', :owner => 'snarf', :group => 'thundercats',
             :ftype => 'file', :mode => 0755)
           Puppet::FileServing::Metadata::WindowsStat.stubs(:new).returns win_stat

--- a/spec/unit/file_system/path_pattern_spec.rb
+++ b/spec/unit/file_system/path_pattern_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::FileSystem::PathPattern do
       expect(Puppet::FileSystem::PathPattern.absolute("c:/absolute/windows/path").to_s).to eq("c:/absolute/windows/path")
     end
 
-    it "can be created with a '..' embedded in a filename on windows", :if => Puppet.features.microsoft_windows? do
+    it "can be created with a '..' embedded in a filename on windows", :if => Puppet::Util::Platform.windows? do
       expect(Puppet::FileSystem::PathPattern.absolute(%q{c:\..my\ot..her\one..}).to_s).to eq(%q{c:\..my\ot..her\one..})
     end
 

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -149,7 +149,7 @@ describe Puppet::FileSystem::Uniquefile do
       expect(File.exist?(path)).to eq(false)
     end
 
-    context "on unix platforms", :unless => Puppet.features.microsoft_windows? do
+    context "on unix platforms", :unless => Puppet::Util::Platform.windows? do
       it "close doesn't unlink if already unlinked" do
         t = tempfile("foo")
         path = t.path
@@ -173,7 +173,7 @@ describe Puppet::FileSystem::Uniquefile do
       expect(File.exist?(path)).to eq(false)
     end
 
-    context "on unix platforms", :unless => Puppet.features.microsoft_windows? do
+    context "on unix platforms", :unless => Puppet::Util::Platform.windows? do
       it "close! doesn't unlink if already unlinked" do
         t = tempfile("foo")
         path = t.path

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -299,7 +299,7 @@ describe "Puppet::FileSystem" do
 
   describe "symlink",
     :if => ! Puppet.features.manages_symlinks? &&
-    Puppet.features.microsoft_windows? do
+    Puppet::Util::Platform.windows? do
 
     let(:file)         { tmpfile("somefile") }
     let(:missing_file) { tmpfile("missingfile") }

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1482,7 +1482,7 @@ describe "The lookup function" do
         expect(lookup('x')).to eql('value x (from environment)')
       end
 
-      context 'obtained using /dev/null', :unless => Puppet.features.microsoft_windows? do
+      context 'obtained using /dev/null', :unless => Puppet::Util::Platform.windows? do
         let(:code_dir_files) { {} }
 
         it 'uses a Hiera version 3 defaults' do

--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -281,7 +281,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
       end
     end
 
-    describe "when diffing files", :unless => Puppet.features.microsoft_windows? do
+    describe "when diffing files", :unless => Puppet::Util::Platform.windows? do
       with_digest_algorithms do
         let(:not_bucketed_plaintext) { "other stuff" }
         let(:not_bucketed_checksum) { digest(not_bucketed_plaintext) }

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::ModuleTool::Applications::Installer do
     installer.stubs(:module_repository).returns(remote_source)
   end
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     before :each do
       Puppet.settings.stubs(:[])
       Puppet.settings.stubs(:[]).with(:module_working_dir).returns(Dir.mktmpdir('installertmp'))

--- a/spec/unit/module_tool/applications/upgrader_spec.rb
+++ b/spec/unit/module_tool/applications/upgrader_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::ModuleTool::Applications::Upgrader do
     installer.stubs(:module_repository).returns(remote_source)
   end
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     before :each do
       Puppet.settings.stubs(:[])
       Puppet.settings.stubs(:[]).with(:module_working_dir).returns(Dir.mktmpdir('upgradertmp'))

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -113,7 +113,7 @@ describe Puppet::Network::HTTP::Connection do
       WebMock.enable!
     end
 
-    it "should provide a useful error message when one is available and certificate validation fails", :unless => Puppet.features.microsoft_windows? do
+    it "should provide a useful error message when one is available and certificate validation fails", :unless => Puppet::Util::Platform.windows? do
       connection = Puppet::Network::HTTP::Connection.new(
         host, port,
         :verify => ConstantErrorValidator.new(:fails_with => 'certificate verify failed',
@@ -124,7 +124,7 @@ describe Puppet::Network::HTTP::Connection do
       end.to raise_error(Puppet::Error, "certificate verify failed: [shady looking signature]")
     end
 
-    it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet.features.microsoft_windows? do
+    it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet::Util::Platform.windows? do
       Puppet[:confdir] = tmpdir('conf')
 
       connection = Puppet::Network::HTTP::Connection.new(
@@ -152,7 +152,7 @@ describe Puppet::Network::HTTP::Connection do
       end.to raise_error(/some other message/)
     end
 
-    it "should check all peer certificates for upcoming expiration", :unless => Puppet.features.microsoft_windows? do
+    it "should check all peer certificates for upcoming expiration", :unless => Puppet::Util::Platform.windows? do
       Puppet[:confdir] = tmpdir('conf')
       cert = Puppet::SSL::CertificateAuthority.new.generate(
         'server', :dns_alt_names => 'foo,bar,baz')

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -71,7 +71,7 @@ describe Puppet::Node do
       expect(new_node.name).to eq(node.name)
     end
 
-    it "validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
+    it "validates against the node json schema", :unless => Puppet::Util::Platform.windows? do
       Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar',
@@ -81,7 +81,7 @@ describe Puppet::Node do
       expect(node.to_json).to validate_against('api/schemas/node.json')
     end
 
-    it "when missing optional parameters validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
+    it "when missing optional parameters validates against the node json schema", :unless => Puppet::Util::Platform.windows? do
       Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar'

--- a/spec/unit/parser/functions/generate_spec.rb
+++ b/spec/unit/parser/functions/generate_spec.rb
@@ -45,7 +45,7 @@ describe "the generate function" do
     expect(scope.function_generate([command])).to eq('yay')
   end
 
-  describe "on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "on Windows", :if => Puppet::Util::Platform.windows? do
     it "should accept the tilde in the path" do
       command = "C:/DOCUME~1/ADMINI~1/foo.bat"
       Dir.expects(:chdir).with(File.dirname(command)).returns("yay")

--- a/spec/unit/pops/loaders/dependency_loader_spec.rb
+++ b/spec/unit/pops/loaders/dependency_loader_spec.rb
@@ -84,7 +84,7 @@ Puppet::Functions.create_function('testmodule::foo') {
 
       context 'when loading files from disk' do
         it 'should always read files as UTF-8' do
-          if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+          if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
             raise 'This test must be run in a codepage other than 65001 to validate behavior'
           end
 
@@ -102,7 +102,7 @@ Puppet::Functions.create_function('testmodule::foo') {
         it 'currently ignores the UTF-8 BOM (Byte Order Mark) when loading module files' do
           bom = "\uFEFF"
 
-          if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+          if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
             raise 'This test must be run in a codepage other than 65001 to validate behavior'
           end
 

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -874,7 +874,7 @@ describe Puppet::Pops::Parser::Lexer2 do
 
   context 'when lexing files from disk' do
     it 'should always read files as UTF-8' do
-      if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+      if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
         raise 'This test must be run in a codepage other than 65001 to validate behavior'
       end
 

--- a/spec/unit/provider/exec/shell_spec.rb
+++ b/spec/unit/provider/exec/shell_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-describe Puppet::Type.type(:exec).provider(:shell), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:exec).provider(:shell), :unless => Puppet::Util::Platform.windows? do
   let(:resource) { Puppet::Type.type(:exec).new(:title => 'foo', :provider => 'shell') }
   let(:provider) { described_class.new(resource) }
 

--- a/spec/unit/provider/exec/windows_spec.rb
+++ b/spec/unit/provider/exec/windows_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:exec).provider(:windows), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:exec).provider(:windows), :if => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   let(:resource) { Puppet::Type.type(:exec).new(:title => 'C:\foo', :provider => :windows) }
@@ -45,7 +45,7 @@ describe Puppet::Type.type(:exec).provider(:windows), :if => Puppet.features.mic
   end
 
   describe "#checkexe" do
-    describe "when the command is absolute", :if => Puppet.features.microsoft_windows? do
+    describe "when the command is absolute", :if => Puppet::Util::Platform.windows? do
       it "should return if the command exists and is a file" do
         command = tmpfile('command')
         FileUtils.touch(command)

--- a/spec/unit/provider/file/windows_spec.rb
+++ b/spec/unit/provider/file/windows_spec.rb
@@ -1,14 +1,14 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
-if Puppet.features.microsoft_windows?
+if Puppet::Util::Platform.windows?
   require 'puppet/util/windows'
   class WindowsSecurity
     extend Puppet::Util::Windows::Security
   end
 end
 
-describe Puppet::Type.type(:file).provider(:windows), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:file).provider(:windows), :if => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   let(:path) { tmpfile('windows_file_spec') }

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet::Util::Platform.windows? do
   let(:resource) do
     Puppet::Type.type(:group).new(
       :title => 'testers',

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -7,7 +7,7 @@ require 'shared_behaviours/all_parsedfile_providers'
 # remove, but I don't want to do so just yet, in case we get pushback to
 # restore Solaris spec tests.
 
-describe Puppet::Type.type(:mount).provider(:parsed), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:mount).provider(:parsed), :unless => Puppet::Util::Platform.windows? do
   before :each do
     Facter.clear
   end

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -189,7 +189,7 @@ describe Puppet::Provider::NameService do
       end
     end
 
-    it "should return a list of groups if resource_type is group", :unless => Puppet.features.microsoft_windows? do
+    it "should return a list of groups if resource_type is group", :unless => Puppet::Util::Platform.windows? do
       described_class.resource_type = Puppet::Type.type(:group)
       Puppet::Etc.expects(:setgrent)
       Puppet::Etc.stubs(:getgrent).returns(*groups)

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -88,7 +88,7 @@ context 'installing myresource' do
             provider.install
           end
         end
-        describe "as a windows path on windows", :if => Puppet.features.microsoft_windows? do
+        describe "as a windows path on windows", :if => Puppet::Util::Platform.windows? do
           it "should treat the source as a local path" do
             resource[:source] = "c:/this/is/a/path/to/a/gem.gem"
             provider.expects(:execute).with { |args| args[2] == "c:/this/is/a/path/to/a/gem.gem" }.returns ""

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
   let (:resource) { Puppet::Resource.new(:package, 'dummy', :parameters => {:name => 'dummy', :ensure => :latest}) }
   let (:provider) { described_class.new(resource) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -17,7 +17,7 @@ describe provider_class do
     provider
   end
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     let(:puppet_gem) { 'gem' }
   else
     let(:puppet_gem) { '/opt/puppetlabs/puppet/bin/gem' }

--- a/spec/unit/provider/package/windows/msi_package_spec.rb
+++ b/spec/unit/provider/package/windows/msi_package_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Provider::Package::Windows::MsiPackage do
     subject.expects(:installer).returns(inst)
   end
 
-  context '::installer', :if => Puppet.features.microsoft_windows? do
+  context '::installer', :if => Puppet::Util::Platform.windows? do
     it 'should return an instance of the COM interface' do
       expect(subject.installer).not_to be_nil
     end

--- a/spec/unit/provider/package/windows/package_spec.rb
+++ b/spec/unit/provider/package/windows/package_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Provider::Package::Windows::Package do
     end
   end
 
-  context '::with_key', :if => Puppet.features.microsoft_windows? do
+  context '::with_key', :if => Puppet::Util::Platform.windows? do
     it 'should search HKLM (64 & 32) and HKCU (64 & 32)' do
       seq = sequence('reg')
 

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
     it { is_expected.to be_versionable }
   end
 
-  describe 'on Windows', :if => Puppet.features.microsoft_windows? do
+  describe 'on Windows', :if => Puppet::Util::Platform.windows? do
     it 'should be the default provider' do
       expect(Puppet::Type.type(:package).defaultprovider).to eq(subject.class)
     end
@@ -126,7 +126,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
       provider.install
     end
 
-    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+    it 'should fail otherwise', :if => Puppet::Util::Platform.windows? do
       expect_execute(command, 5)
 
       expect do
@@ -181,7 +181,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
       provider.uninstall
     end
 
-    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+    it 'should fail otherwise', :if => Puppet::Util::Platform.windows? do
       expect_execute(command, 5)
 
       expect do

--- a/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-require 'puppet/util/windows/taskscheduler' if Puppet.features.microsoft_windows?
+require 'puppet/util/windows/taskscheduler' if Puppet::Util::Platform.windows?
 
 shared_examples_for "a trigger that handles start_date and start_time" do
   let(:trigger) do
@@ -109,7 +109,7 @@ shared_examples_for "a trigger that handles start_date and start_time" do
   end
 end
 
-describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if => Puppet::Util::Platform.windows? do
   before :each do
     Puppet::Type.type(:scheduled_task).stubs(:defaultprovider).returns(described_class)
   end
@@ -686,7 +686,7 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
     end
   end
 
-  describe '#user_insync?', :if => Puppet.features.microsoft_windows? do
+  describe '#user_insync?', :if => Puppet::Util::Platform.windows? do
     let(:resource) { described_class.new(:name => 'foobar', :command => 'C:\Windows\System32\notepad.exe') }
 
     it 'should consider the user as in sync if the name matches' do
@@ -1735,7 +1735,7 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
       end
     end
 
-    describe '#user=', :if => Puppet.features.microsoft_windows? do
+    describe '#user=', :if => Puppet::Util::Platform.windows? do
       before :each do
         @mock_task = stub
         @mock_task.responds_like(Win32::TaskScheduler.new)
@@ -1848,7 +1848,7 @@ describe Puppet::Type.type(:scheduled_task).provider(:win32_taskscheduler), :if 
     end
   end
 
-  describe "Win32::TaskScheduler", :if => Puppet.features.microsoft_windows? do
+  describe "Win32::TaskScheduler", :if => Puppet::Util::Platform.windows? do
 
     let(:name) { SecureRandom.uuid }
 

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -15,7 +15,7 @@ describe "base service provider" do
 
   subject { provider }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     cmd = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(cmd, {:failonfail => false})

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:service).provider(:bsd)
 
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe provider_class, :unless => Puppet::Util::Platform.windows? do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     Facter.stubs(:value).with(:operatingsystem).returns :netbsd

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -9,7 +9,7 @@ provider_class = Puppet::Type.type(:service).provider(:debian)
 
 describe provider_class do
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:gentoo) do
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:init) do
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     cmd = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(cmd, {:failonfail => false})

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Type.type(:service).provider(:launchd) do
   let (:launchd_overrides_10_) { '/var/db/com.apple.xpc.launchd/disabled.plist' }
   subject { resource.provider }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:service).provider(:openbsd)
 
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe provider_class, :unless => Puppet::Util::Platform.windows? do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     Facter.stubs(:value).with(:operatingsystem).returns :openbsd

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:openrc) do
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     cmd = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(cmd, {:failonfail => false})

--- a/spec/unit/provider/service/rcng_spec.rb
+++ b/spec/unit/provider/service/rcng_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:service).provider(:rcng)
 
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe provider_class, :unless => Puppet::Util::Platform.windows? do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     Facter.stubs(:value).with(:operatingsystem).returns :netbsd

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -9,7 +9,7 @@ provider_class = Puppet::Type.type(:service).provider(:src)
 
 describe provider_class do
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:service).provider(:systemd) do
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -7,7 +7,7 @@ describe Puppet::Type.type(:service).provider(:upstart) do
   let(:start_on_default_runlevels) {  "\nstart on runlevel [2,3,4,5]" }
   let(:provider_class) { Puppet::Type.type(:service).provider(:upstart) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -5,9 +5,9 @@
 
 require 'spec_helper'
 
-require 'win32/service' if Puppet.features.microsoft_windows?
+require 'win32/service' if Puppet::Util::Platform.windows?
 
-describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:service).provider(:windows), :if => Puppet::Util::Platform.windows? do
   let(:name)     { 'nonexistentservice' }
   let(:resource) { Puppet::Type.type(:service).new(:name => name, :provider => :windows) }
   let(:provider) { resource.provider }
@@ -172,7 +172,7 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
 
     # We need to guard this section explicitly since rspec will always
     # construct all examples, even if it isn't going to run them.
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       [Win32::Service::SERVICE_AUTO_START, Win32::Service::SERVICE_BOOT_START, Win32::Service::SERVICE_SYSTEM_START].each do |start_type_const|
         start_type = Win32::Service.get_start_type(start_type_const)
         it "should report a service with a startup type of '#{start_type}' as true" do

--- a/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
+++ b/spec/unit/provider/ssh_authorized_key/parsed_spec.rb
@@ -5,7 +5,7 @@ require 'puppet_spec/files'
 
 provider_class = Puppet::Type.type(:ssh_authorized_key).provider(:parsed)
 
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe provider_class, :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   before :each do
@@ -154,7 +154,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
 
 end
 
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe provider_class, :unless => Puppet::Util::Platform.windows? do
   before :each do
     @resource = Puppet::Type.type(:ssh_authorized_key).new(:name => "foo", :user => "random_bob")
 

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -4,7 +4,7 @@ require 'etc'
 
 provider_class = Puppet::Type.type(:user).provider(:hpuxuseradd)
 
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe provider_class, :unless => Puppet::Util::Platform.windows? do
   let :resource do
     Puppet::Type.type(:user).new(
       :title => 'testuser',

--- a/spec/unit/provider/user/user_role_add_spec.rb
+++ b/spec/unit/provider/user/user_role_add_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'puppet_spec/files'
 require 'tempfile'
 
-describe Puppet::Type.type(:user).provider(:user_role_add), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:user).provider(:user_role_add), :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   let(:resource) { Puppet::Type.type(:user).new(:name => 'myuser', :managehome => false, :allowdupe => false) }
   let(:provider) { described_class.new(resource) }

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet::Util::Platform.windows? do
   let(:resource) do
     Puppet::Type.type(:user).new(
       :title => 'testuser',

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 def existing_command
-  Puppet.features.microsoft_windows? ? "cmd" : "echo"
+  Puppet::Util::Platform.windows? ? "cmd" : "echo"
 end
 
 describe Puppet::Provider do

--- a/spec/unit/settings/file_setting_spec.rb
+++ b/spec/unit/settings/file_setting_spec.rb
@@ -169,7 +169,7 @@ describe Puppet::Settings::FileSetting do
       expect(resource.title).to eq(@basepath)
     end
 
-    it "should have a working directory with a root directory not called dev", :if => Puppet.features.microsoft_windows? do
+    it "should have a working directory with a root directory not called dev", :if => Puppet::Util::Platform.windows? do
       # Although C:\Dev\.... is a valid path on Windows, some other code may regard it as a path to be ignored.  e.g. /dev/null resolves to C:\dev\null on Windows.
       path = File.expand_path('somefile')
       expect(path).to_not match(/^[A-Z]:\/dev/i)
@@ -302,7 +302,7 @@ describe Puppet::Settings::FileSetting do
     end
   end
 
-  context "when opening", :unless => Puppet.features.microsoft_windows? do
+  context "when opening", :unless => Puppet::Util::Platform.windows? do
     let(:path) do
       tmpfile('file_setting_spec')
     end

--- a/spec/unit/settings/path_setting_spec.rb
+++ b/spec/unit/settings/path_setting_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Settings::PathSetting do
       expect(subject.munge(nil)).to be_nil
     end
 
-    context "on Windows", :if => Puppet.features.microsoft_windows? do
+    context "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should convert \\ to /" do
         expect(subject.munge('C:\test\directory')).to eq('C:/test/directory')
       end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1305,7 +1305,7 @@ describe Puppet::Settings do
       @settings.to_catalog
     end
 
-    describe "on Microsoft Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Microsoft Windows", :if => Puppet::Util::Platform.windows? do
       before :each do
         Puppet.features.stubs(:root?).returns true
 

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -87,7 +87,7 @@ describe Puppet::SSL::Host do
     expect(Puppet::SSL::Host.localhost).to equal(host)
   end
 
-  it "should create a localhost cert if no cert is available and it is a CA with autosign and it is using DNS alt names", :unless => Puppet.features.microsoft_windows? do
+  it "should create a localhost cert if no cert is available and it is a CA with autosign and it is using DNS alt names", :unless => Puppet::Util::Platform.windows? do
     Puppet[:autosign] = true
     Puppet[:confdir] = tmpdir('conf')
     Puppet[:dns_alt_names] = "foo,bar,baz"
@@ -825,7 +825,7 @@ describe Puppet::SSL::Host do
     end
   end
 
-  describe "when handling JSON", :unless => Puppet.features.microsoft_windows? do
+  describe "when handling JSON", :unless => Puppet::Util::Platform.windows? do
     include PuppetSpec::Files
 
     before do

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet/ssl/inventory'
 
-describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::SSL::Inventory, :unless => Puppet::Util::Platform.windows? do
   let(:cert_inventory) { File.expand_path("/inven/tory") }
 
   # different UTF-8 widths

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -147,7 +147,7 @@ describe Puppet::Transaction::Persistence do
       Dir.mkdir(Puppet[:transactionstorefile])
       persistence = Puppet::Transaction::Persistence.new
 
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         expect do
           persistence.save
         end.to raise_error do |error|

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -7,8 +7,8 @@ describe Puppet::Transaction::ResourceHarness do
   include PuppetSpec::Files
 
   before do
-    @mode_750 = Puppet.features.microsoft_windows? ? '644' : '750'
-    @mode_755 = Puppet.features.microsoft_windows? ? '644' : '755'
+    @mode_750 = Puppet::Util::Platform.windows? ? '644' : '750'
+    @mode_755 = Puppet::Util::Platform.windows? ? '644' : '755'
     path = make_absolute("/my/file")
 
     @transaction = Puppet::Transaction.new(Puppet::Resource::Catalog.new, nil, nil)

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:cron), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:cron), :unless => Puppet::Util::Platform.windows? do
   let(:simple_provider) do
     @provider_class = described_class.provide(:simple) { mk_resource_methods }
     @provider_class.stubs(:suitable?).returns true

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Type.type(:exec) do
   describe "when not stubbing the provider" do
     before do
       path = tmpdir('path')
-      ext = Puppet.features.microsoft_windows? ? '.exe' : ''
+      ext = Puppet::Util::Platform.windows? ? '.exe' : ''
       true_cmd = File.join(path, "true#{ext}")
       false_cmd = File.join(path, "false#{ext}")
 
@@ -257,7 +257,7 @@ describe Puppet::Type.type(:exec) do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       before :each do
         Puppet.features.stubs(:root?).returns(true)
       end
@@ -437,14 +437,14 @@ describe Puppet::Type.type(:exec) do
           Puppet::Type.type(:exec).new(:name => "#{ruby_path} -e 'sleep 1'", :timeout => '0.1')
         end
 
-        context 'on POSIX', :unless => Puppet.features.microsoft_windows? do
+        context 'on POSIX', :unless => Puppet::Util::Platform.windows? do
           it 'sends a SIGTERM and raises a Puppet::Error' do
             Process.expects(:kill).at_least_once
             expect { subject.refresh }.to raise_error Puppet::Error, "Command exceeded timeout"
           end
         end
 
-        context 'on Windows', :if => Puppet.features.microsoft_windows? do
+        context 'on Windows', :if => Puppet::Util::Platform.windows? do
           it 'raises a Puppet::Error' do
             expect { subject.refresh }.to raise_error Puppet::Error, "Command exceeded timeout"
           end

--- a/spec/unit/type/file/checksum_spec.rb
+++ b/spec/unit/type/file/checksum_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 checksum = Puppet::Type.type(:file).attrclass(:checksum)
 describe checksum do
   before do
-    @path = Puppet.features.microsoft_windows? ? "c:/foo/bar" : "/foo/bar"
+    @path = Puppet::Util::Platform.windows? ? "c:/foo/bar" : "/foo/bar"
     @resource = Puppet::Type.type(:file).new :path => @path
     @checksum = @resource.parameter(:checksum)
   end

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -42,12 +42,12 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
       expect(lambda { resource[:source] = %w{ftp://foo/bar} }).to raise_error(Puppet::Error, /Cannot use URLs of type 'ftp' as source for fileserving/)
     end
 
-    it "should strip trailing forward slashes", :unless => Puppet.features.microsoft_windows? do
+    it "should strip trailing forward slashes", :unless => Puppet::Util::Platform.windows? do
       resource[:source] = "/foo/bar\\//"
       expect(resource[:source]).to eq(%w{file:/foo/bar\\})
     end
 
-    it "should strip trailing forward and backslashes", :if => Puppet.features.microsoft_windows? do
+    it "should strip trailing forward and backslashes", :if => Puppet::Util::Platform.windows? do
       resource[:source] = "X:/foo/bar\\//"
       expect(resource[:source]).to eq(%w{file:/X:/foo/bar})
     end
@@ -450,7 +450,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         end
       end
 
-      describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+      describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
         ['', "file:/", "file:///"].each do |prefix|
           it "should be local with prefix '#{prefix}'" do
             resource[:source] = "#{prefix}#{sourcepath}"

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -51,7 +51,7 @@ describe Puppet::Type.type(:file) do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       it "should remove trailing slashes" do
         file[:path] = "X:/foo/bar/baz/"
         expect(file[:path]).to eq("X:/foo/bar/baz")
@@ -76,7 +76,7 @@ describe Puppet::Type.type(:file) do
         expect { file[:path] = "X:" }.to raise_error(/File paths must be fully qualified/)
       end
 
-      describe "when using UNC filenames", :if => Puppet.features.microsoft_windows? do
+      describe "when using UNC filenames", :if => Puppet::Util::Platform.windows? do
         it "should remove trailing slashes" do
           file[:path] = "//localhost/foo/bar/baz/"
           expect(file[:path]).to eq("//localhost/foo/bar/baz")
@@ -1341,7 +1341,7 @@ describe Puppet::Type.type(:file) do
         expect(file.autorequire).to be_empty
       end
 
-      describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+      describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
         describe "when using UNC filenames" do
           it "should autorequire its parent directory" do
             file[:path] = '//localhost/foo/bar/baz'
@@ -1416,7 +1416,7 @@ describe Puppet::Type.type(:file) do
     end
 
     it "should manage the mode of the followed link" do
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         skip "Windows cannot presently manage the mode when following symlinks"
       else
         @link_resource[:links] = :follow

--- a/spec/unit/type/k5login_spec.rb
+++ b/spec/unit/type/k5login_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'fileutils'
 require 'puppet/type'
 
-describe Puppet::Type.type(:k5login), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:k5login), :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   context "the type class" do

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-describe Puppet::Type.type(:mount), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:mount), :unless => Puppet::Util::Platform.windows? do
 
   before :each do
     Puppet::Type.type(:mount).stubs(:defaultprovider).returns providerclass

--- a/spec/unit/type/scheduled_task_spec.rb
+++ b/spec/unit/type/scheduled_task_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-describe Puppet::Type.type(:scheduled_task), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:scheduled_task), :if => Puppet::Util::Platform.windows? do
 
   it 'should use name as the namevar' do
     expect(described_class.new(

--- a/spec/unit/type/ssh_authorized_key_spec.rb
+++ b/spec/unit/type/ssh_authorized_key_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 
-describe Puppet::Type.type(:ssh_authorized_key), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:ssh_authorized_key), :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   before do

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -12,7 +12,7 @@ describe tidy do
     Puppet.settings.stubs(:use)
   end
 
-  context "when normalizing 'path' on windows", :if => Puppet.features.microsoft_windows? do
+  context "when normalizing 'path' on windows", :if => Puppet::Util::Platform.windows? do
     it "replaces backslashes with forward slashes" do
       resource = tidy.new(:path => 'c:\directory')
       expect(resource[:path]).to eq('c:/directory')

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet_spec/compiler'
 
-describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type, :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -266,7 +266,7 @@ describe Puppet::Util::Autoload do
       expect(Puppet::Util::Autoload.cleanpath(path)).to eq(path)
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should convert c:\ to c:/" do
         expect(Puppet::Util::Autoload.cleanpath('c:\\')).to eq('c:/')
       end

--- a/spec/unit/util/execution_stub_spec.rb
+++ b/spec/unit/util/execution_stub_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Util::ExecutionStub do
 
   it "should restore normal execution after 'reset' is called" do
     # Note: "true" exists at different paths in different OSes
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       true_command = [Puppet::Util.which('cmd.exe').tr('/', '\\'), '/c', 'exit 0']
     else
       true_command = [Puppet::Util.which('true')]

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -177,7 +177,7 @@ describe Puppet::Util::FileType do
     end
   end
 
-  describe "the suntab filetype", :unless => Puppet.features.microsoft_windows? do
+  describe "the suntab filetype", :unless => Puppet::Util::Platform.windows? do
     let(:type)           { Puppet::Util::FileType.filetype(:suntab) }
     let(:name)           { type.name }
     let(:crontab_output) { 'suntab_output' }
@@ -194,7 +194,7 @@ describe Puppet::Util::FileType do
     it_should_behave_like "crontab provider"
   end
 
-  describe "the aixtab filetype", :unless => Puppet.features.microsoft_windows? do
+  describe "the aixtab filetype", :unless => Puppet::Util::Platform.windows? do
     let(:type)           { Puppet::Util::FileType.filetype(:aixtab) }
     let(:name)           { type.name }
     let(:crontab_output) { 'aixtab_output' }

--- a/spec/unit/util/lockfile_spec.rb
+++ b/spec/unit/util/lockfile_spec.rb
@@ -56,7 +56,7 @@ describe Puppet::Util::Lockfile do
     end
 
     # We test simultaneous locks using fork which isn't supported on Windows.
-    it "should not be acquired by another process", :unless => Puppet.features.microsoft_windows? do
+    it "should not be acquired by another process", :unless => Puppet::Util::Platform.windows? do
       30.times do
         forks = 3
         results = LockfileSpecHelper.run_in_forks(forks) do

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -68,7 +68,7 @@ describe Puppet::Util::Log.desttypes[:file] do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       let (:abspath) { 'C:\\temp\\log.txt' }
       let (:relpath) { 'log.txt' }
 

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Util::RunMode do
     @run_mode = Puppet::Util::RunMode.new('fake')
   end
 
-  describe Puppet::Util::UnixRunMode, :unless => Puppet.features.microsoft_windows? do
+  describe Puppet::Util::UnixRunMode, :unless => Puppet::Util::Platform.windows? do
     before do
       @run_mode = Puppet::Util::UnixRunMode.new('fake')
     end
@@ -36,7 +36,7 @@ describe Puppet::Util::RunMode do
         end
       end
 
-      it "fails when asking for the conf_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+      it "fails when asking for the conf_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
         as_non_root do
           without_home do
             expect { @run_mode.conf_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -64,7 +64,7 @@ describe Puppet::Util::RunMode do
         end
       end
 
-      it "fails when asking for the code_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+      it "fails when asking for the code_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
         as_non_root do
           without_home do
             expect { @run_mode.code_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -82,7 +82,7 @@ describe Puppet::Util::RunMode do
         as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/cache')) }
       end
 
-      it "fails when asking for the var_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+      it "fails when asking for the var_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
         as_non_root do
           without_home do
             expect { @run_mode.var_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -103,7 +103,7 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
 
-        it "fails when asking for the log_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+        it "fails when asking for the log_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
           as_non_root do
             without_home do
               expect { @run_mode.log_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -125,7 +125,7 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
         end
 
-        it "fails when asking for the run_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+        it "fails when asking for the run_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
           as_non_root do
             without_home do
               expect { @run_mode.run_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -136,7 +136,7 @@ describe Puppet::Util::RunMode do
     end
   end
 
-  describe Puppet::Util::WindowsRunMode, :if => Puppet.features.microsoft_windows? do
+  describe Puppet::Util::WindowsRunMode, :if => Puppet::Util::Platform.windows? do
     before do
       if not Dir.const_defined? :COMMON_APPDATA
         Dir.const_set :COMMON_APPDATA, "/CommonFakeBase"

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Util::SELinux do
       expect(selinux_label_support?('/mnt/nfs/testfile')).to be_falsey
     end
 
-    it "(#8714) don't follow symlinks when determining file systems", :unless => Puppet.features.microsoft_windows? do
+    it "(#8714) don't follow symlinks when determining file systems", :unless => Puppet::Util::Platform.windows? do
       scratch = Pathname(PuppetSpec::Files.tmpdir('selinux'))
 
       self.stubs(:read_mounts).returns({

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -188,7 +188,7 @@ describe Puppet::Util::Storage do
       Dir.mkdir(Puppet[:statefile])
       Puppet::Util::Storage.cache(:yayness)
 
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         expect { Puppet::Util::Storage.store }.to raise_error do |error|
           expect(error).to be_a(Puppet::Util::Windows::Error)
           expect(error.code).to eq(5) # ERROR_ACCESS_DENIED

--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -250,7 +250,7 @@ describe Puppet::Util::SUIDManager do
       end
     end
 
-    describe "on Microsoft Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Microsoft Windows", :if => Puppet::Util::Platform.windows? do
       it "should be root if user is privileged" do
         Puppet::Util::Windows::User.stubs(:admin?).returns true
 

--- a/spec/unit/util/windows/access_control_entry_spec.rb
+++ b/spec/unit/util/windows/access_control_entry_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::AccessControlEntry", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::AccessControlEntry", :if => Puppet::Util::Platform.windows? do
   let(:klass) { Puppet::Util::Windows::AccessControlEntry }
   let(:sid) { 'S-1-5-18' }
   let(:mask) { Puppet::Util::Windows::File::FILE_ALL_ACCESS }

--- a/spec/unit/util/windows/access_control_list_spec.rb
+++ b/spec/unit/util/windows/access_control_list_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::AccessControlList", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::AccessControlList", :if => Puppet::Util::Platform.windows? do
   let(:klass) { Puppet::Util::Windows::AccessControlList }
   let(:system_sid) { 'S-1-5-18' }
   let(:admins_sid) { 'S-1-5-544' }

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 require 'puppet/util/windows'
 
-describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? do
+describe Puppet::Util::Windows::ADSI, :if => Puppet::Util::Platform.windows? do
   let(:connection) { stub 'connection' }
   let(:builtin_localized) { Puppet::Util::Windows::SID.sid_to_name('S-1-5-32') }
   # SYSTEM is special as English can retrieve it via Windows API

--- a/spec/unit/util/windows/api_types_spec.rb
+++ b/spec/unit/util/windows/api_types_spec.rb
@@ -3,7 +3,7 @@
 
 require 'spec_helper'
 
-describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
+describe "FFI::MemoryPointer", :if => Puppet::Util::Platform.windows? do
   # use 2 bad bytes at end so we have even number of bytes / characters
   let (:bad_string) { "hello invalid world".encode(Encoding::UTF_16LE) + "\xDD\xDD".force_encoding(Encoding::UTF_16LE) }
   let (:bad_string_bytes) { bad_string.bytes.to_a }

--- a/spec/unit/util/windows/eventlog_spec.rb
+++ b/spec/unit/util/windows/eventlog_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 require 'puppet/util/windows'
 
-describe Puppet::Util::Windows::EventLog, :if => Puppet.features.microsoft_windows? do
+describe Puppet::Util::Windows::EventLog, :if => Puppet::Util::Platform.windows? do
 
   before(:each) { @event_log = Puppet::Util::Windows::EventLog.new }
   after(:each) { @event_log.close }

--- a/spec/unit/util/windows/security_descriptor_spec.rb
+++ b/spec/unit/util/windows/security_descriptor_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::SecurityDescriptor", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::SecurityDescriptor", :if => Puppet::Util::Platform.windows? do
   let(:system_sid) { Puppet::Util::Windows::SID::LocalSystem }
   let(:admins_sid) { Puppet::Util::Windows::SID::BuiltinAdministrators }
   let(:group_sid) { Puppet::Util::Windows::SID::Nobody }

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 require 'spec_helper'
 
-describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows? do
-  if Puppet.features.microsoft_windows?
+describe "Puppet::Util::Windows::SID", :if => Puppet::Util::Platform.windows? do
+  if Puppet::Util::Platform.windows?
     require 'puppet/util/windows'
   end
 

--- a/spec/unit/util/windows/string_spec.rb
+++ b/spec/unit/util/windows/string_spec.rb
@@ -4,7 +4,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::String", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::String", :if => Puppet::Util::Platform.windows? do
   UTF16_NULL = [0, 0]
 
   def wide_string(str)


### PR DESCRIPTION
Update the windows.md file
Converted the usage of Puppet.features.microsoft_windows? to the
preferred method Puppet::Util::Platform.windows? for all the unit
tests. These tests aren't mocking the returned value or anything
so they don't care which we call.