### PR TITLE
(PUP-8486) Catch undefined_variable in hiera's scope

### DIFF
--- a/lib/hiera/scope.rb
+++ b/lib/hiera/scope.rb
@@ -20,12 +20,34 @@ class Hiera
       elsif key == CALLING_CLASS_PATH
         ans = find_hostclass(@real).gsub(/::/, '/')
       elsif key == CALLING_MODULE
-        ans = @real.lookupvar(MODULE_NAME)
+        ans = safe_lookupvar(MODULE_NAME)
       else
-        ans = @real.lookupvar(key)
+        ans = safe_lookupvar(key)
       end
       ans == EMPTY_STRING ? nil : ans
     end
+
+    # This method is used to handle the throw of :undefined_variable since when
+    # strict variables is not in effect, missing handling of the throw leads to
+    # a more expensive code path.
+    #
+    def safe_lookupvar(key)
+      reason = catch :undefined_variable do
+        return @real.lookupvar(key)
+      end
+
+      case Puppet[:strict]
+      when :off
+        # do nothing
+      when :warning
+        Puppet.warn_once(Puppet::Parser::Scope::UNDEFINED_VARIABLES_KIND, _("Variable: %{name}") % { name: key },
+        _("Undefined variable '%{name}'; %{reason}") % { name: key, reason: reason } )
+      when :error
+        raise ArgumentError, _("Undefined variable '%{name}'; %{reason}") % { name: key, reason: reason }
+      end
+      nil
+    end
+    private :safe_lookupvar
 
     def exist?(key)
       CALLING_KEYS.include?(key) || @real.exist?(key)


### PR DESCRIPTION
Before this, the general handling of undefined variable caused the throw
of :undefined_variable to be translated into an exception  - which in
turn was handled under the control of Puppet[:strict], leading to a
warning or error (or no action).

When running on j9k JRuby it has been showed that the exception is aprox
70 times slower than catching the symbol, and thus when running with
strict mode off or warning, the performance suffers greatly.

This commit adds a catch around the call to `lookupvar` in the special
scope used with hiera and issues the same warning/error under control of
Puppet[:strict] as the original implementation in the real Scope.