### PR TITLE
(PUP-8501) Replace direct references to JSON gem with MultiJson

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   # i18n support (gettext-setup and dependencies)
   s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.2")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
+  s.add_runtime_dependency(%q<multi_json>, "~> 1.10")
   # hocon is an optional hiera backend shipped in puppet-agent packages
   s.add_runtime_dependency(%q<hocon>, "~> 1.0")
   # net-ssh is a runtime dependency of Puppet::Util::NetworkDevice::Transport::Ssh

--- a/.gemspec
+++ b/.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   # i18n support (gettext-setup and dependencies)
   s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.2")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
-  s.add_runtime_dependency(%q<multi_json>, "~> 1.10")
+  s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   # hocon is an optional hiera backend shipped in puppet-agent packages
   s.add_runtime_dependency(%q<hocon>, "~> 1.0")
   # net-ssh is a runtime dependency of Puppet::Util::NetworkDevice::Transport::Ssh

--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,7 @@ group(:development, :test) do
   gem "yarjuf", "~> 2.0"
 
   # json-schema does not support windows, so omit it from the platforms list
-  # json-schema uses multi_json, but chokes with multi_json 1.7.9, so prefer 1.7.7
-  gem "multi_json", "1.7.7", :require => false, :platforms => [:ruby, :jruby]
-  gem "json-schema", "2.1.1", :require => false, :platforms => [:ruby, :jruby]
+  gem "json-schema", "~> 2.0", :require => false, :platforms => [:ruby, :jruby]
 
   if RUBY_VERSION >= '2.0'
     # pin rubocop as 0.50 requires a higher version of the rainbow gem (see below)

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -23,6 +23,7 @@ gem_runtime_dependencies:
   # semantic_puppet: ['>= 0.1.3', '< 2']
   fast_gettext: '~> 1.1.2'
   locale: '~> 2.1'
+  multi_json: '~> 1.10'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -341,7 +341,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     if fact_file
       if fact_file.end_with?("json")
-        given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = MultiJson.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
         given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -341,7 +341,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     if fact_file
       if fact_file.end_with?("json")
-        given_facts = MultiJson.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = Puppet::Util::Json.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
         given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -484,7 +484,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       if fact_file.is_a?(Hash) # when used via the Face API
         given_facts = fact_file
       elsif fact_file.end_with?("json")
-        given_facts = MultiJson.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = Puppet::Util::Json.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
         given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -484,7 +484,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       if fact_file.is_a?(Hash) # when used via the Face API
         given_facts = fact_file
       elsif fact_file.end_with?("json")
-        given_facts = JSON.parse(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = MultiJson.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
         given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       end

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -5,7 +5,7 @@ require 'net/http'
 require 'tempfile'
 require 'uri'
 require 'pathname'
-require 'multi_json'
+require 'puppet/util/json'
 require 'semantic_puppet'
 
 class Puppet::Forge < SemanticPuppet::Dependency::Source
@@ -64,7 +64,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       response = make_http_request(uri)
 
       if response.code == '200'
-        result = MultiJson.load(response.body)
+        result = Puppet::Util::Json.load(response.body)
         uri = decode_uri(result['pagination']['next'])
         matches.concat result['results']
       else
@@ -101,7 +101,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       response = make_http_request(uri)
 
       if response.code == '200'
-        response = MultiJson.load(response.body)
+        response = Puppet::Util::Json.load(response.body)
       else
         raise ResponseError.new(:uri => URI.parse(@host).merge(uri), :response => response)
       end

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -5,7 +5,7 @@ require 'net/http'
 require 'tempfile'
 require 'uri'
 require 'pathname'
-require 'json'
+require 'multi_json'
 require 'semantic_puppet'
 
 class Puppet::Forge < SemanticPuppet::Dependency::Source
@@ -64,7 +64,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       response = make_http_request(uri)
 
       if response.code == '200'
-        result = JSON.parse(response.body)
+        result = MultiJson.load(response.body)
         uri = decode_uri(result['pagination']['next'])
         matches.concat result['results']
       else
@@ -101,7 +101,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
       response = make_http_request(uri)
 
       if response.code == '200'
-        response = JSON.parse(response.body)
+        response = MultiJson.load(response.body)
       else
         raise ResponseError.new(:uri => URI.parse(@host).merge(uri), :response => response)
       end

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'puppet/util/json'
 require 'puppet/error'
 require 'puppet/forge'
 
@@ -82,11 +82,11 @@ module Puppet::Forge::Errors
       @response = "#{response.code} #{response.message.strip}"
 
       begin
-        body = MultiJson.load(response.body)
+        body = Puppet::Util::Json.load(response.body)
         if body['message']
           @message ||= body['message'].strip
         end
-      rescue MultiJson::ParseError
+      rescue Puppet::Util::Json::ParseError
       end
 
       message = if @message

--- a/lib/puppet/forge/errors.rb
+++ b/lib/puppet/forge/errors.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 require 'puppet/error'
 require 'puppet/forge'
 
@@ -82,11 +82,11 @@ module Puppet::Forge::Errors
       @response = "#{response.code} #{response.message.strip}"
 
       begin
-        body = JSON.parse(response.body)
+        body = MultiJson.load(response.body)
         if body['message']
           @message ||= body['message'].strip
         end
-      rescue JSON::ParserError
+      rescue MultiJson::ParseError
       end
 
       message = if @message

--- a/lib/puppet/functions/json_data.rb
+++ b/lib/puppet/functions/json_data.rb
@@ -19,8 +19,8 @@ Puppet::Functions.create_function(:json_data) do
     path = options['path']
     context.cached_file_data(path) do |content|
       begin
-        JSON.parse(content)
-      rescue JSON::ParserError => ex
+        MultiJson.load(content)
+      rescue MultiJson::ParseError => ex
         # Filename not included in message, so we add it here.
         raise Puppet::DataBinding::LookupError, "Unable to parse (%{path}): %{message}" % { path: path, message: ex.message }
       end

--- a/lib/puppet/functions/json_data.rb
+++ b/lib/puppet/functions/json_data.rb
@@ -19,8 +19,8 @@ Puppet::Functions.create_function(:json_data) do
     path = options['path']
     context.cached_file_data(path) do |content|
       begin
-        MultiJson.load(content)
-      rescue MultiJson::ParseError => ex
+        Puppet::Util::Json.load(content)
+      rescue Puppet::Util::Json::ParseError => ex
         # Filename not included in message, so we add it here.
         raise Puppet::DataBinding::LookupError, "Unable to parse (%{path}): %{message}" % { path: path, message: ex.message }
       end

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 require 'uri'
-require 'json'
+require 'multi_json'
 require 'semantic_puppet'
 
 require 'puppet/network/http'
@@ -301,7 +301,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     elsif response['content-type'].is_a?(String)
       content_type, body = parse_response(response)
       if content_type =~ /[pj]son/
-        returned_message = JSON.parse(body)["message"]
+        returned_message = MultiJson.load(body)["message"]
       else
         returned_message = uncompress_body(response)
       end

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 require 'uri'
-require 'multi_json'
+require 'puppet/util/json'
 require 'semantic_puppet'
 
 require 'puppet/network/http'
@@ -301,7 +301,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     elsif response['content-type'].is_a?(String)
       content_type, body = parse_response(response)
       if content_type =~ /[pj]son/
-        returned_message = MultiJson.load(body)["message"]
+        returned_message = Puppet::Util::Json.load(body)["message"]
       else
         returned_message = uncompress_body(response)
       end

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -202,7 +202,7 @@ class Puppet::Module
 
   def read_metadata
     md_file = metadata_file
-    md_file.nil? ? {} : Puppet::Util::Json::load(File.read(md_file, :encoding => 'utf-8'))
+    md_file.nil? ? {} : Puppet::Util::Json.load(File.read(md_file, :encoding => 'utf-8'))
   rescue Errno::ENOENT
     {}
   rescue Puppet::Util::Json::ParseError => e

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -1,6 +1,6 @@
 require 'puppet/util/logging'
 require 'puppet/module/task'
-require 'multi_json'
+require 'puppet/util/json'
 require 'semantic_puppet/gem_version'
 
 # Support for modules
@@ -202,10 +202,10 @@ class Puppet::Module
 
   def read_metadata
     md_file = metadata_file
-    md_file.nil? ? {} : MultiJson::load(File.read(md_file, :encoding => 'utf-8'))
+    md_file.nil? ? {} : Puppet::Util::Json::load(File.read(md_file, :encoding => 'utf-8'))
   rescue Errno::ENOENT
     {}
-  rescue MultiJson::ParseError => e
+  rescue Puppet::Util::Json::ParseError => e
     #TRANSLATORS 'metadata.json' is a specific file name and should not be translated.
     msg = _("%{name} has an invalid and unparsable metadata.json file. The parse error: %{error}") % { name: name, error: e.message }
     case Puppet[:strict]

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -1,6 +1,6 @@
 require 'puppet/util/logging'
 require 'puppet/module/task'
-require 'json'
+require 'multi_json'
 require 'semantic_puppet/gem_version'
 
 # Support for modules
@@ -202,10 +202,10 @@ class Puppet::Module
 
   def read_metadata
     md_file = metadata_file
-    md_file.nil? ? {} : JSON.parse(File.read(md_file, :encoding => 'utf-8'))
+    md_file.nil? ? {} : MultiJson::load(File.read(md_file, :encoding => 'utf-8'))
   rescue Errno::ENOENT
     {}
-  rescue JSON::JSONError => e
+  rescue MultiJson::ParseError => e
     #TRANSLATORS 'metadata.json' is a specific file name and should not be translated.
     msg = _("%{name} has an invalid and unparsable metadata.json file. The parse error: %{error}") % { name: name, error: e.message }
     case Puppet[:strict]

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -1,4 +1,3 @@
-require 'json'
 require 'puppet/util/logging'
 
 class Puppet::Module

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -1,5 +1,5 @@
 require 'net/http'
-require 'multi_json'
+require 'puppet/util/json'
 require 'puppet/util/colors'
 
 module Puppet::ModuleTool
@@ -26,7 +26,7 @@ module Puppet::ModuleTool
         when Net::HTTPOK, Net::HTTPCreated
           Puppet.notice success
         else
-          errors = MultiJson.load(response.body)['error'] rescue "HTTP #{response.code}, #{response.body}"
+          errors = Puppet::Util::Json.load(response.body)['error'] rescue "HTTP #{response.code}, #{response.body}"
           Puppet.warning "#{failure} (#{errors})"
         end
       end
@@ -48,8 +48,8 @@ module Puppet::ModuleTool
         if File.file?(metadata_path)
           File.open(metadata_path) do |f|
             begin
-              @metadata.update(MultiJson.load(f))
-            rescue MultiJson::ParserError => ex
+              @metadata.update(Puppet::Util::Json.load(f))
+            rescue Puppet::Util::Json::ParserError => ex
               raise ArgumentError, _("Could not parse JSON %{metadata_path}") % { metadata_path: metadata_path }, ex.backtrace
             end
           end

--- a/lib/puppet/module_tool/applications/application.rb
+++ b/lib/puppet/module_tool/applications/application.rb
@@ -1,5 +1,5 @@
 require 'net/http'
-require 'json'
+require 'multi_json'
 require 'puppet/util/colors'
 
 module Puppet::ModuleTool
@@ -26,7 +26,7 @@ module Puppet::ModuleTool
         when Net::HTTPOK, Net::HTTPCreated
           Puppet.notice success
         else
-          errors = JSON.parse(response.body)['error'] rescue "HTTP #{response.code}, #{response.body}"
+          errors = MultiJson.load(response.body)['error'] rescue "HTTP #{response.code}, #{response.body}"
           Puppet.warning "#{failure} (#{errors})"
         end
       end
@@ -48,8 +48,8 @@ module Puppet::ModuleTool
         if File.file?(metadata_path)
           File.open(metadata_path) do |f|
             begin
-              @metadata.update(JSON.load(f))
-            rescue JSON::ParserError => ex
+              @metadata.update(MultiJson.load(f))
+            rescue MultiJson::ParserError => ex
               raise ArgumentError, _("Could not parse JSON %{metadata_path}") % { metadata_path: metadata_path }, ex.backtrace
             end
           end

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'multi_json'
+require 'puppet/util/json'
 require 'puppet/file_system'
 require 'pathspec'
 require 'facter'
@@ -140,7 +140,7 @@ module Puppet::ModuleTool
         end
 
         Puppet::FileSystem.open(File.join(build_path, 'checksums.json'), nil, 'wb') do |f|
-          f.write(MultiJson.dump(Checksums.new(build_path), :pretty => true))
+          f.write(Puppet::Util::Json.dump(Checksums.new(build_path), :pretty => true))
         end
       end
 

--- a/lib/puppet/module_tool/applications/builder.rb
+++ b/lib/puppet/module_tool/applications/builder.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'json'
+require 'multi_json'
 require 'puppet/file_system'
 require 'pathspec'
 require 'facter'
@@ -140,7 +140,7 @@ module Puppet::ModuleTool
         end
 
         Puppet::FileSystem.open(File.join(build_path, 'checksums.json'), nil, 'wb') do |f|
-          f.write(JSON.pretty_generate(Checksums.new(build_path)))
+          f.write(MultiJson.dump(Checksums.new(build_path), :pretty => true))
         end
       end
 

--- a/lib/puppet/module_tool/applications/checksummer.rb
+++ b/lib/puppet/module_tool/applications/checksummer.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 require 'puppet/module_tool/checksums'
 
 module Puppet::ModuleTool
@@ -40,10 +40,10 @@ module Puppet::ModuleTool
 
       def checksums
         if checksums_file.exist?
-          JSON.parse(checksums_file.read)
+          MultiJson.load(checksums_file.read)
         elsif metadata_file.exist?
           # Check metadata.json too; legacy modules store their checksums there.
-          JSON.parse(metadata_file.read)['checksums'] or
+          MultiJson.load(metadata_file.read)['checksums'] or
           raise ArgumentError, _("No file containing checksums found.")
         else
           raise ArgumentError, _("No file containing checksums found.")

--- a/lib/puppet/module_tool/applications/checksummer.rb
+++ b/lib/puppet/module_tool/applications/checksummer.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'puppet/util/json'
 require 'puppet/module_tool/checksums'
 
 module Puppet::ModuleTool
@@ -40,10 +40,10 @@ module Puppet::ModuleTool
 
       def checksums
         if checksums_file.exist?
-          MultiJson.load(checksums_file.read)
+          Puppet::Util::Json.load(checksums_file.read)
         elsif metadata_file.exist?
           # Check metadata.json too; legacy modules store their checksums there.
-          MultiJson.load(metadata_file.read)['checksums'] or
+          Puppet::Util::Json.load(metadata_file.read)['checksums'] or
           raise ArgumentError, _("No file containing checksums found.")
         else
           raise ArgumentError, _("No file containing checksums found.")

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 require 'tmpdir'
-require 'multi_json'
+require 'puppet/util/json'
 require 'puppet/file_system'
 
 module Puppet::ModuleTool
@@ -75,7 +75,7 @@ module Puppet::ModuleTool
 
       # @api private
       def module_name
-        metadata = MultiJson.load((root_dir + 'metadata.json').read)
+        metadata = Puppet::Util::Json.load((root_dir + 'metadata.json').read)
         metadata['name'][/-(.*)/, 1]
       end
 

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 require 'tmpdir'
-require 'json'
+require 'multi_json'
 require 'puppet/file_system'
 
 module Puppet::ModuleTool
@@ -75,7 +75,7 @@ module Puppet::ModuleTool
 
       # @api private
       def module_name
-        metadata = JSON.parse((root_dir + 'metadata.json').read)
+        metadata = MultiJson.load((root_dir + 'metadata.json').read)
         metadata['name'][/-(.*)/, 1]
       end
 

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -2,7 +2,7 @@ require 'puppet/util/methodhelper'
 require 'puppet/module_tool'
 require 'puppet/network/format_support'
 require 'uri'
-require 'multi_json'
+require 'puppet/util/json'
 require 'set'
 
 module Puppet::ModuleTool
@@ -102,7 +102,7 @@ module Puppet::ModuleTool
       data = @data.dup.merge('dependencies' => dependencies)
 
       contents = data.keys.map do |k|
-        value = (MultiJson.dump(data[k], :pretty => true) rescue data[k].to_json)
+        value = (Puppet::Util::Json.dump(data[k], :pretty => true) rescue data[k].to_json)
         "#{k.to_json}: #{value}"
       end
 

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -102,7 +102,7 @@ module Puppet::ModuleTool
       data = @data.dup.merge('dependencies' => dependencies)
 
       contents = data.keys.map do |k|
-        value = (Puppet::Util::Json.dump(data[k], :pretty => true) rescue Puppet::Util::Json.dump(data[k]))
+        value = (Puppet::Util::Json.dump(data[k], :pretty => true) rescue data[k].to_json)
         %Q("#{k.to_s}": #{value})
       end
 

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -102,8 +102,8 @@ module Puppet::ModuleTool
       data = @data.dup.merge('dependencies' => dependencies)
 
       contents = data.keys.map do |k|
-        value = (Puppet::Util::Json.dump(data[k], :pretty => true) rescue data[k].to_json)
-        "#{k.to_json}: #{value}"
+        value = (Puppet::Util::Json.dump(data[k], :pretty => true) rescue Puppet::Util::Json.dump(data[k]))
+        %Q("#{k.to_s}": #{value})
       end
 
       "{\n" + contents.join(",\n").gsub(/^/, '  ') + "\n}\n"

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -2,7 +2,7 @@ require 'puppet/util/methodhelper'
 require 'puppet/module_tool'
 require 'puppet/network/format_support'
 require 'uri'
-require 'json'
+require 'multi_json'
 require 'set'
 
 module Puppet::ModuleTool
@@ -102,7 +102,7 @@ module Puppet::ModuleTool
       data = @data.dup.merge('dependencies' => dependencies)
 
       contents = data.keys.map do |k|
-        value = (JSON.pretty_generate(data[k]) rescue data[k].to_json)
+        value = (MultiJson.dump(data[k], :pretty => true) rescue data[k].to_json)
         "#{k.to_json}: #{value}"
       end
 

--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -97,7 +97,7 @@ module Puppet::Network::FormatSupport
   end
 
   def to_json(*args)
-    to_data_hash.to_json(*args)
+    Puppet::Util::Json.dump(to_data_hash, *args)
   end
 
   def render(format = nil)

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -1,5 +1,5 @@
 require 'puppet/network/format_handler'
-require 'multi_json'
+require 'puppet/util/json'
 
 Puppet::Network::FormatHandler.create_serialized_formats(:msgpack, :weight => 20, :mime => "application/x-msgpack", :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
 
@@ -101,11 +101,11 @@ end
 
 Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'application/json', :charset => Encoding::UTF_8, :weight => 15, :required_methods => [:render_method, :intern_method], :intern_method => :from_data_hash) do
   def intern(klass, text)
-    data_to_instance(klass, MultiJson.load(text))
+    data_to_instance(klass, Puppet::Util::Json.load(text))
   end
 
   def intern_multiple(klass, text)
-    MultiJson.load(text).collect do |data|
+    Puppet::Util::Json.load(text).collect do |data|
       data_to_instance(klass, data)
     end
   end
@@ -164,7 +164,7 @@ Puppet::Network::FormatHandler.create(:console,
     end
 
     # ...or pretty-print the inspect outcome.
-    MultiJson.dump(datum, :pretty => true, :quirks_mode => true)
+    Puppet::Util::Json.dump(datum, :pretty => true, :quirks_mode => true)
   end
 
   def render_multiple(data)

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -110,12 +110,8 @@ Puppet::Network::FormatHandler.create_serialized_formats(:json, :mime => 'applic
     end
   end
 
-  # JSON monkey-patches Array, so this works.
-  # https://github.com/ruby/ruby/blob/ruby_1_9_3/ext/json/generator/generator.c#L1416
-  # If we ever change what JSON backend we are using, we will need to make sure this is
-  # still true.
   def render_multiple(instances)
-    instances.to_json
+    Puppet::Util::Json.dump(instances)
   end
 
   # Unlike PSON, we do not need to unwrap the data envelope, because legacy 3.x agents

--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 require 'puppet/parser/environment_compiler'
 
 class Puppet::Network::HTTP::API::Master::V3::Environment
@@ -15,7 +15,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
 
     env_graph = build_environment_graph(catalog)
 
-    response.respond_with(200, "application/json", JSON.dump(env_graph))
+    response.respond_with(200, "application/json", MultiJson.dump(env_graph))
   end
 
   def build_environment_graph(catalog)

--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'puppet/util/json'
 require 'puppet/parser/environment_compiler'
 
 class Puppet::Network::HTTP::API::Master::V3::Environment
@@ -15,7 +15,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
 
     env_graph = build_environment_graph(catalog)
 
-    response.respond_with(200, "application/json", MultiJson.dump(env_graph))
+    response.respond_with(200, "application/json", Puppet::Util::Json.dump(env_graph))
   end
 
   def build_environment_graph(catalog)

--- a/lib/puppet/network/http/api/master/v3/environments.rb
+++ b/lib/puppet/network/http/api/master/v3/environments.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'puppet/util/json'
 
 class Puppet::Network::HTTP::API::Master::V3::Environments
   def initialize(env_loader)
@@ -6,7 +6,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environments
   end
 
   def call(request, response)
-    response.respond_with(200, "application/json", MultiJson.dump({
+    response.respond_with(200, "application/json", Puppet::Util::Json.dump({
       "search_paths" => @env_loader.search_paths,
       "environments" => Hash[@env_loader.list.collect do |env|
         [env.name, {

--- a/lib/puppet/network/http/api/master/v3/environments.rb
+++ b/lib/puppet/network/http/api/master/v3/environments.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 
 class Puppet::Network::HTTP::API::Master::V3::Environments
   def initialize(env_loader)
@@ -6,7 +6,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environments
   end
 
   def call(request, response)
-    response.respond_with(200, "application/json", JSON.dump({
+    response.respond_with(200, "application/json", MultiJson.dump({
       "search_paths" => @env_loader.search_paths,
       "environments" => Hash[@env_loader.list.collect do |env|
         [env.name, {

--- a/lib/puppet/network/http/error.rb
+++ b/lib/puppet/network/http/error.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 
 module Puppet::Network::HTTP::Error
   Issues = Puppet::Network::HTTP::Issues
@@ -13,7 +13,7 @@ module Puppet::Network::HTTP::Error
     end
 
     def to_json
-      JSON({:message => message, :issue_kind => @issue_kind})
+      MultiJson.dump({:message => message, :issue_kind => @issue_kind})
     end
   end
 
@@ -67,7 +67,7 @@ module Puppet::Network::HTTP::Error
     end
 
     def to_json
-      JSON({:message => message, :issue_kind => @issue_kind})
+      MultiJson.dump({:message => message, :issue_kind => @issue_kind})
     end
   end
 end

--- a/lib/puppet/network/http/error.rb
+++ b/lib/puppet/network/http/error.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'puppet/util/json'
 
 module Puppet::Network::HTTP::Error
   Issues = Puppet::Network::HTTP::Issues
@@ -13,7 +13,7 @@ module Puppet::Network::HTTP::Error
     end
 
     def to_json
-      MultiJson.dump({:message => message, :issue_kind => @issue_kind})
+      Puppet::Util::Json.dump({:message => message, :issue_kind => @issue_kind})
     end
   end
 
@@ -67,7 +67,7 @@ module Puppet::Network::HTTP::Error
     end
 
     def to_json
-      MultiJson.dump({:message => message, :issue_kind => @issue_kind})
+      Puppet::Util::Json.dump({:message => message, :issue_kind => @issue_kind})
     end
   end
 end

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -31,8 +31,8 @@ class TaskInstantiator
     else
       json_text = loader.get_contents(metadata)
       begin
-        create_task_from_hash(name, task_source, MultiJson.load(json_text) || EMPTY_HASH)
-      rescue MultiJson::ParseError => ex
+        create_task_from_hash(name, task_source, Puppet::Util::Json.load(json_text) || EMPTY_HASH)
+      rescue Puppet::Util::Json::ParseError => ex
         raise Puppet::ParseError.new(ex.message, metadata)
       rescue Types::TypeAssertionError => ex
         # Not strictly a parser error but from the users perspective, the file content didn't parse properly. The

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -31,8 +31,8 @@ class TaskInstantiator
     else
       json_text = loader.get_contents(metadata)
       begin
-        create_task_from_hash(name, task_source, JSON.parse(json_text) || EMPTY_HASH)
-      rescue JSON::ParserError => ex
+        create_task_from_hash(name, task_source, MultiJson.load(json_text) || EMPTY_HASH)
+      rescue MultiJson::ParseError => ex
         raise Puppet::ParseError.new(ex.message, metadata)
       rescue Types::TypeAssertionError => ex
         # Not strictly a parser error but from the users perspective, the file content didn't parse properly. The

--- a/lib/puppet/pops/serialization/json.rb
+++ b/lib/puppet/pops/serialization/json.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 
 module Puppet::Pops
 module Serialization
@@ -146,12 +146,12 @@ module JSON
     end
 
     def to_a
-      ::JSON.parse(io_string)
+      ::MultiJson.load(io_string)
     end
 
     def to_json
       if @indent > 0
-        ::JSON.pretty_unparse(to_a, { :indent => ' ' * @indent })
+        ::MultiJson.dump(to_a, { :pretty => true, :indent => ' ' * @indent })
       else
         io_string
       end
@@ -284,9 +284,9 @@ module JSON
     def parse_io(io)
       case io
       when IO, StringIO
-        ::JSON.parse(io.read)
+        ::MultiJson.load(io.read)
       when String
-        ::JSON.parse(io)
+        ::MultiJson.load(io)
       else
         io
       end

--- a/lib/puppet/pops/serialization/json.rb
+++ b/lib/puppet/pops/serialization/json.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'puppet/util/json'
 
 module Puppet::Pops
 module Serialization
@@ -146,12 +146,12 @@ module JSON
     end
 
     def to_a
-      ::MultiJson.load(io_string)
+      ::Puppet::Util::Json.load(io_string)
     end
 
     def to_json
       if @indent > 0
-        ::MultiJson.dump(to_a, { :pretty => true, :indent => ' ' * @indent })
+        ::Puppet::Util::Json.dump(to_a, { :pretty => true, :indent => ' ' * @indent })
       else
         io_string
       end
@@ -284,9 +284,9 @@ module JSON
     def parse_io(io)
       case io
       when IO, StringIO
-        ::MultiJson.load(io.read)
+        ::Puppet::Util::Json.load(io.read)
       when String
-        ::MultiJson.load(io)
+        ::Puppet::Util::Json.load(io)
       else
         io
       end

--- a/lib/puppet/pops/serialization/json.rb
+++ b/lib/puppet/pops/serialization/json.rb
@@ -159,7 +159,7 @@ module JSON
 
     # Write a payload object. Not subject to extensions
     def write_pl(obj)
-      @io << obj.to_json << ','
+      @io << Puppet::Util::Json.dump(obj) << ','
     end
 
     def io_string
@@ -198,7 +198,7 @@ module JSON
       if ext.nil?
         case obj
         when Numeric, String, true, false, nil
-          @io << obj.to_json
+          @io << Puppet::Util::Json.dump(obj)
           write_delim
         else
           raise SerializationError, _("Unable to serialize a %{obj}") % { obj: obj.class.name }

--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -7,7 +7,7 @@
 
 require 'net/http'
 require 'cgi'
-require 'json'
+require 'multi_json'
 
 # @api private
 module Puppet::Resource::CapabilityFinder
@@ -92,7 +92,7 @@ module Puppet::Resource::CapabilityFinder
         response = Puppet::Util::Puppetdb::Http.action(url) do |conn, uri|
           conn.get(uri, { 'Accept' => 'application/json'})
         end
-        JSON.parse(response.body)
+        MultiJson.load(response.body)
       end
 
       # The format of the response body is documented at
@@ -104,7 +104,7 @@ module Puppet::Resource::CapabilityFinder
       end
 
       result
-    rescue JSON::JSONError => e
+    rescue MultiJson::ParseError => e
       #TRANSLATOR PuppetDB is a product name and should not be translated
       raise Puppet::DevError, _("Invalid JSON from PuppetDB when looking up %{capability}\n%{detail}") % { capability: cap, detail: e }
     end

--- a/lib/puppet/resource/capability_finder.rb
+++ b/lib/puppet/resource/capability_finder.rb
@@ -7,7 +7,7 @@
 
 require 'net/http'
 require 'cgi'
-require 'multi_json'
+require 'puppet/util/json'
 
 # @api private
 module Puppet::Resource::CapabilityFinder
@@ -92,7 +92,7 @@ module Puppet::Resource::CapabilityFinder
         response = Puppet::Util::Puppetdb::Http.action(url) do |conn, uri|
           conn.get(uri, { 'Accept' => 'application/json'})
         end
-        MultiJson.load(response.body)
+        Puppet::Util::Json.load(response.body)
       end
 
       # The format of the response body is documented at
@@ -104,7 +104,7 @@ module Puppet::Resource::CapabilityFinder
       end
 
       result
-    rescue MultiJson::ParseError => e
+    rescue Puppet::Util::Json::ParseError => e
       #TRANSLATOR PuppetDB is a product name and should not be translated
       raise Puppet::DevError, _("Invalid JSON from PuppetDB when looking up %{capability}\n%{detail}") % { capability: cap, detail: e }
     end

--- a/lib/puppet/syntax_checkers/json.rb
+++ b/lib/puppet/syntax_checkers/json.rb
@@ -20,7 +20,7 @@ class Puppet::SyntaxCheckers::Json < Puppet::Plugins::SyntaxCheckers::SyntaxChec
     #raise ArgumentError.new("Json syntax checker: location_info must be a Hash") unless location_info.is_a?(Hash)
 
     begin
-      JSON.parse(text)
+      MultiJson.load(text)
     rescue => e
       # Cap the message to 100 chars and replace newlines
       msg = _("JSON syntax checker: Cannot parse invalid JSON string. \"%{message}\"") % { message: e.message().slice(0,100).gsub(/\r?\n/, "\\n") }

--- a/lib/puppet/syntax_checkers/json.rb
+++ b/lib/puppet/syntax_checkers/json.rb
@@ -20,7 +20,7 @@ class Puppet::SyntaxCheckers::Json < Puppet::Plugins::SyntaxCheckers::SyntaxChec
     #raise ArgumentError.new("Json syntax checker: location_info must be a Hash") unless location_info.is_a?(Hash)
 
     begin
-      MultiJson.load(text)
+      Puppet::Util::Json.load(text)
     rescue => e
       # Cap the message to 100 chars and replace newlines
       msg = _("JSON syntax checker: Cannot parse invalid JSON string. \"%{message}\"") % { message: e.message().slice(0,100).gsub(/\r?\n/, "\\n") }

--- a/lib/puppet/util/json.rb
+++ b/lib/puppet/util/json.rb
@@ -1,0 +1,32 @@
+module Puppet::Util::Json
+  begin
+    require 'multi_json'
+  rescue LoadError
+    require 'json'
+  end
+
+  # These methods are identical to the fallback implemented by MultiJson
+  # when using the built-in JSON backend, to ensure consistent behavior
+  # whether or not MultiJson can be loaded.
+  def self.load(source, options = {})
+    if defined? MultiJson
+      MultiJson.load(source, options)
+    else
+      if string.respond_to?(:force_encoding)
+          string = string.dup.force_encoding(::Encoding::ASCII_8BIT)
+      end
+
+      options[:symbolize_names] = true if options.delete(:symbolize_keys)
+      ::JSON.parse(string, options)
+    end
+  end
+
+  def self.dump(object, options = {})
+    if defined? MultiJson
+      MultiJson.dump(object, options)
+    else
+      options.merge!(::JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)
+      object.to_json(options)
+    end
+  end
+end

--- a/lib/puppet/util/json.rb
+++ b/lib/puppet/util/json.rb
@@ -5,6 +5,12 @@ module Puppet::Util
 
     begin
       require 'multi_json'
+      # Force backend detection before attempting to use the library
+      # or load any other JSON libraries
+      MultiJson.default_adapter
+
+      # Preserve core type monkey-patching done by the built-in JSON gem
+      require 'json'
     rescue LoadError
       require 'json'
     end

--- a/lib/puppet/util/json.rb
+++ b/lib/puppet/util/json.rb
@@ -40,10 +40,6 @@ module Puppet::Util
         begin
           string = string.read if string.respond_to?(:read)
 
-          if string.respond_to?(:force_encoding)
-            string = string.dup.force_encoding(::Encoding::ASCII_8BIT)
-          end
-
           options[:symbolize_names] = true if options.delete(:symbolize_keys)
           ::JSON.parse(string, options)
         rescue JSON::ParserError => e

--- a/lib/puppet/util/json.rb
+++ b/lib/puppet/util/json.rb
@@ -47,6 +47,14 @@ module Puppet::Util
 
     def self.dump(object, options = {})
       if defined? MultiJson
+        # MultiJson calls `merge` on the options it is passed, which relies
+        # on the options' defining a `to_hash` method. In Ruby 1.9.3,
+        # JSON::Ext::Generator::State only defines `to_h`, not `to_hash`, so we
+        # need to convert it first, similar to what is done in the `else` block
+        # below. Later versions of the JSON gem alias `to_h` to `to_hash`, so this
+        # can be removed once we drop Ruby 1.9.3 support.
+        options = options.to_h if options.class.name == "JSON::Ext::Generator::State"
+
         MultiJson.dump(object, options)
       else
         options.merge!(::JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)

--- a/lib/puppet/util/json.rb
+++ b/lib/puppet/util/json.rb
@@ -1,32 +1,51 @@
-module Puppet::Util::Json
-  begin
-    require 'multi_json'
-  rescue LoadError
-    require 'json'
-  end
-
-  # These methods are identical to the fallback implemented by MultiJson
-  # when using the built-in JSON backend, to ensure consistent behavior
-  # whether or not MultiJson can be loaded.
-  def self.load(source, options = {})
-    if defined? MultiJson
-      MultiJson.load(source, options)
-    else
-      if string.respond_to?(:force_encoding)
-          string = string.dup.force_encoding(::Encoding::ASCII_8BIT)
-      end
-
-      options[:symbolize_names] = true if options.delete(:symbolize_keys)
-      ::JSON.parse(string, options)
+module Puppet::Util
+  module Json
+    class ParseError < StandardError
     end
-  end
 
-  def self.dump(object, options = {})
-    if defined? MultiJson
-      MultiJson.dump(object, options)
-    else
-      options.merge!(::JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)
-      object.to_json(options)
+    begin
+      require 'multi_json'
+    rescue LoadError
+      require 'json'
+    end
+
+    # These methods do similar processing to the fallback implemented by MultiJson
+    # when using the built-in JSON backend, to ensure consistent behavior
+    # whether or not Puppet::Util::Json can be loaded.
+    def self.load(string, options = {})
+      if defined? MultiJson
+        begin
+          MultiJson.load(string, options)
+        rescue MultiJson::ParseError => e
+          raise Puppet::Util::Json::ParseError, e.cause
+        end
+      else
+        begin
+          if string.nil?
+            raise Puppet::Util::Json::ParseError, "Invalid JSON: nil input"
+          end
+
+          string = string.read if string.respond_to?(:read)
+
+          if string.respond_to?(:force_encoding)
+            string = string.dup.force_encoding(::Encoding::ASCII_8BIT)
+          end
+
+          options[:symbolize_names] = true if options.delete(:symbolize_keys)
+          ::JSON.parse(string, options)
+        rescue JSON::ParserError => e
+          raise Puppet::Util::Json::ParseError, e.message
+        end
+      end
+    end
+
+    def self.dump(object, options = {})
+      if defined? MultiJson
+        MultiJson.dump(object, options)
+      else
+        options.merge!(::JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)
+        object.to_json(options)
+      end
     end
   end
 end

--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -35,8 +35,8 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
     return nil unless file_locked?
     file_contents = super
     return nil if file_contents.nil? or file_contents.empty?
-    JSON.parse(file_contents)
-  rescue JSON::ParserError
+    MultiJson.load(file_contents)
+  rescue MultiJson::ParseError
     Puppet.warning _("Unable to read lockfile data from %{path}: not in JSON") % { path: @file_path }
     nil
   end

--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -35,8 +35,8 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
     return nil unless file_locked?
     file_contents = super
     return nil if file_contents.nil? or file_contents.empty?
-    MultiJson.load(file_contents)
-  rescue MultiJson::ParseError
+    Puppet::Util::Json.load(file_contents)
+  rescue Puppet::Util::Json::ParseError
     Puppet.warning _("Unable to read lockfile data from %{path}: not in JSON") % { path: @file_path }
     nil
   end

--- a/lib/puppet/util/json_lockfile.rb
+++ b/lib/puppet/util/json_lockfile.rb
@@ -23,7 +23,7 @@ class Puppet::Util::JsonLockfile < Puppet::Util::Lockfile
   def lock(lock_data = nil)
     return false if locked?
 
-    super(lock_data.to_json)
+    super(Puppet::Util::Json.dump(lock_data))
   end
 
   # Retrieve the (optional) lock data that was specified at the time the file

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -109,7 +109,7 @@ Puppet::Util::Log.newdesttype :file do
   def handle(msg)
     if @json > 0
       @json > 1 ? @file.puts(',') : @json = 2
-      MultiJson.dump(msg.to_structured_hash, @file)
+      Puppet::Util::Json.dump(msg.to_structured_hash, @file)
     else
       @file.puts("#{msg.time} #{msg.source} (#{msg.level}): #{msg}")
     end

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -135,7 +135,7 @@ Puppet::Util::Log.newdesttype :logstash_event do
 
   def handle(msg)
     message = format(msg)
-    $stdout.puts message.to_json
+    $stdout.puts Puppet::Util::Json.dump(message)
   end
 end
 

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -109,7 +109,7 @@ Puppet::Util::Log.newdesttype :file do
   def handle(msg)
     if @json > 0
       @json > 1 ? @file.puts(',') : @json = 2
-      JSON.dump(msg.to_structured_hash, @file)
+      MultiJson.dump(msg.to_structured_hash, @file)
     else
       @file.puts("#{msg.time} #{msg.source} (#{msg.level}): #{msg}")
     end

--- a/spec/integration/network/http/api/indirected_routes_spec.rb
+++ b/spec/integration/network/http/api/indirected_routes_spec.rb
@@ -7,7 +7,7 @@ require 'puppet/network/http/rack/rest'
 require 'puppet/indirector_proxy'
 require 'puppet_spec/files'
 require 'puppet_spec/network'
-require 'json'
+require 'multi_json'
 
 describe Puppet::Network::HTTP::API::IndirectedRoutes do
   include PuppetSpec::Files
@@ -33,7 +33,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
                                          {:accept_header => 'unknown, text/pson'},
                                          {:environment => 'production', :checksum_type => checksum_type})
           handler.call(request, response)
-          resp = JSON.parse(response.body)
+          resp = MultiJson.load(response.body)
 
           expect(resp['checksum']['type']).to eq(checksum_type)
           expect(checksum_valid(checksum_type, checksum, resp['checksum']['value'])).to be_truthy
@@ -44,7 +44,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
                                             {:accept_header => 'unknown, text/pson'},
                                             {:environment => 'production', :checksum_type => checksum_type, :recurse => 'yes'})
           handler.call(request, response)
-          resp = JSON.parse(response.body)
+          resp = MultiJson.load(response.body)
 
           expect(resp.length).to eq(2)
           file = resp.find {|x| x['relative_path'] == 'file.rb'}
@@ -67,7 +67,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
           handler.process(request, response)
 
           expect(response.header["Content-Type"]).to match(/json/)
-          resp = JSON.parse(response.body.first)
+          resp = MultiJson.load(response.body.first)
           expect(resp["message"]).to match(/The indirection name must be purely alphanumeric/)
           expect(resp["issue_kind"]).to be_a_kind_of(String)
         end
@@ -79,7 +79,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
           handler.process(request, response)
 
           expect(response.header["Content-Type"]).to match(/json/)
-          resp = JSON.parse(response.body.first)
+          resp = MultiJson.load(response.body.first)
           expect(resp["message"]).to match(/Could not find indirection/)
           expect(resp["issue_kind"]).to be_a_kind_of(String)
         end

--- a/spec/integration/network/http/api/indirected_routes_spec.rb
+++ b/spec/integration/network/http/api/indirected_routes_spec.rb
@@ -7,7 +7,7 @@ require 'puppet/network/http/rack/rest'
 require 'puppet/indirector_proxy'
 require 'puppet_spec/files'
 require 'puppet_spec/network'
-require 'multi_json'
+require 'puppet/util/json'
 
 describe Puppet::Network::HTTP::API::IndirectedRoutes do
   include PuppetSpec::Files
@@ -33,7 +33,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
                                          {:accept_header => 'unknown, text/pson'},
                                          {:environment => 'production', :checksum_type => checksum_type})
           handler.call(request, response)
-          resp = MultiJson.load(response.body)
+          resp = Puppet::Util::Json.load(response.body)
 
           expect(resp['checksum']['type']).to eq(checksum_type)
           expect(checksum_valid(checksum_type, checksum, resp['checksum']['value'])).to be_truthy
@@ -44,7 +44,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
                                             {:accept_header => 'unknown, text/pson'},
                                             {:environment => 'production', :checksum_type => checksum_type, :recurse => 'yes'})
           handler.call(request, response)
-          resp = MultiJson.load(response.body)
+          resp = Puppet::Util::Json.load(response.body)
 
           expect(resp.length).to eq(2)
           file = resp.find {|x| x['relative_path'] == 'file.rb'}
@@ -67,7 +67,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
           handler.process(request, response)
 
           expect(response.header["Content-Type"]).to match(/json/)
-          resp = MultiJson.load(response.body.first)
+          resp = Puppet::Util::Json.load(response.body.first)
           expect(resp["message"]).to match(/The indirection name must be purely alphanumeric/)
           expect(resp["issue_kind"]).to be_a_kind_of(String)
         end
@@ -79,7 +79,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
           handler.process(request, response)
 
           expect(response.header["Content-Type"]).to match(/json/)
-          resp = MultiJson.load(response.body.first)
+          resp = Puppet::Util::Json.load(response.body.first)
           expect(resp["message"]).to match(/Could not find indirection/)
           expect(resp["issue_kind"]).to be_a_kind_of(String)
         end

--- a/spec/lib/matchers/json.rb
+++ b/spec/lib/matchers/json.rb
@@ -9,7 +9,7 @@ module JSONMatchers
     end
 
     def json(instance)
-      MultiJson.load(instance.to_json)
+      Puppet::Util::Json.load(instance.to_json)
     end
 
     def attr_value(attrs, instance)
@@ -102,11 +102,11 @@ module JSONMatchers
   end
 
   if !Puppet.features.microsoft_windows?
-    require 'multi_json'
+    require 'puppet/util/json'
     require 'json-schema'
 
     class SchemaMatcher
-      JSON_META_SCHEMA = MultiJson.load(File.read('api/schemas/json-meta-schema.json'))
+      JSON_META_SCHEMA = Puppet::Util::Json.load(File.read('api/schemas/json-meta-schema.json'))
 
       def initialize(schema)
         @schema = schema
@@ -123,7 +123,7 @@ module JSONMatchers
     if Puppet.features.microsoft_windows?
       pending("Schema checks cannot be done on windows because of json-schema problems")
     else
-      schema = MultiJson.load(File.read(schema_file))
+      schema = Puppet::Util::Json.load(File.read(schema_file))
       SchemaMatcher.new(schema)
     end
   end

--- a/spec/lib/matchers/json.rb
+++ b/spec/lib/matchers/json.rb
@@ -9,7 +9,7 @@ module JSONMatchers
     end
 
     def json(instance)
-      JSON.parse(instance.to_json)
+      MultiJson.load(instance.to_json)
     end
 
     def attr_value(attrs, instance)
@@ -102,11 +102,11 @@ module JSONMatchers
   end
 
   if !Puppet.features.microsoft_windows?
-    require 'json'
+    require 'multi_json'
     require 'json-schema'
 
     class SchemaMatcher
-      JSON_META_SCHEMA = JSON.parse(File.read('api/schemas/json-meta-schema.json'))
+      JSON_META_SCHEMA = MultiJson.load(File.read('api/schemas/json-meta-schema.json'))
 
       def initialize(schema)
         @schema = schema
@@ -123,7 +123,7 @@ module JSONMatchers
     if Puppet.features.microsoft_windows?
       pending("Schema checks cannot be done on windows because of json-schema problems")
     else
-      schema = JSON.parse(File.read(schema_file))
+      schema = MultiJson.load(File.read(schema_file))
       SchemaMatcher.new(schema)
     end
   end

--- a/spec/lib/puppet_spec/module_tool/shared_functions.rb
+++ b/spec/lib/puppet_spec/module_tool/shared_functions.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 
 module PuppetSpec
   module ModuleTool
@@ -15,7 +15,7 @@ module PuppetSpec
         moddir = File.join(options[:into], name)
         FileUtils.mkdir_p(moddir)
         File.open(File.join(moddir, 'metadata.json'), 'w') do |file|
-          file.puts(JSON.generate(release.metadata))
+          file.puts(MultiJson.dump(release.metadata))
         end
       end
 

--- a/spec/lib/puppet_spec/module_tool/shared_functions.rb
+++ b/spec/lib/puppet_spec/module_tool/shared_functions.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'puppet/util/json'
 
 module PuppetSpec
   module ModuleTool
@@ -15,7 +15,7 @@ module PuppetSpec
         moddir = File.join(options[:into], name)
         FileUtils.mkdir_p(moddir)
         File.open(File.join(moddir, 'metadata.json'), 'w') do |file|
-          file.puts(MultiJson.dump(release.metadata))
+          file.puts(Puppet::Util::Json.dump(release.metadata))
         end
       end
 

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -343,7 +343,7 @@ describe Puppet::Application::FaceBase do
 
       it "should render a non-trivially-keyed Hash with using pretty printed JSON" do
         hash = { [1,2] => 3, [2,3] => 5, [3,4] => 7 }
-        expect(app.render(hash, {})).to eq(JSON.pretty_generate(hash).chomp)
+        expect(app.render(hash, {})).to eq(Puppet::Util::Json.dump(hash, :pretty => true).chomp)
       end
 
       it "should render a {String,Numeric}-keyed Hash into a table" do
@@ -356,7 +356,7 @@ describe Puppet::Application::FaceBase do
         expect(app.render(hash, {})).to eq <<EOT
 5      5
 6.0    6
-four   #{object.to_json.chomp}
+four   #{Puppet::Util::Json.dump(object).chomp}
 one    1
 three  {}
 two    []

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'json'
+require 'multi_json'
 require 'puppet/indirector'
 require 'puppet/indirector/errors'
 require 'puppet/indirector/rest'
@@ -52,7 +52,7 @@ shared_examples_for "a REST terminus method" do |terminus_method|
     describe "when the response code is #{code}" do
       let(:message) { 'error messaged!!!' }
       let(:body) do
-        JSON.generate({
+        MultiJson.dump({
           :issue_kind => 'server-error',
           :message    => message
         })

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'multi_json'
+require 'puppet/util/json'
 require 'puppet/indirector'
 require 'puppet/indirector/errors'
 require 'puppet/indirector/rest'
@@ -52,7 +52,7 @@ shared_examples_for "a REST terminus method" do |terminus_method|
     describe "when the response code is #{code}" do
       let(:message) { 'error messaged!!!' }
       let(:body) do
-        MultiJson.dump({
+        Puppet::Util::Json.dump({
           :issue_kind => 'server-error',
           :message    => message
         })

--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'multi_json'
+require 'puppet/util/json'
 
 require 'puppet/module_tool/applications'
 require 'puppet/file_system'
@@ -23,7 +23,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))
       File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
-        file.puts MultiJson.dump('name' => module_name, 'version' => '1.0.0')
+        file.puts Puppet::Util::Json.dump('name' => module_name, 'version' => '1.0.0')
       end
       true
     end
@@ -39,7 +39,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))
       File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
-        file.puts MultiJson.dump('name' => module_name, 'version' => '1.0.0')
+        file.puts Puppet::Util::Json.dump('name' => module_name, 'version' => '1.0.0')
       end
       FileUtils.touch(File.join(dest, 'extractedmodule/tempfile'))
       Puppet::FileSystem.symlink(File.join(dest, 'extractedmodule/tempfile'), File.join(dest, 'extractedmodule/tempfile2'))
@@ -58,7 +58,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))
       File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
-        file.puts MultiJson.dump('name' => module_name, 'version' => '1.0.0')
+        file.puts Puppet::Util::Json.dump('name' => module_name, 'version' => '1.0.0')
       end
       FileUtils.mkdir(File.join(dest, 'extractedmodule/manifests'))
       FileUtils.touch(File.join(dest, 'extractedmodule/manifests/tempfile'))

--- a/spec/unit/module_tool/applications/unpacker_spec.rb
+++ b/spec/unit/module_tool/applications/unpacker_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'json'
+require 'multi_json'
 
 require 'puppet/module_tool/applications'
 require 'puppet/file_system'
@@ -23,7 +23,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))
       File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
-        file.puts JSON.generate('name' => module_name, 'version' => '1.0.0')
+        file.puts MultiJson.dump('name' => module_name, 'version' => '1.0.0')
       end
       true
     end
@@ -39,7 +39,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))
       File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
-        file.puts JSON.generate('name' => module_name, 'version' => '1.0.0')
+        file.puts MultiJson.dump('name' => module_name, 'version' => '1.0.0')
       end
       FileUtils.touch(File.join(dest, 'extractedmodule/tempfile'))
       Puppet::FileSystem.symlink(File.join(dest, 'extractedmodule/tempfile'), File.join(dest, 'extractedmodule/tempfile2'))
@@ -58,7 +58,7 @@ describe Puppet::ModuleTool::Applications::Unpacker do
     untar.expects(:unpack).with(filename, anything()) do |src, dest, _|
       FileUtils.mkdir(File.join(dest, 'extractedmodule'))
       File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
-        file.puts JSON.generate('name' => module_name, 'version' => '1.0.0')
+        file.puts MultiJson.dump('name' => module_name, 'version' => '1.0.0')
       end
       FileUtils.mkdir(File.join(dest, 'extractedmodule/manifests'))
       FileUtils.touch(File.join(dest, 'extractedmodule/manifests/tempfile'))

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -333,10 +333,6 @@ describe "Puppet Network Format" do
       expect(json.weight).to eq(15)
     end
 
-    it "should use the native JSON gem" do
-      expect(MultiJson.adapter).to eq(MultiJson::Adapters::JsonGem)
-    end
-
     it "should render an instance as JSON" do
       instance = FormatsTest.new("foo")
       expect(json.render(instance)).to eq({"string" => "foo"}.to_json)
@@ -348,20 +344,20 @@ describe "Puppet Network Format" do
     end
 
     it "should intern an instance from a JSON hash" do
-      text = MultiJson.dump({"string" => "parsed_json"})
+      text = Puppet::Util::Json.dump({"string" => "parsed_json"})
       instance = json.intern(FormatsTest, text)
       expect(instance.string).to eq("parsed_json")
     end
 
     it "should skip data_to_hash if data is already an instance of the specified class" do
       # The rest terminus for the report indirected type relies on this behavior
-      data = MultiJson.dump([1, 2])
+      data = Puppet::Util::Json.dump([1, 2])
       instance = json.intern(Array, data)
       expect(instance).to eq([1, 2])
     end
 
     it "should intern multiple instances from a JSON array of hashes" do
-      text = MultiJson.dump(
+      text = Puppet::Util::Json.dump(
         [
           {
             "string" => "BAR"
@@ -375,7 +371,7 @@ describe "Puppet Network Format" do
     end
 
     it "should reject wrapped data from legacy clients as they've never supported JSON" do
-      text = MultiJson.dump(
+      text = Puppet::Util::Json.dump(
         {
           "type" => "FormatsTest",
           "data" => {
@@ -389,8 +385,8 @@ describe "Puppet Network Format" do
 
     it "fails intelligibly when given invalid data" do
       expect do
-        json.intern(Puppet::Node, ' ')
-      end.to raise_error(MultiJson::ParseError)
+        json.intern(Puppet::Node, '')
+      end.to raise_error(Puppet::Util::Json::ParseError)
     end
   end
 

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -333,12 +333,8 @@ describe "Puppet Network Format" do
       expect(json.weight).to eq(15)
     end
 
-    it "should use a native parser implementation" do
-      expect(JSON.parser.name).to eq("JSON::Ext::Parser")
-    end
-
-    it "should use a native generator implementation" do
-      expect(JSON.generator.name).to eq("JSON::Ext::Generator")
+    it "should use the native JSON gem" do
+      expect(MultiJson.adapter).to eq(MultiJson::Adapters::JsonGem)
     end
 
     it "should render an instance as JSON" do
@@ -352,20 +348,20 @@ describe "Puppet Network Format" do
     end
 
     it "should intern an instance from a JSON hash" do
-      text = JSON.dump({"string" => "parsed_json"})
+      text = MultiJson.dump({"string" => "parsed_json"})
       instance = json.intern(FormatsTest, text)
       expect(instance.string).to eq("parsed_json")
     end
 
     it "should skip data_to_hash if data is already an instance of the specified class" do
       # The rest terminus for the report indirected type relies on this behavior
-      data = JSON.dump([1, 2])
+      data = MultiJson.dump([1, 2])
       instance = json.intern(Array, data)
       expect(instance).to eq([1, 2])
     end
 
     it "should intern multiple instances from a JSON array of hashes" do
-      text = JSON.dump(
+      text = MultiJson.dump(
         [
           {
             "string" => "BAR"
@@ -379,7 +375,7 @@ describe "Puppet Network Format" do
     end
 
     it "should reject wrapped data from legacy clients as they've never supported JSON" do
-      text = JSON.dump(
+      text = MultiJson.dump(
         {
           "type" => "FormatsTest",
           "data" => {
@@ -393,8 +389,8 @@ describe "Puppet Network Format" do
 
     it "fails intelligibly when given invalid data" do
       expect do
-        json.intern(Puppet::Node, '')
-      end.to raise_error(JSON::ParserError, /A JSON text must at least contain two octets|unexpected token at ''/)
+        json.intern(Puppet::Node, ' ')
+      end.to raise_error(MultiJson::ParseError)
     end
   end
 

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'json'
+require 'multi_json'
 
 require 'puppet/util/log'
 
@@ -143,7 +143,7 @@ describe Puppet::Util::Log.desttypes[:logstash_event] do
     it "format returns a structure that can be converted to json" do
       dest = described_class.new
       hash = dest.format(@msg)
-      JSON.parse(hash.to_json)
+      MultiJson.load(hash.to_json)
     end
 
     it "handle should send the output to stdout" do

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'multi_json'
+require 'puppet/util/json'
 
 require 'puppet/util/log'
 
@@ -143,7 +143,7 @@ describe Puppet::Util::Log.desttypes[:logstash_event] do
     it "format returns a structure that can be converted to json" do
       dest = described_class.new
       hash = dest.format(@msg)
-      MultiJson.load(hash.to_json)
+      Puppet::Util::Json.load(hash.to_json)
     end
 
     it "handle should send the output to stdout" do


### PR DESCRIPTION
In order to allow us to use the faster jackson backend for JSON parsing
server-side, we need to be able to choose which library to use for JSON
parsing based on what is available. MultiJson chooses from a
prioritized list at startup, based on which libraries are known to be the
fastest. On the server side, that will be Jackson (or rather, the JRuby
wrapper for Jackson, JrJackson), while on the agent side it is currently
the built-in JSON gem. Using MultiJson gives us options for
transparently switching to a faster backend agent-side in the future,
without requiring more code changes.