### PR TITLE
(PUP-8942) Provide support for IP subject alt names

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -735,7 +735,8 @@ A comma-separated list of alternate DNS names for Puppet Server. These are extra
 hostnames (in addition to its `certname`) that the server is allowed to use when
 serving agents. Puppet checks this setting when automatically requesting a
 certificate for Puppet agent or Puppet Server, and when manually generating a
-certificate with `puppet cert generate`.
+certificate with `puppet cert generate`. These can be either IP or DNS, and the type
+should be specified and followed with a colon. Untyped inputs will default to DNS.
 
 In order to handle agent requests at a given hostname (like
 "puppet.example.com"), Puppet Server needs a certificate that proves it's

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -262,9 +262,17 @@ DOC
     end
 
     if options[:dns_alt_names]
-      names = options[:dns_alt_names].split(/\s*,\s*/).map(&:strip) + [name]
-      names = names.sort.uniq.map {|name| "DNS:#{name}" }.join(", ")
-      alt_names_ext = extension_factory.create_extension("subjectAltName", names, false)
+      raw_names = options[:dns_alt_names].split(/\s*,\s*/).map(&:strip) + [name]
+
+      parsed_names = raw_names.map do |name|
+        if !name.start_with?("IP:") && !name.start_with?("DNS:")
+          "DNS:#{name}"
+        else
+          name
+        end
+      end.sort.uniq.join(", ")
+
+      alt_names_ext = extension_factory.create_extension("subjectAltName", parsed_names, false)
 
       extensions << alt_names_ext
     end

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -177,6 +177,17 @@ describe Puppet::SSL::CertificateRequest do
       end
     end
 
+    context "with DNS and IP SAN specified" do
+      before :each do
+        Puppet[:dns_alt_names] = ""
+      end
+
+      it "should return the subjectAltName values" do
+        request.generate(key, :dns_alt_names => 'DNS:foo, bar, IP:172.16.254.1')
+        expect(request.subject_alt_names).to match_array(["DNS:bar", "DNS:foo", "DNS:myname", "IP Address:172.16.254.1"])
+      end
+    end
+
     context "with custom CSR attributes" do
 
       it "adds attributes with single values" do


### PR DESCRIPTION
Currently, CSRs can only be signed using DNS type subject alt names (referred to as ``--dns_alt_names`` or ``--dns-alt-names``). This commit provides support for IP SANs, but does not address any of the naming issues brought up in this ticket. More information on the blocking factors for that name change can be found at #6888.