### PR TITLE
Task/5.3.x/pup 8459/add test for enc regression

### DIFF
--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -1,14 +1,14 @@
 test_name "Master should produce error if enc specifies a nonexistent environment" do
-require 'puppet/acceptance/classifier_utils.rb'
-extend Puppet::Acceptance::ClassifierUtils
+  require 'puppet/acceptance/classifier_utils.rb'
+  extend Puppet::Acceptance::ClassifierUtils
 
-tag 'audit:medium',
-    'audit:unit',
-    'server'
+  tag 'audit:medium',
+      'audit:unit',
+      'server'
 
-testdir = create_tmpdir_for_user master, 'nonexistent_env'
+  testdir = create_tmpdir_for_user master, 'nonexistent_env'
 
-apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
   owner  => #{master.puppet['user']},
@@ -26,18 +26,18 @@ file {
     mode => '0644',
     content => 'notify { "In the production environment": }';
 }
-MANIFEST
+  MANIFEST
 
-if master.is_pe?
-  group = {
-    'name' => 'Environment Does Not Exist',
-    'description' => 'Classify our test agent nodes in an environment that does not exist.',
-    'environment' => 'doesnotexist',
-    'environment_trumps' => true,
-  }
-  create_group_for_nodes(agents, group)
-else
-  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  if master.is_pe?
+    group = {
+        'name'               => 'Environment Does Not Exist',
+        'description'        => 'Classify our test agent nodes in an environment that does not exist.',
+        'environment'        => 'doesnotexist',
+        'environment_trumps' => true,
+    }
+    create_group_for_nodes(agents, group)
+  else
+    apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
     file { "#{testdir}/enc.rb":
       ensure  => file,
       mode    => '0775',
@@ -45,25 +45,25 @@ else
         puts "environment: doesnotexist"
       ';
     }
-  MANIFEST
-end
+    MANIFEST
+  end
 
-master_opts = {
-  'main' => {
-    'environmentpath' => "#{testdir}/environments",
+  master_opts           = {
+      'main' => {
+          'environmentpath' => "#{testdir}/environments",
+      }
   }
-}
-master_opts['master'] = {
-  'node_terminus' => 'exec',
-  'external_nodes' => "#{testdir}/enc.rb",
-} if !master.is_pe?
+  master_opts['master'] = {
+      'node_terminus'  => 'exec',
+      'external_nodes' => "#{testdir}/enc.rb",
+  } if !master.is_pe?
 
-with_puppet_running_on master, master_opts, testdir do
-  agents.each do |agent|
-    on(agent, puppet("agent -t --server #{master} --verbose"), :acceptable_exit_codes => [1]) do |result|
-      assert_match(/Could not find a directory environment named 'doesnotexist'/, result.stderr, "Errors when nonexistent environment is specified") unless agent['locale'] == 'ja'
-      assert_not_match(/In the production environment/, result.stdout, "Executed manifest from production environment")
+  with_puppet_running_on master, master_opts, testdir do
+    agents.each do |agent|
+      on(agent, puppet("agent -t --server #{master} --verbose"), :acceptable_exit_codes => [1]) do |result|
+        assert_match(/Could not find a directory environment named 'doesnotexist'/, result.stderr, "Errors when nonexistent environment is specified") unless agent['locale'] == 'ja'
+        assert_not_match(/In the production environment/, result.stdout, "Executed manifest from production environment")
+      end
     end
   end
-end
 end

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -1,4 +1,4 @@
-test_name "Master should produce error if enc specifies a nonexistent environment"
+test_name "Master should produce error if enc specifies a nonexistent environment" do
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 
@@ -60,9 +60,10 @@ master_opts['master'] = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet("agent -t --server #{master} --verbose"), :acceptable_exit_codes => [1]) do
-      assert_match(/Could not find a directory environment named 'doesnotexist'/, stderr, "Errors when nonexistent environment is specified") unless agent['locale'] == 'ja'
-      assert_not_match(/In the production environment/, stdout, "Executed manifest from production environment")
+    on(agent, puppet("agent -t --server #{master} --verbose"), :acceptable_exit_codes => [1]) do |result|
+      assert_match(/Could not find a directory environment named 'doesnotexist'/, result.stderr, "Errors when nonexistent environment is specified") unless agent['locale'] == 'ja'
+      assert_not_match(/In the production environment/, result.stdout, "Executed manifest from production environment")
     end
   end
+end
 end

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -6,7 +6,7 @@ test_name "Master should produce error if enc specifies a nonexistent environmen
       'audit:unit',
       'server'
 
-  testdir = create_tmpdir_for_user master, 'nonexistent_env'
+  testdir = create_tmpdir_for_user(master, 'nonexistent_env')
 
   apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
@@ -58,10 +58,12 @@ file {
       'external_nodes' => "#{testdir}/enc.rb",
   } if !master.is_pe?
 
-  with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on(master, master_opts, testdir) do
     agents.each do |agent|
       on(agent, puppet("agent -t --server #{master} --verbose"), :acceptable_exit_codes => [1]) do |result|
-        assert_match(/Could not find a directory environment named 'doesnotexist'/, result.stderr, "Errors when nonexistent environment is specified") unless agent['locale'] == 'ja'
+        unless agent['locale'] == 'ja'
+          assert_match(/Could not find a directory environment named 'doesnotexist'/, result.stderr, "Errors when nonexistent environment is specified")
+        end
         assert_not_match(/In the production environment/, result.stdout, "Executed manifest from production environment")
       end
     end

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -1,4 +1,4 @@
-test_name 'Test behavior of directory environments when environmentpath is set to a non-existent directory'
+test_name 'Test behavior of directory environments when environmentpath is set to a non-existent directory' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 require 'puppet/acceptance/classifier_utils'
@@ -21,7 +21,7 @@ puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir"
 
 apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
-step  'Test'
+step  'Test' do
 env_path = '/doesnotexist'
 master_opts = {
   'main' => {
@@ -65,3 +65,5 @@ agents.each do |host|
 end
 
 assert_review(review_results(results,expectations))
+end
+end

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -1,69 +1,69 @@
 test_name 'Test behavior of directory environments when environmentpath is set to a non-existent directory' do
-require 'puppet/acceptance/environment_utils'
-extend Puppet::Acceptance::EnvironmentUtils
-require 'puppet/acceptance/classifier_utils'
-extend Puppet::Acceptance::ClassifierUtils
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
+  require 'puppet/acceptance/classifier_utils'
+  extend Puppet::Acceptance::ClassifierUtils
 
-tag 'audit:medium',
-    'audit:unit',  # The error responses for the agent should be covered by Ruby unit tests.
-                   # The server 404/400 response should be covered by server integration tests.
-    'server'
+  tag 'audit:medium',
+      'audit:unit', # The error responses for the agent should be covered by Ruby unit tests.
+      # The server 404/400 response should be covered by server integration tests.
+      'server'
 
 
-classify_nodes_as_agent_specified_if_classifer_present
+  classify_nodes_as_agent_specified_if_classifer_present
 
-step 'setup environments'
+  step 'setup environments'
 
-stub_forge_on(master)
+  stub_forge_on(master)
 
-testdir = create_tmpdir_for_user master, 'confdir'
-puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
+  testdir                = create_tmpdir_for_user master, 'confdir'
+  puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
 
-apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
+  apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)
 
-step  'Test' do
-env_path = '/doesnotexist'
-master_opts = {
-  'main' => {
-    'environmentpath' => "#{env_path}",
-  }
-}
-env = 'testing'
+  step 'Test' do
+    env_path    = '/doesnotexist'
+    master_opts = {
+        'main' => {
+            'environmentpath' => "#{env_path}",
+        }
+    }
+    env         = 'testing'
 
-results = use_an_environment(env, 'bad environmentpath', master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true)
+    results = use_an_environment(env, 'bad environmentpath', master_opts, testdir, puppet_conf_backup_dir, :directory_environments => true)
 
-expectations = {
-  :puppet_config => {
-    :exit_code => 0,
-    :matches => [%r{basemodulepath = /etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules},
-                 %r{modulepath =},
-                 %r{manifest =},
-                 %r{config_version =}],
-  },
-  :puppet_module_install => {
-    :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
-  },
-  :puppet_module_uninstall => {
-    :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
-  },
-  :puppet_apply => {
-    :exit_code => 1,
-    :matches => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
-  },
-  :puppet_agent => {
-    :exit_code => 1,
-  },
-}
+    expectations = {
+        :puppet_config           => {
+            :exit_code => 0,
+            :matches   => [%r{basemodulepath = /etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules},
+                           %r{modulepath =},
+                           %r{manifest =},
+                           %r{config_version =}],
+        },
+        :puppet_module_install   => {
+            :exit_code => 1,
+            :matches   => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
+        },
+        :puppet_module_uninstall => {
+            :exit_code => 1,
+            :matches   => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
+        },
+        :puppet_apply            => {
+            :exit_code => 1,
+            :matches   => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
+        },
+        :puppet_agent            => {
+            :exit_code => 1,
+        },
+    }
 
-agents.each do |host|
-  unless host['locale'] == 'ja'
-    expectations[:puppet_agent][:matches] = [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
-                                             %r{Could not retrieve catalog; skipping run}]
+    agents.each do |host|
+      unless host['locale'] == 'ja'
+        expectations[:puppet_agent][:matches] = [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
+                                                 %r{Could not retrieve catalog; skipping run}]
+      end
+    end
+
+    assert_review(review_results(results, expectations))
   end
-end
-
-assert_review(review_results(results,expectations))
-end
 end

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -16,7 +16,7 @@ test_name 'Test behavior of directory environments when environmentpath is set t
 
   stub_forge_on(master)
 
-  testdir                = create_tmpdir_for_user master, 'confdir'
+  testdir                = create_tmpdir_for_user(master, 'confdir')
   puppet_conf_backup_dir = create_tmpdir_for_user(master, "puppet-conf-backup-dir")
 
   apply_manifest_on(master, environment_manifest(testdir), :catch_failures => true)

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -1,24 +1,24 @@
 test_name "Agent should use agent environment if there is an enc that does not specify the environment" do
-require 'puppet/acceptance/classifier_utils'
-extend Puppet::Acceptance::ClassifierUtils
+  require 'puppet/acceptance/classifier_utils'
+  extend Puppet::Acceptance::ClassifierUtils
 
-tag 'audit:medium',
-    'audit:integration',
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
 
-classify_nodes_as_agent_specified_if_classifer_present
+  classify_nodes_as_agent_specified_if_classifer_present
 
-testdir = create_tmpdir_for_user master, 'use_agent_env'
+  testdir = create_tmpdir_for_user master, 'use_agent_env'
 
-create_remote_file master, "#{testdir}/enc.rb", <<END
+  create_remote_file master, "#{testdir}/enc.rb", <<END
 #!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 YAML
 END
-on master, "chmod 755 #{testdir}/enc.rb"
+  on master, "chmod 755 #{testdir}/enc.rb"
 
-apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
     ensure => directory,
     mode => "0770",
@@ -42,23 +42,23 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
     mode => "0640",
     content => 'notify { "more_different_string": }',
   }
-MANIFEST
+  MANIFEST
 
-master_opts = {
-  'main' => {
-    'environmentpath' => "#{testdir}/environments",
-    'node_terminus' => 'exec',
-    'external_nodes' => "#{testdir}/enc.rb",
-  },
-}
+  master_opts = {
+      'main' => {
+          'environmentpath' => "#{testdir}/environments",
+          'node_terminus'   => 'exec',
+          'external_nodes'  => "#{testdir}/enc.rb",
+      },
+  }
 
-with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on master, master_opts, testdir do
 
-  agents.each do |agent|
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
-    assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
+    agents.each do |agent|
+      run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
+        assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
+      end
     end
-  end
 
-end
+  end
 end

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -8,15 +8,15 @@ test_name "Agent should use agent environment if there is an enc that does not s
 
   classify_nodes_as_agent_specified_if_classifer_present
 
-  testdir = create_tmpdir_for_user master, 'use_agent_env'
+  testdir = create_tmpdir_for_user(master, 'use_agent_env')
 
-  create_remote_file master, "#{testdir}/enc.rb", <<END
+  create_remote_file(master, "#{testdir}/enc.rb", <<END)
 #!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 YAML
 END
-  on master, "chmod 755 #{testdir}/enc.rb"
+  on(master, "chmod 755 '#{testdir}/enc.rb'")
 
   apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
@@ -52,7 +52,7 @@ END
       },
   }
 
-  with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on(master, master_opts, testdir) do
 
     agents.each do |agent|
       run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -1,4 +1,4 @@
-test_name "Agent should use agent environment if there is an enc that does not specify the environment"
+test_name "Agent should use agent environment if there is an enc that does not specify the environment" do
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
@@ -55,8 +55,10 @@ master_opts = {
 with_puppet_running_on master, master_opts, testdir do
 
   agents.each do |agent|
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different")
-    assert_match(/more_different_string/, stdout, "Did not find more_different_string from \"more_different\" environment")
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
+    assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
+    end
   end
 
+end
 end

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -1,13 +1,13 @@
 test_name "Agent should use agent environment if there is no enc-specified environment" do
 
-tag 'audit:medium',
-    'audit:integration',
-    'audit:refactor',  # This can be combined with use_agent_environment_when_enc_doesnt_specify test
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor', # This can be combined with use_agent_environment_when_enc_doesnt_specify test
+      'server'
 
-testdir = create_tmpdir_for_user master, 'use_agent_env'
+  testdir = create_tmpdir_for_user master, 'use_agent_env'
 
-apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
     ensure => directory,
     mode => "0770",
@@ -31,23 +31,23 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
     mode => "0640",
     content => 'notify { "more_different_string": }',
   }
-MANIFEST
+  MANIFEST
 
-master_opts = {
-  'main' => {
-    'environmentpath' => "#{testdir}/environments",
-  },
-  'master' => {
-    'node_terminus' => 'plain'
-  },
-}
+  master_opts = {
+      'main'   => {
+          'environmentpath' => "#{testdir}/environments",
+      },
+      'master' => {
+          'node_terminus' => 'plain'
+      },
+  }
 
-with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on master, master_opts, testdir do
 
-  agents.each do |agent|
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
-    assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
+    agents.each do |agent|
+      run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
+        assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
+      end
     end
   end
-end
 end

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -1,4 +1,4 @@
-test_name "Agent should use agent environment if there is no enc-specified environment"
+test_name "Agent should use agent environment if there is no enc-specified environment" do
 
 tag 'audit:medium',
     'audit:integration',
@@ -45,7 +45,9 @@ master_opts = {
 with_puppet_running_on master, master_opts, testdir do
 
   agents.each do |agent|
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different")
-    assert_match(/more_different_string/, stdout, "Did not find more_different_string from \"more_different\" environment")
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
+    assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
+    end
   end
+end
 end

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -5,7 +5,7 @@ test_name "Agent should use agent environment if there is no enc-specified envir
       'audit:refactor', # This can be combined with use_agent_environment_when_enc_doesnt_specify test
       'server'
 
-  testdir = create_tmpdir_for_user master, 'use_agent_env'
+  testdir = create_tmpdir_for_user(master, 'use_agent_env')
 
   apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
@@ -42,7 +42,7 @@ test_name "Agent should use agent environment if there is no enc-specified envir
       },
   }
 
-  with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on(master, master_opts, testdir) do
 
     agents.each do |agent|
       run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -6,7 +6,7 @@ test_name "Agent should use environment given by ENC" do
       'audit:integration',
       'server'
 
-  testdir = create_tmpdir_for_user master, 'use_enc_env'
+  testdir = create_tmpdir_for_user(master, 'use_enc_env')
 
   if master.is_pe?
     group = {
@@ -18,14 +18,14 @@ test_name "Agent should use environment given by ENC" do
     create_group_for_nodes(agents, group)
   else
 
-    create_remote_file master, "#{testdir}/enc.rb", <<END
+    create_remote_file(master, "#{testdir}/enc.rb", <<END)
 #!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special
 YAML
 END
-    on master, "chmod 755 #{testdir}/enc.rb"
+    on(master, "chmod 755 '#{testdir}/enc.rb'")
 
   end
 
@@ -65,7 +65,7 @@ END
       'external_nodes' => "#{testdir}/enc.rb",
   } if !master.is_pe?
 
-  with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on(master, master_opts, testdir) do
 
     agents.each do |agent|
       run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose") do |result|

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -1,4 +1,4 @@
-test_name "Agent should use environment given by ENC" do
+test_name 'Agent should use environment given by ENC and only compile a catalog once' do
   require 'puppet/acceptance/classifier_utils.rb'
   extend Puppet::Acceptance::ClassifierUtils
 
@@ -70,6 +70,8 @@ END
     agents.each do |agent|
       run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose") do |result|
         assert_match(/expected_string/, result.stdout, "Did not find expected_string from \"special\" environment")
+        caching_catalog_message_count = result.stdout.split(/Info: Caching catalog for/).length - 1
+        assert_equal(caching_catalog_message_count, 1, 'Should only compile and cache the catalog once during the run')
       end
     end
   end

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -1,4 +1,4 @@
-test_name "Agent should use environment given by ENC"
+test_name "Agent should use environment given by ENC" do
 require 'puppet/acceptance/classifier_utils.rb'
 extend Puppet::Acceptance::ClassifierUtils
 
@@ -68,7 +68,9 @@ master_opts['master'] = {
 with_puppet_running_on master, master_opts, testdir do
 
   agents.each do |agent|
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose")
-    assert_match(/expected_string/, stdout, "Did not find expected_string from \"special\" environment")
+    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose") do |result|
+    assert_match(/expected_string/, result.stdout, "Did not find expected_string from \"special\" environment")
+    end
   end
+end
 end

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,22 +1,22 @@
 test_name "Agent should use environment given by ENC for fetching remote files" do
 
-tag 'audit:medium',
-    'audit:integration',
-    'audit:refactor',    # This test should be rolled into use_enc_environment
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor', # This test should be rolled into use_enc_environment
+      'server'
 
-testdir = create_tmpdir_for_user master, 'respect_enc_test'
+  testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
-create_remote_file master, "#{testdir}/enc.rb", <<END
+  create_remote_file master, "#{testdir}/enc.rb", <<END
 #!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special
 YAML
 END
-on master, "chmod 755 #{testdir}/enc.rb"
+  on master, "chmod 755 #{testdir}/enc.rb"
 
-apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
     ensure => directory,
     mode => "0770",
@@ -37,40 +37,40 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
     mode => "0640",
     content => 'special_environment',
   }
-MANIFEST
+  MANIFEST
 
-master_opts = {
-  'main' => {
-    'environmentpath' => "#{testdir}/environments",
-    'environment_timeout' => 0,
-  },
-  'master' => {
-    'node_terminus' => 'exec',
-    'external_nodes' => "#{testdir}/enc.rb",
-  },
-}
+  master_opts = {
+      'main'   => {
+          'environmentpath'     => "#{testdir}/environments",
+          'environment_timeout' => 0,
+      },
+      'master' => {
+          'node_terminus'  => 'exec',
+          'external_nodes' => "#{testdir}/enc.rb",
+      },
+  }
 
-with_puppet_running_on master, master_opts, testdir do
-  agents.each do |agent|
-    atmp = agent.tmpdir('respect_enc_test')
-    logger.debug "agent: #{agent} \tagent.tmpdir => #{atmp}"
+  with_puppet_running_on master, master_opts, testdir do
+    agents.each do |agent|
+      atmp = agent.tmpdir('respect_enc_test')
+      logger.debug "agent: #{agent} \tagent.tmpdir => #{atmp}"
 
-    create_remote_file master, "#{testdir}/environments/special/manifests/different.pp", <<END
+      create_remote_file master, "#{testdir}/environments/special/manifests/different.pp", <<END
 file { "#{atmp}/special_testy":
   source => "puppet:///modules/amod/testy",
 }
 END
-    on master, "chmod 644 #{testdir}/environments/special/manifests/different.pp"
+      on master, "chmod 644 #{testdir}/environments/special/manifests/different.pp"
 
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --trace")
+      run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --trace")
 
-    on agent, "cat #{atmp}/special_testy" do |result|
-      assert_match(/special_environment/,
-                   result.stdout,
-                   "The file from environment 'special' was not found")
+      on agent, "cat #{atmp}/special_testy" do |result|
+        assert_match(/special_environment/,
+                     result.stdout,
+                     "The file from environment 'special' was not found")
+      end
+
+      on agent, "rm -rf #{atmp}"
     end
-
-    on agent, "rm -rf #{atmp}"
   end
-end
 end

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -5,16 +5,16 @@ test_name "Agent should use environment given by ENC for fetching remote files" 
       'audit:refactor', # This test should be rolled into use_enc_environment
       'server'
 
-  testdir = create_tmpdir_for_user master, 'respect_enc_test'
+  testdir = create_tmpdir_for_user(master, 'respect_enc_test')
 
-  create_remote_file master, "#{testdir}/enc.rb", <<END
+  create_remote_file(master, "#{testdir}/enc.rb", <<END)
 #!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special
 YAML
 END
-  on master, "chmod 755 #{testdir}/enc.rb"
+  on(master, "chmod 755 '#{testdir}/enc.rb'")
 
   apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
@@ -50,27 +50,29 @@ END
       },
   }
 
-  with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on(master, master_opts, testdir) do
     agents.each do |agent|
       atmp = agent.tmpdir('respect_enc_test')
+      teardown do
+        on(agent, "rm -rf '#{atmp}'")
+      end
+
       logger.debug "agent: #{agent} \tagent.tmpdir => #{atmp}"
 
-      create_remote_file master, "#{testdir}/environments/special/manifests/different.pp", <<END
+      create_remote_file(master, "#{testdir}/environments/special/manifests/different.pp", <<END)
 file { "#{atmp}/special_testy":
   source => "puppet:///modules/amod/testy",
 }
 END
-      on master, "chmod 644 #{testdir}/environments/special/manifests/different.pp"
+      on(master, "chmod 644 '#{testdir}/environments/special/manifests/different.pp'")
 
       run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --trace")
 
-      on agent, "cat #{atmp}/special_testy" do |result|
+      on(agent, "cat '#{atmp}/special_testy'") do |result|
         assert_match(/special_environment/,
                      result.stdout,
                      "The file from environment 'special' was not found")
       end
-
-      on agent, "rm -rf #{atmp}"
     end
   end
 end

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,4 +1,4 @@
-test_name "Agent should use environment given by ENC for fetching remote files"
+test_name "Agent should use environment given by ENC for fetching remote files" do
 
 tag 'audit:medium',
     'audit:integration',
@@ -72,4 +72,5 @@ END
 
     on agent, "rm -rf #{atmp}"
   end
+end
 end

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -5,16 +5,16 @@ test_name "Agent should use environment given by ENC for pluginsync" do
       'audit:refactor', # This test should be rolled into use_enc_environment
       'server'
 
-  testdir = create_tmpdir_for_user master, 'respect_enc_test'
+  testdir = create_tmpdir_for_user(master, 'respect_enc_test')
 
-  create_remote_file master, "#{testdir}/enc.rb", <<END
+  create_remote_file(master, "#{testdir}/enc.rb", <<END)
 #!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special
 YAML
 END
-  on master, "chmod 755 #{testdir}/enc.rb"
+  on(master, "chmod 755 #{testdir}/enc.rb")
 
   apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
@@ -49,16 +49,16 @@ END
       },
   }
 
-  with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on(master, master_opts, testdir) do
 
     agents.each do |agent|
       agent_vardir = agent.puppet['vardir']
       teardown do
-        on agent, "rm -rf \"#{agent_vardir}/lib\""
+        on(agent, "rm -rf '#{agent_vardir}/lib'")
       end
 
       run_agent_on(agent, "--no-daemonize --onetime --server #{master}")
-      on agent, "cat \"#{agent_vardir}/lib/puppet/foo.rb\"" do |result|
+      on(agent, "cat '#{agent_vardir}/lib/puppet/foo.rb'") do |result|
         assert_match(/#special_version/, result.stdout, "The plugin from environment 'special' was not synced")
       end
     end

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -1,4 +1,4 @@
-test_name "Agent should use environment given by ENC for pluginsync"
+test_name "Agent should use environment given by ENC for pluginsync" do
 
 tag 'audit:medium',
     'audit:integration',
@@ -58,7 +58,9 @@ with_puppet_running_on master, master_opts, testdir do
     end
 
     run_agent_on(agent, "--no-daemonize --onetime --server #{master}")
-    on agent, "cat \"#{agent_vardir}/lib/puppet/foo.rb\""
-    assert_match(/#special_version/, stdout, "The plugin from environment 'special' was not synced")
+    on agent, "cat \"#{agent_vardir}/lib/puppet/foo.rb\"" do |result|
+    assert_match(/#special_version/, result.stdout, "The plugin from environment 'special' was not synced")
+    end
   end
+end
 end

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -1,22 +1,22 @@
 test_name "Agent should use environment given by ENC for pluginsync" do
 
-tag 'audit:medium',
-    'audit:integration',
-    'audit:refactor',    # This test should be rolled into use_enc_environment
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor', # This test should be rolled into use_enc_environment
+      'server'
 
-testdir = create_tmpdir_for_user master, 'respect_enc_test'
+  testdir = create_tmpdir_for_user master, 'respect_enc_test'
 
-create_remote_file master, "#{testdir}/enc.rb", <<END
+  create_remote_file master, "#{testdir}/enc.rb", <<END
 #!#{master['privatebindir']}/ruby
 puts <<YAML
 parameters:
 environment: special
 YAML
 END
-on master, "chmod 755 #{testdir}/enc.rb"
+  on master, "chmod 755 #{testdir}/enc.rb"
 
-apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
   File {
     ensure => directory,
     mode => "0770",
@@ -37,30 +37,30 @@ apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
     mode => "0640",
     content => "#special_version",
   }
-MANIFEST
+  MANIFEST
 
-master_opts = {
-  'main' => {
-    'environmentpath' => "#{testdir}/environments",
-  },
-  'master' => {
-    'node_terminus' => 'exec',
-    'external_nodes' => "#{testdir}/enc.rb"
-  },
-}
+  master_opts = {
+      'main'   => {
+          'environmentpath' => "#{testdir}/environments",
+      },
+      'master' => {
+          'node_terminus'  => 'exec',
+          'external_nodes' => "#{testdir}/enc.rb"
+      },
+  }
 
-with_puppet_running_on master, master_opts, testdir do
+  with_puppet_running_on master, master_opts, testdir do
 
-  agents.each do |agent|
-    agent_vardir = agent.puppet['vardir']
-    teardown do
-      on agent, "rm -rf \"#{agent_vardir}/lib\""
-    end
+    agents.each do |agent|
+      agent_vardir = agent.puppet['vardir']
+      teardown do
+        on agent, "rm -rf \"#{agent_vardir}/lib\""
+      end
 
-    run_agent_on(agent, "--no-daemonize --onetime --server #{master}")
-    on agent, "cat \"#{agent_vardir}/lib/puppet/foo.rb\"" do |result|
-    assert_match(/#special_version/, result.stdout, "The plugin from environment 'special' was not synced")
+      run_agent_on(agent, "--no-daemonize --onetime --server #{master}")
+      on agent, "cat \"#{agent_vardir}/lib/puppet/foo.rb\"" do |result|
+        assert_match(/#special_version/, result.stdout, "The plugin from environment 'special' was not synced")
+      end
     end
   end
-end
 end

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -1,4 +1,4 @@
-test_name "Use environments from the environmentpath"
+test_name "Use environments from the environmentpath" do
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
@@ -189,4 +189,5 @@ with_puppet_running_on master, master_opts, testdir do
       end
     end
   end
+end
 end

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -1,33 +1,33 @@
 test_name "Use environments from the environmentpath" do
-require 'puppet/acceptance/classifier_utils'
-extend Puppet::Acceptance::ClassifierUtils
+  require 'puppet/acceptance/classifier_utils'
+  extend Puppet::Acceptance::ClassifierUtils
 
-tag 'audit:medium',
-    'audit:integration',
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
 
-classify_nodes_as_agent_specified_if_classifer_present
+  classify_nodes_as_agent_specified_if_classifer_present
 
-testdir = create_tmpdir_for_user master, 'use_environmentpath'
+  testdir = create_tmpdir_for_user master, 'use_environmentpath'
 
-def generate_environment(path_to_env, environment)
-  env_content = <<-EOS
+  def generate_environment(path_to_env, environment)
+    env_content = <<-EOS
   "#{path_to_env}/#{environment}":;
   "#{path_to_env}/#{environment}/manifests":;
   "#{path_to_env}/#{environment}/modules":;
-  EOS
-end
+    EOS
+  end
 
-def generate_module_content(module_name, options = {})
-  base_path = options[:base_path]
-  environment = options[:environment]
-  env_path = options[:env_path]
+  def generate_module_content(module_name, options = {})
+    base_path   = options[:base_path]
+    environment = options[:environment]
+    env_path    = options[:env_path]
 
-  path_to_module = [base_path, env_path, environment, "modules"].compact.join("/")
-  module_info = "module-#{module_name}"
-  module_info << "-from-#{environment}" if environment
+    path_to_module = [base_path, env_path, environment, "modules"].compact.join("/")
+    module_info    = "module-#{module_name}"
+    module_info << "-from-#{environment}" if environment
 
-  module_content = <<-EOS
+    module_content = <<-EOS
   "#{path_to_module}/#{module_name}":;
   "#{path_to_module}/#{module_name}/manifests":;
   "#{path_to_module}/#{module_name}/files":;
@@ -58,20 +58,20 @@ def generate_module_content(module_name, options = {})
     mode => "0640",
     content => "<%= @environment_fact_#{module_name} %>"
   ;
-  EOS
-end
+    EOS
+  end
 
-def generate_site_manifest(path_to_manifest, *modules_to_include)
-  manifest_content = <<-EOS
+  def generate_site_manifest(path_to_manifest, *modules_to_include)
+    manifest_content = <<-EOS
   "#{path_to_manifest}/site.pp":
     ensure => file,
     mode => "0640",
-    content => "#{modules_to_include.map { |m| "include #{m}" }.join("\n")}"
+    content => "#{modules_to_include.map {|m| "include #{m}"}.join("\n")}"
   ;
-  EOS
-end
+    EOS
+  end
 
-apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
+  apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
   owner => #{master.puppet['user']},
@@ -85,26 +85,26 @@ file {
   "#{testdir}/additional":;
   "#{testdir}/modules":;
 #{generate_environment("#{testdir}/base", "shadowed")}
-#{generate_environment("#{testdir}/base", "onlybase")}
-#{generate_environment("#{testdir}/additional", "shadowed")}
+  #{generate_environment("#{testdir}/base", "onlybase")}
+  #{generate_environment("#{testdir}/additional", "shadowed")}
 
-#{generate_module_content("atmp",
-    :base_path => testdir,
-    :env_path => 'base',
-    :environment => 'shadowed')}
-#{generate_site_manifest("#{testdir}/base/shadowed/manifests", "atmp", "globalmod")}
+  #{generate_module_content("atmp",
+                            :base_path   => testdir,
+                            :env_path    => 'base',
+                            :environment => 'shadowed')}
+  #{generate_site_manifest("#{testdir}/base/shadowed/manifests", "atmp", "globalmod")}
 
-#{generate_module_content("atmp",
-    :base_path => testdir,
-    :env_path => 'base',
-    :environment => 'onlybase')}
-#{generate_site_manifest("#{testdir}/base/onlybase/manifests", "atmp", "globalmod")}
+  #{generate_module_content("atmp",
+                            :base_path   => testdir,
+                            :env_path    => 'base',
+                            :environment => 'onlybase')}
+  #{generate_site_manifest("#{testdir}/base/onlybase/manifests", "atmp", "globalmod")}
 
-#{generate_module_content("atmp",
-    :base_path => testdir,
-    :env_path => 'additional',
-    :environment => 'shadowed')}
-#{generate_site_manifest("#{testdir}/additional/shadowed/manifests", "atmp", "globalmod")}
+  #{generate_module_content("atmp",
+                            :base_path   => testdir,
+                            :env_path    => 'additional',
+                            :environment => 'shadowed')}
+  #{generate_site_manifest("#{testdir}/additional/shadowed/manifests", "atmp", "globalmod")}
 
 # And one global module (--modulepath setting)
 #{generate_module_content("globalmod", :base_path => testdir)}
@@ -112,82 +112,82 @@ file {
   "#{testdir}/additional/production/manifests":;
 #{generate_site_manifest("#{testdir}/additional/production/manifests", "globalmod")}
 }
-MANIFEST
+  MANIFEST
 
-def run_with_environment(agent, environment, options = {})
-  expected_exit_code = options[:expected_exit_code] || 2
-  expected_strings = options[:expected_strings]
+  def run_with_environment(agent, environment, options = {})
+    expected_exit_code = options[:expected_exit_code] || 2
+    expected_strings   = options[:expected_strings]
 
-  step "running an agent in environment '#{environment}'"
-  atmp = agent.tmpdir("use_environmentpath_#{environment}")
+    step "running an agent in environment '#{environment}'"
+    atmp = agent.tmpdir("use_environmentpath_#{environment}")
 
-  agent_config = [
-    "-t",
-    "--server", master,
-  ]
-  agent_config << '--environment' << environment if environment
-  # This to test how the agent behaves when using the directory environment
-  # loaders (which will not load an environment if it does not exist)
-  agent_config << "--environmentpath='$confdir/environments'" if agent != master
-  agent_config << {
-    'ENV' => { "FACTER_agent_file_location" => atmp },
-  }
+    agent_config = [
+        "-t",
+        "--server", master,
+    ]
+    agent_config << '--environment' << environment if environment
+    # This to test how the agent behaves when using the directory environment
+    # loaders (which will not load an environment if it does not exist)
+    agent_config << "--environmentpath='$confdir/environments'" if agent != master
+    agent_config << {
+        'ENV' => { "FACTER_agent_file_location" => atmp },
+    }
 
-  on(agent,
-     puppet("agent", *agent_config),
-     :acceptable_exit_codes => [expected_exit_code]) do |result|
+    on(agent,
+       puppet("agent", *agent_config),
+       :acceptable_exit_codes => [expected_exit_code]) do |result|
 
-    yield atmp, result
+      yield atmp, result
+    end
+
+    on agent, "rm -rf #{atmp}"
   end
 
-  on agent, "rm -rf #{atmp}"
-end
-
-master_opts = {
-  'master' => {
-    'environmentpath' => "#{testdir}/additional:#{testdir}/base",
-    'basemodulepath' => "#{testdir}/modules",
+  master_opts = {
+      'master' => {
+          'environmentpath' => "#{testdir}/additional:#{testdir}/base",
+          'basemodulepath'  => "#{testdir}/modules",
+      }
   }
-}
-if master.is_pe?
-  master_opts['master']['basemodulepath'] << ":#{master['sitemoduledir']}"
-end
+  if master.is_pe?
+    master_opts['master']['basemodulepath'] << ":#{master['sitemoduledir']}"
+  end
 
-with_puppet_running_on master, master_opts, testdir do
-  agents.each do |agent|
-    run_with_environment(agent, "shadowed") do |tmpdir,catalog_result|
-      ["module-atmp-from-shadowed", "module-globalmod"].each do |expected|
-        assert_match(/environment fact from #{expected}/, catalog_result.stdout)
+  with_puppet_running_on master, master_opts, testdir do
+    agents.each do |agent|
+      run_with_environment(agent, "shadowed") do |tmpdir, catalog_result|
+        ["module-atmp-from-shadowed", "module-globalmod"].each do |expected|
+          assert_match(/environment fact from #{expected}/, catalog_result.stdout)
+        end
+
+        ["module-atmp-from-shadowed", "module-globalmod"].each do |expected|
+          on agent, "cat #{tmpdir}/file-#{expected}" do |file_result|
+            assert_match(/data file from #{expected}/, file_result.stdout)
+          end
+        end
       end
 
-      ["module-atmp-from-shadowed", "module-globalmod"].each do |expected|
-        on agent, "cat #{tmpdir}/file-#{expected}" do |file_result|
-          assert_match(/data file from #{expected}/, file_result.stdout)
+      run_with_environment(agent, "onlybase") do |tmpdir, catalog_result|
+        ["module-atmp-from-onlybase", "module-globalmod"].each do |expected|
+          assert_match(/environment fact from #{expected}/, catalog_result.stdout)
+        end
+
+        ["module-atmp-from-onlybase", "module-globalmod"].each do |expected|
+          on agent, "cat #{tmpdir}/file-#{expected}" do |file_result|
+            assert_match(/data file from #{expected}/, file_result.stdout)
+          end
+        end
+      end
+
+      run_with_environment(agent, nil, :expected_exit_code => 2) do |tmpdir, catalog_result|
+        assert_no_match(/module-atmp/, catalog_result.stdout, "module-atmp was included despite no environment being loaded")
+
+        assert_match(/environment fact from module-globalmod/, catalog_result.stdout)
+
+        on agent, "cat #{tmpdir}/file-module-globalmod" do |file_result|
+          assert_match(/data file from module-globalmod/, file_result.stdout)
         end
       end
     end
-
-    run_with_environment(agent, "onlybase") do |tmpdir,catalog_result|
-      ["module-atmp-from-onlybase", "module-globalmod"].each do |expected|
-        assert_match(/environment fact from #{expected}/, catalog_result.stdout)
-      end
-
-      ["module-atmp-from-onlybase", "module-globalmod"].each do |expected|
-        on agent, "cat #{tmpdir}/file-#{expected}" do |file_result|
-          assert_match(/data file from #{expected}/, file_result.stdout)
-        end
-      end
-    end
-
-    run_with_environment(agent, nil, :expected_exit_code => 2) do |tmpdir, catalog_result|
-      assert_no_match(/module-atmp/, catalog_result.stdout, "module-atmp was included despite no environment being loaded")
-
-      assert_match(/environment fact from module-globalmod/, catalog_result.stdout)
-
-      on agent, "cat #{tmpdir}/file-module-globalmod" do |file_result|
-        assert_match(/data file from module-globalmod/, file_result.stdout)
-      end
-    end
   end
-end
 end

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -15,7 +15,7 @@ test_name 'C98115 compilation should get new values in variables on each compila
   CONF
   # the module function loading logic is different from inside a single manifest
   #   we exercise both here
-  on(master, "mkdir -p #{fq_tmp_environmentpath}/modules/custom_time/{manifests,functions,facts.d}")
+  on(master, "mkdir -p '#{fq_tmp_environmentpath}'/modules/custom_time/{manifests,functions,facts.d}")
   create_remote_file(master, "#{fq_tmp_environmentpath}/modules/custom_time/manifests/init.pp", <<-FILE)
     class custom_time {
       $t = custom_time::my_system_time()
@@ -46,14 +46,14 @@ test_name 'C98115 compilation should get new values in variables on each compila
 echo -n "custom_time=$(date +%s%N)"
   FILE
 
-  on(master, "chmod -R 0777 #{fq_tmp_environmentpath}/")
+  on(master, "chmod -R 0777 '#{fq_tmp_environmentpath}/'")
 
   windows_fact_location = "#{fq_tmp_environmentpath}/modules/custom_time/facts.d/custom_time.ps1"
   create_remote_file(master, windows_fact_location, <<-FILE)
 echo "custom_time=$(get-date -format HHmmssffffff)"
   FILE
 
-  on(master, "chmod -R 0666 #{windows_fact_location}")
+  on(master, "chmod -R 0666 '#{windows_fact_location}'")
 
 
   step "run agent in #{tmp_environment}, ensure it increments the customtime with each run" do
@@ -63,13 +63,13 @@ echo "custom_time=$(get-date -format HHmmssffffff)"
       agents.each do |agent|
         # ensure our custom facts have been synced
         on(agent,
-           puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+           puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"),
            :accept_all_exit_codes => true)
 
         local_custom_time1 = module_custom_time1 = nil
         local_custom_time2 = module_custom_time2 = nil
 
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"),
            :accept_all_exit_codes => [2]) do |result|
           assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'first custom time was not as expected')
           assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'first module uptime was not as expected')
@@ -80,7 +80,7 @@ echo "custom_time=$(get-date -format HHmmssffffff)"
 
         sleep 1
 
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"),
            :accept_all_exit_codes => [2]) do |result|
           assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'second custom time was not as expected')
           assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'second module uptime was not as expected')

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -1,10 +1,10 @@
 test_name 'C98115 compilation should get new values in variables on each compilation' do
-require 'puppet/acceptance/environment_utils'
-extend Puppet::Acceptance::EnvironmentUtils
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
-    'audit:integration',
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
 
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
@@ -51,14 +51,14 @@ echo -n "custom_time=$(date +%s%N)"
   windows_fact_location = "#{fq_tmp_environmentpath}/modules/custom_time/facts.d/custom_time.ps1"
   create_remote_file(master, windows_fact_location, <<-FILE)
 echo "custom_time=$(get-date -format HHmmssffffff)"
-FILE
+  FILE
 
   on(master, "chmod -R 0666 #{windows_fact_location}")
 
 
   step "run agent in #{tmp_environment}, ensure it increments the customtime with each run" do
-    with_puppet_running_on(master,{}) do
-      local_custom_time_pattern = 'local_(\d+)_local'
+    with_puppet_running_on(master, {}) do
+      local_custom_time_pattern  = 'local_(\d+)_local'
       module_custom_time_pattern = 'module_(\d+)_module'
       agents.each do |agent|
         # ensure our custom facts have been synced
@@ -74,7 +74,7 @@ FILE
           assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'first custom time was not as expected')
           assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'first module uptime was not as expected')
 
-          local_custom_time1 = result.stdout.match(/Notice: #{local_custom_time_pattern}/)[1].to_i
+          local_custom_time1  = result.stdout.match(/Notice: #{local_custom_time_pattern}/)[1].to_i
           module_custom_time1 = result.stdout.match(/Notice: #{module_custom_time_pattern}/)[1].to_i
         end
 
@@ -85,7 +85,7 @@ FILE
           assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'second custom time was not as expected')
           assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'second module uptime was not as expected')
 
-          local_custom_time2 = result.stdout.match(/Notice: #{local_custom_time_pattern}/)[1].to_i
+          local_custom_time2  = result.stdout.match(/Notice: #{local_custom_time_pattern}/)[1].to_i
           module_custom_time2 = result.stdout.match(/Notice: #{module_custom_time_pattern}/)[1].to_i
         end
 


### PR DESCRIPTION
Update a subset of the enc tests
Add a test to verify that we're only compiling and caching the catalog once. (The test catches the regression on agent 5.3.4)