### PR TITLE
(PUP-8542) change target description from yumrepo

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -39,7 +39,7 @@ Puppet::Type.newtype(:yumrepo) do
   end
 
   newparam(:target) do
-    desc "The filename to write the yum repository to."
+    desc "The target parameter will be enabled in a future release and should not be used."
 
     defaultto :absent
   end


### PR DESCRIPTION
The target parameter does not work for yumrepo. So change the description 
so that we inform the user that the parameter will be enabled in a future
release and should not be used.