### PR TITLE
(PUP-9111) Retry reading overrides plist to avoid launchd race

### DIFF
--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -343,4 +343,23 @@ describe Puppet::Type.type(:service).provider(:launchd) do
       expect { provider.jobsearch("NOSUCH") }.to raise_error(Puppet::Error)
     end
   end
+
+  describe "read_overrides" do
+    before do
+      Kernel.stubs(:sleep)
+    end
+    it "should read overrides" do
+      provider.expects(:read_plist).once.returns({})
+      expect(provider.read_overrides).to eq({})
+    end
+    it "should retry if read_plist fails" do
+      provider.expects(:read_plist).once.returns({})
+      provider.expects(:read_plist).once.returns(nil)
+      expect(provider.read_overrides).to eq({})
+    end
+    it "raises Puppet::Error after 20 attempts" do
+      provider.expects(:read_plist).times(20).returns(nil)
+      expect { provider.read_overrides }.to raise_error(Puppet::Error)
+    end
+ end
 end


### PR DESCRIPTION
When restarting a service, the launchd provider calls `stop` and then `start`.
The `stop` method executes `launchctl unload -w <plist path>`, and then calls
`enable`. The `enable` method reads the disable overrides pilst and modifies it.

However, there is a race. While the `launchd` process is changing states, the
disables plist is sometimes zero-length. When this occurs, `read_plist` fails,
causing the refresh to fail.

Add a `read_overrides` method which retries the read_plist with a short sleep.