### PR TITLE
(PUP-8586) Improve missing library debug message

### DIFF
--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -1,7 +1,10 @@
 require 'puppet'
+require 'puppet/util/warnings'
 
 module Puppet::Util
   module Connection
+    extend Puppet::Util::Warnings
+
     # The logic for server and port is kind of gross. In summary:
     # IF an endpoint-specific setting is requested AND that setting has been set by the user
     #    Use that setting.
@@ -26,11 +29,12 @@ module Puppet::Util
       else
         server = Puppet.lookup(:server) do
           if primary_server = Puppet.settings[:server_list][0]
-            Puppet.debug "Dynamically-bound server lookup failed; using first entry"
+            debug_once('Dynamically-bound server lookup failed; using first entry')
             primary_server[0]
           else
             setting ||= :server
-            Puppet.debug "Dynamically-bound server lookup failed, falling back to #{setting} setting"
+            debug_once('Dynamically-bound server lookup failed, falling back to %{setting} setting' %
+                       {setting: setting})
             Puppet.settings[setting]
           end
         end
@@ -55,7 +59,7 @@ module Puppet::Util
       else
         port = Puppet.lookup(:serverport) do
           if primary_server = Puppet.settings[:server_list][0]
-            Puppet.debug "Dynamically-bound port lookup failed; using first entry"
+            debug_once('Dynamically-bound port lookup failed; using first entry')
 
             # Port might not be set, so we want to fallback in that
             # case. We know we don't need to use `setting` here, since
@@ -63,7 +67,8 @@ module Puppet::Util
             (primary_server[1] || Puppet.settings[:masterport])
           else
             port_setting ||= :masterport
-            Puppet.debug "Dynamically-bound port lookup failed; falling back to #{port_setting} setting"
+            debug_once('Dynamically-bound port lookup failed; falling back to %{port_setting} setting' %
+                       {port_setting: port_setting})
             Puppet.settings[port_setting]
           end
         end

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -1,6 +1,9 @@
 require 'puppet'
+require 'puppet/util/warnings'
 
 class Puppet::Util::Feature
+  include Puppet::Util::Warnings
+
   attr_reader :path
 
   # Create a new feature test. You have to pass the feature name, and it must be
@@ -109,8 +112,14 @@ class Puppet::Util::Feature
     begin
       require lib
       true
-    rescue ScriptError => detail
-      Puppet.debug _("Failed to load library '%{lib}' for feature '%{name}': %{detail}") % { lib: lib, name: name, detail: detail }
+    rescue LoadError
+      # Expected case. Required library insn't installed.
+      debug_once(_("Could not find library '%{lib}' required to enable feature '%{name}'") %
+        {lib: lib, name: name})
+      false
+    rescue StandardError, ScriptError => detail
+      debug_once(_("Exception occurred while loading library '%{lib}' required to enable feature '%{name}': %{detail}") %
+        {lib: lib, name: name, detail: detail})
       false
     end
   end

--- a/spec/unit/util/feature_spec.rb
+++ b/spec/unit/util/feature_spec.rb
@@ -88,7 +88,7 @@ describe Puppet::Util::Feature do
     @features.expects(:require).with("foo").raises(LoadError)
     @features.stubs(:require).with("bar")
 
-    Puppet.expects(:debug)
+    @features.expects(:debug_once)
 
     expect(@features).not_to be_myfeature
   end
@@ -100,7 +100,7 @@ describe Puppet::Util::Feature do
     Puppet::Util::RubyGems::Source.stubs(:source).returns(Puppet::Util::RubyGems::Gems18Source)
     Puppet::Util::RubyGems::Gems18Source.any_instance.expects(:clear_paths).times(3)
 
-    Puppet.expects(:debug)
+    @features.expects(:debug_once)
 
     expect(@features).not_to be_myfeature
     expect(@features).to be_myfeature


### PR DESCRIPTION
This commit re-words the debug message emitted when a library required by a
feature could not be loaded. The new message clarifies that an optional feature
is not being enabled and removes the word "fail" which ensnares folks who are
attempting to debug problems unrelated to the feature system.