### PR TITLE
(PUP-8748) Explicity set SSL configuration of Rest::Client

### DIFF
--- a/lib/puppet/rest/ssl_context.rb
+++ b/lib/puppet/rest/ssl_context.rb
@@ -1,16 +1,11 @@
 module Puppet::Rest
   class SSLContext
-    def self.verify_peer(cert_store)
-      Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_PEER, cert_store)
-    end
-
-    def self.verify_none
-      Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_NONE, OpenSSL::X509::Store.new)
-    end
 
     attr_reader :verify_mode, :cert_store
 
-    def initialize(verify_mode, cert_store)
+    # @param [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER] verify_mode
+    # @param [OpenSSL::X509::SSLStore] cert_store
+    def initialize(verify_mode, cert_store = OpenSSL::X509::Store.new)
       @verify_mode = verify_mode
       @cert_store = cert_store
     end

--- a/lib/puppet/rest/ssl_context.rb
+++ b/lib/puppet/rest/ssl_context.rb
@@ -1,0 +1,18 @@
+module Puppet::Rest
+  class SSLContext
+    def self.verify_peer(cert_store)
+      Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_PEER, cert_store)
+    end
+
+    def self.verify_none
+      Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_NONE, OpenSSL::X509::Store.new)
+    end
+
+    attr_reader :verify_mode, :cert_store
+
+    def initialize(verify_mode, cert_store)
+      @verify_mode = verify_mode
+      @cert_store = cert_store
+    end
+  end
+end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -7,6 +7,7 @@ require 'puppet/ssl/certificate_revocation_list'
 require 'puppet/ssl/certificate_request_attributes'
 require 'puppet/rest/errors'
 require 'puppet/rest/routes'
+require 'puppet/rest/ssl_context'
 
 # The class that manages all aspects of our SSL certificates --
 # private keys, public keys, requests, etc.
@@ -190,11 +191,11 @@ DOC
     true
   end
 
-  def http_client(*args)
+  def http_client(ssl_context)
     # This can't be required top-level because Puppetserver uses the Host class too,
     # and we don't ship the gem in that context.
     require 'puppet/rest/client'
-    @http_client ||= Puppet::Rest::Client.new(*args)
+    Puppet::Rest::Client.new(ssl_context: ssl_context)
   end
 
   def certificate
@@ -426,7 +427,9 @@ ERROR_STRING
   # @return [Puppet::SSL::CertificateRequest, nil]
   def download_csr_from_ca
     begin
-      body = Puppet::Rest::Routes.get_certificate_request(http_client, name)
+      body = Puppet::Rest::Routes.get_certificate_request(
+                    http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store)),
+                    name)
       begin
         Puppet::SSL::CertificateRequest.from_s(body)
       rescue OpenSSL::X509::RequestError => e
@@ -452,7 +455,9 @@ ERROR_STRING
     end
 
     if Puppet::SSL::Host.ca_location == :remote
-      Puppet::Rest::Routes.put_certificate_request(http_client, csr.render, name)
+      Puppet::Rest::Routes.put_certificate_request(
+                    http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store)),
+                    csr.render, name)
     end
 
     Puppet::Util.replace_file(certificate_request_location(name), 0644) do |file|
@@ -547,7 +552,9 @@ ERROR_STRING
   # @return nil
   def download_and_save_crl_bundle(store=nil)
     begin
-      client = store ? http_client(ssl_store: store) : http_client
+      client = store ?
+        http_client(Puppet::Rest::SSLContext.verify_peer(store)) :
+        http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store))
       Puppet::Util.replace_file(crl_path, 0644) do |file|
         Puppet::Rest::Routes.get_crls(client, CA_NAME) do |chunk|
           file.write(chunk)
@@ -566,7 +573,9 @@ ERROR_STRING
     return nil if Puppet::SSL::Host.ca_location != :remote
 
     begin
-      cert_bundle = Puppet::Rest::Routes.get_certificate(http_client, CA_NAME)
+      cert_bundle = Puppet::Rest::Routes.get_certificate(
+                    http_client(Puppet::Rest::SSLContext.verify_none),
+                    CA_NAME)
       # This load ensures that the response body is a valid cert bundle.
       # If the text is malformed, load_certificate_bundle will raise.
       begin
@@ -643,7 +652,9 @@ ERROR_STRING
     return nil if Puppet::SSL::Host.ca_location != :remote
 
     begin
-      cert = Puppet::Rest::Routes.get_certificate(http_client, cert_name)
+      cert = Puppet::Rest::Routes.get_certificate(
+                    http_client(Puppet::Rest::SSLContext.verify_peer(ssl_store)),
+                    cert_name)
       begin
         Puppet::SSL::Certificate.from_s(cert)
       rescue OpenSSL::X509::CertificateError

--- a/spec/unit/rest/client_spec.rb
+++ b/spec/unit/rest/client_spec.rb
@@ -27,18 +27,18 @@ describe Puppet::Rest::Client do
       Puppet[:hostcert] = '/fake/cert/path'
       ssl_config.expects(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
 
-      Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.verify_none)
+      Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_NONE))
     end
 
     it 'uses a given client and SSL store when provided' do
       ssl_config.expects(:cert_store=).with(ssl_store)
       Puppet::Rest::Client.new(client: http,
-                               ssl_context: Puppet::Rest::SSLContext.verify_peer(ssl_store))
+                               ssl_context: Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_PEER, ssl_store))
     end
 
     it 'configures a receive timeout when provided' do
       http.expects(:receive_timeout=).with(10)
-      Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.verify_none,
+      Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_NONE),
                                client: http, receive_timeout: 10)
     end
   end
@@ -46,7 +46,7 @@ describe Puppet::Rest::Client do
   context 'when making requests' do
     let(:ssl_config) { stub_everything('ssl config') }
     let(:http) { stub_everything('http', :ssl_config => ssl_config) }
-    let(:client) { Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.verify_none, client: http) }
+    let(:client) { Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.new(OpenSSL::SSL::VERIFY_NONE), client: http) }
     let(:url) { 'https://myserver.com:555/data' }
 
     describe "#get" do

--- a/spec/unit/rest/client_spec.rb
+++ b/spec/unit/rest/client_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 require 'puppet/rest/client'
+require 'puppet/rest/ssl_context'
 
 describe Puppet::Rest::Client do
   context 'when creating a new client' do
@@ -10,7 +11,7 @@ describe Puppet::Rest::Client do
 
     it 'initializes itself with basic defaults' do
       HTTPClient.expects(:new).returns(http)
-      OpenSSL::X509::Store.expects(:new).returns(ssl_store)
+      OpenSSL::X509::Store.stubs(:new).returns(ssl_store)
       # Configure connection with HTTP settings
       Puppet[:http_read_timeout] = 120
       Puppet[:http_connect_timeout] = 10
@@ -26,24 +27,26 @@ describe Puppet::Rest::Client do
       Puppet[:hostcert] = '/fake/cert/path'
       ssl_config.expects(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
 
-      Puppet::Rest::Client.new
+      Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.verify_none)
     end
 
     it 'uses a given client and SSL store when provided' do
       ssl_config.expects(:cert_store=).with(ssl_store)
-      Puppet::Rest::Client.new(client: http, ssl_store: ssl_store)
+      Puppet::Rest::Client.new(client: http,
+                               ssl_context: Puppet::Rest::SSLContext.verify_peer(ssl_store))
     end
 
     it 'configures a receive timeout when provided' do
       http.expects(:receive_timeout=).with(10)
-      Puppet::Rest::Client.new(client: http, receive_timeout: 10)
+      Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.verify_none,
+                               client: http, receive_timeout: 10)
     end
   end
 
   context 'when making requests' do
     let(:ssl_config) { stub_everything('ssl config') }
     let(:http) { stub_everything('http', :ssl_config => ssl_config) }
-    let(:client) { Puppet::Rest::Client.new(client: http) }
+    let(:client) { Puppet::Rest::Client.new(ssl_context: Puppet::Rest::SSLContext.verify_none, client: http) }
     let(:url) { 'https://myserver.com:555/data' }
 
     describe "#get" do

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -464,6 +464,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       Puppet::SSL::Host.ca_location = :remote
       @http = mock("http")
       @host.stubs(:http_client).returns(@http)
+      @host.stubs(:ssl_store).returns(mock("ssl store"))
       @host.stubs(:key).returns(key)
       request = mock("request")
       request.stubs(:generate)
@@ -471,7 +472,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       Puppet::SSL::CertificateRequest.expects(:new).returns(request)
 
       Puppet::Rest::Routes.expects(:put_certificate_request)
-        .with(@host.http_client, "my request", @host.name)
+        .with(@http, "my request", @host.name)
         .returns(nil)
 
       expect(@host.generate_certificate_request).to be true
@@ -507,6 +508,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       @host.stubs(:validate_certificate_with_key)
       @http = mock 'http'
       @host.stubs(:http_client).returns(@http)
+      @host.stubs(:ssl_store).returns(mock("ssl store"))
     end
 
     let(:ca_cert_response) { @pki[:ca_bundle] }


### PR DESCRIPTION
Supersedes https://github.com/puppetlabs/puppet/pull/6880.

This makes the SSL state of the Rest::Client configurable by the caller on creation of the client.