### PR TITLE
(PUP-8498) Make sure faulty resource ref is shown with location info

### DIFF
--- a/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/relationship_validator.rb
@@ -32,8 +32,15 @@ class Puppet::Parser::Compiler
         refs = param.value.is_a?(Array) ? param.value.flatten : [param.value]
         refs.each do |r|
           next if r.nil? || r == :undef
-          unless catalog.resource(r.to_s)
-            msg = _("Could not find resource '%{res}' in parameter '%{param}'") % { res: r.to_s, param: param.name.to_s }
+          res = r.to_s
+          begin
+            found = catalog.resource(res)
+          rescue ArgumentError => e
+            # Raise again but with file and line information
+            raise CatalogValidationError.new(e.message, param.file, param.line)
+          end
+          unless found
+            msg = _("Could not find resource '%{res}' in parameter '%{param}'") % { res: res, param: param.name.to_s }
             raise CatalogValidationError.new(msg, param.file, param.line)
           end
         end

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -520,6 +520,15 @@ describe Puppet::Parser::Compiler do
           PP
         }.to raise_error(/Could not find resource 'Notify\[tooth_fairy\]' in parameter 'require'/)
       end
+
+      it 'faulty references are reported with source location' do
+        expect { 
+          compile_to_catalog(<<-PP)
+            notify{ x : 
+              require => tooth_fairy }
+          PP
+        }.to raise_error(/"tooth_fairy" is not a valid resource reference.*\(line: 2\)/)
+      end
     end
 
     describe "relationships can be formed" do


### PR DESCRIPTION
Before this, the error that resulted when trying to use a resource
reference consisting of only a String title did not include any
information about the source location.

Now the catalog validator rescues this error and re-raises it with
location information.