### PR TITLE
(maint) Improve logging around SSL downloads

### DIFF
--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -69,7 +69,7 @@ EOF
                   "--certname #{certname}"), :acceptable_exit_codes => [0,2])
         unless agent['locale'] == 'ja'
           assert_key_generated(agent)
-          assert_match(/Caching certificate for #{agent}/, stdout, "Expected certificate to be autosigned")
+          assert_match(/Downloaded certificate for #{agent}/, stdout, "Expected certificate to be autosigned")
         end
       end
     end

--- a/lib/puppet/rest/route.rb
+++ b/lib/puppet/rest/route.rb
@@ -2,6 +2,8 @@ require 'uri'
 
 module Puppet::Rest
   class Route
+    attr_reader :server
+
     # Create a Route containing information for querying the given API,
     # hosted at a server determined either by SRV service or by the
     # fallback server on the fallback port.

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -25,6 +25,7 @@ module Puppet::Rest
         client.get("#{base_url}certificate/#{name}", header: header) do |chunk|
           body << chunk
         end
+        Puppet.info _("Downloaded certificate for %{name} from %{server}") % { name: name, server: ca.server }
         body
       end
     end
@@ -41,6 +42,7 @@ module Puppet::Rest
         client.get("#{base_url}certificate_revocation_list/#{name}", header: header) do |chunk|
           block.call(chunk)
         end
+        Puppet.debug _("Downloaded certificate revocation list for %{name} from %{server}") % { name: name, server: ca.server }
       end
     end
 
@@ -77,6 +79,7 @@ module Puppet::Rest
         client.get("#{base_url}certificate_request/#{name}", header: header) do |chunk|
           body << chunk
         end
+        Puppet.debug _("Downloaded existing certificate request for %{name} from %{server}") % { name: name, server: ca.server }
         body
       end
     end


### PR DESCRIPTION
In the process of untangling SSL management from the indirector, some
logging was lost. This commit adds logging around when SSL artifacts are
downloaded.