### PR TITLE
(PUP-4684) Ensure Windows mode of 7 is FullControl

### DIFF
--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -7,11 +7,29 @@ module Puppet::Util::Windows::File
 
   FILE_ATTRIBUTE_READONLY      = 0x00000001
 
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379607(v=vs.85).aspx
+  # The right to use the object for synchronization. This enables a thread to
+  # wait until the object is in the signaled state. Some object types do not
+  # support this access right.
   SYNCHRONIZE                 = 0x100000
+  # The right to delete the object.
+  DELETE                      = 0x00010000
+  # The right to read the information in the object's security descriptor, not including the information in the system access control list (SACL).
+  # READ_CONTROL              = 0x00020000
+  # The right to modify the discretionary access control list (DACL) in the object's security descriptor.
+  WRITE_DAC                   = 0x00040000
+  # The right to change the owner in the object's security descriptor.
+  WRITE_OWNER                 = 0x00080000
+
+  # Combines DELETE, READ_CONTROL, WRITE_DAC, and WRITE_OWNER access.
   STANDARD_RIGHTS_REQUIRED    = 0xf0000
+  # Currently defined to equal READ_CONTROL.
   STANDARD_RIGHTS_READ        = 0x20000
+  # Currently defined to equal READ_CONTROL.
   STANDARD_RIGHTS_WRITE       = 0x20000
+  # Currently defined to equal READ_CONTROL.
   STANDARD_RIGHTS_EXECUTE     = 0x20000
+  # Combines DELETE, READ_CONTROL, WRITE_DAC, WRITE_OWNER, and SYNCHRONIZE access.
   STANDARD_RIGHTS_ALL         = 0x1F0000
   SPECIFIC_RIGHTS_ALL         = 0xFFFF
 


### PR DESCRIPTION
- Previously, the group and other (Everyone) permissions are setup
   so that the ability to modify the DACL is restricted. A member of
   a group cannot take ownership of a file / directory, cannot write
   to the DACL or delete the DACL.

   This is by design to prevent a scenario where a group is given
   read-only access to a file, so that a user in that group may not
   rewrite a DACL, or take ownership, in a way that escalates
   privilege to this file.

   Maintain the same previous behavior, *except* when the mode is
   7, which should be equivalent to (F) / FullControl within the DACL,
   allowing the same behavior that is presently exhibited for a file
   owner.

 - Note that the previous behavior of removing FILE_EXECUTE for files
   written to a directory (86f2876)
   is maintained for the CREATOR OWNER:(OI) and CREATOR GROUP:(OI) ACEs,
   but that perm calculation must additionally ensure that WDAC
   (Write DACL) and WO (Write Owner) permissions are stripped.

 - Note that the FILE_DELETE_CHILD bit is set on the relevant bitmasks
   even when the path is a file rather than a directory. Even though
   the bit is irrelevant to files, it prevents a file from having a
   status of (F) / FullControl in tools like icacls and Get-Acl,
   instead appearing as (M,WDAC,WO) which is much more difficult to
   understand, despite being nearly the same thing.

 - Given a manifest like the following:

```puppet
   user { 'bob':
     ensure => present,
     managehome => false,
     password => 'bob1234!',
     groups => ['Users'],
   }
   user { 'foo':
     ensure => present,
     managehome => false,
     password => 'foo1234!',
     groups => ['Users'],
   }

   file { 'C:\foo':
     ensure => directory,
     owner => 'foo',
     group => 'Administrators',
     mode => '0770',
   }
   file { 'C:\foo\foo.bat':
     ensure => file,
     owner => 'bob',
     mode => '740',
     content => 'echo "hello"'
   }
```

   Puppet would produce the following permissions:

```
   C:\>icacls \foo

   \foo VAGRANT-2008R2\foo:(F)
        BUILTIN\Administrators:(RX,W,DC)
        Everyone:(Rc,S,RA)
        NT AUTHORITY\SYSTEM:(OI)(CI)(F)
        CREATOR OWNER:(CI)(IO)(F)
        CREATOR GROUP:(CI)(IO)(RX,W,DC)
        CREATOR OWNER:(OI)(IO)(R,W,D,WDAC,WO,DC)
        CREATOR GROUP:(OI)(IO)(R,W,DC)

   Successfully processed 1 files; Failed processing 0 files

   C:\>icacls \foo\foo.bat

   \foo\foo.bat VAGRANT-2008R2\bob:(M,WDAC,WO)
                VAGRANT-2008R2\None:(R)
                Everyone:(Rc,S,RA)
                NT AUTHORITY\SYSTEM:(F)

   Successfully processed 1 files; Failed processing 0 files
```

   Note specifically on the directory \foo that the permissions for
   Administrators are (RX,W,DC) despite the fact that a 7 was
   specified for the mode of the group, which should mean (F).
   Similarly CREATOR GROUP:(CI) suffers from the same problem.

   Also note \foo\foo.bat has specified the mode for owner 'bob' as 7
   which should be (F), yet it is written as (M,WDAC,WO).

   Lastly, note that CREATOR OWNER:(OI)(IO) permissions for files have
   (WO) and (WDAC) removed, meaning that an owner cannot change the
   owner of the file they created (typically unnecessary) and cannot
   rewrite the DACL. CREATOR GROUP:(OI)(IO) has a (D) added, allowing
   for the group of a file to delete it. Puppet typically sets the
   group to NONE when it is not being managed.

   With the fix in place, the observed permissions are set as desired.

```
   C:\>icacls \foo
   \foo VAGRANT-2008R2\foo:(F)
        BUILTIN\Administrators:(F)
        Everyone:(Rc,S,RA)
        NT AUTHORITY\SYSTEM:(OI)(CI)(F)
        CREATOR OWNER:(CI)(IO)(F)
        CREATOR GROUP:(CI)(IO)(F)
        CREATOR OWNER:(OI)(IO)(R,W,D,DC)
        CREATOR GROUP:(OI)(IO)(R,W,D,DC)

   Successfully processed 1 files; Failed processing 0 files

   C:\>icacls \foo\foo.bat
   \foo\foo.bat VAGRANT-2008R2\bob:(F)
                VAGRANT-2008R2\None:(R)
                Everyone:(Rc,S,RA)
                NT AUTHORITY\SYSTEM:(F)

   Successfully processed 1 files; Failed processing 0 files
```

 - Update tests to only set 777 mode on files for the sake of cleanup
   when possible. d78afda added this
   to help ensure temporary test directories can be cleaned up after
   tests have run. With this change, there are now some cases where
   the current user cannot write the DACL anymore, so ignore such
   errors. It turns out that in those failing cases, the file system
   can still be cleaned up OK, whether running tests as SYSTEM *or*
   as a local user in development.


Paired-with: Michael Lombardi <michael.lombardi@puppet.com>
Paired-with: Bill Hurt <bill.hurt@puppet.com>