### PR TITLE
(maint) Explicitly pass current environment to autoloader in Puppet::Util::NetworkDevice::Base

### DIFF
--- a/lib/puppet/util/network_device/base.rb
+++ b/lib/puppet/util/network_device/base.rb
@@ -12,7 +12,7 @@ class Puppet::Util::NetworkDevice::Base
 
     @autoloader = Puppet::Util::Autoload.new(self, "puppet/util/network_device/transport")
 
-    if @autoloader.load(@url.scheme)
+    if @autoloader.load(@url.scheme, Puppet.lookup(:current_environment))
       @transport = Puppet::Util::NetworkDevice::Transport.const_get(@url.scheme.capitalize).new(options[:debug])
       @transport.host = @url.host
       @transport.port = @url.port || case @url.scheme ; when "ssh" ; 22 ; when "telnet" ; 23 ; end


### PR DESCRIPTION
This was missed in 4909a533fb as the tests are behind a feature flag that isn't on by default in the testing matrix.