### PR TITLE
(PUP-9077) Fix problems with 3.x functions returning :undef

### DIFF
--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -203,7 +203,9 @@ module Puppet::Parser::Functions
           elsif arity < 0 and args[0].size < (arity+1).abs
             raise ArgumentError, _("%{name}(): Wrong number of arguments given (%{arg_count} for minimum %{min_arg_count})") % { name: name, arg_count: args[0].size, min_arg_count: (arity+1).abs }
           end
-          self.send(real_fname, args[0])
+          result = self.send(real_fname, args[0])
+          # Convert embedded :undef back to sane nil
+          Puppet::Pops::Evaluator::Runtime3FunctionReturnConverter.instance.convert(result, self, nil)
         else
           raise ArgumentError, _("custom functions must be called with a single array that contains the arguments. For example, function_example([1]) instead of function_example(1)")
         end

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -78,6 +78,8 @@ module Serialization
           serialization_issue(Issues::SERIALIZATION_DEFAULT_CONVERTED_TO_STRING, :path => path_to_s)
           'default'
         end
+      elsif :undef == value
+        nil
       elsif value.is_a?(Symbol)
         if @symbol_as_string
           value.to_s

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1138,15 +1138,15 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
 
       it 'does not map :undef to empty string in arrays' do
-        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0][0] }
-        expect(parser.evaluate_string(scope, "$a = {} $b = [$a[nope]] bazinga($b)", __FILE__)).to eq(:undef)
-        expect(parser.evaluate_string(scope, "bazinga([undef])", __FILE__)).to eq(:undef)
+        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0][0] == :undef }
+        expect(parser.evaluate_string(scope, "$a = {} $b = [$a[nope]] bazinga($b)", __FILE__)).to eq(true)
+        expect(parser.evaluate_string(scope, "bazinga([undef])", __FILE__)).to eq(true)
       end
 
       it 'does not map :undef to empty string in hashes' do
-        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0]['a'] }
-        expect(parser.evaluate_string(scope, "$a = {} $b = {a => $a[nope]} bazinga($b)", __FILE__)).to eq(:undef)
-        expect(parser.evaluate_string(scope, "bazinga({a => undef})", __FILE__)).to eq(:undef)
+        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0]['a'] == :undef }
+        expect(parser.evaluate_string(scope, "$a = {} $b = {a => $a[nope]} bazinga($b)", __FILE__)).to eq(true)
+        expect(parser.evaluate_string(scope, "bazinga({a => undef})", __FILE__)).to eq(true)
       end
     end
   end

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -87,6 +87,14 @@ module Serialization
       expect(val2).to eql(val)
     end
 
+    it ':undef' do
+      val = :undef
+      write(val)
+      val2 = read
+      expect(val2).to be_a(NilClass)
+      expect(val2).to eql(nil) # note :undef is not symmetrical as it produces nil
+    end
+
     it 'Regexp' do
       val = /match me/
       write(val)


### PR DESCRIPTION
Since the calling API for 3.x functions requires nil values to be
transformed to Ruby Symbol :undef such values could be returned from 3.x
functions thus causing 4.x functions to also get such values.

This is bad because :undef is a 3.x construct that should not be
exposed in Puppet's modern APIs.

This commit fixes this by rewriting all returned values from 3.x
functions - transforming any nested :undef found in Array or Hash
values. The rewrite does not replace :undef in other types of values.

In this commit, the ToDataConverter is also updated to handle
an :undef value in the rare event that it escaped from a 3.x runtime.