### PR TITLE
(PUP-8601) Add rich data formats

### DIFF
--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -8,10 +8,6 @@ tag 'audit:high',
                          # be adequate to test puppet. Running this in
                          # context of server/agent should not be necessary.
 
-  app_type        = File.basename(__FILE__, '.*')
-  tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
-  fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
-
   manifest = <<-PP
 type Mod::Foo = Object[{
   attributes => {
@@ -30,25 +26,14 @@ class mod {
 include mod
   PP
 
-  step 'create a site.pp with custom type, object and notify' do
-    create_sitepp(master, tmp_environment, manifest)
-  end
+  agents.each do |agent|
+    # This is currently only expected to work with apply as the custom data type
+    # definition will not be present on the agent to deserialize properly
 
-  with_puppet_running_on(master,{}) do
-    agents.each do |agent|
-      step "run the agent on #{agent.hostname} and assert notify output" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
-           :accept_all_exit_codes => true) do |result|
-          assert(result.exit_code == 2, "agent didn't exit properly: (#{result.exit_code})")
-          assert_match(/A foo/, result.stdout, 'agent didn\'t notify correctly')
-        end
-      end
-
-      step "apply manifest on agent #{agent.hostname} and assert notify output" do
-        apply_manifest_on(agent, manifest) do |result|
-          assert(result.exit_code == 0, "agent didn't exit properly: (#{result.exit_code})")
-          assert_match(/A foo/, result.stdout, 'agent didn\'t notify correctly')
-        end
+    step "apply manifest on agent #{agent.hostname} and assert notify output" do
+      apply_manifest_on(agent, manifest) do |result|
+        assert(result.exit_code == 0, "agent didn't exit properly: (#{result.exit_code})")
+        assert_match(/A foo/, result.stdout, 'agent didn\'t notify correctly')
       end
     end
   end

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -208,7 +208,8 @@ module Puppet
         Puppet::Network::HTTP::NoCachePool.new
       },
       :ssl_host => proc { Puppet::SSL::Host.localhost },
-      :plugins => proc { Puppet::Plugins::Configuration.load_plugins }
+      :plugins => proc { Puppet::Plugins::Configuration.load_plugins },
+      :rich_data => false
     }
   end
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2073,7 +2073,7 @@ EOT
   define_settings(
     :main,
     :rich_data => {
-      :default  => false,
+      :default  => true,
       :type     => :boolean,
       :hook    => proc do |value|
         envs = Puppet.lookup(:environments) { nil }

--- a/lib/puppet/indirector/catalog/json.rb
+++ b/lib/puppet/indirector/catalog/json.rb
@@ -17,8 +17,9 @@ class Puppet::Resource::Catalog::Json < Puppet::Indirector::JSON
 
   def to_json(object)
     object.render('json')
-  rescue Puppet::Network::FormatHandler::FormatError
+  rescue Puppet::Network::FormatHandler::FormatError => err
     Puppet.info(_("Unable to serialize catalog to json, retrying with pson"))
+    Puppet.log_exception(err, err.message, level: :debug)
     object.render('pson').force_encoding(Encoding::BINARY)
   end
 end

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -43,8 +43,14 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(_("No handler for %{indirection}") % { indirection: indirection.name }, :NO_INDIRECTION_REMOTE_REQUESTS)
     end
 
-    trusted = Puppet::Context::TrustedInformation.remote(params[:authenticated], params[:node], certificate)
-    Puppet.override(:trusted_information => trusted) do
+    overrides = {
+      trusted_information: Puppet::Context::TrustedInformation.remote(params[:authenticated], params[:node], certificate),
+    }
+    if params[:environment]
+      overrides[:current_environment] = params[:environment]
+    end
+
+    Puppet.override(overrides) do
       send("do_#{method}", indirection, key, params, request, response)
     end
   end

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -191,7 +191,8 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       begin
         yield format
         true
-      rescue Puppet::Network::FormatHandler::FormatError
+      rescue Puppet::Network::FormatHandler::FormatError => err
+        Puppet.log_exception(err, err.message, level: :debug)
         false
       end
     end

--- a/lib/puppet/parser/catalog_compiler.rb
+++ b/lib/puppet/parser/catalog_compiler.rb
@@ -14,9 +14,10 @@ class Puppet::Parser::CatalogCompiler < Puppet::Parser::Compiler
   def compile
     Puppet[:strict_variables] = true
     Puppet[:strict] = :error
-    Puppet[:rich_data] = true
 
-    super
+    Puppet.override(rich_data: true) do
+      super
+    end
 
   rescue Puppet::ParseErrorWithIssue => detail
     detail.node = node.name

--- a/lib/puppet/parser/script_compiler.rb
+++ b/lib/puppet/parser/script_compiler.rb
@@ -37,7 +37,6 @@ class Puppet::Parser::ScriptCompiler
   def compile
     Puppet[:strict_variables] = true
     Puppet[:strict] = :error
-    Puppet[:rich_data] = true
 
     # TRANSLATORS, "For running script" is not user facing
     Puppet.override( @context_overrides , "For running script") do
@@ -67,6 +66,7 @@ class Puppet::Parser::ScriptCompiler
       :current_environment => environment,
       :global_scope => @topscope,             # 4x placeholder for new global scope
       :loaders  => @loaders,                  # 4x loaders
+      :rich_data => true,
     }
   end
 

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -12,7 +12,7 @@ class Puppet::Resource
 
   include Enumerable
   attr_accessor :file, :line, :catalog, :exported, :virtual, :strict
-  attr_reader :type, :title, :parameters, :rich_data_enabled
+  attr_reader :type, :title, :parameters
 
   # @!attribute [rw] sensitive_parameters
   #   @api private
@@ -116,7 +116,7 @@ class Puppet::Resource
 
     unless params.empty?
       data['parameters'] = Puppet::Pops::Serialization::ToDataConverter.convert(params, {
-        :rich_data => environment.rich_data?,
+        :rich_data => Puppet.lookup(:rich_data),
         :symbol_as_string => true,
         :local_reference => false,
         :type_by_reference => true,

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -408,7 +408,7 @@ end
     end
   end
 
-  context 'when compiling a provided catalog with rich data and then applying from file' do
+  context 'when applying from file' do
     include PuppetSpec::Compiler
 
     let(:env_dir) { tmpdir('environments') }
@@ -471,18 +471,18 @@ class amod::bad_type {
       Puppet.pop_context()
     end
 
-    context 'and rich_data is set to false during compile' do
+    context 'and the file is not serialized with rich_data' do
       it 'will notify a string that is the result of Regexp#inspect (from Runtime3xConverter)' do
         catalog = compile_to_catalog(execute, node)
         apply = Puppet::Application[:apply]
         apply.options[:catalog] = file_containing('manifest', catalog.to_json)
         apply.expects(:apply_catalog).with do |cat|
-          cat.resource(:notify, 'rx')['message'].is_a?(String)
-          cat.resource(:notify, 'bin')['message'].is_a?(String)
-          cat.resource(:notify, 'ver')['message'].is_a?(String)
-          cat.resource(:notify, 'vrange')['message'].is_a?(String)
-          cat.resource(:notify, 'tspan')['message'].is_a?(String)
-          cat.resource(:notify, 'tstamp')['message'].is_a?(String)
+          expect(cat.resource(:notify, 'rx')['message']).to be_a(String)
+          expect(cat.resource(:notify, 'bin')['message']).to be_a(String)
+          expect(cat.resource(:notify, 'ver')['message']).to be_a(String)
+          expect(cat.resource(:notify, 'vrange')['message']).to be_a(String)
+          expect(cat.resource(:notify, 'tspan')['message']).to be_a(String)
+          expect(cat.resource(:notify, 'tstamp')['message']).to be_a(String)
         end
         apply.run
       end
@@ -492,7 +492,7 @@ class amod::bad_type {
         apply = Puppet::Application[:apply]
         apply.options[:catalog] = file_containing('manifest', json)
         apply.expects(:apply_catalog).with do |catalog|
-          catalog.resource(:notify, 'bogus')['message'].is_a?(String)
+          expect(catalog.resource(:notify, 'bogus')['message']).to be_a(String)
         end
         apply.run
       end
@@ -508,20 +508,21 @@ class amod::bad_type {
       end
     end
 
-    context 'and rich_data is set to true during compile' do
-      let(:rich_data) { true }
-
+    context 'and the file is serialized with rich_data' do
       it 'will notify a regexp using Regexp#to_s' do
         catalog = compile_to_catalog(execute, node)
         apply = Puppet::Application[:apply]
-        apply.options[:catalog] = file_containing('manifest', catalog.to_json)
+        serialized_catalog = Puppet.override(rich_data: true) do
+          catalog.to_json
+        end
+        apply.options[:catalog] = file_containing('manifest', serialized_catalog)
         apply.expects(:apply_catalog).with do |cat|
-          cat.resource(:notify, 'rx')['message'].is_a?(Regexp)
-          cat.resource(:notify, 'bin')['message'].is_a?(Puppet::Pops::Types::PBinaryType::Binary)
-          cat.resource(:notify, 'ver')['message'].is_a?(SemanticPuppet::Version)
-          cat.resource(:notify, 'vrange')['message'].is_a?(SemanticPuppet::VersionRange)
-          cat.resource(:notify, 'tspan')['message'].is_a?(Puppet::Pops::Time::Timespan)
-          cat.resource(:notify, 'tstamp')['message'].is_a?(Puppet::Pops::Time::Timestamp)
+          expect(cat.resource(:notify, 'rx')['message']).to be_a(Regexp)
+          expect(cat.resource(:notify, 'bin')['message']).to be_a(Puppet::Pops::Types::PBinaryType::Binary)
+          expect(cat.resource(:notify, 'ver')['message']).to be_a(SemanticPuppet::Version)
+          expect(cat.resource(:notify, 'vrange')['message']).to be_a(SemanticPuppet::VersionRange)
+          expect(cat.resource(:notify, 'tspan')['message']).to be_a(Puppet::Pops::Time::Timespan)
+          expect(cat.resource(:notify, 'tstamp')['message']).to be_a(Puppet::Pops::Time::Timestamp)
         end
         apply.run
       end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -7,6 +7,8 @@ describe "apply" do
 
   before :each do
     Puppet[:reports] = "none"
+    # Let exceptions be raised instead of exiting
+    Puppet::Application.any_instance.stubs(:exit_on_fail).yields
   end
 
   describe "when applying provided catalogs" do

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -419,10 +419,11 @@ describe Puppet::Application::Apply do
         @tempfile.path
       end
 
+      let(:default_format) { Puppet::Resource::Catalog.default_format }
       it "should read the catalog in from disk if a file name is provided" do
         @apply.options[:catalog] = temporary_catalog
         catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
-        Puppet::Resource::Catalog.stubs(:convert_from).with(:json,'"something"').returns(catalog)
+        Puppet::Resource::Catalog.stubs(:convert_from).with(default_format, '"something"').returns(catalog)
         @apply.apply
       end
 
@@ -430,7 +431,7 @@ describe Puppet::Application::Apply do
         @apply.options[:catalog] = "-"
         $stdin.expects(:read).returns '"something"'
         catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
-        Puppet::Resource::Catalog.stubs(:convert_from).with(:json,'"something"').returns(catalog)
+        Puppet::Resource::Catalog.stubs(:convert_from).with(default_format, '"something"').returns(catalog)
         @apply.apply
       end
 
@@ -450,7 +451,7 @@ describe Puppet::Application::Apply do
       it "should convert the catalog to a RAL catalog and use a Configurer instance to apply it" do
         @apply.options[:catalog] = temporary_catalog
         catalog = Puppet::Resource::Catalog.new("testing", Puppet::Node::Environment::NONE)
-        Puppet::Resource::Catalog.stubs(:convert_from).with(:json,'"something"').returns catalog
+        Puppet::Resource::Catalog.stubs(:convert_from).with(default_format, '"something"').returns catalog
         catalog.expects(:to_ral).returns "mycatalog"
 
         configurer = stub 'configurer'

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -868,12 +868,12 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to json"
   context 'when dealing with parameters that have non-Data values' do
     context 'and rich_data is enabled' do
       before(:each) do
-        Puppet.push_context(:loaders => Puppet::Pops::Loaders.new(Puppet.lookup(:environments).get(Puppet[:environment])))
-        Puppet[:rich_data] = true
+        Puppet.push_context(
+          :loaders => Puppet::Pops::Loaders.new(Puppet.lookup(:environments).get(Puppet[:environment])),
+          :rich_data => true)
       end
 
       after(:each) do
-        Puppet[:rich_data] = false
         Puppet.pop_context
       end
 


### PR DESCRIPTION
Add two new network formats for representing rich data over json and
msgpack. This allows server and agent to negotiate rich data support and
maintain compatibility across versions.

This slightly changes the behavior of `preferred_serialization_format`.
This now controls the underlying format (json vs msgpack) and the
`rich_data` setting controls whether the rich data variant will be used.

For example, if `preferred_serialization_format` is set to `json` and
`rich_data` is enabled, puppet will list
`application/vnd.puppet.rich+json` first in the list of formats. If
`rich_data` is not enabled then it will list `application/json` first and
not include `application/vnd.puppet.rich+json`.

This also enables rich data by default.