### PR TITLE
(PUP-9093) Make Reports contain stringified rich data

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -131,7 +131,17 @@ class Puppet::Node::Facts
       or fact.is_a? String
       fact
     else
-      fact.to_s
+      result = fact.to_s
+      # The result may be ascii-8bit encoded without being a binary (low level object.inspect returns ascii-8bit string)
+      if result.encoding == Encoding::ASCII_8BIT
+        begin
+          result = result.encode(Encoding::UTF_8)
+        rescue
+          # return the ascii-8bit - it will be taken as a binary
+          result
+        end
+      end
+      result
     end
   end
 end

--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -128,7 +128,10 @@ class ModelLabelProvider
       simple_name[1..-5] + "-Type"
     else
       n = o.name
-      n.nil? ? 'Anonymous Class' : n
+      if n.nil?
+        n = o.respond_to?(:_pcore_type) ? o._pcore_type.name : 'Anonymous Class'
+      end
+      n
     end
   end
 end

--- a/lib/puppet/pops/serialization.rb
+++ b/lib/puppet/pops/serialization.rb
@@ -34,6 +34,7 @@ end
 require_relative 'serialization/json_path'
 require_relative 'serialization/from_data_converter'
 require_relative 'serialization/to_data_converter'
+require_relative 'serialization/to_stringified_converter'
 require_relative 'serialization/serializer'
 require_relative 'serialization/deserializer'
 require_relative 'serialization/json'

--- a/lib/puppet/pops/serialization/to_stringified_converter.rb
+++ b/lib/puppet/pops/serialization/to_stringified_converter.rb
@@ -1,0 +1,223 @@
+module Puppet::Pops
+module Serialization
+
+  # Class that can process an arbitrary object into a value that is assignable to `Data`
+  # and where contents is converted from rich data to one of:
+  # * Numeric (Integer, Float)
+  # * Boolean 
+  # * Undef (nil)
+  # * String
+  # * Array
+  # * Hash
+  # 
+  # The conversion is lossy - the result cannot be deserialized to produce the original data types.
+  # All rich values are transformed to strings..
+  # Hashes with rich keys are transformed to use string representation of such keys.
+  #
+  # @api public
+  class ToStringifiedConverter
+    include Evaluator::Runtime3Support
+
+    # Converts the given _value_ according to the given _options_ and return the result of the conversion
+    #
+    # @param value [Object] the value to convert
+    # @param options {Symbol => <Boolean,String>} options hash
+    # @option options [String] :message_prefix String to prepend to in warnings and errors
+    # @option options [String] :semantic object (AST) to pass to the issue reporter
+    # @return [Data] the processed result. An object assignable to `Data` with rich data stringified.
+    #
+    # @api public
+    def self.convert(value, options = EMPTY_HASH)
+      new(options).convert(value)
+    end
+
+    # Creates a new instance of the processor
+    #
+    # @param options {Symbol => Object} options hash
+    # @option options [String] :message_prefix String to prepend to path in warnings and errors
+    # @option semantic [Object] :semantic object to pass to the issue reporter
+    def initialize(options = EMPTY_HASH)
+      @message_prefix = options[:message_prefix]
+      @semantic = options[:semantic]
+    end
+
+    # Converts the given _value_
+    #
+    # @param value [Object] the value to convert
+    # @return [Data] the processed result. An object assignable to `Data` with rich data stringified.
+    #
+    # @api public
+    def convert(value)
+      @path = []
+      @values = {}
+      to_data(value)
+    end
+
+    private
+
+    def path_to_s
+      s = @message_prefix || ''
+      s << JsonPath.to_json_path(@path)[1..-1]
+      s
+    end
+
+    def to_data(value)
+      if value.is_a?(String)
+        to_string_or_binary(value)
+      elsif value.nil? || Types::PScalarDataType::DEFAULT.instance?(value)
+        value
+      elsif :default == value
+        'default'
+      elsif value.is_a?(Symbol)
+        value.to_s
+      elsif value.instance_of?(Array)
+        process(value) do
+          result = []
+          value.each_with_index do |elem, index|
+            with(index) { result << to_data(elem) }
+          end
+          result
+        end
+      elsif value.instance_of?(Hash)
+        process(value) do
+          if value.keys.all? { |key| key.is_a?(String) && key != PCORE_TYPE_KEY }
+            result = {}
+            value.each_pair { |key, elem| with(key) { result[key] = to_data(elem) } }
+            result
+          else
+            non_string_keyed_hash_to_data(value)
+          end
+        end
+      else
+        unknown_to_string(value)
+      end
+    end
+
+    # Turns an ASCII-8BIT encoded string into a Binary, returns US_ASCII encoded and transforms all other strings to UTF-8
+    # with replacements for non Unicode characters.
+    # If String cannot be represented as UTF-8
+    def to_string_or_binary(value)
+      encoding = value.encoding
+      if encoding == Encoding::ASCII_8BIT
+        Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(value).to_s
+      else
+        # Transform to UTF-8 (do not assume UTF-8 is correct) with source invalid byte
+        # sequences and UTF-8 undefined characters replaced by the default unicode uFFFD character
+        # (black diamond with question mark).
+        value.encode(Encoding::UTF_8, encoding, :invalid => :replace, :undef => :replace)
+      end
+    end
+
+    # Performs a check for endless recursion before
+    # it yields to the given block. The result of yielding is returned.
+    #
+    # @param value [Object] the value
+    # @yield The block that will produce the data for the value
+    # @return [Data] the result of yielding to the given block, or a hash denoting a reference
+    #
+    # @api private
+    def process(value, &block)
+      with_recursive_guard(value, &block)
+    end
+
+    # Pushes `key` to the end of the path and yields to the given block. The
+    # `key` is popped when the yield returns.
+    # @param key [Object] the key to push on the current path
+    # @yield The block that will produce the returned value
+    # @return [Object] the result of yielding to the given block
+    #
+    # @api private
+    def with(key)
+      @path.push(key)
+      value = yield
+      @path.pop
+      value
+    end
+
+    # @param value [Object] the value to use when checking endless recursion
+    # @yield The block that will produce the data
+    # @return [Data] the result of yielding to the given block
+    def with_recursive_guard(value)
+      id = value.object_id
+      if @recursive_lock
+        if @recursive_lock.include?(id)
+          serialization_issue(Issues::SERIALIZATION_ENDLESS_RECURSION, :type_name => value.class.name)
+        end
+        @recursive_lock[id] = true
+      else
+        @recursive_lock = { id => true }
+      end
+      v = yield
+      @recursive_lock.delete(id)
+      v
+    end
+
+    # A hash key that is non conforming
+    def unknown_key_to_string(value)
+      unknown_to_string(value)
+    end
+
+    def unknown_to_string(value)
+      if value.is_a?(Regexp)
+        return Puppet::Pops::Types::PRegexpType.regexp_to_s_with_delimiters(value)
+
+      elsif value.instance_of?(Types::PSensitiveType::Sensitive)
+        # to_s does not differentiate between instances - if they were used as keys in a hash
+        # the stringified result would override all Sensitive keys with the last such key's value
+        # this adds object_id.
+        #
+        return "#<#{value}:#{value.object_id}>"
+
+      elsif value.is_a?(Puppet::Pops::Types::PObjectType)
+        # regular to_s on an ObjectType gives the entire definition
+        return value.name
+
+      end
+
+      # Do a to_s on anything else
+      result = value.to_s
+
+      # The result may be ascii-8bit encoded without being a binary (low level object.inspect returns ascii-8bit string)
+      # This can be the case if runtime objects have very simple implementation (no to_s or inspect method).
+      # They are most likely not of Binary nature. Therefore the encoding is forced and only if it errors
+      # will the result be taken as binary and encoded as base64 string.
+      if result.encoding == Encoding::ASCII_8BIT
+        begin
+          result.force_encoding(Encoding::UTF_8)
+        rescue
+          # The result cannot be represented in UTF-8, make it a binary Base64 encoded string
+          Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(result).to_s
+        end
+      end
+      result
+    end
+
+    def non_string_keyed_hash_to_data(hash)
+      result = {}
+      hash.each_pair do |key, value|
+        if key.is_a?(Symbol)
+          key = key.to_s
+        elsif !key.is_a?(String)
+          key = unknown_key_to_string(key)
+        end
+        with(key) { result[key] = to_data(value) }
+      end
+      result
+    end
+
+    def serialization_issue(issue, options = EMPTY_HASH)
+      semantic = @semantic
+      if semantic.nil?
+        tos = Puppet::Pops::PuppetStack.top_of_stack
+        if tos.empty?
+          semantic = Puppet::Pops::SemanticError.new(issue, nil, EMPTY_HASH)
+        else
+          file, line = stacktrace
+          semantic = Puppet::Pops::SemanticError.new(issue, nil, {:file => file, :line => line})
+        end
+      end
+      optionally_fail(issue,  semantic, options)
+    end
+  end
+end
+end

--- a/lib/puppet/transaction/event.rb
+++ b/lib/puppet/transaction/event.rb
@@ -98,13 +98,9 @@ class Puppet::Transaction::Event
       'redacted' => @redacted,
       'corrective_change' => @corrective_change,
     }
-    Puppet::Pops::Serialization::ToDataConverter.convert(hash, {
-      :rich_data => true,
-      :symbol_as_string => true,
-      :local_reference => false,
-      :type_by_reference => true,
-      :message_prefix => 'Event'
-    })
+    # Use the stringifying converter since rich data is not possible downstream.
+    # (This will destroy some data type information, but this is expected).
+    Puppet::Pops::Serialization::ToStringifiedConverter.convert(hash, :message_prefix => 'Event')
   end
 
   def property=(prop)

--- a/spec/unit/pops/serialization/to_stringified_spec.rb
+++ b/spec/unit/pops/serialization/to_stringified_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+describe 'ToStringifiedConverter' do
+  include PuppetSpec::Compiler
+
+  after(:all) { Puppet::Pops::Loaders.clear }
+
+  let(:env) { Puppet::Node::Environment.create(:testing, []) }
+  let(:loaders) { Puppet::Pops::Loaders.new(env) }
+  let(:node) { Puppet::Node.new(env, environment: env) }
+
+  def transform(v)
+    Puppet::Pops::Serialization::ToStringifiedConverter.convert(v)
+  end
+
+  def eval_transform(source)
+    Puppet.override(:current_environment => env, :loaders => loaders) do
+      transform(evaluate(source: source, node: node))
+    end
+  end
+
+  it 'converts undef to to nil' do
+    expect(transform(nil)).to be_nil
+    expect(eval_transform('undef')).to be_nil
+  end
+
+  it "converts literal default to the string 'default'" do
+    expect(transform(:default)).to eq('default')
+    expect(eval_transform('default')).to eq('default')
+  end
+
+  it "does not convert an integer" do
+    expect(transform(42)).to eq(42)
+  end
+
+  it "does not convert a float" do
+    expect(transform(3.14)).to eq(3.14)
+  end
+
+  it "does not convert a boolean" do
+    expect(transform(true)).to be(true)
+    expect(transform(false)).to be(false)
+  end
+
+  it "does not convert a string (that is free from encoding issues)" do
+    expect(transform("hello")).to eq("hello")
+  end
+
+  it "converts a regexp to a string" do
+    expect(transform(/this|that.*/)).to eq("/this|that.*/")
+    expect(eval_transform('/this|that.*/')).to eq("/this|that.*/")
+  end
+
+  it 'handles a string with an embedded single quote' do
+    expect(transform("ta'phoenix")).to eq("ta'phoenix")
+  end
+
+  it 'handles a string with embedded double quotes' do
+    expect(transform('he said "hi"')).to eq("he said \"hi\"")
+  end
+
+  it 'converts a user defined object to its string representation including attributes' do
+    result = evaluate(code: "type Car = Object[attributes=>{regnbr => String}]", source: "Car(abc123)")
+    expect(transform(result)).to eq("Car({'regnbr' => 'abc123'})")
+  end
+
+  it 'converts a Deferred object to its string representation including attributes' do
+    expect(eval_transform("Deferred(func, [1,2,3])")).to eq("Deferred({'name' => 'func', 'arguments' => [1, 2, 3]})")
+  end
+
+  it 'converts a Sensitive to type + redacted plus id' do
+    sensitive = evaluate(source: "Sensitive('hush')")
+    id = sensitive.object_id
+    expect(transform(sensitive)).to eq("#<Sensitive [value redacted]:#{id}>")
+  end
+
+  it 'converts a Timestamp to String' do
+    expect(eval_transform("Timestamp('2018-09-03T19:45:33.697066000 UTC')")).to eq("2018-09-03T19:45:33.697066000 UTC")
+  end
+
+  it 'does not convert an array' do
+    expect(transform([1,2,3])).to eq([1,2,3])
+  end
+
+  it 'converts the content of an array - for example a Sensitive value' do
+    sensitive = evaluate(source: "Sensitive('hush')")
+    id = sensitive.object_id
+    expect(transform([sensitive])).to eq(["#<Sensitive [value redacted]:#{id}>"])
+  end
+
+  it 'converts the content of a hash - for example a Sensitive value' do
+    sensitive = evaluate(source: "Sensitive('hush')")
+    id = sensitive.object_id
+    expect(transform({'x' => sensitive})).to eq({'x' => "#<Sensitive [value redacted]:#{id}>"})
+  end
+
+  it 'does not convert a hash' do
+    expect(transform({'a' => 10, 'b' => 20})).to eq({'a' => 10, 'b' => 20})
+  end
+
+  it 'converts non Data compliant hash key to string' do
+    expect(transform({['funky', 'key'] => 10})).to eq({'["funky", "key"]' => 10})
+  end
+
+  it 'converts reserved __ptype hash key to string' do
+    expect(transform({'__ptype' => 10})).to eq({'__ptype' => 10})
+  end
+
+  it 'converts a Binary to Base64 string' do
+    expect(eval_transform("Binary('hello', '%s')")).to eq("aGVsbG8=")
+  end
+
+  it 'converts an ASCII-8BIT String to Base64 String' do
+    binary_string = "\x02\x03\x04hello".force_encoding('ascii-8bit')
+    expect(transform(binary_string)).to eq("AgMEaGVsbG8=")
+  end
+
+  it 'converts Runtime (alien) object to its to_s' do
+    class Alien
+    end
+    an_alien = Alien.new
+    expect(transform(an_alien)).to eq(an_alien.to_s)
+  end
+
+  it 'converts a runtime Symbol to String' do
+    expect(transform(:symbolic)).to eq("symbolic")
+  end
+
+  it 'converts a datatype (such as Integer[0,10]) to its puppet source string form' do
+    expect(eval_transform("Integer[0,100]")).to eq("Integer[0, 100]")
+  end
+
+  it 'converts a user defined datatype (such as Car) to its puppet source string form' do
+    result = evaluate(code: "type Car = Object[attributes=>{regnbr => String}]", source: "Car")
+    expect(transform(result)).to eq("Car")
+  end
+
+  it 'converts a self referencing user defined datatype by using named references for cyclic entries' do
+    result = evaluate(code: "type Tree = Array[Variant[String, Tree]]", source: "Tree")
+    expect(transform(result)).to eq("Tree = Array[Variant[String, Tree]]")
+  end
+
+  it 'converts illegal char sequence in an encoding to Unicode Illegal' do
+    invalid_sequence = [0xc2, 0xc2].pack("c*").force_encoding(Encoding::UTF_8)
+    expect(transform(invalid_sequence)).to eq("��")
+  end
+
+  it 'does not convert unassigned char - glyph is same for all unassigned' do
+    unassigned = [243, 176, 128, 128].pack("C*").force_encoding(Encoding::UTF_8) 
+    expect(transform(unassigned)).to eq("󰀀")
+  end
+end

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -645,16 +645,21 @@ Version:
   end
 
   def generate_report
+    # An Event cannot contain rich data - thus its "to_data_hash" stringifies the result.
+    # (This means it cannot be deserialized with intact data types).
+    # Here it is simulated that the values are after stringification.
+    stringifier = Puppet::Pops::Serialization::ToStringifiedConverter
     event_hash = {
       :audited => false,
-      :property => 'message',
-      :previous_value => SemanticPuppet::VersionRange.parse('>=1.0.0'),
-      :desired_value => SemanticPuppet::VersionRange.parse('>=1.2.0'),
-      :historical_value => nil,
-      :message => "defined 'message' as 'a resource'",
-      :name => :message_changed,
-      :status => 'success',
+      :property => stringifier.convert('message'),
+      :previous_value => stringifier.convert(SemanticPuppet::VersionRange.parse('>=1.0.0')),
+      :desired_value => stringifier.convert(SemanticPuppet::VersionRange.parse('>=1.2.0')),
+      :historical_value => stringifier.convert(nil),
+      :message => stringifier.convert("defined 'message' as 'a resource'"),
+      :name => :message_changed, # the name 
+      :status => stringifier.convert('success'),
     }
+
     event = Puppet::Transaction::Event.new(event_hash)
 
     status = Puppet::Resource::Status.new(Puppet::Type.type(:notify).new(:title => "a resource"))


### PR DESCRIPTION
This adds a new `ToStringifiedConverter` that `Event` is now using to serialize its content. Earlier, if `--rich_data` was on, the result would be that a Report could end up containing rich data in JSON form. The downstream processing of that (PDB and report processors as well as other custom consumers) are not expecting this format as the specification states
that events report "before" and "after" as `String` values - although that is a lie as it includes JSON standard data types.

This is also an improvement over earlier processing in that both `Binary` and `ASCII-8BIT` encoded strings are treated as binary and result in `Base64` encoded strings.
All other `String` values are re-encoded to replace illegal and undefined code points with the standard Unicode replacement character. This guards against implementation errors
in custom Ruby logic that produces strings.

This [gist](https://gist.github.com/hlindberg/ae53dc18608e13f6878903c251250ffd) shows the logic used while developing this and shows a result table that is easy to review.
The same logic (only slightly tweaked) is included in this PR as a unit test.

Note that, some usage of `to_s` can produce `ASCII-8BIT` strings even if the content is not really binary in nature. This PR includes logic that checks this after a `to_s`
on a fact, or when stringifying.

While manually testing I found that pcore objects where reported as having "Anonymous  Class", I updated the label for that as well so it now shows the pcore data type name.