### PR TITLE
(PUP-6165) Remove --ordering flag from acceptance test

### DIFF
--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -42,7 +42,7 @@ master_opts = {
 
 with_puppet_running_on(master, master_opts) do
   agents.each do |agent|
-    on(agent, puppet('agent', "--no-daemonize --onetime --verbose --server #{master} --ordering manifest"))
+    on(agent, puppet('agent', "--no-daemonize --onetime --verbose --server #{master}"))
     if stdout !~ /Notice: first.*Notice: second.*Notice: third.*Notice: fourth.*Notice: fifth.*Notice: sixth.*Notice: seventh.*Notice: eighth/m
       fail_test "Output did not include the notify resources in the correct order"
     end


### PR DESCRIPTION
The ordering manifest is the only available ordering available in Puppet
6. The flag itself was deprecated in 5 and removed in 6. This removes it
from the test that ensure manifest ordering is correct.


---

This test is gated on the server tag so it was missed in normal agent PR testing.