### PR TITLE
(PUP-9109) Add query parameters for HTTP request

### DIFF
--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -181,7 +181,7 @@ module Puppet::Util::HttpProxy
         headers.merge!({"Accept-Encoding" => Puppet::Network::HTTP::Compression::ACCEPT_ENCODING})
       end
 
-      response = proxy.send(:head, current_uri.path, headers)
+      response = proxy.send(:head, current_uri, headers)
 
       if [301, 302, 307].include?(response.code.to_i)
         # handle the redirection
@@ -191,9 +191,9 @@ module Puppet::Util::HttpProxy
 
       if method != :head
         if block_given?
-          response = proxy.send("request_#{method}".to_sym, current_uri.path, headers, &block)
+          response = proxy.send("request_#{method}".to_sym, current_uri, headers, &block)
         else
-          response = proxy.send(method, current_uri.path, headers)
+          response = proxy.send(method, current_uri, headers)
         end
       end
 


### PR DESCRIPTION
This commit adds the query parameters to the HTTP request done by
`request_with_redirects`. This is needed for the `source` attribute of
the `file` resource type if the source URL contains query parameters.

The code itself was extracted from #5002, originally developed by
@mcasper. The reason for the extraction is:
* The original PR seems to be stale.
* The PR fixes another (S3) issue as well