### PR TITLE
(PUP-8696) Consistently thread current environment to the autoloader

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -209,7 +209,7 @@ class Application
     # @return [Array<String>] the names of available applications
     # @api public
     def available_application_names
-      @loader.files_to_load.map do |fn|
+      @loader.files_to_load(Puppet.lookup(:current_environment)).map do |fn|
         ::File.basename(fn, '.rb')
       end.uniq
     end

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -209,7 +209,14 @@ class Application
     # @return [Array<String>] the names of available applications
     # @api public
     def available_application_names
-      @loader.files_to_load(Puppet.lookup(:current_environment)).map do |fn|
+      # Use our configured environment to load the application, as it may
+      # be in a module we installed locally, otherwise fallback to our
+      # current environment (*root*). Once we load the application the
+      # current environment will change from *root* to the application
+      # specific environment.
+      environment = Puppet.lookup(:environments).get(Puppet[:environment]) ||
+                    Puppet.lookup(:current_environment)
+      @loader.files_to_load(environment).map do |fn|
         ::File.basename(fn, '.rb')
       end.uniq
     end

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -40,7 +40,8 @@ class Puppet::Application::Doc < Puppet::Application
 
   option("--list", "-l") do |arg|
     require 'puppet/util/reference'
-    puts Puppet::Util::Reference.references.collect { |r| Puppet::Util::Reference.reference(r).doc }.join("\n")
+    refs = Puppet::Util::Reference.references(Puppet.lookup(:current_environment))
+    puts refs.collect { |r| Puppet::Util::Reference.reference(r).doc }.join("\n")
     exit(0)
   end
 
@@ -198,7 +199,8 @@ HELP
     if options[:all]
       # Don't add dynamic references to the "all" list.
       require 'puppet/util/reference'
-      options[:references] = Puppet::Util::Reference.references.reject do |ref|
+      refs = Puppet::Util::Reference.references(Puppet.lookup(:current_environment))
+      options[:references] = refs.reject do |ref|
         Puppet::Util::Reference.reference(ref).dynamic?
       end
     end

--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -41,8 +41,7 @@ class Puppet::Configurer::PluginHandler
       result += locales_downloader.evaluate
     end
 
-
-    Puppet::Util::Autoload.reload_changed
+    Puppet::Util::Autoload.reload_changed(Puppet.lookup(:current_environment))
 
     result
   end

--- a/lib/puppet/datatypes.rb
+++ b/lib/puppet/datatypes.rb
@@ -207,7 +207,7 @@ module Puppet::DataTypes
     end
 
     def load_file(file_name)
-      Puppet::Util::Autoload.load_file(file_name, nil)
+      Puppet::Util::Autoload.load_file(file_name, Puppet.lookup(:current_environment))
     end
   end
 end

--- a/lib/puppet/indirector/terminus.rb
+++ b/lib/puppet/indirector/terminus.rb
@@ -112,7 +112,7 @@ class Puppet::Indirector::Terminus
     # Return all terminus classes for a given indirection.
     def terminus_classes(indirection_name)
       setup_instance_loading indirection_name
-      instance_loader(indirection_name).files_to_load.map do |file|
+      instance_loader(indirection_name).files_to_load(Puppet.lookup(:current_environment)).map do |file|
         File.basename(file).chomp(".rb").intern
       end
     end

--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -170,7 +170,7 @@ class Puppet::Interface
   # @return [void]
   # @api private
   def load_actions
-    loader.loadall
+    loader.loadall(Puppet.lookup(:current_environment))
   end
 
   # Returns a string representation with the face's name and version

--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -6,7 +6,9 @@ module Puppet::Interface::FaceCollection
   def self.faces
     unless @loaded
       @loaded = true
-      names = @loader.files_to_load.map {|fn| ::File.basename(fn, '.rb')}.uniq
+      names = @loader.files_to_load(Puppet.lookup(:current_environment)).map do |fn|
+        ::File.basename(fn, '.rb')
+      end.uniq
       names.each {|name| self[name, :current]}
     end
     @faces.keys.select {|name| @faces[name].length > 0 }

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -50,7 +50,7 @@ module Manager
   # @return [void]
   #
   def loadall
-    typeloader.loadall
+    typeloader.loadall(Puppet.lookup(:current_environment))
   end
 
   # Defines a new type or redefines an existing type with the given name.
@@ -126,7 +126,7 @@ module Manager
     klass.providerloader = Puppet::Util::Autoload.new(klass, "puppet/provider/#{klass.name.to_s}")
 
     # We have to load everything so that we can figure out the default provider.
-    klass.providerloader.loadall Puppet.lookup(:current_environment)
+    klass.providerloader.loadall(Puppet.lookup(:current_environment))
     klass.providify unless klass.providers.empty?
 
     loc = block_given? ? block.source_location : nil

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -211,7 +211,7 @@ module Puppet::Parser::Functions
   end
 
   def self.functiondocs(environment = Puppet.lookup(:current_environment))
-    autoloader.loadall
+    autoloader.loadall(environment)
 
     ret = ""
 

--- a/lib/puppet/reports.rb
+++ b/lib/puppet/reports.rb
@@ -73,7 +73,7 @@ class Puppet::Reports
     docs = ""
 
     # Use this method so they all get loaded
-    instance_loader(:report).loadall
+    instance_loader(:report).loadall(Puppet.lookup(:current_environment))
     loaded_instances(:report).sort { |a,b| a.to_s <=> b.to_s }.each do |name|
       mod = self.report(name)
       docs << "#{name}\n#{"-" * name.to_s.length}\n"
@@ -87,7 +87,7 @@ class Puppet::Reports
   # Lists each of the reports.
   # @api private
   def self.reports
-    instance_loader(:report).loadall
+    instance_loader(:report).loadall(Puppet.lookup(:current_environment))
     loaded_instances(:report)
   end
 end

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1799,7 +1799,7 @@ end
     name = name.intern
 
     # If we don't have it yet, try loading it.
-    @providerloader.load(name) unless provider_hash.has_key?(name)
+    @providerloader.load(name, Puppet.lookup(:current_environment)) unless provider_hash.has_key?(name)
     provider_hash[name]
   end
 
@@ -1966,7 +1966,7 @@ end
   # @return [Array<Puppet::Provider>] Returns an array of all suitable providers.
   #
   def self.suitableprovider
-    providerloader.loadall if provider_hash.empty?
+    providerloader.loadall(Puppet.lookup(:current_environment)) if provider_hash.empty?
     provider_hash.find_all { |name, provider|
       provider.suitable?
     }.collect { |name, provider|

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -128,7 +128,7 @@ class Puppet::Util::Autoload
       # "app_defaults_initialized?" method on the main puppet Settings object.
       # --cprice 2012-03-16
       if Puppet.settings.app_defaults_initialized?
-        env ||= Puppet.lookup(:environments).get(Puppet[:environment])
+        env ||= Puppet.lookup(:current_environment)
 
         if env
           # if the app defaults have been initialized then it should be safe to access the module path setting.

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -45,12 +45,11 @@ class Puppet::Util::Autoload
       loaded[name] = [file, File.mtime(file)]
     end
 
-    def changed?(name)
+    def changed?(name, env = Puppet.lookup(:current_environment))
       name = cleanpath(name).chomp('.rb')
       return true unless loaded.include?(name)
       file, old_mtime = loaded[name]
-      environment = Puppet.lookup(:current_environment)
-      return true unless file == get_file(name, environment)
+      return true unless file == get_file(name, env)
       begin
         old_mtime.to_i != File.mtime(file).to_i
       rescue Errno::ENOENT
@@ -76,7 +75,7 @@ class Puppet::Util::Autoload
       end
     end
 
-    def loadall(path, env = nil)
+    def loadall(path, env = Puppet.lookup(:current_environment))
       # Load every instance of everything we can find.
       files_to_load(path, env).each do |file|
         name = file.chomp(".rb")
@@ -84,19 +83,23 @@ class Puppet::Util::Autoload
       end
     end
 
-    def reload_changed
-      loaded.keys.each { |file| load_file(file, nil) if changed?(file) }
+    def reload_changed(env = Puppet.lookup(:current_environment))
+      loaded.keys.each do |file|
+        if changed?(file, env)
+          load_file(file, env)
+        end
+      end
     end
 
     # Get the correct file to load for a given path
     # returns nil if no file is found
-    def get_file(name, env)
+    def get_file(name, env = Puppet.lookup(:current_environment))
       name = name + '.rb' unless name =~ /\.rb$/
       path = search_directories(env).find { |dir| Puppet::FileSystem.exist?(File.join(dir, name)) }
       path and File.join(path, name)
     end
 
-    def files_to_load(path, env = nil)
+    def files_to_load(path, env)
       search_directories(env).map {|dir| files_in_dir(dir, path) }.flatten.uniq
     end
 
@@ -148,7 +151,7 @@ class Puppet::Util::Autoload
       end
     end
 
-    def libdirs()
+    def libdirs
       # See the comments in #module_directories above.  Basically, we need to be careful not to try to access the
       # libdir before we know for sure that all of the settings have been initialized (e.g., during bootstrapping).
       if (Puppet.settings.app_defaults_initialized?)
@@ -163,7 +166,7 @@ class Puppet::Util::Autoload
     end
 
     def search_directories(env)
-      [gem_directories, module_directories(env), libdirs(), $LOAD_PATH].flatten
+      [gem_directories, module_directories(env), libdirs, $LOAD_PATH].flatten
     end
 
     # Normalize a path. This converts ALT_SEPARATOR to SEPARATOR on Windows
@@ -190,7 +193,7 @@ class Puppet::Util::Autoload
     set_options(options)
   end
 
-  def load(name, env = nil)
+  def load(name, env = Puppet.lookup(:current_environment))
     self.class.load_file(expand(name), env)
   end
 
@@ -204,7 +207,7 @@ class Puppet::Util::Autoload
   #
   # This uses require, rather than load, so that already-loaded files don't get
   # reloaded unnecessarily.
-  def loadall(env = nil)
+  def loadall(env = Puppet.lookup(:current_environment))
     self.class.loadall(@path, env)
   end
 
@@ -212,12 +215,12 @@ class Puppet::Util::Autoload
     self.class.loaded?(expand(name))
   end
 
-  def changed?(name)
-    self.class.changed?(expand(name))
+  def changed?(name, env = Puppet.lookup(:current_environment))
+    self.class.changed?(expand(name), env)
   end
 
-  def files_to_load
-    self.class.files_to_load(@path)
+  def files_to_load(env = Puppet.lookup(:current_environment))
+    self.class.files_to_load(@path, env)
   end
 
   def expand(name)

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -49,14 +49,14 @@ class Puppet::Util::Feature
   end
 
   def load
-    @loader.loadall
+    @loader.loadall(Puppet.lookup(:current_environment))
   end
 
   def method_missing(method, *args)
     return super unless method.to_s =~ /\?$/
 
     feature = method.to_s.sub(/\?$/, '')
-    @loader.load(feature)
+    @loader.load(feature, Puppet.lookup(:current_environment))
 
     respond_to?(method) && self.send(method)
   end

--- a/lib/puppet/util/instance_loader.rb
+++ b/lib/puppet/util/instance_loader.rb
@@ -32,24 +32,6 @@ module Puppet::Util::InstanceLoader
     @instances[type].keys
   end
 
-  # Collect the docs for all of our instances.
-  def instance_docs(type)
-    docs = ""
-
-    # Load all instances.
-    instance_loader(type).loadall
-
-    # Use this method so they all get loaded
-    loaded_instances(type).sort { |a,b| a.to_s <=> b.to_s }.each do |name|
-      mod = self.loaded_instance(type, name)
-      docs << "#{name}\n#{"-" * name.to_s.length}\n"
-
-      docs << Puppet::Util::Docs.scrub(mod.doc) << "\n\n"
-    end
-
-    docs
-  end
-
   # Return the instance hash for our type.
   def instance_hash(type)
     @instances[type.intern]
@@ -65,7 +47,7 @@ module Puppet::Util::InstanceLoader
     name = name.intern
     return nil unless instances = instance_hash(type)
     unless instances.include? name
-      if instance_loader(type).load(name)
+      if instance_loader(type).load(name, Puppet.lookup(:current_environment))
         unless instances.include? name
           Puppet.warning(_("Loaded %{type} file for %{name} but %{type} was not defined") % { type: type, name: name })
           return nil

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -176,7 +176,7 @@ module Logging
                      else
                        error_location_str = Puppet::Util::Errors.error_location(file, line)
                        if error_location_str.empty?
-                         '\n   ' + _('(file & line not available)')
+                         "\n   " + _('(file & line not available)')
                        else
                          "\n   %{error_location}" % { error_location: error_location_str }
                        end

--- a/lib/puppet/util/reference.rb
+++ b/lib/puppet/util/reference.rb
@@ -58,8 +58,8 @@ class Puppet::Util::Reference
 
   end
 
-  def self.references
-    instance_loader(:reference).loadall
+  def self.references(environment)
+    instance_loader(:reference).loadall(environment)
     loaded_instances(:reference).sort { |a,b| a.to_s <=> b.to_s }
   end
 

--- a/spec/integration/util/autoload_spec.rb
+++ b/spec/integration/util/autoload_spec.rb
@@ -24,6 +24,8 @@ require 'puppet_spec/files'
 describe Puppet::Util::Autoload do
   include PuppetSpec::Files
 
+  let(:env) { Puppet::Node::Environment.create(:foo, []) }
+
   def with_file(name, *path)
     path = File.join(*path)
     # Now create a file to load
@@ -49,13 +51,13 @@ describe Puppet::Util::Autoload do
   end
 
   it "should not fail when asked to load a missing file" do
-    expect(Puppet::Util::Autoload.new("foo", "bar").load(:eh)).to be_falsey
+    expect(Puppet::Util::Autoload.new("foo", "bar").load(:eh, env)).to be_falsey
   end
 
   it "should load and return true when it successfully loads a file" do
     with_loader("foo", "bar") { |dir,loader|
       with_file(:mything, dir, "mything.rb") {
-        expect(loader.load(:mything)).to be_truthy
+        expect(loader.load(:mything, env)).to be_truthy
         expect(loader.class).to be_loaded("bar/mything")
         expect(AutoloadIntegrator).to be_thing(:mything)
       }
@@ -65,7 +67,7 @@ describe Puppet::Util::Autoload do
   it "should consider a file loaded when asked for the name without an extension" do
     with_loader("foo", "bar") { |dir,loader|
       with_file(:noext, dir, "noext.rb") {
-        loader.load(:noext)
+        loader.load(:noext, env)
         expect(loader.class).to be_loaded("bar/noext")
       }
     }
@@ -74,7 +76,7 @@ describe Puppet::Util::Autoload do
   it "should consider a file loaded when asked for the name with an extension" do
     with_loader("foo", "bar") { |dir,loader|
       with_file(:noext, dir, "withext.rb") {
-        loader.load(:withext)
+        loader.load(:withext, env)
         expect(loader.class).to be_loaded("bar/withext.rb")
       }
     }

--- a/spec/integration/util/autoload_spec.rb
+++ b/spec/integration/util/autoload_spec.rb
@@ -90,10 +90,11 @@ describe Puppet::Util::Autoload do
 
     file = File.join(libdir, "plugin.rb")
 
-    Puppet.override(:environments => Puppet::Environments::Static.new(Puppet::Node::Environment.create(:production, [modulepath]))) do
+    env = Puppet::Node::Environment.create(:production, [modulepath])
+    Puppet.override(:environments => Puppet::Environments::Static.new(env)) do
       with_loader("foo", "foo") do |dir, loader|
         with_file(:plugin, file.split("/")) do
-          loader.load(:plugin)
+          loader.load(:plugin, env)
           expect(loader.class).to be_loaded("foo/plugin.rb")
         end
       end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -92,6 +92,24 @@ describe Puppet::Application do
 
       expect(Puppet::Application.available_application_names).to eq(%w{ foo })
     end
+
+    it 'finds the application using the configured environment' do
+      Puppet[:environment] = 'production'
+      Puppet::Util::Autoload.expects(:files_to_load).with do |_, env|
+        expect(env.name).to eq(:production)
+      end.returns(%w{ /a/foo.rb })
+
+      expect(Puppet::Application.available_application_names).to eq(%w{ foo })
+    end
+
+    it "falls back to the current environment if the configured environment doesn't exist" do
+      Puppet[:environment] = 'doesnotexist'
+      Puppet::Util::Autoload.expects(:files_to_load).with do |_, env|
+        expect(env.name).to eq(:'*root*')
+      end.returns(%w[a/foo.rb])
+
+      expect(Puppet::Application.available_application_names).to eq(%w[foo])
+    end
   end
 
   describe ".run_mode" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -76,13 +76,19 @@ describe Puppet::Application do
     end
 
     it 'should find applications from multiple paths' do
-      Puppet::Util::Autoload.expects(:files_to_load).with('puppet/application').returns(%w{ /a/foo.rb /b/bar.rb })
+      Puppet::Util::Autoload.expects(:files_to_load).with(
+        'puppet/application',
+        is_a(Puppet::Node::Environment)
+      ).returns(%w{ /a/foo.rb /b/bar.rb })
 
       expect(Puppet::Application.available_application_names).to match_array(%w{ foo bar })
     end
 
     it 'should return unique application names' do
-      Puppet::Util::Autoload.expects(:files_to_load).with('puppet/application').returns(%w{ /a/foo.rb /b/foo.rb })
+      Puppet::Util::Autoload.expects(:files_to_load).with(
+        'puppet/application',
+        is_a(Puppet::Node::Environment)
+      ).returns(%w{ /a/foo.rb /b/foo.rb })
 
       expect(Puppet::Application.available_application_names).to eq(%w{ foo })
     end

--- a/spec/unit/indirector/terminus_spec.rb
+++ b/spec/unit/indirector/terminus_spec.rb
@@ -108,7 +108,7 @@ describe Puppet::Indirector::Terminus do
       # Set up instance loading; it would normally happen automatically
       Puppet::Indirector::Terminus.instance_load :test1, "puppet/indirector/test1"
 
-      Puppet::Indirector::Terminus.instance_loader(:test1).expects(:load).with(:yay)
+      Puppet::Indirector::Terminus.instance_loader(:test1).expects(:load).with(:yay, anything)
       Puppet::Indirector::Terminus.terminus_class(:test1, :yay)
     end
 

--- a/spec/unit/parser/functions/digest_spec.rb
+++ b/spec/unit/parser/functions/digest_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the digest function", :uses_checksums => true do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     n = Puppet::Node.new('unnamed')
     c = Puppet::Parser::Compiler.new(n)

--- a/spec/unit/parser/functions/digest_spec.rb
+++ b/spec/unit/parser/functions/digest_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby
 require 'spec_helper'
 
 describe "the digest function", :uses_checksums => true do

--- a/spec/unit/parser/functions/fail_spec.rb
+++ b/spec/unit/parser/functions/fail_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the 'fail' parser function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :scope do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/file_spec.rb
+++ b/spec/unit/parser/functions/file_spec.rb
@@ -5,10 +5,6 @@ require 'puppet_spec/files'
 describe "the 'file' function" do
   include PuppetSpec::Files
 
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :node     do Puppet::Node.new('localhost') end
   let :compiler do Puppet::Parser::Compiler.new(node) end
   let :scope    do Puppet::Parser::Scope.new(compiler) end

--- a/spec/unit/parser/functions/generate_spec.rb
+++ b/spec/unit/parser/functions/generate_spec.rb
@@ -4,10 +4,6 @@ require 'spec_helper'
 describe "the generate function" do
   include PuppetSpec::Files
 
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :node     do Puppet::Node.new('localhost') end
   let :compiler do Puppet::Parser::Compiler.new(node) end
   let :scope    do Puppet::Parser::Scope.new(compiler) end

--- a/spec/unit/parser/functions/inline_template_spec.rb
+++ b/spec/unit/parser/functions/inline_template_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the inline_template function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let(:node) { Puppet::Node.new('localhost') }
   let(:compiler) { Puppet::Parser::Compiler.new(node) }
   let(:scope) { Puppet::Parser::Scope.new(compiler) }

--- a/spec/unit/parser/functions/regsubst_spec.rb
+++ b/spec/unit/parser/functions/regsubst_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the regsubst function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/scanf_spec.rb
+++ b/spec/unit/parser/functions/scanf_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the scanf function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let(:node) { Puppet::Node.new('localhost') }
   let(:compiler) { Puppet::Parser::Compiler.new(node) }
   let(:scope) { Puppet::Parser::Scope.new(compiler) }

--- a/spec/unit/parser/functions/split_spec.rb
+++ b/spec/unit/parser/functions/split_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the split function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/sprintf_spec.rb
+++ b/spec/unit/parser/functions/sprintf_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the sprintf function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/tag_spec.rb
+++ b/spec/unit/parser/functions/tag_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the 'tag' function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/tagged_spec.rb
+++ b/spec/unit/parser/functions/tagged_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the 'tagged' function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the template function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :node     do Puppet::Node.new('localhost') end
   let :compiler do Puppet::Parser::Compiler.new(node) end
   let :scope    do Puppet::Parser::Scope.new(compiler) end

--- a/spec/unit/parser/functions/versioncmp_spec.rb
+++ b/spec/unit/parser/functions/versioncmp_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the versioncmp function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions_spec.rb
+++ b/spec/unit/parser/functions_spec.rb
@@ -48,8 +48,14 @@ describe Puppet::Parser::Functions do
   end
 
   describe "when calling function to test function existence" do
+    it "should loadall 3x functions" do
+      Puppet::Parser::Functions.autoloader.delegatee.stubs(:loadall)
+
+      Puppet::Parser::Functions.autoloader.loadall
+    end
+
     it "should return false if the function doesn't exist" do
-      Puppet::Parser::Functions.autoloader.stubs(:load)
+      Puppet::Parser::Functions.autoloader.delegatee.stubs(:load)
 
       expect(Puppet::Parser::Functions.function("name")).to be_falsey
     end
@@ -61,7 +67,7 @@ describe Puppet::Parser::Functions do
     end
 
     it "should try to autoload the function if it doesn't exist yet" do
-      Puppet::Parser::Functions.autoloader.expects(:load)
+      Puppet::Parser::Functions.autoloader.delegatee.expects(:load)
 
       Puppet::Parser::Functions.function("name")
     end

--- a/spec/unit/provider/cron/parsed_spec.rb
+++ b/spec/unit/provider/cron/parsed_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby
 
 require 'spec_helper'
 


### PR DESCRIPTION
Previously, the autoloader would fall back to the configured environment (Puppet[:environment]) instead of the current environment (Puppet.lookup(:current_environment)), which caused it to sometimes load code from the wrong environment. For example, agents could load content from locally installed modules instead of pluginsync'ed libdir, because modulepaths have higher precedence.