### PR TITLE
(PUP-8974) Safely deserialize stringified array

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -281,7 +281,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     when "=="
       begin
         arg = clause_array.shift
-        new_array = eval arg
+        new_array = to_array(arg)
         return_value = (values == new_array)
       rescue
         fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
@@ -289,7 +289,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     when "!="
       begin
         arg = clause_array.shift
-        new_array = eval arg
+        new_array = to_array(arg)
         return_value = (values != new_array)
       rescue
         fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
@@ -337,7 +337,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     when "=="
       begin
         arg = clause_array.shift
-        new_array = eval arg
+        new_array = to_array(arg)
         return_value = (result == new_array)
       rescue
         fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
@@ -345,7 +345,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     when "!="
       begin
         arg = clause_array.shift
-        new_array = eval arg
+        new_array = to_array(arg)
         return_value = (result != new_array)
       rescue
         fail(_("Invalid array in command: %{cmd}") % { cmd: cmd_array.join(" ") })
@@ -570,4 +570,13 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       end
     end
   end
+
+  def to_array(string)
+    string.strip # strip leading and trailing space
+      .sub(/^\[\s*['"]/, '') # strip leading [, spaces and single/double quote
+      .sub(/['"]\s*\]$/, '') # strip trailing single/double quote, spaces, and ]
+      .split(/['"]\s*,\s*['"]/) # split around comma, consuming the quotes and spaces before and after
+  end
+
+  private :to_array
 end

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -235,6 +235,11 @@ describe provider_class do
       expect(@provider.process_values(command)).to eq(true)
     end
 
+    it "should return true for an array match with double quotes and spaces" do
+      command = ["values", "fake value", "==   [  \"set\"  ,  \"of\" , \"values\"  ]  "]
+      expect(@provider.process_values(command)).to eq(true)
+    end
+
     it "should return false for an array non match" do
       command = ["values", "fake value", "== ['this', 'should', 'not', 'match']"]
       expect(@provider.process_values(command)).to eq(false)
@@ -247,6 +252,11 @@ describe provider_class do
 
     it "should return true for an array non match with noteq" do
       command = ["values", "fake value", "!= ['this', 'should', 'not', 'match']"]
+      expect(@provider.process_values(command)).to eq(true)
+    end
+
+    it "should return true for an array non match with double quotes and spaces" do
+      command = ["values", "fake value", "!=   [  \"this\"  ,  \"should\" ,\"not\",  \"match\"  ]  "]
       expect(@provider.process_values(command)).to eq(true)
     end
   end
@@ -294,6 +304,11 @@ describe provider_class do
       expect(@provider.process_match(command)).to eq(true)
     end
 
+    it "should return true for an array match with double quotes and spaces" do
+      command = ["match", "fake value", "==   [  \"set\"  ,  \"of\" , \"values\"  ]  "]
+      expect(@provider.process_match(command)).to eq(true)
+    end
+
     it "should return false for an array non match" do
       command = ["match", "fake value", "== ['this', 'should', 'not', 'match']"]
       expect(@provider.process_match(command)).to eq(false)
@@ -306,6 +321,11 @@ describe provider_class do
 
     it "should return true for an array non match with noteq" do
       command = ["match", "fake value", "!= ['this', 'should', 'not', 'match']"]
+      expect(@provider.process_match(command)).to eq(true)
+    end
+
+    it "should return true for an array non match with double quotes and spaces" do
+      command = ["match", "fake value", "!=   [  \"this\"  ,  \"should\" ,\"not\",  \"match\"  ]  "]
       expect(@provider.process_match(command)).to eq(true)
     end
   end


### PR DESCRIPTION
The augeas provider used Kernel#eval to convert stringified arrays to
Ruby arrays. For example, it extracted the array part of the "clause"
below:

    onlyif => 'values HostKey == ["/etc/ssh/ssh_host_rsa_key"]'

and called Kernel#eval with '["/etc/ssh/ssh_host_rsa_key"]'. Using eval
is bad because it executes arbitrary code.

This commit changes the provider to convert the comma delimited
string to a Ruby array. Note it will accept unbalanced quotes, so input
like "[\"a', \"b']" is converted to ['a', 'b']