### PR TITLE
(maint) Bump beaker-puppet to 0.12

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -13,7 +13,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.33')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 0.11")
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 0.12")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
 gem "rake", "~> 10.1"


### PR DESCRIPTION
This pulls in updates to how puppetserver is installed. It allows us to
access the newly reformated nightlies repos so that we can test against
the latest passing puppetserver packages.

This will not impact the puppet 4.10.x tests, as those must still be
pinned to a specific puppetserver release.