### PR TITLE
(PUP-5985) Reevaluate feature blocks

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -14,17 +14,17 @@ or from [Choclately](https://chocolatey.org/packages/ruby).
 When writing a test that cannot possibly run on Windows, e.g. there is
 no mount type on windows, do the following:
 
-    describe Puppet::MyClass, :unless => Puppet.features.microsoft_windows? do
+    describe Puppet::MyClass, :unless => Puppet::Util::Platform.windows? do
       ..
     end
 
 If the test doesn't currently pass on Windows, e.g. due to on going porting, then use an rspec conditional pending block:
 
-    pending("porting to Windows", :if => Puppet.features.microsoft_windows?) do
+    pending("porting to Windows", :if => Puppet::Util::Platform.windows?) do
       <example1>
     end
 
-    pending("porting to Windows", :if => Puppet.features.microsoft_windows?) do
+    pending("porting to Windows", :if => Puppet::Util::Platform.windows?) do
       <example2>
     end
 

--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -54,7 +54,7 @@ class Puppet::Configurer::Downloader
       :backup => false,
       :noop => false
     }
-    if !Puppet.features.microsoft_windows?
+    if !Puppet::Util::Platform.windows?
       defargs.merge!(
         {
           :owner => Process.uid,

--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -7,7 +7,7 @@ class Puppet::Configurer::PluginHandler
   SUPPORTED_LOCALES_MOUNT_AGENT_VERSION = Gem::Version.new("5.3.4")
 
   def download_plugins(environment)
-    source_permissions = Puppet.features.microsoft_windows? ? :ignore : :use
+    source_permissions = Puppet::Util::Platform.windows? ? :ignore : :use
 
     plugin_downloader = Puppet::Configurer::Downloader.new(
       "plugin",

--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -113,7 +113,7 @@ class Puppet::Daemon
     end
 
     # extended signals not supported under windows
-    if !Puppet.features.microsoft_windows?
+    if !Puppet::Util::Platform.windows?
       signals = {:HUP => :restart, :USR1 => :reload, :USR2 => :reopen_logs }
       signals.each do |signal, method|
         Signal.trap(signal) do

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -403,7 +403,7 @@ module Puppet
           files. The command to use can be chosen with the `diff` setting.",
     },
     :diff => {
-      :default => (Puppet.features.microsoft_windows? ? "" : "diff"),
+      :default => (Puppet::Util::Platform.windows? ? "" : "diff"),
       :desc    => "Which diff command to use when printing differences between files. This setting
           has no default value on Windows, as standard `diff` is not available, but Puppet can use many
           third-party diff tools.",
@@ -420,13 +420,13 @@ module Puppet
     },
     :daemonize => {
         :type     => :boolean,
-        :default  => (Puppet.features.microsoft_windows? ? false : true),
+        :default  => (Puppet::Util::Platform.windows? ? false : true),
         :desc     => "Whether to send the process into the background.  This defaults
           to true on POSIX systems, and to false on Windows (where Puppet
           currently cannot daemonize).",
         :short    => "D",
         :hook     => proc do |value|
-          if value and Puppet.features.microsoft_windows?
+          if value and Puppet::Util::Platform.windows?
             raise "Cannot daemonize on Windows"
           end
       end
@@ -685,7 +685,7 @@ module Puppet
       :desc     => "The module repository",
     },
     :module_working_dir => {
-        :default  => (Puppet.features.microsoft_windows? ? Dir.tmpdir() : '$vardir/puppet-module'),
+        :default  => (Puppet::Util::Platform.windows? ? Dir.tmpdir() : '$vardir/puppet-module'),
         :desc     => "The directory into which module tool data is stored",
     },
     :forge_authorization => {

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -14,28 +14,7 @@ Puppet.features.add(:posix) do
 end
 
 # We can use Microsoft Windows functions
-Puppet.features.add(:microsoft_windows) do
-  begin
-    # ruby
-    require 'Win32API' # case matters in this require!
-
-    # Note: Setting codepage here globally ensures all strings returned via
-    # WIN32OLE (Ruby's late-bound COM support) are encoded in Encoding::UTF_8
-    #
-    # Also, this does not modify the value of WIN32OLE.locale - which defaults
-    # to 2048 (at least on US English Windows) and is not listed in the MS
-    # locales table, here: https://msdn.microsoft.com/en-us/library/ms912047(v=winembedded.10).aspx
-    require 'win32ole' ; WIN32OLE.codepage = WIN32OLE::CP_UTF8
-    # gems
-    require 'win32/process'
-    require 'win32/dir'
-    require 'win32/service'
-    true
-  rescue LoadError => err
-    #TRANSLATORS "win32-process", "win32-dir", and "win32-service" are program names and should not be translated
-    warn _("Cannot run on Microsoft Windows without the win32-process, win32-dir and win32-service gems: %{err}") % { err: err } unless Puppet.features.posix?
-  end
-end
+Puppet.features.add(:microsoft_windows) { Puppet::Util::Platform.windows? }
 
 raise Puppet::Error,_("Cannot determine basic system flavour") unless Puppet.features.posix? or Puppet.features.microsoft_windows?
 

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -28,7 +28,10 @@ Puppet.features.add(:usage, :libs => %w{rdoc/ri/ri_paths rdoc/usage})
 Puppet.features.add(:libshadow, :libs => ["shadow"])
 
 # We're running as root.
-Puppet.features.add(:root) { require 'puppet/util/suidmanager'; Puppet::Util::SUIDManager.root? }
+Puppet.features.add(:root) do
+  require 'puppet/util/suidmanager'
+  Puppet::Util::SUIDManager.root?
+end
 
 # We have lcs diff
 Puppet.features.add :diff, :libs => %w{diff/lcs diff/lcs/hunk}

--- a/lib/puppet/feature/eventlog.rb
+++ b/lib/puppet/feature/eventlog.rb
@@ -1,5 +1,5 @@
 require 'puppet/util/feature'
 
-if Puppet.features.microsoft_windows?
+if Puppet::Util::Platform.windows?
   Puppet.features.add(:eventlog)
 end

--- a/lib/puppet/file_serving/base.rb
+++ b/lib/puppet/file_serving/base.rb
@@ -24,7 +24,7 @@ class Puppet::FileServing::Base
       full_path = File.join(path, relative_path)
     end
 
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       # Replace multiple slashes as long as they aren't at the beginning of a filename
       full_path.gsub(%r{(./)/+}, '\1')
     else
@@ -81,6 +81,6 @@ class Puppet::FileServing::Base
   end
 
   def self.absolute?(path)
-    Puppet::Util.absolute_path?(path, :posix) or (Puppet.features.microsoft_windows? and Puppet::Util.absolute_path?(path, :windows))
+    Puppet::Util.absolute_path?(path, :posix) || (Puppet::Util::Platform.windows? && Puppet::Util.absolute_path?(path, :windows))
   end
 end

--- a/lib/puppet/file_serving/fileset.rb
+++ b/lib/puppet/file_serving/fileset.rb
@@ -25,7 +25,7 @@ class Puppet::FileServing::Fileset
   end
 
   def initialize(path, options = {})
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       # REMIND: UNC path
       path = path.chomp(File::SEPARATOR) unless path =~ /^[A-Za-z]:\/$/
     else

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -65,7 +65,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
   end
 
   class WindowsStat < MetaStat
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       require 'puppet/util/windows/security'
     end
 
@@ -88,7 +88,7 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
   def collect_stat(path)
     stat = stat()
 
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       WindowsStat.new(stat, path, @source_permissions)
     else
       MetaStat.new(stat, @source_permissions)

--- a/lib/puppet/module_tool/applications/unpacker.rb
+++ b/lib/puppet/module_tool/applications/unpacker.rb
@@ -14,7 +14,7 @@ module Puppet::ModuleTool
       end
 
       def self.harmonize_ownership(source, target)
-        unless Puppet.features.microsoft_windows?
+        unless Puppet::Util::Platform.windows?
           source = Pathname.new(source) unless source.respond_to?(:stat)
           target = Pathname.new(target) unless target.respond_to?(:stat)
 

--- a/lib/puppet/parser/functions/generate.rb
+++ b/lib/puppet/parser/functions/generate.rb
@@ -14,7 +14,7 @@ Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue
       #TRANSLATORS "fully qualified" refers to a fully qualified file system path
       raise Puppet::ParseError, _("Generators must be fully qualified") unless Puppet::Util.absolute_path?(args[0])
 
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         valid = args[0] =~ /^[a-z]:(?:[\/\\][-.~\w]+)+$/i
       else
         valid = args[0] =~ /^[-\/\w.+]+$/

--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:file).provide :windows do
 
   include Puppet::Util::Warnings
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     require 'puppet/util/windows'
     include Puppet::Util::Windows::Security
   end

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -95,7 +95,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
   def install(useversion = true)
     command = [command(:gemcmd), "install"]
     command += install_options if resource[:install_options]
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       version = resource[:ensure]
       command << "-v" << %Q["#{version}"] if (! resource[:ensure].is_a? Symbol) and useversion
     else

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:package).provide :pip,
   end
 
   def self.cmd
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       ["pip.exe"]
     else
       ["pip", "pip-python"]

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
 
   has_feature :versionable, :install_options, :uninstall_options
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # On windows, we put our ruby ahead of anything that already
     # existed on the system PATH. This means that we do not need to
     # sort out the absolute path.

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1197,7 +1197,7 @@ Generated on #{Time.now}.
 
   def add_user_resources(catalog, sections)
     return unless Puppet.features.root?
-    return if Puppet.features.microsoft_windows?
+    return if Puppet::Util::Platform.windows?
     return unless self[:mkusers]
 
     @config.each do |name, setting|

--- a/lib/puppet/settings/file_setting.rb
+++ b/lib/puppet/settings/file_setting.rb
@@ -156,7 +156,7 @@ class Puppet::Settings::FileSetting < Puppet::Settings::StringSetting
       end
 
       # REMIND fails on Windows because chown/chgrp functionality not supported yet
-      if Puppet.features.root? and !Puppet.features.microsoft_windows?
+      if Puppet.features.root? and !Puppet::Util::Platform.windows?
         resource[:owner] = self.owner if self.owner
         resource[:group] = self.group if self.group
       end

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -210,7 +210,7 @@ module Puppet
         this attribute."
 
       validate do |user|
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           self.fail _("Unable to execute commands as other users on Windows")
         elsif !Puppet.features.root? && resource.current_username() != user
           self.fail _("Only root can execute commands as other users")
@@ -530,7 +530,7 @@ module Puppet
       # Stick the cwd in there if we have it
       reqs << self[:cwd] if self[:cwd]
 
-      file_regex = Puppet.features.microsoft_windows? ? %r{^([a-zA-Z]:[\\/]\S+)} : %r{^(/\S+)}
+      file_regex = Puppet::Util::Platform.windows? ? %r{^([a-zA-Z]:[\\/]\S+)} : %r{^(/\S+)}
 
       self[:command].scan(file_regex) { |str|
         reqs << str

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -749,7 +749,7 @@ Puppet::Type.newtype(:file) do
     # This check is done in retrieve to ensure it happens before we try to use
     # metadata in `copy_source_values`, but so it only fails the resource and not
     # catalog validation (because that would be a breaking change from Puppet 4).
-    if Puppet.features.microsoft_windows? && parameter(:source) &&
+    if Puppet::Util::Platform.windows? && parameter(:source) &&
       [:use, :use_when_creating].include?(self[:source_permissions])
       #TRANSLATORS "source_permissions => ignore" should not be translated
       err_msg = _("Copying owner/mode/group from the source file on Windows is not supported; use source_permissions => ignore.")

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -258,7 +258,7 @@ module Puppet
     def copy_source_value(metadata_method)
       param_name = (metadata_method == :checksum) ? :content : metadata_method
       if resource[param_name].nil? or resource[param_name] == :absent
-        if Puppet.features.microsoft_windows? && [:owner, :group, :mode].include?(metadata_method)
+        if Puppet::Util::Platform.windows? && [:owner, :group, :mode].include?(metadata_method)
           devfail "Should not have tried to use source owner/mode/group on Windows"
         end
 

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -85,7 +85,7 @@ module Puppet
       end
 
       validate do |value|
-        if value == :manual and !Puppet.features.microsoft_windows?
+        if value == :manual && !Puppet::Util::Platform.windows?
           raise Puppet::Error.new(_("Setting enable to manual is only supported on Microsoft Windows."))
         end
       end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -22,13 +22,12 @@ module Util
   require 'puppet/util/posix'
   extend Puppet::Util::POSIX
 
-  # Can't use Puppet.features.microsoft_windows? as it may be mocked out in a test.  This can cause test recurring test failures
   require 'puppet/util/windows/process' if Puppet::Util::Platform.windows?
 
   extend Puppet::Util::SymbolicFileMode
 
   def default_env
-    Puppet.features.microsoft_windows? ?
+    Puppet::Util::Platform.windows? ?
       :windows :
       :posix
   end
@@ -272,7 +271,7 @@ module Util
             raise
           end
         else
-          if Puppet.features.microsoft_windows? && File.extname(dest).empty?
+          if Puppet::Util::Platform.windows? && File.extname(dest).empty?
             exts.each do |ext|
               destext = File.expand_path(dest + ext)
               return destext if FileTest.file? destext and FileTest.executable? destext
@@ -322,7 +321,7 @@ module Util
 
     params = { :scheme => 'file' }
 
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       path = path.gsub(/\\/, '/')
 
       if unc = /^\/\/([^\/]+)(\/.+)/.match(path)
@@ -356,7 +355,7 @@ module Util
     # URI.unescape does, but returns strings in their original encoding
     path = URI.unescape(uri.path.encode(Encoding::UTF_8))
 
-    if Puppet.features.microsoft_windows? and uri.scheme == 'file'
+    if Puppet::Util::Platform.windows? && uri.scheme == 'file'
       if uri.host
         path = "//#{uri.host}" + path # UNC
       else
@@ -570,7 +569,7 @@ module Util
 
       mode = symbolic_mode_to_int(normalize_symbolic_mode(default_mode))
     else
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         mode = DEFAULT_WINDOWS_MODE
       else
         mode = DEFAULT_POSIX_MODE
@@ -583,9 +582,9 @@ module Util
       tempfile = Puppet::FileSystem::Uniquefile.new(Puppet::FileSystem.basename_string(file), Puppet::FileSystem.dir_string(file))
 
       effective_mode =
-      if !Puppet.features.microsoft_windows?
+      if !Puppet::Util::Platform.windows?
         # Grab the current file mode, and fall back to the defaults.
-        
+
         if Puppet::FileSystem.exist?(file)
           stat = Puppet::FileSystem.lstat(file)
           tempfile.chown(stat.uid, stat.gid)
@@ -620,7 +619,7 @@ module Util
 
       tempfile.close
 
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         # Windows ReplaceFile needs a file to exist, so touch handles this
         if !Puppet::FileSystem.exist?(file)
           Puppet::FileSystem.touch(file)

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -184,7 +184,7 @@ module Puppet::Util::Execution
       Puppet.debug "Executing#{user_log_s}: '#{command_str}'"
     end
 
-    null_file = Puppet.features.microsoft_windows? ? 'NUL' : '/dev/null'
+    null_file = Puppet::Util::Platform.windows? ? 'NUL' : '/dev/null'
 
     begin
       stdin = Puppet::FileSystem.open(options[:stdinfile] || null_file, nil, 'r')
@@ -264,7 +264,7 @@ module Puppet::Util::Execution
 
           raise e
         end
-      elsif Puppet.features.microsoft_windows?
+      elsif Puppet::Util::Platform.windows?
         process_info = execute_windows(*exec_args)
         begin
           [stdin, stderr].each {|io| io.close rescue nil}
@@ -290,7 +290,7 @@ module Puppet::Util::Execution
       if !options[:squelch]
         # if we opened a pipe, we need to clean it up.
         reader.close if reader
-        stdout.close! if Puppet.features.microsoft_windows?
+        stdout.close! if Puppet::Util::Platform.windows?
       end
     end
 

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -3,39 +3,53 @@ require 'puppet'
 class Puppet::Util::Feature
   attr_reader :path
 
-  # Create a new feature test.  You have to pass the feature name,
-  # and it must be unique.  You can either provide a block that
-  # will get executed immediately to determine if the feature
-  # is present, or you can pass an option to determine it.
-  # Currently, the only supported option is 'libs' (must be
-  # passed as a symbol), which will make sure that each lib loads
-  # successfully.
-  def add(name, options = {})
+  # Create a new feature test. You have to pass the feature name, and it must be
+  # unique. You can pass a block to determine if the feature is present:
+  #
+  #     Puppet.features.add(:myfeature) do
+  #       # return true or false if feature is available
+  #       # return nil if feature may become available later
+  #     end
+  #
+  # The block should return true if the feature is available, false if it is
+  # not, or nil if the state is unknown. True and false values will be cached. A
+  # nil value will not be cached, and should be used if the feature may become
+  # true in the future.
+  #
+  # Features are often used to detect if a ruby library is installed. To support
+  # that common case, you can pass one or more ruby libraries, and the feature
+  # will be true if all of the libraries load successfully:
+  #
+  #     Puppet.features.add(:myfeature, libs: 'mylib')
+  #     Puppet.features.add(:myfeature, libs: ['mylib', 'myotherlib'])
+  #
+  # If the ruby library is not installed, then the failure is not cached, as
+  # it's assumed puppet may install the gem during catalog application.
+  #
+  # If a feature is defined using `:libs` and a block, then the block is
+  # used and the `:libs` are ignored.
+  #
+  # Puppet evaluates the feature test when the `Puppet.features.myfeature?`
+  # method is called. If the feature test was defined using a block and the
+  # block returns nil, then the feature test will be re-evaluated the next time
+  # `Puppet.features.myfeature?` is called.
+  #
+  # @param [Symbol] name The unique feature name
+  # @param [Hash<Symbol,Array<String>>] options The libraries to load
+  def add(name, options = {}, &block)
     method = name.to_s + "?"
     @results.delete(name)
 
-    if block_given?
-      begin
-        result = yield
-      rescue StandardError,ScriptError => detail
-        warn _("Failed to load feature test for %{name}: %{detail}") % { name: name, detail: detail }
-        result = false
-      end
-      @results[name] = result
-    end
-
     meta_def(method) do
       # we return a cached result if:
-      #  * if a block is given (and we just evaluated it above)
       #  * if we already have a positive result
       #  * if we've tested this feature before and it failed, but we're
       #    configured to always cache
-      if block_given?     ||
-          @results[name]  ||
-          (@results.has_key?(name) && (!Puppet[:always_retry_plugins]))
+      if !@results[name].nil?  ||
+         (@results.has_key?(name) && (!Puppet[:always_retry_plugins]))
         @results[name]
       else
-        @results[name] = test(name, options)
+        @results[name] = test(name, options, &block)
         @results[name]
       end
     end
@@ -64,16 +78,22 @@ class Puppet::Util::Feature
   # Actually test whether the feature is present.  We only want to test when
   # someone asks for the feature, so we don't unnecessarily load
   # files.
-  def test(name, options)
-    return true unless ary = options[:libs]
-    ary = [ary] unless ary.is_a?(Array)
-
-    ary.each do |lib|
-      return false unless load_library(lib, name)
+  def test(name, options, &block)
+    if block_given?
+      begin
+        result = yield
+      rescue StandardError,ScriptError => detail
+        warn _("Failed to load feature test for %{name}: %{detail}") % { name: name, detail: detail }
+        result = nil
+      end
+      @results[name] = result
+      result
+    elsif libs = options[:libs]
+      libs = [libs] unless libs.is_a?(Array)
+      libs.all? { |lib| load_library(lib, name) } ? true : nil
+    else
+      true
     end
-
-    # We loaded all of the required libraries
-    true
   end
 
   private
@@ -86,10 +106,10 @@ class Puppet::Util::Feature
 
     begin
       require lib
+      true
     rescue ScriptError => detail
       Puppet.debug _("Failed to load library '%{lib}' for feature '%{name}': %{detail}") % { lib: lib, name: name, detail: detail }
-      return false
+      false
     end
-    true
   end
 end

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -47,10 +47,10 @@ class Puppet::Util::Feature
       #    configured to always cache
       if !@results[name].nil?  ||
          (@results.has_key?(name) && (!Puppet[:always_retry_plugins]))
-        @results[name]
+        !!@results[name]
       else
         @results[name] = test(name, options, &block)
-        @results[name]
+        !!@results[name]
       end
     end
   end

--- a/lib/puppet/util/feature.rb
+++ b/lib/puppet/util/feature.rb
@@ -42,11 +42,13 @@ class Puppet::Util::Feature
 
     meta_def(method) do
       # we return a cached result if:
-      #  * if we already have a positive result
-      #  * if we've tested this feature before and it failed, but we're
-      #    configured to always cache
-      if !@results[name].nil?  ||
-         (@results.has_key?(name) && (!Puppet[:always_retry_plugins]))
+      #  * if we've tested this feature before
+      #  AND
+      #    * the result was true/false
+      #    OR
+      #    * we're configured to never retry
+      if @results.has_key?(name) &&
+         (!@results[name].nil? || !Puppet[:always_retry_plugins])
         !!@results[name]
       else
         @results[name] = test(name, options, &block)

--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -219,7 +219,7 @@ Puppet::Util::Log.newdesttype :eventlog do
   Puppet::Util::Log::DestEventlog::EVENTLOG_CHARACTER_LIMIT  = 31838
 
   def self.suitable?(obj)
-    Puppet.features.microsoft_windows?
+    Puppet::Util::Platform.windows?
   end
 
   def initialize

--- a/lib/puppet/util/rdoc.rb
+++ b/lib/puppet/util/rdoc.rb
@@ -30,7 +30,7 @@ module Puppet::Util::RDoc
     # replacing Ruby's normal / with \.  When RDoc generates relative paths it
     # uses relative_path_from that will generate errors when the slashes don't
     # properly match.  This is a workaround for that issue.
-    if Puppet.features.microsoft_windows? && RDoc::VERSION !~ /^[0-3]\./
+    if Puppet::Util::Platform.windows? && RDoc::VERSION !~ /^[0-3]\./
       options += [ "--root", Dir.pwd.gsub(/\\/, '/')]
     end
     options += files

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -11,7 +11,7 @@ module Puppet
 
       def self.[](name)
         @run_modes ||= {}
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           @run_modes[name] ||= WindowsRunMode.new(name)
         else
           @run_modes[name] ||= UnixRunMode.new(name)

--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -47,10 +47,12 @@ module Puppet::Util::SUIDManager
   module_function :groups=
 
   def self.root?
-    return Process.uid == 0 unless Puppet.features.microsoft_windows?
-
-    require 'puppet/util/windows/user'
-    Puppet::Util::Windows::User.admin?
+    if Puppet::Util::Platform.windows?
+      require 'puppet/util/windows/user'
+      Puppet::Util::Windows::User.admin?
+    else
+      Process.uid == 0
+    end
   end
 
   # Methods to handle changing uid/gid of the running process. In general,
@@ -61,7 +63,7 @@ module Puppet::Util::SUIDManager
   # If running on Windows or without root, the block will be run with the
   # current euid/egid.
   def asuser(new_uid=nil, new_gid=nil)
-    return yield if Puppet.features.microsoft_windows?
+    return yield if Puppet::Util::Platform.windows?
     return yield unless root?
     return yield unless new_uid or new_gid
 

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -14,6 +14,20 @@ module Puppet::Util::Windows
   class EventLog; end
 
   if Puppet::Util::Platform.windows?
+    require 'Win32API' # case matters in this require!
+
+    # Note: Setting codepage here globally ensures all strings returned via
+    # WIN32OLE (Ruby's late-bound COM support) are encoded in Encoding::UTF_8
+    #
+    # Also, this does not modify the value of WIN32OLE.locale - which defaults
+    # to 2048 (at least on US English Windows) and is not listed in the MS
+    # locales table, here: https://msdn.microsoft.com/en-us/library/ms912047(v=winembedded.10).aspx
+    require 'win32ole' ; WIN32OLE.codepage = WIN32OLE::CP_UTF8
+    # gems
+    require 'win32/process'
+    require 'win32/dir'
+    require 'win32/service'
+
     # these reference platform specific gems
     require 'puppet/util/windows/api_types'
     require 'puppet/util/windows/string'

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -197,8 +197,7 @@ module Puppet::Util::Windows::ADSI
     end
 
     def [](attribute)
-      # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
-      # values are returned as UTF-8
+      # Setting WIN32OLE.codepage ensures values are returned as UTF-8
       native_user.Get(attribute)
     end
 
@@ -249,8 +248,7 @@ module Puppet::Util::Windows::ADSI
       # https://msdn.microsoft.com/en-us/library/aa746342.aspx
       # WIN32OLE objects aren't enumerable, so no map
       groups = []
-      # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
-      # values are returned as UTF-8
+      # Setting WIN32OLE.codepage ensures values are returned as UTF-8
       native_user.Groups.each {|g| groups << g.Name} rescue nil
       groups
     end
@@ -374,8 +372,7 @@ module Puppet::Util::Windows::ADSI
 
       users = []
       wql.each do |u|
-        # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
-        # values are returned as UTF-8
+        # Setting WIN32OLE.codepage ensures values are returned as UTF-8
         users << new(u.name)
       end
 
@@ -534,8 +531,7 @@ module Puppet::Util::Windows::ADSI
 
       groups = []
       wql.each do |g|
-        # Setting WIN32OLE.codepage in the microsoft_windows feature ensures
-        # values are returned as UTF-8
+        # Setting WIN32OLE.codepage ensures values are returned as UTF-8
         groups << new(g.name)
       end
 

--- a/spec/integration/agent/logging_spec.rb
+++ b/spec/integration/agent/logging_spec.rb
@@ -81,7 +81,7 @@ describe 'agent logging' do
       command_line.execute
     end
 
-    if Puppet.features.microsoft_windows? && argv.include?(DAEMONIZE)
+    if Puppet::Util::Platform.windows? && argv.include?(DAEMONIZE)
 
       it "should exit on a platform which cannot daemonize if the --daemonize flag is set" do
         expect { double_of_bin_puppet_agent_call(argv) }.to raise_error(SystemExit)
@@ -128,7 +128,7 @@ describe 'agent logging' do
     loggers << CONSOLE if verbose_or_debug_set_in_argv(argv)
     loggers << 'console' if log_dest_is_set_to(argv, LOGDEST_CONSOLE)
     loggers << '/dev/null/foo' if log_dest_is_set_to(argv, LOGDEST_FILE)
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       # an explicit call to --logdest syslog on windows is swallowed silently with no
       # logger created (see #suitable() of the syslog Puppet::Util::Log::Destination subclass)
       # however Puppet::Util::Log.newdestination('syslog') does get called...so we have

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -255,7 +255,7 @@ end
     expect(@logs.map(&:to_s)).to include(/{environment =>.*/)
   end
 
-  it "applies a given file even when an ENC is configured", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+  it "applies a given file even when an ENC is configured", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
     manifest = file_containing("manifest.pp", "notice('specific manifest applied')")
     enc = script_containing('enc_script',
       :windows => '@echo classes: []' + "\n" + '@echo environment: special',

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -47,7 +47,7 @@ describe Puppet::Configurer do
       t2 = Time.now.tv_sec
 
       # sticky bit only applies to directories in windows
-      file_mode = Puppet.features.microsoft_windows? ? '666' : '100666'
+      file_mode = Puppet::Util::Platform.windows? ? '666' : '100666'
 
       expect(Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode.to_s(8)).to eq(file_mode)
 

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -115,7 +115,7 @@ describe "Puppet defaults" do
     end
   end
 
-  describe "on a Windows-like platform it", :if => Puppet.features.microsoft_windows? do
+  describe "on a Windows-like platform it", :if => Puppet::Util::Platform.windows? do
     let (:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
 
     it "path should not add anything" do
@@ -196,11 +196,11 @@ describe "Puppet defaults" do
   end
 
   describe "daemonize" do
-    it "should default to true", :unless => Puppet.features.microsoft_windows? do
+    it "should default to true", :unless => Puppet::Util::Platform.windows? do
       expect(Puppet.settings[:daemonize]).to eq(true)
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should default to false" do
         expect(Puppet.settings[:daemonize]).to eq(false)
       end
@@ -212,11 +212,11 @@ describe "Puppet defaults" do
   end
 
   describe "diff" do
-    it "should default to 'diff' on POSIX", :unless => Puppet.features.microsoft_windows? do
+    it "should default to 'diff' on POSIX", :unless => Puppet::Util::Platform.windows? do
       expect(Puppet.settings[:diff]).to eq('diff')
     end
 
-    it "should default to '' on Windows", :if => Puppet.features.microsoft_windows? do
+    it "should default to '' on Windows", :if => Puppet::Util::Platform.windows? do
       expect(Puppet.settings[:diff]).to eq('')
     end
   end

--- a/spec/integration/faces/ca_spec.rb
+++ b/spec/integration/faces/ca_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/face'
 
-describe Puppet::Face[:ca, '0.1.0'], :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+describe Puppet::Face[:ca, '0.1.0'], :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
   include PuppetSpec::Files
 
   before :each do

--- a/spec/integration/file_system/uniquefile_spec.rb
+++ b/spec/integration/file_system/uniquefile_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe Puppet::FileSystem::Uniquefile do
-
-  describe "#open_tmp on Windows", :if => Puppet.features.microsoft_windows? do
-
+  describe "#open_tmp on Windows", :if => Puppet::Util::Platform.windows? do
     describe "with UTF8 characters" do
       include PuppetSpec::Files
 
@@ -25,5 +23,4 @@ describe Puppet::FileSystem::Uniquefile do
       end
     end
   end
-
 end

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -141,7 +141,7 @@ describe Puppet::Node::Environment do
       :strict_variables => true
   end
 
-  describe "#extralibs on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#extralibs on Windows", :if => Puppet::Util::Platform.windows? do
 
     describe "with UTF8 characters in PUPPETLIB" do
       let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -211,7 +211,7 @@ describe Puppet::Parser::Compiler do
   describe "the compiler when using 4.x language constructs" do
     include PuppetSpec::Compiler
 
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       it "should be able to determine the configuration version from a local version control repository" do
         pending("Bug #14071 about semantics of Puppet::Util::Execute on Windows")
         # This should always work, because we should always be

--- a/spec/integration/provider/cron/crontab_spec.rb
+++ b/spec/integration/provider/cron/crontab_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'puppet/file_bucket/dipper'
 require 'puppet_spec/compiler'
 
-describe Puppet::Type.type(:cron).provider(:crontab), '(integration)', :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:cron).provider(:crontab), '(integration)', :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 

--- a/spec/integration/provider/service/windows_spec.rb
+++ b/spec/integration/provider/service/windows_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 test_title = 'Integration Tests for Puppet::Type::Service::Provider::Windows'
 
-describe test_title, '(integration)', :if => Puppet.features.microsoft_windows? do
+describe test_title, '(integration)', :if => Puppet::Util::Platform.windows? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:windows) }
 
   require 'puppet/util/windows'

--- a/spec/integration/ssl/certificate_authority_spec.rb
+++ b/spec/integration/ssl/certificate_authority_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet/ssl/certificate_authority'
 
-describe Puppet::SSL::CertificateAuthority, :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+describe Puppet::SSL::CertificateAuthority, :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
   include PuppetSpec::Files
 
   let(:ca) { @ca }

--- a/spec/integration/ssl/host_spec.rb
+++ b/spec/integration/ssl/host_spec.rb
@@ -71,7 +71,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
     end
   end
 
-  it "should pass the verification of its own SSL store", :unless => Puppet.features.microsoft_windows? do
+  it "should pass the verification of its own SSL store", :unless => Puppet::Util::Platform.windows? do
     @host.generate
     @ca = Puppet::SSL::CertificateAuthority.new
     @ca.sign(@host.name)

--- a/spec/integration/test/test_helper_spec.rb
+++ b/spec/integration/test/test_helper_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-describe "Windows UTF8 environment variables", :if => Puppet.features.microsoft_windows? do
+describe "Windows UTF8 environment variables", :if => Puppet::Util::Platform.windows? do
   # The Puppet::Util::Windows::Process class is used to manipulate environment variables as it is known to handle UTF8 characters. Where as the implementation of ENV in ruby does not.
   # before and end all are used to inject environment variables before the test helper 'before_each_test' function is called
   # Do not use before and after hooks in these tests as it may have unintended consequences
@@ -16,7 +16,7 @@ describe "Windows UTF8 environment variables", :if => Puppet.features.microsoft_
     # Need to cleanup this environment variable otherwise it contaminates any subsequent tests
     Puppet::Util::Windows::Process.set_environment_variable(@varname, nil)
   }
-  
+
   it "#after_each_test should preserve UTF8 environment variables" do
     envhash = Puppet::Util::Windows::Process.get_environment_strings
     expect(envhash[@varname]).to eq(@rune_utf8)

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -385,7 +385,7 @@ describe Puppet::Transaction::Report do
         expect(get_cc_count(report)).to eq(0)
       end
 
-      it "link with ensure property change present => absent", :unless => Puppet.features.microsoft_windows? do
+      it "link with ensure property change present => absent", :unless => Puppet::Util::Platform.windows? do
         file = tmpfile("test_file")
         FileUtils.symlink(file, tmpfile("test_link"))
 
@@ -440,7 +440,7 @@ describe Puppet::Transaction::Report do
         expect(get_cc_count(report)).to eq(0)
       end
 
-      it "exec with idempotence issue", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+      it "exec with idempotence issue", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
         report = run_catalogs(Puppet::Type.type(:exec).new(:title => "exec1",
                                                            :command => "/bin/echo foo"),
                               Puppet::Type.type(:exec).new(:title => "exec1",
@@ -458,7 +458,7 @@ describe Puppet::Transaction::Report do
         expect(get_cc_count(report)).to eq(1)
       end
 
-      it "exec with no idempotence issue", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+      it "exec with no idempotence issue", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
         report = run_catalogs(Puppet::Type.type(:exec).new(:title => "exec1",
                                                            :command => "echo foo",
                                                            :path => "/bin",

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet_spec/files'
 
-if Puppet.features.microsoft_windows?
+if Puppet::Util::Platform.windows?
   require 'puppet/util/windows'
   class WindowsSecurity
     extend Puppet::Util::Windows::Security
@@ -1130,7 +1130,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       uri_path = resource.parameters[:source].uri.path
 
       # note that Windows file:// style URIs get an extra / in front of c:/ like /c:/
-      source_prefix = Puppet.features.microsoft_windows? ? '/' : ''
+      source_prefix = Puppet::Util::Platform.windows? ? '/' : ''
 
       # the URI can be round-tripped through unescape
       expect(URI.unescape(uri_path)).to eq(source_prefix + source)
@@ -1438,7 +1438,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       def expects_sid_granted_full_access_explicitly(path, sid)
         inherited_ace = Puppet::Util::Windows::AccessControlEntry::INHERITED_ACE
 

--- a/spec/integration/util/execution_spec.rb
+++ b/spec/integration/util/execution_spec.rb
@@ -4,13 +4,13 @@ describe Puppet::Util::Execution, unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
 
   describe "#execpipe" do
-    it "should set LANG to C avoid localized output", :if => !Puppet.features.microsoft_windows? do
+    it "should set LANG to C avoid localized output", :if => !Puppet::Util::Platform.windows? do
       out = ""
       Puppet::Util::Execution.execpipe('echo $LANG'){ |line| out << line.read.chomp }
       expect(out).to eq("C")
     end
 
-    it "should set LC_ALL to C avoid localized output", :if => !Puppet.features.microsoft_windows? do
+    it "should set LC_ALL to C avoid localized output", :if => !Puppet::Util::Platform.windows? do
       out = ""
       Puppet::Util::Execution.execpipe('echo $LC_ALL'){ |line| out << line.read.chomp }
       expect(out).to eq("C")
@@ -25,7 +25,7 @@ describe Puppet::Util::Execution, unless: Puppet::Util::Platform.jruby? do
     end
   end
 
-  describe "#execute (non-Windows)", :if => !Puppet.features.microsoft_windows? do
+  describe "#execute (non-Windows)", :if => !Puppet::Util::Platform.windows? do
     it "should execute basic shell command" do
       result = Puppet::Util::Execution.execute("ls /tmp", :failonfail => true)
       expect(result.exitstatus).to eq(0)
@@ -33,7 +33,7 @@ describe Puppet::Util::Execution, unless: Puppet::Util::Platform.jruby? do
     end
   end
 
-  describe "#execute (Windows)", :if => Puppet.features.microsoft_windows? do
+  describe "#execute (Windows)", :if => Puppet::Util::Platform.windows? do
     let(:utf8text) do
       # Japanese Lorem Ipsum snippet
       "utf8testfile" + [227, 131, 171, 227, 131, 147, 227, 131, 179, 227, 131, 132, 227,

--- a/spec/integration/util/rdoc/parser_spec.rb
+++ b/spec/integration/util/rdoc/parser_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/rdoc'
 
-describe "RDoc::Parser", :unless => Puppet.features.microsoft_windows? do
+describe "RDoc::Parser", :unless => Puppet::Util::Platform.windows? do
   require 'puppet_spec/files'
   include PuppetSpec::Files
 

--- a/spec/integration/util/settings_spec.rb
+++ b/spec/integration/util/settings_spec.rb
@@ -71,7 +71,7 @@ environment=#{rune_utf8}
     expect(settings[:environment]).to eq(rune_utf8)
   end
 
-  it "reparses configuration if configuration file is touched", :if => !Puppet.features.microsoft_windows? do
+  it "reparses configuration if configuration file is touched", :if => !Puppet::Util::Platform.windows? do
     config = tmpfile("config")
     define_settings(:main,
       :config => {

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'puppet/util/windows'
 
 describe Puppet::Util::Windows::ADSI::User,
-  :if => Puppet.features.microsoft_windows? do
+  :if => Puppet::Util::Platform.windows? do
 
   describe ".initialize" do
     it "cannot reference BUILTIN accounts like SYSTEM due to WinNT moniker limitations" do
@@ -59,7 +59,7 @@ describe Puppet::Util::Windows::ADSI::User,
 end
 
 describe Puppet::Util::Windows::ADSI::Group,
-  :if => Puppet.features.microsoft_windows? do
+  :if => Puppet::Util::Platform.windows? do
 
   let (:administrator_bytes) { [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0] }
   let (:administrators_principal) { Puppet::Util::Windows::SID::Principal.lookup_account_sid(administrator_bytes) }

--- a/spec/integration/util/windows/principal_spec.rb
+++ b/spec/integration/util/windows/principal_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe Puppet::Util::Windows::SID::Principal, :if => Puppet.features.microsoft_windows? do
+describe Puppet::Util::Windows::SID::Principal, :if => Puppet::Util::Platform.windows? do
 
   let (:current_user_sid) { Puppet::Util::Windows::ADSI::User.current_user_sid }
   let (:system_bytes) { [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0] }

--- a/spec/integration/util/windows/process_spec.rb
+++ b/spec/integration/util/windows/process_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'facter'
 
-describe "Puppet::Util::Windows::Process", :if => Puppet.features.microsoft_windows?  do
+describe "Puppet::Util::Windows::Process", :if => Puppet::Util::Platform.windows?  do
   describe "as an admin" do
     it "should have the SeCreateSymbolicLinkPrivilege necessary to create symlinks on Vista / 2008+",
-      :if => Facter.value(:kernelmajversion).to_f >= 6.0 && Puppet.features.microsoft_windows? do
+      :if => Facter.value(:kernelmajversion).to_f >= 6.0 && Puppet::Util::Platform.windows? do
       # this is a bit of a lame duck test since it requires running user to be admin
       # a better integration test would create a new user with the privilege and verify
       expect(Puppet::Util::Windows::User).to be_admin
@@ -14,7 +14,7 @@ describe "Puppet::Util::Windows::Process", :if => Puppet.features.microsoft_wind
     end
 
     it "should not have the SeCreateSymbolicLinkPrivilege necessary to create symlinks on 2003 and earlier",
-      :if => Facter.value(:kernelmajversion).to_f < 6.0 && Puppet.features.microsoft_windows? do
+      :if => Facter.value(:kernelmajversion).to_f < 6.0 && Puppet::Util::Platform.windows? do
       expect(Puppet::Util::Windows::User).to be_admin
       expect(Puppet::Util::Windows::Process.process_privilege_symlink?).to be_falsey
     end

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 require 'spec_helper'
 
-if Puppet.features.microsoft_windows?
+if Puppet::Util::Platform.windows?
   class WindowsSecurityTester
     require 'puppet/util/windows/security'
     include Puppet::Util::Windows::Security
   end
 end
 
-describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::Security", :if => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   before :all do
@@ -470,7 +470,7 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
         end
       end
 
-      describe "for an administrator", :if => (Puppet.features.root? && Puppet.features.microsoft_windows?) do
+      describe "for an administrator", :if => (Puppet.features.root? && Puppet::Util::Platform.windows?) do
         before :each do
           is_dir = Puppet::FileSystem.directory?(path)
           winsec.set_mode(WindowsSecurityTester::S_IRWXU | WindowsSecurityTester::S_IRWXG, path)

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::User", :if => Puppet::Util::Platform.windows? do
   describe "2003 without UAC" do
     before :each do
       Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(5)

--- a/spec/integration/util_spec.rb
+++ b/spec/integration/util_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Util do
     end
   end
 
-  describe "#replace_file on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#replace_file on Windows", :if => Puppet::Util::Platform.windows? do
     it "replace_file should preserve original ACEs from existing replaced file on Windows" do
 
       file = tmpfile("somefile")
@@ -109,7 +109,7 @@ describe Puppet::Util do
     end
   end
 
-  describe "#which on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#which on Windows", :if => Puppet::Util::Platform.windows? do
     let (:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
     let (:filename) { 'foo.exe' }
     let (:filepath) { File.expand_path('C:\\' + rune_utf8 + '\\' + filename) }

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -21,7 +21,7 @@ module PuppetSpec::Files
 
   def make_absolute(path)
     path = File.expand_path(path)
-    path[0] = 'c' if Puppet.features.microsoft_windows?
+    path[0] = 'c' if Puppet::Util::Platform.windows?
     path
   end
 
@@ -41,7 +41,7 @@ module PuppetSpec::Files
 
   def script_containing(name, contents)
     file = tmpfile(name)
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       file += '.bat'
       text = contents[:windows]
     else
@@ -98,7 +98,7 @@ module PuppetSpec::Files
 
   def expect_file_mode(file, mode)
     actual_mode = "%o" % Puppet::FileSystem.stat(file).mode
-    target_mode = if Puppet.features.microsoft_windows?
+    target_mode = if Puppet::Util::Platform.windows?
       mode
     else
       "10" + "%04i" % mode.to_i

--- a/spec/shared_behaviours/path_parameters.rb
+++ b/spec/shared_behaviours/path_parameters.rb
@@ -115,7 +115,7 @@ shared_examples_for "all path parameters" do |param, options|
     end
   end
 
-  describe "on a Windows-like platform it", :if => Puppet.features.microsoft_windows? do
+  describe "on a Windows-like platform it", :if => Puppet::Util::Platform.windows? do
     if array then
       it_should_behave_like "all pathname parameters with arrays", true
     end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -252,7 +252,7 @@ describe Puppet::Agent do
       end
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should never fork" do
         agent = Puppet::Agent.new(AgentTestClient, true)
         expect(agent.should_fork).to be_falsey

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -404,7 +404,7 @@ describe Puppet::Application::Agent do
     end
 
     it "should daemonize if needed" do
-      Puppet.features.stubs(:microsoft_windows?).returns false
+      Puppet::Util::Platform.stubs(:windows?).returns false
       Puppet[:daemonize] = true
       Signal.stubs(:trap)
 

--- a/spec/unit/capability_spec.rb
+++ b/spec/unit/capability_spec.rb
@@ -394,7 +394,7 @@ test { one: hostname => "ahost", export => Cap[two] }
   end
 
   context 'and aliased resources' do
-    let(:drive) { Puppet.features.microsoft_windows? ? 'C:' : '' }
+    let(:drive) { Puppet::Util::Platform.windows? ? 'C:' : '' }
     let(:code) { <<-PUPPET }
       $dir='#{drive}/tmp/test'
       $same_dir='#{drive}/tmp/test/'

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -104,7 +104,7 @@ describe Puppet::Configurer::Downloader do
       end
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should omit the owner" do
         file = generate_file_resource(:path => 'C:/path')
 

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -16,7 +16,7 @@ class TestClient
   end
 end
 
-describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Daemon, :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   class RecordingScheduler

--- a/spec/unit/etc_spec.rb
+++ b/spec/unit/etc_spec.rb
@@ -9,7 +9,7 @@ require 'puppet_spec/character_encoding'
 # - We correctly set external encoding values IF they're valid UTF-8 bytes
 # - We do not modify non-UTF-8 values if they're NOT valid UTF-8 bytes
 
-describe Puppet::Etc, :if => !Puppet.features.microsoft_windows? do
+describe Puppet::Etc, :if => !Puppet::Util::Platform.windows? do
   # http://www.fileformat.info/info/unicode/char/5e0c/index.htm
   # 希 Han Character 'rare; hope, expect, strive for'
   # In EUC_KR: \xfd \xf1 - 253 241

--- a/spec/unit/face/certificate_spec.rb
+++ b/spec/unit/face/certificate_spec.rb
@@ -160,7 +160,7 @@ describe Puppet::Face[:certificate, '0.0.1'], :unless => RUBY_PLATFORM == 'java'
     let(:host) { Puppet::SSL::Host.new(hostname) }
     let(:hostname) { "foobar" }
 
-    it "should sign the certificate request if one is waiting", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+    it "should sign the certificate request if one is waiting", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       subject.generate(hostname, options)
 
       subject.sign(hostname, options)
@@ -176,7 +176,7 @@ describe Puppet::Face[:certificate, '0.0.1'], :unless => RUBY_PLATFORM == 'java'
       end.to raise_error(ArgumentError, /Could not find certificate request for #{hostname}/)
     end
 
-    describe "when ca_location is local", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+    describe "when ca_location is local", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       describe "when the request has dns alt names" do
         before :each do
           subject.generate(hostname, options.merge(:dns_alt_names => 'some,alt,names'))

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -73,7 +73,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
   end
 
   describe "when diffing on a local filebucket" do
-    describe "in non-windows environments or JRuby", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+    describe "in non-windows environments or JRuby", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       with_digest_algorithms do
 
         it "should fail in an informative way when one or more checksum doesn't exists" do
@@ -121,7 +121,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
 
         end
       end
-      describe "in windows environment", :if => Puppet.features.microsoft_windows? do
+      describe "in windows environment", :if => Puppet::Util::Platform.windows? do
         it "should fail in an informative way when trying to diff" do
           @dipper = Puppet::FileBucket::Dipper.new(:Path => tmpdir("bucket"))
           wrong_checksum = "DEADBEEF"
@@ -250,7 +250,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
   end
 
   describe "when diffing on a remote filebucket" do
-    describe "in non-windows environments", :unless => Puppet.features.microsoft_windows? do
+    describe "in non-windows environments", :unless => Puppet::Util::Platform.windows? do
       with_digest_algorithms do
         it "should fail in an informative way when one or more checksum doesn't exists" do
           @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port => "31337")
@@ -271,7 +271,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
       end
     end
 
-    describe "in windows environment", :if => Puppet.features.microsoft_windows? do
+    describe "in windows environment", :if => Puppet::Util::Platform.windows? do
       it "should fail in an informative way when trying to diff" do
         @dipper = Puppet::FileBucket::Dipper.new(:Server => "puppetmaster", :Port => "31337")
         wrong_checksum = "DEADBEEF"

--- a/spec/unit/file_serving/base_spec.rb
+++ b/spec/unit/file_serving/base_spec.rb
@@ -101,13 +101,15 @@ describe Puppet::FileServing::Base do
     let(:path) { '//server/share/filename' }
     let(:file) { Puppet::FileServing::Base.new(path) }
 
+    before :each do
+      Puppet::Util::Platform.stubs(:windows?).returns true
+    end
+
     it "should preserve double slashes at the beginning of the path" do
-      Puppet.features.stubs(:microsoft_windows?).returns(true)
       expect(file.full_path).to eq(path)
     end
 
     it "should strip double slashes not at the beginning of the path" do
-      Puppet.features.stubs(:microsoft_windows?).returns(true)
       file = Puppet::FileServing::Base.new('//server//share//filename')
       expect(file.full_path).to eq(path)
     end
@@ -148,14 +150,14 @@ describe Puppet::FileServing::Base do
     end
 
     it "should accept Windows paths on Windows" do
-      Puppet.features.stubs(:microsoft_windows?).returns(true)
+      Puppet::Util::Platform.stubs(:windows?).returns true
       Puppet.features.stubs(:posix?).returns(false)
 
       expect(Puppet::FileServing::Base).to be_absolute('c:/foo')
     end
 
     it "should reject Windows paths on POSIX" do
-      Puppet.features.stubs(:microsoft_windows?).returns(false)
+      Puppet::Util::Platform.stubs(:windows?).returns false
 
       expect(Puppet::FileServing::Base).not_to be_absolute('c:/foo')
     end

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -241,7 +241,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
     end
   end
 
-  describe "WindowsStat", :if => Puppet.features.microsoft_windows? do
+  describe "WindowsStat", :if => Puppet::Util::Platform.windows? do
     include PuppetSpec::Files
 
     it "should return default owner, group and mode when the given path has an invalid DACL (such as a non-NTFS volume)" do
@@ -388,7 +388,7 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
     end
   end
 
-  describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+  describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
     let(:owner) {'S-1-1-50'}
     let(:group) {'S-1-1-51'}
 
@@ -499,7 +499,7 @@ describe Puppet::FileServing::Metadata, " when pointing to a link", :if => Puppe
         Puppet::FileSystem.expects(:readlink).with(path).at_least_once.returns "/some/other/path"
         @file.stubs("#{digest_algorithm}_file".intern).returns(checksum) # Remove these when :managed links are no longer checksumed.
 
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           win_stat = stub('win_stat', :owner => 'snarf', :group => 'thundercats',
             :ftype => 'link', :mode => 0755)
           Puppet::FileServing::Metadata::WindowsStat.stubs(:new).returns win_stat
@@ -530,7 +530,7 @@ describe Puppet::FileServing::Metadata, " when pointing to a link", :if => Puppe
         Puppet::FileSystem.expects(:stat).with(path).at_least_once.returns stat
         Puppet::FileSystem.expects(:readlink).never
 
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           win_stat = stub('win_stat', :owner => 'snarf', :group => 'thundercats',
             :ftype => 'file', :mode => 0755)
           Puppet::FileServing::Metadata::WindowsStat.stubs(:new).returns win_stat

--- a/spec/unit/file_system/path_pattern_spec.rb
+++ b/spec/unit/file_system/path_pattern_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::FileSystem::PathPattern do
       expect(Puppet::FileSystem::PathPattern.absolute("c:/absolute/windows/path").to_s).to eq("c:/absolute/windows/path")
     end
 
-    it "can be created with a '..' embedded in a filename on windows", :if => Puppet.features.microsoft_windows? do
+    it "can be created with a '..' embedded in a filename on windows", :if => Puppet::Util::Platform.windows? do
       expect(Puppet::FileSystem::PathPattern.absolute(%q{c:\..my\ot..her\one..}).to_s).to eq(%q{c:\..my\ot..her\one..})
     end
 

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -149,7 +149,7 @@ describe Puppet::FileSystem::Uniquefile do
       expect(File.exist?(path)).to eq(false)
     end
 
-    context "on unix platforms", :unless => Puppet.features.microsoft_windows? do
+    context "on unix platforms", :unless => Puppet::Util::Platform.windows? do
       it "close doesn't unlink if already unlinked" do
         t = tempfile("foo")
         path = t.path
@@ -173,7 +173,7 @@ describe Puppet::FileSystem::Uniquefile do
       expect(File.exist?(path)).to eq(false)
     end
 
-    context "on unix platforms", :unless => Puppet.features.microsoft_windows? do
+    context "on unix platforms", :unless => Puppet::Util::Platform.windows? do
       it "close! doesn't unlink if already unlinked" do
         t = tempfile("foo")
         path = t.path

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -302,7 +302,7 @@ describe "Puppet::FileSystem" do
 
   describe "symlink",
     :if => ! Puppet.features.manages_symlinks? &&
-    Puppet.features.microsoft_windows? do
+    Puppet::Util::Platform.windows? do
 
     let(:file)         { tmpfile("somefile") }
     let(:missing_file) { tmpfile("missingfile") }

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1492,7 +1492,7 @@ describe "The lookup function" do
         expect(lookup('x')).to eql('value x (from environment)')
       end
 
-      context 'obtained using /dev/null', :unless => Puppet.features.microsoft_windows? do
+      context 'obtained using /dev/null', :unless => Puppet::Util::Platform.windows? do
         let(:code_dir_files) { {} }
 
         it 'uses a Hiera version 3 defaults' do

--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -110,8 +110,9 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
               if Puppet::Util::Platform.windows? && (['sha512', 'sha384'].include? digest_algorithm)
                 skip "PUP-8257: Skip file bucket test on windows for #{digest_algorithm} due to long path names"
               else
-                checksum = save_bucket_file(plaintext, "/foo/bar")
-                checksum = save_bucket_file(plaintext, "/foo/bar")
+                # save it twice
+                save_bucket_file(plaintext, "/foo/bar")
+                save_bucket_file(plaintext, "/foo/bar")
                 dir_path = "#{Puppet[:bucketdir]}/#{bucket_dir}"
                 expect(Puppet::FileSystem.binread("#{dir_path}/contents")).to eq(plaintext)
                 expect(File.read("#{dir_path}/paths")).to eq("foo/bar\n")
@@ -122,8 +123,8 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
               if Puppet::Util::Platform.windows? && (['sha512', 'sha384'].include? digest_algorithm)
                 skip "PUP-8257: Skip file bucket test on windows for #{digest_algorithm} due to long path names"
               else
-                checksum = save_bucket_file(plaintext, "/foo/bar")
-                checksum = save_bucket_file(plaintext, "/foo/baz")
+                save_bucket_file(plaintext, "/foo/bar")
+                save_bucket_file(plaintext, "/foo/baz")
                 dir_path = "#{Puppet[:bucketdir]}/#{bucket_dir}"
                 expect(Puppet::FileSystem.binread("#{dir_path}/contents")).to eq(plaintext)
                 expect(File.read("#{dir_path}/paths")).to eq("foo/bar\nfoo/baz\n")
@@ -281,7 +282,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
       end
     end
 
-    describe "when diffing files", :unless => Puppet.features.microsoft_windows? do
+    describe "when diffing files", :unless => Puppet::Util::Platform.windows? do
       with_digest_algorithms do
         let(:not_bucketed_plaintext) { "other stuff" }
         let(:not_bucketed_checksum) { digest(not_bucketed_plaintext) }

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::ModuleTool::Applications::Installer, :unless => RUBY_PLATFORM =
     installer.stubs(:module_repository).returns(remote_source)
   end
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     before :each do
       Puppet.settings.stubs(:[])
       Puppet.settings.stubs(:[]).with(:module_working_dir).returns(Dir.mktmpdir('installertmp'))

--- a/spec/unit/module_tool/applications/upgrader_spec.rb
+++ b/spec/unit/module_tool/applications/upgrader_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::ModuleTool::Applications::Upgrader do
     installer.stubs(:module_repository).returns(remote_source)
   end
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     before :each do
       Puppet.settings.stubs(:[])
       Puppet.settings.stubs(:[]).with(:module_working_dir).returns(Dir.mktmpdir('upgradertmp'))

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Network::HTTP::Connection do
       WebMock.enable!
     end
 
-    it "should provide a useful error message when one is available and certificate validation fails", :unless => Puppet.features.microsoft_windows? do
+    it "should provide a useful error message when one is available and certificate validation fails", :unless => Puppet::Util::Platform.windows? do
       connection = Puppet::Network::HTTP::Connection.new(
         host, port,
         :verify => ConstantErrorValidator.new(:fails_with => 'certificate verify failed',
@@ -88,7 +88,7 @@ describe Puppet::Network::HTTP::Connection do
       end.to raise_error(Puppet::Error, "certificate verify failed: [shady looking signature]")
     end
 
-    it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+    it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       Puppet[:confdir] = tmpdir('conf')
 
       connection = Puppet::Network::HTTP::Connection.new(
@@ -116,7 +116,7 @@ describe Puppet::Network::HTTP::Connection do
       end.to raise_error(/some other message/)
     end
 
-    it "should check all peer certificates for upcoming expiration", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+    it "should check all peer certificates for upcoming expiration", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       Puppet[:confdir] = tmpdir('conf')
       cert = Puppet::SSL::CertificateAuthority.new.generate(
         'server', :dns_alt_names => 'foo,bar,baz')

--- a/spec/unit/parser/functions/generate_spec.rb
+++ b/spec/unit/parser/functions/generate_spec.rb
@@ -41,7 +41,7 @@ describe "the generate function" do
     expect(scope.function_generate([command])).to eq('yay')
   end
 
-  describe "on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "on Windows", :if => Puppet::Util::Platform.windows? do
     it "should accept the tilde in the path" do
       command = "C:/DOCUME~1/ADMINI~1/foo.bat"
       Dir.expects(:chdir).with(File.dirname(command)).returns("yay")

--- a/spec/unit/pops/loaders/dependency_loader_spec.rb
+++ b/spec/unit/pops/loaders/dependency_loader_spec.rb
@@ -84,7 +84,7 @@ Puppet::Functions.create_function('testmodule::foo') {
 
       context 'when loading files from disk' do
         it 'should always read files as UTF-8' do
-          if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+          if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
             raise 'This test must be run in a codepage other than 65001 to validate behavior'
           end
 
@@ -102,7 +102,7 @@ Puppet::Functions.create_function('testmodule::foo') {
         it 'currently ignores the UTF-8 BOM (Byte Order Mark) when loading module files' do
           bom = "\uFEFF"
 
-          if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+          if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
             raise 'This test must be run in a codepage other than 65001 to validate behavior'
           end
 

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -922,7 +922,7 @@ describe Puppet::Pops::Parser::Lexer2 do
 
   context 'when lexing files from disk' do
     it 'should always read files as UTF-8' do
-      if Puppet.features.microsoft_windows? && Encoding.default_external == Encoding::UTF_8
+      if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
         raise 'This test must be run in a codepage other than 65001 to validate behavior'
       end
 

--- a/spec/unit/provider/exec/windows_spec.rb
+++ b/spec/unit/provider/exec/windows_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:exec).provider(:windows), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:exec).provider(:windows), :if => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   let(:resource) { Puppet::Type.type(:exec).new(:title => 'C:\foo', :provider => :windows) }
@@ -45,7 +45,7 @@ describe Puppet::Type.type(:exec).provider(:windows), :if => Puppet.features.mic
   end
 
   describe "#checkexe" do
-    describe "when the command is absolute", :if => Puppet.features.microsoft_windows? do
+    describe "when the command is absolute", :if => Puppet::Util::Platform.windows? do
       it "should return if the command exists and is a file" do
         command = tmpfile('command')
         FileUtils.touch(command)

--- a/spec/unit/provider/file/windows_spec.rb
+++ b/spec/unit/provider/file/windows_spec.rb
@@ -1,14 +1,14 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
-if Puppet.features.microsoft_windows?
+if Puppet::Util::Platform.windows?
   require 'puppet/util/windows'
   class WindowsSecurity
     extend Puppet::Util::Windows::Security
   end
 end
 
-describe Puppet::Type.type(:file).provider(:windows), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:file).provider(:windows), :if => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
 
   let(:path) { tmpfile('windows_file_spec') }

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet::Util::Platform.windows? do
   let(:resource) do
     Puppet::Type.type(:group).new(
       :title => 'testers',

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -189,7 +189,7 @@ describe Puppet::Provider::NameService do
       end
     end
 
-    it "should return a list of groups if resource_type is group", :unless => Puppet.features.microsoft_windows? do
+    it "should return a list of groups if resource_type is group", :unless => Puppet::Util::Platform.windows? do
       described_class.resource_type = Puppet::Type.type(:group)
       Puppet::Etc.expects(:setgrent)
       Puppet::Etc.stubs(:getgrent).returns(*groups)

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -88,7 +88,7 @@ context 'installing myresource' do
             provider.install
           end
         end
-        describe "as a windows path on windows", :if => Puppet.features.microsoft_windows? do
+        describe "as a windows path on windows", :if => Puppet::Util::Platform.windows? do
           it "should treat the source as a local path" do
             resource[:source] = "c:/this/is/a/path/to/a/gem.gem"
             provider.expects(:execute).with { |args| args[2] == "c:/this/is/a/path/to/a/gem.gem" }.returns ""

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:package).provider(:pkg), unless: Puppet::Util::Platf
   let (:provider) { described_class.new(resource) }
 
   before(:all) do
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       # Get a pid for $CHILD_STATUS to latch on to
       command = "cmd.exe /c \"exit 0\""
       Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -17,7 +17,7 @@ describe provider_class do
     provider
   end
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     let(:puppet_gem) { 'gem' }
   else
     let(:puppet_gem) { '/opt/puppetlabs/puppet/bin/gem' }

--- a/spec/unit/provider/package/windows/msi_package_spec.rb
+++ b/spec/unit/provider/package/windows/msi_package_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Provider::Package::Windows::MsiPackage do
     subject.expects(:installer).returns(inst)
   end
 
-  context '::installer', :if => Puppet.features.microsoft_windows? do
+  context '::installer', :if => Puppet::Util::Platform.windows? do
     it 'should return an instance of the COM interface' do
       expect(subject.installer).not_to be_nil
     end

--- a/spec/unit/provider/package/windows/package_spec.rb
+++ b/spec/unit/provider/package/windows/package_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Provider::Package::Windows::Package do
     end
   end
 
-  context '::with_key', :if => Puppet.features.microsoft_windows? do
+  context '::with_key', :if => Puppet::Util::Platform.windows? do
     it 'should search HKLM (64 & 32) and HKCU (64 & 32)' do
       seq = sequence('reg')
 

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
     it { is_expected.to be_versionable }
   end
 
-  describe 'on Windows', :if => Puppet.features.microsoft_windows? do
+  describe 'on Windows', :if => Puppet::Util::Platform.windows? do
     it 'should be the default provider' do
       expect(Puppet::Type.type(:package).defaultprovider).to eq(subject.class)
     end
@@ -126,7 +126,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
       provider.install
     end
 
-    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+    it 'should fail otherwise', :if => Puppet::Util::Platform.windows? do
       expect_execute(command, 5)
 
       expect do
@@ -181,7 +181,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
       provider.uninstall
     end
 
-    it 'should fail otherwise', :if => Puppet.features.microsoft_windows? do
+    it 'should fail otherwise', :if => Puppet::Util::Platform.windows? do
       expect_execute(command, 5)
 
       expect do

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -15,7 +15,7 @@ describe "base service provider" do
 
   subject { provider }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     cmd = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(cmd, {:failonfail => false})

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Bsd',
-         :unless => Puppet.features.microsoft_windows? || Puppet::Util::Platform.jruby? do
+         :unless => Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
 
   let(:provider_class) { Puppet::Type.type(:service).provider(:bsd) }
   before :each do

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -8,7 +8,7 @@ require 'spec_helper'
 describe 'Puppet::Type::Service::Provider::Debian', unless: Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:debian) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:gentoo) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -8,7 +8,7 @@ require 'spec_helper'
 describe 'Puppet::Type::Service::Provider::Init', unless: Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:init) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     cmd = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(cmd, {:failonfail => false})

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -14,7 +14,7 @@ describe 'Puppet::Type::Service::Provider::Launchd', unless: Puppet::Util::Platf
   let (:launchd_overrides_10_) { '/var/db/com.apple.xpc.launchd/disabled.plist' }
   subject { resource.provider }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -5,7 +5,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Openbsd',
-    unless: Puppet.features.microsoft_windows? || Puppet::Util::Platform.jruby? do
+    unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:openbsd) }
 
   before :each do
@@ -195,7 +195,7 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   end
 
   describe "#flags=" do
-    it "should run rcctl to set flags", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+    it "should run rcctl to set flags", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
       provider_class.stubs(:rcctl).with(:set, 'sshd', :flags, '-4').returns('')
       provider.expects(:rcctl).with(:set, 'sshd', :flags, '-4')

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:openrc) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     cmd = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(cmd, {:failonfail => false})

--- a/spec/unit/provider/service/rcng_spec.rb
+++ b/spec/unit/provider/service/rcng_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Rcng',
-    :unless => Puppet.features.microsoft_windows? || Puppet::Util::Platform.jruby? do
+    :unless => Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:rcng) }
 
   before :each do

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -8,7 +8,7 @@ require 'spec_helper'
 describe 'Puppet::Type::Service::Provider::Src', unless: Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:src) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:systemd) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -6,7 +6,7 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
   let(:start_on_default_runlevels) {  "\nstart on runlevel [2,3,4,5]" }
   let!(:provider_class) { Puppet::Type.type(:service).provider(:upstart) }
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
     Puppet::Util::Execution.execute(command, {:failonfail => false})

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -5,10 +5,10 @@
 
 require 'spec_helper'
 
-require 'win32/service' if Puppet.features.microsoft_windows?
+require 'win32/service' if Puppet::Util::Platform.windows?
 
 describe 'Puppet::Type::Service::Provider::Windows',
-    :if => Puppet.features.microsoft_windows? && !Puppet::Util::Platform.jruby? do
+    :if => Puppet::Util::Platform.windows? && !Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:windows) }
   let(:name)     { 'nonexistentservice' }
   let(:resource) { Puppet::Type.type(:service).new(:name => name, :provider => :windows) }
@@ -174,7 +174,7 @@ describe 'Puppet::Type::Service::Provider::Windows',
 
     # We need to guard this section explicitly since rspec will always
     # construct all examples, even if it isn't going to run them.
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       [Win32::Service::SERVICE_AUTO_START, Win32::Service::SERVICE_BOOT_START, Win32::Service::SERVICE_SYSTEM_START].each do |start_type_const|
         start_type = Win32::Service.get_start_type(start_type_const)
         it "should report a service with a startup type of '#{start_type}' as true" do

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -4,7 +4,7 @@ require 'etc'
 
 provider_class = Puppet::Type.type(:user).provider(:hpuxuseradd)
 
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe provider_class, :unless => Puppet::Util::Platform.windows? do
   let :resource do
     Puppet::Type.type(:user).new(
       :title => 'testuser',

--- a/spec/unit/provider/user/user_role_add_spec.rb
+++ b/spec/unit/provider/user/user_role_add_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'puppet_spec/files'
 require 'tempfile'
 
-describe Puppet::Type.type(:user).provider(:user_role_add), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:user).provider(:user_role_add), :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   let(:resource) { Puppet::Type.type(:user).new(:name => 'myuser', :managehome => false, :allowdupe => false) }
   let(:provider) { described_class.new(resource) }

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet::Util::Platform.windows? do
   let(:resource) do
     Puppet::Type.type(:user).new(
       :title => 'testuser',

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 def existing_command
-  Puppet.features.microsoft_windows? ? "cmd" : "echo"
+  Puppet::Util::Platform.windows? ? "cmd" : "echo"
 end
 
 describe Puppet::Provider do

--- a/spec/unit/settings/file_setting_spec.rb
+++ b/spec/unit/settings/file_setting_spec.rb
@@ -169,7 +169,7 @@ describe Puppet::Settings::FileSetting do
       expect(resource.title).to eq(@basepath)
     end
 
-    it "should have a working directory with a root directory not called dev", :if => Puppet.features.microsoft_windows? do
+    it "should have a working directory with a root directory not called dev", :if => Puppet::Util::Platform.windows? do
       # Although C:\Dev\.... is a valid path on Windows, some other code may regard it as a path to be ignored.  e.g. /dev/null resolves to C:\dev\null on Windows.
       path = File.expand_path('somefile')
       expect(path).to_not match(/^[A-Z]:\/dev/i)
@@ -206,9 +206,9 @@ describe Puppet::Settings::FileSetting do
     it "should set the owner if running as root and the owner is provided" do
       Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns true
-      Puppet.features.stubs(:microsoft_windows?).returns false
-
+      Puppet::Util::Platform.stubs(:windows?).returns false
       @file.stubs(:owner).returns "foo"
+
       expect(@file.to_resource[:owner]).to eq("foo")
     end
 
@@ -223,9 +223,9 @@ describe Puppet::Settings::FileSetting do
     it "should set the group if running as root and the group is provided" do
       Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns true
-      Puppet.features.stubs(:microsoft_windows?).returns false
-
+      Puppet::Util::Platform.stubs(:windows?).returns false
       @file.stubs(:group).returns "foo"
+
       expect(@file.to_resource[:group]).to eq("foo")
     end
 
@@ -241,22 +241,24 @@ describe Puppet::Settings::FileSetting do
     it "should not set owner if not running as root" do
       Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns false
-      Puppet.features.stubs(:microsoft_windows?).returns false
+      Puppet::Util::Platform.stubs(:windows?).returns false
       @file.stubs(:owner).returns "foo"
+
       expect(@file.to_resource[:owner]).to be_nil
     end
 
     it "should not set group if not running as root" do
       Puppet[:manage_internal_file_permissions] = true
       Puppet.features.expects(:root?).returns false
-      Puppet.features.stubs(:microsoft_windows?).returns false
+      Puppet::Util::Platform.stubs(:windows?).returns false
       @file.stubs(:group).returns "foo"
+
       expect(@file.to_resource[:group]).to be_nil
     end
 
     describe "on Microsoft Windows systems" do
       before :each do
-        Puppet.features.stubs(:microsoft_windows?).returns true
+        Puppet::Util::Platform.stubs(:windows?).returns true
       end
 
       it "should not set owner" do
@@ -308,7 +310,7 @@ describe Puppet::Settings::FileSetting do
     end
   end
 
-  context "when opening", :unless => Puppet.features.microsoft_windows? do
+  context "when opening", :unless => Puppet::Util::Platform.windows? do
     let(:path) do
       tmpfile('file_setting_spec')
     end

--- a/spec/unit/settings/path_setting_spec.rb
+++ b/spec/unit/settings/path_setting_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Settings::PathSetting do
       expect(subject.munge(nil)).to be_nil
     end
 
-    context "on Windows", :if => Puppet.features.microsoft_windows? do
+    context "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should convert \\ to /" do
         expect(subject.munge('C:\test\directory')).to eq('C:/test/directory')
       end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1313,7 +1313,7 @@ describe Puppet::Settings do
       @settings.to_catalog
     end
 
-    describe "on Microsoft Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Microsoft Windows", :if => Puppet::Util::Platform.windows? do
       before :each do
         Puppet.features.stubs(:root?).returns true
 
@@ -1425,7 +1425,7 @@ describe Puppet::Settings do
       before :all do
         # when this spec is run in isolation to build a settings catalog
         # it will not be able to autorequire and load types for the first time
-        # on Windows with microsoft_windows? stubbed to false, because
+        # on Windows with windows? stubbed to false, because
         # Puppet::Util.path_to_uri is called to generate a URI to load code
         # and it manipulates the path based on OS
         # so instead we forcefully "prime" the cached types
@@ -1437,7 +1437,7 @@ describe Puppet::Settings do
       before do
         Puppet.features.stubs(:root?).returns true
         # stubbed to false, as Windows catalogs don't add users / groups
-        Puppet.features.stubs(:microsoft_windows?).returns false
+        Puppet::Util::Platform.stubs(:windows?).returns false
 
         @settings.define_settings :foo,
             :mkusers => { :type => :boolean, :default => true, :desc => "e" },

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -89,7 +89,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
     expect(Puppet::SSL::Host.localhost).to equal(host)
   end
 
-  it "should create a localhost cert if no cert is available and it is a CA with autosign and it is using DNS alt names", :unless => Puppet.features.microsoft_windows? do
+  it "should create a localhost cert if no cert is available and it is a CA with autosign and it is using DNS alt names", :unless => Puppet::Util::Platform.windows? do
     Puppet[:autosign] = true
     Puppet[:confdir] = tmpdir('conf')
     Puppet[:dns_alt_names] = "foo,bar,baz"
@@ -923,7 +923,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
     end
   end
 
-  describe "when handling JSON", :unless => Puppet.features.microsoft_windows? do
+  describe "when handling JSON", :unless => Puppet::Util::Platform.windows? do
     include PuppetSpec::Files
 
     before do

--- a/spec/unit/ssl/inventory_spec.rb
+++ b/spec/unit/ssl/inventory_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet/ssl/inventory'
 
-describe Puppet::SSL::Inventory, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::SSL::Inventory, :unless => Puppet::Util::Platform.windows? do
   let(:cert_inventory) { File.expand_path("/inven/tory") }
 
   # different UTF-8 widths

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -147,7 +147,7 @@ describe Puppet::Transaction::Persistence do
       Dir.mkdir(Puppet[:transactionstorefile])
       persistence = Puppet::Transaction::Persistence.new
 
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         expect do
           persistence.save
         end.to raise_error do |error|

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -7,8 +7,8 @@ describe Puppet::Transaction::ResourceHarness do
   include PuppetSpec::Files
 
   before do
-    @mode_750 = Puppet.features.microsoft_windows? ? '644' : '750'
-    @mode_755 = Puppet.features.microsoft_windows? ? '644' : '755'
+    @mode_750 = Puppet::Util::Platform.windows? ? '644' : '750'
+    @mode_755 = Puppet::Util::Platform.windows? ? '644' : '755'
     path = make_absolute("/my/file")
 
     @transaction = Puppet::Transaction.new(Puppet::Resource::Catalog.new, nil, nil)

--- a/spec/unit/type/cron_spec.rb
+++ b/spec/unit/type/cron_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Puppet::Type.type(:cron), :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:cron), :unless => Puppet::Util::Platform.windows? do
   let(:simple_provider) do
     @provider_class = described_class.provide(:simple) { mk_resource_methods }
     @provider_class.stubs(:suitable?).returns true

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Type.type(:exec) do
   describe "when not stubbing the provider" do
     before do
       path = tmpdir('path')
-      ext = Puppet.features.microsoft_windows? ? '.exe' : ''
+      ext = Puppet::Util::Platform.windows? ? '.exe' : ''
       true_cmd = File.join(path, "true#{ext}")
       false_cmd = File.join(path, "false#{ext}")
 
@@ -257,7 +257,7 @@ describe Puppet::Type.type(:exec) do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       before :each do
         Puppet.features.stubs(:root?).returns(true)
       end
@@ -437,14 +437,14 @@ describe Puppet::Type.type(:exec) do
           Puppet::Type.type(:exec).new(:name => "#{ruby_path} -e 'sleep 1'", :timeout => '0.1')
         end
 
-        context 'on POSIX', :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+        context 'on POSIX', :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
           it 'sends a SIGTERM and raises a Puppet::Error' do
             Process.expects(:kill).at_least_once
             expect { subject.refresh }.to raise_error Puppet::Error, "Command exceeded timeout"
           end
         end
 
-        context 'on Windows', :if => Puppet.features.microsoft_windows? do
+        context 'on Windows', :if => Puppet::Util::Platform.windows? do
           it 'raises a Puppet::Error' do
             expect { subject.refresh }.to raise_error Puppet::Error, "Command exceeded timeout"
           end

--- a/spec/unit/type/file/checksum_spec.rb
+++ b/spec/unit/type/file/checksum_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 checksum = Puppet::Type.type(:file).attrclass(:checksum)
 describe checksum do
   before do
-    @path = Puppet.features.microsoft_windows? ? "c:/foo/bar" : "/foo/bar"
+    @path = Puppet::Util::Platform.windows? ? "c:/foo/bar" : "/foo/bar"
     @resource = Puppet::Type.type(:file).new :path => @path
     @checksum = @resource.parameter(:checksum)
   end

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -42,12 +42,12 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
       expect(lambda { resource[:source] = %w{ftp://foo/bar} }).to raise_error(Puppet::Error, /Cannot use URLs of type 'ftp' as source for fileserving/)
     end
 
-    it "should strip trailing forward slashes", :unless => Puppet.features.microsoft_windows? do
+    it "should strip trailing forward slashes", :unless => Puppet::Util::Platform.windows? do
       resource[:source] = "/foo/bar\\//"
       expect(resource[:source].first).to match(%r{/foo/bar\\$})
     end
 
-    it "should strip trailing forward and backslashes", :if => Puppet.features.microsoft_windows? do
+    it "should strip trailing forward and backslashes", :if => Puppet::Util::Platform.windows? do
       resource[:source] = "X:/foo/bar\\//"
       expect(resource[:source].first).to match(/(file\:|file\:\/\/)\/X:\/foo\/bar$/)
     end
@@ -246,7 +246,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
     describe "and the source is a file" do
       before do
         @metadata.stubs(:ftype).returns "file"
-        Puppet.features.stubs(:microsoft_windows?).returns false
+        Puppet::Util::Platform.stubs(:windows?).returns false
       end
 
       context "when source_permissions is `use`" do
@@ -409,7 +409,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
 
     describe "and the source is a link" do
       before do
-        Puppet.features.stubs(:microsoft_windows?).returns false
+        Puppet::Util::Platform.stubs(:windows?).returns false
       end
 
       it "should set the target to the link destination" do
@@ -456,7 +456,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         end
       end
 
-      describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+      describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
         ['', "file:/", "file:///"].each do |prefix|
           it "should be local with prefix '#{prefix}'" do
             resource[:source] = "#{prefix}#{sourcepath}"

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -51,7 +51,7 @@ describe Puppet::Type.type(:file) do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       it "should remove trailing slashes" do
         file[:path] = "X:/foo/bar/baz/"
         expect(file[:path]).to eq("X:/foo/bar/baz")
@@ -76,7 +76,7 @@ describe Puppet::Type.type(:file) do
         expect { file[:path] = "X:" }.to raise_error(/File paths must be fully qualified/)
       end
 
-      describe "when using UNC filenames", :if => Puppet.features.microsoft_windows? do
+      describe "when using UNC filenames", :if => Puppet::Util::Platform.windows? do
         it "should remove trailing slashes" do
           file[:path] = "//localhost/foo/bar/baz/"
           expect(file[:path]).to eq("//localhost/foo/bar/baz")
@@ -1335,7 +1335,7 @@ describe Puppet::Type.type(:file) do
         expect(file.autorequire).to be_empty
       end
 
-      describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+      describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
         describe "when using UNC filenames" do
           it "should autorequire its parent directory" do
             file[:path] = '//localhost/foo/bar/baz'
@@ -1410,7 +1410,7 @@ describe Puppet::Type.type(:file) do
     end
 
     it "should manage the mode of the followed link" do
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         skip "Windows cannot presently manage the mode when following symlinks"
       else
         @link_resource[:links] = :follow
@@ -1511,7 +1511,8 @@ describe Puppet::Type.type(:file) do
 
     describe "on Windows when source_permissions is `use`" do
       before :each do
-        Puppet.features.stubs(:microsoft_windows?).returns true
+        Puppet::Util::Platform.stubs(:windows?).returns true
+
         file[:source_permissions] = "use"
       end
       let(:err_message) { "Copying owner/mode/group from the" <<

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -88,14 +88,13 @@ describe test_title, "when validating attribute values" do
     end
 
     it "should support :manual as a value on Windows" do
-      Puppet.features.stubs(:microsoft_windows?).returns true
-
+      Puppet::Util::Platform.stubs(:windows?).returns true
       srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :manual)
       expect(srv.should(:enable)).to eq(:manual)
     end
 
     it "should not support :manual as a value when not on Windows" do
-      Puppet.features.stubs(:microsoft_windows?).returns false
+      Puppet::Util::Platform.stubs(:windows?).returns false
 
       expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :manual) }.to raise_error(
         Puppet::Error,

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -12,7 +12,7 @@ describe tidy do
     Puppet.settings.stubs(:use)
   end
 
-  context "when normalizing 'path' on windows", :if => Puppet.features.microsoft_windows? do
+  context "when normalizing 'path' on windows", :if => Puppet::Util::Platform.windows? do
     it "replaces backslashes with forward slashes" do
       resource = tidy.new(:path => 'c:\directory')
       expect(resource[:path]).to eq('c:/directory')

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:type_test).provide(:type_test) do
   mk_resource_methods
 end
 
-describe Puppet::Type, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type, :unless => Puppet::Util::Platform.windows? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -294,7 +294,7 @@ describe Puppet::Util::Autoload do
       expect(Puppet::Util::Autoload.cleanpath(path)).to eq(path)
     end
 
-    describe "on Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows", :if => Puppet::Util::Platform.windows? do
       it "should convert c:\ to c:/" do
         expect(Puppet::Util::Autoload.cleanpath('c:\\')).to eq('c:/')
       end

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -19,10 +19,10 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
     let(:process_handle) { 0xDEADBEEF }
     let(:thread_handle) { 0xCAFEBEEF }
     let(:proc_info_stub) { stub 'processinfo', :process_handle => process_handle, :thread_handle => thread_handle, :process_id => pid}
-    let(:null_file) { Puppet.features.microsoft_windows? ? 'NUL' : '/dev/null' }
+    let(:null_file) { Puppet::Util::Platform.windows? ? 'NUL' : '/dev/null' }
 
     def stub_process_wait(exitstatus)
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         Puppet::Util::Windows::Process.stubs(:wait_process).with(process_handle).returns(exitstatus)
         FFI::WIN32.stubs(:CloseHandle).with(process_handle)
         FFI::WIN32.stubs(:CloseHandle).with(thread_handle)
@@ -33,7 +33,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
     end
 
 
-    describe "#execute_posix (stubs)", :unless => Puppet.features.microsoft_windows? do
+    describe "#execute_posix (stubs)", :unless => Puppet::Util::Platform.windows? do
       before :each do
         # Most of the things this method does are bad to do during specs. :/
         Kernel.stubs(:fork).returns(pid).yields
@@ -124,7 +124,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       end
     end
 
-    describe "#execute_windows (stubs)", :if => Puppet.features.microsoft_windows? do
+    describe "#execute_windows (stubs)", :if => Puppet::Util::Platform.windows? do
       before :each do
         Process.stubs(:create).returns(proc_info_stub)
         stub_process_wait(0)
@@ -183,8 +183,8 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
 
       describe "when setting up input and output files" do
         include PuppetSpec::Files
-        let(:executor) { Puppet.features.microsoft_windows? ? 'execute_windows' : 'execute_posix' }
-        let(:rval) { Puppet.features.microsoft_windows? ? proc_info_stub : pid }
+        let(:executor) { Puppet::Util::Platform.windows? ? 'execute_windows' : 'execute_posix' }
+        let(:rval) { Puppet::Util::Platform.windows? ? proc_info_stub : pid }
 
         before :each do
           Puppet::Util::Execution.stubs(:wait_for_output)
@@ -271,7 +271,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
           end
         end
 
-        describe "on Windows", :if => Puppet.features.microsoft_windows? do
+        describe "on Windows", :if => Puppet::Util::Platform.windows? do
           describe "when squelch is not set" do
             it "should set stdout to a temporary output file" do
               outfile = Puppet::FileSystem::Uniquefile.new('stdout')
@@ -353,7 +353,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
         end
       end
 
-      describe "on Windows", :if => Puppet.features.microsoft_windows? do
+      describe "on Windows", :if => Puppet::Util::Platform.windows? do
         it "should always close the process and thread handles" do
           Puppet::Util::Execution.stubs(:execute_windows).returns(proc_info_stub)
 
@@ -376,7 +376,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       end
     end
 
-    describe "#execute (posix locale)", :unless => Puppet.features.microsoft_windows? do
+    describe "#execute (posix locale)", :unless => Puppet::Util::Platform.windows? do
 
       before :each do
         # there is a danger here that ENV will be modified by exec_posix.  Normally it would only affect the ENV
@@ -469,7 +469,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       end
     end
 
-    describe "#execute (posix user env vars)", :unless => Puppet.features.microsoft_windows? do
+    describe "#execute (posix user env vars)", :unless => Puppet::Util::Platform.windows? do
       # build up a printf-style string that contains a command to get the value of an environment variable
       # from the operating system.  We can substitute into this with the names of the desired environment variables later.
       get_env_var_cmd = 'echo $%s'
@@ -531,7 +531,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       before :each do
         stub_process_wait(0)
 
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           Puppet::Util::Execution.stubs(:execute_windows).returns(proc_info_stub)
         else
           Puppet::Util::Execution.stubs(:execute_posix).returns(pid)
@@ -580,7 +580,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       before :each do
         stub_process_wait(0)
 
-        if Puppet.features.microsoft_windows?
+        if Puppet::Util::Platform.windows?
           Puppet::Util::Execution.stubs(:execute_windows).returns(proc_info_stub)
         else
           Puppet::Util::Execution.stubs(:execute_posix).returns(pid)
@@ -652,7 +652,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
           r, w = IO.pipe
           IO.expects(:pipe).returns([r, w])
 
-          if Puppet.features.microsoft_windows?
+          if Puppet::Util::Platform.windows?
             Puppet::Util::Execution.expects(:execute_windows).raises(Exception, 'execution failed')
           else
             Puppet::Util::Execution.expects(:execute_posix).raises(Exception, 'execution failed')
@@ -665,7 +665,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
           expect(w.closed?)
         end
       end
-      describe "on Windows", :if => Puppet.features.microsoft_windows? do
+      describe "on Windows", :if => Puppet::Util::Platform.windows? do
         context "reading the output" do
           before :each do
             stdout = Puppet::FileSystem::Uniquefile.new('test')

--- a/spec/unit/util/execution_stub_spec.rb
+++ b/spec/unit/util/execution_stub_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::Util::ExecutionStub do
 
   it "should restore normal execution after 'reset' is called", unless: Puppet::Util::Platform.jruby? do
     # Note: "true" exists at different paths in different OSes
-    if Puppet.features.microsoft_windows?
+    if Puppet::Util::Platform.windows?
       true_command = [Puppet::Util.which('cmd.exe').tr('/', '\\'), '/c', 'exit 0']
     else
       true_command = [Puppet::Util.which('true')]

--- a/spec/unit/util/feature_spec.rb
+++ b/spec/unit/util/feature_spec.rb
@@ -9,15 +9,10 @@ describe Puppet::Util::Feature do
     @features.stubs(:warn)
   end
 
-  it "should be able to add new features" do
-    @features.add(:myfeature) {}
-    expect(@features).to respond_to(:myfeature?)
-  end
-
-  it "should call associated code when loading a feature" do
+  it "should not call associated code when loading a feature" do
     $loaded_feature = false
     @features.add(:myfeature) { $loaded_feature = true}
-    expect($loaded_feature).to be_truthy
+    expect($loaded_feature).to eq(false)
   end
 
   it "should consider a feature absent when the feature load fails" do
@@ -30,17 +25,38 @@ describe Puppet::Util::Feature do
     expect(@features).not_to be_failer
   end
 
+  it "should consider a feature to be absent when the feature load returns nil" do
+    @features.add(:failer) { nil }
+    expect(@features).not_to be_failer
+  end
+
   it "should consider a feature to be present when the feature load returns true" do
     @features.add(:available) { true }
     expect(@features).to be_available
   end
 
-  it "should cache the results of a feature load via code block" do
+  it "should cache the results of a feature load via code block when the block returns true" do
     $loaded_feature = 0
-    @features.add(:myfeature) { $loaded_feature += 1 }
+    @features.add(:myfeature) { $loaded_feature += 1; true }
     @features.myfeature?
     @features.myfeature?
     expect($loaded_feature).to eq(1)
+  end
+
+  it "should cache the results of a feature load via code block when the block returns false" do
+    $loaded_feature = 0
+    @features.add(:myfeature) { $loaded_feature += 1; false }
+    @features.myfeature?
+    @features.myfeature?
+    expect($loaded_feature).to eq(1)
+  end
+
+  it "should not cache the results of a feature load via code block when the block returns nil" do
+    $loaded_feature = 0
+    @features.add(:myfeature) { $loaded_feature += 1; nil }
+    @features.myfeature?
+    @features.myfeature?
+    expect($loaded_feature).to eq(2)
   end
 
   it "should invalidate the cache for the feature when loading" do

--- a/spec/unit/util/feature_spec.rb
+++ b/spec/unit/util/feature_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Util::Feature do
     @features.stubs(:warn)
   end
 
-  it "should not call associated code when loading a feature" do
+  it "should not call associated code when adding a feature" do
     $loaded_feature = false
     @features.add(:myfeature) { $loaded_feature = true}
     expect($loaded_feature).to eq(false)
@@ -17,22 +17,27 @@ describe Puppet::Util::Feature do
 
   it "should consider a feature absent when the feature load fails" do
     @features.add(:failer) { raise "foo" }
-    expect(@features).not_to be_failer
+    expect(@features.failer?).to eq(false)
   end
 
   it "should consider a feature to be absent when the feature load returns false" do
     @features.add(:failer) { false }
-    expect(@features).not_to be_failer
+    expect(@features.failer?).to eq(false)
   end
 
   it "should consider a feature to be absent when the feature load returns nil" do
     @features.add(:failer) { nil }
-    expect(@features).not_to be_failer
+    expect(@features.failer?).to eq(false)
   end
 
   it "should consider a feature to be present when the feature load returns true" do
     @features.add(:available) { true }
-    expect(@features).to be_available
+    expect(@features.available?).to eq(true)
+  end
+
+  it "should consider a feature to be present when the feature load returns truthy" do
+    @features.add(:available) { "yes" }
+    expect(@features.available?).to eq(true)
   end
 
   it "should cache the results of a feature load via code block when the block returns true" do
@@ -60,11 +65,8 @@ describe Puppet::Util::Feature do
   end
 
   it "should invalidate the cache for the feature when loading" do
-    # block defined features are evaluated at load time
     @features.add(:myfeature) { false }
     expect(@features).not_to be_myfeature
-    # features with no block have deferred evaluation so an existing cached
-    # value would take precedence
     @features.add(:myfeature)
     expect(@features).to be_myfeature
   end

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -181,7 +181,7 @@ describe Puppet::Util::FileType do
     end
   end
 
-  describe "the suntab filetype", :unless => Puppet.features.microsoft_windows? do
+  describe "the suntab filetype", :unless => Puppet::Util::Platform.windows? do
     let(:type)           { Puppet::Util::FileType.filetype(:suntab) }
     let(:name)           { type.name }
     let(:crontab_output) { 'suntab_output' }
@@ -198,7 +198,7 @@ describe Puppet::Util::FileType do
     it_should_behave_like "crontab provider"
   end
 
-  describe "the aixtab filetype", :unless => Puppet.features.microsoft_windows? do
+  describe "the aixtab filetype", :unless => Puppet::Util::Platform.windows? do
     let(:type)           { Puppet::Util::FileType.filetype(:aixtab) }
     let(:name)           { type.name }
     let(:crontab_output) { 'aixtab_output' }

--- a/spec/unit/util/lockfile_spec.rb
+++ b/spec/unit/util/lockfile_spec.rb
@@ -56,7 +56,7 @@ describe Puppet::Util::Lockfile do
     end
 
     # We test simultaneous locks using fork which isn't supported on Windows.
-    it "should not be acquired by another process", :unless => Puppet.features.microsoft_windows? || RUBY_PLATFORM == 'java' do
+    it "should not be acquired by another process", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       30.times do
         forks = 3
         results = LockfileSpecHelper.run_in_forks(forks) do

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -84,7 +84,7 @@ describe Puppet::Util::Log.desttypes[:file] do
       end
     end
 
-    describe "on Windows systems", :if => Puppet.features.microsoft_windows? do
+    describe "on Windows systems", :if => Puppet::Util::Platform.windows? do
       let (:abspath) { 'C:\\temp\\log.txt' }
       let (:relpath) { 'log.txt' }
 

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -328,7 +328,7 @@ describe Puppet::Util::Log do
     end
 
     it "should restrict its suitability to Windows" do
-      Puppet.features.expects(:microsoft_windows?).returns(false)
+      Puppet::Util::Platform.stubs(:windows?).returns false
 
       expect(Puppet::Util::Log::DestEventlog.suitable?('whatever')).to eq(false)
     end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Util::RunMode do
     @run_mode = Puppet::Util::RunMode.new('fake')
   end
 
-  describe Puppet::Util::UnixRunMode, :unless => Puppet.features.microsoft_windows? do
+  describe Puppet::Util::UnixRunMode, :unless => Puppet::Util::Platform.windows? do
     before do
       @run_mode = Puppet::Util::UnixRunMode.new('fake')
     end
@@ -36,7 +36,7 @@ describe Puppet::Util::RunMode do
         end
       end
 
-      it "fails when asking for the conf_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+      it "fails when asking for the conf_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
         as_non_root do
           without_home do
             expect { @run_mode.conf_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -64,7 +64,7 @@ describe Puppet::Util::RunMode do
         end
       end
 
-      it "fails when asking for the code_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+      it "fails when asking for the code_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
         as_non_root do
           without_home do
             expect { @run_mode.code_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -82,7 +82,7 @@ describe Puppet::Util::RunMode do
         as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/cache')) }
       end
 
-      it "fails when asking for the var_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+      it "fails when asking for the var_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
         as_non_root do
           without_home do
             expect { @run_mode.var_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -103,7 +103,7 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
 
-        it "fails when asking for the log_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+        it "fails when asking for the log_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
           as_non_root do
             without_home do
               expect { @run_mode.log_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -125,7 +125,7 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
         end
 
-        it "fails when asking for the run_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet.features.microsoft_windows? do
+        it "fails when asking for the run_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
           as_non_root do
             without_home do
               expect { @run_mode.run_dir }.to raise_error ArgumentError, /couldn't find HOME/
@@ -136,7 +136,7 @@ describe Puppet::Util::RunMode do
     end
   end
 
-  describe Puppet::Util::WindowsRunMode, :if => Puppet.features.microsoft_windows? do
+  describe Puppet::Util::WindowsRunMode, :if => Puppet::Util::Platform.windows? do
     before do
       if not Dir.const_defined? :COMMON_APPDATA
         Dir.const_set :COMMON_APPDATA, "/CommonFakeBase"

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Util::SELinux do
       expect(selinux_label_support?('/mnt/nfs/testfile')).to be_falsey
     end
 
-    it "(#8714) don't follow symlinks when determining file systems", :unless => Puppet.features.microsoft_windows? do
+    it "(#8714) don't follow symlinks when determining file systems", :unless => Puppet::Util::Platform.windows? do
       scratch = Pathname(PuppetSpec::Files.tmpdir('selinux'))
 
       self.stubs(:read_mounts).returns({

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -200,7 +200,7 @@ describe Puppet::Util::Storage do
       Dir.mkdir(Puppet[:statefile])
       Puppet::Util::Storage.cache(:yayness)
 
-      if Puppet.features.microsoft_windows?
+      if Puppet::Util::Platform.windows?
         expect { Puppet::Util::Storage.store }.to raise_error do |error|
           expect(error).to be_a(Puppet::Util::Windows::Error)
           expect(error.code).to eq(5) # ERROR_ACCESS_DENIED

--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Util::SUIDManager do
 
   describe "#asuser" do
     it "should not get or set euid/egid when not root" do
-      Puppet.features.stubs(:microsoft_windows?).returns(false)
+      Puppet::Util::Platform.stubs(:windows?).returns false
       Process.stubs(:uid).returns(1)
 
       Process.stubs(:egid).returns(51)
@@ -54,7 +54,7 @@ describe Puppet::Util::SUIDManager do
     context "when root and not windows" do
       before :each do
         Process.stubs(:uid).returns(0)
-        Puppet.features.stubs(:microsoft_windows?).returns(false)
+        Puppet::Util::Platform.stubs(:windows?).returns false
       end
 
       it "should set euid/egid" do
@@ -122,7 +122,7 @@ describe Puppet::Util::SUIDManager do
     end
 
     it "should not get or set euid/egid on Windows" do
-      Puppet.features.stubs(:microsoft_windows?).returns true
+      Puppet::Util::Platform.stubs(:windows?).returns false
 
       Puppet::Util::SUIDManager.asuser(user[:uid], user[:gid]) {}
 
@@ -234,7 +234,7 @@ describe Puppet::Util::SUIDManager do
     describe "on POSIX systems" do
       before :each do
         Puppet.features.stubs(:posix?).returns(true)
-        Puppet.features.stubs(:microsoft_windows?).returns(false)
+        Puppet::Util::Platform.stubs(:windows?).returns false
       end
 
       it "should be root if uid is 0" do
@@ -250,7 +250,7 @@ describe Puppet::Util::SUIDManager do
       end
     end
 
-    describe "on Microsoft Windows", :if => Puppet.features.microsoft_windows? do
+    describe "on Microsoft Windows", :if => Puppet::Util::Platform.windows? do
       it "should be root if user is privileged" do
         Puppet::Util::Windows::User.stubs(:admin?).returns true
 

--- a/spec/unit/util/windows/access_control_entry_spec.rb
+++ b/spec/unit/util/windows/access_control_entry_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::AccessControlEntry", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::AccessControlEntry", :if => Puppet::Util::Platform.windows? do
   let(:klass) { Puppet::Util::Windows::AccessControlEntry }
   let(:sid) { 'S-1-5-18' }
   let(:mask) { Puppet::Util::Windows::File::FILE_ALL_ACCESS }

--- a/spec/unit/util/windows/access_control_list_spec.rb
+++ b/spec/unit/util/windows/access_control_list_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::AccessControlList", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::AccessControlList", :if => Puppet::Util::Platform.windows? do
   let(:klass) { Puppet::Util::Windows::AccessControlList }
   let(:system_sid) { 'S-1-5-18' }
   let(:admins_sid) { 'S-1-5-544' }

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 require 'puppet/util/windows'
 
-describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? do
+describe Puppet::Util::Windows::ADSI, :if => Puppet::Util::Platform.windows? do
   let(:connection) { stub 'connection' }
   let(:builtin_localized) { Puppet::Util::Windows::SID.sid_to_name('S-1-5-32') }
   # SYSTEM is special as English can retrieve it via Windows API

--- a/spec/unit/util/windows/api_types_spec.rb
+++ b/spec/unit/util/windows/api_types_spec.rb
@@ -3,7 +3,7 @@
 
 require 'spec_helper'
 
-describe "FFI::MemoryPointer", :if => Puppet.features.microsoft_windows? do
+describe "FFI::MemoryPointer", :if => Puppet::Util::Platform.windows? do
   # use 2 bad bytes at end so we have even number of bytes / characters
   let (:bad_string) { "hello invalid world".encode(Encoding::UTF_16LE) + "\xDD\xDD".force_encoding(Encoding::UTF_16LE) }
   let (:bad_string_bytes) { bad_string.bytes.to_a }

--- a/spec/unit/util/windows/eventlog_spec.rb
+++ b/spec/unit/util/windows/eventlog_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 require 'puppet/util/windows'
 
-describe Puppet::Util::Windows::EventLog, :if => Puppet.features.microsoft_windows? do
+describe Puppet::Util::Windows::EventLog, :if => Puppet::Util::Platform.windows? do
 
   before(:each) { @event_log = Puppet::Util::Windows::EventLog.new }
   after(:each) { @event_log.close }

--- a/spec/unit/util/windows/security_descriptor_spec.rb
+++ b/spec/unit/util/windows/security_descriptor_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::SecurityDescriptor", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::SecurityDescriptor", :if => Puppet::Util::Platform.windows? do
   let(:system_sid) { Puppet::Util::Windows::SID::LocalSystem }
   let(:admins_sid) { Puppet::Util::Windows::SID::BuiltinAdministrators }
   let(:group_sid) { Puppet::Util::Windows::SID::Nobody }

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 require 'spec_helper'
 
-describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows? do
-  if Puppet.features.microsoft_windows?
+describe "Puppet::Util::Windows::SID", :if => Puppet::Util::Platform.windows? do
+  if Puppet::Util::Platform.windows?
     require 'puppet/util/windows'
   end
 

--- a/spec/unit/util/windows/string_spec.rb
+++ b/spec/unit/util/windows/string_spec.rb
@@ -4,7 +4,7 @@
 require 'spec_helper'
 require 'puppet/util/windows'
 
-describe "Puppet::Util::Windows::String", :if => Puppet.features.microsoft_windows? do
+describe "Puppet::Util::Windows::String", :if => Puppet::Util::Platform.windows? do
   UTF16_NULL = [0, 0]
 
   def wide_string(str)

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Util do
     @gte_ruby_2_4 ||= SemanticPuppet::Version.parse(RUBY_VERSION) >= SemanticPuppet::Version.parse('2.4.0')
   end
 
-  if Puppet.features.microsoft_windows?
+  if Puppet::Util::Platform.windows?
     def set_mode(mode, file)
       Puppet::Util::Windows::Security.set_mode(mode, file)
     end
@@ -30,7 +30,7 @@ describe Puppet::Util do
   end
 
   describe "#withenv" do
-    let(:mode) { Puppet.features.microsoft_windows? ? :windows : :posix }
+    let(:mode) { Puppet::Util::Platform.windows? ? :windows : :posix }
 
     before :each do
       @original_path = ENV["PATH"]
@@ -75,7 +75,7 @@ describe Puppet::Util do
     end
   end
 
-  describe "#withenv on POSIX", :unless => Puppet.features.microsoft_windows? do
+  describe "#withenv on POSIX", :unless => Puppet::Util::Platform.windows? do
     it "should preserve case" do
       # start with lower case key,
       env_key = SecureRandom.uuid.downcase
@@ -98,7 +98,7 @@ describe Puppet::Util do
     end
   end
 
-  describe "#withenv on Windows", :if => Puppet.features.microsoft_windows? do
+  describe "#withenv on Windows", :if => Puppet::Util::Platform.windows? do
 
     let(:process) { Puppet::Util::Windows::Process }
 
@@ -152,7 +152,7 @@ describe Puppet::Util do
 
     # In 2.3, the behavior is mostly correct when external codepage is 65001 / UTF-8
     it "works around Ruby bug 8822 (which fails to preserve UTF-8 properly when accessing ENV) (Ruby >= 2.3.x) ",
-      :if => Puppet.features.microsoft_windows? do
+      :if => Puppet::Util::Platform.windows? do
 
       raise 'This test requires a non-UTF8 codepage' if Encoding.default_external == Encoding::UTF_8
 
@@ -229,7 +229,7 @@ describe Puppet::Util do
       end
     end
 
-    describe "on windows", :if => Puppet.features.microsoft_windows? do
+    describe "on windows", :if => Puppet::Util::Platform.windows? do
       it "should default to the platform of the local system" do
         expect(Puppet::Util).to be_absolute_path('C:/foo')
         expect(Puppet::Util).not_to be_absolute_path('/foo')
@@ -320,7 +320,7 @@ describe Puppet::Util do
     describe "when using platform :posix" do
       before :each do
         Puppet.features.stubs(:posix).returns true
-        Puppet.features.stubs(:microsoft_windows?).returns false
+        Puppet::Util::Platform.stubs(:windows?).returns false
       end
 
       %w[/ /foo /foo/../bar].each do |path|
@@ -333,7 +333,7 @@ describe Puppet::Util do
     describe "when using platform :windows" do
       before :each do
         Puppet.features.stubs(:posix).returns false
-        Puppet.features.stubs(:microsoft_windows?).returns true
+        Puppet::Util::Platform.stubs(:windows?).returns true
       end
 
       it "should normalize backslashes" do
@@ -467,7 +467,7 @@ describe Puppet::Util do
     describe "when using platform :posix" do
       before :each do
         Puppet.features.stubs(:posix).returns true
-        Puppet.features.stubs(:microsoft_windows?).returns false
+        Puppet::Util::Platform.stubs(:windows?).returns false
       end
 
       %w[/ /foo /foo/../bar].each do |path|
@@ -506,7 +506,7 @@ describe Puppet::Util do
     describe "when using platform :windows" do
       before :each do
         Puppet.features.stubs(:posix).returns false
-        Puppet.features.stubs(:microsoft_windows?).returns true
+        Puppet::Util::Platform.stubs(:windows?).returns true
       end
 
       it "should url encode \\ as %5C, but not replace : as %3F" do
@@ -574,7 +574,7 @@ describe Puppet::Util do
       end
     end
 
-    describe "when using platform :windows", :if => Puppet.features.microsoft_windows? do
+    describe "when using platform :windows", :if => Puppet::Util::Platform.windows? do
       it "should accept root" do
         expect(Puppet::Util.uri_to_path(URI.parse('file:/C:/'))).to eq('C:/')
       end
@@ -673,7 +673,7 @@ describe Puppet::Util do
       env_path = %w[~/bin /usr/bin /bin].join(File::PATH_SEPARATOR)
 
       env = {:HOME => nil, :PATH => env_path}
-      env.merge!({:HOMEDRIVE => nil, :USERPROFILE => nil}) if Puppet.features.microsoft_windows?
+      env.merge!({:HOMEDRIVE => nil, :USERPROFILE => nil}) if Puppet::Util::Platform.windows?
 
       Puppet::Util.withenv(env) do
         Puppet::Util::Warnings.expects(:warnonce).once
@@ -699,7 +699,7 @@ describe Puppet::Util do
     describe "on POSIX systems" do
       before :each do
         Puppet.features.stubs(:posix?).returns true
-        Puppet.features.stubs(:microsoft_windows?).returns false
+        Puppet::Util::Platform.stubs(:windows?).returns false
       end
 
       it "should walk the search PATH returning the first executable" do
@@ -715,7 +715,7 @@ describe Puppet::Util do
 
       before :each do
         Puppet.features.stubs(:posix?).returns false
-        Puppet.features.stubs(:microsoft_windows?).returns true
+        Puppet::Util::Platform.stubs(:windows?).returns true
       end
 
       describe "when a file extension is specified" do
@@ -817,7 +817,7 @@ describe Puppet::Util do
     # Windows collapses the owner and group modes into a single ACE, resulting
     # in set(0600) => get(0660) and so forth. --daniel 2012-03-30
     modes = [0555, 0660, 0770]
-    modes += [0600, 0700] unless Puppet.features.microsoft_windows?
+    modes += [0600, 0700] unless Puppet::Util::Platform.windows?
     modes.each do |mode|
       it "should copy 0#{mode.to_s(8)} permissions from the target file by default" do
         set_mode(mode, target.path)
@@ -831,7 +831,7 @@ describe Puppet::Util do
       end
     end
 
-    it "should copy the permissions of the source file after yielding on Unix", :if => !Puppet.features.microsoft_windows? do
+    it "should copy the permissions of the source file after yielding on Unix", :if => !Puppet::Util::Platform.windows? do
       set_mode(0555, target.path)
       inode = Puppet::FileSystem.stat(target.path).ino
 


### PR DESCRIPTION
Puppet has two ways of defining features. One version takes a list of
libraries:

    Puppet.features.add(:myfeature, libs: 'mylib')

The libraries are lazily required when `Puppet.features.myfeature?`
is first called. If it's successful, puppet will cache the result, so
future calls to `Puppet.features.myfeature?` are a noop. If it fails,
puppet will not cache the miss, and will try to require the libraries
the next time `Puppet.features.myfeature?` is called.

The other version takes a block and is evaluated when the feature is
added, and the results are always cached, even if the require fails:

    Puppet.features.add(:myfeature) do
      require 'mylib'
    end

If a feature is defined using `:libs` and a block, then the block is
used and the `:libs` are ignored.

This commit changes the following behaviors:

 * Feature tests defined using a block are delayed until
  `Puppet.features.<name>?` is called, as is done for `:libs`.

 * If a block raises a StandardError or ScriptError exception, then the
   result is not cached, just like is done for `:libs`. Note the `:lib`
   case could only raise LoadError which is a subclass of ScriptError.

 * If a block returns nil, then the result is not cached. True and false
   return values are always cached as they were before.

This is a change in behavior for any feature whose block returns nil or
raises a ScriptError or LoadError.

Also if `Puppet[:always_retry_plugins]` is false (as it is in
puppetserver), then the result of the feature test for blocks and
libraries are always cached.