### PR TITLE
(maint) Add additional details on how to run spec tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,7 @@ the [puppet-dev mailing list](https://groups.google.com/forum/#!forum/puppet-dev
       why this is a problem, and how the patch fixes the problem when applied.
   ```
 * Make sure you have added the necessary tests for your changes.
-* Run _all_ the tests to assure nothing else was accidentally broken. First
-  install all the test dependencies with `bundle install --path .bundle`. Then
-  either run all the tests serially with `bundle exec rspec spec` or in parallel
-  with `bundle exec rake parallel:spec[process_count]`
+* For details on how to run tests, please see [the quickstart guide](https://github.com/puppetlabs/puppet/blob/master/docs/quickstart.md)
 
 ## Writing Translatable Code
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -81,3 +81,5 @@ be used to send logs to a file, and to adjust the log level:
 * `PUPPET_TEST_LOG_LEVEL`: change the log level to adjust how much detail
   is captured. It defaults to `notice`; useful values include `info` and
   `debug`.
+
+For details on running tests on windows, see [the windows docs](https://github.com/puppetlabs/puppet/blob/master/docs/windows.md).

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -2,11 +2,12 @@
 
 If you'd like to run Puppet from source on Windows platforms, follow the [Quickstart](./quickstart.md) to using bundler and installing the necessary gems on Windows.
 
-You will need to install Ruby on Windows from [rubyinstaller.org](http://rubyinstaller.org).
+You will need to install Ruby on Windows from [rubyinstaller.org](http://rubyinstaller.org)
+or from [Choclately](https://chocolatey.org/packages/ruby).
 
     C:\> cd C:\work\puppet
     C:\work\puppet> gem install bundler
-    C:\work\puppet> bundle install --path .bundle
+    C:\work\puppet> bundle install --path .bundle --without development extra
     C:\work\puppet> bundle exec puppet --version
     4.7.1
 
@@ -68,4 +69,3 @@ Then run the test as:
  * Don't assume 'C' drive.  Use environment variables to look these up:
 
     "#{ENV['windir']}/system32/netsh.exe"
-


### PR DESCRIPTION
I've found there can be quite a bit of confusion of how exactly to run
spec tests, especially when it comes to windows. This commit attempts to
add some clarity around how to do that. A step by step guide might be
too prescriptive, but it should be quite helpful for those who are
unfamiliar with working in a windows environment.