### PR TITLE
(PUP-7078) Remove Puppet.newtype

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -170,14 +170,6 @@ module Puppet
     end
   end
 
-  # Create a new type.  Just proxy to the Type class.  The mirroring query
-  # code was deprecated in 2008, but this is still in heavy use.  I suppose
-  # this can count as a soft deprecation for the next dev. --daniel 2011-04-12
-  def self.newtype(name, options = {}, &block)
-    Puppet.deprecation_warning(_("Creating %{name} via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.") % { name: name })
-    Puppet::Type.newtype(name, options, &block)
-  end
-
   # Load vendored (setup paths, and load what is needed upfront).
   # See the Vendor class for how to add additional vendored gems/code
   require "puppet/vendor"

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -84,11 +84,4 @@ describe Puppet do
       expect(SemanticPuppet::Version).to be_valid(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
     end
   end
-
-  context "newtype" do
-    it "should issue a deprecation warning" do
-      subject.expects(:deprecation_warning).with("Creating sometype via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.")
-      subject.newtype("sometype")
-    end
-  end
 end


### PR DESCRIPTION
Puppet.newtype has officially been deprecated since 5ceefea32da (2014-11-12), when it started issuing a deprecation warning, and has internally been considered deprecated since 2011. After a nearly four-year deprecation cycle, we're finally removing the method.