### PR TITLE
(PUP-9108) Make the puppetserver-ca gem a feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group(:features) do
   # gem 'ruby-augeas', require: false, platforms: [:ruby]
   # requires native ldap headers/libs
   # gem 'ruby-ldap', '~> 0.9', require: false, platforms: [:ruby]
+  gem 'puppetserver-ca', '~> 0.5', require: false
 end
 
 group(:test) do
@@ -45,7 +46,6 @@ group(:test) do
 
   gem 'rubocop', '~> 0.49', require: false, platforms: [:ruby]
   gem 'rubocop-i18n', '~> 1.2.0', require: false, platforms: [:ruby]
-  gem 'puppetserver-ca', '~> 0.5', require: false
 end
 
 group(:development, optional: true) do

--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -57,11 +57,11 @@ Puppet::Face.define(:node, '0.0.1') do
 
   # clean signed cert for +host+
   def clean_cert(node)
-    begin
-      require 'puppetserver/ca/cli'
+    if Puppet.features.puppetserver_ca?
+      require 'puppetserver/ca/action/clean'
       Puppetserver::Ca::Action::Clean.new(LoggerIO.new).run({ 'certnames' => [node] })
-    rescue LoadError => e
-      Puppet.warning _("Unable to clean up certs for %{node}: %{error}") % { node: node, error: e }
+    else
+      Puppet.info _("Not managing %{node} certs as this host is not a CA") % { node: node }
     end
   end
 

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -72,3 +72,5 @@ Puppet.features.add(:manages_symlinks) do
     WindowsSymlink.is_implemented
   end
 end
+
+Puppet.features.add(:puppetserver_ca, libs: ['puppetserver/ca'])

--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -95,6 +95,12 @@ describe Puppet::Face[:node, '0.0.1'] do
           Puppetserver::Ca::Action::Clean.any_instance.expects(:run).with({ 'certnames' => ['hostname'] }).returns(0)
           subject.clean_cert('hostname')
         end
+
+        it "should not call the CA CLI gem's clean action if the gem is missing" do
+          Puppet.features.expects(:puppetserver_ca?).returns(false)
+          Puppetserver::Ca::Action::Clean.any_instance.expects(:run).never
+          subject.clean_cert("hostname")
+        end
       end
 
       describe "when cleaning cached facts" do


### PR DESCRIPTION
This commit pulls in the puppetserver-ca gem as a feature, rather than
trying to detect it via catching a load error.