### PR TITLE
(maint) - Requiring puppet as Puppet::Util::Platform is uninitialized

### DIFF
--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -1,3 +1,4 @@
+require 'puppet/util/platform'
 module Puppet::Util::Windows
   module ADSI
     class User; end


### PR DESCRIPTION
Currently I am seeing the following error message:

`bundler: failed to load command: pdk (/Users/paula/workspace/puppetlabs-motd/.bundle/gems/ruby/2.5.0/bin/pdk)
NameError: uninitialized constant Puppet::Util::Platform
`
As puppet is not being required the code doesn't have access to the following: `Puppet::Util::Platform`
I have added `require 'puppet/util/platform'` and I am no longer seeing this issue.

Unsure if I should be making this PR against master or any particular branch. Any guidance or input would be greatly appreciated. 
