### PR TITLE
(PUP-7157) remove 'semantic' shim from puppet

### DIFF
--- a/lib/puppet/vendor/load_semantic.rb
+++ b/lib/puppet/vendor/load_semantic.rb
@@ -1,1 +1,0 @@
-$: << File.join([File.dirname(__FILE__), "semantic/lib"])

--- a/lib/puppet/vendor/semantic/lib/semantic.rb
+++ b/lib/puppet/vendor/semantic/lib/semantic.rb
@@ -1,5 +1,0 @@
-require 'puppet/vendor/semantic_puppet/lib/semantic_puppet'
-
-$stderr.puts "Warning: Puppet's internal vendored libraries are Private APIs and can change without warning. The 'semantic' library has been replaced with 'semantic_puppet'."
-
-Semantic = SemanticPuppet


### PR DESCRIPTION
I was having troubles updating/re-loading my gem list locally post https://github.com/puppetlabs/puppet-runtime/pull/55 so some tests were failing for me. They may still need to be updated/removed but figured I'd open the PR to see if they worked on jenkins.