### PR TITLE
(PUP-8545) Don't write directly to /dev/stdout

### DIFF
--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -41,7 +41,7 @@ module Puppet::Util::Plist
 
         Puppet.debug "Plist #{file_path} ill-formatted, converting with plutil"
         begin
-          plist = Puppet::Util::Execution.execute(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', file_path],
+          plist = Puppet::Util::Execution.execute(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', file_path],
                                                   {:failonfail => true, :combine => true})
           return parse_plist(plist)
         rescue Puppet::ExecutionFailure => detail

--- a/spec/unit/util/plist_spec.rb
+++ b/spec/unit/util/plist_spec.rb
@@ -92,7 +92,7 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
       subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(invalid_xml_plist)
       Puppet.expects(:debug).with(regexp_matches(/^Failed with CFFormatError/))
       Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
-      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', plist_path],
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
                                                      {:failonfail => true, :combine => true}).returns(valid_xml_plist)
       expect(subject.read_plist_file(plist_path)).to eq(valid_xml_plist_hash)
     end
@@ -101,7 +101,7 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
       subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(non_plist_data)
       Puppet.expects(:debug).with(regexp_matches(/^Failed with (CFFormatError|NoMethodError)/))
       Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
-      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', plist_path],
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
                                                      {:failonfail => true, :combine => true}).raises(Puppet::ExecutionFailure, 'boom')
       expect(subject.read_plist_file(plist_path)).to eq(nil)
     end
@@ -110,7 +110,7 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
       subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(binary_data)
       Puppet.expects(:debug).with(regexp_matches(/^Failed with (CFFormatError|ArgumentError)/))
       Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
-      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '/dev/stdout', plist_path],
+      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
                                                      {:failonfail => true, :combine => true}).raises(Puppet::ExecutionFailure, 'boom')
       expect(subject.read_plist_file(plist_path)).to eq(nil)
     end


### PR DESCRIPTION
Previously, puppet would try to read plist files with the CFPropertyList
gem. If that failed, it would use `plutil -convert xml1 -o /dev/stdout` to
attempt to work around any issues with the file. It appears, though, that
writing to /dev/stdout directly in ruby 2.4 is blocked.

plutil's man page suggests '-o -' instead:
-o path Specify an alternate path name for the result of the -convert
   operation; this option is only useful with a single file to be converted.
   Specifying - as the path outputs to std-out.

This commit changes the plutil command accordingly, letting certain malformed
plists be read correctly.