### PR TITLE
(PUP-8561) Augeas provider: unescape escaped quotes

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -122,6 +122,13 @@ Puppet::Type.type(:augeas).provide(:augeas) do
           if delim == "'" || delim == "\""
             sc.getch
             argline << sc.scan(/([^\\#{delim}]|(\\.))*/)
+            # Unescape the delimiter so it's actually possible to have a
+            # literal delim inside the string. We only unescape the
+            # delimeter and not every backslash-escaped character so that
+            # things like escaped spaces '\ ' get passed through because
+            # Augeas needs to see them. If we unescaped them, too, users
+            # would be forced to double-escape them
+            argline.last.gsub!(/\\(#{delim})/, '\1')
             sc.getch
           else
             argline << sc.scan(/[^\s]+/)

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -136,7 +136,13 @@ describe provider_class do
     it "should handle escaped doublequotes in doublequoted string" do
       @resource[:context] = "/foo/"
       tokens = @provider.parse_commands("set /foo \"''\\\"''\"")
-      expect(tokens).to eq([[ "set", "/foo", "''\\\"''" ]])
+      expect(tokens).to eq([[ "set", "/foo", "''\"''" ]])
+    end
+
+    it "should preserve escaped single quotes in double quoted strings" do
+      @resource[:context] = "/foo/"
+      tokens = @provider.parse_commands("set /foo \"\\'\"")
+      expect(tokens).to eq([[ "set", "/foo", "\\'" ]])
     end
 
     it "should allow escaped spaces and brackets in paths" do


### PR DESCRIPTION
The argument for commands like 'set' can be enclosed in single or double
quotes. To place the quote character into the string, they can be escaped
with a backslash.

So far, the provider did not remove the backslash-escape from the string,
making it impossible for users to have, e.g., a plain double quote inside a
double-quoted argument.

With this change, backslash-escaped quote characters are unescaped from
strings that are enclosed with that quote character; e.g., a
backslash-escaped double quote is reduced to just a double quote in a
string enclosed in double quotes (but left untouched if the string
is enclosed in single quotes)

Fixes https://tickets.puppetlabs.com/browse/PUP-8561