### PR TITLE
(PUP-8894) Deprecate illegal definition locations.

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -486,6 +486,10 @@ module Issues
     _("Unacceptable name. The name '%{name}' is unacceptable as the name of %{value}") % { name: name, value: label.a_an(semantic) }
   end
 
+  ILLEGAL_DEFINITION_LOCATION = issue :ILLEGAL_DEFINITION_LOCATION, :name, :file do
+    _("Unacceptable location. The name '%{name}' is unacceptable in file '%{file}'") % { name: name, file: file }
+  end
+
   CAPTURES_REST_NOT_LAST = hard_issue :CAPTURES_REST_NOT_LAST, :param_name do
     _("Parameter $%{param} is not last, and has 'captures rest'") % { param: param_name }
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -595,10 +595,11 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     full_path == manifest_setting || full_path.start_with?(manifest_setting)
   end
 
-  # Returns module root directory index in path for files under 'manifests', 'functions' and 'types'
+  # Returns module root directory index in path for files under 'manifests',
+  # 'functions', 'types' and 'plans'
   def find_module_definition_dir(path)
     reverse_index = path.reverse_each.find_index do |dir|
-      dir == 'manifests' || dir == 'functions' || dir == 'types'
+      dir == 'manifests' || dir == 'functions' || dir == 'types' || dir == 'plans'
     end
     return reverse_index.nil? ? nil : (path.length - 1) - reverse_index
   end

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -27,15 +27,16 @@ class ValidatorFactory_4_0 < Factory
     # Configure each issue that should **not** be an error
     #
     # Validate as per the current runtime configuration
-    p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
-    p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
+    p[Issues::RT_NO_STORECONFIGS_EXPORT]     = Puppet[:storeconfigs] ? :ignore : :warning
+    p[Issues::RT_NO_STORECONFIGS]            = Puppet[:storeconfigs] ? :ignore : :warning
 
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
 
     p[Issues::DUPLICATE_KEY]                 = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
-    p[Issues::CLASS_NOT_VIRTUALIZABLE]      = Puppet[:strict] == :off ? :warning : Puppet[:strict]
+    p[Issues::CLASS_NOT_VIRTUALIZABLE]       = Puppet[:strict] == :off ? :warning : Puppet[:strict]
+    p[Issues::ILLEGAL_DEFINITION_LOCATION]   = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p
   end
 end

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -36,7 +36,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::NAME_WITH_HYPHEN]              = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION] = :ignore
     p[Issues::CLASS_NOT_VIRTUALIZABLE]       = Puppet[:strict] == :off ? :warning : Puppet[:strict]
-    p[Issues::ILLEGAL_DEFINITION_LOCATION]   = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
+    p[Issues::ILLEGAL_DEFINITION_LOCATION]   = :deprecation
     p
   end
 end

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -34,7 +34,7 @@ describe "validating 4x" do
     expect(validate(parse('function ::aaa() {}'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
   end
 
-  it 'should raise error for illegal class locations' do
+  it 'should raise error for illegal definition locations' do
     expect(validate(parse('function aaa::ccc() {}', 'aaa/manifests/bbb.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
     expect(validate(parse('class bbb() {}', 'aaa/manifests/init.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
     expect(validate(parse('define aaa::bbb::ccc::eee() {}', 'aaa/manifests/bbb/ddd.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
@@ -224,6 +224,18 @@ describe "validating 4x" do
 
   context 'with --tasks set' do
     before(:each) { Puppet[:tasks] = true }
+
+    it 'raises an error for illegal plan names' do
+      expect(validate(parse('plan aaa::ccc::eee() {}', 'aaa/plans/bbb/ccc/eee.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('plan aaa() {}', 'aaa/plans/aaa.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('plan aaa::bbb() {}', 'aaa/plans/bbb/bbb.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
+
+    it 'accepts legal plan names' do
+      expect(validate(parse('plan aaa::ccc::eee() {}', 'aaa/plans/ccc/eee.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('plan aaa() {}', 'aaa/plans/init.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('plan aaa::bbb() {}', 'aaa/plans/bbb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
 
     it 'produces an error for application' do
       acceptor = validate(parse('application test {}'))

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -10,10 +10,23 @@ describe "validating 4x" do
 
   let(:acceptor) { Puppet::Pops::Validation::Acceptor.new() }
   let(:validator) { Puppet::Pops::Validation::ValidatorFactory_4_0.new().validator(acceptor) }
+  let(:environment) { Puppet::Node::Environment.create(:bar, ['path']) }
 
   def validate(factory)
     validator.validate(factory.model)
     acceptor
+  end
+
+  def deprecation_count(acceptor)
+    acceptor.diagnostics.select {|d| d.severity == :deprecation }.count
+  end
+
+  def with_environment(environment, env_params = {})
+    override_env = environment
+    override_env = environment.override_with(env_params) if env_params.count > 0
+    Puppet.override(current_environment: override_env) do
+      yield
+    end
   end
 
   it 'should raise error for illegal class names' do
@@ -35,44 +48,69 @@ describe "validating 4x" do
   end
 
   it 'should raise error for illegal definition locations' do
-    expect(validate(parse('function aaa::ccc() {}', 'aaa/manifests/bbb.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('class bbb() {}', 'aaa/manifests/init.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('define aaa::bbb::ccc::eee() {}', 'aaa/manifests/bbb/ddd.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    with_environment(environment) do
+      expect(validate(parse('function aaa::ccc() {}', 'path/aaa/manifests/bbb.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('class bbb() {}', 'path/aaa/manifests/init.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('define aaa::bbb::ccc::eee() {}', 'path/aaa/manifests/bbb/ddd.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
   end
 
   it 'should not raise error for legal definition locations' do
-    expect(validate(parse('function aaa::bbb() {}',      'aaa/manifests/bbb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('define bbb() {}',      'aaa/manifests/site.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('class aaa() {}',      'aaa/manifests/init.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('class aaa() {}',      'manifests/site.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('function aaa::bbB::ccc() {}', 'aaa/manifests/bBb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('function aaa::bbb::ccc() {}', 'aaa/manifests/bbb/CCC.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    with_environment(environment) do
+      expect(validate(parse('function aaa::bbb() {}',      'path/aaa/manifests/bbb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('class aaa() {}',      'path/aaa/manifests/init.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('function aaa::bbB::ccc() {}', 'path/aaa/manifests/bBb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('function aaa::bbb::ccc() {}', 'path/aaa/manifests/bbb/CCC.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
   end
 
   it 'should not raise error for class locations when not parsing a file' do
-    #nil file means eval or some other way to get puppet language source code into the catalog
-    expect(validate(parse('function aaa::ccc() {}', nil))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    #nil/'' file means eval or some other way to get puppet language source code into the catalog
+    with_environment(environment) do
+      expect(validate(parse('function aaa::ccc() {}', nil))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('function aaa::ccc() {}', ''))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
   end
 
-  it 'should not raise error for definitions inside initial --manifest' do
-    Puppet[:manifest] = 'a/manifest/file.pp'
-    expect(validate(parse('class aaa() {}', 'a/manifest/file.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+  it 'should not raise error for legal definition locations' do
+    with_environment(environment, :manifest => 'a/manifest/file.pp') do
+      expect(validate(parse('function aaa::bbb() {}',      'path/aaa/manifests/bbb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('class aaa() {}',      'path/aaa/manifests/init.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('function aaa::bbB::ccc() {}', 'path/aaa/manifests/bBb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('function aaa::bbb::ccc() {}', 'path/aaa/manifests/bbb/CCC.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
   end
 
-  it 'should not raise error for definitions inside initial --manifest' do
-    Puppet[:manifest] = 'a/manifest/dir'
-    expect(validate(parse('class aaa() {}', 'a/manifest/dir/file1.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-    expect(validate(parse('class bbb::ccc::ddd() {}', 'a/manifest/dir/and/more/stuff.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+  it 'should not raise error for definitions inside initial --manifest file' do
+    with_environment(environment, :manifest => 'a/manifest/file.pp') do
+      expect(validate(parse('class aaa() {}', 'a/manifest/file.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
   end
 
-  it 'should raise error for definitions not inside initial --manifest' do
-    Puppet[:manifest] = 'a/manifest/somewhere/else'
-    expect(validate(parse('class aaa() {}', 'a/manifest/dir/file1.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+  it 'should not raise error for definitions inside initial --manifest directory' do
+    with_environment(environment, :manifest => 'a/manifest/dir') do
+      expect(validate(parse('class aaa() {}', 'a/manifest/dir/file1.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('class bbb::ccc::ddd() {}', 'a/manifest/dir/and/more/stuff.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
   end
 
-  it 'should raise error if the manifest file does not come from a well formed module path' do
-    skip("This test path won't work on windows.") if Puppet::Util::Platform.windows?
-    expect(validate(parse('class aaa() {}', '/manifest/dir/file1.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)    
+  it 'should not raise error for definitions not inside initial --manifest but also not in modulepath' do
+    with_environment(environment, :manifest => 'a/manifest/somewhere/else') do
+      expect(validate(parse('class aaa() {}', 'a/random/dir/file1.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
+  end
+
+  it 'should raise error if the file is in the modulepath but is not well formed' do
+    with_environment(environment) do
+      expect(validate(parse('class aaa::bbb::ccc() {}', 'path/manifest/aaa/bbb.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      expect(validate(parse('class aaa::bbb::ccc() {}', 'path/aaa/bbb/manifest/ccc.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
+  end
+
+  it 'should not raise error for definitions not inside initial --manifest but also not in modulepath because of only a case difference' do
+    with_environment(environment) do
+        expect(validate(parse('class aaa::bb() {}', 'Path/aaa/manifests/ccc.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
   end
 
   it 'should raise error for illegal type names' do
@@ -98,11 +136,14 @@ describe "validating 4x" do
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
 
-    it 'produces a warning for illegal function locations' do
-      acceptor = validate(parse('function aaa::ccc() {}', 'aaa/manifests/bbb.pp'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    it 'produces a deprecation for illegal function locations' do
+      with_environment(environment) do
+        acceptor = validate(parse('function aaa::ccc() {}', 'path/aaa/manifests/bbb.pp'))
+        expect(deprecation_count(acceptor)).to eql(1)
+        expect(acceptor.warning_count).to eql(1)
+        expect(acceptor.error_count).to eql(0)
+        expect(acceptor).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      end
     end
   end
 
@@ -122,18 +163,21 @@ describe "validating 4x" do
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
-    it 'produces a  warning for exported class resource' do
+    it 'produces a warning for exported class resource' do
       acceptor = validate(parse('@@class { test: }'))
       expect(acceptor.warning_count).to eql(1)
       expect(acceptor.error_count).to eql(0)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
-    it 'produces a warning for illegal function locations' do
-      acceptor = validate(parse('function aaa::ccc() {}', 'aaa/manifests/bbb.pp'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    it 'produces a deprecation for illegal function locations' do
+      with_environment(environment) do
+        acceptor = validate(parse('function aaa::ccc() {}', 'path/aaa/manifests/bbb.pp'))
+        expect(deprecation_count(acceptor)).to eql(1)
+        expect(acceptor.warning_count).to eql(1)
+        expect(acceptor.error_count).to eql(0)
+        expect(acceptor).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      end
     end
   end
 
@@ -167,11 +211,14 @@ describe "validating 4x" do
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
-    it 'produces an error for illegal function locations' do
-      acceptor = validate(parse('function aaa::ccc() {}', 'aaa/manifests/bbb.pp'))
-      expect(acceptor.warning_count).to eql(0)
-      expect(acceptor.error_count).to eql(1)
-      expect(acceptor).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    it 'produces a deprecation for illegal function locations' do
+      with_environment(environment) do
+        acceptor = validate(parse('function aaa::ccc() {}', 'path/aaa/manifests/bbb.pp'))
+        expect(deprecation_count(acceptor)).to eql(1)
+        expect(acceptor.warning_count).to eql(1)
+        expect(acceptor.error_count).to eql(0)
+        expect(acceptor).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      end
     end
   end
 
@@ -184,11 +231,14 @@ describe "validating 4x" do
       expect(acceptor).to_not have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
 
-    it 'does not produce an error or warning for illegal function locations' do
-      acceptor = validate(parse('function aaa::ccc() {}', 'aaa/manifests/bbb.pp'))
-      expect(acceptor.warning_count).to eql(0)
-      expect(acceptor.error_count).to eql(0)
-      expect(acceptor).to_not have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    it 'produces a deprecation for illegal function locations' do
+      with_environment(environment) do
+        acceptor = validate(parse('function aaa::ccc() {}', 'path/aaa/manifests/bbb.pp'))
+        expect(deprecation_count(acceptor)).to eql(1)
+        expect(acceptor.warning_count).to eql(1)
+        expect(acceptor.error_count).to eql(0)
+        expect(acceptor).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      end
     end
   end
 
@@ -226,15 +276,19 @@ describe "validating 4x" do
     before(:each) { Puppet[:tasks] = true }
 
     it 'raises an error for illegal plan names' do
-      expect(validate(parse('plan aaa::ccc::eee() {}', 'aaa/plans/bbb/ccc/eee.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-      expect(validate(parse('plan aaa() {}', 'aaa/plans/aaa.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-      expect(validate(parse('plan aaa::bbb() {}', 'aaa/plans/bbb/bbb.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      with_environment(environment) do
+        expect(validate(parse('plan aaa::ccc::eee() {}', 'path/aaa/plans/bbb/ccc/eee.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+        expect(validate(parse('plan aaa() {}', 'path/aaa/plans/aaa.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+        expect(validate(parse('plan aaa::bbb() {}', 'path/aaa/plans/bbb/bbb.pp'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      end
     end
 
     it 'accepts legal plan names' do
-      expect(validate(parse('plan aaa::ccc::eee() {}', 'aaa/plans/ccc/eee.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-      expect(validate(parse('plan aaa() {}', 'aaa/plans/init.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
-      expect(validate(parse('plan aaa::bbb() {}', 'aaa/plans/bbb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      with_environment(environment) do
+        expect(validate(parse('plan aaa::ccc::eee() {}', 'path/aaa/plans/ccc/eee.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+        expect(validate(parse('plan aaa() {}', 'path/aaa/plans/init.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+        expect(validate(parse('plan aaa::bbb() {}', 'path/aaa/plans/bbb.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+      end
     end
 
     it 'produces an error for application' do


### PR DESCRIPTION
Before this update, there was no check to compare file locations to the definitions contained in them.  After this check, if a definition is located in an inappropriate file, the user will receive a deprecation warning.
