### PR TITLE
(PUP-6894) Unpin ruby 1.9.3 compatible gems 

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -33,19 +33,11 @@ Gem::Specification.new do |s|
   s.specification_version = 3
   s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
-  s.add_runtime_dependency(%q<semantic_puppet>, ["~> 1.0"])
-  # i18n support (gettext-setup and dependencies)
+  s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
   s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.2")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   s.add_runtime_dependency(%q<httpclient>, "~> 2.8")
-  # hocon is an optional hiera backend shipped in puppet-agent packages
-  s.add_runtime_dependency(%q<hocon>, "~> 1.0")
-  # net-ssh is a runtime dependency of Puppet::Util::NetworkDevice::Transport::Ssh
-  # Beaker 3.0.0 to 3.10.0 depends on net-ssh 3.3.0beta1
-  # Beaker 3.11.0+ depends on net-ssh 4.0+
-  # be lenient to allow module testing where Beaker and Puppet are in same Gemfile
-  s.add_runtime_dependency(%q<net-ssh>, [">= 3.0", "< 5"]) if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
 
   # loads platform specific gems like ffi, win32 platform gems
   # as additional runtime dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -39,13 +39,10 @@ group(:development, :test) do
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false
   gem "mocha", '~> 1.5.0', :require => false
-
-  # json-schema does not support windows, so omit it from the platforms list
-  gem "json-schema", "~> 2.0", :require => false, :platforms => [:ruby, :jruby]
+  gem "json-schema", "~> 2.0", :require => false
 
   gem 'rubocop', '~> 0.49', :platforms => [:ruby]
   gem 'rubocop-i18n', '~> 1.2.0', :platforms => [:ruby]
-
 
   gem 'rdoc', "~> 4.1", :platforms => [:ruby]
   gem 'yard'

--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,6 @@ group(:development, :test) do
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false
   gem "rspec-legacy_formatters", "~> 1.0", :require => false
-
-  # Mocha is not compatible across minor version changes; because of this only
-  # versions matching ~> 0.10.5 are supported. All other versions are unsupported
-  # and can be expected to fail.
   gem "mocha", '~> 1.5.0', :require => false
 
   gem "yarjuf", "~> 2.0"
@@ -50,14 +46,9 @@ group(:development, :test) do
   # json-schema does not support windows, so omit it from the platforms list
   gem "json-schema", "~> 2.0", :require => false, :platforms => [:ruby, :jruby]
 
-  if RUBY_VERSION >= '2.0'
-    # pin rubocop as 0.50 requires a higher version of the rainbow gem (see below)
-    gem 'rubocop', '~> 0.49.1', :platforms => [:ruby]
-    gem 'rubocop-i18n', '~> 1.2.0', :platforms => [:ruby]
-  end
+  gem 'rubocop', '~> 0.49', :platforms => [:ruby]
+  gem 'rubocop-i18n', '~> 1.2.0', :platforms => [:ruby]
 
-  # pin rainbow gem as 2.2.1 requires rubygems 2.6.9+ and (donotwant)
-  gem "rainbow", "< 2.2.1", :platforms => [:ruby]
 
   gem 'rdoc', "~> 4.1", :platforms => [:ruby]
   gem 'yard'
@@ -68,6 +59,7 @@ group(:development, :test) do
   gem 'webmock', '~> 1.24'
   gem 'vcr', '~> 2.9'
   gem "hiera-eyaml", :require => false
+  gem "hocon", '~> 1.0', :require => false
 
   gem 'memory_profiler', :platforms => [:mri_21, :mri_22, :mri_23, :mri_24, :mri_25]
 end
@@ -81,7 +73,6 @@ group(:development) do
 end
 
 group(:extra) do
-  gem "rack", "~> 1.4", :require => false
   gem "puppetlabs_spec_helper", :require => false
   gem "msgpack", :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -38,10 +38,7 @@ group(:development, :test) do
   gem "rspec", "~> 3.1", :require => false
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false
-  gem "rspec-legacy_formatters", "~> 1.0", :require => false
   gem "mocha", '~> 1.5.0', :require => false
-
-  gem "yarjuf", "~> 2.0"
 
   # json-schema does not support windows, so omit it from the platforms list
   gem "json-schema", "~> 2.0", :require => false, :platforms => [:ruby, :jruby]

--- a/Rakefile
+++ b/Rakefile
@@ -65,6 +65,7 @@ task :default do
 end
 
 task :spec do
+  ENV["LOG_SPEC_ORDER"] = "true"
   sh %{rspec #{ENV['TEST'] || ENV['TESTS'] || 'spec'}}
 end
 

--- a/api/schemas/file_metadata.json
+++ b/api/schemas/file_metadata.json
@@ -14,10 +14,10 @@
             "enum": ["manage", "follow"]
         },
         "owner": {
-            "type": "integer"
+            "oneOf": [{"type": "string"}, {"type": "integer"}]
         },
         "group": {
-            "type": "integer"
+            "oneOf": [{"type": "string"}, {"type": "integer"}]
         },
         "mode": {
             "type": "integer"

--- a/docs/rspec_tutorial.md
+++ b/docs/rspec_tutorial.md
@@ -285,7 +285,7 @@ a full spec run, you can often narrow down the culprit by a two-step process.
 First, run:
 
 ```
-bundle exec rake ci:spec
+bundle exec rake spec
 ```
 
 which should generate a spec_order.txt file.

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -19,11 +19,11 @@ gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0.1', '< 4']
   hiera: ['>= 3.2.1', '< 4']
-  # PUP-7115 - return to a gem dependency in Puppet 5
-  semantic_puppet: ['~> 1.0']
+  semantic_puppet: '~> 1.0'
   fast_gettext: '~> 1.1.2'
   locale: '~> 2.1'
   multi_json: '~> 1.10'
+  httpclient: '~> 2.8'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"
@@ -36,9 +36,7 @@ gem_platform_dependencies:
       CFPropertyList: '~> 2.2'
   x86-mingw32:
     gem_runtime_dependencies:
-      # Pinning versions that require native extensions
-      # ffi is pinned due to PUP-8438
-      ffi: '<= 1.9.18'
+      ffi: '~> 1.9.25'
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-process: '= 0.7.5'
@@ -48,8 +46,7 @@ gem_platform_dependencies:
       minitar: '~> 0.6.1'
   x64-mingw32:
     gem_runtime_dependencies:
-      # ffi is pinned due to PUP-8438
-      ffi: '<= 1.9.18'
+      ffi: '~> 1.9.25'
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-process: '= 0.7.5'

--- a/spec/lib/matchers/json.rb
+++ b/spec/lib/matchers/json.rb
@@ -101,31 +101,25 @@ module JSONMatchers
     end
   end
 
-  if !Puppet.features.microsoft_windows?
-    require 'puppet/util/json'
-    require 'json-schema'
+  require 'puppet/util/json'
+  require 'json-schema'
 
-    class SchemaMatcher
-      JSON_META_SCHEMA = Puppet::Util::Json.load(File.read('api/schemas/json-meta-schema.json'))
+  class SchemaMatcher
+    JSON_META_SCHEMA = Puppet::Util::Json.load(File.read('api/schemas/json-meta-schema.json'))
 
-      def initialize(schema)
-        @schema = schema
-      end
+    def initialize(schema)
+      @schema = schema
+    end
 
-      def matches?(json)
-        JSON::Validator.validate!(JSON_META_SCHEMA, @schema)
-        JSON::Validator.validate!(@schema, json)
-      end
+    def matches?(json)
+      JSON::Validator.validate!(JSON_META_SCHEMA, @schema)
+      JSON::Validator.validate!(@schema, json)
     end
   end
 
   def validate_against(schema_file)
-    if Puppet.features.microsoft_windows?
-      pending("Schema checks cannot be done on windows because of json-schema problems")
-    else
-      schema = Puppet::Util::Json.load(File.read(schema_file))
-      SchemaMatcher.new(schema)
-    end
+    schema = Puppet::Util::Json.load(File.read(schema_file))
+    SchemaMatcher.new(schema)
   end
 
   def set_json_attribute(*attributes)

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -71,7 +71,7 @@ describe Puppet::Node do
       expect(new_node.name).to eq(node.name)
     end
 
-    it "validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
+    it "validates against the node json schema" do
       Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar',
@@ -81,7 +81,7 @@ describe Puppet::Node do
       expect(node.to_json).to validate_against('api/schemas/node.json')
     end
 
-    it "when missing optional parameters validates against the node json schema", :unless => Puppet.features.microsoft_windows? do
+    it "when missing optional parameters validates against the node json schema" do
       Puppet::Node::Facts.new("hello", "one" => "c", "two" => "b")
       node = Puppet::Node.new("hello",
                               :environment => 'bar'

--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -2,11 +2,6 @@ require 'yaml'
 require 'time'
 
 namespace "ci" do
-  task :spec do
-    ENV["LOG_SPEC_ORDER"] = "true"
-    sh %{rspec --require rspec/legacy_formatters -r yarjuf -f JUnit -o result.xml -fp spec}
-  end
-
   desc "Tar up the acceptance/ directory so that package test runs have tests to run against."
   task :acceptance_artifacts => :tag_creator do
     Dir.chdir("acceptance") do


### PR DESCRIPTION
Remove pins for gems now that Puppet requires ruby 2.3 and up.

Drop RSpec JUnit output formatter and unused rake task.

Add missing httpclient dependency

Run schema validation on Windows