### PR TITLE
(PUP-9024) tagged: downcase arguments before checking

### DIFF
--- a/lib/puppet/parser/functions/tagged.rb
+++ b/lib/puppet/parser/functions/tagged.rb
@@ -9,12 +9,9 @@ Puppet::Parser::Functions::newfunction(:tagged, :type => :rvalue, :arity => -2, 
         {:operation => 'tagged'})
     end
 
-    configtags = compiler.catalog.tags
-    resourcetags = resource.tags
-
     retval = true
     vals.each do |val|
-      unless configtags.include?(val) or resourcetags.include?(val)
+      unless compiler.catalog.tagged?(val) or resource.tagged?(val)
         retval = false
         break
       end

--- a/spec/unit/parser/functions/tagged_spec.rb
+++ b/spec/unit/parser/functions/tagged_spec.rb
@@ -22,4 +22,20 @@ describe "the 'tagged' function" do
       @scope.function_tagged(['one', 'two'])
     end.to raise_error(Puppet::ParseError, /is only available when compiling a catalog/)
   end
+
+  it 'should be case-insensitive' do
+    resource = Puppet::Parser::Resource.new(:file, "/file", :scope => @scope)
+    @scope.stubs(:resource).returns resource
+    @scope.function_tag ["one"]
+
+    expect(@scope.function_tagged(['One'])).to eq(true)
+  end
+
+  it 'should check if all specified tags are included' do
+    resource = Puppet::Parser::Resource.new(:file, "/file", :scope => @scope)
+    @scope.stubs(:resource).returns resource
+    @scope.function_tag ["one"]
+
+    expect(@scope.function_tagged(['one', 'two'])).to eq(false)
+  end
 end


### PR DESCRIPTION
As tags are always stored downcased, we should also downcase
passed arguments, otherwise function will never return true.