### PR TITLE
(PUP-8538) Remove chpasswd username for AIX

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -268,7 +268,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     # Must receive "user:enc_password" as input
     # command, arguments = {:failonfail => true, :combine => true}
     # Fix for bugs #11200 and #10915
-    cmd = [self.class.command(:chpasswd), get_ia_module_args, '-e', '-c', user].flatten
+    cmd = [self.class.command(:chpasswd), get_ia_module_args, '-e', '-c'].flatten
     begin
       output = execute(cmd, {:failonfail => false, :combine => true, :stdinfile => tmpfile.path })
       # chpasswd can return 1, even on success (at least on AIX 6.1); empty output indicates success


### PR DESCRIPTION
Prior to this PR the AIX user resource would fail on newer AIX releases. IBM changed the behavior of `chpasswd` to error when extra parameters were sent to the `chpasswd` command, so setting the password on AIX 7.1 SP5 and AIX 7.2 SP1 would fail. The command contained an unnecessary parameter, which this PR removes. 