### PR TITLE
(maint) Add-back the code removed in 6.0.2

### DIFF
--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -8,13 +8,11 @@ module Puppet::Util::Windows::User
   extend FFI::Library
 
   def admin?
-    elevated_supported = Puppet::Util::Windows::Process.supports_elevated_security?
+    return false unless check_token_membership
 
     # if Vista or later, check for unrestricted process token
-    return Puppet::Util::Windows::Process.elevated_security? if elevated_supported
-
-    # otherwise 2003 or less
-    check_token_membership
+    elevated_supported = Puppet::Util::Windows::Process.supports_elevated_security?
+    return elevated_supported ? Puppet::Util::Windows::Process.elevated_security? : true
   end
   module_function :admin?
 

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -6,54 +6,74 @@ describe "Puppet::Util::Windows::User", :if => Puppet::Util::Platform.windows? d
   describe "2003 without UAC" do
     before :each do
       Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(5)
+      Puppet::Util::Windows::Process.stubs(:supports_elevated_security?).returns(false)
     end
 
     it "should be an admin if user's token contains the Administrators SID" do
       Puppet::Util::Windows::User.expects(:check_token_membership).returns(true)
-      Puppet::Util::Windows::Process.expects(:elevated_security?).never
 
       expect(Puppet::Util::Windows::User).to be_admin
     end
 
     it "should not be an admin if user's token doesn't contain the Administrators SID" do
       Puppet::Util::Windows::User.expects(:check_token_membership).returns(false)
-      Puppet::Util::Windows::Process.expects(:elevated_security?).never
 
       expect(Puppet::Util::Windows::User).not_to be_admin
     end
 
     it "should raise an exception if we can't check token membership" do
       Puppet::Util::Windows::User.expects(:check_token_membership).raises(Puppet::Util::Windows::Error, "Access denied.")
-      Puppet::Util::Windows::Process.expects(:elevated_security?).never
 
       expect { Puppet::Util::Windows::User.admin? }.to raise_error(Puppet::Util::Windows::Error, /Access denied./)
     end
   end
 
-  describe "2008 with UAC" do
+  context "2008 with UAC" do
     before :each do
       Puppet::Util::Windows::Process.stubs(:windows_major_version).returns(6)
+      Puppet::Util::Windows::Process.stubs(:supports_elevated_security?).returns(true)
     end
 
-    it "should be an admin if user is running with elevated privileges" do
-      Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(true)
-      Puppet::Util::Windows::User.expects(:check_token_membership).never
+    describe "in local administrators group" do
+      before :each do
+        Puppet::Util::Windows::User.stubs(:check_token_membership).returns(true)
+      end
 
-      expect(Puppet::Util::Windows::User).to be_admin
+      it "should be an admin if user is running with elevated privileges" do
+        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(true)
+
+        expect(Puppet::Util::Windows::User).to be_admin
+      end
+
+      it "should not be an admin if user is not running with elevated privileges" do
+        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(false)
+
+        expect(Puppet::Util::Windows::User).not_to be_admin
+      end
+
+      it "should raise an exception if the process fails to open the process token" do
+        Puppet::Util::Windows::Process.stubs(:elevated_security?).raises(Puppet::Util::Windows::Error, "Access denied.")
+
+        expect { Puppet::Util::Windows::User.admin? }.to raise_error(Puppet::Util::Windows::Error, /Access denied./)
+      end
     end
 
-    it "should not be an admin if user is not running with elevated privileges" do
-      Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(false)
-      Puppet::Util::Windows::User.expects(:check_token_membership).never
+    describe "not in local administrators group" do
+      before :each do
+        Puppet::Util::Windows::User.stubs(:check_token_membership).returns(false)
+      end
 
-      expect(Puppet::Util::Windows::User).not_to be_admin
-    end
+      it "should not be an admin if user is running with elevated privileges" do
+        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(true)
 
-    it "should raise an exception if the process fails to open the process token" do
-      Puppet::Util::Windows::Process.stubs(:elevated_security?).raises(Puppet::Util::Windows::Error, "Access denied.")
-      Puppet::Util::Windows::User.expects(:check_token_membership).never
+        expect(Puppet::Util::Windows::User).not_to be_admin
+      end
 
-      expect { Puppet::Util::Windows::User.admin? }.to raise_error(Puppet::Util::Windows::Error, /Access denied./)
+      it "should not be an admin if user is not running with elevated privileges" do
+        Puppet::Util::Windows::Process.stubs(:elevated_security?).returns(false)
+
+        expect(Puppet::Util::Windows::User).not_to be_admin
+      end
     end
   end
 

--- a/spec/unit/util/windows/service_spec.rb
+++ b/spec/unit/util/windows/service_spec.rb
@@ -10,6 +10,10 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
       .returns("fake error!")
   end
 
+  def service_state_str(state)
+    Puppet::Util::Windows::Service::SERVICE_STATES[state].to_s
+  end
+
   # The following should emulate a successful call to the private function
   # query_status that returns the value of query_return. This should give
   # us a way to mock changes in service status.
@@ -19,6 +23,12 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
   # returns the value passed in as a param
   def expect_successful_status_query_and_return(query_return)
     subject::SERVICE_STATUS_PROCESS.expects(:new).in_sequence(status_checks).returns(query_return)
+  end
+
+  def expect_successful_status_queries_and_return(*query_returns)
+    query_returns.each do |query_return|
+      expect_successful_status_query_and_return(query_return)
+    end
   end
 
   # The following should emulate a successful call to the private function
@@ -42,8 +52,6 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
   before do
     subject.stubs(:QueryServiceStatusEx).returns(1)
     subject.stubs(:QueryServiceConfigW).returns(1)
-    subject.stubs(:StartServiceW).returns(1)
-    subject.stubs(:ControlService).returns(1)
     subject.stubs(:ChangeServiceConfigW).returns(1)
     subject.stubs(:OpenSCManagerW).returns(scm)
     subject.stubs(:OpenServiceW).returns(service)
@@ -90,7 +98,223 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
     end
   end
 
+  # This shared example contains the unit tests for the wait_on_pending_state
+  # helper as used by service actions like #start and #stop. Before including
+  # this shared example, be sure to mock out any intermediate calls prior to
+  # the pending transition, and make sure that the post-condition _after_ those
+  # intermediate calls leaves the service in the pending state. Before including
+  # this example in your tests, be sure to define the following variables in a `let`
+  # context:
+  #     * action -- The service action
+  shared_examples "a service action waiting on a pending transition" do |pending_state|
+    pending_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[pending_state].to_s
+
+    final_state = Puppet::Util::Windows::Service::FINAL_STATES[pending_state]
+    final_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[final_state].to_s
+
+    it "raises a Puppet::Error if the service query fails" do
+      subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
+
+      expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
+    end
+
+    it "raises a Puppet::Error if the service unexpectedly transitions to a state other than #{pending_state_str} or #{final_state_str}" do
+      invalid_state = (subject::SERVICE_STATES.keys - [pending_state, final_state]).first
+
+      expect_successful_status_query_and_return(dwCurrentState: invalid_state)
+
+      expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
+    end
+
+    it "waits for at least 1 second if the wait_hint/10 is < 1 second" do
+      expect_successful_status_queries_and_return(
+        { :dwCurrentState => pending_state, :dwWaitHint => 0, :dwCheckPoint => 1 },
+        { :dwCurrentState => final_state }
+      )
+
+      subject.expects(:sleep).with(1)
+
+      subject.send(action, mock_service_name)
+    end
+
+    it "waits for at most 10 seconds if wait_hint/10 is > 10 seconds" do
+      expect_successful_status_queries_and_return(
+        { :dwCurrentState => pending_state, :dwWaitHint => 1000000, :dwCheckPoint => 1 },
+        { :dwCurrentState => final_state }
+      )
+
+      subject.expects(:sleep).with(10)
+
+      subject.send(action, mock_service_name)
+    end
+
+    it "does not raise an error if the service makes any progress while transitioning to #{final_state_str}" do
+      expect_successful_status_queries_and_return(
+        # The three "pending_state" statuses simulate the scenario where the service
+        # makes some progress during the transition right when Puppet's about to
+        # time out.
+        { :dwCurrentState => pending_state, :dwWaitHint => 100000, :dwCheckPoint => 1 },
+        { :dwCurrentState => pending_state, :dwWaitHint => 100000, :dwCheckPoint => 1 },
+        { :dwCurrentState => pending_state, :dwWaitHint => 100000, :dwCheckPoint => 2 },
+
+        { :dwCurrentState => final_state }
+      )
+
+      expect { subject.send(action, mock_service_name) }.to_not raise_error
+    end
+
+    it "raises a Puppet::Error if it times out while waiting for the transition to #{final_state_str}" do
+      31.times do
+        expect_successful_status_query_and_return(
+          dwCurrentState: pending_state,
+          dwWaitHint: 10000,
+          dwCheckPoint: 1
+        )
+      end
+
+      expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
+    end
+  end
+
+  # This shared example contains the unit tests for the transition_service_state
+  # helper, which is the helper that all of our service actions like #start, #stop
+  # delegate to. Including these tests under a shared example lets us include them in each of
+  # those service action's unit tests. Before including this example in your tests, be
+  # sure to define the following variables in a `let` context:
+  #     * initial_state         -- The initial state of the service prior to performing the state
+  #                                transition
+  #
+  #     * mock_state_transition -- A lambda that mocks the state transition. This should mock
+  #                                any code in the block that's passed to the
+  #                                transition_service_state helper
+  #
+  # See the unit tests for the #start method to see how this shared example's
+  # included.
+  #
+  shared_examples "a service action that transitions the service state" do |action, valid_initial_states, pending_state, final_state|
+    valid_initial_states_str = valid_initial_states.map do |state|
+      Puppet::Util::Windows::Service::SERVICE_STATES[state]
+    end.join(', ')
+    pending_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[pending_state].to_s
+    final_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[final_state].to_s
+
+    it "noops if the service is already in the #{final_state} state" do
+      expect_successful_status_query_and_return(dwCurrentState: final_state)
+
+      expect { subject.send(action, mock_service_name) }.to_not raise_error
+    end
+
+    # invalid_initial_states will be empty for the #stop action
+    invalid_initial_states = Puppet::Util::Windows::Service::SERVICE_STATES.keys - valid_initial_states - [final_state]
+    unless invalid_initial_states.empty?
+      it "raises a Puppet::Error if the service's initial state is not one of #{valid_initial_states_str}" do
+        invalid_initial_state = invalid_initial_states.first
+        expect_successful_status_query_and_return(dwCurrentState: invalid_initial_state)
+  
+        expect{ subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "when there's a pending transition to the #{final_state} state" do
+      before(:each) do
+        expect_successful_status_query_and_return(dwCurrentState: pending_state)
+      end
+
+      include_examples "a service action waiting on a pending transition", pending_state do
+        let(:action) { action }
+      end
+    end
+
+    # If the service action accepts an unsafe pending state as one of the service's
+    # initial states, then we need to test that the action waits for the service to
+    # transition from that unsafe pending state before doing anything else.
+    unsafe_pending_states = valid_initial_states & Puppet::Util::Windows::Service::UNSAFE_PENDING_STATES
+    unless unsafe_pending_states.empty?
+      unsafe_pending_state = unsafe_pending_states.first
+      unsafe_pending_state_str = Puppet::Util::Windows::Service::SERVICE_STATES[unsafe_pending_state]
+
+      context "waiting for a service with #{unsafe_pending_state_str} as its initial state" do
+        before(:each) do
+          # This mocks the status query to return the 'final_state' by default. Otherwise,
+          # we will fail the tests in the latter parts of the code where we wait for the
+          # service to finish transitioning to the 'final_state'.
+          subject::SERVICE_STATUS_PROCESS.stubs(:new).returns(dwCurrentState: final_state)
+
+          # Set our service's initial state
+          expect_successful_status_query_and_return(dwCurrentState: unsafe_pending_state)
+
+          mock_state_transition.call
+        end
+
+        include_examples "a service action waiting on a pending transition", unsafe_pending_state do
+          let(:action) { action }
+        end
+      end
+    end
+
+    # reads e.g. "waiting for the service to transition to the SERVICE_RUNNING state after executing the 'start' action"
+    #
+    # NOTE: This is really unit testing the wait_on_state_transition helper
+    context "waiting for the service to transition to the #{final_state_str} state after executing the '#{action}' action" do
+      before(:each) do
+        # Set our service's initial state prior to performing the state transition
+        expect_successful_status_query_and_return(dwCurrentState: initial_state)
+
+        mock_state_transition.call
+      end
+
+      it "raises a Puppet::Error if the service query fails" do
+        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
+
+        expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
+      end
+
+      it "waits, then queries again until it transitions to #{final_state_str}" do
+        expect_successful_status_queries_and_return(
+          { :dwCurrentState => initial_state },
+          { :dwCurrentState => initial_state },
+          { :dwCurrentState => final_state }
+        )
+
+        subject.expects(:sleep).with(1).twice
+
+        subject.send(action, mock_service_name)
+      end
+
+      context "when it transitions to the #{pending_state_str} state" do
+        before(:each) do
+          expect_successful_status_query_and_return(dwCurrentState: pending_state)
+        end
+
+        include_examples "a service action waiting on a pending transition", pending_state do
+          let(:action) { action }
+        end
+      end
+
+      it "raises a Puppet::Error if it times out while waiting for the transition to #{final_state_str}" do
+        31.times do
+          expect_successful_status_query_and_return(dwCurrentState: initial_state)
+        end
+
+        expect { subject.send(action, mock_service_name) }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+
   describe "#start" do
+    # rspec will still try to load the tests even though
+    # the :if => Puppet.features.microsoft_windows? filter
+    # is passed-in to the top-level describe block on
+    # non-Windows platforms; it just won't run them. However
+    # on these platforms, the loading will fail because this
+    # test uses a shared example that references variables
+    # from the Windows::Service module when building the unit
+    # tests, which is only available on Windows platforms.
+    # Thus, we add the next here to ensure that rspec does not
+    # attempt to load our test code. This is OK for us to do
+    # because we do not want to run these tests on non-Windows
+    # platforms.
+    next unless Puppet.features.microsoft_windows?
 
     context "when the service control manager cannot be opened" do
       let(:scm) { FFI::Pointer::NULL_HANDLE }
@@ -106,246 +330,95 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
       end
     end
 
-    context "when the service can be opened and is in the stopped state" do
-      before do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+    context "when the service can be opened" do
+      # Can't use rspec's subject here because that
+      # can only be referenced inside an 'it' block.
+      service = Puppet::Util::Windows::Service
+      valid_initial_states = [
+        service::SERVICE_STOP_PENDING,
+        service::SERVICE_STOPPED,
+        service::SERVICE_START_PENDING
+      ]
+      final_state = service::SERVICE_RUNNING
+  
+      include_examples "a service action that transitions the service state", :start, valid_initial_states, service::SERVICE_START_PENDING, final_state do
+        let(:initial_state) { subject::SERVICE_STOPPED }
+        let(:mock_state_transition) do
+          lambda do
+            subject.stubs(:StartServiceW).returns(1)
+          end
+        end
       end
-
-      it "Starts the service once the service reports SERVICE_RUNNING" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.start(mock_service_name)
-      end
-
-      it "Raises an error if after calling StartServiceW the service never transitions to RUNNING or START_PENDING" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_PAUSED}).times(31)
-        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
-      end
-
-      it "raises a puppet error if StartServiceW returns false" do
+  
+      it "raises a Puppet::Error if StartServiceW returns false" do
+        expect_successful_status_query_and_return(dwCurrentState: subject::SERVICE_STOPPED)
+  
         subject.expects(:StartServiceW).returns(FFI::WIN32_FALSE)
-        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
-      end
-    end
 
-    context "when the service hasn't stopped yet:" do
-      it "waits, then queries again until SERVICE_STOPPED" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.expects(:sleep).with(3).twice
+        expect { subject.start(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+  
+      it "starts the service" do
+        expect_successful_status_queries_and_return(
+          { dwCurrentState: subject::SERVICE_STOPPED },
+          { dwCurrentState: subject::SERVICE_RUNNING }
+        )
+  
+        subject.expects(:StartServiceW).returns(1)
+  
         subject.start(mock_service_name)
-      end
-
-      it "waits for at least 1 second if wait hint/10 is < 1 second" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.expects(:sleep).with(1)
-        subject.start(mock_service_name)
-      end
-
-      it "waits for at most 10 seconds if wait hint/10 is > 10 seconds" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 1000000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.expects(:sleep).with(10)
-        subject.start(mock_service_name)
-      end
-
-      it "raises a puppet error if the service query fails" do
-        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(1)
-        subject.expects(:QueryServiceStatusEx).in_sequence(status_checks).returns(FFI::WIN32_FALSE)
-        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
-      end
-
-      it "Does not raise an error if the service makes progress" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 30})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 50})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 98})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        expect{subject.start(mock_service_name)}.to_not raise_error
-      end
-    end
-
-    context "when the service ends up still in STOPPED:" do
-      it "waits, then queries again until RUNNING" do
-        # these will be before the call to controlService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        # everything from here on will be _after_ the call to ControlService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.start(mock_service_name)
-      end
-
-      it "raises a puppet error if the services never exits the RUNNING state" do
-        # these will be before the call to controlService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        # the number of times here is a little strange: there are 31 status queries sleeps because there will be a 31st query
-        # that is the final query where the command has reached the wait hint and it's time to error
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED}).times(31)
-        subject.expects(:sleep).times(30).with(1)
-        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
-      end
-    end
-
-    context "when the service ends up in START_PENDING:" do
-      before(:each) do
-        # these will be before the call to StartService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-      end
-
-      it "waits, then queries again until SERVICE_RUNNING" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.start(mock_service_name)
-      end
-
-      it "waits for at least 1 second if wait hint/10 is < 1 second" do
-        # the first call is executed in wait_for_state, which we aren't testing here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.expects(:sleep).with(1)
-        subject.start(mock_service_name)
-      end
-
-      it "waits for at most 10 seconds if wait hint/10 is > 10 seconds" do
-        # the first call is executed in wait_for_state, which we aren't testing here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 1000000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.expects(:sleep).with(10)
-        subject.start(mock_service_name)
-      end
-
-      it "raises a puppet error if the services configured dwWaitHint is 0, 30 seconds have passed and dwCheckPoint hasn't increased" do
-        # the first call is executed in wait_for_state, which we aren't testing here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(31)
-        subject.expects(:sleep).times(30).with(1)
-        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
-      end
-
-      it "raises a puppet error if the service's configured dwWaitHint has passed and dwCheckPoint hasn't increased" do
-        # the first call is executed in wait_for_state, which we aren't testing here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 40000, :dwCheckPoint => 0}).times(11)
-        subject.expects(:sleep).times(10).with(4)
-        expect{subject.start(mock_service_name)}.to raise_error(Puppet::Error)
-      end
-
-      it "Does not raise an error if the service makes progress" do
-        # the first call is executed in wait_for_state, which we aren't testing here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 2})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 30})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 50})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_START_PENDING, :dwWaitHint => 0, :dwCheckPoint => 98})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-        subject.expects(:sleep).times(5).with(1)
-        expect{subject.start(mock_service_name)}.to_not raise_error
       end
     end
   end
 
   describe "#stop" do
+    next unless Puppet.features.microsoft_windows?
+
     context "when the service control manager cannot be opened" do
       let(:scm) { FFI::Pointer::NULL_HANDLE }
       it "raises a puppet error" do
-        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
       end
     end
 
     context "when the service cannot be opened" do
       let(:service) { FFI::Pointer::NULL_HANDLE }
       it "raises a puppet error" do
-        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+        expect{ subject.start(mock_service_name) }.to raise_error(Puppet::Error)
       end
     end
 
-    context "when the service can be opened and is in the running state:" do
-      before do
-        # this will be before the call to controlService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
+    context "when the service can be opened" do
+      service = Puppet::Util::Windows::Service
+      valid_initial_states = service::SERVICE_STATES.keys - [service::SERVICE_STOPPED]
+      final_state = service::SERVICE_STOPPED
+  
+      include_examples "a service action that transitions the service state", :stop, valid_initial_states, service::SERVICE_STOP_PENDING, final_state do
+        let(:initial_state) { subject::SERVICE_RUNNING }
+        let(:mock_state_transition) do
+          lambda do
+            subject.stubs(:ControlService).returns(1)
+          end
+        end
       end
-      it "raises a puppet error if ControlService returns false" do
-        subject.expects(:ControlService).returns(FFI::WIN32_FALSE)
-        expect{ subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
-      end
-    end
 
-    # No need to retest the wait hint functionality itself here, since
-    # both stop and start use the wait_for_pending_transition helper
-    # which is tested in the start unit tests.
-    context "when the service is already in stop pending or stopped" do
-      it "waits for the service to stop and then exits immediately" do
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 5})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
+      it "raises a Puppet::Error if ControlService returns false" do
+        expect_successful_status_query_and_return(dwCurrentState: subject::SERVICE_RUNNING)
+
+        subject.stubs(:ControlService).returns(FFI::WIN32_FALSE)
+
+        expect { subject.stop(mock_service_name) }.to raise_error(Puppet::Error)
+      end
+  
+      it "stops the service" do
+        expect_successful_status_queries_and_return(
+          { dwCurrentState: subject::SERVICE_RUNNING },
+          { dwCurrentState: subject::SERVICE_STOPPED }
+        )
+
+        subject.expects(:ControlService).returns(1)
+
         subject.stop(mock_service_name)
-      end
-    end
-
-    context "when the service ends up in STOP_PENDING:" do
-      before(:each) do
-        # this will be before the call to controlService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-      end
-
-      it "waits, then queries again until SERVICE_STOPPED" do
-        # the first call is to wait_for_state, which we don't test here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING})
-        # everything from here on will be _after_ the call to ControlService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        subject.stop(mock_service_name)
-      end
-
-      it "raises a puppet error if the services never exits the STOP_PENDING state" do
-        # the first call is to wait_for_state, which we don't test here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(31)
-        expect{subject.stop(mock_service_name)}.to raise_error(Puppet::Error)
-      end
-    end
-
-    context "when the service ends up still in RUNNING:" do
-      before(:each) do
-        # this will be before the call to controlService
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING})
-      end
-      it "waits, then queries again until SERVICE_STOPPED" do
-        # the first call is to wait_for_state, which we don't test here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(10)
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 1})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOP_PENDING, :dwWaitHint => 30000, :dwCheckPoint => 50})
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_STOPPED})
-        subject.stop(mock_service_name)
-      end
-
-      it "raises a puppet error if the services never exits the RUNNING state" do
-        # the first call is to wait_for_state, which we don't test here
-        expect_successful_status_query_and_return({:dwCurrentState => subject::SERVICE_RUNNING, :dwWaitHint => 0, :dwCheckPoint => 0}).times(31)
-        subject.expects(:sleep).times(30).with(1)
-        expect{subject.stop(mock_service_name)}.to raise_error(Puppet::Error)
       end
     end
   end


### PR DESCRIPTION
Now that everything's been tagged for the 6.0.2 release,
we can add these changes back to 6.0.x.

This reverts commit 55fd36dcaf731d54926cb611e57341f95d23b3ab.