### PR TITLE
(PUP-8655) Update usage of peer_certs

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -321,8 +321,9 @@ module Puppet::Network::HTTP
         msg = error.message
         msg << ": [" + @verify.verify_errors.join('; ') + "]"
         raise Puppet::Error, msg, error.backtrace
-      elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert.content, site.host)
-        valid_certnames = [peer_cert.name, *peer_cert.subject_alt_names].uniq
+      elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert, site.host)
+        valid_certnames = [peer_cert.subject.to_s.sub(/.*=/, ''),
+                           *Puppet::SSL::Certificate.subject_alt_names_for(peer_cert)].uniq
         if valid_certnames.size > 1
           expected_certnames = _("expected one of %{certnames}") % { certnames: valid_certnames.join(', ') }
         else

--- a/lib/puppet/ssl/certificate.rb
+++ b/lib/puppet/ssl/certificate.rb
@@ -21,10 +21,14 @@ DOC
     [:s]
   end
 
-  def subject_alt_names
-    alts = content.extensions.find{|ext| ext.oid == "subjectAltName"}
+  def self.subject_alt_names_for(cert)
+    alts = cert.extensions.find{|ext| ext.oid == "subjectAltName"}
     return [] unless alts
     alts.value.split(/\s*,\s*/)
+  end
+
+  def subject_alt_names
+    self.class.subject_alt_names_for(content)
   end
 
   def expiration

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -132,7 +132,7 @@ describe Puppet::Network::HTTP::Connection do
       :verify => ConstantErrorValidator.new(
         :fails_with => 'hostname was not match with server certificate',
         :peer_certs => [Puppet::SSL::CertificateAuthority.new.generate(
-          'not_my_server', :dns_alt_names => 'foo,bar,baz')]))
+          'not_my_server', :dns_alt_names => 'foo,bar,baz').content]))
 
       expect do
         connection.get('request')


### PR DESCRIPTION
In PUP-8655 we updated the DefaultValidator to directly use
OpenSSL::X509::Certificate objects in its peer_certs.

The Puppet::Network::HTTP::Connection object was using this
variable directly when constructing an error message, expecting
a Puppet::SSL::Base subclass.

This updates the Connection to expect the
OpenSSL::X509::Certificate objects when constructing its error message,
and to use the Puppet::SSL::Certificate class as a singleton for the
subject_alt_names_for() helper.