### PR TITLE
(PUP-6964) Make all modules visible when making function calls

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -787,9 +787,9 @@ module Puppet::Functions
         arity = -1
       end
       if arity < 0
-        from = -arity -1 # arity -1 is 0 min param, -2 is min 1 param
-        to = :default    # infinite range
-        count = -arity   # the number of named parameters
+        from = -arity - 1 # arity -1 is 0 min param, -2 is min 1 param
+        to = :default     # infinite range
+        count = -arity    # the number of named parameters
       else
         count = from = to = arity
       end

--- a/lib/puppet/loaders.rb
+++ b/lib/puppet/loaders.rb
@@ -13,6 +13,7 @@ module Puppet
       require 'puppet/pops/loader/static_loader'
       require 'puppet/pops/loader/runtime3_type_loader'
       require 'puppet/pops/loader/ruby_function_instantiator'
+      require 'puppet/pops/loader/ruby_legacy_function_instantiator'
       require 'puppet/pops/loader/ruby_data_type_instantiator'
       require 'puppet/pops/loader/puppet_function_instantiator'
       require 'puppet/pops/loader/type_definition_instantiator'

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -171,7 +171,9 @@ module Puppet::Parser::Functions
           elsif arity < 0 and args[0].size < (arity+1).abs
             raise ArgumentError, _("%{name}(): Wrong number of arguments given (%{arg_count} for minimum %{min_arg_count})") % { name: name, arg_count: args[0].size, min_arg_count: (arity+1).abs }
           end
-          self.send(real_fname, args[0])
+          r = Puppet::Pops::Evaluator::Runtime3FunctionArgumentConverter.convert_return(self.send(real_fname, args[0]))
+          # avoid leaking aribtrary value if not being an rvalue function
+          options[:type] == :rvalue ? r : nil
         else
           raise ArgumentError, _("custom functions must be called with a single array that contains the arguments. For example, function_example([1]) instead of function_example(1)")
         end

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -196,6 +196,22 @@ class Runtime3FunctionArgumentConverter < Runtime3Converter
     o.to_s
   end
 
+  # Converts result back to 4.x by replacing :undef with nil in Array and Hash objects
+  #
+  def self.convert_return(val3x)
+    if val3x == :undef
+      nil
+    elsif val3x.is_a?(Array)
+      val3x.map {|v| convert_return(v) }
+    elsif val3x.is_a?(Hash)
+      hsh = {}
+      val3x.each_pair {|k,v| hsh[convert_return(k)] = convert_return(v)}
+      hsh
+    else
+      val3x
+    end
+  end
+
   @instance = self.new
 end
 

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -311,9 +311,11 @@ module Runtime3Support
     # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.
     # NOTE: Passing an empty string last converts nil/:undef to empty string
     mapped_args = Runtime3FunctionArgumentConverter.map_args(args, scope, '')
-    result = Puppet::Pops::PuppetStack.stack(file, line, scope, "function_#{name}", [mapped_args], &block)
-    # Prevent non r-value functions from leaking their result (they are not written to care about this)
-    Puppet::Parser::Functions.rvalue?(name) ? result : nil
+    # The 3x function performs return value mapping and returns nil if it is not of rvalue type
+    Puppet::Pops::PuppetStack.stack(file, line, scope, "function_#{name}", [mapped_args], &block)
+#    result = Puppet::Pops::PuppetStack.stack(file, line, scope, "function_#{name}", [mapped_args], &block)
+#    # Prevent non r-value functions from leaking their result (they are not written to care about this)
+#    Puppet::Parser::Functions.rvalue?(name) ? result : nil
   end
 
   # The o is used for source reference

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -305,7 +305,7 @@ module Runtime3Support
         return Kernel.eval('_func.call(scope, *args, &block)'.freeze, Kernel.binding, file || '', line)
       end
     end
-    # Call via 3x API if function exists there
+    # Call via 3x API if function exists there without having been autoloaded
     fail(Issues::UNKNOWN_FUNCTION, o, {:name => name}) unless Puppet::Parser::Functions.function(name)
 
     # Arguments must be mapped since functions are unaware of the new and magical creatures in 4x.

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -313,9 +313,6 @@ module Runtime3Support
     mapped_args = Runtime3FunctionArgumentConverter.map_args(args, scope, '')
     # The 3x function performs return value mapping and returns nil if it is not of rvalue type
     Puppet::Pops::PuppetStack.stack(file, line, scope, "function_#{name}", [mapped_args], &block)
-#    result = Puppet::Pops::PuppetStack.stack(file, line, scope, "function_#{name}", [mapped_args], &block)
-#    # Prevent non r-value functions from leaking their result (they are not written to care about this)
-#    Puppet::Parser::Functions.rvalue?(name) ? result : nil
   end
 
   # The o is used for source reference

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -29,7 +29,7 @@ class Loader
   attr_reader :loader_name
 
   # Describes the kinds of things that loaders can load
-  LOADABLE_KINDS = [:func_4x, :func_4xpp, :datatype, :type_pp, :resource_type_pp, :plan, :task].freeze
+  LOADABLE_KINDS = [:func_4x, :func_4xpp, :func_3x, :datatype, :type_pp, :resource_type_pp, :plan, :task].freeze
 
   # @param [String] name the name of the loader. Must be unique among all loaders maintained by a {Loader} instance
   def initialize(loader_name)

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -107,7 +107,7 @@ class Loader
   #
   # @api private
   #
-  def [] (typed_name)
+  def [](typed_name)
     if found = get_entry(typed_name)
       found.value
     else

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -25,7 +25,9 @@ module LoaderPaths
         if loader.loadables.include?(:func_4xpp)
           result << FunctionPathPP.new(loader)
         end
-        # When wanted also add FunctionPath3x to load 3x functions
+        if loader.loadables.include?(:func_3x)
+          result << FunctionPath3x.new(loader)
+        end
     when :plan
       result << PlanPathPP.new(loader)
     when :task

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -31,7 +31,7 @@ module ModuleLoaders
                                                        nil,
                                                        puppet_lib,   # may or may not have a 'lib' above 'puppet'
                                                        'puppet_system',
-                                                        [:func_4x, :datatype]   # only load ruby functions and types from "puppet"
+                                                        [:func_4x, :func_3x, :datatype]   # only load ruby functions and types from "puppet"
                                                        )
   end
 

--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -1,0 +1,54 @@
+# The RubyLegacyFunctionInstantiator instantiates a Puppet::Functions::Function given the ruby source
+# that calls Puppet::Functions.create_function.
+#
+class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
+  # Produces an instance of the Function class with the given typed_name, or fails with an error if the
+  # given ruby source does not produce this instance when evaluated.
+  #
+  # @param loader [Puppet::Pops::Loader::Loader] The loader the function is associated with
+  # @param typed_name [Puppet::Pops::Loader::TypedName] the type / name of the function to load
+  # @param source_ref [URI, String] a reference to the source / origin of the ruby code to evaluate
+  # @param ruby_code_string [String] ruby code in a string
+  #
+  # @return [Puppet::Pops::Functions.Function] - an instantiated function with global scope closure associated with the given loader
+  #
+  def self.create(loader, typed_name, source_ref, ruby_code_string)
+    unless ruby_code_string.is_a?(String) && ruby_code_string =~ /Puppet\:\:Parser\:\:Functions.*newfunction/m
+      raise ArgumentError, _("The code loaded from %{source_ref} does not seem to be a Puppet 3x API function - no 'newfunction' call.") % { source_ref: source_ref }
+    end
+    # make the private loader available in a binding to allow it to be passed on
+    loader_for_function = loader.private_loader
+    here = get_binding(loader_for_function)
+
+    # This will to do the 3x loading and define the "function_<name>" and "real_function_<name>" methods
+    # in the anonymous module used to hold function definitions.
+    #
+    func_info = eval(ruby_code_string, here, source_ref, 1)
+
+    unless func_info.is_a?(Hash)
+      raise ArgumentError, _("The code loaded from %{source_ref} did not produce the expected 3x function info Hash when evaluated. Got '%{klass}'") % { source_ref: source_ref, klass: created.class }
+    end
+    unless func_info[:name] == "function_#{typed_name.name()}"
+      raise ArgumentError, _("The code loaded from %{source_ref} produced mis-matched name, expected 'function_%{type_name}', got %{created_name}") % { 
+        source_ref: source_ref, type_name: typed_name.name, created_name: func_info[:name] }
+    end
+
+    created = Puppet::Functions::Function3x.create_function(typed_name.name(), func_info, loader_for_function)
+
+    # create the function instance - it needs closure (scope), and loader (i.e. where it should start searching for things
+    # when calling functions etc.
+    # It should be bound to global scope
+
+    # Sets closure scope to nil, to let it be picked up at runtime from Puppet.lookup(:global_scope)
+    # If function definition used the loader from the binding to create a new loader, that loader wins
+    created.new(nil, loader_for_function)
+  end
+
+  # Produces a binding where the given loader is bound as a local variable (loader_injected_arg). This variable can be used in loaded
+  # ruby code - e.g. to call Puppet::Function.create_loaded_function(:name, loader,...)
+  #
+  def self.get_binding(loader_injected_arg)
+    binding
+  end
+  private_class_method :get_binding
+end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -516,28 +516,12 @@ class Loaders
     private
 
     def create_loader_with_all_modules_visible(from_module_data)
-      Puppet.debug{"ModuleLoader: module '#{from_module_data.name}' has unknown dependencies - it will have all other modules visible"}
-
       @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", all_module_loaders()))
     end
 
     def create_loader_with_dependencies_first(from_module_data)
-      if from_module_data.unmet_dependencies?
-        if Puppet[:strict] != :off
-          msg = "ModuleLoader: module '#{from_module_data.name}' has unresolved dependencies" \
-              " Use 'puppet module list --tree' to see information about modules"
-          case Puppet[:strict]
-          when :error
-              raise LoaderError.new(msg)
-          when :warning
-            Puppet.warn_once(:unresolved_module_dependencies,
-                             "unresolved_dependencies_for_module_#{from_module_data.name}",
-                             msg)
-          end
-        end
-      end
       dependency_loaders = from_module_data.dependency_names.collect { |name| @index[name].public_loader }
-      visible_loaders = (dependency_loaders + all_module_loaders()).uniq
+      visible_loaders = dependency_loaders + (all_module_loaders() - dependency_loaders)
       @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", visible_loaders))
     end
   end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -505,7 +505,7 @@ class Loaders
         nil
       else
         module_data.private_loader =
-          if module_data.restrict_to_dependencies? && !Puppet[:tasks]
+          if module_data.restrict_to_dependencies?
             create_loader_with_dependencies_first(module_data)
           else
             create_loader_with_all_modules_visible(module_data)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1102,15 +1102,15 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
 
       it 'does not map :undef to empty string in arrays' do
-        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0][0] }
-        expect(parser.evaluate_string(scope, "$a = {} $b = [$a[nope]] bazinga($b)", __FILE__)).to eq(:undef)
-        expect(parser.evaluate_string(scope, "bazinga([undef])", __FILE__)).to eq(:undef)
+        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0][0] == :undef}
+        expect(parser.evaluate_string(scope, "$a = {} $b = [$a[nope]] bazinga($b)", __FILE__)).to eq(true)
+        expect(parser.evaluate_string(scope, "bazinga([undef])", __FILE__)).to eq(true)
       end
 
       it 'does not map :undef to empty string in hashes' do
-        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0]['a'] }
-        expect(parser.evaluate_string(scope, "$a = {} $b = {a => $a[nope]} bazinga($b)", __FILE__)).to eq(:undef)
-        expect(parser.evaluate_string(scope, "bazinga({a => undef})", __FILE__)).to eq(:undef)
+        Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0]['a'] == :undef }
+        expect(parser.evaluate_string(scope, "$a = {} $b = {a => $a[nope]} bazinga($b)", __FILE__)).to eq(true)
+        expect(parser.evaluate_string(scope, "bazinga({a => undef})", __FILE__)).to eq(true)
       end
     end
   end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -271,7 +271,10 @@ describe 'loaders' do
           File.stubs(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
           File.stubs(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).raises Errno::ENOENT
           Puppet[:code] = "$case_number = #{case_number}\ninclude ::user"
-          expect { compiler.compile }.to raise_error(Puppet::Error, /Unknown function/)
+          catalog = compiler.compile
+          resource = catalog.resource('Notify', "case_#{case_number}")
+          expect(resource).not_to be_nil
+          expect(resource['message']).to eq(desc[:expects])
         end
       end
     end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -579,22 +579,22 @@ describe 'loaders' do
         expect(type).to be_a(Puppet::Pops::Types::PIntegerType)
       end
 
-      it 'will not resolve implicit transitive dependencies, a -> c' do
+      it 'will resolve implicit transitive dependencies, a -> c' do
         type = Puppet::Pops::Types::TypeParser.singleton.parse('A::N', Puppet::Pops::Loaders.find_loader('a'))
         expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
         expect(type.name).to eql('A::N')
         type = type.resolved_type
-        expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
-        expect(type.type_string).to eql('C::C')
+        expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+        expect(type.name).to eql('C::C')
       end
 
-      it 'will not resolve reverse dependencies, b -> a' do
+      it 'will resolve reverse dependencies, b -> a' do
         type = Puppet::Pops::Types::TypeParser.singleton.parse('B::X', Puppet::Pops::Loaders.find_loader('b'))
         expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
         expect(type.name).to eql('B::X')
         type = type.resolved_type
-        expect(type).to be_a(Puppet::Pops::Types::PTypeReferenceType)
-        expect(type.type_string).to eql('A::A')
+        expect(type).to be_a(Puppet::Pops::Types::PTypeAliasType)
+        expect(type.name).to eql('A::A')
       end
 
       it 'does not resolve init_typeset when more qualified type is found in typeset' do


### PR DESCRIPTION
This is an updated version of the PR #6614 that now intermixes 3x function loading with 4.x loading, thus making the precedence 4.x, then 3.x per module rather than doing all 3.x at the end of having searched the module path. A small benchmark run showed this to be more or less a wash in terms of performance.

At this point tests needs to be added. PR here for early review and to get a jenkins run. 