### PR TITLE
(PUP-9143) Remove reference to `ca_location` from `puppet device`

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -376,11 +376,6 @@ Licensed under the Apache 2.0 License
 
       Puppet.settings.use :main, :agent, :device, :ssl
 
-      # We need to specify a ca location for all of the SSL-related
-      # indirected classes to work; in fingerprint mode we just need
-      # access to the local files and we don't need a ca.
-      Puppet::SSL::Host.ca_location = :remote
-
       Puppet::Transaction::Report.indirection.terminus_class = :rest
 
       if Puppet[:catalog_cache_terminus]

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -151,7 +151,6 @@ describe Puppet::Application::Device do
     before :each do
       @device.options.stubs(:[])
       Puppet[:libdir] = "/dev/null/lib"
-      Puppet::SSL::Host.stubs(:ca_location=)
       Puppet::Transaction::Report.indirection.stubs(:terminus_class=)
       Puppet::Resource::Catalog.indirection.stubs(:terminus_class=)
       Puppet::Resource::Catalog.indirection.stubs(:cache_class=)
@@ -215,12 +214,6 @@ describe Puppet::Application::Device do
 
     it "should use :main, :agent, :device and :ssl config" do
       Puppet.settings.expects(:use).with(:main, :agent, :device, :ssl)
-
-      @device.setup
-    end
-
-    it "should install a remote ca location" do
-      Puppet::SSL::Host.expects(:ca_location=).with(:remote)
 
       @device.setup
     end


### PR DESCRIPTION
This commit removes a reference to Host#ca_location in the `puppet
device` application that was left over from the CA removal.