### PR TITLE
(PUP-8497) Add the `length` function from stdlib to puppet

### DIFF
--- a/lib/puppet/functions/length.rb
+++ b/lib/puppet/functions/length.rb
@@ -1,0 +1,44 @@
+# Returns the length of an Array, Hash, String, or Binary value.
+#
+# The returned value is a positive integer indicating the number
+# of elements in the container; counting (possibly multibyte) characters for a `String`,
+# bytes in a `Binary`, number of elements in an `Array`, and number of
+# key-value associations in a Hash.
+#
+# @example Using `length`
+#
+# ```puppet
+# "roses".length()        # 5
+# length("violets")       # 7
+# [10, 20].length         # 2
+# {a => 1, b => 3}.length # 2
+# ```
+#
+# @since 5.5.0 - also supporting Binary
+#
+Puppet::Functions.create_function(:length) do
+  dispatch :collection_length do
+    param 'Collection', :arg
+  end
+
+  dispatch :string_length do
+    param 'String', :arg
+  end
+
+  dispatch :binary_length do
+    param 'Binary', :arg
+  end
+
+  def collection_length(col)
+    col.size
+  end
+
+  def string_length(s)
+    s.length
+  end
+
+  def binary_length(bin)
+    bin.length
+  end
+
+end

--- a/spec/unit/functions/length_spec.rb
+++ b/spec/unit/functions/length_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the length function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  context 'for an array it' do
+    it 'returns 0 when empty' do
+      expect(compile_to_catalog("notify { String(length([])): }")).to have_resource('Notify[0]')
+    end
+
+    it 'returns number of elements when not empty' do
+      expect(compile_to_catalog("notify { String(length([1, 2, 3])): }")).to have_resource('Notify[3]')
+    end
+  end
+
+  context 'for a hash it' do
+    it 'returns 0 empty' do
+      expect(compile_to_catalog("notify { String(length({})): }")).to have_resource('Notify[0]')
+    end
+
+    it 'returns number of elements when not empty' do
+      expect(compile_to_catalog("notify { String(length({1=>1,2=>2})): }")).to have_resource('Notify[2]')
+    end
+  end
+
+  context 'for a string it' do
+    it 'returns 0 when empty' do
+      expect(compile_to_catalog("notify { String(length('')): }")).to have_resource('Notify[0]')
+    end
+
+    it 'returns number of characters when not empty' do
+      # note the multibyte characters - åäö each taking two bytes in UTF-8
+      expect(compile_to_catalog('notify { String(length("\u00e5\u00e4\u00f6")): }')).to have_resource('Notify[3]')
+    end
+  end
+
+  context 'for a binary it' do
+    it 'returns 0 when empty' do
+      expect(compile_to_catalog("notify { String(length(Binary(''))): }")).to have_resource('Notify[0]')
+    end
+
+    it 'returns number of bytes when not empty' do
+      expect(compile_to_catalog("notify { String(length(Binary('b25l'))): }")).to have_resource('Notify[3]')
+    end
+  end
+end


### PR DESCRIPTION
This also adds support for the `Binary` data type, and adds
documentation with examples.