### PR TITLE
(PUP-8767) Stringify the output of config version commands

### DIFF
--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -208,7 +208,7 @@ class Puppet::Resource::TypeCollection
       if environment.config_version.nil? || environment.config_version == ""
         @version = Time.now.to_i
       else
-        @version = Puppet::Util::Execution.execute([environment.config_version]).strip
+        @version = Puppet::Util::Execution.execute([environment.config_version]).to_s.strip
       end
     end
 


### PR DESCRIPTION
If you run puppet apply --custom_version='echo foo' then the last run summary YAML ends up looking like this

```
---
version:
  config: !ruby/string:Puppet::Util::Execution::ProcessOutput "foo"
[...]
```

Stringify the process output in order to make the YAML less dependent on Ruby.