### PR TITLE
(maint) Reset ca_location between tests

### DIFF
--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -143,6 +143,9 @@ module Puppet::Test
       Puppet::Application.clear!
       Puppet::Util::Profiler.clear
 
+      Puppet::SSL::Host.reset
+      Puppet::SSL::Host.ca_location = :none
+
       Puppet.clear_deprecation_warnings
     end
 


### PR DESCRIPTION
This fixes order dependent failures caused by some tests setting the
ca_location, which is retained between tests, and others expecting it
not to have been set. For example:
`rspec spec/integration/agent/logging_spec.rb spec/integration/ssl/autosign_spec.rb`