### PR TITLE
(PUP-8510) Enable custom new_function for ruby Object type implementations

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -484,6 +484,7 @@ class PObjectType < PMetaType
     # @api private
   def create_new_function
     impl_class = implementation_class
+    return impl_class.create_new_function(self) if impl_class.respond_to?(:create_new_function)
 
     (param_names, param_types, required_param_count) = parameter_info(impl_class)
 


### PR DESCRIPTION
This commit adds the ability to specify a custom `new_function` in an
Object data type.