### PR TITLE
(maint) Fix tests for OpenSSL 1.1.0

### DIFF
--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -70,12 +70,18 @@ module Puppet::SSL::Oids
     ["1.3.6.1.4.1.34380.1.3.13", 'pp_auth_role', 'Puppet Node Role Name for Authorization'],
   ]
 
+  @did_register_puppet_oids = false
+
   # Register our custom Puppet OIDs with OpenSSL so they can be used as CSR
   # extensions. Without registering these OIDs, OpenSSL will fail when it
   # encounters such an extension in a CSR.
   def self.register_puppet_oids()
-    PUPPET_OIDS.each do |oid_defn|
-      OpenSSL::ASN1::ObjectId.register(*oid_defn)
+    if !@did_register_puppet_oids
+      PUPPET_OIDS.each do |oid_defn|
+        OpenSSL::ASN1::ObjectId.register(*oid_defn)
+      end
+
+      @did_register_puppet_oids = true
     end
   end
 

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -230,12 +230,16 @@ describe OpenSSL::SSL::SSLContext do
 
   it 'explicitly disable SSLv2 ciphers using the ! prefix so they cannot be re-added' do
     cipher_str = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ciphers]
-    expect(cipher_str.split(':')).to include('!SSLv2')
+    if cipher_str
+      expect(cipher_str.split(':')).to include('!SSLv2')
+    end
   end
 
   it 'does not exclude SSLv3 ciphers shared with TLSv1' do
     cipher_str = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ciphers]
-    expect(cipher_str.split(':')).not_to include('!SSLv3')
+    if cipher_str
+      expect(cipher_str.split(':')).not_to include('!SSLv3')
+    end
   end
 
   it 'sets parameters on initialization' do


### PR DESCRIPTION
Cherry picked a commit from master branch to fix the Error produced during rspec run. 
gems/puppet-4.10.11/lib/puppet/ssl/oids.rb:78:in `register': oid exists (OpenSSL::ASN1::ASN1Error)
