### PR TITLE
(PUP-8558) Remove strict_semver option from PMT and always enforce strict semver logic.

### DIFF
--- a/lib/puppet/face/module/install.rb
+++ b/lib/puppet/face/module/install.rb
@@ -120,10 +120,6 @@ Puppet::Face.define(:module, '1.0.0') do
       EOT
     end
 
-    option '--strict-semver' do
-      summary _('Whether version ranges should exclude pre-release versions')
-    end
-
     when_invoked do |name, options|
       Puppet::ModuleTool.set_option_defaults options
       Puppet.notice _("Preparing to install into %{dir} ...") % { dir: options[:target_dir] }

--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -17,10 +17,6 @@ Puppet::Face.define(:module, '1.0.0') do
       summary _("Whether to show dependencies as a tree view")
     end
 
-    option '--strict-semver' do
-      summary _('Whether version ranges should exclude pre-release versions')
-    end
-
     examples <<-'EOT'
       List installed modules:
 
@@ -77,7 +73,6 @@ Puppet::Face.define(:module, '1.0.0') do
 
       output = ''
 
-      environment.modules_strict_semver = !!options[:strict_semver]
       warn_unmet_dependencies(environment)
 
       environment.modulepath.each do |path|

--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -23,7 +23,7 @@ Puppet::Face.define(:module, '1.0.0') do
 
     when_invoked do |term, options|
       Puppet::ModuleTool.set_option_defaults options
-      Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new(options[:module_repository] || Puppet[:module_repository], options[:strict_semver]), options).run
+      Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new(options[:module_repository] || Puppet[:module_repository]), options).run
     end
 
     when_rendering :console do |results, term, options|

--- a/lib/puppet/face/module/uninstall.rb
+++ b/lib/puppet/face/module/uninstall.rb
@@ -56,10 +56,6 @@ Puppet::Face.define(:module, '1.0.0') do
       EOT
     end
 
-    option '--strict-semver' do
-      summary _('Whether version ranges should exclude pre-release versions')
-    end
-
     when_invoked do |name, options|
       name = name.gsub('/', '-')
 

--- a/lib/puppet/face/module/upgrade.rb
+++ b/lib/puppet/face/module/upgrade.rb
@@ -62,10 +62,6 @@ Puppet::Face.define(:module, '1.0.0') do
       EOT
     end
 
-    option '--strict-semver' do
-      summary _('Whether version ranges should exclude pre-release versions')
-    end
-
     when_invoked do |name, options|
       name = name.gsub('/', '-')
       Puppet.notice _("Preparing to upgrade '%{name}' ...") % { name: name }

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -19,10 +19,9 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
 
   attr_reader :host, :repository
 
-  def initialize(host = Puppet[:module_repository], strict_semver = true)
+  def initialize(host = Puppet[:module_repository])
     @host = host
     @repository = Puppet::Forge::Repository.new(host, USER_AGENT)
-    @strict_semver = strict_semver
   end
 
   # Return a list of module metadata hashes that match the search query.
@@ -120,7 +119,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
   class ModuleRelease < SemanticPuppet::Dependency::ModuleRelease
     attr_reader :install_dir, :metadata
 
-    def initialize(source, data, strict_semver = true)
+    def initialize(source, data)
       @data = data
       @metadata = meta = data['metadata']
 
@@ -132,7 +131,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
         dependencies = meta['dependencies'].collect do |dep|
           begin
             Puppet::ModuleTool::Metadata.new.add_dependency(dep['name'], dep['version_requirement'], dep['repository'])
-            Puppet::ModuleTool.parse_module_dependency(release, dep, strict_semver)[0..1]
+            Puppet::ModuleTool.parse_module_dependency(release, dep)[0..1]
           rescue ArgumentError => e
             raise ArgumentError, _("Malformed dependency: %{name}.") % { name: dep['name'] } +
                 ' ' + _("Exception was: %{detail}") % { detail: e }
@@ -224,7 +223,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     l = list.map do |release|
       metadata = release['metadata']
       begin
-        ModuleRelease.new(self, release, @strict_semver)
+        ModuleRelease.new(self, release)
       rescue ArgumentError => e
         Puppet.warning _("Cannot consider release %{name}-%{version}: %{error}") % { name: metadata['name'], version: metadata['version'], error: e }
         false

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -131,8 +131,6 @@ module Puppet
       # Note: environment will have expanded the path
       options[:target_dir] = face_environment.full_modulepath.first
 
-      # Default false to retain backward compatibility with SemanticPuppet 0.1.4
-      options[:strict_semver] = false unless options.include?(:strict_semver)
     end
 
     # Given a hash of options, we should discover or create a
@@ -165,16 +163,15 @@ module Puppet
     # @param where [String] a description of the thing we're parsing the
     #        dependency expression for
     # @param dep [Hash] the dependency description to parse
-    # @param strict_semver [Boolean] set to `false` to relax range semantics to include pre-releases
     # @return [Array(String, SemanticPuppet::VersionRange, String)] a tuple of the
     #         dependent module's name, the version range dependency, and the
     #         unparsed range expression.
-    def self.parse_module_dependency(where, dep, strict_semver = true)
+    def self.parse_module_dependency(where, dep)
       dep_name = dep['name'].tr('/', '-')
       range = dep['version_requirement'] || '>= 0.0.0'
 
       begin
-        parsed_range = Module.parse_range(range, strict_semver)
+        parsed_range = Module.parse_range(range)
       rescue ArgumentError => e
         Puppet.debug "Error in #{where} parsing dependency #{dep_name} (#{e.message}); using empty range."
         parsed_range = SemanticPuppet::VersionRange::EMPTY_RANGE

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -12,7 +12,6 @@ module Puppet::ModuleTool
         @suggestions = []
         @environment = options[:environment_instance]
         @ignore_changes = options[:force] || options[:ignore_changes]
-        @strict_semver  = !!options[:strict_semver]
       end
 
       def run
@@ -61,7 +60,7 @@ module Puppet::ModuleTool
               :path    => mod.modulepath,
             }
             if @options[:version] && mod.version
-              next unless Puppet::Module.parse_range(@options[:version], @strict_semver).include?(SemanticPuppet::Version.parse(mod.version))
+              next unless Puppet::Module.parse_range(@options[:version]).include?(SemanticPuppet::Version.parse(mod.version))
             end
             @installed << mod
           elsif mod_name =~ /#{@name}/

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -54,7 +54,7 @@ module Puppet::ModuleTool
     class ModuleRelease < SemanticPuppet::Dependency::ModuleRelease
       attr_reader :mod, :metadata
 
-      def initialize(source, mod, strict_semver = true)
+      def initialize(source, mod)
         @mod = mod
         @metadata = mod.metadata
         name = mod.forge_name.tr('/', '-')
@@ -70,7 +70,7 @@ module Puppet::ModuleTool
 
         if mod.dependencies
           mod.dependencies.each do |dependency|
-            results = Puppet::ModuleTool.parse_module_dependency(release, dependency, strict_semver)
+            results = Puppet::ModuleTool.parse_module_dependency(release, dependency)
             dep_name, parsed_range, range = results
 
             add_constraint('initialize', dep_name, range.to_s) do |node|

--- a/lib/puppet/module_tool/local_tarball.rb
+++ b/lib/puppet/module_tool/local_tarball.rb
@@ -8,11 +8,11 @@ module Puppet::ModuleTool
   class LocalTarball < SemanticPuppet::Dependency::Source
     attr_accessor :release
 
-    def initialize(filename, strict_semver = true)
+    def initialize(filename)
       unpack(filename, tmpdir)
       Puppet.debug "Unpacked local tarball to #{tmpdir}"
 
-      mod = Puppet::Module.new('tarball', tmpdir, nil, strict_semver)
+      mod = Puppet::Module.new('tarball', tmpdir, nil)
       @release = ModuleRelease.new(self, mod)
     end
 
@@ -52,7 +52,7 @@ module Puppet::ModuleTool
 
         if mod.dependencies
           dependencies = mod.dependencies.map do |dep|
-            Puppet::ModuleTool.parse_module_dependency(release, dep, mod.strict_semver?)[0..1]
+            Puppet::ModuleTool.parse_module_dependency(release, dep)[0..1]
           end
           dependencies = Hash[dependencies]
         end

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -76,10 +76,10 @@ module Puppet::ModuleTool::Shared
       }
 
       if forced?
-        range = Puppet::Module.parse_range(@version, @strict_semver) rescue Puppet::Module.parse_range('>= 0.0.0', @strict_semver)
+        range = Puppet::Module.parse_range(@version) rescue Puppet::Module.parse_range('>= 0.0.0')
       else
         range = (@conditions[mod]).map do |r|
-          Puppet::Module.parse_range(r[:dependency], @strict_semver) rescue Puppet::Module.parse_range('>= 0.0.0', @strict_semver)
+          Puppet::Module.parse_range(r[:dependency]) rescue Puppet::Module.parse_range('>= 0.0.0')
         end.inject(&:&)
       end
 

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -85,7 +85,6 @@ class Puppet::Node::Environment
     @modulepath = modulepath
     @manifest = manifest
     @config_version = config_version
-    @modules_strict_semver = false
   end
 
   # Creates a new Puppet::Node::Environment instance, overriding any of the passed
@@ -240,22 +239,6 @@ class Puppet::Node::Environment
     Puppet.settings.value(param, self.name)
   end
 
-  # A SemanticPuppet::VersionRange version >= 1.0.0 will not include versions with pre-release
-  # identifiers unless that is explicitly declared. This may cause backward compatibility
-  # issues when resolving module dependencies and the flag is therefore set to `false` by default.
-  #
-  # @param flag [Boolean] set to true to resolve module dependencies using strict SemVer semantics
-  #
-  def modules_strict_semver=(flag)
-    @modules_strict_semver = flag
-  end
-
-  # @return [Boolean] the current value of the modules_strict_semver flag.
-  # @api public
-  def modules_strict_semver?
-    @modules_strict_semver
-  end
-
   # @api public
   # @return [Puppet::Resource::TypeCollection] The current global TypeCollection
   def known_resource_types
@@ -330,7 +313,7 @@ class Puppet::Node::Environment
 
       @modules = module_references.collect do |reference|
         begin
-          Puppet::Module.new(reference[:name], reference[:path], self, modules_strict_semver?)
+          Puppet::Module.new(reference[:name], reference[:path], self)
         rescue Puppet::Module::Error => e
           Puppet.log_exception(e)
           nil
@@ -372,7 +355,7 @@ class Puppet::Node::Environment
             Puppet::Module.is_module_directory?(name, path)
           end
           modules_by_path[path] = module_names.sort.map do |name|
-            Puppet::Module.new(name, File.join(path, name), self, modules_strict_semver?)
+            Puppet::Module.new(name, File.join(path, name), self)
           end
         end
       else

--- a/spec/unit/face/module/list_spec.rb
+++ b/spec/unit/face/module/list_spec.rb
@@ -217,66 +217,6 @@ describe "puppet module list" do
       console_output(:tree => true)
     end
 
-    it 'should not warn about dependent module with pre-release version by default' do
-      PuppetSpec::Modules.create('depender', @modpath1, :metadata => {
-        :version => '1.0.0',
-        :dependencies => [{
-          "version_requirement" => ">= 1.0.0",
-          "name"                => "puppetlabs/dependable"
-        }]
-      })
-      PuppetSpec::Modules.create('dependable', @modpath1, :metadata => { :version => '1.0.0-rc1' })
-
-      expected = <<-OUTPUT.unindent
-      #{@modpath1}
-      ├── puppetlabs-dependable (\e[0;36mv1.0.0-rc1\e[0m)
-      └── puppetlabs-depender (\e[0;36mv1.0.0\e[0m)
-      #{@modpath2} (no modules installed)
-      OUTPUT
-
-      expect(console_output).to eq(expected)
-    end
-
-    it 'should warn about dependent module with pre-release version by if pre-release is less than given pre-release' do
-      PuppetSpec::Modules.create('depender', @modpath1, :metadata => {
-        :version => '1.0.0',
-        :dependencies => [{
-          "version_requirement" => ">= 1.0.0-rc1",
-          "name"                => "puppetlabs/dependable"
-        }]
-      })
-      PuppetSpec::Modules.create('dependable', @modpath1, :metadata => { :version => '1.0.0-rc0' })
-
-      expected = <<-OUTPUT.unindent
-      #{@modpath1}
-      ├── puppetlabs-dependable (\e[0;36mv1.0.0-rc0\e[0m)  \e[0;31minvalid\e[0m
-      └── puppetlabs-depender (\e[0;36mv1.0.0\e[0m)
-      #{@modpath2} (no modules installed)
-      OUTPUT
-
-      expect(console_output).to eq(expected)
-    end
-
-    it 'should warn about dependent module with pre-release version when using strict SemVer' do
-      PuppetSpec::Modules.create('depender', @modpath1, :metadata => {
-        :version => '1.0.0',
-        :dependencies => [{
-          "version_requirement" => ">= 1.0.0",
-          "name"                => "puppetlabs/dependable"
-        }]
-      })
-      PuppetSpec::Modules.create('dependable', @modpath1, :metadata => { :version => '1.0.0-rc1' })
-
-      expected = <<-OUTPUT.unindent
-      #{@modpath1}
-      ├── puppetlabs-dependable (\e[0;36mv1.0.0-rc1\e[0m)  \e[0;31minvalid\e[0m
-      └── puppetlabs-depender (\e[0;36mv1.0.0\e[0m)
-      #{@modpath2} (no modules installed)
-      OUTPUT
-
-      expect(console_output(:strict_semver => true)).to eq(expected)
-    end
-
     it "should warn about out of range dependencies" do
       PuppetSpec::Modules.create('dependable', @modpath1, :metadata => { :version => '0.0.1'})
       PuppetSpec::Modules.create('depender', @modpath1, :metadata => {

--- a/spec/unit/face/module/search_spec.rb
+++ b/spec/unit/face/module/search_spec.rb
@@ -187,7 +187,7 @@ describe "puppet module search" do
       searcher = mock("Searcher")
       options[:module_repository] = "http://forge.example.com"
 
-      Puppet::Forge.expects(:new).with("http://forge.example.com", false).returns(forge)
+      Puppet::Forge.expects(:new).with("http://forge.example.com").returns(forge)
       Puppet::ModuleTool::Applications::Searcher.expects(:new).with("puppetlabs-apache", forge, has_entries(options)).returns(searcher)
       searcher.expects(:run)
 

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -901,62 +901,7 @@ describe Puppet::Module do
     let(:notices) { logs.select { |log| log.level == :notice }.map { |log| log.message } }
 
     it 'can parse a strict range' do
-      expect(Puppet::Module.parse_range('>=1.0.0', true).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
-    end
-
-    it 'can parse a non-strict range' do
-      expect(Puppet::Module.parse_range('>=1.0.0', false).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_truthy
-    end
-
-    context 'using parse method with an arity of 1' do
-      around(:each) do |example|
-        begin
-          example.run
-        ensure
-          Puppet::Module.instance_variable_set(:@semver_gem_version, nil)
-          Puppet::Module.instance_variable_set(:@parse_range_method, nil)
-        end
-      end
-
-      it 'will notify when non-strict ranges cannot be parsed' do
-        Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('1.0.0'))
-        Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, true) })
-
-        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-          expect(Puppet::Module.parse_range('>=1.0.0', false).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
-        end
-        expect(notices).to include(/VersionRanges will always be strict when using non-vendored SemanticPuppet gem, version 1\.0\.0/)
-      end
-
-      it 'will notify when strict ranges cannot be parsed' do
-        Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('0.1.4'))
-        Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, false) })
-
-        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-          expect(Puppet::Module.parse_range('>=1.0.0', true).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_truthy
-        end
-        expect(notices).to include(/VersionRanges will never be strict when using non-vendored SemanticPuppet gem, version 0\.1\.4/)
-      end
-
-      it 'will not notify when strict ranges can be parsed' do
-        Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('1.0.0'))
-        Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, true) })
-
-        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-          expect(Puppet::Module.parse_range('>=1.0.0', true).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
-        end
-        expect(notices).to be_empty
-      end
-
-      it 'will not notify when non-strict ranges can be parsed' do
-        Puppet::Module.instance_variable_set(:@semver_gem_version, SemanticPuppet::Version.parse('0.1.4'))
-        Puppet::Module.instance_variable_set(:@parse_range_method, Proc.new { |str| SemanticPuppet::VersionRange.parse(str, false) })
-
-        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-          expect(Puppet::Module.parse_range('>=1.0.0', false).include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_truthy
-        end
-        expect(notices).to be_empty
-      end
+      expect(Puppet::Module.parse_range('>=1.0.0').include?(SemanticPuppet::Version.parse('1.0.1-rc1'))).to be_falsey
     end
   end
 end

--- a/spec/unit/module_tool_spec.rb
+++ b/spec/unit/module_tool_spec.rb
@@ -229,28 +229,6 @@ TREE
       end
     end
 
-    describe ':strict_semver' do
-      context 'when set' do
-        let(:options) do
-          { :strict_semver => true }
-        end
-
-        it 'is not overridden by default' do
-          expect(subject).to include :strict_semver => true
-        end
-      end
-
-      context 'when unset' do
-        let(:options) do
-          { }
-        end
-
-        it 'defaults to false' do
-          expect(subject).to include :strict_semver => false
-        end
-      end
-    end
-
     describe ':target_dir' do
       let(:options) do
         { :target_dir => 'foo' }


### PR DESCRIPTION
This commit removes the option to have relaxed semver in the puppet
module tool. When this was added it caused problems because puppet agent,
puppet server, and puppet all store and look for semantic_puppet in different
locations and with different methods with differing number of arguments, which
caused major discrepancies between versions. This also caused some semver
issues with installing directly from the forge with the PMT. This is the first
step to completely unvendoring semantic_puppet so that it can exist in only one
place and all three products get it from the same location. Removed all
references to strict_semver as well as related logic around pre-release
versioning, code checking to see if this option was set, as well as all related
tests for this option.