### PR TITLE
(PUP-8746) Minor report metric optimization

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -459,8 +459,7 @@ class Puppet::Transaction::Report
   def calculate_time_metrics
     metrics = Hash.new(0)
     resource_statuses.each do |name, status|
-      type = Puppet::Resource.new(name).type
-      metrics[type.to_s.downcase] += status.evaluation_time if status.evaluation_time
+      metrics[status.resource_type.downcase] += status.evaluation_time if status.evaluation_time
     end
 
     @external_times.each do |name, value|


### PR DESCRIPTION
 - lak introduced this original code in Feb 2010, using the
   initializer for Resource in 9919b14f262c994a58eb202cda408f1b90d728e

 - At this point in time, the Resource::Status object was not very
   well defined, and did not contain the type of resource in the
   `resource_type` attribute.

 - Later in Dec 2010 the resource_type value was added in
   1f72c31f9e0223e71e2729da96e0e98ebea5417 but not all code was
   refactored to take advantage of this

 - This code simply uses what is already available, rather than
   creating a new Resource instance that is immediately thrown away,
   solely for the sake of retrieving the type