### PR TITLE
(PUP-7141) stop dup of frozen string in 3x converter

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -77,11 +77,6 @@ class Runtime3Converter
     raise Puppet::Error, "Use of a Ruby BigDecimal value outside Puppet Float range, got '#{o}'"
   end
 
-  def convert_String(o, scope, undef_value)
-    # although wasteful, needed because user code may mutate these strings in Resources
-    o.frozen? ? o.dup : o
-  end
-
   def convert_Object(o, scope, undef_value)
     o
   end

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -325,7 +325,7 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
       r = s[ri+1,s.length]
       if arch = r.scan(ARCH_REGEX)[0]
         a = arch.gsub(/\./, '')
-	r.gsub!(ARCH_REGEX, '')
+        r.gsub!(ARCH_REGEX, '')
       end
     else
       v = s

--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -71,7 +71,7 @@ class Puppet::Provider::Package::Windows
 
     def self.replace_forward_slashes(value)
       if value.include?('/')
-        value.gsub!('/', "\\")
+        value = value.gsub('/', "\\")
         Puppet.debug('Package source parameter contained /s - replaced with \\s')
       end
       value

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -743,7 +743,8 @@ module Puppet
           if entry =~ /^~|^%h/ and not home
             raise ArgumentError, _("purge_ssh_keys value '%{value}' meta character ~ or %{home_placeholder} only allowed for users with a defined home directory") % { value: value, home_placeholder: '%h' }
           end
-          entry.gsub!(/^~\//, "#{home}/")
+          # make sure frozen value is duplicated by using a gsub, second mutating gsub! is then ok
+          entry = entry.gsub(/^~\//, "#{home}/")
           entry.gsub!(/^%h\//, "#{home}/")
           entry
         end


### PR DESCRIPTION
This removes the logic that duplicated frozen strings before giving them to the 3.x "runtime API". That was done because some resource types mutated their given arguments. (Notably the user resource type). 

This PR changes the runtime3converter (no longer duplicates frozen strings) as well as user resource type and a questionable mutating gsub! in the windows package.