### PR TITLE
(docs)(DOC-3488) Link to sprintf docs.

### DIFF
--- a/lib/puppet/parser/functions/sprintf.rb
+++ b/lib/puppet/parser/functions/sprintf.rb
@@ -31,7 +31,17 @@ Puppet::Parser::Functions::newfunction(
 
   The first parameter is format string describing how the rest of the parameters should be formatted.
   See the documentation for the [`Kernel::sprintf` function](https://ruby-doc.org/core/Kernel.html)
-  in Ruby for details."
+  in Ruby for details.
+  
+  To use [named format](https://idiosyncratic-ruby.com/49-what-the-format.html) arguments, provide a
+  hash containing the target string values as the argument to be formatted. For example:
+
+  ```puppet
+  notice sprintf(\"%<x>s : %<y>d\", { 'x' => 'value is', 'y' => 42 })
+  ```
+
+  This statement produces a notice of `value is : 42`."
+
 ) do |args|
   fmt = args[0]
   args = args[1..-1]

--- a/lib/puppet/parser/functions/sprintf.rb
+++ b/lib/puppet/parser/functions/sprintf.rb
@@ -30,7 +30,8 @@ Puppet::Parser::Functions::newfunction(
   :doc => "Perform printf-style formatting of text.
 
   The first parameter is format string describing how the rest of the parameters should be formatted.
-  See the documentation for the `Kernel::sprintf` function in Ruby for all the details."
+  See the documentation for the [`Kernel::sprintf` function](https://ruby-doc.org/core/Kernel.html)
+  in Ruby for details."
 ) do |args|
   fmt = args[0]
   args = args[1..-1]


### PR DESCRIPTION
The `sprintf()` function docs point users to the Ruby docs for the function, but could also link to them. Add a link to the Ruby `sprintf` docs.