### PR TITLE
(PUP-7519) Enable security top YAMLLoad rule in rubocop scans

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'lib/**/*.rb'
     - 'ext/**/*.rb'
   Exclude:
+    - '**/*.spec'
     - '**/*.erb'
     - 'acceptance/**/*'
     - 'autotest/**/*'
@@ -742,9 +743,8 @@ Performance/CompareWithBlock:
 Security/JSONLoad:
   Enabled: false
 
-# TODO PUP-8004
 Security/YAMLLoad:
-  Enabled: false
+  Enabled: true
 
 Style/EmptyCaseCondition:
   Enabled: false


### PR DESCRIPTION
Enabling 'Security/YAMLLoad' rubocop rule for now per PUP-7834 work. There still are some eval and MarshalLoad usages that need to be addressed.