### PR TITLE
(PUP-7400) Yumrepo should manage username/password

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -417,4 +417,23 @@ Puppet::Type.newtype(:yumrepo) do
 
     newvalues(/^\d+$/, :absent)
   end
+
+  newproperty(:username) do
+    desc "Username to use for basic authentication to a repo or really any url.
+      #{ABSENT_DOC}"
+    newvalues(/.*/, :absent)
+  end
+
+  newproperty(:password) do
+    desc "Password to use with the username for basic authentication.
+      #{ABSENT_DOC}"
+    newvalues(/.*/, :absent)
+  end
+
+  private
+
+  def set_sensitive_parameters(sensitive_parameters)
+    parameter(:password).sensitive = true if parameter(:password)
+    super(sensitive_parameters)
+  end
 end

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -399,5 +399,23 @@ describe Puppet::Type.type(:yumrepo) do
       it_behaves_like "a yumrepo parameter that can be absent", :deltarpm_metadata_percentage
       it_behaves_like "a yumrepo parameter that expects a natural value", :deltarpm_metadata_percentage
     end
+
+    describe "username" do
+      it_behaves_like "a yumrepo parameter that can be absent", :username
+    end
+
+    describe "password" do
+      it_behaves_like "a yumrepo parameter that can be absent", :password
+
+      it "redacts password information from the logs" do
+        resource = described_class.new(:name => 'puppetlabs', :password => 'top secret')
+        harness = Puppet::Transaction::ResourceHarness.new(Puppet::Transaction.new(Puppet::Resource::Catalog.new, nil, nil))
+        harness.evaluate(resource)
+        resource[:password] = 'super classified'
+        status = harness.evaluate(resource)
+        sync_event = status.events[0]
+        expect(sync_event.message).to eq 'changed [redacted] to [redacted]'
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds support to yumrepo so that it can manage the username
and password for a given repo. This commit also sets password to be
sensitive so that information doesn't show up in any logs.