### PR TITLE
(maint) Do not report tiny tiny numbers

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -469,6 +469,12 @@ class Puppet::Transaction::Report
 
     metrics[TOTAL] = metrics.values.inject(0) { |a,b| a+b }
 
+    # If we report any time metrics that have such a minuscule value that json
+    # can't parse it, we get failures when we try to submit these metrics to
+    # puppetdb. This ensures that we don't have any values in scientific
+    # notation.
+    metrics.values.map! { |val| "%0.5f" % val if val.is_a?(Float) }
+
     metrics
   end
 end

--- a/lib/puppet/util/metric.rb
+++ b/lib/puppet/util/metric.rb
@@ -26,7 +26,7 @@ class Puppet::Util::Metric
     {
       'name' => @name,
       'label' => @label,
-      'values' => @values
+      'values' => @values.map { |v| [v[0], v[1], v[2].round(3)] }
     }
   end
 


### PR DESCRIPTION
JSON can't handle scientific notation, so this ensures we don't report
any time metrics that are that minuscule. Otherwise, we get failures
when we try to submit these metrics to puppetdb.