### PR TITLE
(PUP-6344) Capture the time of the entire run as the total

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -179,17 +179,13 @@ class Puppet::Configurer
   # Apply supplied catalog and return associated application report
   def apply_catalog(catalog, options)
     report = options[:report]
-    begin
-      report.configuration_version = catalog.version
+    report.configuration_version = catalog.version
 
-      benchmark(:notice, _("Applied catalog in %{seconds} seconds")) do
-        apply_catalog_time = thinmark do
-          catalog.apply(options)
-        end
-        options[:report].add_times(:catalog_application, apply_catalog_time)
+    benchmark(:notice, _("Applied catalog in %{seconds} seconds")) do
+      apply_catalog_time = thinmark do
+        catalog.apply(options)
       end
-    ensure
-      report.finalize_report
+      options[:report].add_times(:catalog_application, apply_catalog_time)
     end
     report
   end
@@ -247,132 +243,144 @@ class Puppet::Configurer
   def run_internal(options)
     report = options[:report]
 
-    # If a cached catalog is explicitly requested, attempt to retrieve it. Skip the node request,
-    # don't pluginsync and switch to the catalog's environment if we successfully retrieve it.
-    if Puppet[:use_cached_catalog]
-      Puppet::GettextConfig.reset_text_domain('agent')
-      Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
-
-      if catalog = prepare_and_retrieve_catalog_from_cache(options)
-        options[:catalog] = catalog
-        @cached_catalog_status = 'explicitly_requested'
-
-        if @environment != catalog.environment && !Puppet[:strict_environment_mode]
-          Puppet.notice _("Local environment: '%{local_env}' doesn't match the environment of the cached catalog '%{catalog_env}', switching agent to '%{catalog_env}'.") % { local_env: @environment, catalog_env: catalog.environment }
-          @environment = catalog.environment
-        end
-
-        report.environment = @environment
-      else
-        # Don't try to retrieve a catalog from the cache again after we've already
-        # failed to do so the first time.
-        Puppet[:use_cached_catalog] = false
-        Puppet[:usecacheonfailure] = false
-        options[:pluginsync] = Puppet::Configurer.should_pluginsync?
-      end
-    end
-
+    prerun_command_successful = false
     begin
-      unless Puppet[:node_name_fact].empty?
-        query_options = get_facts(options)
-      end
+      run_internal_time = thinmark do
+        # If a cached catalog is explicitly requested, attempt to retrieve it. Skip the node request,
+        # don't pluginsync and switch to the catalog's environment if we successfully retrieve it.
+        if Puppet[:use_cached_catalog]
+          Puppet::GettextConfig.reset_text_domain('agent')
+          Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
 
-      configured_environment = Puppet[:environment] if Puppet.settings.set_by_config?(:environment)
+          if catalog = prepare_and_retrieve_catalog_from_cache(options)
+            options[:catalog] = catalog
+            @cached_catalog_status = 'explicitly_requested'
 
-      # We only need to find out the environment to run in if we don't already have a catalog
-      unless (options[:catalog] || Puppet[:strict_environment_mode])
+            if @environment != catalog.environment && !Puppet[:strict_environment_mode]
+              Puppet.notice _("Local environment: '%{local_env}' doesn't match the environment of the cached catalog '%{catalog_env}', switching agent to '%{catalog_env}'.") % { local_env: @environment, catalog_env: catalog.environment }
+              @environment = catalog.environment
+            end
+
+            report.environment = @environment
+          else
+            # Don't try to retrieve a catalog from the cache again after we've already
+            # failed to do so the first time.
+            Puppet[:use_cached_catalog] = false
+            Puppet[:usecacheonfailure] = false
+            options[:pluginsync] = Puppet::Configurer.should_pluginsync?
+          end
+        end
+
         begin
-          node = nil
-          node_retr_time = thinmark do
-            node = options[:node] || Puppet::Node.indirection.find(Puppet[:node_name_value],
-              :environment => Puppet::Node::Environment.remote(@environment),
-              :configured_environment => configured_environment,
-              :ignore_cache => true,
-              :transaction_uuid => @transaction_uuid,
-              :fail_on_404 => true)
+          unless Puppet[:node_name_fact].empty?
+            query_options = get_facts(options)
           end
-          options[:report].add_times(:node_retrieval, node_retr_time)
 
-          if node
-            # If we have deserialized a node from a rest call, we want to set
-            # an environment instance as a simple 'remote' environment reference.
-            if !node.has_environment_instance? && node.environment_name
-              node.environment = Puppet::Node::Environment.remote(node.environment_name)
-            end
+          configured_environment = Puppet[:environment] if Puppet.settings.set_by_config?(:environment)
 
-            @node_environment = node.environment.to_s
+          # We only need to find out the environment to run in if we don't already have a catalog
+          unless (options[:catalog] || Puppet[:strict_environment_mode])
+            begin
+              node = nil
+              node_retr_time = thinmark do
+                node = options[:node] || Puppet::Node.indirection.find(Puppet[:node_name_value],
+                  :environment => Puppet::Node::Environment.remote(@environment),
+                  :configured_environment => configured_environment,
+                  :ignore_cache => true,
+                  :transaction_uuid => @transaction_uuid,
+                  :fail_on_404 => true)
+              end
+              options[:report].add_times(:node_retrieval, node_retr_time)
 
-            if node.environment.to_s != @environment
-              Puppet.notice _("Local environment: '%{local_env}' doesn't match server specified node environment '%{node_env}', switching agent to '%{node_env}'.") % { local_env: @environment, node_env: node.environment }
-              @environment = node.environment.to_s
-              report.environment = @environment
-              query_options = nil
-            else
-              Puppet.info _("Using configured environment '%{env}'") % { env: @environment }
+              if node
+                # If we have deserialized a node from a rest call, we want to set
+                # an environment instance as a simple 'remote' environment reference.
+                if !node.has_environment_instance? && node.environment_name
+                  node.environment = Puppet::Node::Environment.remote(node.environment_name)
+                end
+
+                @node_environment = node.environment.to_s
+
+                if node.environment.to_s != @environment
+                  Puppet.notice _("Local environment: '%{local_env}' doesn't match server specified node environment '%{node_env}', switching agent to '%{node_env}'.") % { local_env: @environment, node_env: node.environment }
+                  @environment = node.environment.to_s
+                  report.environment = @environment
+                  query_options = nil
+                else
+                  Puppet.info _("Using configured environment '%{env}'") % { env: @environment }
+                end
+              end
+            rescue StandardError => detail
+              Puppet.warning(_("Unable to fetch my node definition, but the agent run will continue:"))
+              Puppet.warning(detail)
             end
           end
-        rescue StandardError => detail
-          Puppet.warning(_("Unable to fetch my node definition, but the agent run will continue:"))
-          Puppet.warning(detail)
+
+          current_environment = Puppet.lookup(:current_environment)
+          if current_environment.name == @environment.intern
+            local_node_environment = current_environment
+          else
+            local_node_environment = Puppet::Node::Environment.create(@environment,
+                                            current_environment.modulepath,
+                                            current_environment.manifest,
+                                            current_environment.config_version)
+          end
+          Puppet.push_context({:current_environment => local_node_environment}, "Local node environment for configurer transaction")
+
+          query_options = get_facts(options) unless query_options
+          query_options[:configured_environment] = configured_environment
+
+          unless catalog = prepare_and_retrieve_catalog(options, query_options)
+            return nil
+          end
+
+          if Puppet[:strict_environment_mode] && catalog.environment != @environment
+            Puppet.err _("Not using catalog because its environment '%{catalog_env}' does not match agent specified environment '%{local_env}' and strict_environment_mode is set") % { catalog_env: catalog.environment, local_env: @environment }
+            return nil
+          end
+
+          # Here we set the local environment based on what we get from the
+          # catalog. Since a change in environment means a change in facts, and
+          # facts may be used to determine which catalog we get, we need to
+          # rerun the process if the environment is changed.
+          tries = 0
+          while catalog.environment and not catalog.environment.empty? and catalog.environment != @environment
+            if tries > 3
+              raise Puppet::Error, _("Catalog environment didn't stabilize after %{tries} fetches, aborting run") % { tries: tries }
+            end
+            Puppet.notice _("Local environment: '%{local_env}' doesn't match server specified environment '%{catalog_env}', restarting agent run with environment '%{catalog_env}'") % { local_env: @environment, catalog_env: catalog.environment }
+            @environment = catalog.environment
+            report.environment = @environment
+
+            query_options = get_facts(options)
+            query_options[:configured_environment] = configured_environment
+
+            return nil unless catalog = prepare_and_retrieve_catalog(options, query_options)
+            tries += 1
+          end
+
+          if execute_prerun_command
+            prerun_command_successful = true
+            options[:report].code_id = catalog.code_id
+            options[:report].catalog_uuid = catalog.catalog_uuid
+            options[:report].cached_catalog_status = @cached_catalog_status
+            apply_catalog(catalog, options)
+          end
+        rescue => detail
+          Puppet.log_exception(detail, _("Failed to apply catalog: %{detail}") % { detail: detail })
+          return nil
         end
-      end
-
-      current_environment = Puppet.lookup(:current_environment)
-      if current_environment.name == @environment.intern
-        local_node_environment = current_environment
-      else
-        local_node_environment = Puppet::Node::Environment.create(@environment,
-                                         current_environment.modulepath,
-                                         current_environment.manifest,
-                                         current_environment.config_version)
-      end
-      Puppet.push_context({:current_environment => local_node_environment}, "Local node environment for configurer transaction")
-
-      query_options = get_facts(options) unless query_options
-      query_options[:configured_environment] = configured_environment
-
-      unless catalog = prepare_and_retrieve_catalog(options, query_options)
-        return nil
-      end
-
-      if Puppet[:strict_environment_mode] && catalog.environment != @environment
-        Puppet.err _("Not using catalog because its environment '%{catalog_env}' does not match agent specified environment '%{local_env}' and strict_environment_mode is set") % { catalog_env: catalog.environment, local_env: @environment }
-        return nil
-      end
-
-      # Here we set the local environment based on what we get from the
-      # catalog. Since a change in environment means a change in facts, and
-      # facts may be used to determine which catalog we get, we need to
-      # rerun the process if the environment is changed.
-      tries = 0
-      while catalog.environment and not catalog.environment.empty? and catalog.environment != @environment
-        if tries > 3
-          raise Puppet::Error, _("Catalog environment didn't stabilize after %{tries} fetches, aborting run") % { tries: tries }
-        end
-        Puppet.notice _("Local environment: '%{local_env}' doesn't match server specified environment '%{catalog_env}', restarting agent run with environment '%{catalog_env}'") % { local_env: @environment, catalog_env: catalog.environment }
-        @environment = catalog.environment
-        report.environment = @environment
-
-        query_options = get_facts(options)
-        query_options[:configured_environment] = configured_environment
-
-        return nil unless catalog = prepare_and_retrieve_catalog(options, query_options)
-        tries += 1
-      end
-
-      execute_prerun_command or return nil
-
-      options[:report].code_id = catalog.code_id
-      options[:report].catalog_uuid = catalog.catalog_uuid
-      options[:report].cached_catalog_status = @cached_catalog_status
-      apply_catalog(catalog, options)
-      report.exit_status
-    rescue => detail
-      Puppet.log_exception(detail, _("Failed to apply catalog: %{detail}") % { detail: detail })
-      return nil
+      end #thinmark
     ensure
-      execute_postrun_command or return nil
+      report.add_times(:total, run_internal_time)
+      report.finalize_report
+
+      exit_status = report.exit_status if prerun_command_successful
+      exit_status = nil unless execute_postrun_command
+
+      return exit_status
     end
+
   ensure
     report.cached_catalog_status ||= @cached_catalog_status
     Puppet::Util::Log.close(report)

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -467,8 +467,6 @@ class Puppet::Transaction::Report
       metrics[name.to_s.downcase] = value
     end
 
-    metrics[TOTAL] = metrics.values.inject(0) { |a,b| a+b }
-
     metrics
   end
 end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -359,6 +359,13 @@ describe Puppet::Configurer do
       @agent.apply_catalog(@catalog, {:report => report})
     end
 
+    it "should record a total run time" do
+      report = Puppet::Transaction::Report.new
+      @catalog.stubs(:apply).with(:report => report)
+      report.expects(:add_times).with(:total, anything())
+      @agent.run({:report => report})
+    end
+
     it "should refetch the catalog if the server specifies a new environment in the catalog" do
       catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
       @agent.expects(:retrieve_catalog).returns(catalog).twice

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -357,22 +357,6 @@ describe Puppet::Transaction::Report do
         expect(metric(:time, "tidy")).to eq(9)
       end
 
-      it "should provide the total time for all time metrics collected" do
-        add_statuses(3, :file) do |status|
-          status.evaluation_time = 1
-        end
-        add_statuses(3, :exec) do |status|
-          status.evaluation_time = 2
-        end
-        add_statuses(3, :tidy) do |status|
-          status.evaluation_time = 3
-        end
-
-        @report.finalize_report
-
-        expect(metric(:time, "total")).to eq(18)
-      end
-
       it "should accrue times when called for one resource more than once" do
         @report.add_times :foobar, 50
         @report.add_times :foobar, 30
@@ -391,15 +375,6 @@ describe Puppet::Transaction::Report do
         @report.add_times :foobar, 50
         @report.finalize_report
         expect(metric(:time, "foobar")).to eq(50)
-      end
-
-      it "should have a total time" do
-        add_statuses(3, :file) do |status|
-          status.evaluation_time = 1.25
-        end
-        @report.add_times :config_retrieval, 0.5
-        @report.finalize_report
-        expect(metric(:time, "total")).to eq(4.25)
       end
     end
 
@@ -488,6 +463,7 @@ describe Puppet::Transaction::Report do
       trans = catalog.apply
 
       @report = trans.report
+      @report.add_times(:total, "8675") #Report total is now measured, not calculated.
       @report.finalize_report
     end
 


### PR DESCRIPTION
Without this change, the reported total time is incorrect, since it was double counting.
With this change, the total is now reported from measuring the time of the run operation.
