### PR TITLE
(PUP-8988) Define vendormoduledir as a string

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1323,7 +1323,7 @@ EOT
     },
     :vendormoduledir => {
       :default => lambda { default_vendormoduledir },
-      :type => :directory,
+      :type => :string,
       :desc => "The directory containing **vendored** modules. These modules will
       be used by _all_ environments like those in the `basemodulepath`. The only
       difference is that modules in the `basemodulepath` are pluginsynced, while


### PR DESCRIPTION
Calling `Puppet.settings.use(<section>)` will create files and directories
for all of the `:file` and `:directory` based settings in that section.
Previously, running `puppet lookup` as a non-root user failed, because
lookup uses the `master` section, the `vendormodulesdir` setting is
defined in the `master` section, and the user did not have permission to
create the `/opt/puppetlabs/puppet/vendor_modules` directory.

This commit changes the vendormoduledir setting to be of type `:string`.
This way puppet never tries to manage its existence via a settings
catalog. It doesn't use `:path`, because that settings type is reserved
for settings that allow multiple directories separated by
File::PATH_SEPARATOR.