### PR TITLE
(PUP-6729)(PUP-8939) Ensure Administrators is owner of Puppet Settings as root

### DIFF
--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -16,7 +16,21 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
   # @api private
   class Root
     def value
-      "root"
+      # When running as an Administrator it is possible to create settings files and directories
+      # that are only owned by a single Administrator.  This may make sense for normal file
+      # resources, it doesn't really apply to Puppet settings files. Therefore if we are running
+      # with elevated rights (Puppet.features.root?) and on Windows (Puppet.features.microsoft_windows?)
+      # then all settings files and directories should be owned by the Administrators group.
+      #
+      # Note that the LOCAL SYSTEM user is always an implicit member of the Administrators group
+      # therefore they don't needed to be added to the resultant ACL.  Note we also use the SID representation
+      # to avoid localization issues or account renaming.
+
+      # TODO: Group is also set as SYSTEM (S-1-5-18) when running as SYSTEM, but what about when
+      # using a domain account?
+      Puppet.features.microsoft_windows? ?
+        Puppet::Util::Windows::SID::BuiltinAdministrators :
+        "root"
     end
   end
 
@@ -88,7 +102,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
              when "root"
                Root.new
              when "service"
-               Service.new(:user, "root", @settings, :service_user_available?)
+               Service.new(:user, Root.new.value, @settings, :service_user_available?)
              else
                unknown_value(':owner', value)
              end
@@ -156,23 +170,8 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
       end
 
       if Puppet.features.root?
-        if Puppet.features.microsoft_windows?
-          # When running as an Administrator it is possible to create settings files and directories
-          # that are only owned by a single Administrator.  This may make sense for normal file
-          # resources, it doesn't really apply to Puppet settings files. Therefore if we are running
-          # with elevated rights (Puppet.features.root?) and on Windows (Puppet.features.microsoft_windows?)
-          # then all settings files and directories should be owned by the Administrators group, with the primary
-          # group of LOCAL SYSTEM.  This is the typical configuration for files created as service logged on as
-          # LOCAL SYSTEM. Note that the LOCAL SYSTEM user is always an implicit member of the Administrators group
-          # therefore they don't needed to be added to the resultant ACL.  Note we also use the SID representation
-          # to avoid localization issues or account renaming.
-          resource[:owner] = 'S-1-5-32-544'
-          resource[:group] = 'S-1-5-18'
-        else
-          # REMIND fails on Windows because chown/chgrp functionality not supported yet
-          resource[:owner] = self.owner if self.owner
-          resource[:group] = self.group if self.group
-        end
+        resource[:owner] = self.owner if self.owner
+        resource[:group] = self.group if self.group
       end
     end
 

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -224,7 +224,7 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
             end
           end
 
-          it "should round-trip all 128 modes that do not require deny ACEs" do
+          it "should round-trip all 128 modes that do not require deny ACEs, where owner and group are different" do
             0.upto(1).each do |s|
               0.upto(7).each do |u|
                 0.upto(u).each do |g|
@@ -239,6 +239,25 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
                     winsec.set_mode(mode, path)
                     expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
                   end
+                end
+              end
+            end
+          end
+
+          it "should round-trip all 54 modes that do not require deny ACEs, where owner and group are same" do
+            winsec.set_group(winsec.get_owner(path), path)
+
+            0.upto(1).each do |s|
+              0.upto(7).each do |ug|
+                0.upto(ug).each do |o|
+                  # if user and group superset of other, then
+                  # no deny ace is required, and mode can be converted to win32
+                  # access mask, and back to mode without loss of information
+                  # (provided the owner and group are the same)
+                  next if ((ug & o) != o)
+                  mode = (s << 9 | ug << 6 | ug << 3 | o << 0)
+                  winsec.set_mode(mode, path)
+                  expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
                 end
               end
             end
@@ -564,6 +583,100 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
           #   end
           #   winsec.get_mode(path).to_s(8).should == "777"
           # end
+        end
+
+        describe "#mode=" do
+          it "should round-trip all 128 modes that do not require deny ACEs, where owner and group are different" do
+            winsec.set_owner(sids[:current_user], path)
+            winsec.set_group(sids[:users], path)
+
+            0.upto(1).each do |s|
+              0.upto(7).each do |u|
+                0.upto(u).each do |g|
+                  0.upto(g).each do |o|
+                    # if user is superset of group, and group superset of other, then
+                    # no deny ace is required, and mode can be converted to win32
+                    # access mask, and back to mode without loss of information
+                    # (provided the owner and group are not the same)
+                    next if ((u & g) != g) or ((g & o) != o)
+
+                    mode = (s << 9 | u << 6 | g << 3 | o << 0)
+                    winsec.set_mode(mode, path)
+                    expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
+                  end
+                end
+              end
+            end
+          end
+
+          it "should round-trip all 54 modes that do not require deny ACEs, where owner and group are same" do
+            winsec.set_group(winsec.get_owner(path), path)
+
+            0.upto(1).each do |s|
+              0.upto(7).each do |ug|
+                0.upto(ug).each do |o|
+                  # if user and group superset of other, then
+                  # no deny ace is required, and mode can be converted to win32
+                  # access mask, and back to mode without loss of information
+                  # (provided the owner and group are the same)
+                  next if ((ug & o) != o)
+                  mode = (s << 9 | ug << 6 | ug << 3 | o << 0)
+                  winsec.set_mode(mode, path)
+                  expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
+                end
+              end
+            end
+          end
+
+          # The SYSTEM user is a special case therefore we need to test that we round trip correctly when set
+          it "should round-trip all 128 modes that do not require deny ACEs, when running as a service as SYSTEM" do
+            # The owner and group for files/dirs created, when running as a service under Local System are
+            # Owner = Administrators
+            # Group = SYSTEM
+            winsec.set_owner(sids[:administrators], path)
+            winsec.set_group(sids[:system], path)
+
+            0.upto(1).each do |s|
+              0.upto(7).each do |u|
+                0.upto(u).each do |g|
+                  0.upto(g).each do |o|
+                    # if user is superset of group, and group superset of other, then
+                    # no deny ace is required, and mode can be converted to win32
+                    # access mask, and back to mode without loss of information
+                    # (provided the owner and group are not the same)
+                    next if ((u & g) != g) or ((g & o) != o)
+
+                    mode = (s << 9 | u << 6 | g << 3 | o << 0)
+                    winsec.set_mode(mode, path)
+                    expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
+                  end
+                end
+              end
+            end
+          end
+
+          it "should round-trip all 54 modes that do not require deny ACEs, when running as scheduled task as SYSTEM" do
+            # The owner and group for files/dirs created, when running as a Scheduled Task as Local System are
+            # Owner = SYSTEM
+            # Group = SYSTEM
+            winsec.set_group(sids[:system], path)
+            winsec.set_owner(sids[:system], path)
+
+            0.upto(1).each do |s|
+              0.upto(7).each do |ug|
+                0.upto(ug).each do |o|
+                  # if user and group superset of other, then
+                  # no deny ace is required, and mode can be converted to win32
+                  # access mask, and back to mode without loss of information
+                  # (provided the owner and group are the same)
+                  next if ((ug & o) != o)
+                  mode = (s << 9 | ug << 6 | ug << 3 | o << 0)
+                  winsec.set_mode(mode, path)
+                  expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
+                end
+              end
+            end
+          end
         end
 
         describe "when the parent directory" do

--- a/spec/unit/settings/file_setting_spec.rb
+++ b/spec/unit/settings/file_setting_spec.rb
@@ -30,13 +30,16 @@ describe Puppet::Settings::FileSetting do
       settings
     end
 
+    # S-1-5-32-544 is the well-known SID for Administrators group
+    let(:platform_root) { Puppet.features.microsoft_windows? ? 'S-1-5-32-544' : 'root' }
+
     context "owner" do
       it "can always be root" do
         settings = settings(:user => "the_service", :mkusers => true)
 
         setting = FileSetting.new(:settings => settings, :owner => "root", :desc => "a setting")
 
-        expect(setting.owner).to eq("root")
+        expect(setting.owner).to eq(platform_root)
       end
 
       it "is the service user if we are making users" do
@@ -60,7 +63,7 @@ describe Puppet::Settings::FileSetting do
 
         setting = FileSetting.new(:settings => settings, :owner => "service", :desc => "a setting")
 
-        expect(setting.owner).to eq("root")
+        expect(setting.owner).to eq(platform_root)
       end
 
       it "is unspecified when no specific owner is wanted" do
@@ -85,7 +88,7 @@ describe Puppet::Settings::FileSetting do
 
         setting = FileSetting.new(:settings => settings, :group => "root", :desc => "a setting")
 
-        expect(setting.group).to eq("root")
+        expect(setting.group).to eq(platform_root)
       end
 
       it "is the service group if we are making users" do
@@ -201,86 +204,41 @@ describe Puppet::Settings::FileSetting do
       expect(@file.to_resource[:mode]).to eq(nil)
     end
 
-    context "as root on a non Windows system" do
-      before(:each) do
-        Puppet.features.expects(:root?).at_least_once.returns true
-        Puppet.features.stubs(:microsoft_windows?).returns false
-      end
-
-      it "should set the owner if running as root and the owner is provided" do
-        @file.stubs(:owner).returns "foo"
-        expect(@file.to_resource[:owner]).to eq("foo")
-      end
-
-      it "should not set the owner if manage_internal_file_permissions is disabled" do
-        Puppet[:manage_internal_file_permissions] = false
-        @file.stubs(:owner).returns "foo"
-
-        expect(@file.to_resource[:owner]).to eq(nil)
-      end
-
-      it "should set the group if running as root and the group is provided" do
-        @file.stubs(:group).returns "foo"
-        expect(@file.to_resource[:group]).to eq("foo")
-      end
-
-      it "should not set the group if manage_internal_file_permissions is disabled" do
-        Puppet[:manage_internal_file_permissions] = false
-        @file.stubs(:group).returns "foo"
-
-        expect(@file.to_resource[:group]).to eq(nil)
-      end
+    # these tests are applicable to Windows and non-Windows
+    it "should set the owner if running as root and the owner is provided" do
+      @file.stubs(:owner).returns "foo"
+      expect(@file.to_resource[:owner]).to eq("foo")
     end
 
-    context "not as root on a non Windows system" do
-      before(:each) do
-        Puppet.features.expects(:root?).at_least_once.returns false
-        Puppet.features.stubs(:microsoft_windows?).returns false
-      end
+    it "should not set the owner if manage_internal_file_permissions is disabled" do
+      Puppet[:manage_internal_file_permissions] = false
+      @file.stubs(:owner).returns "foo"
 
-      it "should not set owner if not running as root" do
-        @file.stubs(:owner).returns "foo"
-        expect(@file.to_resource[:owner]).to be_nil
-      end
-
-      it "should not set group if not running as root" do
-        @file.stubs(:group).returns "foo"
-        expect(@file.to_resource[:group]).to be_nil
-      end
+      expect(@file.to_resource[:owner]).to eq(nil)
     end
 
-    describe "as an Administrator on Microsoft Windows systems" do
-      before :each do
-        Puppet.features.expects(:root?).at_least_once.returns true
-        Puppet.features.stubs(:microsoft_windows?).returns true
-      end
-
-      it "should set the owner to well known Administrators SID" do
-        @file.stubs(:owner).returns "foo"
-        expect(@file.to_resource[:owner]).to eq('S-1-5-32-544')
-      end
-
-      it "should not set group" do
-        @file.stubs(:group).returns "foo"
-        expect(@file.to_resource[:group]).to be_nil
-      end
+    it "should set the group if running as root and the group is provided" do
+      @file.stubs(:group).returns "foo"
+      expect(@file.to_resource[:group]).to eq("foo")
     end
 
-    describe "not as an Administrator on Microsoft Windows systems" do
-      before :each do
-        Puppet.features.expects(:root?).at_least_once.returns false
-        Puppet.features.stubs(:microsoft_windows?).returns true
-      end
+    it "should not set the group if manage_internal_file_permissions is disabled" do
+      Puppet[:manage_internal_file_permissions] = false
+      @file.stubs(:group).returns "foo"
 
-      it "should not set owner" do
-        @file.stubs(:owner).returns "foo"
-        expect(@file.to_resource[:owner]).to be_nil
-      end
+      expect(@file.to_resource[:group]).to eq(nil)
+    end
 
-      it "should not set group" do
-        @file.stubs(:group).returns "foo"
-        expect(@file.to_resource[:group]).to be_nil
-      end
+    it "should not set owner if not running as root" do
+      Puppet.features.expects(:root?).returns false
+      @file.stubs(:owner).returns "foo"
+      expect(@file.to_resource[:owner]).to be_nil
+    end
+
+    it "should not set group if not running as root" do
+      Puppet.features.expects(:root?).returns false
+      @file.stubs(:group).returns "foo"
+      expect(@file.to_resource[:group]).to be_nil
     end
 
     it "should set :ensure to the file type" do
@@ -321,7 +279,7 @@ describe Puppet::Settings::FileSetting do
     end
   end
 
-  context "when opening", :unless => Puppet.features.microsoft_windows? do
+  context "when opening" do
     let(:path) do
       tmpfile('file_setting_spec')
     end
@@ -331,7 +289,7 @@ describe Puppet::Settings::FileSetting do
       FileSetting.new(:name => :mysetting, :desc => "creates a file", :settings => settings)
     end
 
-    it "creates a file with mode 0640" do
+    it "creates a file with mode 0640", :unless => Puppet.features.microsoft_windows? do
       setting.mode = '0640'
 
       expect(File).to_not be_exist(path)


### PR DESCRIPTION
Previously there some tests around round tripping the file mode however they
missed many scenarios.  This commit adds the following scenarios;

* Where the owner and group are different as an admin
* Where the owner and group are the same, as an admin or normal user
* Where the files/dirs are created by Puppet when running as a Windows Service
  as LOCAL SYSTEM
* Where the files/dirs are created by Puppet when running as a Scheduled Task
  as LOCAL SYSTEM

---

Previously, when running as an Administrator it was possible to create settings
files and directories that were only owned by a single Administrator.  This may
make sense for normal file resources, it doesn't really apply to Puppet settings
files. Therefore if we are running with elevated rights (Puppet.features.root?)
and on Windows (Puppet.features.microsoft_windows?) then all settings files and
directories should be owned by the Administrators group, with the primary group
of LOCAL SYSTEM.  This is the typical configuration for files created as service
logged on as LOCAL SYSTEM. Note that the LOCAL SYSTEM user is always an implicit
member of the Administrators group therefore they don't needed to be added to
the resultant ACL.  Note we also use the SID representation to avoid
localization issues or account renaming.

- [x] Make sure Administrators always has Full Control
- [x] ~~Remove SYSTEM Full Control, if Administrators already has Full Control~~ Decided not to do
- [x] ~~Fix tests~~