### PR TITLE
(PUP-8905) Do not use the indirector to manage CSRs

### DIFF
--- a/lib/puppet/rest/client.rb
+++ b/lib/puppet/rest/client.rb
@@ -54,6 +54,17 @@ module Puppet::Rest
       end
     end
 
+    # Make a PUT request to the specified URL with the specified params.
+    # @param [String] url the full path to query
+    # @param [String/Hash] body the contents of the PUT request
+    # @param [Hash] query any URL params to add to send to the endpoint
+    # @param [Hash] header any additional entries to add to the default header
+    # @return [Puppet::Rest::Response]
+    def put(url, body:, query: nil, header: nil)
+      response = @client.put(url, body: body, query: query, header: header)
+      Puppet::Rest::Response.new(response)
+    end
+
     private
 
     # Checks for SSL certificates on disk and sets VERIFY_PEER

--- a/lib/puppet/rest/response.rb
+++ b/lib/puppet/rest/response.rb
@@ -25,5 +25,10 @@ module Puppet::Rest
     def ok?
       @message.ok?
     end
+
+    def to_exception
+      message = _("Error %{code} on SERVER: %{returned_message}") % { code: status_code, returned_message: body }
+      Puppet::Rest::ResponseError.new(message, self)
+    end
   end
 end

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -2,6 +2,7 @@ require 'puppet/rest/route'
 
 module Puppet::Rest
   module Routes
+
     ACCEPT_ENCODING = 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
 
     def self.ca
@@ -34,14 +35,50 @@ module Puppet::Rest
     # @param [String] name the crl to fetch
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return nil
-   def self.get_crls(client, name, &block)
-     ca.with_base_url(client.dns_resolver) do |base_url|
-       header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
-       client.get("#{base_url}certificate_revocation_list/#{name}", header: header) do |chunk|
-         block.call(chunk)
-       end
-     end
-   end
+    def self.get_crls(client, name, &block)
+      ca.with_base_url(client.dns_resolver) do |base_url|
+        header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
+        client.get("#{base_url}certificate_revocation_list/#{name}", header: header) do |chunk|
+          block.call(chunk)
+        end
+      end
+    end
 
+    # Make an HTTP request to send the named CSR, using the given
+    # HTTP client.
+    # @param [Puppet::Rest::Client] client the HTTP client to use to make the request
+    # @param [String] csr_pem the contents of the CSR to sent to the CA
+    # @param [String] name the name of the host whose CSR is being submitted
+    # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
+    def self.put_certificate_request(client, csr_pem, name)
+      ca.with_base_url(client.dns_resolver) do |base_url|
+        header = { 'Accept' => 'text/plain',
+                   'Accept-Encoding' => ACCEPT_ENCODING,
+                   'Content-Type' => 'text/plain' }
+        response = client.put("#{base_url}certificate_request/#{name}", body: csr_pem, header: header)
+        if response.ok?
+          Puppet.debug "Submitted certificate request to server."
+        else
+          raise response.to_exception
+        end
+      end
+    end
+
+    # Make an HTTP request to get the named CSR, using the given
+    # HTTP client.
+    # @param [Puppet::Rest::Client] client the HTTP client to use to make the request
+    # @param [String] name the name of the host whose CSR is being queried
+    # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
+    # @return [String] the PEM encoded certificate request
+    def self.get_certificate_request(client, name)
+      ca.with_base_url(client.dns_resolver) do |base_url|
+        header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
+        body = ''
+        client.get("#{base_url}certificate_request/#{name}", header: header) do |chunk|
+          body << chunk
+        end
+        body
+      end
+    end
   end
 end

--- a/spec/integration/ssl/autosign_spec.rb
+++ b/spec/integration/ssl/autosign_spec.rb
@@ -37,6 +37,7 @@ describe "autosigning", :unless => RUBY_PLATFORM == 'java' do
 
     # This is necessary so the terminus instances don't lie around.
     Puppet::SSL::Key.indirection.termini.clear
+    Puppet::SSL::Host.ca_location = :none
   end
 
   def write_csr_attributes(yaml)

--- a/spec/lib/puppet_spec/ssl.rb
+++ b/spec/lib/puppet_spec/ssl.rb
@@ -232,6 +232,7 @@ EOT
         :int_cert => int_cert,
         :int_node_cert => int_node_cert,
         :leaf_cert => leaf_cert,
+        :leaf_key => leaf_key,
         :revoked_root_node_cert => revoked_root_node_cert,
         :revoked_int_cert => revoked_int_cert,
         :revoked_leaf_node_cert => revoked_leaf_node_cert,

--- a/spec/unit/ssl/certificate_revocation_list_spec.rb
+++ b/spec/unit/ssl/certificate_revocation_list_spec.rb
@@ -10,6 +10,7 @@ describe Puppet::SSL::CertificateRevocationList, :unless => Puppet::Util::Platfo
     @cert = ca.host.certificate.content
     @key = ca.host.key.content
     @class = Puppet::SSL::CertificateRevocationList
+    Puppet::SSL::Host.ca_location = :local
   end
 
   def expects_time_close_to_now(time)


### PR DESCRIPTION
This commit updates the SSL::Host class to use the new
Puppet::Rest::Client to submit CSRs, instread of going through the
indirector. Some of the logic can be made simpler once the CA code is
removed.