### PR TITLE
Revert "(PUP-8483) Require Ruby 2.3.0 or up"

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.version = mdata ? mdata[1] : version
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
-  s.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
   s.authors = ["Puppet Labs"]
   s.date = "2012-08-17"
   s.description = "Puppet, an automated configuration management tool"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ notifications:
 rvm:
   - 2.4.0
   - 2.3.6
+  - 2.2.9
+  - 2.1.9
+  - 2.0.0
+  - 1.9.3
 
 env:
   - "CHECK=parallel:spec\\[2\\]"
@@ -17,9 +21,33 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.3.6
+    - rvm: 2.4.0
       env: "CHECK=rubocop"
     - rvm: 2.3.6
+      env: "CHECK=rubocop"
+    - rvm: 2.2.9
+      env: "CHECK=rubocop"
+    - rvm: 2.0.0
+      env: "CHECK=rubocop"
+    - rvm: 1.9.3
+      env: "CHECK=rubocop"
+    - rvm: 2.4.0
       env: "CHECK=commits"
     - rvm: 2.3.6
+      env: "CHECK=commits"
+    - rvm: 2.2.9
+      env: "CHECK=commits"
+    - rvm: 2.0.0
+      env: "CHECK=commits"
+    - rvm: 1.9.3
+      env: "CHECK=commits"
+    - rvm: 2.3.6
+      env: "CHECK=warnings"
+    - rvm: 2.2.9
+      env: "CHECK=warnings"
+    - rvm: 2.1.9
+      env: "CHECK=warnings"
+    - rvm: 2.0.0
+      env: "CHECK=warnings"
+    - rvm: 1.9.3
       env: "CHECK=warnings"

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ group(:development, :test) do
   # ronn is used for generating manpages.
   gem 'ronn', '~> 0.7.3', :platforms => [:ruby]
 
+  # webmock requires addressable as as of 2.5.0 addressable started
+  # requiring the public_suffix gem which requires Ruby 2
+  gem 'addressable', '< 2.5.0'
   gem 'webmock', '~> 1.24'
   gem 'vcr', '~> 2.9'
   gem "hiera-eyaml", :require => false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ matrix:
 # Ruby versions under test
 platform:
   - Ruby24-x64
-  - Ruby23-x64
+  - Ruby21-x64
 
 # Note that locales are mainly code page changes and are not the FULL set of localization
 #  changes that happen when you install French/Germam/Japanese etc. Windows

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,10 +16,13 @@ this.
 
 ## Ruby versions
 
-Puppet needs to work across a variety of ruby versions. Popular ways of making
-sure you have access to the various versions of ruby are to use either
-[rbenv](https://github.com/sstephenson/rbenv) or [rvm](https://rvm.io/). You can
-read up on the linked sites for how to get them installed on your system.
+Puppet needs to work across a variety of ruby versions, including ruby
+1.9.3 and up. Ruby 1.8.7 is no longer supported.
+
+Popular ways of making sure you have access to the various versions of ruby are
+to use either [rbenv](https://github.com/sstephenson/rbenv) or
+[rvm](https://rvm.io/). You can read up on the linked sites for how to get them
+installed on your system.
 
 ## Dependencies
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -14,7 +14,7 @@ gem_test_files: 'spec/**/*'
 gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_forge_project: 'puppet'
-gem_required_ruby_version: '>= 2.3.0'
+gem_required_ruby_version: '>= 1.9.3'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0.1', '< 4']

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,7 +1,7 @@
 require 'puppet/version'
 
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3.0")
-  raise LoadError, _("Puppet %{version} requires ruby 2.3.0 or greater.") % { version: Puppet.version }
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("1.9.3")
+  raise LoadError, _("Puppet %{version} requires ruby 1.9.3 or greater.") % { version: Puppet.version }
 end
 
 Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.3.0'


### PR DESCRIPTION
Our CI system is not yet running against a new enough puppetserver,
since we are still in the process of getting back on to the nightlies
train. Until we can get CI reconfigured to use the latest builds of
puppetserver, we will have to keep 1.9.3 around.

This reverts commit 4be4bc27011ad35201ad10ca71902a1ba2f77dba.