### PR TITLE
(PUP-8997) Deprecate the certificate face

### DIFF
--- a/lib/puppet/face/certificate.rb
+++ b/lib/puppet/face/certificate.rb
@@ -162,4 +162,6 @@ Puppet::Indirector::Face.define(:certificate, '0.0.1') do
 
   deactivate_action(:search)
   deactivate_action(:save)
+
+  deprecate
 end


### PR DESCRIPTION
The `certificate` face was the last of the SSL-related faces that had
not yet been deprecated. This commit deprecates it. All of these faces,
as well as the `cert` application, will be replaced with new, more
streamlined tools in Puppet 6.