### PR TITLE
(PUP-9027) Deprecate CA file settings

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -39,6 +39,8 @@ module Puppet
 
   AS_DURATION = %q{This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y).}
 
+  CA_SETTING_DEPRECATION = _("The '%{setting_name}' setting is deprecated. Starting in Puppet 6, this setting will be ignored in favor of the analagous setting in Puppet Server's config.")
+
   define_settings(:main,
     :confdir  => {
         :default  => nil,
@@ -985,7 +987,10 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0755",
-      :desc => "The root directory for the certificate authority."
+      :desc => "The root directory for the certificate authority.",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cadir' })
+      }
     },
     :cacert => {
       :default => "$cadir/ca_crt.pem",
@@ -993,7 +998,10 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0644",
-      :desc => "The CA certificate."
+      :desc => "The CA certificate.",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cacert' })
+      }
     },
     :cakey => {
       :default => "$cadir/ca_key.pem",
@@ -1001,7 +1009,10 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0640",
-      :desc => "The CA private key."
+      :desc => "The CA private key.",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cakey' })
+      }
     },
     :capub => {
       :default => "$cadir/ca_pub.pem",
@@ -1009,7 +1020,10 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0644",
-      :desc => "The CA public key."
+      :desc => "The CA public key.",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'capub' })
+      }
     },
     :cacrl => {
       :default => "$cadir/ca_crl.pem",
@@ -1018,6 +1032,9 @@ EOT
       :group => "service",
       :mode => "0644",
       :desc => "The certificate revocation list (CRL) for the CA. Will be used if present but otherwise ignored.",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cacrl' })
+      }
     },
     :caprivatedir => {
       :default => "$cadir/private",
@@ -1033,7 +1050,10 @@ EOT
       :owner => "service",
       :group => "service",
       :mode  => "0755",
-      :desc => "Where the CA stores certificate requests"
+      :desc => "Where the CA stores certificate requests",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'csrdir' })
+      }
     },
     :signeddir => {
       :default => "$cadir/signed",
@@ -1041,7 +1061,10 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0755",
-      :desc => "Where the CA stores signed certificates."
+      :desc => "Where the CA stores signed certificates.",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'signeddir' })
+      }
     },
     :capass => {
       :default => "$caprivatedir/ca.pass",
@@ -1057,7 +1080,10 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0644",
-      :desc => "Where the serial number for certificates is stored."
+      :desc => "Where the serial number for certificates is stored.",
+      :hook => proc { |value|
+        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'serial' })
+      }
     },
     :autosign => {
       :default => "$confdir/autosign.conf",

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -752,11 +752,14 @@ change this setting; you also need to:
 
 * On the server: Stop Puppet Server.
 * On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
+  (Note `puppet cert clean` is deprecated and will be replaced with `puppetserver ca clean`
+  in Puppet 6.)
 * On the server: Delete the old certificate (and any old certificate signing requests)
   from the [ssldir](https://puppet.com/docs/puppet/latest/dirs_ssldir.html).
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
 * On the CA server: Sign the certificate request, explicitly allowing alternate names
-  (`puppet cert sign --allow-dns-alt-names <NAME>`).
+  (`puppet cert sign --allow-dns-alt-names <NAME>`). (Note `puppet cert sign` is deprecated
+  and will be replaced with `puppetserver ca sign` in Puppet 6.)
 * On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to retrieve the cert.
 * On the server: Start Puppet Server again.
 
@@ -977,7 +980,8 @@ EOT
     :ca,
     :ca_name => {
       :default    => "Puppet CA: $certname",
-      :desc       => "The name to use the Certificate Authority certificate.",
+      :desc       => "The name to use the Certificate Authority certificate. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
+      :deprecated => :completely,
     },
     :cadir => {
       :default => "$ssldir/ca",
@@ -1030,7 +1034,8 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0750",
-      :desc => "Where the CA stores private certificate information."
+      :desc => "Where the CA stores private certificate information. This setting is deprecated and will be removed in Puppet 6.",
+      :deprecated => :completely,
     },
     :csrdir => {
       :default => "$cadir/requests",
@@ -1056,7 +1061,8 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0640",
-      :desc => "Where the CA stores the password for the private key."
+      :desc => "Where the CA stores the password for the private key. This setting is deprecated and will be removed in Puppet 6.",
+      :deprecated => :completely,
     },
     :serial => {
       :default => "$cadir/serial",
@@ -1072,6 +1078,8 @@ EOT
       :type => :autosign,
       :desc => "Whether (and how) to autosign certificate requests. This setting
         is only relevant on a puppet master acting as a certificate authority (CA).
+        This setting is also deprecated and will be replaced by one in Puppet Server's
+        configs in Puppet 6.
 
         Valid values are true (autosigns all certificate requests; not recommended),
         false (disables autosigning certificates), or the absolute path to a file.
@@ -1098,14 +1106,15 @@ EOT
     :allow_duplicate_certs => {
       :default    => false,
       :type       => :boolean,
-      :desc       => "Whether to allow a new certificate
-      request to overwrite an existing certificate.",
+      :desc       => "Whether to allow a new certificate request to overwrite an existing certificate. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
+      :deprecated => :completely,
     },
     :ca_ttl => {
       :default    => "5y",
       :type       => :duration,
       :desc       => "The default TTL for new certificates.
-      #{AS_DURATION}"
+      #{AS_DURATION} This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
+      :deprecated => :completely,
     },
     :keylength => {
       :default    => 4096,
@@ -1118,7 +1127,8 @@ EOT
       :owner => "service",
       :group => "service",
       :desc => "The inventory file. This is a text file to which the CA writes a
-        complete listing of all certificates."
+        complete listing of all certificates. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
+      :deprecated => :completely,
     }
   )
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -987,7 +987,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0755",
-      :desc => "The root directory for the certificate authority.",
+      :desc => "The root directory for the certificate authority. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cadir' })
       }
@@ -998,7 +998,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0644",
-      :desc => "The CA certificate.",
+      :desc => "The CA certificate. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cacert' })
       }
@@ -1009,7 +1009,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0640",
-      :desc => "The CA private key.",
+      :desc => "The CA private key. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cakey' })
       }
@@ -1020,7 +1020,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0644",
-      :desc => "The CA public key.",
+      :desc => "The CA public key. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'capub' })
       }
@@ -1031,7 +1031,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0644",
-      :desc => "The certificate revocation list (CRL) for the CA. Will be used if present but otherwise ignored.",
+      :desc => "The certificate revocation list (CRL) for the CA. Will be used if present but otherwise ignored. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cacrl' })
       }
@@ -1050,7 +1050,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode  => "0755",
-      :desc => "Where the CA stores certificate requests",
+      :desc => "Where the CA stores certificate requests. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'csrdir' })
       }
@@ -1061,7 +1061,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0755",
-      :desc => "Where the CA stores signed certificates.",
+      :desc => "Where the CA stores signed certificates. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'signeddir' })
       }
@@ -1080,7 +1080,7 @@ EOT
       :owner => "service",
       :group => "service",
       :mode => "0644",
-      :desc => "Where the serial number for certificates is stored.",
+      :desc => "Where the serial number for certificates is stored. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
       :hook => proc { |value|
         Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'serial' })
       }

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -39,8 +39,6 @@ module Puppet
 
   AS_DURATION = %q{This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y).}
 
-  CA_SETTING_DEPRECATION = _("The '%{setting_name}' setting is deprecated. Starting in Puppet 6, this setting will be ignored in favor of the analagous setting in Puppet Server's config.")
-
   define_settings(:main,
     :confdir  => {
         :default  => nil,
@@ -988,9 +986,7 @@ EOT
       :group => "service",
       :mode => "0755",
       :desc => "The root directory for the certificate authority. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cadir' })
-      }
+      :deprecated => :completely,
     },
     :cacert => {
       :default => "$cadir/ca_crt.pem",
@@ -999,9 +995,7 @@ EOT
       :group => "service",
       :mode => "0644",
       :desc => "The CA certificate. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cacert' })
-      }
+      :deprecated => :completely,
     },
     :cakey => {
       :default => "$cadir/ca_key.pem",
@@ -1010,9 +1004,7 @@ EOT
       :group => "service",
       :mode => "0640",
       :desc => "The CA private key. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cakey' })
-      }
+      :deprecated => :completely,
     },
     :capub => {
       :default => "$cadir/ca_pub.pem",
@@ -1021,9 +1013,7 @@ EOT
       :group => "service",
       :mode => "0644",
       :desc => "The CA public key. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'capub' })
-      }
+      :deprecated => :completely,
     },
     :cacrl => {
       :default => "$cadir/ca_crl.pem",
@@ -1032,9 +1022,7 @@ EOT
       :group => "service",
       :mode => "0644",
       :desc => "The certificate revocation list (CRL) for the CA. Will be used if present but otherwise ignored. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'cacrl' })
-      }
+      :deprecated => :completely,
     },
     :caprivatedir => {
       :default => "$cadir/private",
@@ -1051,9 +1039,7 @@ EOT
       :group => "service",
       :mode  => "0755",
       :desc => "Where the CA stores certificate requests. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'csrdir' })
-      }
+      :deprecated => :completely,
     },
     :signeddir => {
       :default => "$cadir/signed",
@@ -1062,9 +1048,7 @@ EOT
       :group => "service",
       :mode => "0755",
       :desc => "Where the CA stores signed certificates. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'signeddir' })
-      }
+      :deprecated => :completely,
     },
     :capass => {
       :default => "$caprivatedir/ca.pass",
@@ -1081,9 +1065,7 @@ EOT
       :group => "service",
       :mode => "0644",
       :desc => "Where the serial number for certificates is stored. This setting is deprecated and will be replaced by one in Puppet Server's configs in Puppet 6.",
-      :hook => proc { |value|
-        Puppet.deprecation_warning(CA_SETTING_DEPRECATION % { setting_name: 'serial' })
-      }
+      :deprecated => :completely,
     },
     :autosign => {
       :default => "$confdir/autosign.conf",

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -943,6 +943,7 @@ describe Puppet::SSL::CertificateAuthority do
         end
 
         it "should be deprecated" do
+          Puppet.expects(:deprecation_warning).with(regexp_matches(/Accessing 'cacert' as a setting is deprecated/))
           Puppet.expects(:deprecation_warning).with(regexp_matches(/certificate_is_alive\? is deprecated/))
           @ca.certificate_is_alive?(@cert)
         end


### PR DESCRIPTION
In Puppet 6, as part of splitting the CA directory out of the SSL
directory, we are also moving the settings related to CA file locations
in puppetserver's config file. Any settings in Puppet's config file will
be ignored starting then.