### PR TITLE
(PUP-8552) Create notdefaultfor blacklist for better management of default providers.

### DIFF
--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -278,7 +278,12 @@ class Puppet::Provider
   # @see Provider.defaultfor
   # @api private
   def self.default_match
-    @defaults.find do |default|
+    return nil if some_default_match(@notdefaults) # Blacklist means this provider cannot be a default
+    some_default_match(@defaults)
+  end
+
+  def self.some_default_match(defaultlist)
+    defaultlist.find do |default|
       default.all? do |key, values|
         case key
           when :feature
@@ -329,6 +334,10 @@ class Puppet::Provider
     @defaults << hash
   end
 
+  def self.notdefaultfor(hash)
+    @notdefaults << hash
+  end
+
   # @return [Integer] Returns a numeric specificity for this provider based on how many requirements it has
   #  and number of _ancestors_. The higher the number the more specific the provider.
   # The number of requirements is based on the hash size of the matching {Provider.defaultfor}.
@@ -346,6 +355,7 @@ class Puppet::Provider
     # complexity of a provider).
     match = default_match
     length = match ? match.length : 0
+
     (length * 100) + ancestors.select { |a| a.is_a? Class }.length
   end
 
@@ -353,6 +363,7 @@ class Puppet::Provider
   # @return [void]
   def self.initvars
     @defaults = []
+    @notdefaults = []
     @commands = {}
   end
 

--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,7 +28,8 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => (22..30).to_a
+  defaultfor :operatingsystem => :fedora
+  notdefaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => (19..21).to_a
 
   def self.update_command
     # In DNF, update is deprecated for upgrade

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -25,7 +25,9 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :coreos
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
-  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10","17.04","17.10","18.04"]
+
+  defaultfor :operatingsystem => :ubuntu
+  notdefaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"] # These are using upstart
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 
   def self.instances

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -23,6 +23,13 @@ context 'default' do
       expect(provider_class).to be_default
     end
   end
+
+  it "should be the default provider on some random future fedora" do
+    Facter.stubs(:value).with(:osfamily).returns(:redhat)
+    Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("8675")
+    expect(provider_class).to be_default
+  end
 end
 
 describe provider_class do

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -7,6 +7,13 @@ describe provider_class do
   include PuppetSpec::Fixtures
   it_behaves_like 'RHEL package provider', provider_class, 'yum'
 
+  it "should have lower specificity" do
+    Facter.stubs(:value).with(:osfamily).returns(:redhat)
+    Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("22")
+    expect(provider_class.specificity).to be < 200
+  end
+
   describe "when supplied the source param" do
     let(:name) { 'baz' }
 

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -26,12 +26,15 @@ describe Puppet::Type.type(:service).provider(:systemd) do
   osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
       Facter.stubs(:value).with(:osfamily).returns(osfamily)
+      Facter.stubs(:value).with(:operatingsystem).returns(osfamily)
+      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("1234")
       expect(described_class).to be_default
     end
   end
 
   it "should be the default provider on rhel7" do
     Facter.stubs(:value).with(:osfamily).returns(:redhat)
+    Facter.stubs(:value).with(:operatingsystem).returns(:redhat)
     Facter.stubs(:value).with(:operatingsystemmajrelease).returns("7")
     expect(described_class).to be_default
   end
@@ -81,12 +84,14 @@ describe Puppet::Type.type(:service).provider(:systemd) do
 
   it "should be the default provider on sles12" do
     Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystem).returns(:suse)
     Facter.stubs(:value).with(:operatingsystemmajrelease).returns("12")
     expect(described_class).to be_default
   end
 
   it "should be the default provider on opensuse13" do
     Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystem).returns(:suse)
     Facter.stubs(:value).with(:operatingsystemmajrelease).returns("13")
     expect(described_class).to be_default
   end
@@ -94,6 +99,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
   # tumbleweed is a rolling release with date-based major version numbers
   it "should be the default provider on tumbleweed" do
     Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystem).returns(:suse)
     Facter.stubs(:value).with(:operatingsystemmajrelease).returns("20150829")
     expect(described_class).to be_default
   end
@@ -101,6 +107,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
   # leap is the next generation suse release
   it "should be the default provider on leap" do
     Facter.stubs(:value).with(:osfamily).returns(:suse)
+    Facter.stubs(:value).with(:operatingsystem).returns(:leap)
     Facter.stubs(:value).with(:operatingsystemmajrelease).returns("42")
     expect(described_class).to be_default
   end

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -360,6 +360,16 @@ describe Puppet::Type.type(:package) do
     end
   end
 
+  it "should select dnf over yum for dnf supported fedora versions" do
+    dnf = Puppet::Type.type(:package).provider(:dnf)
+    yum = Puppet::Type.type(:package).provider(:yum)
+    Facter.stubs(:value).with(:osfamily).returns(:redhat)
+    Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("22")
+
+    expect(dnf.specificity).to be > yum.specificity
+  end
+
   describe "allow_virtual" do
     it "defaults to true on platforms that support virtual packages" do
       pkg = Puppet::Type.type(:package).new(:name => 'yay', :provider => :yum)


### PR DESCRIPTION
Without this change, defaultfor needed to be explicit for os versions to separate older and newer providers.
With this change, newer providers can blacklist older os versions with the new notdefaultfor method,
so that they can be the default for unspecified future os versions without a code update.