### PR TITLE
(PUP-8509) Add flatten() function from stdlib to puppet

### DIFF
--- a/lib/puppet/functions/flatten.rb
+++ b/lib/puppet/functions/flatten.rb
@@ -1,0 +1,64 @@
+# Returns a flat Array produced from its possibly deeply nested given arguments.
+#
+# One or more arguments of any data type can be given to this function.
+# The result is always a flat array representation where any nested arrays are recursively flattened.
+#
+# @example Typical use of `flatten()`
+#
+# ```puppet
+# flatten(['a', ['b', ['c']]])
+# # Would return: ['a','b','c']
+# ```
+#
+# To flatten other kinds of iterables (for example hashes, or intermediate results like from a `reverse_each`)
+# first convert the result to an array using `Array($x)`, or `$x.convert_to(Array)`. See the `new` function
+# for details and options when performing a conversion.
+#
+# @example Flattening a Hash
+#
+# ```puppet
+# $hsh = { a => 1, b => 2}
+#
+# # -- without conversion
+# $hsh.flatten()
+# # Would return [{a => 1, b => 2}]
+#
+# # -- with conversion
+# $hsh.convert_to(Array).flatten()
+# # Would return [a,1,b,2]
+#
+# flatten(Array($hsh))
+# # Would also return [a,1,b,2]
+# ```
+#
+# @example Flattening and concatenating at the same time
+#
+# ```puppet
+# $a1 = [1, [2, 3]]
+# $a2 = [[4,[5,6]]
+# $x = 7
+# flatten($a1, $a2, $x)
+# # would return [1,2,3,4,5,6,7]
+# ```
+#
+# @example Transforming to Array if not already an Array
+#
+# ```puppet
+# flatten(42)
+# # Would return [42]
+#
+# flatten([42])
+# # Would also return [42]
+# ```
+#
+# @since 5.5.0 support for flattening and concatenating at the same time
+#
+Puppet::Functions.create_function(:flatten) do
+  dispatch :flatten_args do
+    repeated_param 'Any', :args
+  end
+
+  def flatten_args(*args)
+    args.flatten()
+  end
+end

--- a/spec/unit/functions/flatten_spec.rb
+++ b/spec/unit/functions/flatten_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the flatten function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  let(:array_fmt) { { 'format' => "%(a", 'separator'=>""} }
+
+  it 'returns flattened array of all its given arguments' do
+    expect(compile_to_catalog("notify { String([1,[2,[3]]].flatten, Array => #{array_fmt}): }")).to have_resource('Notify[(123)]')
+  end
+
+  it 'accepts a single non array value which results in it being wrapped in an array' do
+    expect(compile_to_catalog("notify { String(flatten(1), Array => #{array_fmt}): }")).to have_resource('Notify[(1)]')
+  end
+
+  it 'accepts a single array value - (which is a noop)' do
+    expect(compile_to_catalog("notify { String(flatten([1]), Array => #{array_fmt}): }")).to have_resource('Notify[(1)]')
+  end
+
+  it 'it does not flatten a hash - it is a value that gets wrapped' do
+    expect(compile_to_catalog("notify { String(flatten({a=>1}), Array => #{array_fmt}): }")).to have_resource("Notify[({'a' => 1})]")
+  end
+
+  it 'accepts mix of array and non array arguments and concatenates and flattens them' do
+    expect(compile_to_catalog("notify { String(flatten([1],2,[[3,4]]), Array => #{array_fmt}): }")).to have_resource('Notify[(1234)]')
+  end
+end


### PR DESCRIPTION
This adds the flatten function from stdlib to puppet.
This version is a 4.x implementation of the function and it is backwards
compatible. It adds a new feature in that it will concatenate and
flatten multiple arguments, and this also turns non array values into
being wrapped into an array.