### PR TITLE
(PUP-8696) Consistently thread current environment to the autoloader

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -209,7 +209,7 @@ class Application
     # @return [Array<String>] the names of available applications
     # @api public
     def available_application_names
-      @loader.files_to_load.map do |fn|
+      @loader.files_to_load(Puppet.lookup(:current_environment)).map do |fn|
         ::File.basename(fn, '.rb')
       end.uniq
     end

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -209,7 +209,14 @@ class Application
     # @return [Array<String>] the names of available applications
     # @api public
     def available_application_names
-      @loader.files_to_load(Puppet.lookup(:current_environment)).map do |fn|
+      # Use our configured environment to load the application, as it may
+      # be in a module we installed locally, otherwise fallback to our
+      # current environment (*root*). Once we load the application the
+      # current environment will change from *root* to the application
+      # specific environment.
+      environment = Puppet.lookup(:environments).get(Puppet[:environment]) ||
+                    Puppet.lookup(:current_environment)
+      @loader.files_to_load(environment).map do |fn|
         ::File.basename(fn, '.rb')
       end.uniq
     end

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -40,7 +40,8 @@ class Puppet::Application::Doc < Puppet::Application
 
   option("--list", "-l") do |arg|
     require 'puppet/util/reference'
-    puts Puppet::Util::Reference.references.collect { |r| Puppet::Util::Reference.reference(r).doc }.join("\n")
+    refs = Puppet::Util::Reference.references(Puppet.lookup(:current_environment))
+    puts refs.collect { |r| Puppet::Util::Reference.reference(r).doc }.join("\n")
     exit(0)
   end
 
@@ -198,7 +199,8 @@ HELP
     if options[:all]
       # Don't add dynamic references to the "all" list.
       require 'puppet/util/reference'
-      options[:references] = Puppet::Util::Reference.references.reject do |ref|
+      refs = Puppet::Util::Reference.references(Puppet.lookup(:current_environment))
+      options[:references] = refs.reject do |ref|
         Puppet::Util::Reference.reference(ref).dynamic?
       end
     end

--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -41,8 +41,7 @@ class Puppet::Configurer::PluginHandler
       result += locales_downloader.evaluate
     end
 
-
-    Puppet::Util::Autoload.reload_changed
+    Puppet::Util::Autoload.reload_changed(Puppet.lookup(:current_environment))
 
     result
   end

--- a/lib/puppet/datatypes.rb
+++ b/lib/puppet/datatypes.rb
@@ -207,7 +207,7 @@ module Puppet::DataTypes
     end
 
     def load_file(file_name)
-      Puppet::Util::Autoload.load_file(file_name, nil)
+      Puppet::Util::Autoload.load_file(file_name, Puppet.lookup(:current_environment))
     end
   end
 end

--- a/lib/puppet/indirector/terminus.rb
+++ b/lib/puppet/indirector/terminus.rb
@@ -112,7 +112,7 @@ class Puppet::Indirector::Terminus
     # Return all terminus classes for a given indirection.
     def terminus_classes(indirection_name)
       setup_instance_loading indirection_name
-      instance_loader(indirection_name).files_to_load.map do |file|
+      instance_loader(indirection_name).files_to_load(Puppet.lookup(:current_environment)).map do |file|
         File.basename(file).chomp(".rb").intern
       end
     end

--- a/lib/puppet/interface.rb
+++ b/lib/puppet/interface.rb
@@ -170,7 +170,7 @@ class Puppet::Interface
   # @return [void]
   # @api private
   def load_actions
-    loader.loadall
+    loader.loadall(Puppet.lookup(:current_environment))
   end
 
   # Returns a string representation with the face's name and version

--- a/lib/puppet/interface/face_collection.rb
+++ b/lib/puppet/interface/face_collection.rb
@@ -6,7 +6,9 @@ module Puppet::Interface::FaceCollection
   def self.faces
     unless @loaded
       @loaded = true
-      names = @loader.files_to_load.map {|fn| ::File.basename(fn, '.rb')}.uniq
+      names = @loader.files_to_load(Puppet.lookup(:current_environment)).map do |fn|
+        ::File.basename(fn, '.rb')
+      end.uniq
       names.each {|name| self[name, :current]}
     end
     @faces.keys.select {|name| @faces[name].length > 0 }

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -50,7 +50,7 @@ module Manager
   # @return [void]
   #
   def loadall
-    typeloader.loadall
+    typeloader.loadall(Puppet.lookup(:current_environment))
   end
 
   # Defines a new type or redefines an existing type with the given name.
@@ -124,7 +124,7 @@ module Manager
     klass.providerloader = Puppet::Util::Autoload.new(klass, "puppet/provider/#{klass.name.to_s}")
 
     # We have to load everything so that we can figure out the default provider.
-    klass.providerloader.loadall Puppet.lookup(:current_environment)
+    klass.providerloader.loadall(Puppet.lookup(:current_environment))
     klass.providify unless klass.providers.empty?
 
     loc = block_given? ? block.source_location : nil

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -39,7 +39,7 @@ module Puppet::Parser::Functions
 
     def loadall(env = Puppet.lookup(:current_environment))
       if Puppet[:strict] != :off
-        Puppet.warn_once('deprecations', 'Puppet::Parser::Functions', _("The method 'Puppet::Parser::Functions.autoloader#loadall' is deprecated in favor of using 'Scope#call_function'."))
+        Puppet.warn_once('deprecations', 'Puppet::Parser::Functions#loadall', _("The method 'Puppet::Parser::Functions.autoloader#loadall' is deprecated in favor of using 'Scope#call_function'."))
       end
 
       @delegatee.loadall(env)
@@ -47,7 +47,7 @@ module Puppet::Parser::Functions
 
     def load(name, env = Puppet.lookup(:current_environment))
       if Puppet[:strict] != :off
-        Puppet.warn_once('deprecations', 'Puppet::Parser::Functions', _("The method 'Puppet::Parser::Functions.autoloader#load(\"%{name}\")' is deprecated in favor of using 'Scope#call_function'.") % {name: name})
+        Puppet.warn_once('deprecations', "Puppet::Parser::Functions#load('#{name}')", _("The method 'Puppet::Parser::Functions.autoloader#load(\"%{name}\")' is deprecated in favor of using 'Scope#call_function'.") % {name: name})
       end
 
       @delegatee.load(name, env)
@@ -55,7 +55,7 @@ module Puppet::Parser::Functions
 
     def loaded?(name)
       if Puppet[:strict] != :off
-        Puppet.warn_once('deprecations', 'Puppet::Parser::Functions', _("The method 'Puppet::Parser::Functions.autoloader#loaded?(\"%{name}\")' is deprecated in favor of using 'Scope#call_function'.") % {name: name})
+        Puppet.warn_once('deprecations', "Puppet::Parser::Functions.loaded?('#{name}')", _("The method 'Puppet::Parser::Functions.autoloader#loaded?(\"%{name}\")' is deprecated in favor of using 'Scope#call_function'.") % {name: name})
       end
 
       @delegatee.loaded?(name)

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -211,7 +211,7 @@ module Puppet::Parser::Functions
   end
 
   def self.functiondocs(environment = Puppet.lookup(:current_environment))
-    autoloader.loadall
+    autoloader.loadall(environment)
 
     ret = ""
 

--- a/lib/puppet/reports.rb
+++ b/lib/puppet/reports.rb
@@ -73,7 +73,7 @@ class Puppet::Reports
     docs = ""
 
     # Use this method so they all get loaded
-    instance_loader(:report).loadall
+    instance_loader(:report).loadall(Puppet.lookup(:current_environment))
     loaded_instances(:report).sort { |a,b| a.to_s <=> b.to_s }.each do |name|
       mod = self.report(name)
       docs << "#{name}\n#{"-" * name.to_s.length}\n"
@@ -87,7 +87,7 @@ class Puppet::Reports
   # Lists each of the reports.
   # @api private
   def self.reports
-    instance_loader(:report).loadall
+    instance_loader(:report).loadall(Puppet.lookup(:current_environment))
     loaded_instances(:report)
   end
 end

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1799,7 +1799,7 @@ end
     name = name.intern
 
     # If we don't have it yet, try loading it.
-    @providerloader.load(name) unless provider_hash.has_key?(name)
+    @providerloader.load(name, Puppet.lookup(:current_environment)) unless provider_hash.has_key?(name)
     provider_hash[name]
   end
 
@@ -1966,7 +1966,7 @@ end
   # @return [Array<Puppet::Provider>] Returns an array of all suitable providers.
   #
   def self.suitableprovider
-    providerloader.loadall if provider_hash.empty?
+    providerloader.loadall(Puppet.lookup(:current_environment)) if provider_hash.empty?
     provider_hash.find_all { |name, provider|
       provider.suitable?
     }.collect { |name, provider|

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -125,7 +125,7 @@ class Puppet::Util::Autoload
       # "app_defaults_initialized?" method on the main puppet Settings object.
       # --cprice 2012-03-16
       if Puppet.settings.app_defaults_initialized?
-        env ||= Puppet.lookup(:environments).get(Puppet[:environment])
+        env ||= Puppet.lookup(:current_environment)
 
         if env
           # if the app defaults have been initialized then it should be safe to access the module path setting.

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -35,6 +35,7 @@ class Puppet::Util::Autoload
     # Save the fact that a given path has been loaded.  This is so
     # we can load downloaded plugins if they've already been loaded
     # into memory.
+    # @api private
     def mark_loaded(name, file)
       name = cleanpath(name).chomp('.rb')
       file = File.expand_path(file)
@@ -42,7 +43,8 @@ class Puppet::Util::Autoload
       loaded[name] = [file, File.mtime(file)]
     end
 
-    def changed?(name, env = Puppet.lookup(:current_environment))
+    # @api private
+    def changed?(name, env)
       name = cleanpath(name).chomp('.rb')
       return true unless loaded.include?(name)
       file, old_mtime = loaded[name]
@@ -72,7 +74,7 @@ class Puppet::Util::Autoload
       end
     end
 
-    def loadall(path, env = Puppet.lookup(:current_environment))
+    def loadall(path, env)
       # Load every instance of everything we can find.
       files_to_load(path, env).each do |file|
         name = file.chomp(".rb")
@@ -80,7 +82,7 @@ class Puppet::Util::Autoload
       end
     end
 
-    def reload_changed(env = Puppet.lookup(:current_environment))
+    def reload_changed(env)
       loaded.keys.each do |file|
         if changed?(file, env)
           load_file(file, env)
@@ -90,7 +92,8 @@ class Puppet::Util::Autoload
 
     # Get the correct file to load for a given path
     # returns nil if no file is found
-    def get_file(name, env = Puppet.lookup(:current_environment))
+    # @api private
+    def get_file(name, env)
       name = name + '.rb' unless name =~ /\.rb$/
       path = search_directories(env).find { |dir| Puppet::FileSystem.exist?(File.join(dir, name)) }
       path and File.join(path, name)
@@ -100,6 +103,7 @@ class Puppet::Util::Autoload
       search_directories(env).map {|dir| files_in_dir(dir, path) }.flatten.uniq
     end
 
+    # @api private
     def files_in_dir(dir, path)
       dir = Pathname.new(File.expand_path(dir))
       Dir.glob(File.join(dir, path, "*.rb")).collect do |file|
@@ -107,7 +111,10 @@ class Puppet::Util::Autoload
       end
     end
 
+    # @api private
     def module_directories(env)
+      raise ArgumentError, "Autoloader requires an environment" unless env
+
       # This is a little bit of a hack.  Basically, the autoloader is being
       # called indirectly during application bootstrapping when we do things
       # such as check "features".  However, during bootstrapping, we haven't
@@ -128,26 +135,21 @@ class Puppet::Util::Autoload
       # "app_defaults_initialized?" method on the main puppet Settings object.
       # --cprice 2012-03-16
       if Puppet.settings.app_defaults_initialized?
-        env ||= Puppet.lookup(:current_environment)
-
-        if env
-          # if the app defaults have been initialized then it should be safe to access the module path setting.
-          Puppet::Util::ModuleDirectoriesAdapter.adapt(env) do |a|
-            a.directories ||= env.modulepath.collect do |dir|
-              Dir.entries(dir).reject { |f| f =~ /^\./ }.collect { |f| File.join(dir, f, "lib") }
-            end.flatten.find_all do |d|
-              FileTest.directory?(d)
-            end
-          end.directories
-        else
-          []
-        end
+        # if the app defaults have been initialized then it should be safe to access the module path setting.
+        Puppet::Util::ModuleDirectoriesAdapter.adapt(env) do |a|
+          a.directories ||= env.modulepath.collect do |dir|
+            Dir.entries(dir).reject { |f| f =~ /^\./ }.collect { |f| File.join(dir, f, "lib") }
+          end.flatten.find_all do |d|
+            FileTest.directory?(d)
+          end
+        end.directories
       else
         # if we get here, the app defaults have not been initialized, so we basically use an empty module path.
         []
       end
     end
 
+    # @api private
     def libdirs
       # See the comments in #module_directories above.  Basically, we need to be careful not to try to access the
       # libdir before we know for sure that all of the settings have been initialized (e.g., during bootstrapping).
@@ -158,10 +160,12 @@ class Puppet::Util::Autoload
       end
     end
 
+    # @api private
     def gem_directories
       gem_source.directories
     end
 
+    # @api private
     def search_directories(env)
       [gem_directories, module_directories(env), libdirs, $LOAD_PATH].flatten
     end
@@ -188,7 +192,7 @@ class Puppet::Util::Autoload
     @object = obj
   end
 
-  def load(name, env = Puppet.lookup(:current_environment))
+  def load(name, env)
     self.class.load_file(expand(name), env)
   end
 
@@ -202,7 +206,7 @@ class Puppet::Util::Autoload
   #
   # This uses require, rather than load, so that already-loaded files don't get
   # reloaded unnecessarily.
-  def loadall(env = Puppet.lookup(:current_environment))
+  def loadall(env)
     self.class.loadall(@path, env)
   end
 
@@ -210,11 +214,12 @@ class Puppet::Util::Autoload
     self.class.loaded?(expand(name))
   end
 
-  def changed?(name, env = Puppet.lookup(:current_environment))
+  # @api private
+  def changed?(name, env)
     self.class.changed?(expand(name), env)
   end
 
-  def files_to_load(env = Puppet.lookup(:current_environment))
+  def files_to_load(env)
     self.class.files_to_load(@path, env)
   end
 

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -49,14 +49,14 @@ class Puppet::Util::Feature
   end
 
   def load
-    @loader.loadall
+    @loader.loadall(Puppet.lookup(:current_environment))
   end
 
   def method_missing(method, *args)
     return super unless method.to_s =~ /\?$/
 
     feature = method.to_s.sub(/\?$/, '')
-    @loader.load(feature)
+    @loader.load(feature, Puppet.lookup(:current_environment))
 
     respond_to?(method) && self.send(method)
   end

--- a/lib/puppet/util/instance_loader.rb
+++ b/lib/puppet/util/instance_loader.rb
@@ -32,24 +32,6 @@ module Puppet::Util::InstanceLoader
     @instances[type].keys
   end
 
-  # Collect the docs for all of our instances.
-  def instance_docs(type)
-    docs = ""
-
-    # Load all instances.
-    instance_loader(type).loadall
-
-    # Use this method so they all get loaded
-    loaded_instances(type).sort { |a,b| a.to_s <=> b.to_s }.each do |name|
-      mod = self.loaded_instance(type, name)
-      docs << "#{name}\n#{"-" * name.to_s.length}\n"
-
-      docs << Puppet::Util::Docs.scrub(mod.doc) << "\n\n"
-    end
-
-    docs
-  end
-
   # Return the instance hash for our type.
   def instance_hash(type)
     @instances[type.intern]
@@ -65,7 +47,7 @@ module Puppet::Util::InstanceLoader
     name = name.intern
     return nil unless instances = instance_hash(type)
     unless instances.include? name
-      if instance_loader(type).load(name)
+      if instance_loader(type).load(name, Puppet.lookup(:current_environment))
         unless instances.include? name
           Puppet.warning(_("Loaded %{type} file for %{name} but %{type} was not defined") % { type: type, name: name })
           return nil

--- a/lib/puppet/util/reference.rb
+++ b/lib/puppet/util/reference.rb
@@ -56,8 +56,8 @@ class Puppet::Util::Reference
 
   end
 
-  def self.references
-    instance_loader(:reference).loadall
+  def self.references(environment)
+    instance_loader(:reference).loadall(environment)
     loaded_instances(:reference).sort { |a,b| a.to_s <=> b.to_s }
   end
 

--- a/spec/integration/util/autoload_spec.rb
+++ b/spec/integration/util/autoload_spec.rb
@@ -24,6 +24,8 @@ require 'puppet_spec/files'
 describe Puppet::Util::Autoload do
   include PuppetSpec::Files
 
+  let(:env) { Puppet::Node::Environment.create(:foo, []) }
+
   def with_file(name, *path)
     path = File.join(*path)
     # Now create a file to load
@@ -49,13 +51,13 @@ describe Puppet::Util::Autoload do
   end
 
   it "should not fail when asked to load a missing file" do
-    expect(Puppet::Util::Autoload.new("foo", "bar").load(:eh)).to be_falsey
+    expect(Puppet::Util::Autoload.new("foo", "bar").load(:eh, env)).to be_falsey
   end
 
   it "should load and return true when it successfully loads a file" do
     with_loader("foo", "bar") { |dir,loader|
       with_file(:mything, dir, "mything.rb") {
-        expect(loader.load(:mything)).to be_truthy
+        expect(loader.load(:mything, env)).to be_truthy
         expect(loader.class).to be_loaded("bar/mything")
         expect(AutoloadIntegrator).to be_thing(:mything)
       }
@@ -65,7 +67,7 @@ describe Puppet::Util::Autoload do
   it "should consider a file loaded when asked for the name without an extension" do
     with_loader("foo", "bar") { |dir,loader|
       with_file(:noext, dir, "noext.rb") {
-        loader.load(:noext)
+        loader.load(:noext, env)
         expect(loader.class).to be_loaded("bar/noext")
       }
     }
@@ -74,7 +76,7 @@ describe Puppet::Util::Autoload do
   it "should consider a file loaded when asked for the name with an extension" do
     with_loader("foo", "bar") { |dir,loader|
       with_file(:noext, dir, "withext.rb") {
-        loader.load(:withext)
+        loader.load(:withext, env)
         expect(loader.class).to be_loaded("bar/withext.rb")
       }
     }

--- a/spec/integration/util/autoload_spec.rb
+++ b/spec/integration/util/autoload_spec.rb
@@ -90,10 +90,11 @@ describe Puppet::Util::Autoload do
 
     file = File.join(libdir, "plugin.rb")
 
-    Puppet.override(:environments => Puppet::Environments::Static.new(Puppet::Node::Environment.create(:production, [modulepath]))) do
+    env = Puppet::Node::Environment.create(:production, [modulepath])
+    Puppet.override(:environments => Puppet::Environments::Static.new(env)) do
       with_loader("foo", "foo") do |dir, loader|
         with_file(:plugin, file.split("/")) do
-          loader.load(:plugin)
+          loader.load(:plugin, env)
           expect(loader.class).to be_loaded("foo/plugin.rb")
         end
       end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -92,6 +92,24 @@ describe Puppet::Application do
 
       expect(Puppet::Application.available_application_names).to eq(%w{ foo })
     end
+
+    it 'finds the application using the configured environment' do
+      Puppet[:environment] = 'production'
+      Puppet::Util::Autoload.expects(:files_to_load).with do |_, env|
+        expect(env.name).to eq(:production)
+      end.returns(%w{ /a/foo.rb })
+
+      expect(Puppet::Application.available_application_names).to eq(%w{ foo })
+    end
+
+    it "falls back to the current environment if the configured environment doesn't exist" do
+      Puppet[:environment] = 'doesnotexist'
+      Puppet::Util::Autoload.expects(:files_to_load).with do |_, env|
+        expect(env.name).to eq(:'*root*')
+      end.returns(%w[a/foo.rb])
+
+      expect(Puppet::Application.available_application_names).to eq(%w[foo])
+    end
   end
 
   describe ".run_mode" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -76,13 +76,19 @@ describe Puppet::Application do
     end
 
     it 'should find applications from multiple paths' do
-      Puppet::Util::Autoload.expects(:files_to_load).with('puppet/application').returns(%w{ /a/foo.rb /b/bar.rb })
+      Puppet::Util::Autoload.expects(:files_to_load).with(
+        'puppet/application',
+        is_a(Puppet::Node::Environment)
+      ).returns(%w{ /a/foo.rb /b/bar.rb })
 
       expect(Puppet::Application.available_application_names).to match_array(%w{ foo bar })
     end
 
     it 'should return unique application names' do
-      Puppet::Util::Autoload.expects(:files_to_load).with('puppet/application').returns(%w{ /a/foo.rb /b/foo.rb })
+      Puppet::Util::Autoload.expects(:files_to_load).with(
+        'puppet/application',
+        is_a(Puppet::Node::Environment)
+      ).returns(%w{ /a/foo.rb /b/foo.rb })
 
       expect(Puppet::Application.available_application_names).to eq(%w{ foo })
     end

--- a/spec/unit/indirector/terminus_spec.rb
+++ b/spec/unit/indirector/terminus_spec.rb
@@ -108,7 +108,7 @@ describe Puppet::Indirector::Terminus do
       # Set up instance loading; it would normally happen automatically
       Puppet::Indirector::Terminus.instance_load :test1, "puppet/indirector/test1"
 
-      Puppet::Indirector::Terminus.instance_loader(:test1).expects(:load).with(:yay)
+      Puppet::Indirector::Terminus.instance_loader(:test1).expects(:load).with(:yay, anything)
       Puppet::Indirector::Terminus.terminus_class(:test1, :yay)
     end
 

--- a/spec/unit/parser/functions/digest_spec.rb
+++ b/spec/unit/parser/functions/digest_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the digest function", :uses_checksums => true do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     n = Puppet::Node.new('unnamed')
     c = Puppet::Parser::Compiler.new(n)

--- a/spec/unit/parser/functions/digest_spec.rb
+++ b/spec/unit/parser/functions/digest_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby
 require 'spec_helper'
 
 describe "the digest function", :uses_checksums => true do

--- a/spec/unit/parser/functions/fail_spec.rb
+++ b/spec/unit/parser/functions/fail_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the 'fail' parser function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :scope do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/file_spec.rb
+++ b/spec/unit/parser/functions/file_spec.rb
@@ -5,10 +5,6 @@ require 'puppet_spec/files'
 describe "the 'file' function" do
   include PuppetSpec::Files
 
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :node     do Puppet::Node.new('localhost') end
   let :compiler do Puppet::Parser::Compiler.new(node) end
   let :scope    do Puppet::Parser::Scope.new(compiler) end

--- a/spec/unit/parser/functions/generate_spec.rb
+++ b/spec/unit/parser/functions/generate_spec.rb
@@ -4,10 +4,6 @@ require 'spec_helper'
 describe "the generate function" do
   include PuppetSpec::Files
 
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :node     do Puppet::Node.new('localhost') end
   let :compiler do Puppet::Parser::Compiler.new(node) end
   let :scope    do Puppet::Parser::Scope.new(compiler) end

--- a/spec/unit/parser/functions/inline_template_spec.rb
+++ b/spec/unit/parser/functions/inline_template_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the inline_template function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let(:node) { Puppet::Node.new('localhost') }
   let(:compiler) { Puppet::Parser::Compiler.new(node) }
   let(:scope) { Puppet::Parser::Scope.new(compiler) }

--- a/spec/unit/parser/functions/regsubst_spec.rb
+++ b/spec/unit/parser/functions/regsubst_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the regsubst function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/scanf_spec.rb
+++ b/spec/unit/parser/functions/scanf_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the scanf function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let(:node) { Puppet::Node.new('localhost') }
   let(:compiler) { Puppet::Parser::Compiler.new(node) }
   let(:scope) { Puppet::Parser::Scope.new(compiler) }

--- a/spec/unit/parser/functions/split_spec.rb
+++ b/spec/unit/parser/functions/split_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the split function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/sprintf_spec.rb
+++ b/spec/unit/parser/functions/sprintf_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the sprintf function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/tag_spec.rb
+++ b/spec/unit/parser/functions/tag_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the 'tag' function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/tagged_spec.rb
+++ b/spec/unit/parser/functions/tagged_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the 'tagged' function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions/template_spec.rb
+++ b/spec/unit/parser/functions/template_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the template function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   let :node     do Puppet::Node.new('localhost') end
   let :compiler do Puppet::Parser::Compiler.new(node) end
   let :scope    do Puppet::Parser::Scope.new(compiler) end

--- a/spec/unit/parser/functions/versioncmp_spec.rb
+++ b/spec/unit/parser/functions/versioncmp_spec.rb
@@ -2,10 +2,6 @@
 require 'spec_helper'
 
 describe "the versioncmp function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
   before :each do
     node     = Puppet::Node.new('localhost')
     compiler = Puppet::Parser::Compiler.new(node)

--- a/spec/unit/parser/functions_spec.rb
+++ b/spec/unit/parser/functions_spec.rb
@@ -48,10 +48,29 @@ describe Puppet::Parser::Functions do
   end
 
   describe "when calling function to test function existence" do
-    it "should loadall 3x functions" do
-      Puppet::Parser::Functions.autoloader.delegatee.stubs(:loadall)
+    before :each do
+      Puppet[:strict] = :error
+    end
 
+    it "emits a deprecation warning when loading all 3.x functions" do
+      Puppet::Parser::Functions.autoloader.delegatee.stubs(:loadall)
       Puppet::Parser::Functions.autoloader.loadall
+
+      expect(@logs.map(&:to_s)).to include(/The method 'Puppet::Parser::Functions.autoloader#loadall' is deprecated in favor of using 'Scope#call_function/)
+    end
+
+    it "emits a deprecation warning when loading a single 3.x function" do
+      Puppet::Parser::Functions.autoloader.delegatee.stubs(:load)
+      Puppet::Parser::Functions.autoloader.load('beatles')
+
+      expect(@logs.map(&:to_s)).to include(/The method 'Puppet::Parser::Functions.autoloader#load\("beatles"\)' is deprecated in favor of using 'Scope#call_function'/)
+    end
+
+    it "emits a deprecation warning when checking if a 3x function is loaded" do
+      Puppet::Parser::Functions.autoloader.delegatee.stubs(:loaded?).returns(false)
+      Puppet::Parser::Functions.autoloader.loaded?('beatles')
+
+      expect(@logs.map(&:to_s)).to include(/The method 'Puppet::Parser::Functions.autoloader#loaded\?\(\"beatles\"\)' is deprecated in favor of using 'Scope#call_function'/)
     end
 
     it "should return false if the function doesn't exist" do

--- a/spec/unit/parser/functions_spec.rb
+++ b/spec/unit/parser/functions_spec.rb
@@ -48,8 +48,14 @@ describe Puppet::Parser::Functions do
   end
 
   describe "when calling function to test function existence" do
+    it "should loadall 3x functions" do
+      Puppet::Parser::Functions.autoloader.delegatee.stubs(:loadall)
+
+      Puppet::Parser::Functions.autoloader.loadall
+    end
+
     it "should return false if the function doesn't exist" do
-      Puppet::Parser::Functions.autoloader.stubs(:load)
+      Puppet::Parser::Functions.autoloader.delegatee.stubs(:load)
 
       expect(Puppet::Parser::Functions.function("name")).to be_falsey
     end
@@ -61,7 +67,7 @@ describe Puppet::Parser::Functions do
     end
 
     it "should try to autoload the function if it doesn't exist yet" do
-      Puppet::Parser::Functions.autoloader.expects(:load)
+      Puppet::Parser::Functions.autoloader.delegatee.expects(:load)
 
       Puppet::Parser::Functions.function("name")
     end

--- a/spec/unit/provider/cron/parsed_spec.rb
+++ b/spec/unit/provider/cron/parsed_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby
 
 require 'spec_helper'
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -6,6 +6,8 @@ require 'puppet/util/autoload'
 describe Puppet::Util::Autoload do
   include PuppetSpec::Files
 
+  let(:env) { Puppet::Node::Environment.create(:foo, []) }
+
   before do
     @autoload = Puppet::Util::Autoload.new("foo", "tmp")
 
@@ -89,18 +91,18 @@ describe Puppet::Util::Autoload do
 
         Kernel.expects(:load).raises error
 
-        expect { @autoload.load("foo") }.to raise_error(Puppet::Error)
+        expect { @autoload.load("foo", env) }.to raise_error(Puppet::Error)
       end
     end
 
     it "should not raise an error if the file is missing" do
-      expect(@autoload.load("foo")).to eq(false)
+      expect(@autoload.load("foo", env)).to eq(false)
     end
 
     it "should register loaded files with the autoloader" do
       Puppet::FileSystem.stubs(:exist?).returns true
       Kernel.stubs(:load)
-      @autoload.load("myfile")
+      @autoload.load("myfile", env)
 
       expect(@autoload.class.loaded?("tmp/myfile.rb")).to be
     end
@@ -108,7 +110,7 @@ describe Puppet::Util::Autoload do
     it "should be seen by loaded? on the instance using the short name" do
       Puppet::FileSystem.stubs(:exist?).returns true
       Kernel.stubs(:load)
-      @autoload.load("myfile")
+      @autoload.load("myfile", env)
 
       expect(@autoload.loaded?("myfile.rb")).to be
     end
@@ -117,7 +119,7 @@ describe Puppet::Util::Autoload do
       Puppet::FileSystem.stubs(:exist?).returns true
       Kernel.stubs(:load)
 
-      @autoload.load("myfile")
+      @autoload.load("myfile", env)
 
       expect($LOADED_FEATURES).to be_include(make_absolute("/a/tmp/myfile.rb"))
     end
@@ -128,13 +130,13 @@ describe Puppet::Util::Autoload do
       Puppet::FileSystem.stubs(:exist?).returns true
       Kernel.expects(:load).with(make_absolute("/a/tmp/myfile.rb"), optionally(anything))
 
-      @autoload.load("myfile")
+      @autoload.load("myfile", env)
     end
 
     it "should treat equivalent paths to a loaded file as loaded" do
       Puppet::FileSystem.stubs(:exist?).returns true
       Kernel.stubs(:load)
-      @autoload.load("myfile")
+      @autoload.load("myfile", env)
 
       expect(@autoload.class.loaded?("tmp/myfile")).to be
       expect(@autoload.class.loaded?("tmp/./myfile.rb")).to be
@@ -159,14 +161,14 @@ describe Puppet::Util::Autoload do
       it "should die an if a #{error.to_s} exception is thrown" do
         Kernel.expects(:load).raises error
 
-        expect { @autoload.loadall }.to raise_error(Puppet::Error)
+        expect { @autoload.loadall(env) }.to raise_error(Puppet::Error)
       end
     end
 
     it "should require the full path to the file" do
       Kernel.expects(:load).with(make_absolute("/a/foo/file.rb"), optionally(anything))
 
-      @autoload.loadall
+      @autoload.loadall(env)
     end
   end
 
@@ -184,19 +186,19 @@ describe Puppet::Util::Autoload do
     end
 
     it "#changed? should return true for a file that was not loaded" do
-      expect(@autoload.class.changed?(@file_a)).to be
+      expect(@autoload.class.changed?(@file_a, env)).to be
     end
 
     it "changes should be seen by changed? on the instance using the short name" do
       File.stubs(:mtime).returns(@first_time)
       Puppet::FileSystem.stubs(:exist?).returns true
       Kernel.stubs(:load)
-      @autoload.load("myfile")
+      @autoload.load("myfile", env)
       expect(@autoload.loaded?("myfile")).to be
-      expect(@autoload.changed?("myfile")).not_to be
+      expect(@autoload.changed?("myfile", env)).not_to be
 
       File.stubs(:mtime).returns(@second_time)
-      expect(@autoload.changed?("myfile")).to be
+      expect(@autoload.changed?("myfile", env)).to be
 
       $LOADED_FEATURES.delete("tmp/myfile.rb")
     end
@@ -212,14 +214,14 @@ describe Puppet::Util::Autoload do
         File.stubs(:mtime).with(@file_a).returns(@first_time + 60)
         Puppet::FileSystem.stubs(:exist?).with(@file_a).returns true
         Kernel.expects(:load).with(@file_a, optionally(anything))
-        @autoload.class.reload_changed
+        @autoload.class.reload_changed(env)
       end
 
       it "should do nothing if the file is deleted" do
         File.stubs(:mtime).with(@file_a).raises(Errno::ENOENT)
         Puppet::FileSystem.stubs(:exist?).with(@file_a).returns false
         Kernel.expects(:load).never
-        @autoload.class.reload_changed
+        @autoload.class.reload_changed(env)
       end
     end
 
@@ -236,7 +238,7 @@ describe Puppet::Util::Autoload do
         Puppet::FileSystem.stubs(:exist?).with(@file_b).returns true
         File.stubs(:mtime).with(@file_b).returns @first_time
         Kernel.expects(:load).with(@file_b, optionally(anything))
-        @autoload.class.reload_changed
+        @autoload.class.reload_changed(env)
         expect(@autoload.class.send(:loaded)["file"]).to eq([@file_b, @first_time])
       end
 
@@ -248,7 +250,7 @@ describe Puppet::Util::Autoload do
         File.stubs(:mtime).with(@file_a).returns @first_time
         Puppet::FileSystem.stubs(:exist?).with(@file_a).returns true
         Kernel.expects(:load).with(@file_a, optionally(anything))
-        @autoload.class.reload_changed
+        @autoload.class.reload_changed(env)
         expect(@autoload.class.send(:loaded)["file"]).to eq([@file_a, @first_time])
       end
     end


### PR DESCRIPTION
* Environment is now a required parameter to the autoloader methods
* 3x functions in modules may still try to access the function autoloader, eg https://github.com/puppetlabs/puppetlabs-stdlib/blob/4.12.x/lib/puppet/parser/functions/has_ip_network.rb#L17-L18, so add a delegate that emits a deprecation warning when strict is not off.
* Update call sites pass the current environment to the autoloader
* Autoloader will raise if asked to search the module path for a nil environment

Supersedes https://github.com/puppetlabs/puppet/pull/6816