### PR TITLE
(maint) Bump version to 5.5.7

### DIFF
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 
 module Puppet
-  PUPPETVERSION = '5.5.6'
+  PUPPETVERSION = '5.5.7'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
Due to some late-breaking shenanigans, we ended up shipping 5.5.6
instead of 5.5.5. This has necessitated a manual version bump since we
bypassed our normal automation process here.