### PR TITLE
(maint) Revert larger changes for 6.0.2 release

### DIFF
--- a/lib/puppet/util/windows/service.rb
+++ b/lib/puppet/util/windows/service.rb
@@ -40,26 +40,6 @@ module Puppet::Util::Windows
     SERVICE_CONTROL_PRESHUTDOWN           = 0x0000000F
     SERVICE_CONTROL_TIMECHANGE            = 0x00000010
     SERVICE_CONTROL_TRIGGEREVENT          = 0x00000020
-    SERVICE_CONTROL_SIGNALS               = {
-      SERVICE_CONTROL_STOP                  => :SERVICE_CONTROL_STOP,
-      SERVICE_CONTROL_PAUSE                 => :SERVICE_CONTROL_PAUSE,
-      SERVICE_CONTROL_CONTINUE              => :SERVICE_CONTROL_CONTINUE,
-      SERVICE_CONTROL_INTERROGATE           => :SERVICE_CONTROL_INTERROGATE,
-      SERVICE_CONTROL_SHUTDOWN              => :SERVICE_CONTROL_SHUTDOWN,
-      SERVICE_CONTROL_PARAMCHANGE           => :SERVICE_CONTROL_PARAMCHANGE,
-      SERVICE_CONTROL_NETBINDADD            => :SERVICE_CONTROL_NETBINDADD,
-      SERVICE_CONTROL_NETBINDREMOVE         => :SERVICE_CONTROL_NETBINDREMOVE,
-      SERVICE_CONTROL_NETBINDENABLE         => :SERVICE_CONTROL_NETBINDENABLE,
-      SERVICE_CONTROL_NETBINDDISABLE        => :SERVICE_CONTROL_NETBINDDISABLE,
-      SERVICE_CONTROL_DEVICEEVENT           => :SERVICE_CONTROL_DEVICEEVENT,
-      SERVICE_CONTROL_HARDWAREPROFILECHANGE => :SERVICE_CONTROL_HARDWAREPROFILECHANGE,
-      SERVICE_CONTROL_POWEREVENT            => :SERVICE_CONTROL_POWEREVENT,
-      SERVICE_CONTROL_SESSIONCHANGE         => :SERVICE_CONTROL_SESSIONCHANGE,
-      SERVICE_CONTROL_PRESHUTDOWN           => :SERVICE_CONTROL_PRESHUTDOWN,
-      SERVICE_CONTROL_TIMECHANGE            => :SERVICE_CONTROL_TIMECHANGE,
-      SERVICE_CONTROL_TRIGGEREVENT          => :SERVICE_CONTROL_TRIGGEREVENT
-    }
-
 
     # Service start type codes
     # https://docs.microsoft.com/en-us/windows/desktop/api/Winsvc/nf-winsvc-changeserviceconfigw
@@ -101,14 +81,7 @@ module Puppet::Util::Windows
     SERVICE_START_PENDING    = 0x00000002
     SERVICE_STOP_PENDING     = 0x00000003
     SERVICE_STOPPED          = 0x00000001
-    UNSAFE_PENDING_STATES    = [SERVICE_START_PENDING, SERVICE_STOP_PENDING]
-    FINAL_STATES             = {
-      SERVICE_CONTINUE_PENDING => SERVICE_RUNNING,
-      SERVICE_PAUSE_PENDING    => SERVICE_PAUSED,
-      SERVICE_START_PENDING    => SERVICE_RUNNING,
-      SERVICE_STOP_PENDING     => SERVICE_STOPPED
-    }
-    SERVICE_STATES           = {
+    SERVICE_STATES = {
       SERVICE_CONTINUE_PENDING => :SERVICE_CONTINUE_PENDING,
       SERVICE_PAUSE_PENDING => :SERVICE_PAUSE_PENDING,
       SERVICE_PAUSED => :SERVICE_PAUSED,
@@ -293,41 +266,34 @@ module Puppet::Util::Windows
     end
     module_function :exists?
 
-    # Start a windows service
+    # Start a windows service, assume that the service is already in the stopped state
     #
     # @param [:string] service_name name of the service to start
     def start(service_name)
-      Puppet.debug _("Starting the %{service_name} service") % { service_name: service_name }
-
-      valid_initial_states = [
-        SERVICE_STOP_PENDING,
-        SERVICE_STOPPED,
-        SERVICE_START_PENDING
-      ]
-
-      transition_service_state(service_name, valid_initial_states, SERVICE_RUNNING) do |service|
-        if StartServiceW(service, 0, FFI::Pointer::NULL) == FFI::WIN32_FALSE
-          raise Puppet::Util::Windows::Error, _("Failed to start the service")
+      open_service(service_name, SC_MANAGER_CONNECT, SERVICE_START | SERVICE_QUERY_STATUS) do |service|
+        transition_service_state(service, SERVICE_STOP_PENDING, SERVICE_STOPPED, SERVICE_START_PENDING, SERVICE_RUNNING) do
+          if StartServiceW(service, 0, FFI::Pointer::NULL) == FFI::WIN32_FALSE
+            raise Puppet::Util::Windows::Error.new(_("Failed to start the service"))
+          end
         end
       end
-
-      Puppet.debug _("Successfully started the %{service_name} service") % { service_name: service_name }
     end
     module_function :start
 
-    # Stop a windows service
+    # Use ControlService to send a stop signal to a windows service
     #
     # @param [:string] service_name name of the service to stop
     def stop(service_name)
-      Puppet.debug _("Stopping the %{service_name} service") % { service_name: service_name }
-
-      valid_initial_states = SERVICE_STATES.keys - [SERVICE_STOPPED]
-
-      transition_service_state(service_name, valid_initial_states, SERVICE_STOPPED) do |service|
-        send_service_control_signal(service, SERVICE_CONTROL_STOP)
+      open_service(service_name, SC_MANAGER_CONNECT, SERVICE_STOP | SERVICE_QUERY_STATUS) do |service|
+        transition_service_state(service, SERVICE_START_PENDING, SERVICE_RUNNING, SERVICE_STOP_PENDING, SERVICE_STOPPED) do
+          FFI::MemoryPointer.new(SERVICE_STATUS.size) do |status_ptr|
+            status = SERVICE_STATUS.new(status_ptr)
+            if ControlService(service, SERVICE_CONTROL_STOP, status) == FFI::WIN32_FALSE
+              raise Puppet::Util::Windows::Error.new(_("Failed to send stop control to service, current state is %{current_state}. Failed with") % { current_state: status[:dwCurrentState].to_s })
+            end
+          end
+        end
       end
-
-      Puppet.debug _("Successfully stopped the %{service_name} service") % { service_name: service_name }
     end
     module_function :stop
 
@@ -529,74 +495,24 @@ module Puppet::Util::Windows
       private :open_scm
 
       # @api private
-      # Transition the service to the specified state. The block should perform
-      # the actual transition.
+      # Wait for preceeding_transition, then execute a block, then wait for resulting_transition.
+      # Do not fail on preceeding_transition,
       #
-      # @param [String] service_name the name of the service to transition
-      # @param [[Integer]] valid_initial_states an array of valid states that the service can transition from
-      # @param [:Integer] final_state the state that the service will transition to
-      def transition_service_state(service_name, valid_initial_states, final_state, &block)
-        service_access = SERVICE_START | SERVICE_STOP | SERVICE_PAUSE_CONTINUE | SERVICE_QUERY_STATUS
-        open_service(service_name, SC_MANAGER_CONNECT, service_access) do |service|
-          status = query_status(service)
-          initial_state = status[:dwCurrentState]
-
-          # If the service is already in the final_state, then
-          # no further work needs to be done
-          if initial_state == final_state 
-            Puppet.debug _("The service is already in the %{final_state} state. No further work needs to be done.") % { final_state: SERVICE_STATES[final_state] }
-
-            next
-          end
-
-          # Check that initial_state corresponds to a valid
-          # initial state
-          unless valid_initial_states.include?(initial_state)
-            valid_initial_states_str = valid_initial_states.map do |state|
-              SERVICE_STATES[state]
-            end.join(", ")
-
-            raise Puppet::Error, _("The service must be in one of the %{valid_initial_states} states to perform this transition. It is currently in the %{current_state} state.") % { valid_initial_states: valid_initial_states_str, current_state: SERVICE_STATES[initial_state] }
-          end
-
-          # Check if there's a pending transition to the final_state. If so, then wait for
-          # that transition to finish.
-          possible_pending_states = FINAL_STATES.keys.select do |pending_state|
-            # SERVICE_RUNNING has two pending states, SERVICE_START_PENDING and
-            # SERVICE_CONTINUE_PENDING. That is why we need the #select here
-            FINAL_STATES[pending_state] == final_state
-          end
-          if possible_pending_states.include?(initial_state)
-            Puppet.debug _("There is already a pending transition to the %{final_state} state for the %{service_name} service.")  % { final_state: SERVICE_STATES[final_state], service_name: service_name }
-            wait_on_pending_state(service, initial_state)
-
-            next
-          end
-
-          # If we are in an unsafe pending state like SERVICE_START_PENDING
-          # or SERVICE_STOP_PENDING, then we want to wait for that pending
-          # transition to finish before transitioning the service state.
-          # The reason we do this is because SERVICE_START_PENDING is when
-          # the service thread is being created and initialized, while
-          # SERVICE_STOP_PENDING is when the service thread is being cleaned
-          # up and destroyed. Thus there is a chance that when the service is
-          # in either of these states, its service thread may not yet be ready
-          # to perform the state transition (it may not even exist).
-          if UNSAFE_PENDING_STATES.include?(initial_state)
-            Puppet.debug _("The service is in the %{pending_state} state, which is an unsafe pending state.") % { pending_state: SERVICE_STATES[initial_state] }
-            wait_on_pending_state(service, initial_state)
-            initial_state = FINAL_STATES[initial_state]
-          end
-
-          Puppet.debug _("Transitioning the %{service_name} service from %{initial_state} to %{final_state}") % { service_name: service_name, initial_state: SERVICE_STATES[initial_state], final_state: SERVICE_STATES[final_state] }
-
-          yield service
-
-          Puppet.debug _("Waiting for the transition to finish")
-          wait_on_state_transition(service, initial_state, final_state)
-        end
-      rescue => detail
-        raise Puppet::Error, _("Failed to transition the %{service_name} service to the %{final_state} state. Detail: %{detail}") % { service_name: service_name, final_state: SERVICE_STATES[final_state], detail: detail }, detail.backtrace
+      # @param [:handle] service handle of the service to query
+      # @param [:Integer] preceeding_transition integer value corresponding to the transition state to wait for
+      #   before executing the block
+      # @param [:Integer] resulting_transition integer value corresponding to the transition state to wait for
+      #   after executing the block
+      def transition_service_state(service, preceeding_transition, preceeding_state, resulting_transition, resulting_state, &block)
+        # ignore the return from the pending transition, we don't care what state the service
+        # is in after this point, only that we waited on preceeding_pending_state if that's where
+        # the service was
+        wait_on_pending_transition(service, preceeding_transition, preceeding_state, raise_on_timeout: false)
+        yield
+        # After returning from the block, wait to see a pending or active state.
+        wait_for_state_transition(service, [resulting_transition, resulting_state])
+        # After that If the state is pending, attempt to wait for the pending operation to finish
+        wait_on_pending_transition(service, resulting_transition, resulting_state, raise_on_timeout: true)
       end
       private :transition_service_state
 
@@ -680,110 +596,75 @@ module Puppet::Util::Windows
       private :query_config
 
       # @api private
-      # Sends a service control signal to a service
-      #
-      # @param [:handle] service handle to the service
-      # @param [Integer] signal the service control signal to send
-      def send_service_control_signal(service, signal)
-        FFI::MemoryPointer.new(SERVICE_STATUS.size) do |status_ptr|
-          status = SERVICE_STATUS.new(status_ptr)
-          if ControlService(service, signal, status) == FFI::WIN32_FALSE
-            raise Puppet::Util::Windows::Error, _("Failed to send the %{control_signal} signal to the service. Its current state is %{current_state}. Failed with") % { control_signal: SERVICE_CONTROL_SIGNALS[signal], current_state: SERVICE_STATES[status[:dwCurrentState]] }
-          end
-        end
-      end
-
-      # @api private
-      # Waits for a service to transition from one state to
-      # another state.
+      # waits for a windows service to report one of the acceptable_states
       #
       # @param [:handle] service handle to the service to wait on
-      # @param [Integer] initial_state the state that the service is transitioning from.
-      # @param [Integer] final_state the state that the service is transitioning to
-      def wait_on_state_transition(service, initial_state, final_state)
-        # Get the pending state for this transition. Note that SERVICE_RUNNING
-        # has two possible pending states, which is why we need this logic.
-        if final_state != SERVICE_RUNNING
-          pending_state = FINAL_STATES.key(final_state)
-        elsif initial_state == SERVICE_STOPPED
-          # SERVICE_STOPPED => SERVICE_RUNNING
-          pending_state = SERVICE_START_PENDING
-        else
-          # SERVICE_PAUSED => SERVICE_RUNNING
-          pending_state = SERVICE_CONTINUE_PENDING
-        end
-
-        # Wait for the transition to finish
-        state = nil
+      # @param [Array<Integer>] acceptable_states array of acceptable states to wait for
+      # @return [bool] 'true' once the service is reporting an acceptable_state,
+      #   'false' if the service never reached one of the acceptable_states
+      def wait_for_state_transition(service, acceptable_states)
         elapsed_time = 0
         while elapsed_time <= DEFAULT_TIMEOUT
           status = query_status(service)
           state = status[:dwCurrentState]
-
-          return if state == final_state
-          if state == pending_state
-            Puppet.debug _("The service transitioned to the %{pending_state} state.") % { pending_state: SERVICE_STATES[pending_state] }
-            wait_on_pending_state(service, pending_state)
-            return
+          if acceptable_states.include?(state)
+            return true
           end
-
           sleep(1)
           elapsed_time += 1
         end
-
-        # Timed out while waiting for the transition to finish. Raise an error
-        raise Puppet::Error, _("Timed out while waiting for the service to transition from %{initial_state} to %{final_state} OR from %{initial_state} to %{pending_state} to %{final_state}. The service's current state is %{current_state}.") % { initial_state: SERVICE_STATES[initial_state], final_state: SERVICE_STATES[final_state], pending_state: SERVICE_STATES[pending_state], current_state: SERVICE_STATES[state] }
+        raise Puppet::Error.new(_("Transition timed out, service still in %{current_state}") % { current_state: SERVICE_STATES[state] })
       end
-      private :wait_on_state_transition
+      private :wait_for_state_transition
 
       # @api private
-      # Waits for a service to finish transitioning from
-      # a pending state. The service must be in the pending state
-      # before invoking this routine.
+      # waits for a windows service to report final_state if it
+      # is in pending_state
       #
       # @param [:handle] service handle to the service to wait on
-      # @param [Integer] pending_state the pending state
-      def wait_on_pending_state(service, pending_state)
-        final_state = FINAL_STATES[pending_state]
-
-        Puppet.debug _("Waiting for the pending transition to the %{final_state} state to finish.") % { final_state: SERVICE_STATES[final_state] }
-
+      # @param [Integer] pending_states array of acceptable states to wait on
+      # @param [Integer] final_state the state indicating the transition is finished
+      # @return [bool] 'true' once the service is reporting final_state,
+      #   'false' if the service never reached final_state or was not in pending_states
+      def wait_on_pending_transition(service, pending_state, final_state, raise_on_timeout: false)
         elapsed_time = 0
         last_checkpoint = -1
         loop do
           status = query_status(service)
           state = status[:dwCurrentState]
-
-          # Check if our service has finished transitioning to
-          # the final_state OR if an unexpected transition
-          # has occurred
-          return if state == final_state
+          return true if state == final_state
           unless state == pending_state
-            raise Puppet::Error, _("Unexpected transition to the %{current_state} state while waiting for the pending transition from %{pending_state} to %{final_state} to finish.") % { current_state: SERVICE_STATES[state], pending_state: SERVICE_STATES[pending_state], final_state: SERVICE_STATES[final_state] }
-          end
-
-          # Check if any progress has been made since our last sleep
-          # using the dwCheckPoint. If no progress has been made then
-          # check if we've timed out, and raise an error if so
-          if status[:dwCheckPoint] > last_checkpoint
-            elapsed_time = 0
-            last_checkpoint = status[:dwCheckPoint]
-          else
-            wait_hint = milliseconds_to_seconds(status[:dwWaitHint])
-            timeout = wait_hint < DEFAULT_TIMEOUT ? DEFAULT_TIMEOUT : wait_hint 
-
-            if elapsed_time >= timeout
-              raise Puppet::Error, _("Timed out while waiting for the pending transition from %{pending_state} to %{final_state} to finish. The current state is %{current_state}.") % { pending_state: SERVICE_STATES[pending_state], final_state: SERVICE_STATES[final_state], current_state: SERVICE_STATES[state] }
+            if raise_on_timeout
+              raise Puppet::Error.new(_("Service was not in pending state: %{pending_state}, current state is %{current_state}") % { pending_state: SERVICE_STATES[pending_state], current_state: SERVICE_STATES[state] })
+            else
+              return false
             end
           end
-
-          # Wait a bit before rechecking the service's state
-          wait_time = wait_hint_to_wait_time(status[:dwWaitHint])
-          sleep(wait_time)
-          elapsed_time += wait_time
+          # When the service is in the pending state we need to do the following:
+          # 1. check if any progress has been made since dwWaitHint using dwCheckPoint,
+          #    and fail if no progress was made
+          # 2. if progress has been made, increment elapsed_time and set last_checkpoint
+          # 3. sleep, then loop again if there was progress.
+          time_to_wait = wait_hint_to_wait_time(status[:dwWaitHint])
+          if status[:dwCheckPoint] > last_checkpoint
+            elapsed_time = 0
+          else
+            timeout = milliseconds_to_seconds(status[:dwWaitHint]);
+            timeout = DEFAULT_TIMEOUT if timeout < DEFAULT_TIMEOUT
+            if elapsed_time >= (timeout)
+              if raise_on_timeout
+                raise Puppet::Error.new(_("Pending operation timed out, service still in %{current_state}") % { current_state: SERVICE_STATES[state] })
+              else
+                return false
+              end
+            end
+          end
+          last_checkpoint = status[:dwCheckPoint]
+          sleep(time_to_wait)
+          elapsed_time += time_to_wait
         end
       end
-      private :wait_on_pending_state
+      private :wait_on_pending_transition
 
       # @api private
       #

--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -8,11 +8,13 @@ module Puppet::Util::Windows::User
   extend FFI::Library
 
   def admin?
-    return false unless check_token_membership
+    elevated_supported = Puppet::Util::Windows::Process.supports_elevated_security?
 
     # if Vista or later, check for unrestricted process token
-    elevated_supported = Puppet::Util::Windows::Process.supports_elevated_security?
-    return elevated_supported ? Puppet::Util::Windows::Process.elevated_security? : true
+    return Puppet::Util::Windows::Process.elevated_security? if elevated_supported
+
+    # otherwise 2003 or less
+    check_token_membership
   end
   module_function :admin?
 

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -6,74 +6,54 @@ describe "Puppet::Util::Windows::User", :if => Puppet::Util::Platform.windows? d
   describe "2003 without UAC" do
     before :each do
       Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(5)
-      Puppet::Util::Windows::Process.stubs(:supports_elevated_security?).returns(false)
     end
 
     it "should be an admin if user's token contains the Administrators SID" do
       Puppet::Util::Windows::User.expects(:check_token_membership).returns(true)
+      Puppet::Util::Windows::Process.expects(:elevated_security?).never
 
       expect(Puppet::Util::Windows::User).to be_admin
     end
 
     it "should not be an admin if user's token doesn't contain the Administrators SID" do
       Puppet::Util::Windows::User.expects(:check_token_membership).returns(false)
+      Puppet::Util::Windows::Process.expects(:elevated_security?).never
 
       expect(Puppet::Util::Windows::User).not_to be_admin
     end
 
     it "should raise an exception if we can't check token membership" do
       Puppet::Util::Windows::User.expects(:check_token_membership).raises(Puppet::Util::Windows::Error, "Access denied.")
+      Puppet::Util::Windows::Process.expects(:elevated_security?).never
 
       expect { Puppet::Util::Windows::User.admin? }.to raise_error(Puppet::Util::Windows::Error, /Access denied./)
     end
   end
 
-  context "2008 with UAC" do
+  describe "2008 with UAC" do
     before :each do
       Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(6)
-      Puppet::Util::Windows::Process.stubs(:supports_elevated_security?).returns(true)
     end
 
-    describe "in local administrators group" do
-      before :each do
-        Puppet::Util::Windows::User.stubs(:check_token_membership).returns(true)
-      end
+    it "should be an admin if user is running with elevated privileges" do
+      Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(true)
+      Puppet::Util::Windows::User.expects(:check_token_membership).never
 
-      it "should be an admin if user is running with elevated privileges" do
-        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(true)
-
-        expect(Puppet::Util::Windows::User).to be_admin
-      end
-
-      it "should not be an admin if user is not running with elevated privileges" do
-        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(false)
-
-        expect(Puppet::Util::Windows::User).not_to be_admin
-      end
-
-      it "should raise an exception if the process fails to open the process token" do
-        Puppet::Util::Windows::Process.stubs(:elevated_security?).raises(Puppet::Util::Windows::Error, "Access denied.")
-
-        expect { Puppet::Util::Windows::User.admin? }.to raise_error(Puppet::Util::Windows::Error, /Access denied./)
-      end
+      expect(Puppet::Util::Windows::User).to be_admin
     end
 
-    describe "not in local administrators group" do
-      before :each do
-        Puppet::Util::Windows::User.stubs(:check_token_membership).returns(false)
-      end
+    it "should not be an admin if user is not running with elevated privileges" do
+      Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(false)
+      Puppet::Util::Windows::User.expects(:check_token_membership).never
 
-      it "should not be an admin if user is running with elevated privileges" do
-        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(true)
+      expect(Puppet::Util::Windows::User).not_to be_admin
+    end
 
-        expect(Puppet::Util::Windows::User).not_to be_admin
-      end
+    it "should raise an exception if the process fails to open the process token" do
+      Puppet::Util::Windows::Process.stubs(:elevated_security?).raises(Puppet::Util::Windows::Error, "Access denied.")
+      Puppet::Util::Windows::User.expects(:check_token_membership).never
 
-      it "should not be an admin if user is not running with elevated privileges" do
-        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(false)
-
-        expect(Puppet::Util::Windows::User).not_to be_admin
-      end
+      expect { Puppet::Util::Windows::User.admin? }.to raise_error(Puppet::Util::Windows::Error, /Access denied./)
     end
   end
 

--- a/spec/unit/util/windows/service_spec.rb
+++ b/spec/unit/util/windows/service_spec.rb
@@ -10,10 +10,6 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
       .returns("fake error!")
   end
 
-  def service_state_str(state)
-    Puppet::Util::Windows::Service::SERVICE_STATES[state].to_s
-  end
-
   # The following should emulate a successful call to the private function
   # query_status that returns the value of query_return. This should give
   # us a way to mock changes in service status.
@@ -23,12 +19,6 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
   # returns the value passed in as a param
   def expect_successful_status_query_and_return(query_return)
     subject::SERVICE_STATUS_PROCESS.expects(:new).in_sequence(status_checks).returns(query_return)
-  end
-
-  def expect_successful_status_queries_and_return(*query_returns)
-    query_returns.each do |query_return|
-      expect_successful_status_query_and_return(query_return)
-    end
   end
 
   # The following should emulate a successful call to the private function
@@ -52,6 +42,8 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
   before do
     subject.stubs(:QueryServiceStatusEx).returns(1)
     subject.stubs(:QueryServiceConfigW).returns(1)
+    subject.stubs(:StartServiceW).returns(1)
+    subject.stubs(:ControlService).returns(1)
     subject.stubs(:ChangeServiceConfigW).returns(1)
     subject.stubs(:OpenSCManagerW).returns(scm)
     subject.stubs(:OpenServiceW).returns(service)
@@ -98,223 +90,7 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
     end
   end
 
-  # This shared example contains the unit tests for the wait_on_pending_state
-  # helper as used by service actions like #start and #stop. Before including
-  # this shared example, be sure to mock out any intermediate calls prior to
-  # the pending transition, and make sure that the post-condition _after_ those
-  # intermediate calls leaves the service in the pending state. Before including
-  # this example in your tests, be sure to define the following variables in a `let`
-  # context:
-  #     * action -- The service action
-  shared_examples "a service action waiting on a pending transition" do |pending_state|
-    pending_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[pending_state].to_s
-
-    final_state = Puppet::Util::Windows::Service::FINAL_STATES[pending_state]
-    final_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[final_state].to_s
-
-    it "raises a Puppet::Error if the service query fails" do
-      subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
-
-      expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
-    end
-
-    it "raises a Puppet::Error if the service unexpectedly transitions to a state other than #{pending_state_str} or #{final_state_str}" do
-      invalid_state = (subject::SERVICE_STATES.keys - [pending_state, final_state]).first
-
-      expect_successful_status_query_and_return(dwCurrentState: invalid_state)
-
-      expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
-    end
-
-    it "waits for at least 1 second if the wait_hint/10 is < 1 second" do
-      expect_successful_status_queries_and_return(
-        { :dwCurrentState => pending_state, :dwWaitHint => 0, :dwCheckPoint => 1 },
-        { :dwCurrentState => final_state }
-      )
-
-      subject.expects(:sleep).with(1)
-
-      subject.send(action, mock_service_name)
-    end
-
-    it "waits for at most 10 seconds if wait_hint/10 is > 10 seconds" do
-      expect_successful_status_queries_and_return(
-        { :dwCurrentState => pending_state, :dwWaitHint => 1000000, :dwCheckPoint => 1 },
-        { :dwCurrentState => final_state }
-      )
-
-      subject.expects(:sleep).with(10)
-
-      subject.send(action, mock_service_name)
-    end
-
-    it "does not raise an error if the service makes any progress while transitioning to #{final_state_str}" do
-      expect_successful_status_queries_and_return(
-        # The three "pending_state" statuses simulate the scenario where the service
-        # makes some progress during the transition right when Puppet's about to
-        # time out.
-        { :dwCurrentState => pending_state, :dwWaitHint => 100000, :dwCheckPoint => 1 },
-        { :dwCurrentState => pending_state, :dwWaitHint => 100000, :dwCheckPoint => 1 },
-        { :dwCurrentState => pending_state, :dwWaitHint => 100000, :dwCheckPoint => 2 },
-
-        { :dwCurrentState => final_state }
-      )
-
-      expect { subject.send(action, mock_service_name) }.to_not raise_error
-    end
-
-    it "raises a Puppet::Error if it times out while waiting for the transition to #{final_state_str}" do
-      31.times do
-        expect_successful_status_query_and_return(
-          dwCurrentState: pending_state,
-          dwWaitHint: 10000,
-          dwCheckPoint: 1
-        )
-      end
-
-      expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
-    end
-  end
-
-  # This shared example contains the unit tests for the transition_service_state
-  # helper, which is the helper that all of our service actions like #start, #stop
-  # delegate to. Including these tests under a shared example lets us include them in each of
-  # those service action's unit tests. Before including this example in your tests, be
-  # sure to define the following variables in a `let` context:
-  #     * initial_state         -- The initial state of the service prior to performing the state
-  #                                transition
-  #
-  #     * mock_state_transition -- A lambda that mocks the state transition. This should mock
-  #                                any code in the block that's passed to the
-  #                                transition_service_state helper
-  #
-  # See the unit tests for the #start method to see how this shared example's
-  # included.
-  #
-  shared_examples "a service action that transitions the service state" do |action, valid_initial_states, pending_state, final_state|
-    valid_initial_states_str = valid_initial_states.map do |state|
-      Puppet::Util::Windows::Service::SERVICE_STATES[state]
-    end.join(', ')
-    pending_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[pending_state].to_s
-    final_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[final_state].to_s
-
-    it "noops if the service is already in the #{final_state} state" do
-      expect_successful_status_query_and_return(dwCurrentState: final_state)
-
-      expect { subject.send(action, mock_service_name) }.to_not raise_error
-    end
-
-    # invalid_initial_states will be empty for the #stop action
-    invalid_initial_states = Puppet::Util::Windows::Service::SERVICE_STATES.keys - valid_initial_states - [final_state]
-    unless invalid_initial_states.empty?
-      it "raises a Puppet::Error if the service's initial state is not one of #{valid_initial_states_str}" do
-        invalid_initial_state = invalid_initial_states.first
-        expect_successful_status_query_and_return(dwCurrentState: invalid_initial_state)
-  
-        expect{ subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
-      end
-    end
-
-    context "when there's a pending transition to the #{final_state} state" do
-      before(:each) do
-        expect_successful_status_query_and_return(dwCurrentState: pending_state)
-      end
-
-      include_examples "a service action waiting on a pending transition", pending_state do
-        let(:action) { action }
-      end
-    end
-
-    # If the service action accepts an unsafe pending state as one of the service's
-    # initial states, then we need to test that the action waits for the service to
-    # transition from that unsafe pending state before doing anything else.
-    unsafe_pending_states = valid_initial_states & Puppet::Util::Windows::Service::UNSAFE_PENDING_STATES
-    unless unsafe_pending_states.empty?
-      unsafe_pending_state = unsafe_pending_states.first
-      unsafe_pending_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[unsafe_pending_state]
-
-      context "waiting for a service with #{unsafe_pending_state_str} as its initial state" do
-        before(:each) do
-          # This mocks the status query to return the 'final_state' by default. Otherwise,
-          # we will fail the tests in the latter parts of the code where we wait for the
-          # service to finish transitioning to the 'final_state'.
-          subject::SERVICE_STATUS_PROCESS.stubs(:new).returns(dwCurrentState: final_state)
-
-          # Set our service's initial state
-          expect_successful_status_query_and_return(dwCurrentState: unsafe_pending_state)
-
-          mock_state_transition.call
-        end
-
-        include_examples "a service action waiting on a pending transition", unsafe_pending_state do
-          let(:action) { action }
-        end
-      end
-    end
-
-    # reads e.g. "waiting for the service to transition to the SERVICE_RUNNING state after executing the 'start' action"
-    #
-    # NOTE: This is really unit testing the wait_on_state_transition helper
-    context "waiting for the service to transition to the #{final_state_str} state after executing the '#{action}' action" do
-      before(:each) do
-        # Set our service's initial state prior to performing the state transition
-        expect_successful_status_query_and_return(dwCurrentState: initial_state)
-
-        mock_state_transition.call
-      end
-
-      it "raises a Puppet::Error if the service query fails" do
-        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
-
-        expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
-      end
-
-      it "waits, then queries again until it transitions to #{final_state_str}" do
-        expect_successful_status_queries_and_return(
-          { :dwCurrentState => initial_state },
-          { :dwCurrentState => initial_state },
-          { :dwCurrentState => final_state }
-        )
-
-        subject.expects(:sleep).with(1).twice
-
-        subject.send(action, mock_service_name)
-      end
-
-      context "when it transitions to the #{pending_state_str} state" do
-        before(:each) do
-          expect_successful_status_query_and_return(dwCurrentState: pending_state)
-        end
-
-        include_examples "a service action waiting on a pending transition", pending_state do
-          let(:action) { action }
-        end
-      end
-
-      it "raises a Puppet::Error if it times out while waiting for the transition to #{final_state_str}" do
-        31.times do
-          expect_successful_status_query_and_return(dwCurrentState: initial_state)
-        end
-
-        expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
-      end
-    end
-  end
-
   describe "#start" do
-    # rspec will still try to load the tests even though
-    # the :if => Puppet.features.microsoft_windows? filter
-    # is passed-in to the top-level describe block on
-    # non-Windows platforms; it just won't run them. However
-    # on these platforms, the loading will fail because this
-    # test uses a shared example that references variables
-    # from the Windows::Service module when building the unit
-    # tests, which is only available on Windows platforms.
-    # Thus, we add the next here to ensure that rspec does not
-    # attempt to load our test code. This is OK for us to do
-    # because we do not want to run these tests on non-Windows
-    # platforms.
-    next unless Puppet.features.microsoft_windows?
 
     context "when the service control manager cannot be opened" do
       let(:scm) { FFI::Pointer::NULL_HANDLE }
@@ -330,95 +106,246 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
       end
     end
 
-    context "when the service can be opened" do
-      # Can't use rspec's subject here because that
-      # can only be referenced inside an 'it' block.
-      service = Puppet::Util::Windows::Service
-      valid_initial_states = [
-        service::SERVICE_STOP_PENDING,
-        service::SERVICE_STOPPED,
-        service::SERVICE_START_PENDING
-      ]
-      final_state = service::SERVICE_RUNNING
-  
-      include_examples "a service action that transitions the service state", :start, valid_initial_states, service::SERVICE_START_PENDING, final_state do
-        let(:initial_state) { subject::SERVICE_STOPPED }
-        let(:mock_state_transition) do
-          lambda do
-            subject.stubs(:StartServiceW).returns(1)
-          end
-        end
+    context "when the service can be opened and is in the stopped state" do
+      before do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
       end
-  
-      it "raises a Puppet::Error if StartServiceW returns false" do
-        expect_successful_status_query_and_return(dwCurrentState: subject::SERVICE_STOPPED)
-  
-        subject.expects(:StartServiceW).returns(FFI::WIN32_FALSE)
 
-        expect { subject.start(mock_service_name) }.to raise_error(Puppet::Error)
-      end
-  
-      it "starts the service" do
-        expect_successful_status_queries_and_return(
-          { dwCurrentState: subject::SERVICE_STOPPED },
-          { dwCurrentState: subject::SERVICE_RUNNING }
-        )
-  
-        subject.expects(:StartServiceW).returns(1)
-  
+      it "Starts the service once the service reports SERVICE_RUNNING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
         subject.start(mock_service_name)
+      end
+
+      it "Raises an error if after calling StartServiceW the service never transitions to RUNNING or START_PENDING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_PAUSED}).times(31)
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+
+      it "raises a puppet error if StartServiceW returns false" do
+        subject.expects(:StartServiceW).returns(FFI::WIN32_FALSE)
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service hasn't stopped yet:" do
+      it "waits, then queries again until SERVICE_STOPPED" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(3).twice
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at least 1 second if wait hint/10 is < 1 second" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(1)
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at most 10 seconds if wait hint/10 is > 10 seconds" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 1000000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(10)
+        subject.start(mock_service_name)
+      end
+
+      it "raises a puppet error if the service query fails" do
+        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(1)
+        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
+        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      it "Does not raise an error if the service makes progress" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 30})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 98})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        expect{subject.start(mock_service_name)}.to_not raise_error
+      end
+    end
+
+    context "when the service ends up still in STOPPED:" do
+      it "waits, then queries again until RUNNING" do
+        # these will be before the call to controlService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        # everything from here on will be _after_ the call to ControlService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.start(mock_service_name)
+      end
+
+      it "raises a puppet error if the services never exits the RUNNING state" do
+        # these will be before the call to controlService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        # the number of times here is a little strange: there are 31 status queries sleeps because there will be a 31st query
+        # that is the final query where the command has reached the wait hint and it's time to error
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED}).times(31)
+        subject.expects(:sleep).times(30).with(1)
+        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service ends up in START_PENDING:" do
+      before(:each) do
+        # these will be before the call to StartService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+      end
+
+      it "waits, then queries again until SERVICE_RUNNING" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at least 1 second if wait hint/10 is < 1 second" do
+        # the first call is executed in wait_for_state, which we aren't testing here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(1)
+        subject.start(mock_service_name)
+      end
+
+      it "waits for at most 10 seconds if wait hint/10 is > 10 seconds" do
+        # the first call is executed in wait_for_state, which we aren't testing here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 1000000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).with(10)
+        subject.start(mock_service_name)
+      end
+
+      it "raises a puppet error if the services configured dwWaitHint is 0, 30 seconds have passed and dwCheckPoint hasn't increased" do
+        # the first call is executed in wait_for_state, which we aren't testing here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(31)
+        subject.expects(:sleep).times(30).with(1)
+        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      it "raises a puppet error if the service's configured dwWaitHint has passed and dwCheckPoint hasn't increased" do
+        # the first call is executed in wait_for_state, which we aren't testing here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 40000, :dwCheckPoint => 0}).times(11)
+        subject.expects(:sleep).times(10).with(4)
+        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+
+      it "Does not raise an error if the service makes progress" do
+        # the first call is executed in wait_for_state, which we aren't testing here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 30})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 98})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+        subject.expects(:sleep).times(5).with(1)
+        expect{subject.start(mock_service_name)}.to_not raise_error
       end
     end
   end
 
   describe "#stop" do
-    next unless Puppet.features.microsoft_windows?
-
     context "when the service control manager cannot be opened" do
       let(:scm) { FFI::Pointer::NULL_HANDLE }
       it "raises a puppet error" do
-        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
       end
     end
 
     context "when the service cannot be opened" do
       let(:service) { FFI::Pointer::NULL_HANDLE }
       it "raises a puppet error" do
-        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
       end
     end
 
-    context "when the service can be opened" do
-      service = Puppet::Util::Windows::Service
-      valid_initial_states = service::SERVICE_STATES.keys - [service::SERVICE_STOPPED]
-      final_state = service::SERVICE_STOPPED
-  
-      include_examples "a service action that transitions the service state", :stop, valid_initial_states, service::SERVICE_STOP_PENDING, final_state do
-        let(:initial_state) { subject::SERVICE_RUNNING }
-        let(:mock_state_transition) do
-          lambda do
-            subject.stubs(:ControlService).returns(1)
-          end
-        end
+    context "when the service can be opened and is in the running state:" do
+      before do
+        # this will be before the call to controlService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
       end
-
-      it "raises a Puppet::Error if ControlService returns false" do
-        expect_successful_status_query_and_return(dwCurrentState: subject::SERVICE_RUNNING)
-
-        subject.stubs(:ControlService).returns(FFI::WIN32_FALSE)
-
-        expect { subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+      it "raises a puppet error if ControlService returns false" do
+        subject.expects(:ControlService).returns(FFI::WIN32_FALSE)
+        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
       end
-  
-      it "stops the service" do
-        expect_successful_status_queries_and_return(
-          { dwCurrentState: subject::SERVICE_RUNNING },
-          { dwCurrentState: subject::SERVICE_STOPPED }
-        )
+    end
 
-        subject.expects(:ControlService).returns(1)
-
+    # No need to retest the wait hint functionality itself here, since
+    # both stop and start use the wait_for_pending_transition helper
+    # which is tested in the start unit tests.
+    context "when the service is already in stop pending or stopped" do
+      it "waits for the service to stop and then exits immediately" do
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 5})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
         subject.stop(mock_service_name)
+      end
+    end
+
+    context "when the service ends up in STOP_PENDING:" do
+      before(:each) do
+        # this will be before the call to controlService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+      end
+
+      it "waits, then queries again until SERVICE_STOPPED" do
+        # the first call is to wait_for_state, which we don't test here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING})
+        # everything from here on will be _after_ the call to ControlService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        subject.stop(mock_service_name)
+      end
+
+      it "raises a puppet error if the services never exits the STOP_PENDING state" do
+        # the first call is to wait_for_state, which we don't test here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(31)
+        expect{subject.stop(mock_service_name)}.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when the service ends up still in RUNNING:" do
+      before(:each) do
+        # this will be before the call to controlService
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+      end
+      it "waits, then queries again until SERVICE_STOPPED" do
+        # the first call is to wait_for_state, which we don't test here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(10)
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+        subject.stop(mock_service_name)
+      end
+
+      it "raises a puppet error if the services never exits the RUNNING state" do
+        # the first call is to wait_for_state, which we don't test here
+        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(31)
+        subject.expects(:sleep).times(30).with(1)
+        expect{subject.stop(mock_service_name)}.to raise_error(Puppet::Error)
       end
     end
   end


### PR DESCRIPTION
This reverts a couple of larger, riskier changes for the 6.0.2 release. They are:

* 2d235b17b4 (PUP-9189) Refactor the state transition code in Windows::Service
* 182af7e73c (PUP-9068) Windows admin? check should consider group membership