### PR TITLE
(PUP-8588) Support multiple implementations for a single task

### DIFF
--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -67,7 +67,7 @@ module LoaderPaths
       @generic_path = (the_root_path.nil? ? relative_path : File.join(the_root_path, relative_path))
     end
 
-    def match_many?
+    def fuzzy_matching?
       false
     end
 
@@ -239,7 +239,7 @@ module LoaderPaths
       EMPTY_STRING
     end
 
-    def match_many?
+    def fuzzy_matching?
       true
     end
 

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -3,45 +3,30 @@
 module Puppet::Pops
 module Loader
 class TaskInstantiator
-  def self.create(loader, typed_name, source_refs)
-    name = typed_name.name
-    metadata = source_refs.find {|source_ref| source_ref.end_with?('.json')}
-    implementations = source_refs - [metadata]
-
-    if implementations.empty?
-      raise ArgumentError, _('No source besides task metadata was found in directory %{directory} for task %{name}') %
-        { name: name, directory: File.dirname(source_refs[0]) }
-    end
-    create_task(loader, name, implementations, metadata)
-  end
-
-  def self.create_task(loader, name, implementations, metadata)
+  def self.load_metadata(loader, metadata)
     if metadata.nil?
-      create_task_from_hash(name, implementations, EMPTY_HASH)
+      EMPTY_HASH
     else
       json_text = loader.get_contents(metadata)
       begin
-        create_task_from_hash(name, implementations, Puppet::Util::Json.load(json_text) || EMPTY_HASH)
+        Puppet::Util::Json.load(json_text).freeze || EMPTY_HASH
       rescue Puppet::Util::Json::ParseError => ex
         raise Puppet::ParseError.new(ex.message, metadata)
-      rescue Types::TypeAssertionError => ex
-        # Not strictly a parser error but from the users perspective, the file content didn't parse properly. The
-        # ParserError also conveys file info (even though line is unknown)
-        msg = _('Failed to load metadata for task %{name}: %{reason}') % { :name => name, :reason => ex.message }
-        raise Puppet::ParseError.new(msg, metadata)
       end
     end
   end
 
-  def self.create_task_from_hash(name, implementations, hash)
+  def self.validate_implementations(typed_name, directory, metadata, executables)
+    name = typed_name.name
+    basename = typed_name.name_parts[1] || 'init'
     # If 'implementations' is defined, it needs to mention at least one
     # implementation, and everything it mentions must exist.
-    if hash.key?('implementations')
-      if hash['implementations'].is_a?(Array)
-        implementation_metadata = hash['implementations'].map do |impl|
-          path = implementations.find {|real_impl| File.basename(real_impl) == impl['name']}
+    if metadata.key?('implementations')
+      if metadata['implementations'].is_a?(Array)
+        metadata['implementations'].map do |impl|
+          path = executables.find { |real_impl| File.basename(real_impl) == impl['name'] }
           if path
-            {"name" => impl['name'], "requirements" => impl.fetch('requirements', []), "path" => path}
+            { "name" => impl['name'], "requirements" => impl.fetch('requirements', []), "path" => path }
           else
             raise ArgumentError, _("Task metadata for task %{name} specifies missing implementation %{implementation}") %
               { name: name, implementation: impl['name'] }
@@ -50,38 +35,63 @@ class TaskInstantiator
       else
         # If 'implementations' is the wrong type, we just pass it through and
         # let the task type definition reject it.
-        implementation_metadata = hash['implementations']
+        metadata['implementations']
       end
-    # If implementations isn't defined, then only one executable may exist.
+    # If implementations isn't defined, then we use executables matching the
+    # task name, and only one may exist.
     else
-      if implementations.length > 1
+      implementations = executables.select { |impl| File.basename(impl, '.*') == basename }
+      if implementations.empty?
+        raise ArgumentError, _('No source besides task metadata was found in directory %{directory} for task %{name}') %
+          { name: name, directory: directory }
+      elsif implementations.length > 1
         # XXX This message sucks
         raise ArgumentError, _("Multiple executables were found in directory %{directory} for task %{name}, without differentiating metadata") %
-          { name: name, directory: File.dirname(implementations[0]) }
+          { name: name, directory: implementations[0] }
       end
 
-      implementation_metadata = [{"name" => File.basename(implementations.first), "path" => implementations.first, "requirements" => []}]
+      [{ "name" => File.basename(implementations.first), "path" => implementations.first, "requirements" => [] }]
     end
+  end
+
+  def self.create(loader, typed_name, source_refs)
+    name = typed_name.name
+    basename = typed_name.name_parts[1] || 'init'
+    dirname = File.dirname(source_refs[0])
+    metadata_files, executables = source_refs.partition { |source_ref| source_ref.end_with?('.json') }
+    metadata_file = metadata_files.find { |source_ref| File.basename(source_ref, '.json') == basename }
+
+    metadata = load_metadata(loader, metadata_file)
+
+    implementation_metadata = validate_implementations(typed_name, dirname, metadata, executables)
 
     arguments = {
       'name' => name,
       'implementations' => implementation_metadata
     }
-    hash.each_pair do |key, value|
-      if 'parameters' == key || 'output' == key
-        ps = {}
-        value.each_pair do |k, v|
-          pd = v.dup
-          t = v['type']
-          pd['type'] = t.nil? ? Types::TypeFactory.data : Types::TypeParser.singleton.parse(t)
-          ps[k] = pd
-        end
-        value = ps
-      end
-      arguments[key] = value unless arguments.key?(key)
-    end
 
-    Types::TypeFactory.task.from_hash(arguments)
+    begin
+      metadata.each_pair do |key, value|
+        if %w[parameters output].include?(key)
+          ps = {}
+          value.each_pair do |k, v|
+            pd = v.dup
+            t = v['type']
+            pd['type'] = t.nil? ? Types::TypeFactory.data : Types::TypeParser.singleton.parse(t)
+            ps[k] = pd
+          end
+          value = ps
+        end
+        arguments[key] = value unless arguments.key?(key)
+      end
+
+      Types::TypeFactory.task.from_hash(arguments)
+    rescue Types::TypeAssertionError => ex
+      # Not strictly a parser error but from the users perspective, the file content didn't parse properly. The
+      # ParserError also conveys file info (even though line is unknown)
+      msg = _('Failed to load metadata for task %{name}: %{reason}') % { name: name, reason: ex.message }
+      raise Puppet::ParseError.new(msg, metadata_file)
+    end
   end
 end
 end

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -45,8 +45,7 @@ class TaskInstantiator
         raise ArgumentError, _('No source besides task metadata was found in directory %{directory} for task %{name}') %
           { name: name, directory: directory }
       elsif implementations.length > 1
-        # XXX This message sucks
-        raise ArgumentError, _("Multiple executables were found in directory %{directory} for task %{name}, without differentiating metadata") %
+        raise ArgumentError, _("Multiple executables were found in directory %{directory} for task %{name}; define 'implementations' in metadata to differentiate between them") %
           { name: name, directory: implementations[0] }
       end
 

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -35,20 +35,20 @@ module Pcore
     if Puppet[:tasks]
       add_object_type('Task', <<-PUPPET, loader)
         {
-          attributes => {   
+          attributes => {
             # Fully qualified name of the task
             name => { type => Pattern[/\\A[a-z][a-z0-9_]*(?:::[a-z][a-z0-9_]*)*\\z/] },
 
-            # Full path to executable
-            executable => { type => String },
+            # List of implementations with requirements
+            implementations => { type => Array[Struct[name => String, path => String, Optional[requirements] => Array[String]], 1] },
 
             # Task description
             description => { type => Optional[String], value => undef },
 
             # Puppet Task version
             puppet_task_version => { type => Integer, value => 1 },
-  
-            # Type, description, and sensitive property of each parameter 
+
+            # Type, description, and sensitive property of each parameter
             parameters => {
               type => Optional[Hash[
                 Pattern[/\\A[a-z][a-z0-9_]*\\z/],
@@ -59,7 +59,7 @@ module Pcore
               value => undef
             },
 
-             # Type, description, and sensitive property of each output 
+             # Type, description, and sensitive property of each output
             output => {
               type => Optional[Hash[
                 Pattern[/\\A[a-z][a-z0-9_]*\\z/],
@@ -69,7 +69,7 @@ module Pcore
                   type => Type]]],
               value => undef
             },
- 
+
             supports_noop => { type => Boolean, value => false },
             input_method => { type => String, value => 'both' },
           }

--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -89,15 +89,6 @@ describe 'The Loader' do
           }
         }
 
-        let(:tasks) {
-          {
-            'globtask' => '',
-            'environment' => {
-              'envtask' => ''
-            }
-          }
-        }
-
         let(:functions) {
           {
             'globfunc.pp' => 'function globfunc() {}',
@@ -151,18 +142,6 @@ describe 'The Loader' do
             tn(:function, 'environment::envrubyfunc'),
             tn(:function, 'globrubyfunc')
           )
-        end
-
-        context 'with tasks feature enabled' do
-          let(:tasks_feature) { true }
-
-          it 'finds global tasks in environment' do
-            expect(loader.discover(:task)).to include(tn(:task, 'globtask'))
-          end
-
-          it 'finds tasks prefixed with Environment in environment' do
-            expect(loader.discover(:task)).to include(tn(:task, 'environment::envtask'))
-          end
         end
 
         context 'with multiple modules' do
@@ -433,7 +412,7 @@ describe 'The Loader' do
               logs = []
               Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
                 expect(Loaders.find_loader('c').discover(:task)).to(
-                  contain_exactly(tn(:task, 'environment::envtask'), tn(:task, 'globtask'), tn(:task, 'c::foo')))
+                  contain_exactly(tn(:task, 'c::foo')))
               end
               expect(logs.select { |log| log.level == :warning }.map { |log| log.message }).to(
                 contain_exactly(/unexpected token/, /unrecognized key/, /No source besides task metadata was found/)
@@ -445,7 +424,7 @@ describe 'The Loader' do
               error_collector = []
               Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
                 expect(Loaders.find_loader('c').discover(:task, error_collector)).to(
-                  contain_exactly(tn(:task, 'environment::envtask'), tn(:task, 'globtask'), tn(:task, 'c::foo')))
+                  contain_exactly(tn(:task, 'c::foo')))
               end
               expect(logs.select { |log| log.level == :warning }.map { |log| log.message }).to be_empty
               expect(error_collector.size).to eql(3)

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -192,7 +192,7 @@ describe 'The Task Type' do
 
           it "fails if metadata doesn't specify implementations" do
             compile do
-              expect { module_loader.load(:task, 'testmodule') }.to raise_error(ArgumentError, /Multiple executables were found .* without differentiating metadata/)
+              expect { module_loader.load(:task, 'testmodule') }.to raise_error(ArgumentError, /Multiple executables were found .*/)
             end
           end
 

--- a/spec/unit/pops/types/task_spec.rb
+++ b/spec/unit/pops/types/task_spec.rb
@@ -45,6 +45,8 @@ describe 'The Task Type' do
         { 'testmodule' => testmodule }
       end
 
+      let(:module_loader) { Puppet.lookup(:loaders).find_loader('testmodule') }
+
       def compile(code = nil)
         Puppet[:code] = code
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
@@ -71,7 +73,6 @@ describe 'The Task Type' do
 
         it 'loads task without metadata as a generic Task' do
           compile do
-            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
             task = module_loader.load(:task, 'testmodule::hello')
             expect(task_t.instance?(task)).to be_truthy
             expect(task.name).to eq('testmodule::hello')
@@ -84,7 +85,6 @@ describe 'The Task Type' do
 
           it 'evaluator does not recognize generic tasks' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               expect(module_loader.load(:task, 'testmodule::hello')).to be_nil
             end
           end
@@ -139,14 +139,13 @@ describe 'The Task Type' do
 
         it 'loads a task with parameters' do
           compile do
-            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
             task = module_loader.load(:task, 'testmodule::hello')
             expect(task_t.instance?(task)).to be_truthy
             expect(task.name).to eq('testmodule::hello')
             expect(task._pcore_type).to eq(task_t)
             expect(task.supports_noop).to eql(true)
             expect(task.puppet_task_version).to eql(1)
-            expect(task.executable).to eql("#{modules_dir}/testmodule/tasks/hello.rb")
+            expect(task.implementations).to eql([{"name" => "hello.rb", "path" => "#{modules_dir}/testmodule/tasks/hello.rb", "requirements" => []}])
 
             tp = task.parameters
             expect(tp['message']['description']).to eql('the message')
@@ -156,11 +155,105 @@ describe 'The Task Type' do
 
         it 'loads a task with non-Data parameter' do
           compile do
-            module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
             task = module_loader.load(:task, 'testmodule::non_data')
             expect(task_t.instance?(task)).to be_truthy
             tp = task.parameters
             expect(tp['arg']['type']).to be_a(Puppet::Pops::Types::PHashType)
+          end
+        end
+
+        context 'without an implementation file' do
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'init.json' => '{}'
+              }
+            }
+          }
+
+          it 'fails to load the task' do
+            compile do
+              expect { module_loader.load(:task, 'testmodule') }.to raise_error(ArgumentError, /No source besides task metadata was found/)
+            end
+          end
+        end
+
+        context 'with multiple implementation files' do
+          let(:metadata) { '{}' }
+          let(:testmodule) {
+            {
+              'tasks' => {
+                'init.sh' => '',
+                'init.ps1' => '',
+                'init.json' => metadata,
+              }
+            }
+          }
+
+          it "fails if metadata doesn't specify implementations" do
+            compile do
+              expect { module_loader.load(:task, 'testmodule') }.to raise_error(ArgumentError, /Multiple executables were found .* without differentiating metadata/)
+            end
+          end
+
+          it "returns the implementations if metadata lists them all" do
+            impls = [{'name' => 'init.sh', 'requirements' => ['shell']},
+                     {'name' => 'init.ps1', 'requirements' => ['powershell']}]
+            metadata.replace({'implementations' => impls}.to_json)
+
+            compile do
+              task = module_loader.load(:task, 'testmodule')
+              expect(task_t.instance?(task)).to be_truthy
+              expect(task.implementations).to eql([
+                {"name" => "init.sh", "path" => "#{modules_dir}/testmodule/tasks/init.sh", "requirements" => ['shell']},
+                {"name" => "init.ps1", "path" => "#{modules_dir}/testmodule/tasks/init.ps1", "requirements" => ['powershell']}
+              ])
+            end
+          end
+
+          it "returns a single implementation if metadata only specifies one implementation" do
+            impls = [{'name' => 'init.ps1', 'requirements' => ['powershell']}]
+            metadata.replace({'implementations' => impls}.to_json)
+
+            compile do
+              task = module_loader.load(:task, 'testmodule')
+              expect(task_t.instance?(task)).to be_truthy
+              expect(task.implementations).to eql([
+                {"name" => "init.ps1", "path" => "#{modules_dir}/testmodule/tasks/init.ps1", "requirements" => ['powershell']}
+              ])
+            end
+          end
+
+          it "adds an empty requirements list if one is not specified" do
+            impls = [{'name' => 'init.ps1'}]
+            metadata.replace({'implementations' => impls}.to_json)
+
+            compile do
+              task = module_loader.load(:task, 'testmodule')
+              expect(task_t.instance?(task)).to be_truthy
+              expect(task.implementations).to eql([
+                {"name" => "init.ps1", "path" => "#{modules_dir}/testmodule/tasks/init.ps1", "requirements" => []}
+              ])
+            end
+          end
+
+          it "fails if a specified implementation doesn't exist" do
+            impls = [{'name' => 'init.sh', 'requirements' => ['shell']},
+                     {'name' => 'init.ps1', 'requirements' => ['powershell']},
+                     {'name' => 'init.rb', 'requirements' => ['puppet-agent']}]
+            metadata.replace({'implementations' => impls}.to_json)
+
+            compile do
+              expect { module_loader.load(:task, 'testmodule') }.to raise_error(ArgumentError, /Task metadata for task testmodule specifies missing implementation init\.rb/)
+            end
+          end
+
+          it "fails if the implementations key isn't an array" do
+            metadata.replace({'implementations' => {'init.rb' => []}}.to_json)
+
+            compile do
+              expect { module_loader.load(:task, 'testmodule') }.to raise_error(Puppet::ParseError, /Task initializer has wrong type/)
+            end
           end
         end
 
@@ -184,12 +277,11 @@ describe 'The Task Type' do
             }
           }
 
-          it 'loads the init task with parameters and executable' do
+          it 'loads the init task with parameters and implementations' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               task = module_loader.load(:task, 'testmodule')
               expect(task_t.instance?(task)).to be_truthy
-              expect(task.executable).to eql("#{modules_dir}/testmodule/tasks/init.sh")
+              expect(task.implementations).to eql([{"name" => "init.sh", "path" => "#{modules_dir}/testmodule/tasks/init.sh", "requirements" => []}])
               expect(task.parameters).to be_a(Hash)
               expect(task.parameters['message']['type']).to be_a(Puppet::Pops::Types::PStringType)
             end
@@ -216,12 +308,11 @@ describe 'The Task Type' do
             }
           }
 
-          it 'loads a named task with parameters and executable' do
+          it 'loads a named task with parameters and implementations' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               task = module_loader.load(:task, 'testmodule::hello')
               expect(task_t.instance?(task)).to be_truthy
-              expect(task.executable).to eql("#{modules_dir}/testmodule/tasks/hello.sh")
+              expect(task.implementations).to eql([{"name" => "hello.sh", "path" => "#{modules_dir}/testmodule/tasks/hello.sh", "requirements" => []}])
               expect(task.parameters).to be_a(Hash)
               expect(task.parameters['message']['type']).to be_a(Puppet::Pops::Types::PStringType)
             end
@@ -241,7 +332,6 @@ describe 'The Task Type' do
 
           it 'task is not found' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               expect(module_loader.load(:task, 'testmodule::hello::foo')).to be_nil
             end
           end
@@ -266,7 +356,6 @@ describe 'The Task Type' do
 
           it 'fails with unrecognized key error' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               expect{module_loader.load(:task, 'testmodule::hello')}.to raise_error(
                 /Failed to load metadata for task testmodule::hello:.*unrecognized key 'supports_nop'/)
             end
@@ -284,7 +373,6 @@ describe 'The Task Type' do
 
           it 'loads the task with parameters set to undef' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               task = module_loader.load(:task, 'testmodule::hello')
               expect(task_t.instance?(task)).to be_truthy
               expect(task.parameters).to be_nil
@@ -311,7 +399,6 @@ describe 'The Task Type' do
 
           it 'fails with pattern mismatch error' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               expect{module_loader.load(:task, 'testmodule::hello')}.to raise_error(
                 /entry 'parameters' key of entry 'Message' expects a match for Pattern\[\/\\A\[a-z\]\[a-z0-9_\]\*\\z\/\], got 'Message'/)
             end
@@ -338,7 +425,6 @@ describe 'The Task Type' do
 
           it 'fails with type mismatch error' do
             compile do
-              module_loader = Puppet.lookup(:loaders).find_loader('testmodule')
               expect{module_loader.load(:task, 'testmodule::hello')}.to raise_error(
                 /entry 'puppet_task_version' expects an Integer value, got String/)
             end


### PR DESCRIPTION
Previously, tasks could only have a single executable and a metadata file.
Any task with more than one executable would fail to load. In order to
support cross-platform tasks, we now allow tasks to have multiple
implementations, differentiated with the new 'implementations' key in the
metadata.

The 'implementations' key is a list of executable files, along with a set
of 'requirements', which are implementation-defined features that necessary
to run that version of the task. A task can have multiple executables, so
long as the implementations key is present and lists them. If there are
multiple executables but no implementations key, the task will fail to load
as before.

It is now also possible for tasks to refer to executables that *don't* match
the task name. This allows for multiple implementations of a single task to
have the same file extension, and it also allows multiple tasks to "share" a
single executable. Loading these kinds of tasks is accomplished by redefining
the previous "match_many" behavior to instead be a "fuzzy_match", in which case
the loader will find all files that *might* be part of the task (which in this
case is every file in the tasks directory).  Reading the metadata and
determining which files are *actually* part of the task is delegated to the
TaskInstantiator.

Any task executables that *aren't* mentioned in the implementations list
are ignored. This helps avoid the scenario where swap files, etc could
cause a task to fail to load. It is an error for the implementations list
to specify an executable file that doesn't exist.

A task with a single executable may have an implementations list, but
doesn't need one. If not specified, the single executable will be used as
the only available implementation, and will be considered suitable on all
targets.