### PR TITLE
(PUP-9007) Follow directory symlinks under manifest tree.

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -530,7 +530,7 @@ class Puppet::Node::Environment
       if file == NO_MANIFEST
         empty_parse_result
       elsif File.directory?(file)
-        parse_results = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*.pp')).glob.sort.map do | file_to_parse |
+        parse_results = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**{,/*/**}/*.pp')).glob.sort.uniq.map do | file_to_parse |
           parser.file = file_to_parse
           parser.parse
           end


### PR DESCRIPTION
When doing a `puppet apply /path/to/directory`, documentation at
https://puppet.com/docs/puppet/5.5/dirs_manifest.html#manifest-directory-behavior
indicates that subdirectories are supposed to be parsed.

If a subdirectory happens to be a symlink, it is currently not followed,
due to behavior of Ruby's globbing mechanism.

This patch allows symlinks, using the approach described under:
https://stackoverflow.com/a/2724048/2397004

I guess this can also be cherry-picked to the stable 4.x puppet release.