### PR TITLE
(PUP-8637) Allow merge of definitions to main when --freeze_main is on

### DIFF
--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -132,7 +132,25 @@ class Puppet::Parser::AST::PopsBridge
       yield self
     end
 
+    # Returns true if this Program only contains definitions
+    def is_definitions_only?
+      is_definition?(program_model)
+    end
+
     private
+
+    def is_definition?(o)
+      case o
+      when Puppet::Pops::Model::Program
+        is_definition?(o.body)
+      when Puppet::Pops::Model::BlockExpression
+        o.statements.all {|s| is_definition?(s) }
+      when Puppet::Pops::Model::Definition
+        true
+      else
+        false
+      end
+    end
 
     def instantiate_Parameter(o)
       # 3x needs parameters as an array of `[name]` or `[name, value_expr]`

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -189,8 +189,12 @@ class Puppet::Resource::Type
   def merge(other)
     fail _("%{name} is not a class; cannot add code to it") % { name: name } unless type == :hostclass
     fail _("%{name} is not a class; cannot add code from it") % { name: other.name } unless other.type == :hostclass
-    fail _("Cannot have code outside of a class/node/define because 'freeze_main' is enabled") if name == "" and Puppet.settings[:freeze_main]
-
+    if name == "" && Puppet.settings[:freeze_main]
+      # It is ok to merge definitions into main even if freeze is on (definitions are nodes, classes, defines, functions, and types)
+      unless other.code.is_definitions_only?
+        fail _("Cannot have code outside of a class/node/define because 'freeze_main' is enabled")
+      end
+    end
     if parent and other.parent and parent != other.parent
       fail _("Cannot merge classes with different parent classes (%{name} => %{parent} vs. %{other_name} => %{other_parent})") % { name: name, parent: parent, other_name: other.name, other_parent: other.parent }
     end


### PR DESCRIPTION
Before this, in some circumstances puppet ends up wanting to merge
definitions into main. When freeze_main is on, the check for allowed
merge was very simplistic and did not allow for definitions to be
merged. This is always ok since they are just definitions that does not
lead to any declaration of resources in the catalog.