### PR TITLE
(maint) Use agents not agent

### DIFF
--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -109,7 +109,7 @@ test_name "test the yum package provider" do
 
     step 'Installing a known package using source succeeds' do
       verify_absent agents, 'guid'
-      apply_manifest_on(agent, "package { 'guid': ensure => installed, install_options => '--nogpgcheck', source=>'/tmp/rpmrepo/RPMS/noarch/guid-1.0-1.noarch.rpm' }") do |result|
+      apply_manifest_on(agents, "package { 'guid': ensure => installed, install_options => '--nogpgcheck', source=>'/tmp/rpmrepo/RPMS/noarch/guid-1.0-1.noarch.rpm' }") do |result|
         assert_match('Package[guid]/ensure: created', "#{result.host}: #{result.stdout}")
       end
     end


### PR DESCRIPTION
The acceptance test accidentally used `agent` instead of `agents`[1].
Beaker only defines the former if there is at least one host with the
agent role, while the latter always exists.

[1] https://github.com/puppetlabs/puppet/commit/a5d1913bf6250dc8649d1198603412eb7c8a00e8#diff-68234540237967bc3500e7864184f30eR109