### PR TITLE
(PUP-8537) Change match expression validation to have side effect

### DIFF
--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -908,6 +908,10 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     true
   end
 
+  def idem_MatchExpression(o)
+    false # can have side effect of setting $n match variables
+  end
+
   def idem_RelationshipExpression(o)
     # Always side effect
     false

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -283,7 +283,9 @@ describe "validating 4x" do
       'Foo[a] -> Foo[b]',
       '($a=1)',
       'foo()',
-      '$a.foo()'
+      '$a.foo()',
+      '"foo" =~ /foo/', # may produce or modify $n vars
+      '"foo" !~ /foo/', # may produce or modify $n vars
       ].each do |expr|
 
       it "does not produce error when for productive: #{expr}" do


### PR DESCRIPTION
Before this, it was considered an error to have a match expression
followed by an expression that uses the numeric variables. This was
caused because the "idem" validation did not consider that match
expression have a potential side effect on the numeric match variables
(setting or clearing them).

This is not changed.

It is however not possible (with reasonable effort and cost at runtime)
to authoritatively find cases when a match does not modify the numeric
variables. It therefore allows all match expressions even if some could
have no side effect and thus be a potential error.