### PR TITLE
(PUP-8976) Make it safe to use __ptype as a key in a hash

### DIFF
--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -96,7 +96,7 @@ module Serialization
         end
       elsif value.instance_of?(Hash)
         process(value) do
-          if value.keys.all? { |key| key.is_a?(String) }
+          if value.keys.all? { |key| key.is_a?(String) && key != PCORE_TYPE_KEY }
             result = {}
             value.each_pair { |key, elem| with(key) { result[key] = to_data(elem) } }
             result

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -563,6 +563,17 @@ module Serialization
         expect(warnings).to be_empty
       end
 
+      it 'A Hash with __ptype, __pvalue keys will not be taken as a pcore meta tag' do
+        val = { '__ptype' => 42, '__pvalue' => 43  }
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          write(val)
+          val2 = read
+          expect(val2).to be_a(Hash)
+          expect(val2).to eql({ '__ptype' => 42, '__pvalue' => 43 })
+        end
+        expect(warnings).to be_empty
+      end
+
       it 'A Hash with default values will not loose type information' do
         val = { 'key' => :default  }
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do


### PR DESCRIPTION
Before this, if a Hash had a key `__ptype` it would be taken as a
special type marker. That was bad because it makes some keys reserved in
a hash.

In this commit, such hashes are treated as having "non string keys"
which means it uses an alternative representation. This avoids the
problem when the rare cases there is such a hash occurs.