### PR TITLE
(PUP-9028) Create ssl application for managing client keys/certs

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -46,6 +46,8 @@ HELP
       exit(1)
     end
 
+    Puppet.settings.use(:main, :agent)
+
     action = command_line.args.first
     case action
     when 'submit_request'

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -1,0 +1,65 @@
+require 'puppet/application'
+require 'puppet/ssl/oids'
+
+class Puppet::Application::Ssl < Puppet::Application
+  def summary
+    _("Manage SSL keys and certificates for puppet SSL clients")
+  end
+
+  def help
+    <<-HELP
+puppet-ssl(8) -- #{summary}
+========
+
+SYNOPSIS
+--------
+Manage SSL keys and certificates for an SSL clients needed
+to communicate with a puppet infrastructure.
+
+USAGE
+-----
+puppet ssl <action> [--certname <NAME>]
+
+ACTIONS
+-------
+
+* submit_request:
+  Generate a certificate signing request (CSR) and submit it to the CA. If a private and
+  public key pair already exist, they will be used to generate the CSR. Otherwise a new
+  key pair will be generated. If a CSR has already been submitted with the given `certname`,
+  then the operation will fail.
+
+HELP
+  end
+
+  option('--certname NAME') do |arg|
+    options[:certname] = arg
+  end
+
+  def main
+    if command_line.args.empty?
+      puts help
+      exit(1)
+    end
+
+    action = command_line.args.first
+    case action
+    when 'submit_request'
+      submit_request(options[:certname])
+    else
+      puts "Unknown action '#{action}'"
+      exit(1)
+    end
+  end
+
+  def submit_request(certname = nil)
+    Puppet::SSL::Host.ca_location = :remote
+    ssl = Puppet::SSL::Host.new(certname)
+    ssl.ensure_ca_certificate
+    ssl.generate_certificate_request(dns_alt_names: '')
+    puts "Submitted certificate request for '#{ssl.name}' to https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
+  rescue => e
+    puts "Failed to submit certificate request: #{e.message}"
+    exit 1
+  end
+end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -50,6 +50,7 @@ HELP
     case action
     when 'submit_request'
       submit_request(options[:certname])
+      download_cert(options[:certname])
       exit(0)
     when 'download_cert'
       download_cert(options[:certname])
@@ -64,7 +65,7 @@ HELP
     Puppet::SSL::Host.ca_location = :remote
     ssl = Puppet::SSL::Host.new(certname)
     ssl.ensure_ca_certificate
-    ssl.generate
+    ssl.submit_request
     puts "Submitted certificate request for '#{ssl.name}' to https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
   rescue => e
     puts "Failed to submit certificate request: #{e.message}"

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -47,42 +47,42 @@ HELP
     end
 
     Puppet.settings.use(:main, :agent)
+    Puppet::SSL::Host.ca_location = :remote
+    host = Puppet::SSL::Host.new(options[:certname])
 
     action = command_line.args.first
     case action
     when 'submit_request'
-      submit_request(options[:certname])
-      download_cert(options[:certname])
-      exit(0)
+      submit_request(host)
+      download_cert(host)
     when 'download_cert'
-      download_cert(options[:certname])
-      exit(0)
+      download_cert(host)
     else
       puts "Unknown action '#{action}'"
       exit(1)
     end
+
+    exit(0)
   end
 
-  def submit_request(certname = nil)
-    Puppet::SSL::Host.ca_location = :remote
-    ssl = Puppet::SSL::Host.new(certname)
-    ssl.ensure_ca_certificate
-    ssl.submit_request
-    puts "Submitted certificate request for '#{ssl.name}' to https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
+  def submit_request(host)
+    host.ensure_ca_certificate
+
+    host.submit_request
+    puts "Submitted certificate request for '#{host.name}' to https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
   rescue => e
     puts "Failed to submit certificate request: #{e.message}"
     exit(1)
   end
 
-  def download_cert(certname = nil)
-    Puppet::SSL::Host.ca_location = :remote
-    ssl = Puppet::SSL::Host.new(certname)
-    ssl.ensure_ca_certificate
-    puts "Downloading certificate '#{ssl.name}' from https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
-    if cert = ssl.download_host_certificate
-      puts "Downloaded certificate '#{ssl.name}' with fingerprint #{cert.fingerprint}"
+  def download_cert(host)
+    host.ensure_ca_certificate
+
+    puts "Downloading certificate '#{host.name}' from https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
+    if cert = host.download_host_certificate
+      puts "Downloaded certificate '#{host.name}' with fingerprint #{cert.fingerprint}"
     else
-      puts "No certificate for '#{ssl.name}' on CA"
+      puts "No certificate for '#{host.name}' on CA"
     end
   rescue => e
     puts "Failed to download certificate: #{e.message}"

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -46,6 +46,7 @@ HELP
     case action
     when 'submit_request'
       submit_request(options[:certname])
+      exit(0)
     else
       puts "Unknown action '#{action}'"
       exit(1)
@@ -56,10 +57,10 @@ HELP
     Puppet::SSL::Host.ca_location = :remote
     ssl = Puppet::SSL::Host.new(certname)
     ssl.ensure_ca_certificate
-    ssl.generate_certificate_request(dns_alt_names: '')
+    ssl.generate
     puts "Submitted certificate request for '#{ssl.name}' to https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
   rescue => e
     puts "Failed to submit certificate request: #{e.message}"
-    exit 1
+    exit(1)
   end
 end

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -243,6 +243,15 @@ ERROR_STRING
     end
   end
 
+  def download_host_certificate
+    cert = download_certificate_from_ca(name)
+    return nil unless cert
+
+    validate_certificate_with_key(cert)
+    save_host_certificate(cert)
+    cert
+  end
+
   # Search for an existing CSR for this host either cached on
   # disk or stored by the CA. Returns nil if no request exists.
   # @return [Puppet::SSL::CertificateRequest, nil]

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -522,6 +522,7 @@ ERROR_STRING
       end
     end
   end
+  public :ensure_ca_certificate
 
   # Creates an arry of SSL Certificate objects from a PEM-encoding string
   # of one or more certs.

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -712,6 +712,7 @@ ERROR_STRING
       end
     end
   end
+  public :check_for_certificate_on_disk
 
   # Attempts to download this host's certificate from the CA server.
   # Returns nil if the CA does not yet have a signed cert for this host.

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -288,6 +288,54 @@ ERROR_STRING
     end
   end
 
+  # Generate a keypair, generate a CSR, and submit it. If a local key pair
+  # already exists it will be used to generate the CSR. If a local CSR already
+  # exists and matches the key then the existing CSR will be submitted. If the
+  # CSR and key do not match an exception will be raised.
+  #
+  # @return [Puppet::SSL::CertificateRequest, nil]
+  def submit_request
+    generate_key unless key
+
+    csr = load_certificate_request_from_file
+    if csr
+      if key.content.public_key.to_s != csr.content.public_key.to_s
+        Puppet.warning("The local CSR does not match the agent's public key. Generating a new CSR.")
+
+        request_path = certificate_request_location(name)
+        Puppet::FileSystem.unlink(request_path)
+        csr = nil
+      end
+    end
+
+    if csr
+      validate_csr_with_key(csr, key)
+      submit_certificate_request(csr)
+      @certificate_request = csr
+    else
+      generate_certificate_request
+    end
+
+    @certificate_request
+  end
+
+  def validate_local_csr_with_key(csr, key)
+    if key.content.public_key.to_s != csr.content.public_key.to_s
+      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: csr.fingerprint, csr_public_key: csr.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
+The local CSR does not match the agent's public key.
+CSR fingerprint: %{fingerprint}
+CSR public key: %{csr_public_key}
+Agent public key: %{agent_public_key}
+To fix this, remove the CSR from the agent and then start a puppet run, which will automatically regenerate a CSR.
+On the agent:
+  1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
+  1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f
+  2. puppet agent -t
+ERROR_STRING
+    end
+  end
+  private :validate_local_csr_with_key
+
   def validate_csr_with_key(csr, key)
     if key.content.public_key.to_s != csr.content.public_key.to_s
       raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: csr.fingerprint, csr_public_key: csr.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -1,169 +1,184 @@
 require 'spec_helper'
 require 'puppet/application/ssl'
 require 'webmock/rspec'
+require 'openssl'
 
 describe Puppet::Application::Ssl do
   let(:ssl) { Puppet::Application[:ssl] }
-  let(:ca) do <<-PEM
------BEGIN CERTIFICATE-----
-MIIFaTCCA1GgAwIBAgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRQdXBw
-ZXQgQ0E6IGxvY2FsaG9zdDAeFw0xODA4MTQxOTA5MThaFw0yMzA4MTQxOTA5MTha
-MB8xHTAbBgNVBAMMFFB1cHBldCBDQTogbG9jYWxob3N0MIICIjANBgkqhkiG9w0B
-AQEFAAOCAg8AMIICCgKCAgEAvE0wIzE2Bpu9DzUKgqnSXnRjelrEuEOcyE6A3dcX
-vZftBFvch29WCKfFOyc0TKuAse2FGAPar1RB27+gCzb/egjPLRxZSBksW4McBdvb
-8RNBHitrBGEcwsgr9I/6lx2fEWCBxUuJs390TQDwr7KSuq1JV9qL269bDkQyOOZo
-4Z/puHKHP2jRupMA1MTpJO3ZLT6ks16FyJMifLDYoLUorpLon6sedmB9urAXH8D2
-/TuFnvpzPDn3ZqX53BpUyNvqSn+ZxlFtMwr9csiCfBFesXX67U2D2zjIzyxZ14o0
-ukhl4dHz3Gb/s/71RfCoKT1bIKFqeopl7ZYM/FTOcl0YkRQc90R5opu8RxVdUZ13
-GbdFGLJ8BJNZCvhRdAVl3n9trh8PhNvq0E15ne/atjBF2fShj7C4+zqpAcQpMQwY
-m9az6NKZovC+jIdzDx/6de7JdEzgmU64vEMlWzth0s+dXhLWyVLzdiEPi4kyb+yH
-6/CruOB8zh6C71WfRaj28wbcK5KmGcMMOGKU53HaaFJ5gQ8FIvcjXiCfJ6f8OXpn
-Wq64SmllJexWOnb3NIW3Uda1mVkJ7MJDQJMSdyd2KgQn4DffCMXtX9mJqi3Tvqd0
-e1ZymE8ntNORiWWWQeXrOg4ykbHvuLM6Wi1n+5s4AlEnIOs4424H32seOk82Qrv7
-/zsCAwEAAaOBrzCBrDA3BglghkgBhvhCAQ0EKgwoUHVwcGV0IFJ1YnkvT3BlblNT
-TCBJbnRlcm5hbCBDZXJ0aWZpY2F0ZTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/
-BAUwAwEB/zAdBgNVHQ4EFgQUy+eTVdPJf/oGx+at3UC77aNa2PQwMQYDVR0jBCow
-KKEjpCEwHzEdMBsGA1UEAwwUUHVwcGV0IENBOiBsb2NhbGhvc3SCAQEwDQYJKoZI
-hvcNAQELBQADggIBAHlfauetY8Cun4DBPdFyB/YlgmtCExT9TfGlKUYtZmuzM+dL
-YujirGfMsmkgaA9+uAoBhi4XDcLZ+VdvO9HGZRKfKMRToL41nXBvaACmtOAF0o51
-EsbjP8T66KQhWLLSHI6H91L8nR7jtXT9LYSNEF0aIz9sEyuyt4BsYBoLis/xeTBS
-PXENDI8FQPSGqwWGm8RuMYelg8+IqMh1R0FNC1whw1vwDxps+iUM3JeGJrrcCG3Y
-9KbpqAMBKY5Y0ESZd56uEsOh9WW8floEHhNUQh0tFn2DcqGeDOOelyXdmBdB28y+
-PrgaSvq1XktDBGgTCuDuSNTsFhddVjI41QjYKPZtNt39CSVzp+egrl/CkgGekS/2
-WnadaJgvNfPVnAsJTSs0/3hZlzp5MZZ2hXVA1sGrfKPYVXXLANXifHqUZToHzZ4i
-EW9K8GQFTocVglS42FLVyAVVv4MHN41TMC9M0H79CINMS8e3qqZaaZQz1a1jZ9nO
-5CrxUct82H220Usy8/30+xB+5dAg8ja4eRRBibVXsUO+Wi1Fd+eM3LlRhyk1fuJS
-f+f91Qei36uoggVJV1S5zkq8Qfv7hcm9RElLnJQjvlkbQYhTZcSCaZ5NUSdiDbAI
-WTKH/Z63t/fICwy2ORdxUz58Cp6W6TTxgfm9s/k2MPqGQIKaanaD/z53lC/a
------END CERTIFICATE-----
-PEM
+  let(:name) { 'ssl-client' }
+
+  def generate_cert(name, issuer = nil, issuer_key = nil)
+    # generate CA key pair
+    private_key = OpenSSL::PKey::RSA.new(512)
+    public_key = private_key.public_key
+
+    # generate CSR
+    csr = OpenSSL::X509::Request.new
+    csr.version = 0
+    csr.subject = OpenSSL::X509::Name.new([["CN", name]])
+    csr.public_key = public_key
+    csr.sign(private_key, OpenSSL::Digest::SHA256.new)
+
+    # is it self-signed?
+    issuer ||= csr.subject
+    issuer_key ||= private_key
+
+    # issue cert
+    cert = OpenSSL::X509::Certificate.new
+    cert.version    = 2 # X509v3
+    cert.subject    = csr.subject
+    cert.issuer     = issuer
+    cert.public_key = csr.public_key
+    cert.serial     = 1
+    cert.not_before = Time.now - (60*60*24)
+    cert.not_after  = Time.now + (60*60*24)
+    cert.sign(issuer_key, OpenSSL::Digest::SHA256.new)
+
+    {:private_key => private_key, :csr => csr, :cert => cert}
   end
 
-  let(:crl) do
-    <<-PEM
------BEGIN X509 CRL-----
-MIICmTCBggIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRQdXBwZXQgQ0E6
-IGxvY2FsaG9zdBcNMTgwODE1MTkwOTE3WhcNMjMwODE0MTkwOTE4WqAvMC0wHwYD
-VR0jBBgwFoAUy+eTVdPJf/oGx+at3UC77aNa2PQwCgYDVR0UBAMCAQAwDQYJKoZI
-hvcNAQELBQADggIBAHTanPAGJclIy4BurFqxKw3I9lC4jwPQOSIrcQRtTCwrl6Rv
-yb5mlPF11SxTpLLhlK1JKM1kJoGWbhR4n2ICiV+eQQb9iXZzH25oGA8zMVVh4F2V
-NbZ2Ppnn9xqFhnax5Ytq2IGfgTGGTP24EgmgcAVNtBXB/TJO/EBxMpWn8v0u4lUG
-4TplmoA+Zs23hXstCGakmgvyiTT5WtmnmVSlIon6EvXdUrlX1aBNx+HlIpgUUVMO
-RrO4WV1rtwOAw+lYRosFOKnLGi6oDqku4kbQl4GzFUlFxnS/Xdz9PGHq8O4dNt6E
-zKcAKhH51OwrP6ODbWwjIQSy393JP/uXcpQzv2Xts7J/Pn+BlHwTse6B4TfbKDQO
-SsPsoFjaVQtMUCmYX+VsBBJNKAT4oFsXMz8/V8pU56P2N24sk3vUiHL5+RjA2rN6
-nn6IUq7lFUOzD8P3Bx+hiCqk85FxO1A5MkpgG7gWEoQ5x5UYjGDMFjNw724Um+sY
-66aPl6QwNU7nlmg/T1agplczIjekuf/DuxjniZ7B1S9hLNqRTifqYE9QirRDSB8S
-oPVq5O006EMHQcNiRVEiGQGTS8wCDMDjTv8uCSxaO1nuiBpdZy8SXPC6g9s1j1SR
-GZtYhcGxplP9xw03WU5Smzdepo765oA2+gFLAqGaZLXiUk091JawjWUO65Eg
------END X509 CRL-----
-PEM
+  def generate_crl(name, issuer, issuer_key)
+    crl = OpenSSL::X509::CRL.new
+    crl.version = 1
+    crl.issuer = issuer
+    crl.last_update = Time.now - (60*60*24)
+    crl.next_update =  Time.now + (60*60*24)
+    crl.extensions = [OpenSSL::X509::Extension.new('crlNumber', OpenSSL::ASN1::Integer(0))]
+    crl.sign(issuer_key, OpenSSL::Digest::SHA256.new)
+
+    crl
+  end
+
+  before :all do
+    @ca = generate_cert('ca')
+    @crl = generate_crl('ca', @ca[:cert].subject, @ca[:private_key])
+    @host = generate_cert('ssl-client', @ca[:cert].subject, @ca[:private_key])
   end
 
   before do
     WebMock.disable_net_connect!
 
     Puppet.settings.use(:main)
+    Puppet[:certname] = name
 
     # Host assumes ca cert and crl are present
-    File.open(Puppet[:localcacert], 'w') { |f| f.write(ca) }
-    File.open(Puppet[:hostcrl], 'w') { |f| f.write(crl) }
+    File.open(Puppet[:localcacert], 'w') { |f| f.write(@ca[:cert].to_pem) }
+    File.open(Puppet[:hostcrl], 'w') { |f| f.write(@crl.to_pem) }
+  end
+
+  def expects_command_to_output(expected_message = nil, code = 0)
+    expect {
+      expect {
+        ssl.run_command
+      }.to exit_with(code)
+    }.to output(expected_message).to_stdout
   end
 
   context 'when generating help' do
     it 'prints usage when no arguments are specified' do
       ssl.command_line.args << 'whoops'
 
-      expect {
-        expect {
-          ssl.run_command
-        }.to exit_with(1)
-      }.to output(/Unknown action 'whoops'/).to_stdout
+      expects_command_to_output(/Unknown action 'whoops'/, 1)
     end
 
     it 'rejects unknown actions' do
-      expect {
-        expect {
-          ssl.run_command
-        }.to exit_with(1)
-      }.to output(/^puppet-ssl.*SYNOPSIS/m).to_stdout
+      expects_command_to_output(/^puppet-ssl.*SYNOPSIS/m, 1)
     end
   end
 
   context 'when submitting a CSR' do
-    let(:name) { 'ssl-client' }
     let(:csr_path) { File.join(Puppet[:requestdir], "#{name}.pem") }
 
     before do
-      Puppet[:certname] = name
       ssl.command_line.args << 'submit_request'
+
+      File.open(Puppet[:hostprivkey], 'w') { |f| f.write(@host[:private_key].to_pem) }
+      File.open(Puppet[:hostpubkey], 'w') { |f| f.write(@host[:private_key].public_key.to_pem) }
     end
 
     it 'downloads the CA bundle first when missing' do
       File.delete(Puppet[:localcacert])
-      stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: ca)
-      stub_request(:put, %r{puppet-ca/v1/certificate_request}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: @ca[:cert].to_pem)
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 404)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
 
-      expect {
-        ssl.run_command
-      }.to output.to_stdout
-      expect(File.read(Puppet[:localcacert])).to eq(ca)
+      expects_command_to_output
+
+      expect(File.read(Puppet[:localcacert])).to eq(@ca[:cert].to_pem)
     end
 
     it 'downloads the CRL bundle first when missing' do
       File.delete(Puppet[:hostcrl])
-      stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: crl)
-      stub_request(:put, %r{puppet-ca/v1/certificate_request}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: @crl.to_pem)
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 404)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
 
-      expect {
-        ssl.run_command
-      }.to output.to_stdout
-      expect(File.read(Puppet[:hostcrl])).to eq(crl)
+      expects_command_to_output
+
+      expect(File.read(Puppet[:hostcrl])).to eq(@crl.to_pem)
     end
 
     it 'submits the CSR and saves it locally' do
-      stub_request(:put, %r{puppet-ca/v1/certificate_request}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 404)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
 
-      expect {
-        ssl.run_command
-      }.to output(%r{Submitted certificate request for '#{name}' to https://.*}).to_stdout
+      expects_command_to_output(%r{Submitted certificate request for '#{name}' to https://.*}, 0)
 
       expect(Puppet::FileSystem).to be_exist(csr_path)
     end
 
-    it 'reports an error if the CSR has already been submitted' do
-      body = "#{name} already has a requested certificate; ignoring certificate request"
-      stub_request(:put, %r{puppet-ca/v1/certificate_request})
-        .to_return(status: 400, body: body)
+    it 'detects when a CSR with the same public key has already been submitted' do
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 404)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
 
-      expect {
-        expect {
-          ssl.run_command
-        }.to exit_with(1)
-      }.to output(/Failed to submit certificate request: Error 400 on SERVER: #{body}/).to_stdout
+      expects_command_to_output(%r{Submitted certificate request for '#{name}' to https://.*}, 0)
+
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200, body: @host[:csr].to_pem)
+      #  we skip :put
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
+
+      expects_command_to_output
     end
 
-    it "resends a previously submitted CSR" do
-      body = "#{name} already has a requested certificate; ignoring certificate request"
-      stub_request(:put, %r{puppet-ca/v1/certificate_request})
-        .to_return(
-          {status: 200},
-          {status: 400, body: body}
-        )
+    it "reports an error if the downloaded CSR doesn't match the local public key" do
+      # generate a new host key, whose public key doesn't match the CSR
+      private_key = OpenSSL::PKey::RSA.new(512)
+      File.open(Puppet[:hostprivkey], 'w') { |f| f.write(private_key.to_pem) }
+      File.open(Puppet[:hostpubkey], 'w') { |f| f.write(private_key.public_key.to_pem) }
 
-      expect {
-        ssl.run_command
-      }.to output(%r{Submitted certificate request for '#{name}' to https://.*}).to_stdout
+      body = "The CSR retrieved from the master does not match the agent's public key."
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200, body: @host[:csr].to_pem)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 400, body: body)
 
-      expect {
-        expect {
-          ssl.run_command
-        }.to exit_with(1)
-      }.to output(/Failed to submit certificate request: Error 400 on SERVER: #{body}/).to_stdout
+      expects_command_to_output(/Failed to submit certificate request: #{body}/, 1)
     end
 
-    it 'accepts dns alt names'
-    it 'accepts csr attributes'
-    it 'accepts extension requests'
+    it 'downloads the certificate when autosigning is enabled' do
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 404)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 200, body: @host[:cert].to_pem)
+
+      expects_command_to_output(%r{Submitted certificate request for '#{name}' to https://.*}, 0)
+
+      expect(Puppet::FileSystem).to be_exist(Puppet[:hostcert])
+    end
+
+    it 'accepts dns alt names' do
+      Puppet[:dns_alt_names] = 'majortom'
+
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 404)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
+
+      expects_command_to_output
+
+      csr = Puppet::SSL::CertificateRequest.new(name)
+      csr.read(csr_path)
+      expect(csr.subject_alt_names).to include('DNS:majortom')
+    end
   end
 end

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+require 'puppet/application/ssl'
+require 'webmock/rspec'
+
+describe Puppet::Application::Ssl do
+  let(:ssl) { Puppet::Application[:ssl] }
+  let(:ca) do <<-PEM
+-----BEGIN CERTIFICATE-----
+MIIFaTCCA1GgAwIBAgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRQdXBw
+ZXQgQ0E6IGxvY2FsaG9zdDAeFw0xODA4MTQxOTA5MThaFw0yMzA4MTQxOTA5MTha
+MB8xHTAbBgNVBAMMFFB1cHBldCBDQTogbG9jYWxob3N0MIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAvE0wIzE2Bpu9DzUKgqnSXnRjelrEuEOcyE6A3dcX
+vZftBFvch29WCKfFOyc0TKuAse2FGAPar1RB27+gCzb/egjPLRxZSBksW4McBdvb
+8RNBHitrBGEcwsgr9I/6lx2fEWCBxUuJs390TQDwr7KSuq1JV9qL269bDkQyOOZo
+4Z/puHKHP2jRupMA1MTpJO3ZLT6ks16FyJMifLDYoLUorpLon6sedmB9urAXH8D2
+/TuFnvpzPDn3ZqX53BpUyNvqSn+ZxlFtMwr9csiCfBFesXX67U2D2zjIzyxZ14o0
+ukhl4dHz3Gb/s/71RfCoKT1bIKFqeopl7ZYM/FTOcl0YkRQc90R5opu8RxVdUZ13
+GbdFGLJ8BJNZCvhRdAVl3n9trh8PhNvq0E15ne/atjBF2fShj7C4+zqpAcQpMQwY
+m9az6NKZovC+jIdzDx/6de7JdEzgmU64vEMlWzth0s+dXhLWyVLzdiEPi4kyb+yH
+6/CruOB8zh6C71WfRaj28wbcK5KmGcMMOGKU53HaaFJ5gQ8FIvcjXiCfJ6f8OXpn
+Wq64SmllJexWOnb3NIW3Uda1mVkJ7MJDQJMSdyd2KgQn4DffCMXtX9mJqi3Tvqd0
+e1ZymE8ntNORiWWWQeXrOg4ykbHvuLM6Wi1n+5s4AlEnIOs4424H32seOk82Qrv7
+/zsCAwEAAaOBrzCBrDA3BglghkgBhvhCAQ0EKgwoUHVwcGV0IFJ1YnkvT3BlblNT
+TCBJbnRlcm5hbCBDZXJ0aWZpY2F0ZTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/
+BAUwAwEB/zAdBgNVHQ4EFgQUy+eTVdPJf/oGx+at3UC77aNa2PQwMQYDVR0jBCow
+KKEjpCEwHzEdMBsGA1UEAwwUUHVwcGV0IENBOiBsb2NhbGhvc3SCAQEwDQYJKoZI
+hvcNAQELBQADggIBAHlfauetY8Cun4DBPdFyB/YlgmtCExT9TfGlKUYtZmuzM+dL
+YujirGfMsmkgaA9+uAoBhi4XDcLZ+VdvO9HGZRKfKMRToL41nXBvaACmtOAF0o51
+EsbjP8T66KQhWLLSHI6H91L8nR7jtXT9LYSNEF0aIz9sEyuyt4BsYBoLis/xeTBS
+PXENDI8FQPSGqwWGm8RuMYelg8+IqMh1R0FNC1whw1vwDxps+iUM3JeGJrrcCG3Y
+9KbpqAMBKY5Y0ESZd56uEsOh9WW8floEHhNUQh0tFn2DcqGeDOOelyXdmBdB28y+
+PrgaSvq1XktDBGgTCuDuSNTsFhddVjI41QjYKPZtNt39CSVzp+egrl/CkgGekS/2
+WnadaJgvNfPVnAsJTSs0/3hZlzp5MZZ2hXVA1sGrfKPYVXXLANXifHqUZToHzZ4i
+EW9K8GQFTocVglS42FLVyAVVv4MHN41TMC9M0H79CINMS8e3qqZaaZQz1a1jZ9nO
+5CrxUct82H220Usy8/30+xB+5dAg8ja4eRRBibVXsUO+Wi1Fd+eM3LlRhyk1fuJS
+f+f91Qei36uoggVJV1S5zkq8Qfv7hcm9RElLnJQjvlkbQYhTZcSCaZ5NUSdiDbAI
+WTKH/Z63t/fICwy2ORdxUz58Cp6W6TTxgfm9s/k2MPqGQIKaanaD/z53lC/a
+-----END CERTIFICATE-----
+PEM
+  end
+
+  let(:crl) do
+    <<-PEM
+-----BEGIN X509 CRL-----
+MIICmTCBggIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRQdXBwZXQgQ0E6
+IGxvY2FsaG9zdBcNMTgwODE1MTkwOTE3WhcNMjMwODE0MTkwOTE4WqAvMC0wHwYD
+VR0jBBgwFoAUy+eTVdPJf/oGx+at3UC77aNa2PQwCgYDVR0UBAMCAQAwDQYJKoZI
+hvcNAQELBQADggIBAHTanPAGJclIy4BurFqxKw3I9lC4jwPQOSIrcQRtTCwrl6Rv
+yb5mlPF11SxTpLLhlK1JKM1kJoGWbhR4n2ICiV+eQQb9iXZzH25oGA8zMVVh4F2V
+NbZ2Ppnn9xqFhnax5Ytq2IGfgTGGTP24EgmgcAVNtBXB/TJO/EBxMpWn8v0u4lUG
+4TplmoA+Zs23hXstCGakmgvyiTT5WtmnmVSlIon6EvXdUrlX1aBNx+HlIpgUUVMO
+RrO4WV1rtwOAw+lYRosFOKnLGi6oDqku4kbQl4GzFUlFxnS/Xdz9PGHq8O4dNt6E
+zKcAKhH51OwrP6ODbWwjIQSy393JP/uXcpQzv2Xts7J/Pn+BlHwTse6B4TfbKDQO
+SsPsoFjaVQtMUCmYX+VsBBJNKAT4oFsXMz8/V8pU56P2N24sk3vUiHL5+RjA2rN6
+nn6IUq7lFUOzD8P3Bx+hiCqk85FxO1A5MkpgG7gWEoQ5x5UYjGDMFjNw724Um+sY
+66aPl6QwNU7nlmg/T1agplczIjekuf/DuxjniZ7B1S9hLNqRTifqYE9QirRDSB8S
+oPVq5O006EMHQcNiRVEiGQGTS8wCDMDjTv8uCSxaO1nuiBpdZy8SXPC6g9s1j1SR
+GZtYhcGxplP9xw03WU5Smzdepo765oA2+gFLAqGaZLXiUk091JawjWUO65Eg
+-----END X509 CRL-----
+PEM
+  end
+
+  before do
+    WebMock.disable_net_connect!
+
+    Puppet.settings.use(:main)
+
+    # Host assumes ca cert and crl are present
+    File.open(Puppet[:localcacert], 'w') { |f| f.write(ca) }
+    File.open(Puppet[:hostcrl], 'w') { |f| f.write(crl) }
+  end
+
+  context 'when generating help' do
+    it 'prints usage when no arguments are specified' do
+      ssl.command_line.args << 'whoops'
+
+      expect {
+        expect {
+          ssl.run_command
+        }.to exit_with(1)
+      }.to output(/Unknown action 'whoops'/).to_stdout
+    end
+
+    it 'rejects unknown actions' do
+      expect {
+        expect {
+          ssl.run_command
+        }.to exit_with(1)
+      }.to output(/^puppet-ssl.*SYNOPSIS/m).to_stdout
+    end
+  end
+
+  context 'when submitting a CSR' do
+    let(:name) { 'ssl-client' }
+    let(:csr_path) { File.join(Puppet[:requestdir], "#{name}.pem") }
+
+    before do
+      Puppet[:certname] = name
+      ssl.command_line.args << 'submit_request'
+    end
+
+    it 'downloads the CA bundle first when missing' do
+      File.delete(Puppet[:localcacert])
+      stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: ca)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request}).to_return(status: 200)
+
+      expect {
+        ssl.run_command
+      }.to output.to_stdout
+      expect(File.read(Puppet[:localcacert])).to eq(ca)
+    end
+
+    it 'downloads the CRL bundle first when missing' do
+      File.delete(Puppet[:hostcrl])
+      stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: crl)
+      stub_request(:put, %r{puppet-ca/v1/certificate_request}).to_return(status: 200)
+
+      expect {
+        ssl.run_command
+      }.to output.to_stdout
+      expect(File.read(Puppet[:hostcrl])).to eq(crl)
+    end
+
+    it 'submits the CSR and saves it locally' do
+      stub_request(:put, %r{puppet-ca/v1/certificate_request}).to_return(status: 200)
+
+      expect {
+        ssl.run_command
+      }.to output(%r{Submitted certificate request for '#{name}' to https://.*}).to_stdout
+
+      expect(Puppet::FileSystem).to be_exist(csr_path)
+    end
+
+    it 'reports an error if the CSR has already been submitted' do
+      body = "#{name} already has a requested certificate; ignoring certificate request"
+      stub_request(:put, %r{puppet-ca/v1/certificate_request})
+        .to_return(status: 400, body: body)
+
+      expect {
+        expect {
+          ssl.run_command
+        }.to exit_with(1)
+      }.to output(/Failed to submit certificate request: Error 400 on SERVER: #{body}/).to_stdout
+    end
+
+    it 'accepts dns alt names'
+    it 'accepts csr attributes'
+    it 'accepts extension requests'
+  end
+end

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -144,17 +144,26 @@ describe Puppet::Application::Ssl do
       expects_command_to_output
     end
 
-    it "reports an error if the downloaded CSR doesn't match the local public key" do
-      # generate a new host key, whose public key doesn't match the CSR
+    it "warns if the local CSR doesn't match the local public key, and submits a new CSR" do
+      # write out the local CSR
+      File.open(csr_path, 'w') { |f| f.write(@host[:csr].to_pem) }
+
+      # generate a new host key, whose public key doesn't match
       private_key = OpenSSL::PKey::RSA.new(512)
+      public_key = private_key.public_key
       File.open(Puppet[:hostprivkey], 'w') { |f| f.write(private_key.to_pem) }
-      File.open(Puppet[:hostpubkey], 'w') { |f| f.write(private_key.public_key.to_pem) }
+      File.open(Puppet[:hostpubkey], 'w') { |f| f.write(public_key.to_pem) }
 
-      body = "The CSR retrieved from the master does not match the agent's public key."
-      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200, body: @host[:csr].to_pem)
-      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 400, body: body)
+      # expect CSR to contain the new pub key
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).with do |request|
+        sent_pem = OpenSSL::X509::Request.new(request.body).public_key.to_pem
+        expect(sent_pem).to eq(public_key.to_pem)
+      end.to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
 
-      expects_command_to_output(/Failed to submit certificate request: #{body}/, 1)
+      Puppet.stubs(:warning) # ignore unrelated warnings
+      Puppet.expects(:warning).with("The local CSR does not match the agent's public key. Generating a new CSR.")
+      expects_command_to_output(%r{Submitted certificate request for '#{name}' to https://.*}, 0)
     end
 
     it 'downloads the certificate when autosigning is enabled' do

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -3,7 +3,7 @@ require 'puppet/application/ssl'
 require 'webmock/rspec'
 require 'openssl'
 
-describe Puppet::Application::Ssl do
+describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
   let(:ssl) { Puppet::Application[:ssl] }
   let(:name) { 'ssl-client' }
 

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -143,6 +143,25 @@ PEM
       }.to output(/Failed to submit certificate request: Error 400 on SERVER: #{body}/).to_stdout
     end
 
+    it "resends a previously submitted CSR" do
+      body = "#{name} already has a requested certificate; ignoring certificate request"
+      stub_request(:put, %r{puppet-ca/v1/certificate_request})
+        .to_return(
+          {status: 200},
+          {status: 400, body: body}
+        )
+
+      expect {
+        ssl.run_command
+      }.to output(%r{Submitted certificate request for '#{name}' to https://.*}).to_stdout
+
+      expect {
+        expect {
+          ssl.run_command
+        }.to exit_with(1)
+      }.to output(/Failed to submit certificate request: Error 400 on SERVER: #{body}/).to_stdout
+    end
+
     it 'accepts dns alt names'
     it 'accepts csr attributes'
     it 'accepts extension requests'

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -201,16 +201,14 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
   it "should consider the certificate invalid if it cannot find a key" do
     host = Puppet::SSL::Host.new("foo")
     certificate = mock('cert', :fingerprint => 'DEADBEEF')
-    host.expects(:certificate).twice.returns certificate
     host.expects(:key).returns nil
-    expect { host.validate_certificate_with_key }.to raise_error(Puppet::Error, "No private key with which to validate certificate with fingerprint: DEADBEEF")
+    expect { host.validate_certificate_with_key(certificate) }.to raise_error(Puppet::Error, "No private key with which to validate certificate with fingerprint: DEADBEEF")
   end
 
   it "should consider the certificate invalid if it cannot find a certificate" do
     host = Puppet::SSL::Host.new("foo")
     host.expects(:key).never
-    host.expects(:certificate).returns nil
-    expect { host.validate_certificate_with_key }.to raise_error(Puppet::Error, "No certificate to validate.")
+    expect { host.validate_certificate_with_key(nil) }.to raise_error(Puppet::Error, "No certificate to validate.")
   end
 
   it "should consider the certificate invalid if the SSL certificate's key verification fails" do
@@ -219,9 +217,8 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
     sslcert = mock 'sslcert'
     certificate = mock 'cert', {:content => sslcert, :fingerprint => 'DEADBEEF'}
     host.stubs(:key).returns key
-    host.stubs(:certificate).returns certificate
     sslcert.expects(:check_private_key).with("private_key").returns false
-    expect { host.validate_certificate_with_key }.to raise_error(Puppet::Error, /DEADBEEF/)
+    expect { host.validate_certificate_with_key(certificate) }.to raise_error(Puppet::Error, /DEADBEEF/)
   end
 
   it "should consider the certificate valid if the SSL certificate's key verification succeeds" do
@@ -230,9 +227,8 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
     sslcert = mock 'sslcert'
     certificate = mock 'cert', :content => sslcert
     host.stubs(:key).returns key
-    host.stubs(:certificate).returns certificate
     sslcert.expects(:check_private_key).with("private_key").returns true
-    expect{ host.validate_certificate_with_key }.not_to raise_error
+    expect{ host.validate_certificate_with_key(certificate) }.not_to raise_error
   end
 
   describe "when specifying the CA location" do


### PR DESCRIPTION
Create an ssl application for managing client keys and certs. Currently
it can only generate and submit a certificate request. As part of the
bootstrapping process, the application will download the CA and CRL
bundles if they don't exist, and use them for subsequent REST requests.
The application will also generate a key pair if it doesn't exist, and
use that to generate the CSR.