### PR TITLE
(PUP-9092) Improve process termination handling on Windows

### DIFF
--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -7,6 +7,7 @@ module Puppet::Util::Windows::Process
   extend FFI::Library
 
   WAIT_TIMEOUT = 0x102
+  WAIT_INTERVAL = 15
 
   ERROR_DIRECTORY = 0x10B
   def execute(command, arguments, stdin, stdout, stderr)
@@ -27,8 +28,8 @@ module Puppet::Util::Windows::Process
   module_function :execute
 
   def wait_process(handle)
-    while WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
-      sleep(1)
+    while WaitForSingleObject(handle, WAIT_INTERVAL) == WAIT_TIMEOUT
+      sleep(0)
     end
 
     exit_status = -1

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -7,7 +7,7 @@ module Puppet::Util::Windows::Process
   extend FFI::Library
 
   WAIT_TIMEOUT = 0x102
-  WAIT_INTERVAL = 15
+  WAIT_INTERVAL = 200
 
   ERROR_DIRECTORY = 0x10B
   def execute(command, arguments, stdin, stdout, stderr)


### PR DESCRIPTION
@onyxmaster noticed we always wait a minimum of 1 second when launching external processes on Windows, which can greatly slow down puppet when there are a large number of exec resources. Now we wait at most 1 second, and repeat as necessary until the process exits or we're interrupted. Credit to @onxymaster for finding this and submitting a PR.

This supersedes PR#7038.