### PR TITLE
(docs) Replace Latin abbreviations with English.

### DIFF
--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -150,13 +150,13 @@ Puppet::Type.newtype(:augeas) do
   end
 
   newparam(:lens) do
-    desc "Use a specific lens, e.g. `Hosts.lns`. When this parameter is set, you
+    desc "Use a specific lens, such as `Hosts.lns`. When this parameter is set, you
       must also set the `incl` parameter to indicate which file to load.
       The Augeas documentation includes [a list of available lenses](http://augeas.net/stock_lenses.html)."
   end
 
   newparam(:incl) do
-    desc "Load only a specific file, e.g. `/etc/hosts`. This can greatly speed
+    desc "Load only a specific file, such as `/etc/hosts`. This can greatly speed
       up the execution the resource. When this parameter is set, you must also
       set the `lens` parameter to indicate which lens to use."
   end

--- a/lib/puppet/type/cron.rb
+++ b/lib/puppet/type/cron.rb
@@ -278,9 +278,11 @@ Puppet::Type.newtype(:cron) do
       %w{sunday monday tuesday wednesday thursday friday saturday}
     end
     self.boundaries = [0, 7]
-    desc "The weekday on which to run the command.
-      Optional; if specified, must be between 0 and 7, inclusive, with
-      0 (or 7) being Sunday, or must be the name of the day (e.g., Tuesday)."
+    desc "The weekday on which to run the command. Optional; if specified,
+      must be either:
+
+      -   A number between 0 and 7, inclusive, with 0 or 7 being Sunday
+      -   The name of the day, such as 'Tuesday'."
   end
 
   newproperty(:month, :parent => CronParam) do
@@ -293,8 +295,11 @@ Puppet::Type.newtype(:cron) do
         august september october november december}
     end
     self.boundaries = [1, 12]
-    desc "The month of the year.  Optional; if specified
-      must be between 1 and 12 or the month name (e.g., December)."
+    desc "The month of the year. Optional; if specified,
+      must be either:
+
+      -   A number between 1 and 12, inclusive, with 1 being January
+      -   The name of the month, such as 'December'."
   end
 
   newproperty(:monthday, :parent => CronParam) do
@@ -317,7 +322,7 @@ Puppet::Type.newtype(:cron) do
       but will not associate them with a specific job.
 
       Settings should be specified exactly as they should appear in
-      the crontab, e.g., `PATH=/bin:/usr/bin:/usr/sbin`."
+      the crontab, like `PATH=/bin:/usr/bin:/usr/sbin`."
 
     validate do |value|
       unless value =~ /^\s*(\w+)\s*=\s*(.*)\s*$/ or value == :absent or value == "absent"

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -257,7 +257,7 @@ module Puppet
 
     newparam(:environment) do
       desc "An array of any additional environment variables you want to set for a
-        command. e.g.: `[ 'HOME=/root', 'MAIL=root@example.com']`
+        command, such as `[ 'HOME=/root', 'MAIL=root@example.com']`.
         Note that if you use this to set PATH, it will override the `path`
         attribute. Multiple environment variables should be specified as an
         array."

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -74,7 +74,7 @@ Puppet::Type.newtype(:file) do
       (`File { backup => main }`), so it can affect all file resources.
 
       * If set to `false`, file content won't be backed up.
-      * If set to a string beginning with `.` (e.g., `.puppet-bak`), Puppet will
+      * If set to a string beginning with `.`, such as `.puppet-bak`, Puppet will
         use copy the file in the same directory with that value as the extension
         of the backup. (A value of `true` is a synonym for `.puppet-bak`.)
       * If set to any other string, Puppet will try to back up to a filebucket
@@ -187,8 +187,7 @@ Puppet::Type.newtype(:file) do
       Setting `recurselimit => 2` will manage the direct contents of the
       directory, as well as the contents of the _first_ level of subdirectories.
 
-      And so on --- 3 will manage the contents of the second level of
-      subdirectories, etc."
+      This pattern continues for each incremental value of `recurselimit`."
 
     newvalues(/^[0-9]+$/)
 
@@ -225,9 +224,9 @@ Puppet::Type.newtype(:file) do
   newparam(:ignore) do
     desc "A parameter which omits action on files matching
       specified patterns during recursion.  Uses Ruby's builtin globbing
-      engine, so shell metacharacters are fully supported, e.g. `[a-z]*`.
+      engine, so shell metacharacters such as `[a-z]*` are fully supported.
       Matches that would descend into the directory structure are ignored,
-      e.g., `*/*`."
+      such as `*/*`."
 
     validate do |value|
       unless value.is_a?(Array) or value.is_a?(String) or value == false

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -9,8 +9,8 @@ require 'puppet/parameter/boolean'
 module Puppet
   Type.newtype(:package) do
     @doc = "Manage packages.  There is a basic dichotomy in package
-      support right now:  Some package types (e.g., yum and apt) can
-      retrieve their own package files, while others (e.g., rpm and sun)
+      support right now:  Some package types (such as yum and apt) can
+      retrieve their own package files, while others (such as rpm and sun)
       cannot.  For those package formats that cannot retrieve their own files,
       you can use the `source` parameter to point to the correct file.
 
@@ -242,7 +242,7 @@ module Puppet
             name   => $ssl,
           }
 
-          . etc. .
+          ...
 
           $ssh = $operatingsystem ? {
             solaris => SMCossh,

--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -18,8 +18,8 @@ module Puppet
       time within that schedule, then the resources will get applied;
       otherwise, that work may never get done.
 
-      Thus, it is advisable to use wider scheduling (e.g., over a couple of
-      hours) combined with periods and repetitions.  For instance, if you
+      Thus, it is advisable to use wider scheduling (for example, over a couple
+      of hours) combined with periods and repetitions.  For instance, if you
       wanted to restrict certain resources to only running once, between
       the hours of two and 4 AM, then you would use this schedule:
 
@@ -36,7 +36,7 @@ module Puppet
       because they will be outside the scheduled range.
 
       Puppet automatically creates a schedule for each of the valid periods
-      with the same name as that period (e.g., hourly and daily).
+      with the same name as that period (such as hourly and daily).
       Additionally, a schedule named `puppet` is created and used as the
       default, with the following attributes:
 
@@ -83,7 +83,7 @@ module Puppet
         This is mostly useful for restricting certain resources to being
         applied in maintenance windows or during off-peak hours. Multiple
         ranges can be applied in array context. As a convenience when specifying
-        ranges, you may cross midnight (e.g.: range => "22:00 - 04:00").
+        ranges, you can cross midnight (for example, `range => "22:00 - 04:00"`).
       EOT
 
       # This is lame; properties all use arrays as values, but parameters don't.
@@ -225,9 +225,9 @@ module Puppet
     end
 
     newparam(:periodmatch) do
-      desc "Whether periods should be matched by number (e.g., the two times
-        are in the same hour) or by distance (e.g., the two times are
-        60 minutes apart)."
+      desc "Whether periods should be matched by a numeric value (for instance,
+        whether two times are in the same hour) or by their chronological
+        distance apart (whether two times are 60 minutes apart)."
 
       newvalues(:number, :distance)
 
@@ -241,8 +241,8 @@ module Puppet
 
         Note that the period defines how often a given resource will get
         applied but not when; if you would like to restrict the hours
-        that a given resource can be applied (e.g., only at night during
-        a maintenance window), then use the `range` attribute.
+        that a given resource can be applied (for instance, only at night
+        during a maintenance window), then use the `range` attribute.
 
         If the provided periods are not sufficient, you can provide a
         value to the *repeat* attribute, which will cause Puppet to
@@ -258,9 +258,9 @@ module Puppet
 
         At the moment, Puppet cannot guarantee that level of repetition; that
         is, the resource can applied _up to_ every 10 minutes, but internal
-        factors might prevent it from actually running that often (e.g. if a
-        Puppet run is still in progress when the next run is scheduled to start,
-        that next run will be suppressed).
+        factors might prevent it from actually running that often (for instance,
+        if a Puppet run is still in progress when the next run is scheduled to
+        start, that next run will be suppressed).
 
         See the `periodmatch` attribute for tuning whether to match
         times by their distance apart or by their specific value.

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -107,10 +107,10 @@ Puppet::Type.newtype(:scheduled_task) do
             minutes_interval.
       * For `daily` triggers:
           * `every` --- How often the task should run, as a number of days. Defaults
-            to 1. ("2" means every other day, "3" means every three days, etc.)
+            to 1. ("2" means every other day, "3" means every three days, and so on)
       * For `weekly` triggers:
           * `every` --- How often the task should run, as a number of weeks. Defaults
-            to 1. ("2" means every other week, "3" means every three weeks, etc.)
+            to 1. ("2" means every other week, "3" means every three weeks, and so on)
           * `day_of_week` --- Which days of the week the task should run, as an array.
             Defaults to all days. Each day must be one of `mon`, `tues`,
             `wed`, `thurs`, `fri`, `sat`, `sun`, or `all`.

--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -66,8 +66,8 @@ module Puppet
         Make sure to omit the following in this attribute (and specify them in
         other attributes):
 
-        * Key headers (e.g. 'ssh-rsa') --- put these in the `type` attribute.
-        * Key identifiers / comments (e.g. 'joe@joescomputer.local') --- put these in
+        * Key headers, such as 'ssh-rsa' --- put these in the `type` attribute.
+        * Key identifiers / comments, such as 'joe@joescomputer.local' --- put these in
           the `name` attribute/resource title."
 
       validate do |value|
@@ -82,9 +82,9 @@ module Puppet
 
     newproperty(:target) do
       desc "The absolute filename in which to store the SSH key. This
-        property is optional and should only be used in cases where keys
-        are stored in a non-standard location (i.e.` not in
-        `~user/.ssh/authorized_keys`)."
+        property is optional and should be used only in cases where keys
+        are stored in a non-standard location, for instance when not in
+        `~user/.ssh/authorized_keys`."
 
       defaultto :absent
 

--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -25,8 +25,8 @@ module Puppet
         Make sure to omit the following in this attribute (and specify them in
         other attributes):
 
-        * Key headers (e.g. 'ssh-rsa') --- put these in the `type` attribute.
-        * Key identifiers / comments (e.g. 'joescomputer.local') --- put these in
+        * Key headers, such as 'ssh-rsa' --- put these in the `type` attribute.
+        * Key identifiers / comments, such as 'joescomputer.local' --- put these in
           the `name` attribute/resource title."
     end
 

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -105,7 +105,7 @@ Puppet::Type.newtype(:tidy) do
     desc "Tidy files whose age is equal to or greater than
       the specified time.  You can choose seconds, minutes,
       hours, days, or weeks by specifying the first letter of any
-      of those words (e.g., '1w').
+      of those words (for example, '1w' represents one week).
 
       Specifying 0 will remove all files."
 


### PR DESCRIPTION
For clarity and to aid in localization, remove Latin abbreviations and replace them with English equivalents.

CC @mindymo; this PR is for the March potholes project with edits to content in code repos used to generate docs content.