### PR TITLE
(PUP-7307) Only tidy unmanaged files

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -310,6 +310,10 @@ Puppet::Type.newtype(:tidy) do
 
   # Should we remove the specified file?
   def tidy?(path)
+    # ignore files that are already managed, since we can't tidy
+    # those files anyway
+    return false if catalog.resource(:file, path)
+
     return false unless stat = self.stat(path)
 
     return false if stat.ftype == "directory" and ! rmdirs?

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -316,6 +316,8 @@ describe tidy do
     describe "and determining whether a file should be tidied" do
       before do
         @tidy = Puppet::Type.type(:tidy).new :path => @basepath
+        @catalog = Puppet::Resource::Catalog.new
+        @tidy.catalog = @catalog
         @stat = stub 'stat', :ftype => "file"
         lstat_is(@basepath, @stat)
       end


### PR DESCRIPTION
Adds a check to the `tidy?` function to ignore file paths that are already managed by file resources, since `tidy` cannot generate file resources for those paths anyway.