### PR TITLE
(PUP-9187) Remove references to `puppet cert` in errors and docs

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -734,9 +734,8 @@ module Puppet
       :desc    => <<EOT,
 A comma-separated list of alternate DNS names for Puppet Server. These are extra
 hostnames (in addition to its `certname`) that the server is allowed to use when
-serving agents. Puppet checks this setting when automatically requesting a
-certificate for Puppet agent or Puppet Server, and when manually generating a
-certificate with `puppet cert generate`. These can be either IP or DNS, and the type
+serving agents. Puppet checks this setting when automatically creating a
+certificate for Puppet agent or Puppet Server. These can be either IP or DNS, and the type
 should be specified and followed with a colon. Untyped inputs will default to DNS.
 
 In order to handle agent requests at a given hostname (like
@@ -749,23 +748,12 @@ names.
 
 **Note:** The list of alternate names is locked in when the server's
 certificate is signed. If you need to change the list later, you can't just
-change this setting; you also need to:
-
-* On the server: Stop Puppet Server.
-* On the CA server: Revoke and clean the server's old certificate. (`puppet cert clean <NAME>`)
-  (Note `puppet cert clean` is deprecated and will be replaced with `puppetserver ca clean`
-  in Puppet 6.)
-* On the server: Delete the old certificate (and any old certificate signing requests)
-  from the [ssldir](https://puppet.com/docs/puppet/latest/dirs_ssldir.html).
-* On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to request a new certificate
-* On the CA server: Sign the certificate request, explicitly allowing alternate names
-  (`puppet cert sign --allow-dns-alt-names <NAME>`). (Note `puppet cert sign` is deprecated
-  and will be replaced with `puppetserver ca sign` in Puppet 6.)
-* On the server: Run `puppet agent -t --ca_server <CA HOSTNAME>` to retrieve the cert.
-* On the server: Start Puppet Server again.
+change this setting; you also need to regenerate the certificate. For more
+information on that process, see the [cert regen docs]
+(https://puppet.com/docs/puppet/latest/ssl_regenerate_certificates.html).
 
 To see all the alternate names your servers are using, log into your CA server
-and run `puppet cert list -a`, then check the output for `(alt names: ...)`.
+and run `puppetserver ca list --all`, then check the output for `(alt names: ...)`.
 Most agent nodes should NOT have alternate names; the only certs that should
 have them are Puppet Server nodes that you want other agents to trust.
 EOT
@@ -777,7 +765,7 @@ EOT
 An optional file containing custom attributes to add to certificate signing
 requests (CSRs). You should ensure that this file does not exist on your CA
 puppet master; if it does, unwanted certificate extensions may leak into
-certificates created with the `puppet cert generate` command.
+certificates created with the `puppetserver ca generate` command.
 
 If present, this file must be a YAML hash containing a `custom_attributes` key
 and/or an `extension_requests` key. The value of each key must be a hash, where
@@ -1070,7 +1058,7 @@ EOT
         and non-zero if the cert should not be autosigned.
 
         If a certificate request is not autosigned, it will persist for review. An admin
-        user can use the `puppet cert sign` command to manually sign it, or can delete
+        user can use the `puppetserver ca sign` command to manually sign it, or can delete
         the request.
 
         For info on autosign configuration files, see

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -23,7 +23,7 @@ Puppet::Face.define(:config, '0.0.1') do
       The three most commonly used sections are 'main', 'master', and 'agent'.
       'Main' is the default, and is used by all Puppet applications. Other
       sections can override 'main' values for specific applications --- the
-      'master' section affects puppet master and puppet cert, and the 'agent'
+      'master' section affects Puppet Server, and the 'agent'
       section affects puppet agent.
 
       Less commonly used is the 'user' section, which affects puppet apply. Any

--- a/lib/puppet/face/key.rb
+++ b/lib/puppet/face/key.rb
@@ -8,7 +8,7 @@ Puppet::Indirector::Face.define(:key, '0.0.1') do
   description <<-'EOT'
     This subcommand manages certificate private keys. Keys are created
     automatically by puppet agent and when certificate requests are generated
-    with 'puppet certificate generate'; it should not be necessary to use this
+    with 'puppet ssl submit_request'; it should not be necessary to use this
     subcommand directly.
   EOT
 

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -159,7 +159,7 @@ The certificate retrieved from the master does not match the agent's private key
 Certificate fingerprint: %{fingerprint}
 To fix this, remove the certificate from both the master and the agent and then start a puppet run, which will automatically regenerate a certificate.
 On the master:
-  puppet cert clean %{cert_name}
+  puppetserver ca clean --certname %{cert_name}
 On the agent:
   1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
   1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f
@@ -261,7 +261,7 @@ CSR public key: %{csr_public_key}
 Agent public key: %{agent_public_key}
 To fix this, remove the CSR from both the master and the agent and then start a puppet run, which will automatically regenerate a CSR.
 On the master:
-  puppet cert clean %{cert_name}
+  puppetserver ca clean --certname %{cert_name}
 On the agent:
   1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
   1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f


### PR DESCRIPTION
This commit removes some (and hopefully all) of the last remaning
references to the removed `puppet cert` command in Puppet's logging and
doc strings.