### PR TITLE
(PA-1824) Update ruby flags in Windows test utils for Ruby 2.5

### DIFF
--- a/acceptance/lib/puppet/acceptance/windows_utils.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils.rb
@@ -9,7 +9,7 @@ module Puppet
 require 'win32/dir'
 puts Dir::PROFILE.match(/(.*)\\\\[^\\\\]*/)[1]
 END
-        on(agent, "#{ruby} -rubygems -e \"#{getbasedir}\"").stdout.chomp
+        on(agent, "#{ruby} -e \"#{getbasedir}\"").stdout.chomp
       end
     end
   end


### PR DESCRIPTION
In Ruby 2.5, the `-rubygems` flag is both unnecessary and no longer valid