### PR TITLE
(PUP-6569) Prevent password changes for inactive Windows accounts

### DIFF
--- a/acceptance/lib/puppet/acceptance/windows_utils.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils.rb
@@ -13,6 +13,18 @@ puts Dir::PROFILE.match(/(.*)\\\\[^\\\\]*/)[1]
 END
         on(agent, "#{ruby} -rubygems -e \"#{getbasedir}\"").stdout.chomp
       end
+
+      # Checks whether the account with the given username has the given password on a host
+      def assert_password_matches_on(host, username, password, msg = nil)
+        script = <<-PS1
+  Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+  $ctx = New-Object System.DirectoryServices.AccountManagement.PrincipalContext([System.DirectoryServices.AccountManagement.ContextType]::Machine, $env:COMPUTERNAME)
+  $ctx.ValidateCredentials("#{username}", "#{password}")
+        PS1
+        execute_powershell_script_on(host, script) do |result|
+          assert_match(/True/, result.stdout.strip, msg)
+        end
+      end
     end
   end
 end

--- a/acceptance/tests/windows/prevent_password_changes.rb
+++ b/acceptance/tests/windows/prevent_password_changes.rb
@@ -1,0 +1,76 @@
+test_name 'PUP-6569 Puppet should not reset passwords for disabled, expired, or locked out Windows user accounts' do
+  require 'date'
+  require 'puppet/acceptance/windows_utils'
+
+  extend Puppet::Acceptance::WindowsUtils
+  confine :to, platform: 'windows'
+
+  def random_username
+    "pl#{rand(999999).to_i}"
+  end
+
+  def change_password_manifest(username)
+    return <<-MANIFEST
+    user { '#{username}':
+      ensure   => 'present',
+      password => 'Password-#{rand(999999).to_i}'
+    }
+    MANIFEST
+  end
+
+  OLD_PASSWORD='0ldP@ssword'
+
+  agents.each do |host|
+    disabled_username = random_username
+
+    step "Create a disabled user account" do
+      on(host, "cmd.exe /c net user #{disabled_username} /active:no /add")
+    end
+
+    step "Try to change the disabled user account's password with puppet" do
+      apply_manifest_on(host, change_password_manifest(disabled_username))
+    end
+
+    step "Ensure the password wasn't changed" do
+      assert_password_matches_on(host, disabled_username, OLD_PASSWORD, "Expected the disabled user account's password to remain unchanged")
+    end
+
+    expired_username = random_username
+
+    step "Create an expired user account" do
+      date_format = host["locale"] == "ja" ? "%y/%m/%d" : "%m/%d/%y"
+      on(host, "cmd.exe /c net user #{expired_username} /expires:#{(Date.today - 1).strftime(date_format)} /add")
+    end
+
+    step "Try to change the expired user's password with puppet" do
+      apply_manifest_on(host, change_password_manifest(expired_username))
+    end
+
+    step "Ensure the password wasn't changed" do
+      assert_password_matches_on(host, expired_username, OLD_PASSWORD, "Expected the expired user account's password to remain unchanged")
+    end
+
+    locked_username = random_username
+
+    step "Create a user account, lower the account lockout threshold, and lock the new account by using the wrong password" do
+      on(host, "cmd.exe /c net user #{locked_username} /add")
+      on(host, "cmd.exe /c net accounts /lockoutthreshold:1")
+      on(host, "cmd.exe /c runas /user:#{locked_username} hostname.exe", accept_all_exit_codes: true)
+    end
+
+    step "Try to change the locked account's password with puppet" do
+      apply_manifest_on(host, change_password_manifest(locked_username))
+    end
+
+    step "Ensure the password wasn't changed" do
+      assert_password_matches_on(host, locked_username, OLD_PASSWORD, "Expected the locked out user account's password to remain unchanged")
+    end
+
+    teardown do
+      on(host, "cmd.exe /c net accounts /lockoutthreshold:10")
+      host.user_absent(disabled_username)
+      host.user_absent(expired_username)
+      host.user_absent(locked_username)
+    end
+  end
+end

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -124,7 +124,15 @@ Puppet::Type.type(:user).provide :windows_adsi do
   end
 
   def password=(value)
-    user.password = value
+    if user.disabled?
+      warning _("The user account '%s' is disabled; puppet will not reset the password" % @resource[:name])
+    elsif user.locked_out?
+      warning _("The user account '%s' is locked out; puppet will not reset the password" % @resource[:name])
+    elsif user.expired?
+      warning _("The user account '%s' is expired; puppet will not reset the password" % @resource[:name])
+    else
+      user.password = value
+    end
   end
 
   def uid

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -436,6 +436,26 @@ module Puppet::Util::Windows::ADSI
       op_userflags(*flags) { |userflags, flag| userflags & ~ADS_USERFLAGS[flag] }
     end
 
+    def disabled?
+      userflag_set?(:ADS_UF_ACCOUNTDISABLE)
+    end
+
+    def locked_out?
+      # Note that the LOCKOUT flag is known to be inaccurate when using the
+      # LDAP IADsUser provider, but this class consistently uses the WinNT
+      # provider, which is expected to be accurate.
+      userflag_set?(:ADS_UF_LOCKOUT)
+    end
+
+    def expired?
+      expires = native_object.Get('AccountExpirationDate')
+      expires && expires < Time.now
+    rescue WIN32OLERuntimeError => e
+      # This OLE error code indicates the property can't be found in the cache
+      raise e unless e.message =~ /8000500D/m
+      false
+    end
+
     # UNLEN from lmcons.h - https://stackoverflow.com/a/2155176
     MAX_USERNAME_LENGTH = 256
     def self.current_user_name

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -218,6 +218,9 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     end
 
     it "should set a user's password" do
+      provider.user.expects(:disabled?).returns(false)
+      provider.user.expects(:locked_out?).returns(false)
+      provider.user.expects(:expired?).returns(false)
       provider.user.expects(:password=).with('plaintextbad')
 
       provider.password = "plaintextbad"


### PR DESCRIPTION
Updates the ADSI user provider so that when a user account is locked
out, expired, or disabled, puppet logs a warning and refuses to change
the password.