### PR TITLE
(PUP-8745) Make match() handle type aliases and Variant type

### DIFF
--- a/lib/puppet/functions/match.rb
+++ b/lib/puppet/functions/match.rb
@@ -90,6 +90,17 @@ Puppet::Functions.create_function(:match) do
     do_match(s, regexp)
   end
 
+  def match_PTypeAliasType(alias_t, s)
+    match(s, alias_t.resolved_type)
+  end
+
+  def match_PVariantType(var_t, s)
+    # Find first matching type (or error out if one of the variants is not acceptable)
+    result = nil
+    var_t.types.find {|t| result = match(s, t) }
+    result
+  end
+
   def match_PRegexpType(regexp_t, s)
     raise ArgumentError, _("Given Regexp Type has no regular expression") unless regexp_t.pattern
     do_match(s, regexp_t.regexp)

--- a/spec/unit/functions/match_spec.rb
+++ b/spec/unit/functions/match_spec.rb
@@ -41,6 +41,15 @@ describe 'the match function' do
     it "matches string and type #{pattern} with captures" do
       expect(func.call({}, 'abc123', type(pattern))).to eql(['abc123', 'abc', '123'])
     end
+
+    it "matches string with an alias type for #{pattern} with captures" do
+      expect(func.call({}, 'abc123', alias_type("MyAlias", type(pattern)))).to eql(['abc123', 'abc', '123'])
+    end
+
+    it "matches string with a  matching variant type for #{pattern} with captures" do
+      expect(func.call({}, 'abc123', variant_type(type(pattern)))).to eql(['abc123', 'abc', '123'])
+    end
+
   end
 
   it 'matches an array of strings and yields a map of the result' do
@@ -49,6 +58,15 @@ describe 'the match function' do
 
   it 'raises error if Regexp type without regexp is used' do
     expect{func.call({}, 'abc123', type('Regexp'))}.to raise_error(ArgumentError, /Given Regexp Type has no regular expression/)
+  end
+
+  def variant_type(*t)
+    Puppet::Pops::Types::PVariantType.new(t)
+  end
+
+  def alias_type(name, t)
+    # Create an alias using a nil AST (which is never used because it is given a type as resolution)
+    Puppet::Pops::Types::PTypeAliasType.new(name, nil, t)
   end
 
   def type(s)


### PR DESCRIPTION
Before this, the match function would error if given a type alias or a
variant type. This is bad because it means that regexp based types
cannot be used to match with a result other than true/false.

Now, Variant and aliased types are resolved and work as expected when
they resolve to a regexp based type.