### PR TITLE
(PUP-8908) Resource::Status failed_to_restart improvements

### DIFF
--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -127,7 +127,7 @@
         "report_format": {
             "description": "The report format version documented by this schema",
             "type":        "integer",
-            "enum":        ["9", 9]
+            "enum":        ["10", 10]
         },
 
         "puppet_version": {
@@ -536,6 +536,11 @@
 
                 "failed": {
                     "description": "True if Puppet experienced an error while evaluating this resource, otherwise false. **Deprecated**",
+                    "type":        "boolean"
+                },
+
+                "failed_to_restart": {
+                    "description": "True if Puppet experienced an error while trying to restart this resource (For example, when a Service resource has been notified from another resource), otherwise false.",
                     "type":        "boolean"
                 },
 

--- a/lib/puppet/resource/status.rb
+++ b/lib/puppet/resource/status.rb
@@ -193,6 +193,7 @@ module Puppet
         @changed = data['changed']
         @skipped = data['skipped']
         @failed = data['failed']
+        @failed_to_restart = data['failed_to_restart']
         @corrective_change = data['corrective_change']
         @events = data['events'].map do |event|
           # Older versions contain tags that causes Psych to create instances directly
@@ -213,6 +214,7 @@ module Puppet
           'tags' => @tags.to_a,
           'time' => @time.iso8601(9),
           'failed' => @failed,
+          'failed_to_restart' => self.failed_to_restart?,
           'changed' => @changed,
           'out_of_sync' => @out_of_sync,
           'skipped' => @skipped,

--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -151,9 +151,11 @@ class Puppet::Transaction::EventManager
     end
     return true
   rescue => detail
-    resource.err _("Failed to call %{callback}: %{detail}") % { callback: callback, detail: detail }
+    resource_error_message = _("Failed to call %{callback}: %{detail}") % { callback: callback, detail: detail }
+    resource.err resource_error_message
 
     transaction.resource_status(resource).failed_to_restart = true
+    transaction.resource_status(resource).fail_with_event(resource_error_message)
     resource.log_exception(detail)
     return false
   end

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -224,7 +224,7 @@ class Puppet::Transaction::Report
     @external_times ||= {}
     @host = Puppet[:node_name_value]
     @time = Time.now
-    @report_format = 9
+    @report_format = 10
     @puppet_version = Puppet.version
     @configuration_version = configuration_version
     @transaction_uuid = transaction_uuid

--- a/spec/unit/resource/status_spec.rb
+++ b/spec/unit/resource/status_spec.rb
@@ -165,6 +165,7 @@ describe Puppet::Resource::Status do
       s.out_of_sync = true
       s.skipped = false
       s.provider_used = 'provider_used_class_name'
+      s.failed_to_restart = false
       s
     end
 
@@ -187,6 +188,7 @@ describe Puppet::Resource::Status do
       expect(tripped.changed).to eq(status.changed)
       expect(tripped.out_of_sync).to eq(status.out_of_sync)
       expect(tripped.skipped).to eq(status.skipped)
+      expect(tripped.failed_to_restart).to eq(status.failed_to_restart)
 
       expect(tripped.change_count).to eq(status.change_count)
       expect(tripped.out_of_sync_count).to eq(status.out_of_sync_count)

--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -287,6 +287,18 @@ describe Puppet::Transaction::EventManager do
         expect(@transaction.resource_status(@resource)).to be_failed_to_restart
       end
 
+      it "should set the 'failed' state on the resource status" do
+        @manager.process_events(@resource)
+        expect(@transaction.resource_status(@resource)).to be_failed
+      end
+
+      it "should record a failed event on the resource status" do
+        @manager.process_events(@resource)
+
+        expect(@transaction.resource_status(@resource).events.length).to eq(1)
+        expect(@transaction.resource_status(@resource).events[0].status).to eq('failure')
+      end
+
       it "should not queue a 'restarted' event" do
         @manager.expects(:queue_events).never
         @manager.process_events(@resource)


### PR DESCRIPTION
1) We now (de)serialize the `failed_to_restart` attribute of `Puppet::Resource::Status`.
2) EventManager also calls `resource_status.fail_with_event(message)`, when setting `resource_status.failed_to_restart = true` to set the over-all `failed` attribute on a resource status.