### PR TITLE
(PUP-8691) Acceptance test cleanup after webrick removal

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -227,7 +227,7 @@ module Puppet
         master_puppet_conf = master_opts.dup # shallow clone
 
         results = {}
-        safely_shadow_directory_contents_and_yield(master, puppet_master_config(master, 'codedir'), envdir) do
+        safely_shadow_directory_contents_and_yield(master, puppet_config(master, 'codedir', section: 'master'), envdir) do
           config_print = options[:config_print]
           directory_environments = options[:directory_environments]
 

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -31,7 +31,7 @@ def curl_master_from(agent, path, headers = '', &block)
   on agent, "#{curl_base} '#{url}'", &block
 end
 
-master_user = puppet_master_config(master, 'user')
+master_user = puppet_config(master, 'user', section: 'master')
 environments_dir = create_tmpdir_for_user master, "environments"
 apply_manifest_on(master, <<-MANIFEST)
 File {

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -7,10 +7,10 @@ tag 'audit:medium',
 testdir = create_tmpdir_for_user master, 'prod-env-created'
 
 step 'make environmentpath'
-master_user = puppet_master_config(master, 'user')
-cert_path = puppet_master_config(master, 'hostcert')
-key_path = puppet_master_config(master, 'hostprivkey')
-cacert_path = puppet_master_config(master, 'localcacert')
+master_user = puppet_config(master, 'user', section: 'master')
+cert_path = puppet_config(master, 'hostcert', section: 'master')
+key_path = puppet_config(master, 'hostprivkey', section: 'master')
+cacert_path = puppet_config(master, 'localcacert', section: 'master')
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -69,13 +69,13 @@ MANIFEST
       }
     }
 
-    backup_file = backup_the_file(master, puppet_master_config(master, 'confdir'), testdir, 'puppet.conf')
+    backup_file = backup_the_file(master, puppet_config(master, 'confdir', section: 'master'), testdir, 'puppet.conf')
     lay_down_new_puppet_conf master, conf_opts, testdir
 
     teardown do
       restore_puppet_conf_from_backup( master, backup_file )
       # See PUP-6995
-      on(master, "rm -f #{puppet_master_config(master, 'yamldir')}/node/*.yaml")
+      on(master, "rm -f #{puppet_config(master, 'yamldir', section: 'master')}/node/*.yaml")
     end
     #}}}
 

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -83,7 +83,7 @@ MANIFEST
     catalog_results[master.hostname] = { 'ruby_cat' => '', 'pcore_cat' => '' }
 
     step 'compile catalog using ruby resource' do
-      on master, puppet('master', '--compile', master.hostname) do |result|
+      on master, puppet('catalog', 'find', master.hostname) do |result|
         assert_match(/running ruby code/, result.stderr)
         catalog_results[master.hostname]['ruby_cat'] = JSON.parse(result.stdout.sub(/^[^{]+/,''))
       end
@@ -94,7 +94,7 @@ MANIFEST
     end
 
     step 'compile catalog and make sure that ruby code is NOT executed' do
-      on master, puppet('master', '--compile', master.hostname) do |result|
+      on master, puppet('catalog', 'find', master.hostname) do |result|
         assert_no_match(/running ruby code/, result.stderr)
         catalog_results[master.hostname]['pcore_cat'] = JSON.parse(result.stdout.sub(/^[^{]+/,''))
       end

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -12,7 +12,7 @@ tag 'audit:medium',
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
-  master_confdir = puppet_master_config(master, 'confdir')
+  master_confdir = puppet_config(master, 'confdir', section: 'master')
 
   hiera_conf_backup = master.tmpfile('C99578-hiera-yaml')
 

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -14,7 +14,7 @@ tag 'audit:medium',
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
   puppetserver_config = "#{master['puppetserver-confdir']}/puppetserver.conf"
   existing_loadpath = read_tk_config_string(on(master, "cat #{puppetserver_config}").stdout.strip)['jruby-puppet']['ruby-load-path'].first
-  confdir = puppet_master_config(master, 'confdir')
+  confdir = puppet_config(master, 'confdir', section: 'master')
 
   hiera_conf_backup = master.tmpfile('C99629-hiera-yaml')
 

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -9,7 +9,7 @@ tag 'audit:medium',
 
   # The following two lines are required for the puppetserver service to
   # start correctly. These should be removed when PUP-7102 is resolved.
-  confdir = puppet_master_config(master, 'confdir')
+  confdir = puppet_config(master, 'confdir', section: 'master')
   on(master, "chown puppet:puppet #{confdir}/hiera.yaml")
 
   app_type        = File.basename(__FILE__, '.*')

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -13,7 +13,7 @@ tag 'audit:medium',
   tmp_environment2 = mk_tmp_environment_with_teardown(master, app_type + '2')
   fq_tmp_environmentpath2  = "#{environmentpath}/#{tmp_environment2}"
 
-  master_confdir = puppet_master_config(master, 'confdir')
+  master_confdir = puppet_config(master, 'confdir', section: 'master')
   hiera_conf_backup = master.tmpfile(app_type)
 
   teardown do

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -14,7 +14,7 @@ tag 'audit:medium',
   hiera_conf_backup = master.tmpfile('C99629-hiera-yaml')
 
   step "create hiera v3 global config and data" do
-    confdir = puppet_master_config(master, 'confdir')
+    confdir = puppet_config(master, 'confdir', section: 'master')
 
     step "backup global hiera.yaml" do
       on(master, "cp -a #{confdir}/hiera.yaml #{hiera_conf_backup}", :acceptable_exit_codes => [0,1])

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -11,7 +11,7 @@ tag 'audit:medium',
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
 
-  confdir = puppet_master_config(master, 'confdir')
+  confdir = puppet_config(master, 'confdir', section: 'master')
   hiera_conf_backup = master.tmpfile('C99572-hiera-yaml')
 
   step "backup global hiera.yaml" do

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -9,7 +9,7 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide
 
-codedir = puppet_master_config(master, 'codedir')
+codedir = puppet_config(master, 'codedir', section: 'master')
 module_author = "pmtacceptance"
 module_name   = "nginx"
 

--- a/acceptance/tests/modules/list/with_modulepath.rb
+++ b/acceptance/tests/modules/list/with_modulepath.rb
@@ -4,7 +4,7 @@ test_name "puppet module list (with modulepath)"
 tag 'audit:low',
     'audit:unit'
 
-codedir = puppet_master_config(master, 'codedir')
+codedir = puppet_config(master, 'codedir', section: 'master')
 
 step "Setup"
 apply_manifest_on master, <<-PP

--- a/acceptance/tests/modules/uninstall/with_modulepath.rb
+++ b/acceptance/tests/modules/uninstall/with_modulepath.rb
@@ -5,7 +5,7 @@ tag 'audit:low',       # Module management via pmt is not the primary support wo
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide
 
-codedir = puppet_master_config(master, 'codedir')
+codedir = puppet_config(master, 'codedir', section: 'master')
 
 teardown do
   on master, "rm -rf #{codedir}/modules2"

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -133,7 +133,7 @@ with_puppet_running_on master, master_opts do
   # only one agent is needed because we only care about the file written on the master
   run_agent_on(agents[0], "--no-daemonize --verbose --onetime --node_name_value #{node_name} --server #{master}")
 
-  yamldir = puppet_master_config(master, 'yamldir')
+  yamldir = puppet_config(master, 'yamldir', section: 'master')
   on master, puppet('node', 'search', '"*"', '--node_terminus', 'yaml', '--clientyamldir', yamldir, '--render-as', 'json') do
     assert_match(/"name":["\s]*#{node_name}/, stdout,
                  "Expect node name '#{node_name}' to be present in node yaml content written by the WriteOnlyYaml terminus")

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -24,7 +24,7 @@ test_name "CVE 2013-1652 Poison node cache" do
                 "--key \"#{key_path}\" -k -H 'Accept: pson'"
 
     step "Attempt to poison the master's node cache" do
-      yamldir = puppet_master_config(master, 'yamldir')
+      yamldir = puppet_config(master, 'yamldir', section: 'master')
       exploited = "#{yamldir}/node/you.lose.yaml"
       on master, "rm -rf #{exploited}"
       on master, "rm -rf #{yamldir}/node/*"


### PR DESCRIPTION
Use `puppet config` with master section instead of `puppet master --configprint`.

Use `puppet catalog find` instead of `puppet master --compile`.