### PR TITLE
(maint) Use @object_class in ADSIObject.parse_name error msg

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -134,7 +134,7 @@ module Puppet::Util::Windows::ADSI
   
       def parse_name(name)
         if name =~ /\//
-          raise Puppet::Error.new( _("Value must be in DOMAIN\\user style syntax") )
+          raise Puppet::Error.new( _("Value must be in DOMAIN\\%{object_class} style syntax") % { object_class: @object_class } )
         end
   
         matches = name.scan(/((.*)\\)?(.*)/)


### PR DESCRIPTION
This was overlooked in the Windows ADSI User/Group refactor.