### PR TITLE
(PUP-8773) Fix logging to a JSON file target

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -109,7 +109,7 @@ Puppet::Util::Log.newdesttype :file do
   def handle(msg)
     if @json > 0
       @json > 1 ? @file.puts(',') : @json = 2
-      Puppet::Util::Json.dump(msg.to_structured_hash, @file)
+      @file.puts(Puppet::Util::Json.dump(msg.to_structured_hash))
     else
       @file.puts("#{msg.time} #{msg.source} (#{msg.level}): #{msg}")
     end


### PR DESCRIPTION
This fixes PUP-8773 whereby setting the `--logdest` option to a JSON file target causes the following:

```
[root@localhost ~]# /opt/puppetlabs/bin/puppet agent -t --noop --logdest "/tmp/foo.json"
/opt/puppetlabs/puppet/lib/ruby/vendor_gems/gems/multi_json-1.13.1/lib/multi_json.rb:130:in `current_adapter': undefined method `[]' for #<File:/tmp/foo.json> (NoMethodError)
        from /opt/puppetlabs/puppet/lib/ruby/vendor_gems/gems/multi_json-1.13.1/lib/multi_json.rb:139:in `dump'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/json.rb:61:in `dump'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log/destinations.rb:112:in `handle'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:191:in `block in newmessage'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:190:in `each'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:190:in `newmessage'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:308:in `initialize'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:88:in `new'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:88:in `create'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/logging.rb:11:in `send_log'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/logging.rb:20:in `block (2 levels) in <module:Logging>'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/logging.rb:69:in `log_exception'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:673:in `rescue in exit_on_fail'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:660:in `exit_on_fail'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:366:in `run'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:137:in `run'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:73:in `execute'
        from /opt/puppetlabs/puppet/bin/puppet:5:in `<main>'
```