### PR TITLE
(PUP-8685) Make .gemspec buildable

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -1,40 +1,68 @@
 # -*- encoding: utf-8 -*-
 #
-# PLEASE NOTE
-# This gemspec is not intended to be used for building the Puppet gem.  This
-# gemspec is intended for use with bundler when Puppet is a dependency of
-# another project.  For example, the stdlib project is able to integrate with
-# the master branch of Puppet by using a Gemfile path of
-# git://github.com/puppetlabs/puppet.git
-#
-# Please see the [packaging
-# repository](https://github.com/puppetlabs/packaging) for information on how
-# to build the Puppet gem package.
+# This gemspec can be built using 'gem build .gemspec'. If you'd like to
+# build a platform-specific gem on a different machine, you can pass in the
+# GEM_PLATFORM environment variable. For example, if you wanted to build
+# a Windows gem on a Mac you can do:
+#    GEM_PLATFORM=x86-mingw32 gem build .gemspec
+
+PROJECT_ROOT = File.join(File.dirname(__FILE__))
 
 Gem::Specification.new do |s|
   s.name = "puppet"
-  version = "5.5.3"
-  mdata = version.match(/(\d+\.\d+\.\d+)/)
-  s.version = mdata ? mdata[1] : version
+
+  ## READ THE GEM VERSION ##
+  version_file = File.join(PROJECT_ROOT, 'lib', 'puppet', 'version.rb')
+  version_line_regex = /[^\s]*VERSION = ['"](\d+\.\d+\.\d+)['"]/
+  match_data = version_line_regex.match(File.read(version_file))
+  s.version = match_data[1] if match_data
+  ##
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
   s.authors = ["Puppet Labs"]
   s.date = "2012-08-17"
   s.description = "Puppet, an automated configuration management tool"
-  s.email = "puppet@puppetlabs.com"
+  s.email = "info@puppetlabs.com"
   s.executables = ["puppet"]
-  s.files = ["bin/puppet"]
-  s.homepage = "https://puppetlabs.com"
+
+  ## LIST THE GEM FILES ##
+  includes = Dir.glob([
+    # [A-Z]* handles README.md, CONTRIBUTOR.md, Gemfile, etc.
+    '[A-Z]*',
+    'install.rb',
+    'bin/**/*',
+    'lib/**/*',
+    'conf/**/*',
+    'man/**/*',
+    'examples/**/*',
+    'ext/**/*',
+    'tasks/**/*',
+    'spec/**/*',
+    'locales/**/*'    
+  ])
+
+  # Internally we still build the gem with packaging when we are
+  # about to ship it for a release, so we need to exclude the files
+  # that it uses
+  excludes = Dir.glob(['ext/packaging/**/*', 'pkg/**/*'])
+
+  s.files = includes - excludes
+  s.test_files = Dir.glob('spec/**/*')
+  ##
+
+  s.homepage = "https://github.com/puppetlabs/puppet"
   s.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "puppet"
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
+
+  ## ADD RUNTIME DEPENDENCIES ##
   s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
   # PUP-7115 - return to a gem dependency in Puppet 5
-  # s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])
+  s.add_runtime_dependency(%q<semantic_puppet>, ['~> 1.0'])
   # i18n support (gettext-setup and dependencies)
   s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.2")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
@@ -46,39 +74,38 @@ Gem::Specification.new do |s|
   # Beaker 3.11.0+ depends on net-ssh 4.0+
   # be lenient to allow module testing where Beaker and Puppet are in same Gemfile
   s.add_runtime_dependency(%q<net-ssh>, [">= 3.0", "< 5"]) if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+  ##
 
-  # loads platform specific gems like ffi, win32 platform gems
-  # as additional runtime dependencies
-  gem_deps_path = File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml')
+  ## ADD PLATFORM SPECIFIC DEPENDENCIES (e.g. ffi, win32) ##
 
-  # inside of a Vanagon produced package, project_data.yaml does not exist
-  next unless File.exist?(gem_deps_path)
-
-  # so only load these dependencies from a git clone / bundle install workflow
-  require 'yaml'
-  data = YAML.load_file(gem_deps_path)
-  bundle_platforms = data['bundle_platforms']
-  x64_platform = Gem::Platform.local.cpu == 'x64'
-  data['gem_platform_dependencies'].each_pair do |gem_platform, info|
-    next if gem_platform == 'x86-mingw32' && x64_platform
-    next if gem_platform == 'x64-mingw32' && !x64_platform
-    if bundle_deps = info['gem_runtime_dependencies']
-      bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
-      if bundle_platform == "all"
-        bundle_deps.each_pair do |name, version|
-          s.add_runtime_dependency(name, version)
-        end
-      else
-        # important to use .to_s and not .os for the sake of Windows
-        # .cpu  => x64
-        # .os   => mingw32
-        # .to_s => x64-mingw32
-        if Gem::Platform.local.to_s == gem_platform
-          bundle_deps.each_pair do |name, version|
-            s.add_runtime_dependency(name, version)
-          end
-        end
-      end
-    end
+  # Use the current machine's platform unless an explicit override is given.
+  # It is important to use .to_s and not .os for the sake of Windows
+  #   .cpu  => x64
+  #   .os   => mingw32
+  #   .to_s => x64-mingw32
+  platform = ENV['GEM_PLATFORM'] || Gem::Platform.local.to_s
+ 
+  case platform
+  when /darwin/
+    s.add_runtime_dependency('CFPropertyList', '~> 2.2')
+  when /x86-mingw32|x64-mingw32/
+    # Pinning versions that require native extensions
+ 
+    # ffi is pinned due to PUP-8438
+    s.add_runtime_dependency('ffi', '<= 1.9.18')
+ 
+    # win32-xxxx gems are pinned due to PUP-6445
+    s.add_runtime_dependency('win32-dir', '= 0.4.9')
+    s.add_runtime_dependency('win32-process', '= 0.7.5')
+ 
+    # Use of win32-security is deprecated
+    s.add_runtime_dependency('win32-security', '= 0.2.5')
+    s.add_runtime_dependency('win32-service', '= 0.8.8')
+    s.add_runtime_dependency('minitar', '~> 0.6.1')
+  else
+    # Pass-thru, this means our gem does not have any platform-specific
+    # dependencies
   end
+
+  ##
 end

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,65 +1,12 @@
 ---
 project: 'puppet'
 author: 'Puppet Labs'
-email: 'info@puppetlabs.com'
-homepage: 'https://github.com/puppetlabs/puppet'
 summary: 'Puppet, an automated configuration management tool'
 description: 'Puppet, an automated configuration management tool'
 version_file: 'lib/puppet/version.rb'
-# files and gem_files are space separated lists
-files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
-# The gem specification bits only work on Puppet >= 3.0rc, NOT 2.7.x and earlier
-gem_files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
-gem_test_files: 'spec/**/*'
-gem_executables: 'puppet'
-gem_default_executables: 'puppet'
-gem_forge_project: 'puppet'
-gem_required_ruby_version: '>= 1.9.3'
-gem_required_rubygems_version: '> 1.3.1'
-gem_runtime_dependencies:
-  facter: ['> 2.0.1', '< 4']
-  hiera: ['>= 3.2.1', '< 4']
-  # PUP-7115 - return to a gem dependency in Puppet 5
-  # semantic_puppet: ['>= 0.1.3', '< 2']
-  fast_gettext: '~> 1.1.2'
-  locale: '~> 2.1'
-  multi_json: '~> 1.10'
-gem_rdoc_options:
-  - --title
-  - "Puppet - Configuration Management"
-  - --main
-  - README.md
-  - --line-numbers
-gem_platform_dependencies:
-  universal-darwin:
-    gem_runtime_dependencies:
-      CFPropertyList: '~> 2.2'
-  x86-mingw32:
-    gem_runtime_dependencies:
-      # Pinning versions that require native extensions
-      # ffi is pinned due to PUP-8438
-      ffi: '<= 1.9.18'
-      # win32-xxxx gems are pinned due to PUP-6445
-      win32-dir: '= 0.4.9'
-      win32-process: '= 0.7.5'
-      # Use of win32-security is deprecated
-      win32-security: '= 0.2.5'
-      win32-service: '= 0.8.8'
-      minitar: '~> 0.6.1'
-  x64-mingw32:
-    gem_runtime_dependencies:
-      # ffi is pinned due to PUP-8438
-      ffi: '<= 1.9.18'
-      # win32-xxxx gems are pinned due to PUP-6445
-      win32-dir: '= 0.4.9'
-      win32-process: '= 0.7.5'
-      # Use of win32-security is deprecated
-      win32-security: '= 0.2.5'
-      win32-service: '= 0.8.8'
-      minitar: '~> 0.6.1'
-bundle_platforms:
-  universal-darwin: all
-  x86-mingw32: mingw
-  x64-mingw32: x64_mingw
 pre_tasks:
   'package:apple': 'cfpropertylist'
+gem_platforms:
+  - 'universal-darwin'
+  - 'x86-mingw32'
+  - 'x64-mingw32'


### PR DESCRIPTION
Previously, the .gemspec was only there so that Puppet could
work with Bundler workflows (i.e. be specified as a dependency
in a Gemfile that points to a git ref.). It was not meant to be
buildable. Instead, puppetlabs/packaging's pl:gem task was used
to build the shipped Puppet gem so that all of the gem information
was specified in ext/project_data.yaml.

This was unnecessarily complicated and extremely odd -- one would
expect that a 'gem build .gemspec' would build the gem. This PR removes
all of the gem stuff out of ext/project_data.yaml into the .gemspec so
that it is buildable with `gem build .gemspec`. The only gem-specific information
in ext/project_data.yaml are the gem_platforms that we will need to build
the gem on, since we still have to rely on puppetlabs/packaging to ship
platform-specific versions of the gem.

Note you can pass in a value for the environment variable GEM_PLATFORM
(e.g. x86-mingw32) to build the gem for a specific platform that's
different than the build machine.

Finally, this PR also removes the "files" entry from
ext/project_data.yaml, because puppetlabs/packaging now has the ability
to TAR up the entire working directory by default, if a "files" entry is
not specified (which is what we want to do, anyways). This way,
the .gemspec is self-contained since we can now specify the files we
need there instead.