### PR TITLE
(PUP-7600) LDAP Terminus gives a deprecation warning

### DIFF
--- a/lib/puppet/indirector/ldap.rb
+++ b/lib/puppet/indirector/ldap.rb
@@ -2,6 +2,12 @@ require 'puppet/indirector/terminus'
 require 'puppet/util/ldap/connection'
 
 class Puppet::Indirector::Ldap < Puppet::Indirector::Terminus
+  def initialize
+    #TRANSLATORS 'Puppet::Indirector::Ldap' is a class and should not be translated
+    Puppet.deprecation_warning(_("Puppet::Indirector::Ldap is deprecated and will be removed in a future release of Puppet."));
+    super
+  end
+
   # Perform our ldap search and process the result.
   def find(request)
     ldapsearch(search_filter(request.key)) { |entry| return process(entry) } || nil

--- a/spec/unit/indirector/ldap_spec.rb
+++ b/spec/unit/indirector/ldap_spec.rb
@@ -13,12 +13,33 @@ describe Puppet::Indirector::Ldap do
     end
 
     @connection = mock 'ldap'
+  end
 
-    @searcher = @ldap_class.new
+  describe "when instantiating ldap" do
+    it "should be deprecated" do
+      Puppet.expects(:deprecation_warning).with("Puppet::Indirector::Ldap is deprecated and will be removed in a future release of Puppet.")
+
+      @ldap_class.new
+    end
+
+    it "should not emit a deprecation warning when they are disabled" do
+      Puppet.expects(:warning).with(regexp_matches(/Puppet::Indirector::Ldap is deprecated/)).never
+      Puppet[:disable_warnings] = ['deprecations']
+
+      @ldap_class.new
+    end
+
+    it "should only emit the deprecation warning once" do
+      Puppet.expects(:warning).with(regexp_matches(/Puppet::Indirector::Ldap is deprecated/)).once
+
+      @ldap_class.new
+      @ldap_class.new
+    end
   end
 
   describe "when searching ldap" do
     before do
+      @searcher = @ldap_class.new
       # Stub everything, and we can selectively replace with an expect as
       # we need to for testing.
       @searcher.stubs(:connection).returns(@connection)


### PR DESCRIPTION
This was merged to master, should be in 5.5.x for deprecation.