### PR TITLE
(PUP-8913) Add larger time buffer for crl calculations

### DIFF
--- a/acceptance/tests/ssl/crl_retrieval_and_replacement.rb
+++ b/acceptance/tests/ssl/crl_retrieval_and_replacement.rb
@@ -3,14 +3,19 @@ test_name "Crl retrieval and replacement from master" do
   tag 'risk:medium',
       'server'
 
+  ca_crl_path = puppet_config(master, 'cacrl', section: 'master')
+
+  teardown do
+    on(master, "touch #{ca_crl_path}") # return back to current time
+  end
+
   with_puppet_running_on(master, {}) do
     agents.each do |agent|
-      ca_crl_path = puppet_config(master, 'cacrl', section: 'master')
       crl_path = puppet_config(agent, 'hostcrl', section: 'agent')
 
       step "When a newer crl is available on master" do
-        one_hour_ahead = on(master, "TZ=ZZZ-1:00 date +%Y%m%d%H%M.%S").stdout.chomp
-        on(master, "touch -t #{one_hour_ahead} #{ca_crl_path}")
+        hours_ahead = on(master, "date -d '+2 hours' +%Y%m%d%H%M").stdout.chomp
+        on(master, "touch -t #{hours_ahead} #{ca_crl_path}")
 
         step "Should replace the current agent crl" do
           old_agent_crl_mtime = on(agent, "stat -c '%Y' #{crl_path}").stdout
@@ -22,8 +27,8 @@ test_name "Crl retrieval and replacement from master" do
       end
 
       step "When a newer crl is NOT available on master" do
-        one_hour_behind = on(master, "TZ=ZZZ+1:00 date +%Y%m%d%H%M.%S").stdout.chomp
-        on(master, "touch -t #{one_hour_behind} #{ca_crl_path}")
+        hours_behind = days_ahead = on(master, "date -d '-2 hours' +%Y%m%d%H%M").stdout.chomp
+        on(master, "touch -t #{hours_behind} #{ca_crl_path}")
 
         step "Should NOT replace the current agent crl" do
           old_agent_crl_mtime = on(agent, "stat -c '%Y' #{crl_path}").stdout


### PR DESCRIPTION
Because some OSs had a larger intitial discrepancy between
ca_crl and agent crl file creation times, we needed to
increase the time buffer between the 2 files to be
sure we were actually creating ca_crls older or newer
than the agent crl file.