### PR TITLE
(PUP-6542) Refactor members property to be more like the groups property

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -1,5 +1,35 @@
 module Puppet
   module Acceptance
+    module BeakerUtils
+      # TODO: This should be added to Beaker
+      def assert_matching_arrays(expected, actual, message = "")
+        assert_equal(expected.sort, actual.sort, message)
+      end
+
+      # TODO: Remove the wrappers to user_present
+      # and user_absent if Beaker::Host's user_present
+      # and user_absent functions are fixed to work with
+      # Arista (EOS).
+
+      def user_present(host, username)
+        case host['platform']
+        when /eos/
+          on(host, "useradd #{username}")
+        else
+          host.user_present(username)
+        end
+      end
+
+      def user_absent(host, username)
+        case host['platform']
+        when /eos/
+          on(host, "userdel #{username}", acceptable_exit_codes: [0, 1])
+        else
+          host.user_absent(username)
+        end
+      end
+    end
+
     module CronUtils
       def clean(agent, o={})
         o = {:user => 'tstuser'}.merge(o)

--- a/acceptance/tests/resource/exec/should_run_command_as_user.rb
+++ b/acceptance/tests/resource/exec/should_run_command_as_user.rb
@@ -4,31 +4,11 @@ test_name "The exec resource should be able to run commands as a different user"
   tag 'audit:high',
       'audit:acceptance'
 
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::BeakerUtils
+
   def random_username
     "pl#{rand(999999).to_i}"
-  end
-
-  # TODO: Remove the wrappers to user_present
-  # and user_absent if Beaker::Host's user_present
-  # and user_absent functions are fixed to work with
-  # Arista (EOS).
-
-  def user_present(host, username)
-    case host['platform']
-    when /eos/
-      on(host, "useradd #{username}")
-    else
-      host.user_present(username)
-    end
-  end
-
-  def user_absent(host, username)
-    case host['platform']
-    when /eos/
-      on(host, "userdel #{username}", acceptable_exit_codes: [0, 1])
-    else
-      host.user_absent(username)
-    end
   end
 
   def exec_resource_manifest(params = {})

--- a/acceptance/tests/resource/group/should_manage_members.rb
+++ b/acceptance/tests/resource/group/should_manage_members.rb
@@ -1,0 +1,184 @@
+test_name "should correctly manage the members property for the Group resource" do
+  # These are the only platforms whose group providers manage the members
+  # property
+  confine :to, :platform => /windows|osx|aix/
+
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                         # in ways that might require special permissions
+                         # or be harmful to the system running the test
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::BeakerUtils
+
+  def random_name
+    "pl#{rand(999999).to_i}"
+  end
+
+  def group_manifest(user, params)
+    params_str = params.map do |param, value|
+      value_str = value.to_s
+      value_str = "\"#{value_str}\"" if value.is_a?(String)
+
+      "  #{param} => #{value_str}"
+    end.join(",\n")
+
+    <<-MANIFEST
+group { '#{user}':
+  #{params_str}
+}
+MANIFEST
+  end
+
+  def members_of(host, group)
+    case host['platform']
+    when /windows/
+      # More verbose than 'net localgroup <group>', but more programmatic
+      # because it does not require us to parse stdout
+      get_group_members = <<-PS1
+# Adapted from https://github.com/RamblingCookieMonster/PowerShell/blob/master/Get-ADGroupMembers.ps1
+function Get-Members([string] $group) {
+  $ErrorActionPreference = 'Stop'
+
+  Add-Type -AssemblyName 'System.DirectoryServices.AccountManagement' -ErrorAction Stop
+  $contextType = [System.DirectoryServices.AccountManagement.ContextType]::Machine
+  $groupObject = [System.DirectoryServices.AccountManagement.GroupPrincipal]::FindByIdentity(
+    $contextType,
+    $group
+  )
+
+  if (-Not $groupObject) {
+    throw "Could not find the group '$group'!"
+  }
+
+  $members = $groupObject.GetMembers($false) | ForEach-Object { "'$($_.Name)'" }
+  write-output "[$([string]::join(',', $members))]"
+}
+
+Get-Members #{group}
+PS1
+      Kernel.eval(
+        execute_powershell_script_on(host, get_group_members).stdout.chomp 
+      )
+    else
+      # This reads the group members from the /etc/group file
+      get_group_members = <<-RUBY
+require 'etc'
+
+group_struct = nil
+Etc.group do |g|
+  if g.name == '#{group}'
+    group_struct = g
+    break
+  end
+end
+
+unless group_struct
+  raise "Could not find the group '#{group}'!"
+end
+
+puts(group_struct.mem.to_s)
+RUBY
+
+      script_path = "#{host.tmpfile("get_group_members")}.rb"
+      create_remote_file(host, script_path, get_group_members)
+
+      # The setup step should have already set :privatebindir on the
+      # host. We only include the default here to make this routine
+      # work for local testing, which sometimes skips the setup step.
+      privatebindir = host.has_key?(:privatebindir) ? host[:privatebindir] : '/opt/puppetlabs/puppet/bin'
+
+      result = on(host, "#{privatebindir}/ruby #{script_path}")
+      Kernel.eval(result.stdout.chomp)
+    end
+  end
+
+  agents.each do |agent|
+    users = 6.times.collect { random_name }
+    users.each { |user| agent.user_absent(user) }
+
+    group = random_name
+    agent.group_absent(group)
+    teardown { agent.group_absent(group) }
+
+    step 'Creating the Users' do
+      users.each do |user|
+        agent.user_present(user)
+        teardown { agent.user_absent(user) }
+      end
+    end
+
+    group_members = [users[0], users[1]]
+
+    step 'Ensure that the group is created with the specified members' do
+      manifest = group_manifest(group, members: group_members)
+      apply_manifest_on(agent, manifest)
+      assert_matching_arrays(group_members, members_of(agent, group), "The group was not successfully created with the specified members!")
+    end
+
+    step "Verify that Puppet errors when one of the members does not exist" do
+      manifest = group_manifest(group, members: ['nonexistent_member'])
+      apply_manifest_on(agent, manifest) do |result|
+        assert_match(/Error:.*#{group}/, result.stderr, "Puppet fails to report an error when one of the members in the members property does not exist")
+      end
+    end
+
+    step "Verify that Puppet noops when the group's members are already set" do
+      manifest = group_manifest(group, members: group_members)
+      apply_manifest_on(agent, manifest, catch_changes: true)
+      assert_matching_arrays(group_members, members_of(agent, group), "The group's members somehow changed despite Puppet reporting a noop")
+    end
+
+    step "Verify that Puppet enforces minimum user membership when auth_membership == false" do
+      new_members = [users[2], users[4]]
+
+      manifest = group_manifest(group, members: new_members, auth_membership: false)
+      apply_manifest_on(agent, manifest)
+
+      group_members += new_members
+      assert_matching_arrays(group_members, members_of(agent, group), "Puppet fails to enforce minimum user membership when auth_membership == false")
+    end
+
+    # Run some special, platform-specific tests. If these get too large, then
+    # we should consider placing them in a separate file.
+    case agent['platform']
+    when /windows/
+      step "(Windows) Verify that Puppet prints each group member as DOMAIN\\<user>" do
+        new_members = [users[3]]
+
+        manifest = group_manifest(group, members: new_members, auth_membership: false)
+        apply_manifest_on(agent, manifest) do |result|
+          group_members += new_members
+
+          stdout = result.stdout.chomp
+
+          domain = on(agent, 'hostname').stdout.chomp.upcase
+          group_members.each do |user|
+            assert_match(/#{domain}\\#{user}/, stdout, "Puppet fails to print the group member #{user} as #{domain}\\#{user}")
+          end
+        end
+      end
+    else
+      # On Windows, the user cannot specify a comma-separated list of members
+      # because doing so would fail the validation step.
+      step "(Non-Windows) Verify that Puppet accepts a comma-separated list of members for backwards compatibility" do
+        new_members = [users[3], users[5]]
+
+        manifest = group_manifest(group, members: new_members.join(','), auth_membership: false)
+        apply_manifest_on(agent, manifest)
+
+        group_members += new_members
+        assert_matching_arrays(group_members, members_of(agent, group), "Puppet cannot manage the members property when the members are provided as a comma-separated list")
+      end
+    end
+
+    step "Verify that Puppet enforces inclusive user membership when auth_membership == true" do
+      group_members = [users[0]]
+
+      manifest = group_manifest(group, members: group_members, auth_membership: true)
+      apply_manifest_on(agent, manifest)
+      assert_matching_arrays(group_members, members_of(agent, group), "Puppet fails to enforce inclusive group membership when auth_membership == true")
+    end
+  end
+end

--- a/acceptance/tests/resource/user/should_manage_groups.rb
+++ b/acceptance/tests/resource/user/should_manage_groups.rb
@@ -14,6 +14,9 @@ test_name "should correctly manage the groups property for the User resource" do
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
 
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::BeakerUtils
+
   def random_name
     "pl#{rand(999999).to_i}"
   end
@@ -42,11 +45,6 @@ MANIFEST
     # This bit of code reads the user's groups from the /etc/group file.
     result = on(host, "#{privatebindir}/ruby -e \"require 'puppet'; puts(Puppet::Util::POSIX.groups_of('#{user}').to_s)\"")
     Kernel.eval(result.stdout.chomp)
-  end
-
-  # TODO: This should be added to Beaker
-  def assert_matching_arrays(expected, actual, message = "")
-    assert_equal(expected.sort, actual.sort, message)
   end
 
   agents.each do |agent|

--- a/lib/puppet/provider/group/aix.rb
+++ b/lib/puppet/provider/group/aix.rb
@@ -53,24 +53,10 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
 
       group_hash
     end
-
-    # Define some Puppet Property => AIX Attribute (and vice versa)
-    # conversion functions here. This is so we can unit test them.
-
-    def members_to_users(members)
-      return members unless members.is_a?(Array)
-      members.join(',')
-    end
-
-    def users_to_members(users)
-      users.split(',')
-    end
   end
 
   mapping puppet_property: :members,
-          aix_attribute: :users,
-          property_to_attribute: method(:members_to_users),
-          attribute_to_property: method(:users_to_members)
+          aix_attribute: :users
 
   numeric_mapping puppet_property: :gid,
                   aix_attribute: :id

--- a/lib/puppet/provider/group/pw.rb
+++ b/lib/puppet/provider/group/pw.rb
@@ -9,7 +9,10 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
   defaultfor :operatingsystem => [:freebsd, :dragonfly]
   confine    :operatingsystem => [:freebsd, :dragonfly]
 
-  options :members, :flag => "-M", :method => :mem
+  options :members,
+          :flag    => "-M",
+          :method  => :mem,
+          :unmunge => proc { |members| members.join(',') }
 
   verify :gid, _("GID must be an integer") do |value|
     value.is_a? Integer
@@ -26,9 +29,6 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
 
     if members = @resource.should(:members)
       unless members == :absent
-        if members.is_a?(Array)
-          members = members.join(",")
-        end
         cmd << "-M" << members
       end
     end
@@ -39,10 +39,6 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
   end
 
   def modifycmd(param, value)
-    # members may be an array, need a comma separated list
-    if param == :members and value.is_a?(Array)
-      value = value.join(",")
-    end
     super(param, value)
   end
 end

--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -22,10 +22,12 @@ Puppet::Type.type(:group).provide :windows_adsi do
 
     # Cannot use munge of the group property to canonicalize @should
     # since the default array_matching comparison is not commutative
-
-    current_sids = current.map(&:sid)
     # dupes automatically weeded out when hashes built
-    specified_sids = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should).keys.to_a
+    current_members = Puppet::Util::Windows::ADSI::User.name_sid_hash(current)
+    specified_members = Puppet::Util::Windows::ADSI::User.name_sid_hash(should)
+
+    current_sids = current_members.keys.to_a
+    specified_sids = specified_members.keys.to_a
 
     if @resource[:auth_membership]
       current_sids.sort == specified_sids.sort
@@ -63,7 +65,8 @@ Puppet::Type.type(:group).provide :windows_adsi do
   end
 
   def members
-    group.members
+    @members ||= Puppet::Util::Windows::ADSI::User.name_sid_hash(group.members)
+    @members.keys
   end
 
   def members=(members)

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -116,7 +116,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       ds_value = input_hash[key]
       case ds_to_ns_attribute_map[ds_attribute]
         when :members
-          ds_value = ds_value # only members uses arrays so far
+          ds_value = ds_value.join(',')
         when :gid, :uid
           # OS X stores objects like uid/gid as strings.
           # Try casting to an integer for these cases to be
@@ -344,8 +344,10 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
 
   def set(param, value)
     self.class.validate(param, value)
-    current_members = @property_value_cache_hash[:members]
     if param == :members
+      current_members = @property_value_cache_hash[:members].split(',')
+      value = value.split(',')
+
       # If we are meant to be authoritative for the group membership
       # then remove all existing members who haven't been specified
       # in the manifest.
@@ -409,7 +411,7 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
       end
       if value != "" and not value.nil?
         if property == :members
-          add_members(nil, value)
+          add_members(nil, value.split(','))
         else
           exec_arg_vector = self.class.get_exec_preamble("-create", @resource[:name])
           exec_arg_vector << ns_to_ds_attribute_map[property.intern]

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -1,6 +1,7 @@
 require 'etc'
 require 'facter'
 require 'puppet/property/keyvalue'
+require 'puppet/property/list'
 require 'puppet/parameter/boolean'
 
 module Puppet
@@ -81,15 +82,76 @@ module Puppet
       end
     end
 
-    newproperty(:members, :array_matching => :all, :required_features => :manages_members) do
+    newproperty(:members, :parent => Puppet::Property::List, :required_features => :manages_members) do
       desc "The members of the group. For platforms or directory services where group
         membership is stored in the group objects, not the users. This parameter's
         behavior can be configured with `auth_membership`."
 
+      validate do |value|
+        unless value.is_a?(String)
+          raise ArgumentError, _("The members property must be specified as either an array of strings, or as a single string consisting of a comma-separated list of members")
+        end
+
+        if value.is_a?(Integer) || value =~ /^\d+$/
+          raise ArgumentError, _("User names must be provided, not UID numbers.")
+        end
+
+        if value.empty?
+          raise ArgumentError, _("User names must not be empty. If you want to specify \"no users\" pass an empty array")
+        end
+
+        if provider.respond_to?(:member_valid?)
+          return provider.member_valid?(value)
+        end
+      end
+
+      def inclusive?
+        @resource[:auth_membership]
+      end
+
       def change_to_s(currentvalue, newvalue)
-        currentvalue = currentvalue.join(",") if currentvalue != :absent
-        newvalue = newvalue.join(",")
+        newvalue = newvalue.split(",") if newvalue != :absent
+
+        if provider.respond_to?(:members_to_s)
+          # for Windows ADSI
+          # de-dupe the "newvalue" when the sync event message is generated,
+          # due to final retrieve called after the resource has been modified
+          newvalue = provider.members_to_s(newvalue).split(',').uniq
+        end
+
         super(currentvalue, newvalue)
+      end
+
+      # override Puppet::Property::List#retrieve
+      def retrieve
+        if provider.respond_to?(:members_to_s)
+          # Windows ADSI members returns SIDs, but retrieve needs names
+          # must return qualified names for SIDs for "is" value and puppet resource
+          return provider.members_to_s(provider.members).split(',')
+        end
+
+        super
+      end
+
+      # The members property should also accept a comma separated
+      # list of members (a String parameter) for backwards
+      # compatibility. Unfortunately, the List property would treat
+      # our comma separated list of members as a single-element Array.
+      # This override of should= ensures that a comma separated list of
+      # members is munged to an array of members, which is what we want.
+      # Note that we cannot use `munge` because that will pass in each
+      # array element instead of the entire array if the members property
+      # is specified as an array of members, which would cause each member
+      # to be munged into an array for that case. This is undesirable
+      # behavior.
+      def should=(values)
+        super(values)
+
+        if @should.length == 1 && @should.first.include?(delimiter)
+          @should = @should.first.split(delimiter)
+        end
+
+        @should
       end
 
       def insync?(current)
@@ -98,24 +160,6 @@ module Puppet
         end
 
         super(current)
-      end
-
-      def is_to_s(currentvalue)
-        if provider.respond_to?(:members_to_s)
-          currentvalue = '' if currentvalue.nil?
-          currentvalue = currentvalue.is_a?(Array) ? currentvalue : currentvalue.split(',')
-
-          return provider.members_to_s(currentvalue)
-        end
-
-        super(currentvalue)
-      end
-      alias :should_to_s :is_to_s
-
-      validate do |value|
-        if provider.respond_to?(:member_valid?)
-          return provider.member_valid?(value)
-        end
       end
     end
 

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -472,6 +472,8 @@ module Puppet::Util::Windows::ADSI
     def set_members(desired_members, inclusive = true)
       return if desired_members.nil?
 
+      desired_members = desired_members.split(',').map(&:strip)
+
       current_hash = Hash[ self.member_sids.map { |sid| [sid.sid, sid] } ]
       desired_hash = self.class.name_sid_hash(desired_members)
 

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -118,7 +118,8 @@ describe Puppet::Util::Windows::ADSI::Group,
         # create a test group and add above 5 members by SID
         group = described_class.create(temp_groupname)
         group.commit()
-        group.set_members(users.map { |u| u[:sid]} )
+        members = users.map { |u| u[:sid] }
+        group.set_members(members.join(','))
 
         # most importantly make sure that all name are convertible to SIDs
         expect { described_class.name_sid_hash(group.members) }.to_not raise_error

--- a/spec/unit/provider/group/aix_spec.rb
+++ b/spec/unit/provider/group/aix_spec.rb
@@ -54,23 +54,4 @@ describe 'Puppet::Type::Group::Provider::Aix' do
       expect(provider_class.find(1, ia_module_args)).to eql(expected_group)
     end
   end
-
-  describe '.users_to_members' do
-    it 'converts the users attribute to the members property' do
-      expect(provider_class.users_to_members('foo,bar'))
-        .to eql(['foo', 'bar'])
-    end
-  end
-
-  describe '.members_to_users' do
-    it 'returns the members property as-is if it is not an Array' do
-      expect(provider_class.members_to_users('members'))
-        .to eql('members')
-    end
-
-    it 'returns the members property as a comma-separated string if it is an Array' do
-      expect(provider_class.members_to_users(['user1', 'user2']))
-        .to eql('user1,user2')
-    end
-  end
 end

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -71,11 +71,5 @@ describe provider_class do
       provider.expects(:execute).with(all_of(includes("-M"), includes("user2")), has_entry(:custom_environment, {}))
       provider.members = "user2"
     end
-
-    it "should use -M with all the given users when the members property is changed with an array" do
-      resource[:members] = ["user1", "user2"]
-      provider.expects(:execute).with(all_of(includes("-M"), includes("user3,user4")), has_entry(:custom_environment, {}))
-      provider.members = ["user3", "user4"]
-    end
   end
 end

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -49,25 +49,25 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
     describe "#members_insync?" do
       it "should return true for same lists of members" do
         current = [
-          Puppet::Util::Windows::SID.name_to_principal('user1'),
-          Puppet::Util::Windows::SID.name_to_principal('user2'),
+          'user1',
+          'user2'
         ]
         expect(provider.members_insync?(current, ['user1', 'user2'])).to be_truthy
       end
 
       it "should return true for same lists of unordered members" do
         current = [
-          Puppet::Util::Windows::SID.name_to_principal('user1'),
-          Puppet::Util::Windows::SID.name_to_principal('user2'),
+          'user1',
+          'user2'
         ]
         expect(provider.members_insync?(current, ['user2', 'user1'])).to be_truthy
       end
 
       it "should return true for same lists of members irrespective of duplicates" do
         current = [
-          Puppet::Util::Windows::SID.name_to_principal('user1'),
-          Puppet::Util::Windows::SID.name_to_principal('user2'),
-          Puppet::Util::Windows::SID.name_to_principal('user2'),
+          'user1',
+          'user2',
+          'user2'
         ]
         expect(provider.members_insync?(current, ['user2', 'user1', 'user1'])).to be_truthy
       end
@@ -91,9 +91,9 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return true when current and should contain the same users in a different order" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
-            Puppet::Util::Windows::SID.name_to_principal('user2'),
-            Puppet::Util::Windows::SID.name_to_principal('user3'),
+            'user1',
+            'user2',
+            'user3'
           ]
           expect(provider.members_insync?(current, ['user3', 'user1', 'user2'])).to be_truthy
         end
@@ -104,21 +104,21 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return false when should is nil" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            'user1'
           ]
           expect(provider.members_insync?(current, nil)).to be_falsey
         end
 
         it "should return false when current contains different users than should" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            'user1'
           ]
           expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return false when current contains members and should is empty" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            'user1'
           ]
           expect(provider.members_insync?(current, [])).to be_falsey
         end
@@ -129,16 +129,16 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return false when should user(s) are not the only items in the current" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
-            Puppet::Util::Windows::SID.name_to_principal('user2'),
+            'user1',
+            'user2'
           ]
           expect(provider.members_insync?(current, ['user1'])).to be_falsey
         end
 
         it "should return false when current user(s) is not empty and should is an empty list" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
-            Puppet::Util::Windows::SID.name_to_principal('user2'),
+            'user1',
+            'user2'
           ]
           expect(provider.members_insync?(current, [])).to be_falsey
         end
@@ -156,21 +156,21 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return true when should is nil" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            'user1'
           ]
           expect(provider.members_insync?(current, nil)).to be_truthy
         end
 
         it "should return false when current contains different users than should" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            'user1'
           ]
           expect(provider.members_insync?(current, ['user2'])).to be_falsey
         end
 
         it "should return true when current contains members and should is empty" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
+            'user1'
           ]
           expect(provider.members_insync?(current, [])).to be_truthy
         end
@@ -181,25 +181,25 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
         it "should return true when current user(s) contains at least the should list" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
-            Puppet::Util::Windows::SID.name_to_principal('user2'),
+            'user1',
+            'user2'
           ]
           expect(provider.members_insync?(current, ['user1'])).to be_truthy
         end
 
         it "should return true when current user(s) is not empty and should is an empty list" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
-            Puppet::Util::Windows::SID.name_to_principal('user2'),
+            'user1',
+            'user2'
           ]
           expect(provider.members_insync?(current, [])).to be_truthy
         end
 
         it "should return true when current user(s) contains at least the should list, even unordered" do
           current = [
-            Puppet::Util::Windows::SID.name_to_principal('user3'),
-            Puppet::Util::Windows::SID.name_to_principal('user1'),
-            Puppet::Util::Windows::SID.name_to_principal('user2'),
+            'user3',
+            'user1',
+            'user2'
           ]
           expect(provider.members_insync?(current, ['user2','user1'])).to be_truthy
         end
@@ -238,13 +238,14 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
 
     it "should be able to provide a list of members" do
       provider.group.stubs(:members).returns ['user1', 'user2', 'user3']
+      Puppet::Util::Windows::ADSI::User.stubs(:name_sid_hash)
+        .with(provider.group.members)
+        .returns({ 'user1' => '', 'user2' => '', 'user3' => '' })
 
       expect(provider.members).to match_array(['user1', 'user2', 'user3'])
     end
 
     it "should be able to set group members" do
-      provider.group.stubs(:members).returns ['user1', 'user2']
-
       member_sids = [
         stub(:account => 'user1', :domain => 'testcomputername', :sid => 1),
         stub(:account => 'user2', :domain => 'testcomputername', :sid => 2),
@@ -259,7 +260,7 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
       provider.group.expects(:remove_member_sids).with(member_sids[0])
       provider.group.expects(:add_member_sids).with(member_sids[2])
 
-      provider.members = ['user2', 'user3']
+      provider.members = 'user2,user3'
     end
   end
 
@@ -268,12 +269,13 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
       resource[:members] = ['user1', 'user2']
 
       group = stub 'group'
+      group.stubs(:members).returns([])
       Puppet::Util::Windows::ADSI::Group.expects(:create).with('testers').returns group
 
       create = sequence('create')
       group.expects(:commit).in_sequence(create)
       # due to PUP-1967, defaultto false will set the default to nil
-      group.expects(:set_members).with(['user1', 'user2'], nil).in_sequence(create)
+      group.expects(:set_members).with('user1,user2', nil).in_sequence(create)
 
       provider.create
     end

--- a/spec/unit/provider/nameservice/directoryservice_spec.rb
+++ b/spec/unit/provider/nameservice/directoryservice_spec.rb
@@ -17,13 +17,13 @@ end
 
     it "[#6009] should handle nested arrays of members" do
       current = ["foo", "bar", "baz"]
-      desired = ["foo", ["quux"], "qorp"]
+      desired = "foo,quux,qorp"
       group   = 'example'
 
       @resource.stubs(:[]).with(:name).returns(group)
       @resource.stubs(:[]).with(:auth_membership).returns(true)
       @provider.instance_variable_set(:@property_value_cache_hash,
-                                      { :members => current })
+                                      { :members => current.join(',') })
 
       %w{bar baz}.each do |del|
         @provider.expects(:execute).once.

--- a/spec/unit/type/group_spec.rb
+++ b/spec/unit/type/group_spec.rb
@@ -2,8 +2,21 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:group) do
-  before do
+  let(:mock_group_provider) do
+    described_class.provide(:mock_group_provider) do
+      has_features :manages_members
+      mk_resource_methods
+      def create; end
+      def delete; end
+      def exists?; get(:ensure) != :absent; end
+      def flush; end
+      def self.instances; []; end
+    end
+  end
+
+  before(:each) do
     @class = Puppet::Type.type(:group)
+    described_class.stubs(:defaultprovider).returns mock_group_provider
   end
 
   it "should have a system_groups feature" do
@@ -70,23 +83,108 @@ describe Puppet::Type.type(:group) do
     expect(type.exists?).to eq(true)
   end
 
-  describe "should delegate :members implementation to the provider:"  do
-
-    let (:provider) { @class.provide(:testing) { has_features :manages_members } }
-    let (:provider_instance) { provider.new }
-    let (:type) { @class.new(:name => "group", :provider => provider_instance, :members => ['user1']) }
-
-    it "insync? calls members_insync?" do
-      provider_instance.expects(:members_insync?).with(['user1'], ['user1']).returns true
-      expect(type.property(:members).insync?(['user1'])).to be_truthy
+  describe "when managing members" do
+    def stub_property(resource_hash)
+      described_class.new(resource_hash).property(:members)
     end
 
-    it "is_to_s and should_to_s call members_to_s" do
-      provider_instance.expects(:members_to_s).with(['user2', 'user1']).returns "user2 (), user1 ()"
-      provider_instance.expects(:members_to_s).with(['user1']).returns "user1 ()"
+    describe "validation" do
+      it "raises an error for a non-String value" do
+        expect {
+          described_class.new(:name => 'foo', :members => true)
+        }.to raise_error(Puppet::Error)
+      end
 
-      expect(type.property(:members).is_to_s('user1')).to eq('user1 ()')
-      expect(type.property(:members).should_to_s('user2,user1')).to eq('user2 (), user1 ()')
+      it "raises an error for an array value containing a non-String element" do
+        expect {
+          described_class.new(:name => 'foo', :members => [ true, 'foo' ])
+        }.to raise_error(Puppet::Error)
+      end
+
+      it "raises an error when the members are specified as UIDs instead of usernames" do
+        expect {
+          described_class.new(:name => 'foo', :members => [ '123', '456' ])
+        }.to raise_error(Puppet::Error)
+      end
+
+      it "raises an error when an empty string is passed for a member's username" do
+        expect {
+          described_class.new(:name => 'foo', :members => [ 'foo', '' ])
+        }.to raise_error(Puppet::Error)
+      end
+
+      it "passes for a single member" do
+        expect {
+          described_class.new(:name => 'foo', :members => 'foo')
+        }.to_not raise_error
+      end
+
+      it "passes for a member whose username has a number" do
+        expect {
+          described_class.new(:name => 'foo', :members => 'foo123')
+        }.to_not raise_error
+      end
+
+      it "passes for an array of members" do
+        expect {
+          described_class.new(:name => 'foo', :members => [ 'foo', 'bar' ])
+        }.to_not raise_error
+      end
+
+      it "passes for a comma-separated list of members" do
+        expect {
+          described_class.new(:name => 'foo', :members => 'foo,bar')
+        }.to_not raise_error
+      end
+    end
+
+    describe "#inclusive?" do
+      it "returns false when auth_membership == false" do
+        members_property = stub_property(
+          :name => 'foo',
+          :auth_membership => false,
+          :members => []
+        )
+
+        expect(members_property.inclusive?).to be false
+      end
+
+      it "returns true when auth_membership == true" do
+        members_property = stub_property(
+          :name => 'foo',
+          :auth_membership => true,
+          :members => []
+        )
+
+        expect(members_property.inclusive?).to be true
+      end
+    end
+
+    describe "#should= munging the @should instance variable" do
+      def should_var_of(property)
+        property.instance_variable_get(:@should)
+      end
+
+      it "leaves a single member as-is" do
+        members_property = stub_property(:name => 'foo', :members => [])
+        members_property.should = 'foo'
+
+        expect(should_var_of(members_property)).to eql([ 'foo' ])
+      end
+
+      it "leaves an array of members as-is" do
+        members_property = stub_property(:name => 'foo', :members => [])
+        members_property.should = [ 'foo', 'bar' ]
+
+        expect(should_var_of(members_property)).to eql(['foo', 'bar'])
+      end
+
+      it "munges a comma-separated list of members into an array" do
+        members_property = stub_property(:name => 'foo', :members => [])
+        members_property.should = 'foo,bar' 
+
+        expect(should_var_of(members_property)).to eql(['foo', 'bar'])
+      end
     end
   end
 end

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -338,7 +338,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user')
           adsi_group.expects(:Add).with('WinNT://DOMAIN2/user3,user')
 
-          group.set_members(['user2', 'DOMAIN2\user3'])
+          group.set_members('user2,DOMAIN2\user3')
         end
 
         it "should add the desired_members to an existing group when not inclusive" do
@@ -365,7 +365,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
           adsi_group.expects(:Add).with('WinNT://DOMAIN2/user3,user')
 
-          group.set_members(['user2', 'DOMAIN2\user3'],false)
+          group.set_members('user2,DOMAIN2\user3',false)
         end
 
         it "should return immediately when desired_members is nil" do
@@ -397,7 +397,7 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           adsi_group.expects(:Remove).with('WinNT://DOMAIN/user1,user')
           adsi_group.expects(:Remove).with('WinNT://testcomputername/user2,user')
 
-          group.set_members([])
+          group.set_members('')
         end
 
         it "should do nothing when desired_members is empty and not inclusive" do
@@ -416,13 +416,13 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           adsi_group.expects(:Remove).never
           adsi_group.expects(:Add).never
 
-          group.set_members([],false)
+          group.set_members('',false)
         end
 
         it "should raise an error when a username does not resolve to a SID" do
           expect {
             adsi_group.expects(:Members).returns []
-            group.set_members(['foobar'])
+            group.set_members('foobar')
           }.to raise_error(Puppet::Error, /Could not resolve name: foobar/)
         end
       end


### PR DESCRIPTION
This PR refactors the members property of the Group resource to be more like the groups property of the User resource. Doing so not only makes things consistent, but it also lets Puppet correctly report the change notifications which fixes the bug described in the ticket.