### PR TITLE
(PUP-2997) Allow setting `--logdest` via puppet.conf

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -409,6 +409,8 @@ class Application
   end
 
   def handle_logdest_arg(arg)
+    return if options[:setdest] || arg.nil?
+
     begin
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true

--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -388,6 +388,8 @@ class Application
   end
 
   def setup_logs
+    handle_logdest_arg(Puppet[:logdest])
+
     unless options[:setdest]
       if options[:debug] || options[:verbose]
         Puppet::Util::Log.newdestination(:console)
@@ -412,6 +414,7 @@ class Application
     return if options[:setdest] || arg.nil?
 
     begin
+      Puppet[:logdest] = arg
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true
     rescue => detail

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -312,6 +312,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
+    handle_logdest_arg(Puppet[:logdest])
     Puppet::Util::Log.newdestination(:console) unless options[:setdest]
 
     Signal.trap(:INT) do

--- a/lib/puppet/application/master.rb
+++ b/lib/puppet/application/master.rb
@@ -211,20 +211,22 @@ Copyright (c) 2012 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
   def setup_logs
     set_log_level
+    handle_logdest_arg(Puppet[:logdest])
 
-    if !options[:setdest]
+    unless options[:setdest]
       if options[:node]
-        # We are compiling a catalog for a single node with '--compile' and logging
-        # has not already been configured via '--logdest' so log to the console.
+        # We are compiling a catalog for a single node with '--compile' and a
+        # logging destination has not already been explicitly specified.
         Puppet::Util::Log.newdestination(:console)
       elsif !(Puppet[:daemonize] or options[:rack])
         # We are running a webrick master which has been explicitly foregrounded
-        # and '--logdest' has not been passed, assume users want to see logging
-        # and log to the console.
+        # and a logging destination has not already been explicitly specified,
+        # assume users want to see logging and log to the console.
         Puppet::Util::Log.newdestination(:console)
       else
-        # No explicit log destination has been given with '--logdest' and we're
-        # either a daemonized webrick master or running under rack, log to syslog.
+        # No explicit log destination has been given with '--logdest', or via settings,
+        # and we're either a daemonized webrick master or running under rack, log to
+        # syslog.
         Puppet::Util::Log.newdestination(:syslog)
       end
     end

--- a/lib/puppet/application/script.rb
+++ b/lib/puppet/application/script.rb
@@ -229,9 +229,9 @@ Copyright (c) 2017 Puppet Inc., LLC Licensed under the Apache 2.0 License
   end
 
   def setup
-
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
+    handle_logdest_arg(Puppet[:logdest])
     Puppet::Util::Log.newdestination(:console) unless options[:setdest]
 
     Signal.trap(:INT) do

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -974,6 +974,15 @@ EOT
           }
         end
       end
+    },
+    :logdest => {
+      :type      => :string,
+      :desc      => "Where to send log messages. Choose between 'syslog' (the POSIX syslog
+      service), 'eventlog' (the Windows Event Log), 'console', or the path to a log
+      file."
+      # Sure would be nice to set the Puppet::Util::Log destination here in an :on_initialize_and_write hook,
+      # unfortunately we have a large number of tests that rely on the logging not resetting itself when the
+      # settings are initialized as they test what gets logged during settings initialization.
     }
   )
 

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -12,6 +12,10 @@ describe 'collectors' do
     expect(messages).to include(*expected_messages)
   end
 
+  def warnings
+    @logs.select { |log| log.level == :warning }.map { |log| log.message }
+  end
+  
   context "virtual resource collection" do
     it "matches everything when no query given" do
       expect_the_message_to_be(["the other message", "the message"], <<-MANIFEST)
@@ -313,8 +317,6 @@ describe 'collectors' do
       end
 
       context 'when overriding an already evaluated resource' do
-        let(:logs) { [] }
-        let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
         let(:manifest) { <<-MANIFEST }
           define foo($message) {
             notify { "testing": message => $message }
@@ -325,12 +327,6 @@ describe 'collectors' do
           }
           delayed {'do it now': }
         MANIFEST
-
-        around(:each) do |example|
-          Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-            example.run
-          end
-        end
 
         it 'and --strict=off, it silently skips the override' do
           Puppet[:strict] = :off

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,7 +117,6 @@ RSpec.configure do |config|
     # I suck for letting this float. --daniel 2011-04-21
     Signal.stubs(:trap)
 
-
     # TODO: in a more sane world, we'd move this logging redirection into our TestHelper class.
     #  Without doing so, external projects will all have to roll their own solution for
     #  redirecting logging, and for validating expected log messages.  However, because the

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -91,6 +91,13 @@ describe Puppet::Application::Apply do
       @apply.setup
     end
 
+    it "sets the log destination if logdest is provided via settings" do
+      Puppet::Log.expects(:newdestination).with("set_via_config")
+      Puppet[:logdest] = "set_via_config"
+
+      @apply.setup
+    end
+
     it "should set INT trap" do
       Signal.expects(:trap).with(:INT)
 

--- a/spec/unit/application/master_spec.rb
+++ b/spec/unit/application/master_spec.rb
@@ -155,6 +155,13 @@ describe Puppet::Application::Master, :unless => Puppet.features.microsoft_windo
           @master.setup
         end
       end
+
+      it "sets the log destination using settings" do
+        Puppet::Util::Log.expects(:newdestination).with("set_via_config")
+        Puppet[:logdest] = "set_via_config"
+
+        @master.setup
+      end
     end
 
     it "should print puppet config if asked to in Puppet config" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -648,6 +648,18 @@ describe Puppet::Application do
       @app.handle_logdest_arg(test_arg)
       expect(@app.options[:setdest]).to be_truthy
     end
-  end
 
+    it "does not set the log destination if setdest is true" do
+      Puppet::Util::Log.expects(:newdestination).never
+      @app.options[:setdest] = true
+
+      @app.handle_logdest_arg(test_arg)
+    end
+
+    it "does not set the log destination if arg is nil" do
+      Puppet::Util::Log.expects(:newdestination).never
+
+      @app.handle_logdest_arg(nil)
+    end
+  end
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -398,7 +398,6 @@ describe Puppet::Application do
   end
 
   describe "when calling default setup" do
-
     before :each do
       @app.options.stubs(:[])
     end
@@ -416,6 +415,14 @@ describe Puppet::Application do
       @app.options.stubs(:[]).with(:setdest).returns(false)
 
       Puppet::Util::Log.expects(:setup_default)
+
+      @app.setup
+    end
+  
+    it "sets the log destination if provided via settings" do
+      @app.options.unstub(:[])
+      Puppet[:logdest] = "set_via_config"
+      Puppet::Util::Log.expects(:newdestination).with("set_via_config")
 
       @app.setup
     end
@@ -628,7 +635,6 @@ describe Puppet::Application do
   end
 
   describe "#handle_logdest_arg" do
-
     let(:test_arg) { "arg_test_logdest" }
 
     it "should log an exception that is raised" do


### PR DESCRIPTION
The `--logdest` option can now be set via the `logdest` setting in puppet.conf.

Unfortunately, handling setting the logging destination itself via an `:on_initialize_and_write` hook ended up playing very poorly with a large number of tests that were expecting to be able to arbitrarily reinitialize Puppet's settings without having it affect the logging setup so they could look for warnings/deprecations/errors.

Moving the setting of the log destination itself into the applications turned out to be less problematic, even though it's a bit awkward to work with because of some of the applications overriding `#setup` and `#setup_logs`.
