### PR TITLE
(DOC-3502) Remove (s) from metaparameter docs.

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -391,7 +391,7 @@ class Type
     @key_attributes_cache ||= key_attribute_parameters.collect { |p| p.name }
   end
 
-  # Returns a mapping from the title string to setting of attribute value(s).
+  # Returns a mapping from the title string to setting of attribute values.
   # This default implementation provides a mapping of title to the one and only _namevar_ present
   # in the type's definition.
   # @note Advanced: some logic requires this mapping to be done differently, using a different
@@ -1474,7 +1474,7 @@ class Type
       @subclasses << sub
     end
 
-    # @return [Array<Puppet::Resource>] turns attribute value(s) into list of resources
+    # @return [Array<Puppet::Resource>] turns attribute values into list of resources
     def munge(references)
       references = [references] unless references.is_a?(Array)
       references.collect do |ref|
@@ -1582,7 +1582,7 @@ class Type
       Multiple resources can be specified as an array of references. When this
       attribute is present:
 
-      * The required resource(s) will be applied **before** this resource.
+      * The required resources will be applied **before** this resource.
 
       This is one of the four relationship metaparameters, along with
       `before`, `notify`, and `subscribe`. For more context, including the
@@ -1596,7 +1596,7 @@ class Type
       Multiple resources can be specified as an array of references. When this
       attribute is present:
 
-      * The subscribed resource(s) will be applied _before_ this resource.
+      * The subscribed resources will be applied _before_ this resource.
       * If Puppet makes changes to any of the subscribed resources, it will cause
         this resource to _refresh._ (Refresh behavior varies by resource
         type: services will restart, mounts will unmount and re-mount, etc. Not
@@ -1614,7 +1614,7 @@ class Type
       Multiple resources can be specified as an array of references. When this
       attribute is present:
 
-      * This resource will be applied _before_ the dependent resource(s).
+      * This resource will be applied _before_ the dependent resources.
 
       This is one of the four relationship metaparameters, along with
       `require`, `notify`, and `subscribe`. For more context, including the
@@ -1628,7 +1628,7 @@ class Type
       Multiple resources can be specified as an array of references. When this
       attribute is present:
 
-      * This resource will be applied _before_ the notified resource(s).
+      * This resource will be applied _before_ the notified resources.
       * If Puppet makes changes to this resource, it will cause all of the
         notified resources to _refresh._ (Refresh behavior varies by resource
         type: services will restart, mounts will unmount and re-mount, etc. Not
@@ -1700,7 +1700,7 @@ The value of this parameter must be a reference to a capability resource,
 or an array of such references. Each capability resource referenced here
 must have been exported by another resource in the same environment.
 
-The referenced capability resource(s) will be looked up, added to the
+The referenced capability resources will be looked up, added to the
 current node catalog, and processed following the underlying consumes
 clause.
 


### PR DESCRIPTION
To improve clarity and make localization easier, we should avoid using `(s)` to indicate when something is optionally plural. This PR removes `(s)` from docs generated from code in `/puppet/lib/`, including metaparameter docs.

CC @EamonnTP who reported the issue.