### PR TITLE
(PUP-9104) allow aliases in YAML safe_load

### DIFF
--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -26,7 +26,7 @@ module Puppet::Util::Yaml
   # @raise [YamlLoadException] If deserialization fails.
   # @returns The parsed YAML, which can be Hash, Array or scalar types.
   def self.safe_load(yaml, allowed_classes = [], filename = nil)
-    data = YAML.safe_load(yaml, allowed_classes, [], false, filename)
+    data = YAML.safe_load(yaml, allowed_classes, [], true, filename)
     data = false if data.nil?
     data
   rescue ::Psych::DisallowedClass => detail

--- a/spec/unit/util/yaml_spec.rb
+++ b/spec/unit/util/yaml_spec.rb
@@ -105,6 +105,14 @@ FACTS
         b: 2
       YAML
     end
+
+    it 'loads an alias' do
+      expect(Puppet::Util::Yaml.safe_load(<<~YAML)).to eq('a' => [], 'b' => [])
+        ---
+        a: &1 []
+        b: *1
+      YAML
+    end
   end
 
   context "#safe_load_file" do


### PR DESCRIPTION
By default `safe_load` does not allow aliases which means that the following YAML would fail:

```
---
resources:
  Panos_test[panos_test]:
    parameters:
      ensure:
        system_value:
        - present
      tags:
        system_value:
        - &1 []
  Panos_test[panos_test2]:
    parameters:
      ensure:
        system_value:
        - present
      tags:
        system_value:
        - *1
```

Can be reproduced by using the following commit on `puppetlabs-panos` https://github.com/Thomas-Franklin/puppetlabs-panos/tree/default-bug

- `export PUPPET_GEM_VERSION=https://github.com/puppetlabs/puppet.git#master`
- `bundle install --path=.bundle/gems`
- `bundle exec rake spec_prep`
- update the file path in `puppetlabs-panos/spec/fixtures/device.conf` to point to your `test-password.conf`
- `bundle exec puppet device --modulepath spec/fixtures/modules/ --deviceconfig spec/fixtures/device.conf --target pavm --debug --trace --apply spec/fixtures/test.pp`

On the second run of `bundle exec puppet device` will receive a transaction state error message; by allowing aliases this is not the case.

Stacktrace:

Error: Transaction store file /Users/thomas.franklin/.puppetlabs/opt/puppet/cache/devices/pavm/state/transactionstore.yaml is corrupt (Unknown alias: 1); replacing
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/yaml.rb:36:in `rescue in safe_load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/yaml.rb:28:in `safe_load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/yaml.rb:44:in `safe_load_file'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction/persistence.rb:65:in `block in load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:232:in `block in benchmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:231:in `benchmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction/persistence.rb:63:in `load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction.rb:98:in `evaluate'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/resource/catalog.rb:239:in `block (2 levels) in apply'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:515:in `block in thinmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:514:in `thinmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/resource/catalog.rb:238:in `block in apply'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/log.rb:156:in `with_destination'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/resource/catalog.rb:237:in `apply'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:191:in `block (2 levels) in apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:515:in `block in thinmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:514:in `thinmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:190:in `block in apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:232:in `block in benchmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:231:in `benchmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:189:in `apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:378:in `run_internal'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:242:in `block in run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:216:in `run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:365:in `apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:291:in `block (2 levels) in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:273:in `block in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:233:in `main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:174:in `run_command'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:299:in `block (3 levels) in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:298:in `block (2 levels) in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:245:in `each'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:245:in `collect'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:245:in `block in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:230:in `main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application.rb:390:in `run_command'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application.rb:382:in `block in run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:668:in `exit_on_fail'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application.rb:382:in `run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/command_line.rb:136:in `run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/command_line.rb:73:in `execute'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/bin/puppet:5:in `<top (required)>'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bin/puppet:23:in `load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bin/puppet:23:in `<top (required)>'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:74:in `load'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:28:in `run'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli.rb:424:in `exec'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli.rb:27:in `dispatch'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli.rb:18:in `start'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/exe/bundle:30:in `block in <top (required)>'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/exe/bundle:22:in `<top (required)>'
/Users/thomas.franklin/.rbenv/versions/2.5.1/bin/bundle:23:in `load'
/Users/thomas.franklin/.rbenv/versions/2.5.1/bin/bundle:23:in `<main>'
Wrapped exception:
Unknown alias: 1
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:397:in `visit_Psych_Nodes_Alias'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:330:in `block in register_empty'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:330:in `each'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:330:in `register_empty'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:141:in `visit_Psych_Nodes_Sequence'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each_slice'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each_slice'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each_slice'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each_slice'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each_slice'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `revive_hash'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:311:in `visit_Psych_Nodes_Document'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/psych.rb:325:in `safe_load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/yaml.rb:29:in `safe_load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/yaml.rb:44:in `safe_load_file'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction/persistence.rb:65:in `block in load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:232:in `block in benchmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:231:in `benchmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction/persistence.rb:63:in `load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction.rb:98:in `evaluate'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/resource/catalog.rb:239:in `block (2 levels) in apply'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:515:in `block in thinmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:514:in `thinmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/resource/catalog.rb:238:in `block in apply'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/log.rb:156:in `with_destination'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/resource/catalog.rb:237:in `apply'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:191:in `block (2 levels) in apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:515:in `block in thinmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:514:in `thinmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:190:in `block in apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:232:in `block in benchmark'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:231:in `benchmark'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:189:in `apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:378:in `run_internal'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:242:in `block in run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/configurer.rb:216:in `run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:365:in `apply_catalog'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:291:in `block (2 levels) in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:273:in `block in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:233:in `main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/apply.rb:174:in `run_command'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:299:in `block (3 levels) in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:298:in `block (2 levels) in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:245:in `each'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:245:in `collect'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:245:in `block in main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/context.rb:65:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet.rb:251:in `override'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application/device.rb:230:in `main'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application.rb:390:in `run_command'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application.rb:382:in `block in run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util.rb:668:in `exit_on_fail'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/application.rb:382:in `run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/command_line.rb:136:in `run'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/lib/puppet/util/command_line.rb:73:in `execute'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bundler/gems/puppet-6597624ccfc7/bin/puppet:5:in `<top (required)>'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bin/puppet:23:in `load'
/Users/thomas.franklin/puppet/puppetlabs-panos/.bundle/gems/ruby/2.5.0/bin/puppet:23:in `<top (required)>'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:74:in `load'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:28:in `run'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli.rb:424:in `exec'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli.rb:27:in `dispatch'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/cli.rb:18:in `start'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/exe/bundle:30:in `block in <top (required)>'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/Users/thomas.franklin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.4/exe/bundle:22:in `<top (required)>'
/Users/thomas.franklin/.rbenv/versions/2.5.1/bin/bundle:23:in `load'
/Users/thomas.franklin/.rbenv/versions/2.5.1/bin/bundle:23:in `<main>'