### PR TITLE
(PUP-8705) Add SRV record support with caching

### DIFF
--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -185,7 +185,11 @@ class Puppet::Indirector::Request
     return yield(self) if !self.server.nil?
 
     if Puppet.settings[:use_srv_records]
-      Puppet::Network::Resolver.each_srv_record(Puppet.settings[:srv_domain], srv_service) do |srv_server, srv_port|
+      # We may want to consider not creating a new resolver here
+      # every request eventually, to take advantage of the resolver's
+      # caching behavior.
+      resolver = Puppet::Network::Resolver.new
+      resolver.each_srv_record(Puppet.settings[:srv_domain], srv_service) do |srv_server, srv_port|
         begin
           self.server = srv_server
           self.port   = srv_port

--- a/lib/puppet/network/resolver.rb
+++ b/lib/puppet/network/resolver.rb
@@ -3,14 +3,42 @@ require 'resolv'
 module Puppet::Network
   class Resolver
 
+    class CacheEntry
+      attr_reader :records, :ttl, :resolution_time
+
+      def initialize(records)
+        @records = records
+        @resolution_time = Time.now
+        @ttl = choose_lowest_ttl(records)
+      end
+
+      def choose_lowest_ttl(records)
+        ttl = records.first.ttl
+        records.each do |rec|
+          if rec.ttl < ttl
+            ttl = rec.ttl
+          end
+        end
+        ttl
+      end
+    end
+
     def initialize
       @resolver = Resolv::DNS.new
+
+      # Stores DNS records per service, along with their TTL
+      # and the time at which they were resolved, for cache
+      # eviction.
       @record_cache = {}
     end
 
-    # Iterate through the list of servers that service this hostname
-    # and yield each server/port since SRV records have ports in them
-    # It will override whatever masterport setting is already set.
+    # Iterate through the list of records for this service
+    # and yield each server and port pair. Records are only fetched
+    # via DNS query the first time and cached for the duration of their
+    # service's TTL thereafter.
+    # @param [String] domain the domain to search for
+    # @param [Symbol] service_name the key of the service we are querying
+    # @yields [String, Integer] server and port of selected record
     def each_srv_record(domain, service_name = :puppet, &block)
       if (domain.nil? or domain.empty?)
         Puppet.debug "Domain not known; skipping SRV lookup"
@@ -21,20 +49,20 @@ module Puppet::Network
 
       case service_name
         when :puppet then service = '_x-puppet'
-        when :ca     then service = '_x-puppet-ca'
-        when :report then service = '_x-puppet-report'
         when :file   then service = '_x-puppet-fileserver'
         else              service = "_x-puppet-#{service_name.to_s}"
       end
-      srv_record = "#{service}._tcp.#{domain}"
+      record_name = "#{service}._tcp.#{domain}"
 
-      if @record_cache.has_key?(service_name)
-        records = @record_cache[service_name]
-        Puppet.debug "Using cached record for #{srv_record}"
+      if @record_cache.has_key?(service_name) && !expired?(service_name)
+        records = @record_cache[service_name].records
+        Puppet.debug "Using cached record for #{record_name}"
       else
-        records = @resolver.getresources(srv_record, Resolv::DNS::Resource::IN::SRV)
-        @record_cache[service_name] = records
-        Puppet.debug "Found #{records.size} SRV records for: #{srv_record}"
+        records = @resolver.getresources(record_name, Resolv::DNS::Resource::IN::SRV)
+        if records.size > 0
+          @record_cache[service_name] = CacheEntry.new(records)
+        end
+        Puppet.debug "Found #{records.size} SRV records for: #{record_name}"
       end
 
       if records.size == 0 && service_name != :puppet
@@ -42,7 +70,7 @@ module Puppet::Network
         # for the specific service.
         each_srv_record(domain, :puppet, &block)
       else
-        each_priority(records) do |priority, recs|
+        each_priority(records) do |recs|
           while next_rr = recs.delete(find_weighted_server(recs))
             Puppet.debug "Yielding next server of #{next_rr.target.to_s}:#{next_rr.port}"
             yield next_rr.target.to_s, next_rr.port
@@ -51,6 +79,11 @@ module Puppet::Network
       end
     end
 
+    # Given a list of records of the same priority, chooses a random one
+    # from among them, favoring those with higher weights.
+    # @param [[Resolv::DNS::Resource::IN::SRV]] records a list of records
+    #        of the same priority
+    # @return [Resolv::DNS::Resource::IN:SRV] the chosen record
     def find_weighted_server(records)
       return nil if records.nil? || records.empty?
       return records.first if records.size == 1
@@ -59,12 +92,11 @@ module Puppet::Network
       # This is used to then select hosts until the weight exceeds what
       # random number we selected.  For example, if we have weights of 1 8 and 3:
       #
-      # |-|---|--------|
+      # |-|--------|---|
       #        ^
       # We generate a random number 5, and iterate through the records, adding
       # the current record's weight to the accumulator until the weight of the
       # current record plus previous records is greater than the random number.
-
       total_weight = records.inject(0) { |sum,record|
         sum + weight(record)
       }
@@ -81,8 +113,36 @@ module Puppet::Network
       record.weight == 0 ? 1 : record.weight * 10
     end
 
+    # Returns TTL for the cached records for this service.
+    # @param [String] service_name the service whose TTL we want
+    # @return [Integer] the TTL for this service, in seconds
+    def ttl(service_name)
+      return @record_cache[service_name].ttl
+    end
+
+    # Checks if the cached entry for the given service has expired.
+    # @param [String] service_name the name of the service to check
+    # @return [Boolean] true if the entry has expired, false otherwise.
+    #                  Always returns true if the record had no TTL.
+    def expired?(service_name)
+      if entry = @record_cache[service_name]
+        return Time.now > (entry.resolution_time + entry.ttl)
+      else
+        return true
+      end
+    end
+
     private
 
+    # Groups the records by their priority and yields the groups
+    # in order of highest to lowest priority (lowest to highest numbers),
+    # one at a time.
+    # { 1 => [records], 2 => [records], etc. }
+    #
+    # @param [[Resolv::DNS::Resource::IN::SRV]] records the list of
+    #        records for a given service
+    # @yields [[Resolv::DNS::Resource::IN::SRV]] a group of records of
+    #         the same priority
     def each_priority(records)
       pri_hash = records.inject({}) do |groups, element|
         groups[element.priority] ||= []
@@ -91,7 +151,7 @@ module Puppet::Network
       end
 
       pri_hash.keys.sort.each do |key|
-        yield key, pri_hash[key]
+        yield pri_hash[key]
       end
     end
   end

--- a/lib/puppet/network/resolver.rb
+++ b/lib/puppet/network/resolver.rb
@@ -1,85 +1,98 @@
 require 'resolv'
-module Puppet::Network; end
 
-module Puppet::Network::Resolver
-  # Iterate through the list of servers that service this hostname
-  # and yield each server/port since SRV records have ports in them
-  # It will override whatever masterport setting is already set.
-  def self.each_srv_record(domain, service_name = :puppet, &block)
-    if (domain.nil? or domain.empty?)
-      Puppet.debug "Domain not known; skipping SRV lookup"
-      return
+module Puppet::Network
+  class Resolver
+
+    def initialize
+      @resolver = Resolv::DNS.new
+      @record_cache = {}
     end
 
-    Puppet.debug "Searching for SRV records for domain: #{domain}"
+    # Iterate through the list of servers that service this hostname
+    # and yield each server/port since SRV records have ports in them
+    # It will override whatever masterport setting is already set.
+    def each_srv_record(domain, service_name = :puppet, &block)
+      if (domain.nil? or domain.empty?)
+        Puppet.debug "Domain not known; skipping SRV lookup"
+        return
+      end
 
-    case service_name
-      when :puppet then service = '_x-puppet'
-      when :ca     then service = '_x-puppet-ca'
-      when :report then service = '_x-puppet-report'
-      when :file   then service = '_x-puppet-fileserver'
-      else              service = "_x-puppet-#{service_name.to_s}"
-    end
-    srv_record = "#{service}._tcp.#{domain}"
+      Puppet.debug "Searching for SRV records for domain: #{domain}"
 
-    resolver = Resolv::DNS.new
-    records = resolver.getresources(srv_record, Resolv::DNS::Resource::IN::SRV)
-    Puppet.debug "Found #{records.size} SRV records for: #{srv_record}"
+      case service_name
+        when :puppet then service = '_x-puppet'
+        when :ca     then service = '_x-puppet-ca'
+        when :report then service = '_x-puppet-report'
+        when :file   then service = '_x-puppet-fileserver'
+        else              service = "_x-puppet-#{service_name.to_s}"
+      end
+      srv_record = "#{service}._tcp.#{domain}"
 
-    if records.size == 0 && service_name != :puppet
-      # Try the generic :puppet service if no SRV records were found
-      # for the specific service.
-      each_srv_record(domain, :puppet, &block)
-    else
-      each_priority(records) do |priority, recs|
-        while next_rr = recs.delete(find_weighted_server(recs))
-          Puppet.debug "Yielding next server of #{next_rr.target.to_s}:#{next_rr.port}"
-          yield next_rr.target.to_s, next_rr.port
+      if @record_cache.has_key?(service_name)
+        records = @record_cache[service_name]
+        Puppet.debug "Using cached record for #{srv_record}"
+      else
+        records = @resolver.getresources(srv_record, Resolv::DNS::Resource::IN::SRV)
+        @record_cache[service_name] = records
+        Puppet.debug "Found #{records.size} SRV records for: #{srv_record}"
+      end
+
+      if records.size == 0 && service_name != :puppet
+        # Try the generic :puppet service if no SRV records were found
+        # for the specific service.
+        each_srv_record(domain, :puppet, &block)
+      else
+        each_priority(records) do |priority, recs|
+          while next_rr = recs.delete(find_weighted_server(recs))
+            Puppet.debug "Yielding next server of #{next_rr.target.to_s}:#{next_rr.port}"
+            yield next_rr.target.to_s, next_rr.port
+          end
         end
       end
     end
-  end
 
-  def self.each_priority(records)
-    pri_hash = records.inject({}) do |groups, element|
-      groups[element.priority] ||= []
-      groups[element.priority] << element
-      groups
+    def find_weighted_server(records)
+      return nil if records.nil? || records.empty?
+      return records.first if records.size == 1
+
+      # Calculate the sum of all weights in the list of resource records,
+      # This is used to then select hosts until the weight exceeds what
+      # random number we selected.  For example, if we have weights of 1 8 and 3:
+      #
+      # |-|---|--------|
+      #        ^
+      # We generate a random number 5, and iterate through the records, adding
+      # the current record's weight to the accumulator until the weight of the
+      # current record plus previous records is greater than the random number.
+
+      total_weight = records.inject(0) { |sum,record|
+        sum + weight(record)
+      }
+      current_weight = 0
+      chosen_weight  = 1 + Kernel.rand(total_weight)
+
+      records.each do |record|
+        current_weight += weight(record)
+        return record if current_weight >= chosen_weight
+      end
     end
 
-    pri_hash.keys.sort.each do |key|
-      yield key, pri_hash[key]
+    def weight(record)
+      record.weight == 0 ? 1 : record.weight * 10
     end
-  end
-  private_class_method :each_priority
 
-  def self.find_weighted_server(records)
-    return nil if records.nil? || records.empty?
-    return records.first if records.size == 1
+    private
 
-    # Calculate the sum of all weights in the list of resource records,
-    # This is used to then select hosts until the weight exceeds what
-    # random number we selected.  For example, if we have weights of 1 8 and 3:
-    #
-    # |-|---|--------|
-    #        ^
-    # We generate a random number 5, and iterate through the records, adding
-    # the current record's weight to the accumulator until the weight of the
-    # current record plus previous records is greater than the random number.
+    def each_priority(records)
+      pri_hash = records.inject({}) do |groups, element|
+        groups[element.priority] ||= []
+        groups[element.priority] << element
+        groups
+      end
 
-    total_weight = records.inject(0) { |sum,record|
-      sum + weight(record)
-    }
-    current_weight = 0
-    chosen_weight  = 1 + Kernel.rand(total_weight)
-
-    records.each do |record|
-      current_weight += weight(record)
-      return record if current_weight >= chosen_weight
+      pri_hash.keys.sort.each do |key|
+        yield key, pri_hash[key]
+      end
     end
-  end
-
-  def self.weight(record)
-    record.weight == 0 ? 1 : record.weight * 10
   end
 end

--- a/lib/puppet/rest/route.rb
+++ b/lib/puppet/rest/route.rb
@@ -2,10 +2,6 @@ require 'uri'
 
 module Puppet::Rest
   class Route
-    attr_reader :api, :default_server, :default_port
-
-    attr_reader :server, :port
-
     # Create a Route containing information for querying the given API,
     # hosted at a server determined either by SRV service or by the
     # fallback server on the fallback port.
@@ -14,48 +10,93 @@ module Puppet::Rest
     #                 construction
     # @param [String] default_server the fqdn of the fallback server
     # @param [Integer] port the fallback port
-    def initialize(api:, default_server:, default_port:)
+    # @param [Symbol] srv_service the name of the service when using SRV
+    #                 records
+    def initialize(api:, default_server:, default_port:, srv_service:)
       @api = api
       @default_server = default_server
       @default_port = default_port
+      @srv_service = srv_service
     end
+
+    # Select a server and port to create a base URL for the API specified by this
+    # route. If the connection fails and SRV records are in use, the next suitable
+    # server will be tried. If SRV records are not in use or no successful connection
+    # could be made, fall back to the configured server and port for this API, taking
+    # into account failover settings.
+    # @parma [Puppet::Network::Resolver] dns_resolver the DNS resolver to use to check
+    #                                    SRV records
+    # @yield [URI] supply a base URL to make a request with
+    # @raise [Puppet::Error] if connection to selected server and port fails, and SRV
+    #                        records are not in use
+    def with_base_url(dns_resolver)
+      if @server && @port
+        # First try connecting to the previously selected server and port.
+        begin
+          return yield(base_url)
+        rescue SystemCallError => e
+          if Puppet[:use_srv_records]
+            Puppet.debug "Connection to cached server and port #{@server}:#{@port} failed, reselecting."
+          else
+            raise Puppet::Error, _("Connection to cached server and port %{server}:%{port} failed: %{message}") %
+              { server: @server, port: @port, message: e.message }
+          end
+        end
+      end
+
+      if Puppet[:use_srv_records]
+        dns_resolver.each_srv_record(@srv_service) do |srv_server, srv_port|
+          # Try each of the servers for this service in weighted order
+          # until a working one is found.
+          begin
+            @server = srv_server
+            @port = srv_port
+            return yield(base_url)
+          rescue SystemCallError
+            Puppet.debug "Connection to selected server and port #{@server}:#{@port} failed. Trying next cached SRV record."
+            @server = nil
+            @port = nil
+          end
+        end
+      end
+
+      # If we have provided a specific server and port, use those.
+      if @default_server && @default_port
+        @server = @default_server
+        @port = @default_port
+      else
+        # Otherwise, get server and port from default settings, taking
+        # into account the server list for HA.
+        bound_server = Puppet.lookup(:server) do
+          if primary_server = Puppet.settings[:server_list][0]
+            primary_server[0]
+          else
+            Puppet.settings[:server]
+          end
+        end
+
+        bound_port = Puppet.lookup(:serverport) do
+          if primary_server = Puppet.settings[:server_list][0]
+            primary_server[1]
+          else
+            Puppet.settings[:masterport]
+          end
+        end
+
+        @server = bound_server
+        @port = bound_port
+      end
+
+      Puppet.debug "No more servers in SRV record, falling back to #{@server}:#{@port}" if Puppet[:use_srv_records]
+      return yield(base_url)
+    end
+
+    private
 
     # Returns a URI built from the information stored by this route,
     # e.g. 'https://myserver.com:555/myapi/v1/'
-    def uri
-      server, port = select_server_and_port
-      URI::HTTPS.build(host: server, port: port, path: api)
-    end
-
-    # Return the appropriate server and port for this route
-    # @return [String, Integer] the server and port to use for the request
-    def select_server_and_port
-      unless @server && @port
-        if default_server && default_port
-          @server = default_server
-          @port = default_port
-        else
-          bound_server = Puppet.lookup(:server) do
-            if primary_server = Puppet.settings[:server_list][0]
-              primary_server[0]
-            else
-              Puppet.settings[:server]
-            end
-          end
-
-          bound_port = Puppet.lookup(:serverport) do
-            if primary_server = Puppet.settings[:server_list][0]
-              primary_server[1]
-            else
-              Puppet.settings[:masterport]
-            end
-          end
-
-          @server = bound_server
-          @port = bound_port
-        end
-      end
-      [@server, @port]
+    def base_url
+      URI::HTTPS.build(host: @server, port: @port, path: @api)
     end
   end
 end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -5,8 +5,8 @@ require 'puppet/ssl/certificate'
 require 'puppet/ssl/certificate_request'
 require 'puppet/ssl/certificate_revocation_list'
 require 'puppet/ssl/certificate_request_attributes'
-require 'puppet/rest/routes'
 require 'puppet/rest/errors'
+require 'puppet/rest/routes'
 
 # The class that manages all aspects of our SSL certificates --
 # private keys, public keys, requests, etc.
@@ -198,7 +198,7 @@ DOC
     # This can't be required top-level because Puppetserver uses the Host class too,
     # and we don't ship the gem in that context.
     require 'puppet/rest/client'
-    @http_client ||= Puppet::Rest::Client.new(Puppet::Rest::Routes.ca)
+    @http_client ||= Puppet::Rest::Client.new
   end
 
   def certificate

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -446,19 +446,21 @@ describe Puppet::Indirector::Request do
           Resolv::DNS.expects(:new).returns(@dns_mock)
 
           @port = 7205
-          @host = '_x-puppet._tcp.example.com'
-          @srv_records = [Resolv::DNS::Resource::IN::SRV.new(0, 0, @port, @host)]
+          @target = 'example.com'
+          @srv_records = [Resolv::DNS::Resource::IN::SRV.new(0, 0, @port, @target)]
 
           @dns_mock.expects(:getresources).
             with("_x-puppet._tcp.#{Puppet.settings[:srv_domain]}", Resolv::DNS::Resource::IN::SRV).
             returns(@srv_records)
+
+          Puppet.push_context(:dns_resolver => Puppet::Network::Resolver.new)
         end
 
         it "yields a request using the server and port from the SRV record" do
           count = 0
           rval = @request.do_request do |got|
             count += 1
-            expect(got.server).to eq('_x-puppet._tcp.example.com')
+            expect(got.server).to eq('example.com')
             expect(got.port).to eq(7205)
 
             @block_return
@@ -475,7 +477,7 @@ describe Puppet::Indirector::Request do
           rval = @request.do_request(:puppet, 'puppet', 8140) do |got|
             count += 1
 
-            if got.server == '_x-puppet._tcp.example.com' then
+            if got.server == 'example.com' then
               raise SystemCallError, "example failure"
             else
               second_pass = got

--- a/spec/unit/indirector/request_spec.rb
+++ b/spec/unit/indirector/request_spec.rb
@@ -447,13 +447,13 @@ describe Puppet::Indirector::Request do
 
           @port = 7205
           @target = 'example.com'
-          @srv_records = [Resolv::DNS::Resource::IN::SRV.new(0, 0, @port, @target)]
+          record = Resolv::DNS::Resource::IN::SRV.new(0, 0, @port, @target)
+          record.instance_variable_set(:@ttl, 10)
+          @srv_records = [record]
 
           @dns_mock.expects(:getresources).
             with("_x-puppet._tcp.#{Puppet.settings[:srv_domain]}", Resolv::DNS::Resource::IN::SRV).
             returns(@srv_records)
-
-          Puppet.push_context(:dns_resolver => Puppet::Network::Resolver.new)
         end
 
         it "yields a request using the server and port from the SRV record" do

--- a/spec/unit/rest/route_spec.rb
+++ b/spec/unit/rest/route_spec.rb
@@ -71,7 +71,9 @@ describe Puppet::Rest::Route do
 
           @port = 7502
           @target = 'example.com'
-          @srv_records = [Resolv::DNS::Resource::IN::SRV.new(0, 0, @port, @target)]
+          record = Resolv::DNS::Resource::IN::SRV.new(0, 0, @port, @target)
+          record.instance_variable_set(:@ttl, 10)
+          @srv_records = [record]
 
           @dns_mock.expects(:getresources).
             with("_x-puppet._tcp.test_service", Resolv::DNS::Resource::IN::SRV).

--- a/spec/unit/rest/route_spec.rb
+++ b/spec/unit/rest/route_spec.rb
@@ -3,46 +3,110 @@ require 'spec_helper'
 require 'puppet/rest/route'
 
 describe Puppet::Rest::Route do
-  context '#select_server_and_port' do
-    it 'returns the default server and port when provided' do
-      route = Puppet::Rest::Route.new(api: '/myapi/v1/',
-                                      default_server: 'puppet.example.com',
-                                      default_port: 90210)
-      route.select_server_and_port
-      expect(route.server).to eq('puppet.example.com')
-      expect(route.port).to eq(90210)
+  describe '#with_base_url'do
+    let(:route) { Puppet::Rest::Route.new(api: '/fakeapi/v1/',
+                                                default_server: 'testserver',
+                                                default_port: 555,
+                                                srv_service: :test_service) }
+    let(:dns_resolver) { stub_everything('dns resolver') }
+
+    context 'when not using SRV records' do
+      before :each do
+        Puppet.settings[:use_srv_records] = false
+      end
+
+      it "yields a base URL with the default server and port when they are specified" do
+        count = 0
+        rval = route.with_base_url(dns_resolver) do |url|
+          count += 1
+          expect(url.to_s).to eq('https://testserver:555/fakeapi/v1/')
+          'Block return value'
+        end
+        expect(count).to eq(1)
+        expect(rval).to eq('Block return value')
+      end
+
+      it "yields a base URL with Puppet's configured server and port when no defaults are specified" do
+        Puppet[:server] = 'configured.net'
+        Puppet[:masterport] = 8140
+        fallback_route = Puppet::Rest::Route.new(api: '/fakeapi/v1/',
+                                                 default_server: nil,
+                                                 default_port: nil,
+                                                 srv_service: nil)
+        count = 0
+        rval = fallback_route.with_base_url(dns_resolver) do |url|
+          count += 1
+          expect(url.to_s).to eq('https://configured.net:8140/fakeapi/v1/')
+          'Block return value'
+        end
+        expect(count).to eq(1)
+        expect(rval).to eq('Block return value')
+      end
+
+      it 'yields the first entry in the server list when server_list is in use' do
+        Puppet[:server_list] = [['one.net', 111], ['two.net', 222]]
+        fallback_route = Puppet::Rest::Route.new(api: '/fakeapi/v1/',
+                                                 default_server: nil,
+                                                 default_port: nil,
+                                                 srv_service: nil)
+        count = 0
+        rval = fallback_route.with_base_url(dns_resolver) do |url|
+          count += 1
+          expect(url.to_s).to eq('https://one.net:111/fakeapi/v1/')
+          'Block return value'
+        end
+        expect(count).to eq(1)
+        expect(rval).to eq('Block return value')
+      end
     end
 
-    it 'caches the result' do
-      route = Puppet::Rest::Route.new(api: '/myapi/v1/',
-                                      default_server: 'puppet.example.com',
-                                      default_port: 90210)
-      route.expects(:default_server)
-      route.select_server_and_port
-      # just return the values in @server and @port without looking
-      # at @default_server
-      route.expects(:default_server).never
-      route.select_server_and_port
-    end
+    context 'when using SRV records' do
+      context "when SRV returns servers" do
+        before :each do
+          Puppet.settings[:use_srv_records] = true
+          Puppet.settings[:srv_domain]      = 'example.com'
 
-    it 'looks up the server and port when defaults are nil' do
-      route = Puppet::Rest::Route.new(api: '/myapi/v1/',
-                                      default_server: nil,
-                                      default_port: nil)
-      Puppet.push_context({ :server => 'puppet.example.com' })
-      Puppet.push_context({ :serverport => 90210 })
-      server, port = route.select_server_and_port
-      expect(server).to eq('puppet.example.com')
-      expect(port).to eq(90210)
-    end
-  end
+          @dns_mock = mock('dns')
+          Resolv::DNS.expects(:new).returns(@dns_mock)
 
-  context '#uri' do
-    it 'returns a URI object based on the provided data' do
-      route = Puppet::Rest::Route.new(api: '/myapi/v1/',
-                                      default_server: 'puppet.example.com',
-                                      default_port: 90210)
-      expect(route.uri.to_s).to eq('https://puppet.example.com:90210/myapi/v1/')
+          @port = 7502
+          @target = 'example.com'
+          @srv_records = [Resolv::DNS::Resource::IN::SRV.new(0, 0, @port, @target)]
+
+          @dns_mock.expects(:getresources).
+            with("_x-puppet._tcp.test_service", Resolv::DNS::Resource::IN::SRV).
+            returns(@srv_records)
+        end
+
+        it "yields a URL using the server and port from the SRV record" do
+          count = 0
+          rval = route.with_base_url(Puppet::Network::Resolver.new) do |url|
+            count += 1
+            expect(url.to_s).to eq('https://example.com:7502/fakeapi/v1/')
+            'Block return value'
+          end
+          expect(count).to eq(1)
+
+          expect(rval).to eq('Block return value')
+        end
+
+        it "should fall back to the default server when the block raises a SystemCallError" do
+          count = 0
+          rval = route.with_base_url(Puppet::Network::Resolver.new) do |url|
+            count += 1
+            if url.to_s =~ /example.com/ then
+              raise SystemCallError, "example failure"
+            else
+              expect(url.to_s).to eq('https://testserver:555/fakeapi/v1/')
+            end
+
+            'Block return value'
+          end
+
+          expect(count).to eq(2)
+          expect(rval).to eq('Block return value')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds SRV support with caching to Puppet::Rest::Client. It updates the existing Puppet::Network::Resolver to cache the results of a DNS lookup per service, subject a TTL. In the new REST client, when a server is chosen for a given request, that chosen server is cached until it can't be reached, at which point servers are re-resolved. If SRV records are in use, the Network::Resolver will check its cache at this time, and either return the appropriate cached list of DNS records or query DNS again if the TTL for that service has expired.