### PR TITLE
(PUP-9079) Make it illegal to use __pvalue and __ptype as attr names

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -284,6 +284,9 @@ class PObjectType < PMetaType
     # @api public
     def initialize(name, container, init_hash)
       super(name, container, TypeAsserter.assert_instance_of(nil, TYPE_ATTRIBUTE, init_hash) { "initializer for #{self.class.label(container, name)}" })
+      if name == Serialization::PCORE_TYPE_KEY || name == Serialization::PCORE_VALUE_KEY
+        raise Puppet::ParseError, _("The attribute '%{name}' is reserved and cannot be used") % { name: name}
+      end
       @kind = init_hash[KEY_KIND]
       if @kind == ATTRIBUTE_KIND_CONSTANT # final is implied
         if init_hash.include?(KEY_FINAL) && !@final

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -74,6 +74,26 @@ describe 'The Object Type' do
         /expects a match for Enum\['constant', 'derived', 'given_or_derived', 'reference'\], got 'derivd'/)
     end
 
+    it 'raises an error if the name is __ptype' do
+      obj = <<-OBJECT
+        attributes => {
+          __ptype => String
+        }
+      OBJECT
+      expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
+        /The attribute '__ptype' is reserved and cannot be used/)
+    end
+
+    it 'raises an error if the name is __pvalue' do
+      obj = <<-OBJECT
+        attributes => {
+          __pvalue => String
+        }
+      OBJECT
+      expect { parse_object('MyObject', obj) }.to raise_error(Puppet::ParseError,
+        /The attribute '__pvalue' is reserved and cannot be used/)
+    end
+
     it 'stores value in attribute' do
       tp = parse_object('MyObject', <<-OBJECT)
         attributes => {


### PR DESCRIPTION
Before this it was possible to create an Object data types with
attribute names __ptype and __pvalue, but when using them they
override the internal values used when serializing.

While there may be a better solution (that allows the names) fixing
that would probably require updating all serialization formats. The
approach in this commit (as discussed on the ticket), is simply to make
it illegal to use the two reserved names __ptype and __pvalue.