### PR TITLE
(PUP-9069) Add support for RHEL8

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   defaultfor :osfamily => [:archlinux]
-  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => "7"
+  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8"]
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos


### PR DESCRIPTION
This adds support for the next version of RHEL in the systemd provider.
Note: I have no idea when it'll be released but we need this patch as we
need to make Puppet systemd provider working.