### PR TITLE
(PUP-9015) Append vendored modules to $LOAD_PATH

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -339,13 +339,7 @@ module Puppet
           for those files that Puppet will load on demand, and is only
           guaranteed to work for those cases.  In fact, the autoload
           mechanism is responsible for making sure this directory
-          is in Ruby's search path\n",
-      :call_hook => :on_initialize_and_write,
-      :hook             => proc do |value|
-        $LOAD_PATH.delete(@oldlibdir) if defined?(@oldlibdir) && $LOAD_PATH.include?(@oldlibdir)
-        @oldlibdir = value
-        $LOAD_PATH << value
-      end
+          is in Ruby's search path\n"
     },
     :environment => {
         :default  => "production",

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -115,49 +115,18 @@ class Puppet::Util::Autoload
     def module_directories(env)
       raise ArgumentError, "Autoloader requires an environment" unless env
 
-      # This is a little bit of a hack.  Basically, the autoloader is being
-      # called indirectly during application bootstrapping when we do things
-      # such as check "features".  However, during bootstrapping, we haven't
-      # yet parsed all of the command line parameters nor the config files,
-      # and thus we don't yet know with certainty what the module path is.
-      # This should be irrelevant during bootstrapping, because anything that
-      # we are attempting to load during bootstrapping should be something
-      # that we ship with puppet, and thus the module path is irrelevant.
-      #
-      # In the long term, I think the way that we want to handle this is to
-      # have the autoloader ignore the module path in all cases where it is
-      # not specifically requested (e.g., by a constructor param or
-      # something)... because there are very few cases where we should
-      # actually be loading code from the module path.  However, until that
-      # happens, we at least need a way to prevent the autoloader from
-      # attempting to access the module path before it is initialized.  For
-      # now we are accomplishing that by calling the
-      # "app_defaults_initialized?" method on the main puppet Settings object.
-      # --cprice 2012-03-16
-      if Puppet.settings.app_defaults_initialized?
-        # if the app defaults have been initialized then it should be safe to access the module path setting.
-        Puppet::Util::ModuleDirectoriesAdapter.adapt(env) do |a|
-          a.directories ||= env.modulepath.collect do |dir|
-            Dir.entries(dir).reject { |f| f =~ /^\./ }.collect { |f| File.join(dir, f, "lib") }
-          end.flatten.find_all do |d|
-            FileTest.directory?(d)
-          end
-        end.directories
-      else
-        # if we get here, the app defaults have not been initialized, so we basically use an empty module path.
-        []
-      end
+      Puppet::Util::ModuleDirectoriesAdapter.adapt(env) do |a|
+        a.directories ||= env.modulepath.collect do |dir|
+          Dir.entries(dir).reject { |f| f =~ /^\./ }.collect { |f| File.join(dir, f, "lib") }
+        end.flatten.find_all do |d|
+          FileTest.directory?(d)
+        end
+      end.directories
     end
 
     # @api private
     def libdirs
-      # See the comments in #module_directories above.  Basically, we need to be careful not to try to access the
-      # libdir before we know for sure that all of the settings have been initialized (e.g., during bootstrapping).
-      if (Puppet.settings.app_defaults_initialized?)
-        [Puppet[:libdir]]
-      else
-        []
-      end
+      [Puppet[:libdir]]
     end
 
     # @api private
@@ -180,7 +149,30 @@ class Puppet::Util::Autoload
 
     # @api private
     def search_directories(env)
-      [gem_directories, module_directories(env), libdirs, $LOAD_PATH, vendored_modules].flatten
+      # This is a little bit of a hack.  Basically, the autoloader is being
+      # called indirectly during application bootstrapping when we do things
+      # such as check "features".  However, during bootstrapping, we haven't
+      # yet parsed all of the command line parameters nor the config files,
+      # and thus we don't yet know with certainty what the module path is.
+      # This should be irrelevant during bootstrapping, because anything that
+      # we are attempting to load during bootstrapping should be something
+      # that we ship with puppet, and thus the module path is irrelevant.
+      #
+      # In the long term, I think the way that we want to handle this is to
+      # have the autoloader ignore the module path in all cases where it is
+      # not specifically requested (e.g., by a constructor param or
+      # something)... because there are very few cases where we should
+      # actually be loading code from the module path.  However, until that
+      # happens, we at least need a way to prevent the autoloader from
+      # attempting to access the module path before it is initialized.  For
+      # now we are accomplishing that by calling the
+      # "app_defaults_initialized?" method on the main puppet Settings object.
+      # --cprice 2012-03-16
+      if Puppet.settings.app_defaults_initialized?
+        gem_directories + module_directories(env) + libdirs + $LOAD_PATH + vendored_modules
+      else
+        gem_directories + $LOAD_PATH
+      end
     end
 
     # Normalize a path. This converts ALT_SEPARATOR to SEPARATOR on Windows

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -125,11 +125,6 @@ class Puppet::Util::Autoload
     end
 
     # @api private
-    def libdirs
-      [Puppet[:libdir]]
-    end
-
-    # @api private
     def vendored_modules
       dir = Puppet[:vendormoduledir]
       if dir && File.directory?(dir)
@@ -169,7 +164,12 @@ class Puppet::Util::Autoload
       # "app_defaults_initialized?" method on the main puppet Settings object.
       # --cprice 2012-03-16
       if Puppet.settings.app_defaults_initialized?
-        gem_directories + module_directories(env) + libdirs + $LOAD_PATH + vendored_modules
+        unless @initialized
+          $LOAD_PATH.unshift(Puppet[:libdir])
+          $LOAD_PATH.concat(vendored_modules)
+          @initialized = true
+        end
+        gem_directories + module_directories(env) + $LOAD_PATH
       else
         gem_directories + $LOAD_PATH
       end

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -24,20 +24,6 @@ describe Puppet do
     expect(ENV["PATH"]).to eq(newpath)
   end
 
-  it "should change $LOAD_PATH when :libdir changes" do
-    one = tmpdir('load-path-one')
-    two = tmpdir('load-path-two')
-    expect(one).not_to eq(two)
-
-    Puppet[:libdir] = one
-    expect($LOAD_PATH).to include one
-    expect($LOAD_PATH).not_to include two
-
-    Puppet[:libdir] = two
-    expect($LOAD_PATH).not_to include one
-    expect($LOAD_PATH).to include two
-  end
-
   it 'should propagate --modulepath to base environment' do
     Puppet::Node::Environment.expects(:create).with(
       is_a(Symbol), ['/my/modules'], Puppet::Node::Environment::NO_MANIFEST)

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -24,6 +24,7 @@ describe Puppet::Util::Autoload do
 
     def with_libdir(libdir)
       begin
+        Puppet::Util::Autoload.instance_variable_set(:@initialized, false)
         old_loadpath = $LOAD_PATH.dup
         old_libdir = Puppet[:libdir]
         Puppet[:libdir] = libdir


### PR DESCRIPTION
Append the vendored modules directory to the ruby $LOAD_PATH, which is effectively how things worked before we extracted them into modules. Note vendored_modules have least precedence so that it can be overridden by pluginsynced modules.