### PR TITLE
(PUP-8505) Re-add some server tests back to agent pipeline

### DIFF
--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -8,8 +8,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  tag 'risk:medium',
-      'server'
+  tag 'risk:medium'
 
   test_num        = 'c100300'
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))

--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -11,29 +11,29 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
   tag 'risk:medium',
       'server'
 
-  test_num = 'c100300'
+  test_num        = 'c100300'
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))
-  agent_tmp_dirs = {}
+  agent_tmp_dirs  = {}
   agents.each do |agent|
     agent_tmp_dirs[agent_to_fqdn(agent)] = agent.tmpdir(tmp_environment)
   end
 
   teardown do
     step 'remove all test files on agents' do
-      agents.each { |agent| on(agent, "rm -r '#{agent_tmp_dirs[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true) }
+      agents.each {|agent| on(agent, "rm -r '#{agent_tmp_dirs[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)}
     end
     # note - master teardown is registered by #mk_tmp_environment_with_teardown
   end
 
   step "Create module with binary data file on master" do
     on(master, "mkdir -p #{environmentpath}/#{tmp_environment}/modules/#{test_num}/{manifests,files}")
-    master_module_manifest = "#{environmentpath}/#{tmp_environment}/modules/#{test_num}/manifests/init.pp"
+    master_module_manifest    = "#{environmentpath}/#{tmp_environment}/modules/#{test_num}/manifests/init.pp"
     master_module_binary_file = "#{environmentpath}/#{tmp_environment}/modules/#{test_num}/files/binary_data"
 
     create_remote_file(master, master_module_binary_file, "\xC0\xFF")
     on(master, "chmod 644 #{master_module_binary_file}")
 
-    manifest =<<-MANIFEST
+    manifest = <<-MANIFEST
       class #{test_num}(
       ) {
         \$test_path = \$::fqdn ? #{agent_tmp_dirs}
@@ -50,7 +50,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
 
   step "Create site.pp to classify nodes to include module" do
     site_pp_file = "#{environmentpath}/#{tmp_environment}/manifests/site.pp"
-    site_pp =<<-SITE_PP
+    site_pp      = <<-SITE_PP
       node default {
         include #{test_num}
       }

--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -26,12 +26,12 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
   end
 
   step "Create module with binary data file on master" do
-    on(master, "mkdir -p #{environmentpath}/#{tmp_environment}/modules/#{test_num}/{manifests,files}")
+    on(master, "mkdir -p '#{environmentpath}/#{tmp_environment}/modules/#{test_num}'/{manifests,files}")
     master_module_manifest    = "#{environmentpath}/#{tmp_environment}/modules/#{test_num}/manifests/init.pp"
     master_module_binary_file = "#{environmentpath}/#{tmp_environment}/modules/#{test_num}/files/binary_data"
 
     create_remote_file(master, master_module_binary_file, "\xC0\xFF")
-    on(master, "chmod 644 #{master_module_binary_file}")
+    on(master, "chmod 644 '#{master_module_binary_file}'")
 
     manifest = <<-MANIFEST
       class #{test_num}(
@@ -45,7 +45,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
       }
     MANIFEST
     create_remote_file(master, master_module_manifest, manifest)
-    on(master, "chmod 644 #{master_module_manifest}")
+    on(master, "chmod 644 '#{master_module_manifest}'")
   end
 
   step "Create site.pp to classify nodes to include module" do
@@ -56,7 +56,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
       }
     SITE_PP
     create_remote_file(master, site_pp_file, site_pp)
-    on(master, "chmod 644 #{site_pp_file}")
+    on(master, "chmod 644 '#{site_pp_file}'")
   end
 
   step "start the master" do

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -3,11 +3,10 @@ test_name 'C98346: Binary data type' do
   extend Puppet::Acceptance::PuppetTypeTestTools
 
   tag 'audit:high',
-      'audit:integration', # Tests that binary data is retains integrity
+      'audit:integration' # Tests that binary data is retains integrity
       # between server and agent transport/application.
       # The weak link here is final ruby translation and
       # should not be OS sensitive.
-      'server'
 
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -71,8 +71,7 @@ test_name 'C98346: Binary data type' do
   step "run agent in #{tmp_environment}, run all assertions" do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
-           :accept_all_exit_codes => true) do |result|
+        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"), :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, 'puppet agent run failed')
           run_assertions(assertion_code, result)
         end

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -2,12 +2,12 @@ test_name 'C98346: Binary data type' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
-tag 'audit:high',
-    'audit:integration',  # Tests that binary data is retains integrity
-                          # between server and agent transport/application.
-                          # The weak link here is final ruby translation and
-                          # should not be OS sensitive.
-    'server'
+  tag 'audit:high',
+      'audit:integration', # Tests that binary data is retains integrity
+      # between server and agent transport/application.
+      # The weak link here is final ruby translation and
+      # should not be OS sensitive.
+      'server'
 
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
@@ -17,9 +17,9 @@ tag 'audit:high',
   agents.each do |agent|
     # ugh... this won't work with more than two agents of two types
     if agent.platform =~ /32$/
-      tmp_filename_win  = "C:\\cygwin\\tmp\\#{tmp_environment}.txt"
+      tmp_filename_win = "C:\\cygwin\\tmp\\#{tmp_environment}.txt"
     else
-      tmp_filename_win  = "C:\\cygwin64\\tmp\\#{tmp_environment}.txt"
+      tmp_filename_win = "C:\\cygwin64\\tmp\\#{tmp_environment}.txt"
     end
     tmp_filename_else = "/tmp/#{tmp_environment}.txt"
     if agent.platform =~ /windows/
@@ -37,30 +37,30 @@ tag 'audit:high',
   base64_urlsafe = Base64.urlsafe_encode64("invasion from-space/#{random_string}\n")
 
   test_resources = [
-    {:type => 'notify', :parameters => {:namevar => "1:$hell"}, :pre_code => "$hell = Binary('hello','%b')",
-       :assertions => {:assert_match => 'Notice: 1:hell'}},
-    {:type => 'notify', :parameters => {:namevar => "2:$relaxed"}, :pre_code => "$relaxed = Binary('#{base64_relaxed}')",
-       :assertions => {:assert_match => "Notice: 2:#{base64_relaxed}"}},
-    {:type => 'notify', :parameters => {:namevar => "3:$cHVwcGV0"}, :pre_code => "$cHVwcGV0 = Binary('cHVwcGV0')",
-       :assertions => {:assert_match => 'Notice: 3:cHVwcGV0'}},
-    {:type => 'notify', :parameters => {:namevar => "4:$strict"}, :pre_code => "$strict = Binary('#{base64_strict}')",
-       :assertions => {:assert_match => "Notice: 4:#{base64_strict}"}},
-    {:type => 'notify', :parameters => {:namevar => "5:$urlsafe"}, :pre_code => "$urlsafe = Binary('#{base64_urlsafe}')",
-       :assertions => {:assert_match => "Notice: 5:#{base64_urlsafe}"}},
-    {:type => 'notify', :parameters => {:namevar => "6:$byte_array"}, :pre_code => "$byte_array = Binary([67,68])",
-       :assertions => {:assert_match => "Notice: 6:Q0Q="}},
-    {:type => 'notify', :parameters => {:namevar => "7:${empty_array}empty"}, :pre_code => "$empty_array = Binary([])",
-       :assertions => {:assert_match => "Notice: 7:empty"}},
-    {:type => 'notify', :parameters => {:namevar => "8:${relaxed[1]}"},
-       :assertions => {:assert_match => "Notice: 8:bg=="}},
-    {:type => 'notify', :parameters => {:namevar => "9:${relaxed[1,3]}"},
-       :assertions => {:assert_match => "Notice: 9:bnZh"}},
-    {:type => 'notify', :parameters => {:namevar => "A:${utf8}"}, :pre_code => '$utf8=String(Binary([0xF0, 0x9F, 0x91, 0x92]),"%s")',
-       :assertions => {:assert_match => 'Notice: A:\\xF0\\x9F\\x91\\x92'}},
-    {:type => 'notify', :parameters => {:namevar => "B:${type($bin_file)}"}, :pre_code => '$bin_file=binary_file("empty/blah.txt")',
-       :assertions => {:assert_match => 'Notice: B:Binary'}},
-    {:type => 'file', :parameters => {:namevar => "$pup_tmp_filename", :content => "$relaxed"}, :pre_code => "$pup_tmp_filename = if $osfamily == 'windows' { '#{tmp_filename_win}' } else { '#{tmp_filename_else}' }",
-       :assertions => {:assert_match => /#{base64_relaxed}/}},
+      { :type       => 'notify', :parameters => { :namevar => "1:$hell" }, :pre_code => "$hell = Binary('hello','%b')",
+        :assertions => { :assert_match => 'Notice: 1:hell' } },
+      { :type       => 'notify', :parameters => { :namevar => "2:$relaxed" }, :pre_code => "$relaxed = Binary('#{base64_relaxed}')",
+        :assertions => { :assert_match => "Notice: 2:#{base64_relaxed}" } },
+      { :type       => 'notify', :parameters => { :namevar => "3:$cHVwcGV0" }, :pre_code => "$cHVwcGV0 = Binary('cHVwcGV0')",
+        :assertions => { :assert_match => 'Notice: 3:cHVwcGV0' } },
+      { :type       => 'notify', :parameters => { :namevar => "4:$strict" }, :pre_code => "$strict = Binary('#{base64_strict}')",
+        :assertions => { :assert_match => "Notice: 4:#{base64_strict}" } },
+      { :type       => 'notify', :parameters => { :namevar => "5:$urlsafe" }, :pre_code => "$urlsafe = Binary('#{base64_urlsafe}')",
+        :assertions => { :assert_match => "Notice: 5:#{base64_urlsafe}" } },
+      { :type       => 'notify', :parameters => { :namevar => "6:$byte_array" }, :pre_code => "$byte_array = Binary([67,68])",
+        :assertions => { :assert_match => "Notice: 6:Q0Q=" } },
+      { :type       => 'notify', :parameters => { :namevar => "7:${empty_array}empty" }, :pre_code => "$empty_array = Binary([])",
+        :assertions => { :assert_match => "Notice: 7:empty" } },
+      { :type       => 'notify', :parameters => { :namevar => "8:${relaxed[1]}" },
+        :assertions => { :assert_match => "Notice: 8:bg==" } },
+      { :type       => 'notify', :parameters => { :namevar => "9:${relaxed[1,3]}" },
+        :assertions => { :assert_match => "Notice: 9:bnZh" } },
+      { :type       => 'notify', :parameters => { :namevar => "A:${utf8}" }, :pre_code => '$utf8=String(Binary([0xF0, 0x9F, 0x91, 0x92]),"%s")',
+        :assertions => { :assert_match => 'Notice: A:\\xF0\\x9F\\x91\\x92' } },
+      { :type       => 'notify', :parameters => { :namevar => "B:${type($bin_file)}" }, :pre_code => '$bin_file=binary_file("empty/blah.txt")',
+        :assertions => { :assert_match => 'Notice: B:Binary' } },
+      { :type       => 'file', :parameters => { :namevar => "$pup_tmp_filename", :content => "$relaxed" }, :pre_code => "$pup_tmp_filename = if $osfamily == 'windows' { '#{tmp_filename_win}' } else { '#{tmp_filename_else}' }",
+        :assertions => { :assert_match => /#{base64_relaxed}/ } },
   ]
 
   sitepp_content = generate_manifest(test_resources)
@@ -69,11 +69,11 @@ tag 'audit:high',
   create_sitepp(master, tmp_environment, sitepp_content)
 
   step "run agent in #{tmp_environment}, run all assertions" do
-    with_puppet_running_on(master,{}) do
+    with_puppet_running_on(master, {}) do
       agents.each do |agent|
         on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
-          assert(result.exit_code==2,'puppet agent run failed')
+          assert(result.exit_code == 2, 'puppet agent run failed')
           run_assertions(assertion_code, result)
         end
       end

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -27,10 +27,10 @@ test_name 'C98346: Binary data type' do
     else
       tmp_filename = tmp_filename_else
     end
-    on agent, "echo 'old content' > /tmp/#{tmp_environment}.txt"
+    on(agent, "echo 'old content' > '/tmp/#{tmp_environment}.txt'")
   end
   # create a fake module files... file for binary_file()
-  on master, puppet_apply("-e 'file{[\"#{environmentpath}/#{tmp_environment}/modules\",\"#{environmentpath}/#{tmp_environment}/modules/empty\",\"#{environmentpath}/#{tmp_environment}/modules/empty/files\"]: ensure => \"directory\"} file{\"#{environmentpath}/#{tmp_environment}/modules/empty/files/blah.txt\": content => \"binary, yo\"}'")
+  on(master, puppet_apply("-e 'file{[\"#{environmentpath}/#{tmp_environment}/modules\",\"#{environmentpath}/#{tmp_environment}/modules/empty\",\"#{environmentpath}/#{tmp_environment}/modules/empty/files\"]: ensure => \"directory\"} file{\"#{environmentpath}/#{tmp_environment}/modules/empty/files/blah.txt\": content => \"binary, yo\"}'"))
 
   base64_relaxed = Base64.encode64("invasionfromspace#{random_string}").strip
   base64_strict  = Base64.strict_encode64("invasion from space #{random_string}\n")
@@ -71,7 +71,7 @@ test_name 'C98346: Binary data type' do
   step "run agent in #{tmp_environment}, run all assertions" do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"), :accept_all_exit_codes => true) do |result|
+        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"), :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, 'puppet agent run failed')
           run_assertions(assertion_code, result)
         end

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -71,8 +71,7 @@ test_name 'C98346: Binary data type' do
   step "run agent in #{tmp_environment}, run all assertions" do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"), :accept_all_exit_codes => true) do |result|
-          assert(result.exit_code == 2, 'puppet agent run failed')
+        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"), :acceptable_exit_codes => [2]) do |result|
           run_assertions(assertion_code, result)
         end
       end

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -2,8 +2,7 @@ test_name "Pluginsync'ed external facts should be resolvable on the agent" do
   confine :except, :platform => 'cisco_nexus' #See BKR-749
 
   tag 'audit:medium',
-      'audit:integration',
-      'server'
+      'audit:integration'
 
 #
 # This test is intended to ensure that external facts downloaded onto an agent via

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -78,7 +78,7 @@ MANIFEST
       }
   }
 
-  with_puppet_running_on master, master_opts, codedir do
+  with_puppet_running_on(master, master_opts, codedir) do
     agents.each do |agent|
       factsd         = agent.tmpdir('facts.d')
       pluginfactdest = agent.tmpdir('facts.d')
@@ -86,9 +86,9 @@ MANIFEST
       testfile       = File.join(tmpdir, 'testfile')
 
       teardown do
-        on(master, "rm -rf #{codedir}")
-        on(agent, "rm -rf #{factsd}")
-        on(agent, "rm -rf #{pluginfactdest}")
+        on(master, "rm -rf '#{codedir}'")
+        on(agent, "rm -rf '#{factsd}'")
+        on(agent, "rm -rf '#{pluginfactdest}'")
       end
 
       step "Pluginsync the external fact to the agent and ensure it resolves correctly" do
@@ -109,7 +109,7 @@ MANIFEST
       next if agent['platform'] =~ /windows/
 
       step "In Linux, ensure the pluginsync'ed external fact has the same permissions as its source" do
-        on(agent, puppet('resource', "file #{factsd}/unix_external_fact.sh")) do |result|
+        on(agent, puppet('resource', "file '#{factsd}/unix_external_fact.sh'")) do |result|
           assert_match(/0755/, result.stdout)
         end
       end

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -87,8 +87,7 @@ MANIFEST
 
       teardown do
         on(master, "rm -rf '#{codedir}'")
-        on(agent, "rm -rf '#{factsd}'")
-        on(agent, "rm -rf '#{pluginfactdest}'")
+        on(agent, "rm -rf '#{factsd}' '#{pluginfactdest}'")
       end
 
       step "Pluginsync the external fact to the agent and ensure it resolves correctly" do
@@ -96,9 +95,11 @@ MANIFEST
           assert_match(/foo is bar/, result.stdout)
         end
       end
-      step "Use plugin face to download to the agent"
-      on(agent, puppet('plugin', 'download', '--server', master, '--pluginfactdest', pluginfactdest))
-      assert_match(/Downloaded these plugins: .*external_fact/, stdout) unless agent['locale'] == 'ja'
+      step "Use plugin face to download to the agent" do
+        on(agent, puppet('plugin', 'download', '--server', master, '--pluginfactdest', pluginfactdest)) do |result|
+          assert_match(/Downloaded these plugins: .*external_fact/, result.stdout) unless agent['locale'] == 'ja'
+        end
+      end
 
       step "Ensure it resolves correctly" do
         on(agent, puppet('apply', '--pluginfactdest', pluginfactdest, '-e', "'notify { \"foo is ${foo}\": }'")) do |result|
@@ -126,7 +127,7 @@ MANIFEST
             assert_match(mode, result.stdout)
           end
 
-          on(agent, "rm /tmp/test_target")
+          on(agent, "rm -f /tmp/test_target")
         end
       end
     end

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -12,17 +12,17 @@ test_name "Pluginsync'ed custom facts should be resolvable during application ru
   agents.each do |agent|
     step "Create a codedir with a test module with external fact"
     codedir = agent.tmpdir('4847-codedir')
-    on agent, "mkdir -p #{codedir}/facts"
-    on agent, "mkdir -p #{codedir}/lib/facter"
-    on agent, "mkdir -p #{codedir}/lib/puppet/{type,provider/test4847}"
+    on(agent, "mkdir -p '#{codedir}/facts'")
+    on(agent, "mkdir -p '#{codedir}/lib/facter'")
+    on(agent, "mkdir -p '#{codedir}/lib/puppet/'{type,provider/test4847}")
 
-    on agent, "cat > #{codedir}/lib/puppet/type/test4847.rb", :stdin => <<TYPE
+    on(agent, "cat > #{codedir}/lib/puppet/type/test4847.rb", :stdin => <<TYPE)
 Puppet::Type.newtype(:test4847) do
   newparam(:name, :namevar => true)
 end
 TYPE
 
-    on agent, "cat > #{codedir}/lib/puppet/provider/test4847/only.rb", :stdin => <<PROVIDER
+    on(agent, "cat > #{codedir}/lib/puppet/provider/test4847/only.rb", :stdin => <<PROVIDER)
 Puppet::Type.type(:test4847).provide(:only) do
   commands :anything => "#{codedir}/must_exist.exe"
   def self.instances
@@ -48,7 +48,7 @@ Facter.add('snafu') do
 end
 FACT
 
-    on agent, puppet('apply'), :stdin => <<MANIFEST
+    on(agent, puppet('apply'), :stdin => <<MANIFEST)
   # The file name is chosen to work on Windows and *nix.
   file { "#{codedir}/must_exist.exe":
     ensure => file,
@@ -66,14 +66,14 @@ FACT
   }
 MANIFEST
 
-    on agent, puppet('resource', 'test4847',
+    on(agent, puppet('resource', 'test4847',
                      '--libdir', File.join(codedir, 'lib'),
-                     '--factpath', File.join(codedir, 'facts')) do |result|
+                     '--factpath', File.join(codedir, 'facts'))) do |result|
       assert_match(/fact foo=bar, snafu=zifnab/, result.stderr)
     end
 
     teardown do
-      on(agent, "rm -rf #{codedir}")
+      on(agent, "rm -rf '#{codedir}'")
     end
   end
 end

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -4,76 +4,60 @@ test_name "Pluginsync'ed custom facts should be resolvable during application ru
       'audit:integration',
       'server'
 
-#
-# This test is intended to ensure that custom facts downloaded onto an agent via
-# pluginsync are resolvable by puppet applications besides agent/apply.
-#
+  #
+  # This test is intended to ensure that custom facts downloaded onto an agent via
+  # pluginsync are resolvable by puppet applications besides agent/apply.
+  #
 
-  agents.each do |agent|
-    step "Create a codedir with a test module with external fact"
-    codedir = agent.tmpdir('4847-codedir')
-    on(agent, "mkdir -p '#{codedir}/facts'")
-    on(agent, "mkdir -p '#{codedir}/lib/facter'")
-    on(agent, "mkdir -p '#{codedir}/lib/puppet/'{type,provider/test4847}")
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
 
-    on(agent, "cat > #{codedir}/lib/puppet/type/test4847.rb", :stdin => <<TYPE)
-Puppet::Type.newtype(:test4847) do
-  newparam(:name, :namevar => true)
-end
-TYPE
-
-    on(agent, "cat > #{codedir}/lib/puppet/provider/test4847/only.rb", :stdin => <<PROVIDER)
-Puppet::Type.type(:test4847).provide(:only) do
-  commands :anything => "#{codedir}/must_exist.exe"
-  def self.instances
-    warn "fact foo=\#{Facter.value('foo')}, snafu=\#{Facter.value('snafu')}"
-    []
+  tmp_environment         = mk_tmp_environment_with_teardown(master, 'resolve')
+  master_module_dir       = "#{environmentpath}/#{tmp_environment}/modules/module_name"
+  master_type_dir         = "#{master_module_dir}/lib/puppet/type"
+  master_module_type_file = "#{master_type_dir}/test4847.rb"
+  master_provider_dir     = "#{master_module_dir}/lib/puppet/provider/test4847"
+  master_provider_file    = "#{master_provider_dir}/only.rb"
+  master_facter_dir       = "#{master_module_dir}/lib/facter"
+  master_facter_file      = "#{master_facter_dir}/foo.rb"
+  on(master, "mkdir -p '#{master_type_dir}' '#{master_provider_dir}' '#{master_facter_dir}'")
+  teardown do
+    on(master, "rm -rf '#{master_module_dir}'")
   end
-end
-PROVIDER
 
-    foo_fact = <<FACT
-Facter.add('foo') do
-  setcode do
-    'bar'
-  end
-end
-FACT
+  test_type = <<-TYPE
+      Puppet::Type.newtype(:test4847) do
+        newparam(:name, :namevar => true)
+      end
+  TYPE
+  create_remote_file(master, master_module_type_file, test_type)
 
-    snafu_fact = <<FACT
-Facter.add('snafu') do
-  setcode do
-    'zifnab'
-  end
-end
-FACT
+  test_provider = <<-PROVIDER
+      Puppet::Type.type(:test4847).provide(:only) do
+        def self.instances
+          warn "fact foo=\#{Facter.value('foo')}"
+          []
+        end
+      end
+  PROVIDER
+  create_remote_file(master, master_provider_file, test_provider)
 
-    on(agent, puppet('apply'), :stdin => <<MANIFEST)
-  # The file name is chosen to work on Windows and *nix.
-  file { "#{codedir}/must_exist.exe":
-    ensure => file,
-    mode   => "0755",
-  }
+  foo_fact_content = <<-FACT_FOO
+      Facter.add('foo') do
+        setcode do
+          'bar'
+        end
+      end
+  FACT_FOO
+  create_remote_file(master, master_facter_file, foo_fact_content)
+  on(master, "chmod 755 '#{master_module_type_file}' '#{master_provider_file}' '#{master_facter_file}'")
 
-  file { "#{codedir}/lib/facter/foo.rb":
-    ensure  => file,
-    content => "#{foo_fact}",
-  }
-
-  file { "#{codedir}/facts/snafu.rb":
-    ensure  => file,
-    content => "#{snafu_fact}"
-  }
-MANIFEST
-
-    on(agent, puppet('resource', 'test4847',
-                     '--libdir', File.join(codedir, 'lib'),
-                     '--factpath', File.join(codedir, 'facts'))) do |result|
-      assert_match(/fact foo=bar, snafu=zifnab/, result.stderr)
-    end
-
-    teardown do
-      on(agent, "rm -rf '#{codedir}'")
+  with_puppet_running_on(master, {}) do
+    agents.each do |agent|
+      on(agent, puppet("agent -t --server #{master} --environment #{tmp_environment}"))
+      on(agent, puppet('resource test4847')) do |result|
+        assert_match(/fact foo=bar/, result.stderr)
+      end
     end
   end
 end

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,8 +1,7 @@
 test_name "Pluginsync'ed custom facts should be resolvable during application runs" do
 
   tag 'audit:medium',
-      'audit:integration',
-      'server'
+      'audit:integration'
 
   #
   # This test is intended to ensure that custom facts downloaded onto an agent via

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,28 +1,28 @@
 test_name "Pluginsync'ed custom facts should be resolvable during application runs" do
 
-tag 'audit:medium',
-    'audit:integration',
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
 
 #
 # This test is intended to ensure that custom facts downloaded onto an agent via
 # pluginsync are resolvable by puppet applications besides agent/apply.
 #
 
-agents.each do |agent|
-  step "Create a codedir with a test module with external fact"
-  codedir = agent.tmpdir('4847-codedir')
-  on agent, "mkdir -p #{codedir}/facts"
-  on agent, "mkdir -p #{codedir}/lib/facter"
-  on agent, "mkdir -p #{codedir}/lib/puppet/{type,provider/test4847}"
+  agents.each do |agent|
+    step "Create a codedir with a test module with external fact"
+    codedir = agent.tmpdir('4847-codedir')
+    on agent, "mkdir -p #{codedir}/facts"
+    on agent, "mkdir -p #{codedir}/lib/facter"
+    on agent, "mkdir -p #{codedir}/lib/puppet/{type,provider/test4847}"
 
-  on agent, "cat > #{codedir}/lib/puppet/type/test4847.rb", :stdin => <<TYPE
+    on agent, "cat > #{codedir}/lib/puppet/type/test4847.rb", :stdin => <<TYPE
 Puppet::Type.newtype(:test4847) do
   newparam(:name, :namevar => true)
 end
 TYPE
 
-  on agent, "cat > #{codedir}/lib/puppet/provider/test4847/only.rb", :stdin => <<PROVIDER
+    on agent, "cat > #{codedir}/lib/puppet/provider/test4847/only.rb", :stdin => <<PROVIDER
 Puppet::Type.type(:test4847).provide(:only) do
   commands :anything => "#{codedir}/must_exist.exe"
   def self.instances
@@ -32,7 +32,7 @@ Puppet::Type.type(:test4847).provide(:only) do
 end
 PROVIDER
 
-  foo_fact = <<FACT
+    foo_fact = <<FACT
 Facter.add('foo') do
   setcode do
     'bar'
@@ -40,7 +40,7 @@ Facter.add('foo') do
 end
 FACT
 
-  snafu_fact = <<FACT
+    snafu_fact = <<FACT
 Facter.add('snafu') do
   setcode do
     'zifnab'
@@ -48,7 +48,7 @@ Facter.add('snafu') do
 end
 FACT
 
-  on agent, puppet('apply'), :stdin => <<MANIFEST
+    on agent, puppet('apply'), :stdin => <<MANIFEST
   # The file name is chosen to work on Windows and *nix.
   file { "#{codedir}/must_exist.exe":
     ensure => file,
@@ -66,14 +66,14 @@ FACT
   }
 MANIFEST
 
-  on agent, puppet('resource', 'test4847',
-                   '--libdir', File.join(codedir, 'lib'),
-                   '--factpath', File.join(codedir, 'facts')) do |result|
-    assert_match(/fact foo=bar, snafu=zifnab/, result.stderr)
-  end
+    on agent, puppet('resource', 'test4847',
+                     '--libdir', File.join(codedir, 'lib'),
+                     '--factpath', File.join(codedir, 'facts')) do |result|
+      assert_match(/fact foo=bar, snafu=zifnab/, result.stderr)
+    end
 
-  teardown do
-    on(agent, "rm -rf #{codedir}")
+    teardown do
+      on(agent, "rm -rf #{codedir}")
+    end
   end
-end
 end

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,4 +1,4 @@
-test_name "Pluginsync'ed custom facts should be resolvable during application runs"
+test_name "Pluginsync'ed custom facts should be resolvable during application runs" do
 
 tag 'audit:medium',
     'audit:integration',
@@ -68,11 +68,12 @@ MANIFEST
 
   on agent, puppet('resource', 'test4847',
                    '--libdir', File.join(codedir, 'lib'),
-                   '--factpath', File.join(codedir, 'facts')) do
-    assert_match(/fact foo=bar, snafu=zifnab/, stderr)
+                   '--factpath', File.join(codedir, 'facts')) do |result|
+    assert_match(/fact foo=bar, snafu=zifnab/, result.stderr)
   end
 
   teardown do
     on(agent, "rm -rf #{codedir}")
   end
+end
 end

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -96,7 +96,7 @@ end
 
           step "run the agent" do
             agents.each do |agent|
-              on(agent, puppet('agent', "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\" --test --trace --server #{master}"))
+              on(agent, puppet('agent', "--libdir='#{get_test_file_path(agent, agent_lib_dir)}' --test --trace --server #{master}"))
             end
           end
 
@@ -113,7 +113,7 @@ end
 
       step "verify that the application shows up in help" do
         agents.each do |agent|
-          on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
+          on(agent, PuppetCommand.new(:help, "--libdir='#{get_test_file_path(agent, agent_lib_dir)}'")) do |result|
             assert_match(/^\s+#{app_name}\s+#{app_desc % mode}/, result.stdout)
           end
         end
@@ -121,7 +121,7 @@ end
 
       step "verify that we can run the application" do
         agents.each do |agent|
-          on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
+          on(agent, PuppetCommand.new(:"#{app_name}", "--libdir='#{get_test_file_path(agent, agent_lib_dir)}'")) do |result|
             assert_match(/^#{app_output % mode}/, result.stdout)
           end
         end
@@ -129,7 +129,7 @@ end
 
       step "clear out the libdir on the agents in preparation for the next test" do
         agents.each do |agent|
-          on(agent, "rm -rf #{get_test_file_path(agent, agent_lib_dir)}/*")
+          on(agent, "rm -rf '#{get_test_file_path(agent, agent_lib_dir)}'/*")
         end
       end
 

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,38 +1,32 @@
-test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards" do
+test_name 'the pluginsync functionality should sync app definitions, and they should be runnable afterwards' do
 
   tag 'audit:medium',
       'audit:integration',
       'server'
 
-#
-# This test is intended to ensure that pluginsync syncs app definitions to the agents.
-# Further, the apps should be runnable on the agent after the sync has occurred.
-#
+  #
+  # This test is intended to ensure that pluginsync syncs app definitions to the agents.
+  # Further, the apps should be runnable on the agent after the sync has occurred.
+  #
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
 
   require 'puppet/acceptance/temp_file_utils'
-
   extend Puppet::Acceptance::TempFileUtils
 
-  initialize_temp_dirs()
+  tmp_environment   = mk_tmp_environment_with_teardown(master, 'app')
+  master_module_dir = "#{environmentpath}/#{tmp_environment}/modules"
+  on(master, "mkdir -p '#{master_module_dir}'")
 
-  all_tests_passed = false
-
-###############################################################################
-# BEGIN TEST LOGIC
-###############################################################################
-
-# create some vars to point to the directories that we're going to point the master/agents at
-  environments_dir  = "environments"
-  master_module_dir = "#{environments_dir}/production/modules"
-  agent_lib_dir     = "agent_lib"
+  teardown do
+    on(master, "rm -rf '#{master_module_dir}'")
+  end
 
   app_name   = "superbogus"
-  app_desc   = "a simple %1$s for testing %1$s delivery via plugin sync"
-  app_output = "Hello from the #{app_name} %s"
+  app_desc   = "a simple application for testing application delivery via plugin sync"
+  app_output = "Hello from the #{app_name} application"
 
-  master_module_file_content = {}
-
-  master_module_file_content["application"] = <<-HERE
+  master_module_file_content = <<-HERE
 require 'puppet/application'
 
 class Puppet::Application::#{app_name.capitalize} < Puppet::Application
@@ -40,111 +34,65 @@ class Puppet::Application::#{app_name.capitalize} < Puppet::Application
   def help
     <<-HELP
 
-puppet-#{app_name}(8) -- #{app_desc % "application"}
+puppet-#{app_name}(8) -- #{app_desc}
 ========
     HELP
   end
 
   def main()
-    puts("#{app_output % "application"}")
+    puts("#{app_output}")
   end
 end
   HERE
 
+  # here we create a custom app, which basically doesn't do anything except
+  # for print a hello-world message
+  #
+  master_module_app_path = "#{master_module_dir}/#{app_name}/lib/puppet/application"
+  master_module_app_file = "#{master_module_app_path}/#{app_name}.rb"
+  on(master, "mkdir -p '#{master_module_app_path}'")
+  create_remote_file(master, master_module_app_file, master_module_file_content)
+  on(master, "chmod 755 '#{master_module_app_file}'")
 
-# this begin block is here for handling temp file cleanup via an "ensure" block
-# at the very end of the test.
-  begin
+  step "start the master" do
+    with_puppet_running_on(master, {}) do
+      agents.each do |agent|
 
-    modes = ["application"]
-
-    modes.each do |mode|
-
-      # here we create a custom app, which basically doesn't do anything except
-      # for print a hello-world message
-      agent_module_app_file  = "#{agent_lib_dir}/puppet/#{mode}/#{app_name}.rb"
-      master_module_app_file = "#{master_module_dir}/#{app_name}/lib/puppet/#{mode}/#{app_name}.rb"
-
-
-      # copy all the files to the master
-      step "write our simple module out to the master" do
-        create_test_file(master, master_module_app_file, master_module_file_content[mode], :mkdirs => true)
-      end
-
-      step "verify that the app file exists on the master" do
-        unless test_file_exists?(master, master_module_app_file) then
-          fail_test("Failed to create app file '#{get_test_file_path(master, master_module_app_file)}' on master")
+        agent_lib_dir         = agent.tmpdir('agent_lib_sync')
+        agent_module_app_file = "#{agent_lib_dir}/puppet/application/#{app_name}.rb"
+        teardown do
+          on(agent, "rm -rf '#{agent_lib_dir}'")
         end
-      end
 
-      master_opts = {
-          'main' => {
-              'environmentpath' => "#{get_test_file_path(master, environments_dir)}",
-          }
-      }
-      step "start the master" do
-        with_puppet_running_on master, master_opts do
-
-          # the module files shouldn't exist on the agent yet because they haven't been synced
-          step "verify that the module files don't exist on the agent path" do
-            agents.each do |agent|
-              if test_file_exists?(agent, agent_module_app_file) then
-                fail_test("app file already exists on agent: '#{get_test_file_path(agent, agent_module_app_file)}'")
-              end
-            end
+        # the module files shouldn't exist on the agent yet because they haven't been synced
+        step "verify that the module files don't exist on the agent path" do
+          if file_exists?(agent, agent_module_app_file)
+            fail_test("app file already exists on agent: '#{agent_module_app_file}'")
           end
-
-          step "run the agent" do
-            agents.each do |agent|
-              on(agent, puppet('agent', "--libdir='#{get_test_file_path(agent, agent_lib_dir)}' --test --trace --server #{master}"))
-            end
-          end
-
         end
-      end
 
-      step "verify that the module files were synced down to the agent" do
-        agents.each do |agent|
-          unless test_file_exists?(agent, agent_module_app_file) then
-            fail_test("The app file we expect was not not synced to agent: '#{get_test_file_path(agent, agent_module_app_file)}'")
+        step "run the agent" do
+          on(agent, puppet("agent --libdir='#{agent_lib_dir}' --test --server #{master} --environment '#{tmp_environment}'"))
+        end
+
+        step "verify that the module files were synced down to the agent" do
+          unless file_exists?(agent, agent_module_app_file)
+            fail_test("The app file we expect was not not synced to agent: '#{agent_module_app_file}'")
+          end
+        end
+
+        step "verify that the application shows up in help" do
+          on(agent, PuppetCommand.new(:help, "--libdir='#{agent_lib_dir}'")) do |result|
+            assert_match(/^\s+#{app_name}\s+#{app_desc}/, result.stdout)
+          end
+        end
+
+        step "verify that we can run the application" do
+          on(agent, PuppetCommand.new(:"#{app_name}", "--libdir='#{agent_lib_dir}'")) do |result|
+            assert_match(/^#{app_output}/, result.stdout)
           end
         end
       end
-
-      step "verify that the application shows up in help" do
-        agents.each do |agent|
-          on(agent, PuppetCommand.new(:help, "--libdir='#{get_test_file_path(agent, agent_lib_dir)}'")) do |result|
-            assert_match(/^\s+#{app_name}\s+#{app_desc % mode}/, result.stdout)
-          end
-        end
-      end
-
-      step "verify that we can run the application" do
-        agents.each do |agent|
-          on(agent, PuppetCommand.new(:"#{app_name}", "--libdir='#{get_test_file_path(agent, agent_lib_dir)}'")) do |result|
-            assert_match(/^#{app_output % mode}/, result.stdout)
-          end
-        end
-      end
-
-      step "clear out the libdir on the agents in preparation for the next test" do
-        agents.each do |agent|
-          on(agent, "rm -rf '#{get_test_file_path(agent, agent_lib_dir)}'/*")
-        end
-      end
-
-    end
-
-    all_tests_passed = true
-
-  ensure
-    ##########################################################################################
-    # Clean up all of the temp files created by this test.  It would be nice if this logic
-    # could be handled outside of the test itself; I envision a stanza like this one appearing
-    # in a very large number of the tests going forward unless it is handled by the framework.
-    ##########################################################################################
-    if all_tests_passed then
-      remove_temp_dirs()
     end
   end
 end

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,8 +1,7 @@
 test_name 'the pluginsync functionality should sync app definitions, and they should be runnable afterwards' do
 
   tag 'audit:medium',
-      'audit:integration',
-      'server'
+      'audit:integration'
 
   #
   # This test is intended to ensure that pluginsync syncs app definitions to the agents.

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -96,10 +96,7 @@ end
 
           step "run the agent" do
             agents.each do |agent|
-              on(agent, puppet('agent',
-                               "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\" ",
-                               "--test --trace --server #{master}")
-              )
+              on(agent, puppet('agent', "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\" --test --trace --server #{master}"))
             end
           end
 

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,4 +1,4 @@
-test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
+test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards" do
 
 tag 'audit:medium',
     'audit:integration',
@@ -116,7 +116,7 @@ begin
 
     step "verify that the application shows up in help" do
       agents.each do |agent|
-        on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
+        on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
           assert_match(/^\s+#{app_name}\s+#{app_desc % mode}/, result.stdout)
         end
       end
@@ -124,7 +124,7 @@ begin
 
     step "verify that we can run the application" do
       agents.each do |agent|
-        on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
+        on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
           assert_match(/^#{app_output % mode}/, result.stdout)
         end
       end
@@ -149,4 +149,5 @@ ensure
   if all_tests_passed then
     remove_temp_dirs()
   end
+end
 end

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,38 +1,38 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards" do
 
-tag 'audit:medium',
-    'audit:integration',
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
 
 #
 # This test is intended to ensure that pluginsync syncs app definitions to the agents.
 # Further, the apps should be runnable on the agent after the sync has occurred.
 #
 
-require 'puppet/acceptance/temp_file_utils'
+  require 'puppet/acceptance/temp_file_utils'
 
-extend Puppet::Acceptance::TempFileUtils
+  extend Puppet::Acceptance::TempFileUtils
 
-initialize_temp_dirs()
+  initialize_temp_dirs()
 
-all_tests_passed = false
+  all_tests_passed = false
 
 ###############################################################################
 # BEGIN TEST LOGIC
 ###############################################################################
 
 # create some vars to point to the directories that we're going to point the master/agents at
-environments_dir = "environments"
-master_module_dir = "#{environments_dir}/production/modules"
-agent_lib_dir = "agent_lib"
+  environments_dir  = "environments"
+  master_module_dir = "#{environments_dir}/production/modules"
+  agent_lib_dir     = "agent_lib"
 
-app_name = "superbogus"
-app_desc = "a simple %1$s for testing %1$s delivery via plugin sync"
-app_output = "Hello from the #{app_name} %s"
+  app_name   = "superbogus"
+  app_desc   = "a simple %1$s for testing %1$s delivery via plugin sync"
+  app_output = "Hello from the #{app_name} %s"
 
-master_module_file_content = {}
+  master_module_file_content = {}
 
-master_module_file_content["application"] = <<-HERE
+  master_module_file_content["application"] = <<-HERE
 require 'puppet/application'
 
 class Puppet::Application::#{app_name.capitalize} < Puppet::Application
@@ -49,105 +49,105 @@ puppet-#{app_name}(8) -- #{app_desc % "application"}
     puts("#{app_output % "application"}")
   end
 end
-HERE
+  HERE
 
 
 # this begin block is here for handling temp file cleanup via an "ensure" block
 # at the very end of the test.
-begin
+  begin
 
-  modes = ["application"]
+    modes = ["application"]
 
-  modes.each do |mode|
+    modes.each do |mode|
 
-    # here we create a custom app, which basically doesn't do anything except
-    # for print a hello-world message
-    agent_module_app_file = "#{agent_lib_dir}/puppet/#{mode}/#{app_name}.rb"
-    master_module_app_file = "#{master_module_dir}/#{app_name}/lib/puppet/#{mode}/#{app_name}.rb"
+      # here we create a custom app, which basically doesn't do anything except
+      # for print a hello-world message
+      agent_module_app_file  = "#{agent_lib_dir}/puppet/#{mode}/#{app_name}.rb"
+      master_module_app_file = "#{master_module_dir}/#{app_name}/lib/puppet/#{mode}/#{app_name}.rb"
 
 
-    # copy all the files to the master
-    step "write our simple module out to the master" do
-      create_test_file(master, master_module_app_file, master_module_file_content[mode], :mkdirs => true)
-    end
-
-    step "verify that the app file exists on the master" do
-      unless test_file_exists?(master, master_module_app_file) then
-        fail_test("Failed to create app file '#{get_test_file_path(master, master_module_app_file)}' on master")
+      # copy all the files to the master
+      step "write our simple module out to the master" do
+        create_test_file(master, master_module_app_file, master_module_file_content[mode], :mkdirs => true)
       end
-    end
 
-    master_opts = {
-      'main' => {
-        'environmentpath' => "#{get_test_file_path(master, environments_dir)}",
+      step "verify that the app file exists on the master" do
+        unless test_file_exists?(master, master_module_app_file) then
+          fail_test("Failed to create app file '#{get_test_file_path(master, master_module_app_file)}' on master")
+        end
+      end
+
+      master_opts = {
+          'main' => {
+              'environmentpath' => "#{get_test_file_path(master, environments_dir)}",
+          }
       }
-    }
-    step "start the master" do
-      with_puppet_running_on master, master_opts do
+      step "start the master" do
+        with_puppet_running_on master, master_opts do
 
-        # the module files shouldn't exist on the agent yet because they haven't been synced
-        step "verify that the module files don't exist on the agent path" do
-          agents.each do |agent|
+          # the module files shouldn't exist on the agent yet because they haven't been synced
+          step "verify that the module files don't exist on the agent path" do
+            agents.each do |agent|
               if test_file_exists?(agent, agent_module_app_file) then
                 fail_test("app file already exists on agent: '#{get_test_file_path(agent, agent_module_app_file)}'")
               end
+            end
+          end
+
+          step "run the agent" do
+            agents.each do |agent|
+              on(agent, puppet('agent',
+                               "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\" ",
+                               "--test --trace --server #{master}")
+              )
+            end
+          end
+
+        end
+      end
+
+      step "verify that the module files were synced down to the agent" do
+        agents.each do |agent|
+          unless test_file_exists?(agent, agent_module_app_file) then
+            fail_test("The app file we expect was not not synced to agent: '#{get_test_file_path(agent, agent_module_app_file)}'")
           end
         end
+      end
 
-        step "run the agent" do
-          agents.each do |agent|
-            on(agent, puppet('agent',
-                             "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\" ",
-                             "--test --trace --server #{master}")
-            )
+      step "verify that the application shows up in help" do
+        agents.each do |agent|
+          on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
+            assert_match(/^\s+#{app_name}\s+#{app_desc % mode}/, result.stdout)
           end
         end
-
       end
-    end
 
-    step "verify that the module files were synced down to the agent" do
-      agents.each do |agent|
-        unless test_file_exists?(agent, agent_module_app_file) then
-          fail_test("The app file we expect was not not synced to agent: '#{get_test_file_path(agent, agent_module_app_file)}'")
+      step "verify that we can run the application" do
+        agents.each do |agent|
+          on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
+            assert_match(/^#{app_output % mode}/, result.stdout)
+          end
         end
       end
-    end
 
-    step "verify that the application shows up in help" do
-      agents.each do |agent|
-        on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
-          assert_match(/^\s+#{app_name}\s+#{app_desc % mode}/, result.stdout)
+      step "clear out the libdir on the agents in preparation for the next test" do
+        agents.each do |agent|
+          on(agent, "rm -rf #{get_test_file_path(agent, agent_lib_dir)}/*")
         end
       end
+
     end
 
-    step "verify that we can run the application" do
-      agents.each do |agent|
-        on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
-          assert_match(/^#{app_output % mode}/, result.stdout)
-        end
-      end
-    end
+    all_tests_passed = true
 
-    step "clear out the libdir on the agents in preparation for the next test" do
-      agents.each do |agent|
-        on(agent, "rm -rf #{get_test_file_path(agent, agent_lib_dir)}/*")
-      end
+  ensure
+    ##########################################################################################
+    # Clean up all of the temp files created by this test.  It would be nice if this logic
+    # could be handled outside of the test itself; I envision a stanza like this one appearing
+    # in a very large number of the tests going forward unless it is handled by the framework.
+    ##########################################################################################
+    if all_tests_passed then
+      remove_temp_dirs()
     end
-
   end
-
-  all_tests_passed = true
-
-ensure
-  ##########################################################################################
-  # Clean up all of the temp files created by this test.  It would be nice if this logic
-  # could be handled outside of the test itself; I envision a stanza like this one appearing
-  # in a very large number of the tests going forward unless it is handled by the framework.
-  ##########################################################################################
-  if all_tests_passed then
-    remove_temp_dirs()
-  end
-end
 end

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,8 +1,7 @@
 test_name "the pluginsync functionality should sync feature definitions" do
 
   tag 'audit:medium',
-      'audit:integration',
-      'server'
+      'audit:integration'
 
   #
   # This test is intended to ensure that pluginsync syncs feature definitions to

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -4,194 +4,108 @@ test_name "the pluginsync functionality should sync feature definitions" do
       'audit:integration',
       'server'
 
-#
-# This test is intended to ensure that pluginsync syncs feature definitions to
-# the agents.  It checks the feature twice; once to make sure that it gets
-# loaded successfully during the run in which it was synced, and once to ensure
-# that it still gets loaded successfully during the subsequent run (in which it
-# should not be synced because the files haven't changed.)
-#
+  #
+  # This test is intended to ensure that pluginsync syncs feature definitions to
+  # the agents.  It checks the feature twice; once to make sure that it gets
+  # loaded successfully during the run in which it was synced, and once to ensure
+  # that it still gets loaded successfully during the subsequent run (in which it
+  # should not be synced because the files haven't changed.)
+  #
 
+  require 'puppet/acceptance/environment_utils'
+  extend Puppet::Acceptance::EnvironmentUtils
 
   require 'puppet/acceptance/temp_file_utils'
-
   extend Puppet::Acceptance::TempFileUtils
 
-  initialize_temp_dirs()
+  module_name = 'superbogus'
+  tmp_environment = mk_tmp_environment_with_teardown(master, 'sync')
+  master_module_dir = "#{environmentpath}/#{tmp_environment}/modules"
+  master_module_type_path = "#{master_module_dir}/#{module_name}/lib/puppet/type/"
+  master_module_feature_path = "#{master_module_dir}/#{module_name}/lib/puppet/feature"
+  on(master, "mkdir -p '#{master_module_dir}'")
+  on(master, "mkdir -p '#{master_module_type_path}' '#{master_module_feature_path}'")
 
-  all_tests_passed = false
-
-
-###############################################################################
-# BEGIN TEST LOGIC
-###############################################################################
-
-# create some vars to point to the directories that we're going to point the master/agents at
-  test_identifier   = "pluginsync_should_sync_features"
-  environments_dir  = "environments"
-  master_module_dir = "#{environments_dir}/production/modules"
-  agent_lib_dir     = "agent_lib"
-
-  module_name = "superbogus"
-
-# here we create a custom type, which basically doesn't do anything except for test the value of
-# our custom feature and write the result to a file
-  agent_module_type_file     = "#{agent_lib_dir}/puppet/type/#{module_name}.rb"
-  master_module_type_file    = "#{master_module_dir}/#{module_name}/lib/puppet/type/#{module_name}.rb"
-  master_module_type_content = <<HERE
-module Puppet
-  Type.newtype(:#{module_name}) do
-    newparam(:name) do
-      isnamevar
-    end
-
-    newproperty(:testfeature) do
-      def sync
-        Puppet.info("The value of the #{module_name} feature is: \#{Puppet.features.#{module_name}?}")
-      end
-      def retrieve
-        :absent
-      end
-      def insync?(is)
-        false
-      end
-    end
-  end
-end
-HERE
-
-# here is our custom feature... it always returns true
-  agent_module_feature_file     = "#{agent_lib_dir}/puppet/feature/#{module_name}.rb"
-  master_module_feature_file    = "#{master_module_dir}/#{module_name}/lib/puppet/feature/#{module_name}.rb"
-  master_module_feature_content = <<HERE
-Puppet.features.add(:#{module_name}) do
-  Puppet.info("#{module_name} feature being queried")
-  true
-end
-HERE
-
-
-# manifest file for the master, does nothing but instantiate our custom type
-  master_manifest_dir     = "#{environments_dir}/production/manifests"
-  master_manifest_file    = "#{master_manifest_dir}/site.pp"
-  master_manifest_content = <<HERE
-#{module_name} { "This is the title of the #{module_name} type instance in site.pp":
-    testfeature => "Hi.  I'm setting the testfeature property of #{module_name} here in site.pp",
-}
-HERE
-
-
-# for convenience we build up a list of all of the files we are expecting to deploy on the master
-  all_master_files = [
-      [master_module_feature_file, 'feature'],
-      [master_module_type_file, 'type'],
-      [master_manifest_file, 'manifest']
-  ]
-
-# for convenience we build up a list of all of the files we are expecting to deploy on the agents
-  all_agent_files = [
-      [agent_module_feature_file, 'feature'],
-      [agent_module_type_file, 'type']
-  ]
-
-# the command line args we'll pass to the agent each time we call it
-  agent_args = "--trace --libdir=\"%s\" --pluginsync --no-daemonize --verbose " +
-      "--onetime --test --server #{master}"
-# legal exit codes whenever we run the agent
-#  we need to allow exit code 2, which means "changes were applied" on the agent
-  agent_exit_codes = [0, 2]
-
-# this begin block is here for handling temp file cleanup via an "ensure" block at the very end of the
-# test.
-  begin
-
-    # copy all the files to the master
-    step "write our simple module out to the master" do
-      create_test_file(master, master_module_type_file, master_module_type_content, :mkdirs => true)
-      create_test_file(master, master_module_feature_file, master_module_feature_content, :mkdirs => true)
-      create_test_file(master, master_manifest_file, master_manifest_content, :mkdirs => true)
-    end
-
-    step "verify that the module and manifest files exist on the master" do
-      all_master_files.each do |file_path, desc|
-        unless test_file_exists?(master, file_path) then
-          fail_test("Failed to create #{desc} file '#{get_test_file_path(master, file_path)}' on master")
+  master_module_type_file = "#{master_module_type_path}/#{module_name}.rb"
+  master_module_type_content = <<-HERE
+    module Puppet
+      Type.newtype(:#{module_name}) do
+        newparam(:name) do
+          isnamevar
+        end
+    
+        newproperty(:testfeature) do
+          def sync
+            Puppet.info("The value of the #{module_name} feature is: \#{Puppet.features.#{module_name}?}")
+          end
+          def retrieve
+            :absent
+          end
+          def insync?(is)
+            false
+          end
         end
       end
     end
+  HERE
+  create_remote_file(master, master_module_type_file, master_module_type_content)
 
-    step "start the master" do
+  master_module_feature_file = "#{master_module_feature_path}/#{module_name}.rb"
+  master_module_feature_content = <<-HERE
+    Puppet.features.add(:#{module_name}) do
+      Puppet.info("#{module_name} feature being queried")
+      true
+    end
+  HERE
+  create_remote_file(master, master_module_feature_file, master_module_feature_content)
+  on(master, "chmod 755 '#{master_module_type_file}' '#{master_module_feature_file}'")
 
-      master_opts = {
-          'main' => {
-              'environmentpath' => "#{get_test_file_path(master, environments_dir)}",
-          },
-      }
+  site_pp = <<-HERE
+    #{module_name} { "This is the title of the #{module_name} type instance in site.pp":
+      testfeature => "Hi.  I'm setting the testfeature property of #{module_name} here in site.pp",
+    }
+  HERE
+  create_sitepp(master, tmp_environment, site_pp)
 
-      with_puppet_running_on master, master_opts do
+  step 'start the master' do
+    with_puppet_running_on(master, {}) do
+      agents.each do |agent|
+        agent_lib_dir             = agent.tmpdir('libdir')
+        agent_module_type_file    = "#{agent_lib_dir}/puppet/type/#{module_name}.rb"
+        agent_module_feature_file = "#{agent_lib_dir}/puppet/feature/#{module_name}.rb"
 
-        # the module files shouldn't exist on the agent yet because they haven't been synced
         step "verify that the module files don't exist on the agent path" do
-          agents.each do |agent|
-            all_agent_files.each do |file_path, desc|
-              if test_file_exists?(agent, file_path) then
-                fail_test("#{desc} file already exists on agent: '#{get_test_file_path(agent, file_path)}'")
-              end
+          [agent_module_type_file, agent_module_feature_file].each do |file_path|
+            if file_exists?(agent, file_path)
+              fail_test("file should not exist on the agent yet: '#{file_path}'")
             end
           end
         end
 
+        step 'run the agent and verify that it loaded the feature' do
+          on(agent, puppet("agent -t --libdir='#{agent_lib_dir}' --server #{master} --environment '#{tmp_environment}'"),
+             :acceptable_exit_codes => [2]) do |result|
+            assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
+                         "Expected agent stdout to include confirmation that the feature was 'true'")
+          end
+        end
 
-        step "run the agent and verify that it loaded the feature" do
-          agents.each do |agent|
-            on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
-               :acceptable_exit_codes => agent_exit_codes) do |result|
-              assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
-                           "Expected agent stdout to include confirmation that the feature was 'true'")
+        step 'verify that the module files were synced down to the agent' do
+          [agent_module_type_file, agent_module_feature_file].each do |file_path|
+            unless file_exists?(agent, file_path)
+              fail_test("Expected file to exist on the agent now: '#{file_path}'")
             end
           end
         end
 
-        step "verify that the module files were synced down to the agent" do
-          agents.each do |agent|
-            all_agent_files.each do |file_path, desc|
-              unless test_file_exists?(agent, file_path) then
-                fail_test("Expected #{desc} file not synced to agent: '#{get_test_file_path(agent, file_path)}'")
-              end
-            end
+        step 'run the agent again' do
+          on(agent, puppet("agent -t --libdir='#{agent_lib_dir}' --server #{master} --environment '#{tmp_environment}'"),
+             :acceptable_exit_codes => [2]) do |result|
+            assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
+                         "Expected agent stdout to include confirmation that the feature was 'true'")
           end
         end
-
-        step "run the agent again" do
-          agents.each do |agent|
-            on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
-               :acceptable_exit_codes => agent_exit_codes) do |result|
-              assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
-                           "Expected agent stdout to include confirmation that the feature was 'true'")
-            end
-          end
-        end
-
-        #TODO: was thinking about putting in a check for the timestamps on the files (maybe add a method for that to
-        # the framework?) to verify that they didn't get re-synced, but it seems like more trouble than it's worth
-        # at the moment.
-        #step "verify that the module files were not re-synced" do
-        #  fail_test("NOT YET IMPLEMENTED: verify that the module files were not re-synced")
-        #end
-
       end
-
-      all_tests_passed = true
-
-    end
-  ensure
-    ##########################################################################################
-    # Clean up all of the temp files created by this test.  It would be nice if this logic
-    # could be handled outside of the test itself; I envision a stanza like this one appearing
-    # in a very large number of the tests going forward unless it is handled by the framework.
-    ##########################################################################################
-    if all_tests_passed then
-      remove_temp_dirs()
     end
   end
 end

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,8 +1,8 @@
 test_name "the pluginsync functionality should sync feature definitions" do
 
-tag 'audit:medium',
-    'audit:integration',
-    'server'
+  tag 'audit:medium',
+      'audit:integration',
+      'server'
 
 #
 # This test is intended to ensure that pluginsync syncs feature definitions to
@@ -13,13 +13,13 @@ tag 'audit:medium',
 #
 
 
-require 'puppet/acceptance/temp_file_utils'
+  require 'puppet/acceptance/temp_file_utils'
 
-extend Puppet::Acceptance::TempFileUtils
+  extend Puppet::Acceptance::TempFileUtils
 
-initialize_temp_dirs()
+  initialize_temp_dirs()
 
-all_tests_passed = false
+  all_tests_passed = false
 
 
 ###############################################################################
@@ -27,18 +27,18 @@ all_tests_passed = false
 ###############################################################################
 
 # create some vars to point to the directories that we're going to point the master/agents at
-test_identifier = "pluginsync_should_sync_features"
-environments_dir = "environments"
-master_module_dir = "#{environments_dir}/production/modules"
-agent_lib_dir = "agent_lib"
+  test_identifier   = "pluginsync_should_sync_features"
+  environments_dir  = "environments"
+  master_module_dir = "#{environments_dir}/production/modules"
+  agent_lib_dir     = "agent_lib"
 
-module_name = "superbogus"
+  module_name = "superbogus"
 
 # here we create a custom type, which basically doesn't do anything except for test the value of
 # our custom feature and write the result to a file
-agent_module_type_file = "#{agent_lib_dir}/puppet/type/#{module_name}.rb"
-master_module_type_file = "#{master_module_dir}/#{module_name}/lib/puppet/type/#{module_name}.rb"
-master_module_type_content = <<HERE
+  agent_module_type_file     = "#{agent_lib_dir}/puppet/type/#{module_name}.rb"
+  master_module_type_file    = "#{master_module_dir}/#{module_name}/lib/puppet/type/#{module_name}.rb"
+  master_module_type_content = <<HERE
 module Puppet
   Type.newtype(:#{module_name}) do
     newparam(:name) do
@@ -61,9 +61,9 @@ end
 HERE
 
 # here is our custom feature... it always returns true
-agent_module_feature_file = "#{agent_lib_dir}/puppet/feature/#{module_name}.rb"
-master_module_feature_file = "#{master_module_dir}/#{module_name}/lib/puppet/feature/#{module_name}.rb"
-master_module_feature_content = <<HERE
+  agent_module_feature_file     = "#{agent_lib_dir}/puppet/feature/#{module_name}.rb"
+  master_module_feature_file    = "#{master_module_dir}/#{module_name}/lib/puppet/feature/#{module_name}.rb"
+  master_module_feature_content = <<HERE
 Puppet.features.add(:#{module_name}) do
   Puppet.info("#{module_name} feature being queried")
   true
@@ -72,9 +72,9 @@ HERE
 
 
 # manifest file for the master, does nothing but instantiate our custom type
-master_manifest_dir = "#{environments_dir}/production/manifests"
-master_manifest_file = "#{master_manifest_dir}/site.pp"
-master_manifest_content = <<HERE
+  master_manifest_dir     = "#{environments_dir}/production/manifests"
+  master_manifest_file    = "#{master_manifest_dir}/site.pp"
+  master_manifest_content = <<HERE
 #{module_name} { "This is the title of the #{module_name} type instance in site.pp":
     testfeature => "Hi.  I'm setting the testfeature property of #{module_name} here in site.pp",
 }
@@ -82,116 +82,116 @@ HERE
 
 
 # for convenience we build up a list of all of the files we are expecting to deploy on the master
-all_master_files = [
-    [master_module_feature_file, 'feature'],
-    [master_module_type_file, 'type'],
-    [master_manifest_file, 'manifest']
-]
+  all_master_files = [
+      [master_module_feature_file, 'feature'],
+      [master_module_type_file, 'type'],
+      [master_manifest_file, 'manifest']
+  ]
 
 # for convenience we build up a list of all of the files we are expecting to deploy on the agents
-all_agent_files = [
-    [agent_module_feature_file, 'feature'],
-    [agent_module_type_file, 'type']
-]
+  all_agent_files = [
+      [agent_module_feature_file, 'feature'],
+      [agent_module_type_file, 'type']
+  ]
 
 # the command line args we'll pass to the agent each time we call it
-agent_args = "--trace --libdir=\"%s\" --pluginsync --no-daemonize --verbose " +
-    "--onetime --test --server #{master}"
+  agent_args = "--trace --libdir=\"%s\" --pluginsync --no-daemonize --verbose " +
+      "--onetime --test --server #{master}"
 # legal exit codes whenever we run the agent
 #  we need to allow exit code 2, which means "changes were applied" on the agent
-agent_exit_codes = [0, 2]
+  agent_exit_codes = [0, 2]
 
 # this begin block is here for handling temp file cleanup via an "ensure" block at the very end of the
 # test.
-begin
+  begin
 
-  # copy all the files to the master
-  step "write our simple module out to the master" do
-    create_test_file(master, master_module_type_file, master_module_type_content, :mkdirs => true)
-    create_test_file(master, master_module_feature_file, master_module_feature_content, :mkdirs => true)
-    create_test_file(master, master_manifest_file, master_manifest_content, :mkdirs => true)
-  end
+    # copy all the files to the master
+    step "write our simple module out to the master" do
+      create_test_file(master, master_module_type_file, master_module_type_content, :mkdirs => true)
+      create_test_file(master, master_module_feature_file, master_module_feature_content, :mkdirs => true)
+      create_test_file(master, master_manifest_file, master_manifest_content, :mkdirs => true)
+    end
 
-  step "verify that the module and manifest files exist on the master" do
-    all_master_files.each do |file_path, desc|
-      unless test_file_exists?(master, file_path) then
-        fail_test("Failed to create #{desc} file '#{get_test_file_path(master, file_path)}' on master")
+    step "verify that the module and manifest files exist on the master" do
+      all_master_files.each do |file_path, desc|
+        unless test_file_exists?(master, file_path) then
+          fail_test("Failed to create #{desc} file '#{get_test_file_path(master, file_path)}' on master")
+        end
       end
     end
-  end
 
-  step "start the master" do
+    step "start the master" do
 
-    master_opts = {
-      'main' => {
-        'environmentpath' => "#{get_test_file_path(master, environments_dir)}",
-      },
-    }
+      master_opts = {
+          'main' => {
+              'environmentpath' => "#{get_test_file_path(master, environments_dir)}",
+          },
+      }
 
-    with_puppet_running_on master, master_opts do
+      with_puppet_running_on master, master_opts do
 
-      # the module files shouldn't exist on the agent yet because they haven't been synced
-      step "verify that the module files don't exist on the agent path" do
-        agents.each do |agent|
-          all_agent_files.each do |file_path, desc|
-            if test_file_exists?(agent, file_path) then
-              fail_test("#{desc} file already exists on agent: '#{get_test_file_path(agent, file_path)}'")
+        # the module files shouldn't exist on the agent yet because they haven't been synced
+        step "verify that the module files don't exist on the agent path" do
+          agents.each do |agent|
+            all_agent_files.each do |file_path, desc|
+              if test_file_exists?(agent, file_path) then
+                fail_test("#{desc} file already exists on agent: '#{get_test_file_path(agent, file_path)}'")
+              end
             end
           end
         end
-      end
 
 
-      step "run the agent and verify that it loaded the feature" do
-        agents.each do |agent|
-          on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
-                       :acceptable_exit_codes => agent_exit_codes) do |result|
-            assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
-              "Expected agent stdout to include confirmation that the feature was 'true'")
-          end
-        end
-      end
-
-      step "verify that the module files were synced down to the agent" do
-        agents.each do |agent|
-          all_agent_files.each do |file_path, desc|
-            unless test_file_exists?(agent, file_path) then
-              fail_test("Expected #{desc} file not synced to agent: '#{get_test_file_path(agent, file_path)}'")
+        step "run the agent and verify that it loaded the feature" do
+          agents.each do |agent|
+            on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
+               :acceptable_exit_codes => agent_exit_codes) do |result|
+              assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
+                           "Expected agent stdout to include confirmation that the feature was 'true'")
             end
           end
         end
-      end
 
-      step "run the agent again" do
-        agents.each do |agent|
-          on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
-                          :acceptable_exit_codes => agent_exit_codes) do |result|
-            assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
-                         "Expected agent stdout to include confirmation that the feature was 'true'")
+        step "verify that the module files were synced down to the agent" do
+          agents.each do |agent|
+            all_agent_files.each do |file_path, desc|
+              unless test_file_exists?(agent, file_path) then
+                fail_test("Expected #{desc} file not synced to agent: '#{get_test_file_path(agent, file_path)}'")
+              end
+            end
           end
         end
+
+        step "run the agent again" do
+          agents.each do |agent|
+            on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
+               :acceptable_exit_codes => agent_exit_codes) do |result|
+              assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
+                           "Expected agent stdout to include confirmation that the feature was 'true'")
+            end
+          end
+        end
+
+        #TODO: was thinking about putting in a check for the timestamps on the files (maybe add a method for that to
+        # the framework?) to verify that they didn't get re-synced, but it seems like more trouble than it's worth
+        # at the moment.
+        #step "verify that the module files were not re-synced" do
+        #  fail_test("NOT YET IMPLEMENTED: verify that the module files were not re-synced")
+        #end
+
       end
 
-      #TODO: was thinking about putting in a check for the timestamps on the files (maybe add a method for that to
-      # the framework?) to verify that they didn't get re-synced, but it seems like more trouble than it's worth
-      # at the moment.
-      #step "verify that the module files were not re-synced" do
-      #  fail_test("NOT YET IMPLEMENTED: verify that the module files were not re-synced")
-      #end
+      all_tests_passed = true
 
     end
-
-    all_tests_passed = true
-
+  ensure
+    ##########################################################################################
+    # Clean up all of the temp files created by this test.  It would be nice if this logic
+    # could be handled outside of the test itself; I envision a stanza like this one appearing
+    # in a very large number of the tests going forward unless it is handled by the framework.
+    ##########################################################################################
+    if all_tests_passed then
+      remove_temp_dirs()
+    end
   end
-ensure
-  ##########################################################################################
-  # Clean up all of the temp files created by this test.  It would be nice if this logic
-  # could be handled outside of the test itself; I envision a stanza like this one appearing
-  # in a very large number of the tests going forward unless it is handled by the framework.
-  ##########################################################################################
-  if all_tests_passed then
-    remove_temp_dirs()
-  end
-end
 end

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,4 +1,4 @@
-test_name "the pluginsync functionality should sync feature definitions"
+test_name "the pluginsync functionality should sync feature definitions" do
 
 tag 'audit:medium',
     'audit:integration',
@@ -145,7 +145,7 @@ begin
       step "run the agent and verify that it loaded the feature" do
         agents.each do |agent|
           on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
-                       :acceptable_exit_codes => agent_exit_codes) do
+                       :acceptable_exit_codes => agent_exit_codes) do |result|
             assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
               "Expected agent stdout to include confirmation that the feature was 'true'")
           end
@@ -165,7 +165,7 @@ begin
       step "run the agent again" do
         agents.each do |agent|
           on(agent, puppet('agent', agent_args % get_test_file_path(agent, agent_lib_dir)),
-                          :acceptable_exit_codes => agent_exit_codes) do
+                          :acceptable_exit_codes => agent_exit_codes) do |result|
             assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
                          "Expected agent stdout to include confirmation that the feature was 'true'")
           end
@@ -193,4 +193,5 @@ ensure
   if all_tests_passed then
     remove_temp_dirs()
   end
+end
 end

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -21,12 +21,14 @@ test_name 'utf-8 characters in cached catalog' do
   on(master, "rm -rf '#{codedir}'")
   env_dir = "#{codedir}/environments"
   agents.each do |agent|
-    puts "agent name: #{agent.hostname}, platform: #{agent.platform}"
+
+    step "agent name: #{agent.hostname}, platform: #{agent.platform}"
     agent_vardir = agent.tmpdir("agent_vardir")
     agent_file   = agent.tmpfile("file" + utf8chars)
     teardown do
       on(agent, "rm -rf '#{agent_vardir}' '#{agent_file}'")
     end
+
     step "Apply manifest" do
       on(agent, "rm -rf '#{agent_file}'", :environment => { :LANG => "en_US.UTF-8" })
 
@@ -47,13 +49,13 @@ file { '#{env_dir}/production/manifests/site.pp' :
   ensure => file,
   mode => '0644',
   content => '
-file { "#{agent_file}" :
-  ensure => file,
-  mode => "0644",
-  content => "#{file_content}
-",
-}
-',
+    file { "#{agent_file}" :
+      ensure => file,
+      mode => "0644",
+      content => "#{file_content}
+    ",
+    }
+  ',
 }
 PP
 

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -1,41 +1,41 @@
 test_name 'utf-8 characters in cached catalog' do
 
-  tag 'audit:high',        # utf-8 is high impact in general
+  tag 'audit:high', # utf-8 is high impact in general
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
-      'audit:refactor',    # use mk_temp_environment_with_teardown
+      'audit:refactor', # use mk_temp_environment_with_teardown
       'server'
 
   confine :except, :platform => [
-    'windows',      # PUP-6983
-    'cumulus',      # PUP-7147
-    'cisco_ios',    # PUP-7150
-    'eos-4',        # PUP-7146
-    'aix',          # PUP-7194
-    'huawei',       # PUP-7195
+      'windows', # PUP-6983
+      'cumulus', # PUP-7147
+      'cisco_ios', # PUP-7150
+      'eos-4', # PUP-7146
+      'aix', # PUP-7194
+      'huawei', # PUP-7195
   ]
 
   utf8chars_lit = "€‰ㄘ万竹ÜÖ"
-  utf8chars = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
-  file_content = "This is the file content. file #{utf8chars}"
-  codedir = master.tmpdir("code")
+  utf8chars     = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
+  file_content  = "This is the file content. file #{utf8chars}"
+  codedir       = master.tmpdir("code")
   on(master, "rm -rf #{codedir}")
   env_dir = "#{codedir}/environments"
   agents.each do |agent|
     puts "agent name: #{agent.hostname}, platform: #{agent.platform}"
     agent_vardir = agent.tmpdir("agent_vardir")
-    agent_file = agent.tmpfile("file" + utf8chars) 
+    agent_file   = agent.tmpfile("file" + utf8chars)
     teardown do
       on(agent, "rm -rf #{agent_vardir} #{agent_file}")
     end
     step "Apply manifest" do
       on(
-        agent,
-        "rm -rf #{agent_file}",
-        :environment => {:LANG => "en_US.UTF-8"}
+          agent,
+          "rm -rf #{agent_file}",
+          :environment => { :LANG => "en_US.UTF-8" }
       )
-    
+
       master_manifest =
-<<PP
+          <<PP
     
 File {
   ensure => directory,
@@ -63,83 +63,83 @@ file { "#{agent_file}" :
 }
 
 PP
-        
+
       apply_manifest_on(
-        master,
-        master_manifest,
-        {
-          :acceptable_exit_codes => [0, 2],
-          :catch_failures => true,
-          :environment => {:LANG => "en_US.UTF-8"}
-        }
+          master,
+          master_manifest,
+          {
+              :acceptable_exit_codes => [0, 2],
+              :catch_failures        => true,
+              :environment           => { :LANG => "en_US.UTF-8" }
+          }
       )
     end
 
     master_opts = {
-      'main' => {
-        'environmentpath' => "#{env_dir}",
-      },
-      'agent' => {
-        'use_cached_catalog' => 'true'
-      }
+        'main'  => {
+            'environmentpath' => "#{env_dir}",
+        },
+        'agent' => {
+            'use_cached_catalog' => 'true'
+        }
     }
-    
-    with_puppet_running_on(master, master_opts, codedir) do 
+
+    with_puppet_running_on(master, master_opts, codedir) do
       step "apply utf-8 catalog" do
         on(
-          agent,
-          puppet(
-            "agent -t --vardir #{agent_vardir} --server #{master.hostname}"
-          ),
-          {
-            :acceptable_exit_codes => [2],
-            :environment => {:LANG => "en_US.UTF-8"}
-          }
+            agent,
+            puppet(
+                "agent -t --vardir #{agent_vardir} --server #{master.hostname}"
+            ),
+            {
+                :acceptable_exit_codes => [2],
+                :environment           => { :LANG => "en_US.UTF-8" }
+            }
         )
       end
-    
+
       step "verify cached catalog" do
         catalog_file_name =
-          "#{agent_vardir}/client_data/catalog/#{agent.node_name}.json"
+            "#{agent_vardir}/client_data/catalog/#{agent.node_name}.json"
 
         on(
-          agent,
-          "cat #{catalog_file_name}",
-          :environment => {:LANG => "en_US.UTF-8"}
+            agent,
+            "cat #{catalog_file_name}",
+            :environment => { :LANG => "en_US.UTF-8" }
         ) do |result|
           assert_match(
-            /#{agent_file}/,
-            result.stdout,
-            "cached catalog does not contain expected agent file name"
+              /#{agent_file}/,
+              result.stdout,
+              "cached catalog does not contain expected agent file name"
           )
           assert_match(
-            /#{file_content}/,
-            result.stdout,
-            "cached catalog does not contain expected file content"
+              /#{file_content}/,
+              result.stdout,
+              "cached catalog does not contain expected file content"
           )
         end
       end
-  
+
       step "apply cached catalog" do
         on(
-          agent,
-          puppet("resource file #{agent_file} ensure=absent"),
-          :environment => {:LANG => "en_US.UTF-8"}
+            agent,
+            puppet("resource file #{agent_file} ensure=absent"),
+            :environment => { :LANG => "en_US.UTF-8" }
         )
         on(
-          agent,
-          puppet("catalog apply --vardir #{agent_vardir} --terminus json"),
-          :environment => {:LANG => "en_US.UTF-8"}
+            agent,
+            puppet("catalog apply --vardir #{agent_vardir} --terminus json"),
+            :environment => { :LANG => "en_US.UTF-8" }
         )
         on(
-          agent,
-          "cat #{agent_file}",
-          :environment => {:LANG => "en_US.UTF-8"}
+            agent,
+            "cat #{agent_file}",
+            :environment => { :LANG => "en_US.UTF-8" }
         ) do |result|
           assert_match(
-            /#{utf8chars}/,
-            result.stdout,
-            "result stdout did not contain \"#{utf8chars}\""
+              /#{utf8chars}/,
+              result.stdout,
+              "result stdout did not contain \"#{utf8chars}\""
           )
         end
       end

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -2,17 +2,7 @@ test_name 'utf-8 characters in cached catalog' do
 
   tag 'audit:high', # utf-8 is high impact in general
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
-      'audit:refactor', # use mk_temp_environment_with_teardown
-      'server'
-
-  confine :except, :platform => [
-      'windows', # PUP-6983
-      'cumulus', # PUP-7147
-      'cisco_ios', # PUP-7150
-      'eos-4', # PUP-7146
-      'aix', # PUP-7194
-      'huawei', # PUP-7195
-  ]
+      'audit:refactor' # use mk_temp_environment_with_teardown
 
   utf8chars_lit = "€‰ㄘ万竹ÜÖ"
   utf8chars     = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -106,15 +106,15 @@ PP
           agent,
           "cat #{catalog_file_name}",
           :environment => {:LANG => "en_US.UTF-8"}
-        ) do
+        ) do |result|
           assert_match(
             /#{agent_file}/,
-            stdout,
+            result.stdout,
             "cached catalog does not contain expected agent file name"
           )
           assert_match(
             /#{file_content}/,
-            stdout,
+            result.stdout,
             "cached catalog does not contain expected file content"
           )
         end
@@ -135,10 +135,10 @@ PP
           agent,
           "cat #{agent_file}",
           :environment => {:LANG => "en_US.UTF-8"}
-        ) do
+        ) do |result|
           assert_match(
             /#{utf8chars}/,
-            stdout,
+            result.stdout,
             "result stdout did not contain \"#{utf8chars}\""
           )
         end

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -28,15 +28,9 @@ test_name 'utf-8 characters in cached catalog' do
       on(agent, "rm -rf #{agent_vardir} #{agent_file}")
     end
     step "Apply manifest" do
-      on(
-          agent,
-          "rm -rf #{agent_file}",
-          :environment => { :LANG => "en_US.UTF-8" }
-      )
+      on(agent, "rm -rf #{agent_file}", :environment => { :LANG => "en_US.UTF-8" })
 
-      master_manifest =
-          <<PP
-    
+      master_manifest = <<PP
 File {
   ensure => directory,
   mode => "0755",
@@ -61,18 +55,10 @@ file { "#{agent_file}" :
 }
 ',
 }
-
 PP
 
-      apply_manifest_on(
-          master,
-          master_manifest,
-          {
-              :acceptable_exit_codes => [0, 2],
-              :catch_failures        => true,
-              :environment           => { :LANG => "en_US.UTF-8" }
-          }
-      )
+      apply_manifest_on(master, master_manifest, {:acceptable_exit_codes => [0, 2],
+                                                  :catch_failures => true, :environment => { :LANG => "en_US.UTF-8" }})
     end
 
     master_opts = {
@@ -86,61 +72,24 @@ PP
 
     with_puppet_running_on(master, master_opts, codedir) do
       step "apply utf-8 catalog" do
-        on(
-            agent,
-            puppet(
-                "agent -t --vardir #{agent_vardir} --server #{master.hostname}"
-            ),
-            {
-                :acceptable_exit_codes => [2],
-                :environment           => { :LANG => "en_US.UTF-8" }
-            }
-        )
+        on(agent, puppet("agent -t --vardir #{agent_vardir} --server #{master.hostname}"),
+           { :acceptable_exit_codes => [2], :environment => { :LANG => "en_US.UTF-8" } })
       end
 
       step "verify cached catalog" do
-        catalog_file_name =
-            "#{agent_vardir}/client_data/catalog/#{agent.node_name}.json"
+        catalog_file_name = "#{agent_vardir}/client_data/catalog/#{agent.node_name}.json"
 
-        on(
-            agent,
-            "cat #{catalog_file_name}",
-            :environment => { :LANG => "en_US.UTF-8" }
-        ) do |result|
-          assert_match(
-              /#{agent_file}/,
-              result.stdout,
-              "cached catalog does not contain expected agent file name"
-          )
-          assert_match(
-              /#{file_content}/,
-              result.stdout,
-              "cached catalog does not contain expected file content"
-          )
+        on(agent, "cat #{catalog_file_name}", :environment => { :LANG => "en_US.UTF-8" }) do |result|
+          assert_match(/#{agent_file}/, result.stdout, "cached catalog does not contain expected agent file name")
+          assert_match(/#{file_content}/, result.stdout, "cached catalog does not contain expected file content")
         end
       end
 
       step "apply cached catalog" do
-        on(
-            agent,
-            puppet("resource file #{agent_file} ensure=absent"),
-            :environment => { :LANG => "en_US.UTF-8" }
-        )
-        on(
-            agent,
-            puppet("catalog apply --vardir #{agent_vardir} --terminus json"),
-            :environment => { :LANG => "en_US.UTF-8" }
-        )
-        on(
-            agent,
-            "cat #{agent_file}",
-            :environment => { :LANG => "en_US.UTF-8" }
-        ) do |result|
-          assert_match(
-              /#{utf8chars}/,
-              result.stdout,
-              "result stdout did not contain \"#{utf8chars}\""
-          )
+        on(agent, puppet("resource file #{agent_file} ensure=absent"), :environment => { :LANG => "en_US.UTF-8" })
+        on(agent, puppet("catalog apply --vardir #{agent_vardir} --terminus json"), :environment => { :LANG => "en_US.UTF-8" })
+        on(agent, "cat #{agent_file}", :environment => { :LANG => "en_US.UTF-8" }) do |result|
+          assert_match(/#{utf8chars}/, result.stdout, "result stdout did not contain \"#{utf8chars}\"")
         end
       end
     end


### PR DESCRIPTION
Updated 7 tests to enable them to run in the agent pipeline
I updated the test style and in 3 cases, made serious updates to the tests
    commit (Make major test updates...)
    I changed the test to actually do a pluginsync (which it wasn't before)
      4847_pluginfacts_should_be_resolvable_from_applications.rb
Your best off reviewing the separate commits, as I was careful what I put in each one.