### PR TITLE
(PUP-9018) Return the first module in the modulepath

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -137,11 +137,7 @@ class Puppet::Util::Autoload
       if Puppet.settings.app_defaults_initialized?
         # if the app defaults have been initialized then it should be safe to access the module path setting.
         Puppet::Util::ModuleDirectoriesAdapter.adapt(env) do |a|
-          a.directories ||= env.modulepath.collect do |dir|
-            Dir.entries(dir).reject { |f| f =~ /^\./ }.collect { |f| File.join(dir, f, "lib") }
-          end.flatten.find_all do |d|
-            FileTest.directory?(d)
-          end
+          a.directories ||= env.enum_for(:each_plugin_directory).to_a
         end.directories
       else
         # if we get here, the app defaults have not been initialized, so we basically use an empty module path.
@@ -153,7 +149,7 @@ class Puppet::Util::Autoload
     def libdirs
       # See the comments in #module_directories above.  Basically, we need to be careful not to try to access the
       # libdir before we know for sure that all of the settings have been initialized (e.g., during bootstrapping).
-      if (Puppet.settings.app_defaults_initialized?)
+      if Puppet.settings.app_defaults_initialized?
         [Puppet[:libdir]]
       else
         []

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -23,19 +23,25 @@ describe Puppet::Util::Autoload do
     end
 
     it "should collect all of the lib directories that exist in the current environment's module path" do
-      dira = dir_containing('dir_a', {
+      dira = dir_containing('modules', {
         "one" => {},
         "two" => { "lib" => {} }
       })
 
-      dirb = dir_containing('dir_a', {
+      dirb = dir_containing('modules', {
         "one" => {},
         "two" => { "lib" => {} }
       })
 
-      environment = Puppet::Node::Environment.create(:foo, [dira, dirb])
+      dirc = dir_containing('modules', {
+        "three" => { "lib" => {} }
+      })
 
-      expect(@autoload.class.module_directories(environment)).to eq(["#{dira}/two/lib", "#{dirb}/two/lib"])
+      environment = Puppet::Node::Environment.create(:foo, [dira, dirb, dirc])
+
+      expect(
+        @autoload.class.module_directories(environment)
+      ).to eq(["#{dira}/two/lib", "#{dirb}/two/lib", "#{dirc}/three/lib"])
     end
 
     it "ignores missing module directories" do


### PR DESCRIPTION
Previously, Autoload.module_directories could return duplicate modules
if a module was installed in multiple directories in the modulepath.
Worse if there were different versions of a module installed, then the
Autoloader could load a type from one version of the module, but the
provider from a different one. For example, consider v1 of a module
containing type foo, provider bar, and v2 of the same module containing
type foo, and providers bar and baz. If module v1 comes before v2 in the
modulepath, then puppet will load type foo from v1, but provider baz
from v2. Undefined behavior can result if the v2 provider expects v2 of
the type.

The autoloader behavior is also inconsistent with how the rest of puppet
works. For example, when creating ModuleLoaders we use
`environment.modules`, so only the first module in the modulepath is
visible[1]. Similarly, when serving files from modules, loading facts
from modules, installing modules via PMT and resolving module
dependencies.

This commit uses `Environment#each_plugin_directory` to enumerate the
lib directory for all modules in the environment. As a result of this
change, modules with invalid metadata or invalid module names will not
be included. Those without any metadata continue to be included.

Also the returned module directories will be normalized using
Autoload.cleanup, as is consistent with other usages of
`each_plugin_directory`.

[1] https://github.com/puppetlabs/puppet/blob/5.5.3/lib/puppet/pops/loaders.rb#L415-L420