### PR TITLE
(PUP-8997) Deprecate the `cert` subcommand

### DIFF
--- a/lib/puppet/application/cert.rb
+++ b/lib/puppet/application/cert.rb
@@ -100,7 +100,7 @@ class Puppet::Application::Cert < Puppet::Application
   end
 
   def summary
-    _("Manage certificates and requests")
+    _("Manage certificates and requests (Deprecated)")
   end
 
   def help
@@ -282,6 +282,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
   end
 
   def setup
+    deprecate
+
     require 'puppet/ssl/certificate_authority'
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -127,7 +127,8 @@ describe Puppet::Face[:help, '0.0.1'] do
         expect(subject).to match(%r{ #{appname} })
 
         summary = Puppet::Face[:help, :current].horribly_extract_summary_from(appname)
-        summary and expect(subject).to match(%r{ #{summary}\b})
+        summary_regex = Regexp.escape(summary)
+        summary and expect(subject).to match(%r{ #{summary_regex}$})
       end
     end
   end


### PR DESCRIPTION
This commit deprecates the `cert` application, which will be updated in
Puppet 6 to error with instructions on how to use the Puppet Server CA
CLI to do the actions that `cert` currently performs.

Unlike with face, calling the `deprecate` message in an application only
causes a warning to be issued when it is run, and does not update the
summary (and therefore not the help output), so this commit updates the
summary to indicate the deprecation.