### PR TITLE
(PUP-8761) Make convert_to() accept additional arguments

### DIFF
--- a/lib/puppet/functions/convert_to.rb
+++ b/lib/puppet/functions/convert_to.rb
@@ -23,11 +23,12 @@ Puppet::Functions.create_function(:convert_to) do
   dispatch :convert_to do
     param 'Any', :value
     param 'Type', :type
+    optional_repeated_param 'Any', :args
     optional_block_param 'Callable[1,1]', :block
   end
 
-  def convert_to(value, type, &block)
-    result = call_function('new', type, value)
+  def convert_to(value, type, *args, &block)
+    result = call_function('new', type, value, *args)
     block_given? ? yield(result) : result
   end
 end

--- a/spec/unit/functions/convert_to_spec.rb
+++ b/spec/unit/functions/convert_to_spec.rb
@@ -19,4 +19,7 @@ describe 'the convert_to function' do
     expect(compile_to_catalog('notify{ "testing-${[a,1].convert_to(Hash) |$x| { yay }}": }')).to have_resource('Notify[testing-yay]')
   end
 
+  it 'passes on additional arguments to the new function' do
+    expect(compile_to_catalog('"111".convert_to(Integer, 2) |$x| { notify { "testing-${x}": } }')).to have_resource('Notify[testing-7]')
+  end
 end


### PR DESCRIPTION
Before this it was only possible to call convert_type() with just the
type but not with arguments to the type's new() function.

This is now possible.