### PR TITLE
(PA-1923) Update Windows locale path

### DIFF
--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -4,7 +4,7 @@ require 'puppet/file_system'
 module Puppet::GettextConfig
   LOCAL_PATH = File.absolute_path('../../../locales', File.dirname(__FILE__))
   POSIX_PATH = File.absolute_path('../../../../../share/locale', File.dirname(__FILE__))
-  WINDOWS_PATH = File.absolute_path('../../../../../../../puppet/share/locale', File.dirname(__FILE__))
+  WINDOWS_PATH = File.absolute_path('../../../../../../puppet/share/locale', File.dirname(__FILE__))
 
   # This is the only domain name that won't be a symbol, making it unique from environments.
   DEFAULT_TEXT_DOMAIN = 'default-text-domain'


### PR DESCRIPTION
In puppet6, install paths for puppet agent are updated to build all
all of the agent components with the same prefix, instead of giving each
one its own directory. This adjusts the search path for locale files so
that it matches the new structure.

This PR shouldn't be merged until pathing updates are approved in https://github.com/puppetlabs/puppet-specifications/pull/123.

After that, this PR should be merged alongside the puppet-agent changes that require it, here: https://github.com/puppetlabs/puppet-agent/pull/1517.