### PR TITLE
(PUP-8477) Ensure selinux params not set every run

### DIFF
--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1097,7 +1097,7 @@ describe Puppet::Type.type(:file) do
     end
 
     it "should cache the stat instance" do
-      expect(file.stat).to equal(file.stat)
+      expect(file.stat.object_id).to eql(file.stat.object_id)
     end
   end
 


### PR DESCRIPTION
Prior to this commit, if selinux bindings were not available, Puppet
would be unable to see what the selinux attributes were currently set
to. This would trigger a sync where puppet would attempt to set the
attributes, even though we have no way of managing them. This commit
sets the parent of the sel specific parameters to those defined in
puppet/type/file/selcontext.rb. This brings with it `insync?` which
checks for selinux support, and returns `true` if there is none.
This says that we cannot read in the current state, so we are not
attempting to manage it, so don't try to sync it.

Adding this parent also means we can remove the default getters and
setters for these parameters, since we can use the sync and retrieve
methods defined in selcontext.rb as well.

We had to add the stat method to k5login. This method was originally
defined in the file type. Some of the utilities from selcontext.rb use
stat, so the one in k5login is a stripped down version of the method
from the file type. Along with this, we added a new init method for
k5login so that `@stat` could be set to `:needs_stat` when creating
these resources.