### PR TITLE
(PUP-7534) Add deprecation warning for file checksums in content property of file type

### DIFF
--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -48,6 +48,19 @@ module Puppet
       elsif value.is_a?(String) && checksum?(value)
         # XXX This is potentially dangerous because it means users can't write a file whose
         # entire contents are a plain checksum unless it is a Binary content.
+        Puppet.puppet_deprecation_warning([
+            #TRANSLATORS "content" is an attribute and should not be translated
+            _('Using a checksum in a file\'s "content" property is deprecated.'),
+            #TRANSLATORS "filebucket" is a resource type and should not be translated. The quoted occurrence of "content" is an attribute and should not be translated.
+            _('The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release.'),
+            #TRANSLATORS "content" is an attribute and should not be translated.
+            _('The literal value of the "content" property will be written to the file.'),
+            #TRANSLATORS "static catalogs" should not be translated.
+            _('The checksum retrieval functionality is being replaced by the use of static catalogs.'),
+            _('See https://puppet.com/docs/puppet/latest/static_catalogs.html for more information.')].join(" "),
+            :file => @resource.file,
+            :line => @resource.line
+        ) if !@actual_content && !resource.parameter(:source)
         value
       else
         @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -41,6 +41,11 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
   describe "when setting the desired content" do
     let(:content) { described_class.new(:resource => resource) }
 
+    before do
+      Puppet::Type.type(:file).any_instance.stubs(:file).returns('my/file.pp')
+      Puppet::Type.type(:file).any_instance.stubs(:line).returns 5
+    end
+
     it "should make the actual content available via an attribute" do
       content.should = "this is some content"
 
@@ -221,6 +226,7 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
         describe "with #{compare} target #{time_stat} compared to source" do
           before do
             resource[:checksum] = time_stat
+            resource[:source] = make_absolute('/temp/foo')
             content.should = "{#{time_stat}}#{saved_time}"
           end
 
@@ -237,6 +243,7 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
       describe "with #{time_stat}" do
         before do
           resource[:checksum] = time_stat
+          resource[:source] = make_absolute('/temp/foo')
         end
 
         it "should not be insync if trying to create it" do
@@ -371,6 +378,11 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
     let(:content) { described_class.new(:resource => resource) }
 
     let(:fh) { File.open(filename, 'wb') }
+
+    before do
+      Puppet::Type.type(:file).any_instance.stubs(:file).returns('my/file.pp')
+      Puppet::Type.type(:file).any_instance.stubs(:line).returns 5
+    end
 
     it "should attempt to read from the filebucket if no actual content nor source exists" do
       content.should = "{md5}foo"

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -186,6 +186,12 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
   end
 
   describe "when copying the source values" do
+
+    before do
+      Puppet::Type.type(:file).any_instance.stubs(:file).returns('my/file.pp')
+      Puppet::Type.type(:file).any_instance.stubs(:line).returns 5
+    end
+
     before :each do
       @resource = Puppet::Type.type(:file).new :path => @foobar
 
@@ -200,7 +206,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
       @metadata.stubs(:mode).returns 0173
       @resource[:source_permissions] = :use
       if Puppet::Util::Platform.windows?
-        expect { @source.copy_source_values }.to raise_error("Should not have tried to use source owner/mode/group on Windows")
+        expect { @source.copy_source_values }.to raise_error("Should not have tried to use source owner/mode/group on Windows (file: my/file.pp, line: 5)")
       else
         expect { @source.copy_source_values }.not_to raise_error
       end
@@ -210,7 +216,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
       @metadata.stubs(:mode).returns "173"
       @resource[:source_permissions] = :use
       if Puppet::Util::Platform.windows?
-        expect { @source.copy_source_values }.to raise_error("Should not have tried to use source owner/mode/group on Windows")
+        expect { @source.copy_source_values }.to raise_error("Should not have tried to use source owner/mode/group on Windows (file: my/file.pp, line: 5)")
       else
         expect { @source.copy_source_values }.not_to raise_error
       end


### PR DESCRIPTION
We will be removing the ability to use checksum in the content property to
retrieve content from the filebucket. Properties checksum and checksum_value
should be used instead.