### PR TITLE
(maint) Clarify error on Timeout::Error exception

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -300,12 +300,22 @@ module Puppet::Network::HTTP
     def execute_request(connection, request)
       start = Time.now
       connection.request(request)
-    rescue EOFError => e
+    rescue => exception
       elapsed = (Time.now - start).to_f.round(3)
-      uri = @site.addr + request.path.split('?')[0]
-      eof = EOFError.new(_('request %{uri} interrupted after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
-      eof.set_backtrace(e.backtrace) unless e.backtrace.empty?
-      raise eof
+      uri = [@site.addr, request.path.split('?')[0]].join('/')
+      eclass = exception.class
+
+      err = case exception
+            when EOFError
+              eclass.new(_('request %{uri} interrupted after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
+            when Timeout::Error
+              eclass.new(_('request %{uri} timed out after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
+            else
+              eclass.new(_('request %{uri} failed: %{msg}') % {uri: uri, msg: exception.message})
+            end
+
+      err.set_backtrace(exception.backtrace) unless exception.backtrace.empty?
+      raise err
     end
 
     def with_connection(site, &block)

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -121,7 +121,7 @@ describe Puppet::Network::HTTP::Connection do
 
       expect do
         connection.get('request')
-      end.to raise_error(Puppet::Error, "certificate verify failed: [shady looking signature]")
+      end.to raise_error(Puppet::Error, /certificate verify failed: \[shady looking signature\]/)
     end
 
     it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet.features.microsoft_windows? do


### PR DESCRIPTION
This is another improvement for PUP-3238, though not a solve.

It turns out Net::HTTP will raise other errors, such as Timeout::Error, in
addition to the previously caught EOFErrors. To further clarify to the user
what is happening when these network issues occur, this commit also catches and
adds contexual information to Timeout::Error exceptions.

For completeness, in the event any other type of exception is raised we also
catch it and add the uri context. Seconds elapsed is omitted in the general
case because not knowing what the exception is, it's not certain whether or
not seconds elapsed will be relevant.

See also: bd737a89a213e15c3d1db32e64bd596b08886b2a