### PR TITLE
(PUP-9094) Switch rest client back to our HttpPool

### DIFF
--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -107,7 +107,9 @@ module Puppet::Rest
         url.path += "certificate_request/#{name}"
 
         use_ssl = url.is_a? URI::HTTPS
-        verify_mode = ssl_context.verify_mode == OpenSSL::SSL::VERIFY_PEER
+
+        # See notes above as to why verify_mode is hardcoded to false
+        verify_mode = false
 
         client = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl, verify_mode)
 
@@ -131,7 +133,9 @@ module Puppet::Rest
         url.path += "certificate_request/#{name}"
 
         use_ssl = url.is_a? URI::HTTPS
-        verify_mode = ssl_context.verify_mode == OpenSSL::SSL::VERIFY_PEER
+
+        # See notes above as to why verify_mode is hardcoded to false
+        verify_mode = false
 
         client = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl, verify_mode)
 

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -1,7 +1,11 @@
 require 'puppet/rest/route'
+require 'puppet/network/http_pool'
+require 'puppet/network/http/compression'
 
 module Puppet::Rest
   module Routes
+
+    extend Puppet::Network::HTTP::Compression.module
 
     ACCEPT_ENCODING = 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
 
@@ -12,79 +16,134 @@ module Puppet::Rest
                         srv_service: :ca)
     end
 
-    # Make an HTTP request to fetch the named certificate, using the given
-    # HTTP client.
-    # @param [Puppet::Rest::Client] client the HTTP client to use to make the request
+    # Make an HTTP request to fetch the named certificate
     # @param [String] name the name of the certificate to fetch
+    # @param [Puppet::Rest::SSLContext] ssl_context the ssl content to use when making the request
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM-encoded certificate or certificate bundle
-    def self.get_certificate(client, name)
-      ca.with_base_url(client.dns_resolver) do |url|
+    def self.get_certificate(name, ssl_context)
+      ca.with_base_url(Puppet::Network::Resolver.new) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
-        body = ''
         url.path += "certificate/#{name}"
-        client.get(url, header: header) do |chunk|
-          body << chunk
+
+        use_ssl = url.is_a? URI::HTTPS
+
+        # Deeper levels of the code assume that if we have any number of
+        # certificate related files, we have all of the certificate related
+        # files. This assumption caused us to download the certificate twice.
+        # We have to hard code `verify_mode=false` so we don't attempt to
+        # download the certificate so that we can download the certificate.
+        #
+        # This is related to PUP-9094. We won't have so many issues with this
+        # once we are using the httpclient gem to handle this work. We were
+        # unable to get this work completed in time for Puppet 6.0.0, so we had
+        # to switch back to using Puppet::Network::HttpPool, which has
+        # unfortunate limitations (i.e., an all or nothing approach to cert
+        # verification).
+        verify_mode = false
+
+        client = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl, verify_mode)
+
+        response = client.get(url.request_uri, header)
+        unless response.code.to_i == 200
+          raise Puppet::Rest::ResponseError.new(response.message, response)
         end
+
         Puppet.info _("Downloaded certificate for %{name} from %{server}") % { name: name, server: ca.server }
-        body
+
+        uncompress_body(response)
       end
     end
 
-    # Make an HTTP request to fetch the named crl, using the given
-    # HTTP client. Accepts a block to stream responses to disk.
-    # @param [Puppet::Rest::Client] client the HTTP client to use to make the request
+    # Make an HTTP request to fetch the named crl
     # @param [String] name the crl to fetch
+    # @param [Puppet::Rest::SSLContext] ssl_context the ssl content to use when making the request
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
-    # @return nil
-    def self.get_crls(client, name, &block)
-      ca.with_base_url(client.dns_resolver) do |url|
+    # @return [String] the PEM-encoded crl
+    def self.get_crls(name, ssl_context)
+      ca.with_base_url(Puppet::Network::Resolver.new) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
         url.path += "certificate_revocation_list/#{name}"
-        client.get(url, header: header) do |chunk|
-          block.call(chunk)
+
+        use_ssl = url.is_a? URI::HTTPS
+
+        # Deeper levels of the code assume that if we have any number of
+        # certificate related files, we have all of the certificate related
+        # files. Unfortunately, this causes us to get stuck in an infinite loop,
+        # so we have to hard code `verify_mode=false` so we don't attempt to use
+        # files that do not exist yet in order to download those files.
+        #
+        # This is related to PUP-9094. We won't have so many issues with this
+        # once we are using the httpclient gem to handle this work. We were
+        # unable to get this work completed in time for Puppet 6.0.0, so we had
+        # to switch back to using Puppet::Network::HttpPool, which has
+        # unfortunate limitations (i.e., an all or nothing approach to cert
+        # verification).
+        verify_mode = false
+
+        client = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl, verify_mode)
+
+        response = client.get(url.request_uri, header)
+        unless response.code.to_i == 200
+          raise Puppet::Rest::ResponseError.new(response.message, response)
         end
+
         Puppet.debug _("Downloaded certificate revocation list for %{name} from %{server}") % { name: name, server: ca.server }
+
+        uncompress_body(response)
       end
     end
 
-    # Make an HTTP request to send the named CSR, using the given
-    # HTTP client.
-    # @param [Puppet::Rest::Client] client the HTTP client to use to make the request
+    # Make an HTTP request to send the named CSR
     # @param [String] csr_pem the contents of the CSR to sent to the CA
     # @param [String] name the name of the host whose CSR is being submitted
+    # @param [Puppet::Rest::SSLContext] ssl_context the ssl content to use when making the request
     # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
-    def self.put_certificate_request(client, csr_pem, name)
-      ca.with_base_url(client.dns_resolver) do |url|
+    def self.put_certificate_request(csr_pem, name, ssl_context)
+      ca.with_base_url(Puppet::Network::Resolver.new) do |url|
         header = { 'Accept' => 'text/plain',
                    'Accept-Encoding' => ACCEPT_ENCODING,
                    'Content-Type' => 'text/plain' }
         url.path += "certificate_request/#{name}"
-        response = client.put(url, body: csr_pem, header: header)
-        if response.ok?
+
+        use_ssl = url.is_a? URI::HTTPS
+        verify_mode = ssl_context.verify_mode == OpenSSL::SSL::VERIFY_PEER
+
+        client = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl, verify_mode)
+
+        response = client.put(url.request_uri, csr_pem, header)
+        if response.code.to_i == 200
           Puppet.debug "Submitted certificate request to server."
         else
-          raise response.to_exception
+          raise Puppet::Rest::ResponseError.new(response.message, response)
         end
       end
     end
 
-    # Make an HTTP request to get the named CSR, using the given
-    # HTTP client.
-    # @param [Puppet::Rest::Client] client the HTTP client to use to make the request
+    # Make an HTTP request to get the named CSR
     # @param [String] name the name of the host whose CSR is being queried
+    # @param [Puppet::Rest::SSLContext] ssl_context the ssl content to use when making the request
     # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM encoded certificate request
-    def self.get_certificate_request(client, name)
-      ca.with_base_url(client.dns_resolver) do |url|
+    def self.get_certificate_request(name, ssl_context)
+      ca.with_base_url(Puppet::Network::Resolver.new) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
-        body = ''
         url.path += "certificate_request/#{name}"
-        client.get(url, header: header) do |chunk|
-          body << chunk
+
+        use_ssl = url.is_a? URI::HTTPS
+        verify_mode = ssl_context.verify_mode == OpenSSL::SSL::VERIFY_PEER
+
+        client = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl, verify_mode)
+
+
+        response = client.get(url.request_uri, header)
+        unless response.code.to_i == 200
+          raise Puppet::Rest::ResponseError.new(response.message, response)
         end
+
         Puppet.debug _("Downloaded existing certificate request for %{name} from %{server}") % { name: name, server: ca.server }
-        body
+
+        uncompress_body(response)
       end
     end
   end

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -180,7 +180,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       expects_command_to_output
     end
 
-    it "warns if the local CSR doesn't match the local public key, and submits a new CSR" do
+    it "fails if the local CSR doesn't match the local public key" do
       # write out the local CSR
       File.open(csr_path, 'w') { |f| f.write(@host[:csr].to_pem) }
 
@@ -190,16 +190,10 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       File.open(Puppet[:hostprivkey], 'w') { |f| f.write(private_key.to_pem) }
       File.open(Puppet[:hostpubkey], 'w') { |f| f.write(public_key.to_pem) }
 
-      # expect CSR to contain the new pub key
-      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).with do |request|
-        sent_pem = OpenSSL::X509::Request.new(request.body).public_key.to_pem
-        expect(sent_pem).to eq(public_key.to_pem)
-      end.to_return(status: 200)
       stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
+      stub_request(:get, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200, body: @host[:csr].to_pem)
 
-      Puppet.stubs(:warning) # ignore unrelated warnings
-      Puppet.expects(:warning).with("The local CSR does not match the agent's public key. Generating a new CSR.")
-      expects_command_to_output(%r{Submitted certificate request for '#{name}' to https://.*}, 0)
+      expects_command_to_output(%r{Failed to submit certificate request: The CSR retrieved from the master does not match the agent's public key.}, 1)
     end
 
     it 'downloads the certificate when autosigning is enabled' do


### PR DESCRIPTION
We had been working to have our rest client use the httpclient gem for
cert related HTTP requests. Unfortunately, we weren't able to finish
that work in time for Puppet 6.0.0. This commit switches those requests
back to using Puppet::Network::HttpPool.

Unfortunately, this isn't a clean switch back. We are preserving all the
existing work as much as possible so we can more easily get back to the
httpclient gem in the future. For now, we have to sacrifice some nice
new functionality in favor of the old way of doing things. Notably, if
users have an invalid or out of date cert on their agent, they have to
remove it as the automation will not update it. This is consistent with
how things used to work prior to the httpclient gem.