### PR TITLE
(PUP-9008) Use `initctl version --quiet` to detect upstart daemon

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -16,8 +16,6 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
     Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 
-  confine :exists => "/var/run/upstart-socket-bridge.pid"
-
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
 
   commands :start   => "/sbin/start",
@@ -25,6 +23,16 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
            :restart => "/sbin/restart",
            :status_exec  => "/sbin/status",
            :initctl => "/sbin/initctl"
+
+  # We only want to use upstart as our provider if the upstart daemon is running.
+  # This can be checked by running `initctl version --quiet` on a machine that has
+  # upstart installed.
+  confine :true => begin
+    initctl('version', '--quiet')
+    true
+  rescue
+    false
+  end
 
   # upstart developer haven't implemented initctl enable/disable yet:
   # http://www.linuxplanet.com/linuxplanet/tutorials/7033/2/

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -34,6 +34,43 @@ describe Puppet::Type.type(:service).provider(:upstart) do
     expect(described_class.default?).to be_truthy
   end
 
+  context "upstart daemon existence confine" do
+    # We have a separate method here because our search for the upstart daemon
+    # confine expects it to be the last confine declared in the upstart provider.
+    # If in the future we add other confines below it or change its order, these
+    # unit tests will fail. Placing knowledge of where this confine is located
+    # in one place makes updating it less painful in case we ever need to do this.
+    def assert_upstart_daemon_existence_confine_is(expected_value)
+      upstart_daemon_existence_confine = provider_class.confine_collection.instance_variable_get(:@confines)[-1]
+      expect(upstart_daemon_existence_confine.valid?).to be(expected_value)
+    end
+
+    let(:initctl_version) { ['/sbin/initctl', 'version', '--quiet'] }
+    before(:each) do
+      # Stub out /sbin/initctl
+      Puppet::Util.stubs(:which).with('/sbin/initctl').returns('/sbin/initctl')
+
+      # Both of our tests are asserting the confine :true block that shells out to
+      # `initctl version --quiet`. Its expression is evaluated at provider load-time.
+      # Hence before each test, we want to reload the upstart provider so that the
+      # confine is re-evaluated.
+      Puppet::Type.type(:service).unprovide(:upstart)
+    end
+
+    it "should return true when the daemon is running" do
+      Puppet::Util::Execution.expects(:execute).with(initctl_version, instance_of(Hash))
+      assert_upstart_daemon_existence_confine_is(true)
+    end
+
+    it "should return false when the daemon is not running" do
+      Puppet::Util::Execution.expects(:execute)
+        .with(initctl_version, instance_of(Hash))
+        .raises(Puppet::ExecutionFailure, "initctl failed!")
+
+      assert_upstart_daemon_existence_confine_is(false)
+    end
+  end
+
   describe "excluding services" do
     it "ignores tty and serial on Redhat systems" do
       Facter.stubs(:value).with(:osfamily).returns('RedHat')


### PR DESCRIPTION
Previously, we'd confine the upstart provider to platforms where the
/var/run/upstart-socket-bridge.pid file exists because that would mean
that the upstart daemon was running. This was not quite correct. The
upstart daemon could still be running even if that file did not exist
(e.g. such as on a RHEL 6 machine, for example).

We can use `initctl version --quiet` instead to check if the upstart
daemon's running. If that command fails, then the upstart daemon isn't
running so we cannot use the upstart provider. If it succeeds, then the
upstart daemon is running so we can use the upstart provider. We confine
our provider to platforms that result in a successful execution of this
command.