### PR TITLE
(PUP-7326) Handle unresolvable SIDs in Windows groups

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -23,12 +23,9 @@ Puppet::Type.type(:group).provide :windows_adsi do
     # Cannot use munge of the group property to canonicalize @should
     # since the default array_matching comparison is not commutative
 
+    current_sids = current.map(&:sid)
     # dupes automatically weeded out when hashes built
-    current_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
-    specified_users = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
-
-    current_sids = current_users.keys.to_a
-    specified_sids = specified_users.keys.to_a
+    specified_sids = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should).keys.to_a
 
     if @resource[:auth_membership]
       current_sids.sort == specified_sids.sort
@@ -40,7 +37,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
   def members_to_s(users)
     return '' if users.nil? or !users.kind_of?(Array)
     users = users.map do |user_name|
-      sid = Puppet::Util::Windows::SID.name_to_sid_object(user_name)
+      sid = Puppet::Util::Windows::SID.name_to_principal(user_name)
       if !sid
         resource.debug("#{user_name} (unresolvable to SID)")
         next user_name
@@ -58,7 +55,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
   end
 
   def member_valid?(user_name)
-    ! Puppet::Util::Windows::SID.name_to_sid_object(user_name).nil?
+    ! Puppet::Util::Windows::SID.name_to_principal(user_name).nil?
   end
 
   def group

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:user).provide :windows_adsi do
   def groups_to_s(groups)
     return '' if groups.nil? || !groups.kind_of?(Array)
     groups = groups.map do |group_name|
-      sid = Puppet::Util::Windows::SID.name_to_sid_object(group_name)
+      sid = Puppet::Util::Windows::SID.name_to_principal(group_name)
       if sid.account =~ /\\/
         account, _ = Puppet::Util::Windows::ADSI::Group.parse_name(sid.account)
       else

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -66,7 +66,7 @@ module Puppet::Util::Windows::ADSI
       return sid_uri(sid) if sid.kind_of?(Puppet::Util::Windows::SID::Principal)
 
       begin
-        sid = Puppet::Util::Windows::SID.name_to_sid_object(sid)
+        sid = Puppet::Util::Windows::SID.name_to_principal(sid)
         sid_uri(sid)
       rescue Puppet::Util::Windows::Error, Puppet::Error
         nil
@@ -114,7 +114,7 @@ module Puppet::Util::Windows::ADSI
         Puppet::Util::Windows::SID.sid_to_name('S-1-5-32').upcase,
         # localized version of NT AUTHORITY (can't use S-1-5)
         # for instance AUTORITE NT on French Windows
-        Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM').domain.upcase
+        Puppet::Util::Windows::SID.name_to_principal('SYSTEM').domain.upcase
       ]
     end
 
@@ -139,10 +139,12 @@ module Puppet::Util::Windows::ADSI
       return account, domain
     end
 
+    # returns Puppet::Util::Windows::SID::Principal[]
+    # may contain objects that represent unresolvable SIDs
     def get_sids(adsi_child_collection)
       sids = []
       adsi_child_collection.each do |m|
-        sids << Puppet::Util::Windows::SID.octet_string_to_sid_object(m.objectSID)
+        sids << Puppet::Util::Windows::SID.ads_to_principal(m)
       end
 
       sids
@@ -152,7 +154,7 @@ module Puppet::Util::Windows::ADSI
       return {} if names.nil? || names.empty?
 
       sids = names.map do |name|
-        sid = Puppet::Util::Windows::SID.name_to_sid_object(name)
+        sid = Puppet::Util::Windows::SID.name_to_principal(name)
         raise Puppet::Error.new( "Could not resolve name: #{name}" ) if !sid
         [sid.sid, sid]
       end
@@ -183,7 +185,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def sid
-      @sid ||= Puppet::Util::Windows::SID.octet_string_to_sid_object(native_user.objectSID)
+      @sid ||= Puppet::Util::Windows::SID.octet_string_to_principal(native_user.objectSID)
     end
 
     def uri
@@ -336,12 +338,12 @@ module Puppet::Util::Windows::ADSI
     end
 
     def self.current_user_sid
-      Puppet::Util::Windows::SID.name_to_sid_object(current_user_name)
+      Puppet::Util::Windows::SID.name_to_principal(current_user_name)
     end
 
     def self.exists?(name_or_sid)
       well_known = false
-      if (sid = Puppet::Util::Windows::SID.name_to_sid_object(name_or_sid))
+      if (sid = Puppet::Util::Windows::SID.name_to_principal(name_or_sid))
         return true if sid.account_type == :SidTypeUser
 
         # 'well known group' is special as it can be a group like Everyone OR a user like SYSTEM
@@ -431,7 +433,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def sid
-      @sid ||= Puppet::Util::Windows::SID.octet_string_to_sid_object(native_group.objectSID)
+      @sid ||= Puppet::Util::Windows::SID.octet_string_to_principal(native_group.objectSID)
     end
 
     def commit
@@ -463,13 +465,13 @@ module Puppet::Util::Windows::ADSI
       end
     end
 
+    # returns Puppet::Util::Windows::SID::Principal[]
+    # may contain objects that represent unresolvable SIDs
+    # qualified account names are returned by calling #domain_account
     def members
-      member_sids.map(&:domain_account)
-    end
-
-    def member_sids
       self.class.get_sids(native_group.Members)
     end
+    alias member_sids members
 
     def set_members(desired_members, inclusive = true)
       return if desired_members.nil?
@@ -503,7 +505,7 @@ module Puppet::Util::Windows::ADSI
 
     def self.exists?(name_or_sid)
       well_known = false
-      if (sid = Puppet::Util::Windows::SID.name_to_sid_object(name_or_sid))
+      if (sid = Puppet::Util::Windows::SID.name_to_principal(name_or_sid))
         return true if sid.account_type == :SidTypeGroup
 
         # 'well known group' is special as it can be a group like Everyone OR a user like SYSTEM

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -32,9 +32,10 @@ module Puppet::Util::Windows::SID
         @sid_bytes == compare.sid_bytes
     end
 
-    # added for backward compatibility
+    # returns authority qualified account name
+    # prefer to compare Principal instances with == operator or by #sid
     def to_s
-      @sid
+      @domain_account
     end
 
     # = 8 + max sub identifiers (15) * 4

--- a/lib/puppet/util/windows/principal.rb
+++ b/lib/puppet/util/windows/principal.rb
@@ -65,14 +65,14 @@ module Puppet::Util::Windows::SID
                 last_error = FFI.errno
 
                 if (success == FFI::WIN32_FALSE && last_error != ERROR_INSUFFICIENT_BUFFER)
-                  raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountNameW', last_error)
+                  raise Puppet::Util::Windows::Error.new("Failed to call LookupAccountNameW with account: #{account_name}", last_error)
                 end
 
                 FFI::MemoryPointer.new(:lpwstr, domain_length_ptr.read_dword) do |domain_ptr|
                   if LookupAccountNameW(system_name_ptr, account_name_ptr,
                       sid_ptr, sid_length_ptr,
                       domain_ptr, domain_length_ptr, name_use_enum_ptr) == FFI::WIN32_FALSE
-                   raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountNameW')
+                   raise Puppet::Util::Windows::Error.new("Failed to call LookupAccountNameW with account: #{account_name}")
                   end
 
                   # with a SID returned, loop back through lookup_account_sid to retrieve official name
@@ -116,14 +116,14 @@ module Puppet::Util::Windows::SID
                 last_error = FFI.errno
 
                 if (success == FFI::WIN32_FALSE && last_error != ERROR_INSUFFICIENT_BUFFER)
-                  raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountSidW', last_error)
+                  raise Puppet::Util::Windows::Error.new("Failed to call LookupAccountSidW with bytes: #{sid_bytes}", last_error)
                 end
 
                 FFI::MemoryPointer.new(:lpwstr, name_length_ptr.read_dword) do |name_ptr|
                   FFI::MemoryPointer.new(:lpwstr, domain_length_ptr.read_dword) do |domain_ptr|
                     if LookupAccountSidW(system_name_ptr, sid_ptr, name_ptr, name_length_ptr,
                         domain_ptr, domain_length_ptr, name_use_enum_ptr) == FFI::WIN32_FALSE
-                     raise Puppet::Util::Windows::Error.new('Failed to call LookupAccountSidW')
+                     raise Puppet::Util::Windows::Error.new("Failed to call LookupAccountSidW with bytes: #{sid_bytes}")
                     end
 
                     return new(

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -226,9 +226,7 @@ module Puppet::Util::Windows
     end
     module_function :get_length_sid
 
-    private
-
-    def self.octet_string_to_sid_string(sid_bytes)
+    def octet_string_to_sid_string(sid_bytes)
       sid_string = nil
 
       FFI::MemoryPointer.new(:byte, sid_bytes.length) do |sid_ptr|
@@ -238,6 +236,7 @@ module Puppet::Util::Windows
 
       sid_string
     end
+    module_function :octet_string_to_sid_string
 
     ffi_convention :stdcall
 

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -144,7 +144,7 @@ describe Puppet::Util::Windows::ADSI::Group,
         stub('WIN32OLE', {
           # completely valid SID, but Name is just a stringified version
           :objectSID => [1, 5, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 5, 113, 65, 218, 15, 127, 9, 57, 219, 4, 84, 126, 88, 4, 0, 0],
-          :Name => 'S-1-5-21-3661721861-956923663-2119435483-1111',
+          :Name => 'S-1-5-21-3661721861-956923663-2119435483-1112',
           :ole_respond_to? => true,
         })
       ]
@@ -161,8 +161,8 @@ describe Puppet::Util::Windows::ADSI::Group,
       expect(admins.members[0].account_type).to eq(:SidTypeWellKnownGroup)
 
       # unresolvable SID
-      expect(admins.members[1].sid).to eq('S-1-5-21-3661721861-956923663-2119435483-1111')
-      expect(admins.members[1].account).to eq('S-1-5-21-3661721861-956923663-2119435483-1111 (unresolvable)')
+      expect(admins.members[1].sid).to eq('S-1-5-21-3661721861-956923663-2119435483-1112')
+      expect(admins.members[1].account).to eq('S-1-5-21-3661721861-956923663-2119435483-1112 (unresolvable)')
       expect(admins.members[1].account_type).to eq(:SidTypeUnknown)
     end
 

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -87,7 +87,7 @@ describe Puppet::Util::Windows::ADSI::Group,
 
       # select a virtual account that requires an authority to be able to resolve to SID
       # the Dhcp service is chosen for no particular reason aside from it's a service available on all Windows versions
-      dhcp_virtualaccount = Puppet::Util::Windows::SID.name_to_sid_object('NT SERVICE\Dhcp')
+      dhcp_virtualaccount = Puppet::Util::Windows::SID.name_to_principal('NT SERVICE\Dhcp')
 
       # adding :SidTypeGroup as a group member will cause error in IAdsUser::Add
       # adding :SidTypeDomain (such as S-1-5-80 / NT SERVICE or computer name) won't error
@@ -125,11 +125,45 @@ describe Puppet::Util::Windows::ADSI::Group,
 
         # also verify the names returned are as expected
         expected_usernames = users.map { |u| u[:name] }
-        expect(group.members).to eq(expected_usernames)
+        expect(group.members.map(&:domain_account)).to eq(expected_usernames)
       ensure
         described_class.delete(temp_groupname) if described_class.exists?(temp_groupname)
         Puppet::Util::Windows::ADSI::User.delete(temp_username) if Puppet::Util::Windows::ADSI::User.exists?(temp_username)
       end
+    end
+
+    it 'should return a list of Principal objects even with unresolvable SIDs' do
+      members = [
+        # NULL SID is not localized
+        stub('WIN32OLE', {
+          :objectSID => [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          :Name => 'NULL SID',
+          :ole_respond_to? => true,
+        }),
+        # unresolvable SID is a different story altogether
+        stub('WIN32OLE', {
+          # completely valid SID, but Name is just a stringified version
+          :objectSID => [1, 5, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 5, 113, 65, 218, 15, 127, 9, 57, 219, 4, 84, 126, 88, 4, 0, 0],
+          :Name => 'S-1-5-21-3661721861-956923663-2119435483-1111',
+          :ole_respond_to? => true,
+        })
+      ]
+
+      admins_name = Puppet::Util::Windows::SID.sid_to_name('S-1-5-32-544')
+      admins = Puppet::Util::Windows::ADSI::Group.new(admins_name)
+
+      # touch the native_group member to have it lazily loaded, so COM objects can be stubbed
+      admins.native_group
+      admins.native_group.stubs(:Members).returns(members)
+
+      # well-known NULL SID
+      expect(admins.members[0].sid).to eq('S-1-0-0')
+      expect(admins.members[0].account_type).to eq(:SidTypeWellKnownGroup)
+
+      # unresolvable SID
+      expect(admins.members[1].sid).to eq('S-1-5-21-3661721861-956923663-2119435483-1111')
+      expect(admins.members[1].account).to eq('S-1-5-21-3661721861-956923663-2119435483-1111 (unresolvable)')
+      expect(admins.members[1].account_type).to eq(:SidTypeUnknown)
     end
 
     it 'should return a list of members with UTF-8 names' do
@@ -139,7 +173,7 @@ describe Puppet::Util::Windows::ADSI::Group,
 
         # lookup by English name Administrators is not OK on localized Windows
         admins = Puppet::Util::Windows::ADSI::Group.new(administrators_principal.account)
-        admins.members.each do |name|
+        admins.members.map(&:domain_account).each do |name|
           expect(name.encoding).to be(Encoding::UTF_8)
         end
       ensure

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
   let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }
   let (:null_sid_bytes) { bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
   let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
-  let (:computer_sid) { Puppet::Util::Windows::SID.name_to_sid_object(Puppet::Util::Windows::ADSI.computer_name) }
+  let (:computer_sid) { Puppet::Util::Windows::SID.name_to_principal(Puppet::Util::Windows::ADSI.computer_name) }
   # BUILTIN is localized on German Windows, but not French
   # looking this up like this dilutes the values of the tests as we're comparing two mechanisms
   # for returning the same values, rather than to a known good
@@ -23,6 +23,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq('')
       expect(principal.domain_account).to eq('NULL SID')
       expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
+      expect(principal.to_s).to eq('NULL SID')
     end
 
     it "should create an instance from a well-known account prefixed with NT AUTHORITY" do
@@ -39,6 +40,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
         expect(principal.account).to eq('SYSTEM')
         expect(principal.domain).to eq('NT AUTHORITY')
         expect(principal.domain_account).to eq('NT AUTHORITY\\SYSTEM')
+        expect(principal.to_s).to eq('NT AUTHORITY\\SYSTEM')
       end
 
       # Windows API LookupAccountSid behaves differently if current user is SYSTEM
@@ -87,6 +89,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq(domain)
       expect(principal.domain_account).to eq(qualified_name)
       expect(principal.account_type).to eq(:SidTypeAlias)
+      expect(principal.to_s).to eq(qualified_name)
     end
 
     it "should raise an error when trying to lookup an account that doesn't exist" do
@@ -106,6 +109,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account).to eq(builtin_localized)
       expect(principal.domain).to eq(builtin_localized)
       expect(principal.domain_account).to eq(builtin_localized)
+      expect(principal.to_s).to eq(builtin_localized)
     end
 
     it "should return a BUILTIN domain principal for BUILTIN account names" do
@@ -115,6 +119,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account).to eq(builtin_localized)
       expect(principal.domain).to eq(builtin_localized)
       expect(principal.domain_account).to eq(builtin_localized)
+      expect(principal.to_s).to eq(builtin_localized)
     end
 
   end
@@ -135,6 +140,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq(computer_sid.domain)
       expect(principal.domain_account).to eq(guest_name)
       expect(principal.account_type).to eq(:SidTypeUser)
+      expect(principal.to_s).to eq(guest_name)
     end
 
     it "should create an instance from a well-known group SID" do
@@ -145,6 +151,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq('')
       expect(principal.domain_account).to eq('NULL SID')
       expect(principal.account_type).to eq(:SidTypeWellKnownGroup)
+      expect(principal.to_s).to eq('NULL SID')
     end
 
     it "should create an instance from a well-known BUILTIN Alias SID" do
@@ -160,6 +167,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.domain).to eq(domain)
       expect(principal.domain_account).to eq(qualified_name)
       expect(principal.account_type).to eq(:SidTypeAlias)
+      expect(principal.to_s).to eq(qualified_name)
     end
 
     it "should raise an error when trying to lookup nil" do
@@ -214,6 +222,7 @@ describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft
       expect(principal.account).to eq(builtin_localized)
       expect(principal.domain).to eq(builtin_localized)
       expect(principal.domain_account).to eq(builtin_localized)
+      expect(principal.to_s).to eq(builtin_localized)
     end
   end
 

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -40,23 +40,36 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
     let(:invalid_user) { SecureRandom.uuid }
 
     before :each do
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user1').returns(user1)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user2').returns(user2)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('user3').returns(user3)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with(invalid_user).returns(nil)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('user1').returns(user1)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('user2').returns(user2)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('user3').returns(user3)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with(invalid_user).returns(nil)
     end
 
     describe "#members_insync?" do
       it "should return true for same lists of members" do
-        expect(provider.members_insync?(['user1', 'user2'], ['user1', 'user2'])).to be_truthy
+        current = [
+          Puppet::Util::Windows::SID.name_to_principal('user1'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
+        ]
+        expect(provider.members_insync?(current, ['user1', 'user2'])).to be_truthy
       end
 
       it "should return true for same lists of unordered members" do
-        expect(provider.members_insync?(['user1', 'user2'], ['user2', 'user1'])).to be_truthy
+        current = [
+          Puppet::Util::Windows::SID.name_to_principal('user1'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
+        ]
+        expect(provider.members_insync?(current, ['user2', 'user1'])).to be_truthy
       end
 
       it "should return true for same lists of members irrespective of duplicates" do
-        expect(provider.members_insync?(['user1', 'user2', 'user2'], ['user2', 'user1', 'user1'])).to be_truthy
+        current = [
+          Puppet::Util::Windows::SID.name_to_principal('user1'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
+          Puppet::Util::Windows::SID.name_to_principal('user2'),
+        ]
+        expect(provider.members_insync?(current, ['user2', 'user1', 'user1'])).to be_truthy
       end
 
       it "should return true when current and should members are empty lists" do
@@ -77,7 +90,12 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return true when current and should contain the same users in a different order" do
-          expect(provider.members_insync?(['user1', 'user2', 'user3'], ['user3', 'user1', 'user2'])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
+            Puppet::Util::Windows::SID.name_to_principal('user3'),
+          ]
+          expect(provider.members_insync?(current, ['user3', 'user1', 'user2'])).to be_truthy
         end
 
         it "should return false when current is nil" do
@@ -85,15 +103,24 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return false when should is nil" do
-          expect(provider.members_insync?(['user1'], nil)).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+          ]
+          expect(provider.members_insync?(current, nil)).to be_falsey
         end
 
         it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+          ]
+          expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return false when current contains members and should is empty" do
-          expect(provider.members_insync?(['user1'], [])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_falsey
         end
 
         it "should return false when current is empty and should contains members" do
@@ -101,11 +128,19 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return false when should user(s) are not the only items in the current" do
-          expect(provider.members_insync?(['user1', 'user2'], ['user1'])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
+          ]
+          expect(provider.members_insync?(current, ['user1'])).to be_falsey
         end
 
         it "should return false when current user(s) is not empty and should is an empty list" do
-          expect(provider.members_insync?(['user1','user2'], [])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_falsey
         end
       end
 
@@ -120,15 +155,24 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return true when should is nil" do
-          expect(provider.members_insync?(['user1'], nil)).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+          ]
+          expect(provider.members_insync?(current, nil)).to be_truthy
         end
 
         it "should return false when current contains different users than should" do
-          expect(provider.members_insync?(['user1'], ['user2'])).to be_falsey
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+          ]
+          expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return true when current contains members and should is empty" do
-          expect(provider.members_insync?(['user1'], [])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_truthy
         end
 
         it "should return false when current is empty and should contains members" do
@@ -136,15 +180,28 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         end
 
         it "should return true when current user(s) contains at least the should list" do
-          expect(provider.members_insync?(['user1','user2'], ['user1'])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
+          ]
+          expect(provider.members_insync?(current, ['user1'])).to be_truthy
         end
 
         it "should return true when current user(s) is not empty and should is an empty list" do
-          expect(provider.members_insync?(['user1','user2'], [])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
+          ]
+          expect(provider.members_insync?(current, [])).to be_truthy
         end
 
         it "should return true when current user(s) contains at least the should list, even unordered" do
-          expect(provider.members_insync?(['user3','user1','user2'], ['user2','user1'])).to be_truthy
+          current = [
+            Puppet::Util::Windows::SID.name_to_principal('user3'),
+            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            Puppet::Util::Windows::SID.name_to_principal('user2'),
+          ]
+          expect(provider.members_insync?(current, ['user2','user1'])).to be_truthy
         end
       end
     end
@@ -196,8 +253,8 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
       provider.group.stubs(:member_sids).returns(member_sids[0..1])
 
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(member_sids[1])
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user3').returns(member_sids[2])
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with('user2').returns(member_sids[1])
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with('user3').returns(member_sids[2])
 
       provider.group.expects(:remove_member_sids).with(member_sids[0])
       provider.group.expects(:add_member_sids).with(member_sids[2])
@@ -247,7 +304,7 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
   end
 
   it "should be able to test whether a group exists" do
-    Puppet::Util::Windows::SID.stubs(:name_to_sid_object).returns(nil)
+    Puppet::Util::Windows::SID.stubs(:name_to_principal).returns(nil)
     Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection', :Class => 'Group')
     expect(provider).to be_exists
 

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -81,9 +81,9 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     let(:group3) { stub(:account => 'group3', :domain => '.', :sid => 'group3sid') }
 
     before :each do
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group1').returns(group1)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group2').returns(group2)
-      Puppet::Util::Windows::SID.stubs(:name_to_sid_object).with('group3').returns(group3)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('group1').returns(group1)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('group2').returns(group2)
+      Puppet::Util::Windows::SID.stubs(:name_to_principal).with('group3').returns(group3)
     end
 
     it "should return true for same lists of members" do
@@ -267,7 +267,7 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
   end
 
   it 'should be able to test whether a user exists' do
-    Puppet::Util::Windows::SID.stubs(:name_to_sid_object).returns(nil)
+    Puppet::Util::Windows::SID.stubs(:name_to_principal).returns(nil)
     Puppet::Util::Windows::ADSI.stubs(:connect).returns stub('connection', :Class => 'User')
     expect(provider).to be_exists
 

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -106,14 +106,14 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
     end
 
     it "should be able to check the existence of a user" do
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with(username).returns nil
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with(username).returns nil
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://./#{username},user").returns connection
       connection.expects(:Class).returns('User')
       expect(Puppet::Util::Windows::ADSI::User.exists?(username)).to be_truthy
     end
 
     it "should be able to check the existence of a domain user" do
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with("#{domain}\\#{username}").returns nil
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with("#{domain}\\#{username}").returns nil
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://#{domain}/#{username},user").returns connection
       connection.expects(:Class).returns('User')
       expect(Puppet::Util::Windows::ADSI::User.exists?(domain_username)).to be_truthy
@@ -213,7 +213,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       end
 
       it "should generate the correct URI" do
-        Puppet::Util::Windows::SID.stubs(:octet_string_to_sid_object).returns(sid)
+        Puppet::Util::Windows::SID.stubs(:octet_string_to_principal).returns(sid)
         expect(user.uri).to eq("WinNT://testcomputername/#{username},user")
       end
 
@@ -276,8 +276,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       let(:someone_sid){ stub(:account => 'someone', :domain => 'testcomputername')}
 
       describe "should be able to use SID objects" do
-        let(:system)     { Puppet::Util::Windows::SID.name_to_sid_object('SYSTEM') }
-        let(:invalid)    { Puppet::Util::Windows::SID.name_to_sid_object('foobar') }
+        let(:system)     { Puppet::Util::Windows::SID.name_to_principal('SYSTEM') }
+        let(:invalid)    { Puppet::Util::Windows::SID.name_to_principal('foobar') }
 
         it "to add a member" do
           adsi_group.expects(:Add).with("WinNT://S-1-5-18")
@@ -303,14 +303,14 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       it "should provide its groups as a list of names" do
         names = ['user1', 'user2']
 
-        users = names.map { |name| stub('user', :Name => name, :objectSID => name) }
+        users = names.map { |name| stub('user', :Name => name, :objectSID => name, :ole_respond_to? => true) }
 
         adsi_group.expects(:Members).returns(users)
 
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with('user1').returns(stub(:domain_account => 'HOSTNAME\user1'))
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with('user2').returns(stub(:domain_account => 'HOSTNAME\user2'))
+        Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with('user1').returns(stub(:domain_account => 'HOSTNAME\user1'))
+        Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with('user2').returns(stub(:domain_account => 'HOSTNAME\user2'))
 
-        expect(group.members).to match(['HOSTNAME\user1', 'HOSTNAME\user2'])
+        expect(group.members.map(&:domain_account)).to match(['HOSTNAME\user1', 'HOSTNAME\user2'])
       end
 
       context "calling .set_members" do
@@ -323,16 +323,16 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           ]
 
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(sids[1])
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('DOMAIN2\user3').returns(sids[2])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('user2').returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('DOMAIN2\user3').returns(sids[2])
 
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[0]).returns("WinNT://DOMAIN/user1,user")
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[2]).returns("WinNT://DOMAIN2/user3,user")
 
-          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i], :ole_respond_to? => true)}
           adsi_group.expects(:Members).returns members
 
           adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user')
@@ -350,15 +350,15 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           ]
 
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('user2').returns(sids[1])
-          Puppet::Util::Windows::SID.expects(:name_to_sid_object).with('DOMAIN2\user3').returns(sids[2])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('user2').returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:name_to_principal).with('DOMAIN2\user3').returns(sids[2])
 
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[2]).returns("WinNT://DOMAIN2/user3,user")
 
-          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i], :ole_respond_to? => true)}
           adsi_group.expects(:Members).returns members
 
           adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user').never
@@ -385,13 +385,13 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           ]
 
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[0]).returns("WinNT://DOMAIN/user1,user")
           Puppet::Util::Windows::ADSI.expects(:sid_uri).with(sids[1]).returns("WinNT://testcomputername/user2,user")
 
-          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i], :ole_respond_to? => true)}
           adsi_group.expects(:Members).returns members
 
           adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user')
@@ -407,10 +407,10 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
               stub(:account => 'user2', :domain => 'testcomputername', :sid => 2 ),
           ]
           # use stubbed objectSid on member to return stubbed SID
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(sids[0])
-          Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([1]).returns(sids[1])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(sids[0])
+          Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([1]).returns(sids[1])
 
-          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i])}
+          members = names.each_with_index.map{|n,i| stub(:Name => n, :objectSID => [i], :ole_respond_to? => true)}
           adsi_group.expects(:Members).returns members
 
           adsi_group.expects(:Remove).never
@@ -431,7 +431,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
         adsi_group.expects(:objectSID).returns([0])
         Socket.expects(:gethostname).returns('TESTcomputerNAME')
         computer_sid = stub(:account => groupname,:domain => 'testcomputername')
-        Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([0]).returns(computer_sid)
+        Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([0]).returns(computer_sid)
         expect(group.uri).to eq("WinNT://./#{groupname},group")
       end
     end
@@ -461,7 +461,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
     end
 
     it "should be able to confirm the existence of a group" do
-      Puppet::Util::Windows::SID.expects(:name_to_sid_object).with(groupname).returns nil
+      Puppet::Util::Windows::SID.expects(:name_to_principal).with(groupname).returns nil
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://./#{groupname},group").returns connection
       connection.expects(:Class).returns('Group')
 
@@ -503,14 +503,14 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       Puppet::Util::Windows::ADSI.expects(:execquery).with('select name from win32_group where localaccount = "TRUE"').returns(wmi_groups)
 
       native_group = stub('IADsGroup')
-      Puppet::Util::Windows::SID.expects(:octet_string_to_sid_object).with([]).returns(stub(:domain_account => '.\Administrator'))
-      native_group.expects(:Members).returns([stub(:Name => 'Administrator', :objectSID => [])])
+      Puppet::Util::Windows::SID.expects(:octet_string_to_principal).with([]).returns(stub(:domain_account => '.\Administrator'))
+      native_group.expects(:Members).returns([stub(:Name => 'Administrator', :objectSID => [], :ole_respond_to? => true)])
       Puppet::Util::Windows::ADSI.expects(:connect).with("WinNT://./#{name},group").returns(native_group)
 
       groups = Puppet::Util::Windows::ADSI::Group.to_a
       expect(groups.length).to eq(1)
       expect(groups[0].name).to eq(name)
-      expect(groups[0].members).to eq(['.\Administrator'])
+      expect(groups[0].members.map(&:domain_account)).to eq(['.\Administrator'])
     end
   end
 

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -13,10 +13,10 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
   let(:null_sid)     { 'S-1-0-0' }
   let(:unknown_name) { 'chewbacca' }
 
-  context "#octet_string_to_sid_object" do
+  context "#octet_string_to_principal" do
     it "should properly convert an array of bytes for a well-known non-localized SID" do
       bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-      converted = subject.octet_string_to_sid_object(bytes)
+      converted = subject.octet_string_to_principal(bytes)
 
       expect(converted).to be_an_instance_of Puppet::Util::Windows::SID::Principal
       expect(converted.sid_bytes).to eq(bytes)
@@ -28,13 +28,13 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
 
     it "should raise an error for non-array input" do
       expect {
-        subject.octet_string_to_sid_object(invalid_sid)
+        subject.octet_string_to_principal(invalid_sid)
       }.to raise_error(Puppet::Error, /Octet string must be an array of bytes/)
     end
 
     it "should raise an error for an empty byte array" do
       expect {
-        subject.octet_string_to_sid_object([])
+        subject.octet_string_to_principal([])
       }.to raise_error(Puppet::Error, /Octet string must be an array of bytes/)
     end
 
@@ -42,7 +42,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       expect {
         # S-1-1-1 which is not a valid account
         valid_octet_invalid_user =[1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
-        subject.octet_string_to_sid_object(valid_octet_invalid_user)
+        subject.octet_string_to_principal(valid_octet_invalid_user)
       }.to raise_error do |error|
         expect(error).to be_a(Puppet::Util::Windows::Error)
         expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
@@ -52,7 +52,7 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
     it "should raise an error for a malformed byte array" do
       expect {
         invalid_octet = [2]
-        subject.octet_string_to_sid_object(invalid_octet)
+        subject.octet_string_to_principal(invalid_octet)
       }.to raise_error do |error|
         expect(error).to be_a(Puppet::Util::Windows::Error)
         expect(error.code).to eq(87) # ERROR_INVALID_PARAMETER
@@ -72,12 +72,12 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
     end
 
     it "should return a SID for a passed user or group name" do
-      subject.expects(:name_to_sid_object).with('testers').returns stub(:sid => 'S-1-5-32-547')
+      subject.expects(:name_to_principal).with('testers').returns stub(:sid => 'S-1-5-32-547')
       expect(subject.name_to_sid('testers')).to eq('S-1-5-32-547')
     end
 
     it "should return a SID for a passed fully-qualified user or group name" do
-      subject.expects(:name_to_sid_object).with('MACHINE\testers').returns stub(:sid => 'S-1-5-32-547')
+      subject.expects(:name_to_principal).with('MACHINE\testers').returns stub(:sid => 'S-1-5-32-547')
       expect(subject.name_to_sid('MACHINE\testers')).to eq('S-1-5-32-547')
     end
 
@@ -128,37 +128,108 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
     end
   end
 
-  context "#name_to_sid_object" do
+  context "#name_to_principal" do
     it "should return nil if the account does not exist" do
-      expect(subject.name_to_sid_object(unknown_name)).to be_nil
+      expect(subject.name_to_principal(unknown_name)).to be_nil
     end
 
     it "should return a Puppet::Util::Windows::SID::Principal instance for any valid sid" do
-      expect(subject.name_to_sid_object(sid)).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
+      expect(subject.name_to_principal(sid)).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
     end
 
     it "should accept unqualified account name" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really Syst\u00E8me
-      expect(subject.name_to_sid_object('SYSTEM').sid).to eq(sid)
+      expect(subject.name_to_principal('SYSTEM').sid).to eq(sid)
     end
 
     it "should be case-insensitive" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really Syst\u00E8me
-      expect(subject.name_to_sid_object('SYSTEM')).to eq(subject.name_to_sid_object('system'))
+      expect(subject.name_to_principal('SYSTEM')).to eq(subject.name_to_principal('system'))
     end
 
     it "should be leading and trailing whitespace-insensitive" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really Syst\u00E8me
-      expect(subject.name_to_sid_object('SYSTEM')).to eq(subject.name_to_sid_object(' SYSTEM '))
+      expect(subject.name_to_principal('SYSTEM')).to eq(subject.name_to_principal(' SYSTEM '))
     end
 
     it "should accept domain qualified account names" do
       # NOTE: lookup by name works in localized environments only for a few instances
       # this works in French Windows, even though the account is really AUTORITE NT\\Syst\u00E8me
-      expect(subject.name_to_sid_object('NT AUTHORITY\SYSTEM').sid).to eq(sid)
+      expect(subject.name_to_principal('NT AUTHORITY\SYSTEM').sid).to eq(sid)
+    end
+  end
+
+  context "#ads_to_principal" do
+    it "should raise an error for non-WIN32OLE input" do
+      expect {
+        subject.ads_to_principal(stub('WIN32OLE', { :Name => 'foo' }))
+      }.to raise_error(Puppet::Error, /ads_object must be an IAdsUser or IAdsGroup instance/)
+    end
+
+    it "should raise an error for an empty byte array in the objectSID property" do
+      expect {
+        subject.ads_to_principal(stub('WIN32OLE', { :objectSID => [], :Name => '', :ole_respond_to? => true }))
+      }.to raise_error(Puppet::Error, /Octet string must be an array of bytes/)
+    end
+
+    it "should raise an error for a malformed byte array" do
+      expect {
+        invalid_octet = [2]
+        subject.ads_to_principal(stub('WIN32OLE', { :objectSID => invalid_octet, :Name => '', :ole_respond_to? => true }))
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(87) # ERROR_INVALID_PARAMETER
+      end
+    end
+
+    it "should raise an error when a valid byte array for SID is unresolvable and its Name does not match" do
+      expect {
+        # S-1-1-1 is a valid SID that will not resolve
+        valid_octet_invalid_user = [1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
+        subject.ads_to_principal(stub('WIN32OLE', { :objectSID => valid_octet_invalid_user, :Name => unknown_name, :ole_respond_to? => true }))
+      }.to raise_error do |error|
+        expect(error).to be_a(Puppet::Util::Windows::Error)
+        expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
+      end
+    end
+
+    it "should return a Principal object even when the SID is unresolvable, as long as the Name matches" do
+      # S-1-1-1 is a valid SID that will not resolve
+      valid_octet_invalid_user = [1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
+      unresolvable_user = stub('WIN32OLE', { :objectSID => valid_octet_invalid_user, :Name => 'S-1-1-1', :ole_respond_to? => true })
+      principal = subject.ads_to_principal(unresolvable_user)
+
+      expect(principal).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
+      expect(principal.account).to eq('S-1-1-1 (unresolvable)')
+      expect(principal.domain).to eq(nil)
+      expect(principal.domain_account).to eq('S-1-1-1 (unresolvable)')
+      expect(principal.sid).to eq('S-1-1-1')
+      expect(principal.sid_bytes).to eq(valid_octet_invalid_user)
+      expect(principal.account_type).to eq(:SidTypeUnknown)
+    end
+
+    it "should return a Puppet::Util::Windows::SID::Principal instance for any valid sid" do
+      system_bytes = [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0]
+      adsuser = stub('WIN32OLE', { :objectSID => system_bytes, :Name => 'SYSTEM', :ole_respond_to? => true })
+      expect(subject.ads_to_principal(adsuser)).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
+    end
+
+    it "should properly convert an array of bytes for a well-known non-localized SID, ignoring the Name from the WIN32OLE object" do
+      bytes = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      adsuser = stub('WIN32OLE', { :objectSID => bytes, :Name => unknown_name, :ole_respond_to? => true })
+      converted = subject.ads_to_principal(adsuser)
+
+      expect(converted).to be_an_instance_of Puppet::Util::Windows::SID::Principal
+      expect(converted.sid_bytes).to eq(bytes)
+      expect(converted.sid).to eq(null_sid)
+
+      # carefully select a SID here that is not localized on international Windows
+      expect(converted.account).to eq('NULL SID')
+      # garbage name supplied does not carry forward as SID is looked up again
+      expect(converted.account).to_not eq(adsuser.Name)
     end
   end
 

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -191,8 +191,8 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
         valid_octet_invalid_user = [1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
         subject.ads_to_principal(stub('WIN32OLE', { :objectSID => valid_octet_invalid_user, :Name => unknown_name, :ole_respond_to? => true }))
       }.to raise_error do |error|
-        expect(error).to be_a(Puppet::Util::Windows::Error)
-        expect(error.code).to eq(1332) # ERROR_NONE_MAPPED
+        expect(error).to be_a(Puppet::Error)
+        expect(error.cause.code).to eq(1332) # ERROR_NONE_MAPPED
       end
     end
 


### PR DESCRIPTION
PR #6647 had a single test failure, but was otherwise ready for merge (but unfortunately accidentally merged). That single fail is addressed in a9d6a83. The additional commits improve some of the messages that appear during error handling.




Comments from original PR #6647:

(PUP-7326) Handle Windows unresolvable SIDs

 - bef10f187f10b5083e73c888d1b4f663ce3a67d9 improved the handling of
   account names within local groups that refer to domain or virtual
   accounts. Prior to that change, Puppet could not manage groups
   with virtual accounts, failed to properly disambiguate accounts
   with the same name that came from different authorities (for
   example local Administrator from NT AUTHORITY vs domain), and
   would produce output from `puppet resource` that didn't include
   the authority.

   Puppet has always emitted errors when managing groups with
   unresolvable SIDs (typically domain accounts that have been deleted
   but that are still present in local groups), but the previous 
   change degraded the behavior of `puppet resource` so that instead
   of producing output like the following when an unresolved SID is
   present:

```puppet
   group { 'Bar':
     ensure  => 'present',
     gid     => 'S-1-5-21-969762586-3490402988-3896818487-1004',
     members => ['SYSTEM', 'Administrator', 'Administrator', 'BM', 'S-1-5-21-3661721861-956923663-2119435483-1116'],
   }
```

   It would instead immediately produce an error like:

```
   Error: Could not run: Failed to call LookupAccountSidW:  No mapping between account names and security IDs was done.
```

   The output is now correct:

```puppet
   group { 'Bar':
     ensure  => 'present',
     gid     => 'S-1-5-21-969762586-3490402988-3896818487-1004',
     members => ['NT AUTHORITY\SYSTEM', 'DFSDEMO\Administrator', 'DFS-DEMO-CLIENT\Administrator', 'DFSDEMO\BM', 'S-1-5-21-3661721861-956923663-2119435483-1116 (unresolvable)'],
   }
```

   The previous change introduced the authority prefixes, but also
   encountered difficulties with unresolvable SIDs, earlier in the
   provider lifecycle.

 - With auth_membership => true, unresolvable SIDs will be removed as
   expected from groups that have them. When auth_membership => false
   unresolvable SIDs will be preserved in local groups.

 - Introduces a breaking internal change by returning Windows Group
   :members property to the Windows ADSI group provider as an array of
   SID::Principal objects rather than an array of string as
   DOMAIN\USER qualified account names.

   While breaking the internal API is generally undesirable, the only
   callers should be Puppet itself.

   This was the simplest path to preserving orphaned / unresolvable
   SIDs that may be part of a local group, but that no longer exist
   in the upstream domain controller, without introducing a number of
   new code paths with special case error-handling.

 - Introduces an additional breaking internal change by changing
   Puppet::Util::Windows::SID::Principal#to_s to return a string in
   DOMAIN\USER format rather than in S-1-XXX style string format.
   This was necessary for `puppet resource` to produce manifests with
   friendly account names rather than SIDs.

   6a3d8215385be5b659db8b4792680273db47da69 initially added this
   method for 3rd party backward compatiblity when the class
   Win32::Security::SID was removed as part of 4.3.2. At the time, all
   internal callsites were modified to use #sid accessor of 
   Puppet::Util::Windows::SID::Principal instead of to_s in the prior
   commit at 42fceb295c4f37ca99b5d0d283b30970745dfadb

 - Note that it is unnecessary to implement the same safeguards
   against the user provider, as it should not be possible to have
   unresolvable SIDs for the groups a user is a member of. Local users
   cannot be added to domain groups.


