### PR TITLE
(PUP-9134) handle  __ptype key in ToStringifiedConverter and ToDataHash

### DIFF
--- a/lib/puppet/pops/serialization/from_data_converter.rb
+++ b/lib/puppet/pops/serialization/from_data_converter.rb
@@ -135,6 +135,7 @@ module Serialization
             end
             hash
           else
+            # not a string
             pcore_type_hash_to_value(type, value)
           end
         end
@@ -150,7 +151,7 @@ module Serialization
     def convert(value)
       if value.is_a?(Hash)
         pcore_type = value[PCORE_TYPE_KEY]
-        if pcore_type
+        if pcore_type && (pcore_type.is_a?(String) || pcore_type.is_a?(Hash))
           @pcore_type_procs[pcore_type].call(value, pcore_type)
         else
           build({}) { value.each_pair { |key, elem| with(key) { convert(elem) }}}

--- a/lib/puppet/pops/serialization/to_stringified_converter.rb
+++ b/lib/puppet/pops/serialization/to_stringified_converter.rb
@@ -80,7 +80,7 @@ module Serialization
         end
       elsif value.instance_of?(Hash)
         process(value) do
-          if value.keys.all? { |key| key.is_a?(String) && key != PCORE_TYPE_KEY }
+          if value.keys.all? { |key| key.is_a?(String) && key != PCORE_TYPE_KEY && key != PCORE_VALUE_KEY }
             result = {}
             value.each_pair { |key, elem| with(key) { result[key] = to_data(elem) } }
             result
@@ -199,6 +199,9 @@ module Serialization
           key = key.to_s
         elsif !key.is_a?(String)
           key = unknown_key_to_string(key)
+        end
+        if key == "__ptype" || key =="__pvalue"
+          key = "reserved key: #{key}"
         end
         with(key) { result[key] = to_data(value) }
       end

--- a/spec/unit/pops/serialization/to_stringified_spec.rb
+++ b/spec/unit/pops/serialization/to_stringified_spec.rb
@@ -103,8 +103,12 @@ describe 'ToStringifiedConverter' do
     expect(transform({['funky', 'key'] => 10})).to eq({'["funky", "key"]' => 10})
   end
 
-  it 'converts reserved __ptype hash key to string' do
-    expect(transform({'__ptype' => 10})).to eq({'__ptype' => 10})
+  it 'converts reserved __ptype hash key to different string' do
+    expect(transform({'__ptype' => 10})).to eq({'reserved key: __ptype' => 10})
+  end
+
+  it 'converts reserved __pvalue hash key to different string' do
+    expect(transform({'__pvalue' => 10})).to eq({'reserved key: __pvalue' => 10})
   end
 
   it 'converts a Binary to Base64 string' do


### PR DESCRIPTION
Before this, the ToStringifiedConverter produced hashes that could take the form `{"__ptype" => 10}` which would make FromDataConverter crash as it tries to
parse an Integer as if it was a type name. This is now fixed by:

* Making sure ToStringifiedConverter changes all `__ptype` and `__pvalue` keys in hashes to `"reserved key: __p<the key>"`
* Making sure FromDataHash does something more sensible instead of crashing when given input that is not compliant with the output of ToDataHash