### PR TITLE
(PUP-9159) Request status of the master service

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -397,7 +397,7 @@ class Puppet::Configurer
       port = server[1] || Puppet[:masterport]
       begin
         http = Puppet::Network::HttpPool.http_ssl_instance(host, port)
-        response = http.get('/status/v1/simple')
+        response = http.get('/status/v1/simple/master')
         return [host, port] if response.is_a?(Net::HTTPOK)
 
         Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1019,6 +1019,17 @@ describe Puppet::Configurer do
       expect(options[:report].master_used).to eq('myserver:123')
     end
 
+    it "queries the simple status for the 'master' service" do
+      Puppet.settings[:server_list] = ["myserver:123"]
+      response = Net::HTTPOK.new(nil, 200, 'OK')
+      http = mock('request')
+      http.expects(:get).with('/status/v1/simple/master').returns(response)
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(http)
+      @agent.stubs(:run_internal)
+
+      @agent.run
+    end
+
     it "should report when a server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPInternalServerError.new(nil, 500, 'Internal Server Error')


### PR DESCRIPTION
The 'simple' status includes the status of all trapperkeeper services
such as the broker-service. Request status for the 'master'
service specifically.