### PR TITLE
(PUP-8735) Preserve UTF-8 encoding on recursive file copy

### DIFF
--- a/acceptance/tests/utf8/utf8-recursive-copy.rb
+++ b/acceptance/tests/utf8/utf8-recursive-copy.rb
@@ -1,0 +1,67 @@
+test_name "PUP-8735: UTF-8 characters are preserved after recursively copying directories" do
+  # Translation is not supported on these platforms:
+  confine :except, :platform => /^eos-/
+  confine :except, :platform => /^cisco/
+  confine :except, :platform => /^cumulus/
+  confine :except, :platform => /^solaris/
+
+  # for file_exists?
+  require 'puppet/acceptance/temp_file_utils'
+  extend Puppet::Acceptance::TempFileUtils
+
+  # for enable_locale_language
+  require 'puppet/acceptance/i18n_utils'
+  extend Puppet::Acceptance::I18nUtils
+
+  agents.each do |host|
+    filename = "Fișier"
+    content = <<-CONTENT
+閑けさや
+岩にしみいる
+蝉の声
+    CONTENT
+
+    workdir = host.tmpdir("tmp#{rand(999999).to_i}")
+    source_dir = "#{workdir}/Adresář"
+    target_dir = "#{workdir}/目录"
+
+    manifest = %Q|
+file { ["#{workdir}", "#{source_dir}"]:
+  ensure => directory,
+}
+
+file { "#{source_dir}/#{filename}":
+  ensure  => file,
+  content => "#{content}",
+}
+
+file { "#{source_dir}/#{filename}_Copy":
+  ensure => file,
+  source =>  "#{source_dir}/#{filename}",
+}
+
+file { "#{target_dir}":
+  ensure  => directory,
+  source  => "#{source_dir}",
+  recurse => remote,
+  replace => true,
+}|
+
+    step "Ensure the en_US locale is enabled (and skip this test if not)" do
+      if enable_locale_language(host, 'en_US').nil?
+        skip_test("Host #{host} is missing the en_US locale. Skipping this test.")
+      end
+    end
+
+    step "Create and recursively copy a directory with UTF-8 filenames and contents" do
+      apply_manifest_on(host, manifest, environment: {'LANGUAGE' => 'en_US', 'LANG' => 'en_US'})
+    end
+
+    step "Ensure that the files' names and their contents are preserved" do
+      ["#{target_dir}/#{filename}", "#{target_dir}/#{filename}_Copy"]. each do |filepath|
+        assert(file_exists?(host, filepath), "Expected the UTF-8 directory's files to be recursivly copied, but they were not")
+        assert(file_contents(host, filepath) == content, "Expected the contents of the copied UTF-8 files to be preserved, but they were not")
+      end
+    end
+  end
+end

--- a/lib/puppet/file_serving/fileset.rb
+++ b/lib/puppet/file_serving/fileset.rb
@@ -122,7 +122,7 @@ class Puppet::FileServing::Fileset
     def children
       return [] unless directory?
 
-      Dir.entries(path).
+      Dir.entries(path, encoding: Encoding::UTF_8).
         reject { |child| ignore?(child) }.
         collect { |child| down_level(child) }
     end

--- a/spec/unit/file_serving/fileset_spec.rb
+++ b/spec/unit/file_serving/fileset_spec.rb
@@ -147,12 +147,12 @@ describe Puppet::FileServing::Fileset do
       top_names = %w{one two .svn CVS}
       sub_names = %w{file1 file2 .svn CVS 0 false}
 
-      Dir.stubs(:entries).with(path).returns(top_names)
+      Dir.stubs(:entries).with(path, encoding: Encoding::UTF_8).returns(top_names)
       top_names.each do |subdir|
         @files << subdir # relative path
         subpath = File.join(path, subdir)
         Puppet::FileSystem.stubs(stat_method).with(subpath).returns @dirstat
-        Dir.stubs(:entries).with(subpath).returns(sub_names)
+        Dir.stubs(:entries).with(subpath, encoding: Encoding::UTF_8).returns(sub_names)
         sub_names.each do |file|
           @files << File.join(subdir, file) # relative path
           subfile_path = File.join(subpath, file)
@@ -173,7 +173,7 @@ describe Puppet::FileServing::Fileset do
         extend Mocha::API
         path = File.join(base_path, name)
         Puppet::FileSystem.stubs(:lstat).with(path).returns MockStat.new(path, true)
-        Dir.stubs(:entries).with(path).returns(['.', '..'] + entries.map(&:name))
+        Dir.stubs(:entries).with(path, encoding: Encoding::UTF_8).returns(['.', '..'] + entries.map(&:name))
         entries.each do |entry|
           entry.mock(path)
         end
@@ -295,7 +295,7 @@ describe Puppet::FileServing::Fileset do
     link_path = File.join(path, "mylink")
     Puppet::FileSystem.expects(:stat).with(link_path).raises(Errno::ENOENT)
 
-    Dir.stubs(:entries).with(path).returns(["mylink"])
+    Dir.stubs(:entries).with(path, encoding: Encoding::UTF_8).returns(["mylink"])
 
     fileset = Puppet::FileServing::Fileset.new(path)
 
@@ -319,9 +319,9 @@ describe Puppet::FileServing::Fileset do
     end
 
     it "returns a hash of all files in each fileset with the value being the base path" do
-      Dir.expects(:entries).with(make_absolute("/first/path")).returns(%w{one uno})
-      Dir.expects(:entries).with(make_absolute("/second/path")).returns(%w{two dos})
-      Dir.expects(:entries).with(make_absolute("/third/path")).returns(%w{three tres})
+      Dir.expects(:entries).with(make_absolute("/first/path"), encoding: Encoding::UTF_8).returns(%w{one uno})
+      Dir.expects(:entries).with(make_absolute("/second/path"), encoding: Encoding::UTF_8).returns(%w{two dos})
+      Dir.expects(:entries).with(make_absolute("/third/path"), encoding: Encoding::UTF_8).returns(%w{three tres})
 
       expect(Puppet::FileServing::Fileset.merge(*@filesets)).to eq({
         "." => make_absolute("/first/path"),
@@ -335,15 +335,15 @@ describe Puppet::FileServing::Fileset do
     end
 
     it "includes the base directory from the first fileset" do
-      Dir.expects(:entries).with(make_absolute("/first/path")).returns(%w{one})
-      Dir.expects(:entries).with(make_absolute("/second/path")).returns(%w{two})
+      Dir.expects(:entries).with(make_absolute("/first/path"), encoding: Encoding::UTF_8).returns(%w{one})
+      Dir.expects(:entries).with(make_absolute("/second/path"), encoding: Encoding::UTF_8).returns(%w{two})
 
       expect(Puppet::FileServing::Fileset.merge(*@filesets)["."]).to eq(make_absolute("/first/path"))
     end
 
     it "uses the base path of the first found file when relative file paths conflict" do
-      Dir.expects(:entries).with(make_absolute("/first/path")).returns(%w{one})
-      Dir.expects(:entries).with(make_absolute("/second/path")).returns(%w{one})
+      Dir.expects(:entries).with(make_absolute("/first/path"), encoding: Encoding::UTF_8).returns(%w{one})
+      Dir.expects(:entries).with(make_absolute("/second/path"), encoding: Encoding::UTF_8).returns(%w{one})
 
       expect(Puppet::FileServing::Fileset.merge(*@filesets)["one"]).to eq(make_absolute("/first/path"))
     end


### PR DESCRIPTION
Fixes a bug where, when recursively copying a directory with files saved
in UTF-8 on a non-UTF-8 system, a call to Dir.entries in Fileset would
disregard the encoding of the filenames, producing garbage characters in
the destination filenames.