### PR TITLE
(PUP-8598, 8622, 8635, 8641, 8657, 8676) Add Deferred Type and Make Rich Data work on Agent - For Puppet 6

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -4,6 +4,8 @@ require 'timeout'
 require 'puppet/network/http_pool'
 require 'puppet/util'
 require 'securerandom'
+#require 'puppet/parser/script_compiler'
+require 'puppet/pops/evaluator/deferred_resolver'
 
 class Puppet::Configurer
   require 'puppet/configurer/fact_handler'
@@ -106,6 +108,11 @@ class Puppet::Configurer
     catalog = nil
 
     catalog_conversion_time = thinmark do
+      # Will mutate the result and replace all Deferred values with resolved values
+      if options[:convert_for_node] && options[:convert_with_facts]
+        Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(options[:convert_for_node], options[:convert_with_facts], result)
+      end
+
       catalog = result.to_ral
       catalog.finalize
       catalog.retrieval_duration = duration
@@ -137,7 +144,9 @@ class Puppet::Configurer
       #
       # facts_for_uploading may set Puppet[:node_name_value] as a side effect
       facter_time = thinmark do
-        facts_hash = facts_for_uploading
+        facts = find_facts
+        options[:convert_with_facts] =  facts
+        facts_hash = encode_facts(facts) # encode for uploading # was: facts_for_uploading
       end
       options[:report].add_times(:fact_generation, facter_time) if options[:report]
     end
@@ -350,6 +359,7 @@ class Puppet::Configurer
 
       query_options = get_facts(options) unless query_options
       query_options[:configured_environment] = configured_environment
+      options[:convert_for_node] = node
 
       unless catalog = prepare_and_retrieve_catalog(options, query_options)
         return nil

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -343,7 +343,10 @@ class Puppet::Configurer
                                          current_environment.manifest,
                                          current_environment.config_version)
       end
-      Puppet.push_context({:current_environment => local_node_environment}, "Local node environment for configurer transaction")
+      Puppet.push_context({
+        :current_environment => local_node_environment, 
+        :loaders => Puppet::Pops::Loaders.new(local_node_environment)
+      }, "Local node environment for configurer transaction")
 
       query_options = get_facts(options) unless query_options
       query_options[:configured_environment] = configured_environment

--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -28,7 +28,11 @@ module Puppet::Configurer::FactHandler
   end
 
   def facts_for_uploading
-    facts = find_facts
+    encode_facts(find_facts)
+  end
+
+  def encode_facts(facts)
+    #facts = find_facts
 
     # NOTE: :facts specified as parameters are URI encoded here,
     # then  encoded for a second time depending on their length:

--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -714,6 +714,11 @@ module Puppet::Functions
       inject(:pal_script_compiler)
     end
 
+    # Inject a parameter getting a cached hash for this function
+    def cache_param
+      inject(:cache)
+    end
+
     private
 
     def inject(injection_name)

--- a/lib/puppet/functions/call.rb
+++ b/lib/puppet/functions/call.rb
@@ -6,6 +6,10 @@
 # 2. Any number of arguments to be passed to the called function.
 # 3. An optional lambda, if the function being called supports it.
 #
+# This function can also be used to resolve a `Deferred` given as
+# the only argument to the function (does not accept arguments nor
+# a block).
+#
 # @example Using the `call` function
 #
 # ```puppet
@@ -26,6 +30,29 @@
 # The `call` function can be used to call either Ruby functions or Puppet language
 # functions.
 #
+# When used with `Deferred` values, the deferred value can either describe
+# a function call, or a dig into a variable.
+#
+# @example Resolving a deferred function call
+#
+# ```puppet
+# $d = Deferred('join', [[1,2,3], ':']) # A future call to join that joins the arguments 1,2,3 with ':'
+# notice($d.call())
+# ```
+#
+# Would notice the string "1:2:3".
+#
+# @example Resolving a deferred variable value with optional dig into its structure
+#
+# ```puppet
+# $d = Deferred('$facts', ['processors', 'count'])
+# notice($d.call())
+# ```
+#
+# Would notice the value of `$facts['processors']['count']` at the time when the `call` is made.
+#
+# * Deferred values supported since Puppet 5.6.0
+#
 # @since 5.0.0
 #
 Puppet::Functions.create_function(:call, Puppet::Functions::InternalFunction) do
@@ -36,7 +63,17 @@ Puppet::Functions.create_function(:call, Puppet::Functions::InternalFunction) do
     optional_block_param
   end
 
+  dispatch :call_deferred do
+    scope_param
+    param 'Deferred', :deferred
+  end
+
   def call_impl_block(scope, function_name, *args, &block)
     call_function_with_scope(scope, function_name, *args, &block)
   end
+
+  def call_deferred(scope, deferred)
+    Puppet::Pops::Evaluator::DeferredResolver.resolve(deferred, scope.compiler)
+  end
+
 end

--- a/lib/puppet/pops.rb
+++ b/lib/puppet/pops.rb
@@ -70,6 +70,7 @@ module Puppet
       require 'puppet/pops/evaluator/epp_evaluator'
       require 'puppet/pops/evaluator/collector_transformer'
       require 'puppet/pops/evaluator/puppet_proc'
+      require 'puppet/pops/evaluator/deferred_resolver'
       module Collectors
         require 'puppet/pops/evaluator/collectors/abstract_collector'
         require 'puppet/pops/evaluator/collectors/fixed_set_collector'

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -2,6 +2,20 @@
 #
 module Puppet::Pops
 module Adapters
+
+  class ObjectIdCacheAdapter < Puppet::Pops::Adaptable::Adapter
+    attr_accessor :cache
+
+    def initialize
+      @cache = {}
+    end
+
+    # Retrieves a mutable hash with all stored values
+    def retrieve(o)
+      @cache[o.__id__] ||= {}
+    end
+  end
+
   # A documentation adapter adapts an object with a documentation string.
   # (The intended use is for a source text parser to extract documentation and store this
   # in DocumentationAdapter instances).

--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -1,0 +1,118 @@
+require 'puppet/parser/script_compiler'
+
+module Puppet::Pops
+module Evaluator
+
+# Utility class to help resolve instances of Puppet::Pops::Types::PDeferredType::Deferred
+#
+class DeferredResolver
+  DOLLAR = '$'.freeze
+  DIG    = 'dig'.freeze
+
+  # Resolves and replaces all Deferred values in a catalog's resource attributes
+  # found as direct values or nested inside Array, Hash or Sensitive values.
+  # Deferred values inside of custom Object instances are not resolved as this
+  # is expected to be done by such objects.
+  #
+  # @param node [Puppet::Node] the node for the catalog
+  # @param facts [Puppet::Node::Facts] the facts object for the node
+  # @param catalog [Puppet::Resource::Catalog] the catalog where all deferred values should be replaced
+  # @return [nil] does not return anything - the catalog is modified as a side effect
+  #
+  def self.resolve_and_replace(node, facts, catalog)
+    compiler = Puppet::Parser::ScriptCompiler.new(node.environment, node.name)
+    resolver = new(compiler)
+    resolver.set_facts_variable(facts)
+    # TODO:
+    #    # When scripting the trusted data are always local, but set them anyway
+    #    @scope.set_trusted(node.trusted_data)
+    #
+    #    # Server facts are always about the local node's version etc.
+    #    @scope.set_server_facts(node.server_facts)
+
+    resolver.resolve_futures(catalog)
+    nil
+  end
+
+  # Resolves a value such that a direct Deferred, or any nested Deferred values
+  # are resolved and used instead of the deferred value.
+  # A direct Deferred value, or nested deferred values inside of Array, Hash or
+  # Sensitive values are resolved and replaced inside of freshly created
+  # containers.
+  #
+  # The resolution takes place in the topscope of the given compiler.
+  # Variable values are supposed to already have been set.
+  #
+  # @param value [Object] the (possibly nested) value to resolve
+  # @param compiler [Puppet::Parser::ScriptCompiler, Puppet::Parser::Compiler] the compiler in effect
+  # @return [Object] the resolved value (a new Array, Hash, or Sensitive if needed), with all deferred values resolved
+  #
+  def self.resolve(value, compiler)
+    resolver = new(compiler)
+    resolver.resolve(value)
+  end
+
+  def initialize(compiler)
+    @compiler = compiler
+    # Always resolve in top scope
+    @scope = @compiler.topscope
+    @deferred_class = Puppet::Pops::Types::TypeFactory.deferred.implementation_class
+  end
+
+  # @param facts [Puppet::Node::Facts] the facts to set in $facts in the compiler's topscope
+  #
+  def set_facts_variable(facts)
+    @scope.set_facts(facts.nil? ? {} : facts.values)
+  end
+
+  def resolve_futures(catalog)
+    catalog.resources.each do |r|
+      overrides = {}
+      r.parameters.each_pair do |k, v|
+        overrides[ k ] = resolve(v)
+      end
+      r.parameters.merge!(overrides) unless overrides.empty?
+    end
+  end
+
+  def resolve(x)
+    if x.class == @deferred_class
+      resolve_future(x)
+    elsif x.is_a?(Array)
+      x.map {|v| resolve(v) }
+    elsif x.is_a?(Hash)
+      result = {}
+      x.each_pair {|k,v| result[k] = resolve(v) }
+      result
+    elsif x.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      # rewrap in a new Sensitive after resolving any nested deferred values
+      Puppet::Pops::Types::PSensitiveType::Sensitive.new(resolve(x.unwrap))
+    else
+      x
+    end
+  end
+
+  def resolve_future(f)
+    # If any of the arguments to a future is a future it needs to be resolved first
+    func_name = f.name
+    mapped_arguments = map_arguments(f.arguments)
+    # if name starts with $ then this is a call to dig 
+    if func_name[0] == DOLLAR
+      var_name = func_name[1..-1]
+      func_name = DIG
+      mapped_arguments.insert(0, @scope[var_name])
+    end
+
+    # call the function (name in deferred, or 'dig' for a variable)
+    @scope.call_function(func_name, mapped_arguments)
+  end
+
+  def map_arguments(args)
+    return [] if args.nil?
+    args.map {|v| resolve(v) }
+  end
+  private :map_arguments
+
+end
+end
+end

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -404,7 +404,7 @@ class EvaluatorImpl
     end
 
     left_o = bin_expr.left_expr
-    if left.is_a?(URI) && operator == '+'
+    if (left.is_a?(URI) || left.is_a?(Types::PBinaryType::Binary)) && operator == '+'
       concatenate(left, right)
     elsif (left.is_a?(Array) || left.is_a?(Hash)) && COLLECTION_OPERATORS.include?(operator)
       # Handle operation on collections
@@ -1209,6 +1209,9 @@ class EvaluatorImpl
     when URI
       raise ArgumentError.new(_('An URI can only be merged with an URI or String')) unless y.is_a?(String) || y.is_a?(URI)
       x + y
+    when Types::PBinaryType::Binary
+      raise ArgumentError.new(_('Can only append Binary to a Binary')) unless y.is_a?(Types::PBinaryType::Binary)
+      Types::PBinaryType::Binary.from_binary_string(x.binary_buffer + y.binary_buffer)
     else
       concatenate([x], y)
     end

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -79,6 +79,8 @@ class Dispatch < Evaluator::CallableSignature
               scope
             when :pal_script_compiler
               Puppet.lookup(:pal_script_compiler)
+            when :cache
+              Puppet::Pops::Adapters::ObjectIdCacheAdapter.adapt(scope.compiler)
             else
               raise ArgumentError, _("Unknown injection %{injection_name}") % { injection_name: injection_name }
             end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -72,6 +72,7 @@ class Loaders
   #
   def self.clear
     @@static_loader = nil
+    Puppet::Pops::Types::TypeFactory.clear
     Model.class_variable_set(:@@pcore_ast_initialized, false)
     Model.register_pcore_types
   end

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -101,7 +101,7 @@ module Pcore
         attributes => {
           # Fully qualified name of the function
           name  => { type => Pattern[/\\A[$]?[a-z][a-z0-9_]*(?:::[a-z][a-z0-9_]*)*\\z/] },
-          arguments => { type => Array[Any], value => []},
+          arguments => { type => Optional[Array[Any]], value => undef},
         }
       }
     PUPPET

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -95,6 +95,17 @@ module Pcore
     Resource.register_ptypes(loader, ir)
     Lookup::Context.register_ptype(loader, ir);
     Lookup::DataProvider.register_types(loader)
+
+    add_object_type('Deferred', <<-PUPPET, loader)
+      {
+        attributes => {
+          # Fully qualified name of the function
+          name  => { type => Pattern[/\\A[$]?[a-z][a-z0-9_]*(?:::[a-z][a-z0-9_]*)*\\z/] },
+          arguments => { type => Array[Any], value => []},
+        }
+      }
+    PUPPET
+
   end
 
   # Create and register a new `Object` type in the Puppet Type System and map it to an implementation class

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -6,6 +6,19 @@ module Types
 module TypeFactory
   @type_calculator = TypeCalculator.singleton
 
+  # Clears caches - used when testing
+  def self.clear
+    # these types are cached and needs to be nulled as the representation may change if loaders are cleared
+    @data_t = nil
+    @rich_data_t = nil
+    @rich_data_key_t = nil
+    @array_of_data_t = nil
+    @hash_of_data_t = nil
+    @error_t = nil
+    @task_t = nil
+    @deferred_t = nil
+  end
+
   # Produces the Integer type
   # @api public
   #

--- a/lib/puppet/pops/types/type_factory.rb
+++ b/lib/puppet/pops/types/type_factory.rb
@@ -526,6 +526,10 @@ module TypeFactory
     @task_t ||= TypeParser.singleton.parse('Task')
   end
 
+  def self.deferred
+    @deferred_t ||= TypeParser.singleton.parse('Deferred')
+  end
+
   # Produces a type for URI[String or Hash]
   # @api public
   #

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -469,7 +469,13 @@ describe Puppet::Configurer do
     describe "when using a REST terminus for catalogs" do
       it "should pass the prepared facts and the facts format as arguments when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :rest
-        @agent.expects(:facts_for_uploading).returns(:facts => "myfacts", :facts_format => :foo)
+        # the "facts_for_uploading" are prepeared by first finding facts, and then encoding them
+        # this mocks the "find" with a special value 12345, which is then expected back in the
+        # call to "encode" - the encode in turn returns mocked data that is asserted as being
+        # presented to the catalog terminus as options.
+        #
+        @agent.expects(:find_facts).returns(12345)
+        @agent.expects(:encode_facts).with(12345).returns(:facts => "myfacts", :facts_format => :foo)
         Puppet::Resource::Catalog.indirection.expects(:find).with { |name, options|
           options[:facts] == "myfacts" and options[:facts_format] == :foo
         }.returns @catalog

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -362,7 +362,7 @@ describe Puppet::Configurer do
 
     it 'includes total time metrics in the report after successfully applying the catalog' do
       report = Puppet::Transaction::Report.new
-      @catalog.stubs(:apply).with(:report => report)
+      @catalog.stubs(:apply).with() {|options| options[:report] == report }
       @agent.run(report: report)
 
       expect(report.metrics['time']).to be

--- a/spec/unit/functions/call_spec.rb
+++ b/spec/unit/functions/call_spec.rb
@@ -20,7 +20,9 @@ describe 'the call method' do
         'modules' => {
           'test' => {
             'functions' => {
-              'call_me.pp' => 'function test::call_me() { "called" }'
+              'call_me.pp' => 'function test::call_me() { "called" }',
+              'abc.pp'     => 'function test::abc() { "a-b-c" }',
+              'dash.pp'    => 'function test::dash() { "-" }'
             }
           }
         }
@@ -34,7 +36,7 @@ describe 'the call method' do
     end
 
     it 'call on a built-in 4x Ruby API function' do
-      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[a]')
+      expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[a]')
           $a = call('split', 'a-b-c', '-')
           notify { $a[0]: }
         CODE
@@ -47,7 +49,7 @@ describe 'the call method' do
     end
 
     it 'call a Ruby 4x API built-in with block' do
-      catalog = compile_to_catalog(<<-CODE)
+      catalog = compile_to_catalog(<<-CODE, node)
         $a = 'each'
         $b = [1,2,3]
         call($a, $b) |$index, $v| {
@@ -61,29 +63,64 @@ describe 'the call method' do
     end
 
     it 'call with the calling context' do
-      expect(eval_and_collect_notices(<<-CODE)).to eq(['a'])
+      expect(eval_and_collect_notices(<<-CODE, node)).to eq(['a'])
         class a { call('notice', $title) }
         include a
       CODE
     end
 
     it 'call on a non-existent function name' do
-      expect { compile_to_catalog(<<-CODE) }.to raise_error(Puppet::Error, /Unknown function/)
+      expect { compile_to_catalog(<<-CODE, node) }.to raise_error(Puppet::Error, /Unknown function/)
         $a = call('not_a_function_name')
         notify { $a: }
       CODE
     end
 
     it 'call a deferred value' do
-      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[a]')
+      expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[a]')
           $d = Deferred('split', ['a-b-c', '-'])
           $a = $d.call()
           notify { $a[0]: }
         CODE
     end
 
+    it 'resolves deferred value arguments in an array when calling a deferred' do
+      expect(compile_to_catalog(<<-CODE,node)).to have_resource('Notify[a]')
+          $d = Deferred('split', [Deferred('test::abc'), '-'])
+          $a = $d.call()
+          notify { $a[0]: }
+        CODE
+    end
+
+    it 'resolves deferred value arguments in a Sensitive when calling a deferred' do
+      expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[a]')
+          function my_split(Sensitive $sensy, $on) { $sensy.unwrap |$x| { split($x, $on) } }
+          $d = Deferred('my_split', [ Sensitive(Deferred('test::abc')), '-'])
+          $a = $d.call()
+          notify { $a[0]: }
+        CODE
+    end
+
+    it 'resolves deferred value arguments in a Hash when calling a deferred' do
+      expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[a]')
+          function my_split(Hash $hashy, $on) { split($hashy['key'], $on)  }
+          $d = Deferred('my_split', [ {'key' => Deferred('test::abc')}, '-'])
+          $a = $d.call()
+          notify { $a[0]: }
+        CODE
+    end
+
+    it 'resolves deferred value arguments in a nested structure when calling a deferred' do
+      expect(compile_to_catalog(<<-CODE,node)).to have_resource('Notify[a]')
+          function my_split(Hash $hashy, Array[Sensitive] $sensy) { split($hashy['key'][0], $sensy[0].unwrap |$x| {$x})  }
+          $d = Deferred('my_split', [ {'key' => [Deferred('test::abc')]}, [Sensitive(Deferred('test::dash'))]])
+          $a = $d.call()
+          notify { $a[0]: }
+        CODE
+    end
+
     it 'call dig into a variable' do
-      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[value 3]')
+      expect(compile_to_catalog(<<-CODE, node)).to have_resource('Notify[value 3]')
           $x = { 'a' => [1,2,3] }
           $d = Deferred('$x', ['a', 2])
           $a = $d.call()

--- a/spec/unit/functions/call_spec.rb
+++ b/spec/unit/functions/call_spec.rb
@@ -73,5 +73,22 @@ describe 'the call method' do
         notify { $a: }
       CODE
     end
+
+    it 'call a deferred value' do
+      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[a]')
+          $d = Deferred('split', ['a-b-c', '-'])
+          $a = $d.call()
+          notify { $a[0]: }
+        CODE
+    end
+
+    it 'call dig into a variable' do
+      expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[value 3]')
+          $x = { 'a' => [1,2,3] }
+          $d = Deferred('$x', ['a', 2])
+          $a = $d.call()
+          notify { "value $a": }
+        CODE
+    end
   end
 end

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -425,7 +425,7 @@ describe 'the 4x function api' do
       end
     end
 
-    context 'supports calling ruby functions with lambda from puppet' do
+    context 'functions in a context with a compiler' do
       before(:all) do
         Puppet.push_context( {:loaders => Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, []))})
       end
@@ -443,28 +443,37 @@ describe 'the 4x function api' do
       let(:scope) { s = create_test_scope_for_node(node); s }
       let(:loader) { Puppet::Pops::Loaders.find_loader(nil) }
 
-      it 'function with required block can be called' do
-        # construct ruby function to call
-        fc = Puppet::Functions.create_function('testing::test') do
-          dispatch :test do
-            param 'Integer', :x
-            # block called 'the_block', and using "all_callables"
-            required_block_param #(all_callables(), 'the_block')
+      context 'supports calling ruby functions with lambda from puppet' do
+        it 'function with required block can be called' do
+          # construct ruby function to call
+          fc = Puppet::Functions.create_function('testing::test') do
+            dispatch :test do
+              param 'Integer', :x
+              # block called 'the_block', and using "all_callables"
+              required_block_param #(all_callables(), 'the_block')
+            end
+            def test(x)
+              # call the block with x
+              yield(x)
+            end
           end
-          def test(x)
-            # call the block with x
-            yield(x)
-          end
+          # add the function to the loader (as if it had been loaded from somewhere)
+          the_loader = loader
+          f = fc.new({}, the_loader)
+          loader.set_entry(Puppet::Pops::Loader::TypedName.new(:function, 'testing::test'), f)
+          # evaluate a puppet call
+          source = "testing::test(10) |$x| { $x+1 }"
+          program = parser.parse_string(source, __FILE__)
+          Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns(the_loader)
+          expect(parser.evaluate(scope, program)).to eql(11)
         end
-        # add the function to the loader (as if it had been loaded from somewhere)
-        the_loader = loader
-        f = fc.new({}, the_loader)
-        loader.set_entry(Puppet::Pops::Loader::TypedName.new(:function, 'testing::test'), f)
-        # evaluate a puppet call
-        source = "testing::test(10) |$x| { $x+1 }"
-        program = parser.parse_string(source, __FILE__)
-        Puppet::Pops::Adapters::LoaderAdapter.expects(:loader_for_model_object).at_least_once.returns(the_loader)
-        expect(parser.evaluate(scope, program)).to eql(11)
+      end
+
+      it 'supports injection of a cache' do
+        the_function = create_function_with_cache_param.new(:closure_scope, :loader)
+        expect(the_function.call(scope, 'key', 10)).to eql(nil)
+        expect(the_function.call(scope, 'key', 20)).to eql(10)
+        expect(the_function.call(scope, 'key', 30)).to eql(20)
       end
     end
 
@@ -508,8 +517,8 @@ describe 'the 4x function api' do
           CODE
         end.to raise_error(/Parsing of type string '"Array\[1\+=1\]"' failed with message: <Syntax error at '\]' \(line: 1, column: [0-9]+\)>/m)
       end
-
     end
+
     context 'can use a loader when parsing types in function dispatch, and' do
       let(:parser) {  Puppet::Pops::Parser::EvaluatingParser.new }
 
@@ -854,25 +863,26 @@ describe 'the 4x function api' do
     end
   end
 
-  def create_function_with_param_injection_regular
-    Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
-      attr_injected Puppet::Pops::Types::TypeFactory.type_of(FunctionAPISpecModule::TestDuck), :test_attr
-      attr_injected Puppet::Pops::Types::TypeFactory.string(), :test_attr2, "a_string"
-      attr_injected_producer Puppet::Pops::Types::TypeFactory.integer(), :serial, "an_int"
-
-      dispatch :test do
-        injected_param Puppet::Pops::Types::TypeFactory.string, :x, 'a_string'
-        injected_producer_param Puppet::Pops::Types::TypeFactory.integer, :y, 'an_int'
-        param 'Scalar', :a
-        param 'Scalar', :b
-      end
-
-      def test(x,y,a,b)
-        y_produced = y.produce(nil)
-        "#{x}! #{a}, and #{b} < #{y_produced} = #{ !!(a < y_produced && b < y_produced)}"
-      end
-    end
-  end
+# DEAD TODO REMOVE
+#  def create_function_with_param_injection_regular
+#    Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
+#      attr_injected Puppet::Pops::Types::TypeFactory.type_of(FunctionAPISpecModule::TestDuck), :test_attr
+#      attr_injected Puppet::Pops::Types::TypeFactory.string(), :test_attr2, "a_string"
+#      attr_injected_producer Puppet::Pops::Types::TypeFactory.integer(), :serial, "an_int"
+#
+#      dispatch :test do
+#        injected_param Puppet::Pops::Types::TypeFactory.string, :x, 'a_string'
+#        injected_producer_param Puppet::Pops::Types::TypeFactory.integer, :y, 'an_int'
+#        param 'Scalar', :a
+#        param 'Scalar', :b
+#      end
+#
+#      def test(x,y,a,b)
+#        y_produced = y.produce(nil)
+#        "#{x}! #{a}, and #{b} < #{y_produced} = #{ !!(a < y_produced && b < y_produced)}"
+#      end
+#    end
+#  end
 
   def create_function_with_required_block_all_defaults
     Puppet::Functions.create_function('test') do
@@ -997,6 +1007,22 @@ describe 'the 4x function api' do
 
       def on_error(x)
         "It's not OK to pass a string"
+      end
+    end
+  end
+
+  def create_function_with_cache_param
+    Puppet::Functions.create_function('test', Puppet::Functions::InternalFunction) do
+      dispatch :test do
+        cache_param
+        param 'String', :key
+        param 'Any', :value
+      end
+      def test(cache, k, v)
+        h = cache.retrieve(self)
+        previous = h[k]
+        h[k] = v
+        previous
       end
     end
   end

--- a/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
+++ b/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
@@ -128,6 +128,16 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
     end
 
+    context 'on binary values' do
+      include PuppetSpec::Compiler
+      require 'base64'
+      encoded = Base64.encode64('Hello world').chomp
+      it 'Binary + Binary' do
+        code = 'notice(assert_type(Binary, Binary([72,101,108,108,111,32]) + Binary([119,111,114,108,100])))'
+        expect(eval_and_collect_notices(code)).to eql([encoded])
+      end
+    end
+
     context 'on timespans' do
       include PuppetSpec::Compiler
 

--- a/spec/unit/pops/types/deferred_spec.rb
+++ b/spec/unit/pops/types/deferred_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet_spec/compiler'
+
+module Puppet::Pops
+  module Types
+    describe 'Deferred type' do
+      context 'when used in Puppet expressions' do
+        include PuppetSpec::Compiler
+        it 'is equal to itself only' do
+          expect(eval_and_collect_notices(<<-CODE)).to eq(%w(true true false false))
+            $t = Deferred
+            notice(Deferred =~ Type[Deferred])
+            notice(Deferred == Deferred)
+            notice(Deferred < Deferred)
+            notice(Deferred > Deferred)
+            CODE
+        end
+
+        context 'a Deferred instance' do
+          it 'can be created using positional arguments' do
+            code = <<-CODE
+              $o = Deferred('michelangelo', [1,2,3])
+              notice($o)
+              CODE
+            expect(eval_and_collect_notices(code)).to eq([
+              "Deferred({'name' => 'michelangelo', 'arguments' => [1, 2, 3]})"
+            ])
+          end
+
+          it 'can be created using named arguments' do
+            code = <<-CODE
+              $o = Deferred(name =>'michelangelo', arguments => [1,2,3])
+              notice($o)
+              CODE
+            expect(eval_and_collect_notices(code)).to eq([
+              "Deferred({'name' => 'michelangelo', 'arguments' => [1, 2, 3]})"
+            ])
+          end
+
+          it 'is inferred to have the type Deferred' do
+            pending 'bug in type() function outputs the entire pcore definition'
+            code = <<-CODE
+              $o = Deferred('michelangelo', [1,2,3])
+              notice(type($o))
+              CODE
+            expect(eval_and_collect_notices(code)).to eq([
+              "Deferred"
+            ])
+          end
+
+          it 'exposes name' do
+            code = <<-CODE
+              $o = Deferred(name =>'michelangelo', arguments => [1,2,3])
+              notice($o.name)
+              CODE
+            expect(eval_and_collect_notices(code)).to eq(["michelangelo"])
+          end
+
+          it 'exposes arguments' do
+            code = <<-CODE
+              $o = Deferred(name =>'michelangelo', arguments => [1,2,3])
+              notice($o.arguments)
+              CODE
+            expect(eval_and_collect_notices(code)).to eq(["[1, 2, 3]"])
+          end
+
+          it 'is an instance of its inferred type' do
+            code = <<-CODE
+              $o = Deferred(name =>'michelangelo', arguments => [1,2,3])
+              notice($o =~ type($o))
+              CODE
+            expect(eval_and_collect_notices(code)).to eq(['true'])
+          end
+
+          it 'is an instance of Deferred' do
+            code = <<-CODE
+              $o = Deferred(name =>'michelangelo', arguments => [1,2,3])
+              notice($o =~ Deferred)
+              CODE
+            expect(eval_and_collect_notices(code)).to eq(['true'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/ssl/certificate_factory_spec.rb
+++ b/spec/unit/ssl/certificate_factory_spec.rb
@@ -21,9 +21,11 @@ describe Puppet::SSL::CertificateFactory, :unless => RUBY_PLATFORM == 'java' do
 
   describe "when generating the certificate" do
     it "should return a new X509 certificate" do
-      expect(subject.build(:server, csr, issuer, serial)).not_to eq(
-        subject.build(:server, csr, issuer, serial)
-      )
+      a = subject.build(:server, csr, issuer, serial)
+      b = subject.build(:server, csr, issuer, serial)
+      # The two instances are equal in every aspect except that they are 
+      # different instances - they are `==`, but not hash `eql?`
+      expect(a).not_to eql(b)
     end
 
     it "should set the certificate's version to 2" do


### PR DESCRIPTION
This adds the Deferred type and makes --rich_data work on the agent. It also adds resolution of Deferred values.

@joshcooper This is the rebase for Puppet 6.0.