### PR TITLE
(PUP-8730) Yumrepo Parameters: report_instanceid and fastestmirror_enabled

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -427,4 +427,22 @@ Puppet::Type.newtype(:yumrepo) do
     newvalues(/.*/, :absent)
     sensitive true
   end
+
+  newproperty(:report_instanceid) do
+    desc "Determines if yum reports an AWS instanceid and region as a URL parameter when downloading packages.
+      #{YUM_BOOLEAN_DOC}
+      #{ABSENT_DOC}"
+
+    newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
+  end
+
+  newproperty(:fastestmirror_enabled) do
+    desc "Determines if the fastestmirror plugin is enabled for this repository.
+      #{YUM_BOOLEAN_DOC}
+      #{ABSENT_DOC}"
+
+    newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
+  end
 end

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -398,7 +398,6 @@ describe Puppet::Type.type(:yumrepo) do
       it_behaves_like "a yumrepo parameter that can be absent", :assumeyes
     end
 
-
     describe "cost" do
       it_behaves_like "a yumrepo parameter that can be absent", :cost
       it_behaves_like "a yumrepo parameter that can be an integer", :cost
@@ -471,6 +470,16 @@ describe Puppet::Type.type(:yumrepo) do
         sync_event = status.events[0]
         expect(sync_event.message).to eq 'changed [redacted] to [redacted]'
       end
+    end
+
+    describe "report_instanceid" do
+      it_behaves_like "a yumrepo parameter that expects a boolean parameter", :report_instanceid
+      it_behaves_like "a yumrepo parameter that can be absent", :report_instanceid
+    end
+
+    describe "fastestmirror_enabled" do
+      it_behaves_like "a yumrepo parameter that expects a boolean parameter", :fastestmirror_enabled
+      it_behaves_like "a yumrepo parameter that can be absent", :fastestmirror_enabled
     end
   end
 end


### PR DESCRIPTION
Update the Yumrepo type to include support for the parameters report_instanceid and fastestmirror_enabled.
Both parameters are defined by default on Amazon Linux AMIs and docker images.
report_instanceid is a valid requirement.
fastestmirror_enabled is defined in Amazon Linux, and supported by Chef already, but I am not convinced it does anything. I haven't yet found any applicable yum or fastestmirror plugin source code that consumes this parameter.

https://tickets.puppetlabs.com/browse/PUP-8730