### PR TITLE
(PUP-9130) Drop undef from tags before tagging

### DIFF
--- a/lib/puppet/util/tagging.rb
+++ b/lib/puppet/util/tagging.rb
@@ -10,7 +10,7 @@ module Puppet::Util::Tagging
   def tag(*ary)
     @tags ||= new_tags
 
-    ary.flatten.each do |tag|
+    ary.flatten.compact.each do |tag|
       name = tag.to_s.downcase
       # Add the tag before testing if it's valid since this means that
       # we never need to test the same valid tag twice. This speeds things

--- a/spec/unit/util/tagging_spec.rb
+++ b/spec/unit/util/tagging_spec.rb
@@ -166,6 +166,17 @@ describe Puppet::Util::Tagging do
       tagger.tag("my-tag")
       expect(tagger).to be_tagged("my-tag")
     end
+
+    it 'skips undef /nil tags' do
+      tagger.tag('before')
+      tagger.tag(nil)
+      tagger.tag('after')
+      expect(tagger).to_not be_tagged(nil)
+      expect(tagger).to_not be_tagged('')
+      expect(tagger).to_not be_tagged('undef')
+      expect(tagger).to be_tagged('before')
+      expect(tagger).to be_tagged('after')
+    end
   end
 
   context "when querying if tagged" do


### PR DESCRIPTION
Before this (caused by PUP-9112) an undef/nil value given to
tagging would do `to_s` and end up with an invalid empty string tag.

Now, nil (undef) values are removed from the arguments before tagging.