### PR TITLE
(PUP-8582) Add vendor_modules to basemodulepath

### DIFF
--- a/acceptance/tests/modulepath.rb
+++ b/acceptance/tests/modulepath.rb
@@ -1,0 +1,119 @@
+# REMIND: windows
+test_name 'Supports vendored modules' do
+  tag 'risk:medium'
+
+  # beacon custom type emits a message so we can tell where the
+  # type was loaded from, e.g. vendored, and from which host
+  def beacon_type(message)
+    return <<END
+    Puppet::Type.newtype(:beacon) do
+      newparam(:name,  :namevar => true)
+      newproperty(:message) do
+        def sync; true; end
+        def retrieve; :absent; end
+        def insync?(is); false; end
+        defaultto { "#{message}" }
+      end
+    end
+END
+  end
+
+  def global_modules(host)
+    if host.platform =~ /windows/
+      '/cygdrive/c/ProgramData/PuppetLabs/code/modules'
+    else
+      '/etc/puppetlabs/code/modules'
+    end
+  end
+
+  def vendor_modules(host)
+    if host.platform =~ /windows/
+      '/cygdrive/c/Program Files/Puppet Labs/Puppet/puppet/vendor_modules'
+    else
+      '/opt/puppetlabs/puppet/vendor_modules'
+    end
+  end
+
+  teardown do
+    hosts.each do |host|
+      on(host, "rm -rf #{vendor_modules(host)}/*")
+      on(host, "rm -rf #{global_modules(host)}/*")
+    end
+
+    agents.each do |agent|
+      on(agent, "rm -rf /opt/puppetlabs/puppet/cache/lib")
+    end
+
+    on(master, "rm -rf /etc/puppetlabs/code/environments/production/modules/beacon")
+    on(master, "rm -f /etc/puppetlabs/code/environments/production/manifests/site.pp")
+  end
+
+  step 'create vendored module with a custom type' do
+    hosts.each do |host|
+      vendor_dir = vendor_modules(host)
+      on(host, "mkdir -p #{vendor_dir}/beacon/lib/puppet/type")
+      create_remote_file(host, "#{vendor_dir}/beacon/lib/puppet/type/beacon.rb", beacon_type("vendored module from #{host}"))
+    end
+  end
+
+  step 'vendored modules work locally' do
+    hosts.each do |host|
+      on(host, puppet("apply -e \"beacon { 'ping': }\"")) do |result|
+        assert_match(/defined 'message' as 'vendored module from #{host}'/, result.stdout)
+      end
+    end
+  end
+
+  step 'vendored modules can be excluded' do
+    hosts.each do |host|
+      on(host, puppet("describe --basemodulepath '$codedir/modules' beacon"), accept_all_exit_codes: true) do |result|
+        assert_match(/Unknown type beacon/, result.stdout)
+      end
+    end
+  end
+
+  step 'global modules override vendored modules' do
+    agents.each do |agent|
+      # skip the agent on the master, as we don't want to install the
+      # global module on the master until later 
+      next if agent == master
+
+      global_dir = global_modules(agent)
+      on(agent, "mkdir -p #{global_dir}/beacon/lib/puppet/type")
+      create_remote_file(agent, "#{global_dir}/beacon/lib/puppet/type/beacon.rb", beacon_type("global module from #{agent}"))
+
+      on(agent, puppet("apply -e \"beacon { 'ping': }\"")) do |result|
+        assert_match(/defined 'message' as 'global module from #{agent}'/, result.stdout)
+      end
+    end
+  end
+
+  step "prepare server" do
+    create_remote_file(master, "/etc/puppetlabs/code/environments/production/manifests/site.pp", "beacon { 'ping': }")
+    on(master, "chown -R puppet:puppet /etc/puppetlabs/code/environments/production/manifests/site.pp")
+    on(master, "chown -R puppet:puppet #{vendor_modules(master)}")
+  end
+
+  with_puppet_running_on(master, {}) do
+    step "agent downloads and uses server's vendored module" do
+      agents.each do |agent|
+        on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [0,2]) do |result|
+          assert_match(/defined 'message' as 'vendored module from #{master}'/, result.stdout)
+        end
+      end
+    end
+
+    step "agent downloads and uses newly installed global module from the server" do
+      global_dir = global_modules(master)
+      on(master, "mkdir -p #{global_dir}/beacon/lib/puppet/type")
+      create_remote_file(master, "#{global_dir}/beacon/lib/puppet/type/beacon.rb", beacon_type("server module from #{master}"))
+      on(master, "chown -R puppet:puppet #{global_dir}")
+
+      agents.each do |agent|
+        on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [0,2]) do |result|
+          assert_match(/defined 'message' as 'server module from #{master}'/, result.stdout)
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -32,6 +32,20 @@ module Puppet
       %w[md5 md5lite sha256 sha256lite sha384 sha512 sha224 sha1 sha1lite mtime ctime]
   end
 
+  def self.default_basemodulepath
+    if Puppet::Util::Platform.windows?
+      path = ['$codedir/modules']
+      installdir = Facter.value(:env_windows_installdir)
+      if installdir
+        path << "#{installdir}/puppet/modules"
+        path << "#{installdir}/puppet/vendor_modules"
+      end
+      path.join(File::PATH_SEPARATOR)
+    else
+      '$codedir/modules:/opt/puppetlabs/puppet/modules:/opt/puppetlabs/puppet/vendor_modules'
+    end
+  end
+
   ############################################################################################
   # NOTE: For information about the available values for the ":type" property of settings,
   #   see the docs for Settings.define_settings
@@ -1286,7 +1300,7 @@ EOT
       :desc       => "File that provides mapping between custom SSL oids and user-friendly names"
     },
     :basemodulepath => {
-      :default => "$codedir/modules#{File::PATH_SEPARATOR}/opt/puppetlabs/puppet/modules",
+      :default => lambda { default_basemodulepath },
       :type => :path,
       :desc => "The search path for **global** modules. Should be specified as a
         list of directories separated by the system path separator character. (The

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -123,4 +123,32 @@ describe "Defaults" do
       Puppet.settings.handlearg("--server", "test_server")
     end
   end
+
+  describe 'basemodulepath' do
+    it 'includes the user, system and vendor modules', :unless => Puppet::Util::Platform.windows? do
+      expect(
+        Puppet[:basemodulepath]
+      ).to match(%r{.*/code/modules:/opt/puppetlabs/puppet/modules:/opt/puppetlabs/puppet/vendor_modules$})
+    end
+
+    describe 'on windows', :if => Puppet::Util::Platform.windows? do
+      let(:installdir) { 'C:\Program Files\Puppet Labs\Puppet' }
+
+      it 'includes user, system and vendor modules' do
+        Facter.stubs(:value).with(:env_windows_installdir).returns(installdir)
+
+        expect(
+          Puppet.default_basemodulepath
+        ).to eq('$codedir/modules;C:\Program Files\Puppet Labs\Puppet/puppet/modules;C:\Program Files\Puppet Labs\Puppet/puppet/vendor_modules')
+      end
+
+      it 'includes user modules if installdir fact is missing' do
+        Facter.stubs(:value).with(:env_windows_installdir).returns(nil)
+
+        expect(
+          Puppet.default_basemodulepath
+        ).to eq('$codedir/modules')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Append the vendor_modules directory to the basemodulepath setting so that vendored modules are available in all environments.

On most platforms, the resulting basemodulepath corresponds to global, site and vendored modules directories, respectively.

On Windows, the resulting basemodulepath contains at least the global modules directory. Additionally if the env_windows_installdir fact[1] is set, which it is when running from puppet-agent packages, then we include the site and vendored modules directories.

For all platforms, the global modules directory ($codedir/modules) depends on whether we are running in a privileged context or not (so it's either in /etc/puppetlabs or ~/.puppetlabs).

[1] https://puppet.com/docs/facter/3.11/core_facts.html#envwindowsinstalldir