### PR TITLE
(PUP-8320) Make filter less strict and accept truthy predicate

### DIFF
--- a/lib/puppet/parser/functions/filter.rb
+++ b/lib/puppet/parser/functions/filter.rb
@@ -5,7 +5,7 @@ Puppet::Parser::Functions::newfunction(
   :doc => <<-DOC
 Applies a [lambda](https://puppet.com/docs/puppet/latest/lang_lambdas.html)
 to every value in a data structure and returns an array or hash containing any elements
-for which the lambda evaluates to `true`.
+for which the lambda evaluates to a truthy value (not `false` or `undef`).
 
 This function takes two mandatory arguments, in this order:
 

--- a/spec/unit/functions/filter_spec.rb
+++ b/spec/unit/functions/filter_spec.rb
@@ -122,18 +122,18 @@ describe 'the filter method' do
     expect(catalog).to have_resource("File[/file_blueb]").with_parameter(:ensure, 'present')
   end
 
-  it 'filters on an array will not include elements for which the block returns truthy but not true' do
+  it 'filters on an array will include elements for which the block returns truthy' do
     catalog = compile_to_catalog(<<-MANIFEST)
-      $r = [1, 2, 3].filter |$v| { $v } == []
+      $r = [1, 2, false, undef].filter |$v| { $v } == [1, 2]
       notify { "eval_${$r}": }
     MANIFEST
 
     expect(catalog).to have_resource('Notify[eval_true]')
   end
 
-  it 'filters on a hash will not include elements for which the block returns truthy but not true' do
+  it 'filters on a hash will not include elements for which the block returns truthy' do
     catalog = compile_to_catalog(<<-MANIFEST)
-      $r = {a => 1, b => 2, c => 3}.filter |$k, $v| { $v } == {}
+      $r = {a => 1, b => 2, c => false, d=> undef}.filter |$k, $v| { $v } == {a => 1, b => 2}
       notify { "eval_${$r}": }
     MANIFEST
 


### PR DESCRIPTION
Before this, `filter()` was different from other functions taking
a predicate lambda in that it required the lambda to return
a boolean `true` to not filter.

This is now changed to make `filter` behave like the other functions
where any truthy value returned from the lambda means do not filter this
value.