### PR TITLE
(maint) Drop strict=off around tests no longer needing this

### DIFF
--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -483,13 +483,6 @@ describe Puppet::Parser::Compiler do
     end
 
     describe "relationships to non existing resources (even with strict==off)" do
-      # At some point in the future, this test can be modified to simply ignore the strict flag,
-      # but since the current version is a change from being under control of strict, this is now
-      # explicit - the standard setting is strict == warning, here setting it to off
-      #
-      before(:each) do
-        Puppet[:strict] = :off
-      end
 
       [ 'before',
         'subscribe',


### PR DESCRIPTION
This removes strict=off in a before around relationship tests
that always error. This is done since the behavior is no longer
under control of the strict flag and the change from being under control
of strict happened several releases ago.

It is just confusing to test with strict=off for behavior that is the
same for all settings of strict (we are not testing this for all other
things in the code base).