### PR TITLE
Batchable resources

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -226,6 +226,10 @@ class Type
     }
   end
 
+  def self.batchable?
+    self.respond_to?(:batch_sync)
+  end
+
   # @comment These `apply_to` methods are horrible.  They should really be implemented
   #   as part of the usual system of constraints that apply to a type and
   #   provider pair, but were implemented as a separate shadow system.

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -66,6 +66,12 @@ module Puppet
       :methods => [:package_settings_insync?, :package_settings, :package_settings=]
     feature :virtual_packages, "The provider accepts virtual package names for install and uninstall."
 
+    def self.batch_sync(resources, param_name)
+      self.fail(Puppet::Error, _("Only ensure is supported for batch application")) if param_name != :ensure
+
+      resources.each { |r| r.parameter(param_name).sync }
+    end
+
     ensurable do
       desc <<-EOT
         What state the package should be in. On packaging systems that can


### PR DESCRIPTION
Implement the ability to declare a `batch_sync` methods on resources that results in collapsing adjacent graph entries for that resource into a single `batch_sync` invocation. Implement `batch_sync` for yum as a POC.