### PR TITLE
(PUP-8530) Remove trusted_server_facts setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -673,13 +673,6 @@ module Puppet
           essentially means that you can't have any code outside of a node,
           class, or definition other than in the site manifest.",
     },
-    :trusted_server_facts => {
-      :default => true,
-      :type    => :boolean,
-      :deprecated => :completely,
-      :desc    => "The 'trusted_server_facts' setting is deprecated and has no effect as the
-        feature this enabled is now always on. The setting will be removed in a future version of puppet.",
-    },
     :preview_outputdir => {
       :default => '$vardir/preview',
       :type     => :directory,

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -769,8 +769,8 @@ class Puppet::Parser::Scope
       raise Puppet::ParseError, _("Attempt to assign to a reserved variable name: '%{name}'") % { name: name }
     end
 
-    # Check for server_facts reserved variable name if the trusted_sever_facts setting is true
-    if name == VARNAME_SERVER_FACTS && !options[:privileged] && Puppet[:trusted_server_facts]
+    # Check for server_facts reserved variable name
+    if name == VARNAME_SERVER_FACTS && !options[:privileged]
       raise Puppet::ParseError, _("Attempt to assign to a reserved variable name: '%{name}'") % { name: name }
     end
 


### PR DESCRIPTION
Trusted server facts are always enabled and have been deprecated[1]
since 5.0. Remove the setting and conditional logic.

[1] https://tickets.puppetlabs.com/browse/PUP-6112