### PR TITLE
(PUP-8767) Emit config version as a string

### DIFF
--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -208,7 +208,7 @@ class Puppet::Resource::TypeCollection
       if environment.config_version.nil? || environment.config_version == ""
         @version = Time.now.to_i
       else
-        @version = Puppet::Util::Execution.execute([environment.config_version]).strip
+        @version = Puppet::Util::Execution.execute([environment.config_version]).to_s.strip
       end
     end
 

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1695,7 +1695,9 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
     it "should succeed the file resource if command succeeds" do
       catalog.add_resource(described_class.new(:path => path, :content => "foo", :validate_cmd => "/usr/bin/env true"))
-      Puppet::Util::Execution.expects(:execute).with("/usr/bin/env true", {:combine => true, :failonfail => true}).returns ''
+      Puppet::Util::Execution.expects(:execute)
+        .with("/usr/bin/env true", {:combine => true, :failonfail => true})
+        .returns Puppet::Util::Execution::ProcessOutput.new('', 0)
       report = catalog.apply.report
       expect(report.resource_statuses["File[#{path}]"]).not_to be_failed
       expect(Puppet::FileSystem.exist?(path)).to be_truthy

--- a/spec/shared_examples/rhel_package_provider.rb
+++ b/spec/shared_examples/rhel_package_provider.rb
@@ -68,7 +68,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
       before(:each) do
         Puppet::Util.stubs(:which).with("rpm").returns("/bin/rpm")
         provider.stubs(:which).with("rpm").returns("/bin/rpm")
-        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], {:combine => true, :custom_environment => {}, :failonfail => true}).returns("4.10.1\n").at_most_once
+        Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], {:combine => true, :custom_environment => {}, :failonfail => true}).returns(Puppet::Util::Execution::ProcessOutput.new("4.10.1\n", 0)).at_most_once
         Facter.stubs(:value).with(:operatingsystemmajrelease).returns('6')
       end
       it "should call #{provider_name} install for :installed" do
@@ -84,7 +84,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
           end
           it "should catch #{provider_name} install failures when status code is wrong" do
             resource.stubs(:should).with(:ensure).returns :installed
-            Puppet::Util::Execution.expects(:execute).with(["/usr/bin/#{provider_name}", '-e', error_level, '-y', :install, name]).returns("No package #{name} available.")
+            Puppet::Util::Execution.expects(:execute).with(["/usr/bin/#{provider_name}", '-e', error_level, '-y', :install, name]).returns(Puppet::Util::Execution::ProcessOutput.new("No package #{name} available.", 0))
             expect {
               provider.install
             }.to raise_error(Puppet::Error, "Could not find package #{name}")

--- a/spec/unit/provider/package/aptitude_spec.rb
+++ b/spec/unit/provider/package/aptitude_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Type.type(:package).provider(:aptitude) do
         Puppet::Util::Execution.expects(:execute).with(
           [dpkgquery_path, '-W', '--showformat', "'${Status} ${Package} ${Version}\\n'", 'faff'],
           {:failonfail => true, :combine => true, :custom_environment => {}}
-        ).returns(output)
+        ).returns(Puppet::Util::Execution::ProcessOutput.new(output, 0))
 
         expect(pkg.property(:ensure).retrieve).to eq(expect)
       end

--- a/spec/unit/provider/package/aptrpm_spec.rb
+++ b/spec/unit/provider/package/aptrpm_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Type.type(:package).provider(:aptrpm) do
     before(:each) do
       Puppet::Util.stubs(:which).with("rpm").returns("/bin/rpm")
       pkg.provider.stubs(:which).with("rpm").returns("/bin/rpm")
-      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], {:combine => true, :custom_environment => {}, :failonfail => true}).returns("4.10.1\n").at_most_once
+      Puppet::Util::Execution.expects(:execute).with(["/bin/rpm", "--version"], {:combine => true, :custom_environment => {}, :failonfail => true}).returns(Puppet::Util::Execution::ProcessOutput.new("4.10.1\n", 0)).at_most_once
     end
 
     def rpm_args

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -68,7 +68,7 @@ describe provider_class do
     end
 
     def dpkg_query_execution_returns(output)
-      Puppet::Util::Execution.expects(:execute).with(query_args, execute_options).returns(output)
+      Puppet::Util::Execution.expects(:execute).with(query_args, execute_options).returns(Puppet::Util::Execution::ProcessOutput.new(output, 0))
     end
 
     before do

--- a/spec/unit/provider/package/nim_spec.rb
+++ b/spec/unit/provider/package/nim_spec.rb
@@ -27,7 +27,7 @@ describe provider_class do
   end
 
   let(:bff_showres_output) {
-    <<END
+    Puppet::Util::Execution::ProcessOutput.new(<<END, 0)
 mypackage.foo                                                           ALL  @@I:mypackage.foo _all_filesets
  @ 1.2.3.1  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.1
  + 1.2.3.4  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.4
@@ -37,7 +37,7 @@ END
   }
 
   let(:rpm_showres_output) {
-    <<END
+    Puppet::Util::Execution::ProcessOutput.new(<<END, 0)
 mypackage.foo                                                                ALL  @@R:mypackage.foo _all_filesets
  @@R:mypackage.foo-1.2.3-1 1.2.3-1
  @@R:mypackage.foo-1.2.3-4 1.2.3-4
@@ -168,9 +168,6 @@ OUTPUT
 
       expect { @provider.install }.to raise_error(Puppet::Error, "NIM package provider is unable to downgrade packages")
     end
-
-
-
   end
 
   context "when uninstalling" do
@@ -187,9 +184,7 @@ OUTPUT
       @provider.class.expects(:pkglist).with(:pkgname => 'mypackage.foo').returns(nil)
       @provider.uninstall
     end
-
   end
-
 
   context "when parsing nimclient showres output" do
     describe "#parse_showres_output" do
@@ -231,7 +226,6 @@ END
           expect(subject.send(:determine_latest_version, nimclient_showres_output, 'mypackage.foo')).to eq([:rpm, nil])
         end
       end
-
     end
 
     describe "#determine_package_type" do
@@ -244,7 +238,4 @@ END
       end
     end
   end
-
-
-
 end

--- a/spec/unit/provider/package/opkg_spec.rb
+++ b/spec/unit/provider/package/opkg_spec.rb
@@ -74,7 +74,7 @@ describe Puppet::Type.type(:package).provider(:opkg) do
         end
 
         it "should install from the path segment of the URL" do
-          Puppet::Util::Execution.expects(:execute).returns("")
+          Puppet::Util::Execution.expects(:execute).returns(Puppet::Util::Execution::ProcessOutput.new("", 0))
           provider.install
         end
       end
@@ -165,7 +165,7 @@ OPKG_OUTPUT
     end
 
     it "should return a nil if the package isn't found" do
-      Puppet::Util::Execution.expects(:execute).returns("")
+      Puppet::Util::Execution.expects(:execute).returns(Puppet::Util::Execution::ProcessOutput.new("", 0))
       expect(provider.query).to be_nil
     end
 

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -115,7 +115,9 @@ describe Puppet::Type.type(:package).provider(:pkg) do
       end
 
       it "should work correctly for ensure latest on solaris 11(known UFOXI)" do
-        Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'update', '-n', 'dummy'], {:failonfail => false, :combine => true}).returns ''
+        Puppet::Util::Execution.expects(:execute)
+          .with(['/bin/pkg', 'update', '-n', 'dummy'], {:failonfail => false, :combine => true})
+          .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
         $CHILD_STATUS.stubs(:exitstatus).returns 0
 
         described_class.expects(:pkg).with(:list,'-Hvn','dummy').returns File.read(my_fixture('dummy_solaris11.known'))
@@ -180,7 +182,9 @@ describe Puppet::Type.type(:package).provider(:pkg) do
     context ":query" do
       context "on solaris 10" do
         it "should find the package" do
-          Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true}).returns File.read(my_fixture('dummy_solaris10'))
+          Puppet::Util::Execution.expects(:execute)
+            .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
+            .returns(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('dummy_solaris10')), 0))
           $CHILD_STATUS.stubs(:exitstatus).returns 0
           expect(provider.query).to eq({
             :name      => 'dummy',
@@ -192,7 +196,9 @@ describe Puppet::Type.type(:package).provider(:pkg) do
         end
 
         it "should return :absent when the package is not found" do
-          Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true}).returns ''
+          Puppet::Util::Execution.expects(:execute)
+            .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
+            .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
           $CHILD_STATUS.stubs(:exitstatus).returns 1
           expect(provider.query).to eq({:ensure => :absent, :name => "dummy"})
         end
@@ -201,7 +207,9 @@ describe Puppet::Type.type(:package).provider(:pkg) do
       context "on solaris 11" do
         it "should find the package" do
           $CHILD_STATUS.stubs(:exitstatus).returns 0
-          Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true}).returns File.read(my_fixture('dummy_solaris11.installed'))
+          Puppet::Util::Execution.expects(:execute)
+            .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
+            .returns(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('dummy_solaris11.installed')), 0))
           expect(provider.query).to eq({
             :name      => 'dummy',
             :status    => 'installed',
@@ -212,14 +220,19 @@ describe Puppet::Type.type(:package).provider(:pkg) do
         end
 
         it "should return :absent when the package is not found" do
-          Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true}).returns ''
+          Puppet::Util::Execution
+            .expects(:execute)
+            .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
+            .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
           $CHILD_STATUS.stubs(:exitstatus).returns 1
           expect(provider.query).to eq({:ensure => :absent, :name => "dummy"})
         end
       end
 
       it "should return fail when the packageline cannot be parsed" do
-        Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true}).returns(File.read(my_fixture('incomplete')))
+        Puppet::Util::Execution.expects(:execute)
+          .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
+          .returns(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('incomplete')), 0))
         $CHILD_STATUS.stubs(:exitstatus).returns 0
         expect {
           provider.query
@@ -238,8 +251,12 @@ describe Puppet::Type.type(:package).provider(:pkg) do
           end
           it "should accept all licenses" do
             provider.expects(:query).with().returns({:ensure => :absent})
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'install', *hash[:flags], 'dummy'], {:failonfail => false, :combine => true}).returns ''
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true}).returns ''
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'install', *hash[:flags], 'dummy'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
             $CHILD_STATUS.stubs(:exitstatus).returns 0
             provider.install
           end
@@ -249,16 +266,24 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             resource[:ensure] = '0.0.7,5.11-0.151006:20131230T130000Z'
             $CHILD_STATUS.stubs(:exitstatus).returns 0
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true}).returns 'pkg://foo/dummy@0.0.6,5.11-0.151006:20131230T130000Z  installed -----'
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'update', *hash[:flags], 'dummy@0.0.7,5.11-0.151006:20131230T130000Z'], {:failonfail => false, :combine => true}).returns ''
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('pkg://foo/dummy@0.0.6,5.11-0.151006:20131230T130000Z  installed -----', 0))
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'update', *hash[:flags], 'dummy@0.0.7,5.11-0.151006:20131230T130000Z'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
             provider.install
           end
 
           it "should install specific version(2)" do
             resource[:ensure] = '0.0.8'
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true}).returns 'pkg://foo/dummy@0.0.7,5.11-0.151006:20131230T130000Z  installed -----'
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'update', *hash[:flags], 'dummy@0.0.8'], {:failonfail => false, :combine => true}).returns ''
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('pkg://foo/dummy@0.0.7,5.11-0.151006:20131230T130000Z  installed -----', 0))
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'update', *hash[:flags], 'dummy@0.0.8'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
             $CHILD_STATUS.stubs(:exitstatus).returns 0
             provider.install
           end
@@ -268,14 +293,18 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             provider.expects(:query).with().returns({:ensure => '0.0.8,5.11-0.151106:20131230T130000Z'})
             $CHILD_STATUS.stubs(:exitstatus).returns 0
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'update', *hash[:flags], 'dummy@0.0.7'], {:failonfail => false, :combine => true}).returns ''
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'update', *hash[:flags], 'dummy@0.0.7'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
             provider.install
           end
 
           it "should install any if version is not specified" do
             resource[:ensure] = :present
             provider.expects(:query).with().returns({:ensure => :absent})
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'install', *hash[:flags], 'dummy'], {:failonfail => false, :combine => true}).returns ''
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'install', *hash[:flags], 'dummy'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
             $CHILD_STATUS.stubs(:exitstatus).returns 0
             provider.install
@@ -285,7 +314,9 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             resource[:ensure] = '0.0.7'
             provider.expects(:query).with().returns({:ensure => :absent})
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
-            Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'install', *hash[:flags], 'dummy@0.0.7'], {:failonfail => false, :combine => true}).returns ''
+            Puppet::Util::Execution.expects(:execute)
+              .with(['/bin/pkg', 'install', *hash[:flags], 'dummy@0.0.7'], {:failonfail => false, :combine => true})
+              .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
             $CHILD_STATUS.stubs(:exitstatus).returns 0
             provider.install
           end
@@ -294,7 +325,9 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             resource[:ensure] = '1.0-0.151006'
             is = :absent
             provider.expects(:query).with().returns({:ensure => is})
-            described_class.expects(:pkg).with(:list, '-Hvfa', 'dummy@1.0-0.151006').returns File.read(my_fixture('dummy_implicit_version'))
+            described_class.expects(:pkg)
+              .with(:list, '-Hvfa', 'dummy@1.0-0.151006')
+              .returns(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('dummy_implicit_version')), 0))
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'install', '-n', 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
             provider.expects(:unhold).with()
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'install', *hash[:flags], 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
@@ -320,7 +353,9 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             resource[:ensure] = '1.0-0.151006'
             is = '1.0,5.11-0.151006:20140220T084443Z'
             provider.expects(:warning).with("Implicit version 1.0-0.151006 has 3 possible matches")
-            described_class.expects(:pkg).with(:list, '-Hvfa', 'dummy@1.0-0.151006').returns File.read(my_fixture('dummy_implicit_version'))
+            described_class.expects(:pkg)
+              .with(:list, '-Hvfa', 'dummy@1.0-0.151006')
+              .returns(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('dummy_implicit_version')), 0))
             Puppet::Util::Execution.expects(:execute).with(['/bin/pkg', 'update', '-n', 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
             $CHILD_STATUS.stubs(:exitstatus).returns 4
             provider.insync?(is)

--- a/spec/unit/provider/package/urpmi_spec.rb
+++ b/spec/unit/provider/package/urpmi_spec.rb
@@ -7,7 +7,9 @@ describe Puppet::Type.type(:package).provider(:urpmi) do
     %w[rpm urpmi urpme urpmq].each do |executable|
       Puppet::Util.stubs(:which).with(executable).returns(executable)
     end
-    Puppet::Util::Execution.stubs(:execute).with(['rpm', '--version'], anything).returns 'RPM version 4.9.1.3'
+    Puppet::Util::Execution.stubs(:execute)
+      .with(['rpm', '--version'], anything)
+      .returns(Puppet::Util::Execution::ProcessOutput.new('RPM version 4.9.1.3', 0))
   end
 
   let(:resource) do
@@ -53,13 +55,17 @@ describe Puppet::Type.type(:package).provider(:urpmi) do
     let(:urpmq_output) { 'foopkg : Lorem ipsum dolor sit amet, consectetur adipisicing elit ( 7.8.9-1.mga2 )' }
 
     it "uses urpmq to determine the latest package" do
-      Puppet::Util::Execution.expects(:execute).with(['urpmq', '-S', 'foopkg'], anything).returns urpmq_output
+      Puppet::Util::Execution.expects(:execute)
+        .with(['urpmq', '-S', 'foopkg'], anything)
+        .returns(Puppet::Util::Execution::ProcessOutput.new(urpmq_output, 0))
       expect(subject.latest).to eq('7.8.9-1.mga2')
     end
 
     it "falls back to the current version" do
       resource[:ensure] = '5.4.3'
-      Puppet::Util::Execution.expects(:execute).with(['urpmq', '-S', 'foopkg'], anything).returns ''
+      Puppet::Util::Execution.expects(:execute)
+        .with(['urpmq', '-S', 'foopkg'], anything)
+        .returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
       expect(subject.latest).to eq('5.4.3')
     end
   end

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -74,7 +74,7 @@ describe Puppet::Type.type(:service).provider(:openrc) do
         Puppet::Util::Execution.expects(:execute).with(
           includes('/bin/rc-status'),
           has_entry(:custom_environment, {:RC_SVCNAME => nil})
-        ).returns ''
+        ).returns(Puppet::Util::Execution::ProcessOutput.new('', 0))
         subject.enabled?
       end
     end

--- a/spec/unit/resource/type_collection_spec.rb
+++ b/spec/unit/resource/type_collection_spec.rb
@@ -320,7 +320,10 @@ describe Puppet::Resource::TypeCollection do
       let(:environment) { Puppet::Node::Environment.create(:testing, [], '', '/my/foo') }
 
       it "should use the output of the environment's config_version setting if one is provided" do
-        Puppet::Util::Execution.expects(:execute).with(["/my/foo"]).returns "output\n"
+        Puppet::Util::Execution.expects(:execute)
+          .with(["/my/foo"])
+          .returns Puppet::Util::Execution::ProcessOutput.new("output\n", 0)
+        expect(@code.version).to be_instance_of(String)
         expect(@code.version).to eq("output")
       end
 

--- a/spec/unit/util/diff_spec.rb
+++ b/spec/unit/util/diff_spec.rb
@@ -4,12 +4,16 @@ require 'puppet/util/diff'
 require 'puppet/util/execution'
 
 describe Puppet::Util::Diff do
+  let(:baz_output) { Puppet::Util::Execution::ProcessOutput.new('baz', 0) }
+
   describe ".diff" do
     it "should execute the diff command with arguments" do
       Puppet[:diff] = 'foo'
       Puppet[:diff_args] = 'bar'
 
-      Puppet::Util::Execution.expects(:execute).with(['foo', 'bar', 'a', 'b'], {:failonfail => false, :combine => false}).returns('baz')
+      Puppet::Util::Execution.expects(:execute)
+        .with(['foo', 'bar', 'a', 'b'], {:failonfail => false, :combine => false})
+        .returns(baz_output)
       expect(subject.diff('a', 'b')).to eq('baz')
     end
 
@@ -17,7 +21,9 @@ describe Puppet::Util::Diff do
       Puppet[:diff] = 'foo'
       Puppet[:diff_args] = 'bar qux'
 
-      Puppet::Util::Execution.expects(:execute).with(['foo', 'bar', 'qux', 'a', 'b'], anything).returns('baz')
+      Puppet::Util::Execution.expects(:execute)
+        .with(['foo', 'bar', 'qux', 'a', 'b'], anything)
+        .returns(baz_output)
       expect(subject.diff('a', 'b')).to eq('baz')
     end
 
@@ -25,7 +31,9 @@ describe Puppet::Util::Diff do
       Puppet[:diff] = 'foo'
       Puppet[:diff_args] = ''
 
-      Puppet::Util::Execution.expects(:execute).with(['foo', 'a', 'b'], {:failonfail => false, :combine => false}).returns('baz')
+      Puppet::Util::Execution.expects(:execute)
+        .with(['foo', 'a', 'b'], {:failonfail => false, :combine => false})
+        .returns(baz_output)
       expect(subject.diff('a', 'b')).to eq('baz')
     end
 

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -821,7 +821,8 @@ describe Puppet::Util::Execution do
 
   describe "execfail" do
     it "returns the executed command output" do
-      Puppet::Util::Execution.stubs(:execute).returns("process output")
+      Puppet::Util::Execution.stubs(:execute)
+        .returns(Puppet::Util::Execution::ProcessOutput.new("process output", 0))
       expect(Puppet::Util::Execution.execfail('echo hello', Puppet::Error)).to eq('process output')
     end
 

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -108,14 +108,18 @@ describe Puppet::Util::FileType do
 
     describe "#read" do
       it "should run crontab -l as the target user" do
-        Puppet::Util::Execution.expects(:execute).with(['crontab', '-l'], user_options).returns crontab
+        Puppet::Util::Execution.expects(:execute)
+          .with(['crontab', '-l'], user_options)
+          .returns(Puppet::Util::Execution::ProcessOutput.new(crontab, 0))
         expect(cron.read).to eq(crontab)
       end
 
       it "should not switch user if current user is the target user" do
         Puppet::Util.expects(:uid).with(uid).returns 9000
         Puppet::Util::SUIDManager.expects(:uid).returns 9000
-        Puppet::Util::Execution.expects(:execute).with(['crontab', '-l'], options).returns crontab
+        Puppet::Util::Execution
+          .expects(:execute).with(['crontab', '-l'], options)
+          .returns(Puppet::Util::Execution::ProcessOutput.new(crontab, 0))
         expect(cron.read).to eq(crontab)
       end
 

--- a/spec/unit/util/plist_spec.rb
+++ b/spec/unit/util/plist_spec.rb
@@ -92,8 +92,10 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
       subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(invalid_xml_plist)
       Puppet.expects(:debug).with(regexp_matches(/^Failed with CFFormatError/))
       Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
-      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
-                                                     {:failonfail => true, :combine => true}).returns(valid_xml_plist)
+      Puppet::Util::Execution.expects(:execute)
+        .with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
+              {:failonfail => true, :combine => true})
+        .returns(Puppet::Util::Execution::ProcessOutput.new(valid_xml_plist, 0))
       expect(subject.read_plist_file(plist_path)).to eq(valid_xml_plist_hash)
     end
     it "returns nil when direct parsing and plutil conversion both fail" do
@@ -101,8 +103,10 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
       subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(non_plist_data)
       Puppet.expects(:debug).with(regexp_matches(/^Failed with (CFFormatError|NoMethodError)/))
       Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
-      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
-                                                     {:failonfail => true, :combine => true}).raises(Puppet::ExecutionFailure, 'boom')
+      Puppet::Util::Execution.expects(:execute)
+        .with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
+              {:failonfail => true, :combine => true})
+        .raises(Puppet::ExecutionFailure, 'boom')
       expect(subject.read_plist_file(plist_path)).to eq(nil)
     end
     it "returns nil when file is a non-plist binary blob" do
@@ -110,8 +114,10 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
       subject.stubs(:open_file_with_args).with(plist_path, 'r:UTF-8').returns(binary_data)
       Puppet.expects(:debug).with(regexp_matches(/^Failed with (CFFormatError|ArgumentError)/))
       Puppet.expects(:debug).with("Plist #{plist_path} ill-formatted, converting with plutil")
-      Puppet::Util::Execution.expects(:execute).with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
-                                                     {:failonfail => true, :combine => true}).raises(Puppet::ExecutionFailure, 'boom')
+      Puppet::Util::Execution.expects(:execute)
+        .with(['/usr/bin/plutil', '-convert', 'xml1', '-o', '-', plist_path],
+              {:failonfail => true, :combine => true})
+        .raises(Puppet::ExecutionFailure, 'boom')
       expect(subject.read_plist_file(plist_path)).to eq(nil)
     end
   end


### PR DESCRIPTION
If `config_version` was an executable, then we emitted the YAML tag for a `Puppet::Util::Execution::ProcessOutput` class in the last run summary. Capture the config version output as a String instead. Also update specs to accurate reflect what the `execute` method returns.