### PR TITLE
(PUP-2838) Fix invalid .dot files due to missing escapes of quoted strings in resource names

### DIFF
--- a/lib/puppet/external/dot.rb
+++ b/lib/puppet/external/dot.rb
@@ -208,10 +208,10 @@ module DOT
 
       label = @options['shape'] != 'record' && @ports.length == 0 ?
           @options['label'] ?
-            t + $tab + "label = \"#{@options['label']}\"\n" :
+            t + $tab + "label = #{stringify(@options['label'])}\n" :
             '' :
           t + $tab + 'label = "' + " \\\n" +
-          t + $tab2 + "#{@options['label']}| \\\n" +
+          t + $tab2 + "#{stringify(@options['label'])}| \\\n" +
           @ports.collect{ |i|
             t + $tab2 + i.to_s
           }.join( "| \\\n" ) + " \\\n" +
@@ -224,6 +224,12 @@ module DOT
         }.compact.join( ",\n" ) + ( label != '' ? ",\n" : "\n" ) +
         label +
         t + "]\n"
+    end
+
+    private
+
+    def stringify(s)
+      %("#{s.gsub('"', '\\"')}")
     end
 
   end

--- a/lib/puppet/external/dot.rb
+++ b/lib/puppet/external/dot.rb
@@ -15,7 +15,7 @@ module DOT
 
   # if we don't like 4 spaces, we can change it any time
 
-  def change_tab (t)
+  def change_tab(t)
     $tab  = t
     $tab2 = t * 2
   end
@@ -118,7 +118,7 @@ module DOT
 
     attr_accessor :name
 
-    def initialize (params = {})
+    def initialize(params = {})
       @label = params['name'] ? params['name'] : ''
     end
 
@@ -134,7 +134,7 @@ module DOT
     # attr_reader :parent
     attr_accessor :name, :options
 
-    def initialize (params = {}, option_list = [])
+    def initialize(params = {}, option_list = [])
       super(params)
       @name   = params['name']   ? params['name']   : nil
       @parent = params['parent'] ? params['parent'] : nil
@@ -168,7 +168,7 @@ module DOT
 
     attr_accessor :label
 
-    def initialize (params = {})
+    def initialize(params = {})
       super(params)
       @name = params['label'] ? params['label'] : ''
     end
@@ -181,7 +181,7 @@ module DOT
   # node element
 
   class DOTNode < DOTElement
-    def initialize (params = {}, option_list = NODE_OPTS)
+    def initialize(params = {}, option_list = NODE_OPTS)
       super(params, option_list)
       @ports = params['ports'] ? params['ports'] : []
     end
@@ -190,11 +190,11 @@ module DOT
       @ports.each { |i| yield i }
     end
 
-    def << (thing)
+    def <<(thing)
       @ports << thing
     end
 
-    def push (thing)
+    def push(thing)
       @ports.push(thing)
     end
 
@@ -202,7 +202,7 @@ module DOT
       @ports.pop
     end
 
-    def to_s (t = '')
+    def to_s(t = '')
 
       # This code is totally incomprehensible; it needs to be replaced!
 
@@ -238,7 +238,7 @@ module DOT
   # notation.
 
   class DOTSubgraph < DOTElement
-    def initialize (params = {}, option_list = GRAPH_OPTS)
+    def initialize(params = {}, option_list = GRAPH_OPTS)
       super(params, option_list)
       @nodes      = params['nodes'] ? params['nodes'] : []
       @dot_string = 'graph'
@@ -248,11 +248,11 @@ module DOT
       @nodes.each{ |i| yield i }
     end
 
-    def << (thing)
+    def <<(thing)
       @nodes << thing
     end
 
-    def push (thing)
+    def push(thing)
       @nodes.push( thing )
     end
 
@@ -260,7 +260,7 @@ module DOT
       @nodes.pop
     end
 
-    def to_s (t = '')
+    def to_s(t = '')
       hdr = t + "#{@dot_string} #{@name} {\n"
 
       options = @options.to_a.collect{ |name, val|
@@ -281,7 +281,7 @@ module DOT
 
   class DOTDigraph < DOTSubgraph
 
-  def initialize (params = {}, option_list = GRAPH_OPTS)
+  def initialize(params = {}, option_list = GRAPH_OPTS)
     super(params, option_list)
     @dot_string = 'digraph'
   end
@@ -294,7 +294,7 @@ module DOT
 
     attr_accessor :from, :to
 
-    def initialize (params = {}, option_list = EDGE_OPTS)
+    def initialize(params = {}, option_list = EDGE_OPTS)
       super(params, option_list)
       @from = params['from'] ? params['from'] : nil
       @to   = params['to'] ? params['to'] : nil
@@ -304,7 +304,7 @@ module DOT
       '--'
     end
 
-    def to_s (t = '')
+    def to_s(t = '')
       t + "#{@from} #{edge_link} #{to} [\n" +
         @options.to_a.collect{ |i|
           i[1] && i[0] != 'label' ?

--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -436,7 +436,7 @@ class Puppet::Graph::SimpleGraph
   # undirected Graph.  _params_ can contain any graph property specified in
   # rdot.rb. If an edge or vertex label is a kind of Hash then the keys
   # which match +dot+ properties will be used as well.
-  def to_dot_graph (params = {})
+  def to_dot_graph(params = {})
     params['name'] ||= self.class.name.gsub(/:/,'_')
     fontsize   = params['fontsize'] ? params['fontsize'] : '8'
     graph      = (directed? ? DOT::DOTDigraph : DOT::DOTSubgraph).new(params)
@@ -466,7 +466,7 @@ class Puppet::Graph::SimpleGraph
   end
 
   # Output the dot format as a string
-  def to_dot (params={}) to_dot_graph(params).to_s; end
+  def to_dot(params={}) to_dot_graph(params).to_s; end
 
   # Produce the graph files if requested.
   def write_graph(name)

--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -443,7 +443,7 @@ class Puppet::Graph::SimpleGraph
     edge_klass = directed? ? DOT::DOTDirectedEdge : DOT::DOTEdge
     vertices.each do |v|
       name = v.ref
-      params = {'name'     => '"'+name+'"',
+      params = {'name'     => stringify(name),
         'fontsize' => fontsize,
         'label'    => name}
       v_label = v.ref
@@ -451,14 +451,18 @@ class Puppet::Graph::SimpleGraph
       graph << DOT::DOTNode.new(params)
     end
     edges.each do |e|
-      params = {'from'     => '"'+ e.source.ref + '"',
-        'to'       => '"'+ e.target.ref + '"',
+      params = {'from'     => stringify(e.source.ref),
+        'to'       => stringify(e.target.ref),
         'fontsize' => fontsize }
       e_label = e.ref
       params.merge!(e_label) if e_label and e_label.kind_of? Hash
       graph << edge_klass.new(params)
     end
     graph
+  end
+
+  def stringify(s)
+    %("#{s.gsub('"', '\\"')}")
   end
 
   # Output the dot format as a string


### PR DESCRIPTION
When using resource names with quotes, the `--graph` functionality of puppet produce a broken dot file:

```
λ dot /var/puppet/state/graphs/relationships.dot
Error: /var/puppet/state/graphs/relationships.dot: syntax error in line 5765 near '"'
```

The [puppetlabs/puppetlabs-postgresql](https://github.com/puppetlabs/puppetlabs-postgresql) generates [a](https://github.com/puppetlabs/puppetlabs-postgresql/blob/5d50a6658bd49bf2c58478d4258ef06f614c4bc3/manifests/server/schema.pp#L46) [lot](https://github.com/puppetlabs/puppetlabs-postgresql/blob/5d50a6658bd49bf2c58478d4258ef06f614c4bc3/manifests/server/schema.pp#L53) [of](https://github.com/puppetlabs/puppetlabs-postgresql/blob/217405e04c1872501df9f67800ad2df6390e213e/manifests/server/database.pp#L76) [such](https://github.com/puppetlabs/puppetlabs-postgresql/blob/217405e04c1872501df9f67800ad2df6390e213e/manifests/server/database.pp#L107) [resources](https://github.com/puppetlabs/puppetlabs-postgresql/blob/217405e04c1872501df9f67800ad2df6390e213e/manifests/server/database.pp#L118).

This Pull-Request workaround the problem by escaping quotes when generating the dot graph. A better fix strategy is described in the existing code, unfortunately I can't afford it 😄:

https://github.com/puppetlabs/puppet/blob/f01045901935c3cf62f2f4d0b83be7ea78972ac3/lib/puppet/external/dot.rb#L207