### PR TITLE
(PUP-7834) Safely deserialize YAML

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -736,14 +736,6 @@ Performance/Caller:
 Performance/CompareWithBlock:
   Enabled: false
 
-# TODO PUP-8004
-Security/JSONLoad:
-  Enabled: false
-
-# TODO PUP-8004
-Security/YAMLLoad:
-  Enabled: false
-
 Style/EmptyCaseCondition:
   Enabled: false
 

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -353,7 +353,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       if fact_file.end_with?("json")
         given_facts = Puppet::Util::Json.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
-        given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = Puppet::Util::Yaml.safe_load_file(fact_file)
       end
 
       unless given_facts.instance_of?(Hash)

--- a/lib/puppet/application_support.rb
+++ b/lib/puppet/application_support.rb
@@ -52,11 +52,10 @@ module Puppet
     def self.configure_indirector_routes(application_name)
       route_file = Puppet[:route_file]
       if Puppet::FileSystem.exist?(route_file)
-        routes = YAML.load_file(route_file)
+        routes = Puppet::Util::Yaml.safe_load_file(route_file, [Symbol])
         application_routes = routes[application_name]
         Puppet::Indirector.configure_routes(application_routes) if application_routes
       end
     end
-
   end
 end

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -511,7 +511,7 @@ Puppet::Face.define(:epp, '0.0.1') do
       elsif fact_file.end_with?("json")
         given_facts = Puppet::Util::Json.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       else
-        given_facts = YAML.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
+        given_facts = Puppet::Util::Yaml.safe_load_file(fact_file)
       end
 
       unless given_facts.instance_of?(Hash)

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -405,7 +405,7 @@ Puppet::Face.define(:epp, '0.0.1') do
     if values_file = options[:values_file]
       begin
         if values_file =~ /\.yaml$/
-          template_values = YAML.load_file(values_file)
+          template_values = Puppet::Util::Yaml.safe_load_file(values_file, [Symbol])
         elsif values_file =~ /\.pp$/
           evaluating_parser = Puppet::Pops::Parser::EvaluatingParser.new
           template_values = evaluating_parser.evaluate_file(compiler.topscope, values_file)

--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -56,9 +56,8 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
           {}
         end
       rescue Puppet::Util::Yaml::YamlLoadError => ex
-        # Psych errors includes the absolute path to the file, so no need to add that
-        # to the message
-        raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"
+        # YamlLoadErrors include the absolute path to the file, so no need to add that
+        raise Puppet::DataBinding::LookupError, _("Unable to parse %{message}") % { message: ex.message }
       end
     end
   end

--- a/lib/puppet/functions/eyaml_lookup_key.rb
+++ b/lib/puppet/functions/eyaml_lookup_key.rb
@@ -46,7 +46,7 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
     path = options['path']
     context.cached_file_data(path) do |content|
       begin
-        data = YAML.load(content, path)
+        data = Puppet::Util::Yaml.safe_load(content, [Symbol], path)
         if data.is_a?(Hash)
           Puppet::Pops::Lookup::HieraConfig.symkeys_to_string(data)
         else
@@ -55,7 +55,7 @@ Puppet::Functions.create_function(:eyaml_lookup_key) do
           Puppet.warning(msg)
           {}
         end
-      rescue YAML::SyntaxError => ex
+      rescue Puppet::Util::Yaml::YamlLoadError => ex
         # Psych errors includes the absolute path to the file, so no need to add that
         # to the message
         raise Puppet::DataBinding::LookupError, "Unable to parse #{ex.message}"

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -31,7 +31,8 @@ Puppet::Functions.create_function(:yaml_data) do
           {}
         end
       rescue Puppet::Util::Yaml::YamlLoadError => ex
-        raise Puppet::DataBinding::LookupError, "Unable to parse (%{path}): %{message}" % { path: path, message: ex.message }
+        # YamlLoadErrors include the absolute path to the file, so no need to add that
+        raise Puppet::DataBinding::LookupError, _("Unable to parse %{message}") % { message: ex.message }
       end
     end
   end

--- a/lib/puppet/indirector/catalog/yaml.rb
+++ b/lib/puppet/indirector/catalog/yaml.rb
@@ -3,20 +3,4 @@ require 'puppet/indirector/yaml'
 
 class Puppet::Resource::Catalog::Yaml < Puppet::Indirector::Yaml
   desc "Store catalogs as flat files, serialized using YAML."
-
-  private
-
-  # Override these, because yaml doesn't want to convert our self-referential
-  # objects.  This is hackish, but eh.
-  def from_yaml(text)
-    if config = YAML.load(text)
-      return config
-    end
-  end
-
-  def to_yaml(config)
-    # We can't yaml-dump classes.
-    #config.edgelist_class = nil
-    YAML.dump(config)
-  end
 end

--- a/lib/puppet/indirector/facts/yaml.rb
+++ b/lib/puppet/indirector/facts/yaml.rb
@@ -8,8 +8,10 @@ class Puppet::Node::Facts::Yaml < Puppet::Indirector::Yaml
   def search(request)
     node_names = []
     Dir.glob(yaml_dir_path).each do |file|
-      facts = YAML.load_file(file)
-      node_names << facts.name if node_matches?(facts, request.options)
+      facts = load_file(file)
+      if facts && node_matches?(facts, request.options)
+        node_names << facts.name
+      end
     end
     node_names
   end

--- a/lib/puppet/indirector/node/exec.rb
+++ b/lib/puppet/indirector/node/exec.rb
@@ -38,11 +38,9 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
   # Turn our outputted objects into a Puppet::Node instance.
   def create_node(name, result, facts = nil)
     node = Puppet::Node.new(name)
-    set = false
     [:parameters, :classes, :environment].each do |param|
       if value = result[param]
         node.send(param.to_s + "=", value)
-        set = true
       end
     end
 
@@ -52,7 +50,7 @@ class Puppet::Node::Exec < Puppet::Indirector::Exec
 
   # Translate the yaml string into Ruby objects.
   def translate(name, output)
-    YAML.load(output).inject({}) do |hash, data|
+    Puppet::Util::Yaml.safe_load(output, [Symbol]).inject({}) do |hash, data|
       case data[0]
       when String
         hash[data[0].intern] = data[1]

--- a/lib/puppet/indirector/node/yaml.rb
+++ b/lib/puppet/indirector/node/yaml.rb
@@ -4,10 +4,4 @@ require 'puppet/indirector/yaml'
 class Puppet::Node::Yaml < Puppet::Indirector::Yaml
   desc "Store node information as flat files, serialized using YAML,
     or deserialize stored YAML nodes."
-
-  protected
-
-  def fix(object)
-    object
-  end
 end

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -9,7 +9,7 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
     return nil unless Puppet::FileSystem.exist?(file)
 
     begin
-      return fix(Puppet::Util::Yaml.load_file(file))
+      return load_file(file)
     rescue Puppet::Util::Yaml::YamlLoadError => detail
       raise Puppet::Error, _("Could not parse YAML data for %{indirection} %{request}: %{detail}") % { indirection: indirection.name, request: request.key, detail: detail }, detail.backtrace
     end
@@ -51,13 +51,13 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
 
   def search(request)
     Dir.glob(path(request.key,'')).collect do |file|
-      fix(Puppet::Util::Yaml.load_file(file))
+      load_file(file)
     end
   end
 
   protected
 
-  def fix(object)
-    object
+  def load_file(file)
+    Puppet::Util::Yaml.safe_load_file(file, [model, Symbol])
   end
 end

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -140,7 +140,7 @@ class Puppet::Module
     end
 
     def read_metadata(file)
-      File.open(file) { |fh| JSON.load(fh) } if file
+      Puppet::Util::Json.load(Puppet::FileSystem.read(file, :encoding => 'utf-8')) if file
     rescue SystemCallError, IOError => err
       msg = _("Error reading metadata: %{message}" % {message: err.message})
       raise InvalidMetadata.new(msg, 'puppet.tasks/unreadable-metadata')

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -23,13 +23,25 @@ Puppet::Network::FormatHandler.create_serialized_formats(:msgpack, :weight => 20
 end
 
 Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
+  def allowed_yaml_classes
+    @allowed_yaml_classes ||= [
+      Puppet::Node::Facts,
+      Puppet::Node,
+      Puppet::Transaction::Report,
+      Puppet::Resource,
+      Puppet::Resource::Catalog
+    ]
+  end
+
   def intern(klass, text)
-    data = YAML.load(text)
+    data = Puppet::Util::Yaml.safe_load(text, allowed_yaml_classes)
     data_to_instance(klass, data)
+  rescue Puppet::Util::Yaml::YamlLoadError => e
+    raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a valid instance of %{klass}: %{message}") % { klass: klass, message: e.message }
   end
 
   def intern_multiple(klass, text)
-    data = YAML.load(text)
+    data = Puppet::Util::Yaml.safe_load(text, allowed_yaml_classes)
     unless data.respond_to?(:collect)
       raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a collection of instances when calling intern_multiple")
     end
@@ -37,6 +49,8 @@ Puppet::Network::FormatHandler.create_serialized_formats(:yaml) do
     data.collect do |datum|
       data_to_instance(klass, datum)
     end
+  rescue Puppet::Util::Yaml::YamlLoadError => e
+    raise Puppet::Network::FormatHandler::FormatError, _("Serialized YAML did not contain a valid instance of %{klass}: %{message}") % { klass: klass, message: e.message }
   end
 
   def data_to_instance(klass, data)

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -814,7 +814,7 @@ class Puppet::Parser::Scope
   end
 
   # Deeply freezes the given object. The object and its content must be of the types:
-  # Array, Hash, Numeric, Boolean, Symbol, Regexp, NilClass, or String. All other types raises an Error.
+  # Array, Hash, Numeric, Boolean, Regexp, NilClass, or String. All other types raises an Error.
   # (i.e. if they are assignable to Puppet::Pops::Types::Data type).
   #
   def deep_freeze(object)

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -132,7 +132,7 @@ class HieraConfig
       if config_path.exist?
         env_context = EnvironmentContext.adapt(lookup_invocation.scope.compiler.environment)
         loaded_config = env_context.cached_file_data(config_path) do |content|
-          parsed = YAML.load(content, config_path)
+          parsed = Puppet::Util::Yaml.safe_load(content, [Symbol], config_path)
 
           # For backward compatibility, we must treat an empty file, or a yaml that doesn't
           # produce a Hash as Hiera version 3 default.

--- a/lib/puppet/ssl/certificate_request_attributes.rb
+++ b/lib/puppet/ssl/certificate_request_attributes.rb
@@ -21,7 +21,7 @@ class Puppet::SSL::CertificateRequestAttributes
   def load
     Puppet.info(_("csr_attributes file loading from %{path}") % { path: path })
     if Puppet::FileSystem.exist?(path)
-      hash = Puppet::Util::Yaml.load_file(path, {})
+      hash = Puppet::Util::Yaml.safe_load_file(path, [Symbol]) || {}
       if ! hash.is_a?(Hash)
         raise Puppet::Error, _("invalid CSR attributes, expected instance of Hash, received instance of %{klass}") % { klass: hash.class }
       end

--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -104,7 +104,7 @@ module Puppet::SSL::Oids
     if File.exists?(custom_oid_file) && File.readable?(custom_oid_file)
       mapping = nil
       begin
-        mapping = YAML.load_file(custom_oid_file)
+        mapping = Puppet::Util::Yaml.safe_load_file(custom_oid_file, [Symbol])
       rescue => err
         raise Puppet::Error, _("Error loading ssl custom OIDs mapping file from '%{custom_oid_file}': %{err}") % { custom_oid_file: custom_oid_file, err: err }, err.backtrace
       end

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -62,7 +62,7 @@ class Puppet::Transaction::Persistence
     result = nil
     Puppet::Util.benchmark(:debug, _("Loaded transaction store file in %{seconds} seconds")) do
       begin
-        result = Puppet::Util::Yaml.load_file(filename, false, true)
+        result = Puppet::Util::Yaml.safe_load_file(filename, [Symbol])
       rescue Puppet::Util::Yaml::YamlLoadError => detail
         Puppet.log_exception(detail, _("Transaction store file %{filename} is corrupt (%{detail}); replacing") % { filename: filename, detail: detail }, { :level => :warning })
 

--- a/lib/puppet/util/storage.rb
+++ b/lib/puppet/util/storage.rb
@@ -55,7 +55,7 @@ class Puppet::Util::Storage
     end
     Puppet::Util.benchmark(:debug, "Loaded state in %{seconds} seconds") do
       begin
-        @@state = Puppet::Util::Yaml.load_file(filename)
+        @@state = Puppet::Util::Yaml.safe_load_file(filename, [Symbol, Time])
       rescue Puppet::Util::Yaml::YamlLoadError => detail
         Puppet.err _("Checksumfile %{filename} is corrupt (%{detail}); replacing") % { filename: filename, detail: detail }
 

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -5,7 +5,7 @@ class Puppet::Util::TagSet < Set
   include Puppet::Network::FormatSupport
 
   def self.from_yaml(yaml)
-    self.new(YAML.load(yaml))
+    self.new(Puppet::Util::Yaml.safe_load(yaml, [Symbol]))
   end
 
   def to_yaml

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -46,6 +46,8 @@ module Puppet::Util::Yaml
 
   # @deprecated Use {#safe_load_file} instead.
   def self.load_file(filename, default_value = false, strip_classes = false)
+    Puppet.deprecation_warning(_("Puppet::Util::Yaml.load_file is deprecated. Use safe_load_file instead."))
+
     if(strip_classes) then
       data = YAML::parse_file(filename)
       data.root.each do |o|

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -1,11 +1,7 @@
 require 'yaml'
 
 module Puppet::Util::Yaml
-  if defined?(::Psych::SyntaxError)
-    YamlLoadExceptions = [::StandardError, ::Psych::Exception]
-  else
-    YamlLoadExceptions = [::StandardError]
-  end
+  YamlLoadExceptions = [::StandardError, ::Psych::Exception]
 
   class YamlLoadError < Puppet::Error; end
 

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -29,6 +29,9 @@ module Puppet::Util::Yaml
     data = YAML.safe_load(yaml, allowed_classes, [], false, filename)
     data = false if data.nil?
     data
+  rescue ::Psych::DisallowedClass => detail
+    path = filename ? "(#{filename})" : "(<unknown>)"
+    raise YamlLoadError.new("#{path}: #{detail.message}", detail)
   rescue *YamlLoadExceptions => detail
     raise YamlLoadError.new(detail.message, detail)
   end

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -22,12 +22,13 @@ module Puppet::Util::Yaml
   #
   # Attempting to deserialize other classes will raise an YamlLoadError
   # exception unless they are specified in the array of *allowed_classes*.
-  # @param String yaml The yaml content to parse
-  # @param Array allowed_classes Additional list of classes that can be
-  # deserialized
-  # @param String filename The filename to load from, used if an exception
-  # is raised.
-  # @returns The parsed YAML, typically a Hash
+  # @param [String] yaml The yaml content to parse.
+  # @param [Array] allowed_classes Additional list of classes that can be
+  # deserialized.
+  # @param [String] filename The filename to load from, used if an exception
+  #   is raised.
+  # @raise [YamlLoadException] If deserialization fails.
+  # @returns The parsed YAML, which can be Hash, Array or scalar types.
   def self.safe_load(yaml, allowed_classes = [], filename = nil)
     data = YAML.safe_load(yaml, allowed_classes, [], false, filename)
     data = false if data.nil?
@@ -44,6 +45,7 @@ module Puppet::Util::Yaml
     safe_load(yaml, allowed_classes, filename)
   end
 
+  # @deprecated Use {#safe_load_file} instead.
   def self.load_file(filename, default_value = false, strip_classes = false)
     if(strip_classes) then
       data = YAML::parse_file(filename)

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -2,12 +2,47 @@ require 'yaml'
 
 module Puppet::Util::Yaml
   if defined?(::Psych::SyntaxError)
-    YamlLoadExceptions = [::StandardError, ::Psych::SyntaxError]
+    YamlLoadExceptions = [::StandardError, ::Psych::Exception]
   else
     YamlLoadExceptions = [::StandardError]
   end
 
   class YamlLoadError < Puppet::Error; end
+
+  # Safely load the content as YAML. By default only the following
+  # classes can be deserialized:
+  #
+  # * TrueClass
+  # * FalseClass
+  # * NilClass
+  # * Numeric
+  # * String
+  # * Array
+  # * Hash
+  #
+  # Attempting to deserialize other classes will raise an YamlLoadError
+  # exception unless they are specified in the array of *allowed_classes*.
+  # @param String yaml The yaml content to parse
+  # @param Array allowed_classes Additional list of classes that can be
+  # deserialized
+  # @param String filename The filename to load from, used if an exception
+  # is raised.
+  # @returns The parsed YAML, typically a Hash
+  def self.safe_load(yaml, allowed_classes = [], filename = nil)
+    data = YAML.safe_load(yaml, allowed_classes, [], false, filename)
+    data = false if data.nil?
+    data
+  rescue *YamlLoadExceptions => detail
+    raise YamlLoadError.new(detail.message, detail)
+  end
+
+  # Safely load the content from a file as YAML.
+  #
+  # @see Puppet::Util::Yaml.safe_load
+  def self.safe_load_file(filename, allowed_classes = [])
+    yaml = Puppet::FileSystem.read(filename, :encoding => 'bom|utf-8')
+    safe_load(yaml, allowed_classes, filename)
+  end
 
   def self.load_file(filename, default_value = false, strip_classes = false)
     if(strip_classes) then

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -51,10 +51,7 @@ describe Puppet::Configurer do
 
       expect(Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode.to_s(8)).to eq(file_mode)
 
-      summary = nil
-      File.open(Puppet[:lastrunfile], "r") do |fd|
-        summary = YAML.load(fd.read)
-      end
+      summary = Puppet::Util::Yaml.safe_load_file(Puppet[:lastrunfile])
 
       expect(summary).to be_a(Hash)
       %w{time changes events resources}.each do |key|

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -462,7 +462,7 @@ Searching for "a"
       lookup.options[:render_as] = :yaml
       lookup.command_line.stubs(:args).returns(['a'])
       output = run_lookup(lookup)
-      expect(YAML.load(output)).to eq(expected_yaml_hash)
+      expect(Puppet::Util::Yaml.safe_load(output, [Symbol])).to eq(expected_yaml_hash)
     end
 
     it 'can produce a json explanation' do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -504,7 +504,7 @@ describe Puppet::Application do
         ROUTES
       end
 
-      expect { @app.configure_indirector_routes }.to raise_error(Psych::SyntaxError, /mapping values are not allowed/)
+      expect { @app.configure_indirector_routes }.to raise_error(Puppet::Error, /mapping values are not allowed/)
     end
   end
 

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -115,10 +115,11 @@ describe "The lookup function" do
     nil
   end
 
-  def lookup(key, options = {}, explain = false)
+  def lookup(key, options = {}, explain = false, type = nil)
+    value_type = type ? ", #{type}" : ''
     nc_opts = options.empty? ? '' : ", #{Puppet::Pops::Types::TypeFormatter.string(options)}"
     keys = key.is_a?(Array) ? key : [key]
-    collect_notices(keys.map { |k| "notice(String(lookup('#{k}'#{nc_opts}), '%p'))" }.join("\n"), explain)
+    collect_notices(keys.map { |k| "notice(String(lookup('#{k}'#{value_type}#{nc_opts}), '%p'))" }.join("\n"), explain)
     if explain
       explanation
     else
@@ -805,9 +806,24 @@ describe "The lookup function" do
           YAML
         end
 
-        it 'fails lookup and reports a type mismatch' do
+        it 'fails lookup and reports parsing failed' do
           expect { lookup('a') }.to raise_error do |e|
-            expect(e.message).to match(/key 'a'.*data_hash function 'yaml_data'.*using location.*wrong type, expects Puppet::LookupValue, got Runtime/)
+            expect(e.message).to match(/Unable to parse .*: Tried to load unspecified class: Puppet::Graph::Key/)
+          end
+        end
+      end
+
+      context 'that contains a legal yaml hash with unexpected types' do
+        let(:common_yaml) do
+          <<-YAML.unindent
+          ---
+          a: 123
+          YAML
+        end
+
+        it 'fails lookup and reports a type mismatch' do
+          expect { lookup('a', {}, false, String) }.to raise_error do |e|
+            expect(e.message).to match(/Found value has wrong type, expects a String value, got Integer \(line: 1, column: \d+\)/)
           end
         end
       end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1792,6 +1792,7 @@ describe "The lookup function" do
                 a_ref: "A reference to %{hiera('a')}"
                 b_ref: "A reference to %{hiera('b')}"
                 c_ref: "%{alias('c')}"
+                :symbol: "A symbol"
                 YAML
             }
           end

--- a/spec/unit/graph/simple_graph_spec.rb
+++ b/spec/unit/graph/simple_graph_spec.rb
@@ -636,7 +636,7 @@ describe Puppet::Graph::SimpleGraph do
           # the serialized objects easily without invoking any
           # yaml_initialize hooks.
           yaml_form.gsub!('!ruby/object:Puppet::', '!hack/object:Puppet::')
-          serialized_object = YAML.load(yaml_form)
+          serialized_object = Puppet::Util::Yaml.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
 
           # Check that the object contains instance variables @edges and
           # @vertices only.  @reversal is also permitted, but we don't
@@ -704,7 +704,7 @@ describe Puppet::Graph::SimpleGraph do
           reference_graph = Puppet::Graph::SimpleGraph.new
           send(graph_to_test, reference_graph)
           yaml_form = graph_to_yaml(reference_graph, which_format)
-          recovered_graph = YAML.load(yaml_form)
+          recovered_graph = Puppet::Util::Yaml.safe_load(yaml_form, [Symbol,Puppet::Graph::SimpleGraph])
 
           # Test that the recovered vertices match the vertices in the
           # reference graph.
@@ -748,7 +748,7 @@ describe Puppet::Graph::SimpleGraph do
       derived.add_edge('a', 'b')
       derived.foo = 1234
       yaml = YAML.dump(derived)
-      recovered_derived = YAML.load(yaml)
+      recovered_derived = Puppet::Util::Yaml.safe_load(yaml, [Puppet::TestDerivedClass])
       expect(recovered_derived.class).to equal(Puppet::TestDerivedClass)
       expect(recovered_derived.edges.length).to eq(1)
       expect(recovered_derived.edges[0].source).to eq('a')

--- a/spec/unit/indirector/facts/yaml_spec.rb
+++ b/spec/unit/indirector/facts/yaml_spec.rb
@@ -4,7 +4,22 @@ require 'spec_helper'
 require 'puppet/node/facts'
 require 'puppet/indirector/facts/yaml'
 
+def dir_containing_facts(hash)
+  yamldir = tmpdir('yaml_facts')
+
+  Puppet[:clientyamldir] = yamldir
+  dir = File.join(yamldir, 'facts')
+  Dir.mkdir(dir)
+  hash.each_pair do |file, facts|
+    File.open(File.join(dir, file), 'wb') do |f|
+      f.write(YAML.dump(facts))
+    end
+  end
+end
+
 describe Puppet::Node::Facts::Yaml do
+  include PuppetSpec::Files
+
   it "should be a subclass of the Yaml terminus" do
     expect(Puppet::Node::Facts::Yaml.superclass).to equal(Puppet::Indirector::Yaml)
   end
@@ -33,25 +48,22 @@ describe Puppet::Node::Facts::Yaml do
     def assert_search_matches(matching, nonmatching, query)
       request = Puppet::Indirector::Request.new(:inventory, :search, nil, nil, query)
 
-      Dir.stubs(:glob).returns(matching.keys + nonmatching.keys)
-      [matching, nonmatching].each do |examples|
-        examples.each do |key, value|
-          YAML.stubs(:load_file).with(key).returns value
-        end
-      end
-      expect(Puppet::Node::Facts::Yaml.new.search(request)).to match_array(matching.values.map {|facts| facts.name})
+      dir_containing_facts(matching.merge(nonmatching))
+
+      results = Puppet::Node::Facts::Yaml.new.search(request)
+      expect(results).to match_array(matching.values.map {|facts| facts.name})
     end
 
     it "should return node names that match the search query options" do
       assert_search_matches({
-          '/path/to/matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386", 'processor_count' => '4'),
-          '/path/to/matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "i386", 'processor_count' => '4', 'randomfact' => 'foo')
+          'matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386", 'processor_count' => '4'),
+          'matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "i386", 'processor_count' => '4', 'randomfact' => 'foo')
         },
         {
-          "/path/to/nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '4'),
-          "/path/to/nonmatching1.yaml" => Puppet::Node::Facts.new("nonmatchingnode1", "architecture" => "powerpc", 'processor_count' => '5'),
-          "/path/to/nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5'),
-          "/path/to/nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3",                              'processor_count' => '4'),
+          "nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '4'),
+          "nonmatching1.yaml" => Puppet::Node::Facts.new("nonmatchingnode1", "architecture" => "powerpc", 'processor_count' => '5'),
+          "nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5'),
+          "nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3",                              'processor_count' => '4'),
         },
         {'facts.architecture' => 'i386', 'facts.processor_count' => '4'}
       )
@@ -59,25 +71,24 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should return empty array when no nodes match the search query options" do
       assert_search_matches({}, {
-          "/path/to/nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '10'),
-          "/path/to/nonmatching1.yaml" => Puppet::Node::Facts.new("nonmatchingnode1", "architecture" => "powerpc", 'processor_count' => '5'),
-          "/path/to/nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5'),
-          "/path/to/nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3",                              'processor_count' => '4'),
+          "nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '10'),
+          "nonmatching1.yaml" => Puppet::Node::Facts.new("nonmatchingnode1", "architecture" => "powerpc", 'processor_count' => '5'),
+          "nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5'),
+          "nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3",                              'processor_count' => '4'),
         },
         {'facts.processor_count.lt' => '4', 'facts.processor_count.gt' => '4'}
       )
     end
 
-
     it "should return node names that match the search query options with the greater than operator" do
       assert_search_matches({
-          '/path/to/matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
-          '/path/to/matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '10', 'randomfact' => 'foo')
+          'matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
+          'matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '10', 'randomfact' => 'foo')
         },
         {
-          "/path/to/nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '4'),
-          "/path/to/nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '3'),
-          "/path/to/nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                       ),
+          "nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '4'),
+          "nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '3'),
+          "nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                       ),
         },
         {'facts.processor_count.gt' => '4'}
       )
@@ -85,13 +96,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should return node names that match the search query options with the less than operator" do
       assert_search_matches({
-          '/path/to/matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
-          '/path/to/matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '30', 'randomfact' => 'foo')
+          'matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
+          'matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '30', 'randomfact' => 'foo')
         },
         {
-          "/path/to/nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '50' ),
-          "/path/to/nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '100'),
-          "/path/to/nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                         ),
+          "nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '50' ),
+          "nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '100'),
+          "nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                         ),
         },
         {'facts.processor_count.lt' => '50'}
       )
@@ -99,13 +110,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should return node names that match the search query options with the less than or equal to operator" do
       assert_search_matches({
-          '/path/to/matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
-          '/path/to/matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '50', 'randomfact' => 'foo')
+          'matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
+          'matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '50', 'randomfact' => 'foo')
         },
         {
-          "/path/to/nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '100' ),
-          "/path/to/nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5000'),
-          "/path/to/nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                          ),
+          "nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '100' ),
+          "nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5000'),
+          "nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                          ),
         },
         {'facts.processor_count.le' => '50'}
       )
@@ -113,13 +124,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should return node names that match the search query options with the greater than or equal to operator" do
       assert_search_matches({
-          '/path/to/matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '100'),
-          '/path/to/matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '50', 'randomfact' => 'foo')
+          'matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '100'),
+          'matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '50', 'randomfact' => 'foo')
         },
         {
-          "/path/to/nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '40'),
-          "/path/to/nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '9' ),
-          "/path/to/nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                        ),
+          "nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '40'),
+          "nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '9' ),
+          "nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                        ),
         },
         {'facts.processor_count.ge' => '50'}
       )
@@ -127,13 +138,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should return node names that match the search query options with the not equal operator" do
       assert_search_matches({
-          '/path/to/matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => 'arm'                           ),
-          '/path/to/matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => 'powerpc', 'randomfact' => 'foo')
+          'matching.yaml'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => 'arm'                           ),
+          'matching1.yaml' => Puppet::Node::Facts.new("matchingnode1", "architecture" => 'powerpc', 'randomfact' => 'foo')
         },
         {
-          "/path/to/nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "i386"                           ),
-          "/path/to/nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386", 'processor_count' => '9' ),
-          "/path/to/nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                     ),
+          "nonmatching.yaml"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "i386"                           ),
+          "nonmatching2.yaml" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386", 'processor_count' => '9' ),
+          "nonmatching3.yaml" => Puppet::Node::Facts.new("nonmatchingnode3"                                                     ),
         },
         {'facts.architecture.ne' => 'i386'}
       )
@@ -146,13 +157,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should be able to query based on meta.timestamp.gt" do
       assert_search_matches({
-          '/path/to/2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
-          '/path/to/2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
         },
         {
-          '/path/to/2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
-          '/path/to/2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
-          '/path/to/2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+          '2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
         },
         {'meta.timestamp.gt' => '2010-10-15'}
       )
@@ -160,13 +171,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should be able to query based on meta.timestamp.le" do
       assert_search_matches({
-          '/path/to/2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
-          '/path/to/2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
-          '/path/to/2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+          '2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
         },
         {
-          '/path/to/2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
-          '/path/to/2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
         },
         {'meta.timestamp.le' => '2010-10-15'}
       )
@@ -174,13 +185,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should be able to query based on meta.timestamp.lt" do
       assert_search_matches({
-          '/path/to/2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
-          '/path/to/2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
         },
         {
-          '/path/to/2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
-          '/path/to/2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
-          '/path/to/2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+          '2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
         },
         {'meta.timestamp.lt' => '2010-10-15'}
       )
@@ -188,13 +199,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should be able to query based on meta.timestamp.ge" do
       assert_search_matches({
-          '/path/to/2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
-          '/path/to/2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
-          '/path/to/2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+          '2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
         },
         {
-          '/path/to/2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
-          '/path/to/2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
         },
         {'meta.timestamp.ge' => '2010-10-15'}
       )
@@ -202,13 +213,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should be able to query based on meta.timestamp.eq" do
       assert_search_matches({
-          '/path/to/2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+          '2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
         },
         {
-          '/path/to/2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
-          '/path/to/2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
-          '/path/to/2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
-          '/path/to/2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
         },
         {'meta.timestamp.eq' => '2010-10-15'}
       )
@@ -216,13 +227,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should be able to query based on meta.timestamp" do
       assert_search_matches({
-          '/path/to/2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+          '2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
         },
         {
-          '/path/to/2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
-          '/path/to/2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
-          '/path/to/2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
-          '/path/to/2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
         },
         {'meta.timestamp' => '2010-10-15'}
       )
@@ -230,13 +241,13 @@ describe Puppet::Node::Facts::Yaml do
 
     it "should be able to query based on meta.timestamp.ne" do
       assert_search_matches({
-          '/path/to/2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
-          '/path/to/2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
-          '/path/to/2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
-          '/path/to/2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-11-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-01.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
         },
         {
-          '/path/to/2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+          '2010-10-15.yaml' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
         },
         {'meta.timestamp.ne' => '2010-10-15'}
       )

--- a/spec/unit/indirector/node/exec_spec.rb
+++ b/spec/unit/indirector/node/exec_spec.rb
@@ -5,37 +5,39 @@ require 'puppet/indirector/node/exec'
 require 'puppet/indirector/request'
 
 describe Puppet::Node::Exec do
+  let(:indirection) { mock 'indirection' }
+  let(:searcher) { Puppet::Node::Exec.new }
+
   before do
-    @indirection = mock 'indirection'
     Puppet.settings[:external_nodes] = File.expand_path("/echo")
-    @searcher = Puppet::Node::Exec.new
   end
 
   describe "when constructing the command to run" do
     it "should use the external_node script as the command" do
       Puppet[:external_nodes] = "/bin/echo"
-      expect(@searcher.command).to eq(%w{/bin/echo})
+      expect(searcher.command).to eq(%w{/bin/echo})
     end
 
     it "should throw an exception if no external node command is set" do
       Puppet[:external_nodes] = "none"
-      expect { @searcher.find(stub('request', :key => "foo")) }.to raise_error(ArgumentError)
+      expect { searcher.find(stub('request', :key => "foo")) }.to raise_error(ArgumentError)
     end
   end
 
   describe "when handling the results of the command" do
     let(:testing_env) { Puppet::Node::Environment.create(:testing, []) }
     let(:other_env) { Puppet::Node::Environment.create(:other, []) }
-    let(:request) { Puppet::Indirector::Request.new(:node, :find, @name, nil) }
+    let(:request) { Puppet::Indirector::Request.new(:node, :find, name, environment: testing_env) }
+    let(:name) { 'yay' }
+    let(:facts) { Puppet::Node::Facts.new(name, {}) }
+
     before do
-      @name = "yay"
-      @node = Puppet::Node.new(@name)
-      @node.stubs(:fact_merge)
-      Puppet::Node.expects(:new).with(@name).returns(@node)
+      Puppet::Node::Facts.indirection.stubs(:find).returns(facts)
+
       @result = {}
       # Use a local variable so the reference is usable in the execute definition.
       result = @result
-      @searcher.meta_def(:execute) do |command, arguments|
+      searcher.meta_def(:execute) do |command, arguments|
         return YAML.dump(result)
       end
     end
@@ -49,39 +51,44 @@ describe Puppet::Node::Exec do
     end
 
     it "should translate the YAML into a Node instance" do
-      # Use an empty hash
-      expect(@searcher.find(request)).to equal(@node)
+      @result = {}
+      node = searcher.find(request)
+      expect(node.name).to eq(name)
+      expect(node.parameters).to include('environment')
+      expect(node.facts).to eq(facts)
+      expect(node.environment.name).to eq(:'*root*') # request env is ignored
     end
 
     it "should set the resulting parameters as the node parameters" do
       @result[:parameters] = {"a" => "b", "c" => "d"}
-      @searcher.find(request)
-      expect(@node.parameters).to eq({"a" => "b", "c" => "d", "environment" => "*root*"})
+      node = searcher.find(request)
+      expect(node.parameters).to eq({"a" => "b", "c" => "d", "environment" => "*root*"})
+
     end
 
     it "should set the resulting classes as the node classes" do
       @result[:classes] = %w{one two}
-      @searcher.find(request)
-      expect(@node.classes).to eq([ 'one', 'two' ])
+      node = searcher.find(request)
+      expect(node.classes).to eq([ 'one', 'two' ])
     end
 
     it "should merge facts from the request if supplied" do
       facts = Puppet::Node::Facts.new('test', 'foo' => 'bar')
       request.options[:facts] = facts
-      @node.expects(:fact_merge).with(facts)
-      @searcher.find(request)
+      node = searcher.find(request)
+      expect(node.facts).to eq(facts)
     end
 
     it "should set the node's environment if one is provided" do
       @result[:environment] = "testing"
-      @searcher.find(request)
-      expect(@node.environment.name).to eq(:testing)
+      node = searcher.find(request)
+      expect(node.environment.name).to eq(:testing)
     end
 
     it "should set the node's environment based on the request if not otherwise provided" do
       request.environment = "other"
-      @searcher.find(request)
-      expect(@node.environment.name).to eq(:other)
+      node = searcher.find(request)
+      expect(node.environment.name).to eq(:other)
     end
   end
 end

--- a/spec/unit/indirector/node/exec_spec.rb
+++ b/spec/unit/indirector/node/exec_spec.rb
@@ -63,7 +63,20 @@ describe Puppet::Node::Exec do
       @result[:parameters] = {"a" => "b", "c" => "d"}
       node = searcher.find(request)
       expect(node.parameters).to eq({"a" => "b", "c" => "d", "environment" => "*root*"})
+    end
 
+    it "accepts symbolic parameter names" do
+      @result[:parameters] = {:name => "value"}
+      node = searcher.find(request)
+      expect(node.parameters).to include({:name => "value"})
+    end
+
+    it "raises when deserializing unacceptable objects" do
+      @result[:parameters] = {'name' => Object.new }
+
+      expect {
+        searcher.find(request)
+      }.to raise_error(Puppet::Error, /Could not load external node results for yay: Tried to load unspecified class: Object/)
     end
 
     it "should set the resulting classes as the node classes" do

--- a/spec/unit/indirector/node/exec_spec.rb
+++ b/spec/unit/indirector/node/exec_spec.rb
@@ -76,7 +76,8 @@ describe Puppet::Node::Exec do
 
       expect {
         searcher.find(request)
-      }.to raise_error(Puppet::Error, /Could not load external node results for yay: Tried to load unspecified class: Object/)
+      }.to raise_error(Puppet::Error,
+                       /Could not load external node results for yay: \(<unknown>\): Tried to load unspecified class: Object/)
     end
 
     it "should set the resulting classes as the node classes" do

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -129,8 +129,9 @@ describe Puppet::Node::Facts, "when indirecting" do
       end
 
       def deserialize_yaml_facts(facts)
+        facts.sanitize
         format = Puppet::Network::FormatHandler.format('yaml')
-        format.intern(Puppet::Node::Facts, facts.to_yaml)
+        format.intern(Puppet::Node::Facts, YAML.dump(facts.to_data_hash))
       end
 
       it 'preserves `_timestamp` value' do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -113,20 +113,23 @@ describe Puppet::Node do
     end
 
     it "a node can roundtrip" do
-      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
+      expect(Puppet::Util::Yaml.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
     end
 
     it "limits the serialization of environment to be just the name" do
       yaml_file = file_containing("temp_yaml", @node.to_yaml)
-      node_yaml = Puppet::Util::Yaml.load_file(yaml_file, false, true)
-      expect(node_yaml['environment']).to eq('production')
+      expect(File.read(yaml_file)).to eq(<<~NODE)
+        --- !ruby/object:Puppet::Node
+        name: mynode
+        environment: production
+      NODE
     end
   end
 
   describe "when serializing using yaml and values classes and parameters are missing in deserialized hash" do
     it "a node can roundtrip" do
       @node = Puppet::Node.from_data_hash({'name' => "mynode"})
-      expect(YAML.load(@node.to_yaml).name).to eql("mynode")
+      expect(Puppet::Util::Yaml.safe_load(@node.to_yaml, [Puppet::Node]).name).to eql("mynode")
     end
 
     it "errors if name is nil" do

--- a/spec/unit/provider/cron/crontab_spec.rb
+++ b/spec/unit/provider/cron/crontab_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Type.type(:cron).provider(:crontab) do
 
     ########################################################################
     # Simple input fixtures for testing.
-    samples = YAML.load(File.read(my_fixture('single_line.yaml')))
+    samples = Puppet::Util::Yaml.safe_load(File.read(my_fixture('single_line.yaml')), [Symbol])
 
     samples.each do |name, data|
       it "should parse crontab line #{name} correctly" do

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -792,7 +792,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
       @catalog.add_edge("one", "two")
 
       text = YAML.dump(@catalog)
-      @newcatalog = YAML.load(text)
+      @newcatalog = Puppet::Util::Yaml.safe_load(text, [Puppet::Resource::Catalog])
     end
 
     it "should get converted back to a catalog" do

--- a/spec/unit/ssl/certificate_request_attributes_spec.rb
+++ b/spec/unit/ssl/certificate_request_attributes_spec.rb
@@ -10,6 +10,7 @@ describe Puppet::SSL::CertificateRequestAttributes do
       "custom_attributes" => {
         "1.3.6.1.4.1.34380.2.2"=>[3232235521, 3232235777], # system IPs in hex
         "1.3.6.1.4.1.34380.2.0"=>"hostname.domain.com",
+        "1.3.6.1.4.1.34380.1.1.3"=>:node_image_name,
         # different UTF-8 widths
         # 1-byte A
         # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
@@ -65,6 +66,14 @@ describe Puppet::SSL::CertificateRequestAttributes do
         expect {
           csr_attributes.load
         }.to raise_error(Puppet::Error, /unexpected attributes.*unintentional/)
+      end
+
+      it "raises a Puppet::Util::Yaml::YamlLoadError if an unexpected ruby object is present" do
+        csr_attributes_hash['custom_attributes']['whoops'] = Object.new
+        Puppet::Util::Yaml.dump(csr_attributes_hash, csr_attributes_path)
+        expect {
+          csr_attributes.load
+        }.to raise_error(Puppet::Util::Yaml::YamlLoadError, /Tried to load unspecified class: Object/)
       end
     end
   end

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -165,6 +165,18 @@ describe Puppet::Util::Storage do
 
         Puppet::Util::Storage.load
       end
+
+      it 'should load Time and Symbols' do
+        state = {
+          'File[/etc/puppetlabs/puppet]' =>
+          { :checked => Time.new('2018-08-08 15:28:25.546999000 -07:00') }
+        }
+        write_state_file(YAML.dump(state))
+
+        Puppet::Util::Storage.load
+
+        expect(Puppet::Util::Storage.state).to eq(state.dup)
+      end
     end
   end
 

--- a/spec/unit/util/tag_set_spec.rb
+++ b/spec/unit/util/tag_set_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Util::TagSet do
     array = ['a', :b, 1, 5.4]
     set.merge(array)
 
-    expect(Set.new(YAML.load(set.to_yaml))).to eq(Set.new(array))
+    expect(Set.new(Puppet::Util::Yaml.safe_load(set.to_yaml, [Symbol, Puppet::Util::TagSet]))).to eq(Set.new(array))
   end
 
   it 'deserializes from a yaml array' do
@@ -42,5 +42,12 @@ describe Puppet::Util::TagSet do
     set.merge(array)
 
     expect(set.join(', ')).to be_one_of('a, b', 'b, a')
+  end
+
+  it 'raises when deserializing unacceptable objects' do
+    yaml = [Object.new].to_yaml
+    expect {
+      Puppet::Util::TagSet.from_yaml(yaml)
+    }.to raise_error(Puppet::Util::Yaml::YamlLoadError, /Tried to load unspecified class: Object/)
   end
 end

--- a/spec/unit/util/yaml_spec.rb
+++ b/spec/unit/util/yaml_spec.rb
@@ -37,7 +37,7 @@ describe Puppet::Util::Yaml do
     it "returns false" do
       Puppet::FileSystem.touch(filename)
 
-      expect(Puppet::Util::Yaml.load_file(filename)).to be_falsey
+      expect(Puppet::Util::Yaml.load_file(filename)).to eq(false)
     end
 
     it "allows return value to be overridden" do

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -152,7 +152,7 @@ describe Puppet::Util do
 
     # In 2.3, the behavior is mostly correct when external codepage is 65001 / UTF-8
     it "works around Ruby bug 8822 (which fails to preserve UTF-8 properly when accessing ENV) (Ruby >= 2.3.x) ",
-      :if => ((match = RUBY_VERSION.match(/^2\.(\d+)\./)) && match.captures[0].to_i >= 3 && Puppet.features.microsoft_windows?) do
+      :if => Puppet.features.microsoft_windows? do
 
       raise 'This test requires a non-UTF8 codepage' if Encoding.default_external == Encoding::UTF_8
 


### PR DESCRIPTION
* Add Puppet::Util::Yaml#{safe_load,safe_load_file} methods.
* Rework puppet to call those methods, passing a list of acceptable classes to deserialize, if needed
* Enable rubocop check so that we don't call `YAML.load`
