### PR TITLE
(PUP-8502) Use node terminus "plain" for lookup CLI unless --compile

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -318,7 +318,17 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       Puppet.settings[:node_cache_terminus] = nil
     end
 
-    node = Puppet::Node.indirection.find(node) unless node.is_a?(Puppet::Node) # to allow unit tests to pass a node instance
+    unless node.is_a?(Puppet::Node) # to allow unit tests to pass a node instance
+      ni = Puppet::Node.indirection
+      tc = ni.terminus_class
+      if tc == :plain || options[:compile]
+        node = ni.find(node)
+      else
+        ni.terminus_class = :plain
+        node = ni.find(node)
+        ni.terminus_class = tc
+      end
+    end
 
     fact_file = options[:fact_file]
 

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -90,6 +90,27 @@ describe 'lookup' do
       expect(lookup('a')).to eql('value a')
     end
 
+    context 'uses node_terminus' do
+      require 'puppet/indirector/node/exec'
+      require 'puppet/indirector/node/plain'
+
+      let(:node) { Puppet::Node.new('testnode', :environment => env) }
+
+      it ':plain without --compile' do
+        Puppet.settings[:node_terminus] = 'exec'
+        Puppet::Node::Plain.any_instance.expects(:find).returns(node)
+        Puppet::Node::Exec.any_instance.expects(:find).never
+        expect(lookup('a')).to eql('value a')
+      end
+
+      it 'configured in Puppet settings with --compile' do
+        Puppet.settings[:node_terminus] = 'exec'
+        Puppet::Node::Plain.any_instance.expects(:find).never
+        Puppet::Node::Exec.any_instance.expects(:find).returns(node)
+        expect(lookup('a', :compile => true)).to eql('value a')
+      end
+    end
+
     context 'configured with the wrong environment' do
       let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, env_name, 'modules')]) }
       it 'does not find data in non-existing environment' do


### PR DESCRIPTION
This commit ensures that the lookup CLI uses the node terminus "plain"
unless given the --compile flag. The reason for this is that an ENC
can pull in classes and cause a compile anyway.

Acceptance tests must be created to ensure that the lookup CLI works
correctly in combination with an ENC. We need tests asserting that:

1. node terminus "plain" is used by the lookup CLI even when another
   terminus such as "exec" is configured.
2. a configured node terminus which is different from "plain" is used
   when the lookup CLI is passed the --compile flag.

Both cases have been tested manually.