### PR TITLE
(PUP-9048) Make Debian init service provider default for Devuan

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -19,6 +19,7 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
 
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ['1','2']
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ['5','6','7']
+  defaultfor :operatingsystem => :devuan
 
   # Remove the symlinks
   def disable

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -47,6 +47,11 @@ describe provider_class do
     end
   end
 
+  it "should be the default provider on Devuan" do
+    Facter.expects(:value).with(:operatingsystem).at_least_once.returns('Devuan')
+    expect(provider_class.default?).to be_truthy
+  end
+
   it "should be the default provider on Debian" do
     Facter.expects(:value).with(:operatingsystem).at_least_once.returns('Debian')
     Facter.expects(:value).with(:operatingsystemmajrelease).returns('7')


### PR DESCRIPTION
Since facter 3.7 Devuan will be detected as operatingsystem and should use the right service provider https://tickets.puppetlabs.com/browse/FACT-1579