### PR TITLE
(PUP-8667) Move tidy's "File does not exist" message from info to debug

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -338,7 +338,7 @@ Puppet::Type.newtype(:tidy) do
     begin
       Puppet::FileSystem.lstat(path)
     rescue Errno::ENOENT
-      info _("File does not exist")
+      debug _("File does not exist")
       return nil
     rescue Errno::EACCES
       #TRANSLATORS "stat" is a program name and should not be translated


### PR DESCRIPTION
Having the "File does not exist" message from the tidy resource can be very chatty for letting a user know that their desired state is already achieved. The message can still be useful for debugging, however. So, we now only emit the message if the log level is debug or higher.

An example of when the "File does not exist" message would be annoying, is if there is a tidy resource for the directory `/tmp/foo`, with `rmdirs => true`. The tidy resource would remove the `/tmp/foo` directory itself, and subsequent runs would emit the "File does not exist" message until something recreated the `/tmp/foo` directory.