### PR TITLE
(PUP-9144) Add the ability to continue building a catalog with PAL

### DIFF
--- a/lib/puppet/parser/catalog_compiler.rb
+++ b/lib/puppet/parser/catalog_compiler.rb
@@ -29,4 +29,28 @@ class Puppet::Parser::CatalogCompiler < Puppet::Parser::Compiler
     raise Puppet::Error, message, detail.backtrace
   end
 
+  # Evaluates all added constructs, and validates the resulting catalog.
+  # This can be called whenever a series of evaluation of puppet code strings
+  # have reached a stable state (essentially that there are no relationships to
+  # non-existing resources).
+  #
+  # Raises an error if validation fails.
+  #
+  def compile_additions
+    evaluate_additions
+    validate
+  end
+
+  # Evaluates added constructs that are lazily evaluated until all of them have been evaluated.
+  # 
+  def evaluate_additions
+    evaluate_generators
+    finish
+  end
+
+  # Validates the current state of the catalog.
+  # Does not cause evaluation of lazy constructs.
+  def validate
+    validate_catalog(CatalogValidator::FINAL)
+  end
 end

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -577,6 +577,7 @@ class Puppet::Parser::Compiler
       end
     end
   end
+  protected :evaluate_generators
 
   # Find and evaluate our main object, if possible.
   def evaluate_main
@@ -641,6 +642,7 @@ class Puppet::Parser::Compiler
 
     add_resource_metaparams
   end
+  protected :finish
 
   def add_resource_metaparams
     unless main = catalog.resource(:class, :main)
@@ -780,8 +782,8 @@ class Puppet::Parser::Compiler
     settings_resource = Puppet::Parser::Resource.new('class', SETTINGS, :scope => @topscope)
 
     @catalog.add_resource(settings_resource)
-
     settings_type.evaluate_code(settings_resource)
+    settings_resource.instance_variable_set(:@evaluated, true) # Prevents settings from being reevaluated
 
     scope = @topscope.class_scope(settings_type)
     scope.merge_settings(environment.name)

--- a/lib/puppet_pal.rb
+++ b/lib/puppet_pal.rb
@@ -364,6 +364,41 @@ module Pal
       end
     end
 
+
+    # Compiles the result of additional evaluation taking place in a PAL catalog compilation.
+    # This will evaluate all lazy constructs until all have been evaluated, and will the validate
+    # the result.
+    #
+    # This should be called if evaluating string or files of puppet logic after the initial
+    # compilation taking place by giving PAL a manifest or code-string.
+    # This method should be called when a series of evaluation should have reached a
+    # valid state (there should be no dangling relationships (to resources that does not
+    # exist).
+    #
+    # As an alternative the methods `evaluate_additions` can be called without any
+    # requirements on consistency and then calling `validate` at the end.
+    #
+    # Can be called multiple times.
+    #
+    # @return [Void]
+    def compile_additions
+      internal_compiler.compile_additions
+    end
+
+    # Validates the state of the catalog (without performing evaluation of any elements
+    # requiring lazy evaluation. Can be called multiple times.
+    #
+    def validate
+      internal_compiler.validate
+    end
+
+    # Evaluates all lazy constructs that were produced as a side effect of evaluating puppet logic.
+    # Can be called multiple times.
+    #
+    def evaluate_additions
+      internal_compiler.evaluate_additions
+    end
+
   end
 
   # The JsonCatalogEncoder is a wrapper around a catalog produced by the Pal::CatalogCompiler.with_json_encoding


### PR DESCRIPTION
Before this, after the initial compilation (controlled by manifest/code
options) with PAL for catalog compilation there was no way to get lazy
constructs evaluated or to again run validation. Lazy constructs and
validation was performed for the initial compilation so the problem
addressed here is not super critical, but makes it impossible to
continue to build up the catalog with dynamic sequences.

To fix this, the PAL API for the exposed `CatalogCompiler` class is
extended with three methods: `compile_additions`, `evaluate_additions`
and `validate`, where the first method calls the other two. This allows
a dynamic sequence of operations that for example uses `evaluate_string`
to add definitions, declare a user defined resource in the catalog and
make it (and all other queued lazy constructs) to be run on demand.

This alters the standard compiler so that it exposes the relevant
methods to its subclasses by making some methods `protected`.