### PR TITLE
(PUP-7675) Add support for convert_to lookup option

### DIFF
--- a/lib/puppet/functions/lookup.rb
+++ b/lib/puppet/functions/lookup.rb
@@ -207,7 +207,8 @@ Puppet::Functions.create_function(:lookup, Puppet::Functions::InternalFunction) 
   end
 
   def do_lookup(scope, name, value_type, default_value, has_default, override, default_values_hash, merge, &block)
-    Puppet::Pops::Lookup.lookup(name, value_type, default_value, has_default, merge, Puppet::Pops::Lookup::Invocation.new(scope, override, default_values_hash), &block)
+    Puppet::Pops::Lookup.lookup(name, value_type, default_value, has_default, merge,
+      Puppet::Pops::Lookup::Invocation.new(scope, override, default_values_hash), &block)
   end
 
   def hash_args(options_hash)

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -5,8 +5,6 @@ module Puppet::Pops
 module Lookup
   LOOKUP_OPTIONS = 'lookup_options'.freeze
   GLOBAL = '__global__'.freeze
-  CONVERT_TO = 'convert_to'.freeze
-  NEW = 'new'.freeze
 
   # Performs a lookup in the configured scopes and optionally merges the default.
   #
@@ -57,31 +55,6 @@ module Lookup
       else
         lookup_invocation.emit_debug_info(debug_preamble(names)) if Puppet[:debug]
         fail_lookup(names)
-      end
-    else
-      opt_key = Puppet::Pops::Lookup::LookupKey.new(result_with_name[0])
-      options = lookup_invocation.lookup_adapter.lookup_lookup_options(opt_key, lookup_invocation)
-      ct = options[CONVERT_TO] unless options.nil?
-      if !ct.nil?
-        ct = ct.is_a?(Array) ? ct : [ct]
-        if ct[0].is_a?(String)
-          begin
-            ct[0] = Puppet::Pops::Types::TypeParser.singleton.parse(ct[0])
-          rescue StandardError => e
-            raise Puppet::DataBinding::LookupError,
-              _("Invalid data type in lookup_options for key '%{key}' could not parse '%{source}', error: '%{msg}") %
-                { key: result_with_name[0], source: ct[0], msg: e.message}
-          end
-        end
-        # TODO: if this fails the error needs to reference the lookup_option file/line
-        new_args = [ct[0], answer, *(ct[1..-1])]
-        begin
-          answer = lookup_invocation.scope.call_function(NEW, new_args)
-        rescue StandardError => e
-          raise Puppet::DataBinding::LookupError,
-            _("The convert_to lookup_option for key '%{key}' raised error: %{msg}") %
-              { key: result_with_name[0], msg: e.message}
-        end
       end
     end
     lookup_invocation.emit_debug_info(debug_preamble(names)) if Puppet[:debug]

--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -68,7 +68,7 @@ module Lookup
           begin
             ct[0] = Puppet::Pops::Types::TypeParser.singleton.parse(ct[0])
           rescue StandardError => e
-            raise Puppet::DataBinding::LookupError
+            raise Puppet::DataBinding::LookupError,
               _("Invalid data type in lookup_options for key '%{key}' could not parse '%{source}', error: '%{msg}") %
                 { key: result_with_name[0], source: ct[0], msg: e.message}
           end

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -90,7 +90,7 @@ class LookupAdapter < DataAdapter
   def convert_result(key, lookup_options, lookup_invocation, the_lookup)
     result = the_lookup.call
     convert_to = lookup_options[CONVERT_TO]
-    return result if convert_to.nil? || result.nil?
+    return result if convert_to.nil?
 
     convert_to = convert_to.is_a?(Array) ? convert_to : [convert_to]
     if convert_to[0].is_a?(String)

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -104,8 +104,9 @@ class LookupAdapter < DataAdapter
     end
     begin
       result = lookup_invocation.scope.call_function(NEW, [convert_to[0], result, *convert_to[1..-1]])
-      # TRANSLATORS 'lookup_options' and 'convert_to' should not be translated
-      lookup_invocation.report_text { _("Applying lookup_option convert_to with arguments %{args}") % { args: convert_to } }
+      # TRANSLATORS 'lookup_options', 'convert_to' and args_string variable should not be translated,
+      args_string = Puppet::Pops::Types::StringConverter.singleton.convert(convert_to)
+      lookup_invocation.report_text { _("Applying convert_to lookup_option with arguments %{args}") % { args: args_string } }
     rescue StandardError => e
       raise Puppet::DataBinding::LookupError,
         _("The convert_to lookup_option for key '%{key}' raised error: %{msg}") %

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -16,6 +16,8 @@ class LookupAdapter < DataAdapter
 
   HASH = 'hash'.freeze
   MERGE = 'merge'.freeze
+  CONVERT_TO = 'convert_to'.freeze
+  NEW = 'new'.freeze
 
   def self.create_adapter(compiler)
     new(compiler)
@@ -52,18 +54,62 @@ class LookupAdapter < DataAdapter
         catch(:no_such_key) { do_lookup(LookupKey::LOOKUP_OPTIONS, lookup_invocation, HASH) }
         nil
       else
+        lookup_options = lookup_lookup_options(key, lookup_invocation) || {}
+
         if merge.nil?
           # Used cached lookup_options
-          merge = lookup_merge_options(key, lookup_invocation)
+          # merge = lookup_merge_options(key, lookup_invocation)
+          merge = lookup_options[MERGE]
           lookup_invocation.report_merge_source(LOOKUP_OPTIONS) unless merge.nil?
         end
-        lookup_invocation.with(:data, key.to_s) do
-          catch(:no_such_key) { return do_lookup(key, lookup_invocation, merge) }
-          throw :no_such_key if lookup_invocation.global_only?
-          key.dig(lookup_invocation, lookup_default_in_module(key, lookup_invocation))
-        end
+        convert_result(key.to_s, lookup_options, lookup_invocation, lambda do
+          lookup_invocation.with(:data, key.to_s) do
+            catch(:no_such_key) { return do_lookup(key, lookup_invocation, merge) }
+            throw :no_such_key if lookup_invocation.global_only?
+            key.dig(lookup_invocation, lookup_default_in_module(key, lookup_invocation))
+          end
+        end)
       end
     end
+  end
+
+  # Performs a possible conversion of the result of calling `the_lookup` lambda
+  # The conversion takes place if there is a 'convert_to' key in the lookup_options
+  # If there is no conversion, the result of calling `the_lookup` is returned
+  # otherwise the successfully converted value.
+  # Errors are raised if the convert_to is faulty (bad type string, or if a call to
+  # new(T, <args>) fails.
+  #
+  # @param key [String] The key to lookup
+  # @param lookup_options [Hash] a hash of options
+  # @param lookup_invocation [Invocation] the lookup invocation
+  # @param the_lookup [Lambda] zero arg lambda that performs the lookup of a value
+  # @return [Object] the looked up value, or converted value if there was conversion
+  # @throw :no_such_key when the object is not found (if thrown by `the_lookup`)
+  #
+  def convert_result(key, lookup_options, lookup_invocation, the_lookup)
+    result = the_lookup.call
+    convert_to = lookup_options[CONVERT_TO]
+    return result if convert_to.nil? || result.nil?
+
+    convert_to = convert_to.is_a?(Array) ? convert_to : [convert_to]
+    if convert_to[0].is_a?(String)
+      begin
+        convert_to[0] = Puppet::Pops::Types::TypeParser.singleton.parse(convert_to[0])
+      rescue StandardError => e
+        raise Puppet::DataBinding::LookupError,
+          _("Invalid data type in lookup_options for key '%{key}' could not parse '%{source}', error: '%{msg}") %
+            { key: key, source: convert_to[0], msg: e.message}
+      end
+    end
+    begin
+      result = lookup_invocation.scope.call_function(NEW, [convert_to[0], result, *convert_to[1..-1]])
+    rescue StandardError => e
+      raise Puppet::DataBinding::LookupError,
+        _("The convert_to lookup_option for key '%{key}' raised error: %{msg}") %
+          { key: key, msg: e.message}
+    end
+    result
   end
 
   def lookup_global(key, lookup_invocation, merge_strategy)

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -104,6 +104,8 @@ class LookupAdapter < DataAdapter
     end
     begin
       result = lookup_invocation.scope.call_function(NEW, [convert_to[0], result, *convert_to[1..-1]])
+      # TRANSLATORS 'lookup_options' and 'convert_to' should not be translated
+      lookup_invocation.report_text { _("Applying lookup_option convert_to with arguments %{args}") % { args: convert_to } }
     rescue StandardError => e
       raise Puppet::DataBinding::LookupError,
         _("The convert_to lookup_option for key '%{key}' raised error: %{msg}") %

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -89,7 +89,6 @@ describe Puppet::Application::Lookup do
     end
   end
 
-
   context 'when given a valid configuration' do
     let (:lookup) { Puppet::Application[:lookup] }
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2806,9 +2806,24 @@ describe "The lookup function" do
           mod_a::f:
             a:
               a: value mod_a::f.a.a (from module)
+          mod_a::to_array1: 'hello'
+          mod_a::to_array2: 'hello'
+          mod_a::to_int: 'bananas'
+          mod_a::to_bad_type: 'pyjamas'
           lookup_options:
             mod_a::e:
               merge: deep
+            mod_a::to_array1:
+              merge: deep
+              convert_to: "Array"
+            mod_a::to_array2:
+              convert_to:
+                - "Array"
+                - true
+            mod_a::to_int:
+              convert_to: "Integer"
+            mod_a::to_bad_type:
+              convert_to: "ComicSans"
           YAML
 
 
@@ -2894,6 +2909,24 @@ describe "The lookup function" do
 
         it 'lookup_options from default hierarchy does not effect values found in the regular hierarchy' do
           expect(lookup('mod_a::d')).to eql('a' => 'value mod_a::d.a (from module)')
+        end
+
+        context "and conversion via convert_to" do
+          it 'converts with a single data type value' do
+            expect(lookup('mod_a::to_array1')).to eql(['h', 'e', 'l', 'l', 'o'])
+          end
+
+          it 'converts with an array of arguments to the convert_to call' do
+            expect(lookup('mod_a::to_array2')).to eql(['hello'])
+          end
+
+          it 'errors if a convert_to lookup_option cannot be performed because value does not match type' do
+            expect{lookup('mod_a::to_int')}.to raise_error(/The string 'bananas' cannot be converted to Integer/)
+          end
+
+          it 'errors if a convert_to lookup_option cannot be performed because type does not exist' do
+            expect{lookup('mod_a::to_bad_type')}.to raise_error(/Creation of new instance of type 'TypeReference\['ComicSans'\]' is not supported/)
+          end
         end
 
         it 'the default hierarchy lookup is included in the explain output' do

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2921,11 +2921,11 @@ describe "The lookup function" do
           end
 
           it 'errors if a convert_to lookup_option cannot be performed because value does not match type' do
-            expect{lookup('mod_a::to_int')}.to raise_error(/The string 'bananas' cannot be converted to Integer/)
+            expect{lookup('mod_a::to_int')}.to raise_error(/The convert_to lookup_option for key 'mod_a::to_int' raised error.*The string 'bananas' cannot be converted to Integer/)
           end
 
           it 'errors if a convert_to lookup_option cannot be performed because type does not exist' do
-            expect{lookup('mod_a::to_bad_type')}.to raise_error(/Creation of new instance of type 'TypeReference\['ComicSans'\]' is not supported/)
+            expect{lookup('mod_a::to_bad_type')}.to raise_error(/The convert_to lookup_option for key 'mod_a::to_bad_type' raised error.*Creation of new instance of type 'TypeReference\['ComicSans'\]' is not supported/)
           end
         end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2927,6 +2927,16 @@ describe "The lookup function" do
           it 'errors if a convert_to lookup_option cannot be performed because type does not exist' do
             expect{lookup('mod_a::to_bad_type')}.to raise_error(/The convert_to lookup_option for key 'mod_a::to_bad_type' raised error.*Creation of new instance of type 'TypeReference\['ComicSans'\]' is not supported/)
           end
+
+          it 'adds explanation that conversion took place with a type' do
+            explanation = explain('mod_a::to_array1')
+            expect(explanation).to include('Applying convert_to lookup_option with arguments [Array]')
+          end
+
+          it 'adds explanation that conversion took place with a type and arguments' do
+            explanation = explain('mod_a::to_array2')
+            expect(explanation).to include('Applying convert_to lookup_option with arguments [Array, true]')
+          end
         end
 
         it 'the default hierarchy lookup is included in the explain output' do

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2810,6 +2810,7 @@ describe "The lookup function" do
           mod_a::to_array2: 'hello'
           mod_a::to_int: 'bananas'
           mod_a::to_bad_type: 'pyjamas'
+          mod_a::undef_value: null
           lookup_options:
             mod_a::e:
               merge: deep
@@ -2824,6 +2825,10 @@ describe "The lookup function" do
               convert_to: "Integer"
             mod_a::to_bad_type:
               convert_to: "ComicSans"
+            mod_a::undef_value:
+              convert_to:
+                - "Array"
+                - true
           YAML
 
 
@@ -2918,6 +2923,10 @@ describe "The lookup function" do
 
           it 'converts with an array of arguments to the convert_to call' do
             expect(lookup('mod_a::to_array2')).to eql(['hello'])
+          end
+
+          it 'does not convert an undef/nil value that has convert_to option' do
+            expect(lookup('mod_a::undef_value')).to eql(nil)
           end
 
           it 'errors if a convert_to lookup_option cannot be performed because value does not match type' do

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -2925,8 +2925,8 @@ describe "The lookup function" do
             expect(lookup('mod_a::to_array2')).to eql(['hello'])
           end
 
-          it 'does not convert an undef/nil value that has convert_to option' do
-            expect(lookup('mod_a::undef_value')).to eql(nil)
+          it 'converts an undef/nil value that has convert_to option' do
+            expect(lookup('mod_a::undef_value')).to eql([nil])
           end
 
           it 'errors if a convert_to lookup_option cannot be performed because value does not match type' do

--- a/spec/unit/pops/lookup/interpolation_spec.rb
+++ b/spec/unit/pops/lookup/interpolation_spec.rb
@@ -25,6 +25,11 @@ describe 'Puppet::Pops::Lookup::Interpolation' do
       found = sub_lookup(name, lookup_invocation, segments, found) unless segments.empty?
       @interpolator.interpolate(found, lookup_invocation, true)
     end
+
+    # ignore requests for lookup options when testing interpolation
+    def lookup_lookup_options(_, _)
+      nil
+    end
   end
 
   let(:interpolator) { Class.new { include Lookup::Interpolation }.new }


### PR DESCRIPTION
This adds support for convert_to in lookup_options.
The convert_to key should be either String (a data type string), or Tuple[String, Any, 1].

The result is only converted at the very end.
There is no conversion of a default value given to the lookup function,
or returned from a block computing the default value - they must return
the expected result type.