### PR TITLE
(PUP-5475) Update windows service acceptance tests with new timeout

### DIFF
--- a/acceptance/tests/resource/service/windows.rb
+++ b/acceptance/tests/resource/service/windows.rb
@@ -35,7 +35,7 @@ MANIFEST
   # startup
   mock_service_startfail = {
     :name => "mock_service_startfail",
-    :start_sleep => 20,
+    :start_sleep => 60,
     :pause_sleep => 0,
     :continue_sleep => 0,
     :stop_sleep => 0,
@@ -49,7 +49,7 @@ MANIFEST
     :start_sleep => 0,
     :pause_sleep => 0,
     :continue_sleep => 0,
-    :stop_sleep => 20,
+    :stop_sleep => 60,
   }
 
   agents.each do |agent|


### PR DESCRIPTION
We added a floor on the timeout when puppet is waiting for pending states to
30 seconds. This broke the service acceptance tests because they were set to
'break' at 4 seconds (which is impossible with the new 30 second minimum
timeout). This commit updates the tests to break at 30 seconds by having the
broken services wait for 60 seconds.

This wait time is long, and will add just about a minute to the test run for
services. However we believe it's important to test the failure state that
puppet will actually time out, so we believe it's worth the extra time.