### PR TITLE
(PUP-9137) Avoid reloading a 3x function

### DIFF
--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -420,12 +420,13 @@ describe 'loaders' do
     let(:scope) { compiler.topscope }
     let(:loader) { compiler.loaders.private_loader_for_module('user') }
 
-      before(:each) do
-        Puppet.push_context(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders)
-      end
-      after(:each) do
-        Puppet.pop_context
-      end
+
+    before(:each) do
+      Puppet.push_context(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders)
+    end
+    after(:each) do
+      Puppet.pop_context
+    end
 
     it 'a 3x function is loaded once' do
       # create a 3x function that when called will do a load of "callee_ws"


### PR DESCRIPTION
Before this, when a 4x loader tries to load a 3x function it
would not check if the 3c function had already been loaded via
the 3x API. This would cause the function to be reloaded and
the information already loaded would be overwritten and this causes
a warning to be issued.

Now, a check is made if function is already loaded and if so using
the loaded function instead of loading it again.