### PR TITLE
(PUP-5475) Refactor windows service provider to connect directly to windows API

### DIFF
--- a/acceptance/fixtures/MockService.cs
+++ b/acceptance/fixtures/MockService.cs
@@ -1,0 +1,80 @@
+/*
+
+The MockService is a C# class representing a stubbed service. We will
+compile this class into the service's .exe file.
+
+Here, we implement four methods:
+    * OnStart    -- called when SCM starts the service
+    * OnPause    -- called when SCM pauses the service
+    * OnContinue -- called when SCM resumes a paused service
+    * OnStop     -- called when SCM stops a service
+
+Before calling one of these 'On' methods, the ServiceBase class sets
+the service state to the corresponding PENDING state. The service state
+is in this PENDING state until the 'On' method is finished, whereby it is
+then transitioned into the corresponding final state. Thus if we sleep for a
+few seconds in the 'On' method, then note that SCM will report our service
+state as being in the PENDING state while we're asleep. For example, if the
+'On' method is 'OnStart', the service state is set to START_PENDING before
+calling 'OnStart', is START_PENDING while executing 'OnStart', and then is set
+to RUNNING after exiting 'OnStart'.
+
+When testing the Windows service provider, we really want to test to ensure
+that it handles the state transitions correctly. For example, we want to
+check that:
+    * It waits for the appropriate PENDING state to finish
+    * It sets the service state to the appropriate final state
+
+The reason we want to do this is because our service provider is communicating
+with SCM directly, which does not care how the service implements these
+transitions so long as it implements them. C#'s ServiceBase class implements
+these state transitions for us. Thus by going to sleep in all of our 'On' methods,
+we simulate transitioning to the corresponding PENDING state. When we wake-up
+and exit the 'On' method, we will transition to the appropriate final state.
+
+NOTE: Normally, you're supposed to have the service thread in a separate process.
+The 'On' methods in this class would send signals to the service thread and then wait
+for those signals to be processed. Sending and waiting for these signals is quite
+hard and unnecessary for our use-case, which is why our MockService does not have
+the service thread.
+
+*/
+
+using System;
+using System.ServiceProcess;
+
+public class MockService : ServiceBase {
+  public static void Main() {
+    System.ServiceProcess.ServiceBase.Run(new MockService());
+  }
+
+  public MockService() {
+    ServiceName = "%{service_name}";
+    CanStop = true;
+    CanPauseAndContinue = true;
+  }
+
+  private void Sleep(int seconds) {
+    System.Threading.Thread.Sleep(seconds * 1000);
+  }
+
+  protected override void OnStart(string [] args) {
+    RequestAdditionalTime(10000);
+    Sleep(8);
+  }
+
+  protected override void OnPause() {
+    RequestAdditionalTime(10000);
+    Sleep(8);
+  }
+
+  protected override void OnContinue() {
+    RequestAdditionalTime(10000);
+    Sleep(8);
+  }
+
+  protected override void OnStop() {
+    RequestAdditionalTime(10000);
+    Sleep(8);
+  }
+}

--- a/acceptance/fixtures/MockService.cs
+++ b/acceptance/fixtures/MockService.cs
@@ -54,27 +54,24 @@ public class MockService : ServiceBase {
     CanPauseAndContinue = true;
   }
 
-  private void Sleep(int seconds) {
+  private void StubPendingTransition(int seconds) {
+    RequestAdditionalTime(2000);
     System.Threading.Thread.Sleep(seconds * 1000);
   }
 
   protected override void OnStart(string [] args) {
-    RequestAdditionalTime(10000);
-    Sleep(%{start_sleep});
+    StubPendingTransition(%{start_sleep});
   }
 
   protected override void OnPause() {
-    RequestAdditionalTime(10000);
-    Sleep(%{pause_sleep});
+    StubPendingTransition(%{pause_sleep});
   }
 
   protected override void OnContinue() {
-    RequestAdditionalTime(10000);
-    Sleep(%{continue_sleep});
+    StubPendingTransition(%{continue_sleep});
   }
 
   protected override void OnStop() {
-    RequestAdditionalTime(10000);
-    Sleep(%{stop_sleep});
+    StubPendingTransition(%{stop_sleep});
   }
 }

--- a/acceptance/fixtures/MockService.cs
+++ b/acceptance/fixtures/MockService.cs
@@ -60,21 +60,21 @@ public class MockService : ServiceBase {
 
   protected override void OnStart(string [] args) {
     RequestAdditionalTime(10000);
-    Sleep(8);
+    Sleep(%{start_sleep});
   }
 
   protected override void OnPause() {
     RequestAdditionalTime(10000);
-    Sleep(8);
+    Sleep(%{pause_sleep});
   }
 
   protected override void OnContinue() {
     RequestAdditionalTime(10000);
-    Sleep(8);
+    Sleep(%{continue_sleep});
   }
 
   protected override void OnStop() {
     RequestAdditionalTime(10000);
-    Sleep(8);
+    Sleep(%{stop_sleep});
   }
 }

--- a/acceptance/lib/puppet/acceptance/windows_utils.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils.rb
@@ -3,6 +3,8 @@ require 'puppet/acceptance/common_utils'
 module Puppet
   module Acceptance
     module WindowsUtils
+      require 'puppet/acceptance/windows_utils/service.rb'
+
       def profile_base(agent)
         ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
         getbasedir = <<'END'

--- a/acceptance/lib/puppet/acceptance/windows_utils/service.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils/service.rb
@@ -1,0 +1,94 @@
+module Puppet
+  module Acceptance
+    module WindowsUtils
+      # Sets up a mock service on the host. The methodology here is a simplified
+      # version of what's described in https://msdn.microsoft.com/en-us/magazine/mt703436.aspx
+      def setup_service(host, config = {})
+        config[:name] ||= "Mock Service"
+        config[:display_name] ||= "#{config[:name]} (Puppet Acceptance Tests)"
+        config[:description] ||= "Service created solely for acceptance testing the Puppet Windows Service provider"
+
+        # Create a temporary directory to store the service's C# source code +
+        # its .exe file.
+        tmpdir = host.tmpdir("mock_service")
+
+        # Copy-over the C# code
+        code_fixture_path = File.join(
+          File.dirname(__FILE__),
+          '..',
+          '..',
+          '..',
+          '..',
+          'fixtures',
+          'MockService.cs'
+        )
+        code = File.read(code_fixture_path) % { service_name: config[:name] } 
+        code_path_unix = "#{tmpdir}/source.cs"
+        code_path_win = code_path_unix.gsub('/', '\\')
+        create_remote_file(host, code_path_unix, code)
+
+        # Create the service.exe file by compiling the copied over C# code
+        # with PowerShell
+        service_exe_path_win = "#{tmpdir}/#{config[:name]}.exe".gsub('/', '\\')
+        create_service_exe = "\"Add-Type"\
+          " -TypeDefinition (Get-Content #{code_path_win} | Out-String)"\
+          " -Language CSharp"\
+          " -OutputAssembly #{service_exe_path_win}"\
+          " -OutputType ConsoleApplication"\
+          " -ReferencedAssemblies 'System.ServiceProcess'\""
+        on host, powershell(create_service_exe)
+
+        # Now register the service with SCM
+        register_service_with_scm = "\"New-Service"\
+          " #{config[:name]}"\
+          " #{service_exe_path_win}"\
+          " -DisplayName '#{config[:display_name]}'"\
+          " -Description '#{config[:description]}'"\
+          " -StartupType Automatic\""
+        on host, powershell(register_service_with_scm)
+        
+        # Ensure that our service is deleted after the tests
+        teardown { delete_service(host, config[:name]) }
+      end
+
+      def delete_service(host, name)
+        # Check if our service has already been deleted. If so, then we
+        # have nothing else to do.
+        begin
+          on host, powershell("Get-Service #{name}")
+        rescue Beaker::Host::CommandFailure
+          return
+        end
+
+        # Ensure that our service process is killed. We cannot do a Stop-Service here
+        # b/c there's a chance that our service could be in a pending state (e.g.
+        # "PausePending", "ContinuePending"). If this is the case, then Stop-Service
+        # will fail.
+        on host, powershell("\"Get-Process #{name} -ErrorAction SilentlyContinue | Stop-Process -Force\" | exit 0")
+
+        # Now remove our service. We use sc.exe because older versions of PowerShell
+        # may not have the Remove-Service commandlet.
+        on agent, "sc.exe delete #{name}"
+      end
+
+      # Config should be a hash of <property> => <expected value>
+      def assert_service_properties_on(host, name, properties = {})
+        properties.each do |property, expected_value|
+          # We need to get the underlying WMI object for the service since that
+          # object contains all of our service properties. The one returned by
+          # Get-Service only has these properties for newer versions of PowerShell.
+          get_property_value = "\"Get-WmiObject -Class Win32_Service"\
+            " | Where-Object { \\$_.name -eq '#{name}' }"\
+            " | ForEach-Object { \\$_.#{property} }\""
+
+          on(host, powershell(get_property_value)) do |result|
+            actual_value = result.stdout.chomp
+
+            property_str = "#{name}[#{property}]"
+            assert_match(expected_value, actual_value, "EXPECTED: #{property_str} = #{expected_value}, ACTUAL: #{property_str} = #{actual_value}") 
+          end
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/service/windows.rb
+++ b/acceptance/tests/resource/service/windows.rb
@@ -1,0 +1,120 @@
+test_name "Windows Service Provider" do
+  confine :to, :platform => 'windows'
+
+  tag 'audit:medium',
+      'audit:acceptance'
+
+  require 'puppet/acceptance/windows_utils'
+  extend Puppet::Acceptance::WindowsUtils
+
+  def service_manifest(name, params)
+    params_str = params.map do |param, value|
+      value_str = value.to_s
+      value_str = "\"#{value_str}\"" if value.is_a?(String)
+
+      "  #{param} => #{value_str}"
+    end.join(",\n")
+
+    <<-MANIFEST
+service { '#{name}':
+  #{params_str}
+}
+MANIFEST
+  end
+
+  agents.each do |agent|
+    mock_service = "mock_service_123"
+    delete_service(agent, mock_service)
+
+    # TODO: Once non-existent service semantics have been properly enabled for
+    # Windows, these tests + the AIX non-existent service tests should be moved
+    # into a generic 'run_nonexistent_service_tests' routine. To make that move
+    # easier, we've written these tests in a more generic style.
+    #
+    # NOTE: Currently, we only run a subset of the nonexistent service tests.
+    {
+      'enabling' => { enable: true },
+      'starting' => { ensure: :running }
+    }.each do |operation, property|
+      manifest = service_manifest(mock_service, property)
+      step "Verify #{operation} a non-existent service prints an error message but does not fail the run without detailed exit codes" do
+        apply_manifest_on(agent, manifest) do |result|
+          assert_match(/#{mock_service}/, result.stderr, "non-existent service should error when started, but received #{result.stderr}")
+        end
+      end
+
+      step "Verify #{operation} a non-existent service with detailed exit codes correctly returns an error code" do
+        apply_manifest_on(agent, manifest, :acceptable_exit_codes => [4])
+      end
+    end
+
+    setup_service(agent, name: 'mock_service_123')
+
+    step 'Verify that enable = false disables the service' do
+      apply_manifest_on(agent, service_manifest(mock_service, enable: false))
+      assert_service_properties_on(agent, mock_service, StartMode: 'Disabled')
+    end
+
+    step 'Verify that enable = manual indicates that the service can be started on demand' do
+      apply_manifest_on(agent, service_manifest(mock_service, enable: :manual))
+      assert_service_properties_on(agent, mock_service, StartMode: 'Manual')
+    end
+
+    step 'Verify that enable = true indicates that the service is started automatically upon reboot' do
+      apply_manifest_on(agent, service_manifest(mock_service, enable: true))
+      assert_service_properties_on(agent, mock_service, StartMode: 'Auto')
+    end
+
+    step 'Verify that enable noops if the enable property is already synced' do
+      apply_manifest_on(agent, service_manifest(mock_service, enable: true), catch_changes: true)
+      assert_service_properties_on(agent, mock_service, StartMode: 'Auto')
+    end
+
+    step 'Verify that we can start the service' do
+      apply_manifest_on(agent, service_manifest(mock_service, ensure: :running))
+      assert_service_properties_on(agent, mock_service, State: 'Running')
+    end
+
+    step 'Verify that we can stop the service' do
+      apply_manifest_on(agent, service_manifest(mock_service, ensure: :stopped))
+      assert_service_properties_on(agent, mock_service, State: 'Stopped')
+    end
+
+    step 'Verify that ensure noops if the ensure property is already synced' do
+      apply_manifest_on(agent, service_manifest(mock_service, ensure: :stopped), catch_changes: true)
+      assert_service_properties_on(agent, mock_service, State: 'Stopped')
+    end
+
+    step 'Verify that we can query the service with the RAL' do
+      on(agent, puppet("resource service #{mock_service}")) do |result|
+        assert_match( /enable => 'true'/, result.stdout, "Failed to query the service with the RAL on #{agent}")
+      end
+    end
+
+    step 'Disable the service to prepare for our subsequent tests' do
+      apply_manifest_on(agent, service_manifest(mock_service, enable: false))
+      assert_service_properties_on(agent, mock_service, StartMode: 'Disabled')
+    end
+
+    step 'Verify that starting a disabled service fails if the enable property is not managed' do
+      apply_manifest_on(agent, service_manifest(mock_service, ensure: :running)) do |result|
+        assert_match(/#{mock_service}/, result.stderr, 'Windows service provider is able to start a disabled service without managing the enable property')
+      end
+    end
+
+    step 'Verify that enable = false, ensure = running leaves the service disabled and in the running state' do
+      apply_manifest_on(agent, service_manifest(mock_service, enable: false, ensure: :running))
+      assert_service_properties_on(agent, mock_service, StartMode: 'Disabled', State: 'Running')
+    end
+
+    step 'Stop the service to prepare for our subsequent tests' do
+      apply_manifest_on(agent, service_manifest(mock_service, ensure: :stopped))
+      assert_service_properties_on(agent, mock_service, State: 'Stopped')
+    end
+
+    step 'Verify that enable = true, ensure = running leaves the service enabled and in the running state' do
+      apply_manifest_on(agent, service_manifest(mock_service, enable: true, ensure: :running))
+      assert_service_properties_on(agent, mock_service, StartMode: 'Auto', State: 'Running')
+    end
+  end
+end

--- a/acceptance/tests/resource/service/windows.rb
+++ b/acceptance/tests/resource/service/windows.rb
@@ -21,10 +21,39 @@ service { '#{name}':
 }
 MANIFEST
   end
+  mock_service_nofail = {
+    :name => "mock_service_nofail",
+    :start_sleep => 0,
+    :pause_sleep => 0,
+    :continue_sleep => 0,
+    :stop_sleep => 0,
+  }
+
+  # The wait hint we provide in MockService.cs is
+  # 10 seconds, having the service sleep for 20
+  # will supply the failure scenario on a failed
+  # startup
+  mock_service_startfail = {
+    :name => "mock_service_startfail",
+    :start_sleep => 20,
+    :pause_sleep => 0,
+    :continue_sleep => 0,
+    :stop_sleep => 0,
+  }
+  # The wait hint we provide in MockService.cs is
+  # 10 seconds, having the service sleep for 20
+  # will supply the failure scenario on a failed
+  # shutdown
+  mock_service_stopfail = {
+    :name => "mock_service_stopfail",
+    :start_sleep => 0,
+    :pause_sleep => 0,
+    :continue_sleep => 0,
+    :stop_sleep => 20,
+  }
 
   agents.each do |agent|
-    mock_service = "mock_service_123"
-    delete_service(agent, mock_service)
+    delete_service(agent, mock_service_nofail[:name])
 
     # TODO: Once non-existent service semantics have been properly enabled for
     # Windows, these tests + the AIX non-existent service tests should be moved
@@ -36,10 +65,10 @@ MANIFEST
       'enabling' => { enable: true },
       'starting' => { ensure: :running }
     }.each do |operation, property|
-      manifest = service_manifest(mock_service, property)
+      manifest = service_manifest(mock_service_nofail[:name], property)
       step "Verify #{operation} a non-existent service prints an error message but does not fail the run without detailed exit codes" do
         apply_manifest_on(agent, manifest) do |result|
-          assert_match(/#{mock_service}/, result.stderr, "non-existent service should error when started, but received #{result.stderr}")
+          assert_match(/#{mock_service_nofail[:name]}/, result.stderr, "non-existent service should error when started, but received #{result.stderr}")
         end
       end
 
@@ -48,73 +77,102 @@ MANIFEST
       end
     end
 
-    setup_service(agent, name: 'mock_service_123')
+    setup_service(agent, mock_service_nofail, 'MockService.cs')
 
     step 'Verify that enable = false disables the service' do
-      apply_manifest_on(agent, service_manifest(mock_service, enable: false))
-      assert_service_properties_on(agent, mock_service, StartMode: 'Disabled')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], enable: false))
+      assert_service_properties_on(agent, mock_service_nofail[:name], StartMode: 'Disabled')
     end
 
     step 'Verify that enable = manual indicates that the service can be started on demand' do
-      apply_manifest_on(agent, service_manifest(mock_service, enable: :manual))
-      assert_service_properties_on(agent, mock_service, StartMode: 'Manual')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], enable: :manual))
+      assert_service_properties_on(agent, mock_service_nofail[:name], StartMode: 'Manual')
     end
 
     step 'Verify that enable = true indicates that the service is started automatically upon reboot' do
-      apply_manifest_on(agent, service_manifest(mock_service, enable: true))
-      assert_service_properties_on(agent, mock_service, StartMode: 'Auto')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], enable: true))
+      assert_service_properties_on(agent, mock_service_nofail[:name], StartMode: 'Auto')
     end
 
     step 'Verify that enable noops if the enable property is already synced' do
-      apply_manifest_on(agent, service_manifest(mock_service, enable: true), catch_changes: true)
-      assert_service_properties_on(agent, mock_service, StartMode: 'Auto')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], enable: true), catch_changes: true)
+      assert_service_properties_on(agent, mock_service_nofail[:name], StartMode: 'Auto')
     end
 
     step 'Verify that we can start the service' do
-      apply_manifest_on(agent, service_manifest(mock_service, ensure: :running))
-      assert_service_properties_on(agent, mock_service, State: 'Running')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], ensure: :running))
+      assert_service_properties_on(agent, mock_service_nofail[:name], State: 'Running')
     end
 
     step 'Verify that we can stop the service' do
-      apply_manifest_on(agent, service_manifest(mock_service, ensure: :stopped))
-      assert_service_properties_on(agent, mock_service, State: 'Stopped')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], ensure: :stopped))
+      assert_service_properties_on(agent, mock_service_nofail[:name], State: 'Stopped')
     end
 
     step 'Verify that ensure noops if the ensure property is already synced' do
-      apply_manifest_on(agent, service_manifest(mock_service, ensure: :stopped), catch_changes: true)
-      assert_service_properties_on(agent, mock_service, State: 'Stopped')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], ensure: :stopped), catch_changes: true)
+      assert_service_properties_on(agent, mock_service_nofail[:name], State: 'Stopped')
     end
 
     step 'Verify that we can query the service with the RAL' do
-      on(agent, puppet("resource service #{mock_service}")) do |result|
+      on(agent, puppet("resource service #{mock_service_nofail[:name]}")) do |result|
         assert_match( /enable => 'true'/, result.stdout, "Failed to query the service with the RAL on #{agent}")
       end
     end
 
     step 'Disable the service to prepare for our subsequent tests' do
-      apply_manifest_on(agent, service_manifest(mock_service, enable: false))
-      assert_service_properties_on(agent, mock_service, StartMode: 'Disabled')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], enable: false))
+      assert_service_properties_on(agent, mock_service_nofail[:name], StartMode: 'Disabled')
     end
 
     step 'Verify that starting a disabled service fails if the enable property is not managed' do
-      apply_manifest_on(agent, service_manifest(mock_service, ensure: :running)) do |result|
-        assert_match(/#{mock_service}/, result.stderr, 'Windows service provider is able to start a disabled service without managing the enable property')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], ensure: :running)) do |result|
+        assert_match(/#{mock_service_nofail[:name]}/, result.stderr, 'Windows service provider is able to start a disabled service without managing the enable property')
       end
     end
 
     step 'Verify that enable = false, ensure = running leaves the service disabled and in the running state' do
-      apply_manifest_on(agent, service_manifest(mock_service, enable: false, ensure: :running))
-      assert_service_properties_on(agent, mock_service, StartMode: 'Disabled', State: 'Running')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], enable: false, ensure: :running))
+      assert_service_properties_on(agent, mock_service_nofail[:name], StartMode: 'Disabled', State: 'Running')
     end
 
     step 'Stop the service to prepare for our subsequent tests' do
-      apply_manifest_on(agent, service_manifest(mock_service, ensure: :stopped))
-      assert_service_properties_on(agent, mock_service, State: 'Stopped')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], ensure: :stopped))
+      assert_service_properties_on(agent, mock_service_nofail[:name], State: 'Stopped')
     end
 
     step 'Verify that enable = true, ensure = running leaves the service enabled and in the running state' do
-      apply_manifest_on(agent, service_manifest(mock_service, enable: true, ensure: :running))
-      assert_service_properties_on(agent, mock_service, StartMode: 'Auto', State: 'Running')
+      apply_manifest_on(agent, service_manifest(mock_service_nofail[:name], enable: true, ensure: :running))
+      assert_service_properties_on(agent, mock_service_nofail[:name], StartMode: 'Auto', State: 'Running')
     end
+
+    # delete the service so it doesn't interfere with subsequent tests
+    delete_service(agent, mock_service_nofail[:name])
+
+    setup_service(agent, mock_service_startfail, 'MockService.cs')
+
+    step 'Verify that starting a service fails if the service does not start by the expiration of the wait hint' do
+      apply_manifest_on(agent, service_manifest(mock_service_startfail[:name], ensure: :running)) do |result|
+        assert_match(/#{mock_service_startfail[:name]}/, result.stderr, 'No progress made on service operation and dwWaitHint exceeded')
+      end
+    end
+
+    # delete the service so it doesn't interfere with subsequent tests
+    delete_service(agent, mock_service_startfail[:name])
+
+    setup_service(agent, mock_service_stopfail, 'MockService.cs')
+
+    step 'Start the Service to prepare for subsequent test' do
+      apply_manifest_on(agent, service_manifest(mock_service_stopfail[:name], enable: true, ensure: :running))
+    end
+
+    step 'Verify that stopping a service fails if the service does not stop by the expiration of the wait hint' do
+      apply_manifest_on(agent, service_manifest(mock_service_stopfail[:name], ensure: :stopped)) do |result|
+        assert_match(/#{mock_service_stopfail[:name]}/, result.stderr, 'No progress made on service operation and dwWaitHint exceeded')
+      end
+    end
+
+    # delete the service so it doesn't interfere with subsequent tests
+    delete_service(agent, mock_service_stopfail[:name])
   end
 end

--- a/acceptance/tests/resource/service/windows_mixed_utf8.rb
+++ b/acceptance/tests/resource/service/windows_mixed_utf8.rb
@@ -1,0 +1,73 @@
+test_name "Windows Service Provider With Mixed UTF-8 Service Names" do
+  confine :to, :platform => 'windows'
+
+  tag 'audit:medium',
+      'audit:acceptance'
+
+  require 'puppet/acceptance/windows_utils'
+  extend Puppet::Acceptance::WindowsUtils
+
+  def service_manifest(name, params)
+    params_str = params.map do |param, value|
+      value_str = value.to_s
+      value_str = "\"#{value_str}\"" if value.is_a?(String)
+
+      "  #{param} => #{value_str}"
+    end.join(",\n")
+
+    <<-MANIFEST
+service { '#{name}':
+  #{params_str}
+}
+MANIFEST
+  end
+
+  [
+    # different UTF-8 widths
+    # 1-byte A
+    # 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+    # 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+    # 4-byte ܎ - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+    {
+      :name => "A\u06FF\u16A0\u{2070E}",
+      :start_sleep => 0,
+      :pause_sleep => 0,
+      :continue_sleep => 0,
+      :stop_sleep => 0,
+    }
+  ].each do |mock_service|
+    agents.each do |agent|
+      setup_service(agent, mock_service, 'MockService.cs')
+
+      step 'Verify that enable = false disables the service' do
+        apply_manifest_on(agent, service_manifest(mock_service[:name], enable: false))
+        assert_service_properties_on(agent, mock_service[:name], StartMode: 'Disabled')
+      end
+
+      step 'Verify that enable = manual indicates that the service can be started on demand' do
+        apply_manifest_on(agent, service_manifest(mock_service[:name], enable: :manual))
+        assert_service_properties_on(agent, mock_service[:name], StartMode: 'Manual')
+      end
+
+      step 'Verify that enable = true indicates that the service is started automatically upon reboot' do
+        apply_manifest_on(agent, service_manifest(mock_service[:name], enable: true))
+        assert_service_properties_on(agent, mock_service[:name], StartMode: 'Auto')
+      end
+
+      step 'Verify that we can start the service' do
+        apply_manifest_on(agent, service_manifest(mock_service[:name], ensure: :running))
+        assert_service_properties_on(agent, mock_service[:name], State: 'Running')
+      end
+
+      step 'Verify idempotence' do
+        apply_manifest_on(agent, service_manifest(mock_service[:name], ensure: :running))
+        assert_service_properties_on(agent, mock_service[:name], State: 'Running')
+      end
+
+      step 'Verify that we can stop the service' do
+        apply_manifest_on(agent, service_manifest(mock_service[:name], ensure: :stopped))
+        assert_service_properties_on(agent, mock_service[:name], State: 'Stopped')
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -16,54 +16,48 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
 
   has_feature :refreshable
 
-  commands :net => 'net.exe'
-
   def enable
-    w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_AUTO_START )
-    raise Puppet::Error.new("Win32 service enable of #{@resource[:name]} failed" ) if( w32ss.nil? )
+    Puppet::Util::Windows::Service.set_startup_mode( @resource[:name], :SERVICE_AUTO_START )
   rescue => detail
-    raise Puppet::Error.new("Cannot enable #{@resource[:name]}, error was: #{detail}", detail )
+    raise Puppet::Error.new(_("Cannot enable %{resource_name}, error was: %{detail}") % { resource_name: @resource[:name], detail: detail }, detail )
   end
 
   def disable
-    w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_DISABLED )
-    raise Puppet::Error.new("Win32 service disable of #{@resource[:name]} failed" ) if( w32ss.nil? )
+    Puppet::Util::Windows::Service.set_startup_mode( @resource[:name], :SERVICE_DISABLED )
   rescue => detail
-    raise Puppet::Error.new("Cannot disable #{@resource[:name]}, error was: #{detail}", detail )
+    raise Puppet::Error.new(_("Cannot disable %{resource_name}, error was: %{detail}") % { resource_name: @resource[:name], detail: detail }, detail )
   end
 
   def manual_start
-    w32ss = Win32::Service.configure( 'service_name' => @resource[:name], 'start_type' => Win32::Service::SERVICE_DEMAND_START )
-    raise Puppet::Error.new("Win32 service manual enable of #{@resource[:name]} failed" ) if( w32ss.nil? )
+    Puppet::Util::Windows::Service.set_startup_mode( @resource[:name], :SERVICE_DEMAND_START )
   rescue => detail
-    raise Puppet::Error.new("Cannot enable #{@resource[:name]} for manual start, error was: #{detail}", detail )
+    raise Puppet::Error.new(_("Cannot enable %{resource_name} for manual start, error was: %{detail}") % { resource_name: @resource[:name], detail: detail }, detail )
   end
 
   def enabled?
-    w32ss = Win32::Service.config_info( @resource[:name] )
-    raise Puppet::Error.new("Win32 service query of #{@resource[:name]} failed" ) unless( !w32ss.nil? && w32ss.instance_of?( Struct::ServiceConfigInfo ) )
-    debug("Service #{@resource[:name]} start type is #{w32ss.start_type}")
-    case w32ss.start_type
-      when Win32::Service.get_start_type(Win32::Service::SERVICE_AUTO_START),
-           Win32::Service.get_start_type(Win32::Service::SERVICE_BOOT_START),
-           Win32::Service.get_start_type(Win32::Service::SERVICE_SYSTEM_START)
+    start_type = Puppet::Util::Windows::Service.service_start_type(@resource[:name])
+    debug("Service #{@resource[:name]} start type is #{start_type}")
+    case start_type
+      when :SERVICE_AUTO_START,
+           :SERVICE_BOOT_START,
+           :SERVICE_SYSTEM_START
         :true
-      when Win32::Service.get_start_type(Win32::Service::SERVICE_DEMAND_START)
+      when :SERVICE_DEMAND_START
         :manual
-      when Win32::Service.get_start_type(Win32::Service::SERVICE_DISABLED)
+      when :SERVICE_DISABLED
         :false
       else
-        raise Puppet::Error.new("Unknown start type: #{w32ss.start_type}")
+        raise Puppet::Error.new(_("Unknown start type: %{start_type}") % { start_type: start_type })
     end
   rescue => detail
-    raise Puppet::Error.new("Cannot get start type for #{@resource[:name]}, error was: #{detail}", detail )
+    raise Puppet::Error.new(_("Cannot get start type %{resource_name}, error was: %{detail}") % { resource_name: @resource[:name], detail: detail }, detail )
   end
 
   def start
     if enabled? == :false
       # If disabled and not managing enable, respect disabled and fail.
       if @resource[:enable].nil?
-        raise Puppet::Error, "Will not start disabled service #{@resource[:name]} without managing enable. Specify 'enable => false' to override."
+        raise Puppet::Error.new(_("Will not start disabled service %{resource_name} without managing enable. Specify 'enable => false' to override.") % { resource_name: @resource[:name] })
       # Otherwise start. If enable => false, we will later sync enable and
       # disable the service again.
       elsif @resource[:enable] == :true
@@ -72,35 +66,38 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
         manual_start
       end
     end
-
-    net(:start, @resource[:name])
-  rescue Puppet::ExecutionFailure => detail
-    raise Puppet::Error.new("Cannot start #{@resource[:name]}, error was: #{detail}", detail )
+    Puppet::Util::Windows::Service.start(@resource[:name])
   end
 
   def stop
-    net(:stop, @resource[:name])
-  rescue Puppet::ExecutionFailure => detail
-    raise Puppet::Error.new("Cannot stop #{@resource[:name]}, error was: #{detail}", detail )
+    Puppet::Util::Windows::Service.stop(@resource[:name])
   end
 
   def status
-    w32ss = Win32::Service.status( @resource[:name] )
-    raise Puppet::Error.new("Win32 service query of #{@resource[:name]} failed" ) unless( !w32ss.nil? && w32ss.instance_of?( Struct::ServiceStatus ) )
-    state = case w32ss.current_state
-      when "stopped", "pause pending", "stop pending", "paused" then :stopped
-      when "running", "continue pending", "start pending"       then :running
+    current_state = Puppet::Util::Windows::Service.service_state(@resource[:name])
+    state = case current_state
+      when :SERVICE_STOPPED,
+           :SERVICE_PAUSED,
+           :SERVICE_STOP_PENDING,
+           :SERVICE_PAUSE_PENDING
+        :stopped
+      when :SERVICE_RUNNING,
+           :SERVICE_CONTINUE_PENDING,
+           :SERVICE_START_PENDING
+        :running
       else
-        raise Puppet::Error.new("Unknown service state '#{w32ss.current_state}' for service '#{@resource[:name]}'")
+        raise Puppet::Error.new(_("Unknown service state '%{current_state}' for service '%{resource_name}'") % { current_state: current_state, resource_name: @resource[:name] })
     end
-    debug("Service #{@resource[:name]} is #{w32ss.current_state}")
+    debug("Service #{@resource[:name]} is #{current_state}")
     return state
-  rescue => detail
-    raise Puppet::Error.new("Cannot get status of #{@resource[:name]}, error was: #{detail}", detail )
   end
 
   # returns all providers for all existing services and startup state
   def self.instances
-    Win32::Service.services.collect { |s| new(:name => s.service_name) }
+    services = []
+    Puppet::Util::Windows::Service.services.each do |service_name, _|
+      services.push(new(:name => service_name))
+    end
+    services
   end
 end

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -32,5 +32,6 @@ module Puppet::Util::Windows
     require 'puppet/util/windows/adsi'
     require 'puppet/util/windows/registry'
     require 'puppet/util/windows/eventlog'
+    require 'puppet/util/windows/service'
   end
 end

--- a/lib/puppet/util/windows/service.rb
+++ b/lib/puppet/util/windows/service.rb
@@ -1,0 +1,754 @@
+require 'puppet/util/windows'
+require 'ffi'
+
+module Puppet::Util::Windows
+  # This module is designed to provide an API between the windows system and puppet for
+  # service management.
+  #
+  # for an overview of the service state transitions see: https://docs.microsoft.com/en-us/windows/desktop/Services/service-status-transitions
+  module Service
+    extend FFI::Library
+    extend Puppet::Util::Windows::String
+
+    FILE = Puppet::Util::Windows::File
+    # Service control codes
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-controlserviceexw
+    SERVICE_CONTROL_STOP                  = 0x00000001
+    SERVICE_CONTROL_PAUSE                 = 0x00000002
+    SERVICE_CONTROL_CONTINUE              = 0x00000003
+    SERVICE_CONTROL_INTERROGATE           = 0x00000004
+    SERVICE_CONTROL_SHUTDOWN              = 0x00000005
+    SERVICE_CONTROL_PARAMCHANGE           = 0x00000006
+    SERVICE_CONTROL_NETBINDADD            = 0x00000007
+    SERVICE_CONTROL_NETBINDREMOVE         = 0x00000008
+    SERVICE_CONTROL_NETBINDENABLE         = 0x00000009
+    SERVICE_CONTROL_NETBINDDISABLE        = 0x0000000A
+    SERVICE_CONTROL_DEVICEEVENT           = 0x0000000B
+    SERVICE_CONTROL_HARDWAREPROFILECHANGE = 0x0000000C
+    SERVICE_CONTROL_POWEREVENT            = 0x0000000D
+    SERVICE_CONTROL_SESSIONCHANGE         = 0x0000000E
+    SERVICE_CONTROL_PRESHUTDOWN           = 0x0000000F
+    SERVICE_CONTROL_TIMECHANGE            = 0x00000010
+    SERVICE_CONTROL_TRIGGEREVENT          = 0x00000020
+
+    # Service start type codes
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-changeserviceconfigw
+    SERVICE_AUTO_START = 0x00000002
+    SERVICE_BOOT_START = 0x00000000
+    SERVICE_DEMAND_START = 0x00000003
+    SERVICE_DISABLED = 0x00000004
+    SERVICE_SYSTEM_START = 0x00000001
+    SERVICE_START_TYPES = {
+      SERVICE_AUTO_START => :SERVICE_AUTO_START,
+      SERVICE_BOOT_START => :SERVICE_BOOT_START,
+      SERVICE_DEMAND_START => :SERVICE_DEMAND_START,
+      SERVICE_DISABLED => :SERVICE_DISABLED,
+      SERVICE_SYSTEM_START => :SERVICE_SYSTEM_START,
+    }
+
+    # Service type codes
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-changeserviceconfigw
+    SERVICE_FILE_SYSTEM_DRIVER  = 0x00000002
+    SERVICE_KERNEL_DRIVER       = 0x00000001
+    SERVICE_WIN32_OWN_PROCESS   = 0x00000010
+    SERVICE_WIN32_SHARE_PROCESS = 0x00000020
+    SERVICE_USER_OWN_PROCESS    = 0x00000050
+    SERVICE_USER_SHARE_PROCESS  = 0x00000060
+    # Available only if service is also SERVICE_WIN32_OWN_PROCESS or SERVICE_WIN32_SHARE_PROCESS
+    SERVICE_INTERACTIVE_PROCESS = 0x00000100
+    ALL_SERVICE_TYPES =
+      SERVICE_FILE_SYSTEM_DRIVER |
+      SERVICE_KERNEL_DRIVER |
+      SERVICE_WIN32_OWN_PROCESS |
+      SERVICE_WIN32_SHARE_PROCESS
+
+    # Current state codes
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_service_status_process
+    SERVICE_CONTINUE_PENDING = 0x00000005
+    SERVICE_PAUSE_PENDING    = 0x00000006
+    SERVICE_PAUSED           = 0x00000007
+    SERVICE_RUNNING          = 0x00000004
+    SERVICE_START_PENDING    = 0x00000002
+    SERVICE_STOP_PENDING     = 0x00000003
+    SERVICE_STOPPED          = 0x00000001
+    SERVICE_STATES = {
+      SERVICE_CONTINUE_PENDING => :SERVICE_CONTINUE_PENDING,
+      SERVICE_PAUSE_PENDING => :SERVICE_PAUSE_PENDING,
+      SERVICE_PAUSED => :SERVICE_PAUSED,
+      SERVICE_RUNNING => :SERVICE_RUNNING,
+      SERVICE_START_PENDING => :SERVICE_START_PENDING,
+      SERVICE_STOP_PENDING => :SERVICE_STOP_PENDING,
+      SERVICE_STOPPED => :SERVICE_STOPPED,
+    }
+
+    # Service accepts control codes
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_service_status_process
+    SERVICE_ACCEPT_STOP                  = 0x00000001
+    SERVICE_ACCEPT_PAUSE_CONTINUE        = 0x00000002
+    SERVICE_ACCEPT_SHUTDOWN              = 0x00000004
+    SERVICE_ACCEPT_PARAMCHANGE           = 0x00000008
+    SERVICE_ACCEPT_NETBINDCHANGE         = 0x00000010
+    SERVICE_ACCEPT_HARDWAREPROFILECHANGE = 0x00000020
+    SERVICE_ACCEPT_POWEREVENT            = 0x00000040
+    SERVICE_ACCEPT_SESSIONCHANGE         = 0x00000080
+    SERVICE_ACCEPT_PRESHUTDOWN           = 0x00000100
+    SERVICE_ACCEPT_TIMECHANGE            = 0x00000200
+    SERVICE_ACCEPT_TRIGGEREVENT          = 0x00000400
+    SERVICE_ACCEPT_USER_LOGOFF           = 0x00000800
+
+    # Service manager access codes
+    # https://docs.microsoft.com/en-us/windows/desktop/Services/service-security-and-access-rights
+    SC_MANAGER_CREATE_SERVICE     = 0x00000002
+    SC_MANAGER_CONNECT            = 0x00000001
+    SC_MANAGER_ENUMERATE_SERVICE  = 0x00000004
+    SC_MANAGER_LOCK               = 0x00000008
+    SC_MANAGER_MODIFY_BOOT_CONFIG = 0x00000020
+    SC_MANAGER_QUERY_LOCK_STATUS  = 0x00000010
+    SC_MANAGER_ALL_ACCESS         =
+      FILE::STANDARD_RIGHTS_REQUIRED |
+      SC_MANAGER_CREATE_SERVICE      |
+      SC_MANAGER_CONNECT             |
+      SC_MANAGER_ENUMERATE_SERVICE   |
+      SC_MANAGER_LOCK                |
+      SC_MANAGER_MODIFY_BOOT_CONFIG  |
+      SC_MANAGER_QUERY_LOCK_STATUS
+
+
+    # Service access codes
+    # https://docs.microsoft.com/en-us/windows/desktop/Services/service-security-and-access-rights
+    SERVICE_CHANGE_CONFIG        = 0x0002
+    SERVICE_ENUMERATE_DEPENDENTS = 0x0008
+    SERVICE_INTERROGATE          = 0x0080
+    SERVICE_PAUSE_CONTINUE       = 0x0040
+    SERVICE_QUERY_STATUS         = 0x0004
+    SERVICE_QUERY_CONFIG         = 0x0001
+    SERVICE_START                = 0x0010
+    SERVICE_STOP                 = 0x0020
+    SERVICE_USER_DEFINED_CONTROL = 0x0100
+    SERVICE_ALL_ACCESS           =
+      FILE::STANDARD_RIGHTS_REQUIRED |
+      SERVICE_CHANGE_CONFIG          |
+      SERVICE_ENUMERATE_DEPENDENTS   |
+      SERVICE_INTERROGATE            |
+      SERVICE_PAUSE_CONTINUE         |
+      SERVICE_QUERY_STATUS           |
+      SERVICE_QUERY_CONFIG           |
+      SERVICE_START                  |
+      SERVICE_STOP                   |
+      SERVICE_USER_DEFINED_CONTROL
+
+    # Service config codes
+    # From the windows 10 SDK:
+    # //
+    # // Value to indicate no change to an optional parameter
+    # //
+    # #define SERVICE_NO_CHANGE              0xffffffff
+    SERVICE_NO_CHANGE = 0xffffffff
+
+    # Service enum codes
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/nf-winsvc-enumservicesstatusexa
+    SERVICE_ACTIVE = 0x00000001
+    SERVICE_INACTIVE = 0x00000002
+    SERVICE_STATE_ALL =
+      SERVICE_ACTIVE |
+      SERVICE_INACTIVE
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_enum_service_status_processw
+    SERVICENAME_MAX = 256
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_service_status_process
+    # typedef struct _SERVICE_STATUS_PROCESS {
+    #   DWORD dwServiceType;
+    #   DWORD dwCurrentState;
+    #   DWORD dwControlsAccepted;
+    #   DWORD dwWin32ExitCode;
+    #   DWORD dwServiceSpecificExitCode;
+    #   DWORD dwCheckPoint;
+    #   DWORD dwWaitHint;
+    #   DWORD dwProcessId;
+    #   DWORD dwServiceFlags;
+    # } SERVICE_STATUS_PROCESS, *LPSERVICE_STATUS_PROCESS;
+    class SERVICE_STATUS_PROCESS < FFI::Struct
+      layout(
+        :dwServiceType, :dword,
+        :dwCurrentState, :dword,
+        :dwControlsAccepted, :dword,
+        :dwWin32ExitCode, :dword,
+        :dwServiceSpecificExitCode, :dword,
+        :dwCheckPoint, :dword,
+        :dwWaitHint, :dword,
+        :dwProcessId, :dword,
+        :dwServiceFlags, :dword
+      )
+    end
+
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_enum_service_status_processw
+    # typedef struct _ENUM_SERVICE_STATUS_PROCESSW {
+    #   LPWSTR                 lpServiceName;
+    #   LPWSTR                 lpDisplayName;
+    #   SERVICE_STATUS_PROCESS ServiceStatusProcess;
+    # } ENUM_SERVICE_STATUS_PROCESSW, *LPENUM_SERVICE_STATUS_PROCESSW;
+    class ENUM_SERVICE_STATUS_PROCESSW < FFI::Struct
+      layout(
+        :lpServiceName, :pointer,
+        :lpDisplayName, :pointer,
+        :ServiceStatusProcess, SERVICE_STATUS_PROCESS
+      )
+    end
+
+    # typedef struct _SERVICE_STATUS {
+    #   DWORD dwServiceType;
+    #   DWORD dwCurrentState;
+    #   DWORD dwControlsAccepted;
+    #   DWORD dwWin32ExitCode;
+    #   DWORD dwServiceSpecificExitCode;
+    #   DWORD dwCheckPoint;
+    #   DWORD dwWaitHint;
+    # } SERVICE_STATUS, *LPSERVICE_STATUS;
+    class SERVICE_STATUS < FFI::Struct
+      layout(
+        :dwServiceType, :dword,
+        :dwCurrentState, :dword,
+        :dwControlsAccepted, :dword,
+        :dwWin32ExitCode, :dword,
+        :dwServiceSpecificExitCode, :dword,
+        :dwCheckPoint, :dword,
+        :dwWaitHint, :dword,
+      )
+    end
+
+    # typedef struct _QUERY_SERVICE_CONFIGW {
+    #   DWORD  dwServiceType;
+    #   DWORD  dwStartType;
+    #   DWORD  dwErrorControl;
+    #   LPWSTR lpBinaryPathName;
+    #   LPWSTR lpLoadOrderGroup;
+    #   DWORD  dwTagId;
+    #   LPWSTR lpDependencies;
+    #   LPWSTR lpServiceStartName;
+    #   LPWSTR lpDisplayName;
+    # } QUERY_SERVICE_CONFIGW, *LPQUERY_SERVICE_CONFIGW;
+    class QUERY_SERVICE_CONFIGW < FFI::Struct
+      layout(
+        :dwServiceType, :dword,
+        :dwStartType, :dword,
+        :dwErrorControl, :dword,
+        :lpBinaryPathName, :pointer,
+        :lpLoadOrderGroup, :pointer,
+        :dwTagId, :dword,
+        :lpDependencies, :pointer,
+        :lpServiceStartName, :pointer,
+        :lpDisplayName, :pointer,
+      )
+    end
+
+    # Start a windows service, assume that the service is already in the stopped state
+    #
+    # @param [:string] service_name name of the service to start
+    def start(service_name)
+      open_service(service_name, SC_MANAGER_CONNECT, SERVICE_START | SERVICE_QUERY_STATUS) do |service|
+        # don't attempt to fail here if the service isn't stopped because windows error codes
+        # are likely more informative than ours and a failed call to StartServiceW will produce
+        # those errors
+        wait_for_pending_transition(service, SERVICE_STOP_PENDING, SERVICE_STOPPED)
+        if StartServiceW(service, 0, FFI::Pointer::NULL) == FFI::WIN32_FALSE
+          raise Puppet::Util::Windows::Error.new(_("Failed to start the service"))
+        end
+        unless wait_for_pending_transition(service, SERVICE_START_PENDING, SERVICE_RUNNING)
+          raise Puppet::Error.new(_("Failed to start the service, after calling StartService the service is not in SERVICE_START_PENDING or SERVICE_RUNNING"))
+        end
+      end
+    end
+    module_function :start
+
+    # Use ControlService to send a stop signal to a windows service
+    #
+    # @param [:string] service_name name of the service to stop
+    def stop(service_name)
+      open_service(service_name, SC_MANAGER_CONNECT, SERVICE_STOP | SERVICE_QUERY_STATUS) do |service|
+        FFI::MemoryPointer.new(SERVICE_STATUS.size) do |status_ptr|
+          status = SERVICE_STATUS.new(status_ptr)
+          # don't attempt to fail here if the service isn't started because windows error codes
+          # are likely more informative than ours and a failed call to ControlService will produce
+          # those errors
+          wait_for_pending_transition(service, SERVICE_START_PENDING, SERVICE_RUNNING)
+          if ControlService(service, SERVICE_CONTROL_STOP, status) == FFI::WIN32_FALSE
+            raise Puppet::Util::Windows::Error.new(_("Failed to send stop control to service, current state is %{current_state}. Failed with") % { current_state: status[:dwCurrentState].to_s })
+          end
+          unless wait_for_pending_transition(service, SERVICE_STOP_PENDING, SERVICE_STOPPED)
+            raise Puppet::Error.new(_("Failed to stop the service, after calling ControlService the service is not in SERVICE_STOP_PENDING or SERVICE_STOPPED"))
+          end
+        end
+      end
+    end
+    module_function :stop
+
+    # Query the state of a service using QueryServiceStatusEx
+    #
+    # @param [:string] service_name name of the service to query
+    # @return [string] the status of the service
+    def service_state(service_name)
+      status = nil
+      open_service(service_name, SC_MANAGER_CONNECT, SERVICE_QUERY_STATUS) do |service|
+        status = query_status(service)
+      end
+      state = SERVICE_STATES[status[:dwCurrentState]]
+      if state.nil?
+        raise Puppet::Error.new(_("Unknown Service state '%{current_state}' for '%{service_name}'") % { current_state: status[:dwCurrentState].to_s, service_name: service_name})
+      end
+      state
+    end
+    module_function :service_state
+
+    # Query the configuration of a service using QueryServiceConfigW
+    #
+    # @param [:string] service_name name of the service to query
+    # @return [QUERY_SERVICE_CONFIGW.struct] the configuration of the service
+    def service_start_type(service_name)
+      config = nil
+      open_service(service_name, SC_MANAGER_CONNECT, SERVICE_QUERY_CONFIG) do |service|
+        config = query_config(service)
+      end
+      start_type = SERVICE_START_TYPES[config[:dwStartType]]
+      if start_type.nil?
+        raise Puppet::Error.new(_("Unknown start type '%{start_type}' for '%{service_name}'") % { start_type: config[:dwStartType].to_s, service_name: service_name})
+      end
+      start_type
+    end
+    module_function :service_start_type
+
+    # Change the startup mode of a windows service
+    #
+    # @param [string] service_name the name of the service to modify
+    # @param [Int] startup_type a code corresponding to a start type for
+    #  windows service, see the "Service start type codes" section in the
+    #  Puppet::Util::Windows::Service file for the list of available codes
+    def set_startup_mode(service_name, startup_type)
+      startup_code = SERVICE_START_TYPES.key(startup_type)
+      if startup_code.nil?
+        raise Puppet::Error.new(_("Unknown start type %{start_type}") % {startup_type: startup_type.to_s})
+      end
+      open_service(service_name, SC_MANAGER_CONNECT, SERVICE_CHANGE_CONFIG) do |service|
+        # Currently the only thing puppet's API can really manage
+        # in this list is dwStartType (the third param). Thus no
+        # generic function was written to make use of all the params
+        # since the API as-is couldn't use them anyway
+        success = ChangeServiceConfigW(
+          service,
+          SERVICE_NO_CHANGE,  # dwServiceType
+          startup_code,       # dwStartType
+          SERVICE_NO_CHANGE,  # dwErrorControl
+          FFI::Pointer::NULL, # lpBinaryPathName
+          FFI::Pointer::NULL, # lpLoadOrderGroup
+          FFI::Pointer::NULL, # lpdwTagId
+          FFI::Pointer::NULL, # lpDependencies
+          FFI::Pointer::NULL, # lpServiceStartName
+          FFI::Pointer::NULL, # lpPassword
+          FFI::Pointer::NULL  # lpDisplayName
+        )
+        if success == FFI::WIN32_FALSE
+          raise Puppet::Util::Windows::Error.new(_("Failed to update service configuration"))
+        end
+      end
+    end
+    module_function :set_startup_mode
+
+    # enumerate over all services in all states and return them as a hash
+    #
+    # @return [Hash] a hash containing services:
+    #   { 'service name' => {
+    #                         'display_name' => 'display name',
+    #                         'service_status_process' => SERVICE_STATUS_PROCESS struct
+    #                       }
+    #   }
+    def services
+      services = {}
+      open_scm(SC_MANAGER_ENUMERATE_SERVICE) do |scm|
+        size_required = 0
+        services_returned = 0
+        FFI::MemoryPointer.new(:dword) do |bytes_pointer|
+          FFI::MemoryPointer.new(:dword) do |svcs_ret_ptr|
+            FFI::MemoryPointer.new(:dword) do |resume_ptr|
+              resume_ptr.write_dword(0)
+              # Fetch the bytes of memory required to be allocated
+              # for QueryServiceConfigW to return succesfully. This
+              # is done by sending NULL and 0 for the pointer and size
+              # respectively, letting the command fail, then reading the
+              # value of pcbBytesNeeded
+              #
+              # return value will be false from this call, since it's designed
+              # to fail. Just ignore it
+              EnumServicesStatusExW(
+                scm,
+                :SC_ENUM_PROCESS_INFO,
+                ALL_SERVICE_TYPES,
+                SERVICE_STATE_ALL,
+                FFI::Pointer::NULL,
+                0,
+                bytes_pointer,
+                svcs_ret_ptr,
+                resume_ptr,
+                FFI::Pointer::NULL
+              )
+              size_required = bytes_pointer.read_dword
+              FFI::MemoryPointer.new(size_required) do |buffer_ptr|
+                resume_ptr.write_dword(0)
+                svcs_ret_ptr.write_dword(0)
+                success = EnumServicesStatusExW(
+                  scm,
+                  :SC_ENUM_PROCESS_INFO,
+                  ALL_SERVICE_TYPES,
+                  SERVICE_STATE_ALL,
+                  buffer_ptr,
+                  buffer_ptr.size,
+                  bytes_pointer,
+                  svcs_ret_ptr,
+                  resume_ptr,
+                  FFI::Pointer::NULL
+                )
+                if success == FFI::WIN32_FALSE
+                  raise Puppet::Util::Windows::Error.new(_("Failed to fetch services"))
+                end
+                # Now that the buffer is populated with services
+                # we pull the data from memory using pointer arithmetic:
+                # the number of services returned by the function is
+                # available to be read from svcs_ret_ptr, and we iterate
+                # that many times moving the cursor pointer the length of
+                # ENUM_SERVICE_STATUS_PROCESSW.size. This should iterate
+                # over the buffer and extract each struct.
+                services_returned = svcs_ret_ptr.read_dword
+                cursor_ptr = FFI::Pointer.new(ENUM_SERVICE_STATUS_PROCESSW, buffer_ptr)
+                0.upto(services_returned - 1) do |index|
+                  service = ENUM_SERVICE_STATUS_PROCESSW.new(cursor_ptr[index])
+                  services[service[:lpServiceName].read_arbitrary_wide_string_up_to(SERVICENAME_MAX)] = {
+                    :display_name => service[:lpDisplayName].read_arbitrary_wide_string_up_to(SERVICENAME_MAX),
+                    :service_status_process => service[:ServiceStatusProcess]
+                  }
+                end
+              end # buffer_ptr
+            end # resume_ptr
+          end # scvs_ret_ptr
+        end # bytes_ptr
+      end # open_scm
+      services
+    end
+    module_function :services
+
+    class << self
+      # @api private
+      # Opens a connection to the SCManager on windows then uses that
+      # handle to create a handle to a specific service in windows
+      # corresponding to service_name
+      #
+      # this function takes a block that executes within the context of
+      # the open service handler, and will close the service and SCManager
+      # handles once the block finishes
+      #
+      # @param [string] service_name the name of the service to open
+      # @param [Integer] scm_access code corresponding to the access type requested for the scm
+      # @param [Integer] service_access code corresponding to the access type requested for the service
+      # @yieldparam [:handle] service the windows native handle used to access
+      #   the service
+      def open_service(service_name, scm_access, service_access, &block)
+        service = FFI::Pointer::NULL_HANDLE
+        open_scm(scm_access) do |scm|
+          service = OpenServiceW(scm, wide_string(service_name), service_access)
+          raise Puppet::Util::Windows::Error.new(_("Failed to open a handle to the service")) if service == FFI::Pointer::NULL_HANDLE
+          yield service
+        end
+      ensure
+        CloseServiceHandle(service)
+      end
+      private :open_service
+
+      # @api private
+      #
+      # Opens a handle to the service control manager
+      #
+      # @param [Integer] scm_access code corresponding to the access type requested for the scm
+      def open_scm(scm_access, &block)
+        scm = OpenSCManagerW(FFI::Pointer::NULL, FFI::Pointer::NULL, scm_access)
+        raise Puppet::Util::Windows::Error.new(_("Failed to open a handle to the service control manager")) if scm == FFI::Pointer::NULL_HANDLE
+        yield scm
+      ensure
+        CloseServiceHandle(scm)
+      end
+      private :open_scm
+
+      # @api private
+      # perform QueryServiceStatusEx on a windows service and return the
+      # result
+      #
+      # @param [:handle] service handle of the service to query
+      # @return [SERVICE_STATUS_PROCESS struct] the result of the query
+      def query_status(service)
+        size_required = nil
+        status = nil
+        # Fetch the bytes of memory required to be allocated
+        # for QueryServiceConfigW to return succesfully. This
+        # is done by sending NULL and 0 for the pointer and size
+        # respectively, letting the command fail, then reading the
+        # value of pcbBytesNeeded
+        FFI::MemoryPointer.new(:lpword) do |bytes_pointer|
+          # return value will be false from this call, since it's designed
+          # to fail. Just ignore it
+          QueryServiceStatusEx(
+            service,
+            :SC_STATUS_PROCESS_INFO,
+            FFI::Pointer::NULL,
+            0,
+            bytes_pointer
+          )
+          size_required = bytes_pointer.read_dword
+          FFI::MemoryPointer.new(size_required) do |ssp_ptr|
+            status = SERVICE_STATUS_PROCESS.new(ssp_ptr)
+            success = QueryServiceStatusEx(
+              service,
+              :SC_STATUS_PROCESS_INFO,
+              ssp_ptr,
+              size_required,
+              bytes_pointer
+            )
+            if success == FFI::WIN32_FALSE
+              raise Puppet::Util::Windows::Error.new(_("Service query failed"))
+            end
+          end
+        end
+        status
+      end
+      private :query_status
+
+      # @api private
+      # perform QueryServiceConfigW on a windows service and return the
+      # result
+      #
+      # @param [:handle] service handle of the service to query
+      # @return [QUERY_SERVICE_CONFIGW struct] the result of the query
+      def query_config(service)
+        config = nil
+        size_required = nil
+        # Fetch the bytes of memory required to be allocated
+        # for QueryServiceConfigW to return succesfully. This
+        # is done by sending NULL and 0 for the pointer and size
+        # respectively, letting the command fail, then reading the
+        # value of pcbBytesNeeded
+        FFI::MemoryPointer.new(:lpword) do |bytes_pointer|
+          # return value will be false from this call, since it's designed
+          # to fail. Just ignore it
+          QueryServiceConfigW(service, FFI::Pointer::NULL, 0, bytes_pointer)
+          size_required = bytes_pointer.read_dword
+          FFI::MemoryPointer.new(size_required) do |ssp_ptr|
+            config = QUERY_SERVICE_CONFIGW.new(ssp_ptr)
+            success = QueryServiceConfigW(
+              service,
+              ssp_ptr,
+              size_required,
+              bytes_pointer
+            )
+            if success == FFI::WIN32_FALSE
+              raise Puppet::Util::Windows::Error.new(_("Service query failed"))
+            end
+          end
+        end
+        config
+      end
+      private :query_config
+
+      # @api private
+      # waits for a windows service to report final_state if it
+      # is in pending_state
+      #
+      # @param [:handle] service handle to the service to wait on
+      # @param [Integer] pending_state the state to wait on
+      # @param [Integer] final_state the state indicating the transition is finished
+      # @return [bool] 'true' once the service is reporting final_state,
+      #   'false' if the service was not in pending_state or finaL_state
+      def wait_for_pending_transition(service, pending_state, final_state)
+        elapsed_time = 0
+        last_checkpoint = -1
+        loop do
+          status = query_status(service)
+          state = status[:dwCurrentState]
+          return true if state == final_state
+          unless state == pending_state
+            return false
+          end
+          # When the service is in the pending state we need to do the following:
+          # 1. check if any progress has been made since dwWaitHint using dwCheckPoint,
+          #    and fail if no progress was made
+          # 2. if progress has been made, increment elapsed_time and set last_checkpoint
+          # 3. sleep, then loop again if there was progress.
+          time_to_wait = wait_hint_to_wait_time(status[:dwWaitHint])
+          if status[:dwCheckPoint] > last_checkpoint
+            elapsed_time = 0
+          else
+            if elapsed_time > (status[:dwWaitHint] / 1000)
+              raise Puppet::Error.new(_("No progress made on service operation and dwWaitHint exceeded"))
+            end
+            elapsed_time += time_to_wait
+          end
+          last_checkpoint = status[:dwCheckPoint]
+          sleep(time_to_wait)
+        end
+      end
+      private :wait_for_pending_transition
+
+      # @api private
+      #
+      # process the wait hint listed by a service to something
+      # usable by ruby sleep
+      #
+      # @param [Integer] wait_hint the wait hint of a service in milliseconds
+      # @return [Integer] the time to wait in seconds between querying the service
+      def wait_hint_to_wait_time(wait_hint)
+        # The first divisor begs a little explanation: the value of
+        # :dwWaitHint will return in milliseconds, but ruby sleep
+        # takes seconds. So we need at least / 1000. After that, the
+        # suggested operation is to wait 1/10 of the actual wait hint
+        # between querying the service. So we get wait_hint / 10000
+        wait_time = wait_hint / 10000;
+        wait_time = 1 if wait_time < 1
+        wait_time = 10 if wait_time > 10
+        wait_time
+      end
+      private :wait_hint_to_wait_time
+    end
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-openscmanagerw
+    # SC_HANDLE OpenSCManagerW(
+    #   LPCWSTR lpMachineName,
+    #   LPCWSTR lpDatabaseName,
+    #   DWORD   dwDesiredAccess
+    # );
+    ffi_lib :advapi32
+    attach_function_private :OpenSCManagerW,
+      [:lpcwstr, :lpcwstr, :dword], :handle
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-openservicew
+    # SC_HANDLE OpenServiceW(
+    #   SC_HANDLE hSCManager,
+    #   LPCWSTR   lpServiceName,
+    #   DWORD     dwDesiredAccess
+    # );
+    ffi_lib :advapi32
+    attach_function_private :OpenServiceW,
+      [:handle, :lpcwstr, :dword], :handle
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-closeservicehandle
+    # BOOL CloseServiceHandle(
+    #   SC_HANDLE hSCObject
+    # );
+    ffi_lib :advapi32
+    attach_function_private :CloseServiceHandle,
+      [:handle], :win32_bool
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/nf-winsvc-queryservicestatusex
+    # BOOL QueryServiceStatusEx(
+    #   SC_HANDLE      hService,
+    #   SC_STATUS_TYPE InfoLevel,
+    #   LPBYTE         lpBuffer,
+    #   DWORD          cbBufSize,
+    #   LPDWORD        pcbBytesNeeded
+    # );
+    SC_STATUS_TYPE = enum(
+      :SC_STATUS_PROCESS_INFO, 0,
+    )
+    ffi_lib :advapi32
+    attach_function_private :QueryServiceStatusEx,
+      [:handle, SC_STATUS_TYPE, :lpbyte, :dword, :lpdword], :win32_bool
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-queryserviceconfigw
+    # BOOL QueryServiceConfigW(
+    #   SC_HANDLE               hService,
+    #   LPQUERY_SERVICE_CONFIGW lpServiceConfig,
+    #   DWORD                   cbBufSize,
+    #   LPDWORD                 pcbBytesNeeded
+    # );
+    ffi_lib :advapi32
+    attach_function_private :QueryServiceConfigW,
+      [:handle, :lpbyte, :dword, :lpdword], :win32_bool
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-startservicew
+    # BOOL StartServiceW(
+    #   SC_HANDLE hService,
+    #   DWORD     dwNumServiceArgs,
+    #   LPCWSTR   *lpServiceArgVectors
+    # );
+    ffi_lib :advapi32
+    attach_function_private :StartServiceW,
+      [:handle, :dword, :pointer], :win32_bool
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/nf-winsvc-controlservice
+    # BOOL ControlService(
+    #   SC_HANDLE        hService,
+    #   DWORD            dwControl,
+    #   LPSERVICE_STATUS lpServiceStatus
+    # );
+    ffi_lib :advapi32
+    attach_function_private :ControlService,
+      [:handle, :dword, :pointer], :win32_bool
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/nf-winsvc-changeserviceconfigw
+    # BOOL ChangeServiceConfigW(
+    #   SC_HANDLE hService,
+    #   DWORD     dwServiceType,
+    #   DWORD     dwStartType,
+    #   DWORD     dwErrorControl,
+    #   LPCWSTR   lpBinaryPathName,
+    #   LPCWSTR   lpLoadOrderGroup,
+    #   LPDWORD   lpdwTagId,
+    #   LPCWSTR   lpDependencies,
+    #   LPCWSTR   lpServiceStartName,
+    #   LPCWSTR   lpPassword,
+    #   LPCWSTR   lpDisplayName
+    # );
+    ffi_lib :advapi32
+    attach_function_private :ChangeServiceConfigW,
+      [
+        :handle,
+        :dword,
+        :dword,
+        :dword,
+        :lpcwstr,
+        :lpcwstr,
+        :lpdword,
+        :lpcwstr,
+        :lpcwstr,
+        :lpcwstr,
+        :lpcwstr
+      ], :win32_bool
+
+
+    # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/nf-winsvc-enumservicesstatusexw
+    # BOOL EnumServicesStatusExW(
+    #   SC_HANDLE    hSCManager,
+    #   SC_ENUM_TYPE InfoLevel,
+    #   DWORD        dwServiceType,
+    #   DWORD        dwServiceState,
+    #   LPBYTE       lpServices,
+    #   DWORD        cbBufSize,
+    #   LPDWORD      pcbBytesNeeded,
+    #   LPDWORD      lpServicesReturned,
+    #   LPDWORD      lpResumeHandle,
+    #   LPCWSTR      pszGroupName
+    # );
+    SC_ENUM_TYPE = enum(
+      :SC_ENUM_PROCESS_INFO, 0,
+    )
+    ffi_lib :advapi32
+    attach_function_private :EnumServicesStatusExW,
+      [
+        :handle,
+        SC_ENUM_TYPE,
+        :dword,
+        :dword,
+        :lpbyte,
+        :dword,
+        :lpdword,
+        :lpdword,
+        :lpdword,
+        :lpcwstr
+      ], :win32_bool
+  end
+end

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -13,55 +13,34 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
   let(:provider) { resource.provider }
   let(:config)   { Struct::ServiceConfigInfo.new }
   let(:status)   { Struct::ServiceStatus.new }
+  let(:service_util) { Puppet::Util::Windows::Service }
+  let(:service_handle) { mock() }
 
   before :each do
     # make sure we never actually execute anything (there are two execute methods)
     provider.class.expects(:execute).never
     provider.expects(:execute).never
-
-    Win32::Service.stubs(:config_info).with(name).returns(config)
-    Win32::Service.stubs(:status).with(name).returns(status)
   end
 
   describe ".instances" do
     it "should enumerate all services" do
-      list_of_services = ['snmptrap', 'svchost', 'sshd'].map { |s| stub('service', :service_name => s) }
-      Win32::Service.expects(:services).returns(list_of_services)
+      list_of_services = {'snmptrap' => {}, 'svchost' => {}, 'sshd' => {}}
+      service_util.expects(:services).returns(list_of_services)
 
       expect(described_class.instances.map(&:name)).to match_array(['snmptrap', 'svchost', 'sshd'])
     end
   end
 
   describe "#start" do
-    before :each do
-      config.start_type = Win32::Service.get_start_type(Win32::Service::SERVICE_AUTO_START)
-    end
-
     it "should start the service" do
-      provider.expects(:net).with(:start, name)
-
+      service_util.expects(:service_start_type).with(name).returns(:SERVICE_AUTO_START)
+      service_util.expects(:start).with(name)
       provider.start
     end
 
-    it "should raise an error if the start command fails" do
-      provider.expects(:net).with(:start, name).raises(Puppet::ExecutionFailure, "The service name is invalid.")
-
-      expect {
-        provider.start
-      }.to raise_error(Puppet::Error, /Cannot start #{name}, error was: The service name is invalid./)
-    end
-
-    it "raises an error if the service doesn't exist" do
-      Win32::Service.expects(:config_info).with(name).raises(SystemCallError, 'OpenService')
-
-      expect {
-        provider.start
-      }.to raise_error(Puppet::Error, /Cannot get start type for #{name}/)
-    end
-
-    describe "when the service is disabled" do
+    context "when the service is disabled" do
       before :each do
-        config.start_type = Win32::Service.get_start_type(Win32::Service::SERVICE_DISABLED)
+        service_util.expects(:service_start_type).with(name).returns(:SERVICE_DISABLED)
       end
 
       it "should refuse to start if not managing enable" do
@@ -70,18 +49,16 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
 
       it "should enable if managing enable and enable is true" do
         resource[:enable] = :true
-
-        provider.expects(:net).with(:start, name)
-        Win32::Service.expects(:configure).with('service_name' => name, 'start_type' => Win32::Service::SERVICE_AUTO_START).returns(Win32::Service)
+        service_util.expects(:start).with(name)
+        service_util.expects(:set_startup_mode).with(name, :SERVICE_AUTO_START)
 
         provider.start
       end
 
       it "should manual start if managing enable and enable is false" do
         resource[:enable] = :false
-
-        provider.expects(:net).with(:start, name)
-        Win32::Service.expects(:configure).with('service_name' => name, 'start_type' => Win32::Service::SERVICE_DEMAND_START).returns(Win32::Service)
+        service_util.expects(:start).with(name)
+        service_util.expects(:set_startup_mode).with(name, :SERVICE_DEMAND_START)
 
         provider.start
       end
@@ -90,43 +67,35 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
 
   describe "#stop" do
     it "should stop a running service" do
-      provider.expects(:net).with(:stop, name)
+      service_util.expects(:stop).with(name)
 
       provider.stop
-    end
-
-    it "should raise an error if the stop command fails" do
-      provider.expects(:net).with(:stop, name).raises(Puppet::ExecutionFailure, 'The service name is invalid.')
-
-      expect {
-        provider.stop
-      }.to raise_error(Puppet::Error, /Cannot stop #{name}, error was: The service name is invalid./)
     end
   end
 
   describe "#status" do
-    ['stopped', 'paused', 'stop pending', 'pause pending'].each do |state|
+    [
+      :SERVICE_STOPPED,
+      :SERVICE_PAUSED,
+      :SERVICE_STOP_PENDING,
+      :SERVICE_PAUSE_PENDING,
+    ].each do |state|
       it "should report a #{state} service as stopped" do
-        status.current_state = state
-
+        service_util.expects(:service_state).with(name).returns(state)
         expect(provider.status).to eq(:stopped)
       end
     end
 
-    ["running", "continue pending", "start pending" ].each do |state|
+    [
+      :SERVICE_RUNNING,
+      :SERVICE_CONTINUE_PENDING,
+      :SERVICE_START_PENDING,
+    ].each do |state|
       it "should report a #{state} service as running" do
-        status.current_state = state
+        service_util.expects(:service_state).with(name).returns(state)
 
         expect(provider.status).to eq(:running)
       end
-    end
-
-    it "raises an error if the service doesn't exist" do
-      Win32::Service.expects(:status).with(name).raises(SystemCallError, 'OpenService')
-
-      expect {
-        provider.status
-      }.to raise_error(Puppet::Error, /Cannot get status of #{name}/)
     end
   end
 
@@ -151,33 +120,25 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
 
   describe "#enabled?" do
     it "should report a service with a startup type of manual as manual" do
-      config.start_type = Win32::Service.get_start_type(Win32::Service::SERVICE_DEMAND_START)
-
+      service_util.expects(:service_start_type).with(name).returns(:SERVICE_DEMAND_START)
       expect(provider.enabled?).to eq(:manual)
     end
 
     it "should report a service with a startup type of disabled as false" do
-      config.start_type = Win32::Service.get_start_type(Win32::Service::SERVICE_DISABLED)
-
+      service_util.expects(:service_start_type).with(name).returns(:SERVICE_DISABLED)
       expect(provider.enabled?).to eq(:false)
-    end
-
-    it "raises an error if the service doesn't exist" do
-      Win32::Service.expects(:config_info).with(name).raises(SystemCallError, 'OpenService')
-
-      expect {
-        provider.enabled?
-      }.to raise_error(Puppet::Error, /Cannot get start type for #{name}/)
     end
 
     # We need to guard this section explicitly since rspec will always
     # construct all examples, even if it isn't going to run them.
     if Puppet.features.microsoft_windows?
-      [Win32::Service::SERVICE_AUTO_START, Win32::Service::SERVICE_BOOT_START, Win32::Service::SERVICE_SYSTEM_START].each do |start_type_const|
-        start_type = Win32::Service.get_start_type(start_type_const)
+      [
+        :SERVICE_AUTO_START,
+        :SERVICE_BOOT_START,
+        :SERVICE_SYSTEM_START
+      ].each do |start_type|
         it "should report a service with a startup type of '#{start_type}' as true" do
-          config.start_type = start_type
-
+          service_util.expects(:service_start_type).with(name).returns(start_type)
           expect(provider.enabled?).to eq(:true)
         end
       end
@@ -186,12 +147,12 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
 
   describe "#enable" do
     it "should set service start type to Service_Auto_Start when enabled" do
-      Win32::Service.expects(:configure).with('service_name' => name, 'start_type' => Win32::Service::SERVICE_AUTO_START).returns(Win32::Service)
+      service_util.expects(:set_startup_mode).with(name, :SERVICE_AUTO_START)
       provider.enable
     end
 
-    it "raises an error if the service doesn't exist" do
-      Win32::Service.expects(:configure).with(has_entry('service_name' => name)).raises(SystemCallError, 'OpenService')
+    it "raises an error if set_startup_mode fails" do
+      service_util.expects(:set_startup_mode).with(name, :SERVICE_AUTO_START).raises(Puppet::Error.new('foobar'))
 
       expect {
         provider.enable
@@ -201,12 +162,12 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
 
   describe "#disable" do
     it "should set service start type to Service_Disabled when disabled" do
-      Win32::Service.expects(:configure).with('service_name' => name, 'start_type' => Win32::Service::SERVICE_DISABLED).returns(Win32::Service)
+      service_util.expects(:set_startup_mode).with(name, :SERVICE_DISABLED)
       provider.disable
-     end
+    end
 
-    it "raises an error if the service doesn't exist" do
-      Win32::Service.expects(:configure).with(has_entry('service_name' => name)).raises(SystemCallError, 'OpenService')
+    it "raises an error if set_startup_mode fails" do
+      service_util.expects(:set_startup_mode).with(name, :SERVICE_DISABLED).raises(Puppet::Error.new('foobar'))
 
       expect {
         provider.disable
@@ -216,12 +177,12 @@ describe Puppet::Type.type(:service).provider(:windows), :if => Puppet.features.
 
   describe "#manual_start" do
     it "should set service start type to Service_Demand_Start (manual) when manual" do
-      Win32::Service.expects(:configure).with('service_name' => name, 'start_type' => Win32::Service::SERVICE_DEMAND_START).returns(Win32::Service)
+      service_util.expects(:set_startup_mode).with(name, :SERVICE_DEMAND_START)
       provider.manual_start
     end
 
-    it "raises an error if the service doesn't exist" do
-      Win32::Service.expects(:configure).with(has_entry('service_name' => name)).raises(SystemCallError, 'OpenService')
+    it "raises an error if set_startup_mode fails" do
+      service_util.expects(:set_startup_mode).with(name, :SERVICE_DEMAND_START).raises(Puppet::Error.new('foobar'))
 
       expect {
         provider.manual_start

--- a/spec/unit/util/windows/service_spec.rb
+++ b/spec/unit/util/windows/service_spec.rb
@@ -1,0 +1,421 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_windows? do
+  require 'puppet/util/windows'
+
+  # The following should emulate a successful call to the private function
+  # query_status that returns the value of query_return. This should give
+  # us a way to mock changes in service status.
+  #
+  # Everything else is stubbed, the emulation of the successful call is really
+  # just an expectation of subject::SERVICE_STATUS_PROCESS.new in sequence that
+  # returns the value passed in as a param
+  def expect_successful_status_query_and_return(query_return)
+    subject::SERVICE_STATUS_PROCESS.expects(:new).in_sequence(status_checks).returns(query_return)
+  end
+
+  # The following should emulate a successful call to the private function
+  # query_config that returns the value of query_return. This should give
+  # us a way to mock changes in service configuration.
+  #
+  # Everything else is stubbed, the emulation of the successful call is really
+  # just an expectation of subject::QUERY_SERVICE_CONFIGW.new in sequence that
+  # returns the value passed in as a param
+  def expect_successful_config_query_and_return(query_return)
+    subject::QUERY_SERVICE_CONFIGW.expects(:new).in_sequence(status_checks).returns(query_return)
+  end
+
+  let(:subject)      { Puppet::Util::Windows::Service }
+  let(:pointer) { mock() }
+  let(:status_checks) { sequence('status_checks') }
+  let(:mock_service_name) { mock() }
+  let(:service) { mock() }
+  let(:scm) { mock() }
+
+  before do
+    subject.stubs(:QueryServiceStatusEx).returns(1)
+    subject.stubs(:QueryServiceConfigW).returns(1)
+    subject.stubs(:StartServiceW).returns(1)
+    subject.stubs(:ControlService).returns(1)
+    subject.stubs(:ChangeServiceConfigW).returns(1)
+    subject.stubs(:OpenSCManagerW).returns(scm)
+    subject.stubs(:OpenServiceW).returns(service)
+    subject.stubs(:CloseServiceHandle)
+    subject.stubs(:EnumServicesStatusExW).returns(1)
+    subject.stubs(:wide_string)
+    subject::SERVICE_STATUS_PROCESS.stubs(:new)
+    subject::QUERY_SERVICE_CONFIGW.stubs(:new)
+    subject::SERVICE_STATUS.stubs(:new).returns({:dwCurrentState => subject::SERVICE_RUNNING})
+    Puppet::Util::Windows::Error.stubs(:new).raises(Puppet::Error.new('fake error'))
+    FFI::MemoryPointer.stubs(:new).yields(pointer)
+    pointer.stubs(:read_dword)
+    pointer.stubs(:write_dword)
+    pointer.stubs(:size)
+  end
+
+  describe "#start" do
+
+    context "when the service control manager cannot be opened" do
+      let(:scm) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service cannot be opened" do
+      let(:service) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service can be opened and is in the stopped state" do
+      before do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+      end
+
+      it "Starts the service once the service reports SERVICE_RUNNING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.start(mock_service_name)
+      end
+
+      it "Raises an error if after calling StartServiceW the service is not in RUNNING or START_PENDING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_PAUSED})
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+
+      it "raises a puppet error if StartServiceW returns false" do
+        subject.expects(:StartServiceW).returns(FFI::WIN32_FALSE)
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service hasn't stopped yet:" do
+      it "waits, then queries again until SERVICE_STOPPED" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(3).twice
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at least 1 second if wait hint/10 is < 1 second" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(1)
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at most 10 seconds if wait hint/10 is > 10 seconds" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 1000000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(10)
+        subject.start(mock_service_name)
+      end
+
+      it "raises a puppet error if the service query fails" do
+        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(1)
+        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
+        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      it "raises a puppet error if the services configured dwWaitHint has passed and dwCheckPoint hasn't increased" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        subject.expects(:sleep).twice.with(1)
+        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      it "Does not raise an error if the service makes progress" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 30})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 98})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).times(5).with(1)
+        expect{subject.start(mock_service_name)}.to_not raise_error
+      end
+    end
+
+    context "when the service ends up in START_PENDING:" do
+      it "waits, then queries again until SERVICE_RUNNING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(3).twice
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at least 1 second if wait hint/10 is < 1 second" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(1)
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at most 10 seconds if wait hint/10 is > 10 seconds" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 1000000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(10)
+        subject.start(mock_service_name)
+      end
+
+      it "raises a puppet error if the service's configured dwWaitHint has passed and dwCheckPoint hasn't increased" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        subject.expects(:sleep).twice.with(1)
+        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      it "Does not raise an error if the service makes progress" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 30})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 98})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).times(5).with(1)
+        expect{subject.start(mock_service_name)}.to_not raise_error
+      end
+    end
+  end
+
+  describe "#stop" do
+    context "when the service control manager cannot be opened" do
+      let(:scm) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service cannot be opened" do
+      let(:service) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service can be opened and is in the running state:" do
+      before do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+      end
+
+      it "Sends the SERVICE_CONTROL_STOP to the service once the service reports SERVICE_RUNNING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        subject.stop(mock_service_name)
+      end
+
+      it "Raises an error if after calling ControlService the service is not in STOPPED or STOP_PENDING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_PAUSED})
+        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+
+      it "raises a puppet error if ControlService returns false" do
+        subject.expects(:ControlService).returns(FFI::WIN32_FALSE)
+        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    # No need to retest much of the wait functionality here, since
+    # both stop and start use the wait_for_pending_transition helper
+    # which is tested in the start unit tests.
+    context "when the service hasn't started yet:" do
+      it "waits, then queries again until SERVICE_STOPPED" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        subject.expects(:sleep).with(3).twice
+        subject.stop(mock_service_name)
+      end
+    end
+
+    context "when the service ends up in STOP_PENDING:" do
+      it "waits, then queries again until SERVICE_RUNNING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        subject.expects(:sleep).with(3).twice
+        subject.stop(mock_service_name)
+      end
+    end
+  end
+
+  describe "#service_state" do
+    context "when the service control manager cannot be opened" do
+      let(:scm) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.service_state(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service cannot be opened" do
+      let(:service) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.service_state(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service can be opened" do
+      it "raises Puppet::Error if the result of the query is empty" do
+        expect_successful_status_query_and_return({})
+        expect{subject.service_state(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      it "raises Puppet::Error if the result of the query is an unknown state" do
+        expect_successful_status_query_and_return({:dwCurrentState => 999})
+        expect{subject.service_state(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      # We need to guard this section explicitly since rspec will always
+      # construct all examples, even if it isn't going to run them.
+      if Puppet.features.microsoft_windows?
+        {
+          :SERVICE_STOPPED => Puppet::Util::Windows::Service::SERVICE_STOPPED,
+          :SERVICE_PAUSED => Puppet::Util::Windows::Service::SERVICE_PAUSED,
+          :SERVICE_STOP_PENDING => Puppet::Util::Windows::Service::SERVICE_STOP_PENDING,
+          :SERVICE_PAUSE_PENDING => Puppet::Util::Windows::Service::SERVICE_PAUSE_PENDING,
+          :SERVICE_RUNNING => Puppet::Util::Windows::Service::SERVICE_RUNNING,
+          :SERVICE_CONTINUE_PENDING => Puppet::Util::Windows::Service::SERVICE_CONTINUE_PENDING,
+          :SERVICE_START_PENDING => Puppet::Util::Windows::Service::SERVICE_START_PENDING,
+        }.each do |state_name, state|
+          it "queries the service and returns #{state_name}" do
+            expect_successful_status_query_and_return({:dwCurrentState => state})
+            expect(subject.service_state(mock_service_name)).to eq(state_name)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#service_start_type" do
+    context "when the service control manager cannot be opened" do
+      let(:scm) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.service_start_type(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service cannot be opened" do
+      let(:service) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.service_start_type(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service can be opened" do
+
+      # We need to guard this section explicitly since rspec will always
+      # construct all examples, even if it isn't going to run them.
+      if Puppet.features.microsoft_windows?
+        {
+          :SERVICE_AUTO_START => Puppet::Util::Windows::Service::SERVICE_AUTO_START,
+          :SERVICE_BOOT_START => Puppet::Util::Windows::Service::SERVICE_BOOT_START,
+          :SERVICE_SYSTEM_START => Puppet::Util::Windows::Service::SERVICE_SYSTEM_START,
+          :SERVICE_DEMAND_START => Puppet::Util::Windows::Service::SERVICE_DEMAND_START,
+          :SERVICE_DISABLED => Puppet::Util::Windows::Service::SERVICE_DISABLED,
+        }.each do |start_type_name, start_type|
+          it "queries the service and returns the service start type #{start_type_name}" do
+            expect_successful_config_query_and_return({:dwStartType => start_type})
+            expect(subject.service_start_type(mock_service_name)).to eq(start_type_name)
+          end
+        end
+      end
+      it "raises a puppet error if the service query fails" do
+        subject.expects(:QueryServiceConfigW).in_sequence(status_checks)
+        subject.expects(:QueryServiceConfigW).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
+        expect{ subject.service_start_type(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+
+  describe "#set_startup_mode" do
+    let(:status_checks) { sequence('status_checks') }
+
+    context "when the service control manager cannot be opened" do
+      let(:scm) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.set_startup_mode(mock_service_name, :SERVICE_DEMAND_START) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service cannot be opened" do
+      let(:service) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.set_startup_mode(mock_service_name, :SERVICE_DEMAND_START) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service can be opened" do
+      it "Raises an error on an unsuccessful change" do
+        subject.expects(:ChangeServiceConfigW).returns(FFI::WIN32_FALSE)
+        expect{ subject.set_startup_mode(mock_service_name, :SERVICE_DEMAND_START) }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+
+  describe "#services" do
+    let(:pointer_sequence) { sequence('pointer_sequence') }
+
+    context "when the service control manager cannot be opened" do
+      let(:scm) { FFI::Pointer::NULL_HANDLE }
+      it "raises a puppet error" do
+        expect{ subject.services }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service control manager is open" do
+      let(:cursor) { [ 'svc1', 'svc2', 'svc3' ] }
+      let(:svc1name_ptr) { mock() }
+      let(:svc2name_ptr) { mock() }
+      let(:svc3name_ptr) { mock() }
+      let(:svc1displayname_ptr) { mock() }
+      let(:svc2displayname_ptr) { mock() }
+      let(:svc3displayname_ptr) { mock() }
+      let(:svc1) { { :lpServiceName => svc1name_ptr, :lpDisplayName => svc1displayname_ptr, :ServiceStatusProcess => 'foo' } }
+      let(:svc2) { { :lpServiceName => svc2name_ptr, :lpDisplayName => svc2displayname_ptr, :ServiceStatusProcess => 'foo' } }
+      let(:svc3) { { :lpServiceName => svc3name_ptr, :lpDisplayName => svc3displayname_ptr, :ServiceStatusProcess => 'foo' } }
+
+      it "Raises an error if EnumServicesStatusExW fails" do
+        subject.expects(:EnumServicesStatusExW).in_sequence(pointer_sequence)
+        subject.expects(:EnumServicesStatusExW).in_sequence(pointer_sequence).returns(FFI::WIN32_FALSE)
+        expect{ subject.services }.to raise_error(Puppet::Error)
+      end
+
+      it "Reads the buffer using pointer arithmetic to create a hash of service entries" do
+        # the first read_dword is for reading the bytes required, let that return 3 too.
+        # the second read_dword will actually read the number of services returned
+        pointer.expects(:read_dword).twice.returns(3)
+        FFI::Pointer.expects(:new).with(subject::ENUM_SERVICE_STATUS_PROCESSW, pointer).returns(cursor)
+        subject::ENUM_SERVICE_STATUS_PROCESSW.expects(:new).in_sequence(pointer_sequence).with('svc1').returns(svc1)
+        subject::ENUM_SERVICE_STATUS_PROCESSW.expects(:new).in_sequence(pointer_sequence).with('svc2').returns(svc2)
+        subject::ENUM_SERVICE_STATUS_PROCESSW.expects(:new).in_sequence(pointer_sequence).with('svc3').returns(svc3)
+        svc1name_ptr.expects(:read_arbitrary_wide_string_up_to).returns('svc1')
+        svc2name_ptr.expects(:read_arbitrary_wide_string_up_to).returns('svc2')
+        svc3name_ptr.expects(:read_arbitrary_wide_string_up_to).returns('svc3')
+        svc1displayname_ptr.expects(:read_arbitrary_wide_string_up_to).returns('service 1')
+        svc2displayname_ptr.expects(:read_arbitrary_wide_string_up_to).returns('service 2')
+        svc3displayname_ptr.expects(:read_arbitrary_wide_string_up_to).returns('service 3')
+        expect(subject.services).to eq({
+          'svc1' => { :display_name => 'service 1', :service_status_process => 'foo' },
+          'svc2' => { :display_name => 'service 2', :service_status_process => 'foo' },
+          'svc3' => { :display_name => 'service 3', :service_status_process => 'foo' }
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Neither net.exe or sc.exe really satisfy our management needs for windows services, so this PR adds a new Util::Windows::Service ruby module to puppet's utilities that implements service control on windows directly with the windows API via FFI.

Subsequently, this PR updates the service provider to re-implement the various functions of the provider API using the Windows::Service utility rather than win32-service + net.exe