### PR TITLE
(PUP-8649) Add vendor modules directory to load path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,12 @@ task :default do
 end
 
 task :spec do
-  sh %{rspec #{ENV['TEST'] || ENV['TESTS'] || 'spec'}}
+  tests = ENV['TEST'] || ENV['TESTS']
+  unless tests
+    modules_tests = Dir.glob("lib/puppet/vendor/modules/*/spec/{unit,integration}").join(' ')
+    tests = "spec #{modules_tests}"
+  end
+  sh %{rspec #{tests}}
 end
 
 desc 'run static analysis with rubocop'

--- a/lib/puppet/vendor/load_modules.rb
+++ b/lib/puppet/vendor/load_modules.rb
@@ -1,0 +1,3 @@
+Dir.glob("#{File.dirname(__FILE__)}/modules/*/lib") do |lib|
+  $: << lib
+end

--- a/util/rspec_grouper
+++ b/util/rspec_grouper
@@ -18,7 +18,13 @@ module Parallel
 
       def initialize(group_size)
         config = ::RSpec::Core::Configuration.new
-        options = ::RSpec::Core::ConfigurationOptions.new((ENV['TEST'] || ENV['TESTS'] || 'spec').split(';'))
+        tests = ENV['TEST'] || ENV['TESTS']
+        if tests
+          specs = tests.split(';')
+        else
+          specs = ['spec'] + Dir.glob("lib/puppet/vendor/modules/*/spec/{unit,integration}")
+        end
+        options = ::RSpec::Core::ConfigurationOptions.new(specs)
         options.configure config
 
         # This will scan and load all spec examples


### PR DESCRIPTION
Add the lib directory for each vendored module to the ruby load path.
Currently, the 'lib/puppet/vendor/modules' directory doesn't exist yet,
so this commit is a noop.

Note `Puppet::Vendor.load_vendored` automatically requires everything in
`lib/puppet/vendor/load_*` so we don't need an explicit require.

Updates the rake spec and parallel:spec tasks to include vendored
modules' specs, provided an explicit list of tests wasn't given.