### PR TITLE
PUP-8983: use correct file mode for temp file when replacing a file

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -587,9 +587,9 @@ module Util
         if Puppet::FileSystem.exist?(file)
           stat = Puppet::FileSystem.lstat(file)
           tempfile.chown(stat.uid, stat.gid)
-          stat.mode
+          tempfile.chmod(stat.mode)
         else
-          mode
+          tempfile.chmod(mode)
         end
       end
 


### PR DESCRIPTION
I was looking at the code to see if i could create a PR to address PUP-8983 and it looks like this is a bug.  im not the best ruby coder but my understanding is in the current behaviour  the mode[[1]](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/util.rb#L590)[[2]](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/util.rb#L590) statements have no effect 