### PR TITLE
(PUP-9110) Serialize Ascii-8bit string as rich Binary, and convert Binary on agent

### DIFF
--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -97,6 +97,9 @@ class DeferredResolver
     elsif x.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
       # rewrap in a new Sensitive after resolving any nested deferred values
       Puppet::Pops::Types::PSensitiveType::Sensitive.new(resolve(x.unwrap))
+    elsif x.is_a?(Puppet::Pops::Types::PBinaryType::Binary)
+      # use the ASCII-8BIT string that it wraps
+      x.binary_buffer
     else
       x
     end

--- a/lib/puppet/pops/serialization.rb
+++ b/lib/puppet/pops/serialization.rb
@@ -19,6 +19,7 @@ module Serialization
 
   # Type key used for symbols
   PCORE_TYPE_SENSITIVE = 'Sensitive'.freeze
+  PCORE_TYPE_BINARY = 'Binary'.freeze
 
   # Type key used for symbols
   PCORE_TYPE_SYMBOL = 'Symbol'.freeze

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -70,7 +70,15 @@ module Serialization
 
     def to_data(value)
       if value.nil? || Types::PScalarDataType::DEFAULT.instance?(value)
-        value
+        if @rich_data && value.is_a?(String) && value.encoding == Encoding::ASCII_8BIT
+          # Transform the binary string to rich Binary
+          {
+            PCORE_TYPE_KEY => PCORE_TYPE_BINARY,
+            PCORE_VALUE_KEY => Puppet::Pops::Types::PBinaryType::Binary.from_binary_string(value).to_s
+          }
+        else
+          value
+        end
       elsif :default == value
         if @rich_data
           { PCORE_TYPE_KEY => PCORE_TYPE_DEFAULT }

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -146,6 +146,15 @@ module Serialization
       expect(val2).to eql(val)
     end
 
+    it 'ACII_8BIT String as Binary' do
+      val = Types::PBinaryType::Binary.from_base64('w5ZzdGVuIG1lZCByw7ZzdGVuCg==')
+      strval = val.binary_buffer
+      write(strval)
+      val2 = read
+      expect(val2).to be_a(Types::PBinaryType::Binary)
+      expect(val2).to eql(val)
+    end
+
     it 'URI' do
       val = URI('http://bob:ewing@dallas.example.com:8080/oil/baron?crude=cash#leftovers')
       write(val)


### PR DESCRIPTION
This serializes an ASCII-8BIT as rich Binary data type in a catalog, and when the agent resolves the catalog for Deferred values, it also replaces
and Binary with its ASCII-8BIT equivalent String.