### PR TITLE
(PUP-8970) Skip cron tests on Fedora 28

### DIFF
--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -1,6 +1,7 @@
 test_name "Cron: should allow changing parameters after creation"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -1,6 +1,7 @@
 test_name "Cron: check idempotency"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -1,6 +1,7 @@
 test_name "should create cron"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -1,6 +1,7 @@
 test_name "puppet should match existing job"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:unit'

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -1,6 +1,7 @@
 test_name "puppet should remove a crontab entry as expected"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though

--- a/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
@@ -1,6 +1,7 @@
 test_name "(#656) leading and trailing whitespace in cron entries should should be stripped"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:unit'

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -1,6 +1,7 @@
 test_name "puppet should remove a crontab entry based on command matching"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -1,6 +1,7 @@
 test_name "puppet should update existing crontab entry"
 confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See PUP-5500
+confine :except, :platform => /^fedora-28/
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though


### PR DESCRIPTION
Fedora 28 does not ship with a crontab executable -- [PC-697](https://tickets.puppetlabs.com/browse/PC-697) has been filed to address this better, but for now, [here's a successful run](https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/189/) of these changes alongside the agent platform adddition from https://github.com/puppetlabs/puppet-agent/pull/1462.

