### PR TITLE
(PUP-9135) Treat task metadata referring to missing module as invalid

### DIFF
--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -63,11 +63,6 @@ class Puppet::Module
     end
 
     def self.get_file_details(path, mod)
-      unless File.absolute_path(path) == File.path(path)
-        msg = _("File pathnames cannot include relative paths")
-        raise InvalidMetadata.new(msg, 'puppet.tasks/invalid-metadata')
-      end
-
       # This gets the path from the starting point onward
       # For files this should be the file subpath from the metadata
       # For directories it should be the directory subpath plus whatever we globbed
@@ -102,6 +97,11 @@ class Puppet::Module
         end
 
         path = File.join(pup_module.path, mount, endpath)
+        unless File.absolute_path(path) == File.path(path).chomp('/')
+          msg = _("File pathnames cannot include relative paths")
+          raise InvalidMetadata.new(msg, 'puppet.tasks/invalid-metadata')
+        end
+
         unless File.exist?(path)
           msg = _("Could not find %{path} on disk" % { path: path })
           raise InvalidFile.new(msg)

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -90,12 +90,13 @@ class Puppet::Module
 
         pup_module = Puppet::Module.find(module_name, env)
         if pup_module.nil?
-          raise Puppet::Module::MissingModule, _("Module %{module_name} not found in environment %{environment_name}.") %
-            {module_name: pup_module.name, environment_name: env}
+          msg = _("Could not find module %{module_name} containing task file %{filename}" %
+                  {module_name: module_name, filename: endpath})
+          raise InvalidMetadata.new(msg, 'puppet.tasks/invalid-metadata')
         end
 
         unless MOUNTS.include? mount
-          msg = _("Files must be saved in module directories that Puppet makes available via mount points: %{mounts}" % 
+          msg = _("Files must be saved in module directories that Puppet makes available via mount points: %{mounts}" %
                   {mounts: MOUNTS.join(', ')})
           raise InvalidMetadata.new(msg, 'puppet.tasks/invalid-metadata')
         end


### PR DESCRIPTION
Previously, we were raising a ModuleNotFound error in the case where a task
depended on a file from another module that didn't exist. Raising that
error caused a failure that was difficult to debug (the task was treated as
simply not existing). In reality, this scenario is generally a problem with
the metadata just like any other metadata error. Because of that, we now
raise InvalidMetadata, which causes the actual error message to propagate
through puppet-server and orchestrator, to the client.

Additionally, this error message was vague and fairly unhelpful as it
didn't explain *why* it was trying to load that module in the first place.
That message has been improved.

(PUP-9135) Check for path traversal before checking file existence

Previously, we were checking whether the referred file existed *before*
checking whether it was a path traversal. This allowed a potential
disclosure of file existence, through the roundabout method of deploying
some task metadata using a path traversal to refer to a path of interest
and then attempting to run the task and checking the error message. We now
check for path traversal *first*, which also avoids checking it for every
separate file in a directory.