### PR TITLE
(PUP-8549) Force tag validation to be done in UTF-8

### DIFF
--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -108,7 +108,12 @@ module Puppet::Util::Tagging
 
   def valid_tag?(maybe_tag)
     begin
-      maybe_tag.encode(Encoding::UTF_8) =~ ValidTagRegex
+      tag_enc = maybe_tag.encoding
+      if tag_enc == Encoding::UTF_8 || tag_enc == Encoding::ASCII
+        maybe_tag =~ ValidTagRegex
+      else
+        maybe_tag.encode(Encoding::UTF_8) =~ ValidTagRegex
+      end
     rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
       false
     end

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::Util::Tagging do
     "\"",
     "'",
   ].each do |char|
-    it "should not allow UTF-8 punctuation characters" do
+    it "should not allow UTF-8 punctuation characters, e.g. #{char}" do
       expect { tagger.tag(char) }.to raise_error(Puppet::ParseError)
     end
   end

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -96,6 +96,20 @@ describe Puppet::Util::Tagging do
     end
   end
 
+  it "should allow encodings that can be coerced to UTF-8" do
+     chinese = "標記你是它".force_encoding(Encoding::UTF_8)
+     ascii   = "tags--".force_encoding(Encoding::ASCII_8BIT)
+     jose    = "jos\xE9".force_encoding(Encoding::ISO_8859_1)
+
+     [chinese, ascii, jose].each do |tag|
+       expect(tagger.valid_tag?(tag)).to be_truthy
+     end
+  end
+
+  it "should not allow strings that cannot be converted to UTF-8" do
+    invalid = "\xA0".force_encoding(Encoding::ASCII_8BIT)
+    expect(tagger.valid_tag?(invalid)).to be_falsey
+  end
 
   it "should add qualified classes as tags" do
     tagger.tag("one::two")


### PR DESCRIPTION
Previously, when checking if a string was a valid tag we would not
ensure the encoding of either the tag string or the validation regex.
Usually, when one is in a "compatible" encoding of the other, ie the
string is in ASCII_8BIT and the regex is in UTF_8 Ruby will attempt to
"do the right thing" and convert one to the other.

However, this implicit converstion may convert the regex to the value
of the string, which means a new regex will be compiled each time a
string with a different encoding is reached. And because we will often
read manifests of one encoding and then create strings out of them into
a different encoding we may end up recompiling the regex frequently
during a catalog compilation. This is primarily a problem because the
character class `[[:alnum:]]` that we use in tag validation is gigantic
in UTF-8.

To disallow, or at least limit, regex recompilation we want strings that
we compare to the validation regex to be encoded in UTF-8 whenever
possible. To do so we wrap the regex matching in a method and encode our
inputs, with our inputs forced to UTF-8 we also force the regex to UTF-8
for consistency.