### PR TITLE
(PUP-8672) Ensure cache expiration clears translation domains

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -443,10 +443,9 @@ module Puppet::Environments
     # Also clears caches in Settings that may prevent the entry from being updated
     def evict_if_expired(name)
       if (result = @cache[name]) && (result.expired? || @cache_expiration_service.expired?(name))
-      Puppet.debug {"Evicting cache entry for environment '#{name}'"}
-        @cache.delete(name)
+        Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name)
-
+        clear(name)
         Puppet.settings.clear_environment_settings(name)
       end
     end

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -73,6 +73,18 @@ module Puppet::GettextConfig
   end
 
   # @api private
+  # Resets the thread's configured text_domain to the default text domain.
+  # In Puppet Server, thread A may process a compile request that configures
+  # a domain, while thread B may invalidate that environment and delete the
+  # domain. That leaves thread A with an invalid text_domain selected.
+  # To avoid that, clear_text_domain after any processing that needs the
+  # non-default text domain.
+  def self.clear_text_domain
+    return if @gettext_disabled || !gettext_loaded?
+    FastGettext.text_domain = nil
+  end
+
+  # @api private
   # Creates a default text domain containing the translations for
   # Puppet as the start of chain. When semantic_puppet gets initialized,
   # its translations are added to this chain. This is used as a cache

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -63,6 +63,7 @@ module Puppet::GettextConfig
   def self.reset_text_domain(domain_name)
     return if @gettext_disabled || !gettext_loaded?
 
+    Puppet.debug "Reset text domain to #{domain_name.inspect}"
     FastGettext.add_text_domain(domain_name,
                                 type: :chain,
                                 chain: [],
@@ -99,7 +100,10 @@ module Puppet::GettextConfig
     return if @gettext_disabled || !gettext_loaded?
 
     if FastGettext.translation_repositories.include?(domain_name)
+      Puppet.debug "Use text domain #{domain_name.inspect}"
       FastGettext.text_domain = domain_name
+    else
+      Puppet.debug "Requested unknown text domain #{domain_name.inspect}"
     end
   end
 
@@ -117,9 +121,12 @@ module Puppet::GettextConfig
   def self.delete_text_domain(domain_name)
     return if @gettext_disabled || !gettext_loaded?
 
-    FastGettext.translation_repositories.delete(domain_name)
+    deleted = FastGettext.translation_repositories.delete(domain_name)
     if FastGettext.text_domain == domain_name
+      Puppet.debug "Deleted current text domain #{domain_name.inspect}: #{!deleted.nil?}"
       FastGettext.text_domain = nil
+    else
+      Puppet.debug "Deleted text domain #{domain_name.inspect}: #{!deleted.nil?}"
     end
   end
 

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -6,6 +6,7 @@ module Puppet::GettextConfig
   POSIX_PATH = File.absolute_path('../../../../../share/locale', File.dirname(__FILE__))
   WINDOWS_PATH = File.absolute_path('../../../../../../../puppet/share/locale', File.dirname(__FILE__))
 
+  # This is the only domain name that won't be a symbol, making it unique from environments.
   DEFAULT_TEXT_DOMAIN = 'default-text-domain'
 
   # Load gettext helpers and track whether they're available.
@@ -59,9 +60,10 @@ module Puppet::GettextConfig
   # Clears the translation repository for the given text domain,
   # creating it if it doesn't exist, then adds default translations
   # and switches to using this domain.
-  # @param [String] domain_name the name of the domain to create
+  # @param [String, Symbol] domain_name the name of the domain to create
   def self.reset_text_domain(domain_name)
     return if @gettext_disabled || !gettext_loaded?
+    domain_name = domain_name.to_sym
 
     Puppet.debug "Reset text domain to #{domain_name.inspect}"
     FastGettext.add_text_domain(domain_name,
@@ -107,9 +109,10 @@ module Puppet::GettextConfig
 
   # @api private
   # Switches the active text domain, if the requested domain exists.
-  # @param [String] domain_name the name of the domain to switch to
+  # @param [String, Symbol] domain_name the name of the domain to switch to
   def self.use_text_domain(domain_name)
     return if @gettext_disabled || !gettext_loaded?
+    domain_name = domain_name.to_sym
 
     if FastGettext.translation_repositories.include?(domain_name)
       Puppet.debug "Use text domain #{domain_name.inspect}"
@@ -129,9 +132,10 @@ module Puppet::GettextConfig
 
   # @api private
   # Deletes the text domain with the given name
-  # @param [String] domain_name the name of the domain to delete
+  # @param [String, Symbol] domain_name the name of the domain to delete
   def self.delete_text_domain(domain_name)
     return if @gettext_disabled || !gettext_loaded?
+    domain_name = domain_name.to_sym
 
     deleted = FastGettext.translation_repositories.delete(domain_name)
     if FastGettext.text_domain == domain_name
@@ -164,7 +168,7 @@ module Puppet::GettextConfig
   # Since we are currently (Nov 2017) vendoring semantic_puppet, in normal
   # flows these translations will be copied along with Puppet's.
   #
-  # @param [String] domain_name the name of the domain to add translations to
+  # @param [Symbol] domain_name the name of the domain to add translations to
   def self.copy_default_translations(domain_name)
     return if @gettext_disabled || !gettext_loaded?
 

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -49,17 +49,13 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     node = node_from_request(facts, request)
     node.trusted_data = Puppet.lookup(:trusted_information) { Puppet::Context::TrustedInformation.local(node) }.to_h
 
-    node.environment.use_text_domain if node.environment
-
-    if catalog = compile(node, request.options)
-      return catalog
+    if node.environment
+      node.environment.with_text_domain do
+        compile(node, request.options)
+      end
     else
-      # This shouldn't actually happen; we should either return
-      # a config or raise an exception.
-      return nil
+      compile(node, request.options)
     end
-  ensure
-    Puppet::GettextConfig.clear_text_domain
   end
 
   # filter-out a catalog to remove exported resources

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -58,6 +58,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       # a config or raise an exception.
       return nil
     end
+  ensure
+    Puppet::GettextConfig.clear_text_domain
   end
 
   # filter-out a catalog to remove exported resources

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -435,7 +435,7 @@ class Puppet::Node::Environment
 
   # Loads module translations for the current environment once for
   # the lifetime of the environment.
-  def use_text_domain
+  def with_text_domain
     return if Puppet[:disable_i18n]
 
     if @text_domain.nil?
@@ -445,6 +445,10 @@ class Puppet::Node::Environment
     else
       Puppet::GettextConfig.use_text_domain(@text_domain)
     end
+
+    yield
+  ensure
+    Puppet::GettextConfig.clear_text_domain
   end
 
   # Checks if a reparse is required (cache of files is stale).

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -123,7 +123,6 @@ module Puppet
                 $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
               end
 
-              Puppet::GettextConfig.reset_text_domain('cli')
               Puppet::ModuleTranslations.load_from_modulepath(configured_environment.modules)
               Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
 

--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -95,8 +95,13 @@ describe Puppet::GettextConfig do
     end
 
     it 'should copy default translations when creating a non-default text domain' do
+      Puppet::GettextConfig.reset_text_domain(:test)
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, :test)
+    end
+
+    it 'should normalize domain name when creating a non-default text domain' do
       Puppet::GettextConfig.reset_text_domain('test')
-      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, :test)
     end
   end
 
@@ -116,22 +121,22 @@ describe Puppet::GettextConfig do
 
   describe "deleting text domains" do
     it 'can delete a text domain by name' do
-      Puppet::GettextConfig.reset_text_domain('test')
-      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
-      Puppet::GettextConfig.delete_text_domain(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN)
-      expect(Puppet::GettextConfig.loaded_text_domains).not_to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN)
+      Puppet::GettextConfig.reset_text_domain(:test)
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, :test)
+      Puppet::GettextConfig.delete_text_domain(:test)
+      expect(Puppet::GettextConfig.loaded_text_domains).to eq([Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN])
     end
 
     it 'can delete all non-default text domains' do
-      Puppet::GettextConfig.reset_text_domain('test')
-      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
+      Puppet::GettextConfig.reset_text_domain(:test)
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, :test)
       Puppet::GettextConfig.delete_environment_text_domains
-      expect(Puppet::GettextConfig.loaded_text_domains).not_to include('test')
+      expect(Puppet::GettextConfig.loaded_text_domains).to eq([Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN])
     end
 
     it 'can delete all text domains' do
-      Puppet::GettextConfig.reset_text_domain('test')
-      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, 'test')
+      Puppet::GettextConfig.reset_text_domain(:test)
+      expect(Puppet::GettextConfig.loaded_text_domains).to include(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN, :test)
       Puppet::GettextConfig.delete_all_text_domains
       expect(Puppet::GettextConfig.loaded_text_domains).to be_empty
     end

--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -100,6 +100,20 @@ describe Puppet::GettextConfig do
     end
   end
 
+  describe "clearing the configured text domain" do
+    it 'succeeds' do
+      Puppet::GettextConfig.clear_text_domain
+      expect(FastGettext.text_domain).to be_nil
+    end
+
+    it 'falls back to default' do
+      Puppet::GettextConfig.reset_text_domain(:test)
+      expect(FastGettext.text_domain).to eq(:test)
+      Puppet::GettextConfig.clear_text_domain
+      expect(FastGettext.text_domain).to eq(Puppet::GettextConfig::DEFAULT_TEXT_DOMAIN)
+    end
+  end
+
   describe "deleting text domains" do
     it 'can delete a text domain by name' do
       Puppet::GettextConfig.reset_text_domain('test')

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -496,15 +496,16 @@ describe Puppet::Node::Environment do
     it "creates a new text domain the first time we try to use the text domain" do
       Puppet::GettextConfig.expects(:reset_text_domain).with(env.name)
       Puppet::ModuleTranslations.expects(:load_from_modulepath)
+      Puppet::GettextConfig.expects(:clear_text_domain)
 
-      env.use_text_domain
+      env.with_text_domain do; end
     end
 
     it "uses the existing text domain once it has been created" do
-      env.use_text_domain
+      env.with_text_domain do; end
 
       Puppet::GettextConfig.expects(:use_text_domain).with(env.name)
-      env.use_text_domain
+      env.with_text_domain do; end
     end
   end
 


### PR DESCRIPTION
Previously we never successfully cleared translation repositories because we used symbols as the keys when creating them but strings as the keys when deleting them. Normalize environment names to symbols so that we consistently add and delete translation repositories, and fix issues with thread-specific storage for `text_domain` working with Puppet Server where multiple threads may use the same JRuby instance.