### PR TITLE
(PUP-8943) Match full selmodule name in exists? check

### DIFF
--- a/lib/puppet/provider/selmodule/semodule.rb
+++ b/lib/puppet/provider/selmodule/semodule.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
     self.debug "Checking for module #{@resource[:name]}"
     execpipe("#{command(:semodule)} --list") do |out|
       out.each_line do |line|
-        if line =~ /#{@resource[:name]}\b/
+        if line =~ /^#{@resource[:name]}\b/
           return :true
         end
       end

--- a/spec/unit/provider/selmodule_spec.rb
+++ b/spec/unit/provider/selmodule_spec.rb
@@ -30,6 +30,12 @@ describe provider_class do
       expect(@provider.exists?).to be_nil
     end
 
+    it "should return nil if module with same suffix is loaded" do
+      @provider.expects(:command).with(:semodule).returns "/usr/sbin/semodule"
+      @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields StringIO.new("bar\t1.2.3\nmyfoo\t1.0.0\n")
+      expect(@provider.exists?).to be_nil
+    end
+
     it "should return nil if no modules are loaded" do
       @provider.expects(:command).with(:semodule).returns "/usr/sbin/semodule"
       @provider.expects(:execpipe).with("/usr/sbin/semodule --list").yields StringIO.new("")


### PR DESCRIPTION
Add a beginning-of-line marker to the regex to match the
complete selmodule name.

If not matching the beginning of the line, a modulename of
`foo` also matches for a moudlename of `myfoo`.