### PR TITLE
(PUP-9193) Fix windows exe package provider to fail

### DIFF
--- a/acceptance/tests/resource/package/windows.rb
+++ b/acceptance/tests/resource/package/windows.rb
@@ -46,6 +46,13 @@ MANIFEST
     mock_package[:install_commands] = 'System.IO.File.ReadAllLines("install.txt");'
     installer_location = create_mock_package(agent, tmpdir, mock_package)
 
+    # Since we didn't add the install.txt package the installation should fail with code 1004
+    step 'Verify that ensure = present fails when an installer fails with a non-zero exit code' do
+      apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :present}, installer_location)) do |result|
+        assert_match(/#{mock_package[:name]}/, result.stderr, 'Windows package provider did not fail when the package install failed')
+      end
+    end
+
     step 'Verify that ensure = present installs a package that requires additional resources' do
       create_remote_file(agent, "#{tmpdir}/install.txt", 'foobar')
       apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :present}, installer_location))

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -62,14 +62,14 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
   def install
     installer = Puppet::Provider::Package::Windows::Package.installer_class(resource)
 
-    command = [installer.install_command(resource), install_options].flatten.compact.join(' ')
+    command = installer.install_command(resource, install_options)
     output = execute(command, :failonfail => false, :combine => true, :cwd => File.dirname(resource[:source]))
 
     check_result(output.exitstatus)
   end
 
   def uninstall
-    command = [package.uninstall_command, uninstall_options].flatten.compact.join(' ')
+    command = package.uninstall_command(uninstall_options)
     output = execute(command, :failonfail => false, :combine => true)
 
     check_result(output.exitstatus)

--- a/lib/puppet/provider/package/windows/msi_package.rb
+++ b/lib/puppet/provider/package/windows/msi_package.rb
@@ -51,12 +51,12 @@ class Puppet::Provider::Package::Windows
         resource[:name] == name
     end
 
-    def self.install_command(resource)
-      ['msiexec.exe', '/qn', '/norestart', '/i', munge(resource[:source])]
+    def self.install_command(resource, install_options)
+      ['msiexec.exe', '/qn', '/norestart', '/i', munge(resource[:source]), install_options].flatten.compact.join(' ')
     end
 
-    def uninstall_command
-      ['msiexec.exe', '/qn', '/norestart', '/x', productcode]
+    def uninstall_command(uninstall_options)
+      ['msiexec.exe', '/qn', '/norestart', '/x', productcode, uninstall_options].flatten.compact.join(' ')
     end
   end
 end

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -24,6 +24,7 @@ module Puppet::Util::Windows
     require 'puppet/util/windows/file'
     require 'puppet/util/windows/security'
     require 'puppet/util/windows/user'
+    require 'puppet/util/windows/powershell_command_string'
     require 'puppet/util/windows/process'
     require 'puppet/util/windows/root_certs'
     require 'puppet/util/windows/access_control_entry'

--- a/lib/puppet/util/windows/powershell_command_string.rb
+++ b/lib/puppet/util/windows/powershell_command_string.rb
@@ -1,0 +1,42 @@
+module Puppet::Util::Windows
+  # This module is a helper to create a string that performs an action from powershell
+  # and returns the exit code to puppet when used with Puppet::Util::Execution.execute
+  module PowershellCommandString
+
+    DEFAULT_POWERSHELL_ARGS = '-ExecutionPolicy Bypass -InputFormat None -NoLogo -NoProfile -NonInteractive'
+    DEFAULT_START_PROCESS_ARGS = '-NoNewWindow -Wait'
+
+    # Construct a command string that can be used with Util::Execution::execute to call to powershell to execute a command.
+    # The general construction of the command is:
+    #
+    # powershell.exe -Command exit (Start-Process -PassThru command).ExitCode
+    #
+    # We call from powershell to the 'exit' command that will call to Start-Process "command" to get "command"s exit code
+    # so that when powershell exits it will exit with the same exit code.
+    def self.make_powershell_command(command, arguments: [], powershell_args: DEFAULT_POWERSHELL_ARGS, start_process_args: DEFAULT_START_PROCESS_ARGS)
+      parsed_args = parse_arguments(arguments)
+      unless parsed_args.empty?
+        argument_string = '-ArgumentList \'' + parsed_args + '\''
+      end
+      [
+        'powershell.exe',
+        powershell_args,
+        '-Command',
+        'exit',
+        '(',
+        'Start-Process',
+        '-PassThru', # We always use -PassThru so .ExitCode recieves the code from "command"
+        start_process_args,
+        '-FilePath',
+        command,
+        argument_string,
+        ').ExitCode',
+      ].flatten.compact.join(' ')
+    end
+
+    def self.parse_arguments(args)
+      return '' if args.nil?
+      args.compact.delete_if { |arg| arg.empty? }.flatten.join(' ')
+    end
+  end
+end


### PR DESCRIPTION
Previously, the windows package provider for exe packages would ignore the
exit code from the installation because cmd.exe would return the exit code
from the cmd.exe executable and not the installer executable.

This commit changes the package provider for exe packages to use
powershell.exe instead of cmd.exe. A helper module PowershellCommandString has
been added to assist with building the appropriate command that can execute an
executable from powershell and return the appropriate error code.