### PR TITLE
(PUP-8967) Request simple status to detect if server is functional

### DIFF
--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -16,7 +16,7 @@ test_name "Priority of server_list setting over server setting" do
             on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
                :acceptable_exit_codes => [0, 2]) do |result|
               unless agent['locale'] == 'ja'
-                assert_match(/Selected master: #{master}:#{master_port}/,
+                assert_match(/Selected puppet server: #{master}:#{master_port}/,
                              result.stdout, "should have selected the working master")
               end
             end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -395,8 +395,11 @@ class Puppet::Configurer
       port = server[1] || Puppet[:masterport]
       begin
         http = Puppet::Network::HttpPool.http_ssl_instance(host, port)
-        http.head('/status/v1/simple')
-        return [host, port]
+        response = http.get('/status/v1/simple')
+        return [host, port] if response.is_a?(Net::HTTPOK)
+
+        Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %
+                     { host: host, port: port, code: response.code, reason: response.message })
       rescue
         # Nothing to see here
         Puppet.debug(_("Puppet server %{host}:%{port} is unreachable") % { host: host, port: port })

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -217,26 +217,22 @@ class Puppet::Configurer
 
         # Skip failover logic if the server_list setting is empty
         if Puppet.settings[:server_list].nil? || Puppet.settings[:server_list].empty?
-          do_failover = false;
+          do_failover = false
         else
           do_failover = true
         end
         # When we are passed a catalog, that means we're in apply
         # mode. We shouldn't try to do any failover in that case.
         if options[:catalog].nil? && do_failover
-          found = find_functional_server()
-          server = found[:server]
-          if server.nil?
-            Puppet.warning _("Could not select a functional puppet master")
-            server = [nil, nil]
-          end
-          Puppet.override(:server => server[0], :serverport => server[1]) do
-            if !server.first.nil?
-              Puppet.debug "Selected master: #{server[0]}:#{server[1]}"
-              report.master_used = "#{server[0]}:#{server[1]}"
+          server, port = find_functional_server
+          Puppet.override(server: server, serverport: port) do
+            if server
+              Puppet.debug _("Selected puppet server: %{server}:%{port}") % { server: server, port: port }
+              report.master_used = "#{server}:#{port}"
+            else
+              Puppet.warning _("Could not select a functional puppet server")
             end
-
-            completed = run_internal(options.merge(:node => found[:node]))
+            completed = run_internal(options)
           end
         else
           completed = run_internal(options)
@@ -290,7 +286,7 @@ class Puppet::Configurer
         begin
           node = nil
           node_retr_time = thinmark do
-            node = options[:node] || Puppet::Node.indirection.find(Puppet[:node_name_value],
+            node = Puppet::Node.indirection.find(Puppet[:node_name_value],
               :environment => Puppet::Node::Environment.remote(@environment),
               :configured_environment => configured_environment,
               :ignore_cache => true,
@@ -393,32 +389,20 @@ class Puppet::Configurer
   end
   private :run_internal
 
-  def find_functional_server()
-    configured_environment = Puppet[:environment] if Puppet.settings.set_by_config?(:environment)
-
-    node = nil
-    selected_server = Puppet.settings[:server_list].find do |server|
-      # Puppet.override doesn't return the result of its block, so we
-      # need to handle this manually
-      found = false
-      server[1] ||= Puppet[:masterport]
-      Puppet.override(:server => server[0], :serverport => server[1]) do
-        begin
-          node = Puppet::Node.indirection.find(Puppet[:node_name_value],
-              :environment => Puppet::Node::Environment.remote(@environment),
-              :configured_environment => configured_environment,
-              :ignore_cache => true,
-              :transaction_uuid => @transaction_uuid,
-              :fail_on_404 => false)
-          found = true
-        rescue
-          # Nothing to see here
-        end
+  def find_functional_server
+    Puppet.settings[:server_list].each do |server|
+      host = server[0]
+      port = server[1] || Puppet[:masterport]
+      begin
+        http = Puppet::Network::HttpPool.http_ssl_instance(host, port)
+        http.head('/status/v1/simple')
+        return [host, port]
+      rescue
+        # Nothing to see here
+        Puppet.debug(_("Puppet server %{host}:%{port} is unreachable") % { host: host, port: port })
       end
-      found
     end
-    { :node => node,
-      :server => selected_server }
+    [nil, nil]
   end
   private :find_functional_server
 

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -201,7 +201,7 @@ class Puppet::Indirector::Request
     end
 
     # ... Fall back onto the default server.
-     bound_server = Puppet.lookup(:server) do
+    bound_server = Puppet.lookup(:server) do
       if primary_server = Puppet.settings[:server_list][0]
         primary_server[0]
       else

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1010,32 +1010,30 @@ describe Puppet::Configurer do
 
     it "should select a server when provided" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
-      Puppet::Network::HTTP::Pool.expects(:new).returns(pool)
-      Puppet.expects(:override).with({:http_pool => pool}).yields
-      Puppet.expects(:override).with({:server => "myserver", :serverport => '123'}).twice.yields
-      Puppet::Node.indirection.expects(:find).returns(nil)
-      @agent.expects(:run_internal).returns(nil)
-      @agent.run
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(mock('request', head: nil))
+      @agent.stubs(:run_internal)
+
+      options = {}
+      @agent.run(options)
+      expect(options[:report].master_used).to eq('myserver:123')
     end
 
     it "should fallback to an empty server when failover fails" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
-      Puppet::Network::HTTP::Pool.expects(:new).returns(pool)
-      Puppet.expects(:override).with({:http_pool => pool}).yields
-      Puppet.expects(:override).with({:server => "myserver", :serverport => '123'}).yields
-      Puppet.expects(:override).with({:server => nil, :serverport => nil}).yields
       error = Net::HTTPError.new(400, 'dummy server communication error')
-      Puppet::Node.indirection.expects(:find).raises(error)
-      @agent.expects(:run_internal).returns(nil)
-      @agent.run
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(error)
+      @agent.stubs(:run_internal)
+
+      options = {}
+      @agent.run(options)
+      expect(options[:report].master_used).to be_nil
     end
 
     it "should not make multiple node requets when the server is found" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      Puppet::Node.indirection.expects(:find).returns("mynode").once
-      @agent.expects(:prepare_and_retrieve_catalog).returns(nil)
+      Puppet::Network::HttpPool.expects(:http_ssl_instance).once
+      @agent.stubs(:run_internal)
+
       @agent.run
     end
   end


### PR DESCRIPTION
Previously, puppet would make a node request to determine which server
in its `server_list` was functional. The node request is non-trivial as
puppetserver needs to acquire a JRuby instance, query puppetdb and
classifier for node information, and return it. The agent normally
passed the node object through to the normal agent run, so the effort
wasn't wasted. But if `strict_environment_mode` is enabled, then the
node was never used.

Also, if there is a classification error, then the agent will interpret
that to mean the server is unreachable until it exhausts all servers in
the list.

This commit switches the agent to sending a HEAD request to the
/status/v1/simple endpoint. This means the agent will make at least one
additional HTTP request per run when using `server_list`. But it should
be negligible because the connection is persisted, puppetserver handles
the request in clojure, and doesn't query puppetserver metrics. In fact
the HEAD response body will be empty.