### PR TITLE
(PUP-8985) Default manage_internal_file_permissions to false on Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -249,7 +249,7 @@ module Puppet
         :desc     => "Whether to create the necessary user and group that puppet agent will run as.",
     },
     :manage_internal_file_permissions => {
-        :default  => true,
+        :default  => ! Puppet::Util::Platform.windows?,
         :type     => :boolean,
         :desc     => "Whether Puppet should manage the owner, group, and mode of files it uses internally",
     },

--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Settings do
     expect(File.directory?(settings[:maindir])).to be_truthy
   end
 
-  it "should make its directories with the correct modes" do
+  it "should make its directories with the correct modes", :if => !Puppet::Util::Platform.windows? do
     define_settings(:main,
         :maindir => {
             :default => tmpfile("main"),

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -119,6 +119,19 @@ describe "Defaults" do
     end
   end
 
+  describe 'manage_internal_file_permissions' do
+    describe 'on windows', :if => Puppet::Util::Platform.windows? do
+      it 'should default to false' do
+        expect(Puppet.settings[:manage_internal_file_permissions]).to be false
+      end
+    end
+    describe 'on non-windows', :if => ! Puppet::Util::Platform.windows? do
+      it 'should default to true' do
+        expect(Puppet.settings[:manage_internal_file_permissions]).to be true
+      end
+    end
+  end
+
   describe 'basemodulepath' do
     it 'includes the global and system modules on non-windows', :unless => Puppet::Util::Platform.windows? do
       expect(

--- a/spec/unit/settings/autosign_setting_spec.rb
+++ b/spec/unit/settings/autosign_setting_spec.rb
@@ -72,7 +72,7 @@ describe Puppet::Settings::AutosignSetting do
   end
 
   describe "converting the setting to a resource" do
-    it "converts the file path to a file resource" do
+    it "converts the file path to a file resource", :if => !Puppet::Util::Platform.windows? do
       path = File.expand_path('/path/to/autosign.conf')
       settings.stubs(:value).with('autosign', nil, false).returns(path)
       Puppet::FileSystem.stubs(:exist?).with(path).returns true

--- a/spec/unit/settings/file_setting_spec.rb
+++ b/spec/unit/settings/file_setting_spec.rb
@@ -182,12 +182,14 @@ describe Puppet::Settings::FileSetting do
     end
 
     it "should set the mode on the file if a mode is provided as an octal number" do
+      Puppet[:manage_internal_file_permissions] = true
       @file.mode = 0755
 
       expect(@file.to_resource[:mode]).to eq('755')
     end
 
     it "should set the mode on the file if a mode is provided as a string" do
+      Puppet[:manage_internal_file_permissions] = true
       @file.mode = '0755'
 
       expect(@file.to_resource[:mode]).to eq('755')
@@ -202,6 +204,7 @@ describe Puppet::Settings::FileSetting do
     end
 
     it "should set the owner if running as root and the owner is provided" do
+      Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns true
       Puppet.features.stubs(:microsoft_windows?).returns false
 
@@ -218,6 +221,7 @@ describe Puppet::Settings::FileSetting do
     end
 
     it "should set the group if running as root and the group is provided" do
+      Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns true
       Puppet.features.stubs(:microsoft_windows?).returns false
 
@@ -235,6 +239,7 @@ describe Puppet::Settings::FileSetting do
 
 
     it "should not set owner if not running as root" do
+      Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns false
       Puppet.features.stubs(:microsoft_windows?).returns false
       @file.stubs(:owner).returns "foo"
@@ -242,6 +247,7 @@ describe Puppet::Settings::FileSetting do
     end
 
     it "should not set group if not running as root" do
+      Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns false
       Puppet.features.stubs(:microsoft_windows?).returns false
       @file.stubs(:group).returns "foo"


### PR DESCRIPTION
Previously the MSI packaging for Puppet Agent changed the default for the
manage_internal_file_permissions setting to false as part of CVE-2018-6513.
However puppet still had a default of true.  This commit changes the default to
false for Windows platforms, to mirror that of the packaging, and to not undo
the remediation for the CVE.