### PR TITLE
(PUP-9112) Stop transforming puppet undef to :undef in structures

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -61,7 +61,7 @@ class Runtime3Converter
   end
 
   def convert_NilClass(o, scope, undef_value)
-    @inner ? :undef : undef_value
+    @inner ? nil : undef_value
   end
 
   def convert_Integer(o, scope, undef_value)
@@ -98,7 +98,8 @@ class Runtime3Converter
   end
 
   def convert_Symbol(o, scope, undef_value)
-    o == :undef && !@inner ? undef_value : o
+    o == :undef ? undef_value : o
+    #o == :undef && !@inner ? undef_value : o
   end
 
   def convert_PAnyType(o, scope, undef_value)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1139,14 +1139,14 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it 'does not map :undef to empty string in arrays' do
         Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0][0] }
-        expect(parser.evaluate_string(scope, "$a = {} $b = [$a[nope]] bazinga($b)", __FILE__)).to eq(:undef)
-        expect(parser.evaluate_string(scope, "bazinga([undef])", __FILE__)).to eq(:undef)
+        expect(parser.evaluate_string(scope, "$a = {} $b = [$a[nope]] bazinga($b)", __FILE__)).to eq(nil)
+        expect(parser.evaluate_string(scope, "bazinga([undef])", __FILE__)).to eq(nil)
       end
 
       it 'does not map :undef to empty string in hashes' do
         Puppet::Parser::Functions.newfunction("bazinga", :type => :rvalue) { |args| args[0]['a'] }
-        expect(parser.evaluate_string(scope, "$a = {} $b = {a => $a[nope]} bazinga($b)", __FILE__)).to eq(:undef)
-        expect(parser.evaluate_string(scope, "bazinga({a => undef})", __FILE__)).to eq(:undef)
+        expect(parser.evaluate_string(scope, "$a = {} $b = {a => $a[nope]} bazinga($b)", __FILE__)).to eq(nil)
+        expect(parser.evaluate_string(scope, "bazinga({a => undef})", __FILE__)).to eq(nil)
       end
     end
   end

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -38,12 +38,12 @@ describe 'when converting to 3.x' do
     expect(converter.convert(nil, {}, 'undef value')).to eql('undef value')
   end
 
-  it 'does not convert a symbol nested in an array' do
-    expect(converter.convert({'foo' => :undef}, {}, 'undef value')).to eql({'foo' => :undef})
+  it 'convert a symbol nested in an array' do
+    expect(converter.convert({'foo' => :undef}, {}, 'undef value')).to eql({'foo' => 'undef value'})
   end
 
-  it 'converts nil to :undef when nested in an array' do
-    expect(converter.convert({'foo' => nil}, {}, 'undef value')).to eql({'foo' => :undef})
+  it 'does not converts nil to given undef value when nested in an array' do
+    expect(converter.convert({'foo' => nil}, {}, 'undef value')).to eql({'foo' => nil})
   end
 
   it 'does not convert a Regex instance to string' do


### PR DESCRIPTION
Before this, all undef/nil values were transformed to :undef in
structured values given to resources and functions.

This commit stops such transformation and uses nil (except for top level
values where nil becomes an empty string).

This commit only modifies tests that asserted that the conversion took
place as per the old specification.