### PR TITLE
(PUP-8654) Use REST client to download CRLs

### DIFF
--- a/lib/puppet/rest/client.rb
+++ b/lib/puppet/rest/client.rb
@@ -38,8 +38,8 @@ module Puppet::Rest
       @dns_resolver = Puppet::Network::Resolver.new
     end
 
-    # Make a GET request to the specified endpoint with the specified params.
-    # @param [String] endpoint the endpoint of the configured API to query
+    # Make a GET request to the specified URL with the specified params.
+    # @param [String] url the full path to query
     # @param [Hash] query any URL params to add to send to the endpoint
     # @param [Hash] header any additional entries to add to the default header
     # @yields [String] chunks of the response body

--- a/lib/puppet/rest/client.rb
+++ b/lib/puppet/rest/client.rb
@@ -38,8 +38,8 @@ module Puppet::Rest
       @dns_resolver = Puppet::Network::Resolver.new
     end
 
-    # Make a GET request to the specified URL with the specified params.
-    # @param [String] url the full path to query
+    # Make a GET request to the specified endpoint with the specified params.
+    # @param [String] endpoint the endpoint of the configured API to query
     # @param [Hash] query any URL params to add to send to the endpoint
     # @param [Hash] header any additional entries to add to the default header
     # @yields [String] chunks of the response body
@@ -66,6 +66,7 @@ module Puppet::Rest
       if ssl_certificates_are_present?(ca_path)
         ssl_config.verify_mode = OpenSSL::SSL::VERIFY_PEER
         ssl_config.add_trust_ca(ca_path)
+        ssl_config.verify_callback = Puppet::SSL::Validator::DefaultValidator.new(ca_path)
         ssl_config.set_client_cert_file(Puppet[:hostcert], Puppet[:hostprivkey])
       else
         ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -21,7 +21,7 @@ module Puppet::Rest
       ca.with_base_url(client.dns_resolver) do |base_url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
         body = ''
-        client.get(base_url + "certificate/#{name}", header: header) do |chunk|
+        client.get("#{base_url}certificate/#{name}", header: header) do |chunk|
           body << chunk
         end
         body

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -19,7 +19,7 @@ module Puppet::Rest
     # @return [String] the PEM-encoded certificate or certificate bundle
     def self.get_certificate(client, name)
       ca.with_base_url(client.dns_resolver) do |base_url|
-        header = { 'Accept' => 'text/plain', 'accept-encoding' => ACCEPT_ENCODING }
+        header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
         body = ''
         client.get(base_url + "certificate/#{name}", header: header) do |chunk|
           body << chunk
@@ -36,7 +36,7 @@ module Puppet::Rest
     # @return nil
    def self.get_crls(client, name, &block)
      ca.with_base_url(client.dns_resolver) do |base_url|
-       header = { 'Accept' => 'text/plain', 'accept-encoding' => ACCEPT_ENCODING }
+       header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
        client.get("#{base_url}certificate_revocation_list/#{name}", header: header) do |chunk|
          block.call(chunk)
        end

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -28,14 +28,20 @@ module Puppet::Rest
       end
     end
 
-    def self.get_crls(client, name)
-      header = { 'Accept' => 'text/plain', 'accept-encoding' => ACCEPT_ENCODING }
-      body = ''
-      client.get("certificate_revocation_list/#{name}", header: header) do |chunk|
-        body << chunk
-      end
-      body
-    end
+    # Make an HTTP request to fetch the named crl, using the given
+    # HTTP client. Accepts a block to stream responses to disk.
+    # @param [Puppet::Rest::Client] client the HTTP client to use to make the request
+    # @param [String] name the crl to fetch
+    # @raise [Puppet::Rest::ResponseError] if the response status is not OK
+    # @return nil
+   def self.get_crls(client, name, &block)
+     ca.with_base_url(client.dns_resolver) do |base_url|
+       header = { 'Accept' => 'text/plain', 'accept-encoding' => ACCEPT_ENCODING }
+       client.get("#{base_url}certificate_revocation_list/#{name}", header: header) do |chunk|
+         block.call(chunk)
+       end
+     end
+   end
 
   end
 end

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -27,5 +27,15 @@ module Puppet::Rest
         body
       end
     end
+
+    def self.get_crls(client, name)
+      header = { 'Accept' => 'text/plain', 'accept-encoding' => ACCEPT_ENCODING }
+      body = ''
+      client.get("certificate_revocation_list/#{name}", header: header) do |chunk|
+        body << chunk
+      end
+      body
+    end
+
   end
 end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -400,7 +400,6 @@ ERROR_STRING
   def ensure_crl_if_needed
     if use_crl? && !Puppet::FileSystem.exist?(crl_path)
       download_and_save_crl_bundle
-      load_crls(crl_path)
     end
   end
 

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -757,29 +757,6 @@ describe Puppet::SSL::Host do
       host.ssl_store(OpenSSL::X509::PURPOSE_SSL_SERVER)
     end
 
-    context "and the CRL is on disk" do
-      before do
-        @pki = PuppetSpec::SSL.create_chained_pki
-
-        @revoked_cert = @pki[:revoked_root_node_cert]
-
-        localcacert = Puppet.settings[:localcacert]
-        Puppet::Util.replace_file(localcacert, 0644) {|f| f.write @pki[:ca_bundle] }
-        Puppet::Util.replace_file(Puppet.settings[:hostcrl], 0644) do |f|
-          f.write @pki[:crl_chain]
-        end
-      end
-
-      after do
-        Puppet::FileSystem.unlink(Puppet.settings[:localcacert])
-        Puppet::FileSystem.unlink(Puppet.settings[:hostcrl])
-      end
-
-      it "retrieves it and can correctly identify revoked certs" do
-        expect(@host.ssl_store.verify(@revoked_cert)).to be false
-      end
-    end
-
     context "and the CRL is not on disk" do
       before do
         @pki = PuppetSpec::SSL.create_chained_pki


### PR DESCRIPTION
Previous to this change, the CRLs used the indirector to find and save
the CRLs to disk. This change updates the usage in the ssl host class to
use the rest httpclient instead.