### PR TITLE
(PUP-9194) Use the cwd param. for check commands (e.g. unless, onlyif)

### DIFF
--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -46,10 +46,7 @@ class Puppet::Provider::Exec < Puppet::Provider
     #
     # This is backwards compatible all the way to Ruby 1.8.7.
     Timeout::timeout(resource[:timeout], Timeout::Error) do
-      # If we're running a command that's meant to be a check on whether we should run
-      # our actual command (e.g. like a command passed to the :onlyif or :unless properties),
-      # then we should not set the cwd when executing the check's corresponding command.
-      cwd = check ? nil : resource[:cwd]
+      cwd = resource[:cwd]
       cwd ||= Dir.pwd
 
       # note that we are passing "false" for the "override_locale" parameter, which ensures that the user's


### PR DESCRIPTION
PUP-6919 introduced a regression where check commands like unless
and onlyif no longer respected the cwd parameter. Instead, they would
always execute in the pwd. The regression came about due to a
misinterpretation of the code in the original base Exec provider.
Specifically, the base Exec provider was cleaned up to utilize the
newly added :cwd option in Puppet::Util::Execution.execute. The cleanup
tried to preserve the original semantics of the code, but ended up
mistaking an unless statement for an if statement, which made it seem like
a check command did not use the cwd parameter (when, in fact, it did).

This commit fixes the base Exec provider to now use the cwd parameter for
check commands. It also updates the acceptance tests with this
change.