### PR TITLE
(PUP-8495) Systemd support, Ubuntu 18.04

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :coreos
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
-  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10","17.04","17.10"]
+  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10","17.04","17.10","18.04"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 
   def self.instances

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -126,7 +126,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     expect(described_class).not_to be_default
   end
 
-  [ '15.04', '15.10', '16.04', '16.10', '17.04', '17.10' ].each do |ver|
+  [ '15.04', '15.10', '16.04', '16.10', '17.04', '17.10', '18.04' ].each do |ver|
     it "should be the default provider on ubuntu#{ver}" do
       Facter.stubs(:value).with(:osfamily).returns(:debian)
       Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)


### PR DESCRIPTION
As requested in https://github.com/puppetlabs/puppet/pull/6706#issuecomment-373134781

~Removing any versions from `defaultfor :operatingsystem => :ubuntu` should be work in the same way like `defaultfor :osfamily => :redhat` in systemd.rb and redhat.rb~

Add 18.04 to the list for systemd.