### PR TITLE
(PUP-9107) Deprecate ability to change catalog ordering

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1805,7 +1805,16 @@ EOT
       Regardless of this setting's value, Puppet will always obey explicit
       dependencies set with the before/require/notify/subscribe metaparameters
       and the `->`/`~>` chaining arrows; this setting only affects the relative
-      ordering of _unrelated_ resources."
+      ordering of _unrelated_ resources.
+
+      This setting is deprecated, and will always have a value of `manifest` in
+      6.0 and up.",
+      :call_hook => :on_initialize_and_write,
+      :hook => proc { |value|
+        if value != "manifest"
+          Puppet.deprecation_warning(_('Setting %{name} is deprecated.') % { name: 'ordering' }, 'setting-ordering')
+        end
+      }
     }
   )
 

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -150,4 +150,24 @@ describe "Defaults" do
       ).to match(%r{.*/code/modules})
     end
   end
+
+  describe 'ordering' do
+    it 'issues a deprecation warning when set to title-hash' do
+      Puppet.expects(:deprecation_warning).with('Setting ordering is deprecated.', 'setting-ordering')
+
+      Puppet.settings[:ordering] = 'title-hash'
+    end
+
+    it 'issues a deprecation warning when set to random' do
+      Puppet.expects(:deprecation_warning).with('Setting ordering is deprecated.', 'setting-ordering')
+
+      Puppet.settings[:ordering] = 'random'
+    end
+
+    it 'does not issue a deprecation warning when set to manifest' do
+      Puppet.expects(:deprecation_warning).with('Setting ordering is deprecated.', 'setting-ordering').never
+
+      Puppet.settings[:ordering] = 'manifest'
+    end
+  end
 end


### PR DESCRIPTION
The ability to set a catalog ordering other than "manifest" is going to be removed in 6.0.0 (PUP-6165). We now issue a deprecation warning if someone is using a value other than "manifest", and have updated the setting's documentation to mention that in 6.0.0 and up it will effectively always be set to "manifest".