### PR TITLE
(PUP-8748) Configure connection verify mode when making a request

### DIFF
--- a/lib/puppet/rest/client.rb
+++ b/lib/puppet/rest/client.rb
@@ -8,14 +8,12 @@ module Puppet::Rest
   class Client
     attr_reader :dns_resolver
 
-    # Create a new HTTP client for querying the given API.
-    # @param [OpenSSL::X509::Store] ssl_store the SSL configuration for this client
+    # Create a new HTTP client.
     # @param [Integer] receive_timeout how long in seconds this client will wait
     #                  for a response after making a request
     # @param [HTTPClient] client the third-party HTTP client wrapped by this
     #                     class. This param is only used for testing.
-    def initialize(ssl_store: OpenSSL::X509::Store.new,
-                   receive_timeout: Puppet[:http_read_timeout],
+    def initialize(receive_timeout: Puppet[:http_read_timeout],
                    client: HTTPClient.new(agent_name: nil,
                                           default_header: {
                                             'User-Agent' => Puppet[:http_user_agent],
@@ -27,15 +25,30 @@ module Puppet::Rest
       @client.receive_timeout = receive_timeout
       @client.transparent_gzip_decompression = true
 
+      @client.ssl_config.clear_cert_store
+      ca_path = Puppet[:ssl_client_ca_auth] || Puppet[:localcacert]
+      @client.ssl_config.verify_callback = Puppet::SSL::Validator::DefaultValidator.new(ca_path)
+
       if Puppet[:http_debug]
         @client.debug_dev = $stderr
       end
 
-      @client.ssl_config.cert_store = ssl_store
-
-      configure_verify_mode(@client.ssl_config)
-
       @dns_resolver = Puppet::Network::Resolver.new
+    end
+
+    # In order to use this client to talk to a puppet master,
+    # this method must be called with an appropriate context before making
+    # a request.
+    # For an unverified connection (for downloading the CA cert intially),
+    # pass Puppet::Rest::SSLContext.verify_none.
+    # For a verified connection, pass Puppet::Rest::Client::SSLContext.verify_peer
+    # with a SSLStore that has been configured with th necesary certs and CRLs.
+    # @param [Puppet::Rest::SSLContext] ssl_context an object specifying the desired
+    #        verify mode and certificate configuration to use for connections created
+    #        by this client.
+    def configure_verify_mode(ssl_context)
+      @client.ssl_config.cert_store = ssl_context.cert_store
+      @client.ssl_config.verify_mode = ssl_context.verify_mode
     end
 
     # Make a GET request to the specified URL with the specified params.
@@ -45,12 +58,14 @@ module Puppet::Rest
     # @yields [String] chunks of the response body
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     def get(url, query: nil, header: nil, &block)
-      begin
-        @client.get_content(url, { query: query, header: header }) do |chunk|
-          block.call(chunk)
+      make_request_with_cleanup do
+        begin
+          @client.get_content(url, { query: query, header: header }) do |chunk|
+            block.call(chunk)
+          end
+        rescue HTTPClient::BadResponseError => e
+          raise Puppet::Rest::ResponseError.new(e.message, Puppet::Rest::Response.new(e.res))
         end
-      rescue HTTPClient::BadResponseError => e
-        raise Puppet::Rest::ResponseError.new(e.message, Puppet::Rest::Response.new(e.res))
       end
     end
 
@@ -61,31 +76,32 @@ module Puppet::Rest
     # @param [Hash] header any additional entries to add to the default header
     # @return [Puppet::Rest::Response]
     def put(url, body:, query: nil, header: nil)
-      response = @client.put(url, body: body, query: query, header: header)
-      Puppet::Rest::Response.new(response)
+      make_request_with_cleanup do
+        response = @client.put(url, body: body, query: query, header: header)
+        Puppet::Rest::Response.new(response)
+      end
     end
 
     private
 
-    # Checks for SSL certificates on disk and sets VERIFY_PEER
-    # if they are found. Otherwise, sets VERIFY_NONE.
-    def configure_verify_mode(ssl_config)
-      # Either the path to an external CA or to our CA cert from the Puppet master
-      # TODO We may be able to consolidate this with the current intermediate CA work?
-      ca_path = Puppet[:ssl_client_ca_auth] || Puppet[:localcacert]
-
-      if ssl_certificates_are_present?(ca_path)
-        ssl_config.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        ssl_config.add_trust_ca(ca_path)
-        ssl_config.verify_callback = Puppet::SSL::Validator::DefaultValidator.new(ca_path)
-        ssl_config.set_client_cert_file(Puppet[:hostcert], Puppet[:hostprivkey])
-      else
-        ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      end
+    # If the request within the block of this function used an insecure connection,
+    # reset the SSL state to ensure that it isn't used for any future requests.
+    def make_request_with_cleanup(*args)
+      yield(args)
+    ensure
+      reset_all if insecure?
     end
 
-    def ssl_certificates_are_present?(ca_path)
-      Puppet::FileSystem.exist?(Puppet[:hostcert]) && Puppet::FileSystem.exist?(ca_path)
+    # Reset the SSL configuration to VERIFY_PEER to ensure a secure
+    # connection, and reset all existing connections to delete any
+    # that were configured to be insecure.
+    def reset_all
+      @client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      @client.reset_all
+    end
+
+    def insecure?
+      @client.ssl_config.verify_mode == OpenSSL::SSL::VERIFY_NONE
     end
   end
 end

--- a/lib/puppet/rest/ssl_context.rb
+++ b/lib/puppet/rest/ssl_context.rb
@@ -1,0 +1,18 @@
+module Puppet::Rest
+  class SSLContext
+    def self.verify_peer(cert_store)
+      Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_PEER, cert_store)
+    end
+
+    def self.verify_none
+      Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_NONE, OpenSSL::X509::Store.new)
+    end
+
+    attr_reader :verify_mode, :cert_store
+
+    def initialize(verify_mode, cert_store)
+      @verify_mode = verify_mode
+      @cert_store = cert_store
+    end
+  end
+end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -7,6 +7,7 @@ require 'puppet/ssl/certificate_revocation_list'
 require 'puppet/ssl/certificate_request_attributes'
 require 'puppet/rest/errors'
 require 'puppet/rest/routes'
+require 'puppet/rest/ssl_context'
 
 # The class that manages all aspects of our SSL certificates --
 # private keys, public keys, requests, etc.
@@ -190,11 +191,13 @@ DOC
     true
   end
 
-  def http_client(*args)
+  def http_client(ssl_context)
     # This can't be required top-level because Puppetserver uses the Host class too,
     # and we don't ship the gem in that context.
     require 'puppet/rest/client'
-    @http_client ||= Puppet::Rest::Client.new(*args)
+    @http_client ||= Puppet::Rest::Client.new()
+    @http_client.configure_verify_mode(ssl_context)
+    @http_client
   end
 
   def certificate
@@ -426,7 +429,9 @@ ERROR_STRING
   # @return [Puppet::SSL::CertificateRequest, nil]
   def download_csr_from_ca
     begin
-      body = Puppet::Rest::Routes.get_certificate_request(http_client, name)
+      body = Puppet::Rest::Routes.get_certificate_request(
+        http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store)),
+        name)
       begin
         Puppet::SSL::CertificateRequest.from_s(body)
       rescue OpenSSL::X509::RequestError => e
@@ -452,7 +457,9 @@ ERROR_STRING
     end
 
     if Puppet::SSL::Host.ca_location == :remote
-      Puppet::Rest::Routes.put_certificate_request(http_client, csr.render, name)
+      Puppet::Rest::Routes.put_certificate_request(
+        http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store)),
+        csr.render, name)
     end
 
     Puppet::Util.replace_file(certificate_request_location(name), 0644) do |file|
@@ -547,7 +554,8 @@ ERROR_STRING
   # @return nil
   def download_and_save_crl_bundle(store=nil)
     begin
-      client = store ? http_client(ssl_store: store) : http_client
+      client = store ? http_client(Puppet::Rest::SSLContext.verify_peer(store)) :
+                       http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store))
       Puppet::Util.replace_file(crl_path, 0644) do |file|
         Puppet::Rest::Routes.get_crls(client, CA_NAME) do |chunk|
           file.write(chunk)
@@ -566,7 +574,9 @@ ERROR_STRING
     return nil if Puppet::SSL::Host.ca_location != :remote
 
     begin
-      cert_bundle = Puppet::Rest::Routes.get_certificate(http_client, CA_NAME)
+      cert_bundle = Puppet::Rest::Routes.get_certificate(
+                    http_client(Puppet::Rest::SSLContext.verify_none),
+                    CA_NAME)
       # This load ensures that the response body is a valid cert bundle.
       # If the text is malformed, load_certificate_bundle will raise.
       begin
@@ -643,7 +653,9 @@ ERROR_STRING
     return nil if Puppet::SSL::Host.ca_location != :remote
 
     begin
-      cert = Puppet::Rest::Routes.get_certificate(http_client, cert_name)
+      cert = Puppet::Rest::Routes.get_certificate(
+                    http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store)),
+                    cert_name)
       begin
         Puppet::SSL::Certificate.from_s(cert)
       rescue OpenSSL::X509::CertificateError

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -465,13 +465,14 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       @http = mock("http")
       @host.stubs(:http_client).returns(@http)
       @host.stubs(:key).returns(key)
+      @host.expects(:ssl_store).returns(mock("fake store"))
       request = mock("request")
       request.stubs(:generate)
       request.expects(:render).returns("my request").twice
       Puppet::SSL::CertificateRequest.expects(:new).returns(request)
 
       Puppet::Rest::Routes.expects(:put_certificate_request)
-        .with(@host.http_client, "my request", @host.name)
+        .with(@http, "my request", @host.name)
         .returns(nil)
 
       expect(@host.generate_certificate_request).to be true
@@ -505,6 +506,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       Puppet[:certdir] = tmpdir('certs')
       @host.stubs(:key).returns mock("key")
       @host.stubs(:validate_certificate_with_key)
+      @host.stubs(:ssl_store).returns(mock("fake store"))
       @http = mock 'http'
       @host.stubs(:http_client).returns(@http)
     end


### PR DESCRIPTION
This commit makes the SSL configuration of the Puppet::Rest::Client
configurable by the caller. By default, the client is not configured to
use any certs but has VERIFY_PEER enabled, which will result in an SSL
Error if a caller tries to make a request without first properly
configuring the client. If the client is configured to use VERIFY_NONE,
the state will reset to VERIFY_PEER after the request is made.
This ensures that we will not make insecure requests by mistake.