### PR TITLE
(PUP-9153) Support task spec revision 3

### DIFF
--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -1,58 +1,9 @@
 # The TypeDefinitionInstantiator instantiates a type alias or a type definition
 #
+require 'puppet/module/task'
 module Puppet::Pops
 module Loader
 class TaskInstantiator
-  def self.load_metadata(loader, metadata)
-    if metadata.nil?
-      EMPTY_HASH
-    else
-      json_text = loader.get_contents(metadata)
-      begin
-        Puppet::Util::Json.load(json_text).freeze || EMPTY_HASH
-      rescue Puppet::Util::Json::ParseError => ex
-        raise Puppet::ParseError.new(ex.message, metadata)
-      end
-    end
-  end
-
-  def self.validate_implementations(typed_name, directory, metadata, executables)
-    name = typed_name.name
-    basename = typed_name.name_parts[1] || 'init'
-    # If 'implementations' is defined, it needs to mention at least one
-    # implementation, and everything it mentions must exist.
-    if metadata.key?('implementations')
-      if metadata['implementations'].is_a?(Array)
-        metadata['implementations'].map do |impl|
-          path = executables.find { |real_impl| File.basename(real_impl) == impl['name'] }
-          if path
-            { "name" => impl['name'], "requirements" => impl.fetch('requirements', []), "path" => path }
-          else
-            raise ArgumentError, _("Task metadata for task %{name} specifies missing implementation %{implementation}") %
-              { name: name, implementation: impl['name'] }
-          end
-        end
-      else
-        # If 'implementations' is the wrong type, we just pass it through and
-        # let the task type definition reject it.
-        metadata['implementations']
-      end
-    # If implementations isn't defined, then we use executables matching the
-    # task name, and only one may exist.
-    else
-      implementations = executables.select { |impl| File.basename(impl, '.*') == basename }
-      if implementations.empty?
-        raise ArgumentError, _('No source besides task metadata was found in directory %{directory} for task %{name}') %
-          { name: name, directory: directory }
-      elsif implementations.length > 1
-        raise ArgumentError, _("Multiple executables were found in directory %{directory} for task %{name}; define 'implementations' in metadata to differentiate between them") %
-          { name: name, directory: implementations[0] }
-      end
-
-      [{ "name" => File.basename(implementations.first), "path" => implementations.first, "requirements" => [] }]
-    end
-  end
-
   def self.create(loader, typed_name, source_refs)
     name = typed_name.name
     basename = typed_name.name_parts[1] || 'init'
@@ -60,31 +11,16 @@ class TaskInstantiator
     metadata_files, executables = source_refs.partition { |source_ref| source_ref.end_with?('.json') }
     metadata_file = metadata_files.find { |source_ref| File.basename(source_ref, '.json') == basename }
 
-    metadata = load_metadata(loader, metadata_file)
+    metadata = Puppet::Module::Task.read_metadata(metadata_file) || {}
 
-    implementation_metadata = validate_implementations(typed_name, dirname, metadata, executables)
+    files = Puppet::Module::Task.find_files(name, dirname, metadata, executables)
 
-    arguments = {
-      'name' => name,
-      'implementations' => implementation_metadata
-    }
+    task = { 'name' => name, 'metadata' => metadata, 'files' => files }
 
     begin
-      metadata.each_pair do |key, value|
-        if %w[parameters output].include?(key)
-          ps = {}
-          value.each_pair do |k, v|
-            pd = v.dup
-            t = v['type']
-            pd['type'] = t.nil? ? Types::TypeFactory.data : Types::TypeParser.singleton.parse(t)
-            ps[k] = pd
-          end
-          value = ps
-        end
-        arguments[key] = value unless arguments.key?(key)
-      end
+      task['parameters'] = convert_types(metadata['parameters'])
 
-      Types::TypeFactory.task.from_hash(arguments)
+      Types::TypeFactory.task.from_hash(task)
     rescue Types::TypeAssertionError => ex
       # Not strictly a parser error but from the users perspective, the file content didn't parse properly. The
       # ParserError also conveys file info (even though line is unknown)
@@ -92,6 +28,13 @@ class TaskInstantiator
       raise Puppet::ParseError.new(msg, metadata_file)
     end
   end
+
+  def self.convert_types(args)
+    args.each_with_object({}) do |(k, v), hsh|
+      hsh[k] = v['type'].nil? ? Types::TypeFactory.data : Types::TypeParser.singleton.parse(v['type'])
+    end if args
+  end
+  private_class_method :convert_types
 end
 end
 end

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -39,39 +39,16 @@ module Pcore
             # Fully qualified name of the task
             name => { type => Pattern[/\\A[a-z][a-z0-9_]*(?:::[a-z][a-z0-9_]*)*\\z/] },
 
-            # List of implementations with requirements
-            implementations => { type => Array[Struct[name => String, path => String, Optional[requirements] => Array[String]], 1] },
+            # List of file references referenced by metadata and their paths on disk.
+            # If there are no implementations listed in metadata, the first file is always
+            # the task executable.
+            files => { type => Array[Struct[name => String, path => String]] },
 
-            # Task description
-            description => { type => Optional[String], value => undef },
+            # Task metadata
+            metadata => { type => Hash[String, Any] },
 
-            # Puppet Task version
-            puppet_task_version => { type => Integer, value => 1 },
-
-            # Type, description, and sensitive property of each parameter
-            parameters => {
-              type => Optional[Hash[
-                Pattern[/\\A[a-z][a-z0-9_]*\\z/],
-                Struct[
-                  Optional[description] => String,
-                  Optional[sensitive] => Boolean,
-                  type => Type]]],
-              value => undef
-            },
-
-             # Type, description, and sensitive property of each output
-            output => {
-              type => Optional[Hash[
-                Pattern[/\\A[a-z][a-z0-9_]*\\z/],
-                Struct[
-                  Optional[description] => String,
-                  Optional[sensitive] => Boolean,
-                  type => Type]]],
-              value => undef
-            },
-
-            supports_noop => { type => Boolean, value => false },
-            input_method => { type => Optional[String] },
+            # Map parameter names to their parsed data type
+            parameters => { type => Optional[Hash[Pattern[/\\A[a-z][a-z0-9_]*\\z/], Type]], value => undef },
           }
         }
       PUPPET

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -504,9 +504,7 @@ module Pal
       params_type = if params.nil?
         T_GENERIC_TASK_HASH
       else
-        key_to_type = {}
-        @task.parameters.each_pair { |k, v| key_to_type[k] = v['type'] }
-        Puppet::Pops::Types::TypeFactory.struct(key_to_type)
+        Puppet::Pops::Types::TypeFactory.struct(params)
       end
       return true if params_type.instance?(args_hash)
 

--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -329,13 +329,6 @@ describe 'The Loader' do
               'bad_syntax.json' => <<-TXT.unindent,
                 text => This is not a task because JSON is unparsable
                 TXT
-              'bad_content.sh' => '',
-              'bad_content.json' => <<-JSON.unindent,
-                {
-                  "description": "This is not a task because parameters is misspelled",
-                  "paramters": { "string_param": { "type": "String[1]" } }
-                }
-                JSON
               'missing_adjacent.json' => <<-JSON.unindent,
                 {
                   "description": "This is not a task because there is no adjacent file with the same base name",
@@ -415,7 +408,7 @@ describe 'The Loader' do
                   contain_exactly(tn(:task, 'c::foo')))
               end
               expect(logs.select { |log| log.level == :warning }.map { |log| log.message }).to(
-                contain_exactly(/unexpected token/, /unrecognized key/, /No source besides task metadata was found/)
+                contain_exactly(/unexpected token/, /No source besides task metadata was found/)
               )
             end
 
@@ -427,11 +420,11 @@ describe 'The Loader' do
                   contain_exactly(tn(:task, 'c::foo')))
               end
               expect(logs.select { |log| log.level == :warning }.map { |log| log.message }).to be_empty
-              expect(error_collector.size).to eql(3)
+              expect(error_collector.size).to eql(2)
               expect(error_collector.all? { |e| e.is_a?(Puppet::DataTypes::Error) })
               expect(error_collector.all? { |e| e.issue_code == Puppet::Pops::Issues::LOADER_FAILURE.issue_code })
               expect(error_collector.map { |e| e.details['original_error'] }).to(
-                contain_exactly(/unexpected token/, /unrecognized key/, /No source besides task metadata was found/)
+                contain_exactly(/unexpected token/, /No source besides task metadata was found/)
               )
             end
 

--- a/spec/unit/pops/loaders/module_loaders_spec.rb
+++ b/spec/unit/pops/loaders/module_loaders_spec.rb
@@ -104,8 +104,8 @@ describe 'FileBased module loader' do
 
       task = module_loader.load_typed(typed_name(:task, 'testmodule::foo')).value
       expect(task.name).to eq('testmodule::foo')
-      expect(task.implementations.length).to eq(1)
-      expect(task.implementations[0]['name']).to eq('foo.py')
+      expect(task.files.length).to eq(1)
+      expect(task.files[0]['name']).to eq('foo.py')
     end
 
     it 'can load tasks with multiple implementations' do
@@ -116,7 +116,7 @@ describe 'FileBased module loader' do
 
       task = module_loader.load_typed(typed_name(:task, 'testmodule::foo')).value
       expect(task.name).to eq('testmodule::foo')
-      expect(task.implementations.map {|impl| impl['name']}).to eq(['foo.py', 'foo.ps1'])
+      expect(task.files.map {|impl| impl['name']}).to eq(['foo.py', 'foo.ps1'])
     end
 
     it 'can load multiple tasks with multiple files' do
@@ -128,11 +128,11 @@ describe 'FileBased module loader' do
       foobar_task = module_loader.load_typed(typed_name(:task, 'testmodule::foobar')).value
 
       expect(foo_task.name).to eq('testmodule::foo')
-      expect(foo_task.implementations.length).to eq(1)
-      expect(foo_task.implementations[0]['name']).to eq('foo.py')
+      expect(foo_task.files.length).to eq(1)
+      expect(foo_task.files[0]['name']).to eq('foo.py')
       expect(foobar_task.name).to eq('testmodule::foobar')
-      expect(foobar_task.implementations.length).to eq(1)
-      expect(foobar_task.implementations[0]['name']).to eq('foobar.py')
+      expect(foobar_task.files.length).to eq(1)
+      expect(foobar_task.files[0]['name']).to eq('foobar.py')
     end
 
     it "won't load tasks with invalid names" do

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -767,13 +767,13 @@ describe 'Puppet Pal' do
               [ signature.runnable_with?('string_param' => 'foo', 'int_param' => 10),
                 signature.runnable_with?('anything_goes' => 'foo'),
                 signature.task_hash['name'],
-                signature.task_hash['parameters']['string_param']['description'],
-                signature.task.description,
-                signature.task.parameters['int_param']['type'],
+                signature.task_hash['metadata']['parameters']['string_param']['description'],
+                signature.task_hash['metadata']['description'],
+                signature.task_hash['metadata']['parameters']['int_param']['type'],
               ]
             end
           end
-          expect(result).to eq([true, false, 'b::atask', 'A string parameter', 'test task b::atask', Puppet::Pops::Types::PIntegerType::DEFAULT])
+          expect(result).to eq([true, false, 'b::atask', 'A string parameter', 'test task b::atask', 'Integer'])
         end
 
         it '"TaskSignature#runnable_with?" calls a given lambda if there is an error' do
@@ -802,7 +802,7 @@ describe 'Puppet Pal' do
               signature.task_hash
             end
           end
-          expect(result['input_method']).to be_nil
+          expect(result['metadata']['input_method']).to be_nil
         end
 
         it 'task input_method is parsed from task metadata' do
@@ -812,7 +812,7 @@ describe 'Puppet Pal' do
               signature.task_hash
             end
           end
-          expect(result['input_method']).to eq('stdin')
+          expect(result['metadata']['input_method']).to eq('stdin')
         end
 
         it '"list_tasks" returns an array with all tasks that can be loaded' do

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -136,7 +136,7 @@ describe Puppet::Module::Task do
     it "loads metadata for a task" do
       metadata  = {'desciption': 'some info'}
       Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe task1.json})
-      Puppet::Module::Task.any_instance.stubs(:read_metadata).returns(metadata)
+      Puppet::Module::Task.stubs(:read_metadata).returns(metadata)
 
       tasks = Puppet::Module::Task.tasks_in_module(mymod)
 
@@ -180,7 +180,7 @@ describe Puppet::Module::Task do
       metadata  = {'desciption' => 'some info',
         'implementations' => [ {"name" => "task1.exe"}, ] }
       Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe task1.sh task1.json})
-      Puppet::Module::Task.any_instance.stubs(:read_metadata).returns(metadata)
+      Puppet::Module::Task.stubs(:read_metadata).returns(metadata)
 
       tasks = Puppet::Module::Task.tasks_in_module(mymod)
 
@@ -192,7 +192,7 @@ describe Puppet::Module::Task do
       metadata  = {'desciption' => 'some info',
                    'implementations' => [ {"name" => "task2.sh"}, ] }
       Dir.expects(:glob).with(tasks_glob).returns(%w{task1.exe task2.sh task1.json})
-      Puppet::Module::Task.any_instance.stubs(:read_metadata).returns(metadata)
+      Puppet::Module::Task.stubs(:read_metadata).returns(metadata)
 
       tasks = Puppet::Module::Task.tasks_in_module(mymod)
 


### PR DESCRIPTION
Simplify task methods. Also refactor them to make it easier to re-use `Task.find_files` and `Task.find_implementations`.

Drop `requirements` from `Task#implementations`. Requirements are retrieved from `metadata`, the separate implementations helper is around finding paths to the implementation files.

Adds support for `files` and additions to `implementations` in the Task
spec revision 3.

Updates the `Task` pcore type definition to more closely mirror how the
Task Info Service represents task data. Also allow unknown keys in the
metadata.

Refactors the TaskInstantiator to share validation with Module::Task.

Once PUP-5942 is complete, we should update the metadata representation
to include validation of known properties with an open-ended Struct.