### PR TITLE
(PUP-2868) Add information about section and environment to config

### DIFF
--- a/spec/integration/faces/config_spec.rb
+++ b/spec/integration/faces/config_spec.rb
@@ -64,6 +64,10 @@ rando_key=foobar
       config.get_action(action).when_rendering(:console).call(result)
     end
 
+    before :each do
+      subject.stubs(:report_section_and_environment)
+    end
+
     # key must be a defined setting
     ['rando_key', MIXED_UTF8].each do |key|
       it "can change '#{key}' keyed ASCII value to a UTF-8 value and read it back" do


### PR DESCRIPTION
Without this change, it is confusing to users what section is used in the config when they don't specify a section for the config command.  With this change, a message is printed to stderr for all commands, and an extra warning is given to the print command if the user doesn't specify a section.