### PR TITLE
(PUP-9009) Add Zypper package provider source

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -1,4 +1,4 @@
-Puppet::Type.type(:package).provide :zypper, :parent => :rpm do
+Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
   desc "Support for SuSE `zypper` package manager. Found in SLES10sp2+ and SLES11.
 
     This provider supports the `install_options` attribute, which allows command-line flags to be passed to zypper.


### PR DESCRIPTION
Prior to this PR, the zypper package provider did not have a source,
so the package lists would be duplicated with the rpm provider. This
PR adds rpm as the source to the zypper package provider to
eliminate the duplicate package when using `providers_by_source`.