### PR TITLE
(docs) Address some issues when generating type reference docs

### DIFF
--- a/lib/puppet/type/augeas.rb
+++ b/lib/puppet/type/augeas.rb
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:augeas) do
   end
 
   newparam(:type_check) do
-    desc "Whether augeas should perform typechecking. Defaults to false."
+    desc "Whether augeas should perform typechecking."
     newvalues(:true, :false)
 
     defaultto :false

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -78,8 +78,8 @@ module Puppet
 
       attr_reader :output
       desc "The expected exit code(s).  An error will be returned if the
-        executed command has some other exit code.  Defaults to 0. Can be
-        specified as an array of acceptable exit codes or a single value.
+        executed command has some other exit code. Can be specified as an array
+        of acceptable exit codes or a single value.
 
         On POSIX systems, exit codes are always integers between 0 and 255.
 
@@ -230,7 +230,7 @@ module Puppet
 
     newparam(:logoutput) do
       desc "Whether to log command output in addition to logging the
-        exit code.  Defaults to `on_failure`, which only logs the output
+        exit code. Defaults to `on_failure`, which only logs the output
         when the command has an exit code that does not match any value
         specified by the `returns` attribute. As with any resource type,
         the log level can be controlled with the `loglevel` metaparameter."
@@ -305,10 +305,9 @@ module Puppet
 
     newparam(:tries) do
       desc "The number of times execution of the command should be tried.
-        Defaults to '1'. This many attempts will be made to execute
-        the command until an acceptable return code is returned.
-        Note that the timeout parameter applies to each try rather than
-        to the complete set of tries."
+        This many attempts will be made to execute the command until an
+        acceptable return code is returned. Note that the timeout parameter
+        applies to each try rather than to the complete set of tries."
 
       munge do |value|
         if value.is_a?(String)

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -207,7 +207,7 @@ Puppet::Type.newtype(:file) do
       whose content doesn't match what the `source` or `content` attribute
       specifies.  Setting this to false allows file resources to initialize files
       without overwriting future changes.  Note that this only affects content;
-      Puppet will still manage ownership and permissions. Defaults to `true`."
+      Puppet will still manage ownership and permissions."
     defaultto :true
   end
 
@@ -320,7 +320,7 @@ Puppet::Type.newtype(:file) do
 
   newparam(:validate_replacement) do
     desc "The replacement string in a `validate_cmd` that will be replaced
-      with an input file name. Defaults to: `%`"
+      with an input file name."
 
     defaultto '%'
   end

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -141,7 +141,7 @@ module Puppet
     end
 
     newparam(:allowdupe, :boolean => true, :parent => Puppet::Parameter::Boolean) do
-      desc "Whether to allow duplicate GIDs. Defaults to `false`."
+      desc "Whether to allow duplicate GIDs."
 
       defaultto false
     end

--- a/lib/puppet/type/k5login.rb
+++ b/lib/puppet/type/k5login.rb
@@ -29,7 +29,7 @@ Puppet::Type.newtype(:k5login) do
 
   # To manage the mode of the file
   newproperty(:mode) do
-    desc "The desired permissions mode of the `.k5login` file. Defaults to `644`."
+    desc "The desired permissions mode of the `.k5login` file."
     defaultto { "644" }
   end
 
@@ -104,7 +104,7 @@ Puppet::Type.newtype(:k5login) do
     super
   end
 
-  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
   provide(:k5login) do
     desc "The k5login provider is the only provider for the k5login

--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -32,7 +32,7 @@ module Puppet
     end
 
     newparam(:withpath) do
-      desc "Whether to show the full object path. Defaults to false."
+      desc "Whether to show the full object path."
       defaultto :false
 
       newvalues(:true, :false)

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -411,8 +411,7 @@ module Puppet
 
     newparam(:configfiles) do
       desc "Whether to keep or replace modified config files when installing or
-        upgrading a package. This only affects the `apt` and `dpkg` providers.
-        Defaults to `keep`."
+        upgrading a package. This only affects the `apt` and `dpkg` providers."
 
       defaultto :keep
 
@@ -547,9 +546,7 @@ module Puppet
 
         If you use this, be careful of notifying classes when you want to restart
         services. If the class also contains a refreshable package, doing so could
-        cause unnecessary re-installs.
-
-        Defaults to `false`."
+        cause unnecessary re-installs."
       newvalues(:true, :false)
 
       defaultto :false

--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -312,7 +312,7 @@ module Puppet
 
     newparam(:repeat) do
       desc "How often a given resource may be applied in this schedule's `period`.
-        Defaults to 1; must be an integer."
+        Must be an integer."
 
       defaultto 1
 

--- a/lib/puppet/type/selboolean.rb
+++ b/lib/puppet/type/selboolean.rb
@@ -15,8 +15,8 @@ module Puppet
     end
 
     newparam(:persistent) do
-      desc "If set true, SELinux booleans will be written to disk and persist across reboots.
-        The default is `false`."
+      desc "If set to true, SELinux booleans will be written to disk and persist across
+        reboots."
 
       defaultto :false
       newvalues(:true, :false)

--- a/lib/puppet/type/selmodule.rb
+++ b/lib/puppet/type/selmodule.rb
@@ -23,10 +23,9 @@ Puppet::Type.newtype(:selmodule) do
   newparam(:selmoduledir) do
 
     desc "The directory to look for the compiled pp module file in.
-      Currently defaults to `/usr/share/selinux/targeted`.  If the
-      `selmodulepath` attribute is not specified, Puppet will expect to find
-      the module in `<selmoduledir>/<name>.pp`, where `name` is the value of the
-      `name` parameter."
+      If the `selmodulepath` attribute is not specified, Puppet expects to
+      find the module in `<selmoduledir>/<name>.pp`, where `name` is the
+      value of the `name` parameter."
 
     defaultto "/usr/share/selinux/targeted"
   end

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -135,8 +135,7 @@ module Puppet
 
     newparam(:hasstatus) do
       desc "Declare whether the service's init script has a functional status
-        command; defaults to `true`. This attribute's default value changed in
-        Puppet 2.7.0.
+        command. This attribute's default value changed in Puppet 2.7.0.
 
         The init script's status command must return 0 if the service is
         running and a nonzero value otherwise. Ideally, these exit codes
@@ -230,9 +229,7 @@ module Puppet
     newparam :hasrestart do
       desc "Specify that an init script has a `restart` command.  If this is
         false and you do not specify a command in the `restart` attribute,
-        the init script's `stop` and `start` commands will be used.
-
-        Defaults to false."
+        the init script's `stop` and `start` commands will be used."
       newvalues(:true, :false)
     end
 

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -188,7 +188,7 @@ Puppet::Type.newtype(:tidy) do
   end
 
   newparam(:type) do
-    desc "Set the mechanism for determining age. Default: atime."
+    desc "Set the mechanism for determining age."
 
     newvalues(:atime, :mtime, :ctime)
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -392,9 +392,7 @@ module Puppet
         that the user is a part of.
 
         If `inclusive` is specified, Puppet will ensure that the user is a
-        member of **only** specified groups.
-
-        Defaults to `minimum`."
+        member of **only** specified groups."
 
       newvalues(:inclusive, :minimum)
 
@@ -405,13 +403,13 @@ module Puppet
       desc "Whether the user is a system user, according to the OS's criteria;
       on most platforms, a UID less than or equal to 500 indicates a system
       user. This parameter is only used when the resource is created and will
-      not affect the UID when the user is present. Defaults to `false`."
+      not affect the UID when the user is present."
 
       defaultto false
     end
 
     newparam(:allowdupe, :boolean => true, :parent => Puppet::Parameter::Boolean) do
-      desc "Whether to allow duplicate UIDs. Defaults to `false`."
+      desc "Whether to allow duplicate UIDs."
 
       defaultto false
     end
@@ -419,7 +417,7 @@ module Puppet
     newparam(:managehome, :boolean => true, :parent => Puppet::Parameter::Boolean) do
       desc "Whether to manage the home directory when Puppet creates or removes the user.
         This creates the home directory if Puppet also creates the user account, and deletes the
-        home directory if Puppet also removes the user account. Defaults to `false`.
+        home directory if Puppet also removes the user account.
 
         This parameter has no effect unless Puppet is also creating or removing the user in the
         resource at the same time. For instance, Puppet creates a home directory for a managed
@@ -545,7 +543,7 @@ module Puppet
     newparam(:role_membership) do
       desc "Whether specified roles should be considered the **complete list**
         (`inclusive`) or the **minimum list** (`minimum`) of roles the user
-        has. Defaults to `minimum`."
+        has."
 
       newvalues(:inclusive, :minimum)
 
@@ -571,7 +569,7 @@ module Puppet
     newparam(:auth_membership) do
       desc "Whether specified auths should be considered the **complete list**
         (`inclusive`) or the **minimum list** (`minimum`) of auths the user
-        has. Defaults to `minimum`."
+        has."
 
       newvalues(:inclusive, :minimum)
 
@@ -597,7 +595,7 @@ module Puppet
     newparam(:profile_membership) do
       desc "Whether specified roles should be treated as the **complete list**
         (`inclusive`) or the **minimum list** (`minimum`) of roles
-        of which the user is a member. Defaults to `minimum`."
+        of which the user is a member."
 
       newvalues(:inclusive, :minimum)
 
@@ -619,7 +617,7 @@ module Puppet
     newparam(:key_membership) do
       desc "Whether specified key/value pairs should be considered the
         **complete list** (`inclusive`) or the **minimum list** (`minimum`) of
-        the user's attributes. Defaults to `minimum`."
+        the user's attributes."
 
       newvalues(:inclusive, :minimum)
 
@@ -653,7 +651,7 @@ module Puppet
     newparam(:attribute_membership) do
       desc "Whether specified attribute value pairs should be treated as the
         **complete list** (`inclusive`) or the **minimum list** (`minimum`) of
-        attribute/value pairs for the user. Defaults to `minimum`."
+        attribute/value pairs for the user."
 
       newvalues(:inclusive, :minimum)
 

--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -273,7 +273,7 @@ Puppet::Type.newtype(:yumrepo) do
     desc "Enable bandwidth throttling for downloads. This option
       can be expressed as a absolute data rate in bytes/sec or a
       percentage `60%`. An SI prefix (k, M or G) may be appended
-      to the data rate values.\n#{ABSENT_DOC}"
+      to the data rate values.#{ABSENT_DOC}"
 
     newvalues(/^\d+[kMG%]?$/, :absent)
   end
@@ -283,7 +283,7 @@ Puppet::Type.newtype(:yumrepo) do
       in bytes/second. Used with the `throttle` option. If `throttle`
       is a percentage and `bandwidth` is `0` then bandwidth throttling
       will be disabled. If `throttle` is expressed as a data rate then
-      this option is ignored.\n#{ABSENT_DOC}"
+      this option is ignored.#{ABSENT_DOC}"
 
     newvalues(/^\d+[kMG]?$/, :absent)
   end

--- a/lib/puppet/type/zone.rb
+++ b/lib/puppet/type/zone.rb
@@ -262,7 +262,7 @@ end
   # Specify the sysidcfg file.  This is pretty hackish, because it's
   # only used to boot the zone the very first time.
   newparam(:sysidcfg) do
-    desc %{The text to go into the `sysidcfg` file when the zone is first
+    desc "The text to go into the `sysidcfg` file when the zone is first
       booted.  The best way is to use a template:
 
           # $confdir/modules/site/templates/sysidcfg.erb
@@ -290,7 +290,7 @@ end
           }
 
       The `sysidcfg` only matters on the first booting of the zone,
-      so Puppet only checks for it at that time.}
+      so Puppet only checks for it at that time."
   end
 
   newparam(:create_args) do


### PR DESCRIPTION
Several type attributes list default values in their description, but also have `defaultto` definitions. When generating reference docs, this results in output that contains duplicate lists of default values. Remove these redundant defaults from the descriptions.

Defaults that required additional information were intentionally left in the description, but should be minded should the `defaultto` value change.

Two attributes also included extraneous formatting that appeared in output as raw text. Remove or replace that formatting.