### PR TITLE
(PUP-8507) Add function `join` from stdlib to puppet

### DIFF
--- a/lib/puppet/functions/join.rb
+++ b/lib/puppet/functions/join.rb
@@ -1,0 +1,56 @@
+# Joins the values of an Array into a string with elements separated by a delimiter.
+#
+# Supports up to two arguments
+# * **values** - first argument is required and must be an an `Array`
+# * **delimiter** - second arguments is the delimiter between elements, must be a `String` if given, and defaults to an empty string.
+#
+# @example Typical use of `join`
+#
+# ```puppet
+# join(['a','b','c'], ",")
+# # Would result in: "a,b,c"
+# ```
+#
+# Note that array is flattened before elements are joined, but flattening does not extend to arrays nested in hashes or other objects.
+#
+# @example Arrays nested in hashes are not joined
+#
+# ```puppet
+# $a = [1,2, undef, 'hello', [x,y,z], {a => 2, b => [3, 4]}]
+# notice join($a, ', ')
+#
+# # would result in noticing:
+# # 1, 2, , hello, x, y, z, {"a"=>2, "b"=>[3, 4]}
+# ```
+#
+# For joining iterators and other containers of elements a conversion must first be made to
+# an `Array`. The reason for this is that there are many options how such a conversion should
+# be made.
+#
+# @example Joining the result of a reverse_each converted to an array
+# 
+# ```puppet
+# [1,2,3].reverse_each.convert_to(Array).join(', ')
+# # would result in: "3, 2, 1"
+# ```
+# @example Joining a hash
+#
+# ```puppet
+# {a => 1, b => 2}.convert_to(Array).join(', ')
+# # would result in "a, 1, b, 2"
+# ```
+#
+# For more detailed control over the formatting (including indentations and line breaks, delimiters around arrays
+# and hash entries, between key/values in hash entries, and individual formatting of values in the array)
+# see the `new` function for `String` and its formatting options for `Array` and `Hash`.
+#
+Puppet::Functions.create_function(:join) do
+  dispatch :join do
+    param 'Array', :arg
+    optional_param 'String', :delimiter
+  end
+
+  def join(arg, delimiter = '', puppet_formatting = false)
+      arg.join(delimiter)
+  end
+end

--- a/spec/unit/functions/join_spec.rb
+++ b/spec/unit/functions/join_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the join function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'joins an array with empty string delimiter if delimiter is not given' do
+    expect(compile_to_catalog("notify { join([1,2,3]): }")).to have_resource('Notify[123]')
+  end
+
+  it 'joins an array with given string delimiter' do
+    expect(compile_to_catalog("notify { join([1,2,3],'x'): }")).to have_resource('Notify[1x2x3]')
+  end
+
+  it 'results in empty string if array is empty' do
+    expect(compile_to_catalog('notify { "x${join([])}y": }')).to have_resource('Notify[xy]')
+  end
+
+  it 'flattens nested arrays' do
+    expect(compile_to_catalog("notify { join([1,2,[3,4]]): }")).to have_resource('Notify[1234]')
+  end
+
+  it 'does not flatten arrays nested in hashes' do
+    expect(compile_to_catalog("notify { join([1,2,{a => [3,4]}]): }")).to have_resource('Notify[12{"a"=>[3, 4]}]')
+  end
+
+  it 'formats nil/undef as empty string' do
+    expect(compile_to_catalog('notify { join([undef, undef], "x"): }')).to have_resource('Notify[x]')
+  end
+end


### PR DESCRIPTION
In addition to being backwards compatible this version of `join()` also:
* adds support for joining Iterables (such as from `reverse_each` and 
  Hash
* adds support for joining nested hashes and arrays nested in hashes
* improves documentation by including several examples and explains
  details about how the join behaves.