### PR TITLE
(PUP-8733) Store full file path in LOADED_FEATURES in autoloader

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -37,8 +37,8 @@ class Puppet::Util::Autoload
     # into memory.
     def mark_loaded(name, file)
       name = cleanpath(name).chomp('.rb')
-      ruby_file = name + ".rb"
-      $LOADED_FEATURES << ruby_file unless $LOADED_FEATURES.include?(ruby_file)
+      file = File.expand_path(file)
+      $LOADED_FEATURES << file unless $LOADED_FEATURES.include?(file)
       loaded[name] = [file, File.mtime(file)]
     end
 

--- a/spec/integration/data_binding_spec.rb
+++ b/spec/integration/data_binding_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'puppet/indirector/hiera'
 
 require 'puppet_spec/compiler'
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -79,6 +79,10 @@ describe Puppet::Util::Autoload do
       File.stubs(:mtime).returns @time_a
     end
 
+    after(:each) do
+      $LOADED_FEATURES.delete("/a/tmp/myfile.rb")
+    end
+
     [RuntimeError, LoadError, SyntaxError].each do |error|
       it "should die with Puppet::Error if a #{error.to_s} exception is thrown" do
         Puppet::FileSystem.stubs(:exist?).returns true
@@ -99,8 +103,6 @@ describe Puppet::Util::Autoload do
       @autoload.load("myfile")
 
       expect(@autoload.class.loaded?("tmp/myfile.rb")).to be
-
-      $LOADED_FEATURES.delete("tmp/myfile.rb")
     end
 
     it "should be seen by loaded? on the instance using the short name" do
@@ -109,8 +111,6 @@ describe Puppet::Util::Autoload do
       @autoload.load("myfile")
 
       expect(@autoload.loaded?("myfile.rb")).to be
-
-      $LOADED_FEATURES.delete("tmp/myfile.rb")
     end
 
     it "should register loaded files with the main loaded file list so they are not reloaded by ruby" do
@@ -119,9 +119,7 @@ describe Puppet::Util::Autoload do
 
       @autoload.load("myfile")
 
-      expect($LOADED_FEATURES).to be_include("tmp/myfile.rb")
-
-      $LOADED_FEATURES.delete("tmp/myfile.rb")
+      expect($LOADED_FEATURES).to be_include(make_absolute("/a/tmp/myfile.rb"))
     end
 
     it "should load the first file in the searchpath" do
@@ -131,8 +129,6 @@ describe Puppet::Util::Autoload do
       Kernel.expects(:load).with(make_absolute("/a/tmp/myfile.rb"), optionally(anything))
 
       @autoload.load("myfile")
-
-      $LOADED_FEATURES.delete("tmp/myfile.rb")
     end
 
     it "should treat equivalent paths to a loaded file as loaded" do
@@ -144,8 +140,6 @@ describe Puppet::Util::Autoload do
       expect(@autoload.class.loaded?("tmp/./myfile.rb")).to be
       expect(@autoload.class.loaded?("./tmp/myfile.rb")).to be
       expect(@autoload.class.loaded?("tmp/../tmp/myfile.rb")).to be
-
-      $LOADED_FEATURES.delete("tmp/myfile.rb")
     end
   end
 


### PR DESCRIPTION
The implementations of `require` in JRuby and MRI don't check the same
paths in `$LOADED_FEATURES`. Both check a version of the relative path, but
MRI checks with the file extension and JRuby checks without. Both check the
absolute path, so if we save that instead we should get consistent behavior
across platforms.