### PR TITLE
(PUP-8987) Add resource_api to gemspec/Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ end
 gem "facter", *location_for(ENV['FACTER_LOCATION']) if ENV.has_key?('FACTER_LOCATION')
 gem "hiera", *location_for(ENV['HIERA_LOCATION']) if ENV.has_key?('HIERA_LOCATION')
 gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ["~> 1.0"])
+gem "puppet-resource_api", *location_for(ENV['RESOURCE_API_LOCATION'] || ["~> 1.5"])
 
 group(:features) do
   gem 'diff-lcs', '~> 1.3', require: false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -24,6 +24,7 @@ gem_runtime_dependencies:
   locale: '~> 2.1'
   multi_json: '~> 1.10'
   httpclient: '~> 2.8'
+  puppet-resource_api: '~>1.5'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"


### PR DESCRIPTION
The resource API will be shipping as part of puppet-agent 6.0, and we
are currently planning to encourage the community and partners to
build content for it. It should be part of the default Puppet Gem
distribution so that it can be picked up by PDK and other
non-package-based workflows easily.