### PR TITLE
(PUP-6920) Execute windows package installs in source dir

### DIFF
--- a/acceptance/fixtures/MockInstaller.cs
+++ b/acceptance/fixtures/MockInstaller.cs
@@ -1,0 +1,42 @@
+/*
+
+The MockInstaller is a C# class representing a stubbed exe installer. We will
+compile this class into an installable .exe file.
+
+A MockInstaller _MUST_ come alongside a MockUninstaller, so we can uninstall the
+fake package from the system
+
+*/
+using System;
+
+public class MockInstaller
+{   public static void Main()
+   {
+        try
+        {
+            %{install_commands}
+        }
+        catch {
+            Environment.Exit(1003);
+        }
+        string keyName = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+        Microsoft.Win32.RegistryKey key;
+        key = Microsoft.Win32.Registry.LocalMachine.CreateSubKey(keyName + "\\%{package_display_name}");
+        /*
+            Puppet deems an exe package 'installable' by identifying whether or not the following registry
+            values exist in the Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PackageName key:
+
+            * DisplayName
+            * DisplayVersion
+            * UninstallString
+
+            So we must set those values in the registry for this to be an 'installable package' manageable by
+            puppet.
+         */
+        key.SetValue("DisplayName", "%{package_display_name}");
+        key.SetValue("DisplayVersion", "1.0.0");
+        key.SetValue("UninstallString", @"%{uninstaller_location}");
+        key.Close();
+        Console.WriteLine("Installing...");
+   }
+}

--- a/acceptance/fixtures/MockUninstaller.cs
+++ b/acceptance/fixtures/MockUninstaller.cs
@@ -1,0 +1,32 @@
+/*
+
+The MockUninstaller is a C# class representing a stubbed exe uninstaller. We will
+compile this class into an usable .exe file.
+
+A MockInstaller _MUST_ come alongside a MockUninstaller, so we can uninstall the
+fake package from the system
+
+*/
+using System;
+
+public class MockInstaller
+{   public static void Main()
+   {
+        try
+        {
+            %{uninstall_commands}
+        }
+        catch {
+            Environment.Exit(1003);
+        }
+        string keyName = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+        Console.WriteLine("Uninstalling...");
+        /*
+            Remove the entire registry key created by the installer exe
+         */
+        using (Microsoft.Win32.RegistryKey _key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(keyName, true))
+        {
+            _key.DeleteSubKeyTree("%{package_display_name}");
+        }
+   }
+}

--- a/acceptance/lib/puppet/acceptance/windows_utils.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils.rb
@@ -4,6 +4,7 @@ module Puppet
   module Acceptance
     module WindowsUtils
       require 'puppet/acceptance/windows_utils/service.rb'
+      require 'puppet/acceptance/windows_utils/package_installer.rb'
 
       def profile_base(agent)
         ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)

--- a/acceptance/lib/puppet/acceptance/windows_utils/package_installer.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils/package_installer.rb
@@ -1,0 +1,69 @@
+module Puppet
+  module Acceptance
+    module WindowsUtils
+      # Sets up a mock installer on the host.
+
+      def create_mock_package(host, tmpdir, config = {}, installer_file = 'MockInstaller.cs', uninstaller_file = 'MockUninstaller.cs')
+        installer_exe_path = "#{tmpdir}/#{config[:name].gsub(/\s+/, '')}Installer.exe".gsub('/', '\\')
+        uninstaller_exe_path = "#{tmpdir}/#{config[:name].gsub(/\s+/, '')}Uninstaller.exe".gsub('/', '\\')
+        tranformations = {
+          package_display_name: config[:name],
+          uninstaller_location: uninstaller_exe_path,
+          install_commands:     config[:install_commands],
+          uninstall_commands:   config[:uninstall_commands]
+        }
+
+        [
+          { source: installer_file, destination: installer_exe_path },
+          { source: uninstaller_file, destination: uninstaller_exe_path },
+        ].each do |exe|
+          fixture_path = File.join(
+            File.dirname(__FILE__),
+            '..',
+            '..',
+            '..',
+            '..',
+            'fixtures',
+            exe[:source]
+          )
+          code = File.read(fixture_path) % tranformations
+          build_mock_exe(host, exe[:destination], code)
+        end
+        # If the registry key still exists from a previous package install, then delete it.
+        teardown do
+          if package_installed?(host, config[:name])
+            on host, powershell("\"Remove-Item HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\#{config[:name]}\"")
+          end
+        end
+        # return the installer path for tests to use as the source: attribute
+        installer_exe_path
+      end
+
+      def build_mock_exe(host, destination, code)
+        # Make a source file containing the code on the SUT, the source file
+        # will be the same location/name as the destination exe but with the .cs
+        # extension
+        source_path_on_host = destination.gsub(/\.exe$/, '.cs')
+        create_remote_file(host, source_path_on_host.gsub('\\', '/'), code)
+        # Create the installer.exe file by compiling the copied over C# code
+        # with PowerShell
+        create_installer_exe = "\"Add-Type"\
+          " -TypeDefinition (Get-Content #{source_path_on_host} | Out-String)"\
+          " -Language CSharp"\
+          " -OutputAssembly #{destination}"\
+          " -OutputType ConsoleApplication\""
+        on host, powershell(create_installer_exe)
+      end
+
+      def package_installed?(host, name)
+        # A successfully installed mock package will have created a registry key under
+        # HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall. Simply checking
+        # for that key should suffice as an indicator that the installer completed
+        test_key = "\"Test-Path HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\#{name}\""
+        on(host, powershell(test_key)) do |result|
+          return result.stdout.chomp == 'True'
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/package/windows.rb
+++ b/acceptance/tests/resource/package/windows.rb
@@ -1,0 +1,61 @@
+test_name "Windows Package Provider" do
+  confine :to, :platform => 'windows'
+
+  tag 'audit:medium',
+      'audit:acceptance'
+
+  require 'puppet/acceptance/windows_utils'
+  extend Puppet::Acceptance::WindowsUtils
+
+  def package_manifest(name, params, installer_source)
+    params_str = params.map do |param, value|
+      value_str = value.to_s
+      value_str = "\"#{value_str}\"" if value.is_a?(String)
+
+      "  #{param} => #{value_str}"
+    end.join(",\n")
+
+    <<-MANIFEST
+package { '#{name}':
+  source => '#{installer_source}',
+  #{params_str}
+}
+MANIFEST
+  end
+
+  mock_package = {
+    :name => "MockPackage"
+  }
+
+  agents.each do |agent|
+    tmpdir = agent.tmpdir("mock_installer")
+    installer_location = create_mock_package(agent, tmpdir, mock_package)
+
+    step 'Verify that ensure = present installs the package' do
+      apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :present}, installer_location))
+      assert(package_installed?(agent, mock_package[:name]), 'Package succesfully installed')
+    end
+
+    step 'Verify that ensure = absent removes the package' do
+      apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :absent}, installer_location))
+      assert_equal(false, package_installed?(agent, mock_package[:name]), 'Package successfully Uninstalled')
+    end
+
+    tmpdir = agent.tmpdir("mock_installer")
+    mock_package[:name] = "MockPackageWithFile"
+    mock_package[:install_commands] = 'System.IO.File.ReadAllLines("install.txt");'
+    installer_location = create_mock_package(agent, tmpdir, mock_package)
+
+    step 'Verify that ensure = present installs a package that requires additional resources' do
+      create_remote_file(agent, "#{tmpdir}/install.txt", 'foobar')
+      apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :present}, installer_location))
+      assert(package_installed?(agent, mock_package[:name]), 'Package succesfully installed')
+    end
+
+    step 'Verify that ensure = absent removes the package that required additional resources' do
+      apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :absent}, installer_location))
+      assert_equal(false, package_installed?(agent, mock_package[:name]), 'Package successfully Uninstalled')
+    end
+  end
+
+end

--- a/acceptance/tests/resource/service/windows.rb
+++ b/acceptance/tests/resource/service/windows.rb
@@ -24,6 +24,7 @@ service { '#{name}':
 }
 MANIFEST
   end
+
   mock_service_nofail = {
     :name => "mock_service_nofail",
     :start_sleep => 0,

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
     installer = Puppet::Provider::Package::Windows::Package.installer_class(resource)
 
     command = [installer.install_command(resource), install_options].flatten.compact.join(' ')
-    output = execute(command, :failonfail => false, :combine => true)
+    output = execute(command, :failonfail => false, :combine => true, :cwd => File.dirname(resource[:source]))
 
     check_result(output.exitstatus)
   end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -172,7 +172,7 @@ module Puppet
               when is == @latest
                 return true
               when is == :present
-                # This will only happen on retarded packaging systems
+                # This will only happen on packaging systems
                 # that can't query versions.
                 return true
               else

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -1,9 +1,9 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 
-describe Puppet::Type.type(:package).provider(:windows) do
+describe Puppet::Type.type(:package).provider(:windows), :if => Puppet.features.microsoft_windows? do
   let (:name)        { 'mysql-5.1.58-win-x64' }
-  let (:source)      { 'E:\mysql-5.1.58-win-x64.msi' }
+  let (:source)      { 'E:\Rando\Directory\mysql-5.1.58-win-x64.msi' }
   let (:resource)    {  Puppet::Type.type(:package).new(:name => name, :provider => :windows, :source => source) }
   let (:provider)    { resource.provider }
   let (:execute_options) do {:failonfail => false, :combine => true} end
@@ -86,7 +86,7 @@ describe Puppet::Type.type(:package).provider(:windows) do
   context '#install' do
     let(:command) { 'blarg.exe /S' }
     let(:klass) { mock('installer', :install_command => ['blarg.exe', '/S'] ) }
-
+    let(:execute_options) do {:failonfail => false, :combine => true, :cwd => 'E:\Rando\Directory'} end
     before :each do
       Puppet::Provider::Package::Windows::Package.expects(:installer_class).returns(klass)
     end


### PR DESCRIPTION
This commit updates the windows package provider to execute package
installations in the same directory as the package resource.