### PR TITLE
(PUP-8421) Do not attept to fix permission on yumrepo files that do not exist on disk

### DIFF
--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -179,6 +179,7 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
 
     target_mode = 0644
     inifile.each_file do |file|
+      next unless Puppet::FileSystem.exist?(file)
       current_mode = Puppet::FileSystem.stat(file).mode & 0777
       unless current_mode == target_mode
         resource.info _("changing mode of %{file} from %{current_mode} to %{target_mode}") %


### PR DESCRIPTION
In the event that a yumrepo file is deleted after a prefetch has been called,
puppet attempts to stat the deleted file when updating another yumrepo
resource. Instead we check to make sure the file exists on disk before calling
stat.