### PR TITLE
(PUP-8531) Remove unused app_management config setting

### DIFF
--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -82,7 +82,7 @@ PP
 
   def mod_manifest_metadata_json(module_name = nil, testdir)
     if module_name
-      metadata_manifest = <<PPmetadata
+      <<PPmetadata
       file { '#{testdir}/environments/production/modules/#{module_name}/metadata.json':
         ensure => file,
         content => '

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -299,8 +299,6 @@ PP
     'main' => {
       'environmentpath' => "#{testdir}/environments",
       'hiera_config' => "#{testdir}/hiera.yaml",
-      # required for site{}
-      'app_management' => true,
     },
   }
   with_puppet_running_on master, master_opts, testdir do

--- a/benchmarks/serialization/catalog.json
+++ b/benchmarks/serialization/catalog.json
@@ -430,7 +430,6 @@
         "puppetdb_host": "agent.demo.com",
         "puppetdb_port": 8081,
         "code_manager_auto_configure": false,
-        "app_management": true,
         "check_for_updates": true,
         "send_analytics_data": true,
         "replication_mode": "none",
@@ -2790,55 +2789,6 @@
         "store_usage": "1gb",
         "temp_usage": "1gb",
         "usage_ensure": "present"
-      }
-    },
-    {
-      "type": "Pe_ini_setting",
-      "title": "deprecated puppetserver puppetconf app_management",
-      "tags": [
-        "pe_ini_setting",
-        "class",
-        "puppet_enterprise::profile::master",
-        "puppet_enterprise",
-        "profile",
-        "master",
-        "node",
-        "default"
-      ],
-      "file": "\/opt\/puppetlabs\/puppet\/modules\/puppet_enterprise\/manifests\/profile\/master.pp",
-      "line": 120,
-      "exported": false,
-      "parameters": {
-        "setting": "app_management",
-        "ensure": "absent",
-        "section": "master",
-        "path": "\/etc\/puppetlabs\/puppet\/puppet.conf",
-        "notify": "Service[pe-puppetserver]"
-      }
-    },
-    {
-      "type": "Pe_ini_setting",
-      "title": "puppetserver puppetconf app_management",
-      "tags": [
-        "pe_ini_setting",
-        "class",
-        "puppet_enterprise::profile::master",
-        "puppet_enterprise",
-        "profile",
-        "master",
-        "node",
-        "default"
-      ],
-      "file": "\/opt\/puppetlabs\/puppet\/modules\/puppet_enterprise\/manifests\/profile\/master.pp",
-      "line": 126,
-      "exported": false,
-      "parameters": {
-        "setting": "app_management",
-        "value": true,
-        "section": "main",
-        "ensure": "present",
-        "path": "\/etc\/puppetlabs\/puppet\/puppet.conf",
-        "notify": "Service[pe-puppetserver]"
       }
     },
     {
@@ -33374,14 +33324,6 @@
     {
       "source": "Class[Puppet_enterprise::Profile::Amq::Broker]",
       "target": "Puppet_enterprise::Amq::Config::System_usage[agent.demo.com - systemusage]"
-    },
-    {
-      "source": "Class[Puppet_enterprise::Profile::Master]",
-      "target": "Pe_ini_setting[deprecated puppetserver puppetconf app_management]"
-    },
-    {
-      "source": "Class[Puppet_enterprise::Profile::Master]",
-      "target": "Pe_ini_setting[puppetserver puppetconf app_management]"
     },
     {
       "source": "Class[Puppet_enterprise::Profile::Master]",

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -678,16 +678,6 @@ module Puppet
     }
   )
 
-  define_settings(:main,
-      # Whether the application management feature is on or off - now deprecated and always on.
-      :app_management => {
-          :default  => false,
-          :type     => :boolean,
-          :desc       => "This setting has no effect and will be removed in a future Puppet version.",
-          :deprecated => :completely,
-      }
-  )
-
   Puppet.define_settings(:module_tool,
     :module_repository  => {
       :default  => 'https://forgeapi.puppet.com',

--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -377,8 +377,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     result = @resource_table[title_key]
     if result.nil?
       # an instance has to be created in order to construct the unique key used when
-      # searching for aliases, or when app_management is active and nothing is found in
-      # which case it is needed by the CapabilityFinder.
+      # searching for aliases, or nothing is found as it is needed by the CapabilityFinder.
       res = Puppet::Resource.new(type, title, { :environment => @environment_instance })
 
       # Must check with uniqueness key because of aliases or if resource transforms title in title

--- a/spec/unit/network/http/api/master/v3/environment_spec.rb
+++ b/spec/unit/network/http/api/master/v3/environment_spec.rb
@@ -9,7 +9,6 @@ describe Puppet::Network::HTTP::API::Master::V3::Environment do
   let(:loader) { Puppet::Environments::Static.new(environment) }
 
   around :each do |example|
-    Puppet[:app_management] = true
     Puppet.override(:environments => loader) do
       Puppet::Type.newtype :sql, :is_capability => true do
         newparam :name, :namevar => true


### PR DESCRIPTION
The config setting has been deprecated for a while, and has not done anything during that time.