### PR TITLE
(PUP-9136) Explicitly call `configure_type_defaults_on` where needed

### DIFF
--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -12,6 +12,8 @@ module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"
 module_dependencies = []
 
+configure_type_defaults_on master
+
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do
   rm_installed_modules_from_hosts orig_installed_modules, (get_installed_modules_for_hosts hosts)

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -5,6 +5,8 @@ tag 'audit:low',
     'audit:refactor'     # Master is not required for this test.
                          # Refactor to use agent.
 
+configure_type_defaults_on master
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/appleseed"
   on master, "rm -rf #{master['sitemoduledir']}/crakorn"

--- a/acceptance/tests/modules/list/with_installed_modules.rb
+++ b/acceptance/tests/modules/list/with_installed_modules.rb
@@ -3,6 +3,8 @@ test_name "puppet module list (with installed modules)"
 tag 'audit:low',
     'audit:unit'
 
+configure_type_defaults_on master
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -3,6 +3,8 @@ test_name "puppet module list (with invalid dependencies)"
 tag 'audit:low',
     'audit:unit'
 
+configure_type_defaults_on master
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_missing_dependencies.rb
+++ b/acceptance/tests/modules/list/with_missing_dependencies.rb
@@ -3,6 +3,8 @@ test_name "puppet module list (with missing dependencies)"
 tag 'audit:low',
     'audit:unit'
 
+configure_type_defaults_on master
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/thelock"
   on master, "rm -rf #{master['distmoduledir']}/appleseed"

--- a/acceptance/tests/modules/list/with_repeated_dependencies.rb
+++ b/acceptance/tests/modules/list/with_repeated_dependencies.rb
@@ -3,6 +3,8 @@ test_name "puppet module list (with repeated dependencies)"
 tag 'audit:low',
     'audit:unit'
 
+configure_type_defaults_on master
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"
   on master, "rm -rf #{master['distmoduledir']}/steward"

--- a/acceptance/tests/modules/uninstall/using_directory_name.rb
+++ b/acceptance/tests/modules/uninstall/using_directory_name.rb
@@ -5,6 +5,8 @@ tag 'audit:low',       # Module management via pmt is not the primary support wo
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide
 
+configure_type_defaults_on master
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/apache"
   on master, "rm -rf #{master['distmoduledir']}/crakorn"

--- a/acceptance/tests/modules/uninstall/using_version_filter.rb
+++ b/acceptance/tests/modules/uninstall/using_version_filter.rb
@@ -7,6 +7,8 @@ tag 'audit:low',       # Module management via pmt is not the primary support wo
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide
 
+configure_type_defaults_on master
+
 module_author = "jimmy"
 module_name   = "crakorn"
 module_dependencies = []

--- a/acceptance/tests/modules/uninstall/with_active_dependency.rb
+++ b/acceptance/tests/modules/uninstall/with_active_dependency.rb
@@ -5,6 +5,8 @@ tag 'audit:low',       # Module management via pmt is not the primary support wo
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide
 
+configure_type_defaults_on master
+
 step "Setup"
 apply_manifest_on master, <<-PP
 file {

--- a/acceptance/tests/modules/uninstall/with_module_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_module_installed.rb
@@ -5,6 +5,8 @@ tag 'audit:low',       # Module management via pmt is not the primary support wo
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide
 
+configure_type_defaults_on master
+
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/crakorn"
 end

--- a/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
+++ b/acceptance/tests/modules/uninstall/with_multiple_modules_installed.rb
@@ -13,6 +13,7 @@ step 'Setup'
 testdir = master.tmpdir('unistallmultiple')
 
 stub_forge_on(master)
+configure_type_defaults_on master
 
 teardown do
   on master, "rm -rf #{master['distmoduledir']}/java"

--- a/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
+++ b/acceptance/tests/modules/upgrade/in_a_secondary_directory.rb
@@ -15,6 +15,7 @@ end
 step 'Setup'
 
 stub_forge_on(master)
+configure_type_defaults_on master
 
 on master, "mkdir -p #{master['distmoduledir']}"
 on master, puppet("module install pmtacceptance-java --version 1.6.0 --target-dir #{master['distmoduledir']}")

--- a/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
+++ b/acceptance/tests/modules/upgrade/that_was_installed_twice.rb
@@ -19,6 +19,7 @@ end
 step 'Setup'
 
 stub_forge_on(master)
+configure_type_defaults_on master
 
 on master, puppet("module install pmtacceptance-java --version 1.7.0 --modulepath #{prod_env_modulepath}")
 on master, puppet("module install pmtacceptance-java --version 1.6.0 --modulepath #{master['distmoduledir']}")

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -12,6 +12,7 @@ tag 'audit:low',       # Module management via pmt is not the primary support wo
 fq_prod_env_modpath = "#{environmentpath}/production/modules"
 
 stub_forge_on(master)
+configure_type_defaults_on master
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -8,6 +8,8 @@ tag 'audit:medium',
 # doc:
 # https://puppet.com/docs/puppet/latest/hiera_automatic.html
 
+configure_type_defaults_on master
+
 @module_name = "puppet_lookup_command_test"
 
 ### @testroot = "/etc/puppetlabs"

--- a/acceptance/tests/reports/finalized_on_cycle.rb
+++ b/acceptance/tests/reports/finalized_on_cycle.rb
@@ -26,6 +26,8 @@ notify { 'bar':
 MANIFEST
 
 agents.each do |agent|
+  configure_type_defaults_on agent
+
   tmpdir = agent.tmpdir('report_finalized')
   check = "#{tmpdir}/check_report.rb"
   manifest = "#{tmpdir}/manifest.pp"

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -23,6 +23,8 @@ package_name = {'el'     => 'httpd',
 }
 
 agents.each do |agent|
+  configure_type_defaults_on agent
+
   platform = agent.platform.variant
 
   if agent['platform'] =~ /(debian|ubuntu)/


### PR DESCRIPTION
Beaker 4 removed the implicit calls to `configure_type_defaults_on`,
which populated values in the hash on a Beaker::Host object. This
updates the puppet tests to call it explicitly where those values are
needed.