### PR TITLE
(PUP-9106) Ensure SYSTEM ACE entries are Full Control

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -324,6 +324,20 @@ module Puppet::Util::Windows::Security
       # we don't check S_ISYSTEM_MISSING bit, but automatically carry over existing SYSTEM perms
       # by default set SYSTEM perms to full
       system_allow = FILE::FILE_ALL_ACCESS
+    else
+      # It is possible to set SYSTEM with a mode other than Full Control (7) however this makes no sense and in practical terms
+      # should not be done.  We can trap these instances and correct them before being applied.
+      if (sd.owner == well_known_system_sid) && (owner_allow != FILE::FILE_ALL_ACCESS)
+        #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
+        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the owner, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode, path: path }
+        owner_allow = FILE::FILE_ALL_ACCESS
+      end
+
+      if (sd.group == well_known_system_sid) && (group_allow != FILE::FILE_ALL_ACCESS)
+        #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
+        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the group, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode, path: path }
+        group_allow = FILE::FILE_ALL_ACCESS
+      end
     end
 
     # even though FILE_DELETE_CHILD only applies to directories, it can be set on files

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -579,7 +579,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
         if Puppet::Util::Platform.windows? && ['sha512', 'sha384'].include?(example.metadata[:digest_algorithm])
           skip "PUP-8257: Skip file bucket test on windows for #{example.metadata[:digest_algorithm]} due to long path names"
         end
-        
+
         bucket = Puppet::Type.type(:filebucket).new :path => tmpfile("filebucket"), :name => "mybucket"
         file = described_class.new({:path => tmpfile("bucket_backs"), :backup => "mybucket", :content => "foo", :force => true}.merge(resource_options))
         catalog.add_resource file
@@ -1283,7 +1283,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
   describe "when sourcing" do
     it "should give a deprecation warning when the user sets source_permissions" do
       Puppet.expects(:puppet_deprecation_warning).with(
-        'The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`.', 
+        'The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`.',
         {:file => 'my/file.pp', :line => 5})
 
       catalog.add_resource described_class.new(:path => path, :content => 'this is content', :source_permissions => :use_when_creating)
@@ -1525,12 +1525,12 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
               catalog.apply
             end
 
-            it "should allow the user to explicitly set the mode to 4" do
+            it "should not allow the user to explicitly set the mode to 4 ,and correct to 7" do
               system_aces = get_aces_for_path_by_sid(path, @sids[:system])
               expect(system_aces).not_to be_empty
 
               system_aces.each do |ace|
-                expect(ace.mask).to eq(Puppet::Util::Windows::File::FILE_GENERIC_READ)
+                expect(ace.mask).to eq(Puppet::Util::Windows::File::FILE_ALL_ACCESS)
               end
             end
 
@@ -1612,13 +1612,13 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
                 catalog.apply
               end
 
-              it "should allow the user to explicitly set the mode to 4" do
+              it "should not allow the user to explicitly set the mode to 4, and correct to 7" do
                 system_aces = get_aces_for_path_by_sid(dir, @sids[:system])
                 expect(system_aces).not_to be_empty
 
                 system_aces.each do |ace|
                   # unlike files, Puppet sets execute bit on directories that are readable
-                  expect(ace.mask).to eq(Puppet::Util::Windows::File::FILE_GENERIC_READ | Puppet::Util::Windows::File::FILE_GENERIC_EXECUTE)
+                  expect(ace.mask).to eq(Puppet::Util::Windows::File::FILE_ALL_ACCESS)
                 end
               end
 

--- a/spec/integration/util/windows/security_spec.rb
+++ b/spec/integration/util/windows/security_spec.rb
@@ -285,10 +285,11 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
                     # access mask, and back to mode without loss of information
                     # (provided the owner and group are not the same)
                     next if ((u & g) != g) or ((g & o) != o)
-
-                    mode = (s << 9 | u << 6 | g << 3 | o << 0)
-                    winsec.set_mode(mode, path)
-                    expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
+                    applied_mode  = (s << 9 | u << 6 | g << 3 | o << 0)
+                    # SYSTEM must always be Full Control (7)
+                    expected_mode = (s << 9 | u << 6 | 7 << 3 | o << 0)
+                    winsec.set_mode(applied_mode, path)
+                    expect(winsec.get_mode(path).to_s(8)).to eq(expected_mode.to_s(8))
                   end
                 end
               end
@@ -634,9 +635,11 @@ describe "Puppet::Util::Windows::Security", :if => Puppet.features.microsoft_win
                   # access mask, and back to mode without loss of information
                   # (provided the owner and group are the same)
                   next if ((ug & o) != o)
-                  mode = (s << 9 | ug << 6 | ug << 3 | o << 0)
-                  winsec.set_mode(mode, path)
-                  expect(winsec.get_mode(path).to_s(8)).to eq(mode.to_s(8))
+                  applied_mode  = (s << 9 | ug << 6 | ug << 3 | o << 0)
+                  # SYSTEM must always be Full Control (7)
+                  expected_mode = (s << 9 | 7 << 6 | 7 << 3 | o << 0)
+                  winsec.set_mode(applied_mode, path)
+                  expect(winsec.get_mode(path).to_s(8)).to eq(expected_mode.to_s(8))
                 end
               end
             end


### PR DESCRIPTION
Previously it was possible to specify an octal mode for setting file permissions
which would end up with the SYSTEM account in Windows not having Full Control.
This could then cause permission issues as the SYSTEM account is a priveledged
account.  This commit intercepts attempts to set the mode on files/directories
for the SYSTEM account to something other than Full Control; and then issues a
warning and corrects the ACE back to Full Control.

- [x] Figure out wording of the warning
- [ ] Should this be warn_once? the `kind` thing makes it difficult
- [x] Need to figure out that TODO odd symlink test.