### PR TITLE
(PUP-6919) Change to the cwd before changing privileges in execute_posix

### DIFF
--- a/acceptance/tests/resource/exec/should_run_command_as_user.rb
+++ b/acceptance/tests/resource/exec/should_run_command_as_user.rb
@@ -1,0 +1,55 @@
+test_name "The exec resource should be able to run commands under a different user" do
+  confine :except, :platform => 'windows'
+
+  tag 'audit:high',
+      'audit:acceptance'
+
+  def random_username
+  "pl#{rand(999999).to_i}"
+  end
+
+  def exec_resource_manifest(params = {})
+    default_params = {
+      :logoutput => true,
+      :path      => '/usr/bin:/usr/sbin:/bin:/sbin',
+      :command   => 'echo Hello'
+    }
+    params = default_params.merge(params)
+
+    params_str = params.map do |param, value|
+      value_str = value.to_s
+      value_str = "'#{value_str}'" if value.is_a?(String)
+      "  #{param} => #{value_str}"
+    end.join(",\n")
+
+    <<-MANIFEST
+exec { 'run_test_command':
+  #{params_str}
+}
+MANIFEST
+  end
+
+  agents.each do |agent|
+    username = random_username
+
+    # Create our user. Ensure that we start with a clean slate.
+    agent.user_absent(username)
+    agent.user_present(username)
+    teardown { agent.user_absent(username) }
+
+    tmpdir = agent.tmpdir("forbidden")
+    on(agent, "chmod 700 #{tmpdir}")
+
+    step "Runs the command even when the user doesn't have permissions to access the pwd" do
+      # Can't use apply_manifest_on here because that does not take the :cwd
+      # as an option.
+      tmpfile = agent.tmpfile("exec_user_perms_manifest")
+      create_remote_file(agent, tmpfile, exec_resource_manifest(user: username))
+      on(agent, "cd #{tmpdir} && puppet apply #{tmpfile} --detailed-exitcodes", acceptable_exit_codes: [0, 2])
+    end
+
+    step "Runs the command even when the user doesn't have permission to access the cwd" do
+      apply_manifest_on(agent, exec_resource_manifest(user: username, cwd: tmpdir), catch_failures: true)
+    end
+  end
+end

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -81,7 +81,7 @@ describe Puppet::Util::Execution do
 
       it "should fork a child process to execute the command" do
         Kernel.expects(:fork).returns(pid).yields
-        Kernel.expects(:exec).with('test command', instance_of(Hash))
+        Kernel.expects(:exec).with('test command')
 
         call_exec_posix('test command', {}, @stdin, @stdout, @stderr)
       end
@@ -100,7 +100,7 @@ describe Puppet::Util::Execution do
       end
 
       it "should exit failure if there is a problem execing the command" do
-        Kernel.expects(:exec).with('test command', instance_of(Hash)).raises("failed to execute!")
+        Kernel.expects(:exec).with('test command').raises("failed to execute!")
         Puppet::Util::Execution.stubs(:puts)
         Puppet::Util::Execution.expects(:exit!).with(1)
 
@@ -108,13 +108,13 @@ describe Puppet::Util::Execution do
       end
 
       it "should properly execute commands specified as arrays" do
-        Kernel.expects(:exec).with('test command', 'with', 'arguments', instance_of(Hash))
+        Kernel.expects(:exec).with('test command', 'with', 'arguments')
 
         call_exec_posix(['test command', 'with', 'arguments'], {:uid => 50, :gid => 55}, @stdin, @stdout, @stderr)
       end
 
       it "should properly execute string commands with embedded newlines" do
-        Kernel.expects(:exec).with("/bin/echo 'foo' ; \n /bin/echo 'bar' ;", instance_of(Hash))
+        Kernel.expects(:exec).with("/bin/echo 'foo' ; \n /bin/echo 'bar' ;")
 
         call_exec_posix("/bin/echo 'foo' ; \n /bin/echo 'bar' ;", {:uid => 50, :gid => 55}, @stdin, @stdout, @stderr)
       end
@@ -135,7 +135,8 @@ describe Puppet::Util::Execution do
 
         it 'should run the command in the specified working directory' do
           File.expects(:directory?).with(cwd).returns(true)
-          Kernel.expects(:exec).with('test command', has_entries(:chdir => cwd))
+          Dir.expects(:chdir).with(cwd)
+          Kernel.expects(:exec).with('test command')
 
           call_exec_posix('test command', { :cwd => cwd }, @stdin, @stdout, @stderr)
         end


### PR DESCRIPTION
Previously in execute_posix, we'd cd into the cwd after changing the
process' privileges to run under a different user. This was causing
failures for the case when the user did not have permissions to access
the cwd.

This commit changes to the cwd before changing privileges.

This commit adds an acceptance test that replicates this bug, and also adds another
acceptance test to ensure that the exec resource can still run the command under a
different user even if that user does not have permissions to access the
pwd. The latter acceptance test is how this bug was originally detected
and is also a separate requirement of the exec resource.