### PR TITLE
(PUP-8495) Systemd support, Ubuntu 17.04 and 17.10

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :coreos
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
-  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10"]
+  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10","17.04","17.10"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 
   def self.instances

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -126,7 +126,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     expect(described_class).not_to be_default
   end
 
-  [ '15.04', '15.10', '16.04', '16.10' ].each do |ver|
+  [ '15.04', '15.10', '16.04', '16.10', '17.04', '17.10' ].each do |ver|
     it "should be the default provider on ubuntu#{ver}" do
       Facter.stubs(:value).with(:osfamily).returns(:debian)
       Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)


### PR DESCRIPTION
This is a trivial patch that adds support for Ubuntu 17.04 and 17.10.