### PR TITLE
(PUP-8623) Drop deprecation of empty(undef)

### DIFF
--- a/lib/puppet/functions/empty.rb
+++ b/lib/puppet/functions/empty.rb
@@ -66,7 +66,6 @@ Puppet::Functions.create_function(:empty) do
   # (Yes, it is strange, but undef was passed as empty string in 3.x API)
   #
   def undef_empty(x)
-    deprecation_warning_for('Undef')
     true
   end
 

--- a/spec/unit/functions/empty_spec.rb
+++ b/spec/unit/functions/empty_spec.rb
@@ -67,11 +67,11 @@ describe 'the empty function' do
   end
 
   context 'for undef it' do
-    it 'returns true and issues deprecation warning' do
+    it 'returns true without deprecation warning' do
       Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
         expect(compile_to_catalog("notify { String(empty(undef)): }")).to have_resource('Notify[true]')
       end
-      expect(warnings).to include(/Calling function empty\(\) with Undef value is deprecated/)
+      expect(warnings).to_not include(/Calling function empty\(\) with Undef value is deprecated/)
     end
   end
 end


### PR DESCRIPTION
Before this (introduced in Puppet 5.5.0), the empty function would issue
a deprecation warning for empty(undef). This deprecation is now dropped.