### PR TITLE
(PUP-8959) Update test to fix order-dependent issue

### DIFF
--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -108,7 +108,7 @@ describe Puppet::GettextConfig do
   describe "clearing the configured text domain" do
     it 'succeeds' do
       Puppet::GettextConfig.clear_text_domain
-      expect(FastGettext.text_domain).to be_nil
+      expect(FastGettext.text_domain).to eq(FastGettext.default_text_domain)
     end
 
     it 'falls back to default' do


### PR DESCRIPTION
If a default text domain is still present, then calling `text_domain`
will not return nil. Update the test to ensure that the configured text
domain is `default_text_domain` after calling `clear_text_domain`, to
make it resilient to whether the default is set or nil.