### PR TITLE
(PUP-6716) Purge local users on Windows

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -146,6 +146,16 @@ There also may be scenarios where you want to specify the host(s) to release. E.
     HOST_NAMES=lvwwr9tdplg351u bundle exec rake ci:release_hosts
     HOST_NAMES=lvwwr9tdplg351u,ylrqjh5l6xvym4t bundle exec rake ci:release_hosts
 
+### Syncing local development code with VMPooler Windows machines
+
+If you want to copy local code to a Windows machine that is running in beaker, you can use the `ci:sync:windows` rake task:
+
+    WIN_MACHINE=edqa6se2xxo5r21 rake ci:sync:windows
+
+Optional environment variables for this are:
+
+    LIB_DIR (defaults to `type`) - Path in `lib/puppet` to sync with the Windows machine.
+
 
 Running Tests on Vagrant Boxen
 ------------------------------

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -18,6 +18,16 @@ EOS
       Rake::Task["ci:test:aio"].invoke
     end
   end
+
+  namespace :sync do
+    task :windows do
+      raise 'WIN_MACHINE environment variable is required' unless ENV['WIN_MACHINE']
+      win_machine = ENV['WIN_MACHINE'] + '.delivery.puppetlabs.net'
+      path = ENV['LIB_DIR'] || 'type' # 'lib/puppet' prefix is implicit.
+      dest_path = path.split('/')[0...-1].join
+      system("scp -r #{File.dirname(__FILE__)}/../lib/puppet/#{path} Administrator@#{win_machine}:'C:/Program\\ Files/Puppet\\ Labs/Puppet/sys/ruby/lib/ruby/vendor_ruby/puppet/#{dest_path}'")
+    end
+  end
 end
 
 def get_test_sample

--- a/acceptance/tests/resource/user/should_purge.rb
+++ b/acceptance/tests/resource/user/should_purge.rb
@@ -1,0 +1,60 @@
+test_name "should purge a user" do
+  confine :except, :platform => /^eos-/ # See ARISTA-37
+  confine :except, :platform => /^cisco_/ # See PUP-5828
+  # Until purging works on AIX, Solaris, and OSX. See PUP-9188
+  confine :except, :platform => /^aix/
+  confine :except, :platform => /^solaris/
+  confine :except, :platform => /^osx/
+  tag 'audit:medium',
+      'audit:acceptance'
+
+  agents.each do |agent|
+    unmanaged = "unmanaged-#{rand(999999).to_i}"
+    managed = "managed-#{rand(999999).to_i}"
+    step "ensure that the unmanaged and managed users do not exist" do
+      agent.user_absent(unmanaged)
+      agent.user_absent(managed)
+    end
+
+    step "create the unmanaged user" do
+      on agent, puppet_resource('user', unmanaged, 'ensure=present')
+    end
+
+    step "verify the user exists" do
+      assert(agent.user_list.include?(unmanaged), "Unmanaged user was not created")
+    end
+
+    step "create the managed user and purge unmanaged users" do
+      manifest = %Q|
+      user {'#{managed}':
+        ensure => present
+      }
+      resources { 'user':
+        purge => true,
+        unless_system_user => true
+      }|
+      apply_manifest_on(agent, manifest)
+    end
+
+    step "verify the unmanaged user is purged" do
+      assert(!agent.user_list.include?(unmanaged), "Unmanaged user was not purged")
+    end
+
+    step "verify managed user is not purged" do
+      assert(agent.user_list.include?(managed), "Managed user was purged")
+    end
+
+    step "verify system user is not purged" do
+      if agent['platform'] =~ /windows/
+        assert(agent.user_list.include?("Administrator"), "System user (Administrator) was purged")
+      else
+        assert(agent.user_list.include?("root"), "System user (root) was purged")
+      end
+    end
+
+    teardown do
+      agent.user_absent(unmanaged)
+      agent.user_absent(managed)
+    end
+  end
+end

--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -87,6 +87,12 @@ Puppet::Type.newtype(:resources) do
     end
   end
 
+  WINDOWS_SYSTEM_SID_REGEXES =
+      # Administrator, Guest, Domain Admins, Schema Admins, Enterprise Admins.
+      # https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
+      [/S-1-5-21.+-500/, /S-1-5-21.+-501/, /S-1-5-21.+-512/, /S-1-5-21.+-518/,
+       /S-1-5-21.+-519/]
+
   def check(resource)
     @checkmethod ||= "#{self[:name]}_check"
     @hascheck ||= respond_to?(@checkmethod)
@@ -145,8 +151,12 @@ Puppet::Type.newtype(:resources) do
 
     return false if system_users.include?(resource[:name])
     return false if unless_uids && unless_uids.include?(current_uid)
-
-    current_uid > self[:unless_system_user]
+    if current_uid.is_a?(String)
+      # Windows user; is a system user if any regex matches.
+      WINDOWS_SYSTEM_SID_REGEXES.none? { |regex| current_uid =~ regex }
+    else
+      current_uid > self[:unless_system_user]
+    end
   end
 
   def system_users

--- a/spec/unit/type/resources_spec.rb
+++ b/spec/unit/type/resources_spec.rb
@@ -92,6 +92,24 @@ describe resources do
         user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
         expect(res.user_check(user)).to be_falsey
       end
+
+      it "should not purge Windows system users" do
+        res = Puppet::Type.type(:resources).new :name => :user, :purge => true
+        res.catalog = Puppet::Resource::Catalog.new
+        user_hash = {:name => 'Administrator', :uid => 'S-1-5-21-12345-500'}
+        user = Puppet::Type.type(:user).new(user_hash)
+        user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
+        expect(res.user_check(user)).to be_falsey
+      end
+
+      it "should not purge Windows system users" do
+        res = Puppet::Type.type(:resources).new :name => :user, :purge => true
+        res.catalog = Puppet::Resource::Catalog.new
+        user_hash = {:name => 'other', :uid => 'S-1-5-21-12345-1001'}
+        user = Puppet::Type.type(:user).new(user_hash)
+        user.stubs(:retrieve_resource).returns Puppet::Resource.new("user", user_hash[:name], :parameters => user_hash)
+        expect(res.user_check(user)).to be_truthy
+      end
     end
 
     %w(FreeBSD OpenBSD).each do |os|


### PR DESCRIPTION
Attempting to purge local users was failing on Windows, since the code
for that was Unix-centric, assuming a numeric user ID. Windows uses
a string for this (the SID), so a comparison was failing.

This adds in some logic to check for system users by marking some SID
formats as system users, via regex.