### PR TITLE
(PUP-8485) Cache failed confine lookups

### DIFF
--- a/lib/puppet/confine.rb
+++ b/lib/puppet/confine.rb
@@ -21,7 +21,7 @@ class Puppet::Confine
   end
 
   def self.test(name)
-    unless @tests[name]
+    unless @tests.include?(name)
       begin
         require "puppet/confine/#{name}"
       rescue LoadError => detail
@@ -29,6 +29,9 @@ class Puppet::Confine
           warn "Could not load confine test '#{name}': #{detail}"
         end
         # Could not find file
+        if !Puppet[:always_retry_plugins]
+          @tests[name] = nil
+        end
       end
     end
     @tests[name]

--- a/spec/unit/confine_spec.rb
+++ b/spec/unit/confine_spec.rb
@@ -74,4 +74,20 @@ describe Puppet::Confine do
       expect(@confine.result).to eq([true, false, true, false])
     end
   end
+
+  describe "when requiring" do
+    it "does not cache failed requires when always_retry_plugins is true" do
+      Puppet[:always_retry_plugins] = true
+      Puppet::Confine.expects(:require).with('puppet/confine/osfamily').twice.raises(LoadError)
+      Puppet::Confine.test(:osfamily)
+      Puppet::Confine.test(:osfamily)
+    end
+
+    it "caches failed requires when always_retry_plugins is false" do
+      Puppet[:always_retry_plugins] = false
+      Puppet::Confine.expects(:require).with('puppet/confine/osfamily').once.raises(LoadError)
+      Puppet::Confine.test(:osfamily)
+      Puppet::Confine.test(:osfamily)
+    end
+  end
 end


### PR DESCRIPTION
When `always_retry_plugins` is not set we can cache the result of
Confine tests to avoid repeatedly requiring a file that doesn't exist.
Require calls generate a lot of garbage so this is a meaningful
optimization.