### PR TITLE
(PUP-8988) Don't pluginsync vendored modules

### DIFF
--- a/acceptance/tests/modulepath.rb
+++ b/acceptance/tests/modulepath.rb
@@ -75,7 +75,7 @@ END
 
   step 'vendored modules can be excluded' do
     hosts.each do |host|
-      on(host, puppet("describe --basemodulepath '$codedir/modules' beacon"), accept_all_exit_codes: true) do |result|
+      on(host, puppet("describe --vendormoduledir '' beacon"), accept_all_exit_codes: true) do |result|
         assert_match(/Unknown type beacon/, result.stdout)
       end
     end
@@ -84,7 +84,7 @@ END
   step 'global modules override vendored modules' do
     agents.each do |agent|
       # skip the agent on the master, as we don't want to install the
-      # global module on the master until later 
+      # global module on the master until later
       next if agent == master
 
       global_dir = global_modules(agent)
@@ -106,10 +106,10 @@ END
   end
 
   with_puppet_running_on(master, {}) do
-    step "agent downloads and uses server's vendored module" do
+    step "agent doesn't pluginsync the vendored module, instead using its local vendored module" do
       agents.each do |agent|
         on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [0,2]) do |result|
-          assert_match(/defined 'message' as 'vendored module from #{master}'/, result.stdout)
+          assert_match(/defined 'message' as 'vendored module from #{agent}'/, result.stdout)
         end
       end
     end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -38,11 +38,23 @@ module Puppet
       installdir = Facter.value(:env_windows_installdir)
       if installdir
         path << "#{installdir}/puppet/modules"
-        path << "#{installdir}/puppet/vendor_modules"
       end
       path.join(File::PATH_SEPARATOR)
     else
-      '$codedir/modules:/opt/puppetlabs/puppet/modules:/opt/puppetlabs/puppet/vendor_modules'
+      '$codedir/modules:/opt/puppetlabs/puppet/modules'
+    end
+  end
+
+  def self.default_vendormoduledir
+    if Puppet::Util::Platform.windows?
+      installdir = Facter.value(:env_windows_installdir)
+      if installdir
+        "#{installdir}\\puppet\\vendor_modules"
+      else
+        nil
+      end
+    else
+      '/opt/puppetlabs/puppet/vendor_modules'
     end
   end
 
@@ -1308,6 +1320,14 @@ EOT
         the `modules` directory of the active environment will have priority over
         any global directories. For more info, see
         <https://puppet.com/docs/puppet/latest/environments_about.html>",
+    },
+    :vendormoduledir => {
+      :default => lambda { default_vendormoduledir },
+      :type => :directory,
+      :desc => "The directory containing **vendored** modules. These modules will
+      be used by _all_ environments like those in the `basemodulepath`. The only
+      difference is that modules in the `basemodulepath` are pluginsynced, while
+      vendored modules are not",
     },
     :ssl_client_header => {
       :default    => "HTTP_X_CLIENT_DN",

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -161,13 +161,26 @@ class Puppet::Util::Autoload
     end
 
     # @api private
+    def vendored_modules
+      dir = Puppet[:vendormoduledir]
+      if dir && File.directory?(dir)
+        Dir.entries(dir)
+          .reject { |f| f =~ /^\./ }
+          .collect { |f| File.join(dir, f, "lib") }
+          .find_all { |d| FileTest.directory?(d) }
+      else
+        []
+      end
+    end
+
+    # @api private
     def gem_directories
       gem_source.directories
     end
 
     # @api private
     def search_directories(env)
-      [gem_directories, module_directories(env), libdirs, $LOAD_PATH].flatten
+      [gem_directories, module_directories(env), libdirs, $LOAD_PATH, vendored_modules].flatten
     end
 
     # Normalize a path. This converts ALT_SEPARATOR to SEPARATOR on Windows

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -125,21 +125,21 @@ describe "Defaults" do
   end
 
   describe 'basemodulepath' do
-    it 'includes the user, system and vendor modules', :unless => Puppet::Util::Platform.windows? do
+    it 'includes the user and system modules', :unless => Puppet::Util::Platform.windows? do
       expect(
         Puppet[:basemodulepath]
-      ).to match(%r{.*/code/modules:/opt/puppetlabs/puppet/modules:/opt/puppetlabs/puppet/vendor_modules$})
+      ).to match(%r{.*/code/modules:/opt/puppetlabs/puppet/modules$})
     end
 
     describe 'on windows', :if => Puppet::Util::Platform.windows? do
       let(:installdir) { 'C:\Program Files\Puppet Labs\Puppet' }
 
-      it 'includes user, system and vendor modules' do
+      it 'includes user and system modules' do
         Facter.stubs(:value).with(:env_windows_installdir).returns(installdir)
 
         expect(
           Puppet.default_basemodulepath
-        ).to eq('$codedir/modules;C:\Program Files\Puppet Labs\Puppet/puppet/modules;C:\Program Files\Puppet Labs\Puppet/puppet/vendor_modules')
+        ).to eq('$codedir/modules;C:\Program Files\Puppet Labs\Puppet/puppet/modules')
       end
 
       it 'includes user modules if installdir fact is missing' do
@@ -148,6 +148,32 @@ describe "Defaults" do
         expect(
           Puppet.default_basemodulepath
         ).to eq('$codedir/modules')
+      end
+    end
+  end
+
+  describe 'vendormoduledir' do
+    it 'includes the default vendormoduledir', :unless => Puppet::Util::Platform.windows? do
+      expect(
+        Puppet[:vendormoduledir]
+      ).to eq('/opt/puppetlabs/puppet/vendor_modules')
+    end
+
+    describe 'on windows', :if => Puppet::Util::Platform.windows? do
+      let(:installdir) { 'C:\Program Files\Puppet Labs\Puppet' }
+
+      it 'includes the default vendormoduledir' do
+        Facter.stubs(:value).with(:env_windows_installdir).returns(installdir)
+
+        expect(
+          Puppet.default_vendormoduledir
+        ).to eq('C:\Program Files\Puppet Labs\Puppet\puppet\vendor_modules')
+      end
+
+      it 'is nil if installdir fact is missing' do
+        Facter.stubs(:value).with(:env_windows_installdir).returns(nil)
+
+        expect(Puppet.default_vendormoduledir).to be_nil
       end
     end
   end


### PR DESCRIPTION
Previously, vendored modules behaved like any other module in the
modulepath. When acting as a server, agents would pluginsync the
vendored modules. This can cause problems if the vendored module is not
compatible with an older agent.

This commit makes vendored modules behave as though they are part of
puppet. They are not pluginsynced, but the autoloader can resolve
types, providers, etc from vendored modules. Vendored modules always
have least precedence.