### PR TITLE
(PUP-9068) Windows admin? check should consider group membership

### DIFF
--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -8,13 +8,11 @@ module Puppet::Util::Windows::User
   extend FFI::Library
 
   def admin?
-    elevated_supported = Puppet::Util::Windows::Process.supports_elevated_security?
+    return false unless check_token_membership
 
     # if Vista or later, check for unrestricted process token
-    return Puppet::Util::Windows::Process.elevated_security? if elevated_supported
-
-    # otherwise 2003 or less
-    check_token_membership
+    elevated_supported = Puppet::Util::Windows::Process.supports_elevated_security?
+    return elevated_supported ? Puppet::Util::Windows::Process.elevated_security? : true
   end
   module_function :admin?
 


### PR DESCRIPTION
Previously the "root" user check on Windows would only consider the elevation
token, or for Windows 2003, the group membership.  However on modern Windows
operating systems it is possible to craft a user which is NOT a member of local
administrators, which can elevate.  This causes Puppet to consider that user an
Administrator, even though they are not members of the Local Administrators
group.

This commit modifies the Puppet::Util::Windows::User.admin? method to first
check if the user is a member of the Local Adminstrators group, and then check
the token for elevation, assuming it's supported.

This commit also modifies the tests to test for these scenarios and make the
unit tests less coupled with execution order of methods.

Paired with @ThoughtCrhyme 