### PR TITLE
(PUP-8492) Move the empty() function from stdlib to puppet

### DIFF
--- a/lib/puppet/functions/empty.rb
+++ b/lib/puppet/functions/empty.rb
@@ -1,0 +1,56 @@
+# Returns `true` if the given argument is an empty collection of values.
+#
+# This function can answer if one of the following is empty:
+# * `Array`, `Hash` - having zero entries
+# * `String`, `Binary` - having zero length
+# * `Numeric` - for backwards compatibility with the stdlib function with the same name,
+#   a result of `false` is returned for all `Numeric` values instead of raising an error.
+#   This may be changed in a future release of puppet.
+#
+# @example Using `empty`
+#
+# ```puppet
+# notice([].empty)
+# notice(empty([]))
+# # would both notice 'true'
+# ```
+#
+# @since Puppet 5.5.0 - support for Binary
+#
+Puppet::Functions.create_function(:empty) do
+  dispatch :collection_empty do
+    param 'Collection', :coll
+  end
+
+  dispatch :string_empty do
+    param 'String', :str
+  end
+
+  dispatch :numeric_empty do
+    param 'Numeric', :num
+  end
+
+  dispatch :binary_empty do
+    param 'Binary', :bin
+  end
+
+  def collection_empty(coll)
+    coll.empty?
+  end
+
+  def string_empty(str)
+    str.empty?
+  end
+
+  # For compatibility reasons - return false rather than error on floats and integers
+  # (Yes, it is strange)
+  #
+  def numeric_empty(num)
+    false
+  end
+
+  def binary_empty(bin)
+    bin.length == 0
+  end
+
+end

--- a/spec/unit/functions/empty_spec.rb
+++ b/spec/unit/functions/empty_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the empty function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  context 'for an array it' do
+    it 'returns true when empty' do
+      expect(compile_to_catalog("notify { String(empty([])): }")).to have_resource('Notify[true]')
+    end
+
+    it 'returns false when not empty' do
+      expect(compile_to_catalog("notify { String(empty([1])): }")).to have_resource('Notify[false]')
+    end
+  end
+
+  context 'for a hash it' do
+    it 'returns true when empty' do
+      expect(compile_to_catalog("notify { String(empty({})): }")).to have_resource('Notify[true]')
+    end
+
+    it 'returns false when not empty' do
+      expect(compile_to_catalog("notify { String(empty({1=>1})): }")).to have_resource('Notify[false]')
+    end
+  end
+
+  context 'for numeric values it' do
+    it 'always returns false for integer values (including 0)' do
+      expect(compile_to_catalog("notify { String(empty(0)): }")).to have_resource('Notify[false]')
+    end
+
+    it 'always returns false for float values (including 0.0)' do
+      expect(compile_to_catalog("notify { String(empty(0.0)): }")).to have_resource('Notify[false]')
+    end
+  end
+
+  context 'for a string it' do
+    it 'returns true when empty' do
+      expect(compile_to_catalog("notify { String(empty('')): }")).to have_resource('Notify[true]')
+    end
+
+    it 'returns false when not empty' do
+      expect(compile_to_catalog("notify { String(empty(' ')): }")).to have_resource('Notify[false]')
+    end
+  end
+
+  context 'for a binary it' do
+    it 'returns true when empty' do
+      expect(compile_to_catalog("notify { String(empty(Binary(''))): }")).to have_resource('Notify[true]')
+    end
+
+    it 'returns false when not empty' do
+      expect(compile_to_catalog("notify { String(empty(Binary('b25l'))): }")).to have_resource('Notify[false]')
+    end
+  end
+end


### PR DESCRIPTION
This moves the `empty()` function from stdlib to puppet and brings it up
to the 4.x function API. This new version is backwards compatible. It
also adds support for asking a `Binary` value if it is empty.