### PR TITLE
(PUP-8476) Make EPP comment not trim left by default and add <%#-

### DIFF
--- a/lib/puppet/pops/parser/epp_support.rb
+++ b/lib/puppet/pops/parser/epp_support.rb
@@ -229,6 +229,7 @@ module EppSupport
 
         when "#"
           # template comment
+
           # drop the scanned <%, and skip past -%>, or %>, but also skip %%>
           s.slice!(-2..-1)
 
@@ -240,8 +241,11 @@ module EppSupport
             @mode = :error
             return s
           end
-          # Always trim leading whitespace on the same line when there is a comment
-          s.sub!(/[ \t]*\z/, '')
+          # Trim leading whitespace on the same line when start was <%#-
+          if part[1] == '-'
+            s.sub!(/[ \t]*\z/, '')
+          end
+
           @skip_leading = true if part.end_with?("-%>")
           # Continue scanning for more text
 


### PR DESCRIPTION
This changes the default behaviour of an EPP comment `<%#` to not trim
left by default as that is both not compatible with ERB and makes it
hard to use when spaces should be kept.

To make it possible to trim left, a new EPP tag `<%#-` has been added
that will make the EPP comment behave as it did prior to this change.