### PR TITLE
(PUP-8494) Retain issue arguments in logs and errors

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -46,7 +46,7 @@ module Puppet
 
   # Contains an issue code and can be annotated with an environment and a node
   class ParseErrorWithIssue < Puppet::ParseError
-    attr_reader :issue_code, :basic_message
+    attr_reader :issue_code, :basic_message, :arguments
     attr_accessor :environment, :node
 
     # @param message [String] The error message
@@ -55,11 +55,13 @@ module Puppet
     # @param pos [Integer] The position on the line
     # @param original [Exception] Original exception
     # @param issue_code [Symbol] The issue code
+    # @param arguments [Hash{Symbol=>Object}] Issue arguments
     #
-    def initialize(message, file=nil, line=nil, pos=nil, original=nil, issue_code= nil)
+    def initialize(message, file=nil, line=nil, pos=nil, original=nil, issue_code= nil, arguments = nil)
       super(message, file, line, pos, original)
       @issue_code = issue_code
       @basic_message = message
+      @arguments = arguments
     end
 
     def to_s
@@ -83,7 +85,8 @@ module Puppet
             line,
             nil,
             nil,
-            issue.issue_code)
+            issue.issue_code,
+            args)
     end
   end
 

--- a/lib/puppet/pops/issue_reporter.rb
+++ b/lib/puppet/pops/issue_reporter.rb
@@ -90,6 +90,7 @@ class IssueReporter
     Puppet::Util::Log.create({
       :level => :warning,
       :message => issue.format(args),
+      :arguments => args,
       :issue_code => issue.issue_code,
       :file => semantic.file,
       :line => semantic.line,
@@ -98,7 +99,7 @@ class IssueReporter
   end
 
   def self.error(exception_class, semantic, issue, args)
-    raise exception_class.new(issue.format(args), semantic.file, semantic.line, semantic.pos, nil, issue.issue_code)
+    raise exception_class.new(issue.format(args), semantic.file, semantic.line, semantic.pos, nil, issue.issue_code, args)
   end
 
   def self.create_exception(exception_class, emit_message, formatter, diagnostic)
@@ -109,7 +110,7 @@ class IssueReporter
       line = diagnostic.source_pos.line
       pos = diagnostic.source_pos.pos
     end
-    exception_class.new(format_with_prefix(emit_message, formatter.format_message(diagnostic)), file, line, pos, nil, diagnostic.issue.issue_code)
+    exception_class.new(format_with_prefix(emit_message, formatter.format_message(diagnostic)), file, line, pos, nil, diagnostic.issue.issue_code, diagnostic.arguments)
   end
   private_class_method :create_exception
 
@@ -124,6 +125,7 @@ class IssueReporter
     Puppet::Util::Log.create({
         :level => severity,
         :message => formatter.format_message(diagnostic),
+        :arguments => diagnostic.arguments,
         :issue_code => diagnostic.issue.issue_code,
         :file => file,
         :line => line,

--- a/lib/puppet/pops/parser/lexer_support.rb
+++ b/lib/puppet/pops/parser/lexer_support.rb
@@ -30,7 +30,7 @@ module LexerSupport
 
   # Raises a Puppet::LexError with the given message
   def lex_error_without_pos(issue, args = {})
-    raise Puppet::ParseErrorWithIssue.new(issue.format(args), nil, nil, nil, nil, issue.issue_code)
+    raise Puppet::ParseErrorWithIssue.new(issue.format(args), nil, nil, nil, nil, issue.issue_code, args)
   end
 
   # Raises a Puppet::ParserErrorWithIssue with the given issue and arguments
@@ -73,7 +73,8 @@ module LexerSupport
         line(pos),
         position(pos),
         nil,
-        issue.issue_code)
+        issue.issue_code,
+        args)
   end
 
   # Asserts that the given string value is a float, or an integer in decimal, octal or hex form.


### PR DESCRIPTION
This commit ensures that the arguments hash used when an issue message
is formatted is retained in logged entries and raised errors. The hash
makes it possible to write tests that asserts that warnings or errors
are emitted with correct input rather than verifying the fully formatted
message using string matching.