### PR TITLE
(maint) Add trace, clearer message to EOFError

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -4,6 +4,7 @@ require 'puppet/ssl/configuration'
 require 'puppet/ssl/validator'
 require 'puppet/network/http'
 require 'uri'
+require 'time'
 
 module Puppet::Network::HTTP
 
@@ -205,7 +206,14 @@ module Puppet::Network::HTTP
     end
 
     def execute_request(connection, request)
+      start = Time.now
       connection.request(request)
+    rescue EOFError => e
+      elapsed = (Time.now - start).to_f.round(3)
+      uri = @site.addr + request.path.split('?')[0]
+      eof = EOFError.new(_('request %{uri} interrupted after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
+      eof.set_backtrace(e.backtrace) unless e.backtrace.empty?
+      raise eof
     end
 
     def with_connection(site, &block)


### PR DESCRIPTION
This is an improvement for PUP-3238, though not a solve.

Net::HTTP will raise an EOFError when something goes wrong at the network stack level, such as a connection being interrupted or terminated by a load balancer in the middle of a transaction. By default, Ruby raises an EOFError with the message "end of file reached" and no backtrace.

This commit catches EOFError exceptions raised by Net::HTTP#request, and re-raises the EOFError with a meaningful message and backtrace. Because this type of error is typically caused by problems from the network stack level, which are frequently timeout-related, the error message will include how long the request ran before termination.

At the very least it will be much clearer what is happening when these kinds of errors occur. It will also show a stack trace when Puppet is run with `--trace`, which previously was not the case.

Previously:
```
Error: Could not retrieve catalog from remote server: end of file reached
```

Now:
```
Error: Could not retrieve catalog from remote server: request https://master.llu.puppet.vm:9140/puppet/v3/catalog/master.llu.puppet.vm interrupted after 1.004 seconds
```