### PR TITLE
(PUP-8950) Handle SSL connection errors in new client

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -313,14 +313,18 @@ module Puppet::Network::HTTP
       end
       response
     rescue OpenSSL::SSL::SSLError => error
+      self.class.handle_connection_error(error, @verify, site.host)
+    end
+
+    def self.handle_connection_error(error, verifier, host)
       # can be nil
-      peer_cert = @verify.peer_certs.last
+      peer_cert = verifier.peer_certs.last
 
       if error.message.include? "certificate verify failed"
         msg = error.message
-        msg << ": [" + @verify.verify_errors.join('; ') + "]"
+        msg << ": [" + verifier.verify_errors.join('; ') + "]"
         raise Puppet::Error, msg, error.backtrace
-      elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert, site.host)
+      elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert, host)
         valid_certnames = [peer_cert.subject.to_s.sub(/.*=/, ''),
                            *Puppet::SSL::Certificate.subject_alt_names_for(peer_cert)].uniq
         if valid_certnames.size > 1
@@ -329,7 +333,7 @@ module Puppet::Network::HTTP
           expected_certnames = _("expected %{certname}") % { certname: valid_certnames.first }
         end
 
-        msg = _("Server hostname '%{host}' did not match server certificate; %{expected_certnames}") % { host: site.host, expected_certnames: expected_certnames }
+        msg = _("Server hostname '%{host}' did not match server certificate; %{expected_certnames}") % { host: host, expected_certnames: expected_certnames }
         raise Puppet::Error, msg, error.backtrace
       else
         raise

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -313,31 +313,7 @@ module Puppet::Network::HTTP
       end
       response
     rescue OpenSSL::SSL::SSLError => error
-      self.class.handle_connection_error(error, @verify, site.host)
-    end
-
-    def self.handle_connection_error(error, verifier, host)
-      # can be nil
-      peer_cert = verifier.peer_certs.last
-
-      if error.message.include? "certificate verify failed"
-        msg = error.message
-        msg << ": [" + verifier.verify_errors.join('; ') + "]"
-        raise Puppet::Error, msg, error.backtrace
-      elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert, host)
-        valid_certnames = [peer_cert.subject.to_s.sub(/.*=/, ''),
-                           *Puppet::SSL::Certificate.subject_alt_names_for(peer_cert)].uniq
-        if valid_certnames.size > 1
-          expected_certnames = _("expected one of %{certnames}") % { certnames: valid_certnames.join(', ') }
-        else
-          expected_certnames = _("expected %{certname}") % { certname: valid_certnames.first }
-        end
-
-        msg = _("Server hostname '%{host}' did not match server certificate; %{expected_certnames}") % { host: host, expected_certnames: expected_certnames }
-        raise Puppet::Error, msg, error.backtrace
-      else
-        raise
-      end
+      Puppet::Util::SSL.handle_connection_error(error, @verify, site.host)
     end
   end
 end

--- a/lib/puppet/rest/client.rb
+++ b/lib/puppet/rest/client.rb
@@ -3,7 +3,7 @@ require 'httpclient'
 require 'puppet'
 require 'puppet/rest/response'
 require 'puppet/rest/errors'
-require 'puppet/network/http/connection'
+require 'puppet/util/ssl'
 
 module Puppet::Rest
   class Client
@@ -53,7 +53,7 @@ module Puppet::Rest
       rescue HTTPClient::BadResponseError => e
         raise Puppet::Rest::ResponseError.new(e.message, Puppet::Rest::Response.new(e.res))
       rescue OpenSSL::OpenSSLError => e
-        Puppet::Network::HTTP::Connection.handle_connection_error(e, @verifier, url.host)
+        Puppet::Util::SSL.handle_connection_error(e, @verifier, url.host)
       end
     end
 
@@ -68,7 +68,7 @@ module Puppet::Rest
         response = @client.put(url.to_s, body: body, query: query, header: header)
         Puppet::Rest::Response.new(response)
       rescue OpenSSL::OpenSSLError => e
-        Puppet::Network::HTTP::Connection.handle_connection_error(e, @verifier, url.host)
+        Puppet::Util::SSL.handle_connection_error(e, @verifier, url.host)
       end
     end
 

--- a/lib/puppet/rest/client.rb
+++ b/lib/puppet/rest/client.rb
@@ -3,6 +3,7 @@ require 'httpclient'
 require 'puppet'
 require 'puppet/rest/response'
 require 'puppet/rest/errors'
+require 'puppet/network/http/connection'
 
 module Puppet::Rest
   class Client
@@ -31,43 +32,50 @@ module Puppet::Rest
         @client.debug_dev = $stderr
       end
 
+      @ca_path = Puppet[:ssl_client_ca_auth] || Puppet[:localcacert]
+      @verifier = Puppet::SSL::Validator::DefaultValidator.new(@ca_path)
       configure_verify_mode(ssl_context)
 
       @dns_resolver = Puppet::Network::Resolver.new
     end
 
     # Make a GET request to the specified URL with the specified params.
-    # @param [String] url the full path to query
+    # @param [URI] url the full path to query
     # @param [Hash] query any URL params to add to send to the endpoint
     # @param [Hash] header any additional entries to add to the default header
     # @yields [String] chunks of the response body
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     def get(url, query: nil, header: nil, &block)
       begin
-        @client.get_content(url, { query: query, header: header }) do |chunk|
+        @client.get_content(url.to_s, { query: query, header: header }) do |chunk|
           block.call(chunk)
         end
       rescue HTTPClient::BadResponseError => e
         raise Puppet::Rest::ResponseError.new(e.message, Puppet::Rest::Response.new(e.res))
+      rescue OpenSSL::OpenSSLError => e
+        Puppet::Network::HTTP::Connection.handle_connection_error(e, @verifier, url.host)
       end
     end
 
     # Make a PUT request to the specified URL with the specified params.
-    # @param [String] url the full path to query
+    # @param [URI] url the full path to query
     # @param [String/Hash] body the contents of the PUT request
     # @param [Hash] query any URL params to add to send to the endpoint
     # @param [Hash] header any additional entries to add to the default header
     # @return [Puppet::Rest::Response]
     def put(url, body:, query: nil, header: nil)
-      response = @client.put(url, body: body, query: query, header: header)
-      Puppet::Rest::Response.new(response)
+      begin
+        response = @client.put(url.to_s, body: body, query: query, header: header)
+        Puppet::Rest::Response.new(response)
+      rescue OpenSSL::OpenSSLError => e
+        Puppet::Network::HTTP::Connection.handle_connection_error(e, @verifier, url.host)
+      end
     end
 
     private
 
     def configure_verify_mode(ssl_context)
-      ca_path = Puppet[:ssl_client_ca_auth] || Puppet[:localcacert]
-      @client.ssl_config.verify_callback = Puppet::SSL::Validator::DefaultValidator.new(ca_path)
+      @client.ssl_config.verify_callback = @verifier
       @client.ssl_config.cert_store = ssl_context.cert_store
       @client.ssl_config.verify_mode = ssl_context.verify_mode
     end

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -19,10 +19,11 @@ module Puppet::Rest
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM-encoded certificate or certificate bundle
     def self.get_certificate(client, name)
-      ca.with_base_url(client.dns_resolver) do |base_url|
+      ca.with_base_url(client.dns_resolver) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
         body = ''
-        client.get("#{base_url}certificate/#{name}", header: header) do |chunk|
+        url.path += "certificate/#{name}"
+        client.get(url, header: header) do |chunk|
           body << chunk
         end
         Puppet.info _("Downloaded certificate for %{name} from %{server}") % { name: name, server: ca.server }
@@ -37,9 +38,10 @@ module Puppet::Rest
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return nil
     def self.get_crls(client, name, &block)
-      ca.with_base_url(client.dns_resolver) do |base_url|
+      ca.with_base_url(client.dns_resolver) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
-        client.get("#{base_url}certificate_revocation_list/#{name}", header: header) do |chunk|
+        url.path += "certificate_revocation_list/#{name}"
+        client.get(url, header: header) do |chunk|
           block.call(chunk)
         end
         Puppet.debug _("Downloaded certificate revocation list for %{name} from %{server}") % { name: name, server: ca.server }
@@ -53,11 +55,12 @@ module Puppet::Rest
     # @param [String] name the name of the host whose CSR is being submitted
     # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
     def self.put_certificate_request(client, csr_pem, name)
-      ca.with_base_url(client.dns_resolver) do |base_url|
+      ca.with_base_url(client.dns_resolver) do |url|
         header = { 'Accept' => 'text/plain',
                    'Accept-Encoding' => ACCEPT_ENCODING,
                    'Content-Type' => 'text/plain' }
-        response = client.put("#{base_url}certificate_request/#{name}", body: csr_pem, header: header)
+        url.path += "certificate_request/#{name}"
+        response = client.put(url, body: csr_pem, header: header)
         if response.ok?
           Puppet.debug "Submitted certificate request to server."
         else
@@ -73,10 +76,11 @@ module Puppet::Rest
     # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM encoded certificate request
     def self.get_certificate_request(client, name)
-      ca.with_base_url(client.dns_resolver) do |base_url|
+      ca.with_base_url(client.dns_resolver) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
         body = ''
-        client.get("#{base_url}certificate_request/#{name}", header: header) do |chunk|
+        url.path += "certificate_request/#{name}"
+        client.get(url, header: header) do |chunk|
           body << chunk
         end
         Puppet.debug _("Downloaded existing certificate request for %{name} from %{server}") % { name: name, server: ca.server }

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -8,6 +8,13 @@ require 'puppet/ssl/certificate_request_attributes'
 require 'puppet/rest/errors'
 require 'puppet/rest/routes'
 require 'puppet/rest/ssl_context'
+begin
+  # This may fail when being loaded from Puppet Server. However loading the
+  # client monkey patches the SSL Store and we need to have those monkey
+  # patches in as soon as possible on the agent.
+  require 'puppet/rest/client'
+rescue LoadError
+end
 
 # The class that manages all aspects of our SSL certificates --
 # private keys, public keys, requests, etc.
@@ -192,9 +199,6 @@ DOC
   end
 
   def http_client(ssl_context)
-    # This can't be required top-level because Puppetserver uses the Host class too,
-    # and we don't ship the gem in that context.
-    require 'puppet/rest/client'
     Puppet::Rest::Client.new(ssl_context: ssl_context)
   end
 

--- a/spec/lib/puppet_spec/validators.rb
+++ b/spec/lib/puppet_spec/validators.rb
@@ -1,0 +1,37 @@
+class ConstantErrorValidator
+  def initialize(args)
+    @fails_with = args[:fails_with]
+    @error_string = args[:error_string] || ""
+    @peer_certs = args[:peer_certs] || []
+  end
+
+  def setup_connection(connection)
+    connection.stubs(:start).raises(OpenSSL::SSL::SSLError.new(@fails_with))
+  end
+
+  def peer_certs
+    @peer_certs
+  end
+
+  def verify_errors
+    [@error_string]
+  end
+end
+
+class NoProblemsValidator
+  def initialize(cert)
+    @cert = cert
+  end
+
+  def setup_connection(connection)
+  end
+
+  def peer_certs
+    [@cert]
+  end
+
+  def verify_errors
+    []
+  end
+end
+

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/network/http/connection'
+require 'puppet_spec/validators'
 
 describe Puppet::Network::HTTP::Connection do
 
@@ -59,43 +60,6 @@ describe Puppet::Network::HTTP::Connection do
           expect(block_executed).to eq(true)
         end
       end
-    end
-  end
-
-  class ConstantErrorValidator
-    def initialize(args)
-      @fails_with = args[:fails_with]
-      @error_string = args[:error_string] || ""
-      @peer_certs = args[:peer_certs] || []
-    end
-
-    def setup_connection(connection)
-      connection.stubs(:start).raises(OpenSSL::SSL::SSLError.new(@fails_with))
-    end
-
-    def peer_certs
-      @peer_certs
-    end
-
-    def verify_errors
-      [@error_string]
-    end
-  end
-
-  class NoProblemsValidator
-    def initialize(cert)
-      @cert = cert
-    end
-
-    def setup_connection(connection)
-    end
-
-    def peer_certs
-      [@cert]
-    end
-
-    def verify_errors
-      []
     end
   end
 


### PR DESCRIPTION
Prior to this, despite using the existing validator, we did not handle
erros that might be thrown from validation. This refactors existing
validation handling to be used by our new client.