### PR TITLE
(PUP-8240) make epp read with preserved line endings

### DIFF
--- a/lib/puppet/pops/parser/epp_parser.rb
+++ b/lib/puppet/pops/parser/epp_parser.rb
@@ -6,7 +6,7 @@ class Puppet::Pops::Parser::EppParser < Puppet::Pops::Parser::Parser
   # @return [void]
   #
   def initvars
-    self.lexer = Puppet::Pops::Parser::Lexer2.new()# {:mode => :epp})
+    self.lexer = Puppet::Pops::Parser::Lexer2.new()
   end
 
   # Parses a file expected to contain epp text/DSL logic.

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -647,7 +647,7 @@ class Lexer2
   #
   def lex_file(file)
     initvars
-    contents = Puppet::FileSystem.exist?(file) ? Puppet::FileSystem.read(file, :encoding => 'utf-8') : ''
+    contents = Puppet::FileSystem.exist?(file) ? Puppet::FileSystem.read(file, :mode => 'rb', :encoding => 'utf-8') : ''
     assert_not_bom(contents)
     @scanner = StringScanner.new(contents.freeze)
     @locator = Locator.locator(contents, file)

--- a/spec/unit/functions/epp_spec.rb
+++ b/spec/unit/functions/epp_spec.rb
@@ -117,6 +117,9 @@ describe "the epp function" do
     end
   end
 
+  it "preserves CRLF when reading the template" do
+    expect(eval_template("some text that\r\nis static with CRLF")).to eq("some text that\r\nis static with CRLF")
+  end
 
   # although never a problem with epp
   it "is not interfered with by having a variable named 'string' (#14093)" do
@@ -148,7 +151,7 @@ describe "the epp function" do
   def eval_template_with_args(content, args_hash)
     file_path = tmpdir('epp_spec_content')
     filename = File.join(file_path, "template.epp")
-    File.open(filename, "w+") { |f| f.write(content) }
+    File.open(filename, "wb+") { |f| f.write(content) }
 
     Puppet::Parser::Files.stubs(:find_template).returns(filename)
     epp_function.call(scope, 'template', args_hash)
@@ -157,7 +160,7 @@ describe "the epp function" do
   def eval_template(content)
     file_path = tmpdir('epp_spec_content')
     filename = File.join(file_path, "template.epp")
-    File.open(filename, "w+") { |f| f.write(content) }
+    File.open(filename, "wb+") { |f| f.write(content) }
 
     Puppet::Parser::Files.stubs(:find_template).returns(filename)
     epp_function.call(scope, 'template')


### PR DESCRIPTION
Before this the lexer read with only encoding set - it needs to also pass in mode = 'rb' in order to preserve line endings when reading on windows.
The special method "read_preserve_line_endings" available in the Windows implementation of FileSystem cannot be used as it takes no options and cannot be guaranteed to return UTF-8 (which it must for EPP).

The change here is simply to pass in `:mode => 'rb'`