### PR TITLE
(PUP-9073) Add multi-platform task support to task info service

### DIFF
--- a/lib/puppet/info_service/task_information_service.rb
+++ b/lib/puppet/info_service/task_information_service.rb
@@ -23,10 +23,14 @@ class Puppet::InfoService::TaskInformationService
 
     task = pup_module.tasks.find { |t| t.name == task_name }
     if task.nil?
-      raise Puppet::Module::Task::TaskNotFound, _("Task %{task_name} not found in module %{module_name}.") %
-                                                 {task_name: task_name, module_name: module_name}
+      raise Puppet::Module::Task::TaskNotFound.new(task_name, module_name)
     end
 
-    {:metadata_file => task.metadata_file, :files => task.files}
+    begin
+      task.validate
+      {:metadata => task.metadata, :files => task.files}
+    rescue Puppet::Module::Task::Error => err
+      { :metadata => nil, :files => [], :error => err.to_h }
+    end
   end
 end

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -2,10 +2,47 @@ require 'puppet/util/logging'
 
 class Puppet::Module
   class Task
-    class Error < Puppet::Error; end
-    class InvalidName < Error; end
-    class InvalidFile < Error; end
-    class TaskNotFound < Error; end
+    class Error < Puppet::Error
+      attr_accessor :kind, :details
+      def initialize(message, kind, details = nil)
+        super(message)
+        @details = details || {}
+        @kind = kind
+      end
+
+      def to_h
+        {
+          msg: message,
+          kind: kind,
+          details: details
+        }
+      end
+    end
+
+    class InvalidName < Error
+      def initialize(name)
+        msg = _("Task names must start with a lowercase letter and be composed of only lowercase letters, numbers, and underscores")
+        super(msg, 'puppet.tasks/invalid-name')
+      end
+    end
+
+    class InvalidFile < Error
+      def initialize(msg)
+        super(msg, 'puppet.tasks/invalid-file')
+      end
+    end
+
+    class InvalidTask < Error
+    end
+    class InvalidMetadata < Error
+    end
+    class TaskNotFound < Error
+      def initialize(task_name, module_name)
+        msg = _("Task %{task_name} not found in module %{module_name}.") %
+          {task_name: task_name, module_name: module_name}
+        super(msg, 'puppet.tasks/task-not-found', { 'name' => task_name })
+      end
+    end
 
     FORBIDDEN_EXTENSIONS = %w{.conf .md}
 
@@ -24,6 +61,47 @@ class Puppet::Module
       return true
     end
 
+    # Copied from TaskInstantiator so we can use the Error classes here
+    # TODO: harmonize on one implementation
+    # Executables list should contain the full path of all possible implementation files
+    def self.find_implementations(name, directory, metadata, executables)
+      basename = name.split('::')[1] || 'init'
+      # If 'implementations' is defined, it needs to mention at least one
+      # implementation, and everything it mentions must exist.
+      metadata ||= {}
+      if metadata.key?('implementations')
+        unless metadata['implementations'].is_a?(Array)
+          msg = _("Task metadata for task %{name} does not specify implementations as an array" % { name: name })
+          raise InvalidMetadata.new(msg, 'puppet.tasks/invalid-metadata')
+        end
+
+        implementations = metadata['implementations'].map do |impl|
+          path = executables.find { |real_impl| File.basename(real_impl) == impl['name'] }
+          unless path
+            msg = _("Task metadata for task %{name} specifies missing implementation %{implementation}" % { name: name, implementation: impl['name'] })
+            raise InvalidTask.new(msg, 'puppet.tasks/missing-implementation', { missing: [impl['name']] } )
+          end
+          { "name" => impl['name'], "requirements" => impl.fetch('requirements', []), "path" => path }
+        end
+        return implementations
+      end
+
+      # If implementations isn't defined, then we use executables matching the
+      # task name, and only one may exist.
+      implementations = executables.select { |impl| File.basename(impl, '.*') == basename }
+      if implementations.empty?
+        msg = _('No source besides task metadata was found in directory %{directory} for task %{name}') %
+          { name: name, directory: directory }
+        raise InvalidTask.new(msg, 'puppet.tasks/no-implementation')
+      elsif implementations.length > 1
+        msg =_("Multiple executables were found in directory %{directory} for task %{name}; define 'implementations' in metadata to differentiate between them") %
+          { name: name, directory: implementations[0] }
+        raise InvalidTask.new(msg, 'puppet.tasks/multiple-implementations')
+      end
+
+      [{ "name" => File.basename(implementations.first), "path" => implementations.first, "requirements" => [] }]
+    end
+
     def self.is_tasks_metadata_filename?(name)
       is_tasks_filename?(name) && name.end_with?('.json')
     end
@@ -33,37 +111,58 @@ class Puppet::Module
     end
 
     def self.tasks_in_module(pup_module)
-      Dir.glob(File.join(pup_module.tasks_directory, '*'))
+      task_files = Dir.glob(File.join(pup_module.tasks_directory, '*'))
         .keep_if { |f| is_tasks_filename?(f) }
-        .group_by { |f| task_name_from_path(f) }
-        .map { |task, files| new_with_files(pup_module, task, files) }
+
+      module_executables = task_files.reject(&method(:is_tasks_metadata_filename?)).map.to_a
+
+      tasks = task_files.group_by { |f| task_name_from_path(f) }
+
+      tasks.map do |task, executables|
+        new_with_files(pup_module, task, executables, module_executables)
+      end
     end
 
-    attr_reader :name, :module, :metadata_file, :files
+    attr_reader :name, :module, :metadata_file, :metadata
 
-    def initialize(pup_module, task_name, files, metadata_file = nil)
+    # file paths must be relative to the modules task directory
+    def initialize(pup_module, task_name,  module_executables, metadata_file = nil)
       if !Puppet::Module::Task.is_task_name?(task_name)
         raise InvalidName, _("Task names must start with a lowercase letter and be composed of only lowercase letters, numbers, and underscores")
-      end
-
-      all_files = metadata_file.nil? ? files : files + [metadata_file]
-      all_files.each do |f|
-        if !f.start_with?(pup_module.tasks_directory)
-          msg = _("The file '%{path}' is not located in the %{module_name} module's tasks directory") %
-                       {path: f.to_s, module_name: pup_module.name}
-
-          # we can include some extra context for the log message:
-          Puppet.err(msg + " (#{pup_module.tasks_directory})")
-          raise InvalidFile, msg
-        end
       end
 
       name = task_name == "init" ? pup_module.name : "#{pup_module.name}::#{task_name}"
 
       @module = pup_module
       @name = name
-      @metadata_file = metadata_file if metadata_file
-      @files = files
+      @metadata_file = metadata_file
+      @module_executables = module_executables || []
+    end
+
+    def read_metadata(file)
+      File.open(file) { |fh| JSON.load(fh) } if file
+    rescue SystemCallError, IOError => err
+      msg = _("Error reading metadata: %{message}" % {message: err.message})
+      raise InvalidMetadata.new(msg, 'puppet.tasks/unreadable-metadata')
+    rescue JSON::ParserError => err
+      raise InvalidMetadata.new(err.message, 'puppet.tasks/unparseable-metadata')
+    end
+
+    def metadata
+      @metadata ||= read_metadata(@metadata_file)
+    end
+
+    def implementations
+      @implementations ||= self.class.find_implementations(@name, @module.tasks_directory, metadata, @module_executables)
+    end
+
+    def files
+      implementations.map {|imp| { 'name' => imp['name'], 'path' => imp['path'] } }
+    end
+
+    def validate
+      implementations
+      true
     end
 
     def ==(other)
@@ -71,16 +170,13 @@ class Puppet::Module
       self.module == other.module
     end
 
-    def self.new_with_files(pup_module, name, tasks_files)
-      files = tasks_files.map do |filename|
-        File.join(pup_module.tasks_directory, File.basename(filename))
-      end
-
-      metadata_files, exe_files = files.partition { |f| is_tasks_metadata_filename?(f) }
-      Puppet::Module::Task.new(pup_module, name, exe_files, metadata_files.first)
+    def self.new_with_files(pup_module, name, task_files, module_executables)
+      metadata_file = task_files.find { |f| is_tasks_metadata_filename?(f) }
+      Puppet::Module::Task.new(pup_module, name, module_executables, metadata_file)
     end
     private_class_method :new_with_files
 
+    # Abstracted here so we can add support for subdirectories later
     def self.task_name_from_path(path)
       return File.basename(path, '.*')
     end

--- a/spec/lib/puppet_spec/modules.rb
+++ b/spec/lib/puppet_spec/modules.rb
@@ -25,7 +25,11 @@ module PuppetSpec::Modules
         FileUtils.mkdir_p(tasks_dir)
         tasks.each do |task_files|
           task_files.each do |task_file|
-            FileUtils.touch(File.join(tasks_dir, task_file))
+            if task_file.is_a?(String)
+              # default content to acceptable metadata
+              task_file = { :name => task_file, :content => "{}" }
+            end
+            File.write(File.join(tasks_dir, task_file[:name]), task_file[:content])
           end
         end
       end

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -19,57 +19,60 @@ describe Puppet::Module::Task do
                       "Task names must start with a lowercase letter and be composed of only lowercase letters, numbers, and underscores")
   end
 
-  it "cannot construct tasks whose files are outside of their module's tasks directory" do
-    outside_file = "/var/root/secret_tasks/classified"
-    expect { Puppet::Module::Task.new(mymod, "fail", [outside_file]) }
-      .to raise_error(Puppet::Module::Task::InvalidFile,
-                     "The file '#{outside_file}' is not located in the mymod module's tasks directory")
-  end
-
   it "constructs tasks as expected when every task has a metadata file with the same name (besides extension)" do
-    Dir.expects(:glob).with(tasks_glob).returns(%w{task1.json task1 task2.json task2.exe task3.json task3.sh})
+    task_files = %w{task1.json task1 task2.json task2.exe task3.json task3.sh}.map { |bn| "#{tasks_path}/#{bn}" }
+    Dir.expects(:glob).with(tasks_glob).returns(task_files)
     tasks = Puppet::Module::Task.tasks_in_module(mymod)
+    Puppet::Module::Task.any_instance.stubs(:metadata).returns({})
 
     expect(tasks.count).to eq(3)
     expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1 mymod::task2 mymod::task3})
     expect(tasks.map{|t| t.metadata_file}).to eq(["#{tasks_path}/task1.json",
                                                   "#{tasks_path}/task2.json",
                                                   "#{tasks_path}/task3.json"])
-    expect(tasks.map{|t| t.files}).to eq([["#{tasks_path}/task1"],
-                                          ["#{tasks_path}/task2.exe"],
-                                          ["#{tasks_path}/task3.sh"]])
+    expect(tasks.map{|t| t.files.map { |f| f["path"] } }).to eq([["#{tasks_path}/task1"],
+                                                                 ["#{tasks_path}/task2.exe"],
+                                                                 ["#{tasks_path}/task3.sh"]])
+    expect(tasks.map{|t| t.files.map { |f| f["name"] } }).to eq([["task1"],
+                                                                 ["task2.exe"],
+                                                                 ["task3.sh"]])
 
     tasks.map{|t| t.metadata_file}.each do |metadata_file|
       expect(metadata_file).to eq(File.absolute_path(metadata_file))
     end
 
-    tasks.map{|t| t.files}.each do |task_files|
-      task_file = task_files[0]
-      expect(task_file).to eq(File.absolute_path(task_file))
+    tasks.map{|t| t.files}.each do |file_data|
+      path = file_data[0]['path']
+      expect(path).to eq(File.absolute_path(path))
     end
   end
 
   it "constructs tasks as expected when some tasks don't have a metadata file" do
-    Dir.expects(:glob).with(tasks_glob).returns(%w{task1 task2.exe task3.json task3.sh})
+    task_files = %w{task1 task2.exe task3.json task3.sh}.map { |bn| "#{tasks_path}/#{bn}" }
+    Dir.expects(:glob).with(tasks_glob).returns(task_files)
+    Puppet::Module::Task.any_instance.stubs(:metadata).returns({})
     tasks = Puppet::Module::Task.tasks_in_module(mymod)
 
     expect(tasks.count).to eq(3)
     expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1 mymod::task2 mymod::task3})
     expect(tasks.map{|t| t.metadata_file}).to eq([nil, nil, "#{tasks_path}/task3.json"])
-    expect(tasks.map{|t| t.files}).to eq([["#{tasks_path}/task1"],
+    expect(tasks.map{|t| t.files.map { |f| f["path"] } }).to eq([["#{tasks_path}/task1"],
                                           ["#{tasks_path}/task2.exe"],
                                           ["#{tasks_path}/task3.sh"]])
   end
 
-  it "constructs tasks as expected when a task has multiple executable files" do
-    Dir.expects(:glob).with(tasks_glob).returns(%w{task1.elf task1.exe task1.json task2.ps1 task2.sh})
-    tasks = Puppet::Module::Task.tasks_in_module(mymod)
 
-    expect(tasks.count).to eq(2)
-    expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1 mymod::task2})
-    expect(tasks.map{|t| t.metadata_file}).to eq(["#{tasks_path}/task1.json", nil])
-    expect(tasks.map{|t| t.files}).to eq([["#{tasks_path}/task1.elf", "#{tasks_path}/task1.exe"],
-                                          ["#{tasks_path}/task2.ps1", "#{tasks_path}/task2.sh"]])
+  it "constructs a task as expected when a task has implementations" do
+    task_files = %w{task1.elf task1.sh task1.json}.map { |bn| "#{tasks_path}/#{bn}" }
+    Dir.expects(:glob).with(tasks_glob).returns(task_files)
+    tasks = Puppet::Module::Task.tasks_in_module(mymod)
+    Puppet::Module::Task.any_instance.stubs(:metadata).returns({'implementations' =>
+    [{"name" => "task1.sh"}]})
+
+    expect(tasks.count).to eq(1)
+    expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1})
+    expect(tasks.map{|t| t.metadata_file}).to eq(["#{tasks_path}/task1.json"])
+    expect(tasks.map{|t| t.files.map{ |f| f["path"] } }).to eq([["#{tasks_path}/task1.sh"]])
   end
 
   it "finds files whose names (besides extensions) are valid task names" do
@@ -98,5 +101,105 @@ describe Puppet::Module::Task do
 
   it "gives the 'init' task a name that is just the module's name" do
     expect(Puppet::Module::Task.new(mymod, 'init', ["#{tasks_path}/init.sh"]).name).to eq('mymod')
+  end
+
+  describe :metadata do
+    it "loads metadata for a task" do
+      metadata  = {'desciption': 'some info'}
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe task1.json})
+      Puppet::Module::Task.any_instance.stubs(:read_metadata).returns(metadata)
+
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+      expect(tasks.count).to eq(1)
+      expect(tasks[0].metadata).to eq(metadata)
+    end
+
+    it 'returns nil for metadata if no file is present' do
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe})
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+      expect(tasks.count).to eq(1)
+      expect(tasks[0].metadata).to be_nil
+    end
+  end
+
+  describe :validate do
+    it "validates when there is no metadata" do
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe})
+
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+      expect(tasks.count).to eq(1)
+      expect(tasks[0].validate).to eq(true)
+    end
+
+    it "validates when an implementation isn't used" do
+      metadata  = {'desciption' => 'some info',
+        'implementations' => [ {"name" => "task1.exe"}, ] }
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe task1.sh task1.json})
+      Puppet::Module::Task.any_instance.stubs(:read_metadata).returns(metadata)
+
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+      expect(tasks.count).to eq(1)
+      expect(tasks[0].validate).to be(true)
+    end
+
+    it "validates when an implementation is another task" do
+      metadata  = {'desciption' => 'some info',
+                   'implementations' => [ {"name" => "task2.sh"}, ] }
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe task2.sh task1.json})
+      Puppet::Module::Task.any_instance.stubs(:read_metadata).returns(metadata)
+
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+      expect(tasks.count).to eq(2)
+      expect(tasks.map(&:validate)).to eq([true, true])
+    end
+
+    it "fails validation when there is no metadata and multiple task files" do
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.elf task1.exe task1.json task2.ps1 task2.sh})
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+      Puppet::Module::Task.any_instance.stubs(:metadata).returns({})
+
+      tasks.each do |task|
+        expect {task.validate}.to raise_error(Puppet::Module::Task::InvalidTask)
+      end
+    end
+
+    it "fails validation when an implementation references a non-existant file" do
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.elf task1.exe task1.json})
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+      Puppet::Module::Task.any_instance.stubs(:metadata).returns({'implementations' => [ { 'name' => 'task1.sh' } ] })
+
+      tasks.each do |task|
+        expect {task.validate}.to raise_error(Puppet::Module::Task::InvalidTask)
+      end
+    end
+
+    it 'fails validation when there is metadata but no executable' do
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.json task2.sh})
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+      Puppet::Module::Task.any_instance.stubs(:metadata).returns({})
+
+      expect { tasks.find { |t| t.name == 'mymod::task1' }.validate }.to raise_error(Puppet::Module::Task::InvalidTask)
+    end
+
+    it 'fails validation when the implementations are not an array' do
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.json task2.sh})
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+      Puppet::Module::Task.any_instance.stubs(:metadata).returns({"implemenations" => {}})
+
+      expect { tasks.find { |t| t.name == 'mymod::task1' }.validate }.to raise_error(Puppet::Module::Task::InvalidTask)
+    end
+
+    it 'fails validation when the implementation is json' do
+      Dir.expects(:glob).with(tasks_glob).returns(%w{task1.json task1.sh})
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+      Puppet::Module::Task.any_instance.stubs(:metadata).returns({'implementations' => [ { 'name' => 'task1.json' } ] })
+
+      expect { tasks.find { |t| t.name == 'mymod::task1' }.validate }.to raise_error(Puppet::Module::Task::InvalidTask)
+    end
   end
 end


### PR DESCRIPTION
Previously the task details of the info service to included only
information about the files present in the tasks directory matching the
task name. In order to support the multi-platform tasks it has to
instead read the metadata.json file, find all task implementation and
include file information about them. So that validation logic doesn't
have to implemented twice task validation has moved out of puppet-server
into puppet ruby code. This will also allow the logic to be shared with
bolt.

This commit should not be merged until puppet-server is ready for the new task details schema