### PR TITLE
(PUP-9064) Ignore X509 purpose during cert verification

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -390,11 +390,11 @@ class Puppet::SSL::CertificateAuthority
   # Certificate Revocation List and flags
   #
   # @return [OpenSSL::X509::Store]
-  def create_x509_store
-    store = OpenSSL::X509::Store.new()
+  def create_x509_store(purpose)
+    store = OpenSSL::X509::Store.new
     store.add_file(Puppet[:cacert])
     store.add_crl(crl.content) if self.crl
-    store.purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT
+    store.purpose = purpose
     if Puppet.settings[:certificate_revocation]
       store.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL | OpenSSL::X509::V_FLAG_CRL_CHECK
     end
@@ -407,17 +407,18 @@ class Puppet::SSL::CertificateAuthority
   # certificate with that name.
   #
   # @param name [String] certificate name to verify
+  # @param purpose [Integer] bitwise combination of X509::PURPOSE_*
   #
   # @raise [ArgumentError] if the certificate name cannot be found
   #   (i.e. doesn't exist or is unsigned)
   # @raise [CertificateVerficationError] if the certificate has been revoked
   #
   # @return [Boolean] true if signed, there are no cases where false is returned
-  def verify(name)
+  def verify(name, purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT)
     unless cert = Puppet::SSL::Certificate.indirection.find(name)
       raise ArgumentError, _("Could not find a certificate for %{name}") % { name: name }
     end
-    store = create_x509_store
+    store = create_x509_store(purpose)
 
     raise CertificateVerificationError.new(store.error), store.error_string unless store.verify(cert.content)
   end

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -193,26 +193,6 @@ class Puppet::SSL::CertificateAuthority
     Puppet::SSL::Certificate.indirection.search(name).collect { |c| c.name }
   end
 
-  # Return all the certificate objects as found by the indirector
-  # API for PE license checking.
-  #
-  # Created to prevent the case of reading all certs from disk, getting
-  # just their names and verifying the cert for each name, which then
-  # causes the cert to again be read from disk.
-  #
-  # @author Jeff Weiss <jeff.weiss@puppetlabs.com>
-  # @api Puppet Enterprise Licensing
-  #
-  # @param name [Array<string>] filter to cerificate names
-  #
-  # @return [Array<Puppet::SSL::Certificate>]
-  #
-  # @deprecated Use Puppet::SSL::CertificateAuthority#list or Puppet Server Certificate status API
-  def list_certificates(name='*')
-    Puppet.deprecation_warning(_("Puppet::SSL::CertificateAuthority#list_certificates is deprecated. Please use Puppet::SSL::CertificateAuthority#list or the certificate status API to query certificate information. See https://puppet.com/docs/puppet/latest/http_api/http_certificate_status.html"))
-    Puppet::SSL::Certificate.indirection.search(name)
-  end
-
   # Read the next serial from the serial file, and increment the
   # file so this one is considered used.
   def next_serial
@@ -406,37 +386,6 @@ class Puppet::SSL::CertificateAuthority
     return true                 # good enough for us!
   end
 
-  # Utility method for optionally caching the X509 Store for verifying a
-  # large number of certificates in a short amount of time--exactly the
-  # case we have during PE license checking.
-  #
-  # @example Use the cached X509 store
-  #   x509store(:cache => true)
-  #
-  # @example Use a freshly create X509 store
-  #   x509store
-  #   x509store(:cache => false)
-  #
-  # @param [Hash] options the options used for retrieving the X509 Store
-  # @option options [Boolean] :cache whether or not to use a cached version
-  #   of the X509 Store
-  #
-  # @return [OpenSSL::X509::Store]
-  #
-  # @deprecated Strictly speaking, #x509_store is marked API private, so we
-  #   don't need to publicly deprecate it. But it marked as deprecated here to
-  #   avoid the exceedingly small chance that someone comes in and uses it from
-  #   within this class before it is removed.
-  def x509_store(options = {})
-    if (options[:cache])
-      return @x509store unless @x509store.nil?
-      @x509store = create_x509_store
-    else
-      create_x509_store
-    end
-  end
-  private :x509_store
-
   # Creates a brand new OpenSSL::X509::Store with the appropriate
   # Certificate Revocation List and flags
   #
@@ -452,34 +401,6 @@ class Puppet::SSL::CertificateAuthority
     store
   end
   private :create_x509_store
-
-  # Utility method which is API for PE license checking.
-  # This is used rather than `verify` because
-  #  1) We have already read the certificate from disk into memory.
-  #     To read the certificate from disk again is just wasteful.
-  #  2) Because we're checking a large number of certificates against
-  #     a transient CertificateAuthority, we can relatively safely cache
-  #     the X509 Store that actually does the verification.
-  #
-  # Long running instances of CertificateAuthority will certainly
-  # want to use `verify` because it will recreate the X509 Store with
-  # the absolutely latest CRL.
-  #
-  # Additionally, this method explicitly returns a boolean whereas
-  # `verify` will raise an error if the certificate has been revoked.
-  #
-  # @author Jeff Weiss <jeff.weiss@puppetlabs.com>
-  # @api Puppet Enterprise Licensing
-  #
-  # @param cert [Puppet::SSL::Certificate] the certificate to check validity of
-  #
-  # @return [Boolean] true if signed, false if unsigned or revoked
-  #
-  # @deprecated use Puppet::SSL::CertificateAuthority#verify or Puppet Server certificate status API
-  def certificate_is_alive?(cert)
-    Puppet.deprecation_warning(_("Puppet::SSL::CertificateAuthority#certificate_is_alive? is deprecated. Please use Puppet::SSL::CertificateAuthority#verify or the certificate status API to query certificate information. See https://puppet.com/docs/puppet/latest/http_api/http_certificate_status.html"))
-    x509_store(:cache => true).verify(cert.content)
-  end
 
   # Verify a given host's certificate. The certname is passed in, and
   # the indirector will be used to locate the actual contents of the

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -414,7 +414,7 @@ class Puppet::SSL::CertificateAuthority
   # @raise [CertificateVerficationError] if the certificate has been revoked
   #
   # @return [Boolean] true if signed, there are no cases where false is returned
-  def verify(name, purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT)
+  def verify(name, purpose = OpenSSL::X509::PURPOSE_ANY)
     unless cert = Puppet::SSL::Certificate.indirection.find(name)
       raise ArgumentError, _("Could not find a certificate for %{name}") % { name: name }
     end

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -786,19 +786,6 @@ describe Puppet::SSL::CertificateAuthority, unless: Puppet::Util::Platform.jruby
       expect(@ca.list).to eq(%w{cert1 cert2})
     end
 
-    it "should list the full certificates" do
-      cert1 = stub 'cert1', :name => "cert1"
-      cert2 = stub 'cert2', :name => "cert2"
-      Puppet::SSL::Certificate.indirection.expects(:search).with("*").returns [cert1, cert2]
-      expect(@ca.list_certificates).to eq([cert1, cert2])
-    end
-
-    it "should print a deprecation when using #list_certificates" do
-      Puppet::SSL::Certificate.indirection.stubs(:search).with("*").returns [:foo, :bar]
-      Puppet.expects(:deprecation_warning).with(regexp_matches(/list_certificates is deprecated/))
-      @ca.list_certificates
-    end
-
     describe "and printing certificates" do
       it "should return nil if the certificate cannot be found" do
         Puppet::SSL::Certificate.indirection.expects(:find).with("myhost").returns nil
@@ -912,40 +899,6 @@ describe Puppet::SSL::CertificateAuthority, unless: Puppet::Util::Platform.jruby
         @store.expects(:error_string)
 
         expect { @ca.verify("me") }.to raise_error(Puppet::SSL::CertificateAuthority::CertificateVerificationError)
-      end
-
-      describe "certificate_is_alive?" do
-        it "should return false if verification fails" do
-          @cert.expects(:content).returns "mycert"
-
-          @store.expects(:verify).with("mycert").returns false
-
-          expect(@ca.certificate_is_alive?(@cert)).to be_falsey
-        end
-
-        it "should return true if verification passes" do
-          @cert.expects(:content).returns "mycert"
-
-          @store.expects(:verify).with("mycert").returns true
-
-          expect(@ca.certificate_is_alive?(@cert)).to be_truthy
-        end
-
-        it "should use a cached instance of the x509 store" do
-          OpenSSL::X509::Store.stubs(:new).returns(@store).once
-
-          @cert.expects(:content).returns "mycert"
-
-          @store.expects(:verify).with("mycert").returns true
-
-          @ca.certificate_is_alive?(@cert)
-          @ca.certificate_is_alive?(@cert)
-        end
-
-        it "should be deprecated" do
-          Puppet.expects(:deprecation_warning).with(regexp_matches(/certificate_is_alive\? is deprecated/))
-          @ca.certificate_is_alive?(@cert)
-        end
       end
     end
 

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -871,8 +871,7 @@ describe Puppet::SSL::CertificateAuthority, unless: Puppet::Util::Platform.jruby
       end
 
       it "should set the store purpose to OpenSSL::X509::PURPOSE_SSL_CLIENT" do
-        Puppet[:cacert] = cacert
-        @store.expects(:add_file).with cacert
+        @store.expects(:purpose=).with OpenSSL::X509::PURPOSE_SSL_CLIENT
 
         @ca.verify("me")
       end

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -871,7 +871,7 @@ describe Puppet::SSL::CertificateAuthority, unless: Puppet::Util::Platform.jruby
       end
 
       it "should set the store purpose to OpenSSL::X509::PURPOSE_SSL_CLIENT" do
-        @store.expects(:purpose=).with OpenSSL::X509::PURPOSE_SSL_CLIENT
+        @store.expects(:purpose=).with OpenSSL::X509::PURPOSE_ANY
 
         @ca.verify("me")
       end


### PR DESCRIPTION
The puppet cert, ca, etc subcommands have various methods for
determining if a certificate is valid. This is used to see which certs
have been signed, are still waiting to be signed, or have been revoked.
Historically, puppet set the purpose to PURPOSE_SSL_CLIENT on the
X509::Store used to verify certificates, but ruby+openssl 1.0 ignored
it. When using openssl 1.1, purpose is checked, which causes
CertificateAuthority#verify to raise an error when verifying the puppet
CA cert, since it doesn't have the 'SSL Client' purpose. This
corresponds to the 'id-kp-clientAuth' extended key usage extension[1].

However, puppet doesn't really need to care about the purpose when
determining if the cert has been signed, is expired, or revoked. This
commit changes the verify method to default to PURPOSE_ANY, and
preserves the behavior prior to openssl 1.1.

Note this does not affect TLS communication between the agent and
server. When acting as an SSL client, openssl always verifies that the
server's cert has the id-kp-serverAuth extended key usage extension. If
it doesn't, openssl sends a fatal TLS alert message of type 42 'Bad
Certificate' and closes the connection.

[1] https://tools.ietf.org/html/rfc5280#section-4.2.1.12