### PR TITLE
(maint) Deprecate settings used by `puppet master`

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1161,6 +1161,7 @@ EOT
       :bindaddress => {
         :default    => "*",
         :desc       => "The address a listening server should bind to.",
+        :deprecated  => :completely,
       }
   )
 
@@ -1210,11 +1211,15 @@ EOT
   define_settings(:master,
     :user => {
       :default    => "puppet",
-      :desc       => "The user puppet master should run as.",
+      :desc       => "The user Puppet Server will run as. Used to ensure
+      the agent side processes (agent, apply, etc) create files and
+      directories readable by Puppet Server when necessary.",
     },
     :group => {
       :default    => "puppet",
-      :desc       => "The group puppet master should run as.",
+      :desc       => "The group Puppet Server will run as. Used to ensure
+      the agent side processes (agent, apply, etc) create files and
+      directories readable by Puppet Server when necessary.",
     },
     :default_manifest => {
       :default    => "./manifests",
@@ -1260,6 +1265,7 @@ EOT
       :group => "service",
       :mode => "0660",
       :create => true,
+      :deprecated => :completely,
       :desc => "Where the puppet master web server saves its access log. This is
         only used when running a WEBrick puppet master. When puppet master is
         running under a Rack server like Passenger, that web server will have
@@ -1267,9 +1273,9 @@ EOT
     },
     :masterport => {
       :default    => 8140,
-      :desc       => "The port for puppet master traffic. For puppet master,
-      this is the port to listen on; for puppet agent, this is the port
-      to make requests on. Both applications use this setting to get the port.",
+      :desc       => "The default port puppet subcommands use to communicate
+      with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
+      overridden by more specific settings (see `ca_port`, `report_port`).",
     },
     :node_name => {
       :default    => "cert",
@@ -1291,13 +1297,16 @@ EOT
     :rest_authconfig => {
       :default    => "$confdir/auth.conf",
       :type       => :file,
+      :deprecated  => :completely,
       :desc       => "The configuration file that defines the rights to the different
-      rest indirections.  This can be used as a fine-grained
-      authorization system for `puppet master`.",
+      rest indirections.  This can be used as a fine-grained authorization system for
+      `puppet master`.  The `puppet master` command is deprecated and Puppet Server
+      uses its own auth.conf that must be placed within its configuration directory.",
     },
     :ca => {
       :default    => true,
       :type       => :boolean,
+      :deprecated  => :completely,
       :desc       => "Whether the master should function as a certificate authority.",
     },
     :trusted_oid_mapping_file => {

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1077,6 +1077,7 @@ EOT
     :autosign => {
       :default => "$confdir/autosign.conf",
       :type => :autosign,
+      :deprecated => :completely,
       :desc => "Whether (and how) to autosign certificate requests. This setting
         is only relevant on a puppet master acting as a certificate authority (CA).
         This setting is also deprecated and will be replaced by one in Puppet Server's

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -257,8 +257,9 @@ module Puppet
           on the CLI.",
     },
     :configprint => {
-        :default  => "",
-        :desc     => "Prints the value of a specific configuration setting.  If the name of a
+        :default    => "",
+        :deprecated => :completely,
+        :desc       => "Prints the value of a specific configuration setting.  If the name of a
           setting is provided for this, then the value is printed and puppet
           exits.  Comma-separate multiple values.  For a list of all values,
           specify 'all'. This setting is deprecated, the 'puppet config' command replaces this functionality.",

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -221,9 +221,6 @@ module Puppet::Test
       # Initialize "app defaults" settings to a good set of test values
       Puppet.settings.initialize_app_defaults(app_defaults_for_tests)
 
-      # Avoid opening ports to the outside world
-      Puppet.settings[:bindaddress] = "127.0.0.1"
-
       # We don't want to depend upon the reported domain name of the
       # machine running the tests, nor upon the DNS setup of that
       # domain.

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -7,6 +7,7 @@ require 'puppet/network/server'
 
 describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windows? do
   before :each do
+    Puppet[:bindaddress] = '127.0.0.1'
     @master = Puppet::Application[:master]
     @daemon = stub_everything 'daemon'
     Puppet::Daemon.stubs(:new).returns(@daemon)
@@ -357,6 +358,7 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
 
       it "should log a deprecation notice when running a WEBrick server" do
         Puppet.expects(:deprecation_warning).with("The WEBrick Puppet master server is deprecated and will be removed in a future release. Please use Puppet Server instead. See http://links.puppet.com/deprecate-rack-webrick-servers for more information.")
+        Puppet.expects(:deprecation_warning).with("Accessing 'bindaddress' as a setting is deprecated.")
 
         @master.main
       end


### PR DESCRIPTION
As part of PUP-8591 we removed the master application in Puppet 6. This
orphaned many settings that are not applicable to running a master with
Puppet Server or are better served living within its configuration
files.

To prepare for the removal of the puppet master application in Puppet 6,
this patch deprecates those settings.


---

Also correctly deprecates configprint.