### PR TITLE
(docs)(DOC-3458) Note that PE defaults may differ

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -54,6 +54,13 @@ config.header = <<EOT
 
 * Each of these settings can be specified in `puppet.conf` or on the
   command line.
+* Puppet Enterprise (PE) shares configuration settings used in open source
+  Puppet and documented in the configuration reference. However, PE defaults
+  for certain settings might differ from the Puppet defaults. Some examples of
+  settings that have different PE defaults include `disable18n`,
+  `environment_timeout`, `always_retry_plugins`, and the Puppet Server JRuby
+  `max-active-instances` setting. To verify PE configuration defaults, check
+  the `puppet.conf` file after installation.
 * When using boolean settings on the command line, use `--setting` and
   `--no-setting` instead of `--setting (true|false)`. (Using `--setting false`
   results in "Error: Could not parse application options: needless argument".)

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -54,13 +54,12 @@ config.header = <<EOT
 
 * Each of these settings can be specified in `puppet.conf` or on the
   command line.
-* Puppet Enterprise (PE) shares configuration settings used in open source
-  Puppet and documented in the configuration reference. However, PE defaults
-  for certain settings might differ from the Puppet defaults. Some examples of
-  settings that have different PE defaults include `disable18n`,
-  `environment_timeout`, `always_retry_plugins`, and the Puppet Server JRuby
-  `max-active-instances` setting. To verify PE configuration defaults, check
-  the `puppet.conf` file after installation.
+* Puppet Enterprise (PE) and open source Puppet share the configuration settings
+  that are documented here. However, PE defaults for some settings differ from
+  the open source Puppet defaults. Some examples of settings that have different
+  PE defaults include `disable18n`, `environment_timeout`, `always_retry_plugins`,
+  and the Puppet Server JRuby `max-active-instances` setting. To verify PE
+  configuration defaults, check the `puppet.conf` file after installation.
 * When using boolean settings on the command line, use `--setting` and
   `--no-setting` instead of `--setting (true|false)`. (Using `--setting false`
   results in "Error: Could not parse application options: needless argument".)


### PR DESCRIPTION
Some `puppet.conf` settings are modified in a default PE installation. This leads to some customer confusion, such as assuming the open source configuration reference generated from Puppet code is incorrect (DOCUMENT-803).

This PR adds a bullet point to the top of the configuration reference noting that PE defaults might differ, provides examples, and reminds users to check `puppet.conf` to confirm PE defaults. An equivalent paragraph is also being added to the PE configuration overview.

CC @melamos