### PR TITLE
(PUP-9180) Convert nested :undef to nil in 3x converter

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -105,8 +105,8 @@ class Runtime3Converter
   end
 
   def convert_Symbol(o, scope, undef_value)
-    o == :undef ? undef_value : o
-    #o == :undef && !@inner ? undef_value : o
+    return o unless o == :undef
+    !@inner ? undef_value : nil
   end
 
   def convert_PAnyType(o, scope, undef_value)

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -30,20 +30,34 @@ describe 'when converting to 3.x' do
     expect(converter.convert(v, {}, nil)).to equal(v)
   end
 
-  it 'converts the symbol :undef to the undef value' do
+  it 'converts top level symbol :undef to the given undef value' do
     expect(converter.convert(:undef, {}, 'undef value')).to eql('undef value')
   end
 
-  it 'converts the nil to the undef value' do
+  it 'converts top level nil value to the given undef value' do
     expect(converter.convert(nil, {}, 'undef value')).to eql('undef value')
   end
 
-  it 'convert a symbol nested in an array' do
-    expect(converter.convert({'foo' => :undef}, {}, 'undef value')).to eql({'foo' => 'undef value'})
+  it 'converts nested :undef in a hash to nil' do
+    expect(converter.convert({'foo' => :undef}, {}, 'undef value')).to eql({'foo' => nil})
+  end
+
+  it 'converts nested :undef in an array to nil' do
+    expect(converter.convert(['boo', :undef], {}, 'undef value')).to eql(['boo', nil])
   end
 
   it 'does not converts nil to given undef value when nested in an array' do
     expect(converter.convert({'foo' => nil}, {}, 'undef value')).to eql({'foo' => nil})
+  end
+
+  it 'does not convert top level symbols' do
+    expect(converter.convert(:default, {}, 'undef value')).to eql(:default)
+    expect(converter.convert(:whatever, {}, 'undef value')).to eql(:whatever)
+  end
+
+  it 'does not convert nested symbols' do
+    expect(converter.convert([:default], {}, 'undef value')).to eql([:default])
+    expect(converter.convert([:whatever], {}, 'undef value')).to eql([:whatever])
   end
 
   it 'does not convert a Regex instance to string' do

--- a/spec/unit/pops/evaluator/runtime3_converter_spec.rb
+++ b/spec/unit/pops/evaluator/runtime3_converter_spec.rb
@@ -46,6 +46,10 @@ describe 'when converting to 3.x' do
     expect(converter.convert(['boo', :undef], {}, 'undef value')).to eql(['boo', nil])
   end
 
+  it 'converts deeply nested :undef in to nil' do
+    expect(converter.convert({'foo' => [[:undef]], 'bar' => { 'x' => :undef }}, {}, 'undef value')).to eql({'foo' => [[nil]], 'bar' => { 'x' => nil}})
+  end
+
   it 'does not converts nil to given undef value when nested in an array' do
     expect(converter.convert({'foo' => nil}, {}, 'undef value')).to eql({'foo' => nil})
   end


### PR DESCRIPTION
Before this, nested :undef values were converted to the given
"undef value" (either nil, or empty string). When this was changed for
puppet 6.0.0 the language no longer produces :undef and the logic was
simplified. This did however break tests that assumed that functions
would be called with :undef.

This commit makes one change; a nested `:undef` will be converted to
`nil`.