### PR TITLE
(PUP-8492) make empty(undef) work

### DIFF
--- a/lib/puppet/functions/empty.rb
+++ b/lib/puppet/functions/empty.rb
@@ -52,6 +52,7 @@ Puppet::Functions.create_function(:empty) do
   # (Yes, it is strange)
   #
   def numeric_empty(num)
+    deprecation_warning_for('Numeric')
     false
   end
 
@@ -63,6 +64,14 @@ Puppet::Functions.create_function(:empty) do
   # (Yes, it is strange, but undef was passed as empty string in 3.x API)
   #
   def undef_empty(x)
+    deprecation_warning_for('Undef')
     true
+  end
+
+  def deprecation_warning_for(arg_type)
+    stacktrace = Puppet::Pops::PuppetStack.stacktrace()
+    file, line = stacktrace[0] # defaults to nil
+    msg = _("Calling function empty() with %{arg_type} value is deprecated.") % { arg_type: arg_type }
+    Puppet.warn_once('deprecations', "empty-from-#{file}-#{line}", msg, file, line)
   end
 end

--- a/lib/puppet/functions/empty.rb
+++ b/lib/puppet/functions/empty.rb
@@ -5,7 +5,9 @@
 # * `String`, `Binary` - having zero length
 #
 # For backwards compatibility with the stdlib function with the same name the
-# following data types are also accepted by the function instead of raising an error:
+# following data types are also accepted by the function instead of raising an error.
+# Using these is deprecated and will raise a warning:
+#
 # * `Numeric` - `false` is returned for all `Numeric` values.
 # * `Undef` - `true` is returned for all `Undef` values.
 #

--- a/lib/puppet/functions/empty.rb
+++ b/lib/puppet/functions/empty.rb
@@ -3,9 +3,11 @@
 # This function can answer if one of the following is empty:
 # * `Array`, `Hash` - having zero entries
 # * `String`, `Binary` - having zero length
-# * `Numeric` - for backwards compatibility with the stdlib function with the same name,
-#   a result of `false` is returned for all `Numeric` values instead of raising an error.
-#   This may be changed in a future release of puppet.
+#
+# For backwards compatibility with the stdlib function with the same name the
+# following data types are also accepted by the function instead of raising an error:
+# * `Numeric` - `false` is returned for all `Numeric` values.
+# * `Undef` - `true` is returned for all `Undef` values.
 #
 # @example Using `empty`
 #
@@ -34,6 +36,10 @@ Puppet::Functions.create_function(:empty) do
     param 'Binary', :bin
   end
 
+  dispatch :undef_empty do
+    param 'Undef', :x
+  end
+
   def collection_empty(coll)
     coll.empty?
   end
@@ -53,4 +59,10 @@ Puppet::Functions.create_function(:empty) do
     bin.length == 0
   end
 
+  # For compatibility reasons - return true rather than error on undef
+  # (Yes, it is strange, but undef was passed as empty string in 3.x API)
+  #
+  def undef_empty(x)
+    true
+  end
 end

--- a/spec/unit/functions/empty_spec.rb
+++ b/spec/unit/functions/empty_spec.rb
@@ -56,4 +56,10 @@ describe 'the empty function' do
       expect(compile_to_catalog("notify { String(empty(Binary('b25l'))): }")).to have_resource('Notify[false]')
     end
   end
+
+  context 'for undef it' do
+    it 'returns true' do
+      expect(compile_to_catalog("notify { String(empty(undef)): }")).to have_resource('Notify[true]')
+    end
+  end
 end

--- a/spec/unit/functions/empty_spec.rb
+++ b/spec/unit/functions/empty_spec.rb
@@ -7,6 +7,9 @@ describe 'the empty function' do
   include PuppetSpec::Compiler
   include Matchers::Resource
 
+  let(:logs) { [] }
+  let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+
   context 'for an array it' do
     it 'returns true when empty' do
       expect(compile_to_catalog("notify { String(empty([])): }")).to have_resource('Notify[true]')
@@ -29,11 +32,17 @@ describe 'the empty function' do
 
   context 'for numeric values it' do
     it 'always returns false for integer values (including 0)' do
-      expect(compile_to_catalog("notify { String(empty(0)): }")).to have_resource('Notify[false]')
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        expect(compile_to_catalog("notify { String(empty(0)): }")).to have_resource('Notify[false]')
+      end
+      expect(warnings).to include(/Calling function empty\(\) with Numeric value is deprecated/)
     end
 
     it 'always returns false for float values (including 0.0)' do
-      expect(compile_to_catalog("notify { String(empty(0.0)): }")).to have_resource('Notify[false]')
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        expect(compile_to_catalog("notify { String(empty(0.0)): }")).to have_resource('Notify[false]')
+      end
+      expect(warnings).to include(/Calling function empty\(\) with Numeric value is deprecated/)
     end
   end
 
@@ -58,8 +67,11 @@ describe 'the empty function' do
   end
 
   context 'for undef it' do
-    it 'returns true' do
-      expect(compile_to_catalog("notify { String(empty(undef)): }")).to have_resource('Notify[true]')
+    it 'returns true and issues deprecation warning' do
+      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+        expect(compile_to_catalog("notify { String(empty(undef)): }")).to have_resource('Notify[true]')
+      end
+      expect(warnings).to include(/Calling function empty\(\) with Undef value is deprecated/)
     end
   end
 end


### PR DESCRIPTION
This PR fixes that empty(undef) must return true instead of failing.
This PR also adds deprecation warning for calling empty with Numeric or Undef argument.