### PR TITLE
(PUP-8597) Change __pcore_<tag>__ to __p<tag>

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2061,7 +2061,7 @@ EOT
       end,
       :desc     => <<-'EOT'
         Enables having extended data in the catalog by storing them as a hash with the special key
-        `__pcore_type__`. When enabled, resource containing values of the data types `Binary`, `Regexp`,
+        `__ptype`. When enabled, resource containing values of the data types `Binary`, `Regexp`,
         `SemVer`, `SemVerRange`, `Timespan` and `Timestamp`, as well as instances of types derived
         from `Object` retain their data type.
       EOT

--- a/lib/puppet/pops/serialization.rb
+++ b/lib/puppet/pops/serialization.rb
@@ -7,12 +7,14 @@ module Serialization
   class SerializationError < Puppet::Error
   end
 
-  PCORE_TYPE_KEY = '__pcore_type__'.freeze
+  PCORE_TYPE_KEY = '__ptype'.freeze
+  PCORE_TYPE_KEY_OLD = '__pcore_type__'.freeze
 
   # Key used when the value can be represented as, and recreated from, a single string that can
   # be passed to a `from_string` method or an array of values that can be passed to the default
   # initializer method.
-  PCORE_VALUE_KEY = '__pcore_value__'.freeze
+  PCORE_VALUE_KEY = '__pvalue'.freeze
+  PCORE_VALUE_KEY_OLD = '__pcore_value__'.freeze
 
   # Type key used for hashes that contain keys that are not of type String
   PCORE_TYPE_HASH = 'Hash'.freeze

--- a/lib/puppet/pops/serialization.rb
+++ b/lib/puppet/pops/serialization.rb
@@ -8,13 +8,11 @@ module Serialization
   end
 
   PCORE_TYPE_KEY = '__ptype'.freeze
-  PCORE_TYPE_KEY_OLD = '__pcore_type__'.freeze
 
   # Key used when the value can be represented as, and recreated from, a single string that can
   # be passed to a `from_string` method or an array of values that can be passed to the default
   # initializer method.
   PCORE_VALUE_KEY = '__pvalue'.freeze
-  PCORE_VALUE_KEY_OLD = '__pcore_value__'.freeze
 
   # Type key used for hashes that contain keys that are not of type String
   PCORE_TYPE_HASH = 'Hash'.freeze

--- a/lib/puppet/pops/serialization/from_data_converter.rb
+++ b/lib/puppet/pops/serialization/from_data_converter.rb
@@ -64,7 +64,7 @@ module Serialization
     # @option options [Loaders::Loader] :loader the loader to use. Can be `nil` in which case the default is
     #    determined by the {Types::TypeParser}.
     # @option options [Boolean] :allow_unresolved `true` to allow that rich_data hashes are kept "as is" if the
-    #    designated '__pcore_type__' cannot be resolved. Defaults to `false`.
+    #    designated '__ptype' cannot be resolved. Defaults to `false`.
     # @return [RichData] the processed result.
     #
     # @api public
@@ -78,7 +78,7 @@ module Serialization
     # @option options [Loaders::Loader] :loader the loader to use. Can be `nil` in which case the default is
     #    determined by the {Types::TypeParser}.
     # @option options [Boolean] :allow_unresolved `true` to allow that rich_data hashes are kept "as is" if the
-    #    designated '__pcore_type__' cannot be resolved. Defaults to `false`.
+    #    designated '__ptype' cannot be resolved. Defaults to `false`.
     #
     # @api public
     def initialize(options = EMPTY_HASH)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -35,7 +35,6 @@ class Puppet::Resource
   TYPE_SITE  = 'Site'.freeze
 
   PCORE_TYPE_KEY = '__ptype'.freeze
-  PCORE_TYPE_KEY_OLD = '__pcore_type__'.freeze
   VALUE_KEY = 'value'.freeze
 
   def self.from_data_hash(data)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -34,7 +34,8 @@ class Puppet::Resource
   TYPE_NODE  = 'Node'.freeze
   TYPE_SITE  = 'Site'.freeze
 
-  PCORE_TYPE_KEY = '__pcore_type__'.freeze
+  PCORE_TYPE_KEY = '__ptype'.freeze
+  PCORE_TYPE_KEY_OLD = '__pcore_type__'.freeze
   VALUE_KEY = 'value'.freeze
 
   def self.from_data_hash(data)

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -447,11 +447,11 @@ module Serialization
         expect{ read }.to raise_error(Puppet::Error, 'No implementation mapping found for Puppet Type MyType')
       end
 
-      context "succeds but produces an rich_type hash when deserializer has 'allow_unresolved' set to true" do
+      context "succeeds but produces an rich_type hash when deserializer has 'allow_unresolved' set to true" do
         let(:from_converter) { FromDataConverter.new(:allow_unresolved => true) }
         it do
           write(type.create(32))
-          expect(read).to eql({'__pcore_type__'=>'MyType', 'x'=>32})
+          expect(read).to eql({'__ptype'=>'MyType', 'x'=>32})
         end
       end
     end
@@ -589,7 +589,7 @@ module Serialization
   context 'will fail when' do
     it 'the value of a type description is something other than a String or a Hash' do
       expect do
-        from_converter.convert({ '__pcore_type__' => { '__pcore_type__' => 'Pcore::TimestampType', '__pcore_value__' => 12345 }})
+        from_converter.convert({ '__ptype' => { '__ptype' => 'Pcore::TimestampType', '__pvalue' => 12345 }})
       end.to raise_error(/Cannot create a Pcore::TimestampType from a (Fixnum|Integer)/)
     end
   end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -882,7 +882,7 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to json"
 
       it 'should generate rich value hash for parameter values that are not Data' do
         s = catalog_w_regexp.to_json
-        expect(s).to include('"parameters":{"message":{"__pcore_type__":"Regexp","__pcore_value__":"[a-z]+"}}')
+        expect(s).to include('"parameters":{"message":{"__ptype":"Regexp","__pvalue":"[a-z]+"}}')
       end
 
       it 'should read and convert rich value hash containing Regexp from json' do
@@ -951,7 +951,7 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to json"
       let(:catalog_w_regexp)  { compile_to_catalog("notify {'foo': message => /[a-z]+/ }") }
 
       it 'should not generate rich value hash for parameter values that are not Data' do
-        expect(catalog_w_regexp.to_json).not_to include('"__pcore_type__"')
+        expect(catalog_w_regexp.to_json).not_to include('"__ptype"')
       end
 
       it 'should convert parameter containing Regexp into strings' do


### PR DESCRIPTION
This shortens the tags used by pcore rich serialization to use the
shorter tags `__ptype` and `__pvalue`.