### PR TITLE
(PUP-6639) ignore white space after '=' and before the value

### DIFF
--- a/lib/puppet/util/inifile.rb
+++ b/lib/puppet/util/inifile.rb
@@ -148,7 +148,7 @@ module Puppet::Util::IniConfig
     )
     INI_CONTINUATION = /^[ \t\r\n\f]/
     INI_SECTION_NAME = /^\[([^\]]+)\]/
-    INI_PROPERTY     = /^\s*([^\s=]+)\s*\=(.*)$/
+    INI_PROPERTY     = /^\s*([^\s=]+)\s*\=\s*(.*)$/
 
     # @api private
     def parse(text)
@@ -177,10 +177,9 @@ module Puppet::Util::IniConfig
           section = add_section(section_name)
           optname = nil
         elsif (match = l.match(INI_PROPERTY))
-          # We allow space around the keys, but not the values
-          # For the values, we don't know if space is significant
+          # the regex strips leading white space from the value, and here we strip the trailing white space as well
           key = match[1]
-          val = match[2]
+          val = match[2].rstrip
 
           if section.nil?
             raise IniParseError.new(_("Property with key %{key} outside of a section") % { key: key.inspect })

--- a/spec/unit/util/inifile_spec.rb
+++ b/spec/unit/util/inifile_spec.rb
@@ -159,8 +159,8 @@ describe Puppet::Util::IniConfig::PhysicalFile do
 
     end
 
-    describe "parsing properties" do
-      it "raises an error if the property is not within a section" do
+    describe 'parsing properties' do
+      it 'raises an error if the property is not within a section' do
         text = "key=val\n"
 
         expect {
@@ -169,13 +169,44 @@ describe Puppet::Util::IniConfig::PhysicalFile do
                          /Property with key "key" outside of a section/)
       end
 
-      it "adds the property to the current section" do
+      it 'adds the property to the current section' do
         text = "[main]\nkey=val\n"
 
         subject.parse(text)
         expect(subject.contents).to have(1).items
         sect = subject.contents[0]
-        expect(sect['key']).to eq "val"
+        expect(sect['key']).to eq 'val'
+      end
+
+      context 'with white space' do
+        let(:section) do
+          text = <<-INIFILE
+[main]
+  leading_white_space=value1
+white_space_after_key =value2
+white_space_after_equals= value3
+white_space_after_value=value4\t
+INIFILE
+          subject.parse(text)
+          expect(subject.contents).to have(1).items
+          subject.contents[0]
+        end
+
+        it 'allows and ignores white space before the key' do
+          expect(section['leading_white_space']).to eq('value1')
+        end
+
+        it 'allows and ignores white space before the equals' do
+          expect(section['white_space_after_key']).to eq('value2')
+        end
+
+        it 'allows and ignores white space after the equals' do
+          expect(section['white_space_after_equals']).to eq('value3')
+        end
+
+        it 'allows and ignores white spaces after the value' do
+          expect(section['white_space_after_value']).to eq('value4')
+        end
       end
     end
 


### PR DESCRIPTION
Ignore white space that occurs between the '=' and the value so that the
white space is not included as part of the value.