### PR TITLE
(DO NOT MERGE)(BOLT-841) Add modulepath to task details

### DIFF
--- a/lib/puppet/info_service/task_information_service.rb
+++ b/lib/puppet/info_service/task_information_service.rb
@@ -28,7 +28,7 @@ class Puppet::InfoService::TaskInformationService
 
     begin
       task.validate
-      {:metadata => task.metadata, :files => task.files}
+      {:metadata => task.metadata, :files => task.files, :module => pup_module.path}
     rescue Puppet::Module::Task::Error => err
       { :metadata => nil, :files => [], :error => err.to_h }
     end

--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -15,7 +15,7 @@ class TaskInstantiator
 
     files = Puppet::Module::Task.find_files(name, dirname, metadata, executables)
 
-    task = { 'name' => name, 'metadata' => metadata, 'files' => files }
+    task = { 'name' => name, 'metadata' => metadata, 'files' => files, 'module' => dirname.chomp("/tasks") }
 
     begin
       task['parameters'] = convert_types(metadata['parameters'])

--- a/lib/puppet/pops/pcore.rb
+++ b/lib/puppet/pops/pcore.rb
@@ -47,6 +47,9 @@ module Pcore
             # Task metadata
             metadata => { type => Hash[String, Any] },
 
+            # The path of the module the task came from
+            module => { type => String },
+
             # Map parameter names to their parsed data type
             parameters => { type => Optional[Hash[Pattern[/\\A[a-z][a-z0-9_]*\\z/], Type]], value => undef },
           }

--- a/spec/unit/info_service_spec.rb
+++ b/spec/unit/info_service_spec.rb
@@ -44,7 +44,7 @@ describe "Puppet::InfoService" do
         end
 
         it 'returns the right set of keys' do
-          expect(@result.keys.sort).to eq([:files, :metadata])
+          expect(@result.keys.sort).to eq([:files, :metadata, :module])
         end
 
         it 'specifies the metadata_file correctly' do
@@ -102,7 +102,7 @@ describe "Puppet::InfoService" do
         end
 
         it 'returns the right set of keys' do
-          expect(@result.keys.sort).to eq([:files, :metadata])
+          expect(@result.keys.sort).to eq([:files, :metadata, :module])
         end
 
         it 'specifies the metadata_file correctly' do

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -30,6 +30,7 @@ describe Puppet::Module::Task do
 
     expect(tasks.count).to eq(3)
     expect(tasks.map{|t| t.name}).to eq(%w{mymod::task1 mymod::task2 mymod::task3})
+    expect(tasks.map{|t| t.module.name}).to eq(%w{mymod mymod mymod})
     expect(tasks.map{|t| t.metadata_file}).to eq(["#{tasks_path}/task1.json",
                                                   "#{tasks_path}/task2.json",
                                                   "#{tasks_path}/task3.json"])
@@ -134,6 +135,7 @@ describe Puppet::Module::Task do
     Puppet::Module::Task.any_instance.stubs(:metadata).returns({'files' => short_files})
 
     expect(tasks.count).to eq(1)
+    expect(tasks.map{|t| t.module.name}).to eq(%w{mymod})
     expect(tasks.map{|t| t.files.map{ |f| f["path"] } }).to eq([["#{tasks_path}/task1.sh"] + long_files])
   end
 


### PR DESCRIPTION
**What** This adds the path of the module that a task is found in to the task info
**Why** This allows us to print the module path when showing task details, for instance using the `bolt task show` command