### PR TITLE
(PUP-8703) Fix error raised from Numeric("0")

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -906,11 +906,15 @@ class PNumericType < PScalarDataType
           0
         else
           begin
-            if from[0] == '0' && (from[1].downcase == 'b' || from[1].downcase == 'x')
-              Integer(from)
-            else
-              Puppet::Pops::Utils.to_n(from)
+            if from[0] == '0'
+              second_char = (from[1] || '').downcase
+              if second_char == 'b' || second_char == 'x'
+                # use built in conversion
+                return Integer(from)
+              end
             end
+
+            Puppet::Pops::Utils.to_n(from)
           rescue TypeError => e
             raise TypeConversionError.new(e.message)
           rescue ArgumentError => e

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -391,6 +391,7 @@ describe 'the new function' do
       "010" => "Notify[Integer, 8]",
       "0.10" => "Notify[Float, 0.1]",
       "0b10" => "Notify[Integer, 2]",
+      "0"    => "Notify[Integer, 0]",
       false => "Notify[Integer, 0]",
       true => "Notify[Integer, 1]",
     }.each do |input, result|


### PR DESCRIPTION
This is a bugfix since `Numeric("0")` should return `0`.
Instead it raised an error.