### PR TITLE
(PUP-8898) Change default input_method for Task

### DIFF
--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -71,7 +71,7 @@ module Pcore
             },
 
             supports_noop => { type => Boolean, value => false },
-            input_method => { type => String, value => 'both' },
+            input_method => { type => Optional[String] },
           }
         }
       PUPPET

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -799,6 +799,26 @@ describe 'Puppet Pal' do
           expect(result).to be(nil)
         end
 
+        it 'default task input_method is nil' do
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
+            ctx.with_script_compiler do |c|
+              signature = c.task_signature('a::atask')
+              signature.task_hash
+            end
+          end
+          expect(result['input_method']).to be_nil
+        end
+
+        it 'task input_method is parsed from task metadata' do
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|
+            ctx.with_script_compiler do |c|
+              signature = c.task_signature('b::atask')
+              signature.task_hash
+            end
+          end
+          expect(result['input_method']).to eq('stdin')
+        end
+
         it '"list_tasks" returns an array with all tasks that can be loaded' do
           testing_env_dir # creates the structure
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|


### PR DESCRIPTION
Make default input_method nil instead of "both". This allows Bolt to define default input_method based on combo of task language and transport.