### PR TITLE
(PUP-8957) Revert changes that made SMF return :absent (again)

### DIFF
--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -19,11 +19,11 @@ end
 
 agents.each do |agent|
   clean agent, :service => 'tstapp'
-  manifest, method = setup agent, :service => 'tstapp'
+  manifest, _ = setup agent, :service => 'tstapp'
 
   step "SMF: ensure it is created with a manifest"
   apply_manifest_on(agent, 'service {tstapp : ensure=>running, manifest=>"%s"}' % manifest) do
-    assert_match( /defined 'ensure' as 'running'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure changed 'stopped'.* to 'running'/, result.stdout, "err: #{agent}")
   end
 
   step "SMF: verify with svcs that the service is online"
@@ -39,19 +39,9 @@ agents.each do |agent|
     assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
   end
 
-  step "SMF: ensure non-existent services return :absent"
-  on(agent, puppet("resource service bogus")) do
-    assert_match( /ensure => 'absent'/, result.stdout, "err: #{agent}")
-  end
-
   step "SMF: ensure you can stop the service"
   apply_manifest_on(agent, 'service {tstapp : ensure=>stopped}') do
     assert_match( /changed 'running'.* to 'stopped'/, result.stdout, "err: #{agent}")
-  end
-
-  step "SMF: ensure stopping a non-existent service doesn't throw an error"
-  apply_manifest_on(agent, 'service {bogus : ensure=>stopped}', :acceptable_exit_codes => [0,1,2,4,6]) do
-    assert_equal(exit_code, 0, "'puppet resource service' should have an exit code of 0")
   end
 
   step "SMF: verify with svcs that the service is not online"

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -108,8 +108,6 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
   end
 
   def stop
-    # Don't try to stop non-existing services (PUP-8167)
-    return if self.status == :absent
     # Wait for the service to actually stop before returning.
     super
     self.wait('offline', 'disabled', 'uninitialized')
@@ -138,8 +136,9 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
       states = service_states
       state = states[1] == "-" ? states[0] : states[1]
     rescue Puppet::ExecutionFailure
+      # TODO (PUP-8957): Should this be set back to INFO ?
       debug "Could not get status on service #{self.name} #{$!}"
-      return :absent
+      return :stopped
     end
 
     case state

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -18,8 +18,6 @@ describe provider_class, :if => Puppet.features.posix? do
 
     FileTest.stubs(:file?).with('/usr/sbin/svcadm').returns true
     FileTest.stubs(:executable?).with('/usr/sbin/svcadm').returns true
-    FileTest.stubs(:file?).with('/usr/sbin/svccfg').returns true
-    FileTest.stubs(:executable?).with('/usr/sbin/svccfg').returns true
     FileTest.stubs(:file?).with('/usr/bin/svcs').returns true
     FileTest.stubs(:executable?).with('/usr/bin/svcs').returns true
     Facter.stubs(:value).with(:operatingsystem).returns('Solaris')
@@ -76,9 +74,9 @@ describe provider_class, :if => Puppet.features.posix? do
       @provider.expects(:svcs).with('-H', '-o', 'state,nstate', "/system/myservice").returns("online\t-")
       @provider.status
     end
-    it "should return absent if svcs can't find the service" do
+    it "should return stopped if svcs can't find the service" do
       @provider.stubs(:svcs).raises(Puppet::ExecutionFailure.new("no svc found"))
-      expect(@provider.status).to eq(:absent)
+      expect(@provider.status).to eq(:stopped)
     end
     it "should return running if online in svcs output" do
       @provider.stubs(:svcs).returns("online\t-")
@@ -168,14 +166,12 @@ describe provider_class, :if => Puppet.features.posix? do
 
   describe "when stopping" do
     it "should execute external command 'svcadm disable /system/myservice'" do
-      @provider.stubs(:status).returns :running
       @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, '-s', "/system/myservice"], true)
       @provider.expects(:wait).with('offline', 'disabled', 'uninitialized')
       @provider.stop
     end
 
     it "should error if timeout occurs while stopping the service" do
-      @provider.stubs(:status).returns :running
       @provider.expects(:texecute).with(:stop, ["/usr/sbin/svcadm", :disable, '-s', "/system/myservice"], true)
       Timeout.expects(:timeout).with(60).raises(Timeout::Error)
       expect { @provider.stop }.to raise_error Puppet::Error, ('Timed out waiting for /system/myservice to transition states')


### PR DESCRIPTION
This commit reverts any changes that made the SMF provider return
:absent for nonexistent services, while preserving some of the
acceptance test improvements made during this work (e.g. like
consolidating all SMF tests to a single file). These involve the
following commits:
  * (PUP-6797) service should check for smf service first
  ** Hash: 3d7a3c4c1c6697047ae356c8765928f68618bc69
  * (PUP-6860) puppet on solaris 11 should support exists? for services
  ** Hash: dd30a54c9ff5fba9f980147b4a7af80442e009ed
  * (PUP-6797) Update SMF tests for nonexistent service
  ** Hash: 7085af0b7e508d86caa9e30bf44bed931d65f0df
  * (maint) (PUP-6767) remove redundant smf acceptance testing
  ** Hash: b539fe581f372514e28f4c7e095d81dc8b0f500c
  * (PUP-8167) SMF provider: do not try to stop :absent services
  ** Hash: 7183a352288867392c1c934270c494e7b1270ab0