### PR TITLE
(PUP-8655) Remove host parameter for validator initialization

### DIFF
--- a/lib/puppet/ssl/validator/default_validator.rb
+++ b/lib/puppet/ssl/validator/default_validator.rb
@@ -15,16 +15,13 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
   # Creates a new DefaultValidator, optionally with an SSL Configuration and SSL Host.
   #
   # @param ca_path [String] Filepath for the cacert
-  # @param ssl_host [Puppet::SSL::Host] The SSL host to use
   #
   # @api private
   #
   def initialize(
-    ca_path = Puppet[:ssl_client_ca_auth] || Puppet[:localcacert],
-    ssl_host = Puppet.lookup(:ssl_host))
+    ca_path = Puppet[:ssl_client_ca_auth] || Puppet[:localcacert])
 
     reset!
-    @ssl_host = ssl_host
     @ca_path = ca_path
   end
 
@@ -109,16 +106,17 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
   #
   # @param [Net::HTTP] connection The connection to validate
   #
+  # @param [Puppet::SSL::Host] host The host object containing SSL data
   # @return [void]
   #
   # @api private
   #
-  def setup_connection(connection)
+  def setup_connection(connection, ssl_host = Puppet.lookup(:ssl_host))
     if ssl_certificates_are_present?
-      connection.cert_store = @ssl_host.ssl_store
+      connection.cert_store = ssl_host.ssl_store
       connection.ca_file = @ca_path
-      connection.cert = @ssl_host.certificate.content
-      connection.key = @ssl_host.key.content
+      connection.cert = ssl_host.certificate.content
+      connection.key = ssl_host.key.content
       connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
       connection.verify_callback = self
     else

--- a/spec/unit/ssl/validator_spec.rb
+++ b/spec/unit/ssl/validator_spec.rb
@@ -18,12 +18,11 @@ describe Puppet::SSL::Validator::DefaultValidator do
   end
 
   subject do
-    described_class.new(ca_path, ssl_host)
+    described_class.new(ca_path)
   end
 
   before :each do
     subject.stubs(:read_file).returns(root_ca)
-
   end
 
   describe '#call' do
@@ -187,7 +186,7 @@ describe Puppet::SSL::Validator::DefaultValidator do
       connection.expects(:verify_callback=).with(subject)
       connection.expects(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
 
-      subject.setup_connection(connection)
+      subject.setup_connection(connection, ssl_host)
     end
 
     context 'when no file path is found' do


### PR DESCRIPTION
Previous to this commit, the DefaultValidator took a parameter of a
Puppet::SSL::Host to initialize. This commit removes that requirement and does
the lookup for the ssl_host if #setup_connection method is called. This allows
for any arbitrary class to still use this class for for SSL verification without
requiring the need for a Puppet::SSL::Host.