### PR TITLE
(PUP-8984) Add --format=json option to `puppet parser validate`

### DIFF
--- a/lib/puppet/error.rb
+++ b/lib/puppet/error.rb
@@ -71,6 +71,19 @@ module Puppet
       msg
     end
 
+    def to_h
+      {
+        :issue_code => issue_code,
+        :message => basic_message,
+        :full_message => to_s,
+        :file => file,
+        :line => line,
+        :pos => pos,
+        :environment => environment.to_s,
+        :node => node.to_s,
+      }
+    end
+
     def self.from_issue_and_stack(issue, args = {})
       filename, line = Puppet::Pops::PuppetStack.top_of_stack
 

--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -11,6 +11,7 @@ Puppet::Face.define(:parser, '0.0.1') do
     summary _("Validate the syntax of one or more Puppet manifests.")
     arguments _("[<manifest>] [<manifest> ...]")
     returns _("Nothing, or the first syntax error encountered.")
+
     description <<-'EOT'
       This action validates Puppet DSL syntax without compiling a catalog or
       syncing any resources. If no manifest files are provided, it will
@@ -34,30 +35,66 @@ Puppet::Face.define(:parser, '0.0.1') do
       $ cat init.pp | puppet parser validate
     EOT
     when_invoked do |*args|
-      args.pop
-      files = args
+      files = args.slice(0..-2)
+
+      parse_errors = {}
+
       if files.empty?
         if not STDIN.tty?
           Puppet[:code] = STDIN.read
-          validate_manifest
+          parse_errors['STDIN'] = validate_manifest(nil)
         else
           manifest = Puppet.lookup(:current_environment).manifest
           files << manifest
           Puppet.notice _("No manifest specified. Validating the default manifest %{manifest}") % { manifest: manifest }
         end
       end
+
       missing_files = []
+
       files.each do |file|
         if Puppet::FileSystem.exist?(file)
-          validate_manifest(file)
+          error = validate_manifest(file)
+          parse_errors[file] = error if error
         else
           missing_files << file
         end
       end
+
       unless missing_files.empty?
         raise Puppet::Error, _("One or more file(s) specified did not exist:\n%{files}") % { files: missing_files.collect {|f| " " * 3 + f + "\n"} }
       end
-      nil
+
+      parse_errors
+    end
+
+    when_rendering :console do |errors|
+      unless errors.empty?
+        errors.each { |_, error| Puppet.log_exception(error) }
+
+        exit(1)
+      end
+
+      # Prevent face_base renderer from outputting "null"
+      exit(0)
+    end
+
+    when_rendering :json do |errors|
+      unless errors.empty?
+        ignore_error_keys = [ :arguments, :environment, :node ]
+
+        data = errors.map do |file, error|
+          file_errors = error.to_h.reject { |k, _| ignore_error_keys.include?(k) }
+          [file, file_errors]
+        end.to_h
+
+        puts Puppet::Util::Json.dump(Puppet::Pops::Serialization::ToDataConverter.convert(data, rich_data: false), :pretty => true)
+
+        exit(1)
+      end
+
+      # Prevent face_base renderer from outputting "null"
+      exit(0)
     end
   end
 
@@ -75,7 +112,7 @@ Puppet::Face.define(:parser, '0.0.1') do
       * 'pn' is the Puppet Extended S-Expression Notation.
       * 'json' outputs the same graph as 'pn' but with JSON syntax.
 
-      The output will be "pretty printed" when the option --pretty is given together with --format 'pn' or 'json'. 
+      The output will be "pretty printed" when the option --pretty is given together with --format 'pn' or 'json'.
       This option has no effect on the 'old' format.
 
       The command accepts one or more manifests (.pp) files, or an -e followed by the puppet
@@ -173,15 +210,17 @@ Puppet::Face.define(:parser, '0.0.1') do
   def validate_manifest(manifest = nil)
     env = Puppet.lookup(:current_environment)
     loaders = Puppet::Pops::Loaders.new(env)
+
     Puppet.override( {:loaders => loaders } , _('For puppet parser validate')) do
       begin
         validation_environment = manifest ? env.override_with(:manifest => manifest) : env
         validation_environment.check_for_reparse
         validation_environment.known_resource_types.clear
-      rescue => detail
-        Puppet.log_exception(detail)
-        exit(1)
+      rescue Puppet::ParseError => parse_error
+        return parse_error
       end
     end
+
+    nil
   end
 end


### PR DESCRIPTION
Tools like the Puppet Development Kit which invoke `puppet parser validate` on behalf of the user need a consistent, machine-readable output format so that they don't have to rely on complex and brittle regular expressions matching output that may change between Puppet releases.