### PR TITLE
(PUP-8519) Fix problem with error using missing issue code

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -740,6 +740,10 @@ module Issues
     _('Heredoc without any following lines of text')
   end
 
+  HEREDOC_EMPTY_ENDTAG = hard_issue :HEREDOC_EMPTY_ENDTAG do
+    _('Heredoc with an empty endtag')
+  end
+
   HEREDOC_MULTIPLE_AT_ESCAPES = hard_issue :HEREDOC_MULTIPLE_AT_ESCAPES, :escapes do
     _("An escape char for @() may only appear once. Got '%{escapes}'") % { escapes: escapes.join(', ') }
   end

--- a/lib/puppet/pops/parser/heredoc_support.rb
+++ b/lib/puppet/pops/parser/heredoc_support.rb
@@ -34,7 +34,7 @@ module HeredocSupport
       endtag = $1.strip
     end
 
-    lex_error(Issues::HEREDOC_MISSING_ENDTAG) unless endtag.length >= 1
+    lex_error(Issues::HEREDOC_EMPTY_ENDTAG) unless endtag.length >= 1
 
     resulting_escapes = []
     if escapes

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -540,6 +540,15 @@ describe 'Lexer2' do
         expect_issue(code, Puppet::Pops::Issues::HEREDOC_WITHOUT_TEXT)
       end
 
+      it 'detects and reports HEREDOC_EMPTY_ENDTAG' do
+        code = <<-CODE
+        @("")
+        Text
+        |-END
+        CODE
+        expect_issue(code, Puppet::Pops::Issues::HEREDOC_EMPTY_ENDTAG)
+      end
+
       it 'detects and reports HEREDOC_MULTIPLE_AT_ESCAPES' do
         code = <<-CODE
         @(END:syntax/tst)


### PR DESCRIPTION
When a heredoc is used with empty endtag spec (for example `@("")`) this
error was reported with an issue code that does not exist causing a
different error to be raised (a Ruby NameError).

This is now corrected and the issue HEREDOC_EMPTY_ENDTAG is raised.