### PR TITLE
(maint) Pin Rake to versions that support Ruby < 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group(:development, :test) do
   # be removed here *yet* due to TravisCI / AppVeyor which call:
   # bundle install --without development
   # PUP-7433 describes work necessary to restructure this
-  gem "rake", '~> 12.0', :require => false
+  gem "rake", '~> 12.2.1', :require => false
   gem "rspec", "~> 3.1", :require => false
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false


### PR DESCRIPTION
Previously we pinned Rake to a float through the 12 version series.
However 12.3 dropped support for versions of Ruby less than 2.0.

This works fine for our master branch but for 5.x release of Puppet
we still support Ruby 1.9, run in a runtime that implements 1.9's
interface in Puppet Server and use 1.9 for some of our automation.

This pins us to the last minor series of Rake that supports Ruby 1.9.
It sets the minimum version to 12.2.1 specifically because that is the
version of Rake that the last vesion of our packaging utilties that
support Ruby 1.9 uses (packaging 0.99.8). It floats the version along
the 12.2 minor series to pick up any bugfix patches.