### PR TITLE
(PUP-8683) Change default http read and run timeouts

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -594,9 +594,10 @@ module Puppet
       #{AS_DURATION}",
     },
     :http_read_timeout => {
+      :default => "10m",
       :type    => :duration,
-      :desc    => "The time to wait for one block to be read from an HTTP connection. If nothing is
-      read after the elapsed interval then the connection will be closed. The default value is unlimited.
+      :desc    => "The time to wait for data to be read from an HTTP connection. If nothing is
+      read after the elapsed interval then the connection will be closed. The default value is 10 minutes.
       #{AS_DURATION}",
     },
     :http_user_agent => {
@@ -1598,11 +1599,11 @@ EOT
           it with the `--no-client` option. #{AS_DURATION}",
     },
     :runtimeout => {
-      :default  => 0,
+      :default  => "1h",
       :type     => :duration,
       :desc     => "The maximum amount of time an agent run is allowed to take.
-          A Puppet agent run that exceeds this timeout will be aborted.
-          Defaults to 0, which is unlimited. #{AS_DURATION}",
+          A Puppet agent run that exceeds this timeout will be aborted. A value
+          of 0 disables the timeout. Defaults to 1 hour. #{AS_DURATION}",
     },
     :ca_server => {
       :default    => "$server",


### PR DESCRIPTION
Previously puppet could hang reading from a socket if the response never
arrived, for example if the TCP FIN or RST never arrived. Set a default
http read timeout to avoid that. Note the http connect timeout already
defaults to 2 minutes.

Similarly, set the watchdog timeout (runtimeout) to 1 hour. If a puppet
run takes more than that it will be killed by the watchdog. Overrun can
occur but at least puppet won't hang indefinitely, such as if puppet
executes a command that waits indefinitely. Prime example is a Windows
MSI that displays a UI waiting for user input that never happens.