### PR TITLE
(PUP-8396) Add confine detecting upstart socket pid

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -16,6 +16,8 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
     Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 
+  confine :exists => "/var/run/upstart-socket-bridge.pid"
+
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
 
   commands :start   => "/sbin/start",


### PR DESCRIPTION
Prior to this commit, the upstart provider would be detected as
suitable on Ubuntu and RHEL 6 as long as /sbin/start was present.
Unfortunately, on newer versions of Ubuntu, such as 16.04, it is
possible for /sbin/start to be present, but for upstart to not be
in use.  In that scenario, puppet resource service will simply
fail as it will not be able to execute initctl since the upstart
socket will not be present.

This commit adds a confine to the upstart provider that checks for
the existence of the upstart socket pid file.  If that is present,
it is more reasonable to assume that upstart is in use and can
be checked.  If it is not present, such as on Ubuntu 16.04, we
will fall through to systemd even when the upstart package happens
to be installed.