### PR TITLE
(PUP-5921) Issue a deprecation warning when users set source_permissions.

### DIFF
--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -71,7 +71,12 @@ end
         end
 
         step "run the agent" do
-          on(agent, puppet("agent --libdir='#{agent_lib_dir}' --test --server #{master} --environment '#{tmp_environment}'"))
+          on(agent, puppet("agent --libdir='#{agent_lib_dir}' --test --server #{master} --environment '#{tmp_environment}'")) do |result|
+            assert_no_match(
+              /The \`source_permissions\` parameter is deprecated/,
+              result.stderr,
+              "pluginsync should not get a deprecation warning for source_permissions")
+          end
         end
 
         step "verify that the module files were synced down to the agent" do

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -152,7 +152,7 @@ module Puppet
         next if metadata_method == :group and !Puppet.features.root?
 
         case resource[:source_permissions]
-        when :ignore
+        when :ignore, nil
           next
         when :use_when_creating
           next if Puppet::FileSystem.exist?(resource[:path])
@@ -352,5 +352,14 @@ module Puppet
 
     defaultto :ignore
     newvalues(:use, :use_when_creating, :ignore)
+     munge do |value|
+      value = value ? value.to_sym : :ignore
+      if @resource.file && @resource.line && value != :ignore
+        #TRANSLATORS "source_permissions" is a parameter name and should not be translated
+        Puppet.puppet_deprecation_warning(_("The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`."), file: @resource.file, line: @resource.line)
+      end
+
+      value
+     end
   end
 end

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -602,7 +602,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       end
     end
 
-    it "should not give a deprecation warning when given actual content" do
+    it "should not give a checksum deprecation warning when given actual content" do
       Puppet.expects(:puppet_deprecation_warning).never
       catalog.add_resource described_class.new(:path => path, :content => 'this is content')
       catalog.apply
@@ -613,14 +613,14 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         let(:filebucket_digest) { method(:digest) }
       end
 
-      it "should give a deprecation warning" do
+      it "should give a checksum deprecation warning" do
         Puppet.expects(:puppet_deprecation_warning).with('Using a checksum in a file\'s "content" property is deprecated. The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release. The literal value of the "content" property will be written to the file. The checksum retrieval functionality is being replaced by the use of static catalogs. See https://puppet.com/docs/puppet/latest/static_catalogs.html for more information.', {:file => 'my/file.pp', :line => 5})
         d = digest("this is some content")
         catalog.add_resource described_class.new(:path => path, :content => "{#{digest_algorithm}}#{d}")
         catalog.apply
       end
 
-      it "should not give a deprecation warning when no content is specified while checksum and checksum value are used" do
+      it "should not give a checksum deprecation warning when no content is specified while checksum and checksum value are used" do
         Puppet.expects(:puppet_deprecation_warning).never
         d = digest("this is some content")
         catalog.add_resource described_class.new(:path => path, :checksum => digest_algorithm, :checksum_value => d)
@@ -1281,6 +1281,21 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
   end
 
   describe "when sourcing" do
+    it "should give a deprecation warning when the user sets source_permissions" do
+      Puppet.expects(:puppet_deprecation_warning).with(
+        'The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`.', 
+        {:file => 'my/file.pp', :line => 5})
+
+      catalog.add_resource described_class.new(:path => path, :content => 'this is content', :source_permissions => :use_when_creating)
+      catalog.apply
+    end
+
+    it "should not give a deprecation warning when the user does not set source_permissions" do
+      Puppet.expects(:puppet_deprecation_warning).never
+      catalog.add_resource described_class.new(:path => path, :content => 'this is content')
+      catalog.apply
+    end
+
     with_checksum_types "source", "default_values" do
       before(:each) do
         set_mode(0770, checksum_file)

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -160,6 +160,11 @@ describe Puppet::Configurer::Downloader do
       expect(@dler.catalog.host_config).to eq(false)
     end
 
+    it "should not issue a deprecation warning for source_permissions" do
+      Puppet.expects(:puppet_deprecation_warning).never
+      catalog = @dler.catalog
+      expect(catalog.resources.size).to eq(1) # Must consume catalog to fix warnings
+    end
   end
 
   describe "when downloading" do


### PR DESCRIPTION
Allowing default source_permissions to be nil so we can detect user setting the value.