### PR TITLE
(PUP-9093) Add test for facts sanitize regarding to_s returning 8bit str

### DIFF
--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -81,6 +81,18 @@ describe Puppet::Node::Facts, "when indirecting" do
       @facts.sanitize
       expect(@facts.values["test"]).to eq({"(?-mix:foo)" => ["bar", "(?-mix:baz)"]})
     end
+
+    it "should handle alien values having a to_s that returns ascii-8bit" do
+      class Alien
+      end
+      an_alien = Alien.new
+      @facts.values["test"] = an_alien
+      @facts.sanitize
+      fact_value = @facts.values['test']
+      expect(fact_value).to eq(an_alien.to_s)
+      expect(fact_value.encoding).to eq(Encoding::UTF_8)
+    end
+
   end
 
   describe "when indirecting" do


### PR DESCRIPTION
This adds a test that prevents a string returned from `to_s` on
some arbitrary "alien" runtime value to be returned with ascii-8bit
encoding (which is bad because that is later taken as being a binary
value and not text).