### PR TITLE
(PUP-8541) Make lookup of yaml_data fail on bad data when --strict=error

### DIFF
--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -50,7 +50,9 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
         if data.is_a?(Hash)
           Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
         else
-          Puppet.warning(_("%{path}: file does not contain a valid yaml hash") % { path: path })
+          msg = _("%{path}: file does not contain a valid yaml hash") % { path: path }
+          raise Puppet::DataBinding::LookupError, msg if Puppet[:strict] == :error && data != false
+          Puppet.warning(msg)
           {}
         end
       rescue YAML::SyntaxError => ex

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -25,7 +25,9 @@ Puppet::Functions.create_function(:yaml_data) do
         if data.is_a?(Hash)
           Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
         else
-          Puppet.warning(_("%{path}: file does not contain a valid yaml hash" % { path: path }))
+          msg = _("%{path}: file does not contain a valid yaml hash" % { path: path })
+          raise Puppet::DataBinding::LookupError, msg if Puppet[:strict] == :error && data != false
+          Puppet.warning(msg)
           {}
         end
       rescue YAML::SyntaxError => ex


### PR DESCRIPTION
Prior to this commit, a warning would be logged when data that was read
by the lookup function `yaml_data` or `eyaml_lookup_key` wasn't in the
form of a hash. This commit retains that behavior with the addition that
if `--strict=error` is given, and the data doesn't indicate an empty
file (`YAML#load` returns `false` for this), then an error will be
raised.