### PR TITLE
(PUP-8952) Respect server_list setting when using Rest::Client

### DIFF
--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -6,57 +6,58 @@ test_name "Priority of server_list setting over server setting" do
 
   master_port = 8140
 
-  step "Conflict warnings for server settings"
-  with_puppet_running_on(master, {}) do
-    agents.each do |agent|
-      tmpconf = agent.tmpfile('puppet_conf_test')
-
-      step "Should emit a warning when trying to set both server and server_list" do
-        step "when server is set first" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server #{master}", "--server_list #{master}:#{master_port},another:123"),
-            :acceptable_exit_codes => [0, 2]) do |result|
-            unless agent['locale'] == 'ja'
-              assert_match(/Attempted to set both server and server_list/,
-                           result.stderr, "a warning should have been issued because both server setttings were used")
-            end
-          end
-        end
-
-        step "when server_list is set first" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list #{master}:#{master_port},another:123", "--server #{master}"),
-            :acceptable_exit_codes => [0, 2]) do |result|
-            unless agent['locale'] == 'ja'
-              assert_match(/Attempted to set both server and server_list/,
-                           result.stderr, "a warning should have been issued because both server setttings were used")
-            end
-          end
+  step "Server_list setting takes priority over server" do
+    step "Invalid server setting with valid server_list setting should successfully contact master" do
+      on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
+         :acceptable_exit_codes => [0, 2]) do |result|
+        unless agent['locale'] == 'ja'
+          assert_match(/Selected master: #{master}:#{master_port}/,
+                       result.stdout, "should have selected the working master")
         end
       end
+    end
+  end
 
-      step "Should not emit a warning when only one setting is used" do
-        step "only server_list" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list #{master}:#{master_port},another:123"),
-            :acceptable_exit_codes => [0, 2]) do |result|
-              assert_no_match(/Attempted to set both server and server_list/,
-                              result.stderr, "a warning should not have been issued because only one settting was used")
-          end
-        end
+  step "Conflict warnings for server settings" do
+    with_puppet_running_on(master, {}) do
+      agents.each do |agent|
+        tmpconf = agent.tmpfile('puppet_conf_test')
 
-        step "only server" do
-          on(agent, puppet("agent", "--config #{tmpconf}", "-t", "--server #{master}"),
-            :acceptable_exit_codes => [0, 2]) do |result|
-              assert_no_match(/Attempted to set both server and server_list/, result.stderr, "a warning should not have been issued because only one settting was used")
-          end
-        end
-
-        step "Server_list setting takes priority over server" do
-          step "Invalid server setting with valid server_list setting should successfully contact master" do
-            on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
-               :acceptable_exit_codes => [0, 2]) do |result|
+        step "Should emit a warning when trying to set both server and server_list" do
+          step "when server is set first" do
+            on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server #{master}", "--server_list #{master}:#{master_port},another:123"),
+              :acceptable_exit_codes => [0, 2]) do |result|
               unless agent['locale'] == 'ja'
-                assert_match(/Selected master: #{master}:#{master_port}/,
-                             result.stdout, "should have selected the working master")
+                assert_match(/Attempted to set both server and server_list/,
+                             result.stderr, "a warning should have been issued because both server setttings were used")
               end
+            end
+          end
+
+          step "when server_list is set first" do
+            on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list #{master}:#{master_port},another:123", "--server #{master}"),
+              :acceptable_exit_codes => [0, 2]) do |result|
+              unless agent['locale'] == 'ja'
+                assert_match(/Attempted to set both server and server_list/,
+                             result.stderr, "a warning should have been issued because both server setttings were used")
+              end
+            end
+          end
+        end
+
+        step "Should not emit a warning when only one setting is used" do
+          step "only server_list" do
+            on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list #{master}:#{master_port},another:123"),
+              :acceptable_exit_codes => [0, 2]) do |result|
+                assert_no_match(/Attempted to set both server and server_list/,
+                                result.stderr, "a warning should not have been issued because only one settting was used")
+            end
+          end
+
+          step "only server" do
+            on(agent, puppet("agent", "--config #{tmpconf}", "-t", "--server #{master}"),
+              :acceptable_exit_codes => [0, 2]) do |result|
+                assert_no_match(/Attempted to set both server and server_list/, result.stderr, "a warning should not have been issued because only one settting was used")
             end
           end
         end

--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -6,22 +6,22 @@ test_name "Priority of server_list setting over server setting" do
 
   master_port = 8140
 
-  step "Server_list setting takes priority over server" do
-    step "Invalid server setting with valid server_list setting should successfully contact master" do
-      on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
-         :acceptable_exit_codes => [0, 2]) do |result|
-        unless agent['locale'] == 'ja'
-          assert_match(/Selected master: #{master}:#{master_port}/,
-                       result.stdout, "should have selected the working master")
-        end
-      end
-    end
-  end
-
   step "Conflict warnings for server settings" do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
         tmpconf = agent.tmpfile('puppet_conf_test')
+
+        step "Server_list setting takes priority over server" do
+          step "Invalid server setting with valid server_list setting should successfully contact master" do
+            on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
+               :acceptable_exit_codes => [0, 2]) do |result|
+              unless agent['locale'] == 'ja'
+                assert_match(/Selected master: #{master}:#{master_port}/,
+                             result.stdout, "should have selected the working master")
+              end
+            end
+          end
+        end
 
         step "Should emit a warning when trying to set both server and server_list" do
           step "when server is set first" do

--- a/lib/puppet/rest/client.rb
+++ b/lib/puppet/rest/client.rb
@@ -40,7 +40,7 @@ module Puppet::Rest
     end
 
     # Make a GET request to the specified URL with the specified params.
-    # @param [URI] url the full path to query
+    # @param [URI::HTTPS] url the full path to query
     # @param [Hash] query any URL params to add to send to the endpoint
     # @param [Hash] header any additional entries to add to the default header
     # @yields [String] chunks of the response body
@@ -58,7 +58,7 @@ module Puppet::Rest
     end
 
     # Make a PUT request to the specified URL with the specified params.
-    # @param [URI] url the full path to query
+    # @param [URI::HTTPS] url the full path to query
     # @param [String/Hash] body the contents of the PUT request
     # @param [Hash] query any URL params to add to send to the endpoint
     # @param [Hash] header any additional entries to add to the default header

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -7,8 +7,8 @@ module Puppet::Rest
 
     def self.ca
       @ca ||= Route.new(api: '/puppet-ca/v1/',
-                        default_server: Puppet[:ca_server],
-                        default_port: Puppet[:ca_port],
+                        server_setting: :ca_server,
+                        port_setting: :ca_port,
                         srv_service: :ca)
     end
 

--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -1,0 +1,74 @@
+require 'puppet'
+
+module Puppet::Util
+  module Connection
+    # The logic for server and port is kind of gross. In summary:
+    # IF an endpoint-specific setting is requested AND that setting has been set by the user
+    #    Use that setting.
+    #         The defaults for these settings are the "normal" server/masterport settings, so
+    #         when they are unset we instead want to "fall back" to the failover-selected
+    #         host/port pair.
+    # ELSE IF we have a failover-selected host/port
+    #    Use what the failover logic came up with
+    # ELSE IF the server_list setting is in use
+    #    Use the first entry - failover hasn't happened yet, but that
+    #    setting is still authoritative
+    # ELSE
+    #    Go for the legacy server/masterport settings, and hope for the best
+
+    # Determines which server to use based on the specified setting, taking into
+    # account HA fallback from server_list.
+    # @param [Symbol] setting The preferred server setting to use
+    # @return [String] the name of the server for use in the request
+    def self.determine_server(setting)
+      if setting && setting != :server && Puppet.settings.set_by_config?(setting)
+        Puppet[setting]
+      else
+        server = Puppet.lookup(:server) do
+          if primary_server = Puppet.settings[:server_list][0]
+            Puppet.debug "Dynamically-bound server lookup failed; using first entry"
+            primary_server[0]
+          else
+            setting ||= :server
+            Puppet.debug "Dynamically-bound server lookup failed, falling back to #{setting} setting"
+            Puppet.settings[setting]
+          end
+        end
+        server
+      end
+    end
+
+    # Determines which port to use based on the specified setting, taking into
+    # account HA fallback from server_list.
+    # For port there's a little bit of an extra snag: setting a specific
+    # server setting and relying on the default port for that server is
+    # common, so we also want to check if the assocaited SERVER setting
+    # has been set by the user. If either of those are set we ignore the
+    # failover-selected port.
+    # @param [Symbol] port_setting The preferred port setting to use
+    # @param [Symbol] server_setting The server setting assoicated with this route.
+    # @return [String] the port to use for use in the request
+    def self.determine_port(port_setting, server_setting)
+      if (port_setting && port_setting != :masterport && Puppet.settings.set_by_config?(port_setting)) ||
+         (server_setting && server_setting != :server && Puppet.settings.set_by_config?(server_setting))
+        Puppet.settings[port_setting].to_i
+      else
+        port = Puppet.lookup(:serverport) do
+          if primary_server = Puppet.settings[:server_list][0]
+            Puppet.debug "Dynamically-bound port lookup failed; using first entry"
+
+            # Port might not be set, so we want to fallback in that
+            # case. We know we don't need to use `setting` here, since
+            # the default value of every port setting is `masterport`
+            (primary_server[1] || Puppet.settings[:masterport])
+          else
+            port_setting ||= :masterport
+            Puppet.debug "Dynamically-bound port lookup failed; falling back to #{port_setting} setting"
+            Puppet.settings[port_setting]
+          end
+        end
+        port.to_i
+      end
+    end
+  end
+end

--- a/lib/puppet/util/ssl.rb
+++ b/lib/puppet/util/ssl.rb
@@ -54,7 +54,7 @@ module Puppet::Util::SSL
   end
 
   ##
-  # Extract and format meaningful error messages from OpenSSS::OpenSSLErrors
+  # Extract and format meaningful error messages from OpenSSL::OpenSSLErrors
   # and a Validator. Re-raises the error if unknown.
   #
   # @api private

--- a/spec/unit/rest/route_spec.rb
+++ b/spec/unit/rest/route_spec.rb
@@ -54,6 +54,22 @@ describe Puppet::Rest::Route do
         expect(count).to eq(1)
         expect(rval).to eq('Block return value')
       end
+
+      it 'falls back to :server and :masterport if nil is passed' do
+        Puppet[:server] = 'one.net'
+        Puppet[:masterport] = 111
+        nil_route = Puppet::Rest::Route.new(api: '/fakeapi/v1/',
+                                            server_setting: nil,
+                                            port_setting: nil)
+        count = 0
+        rval = nil_route.with_base_url(dns_resolver) do |url|
+          count += 1
+          expect(url.to_s).to eq('https://one.net:111/fakeapi/v1/')
+          'Block return value'
+        end
+        expect(count).to eq(1)
+        expect(rval).to eq('Block return value')
+      end
     end
 
     context 'when using SRV records' do


### PR DESCRIPTION
This commit updates the server resolution logic of the
Puppet::Rest::Client to respect the `server_list` setting. Previously
is was falling back to the `server` setting (or whatever server it was
configured with) even when `server_list` was set and supposed to take
precedence.

This commit also updates the acceptance test to verify that
`server_list` is preferred first, to avoid hiding that large bug behind
less consequential failures.