### PR TITLE
(PUP-9193) Make puppet honor installation exit code, still suppress console

### DIFF
--- a/acceptance/tests/resource/package/windows.rb
+++ b/acceptance/tests/resource/package/windows.rb
@@ -46,6 +46,13 @@ MANIFEST
     mock_package[:install_commands] = 'System.IO.File.ReadAllLines("install.txt");'
     installer_location = create_mock_package(agent, tmpdir, mock_package)
 
+    # Since we didn't add the install.txt package the installation should fail with code 1004
+    step 'Verify that ensure = present fails when an installer fails with a non-zero exit code' do
+      apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :present}, installer_location)) do |result|
+        assert_match(/#{mock_package[:name]}/, result.stderr, 'Windows package provider did not fail when the package install failed')
+      end
+    end
+
     step 'Verify that ensure = present installs a package that requires additional resources' do
       create_remote_file(agent, "#{tmpdir}/install.txt", 'foobar')
       apply_manifest_on(agent, package_manifest(mock_package[:name], {ensure: :present}, installer_location))

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -63,14 +63,14 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
     installer = Puppet::Provider::Package::Windows::Package.installer_class(resource)
 
     command = [installer.install_command(resource), install_options].flatten.compact.join(' ')
-    output = execute(command, :failonfail => false, :combine => true, :cwd => File.dirname(resource[:source]))
+    output = execute(command, :failonfail => false, :combine => true, :cwd => File.dirname(resource[:source]), :suppress_window => true)
 
     check_result(output.exitstatus)
   end
 
   def uninstall
     command = [package.uninstall_command, uninstall_options].flatten.compact.join(' ')
-    output = execute(command, :failonfail => false, :combine => true)
+    output = execute(command, :failonfail => false, :combine => true, :suppress_window => true)
 
     check_result(output.exitstatus)
   end

--- a/lib/puppet/provider/package/windows/exe_package.rb
+++ b/lib/puppet/provider/package/windows/exe_package.rb
@@ -42,17 +42,10 @@ class Puppet::Provider::Package::Windows
     end
 
     def self.install_command(resource)
-      ['cmd.exe', '/c', 'start', '"puppet-install"', '/w', munge(resource[:source])]
+      munge(resource[:source])
     end
 
     def uninstall_command
-      # 1. Launch using cmd /c start because if the executable is a console
-      #    application Windows will automatically display its console window
-      # 2. Specify a quoted title, otherwise if uninstall_string is quoted,
-      #    start will interpret that to be the title, and get confused
-      # 3. Specify /w (wait) to wait for uninstall to finish
-      command = ['cmd.exe', '/c', 'start', '"puppet-uninstall"', '/w']
-
       # Only quote bare uninstall strings, e.g.
       #   C:\Program Files (x86)\Notepad++\uninstall.exe
       # Don't quote uninstall strings that are already quoted, e.g.
@@ -60,9 +53,9 @@ class Puppet::Provider::Package::Windows
       # Don't quote uninstall strings that contain arguments:
       #   "C:\Program Files (x86)\Git\unins000.exe" /SILENT
       if uninstall_string =~ /\A[^"]*.exe\Z/i
-        command << "\"#{uninstall_string}\""
+        command = "\"#{uninstall_string}\""
       else
-        command << uninstall_string
+        command = uninstall_string
       end
 
       command

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -157,6 +157,7 @@ module Puppet::Util::Execution
         :override_locale => true,
         :custom_environment => {},
         :sensitive => false,
+        :suppress_window => false,
     }
 
     options = default_options.merge(options)

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -8,6 +8,8 @@ module Puppet::Util::Windows::Process
 
   WAIT_TIMEOUT = 0x102
   WAIT_INTERVAL = 200
+  # https://docs.microsoft.com/en-us/windows/desktop/ProcThread/process-creation-flags
+  CREATE_NO_WINDOW = 0x08000000
 
   def execute(command, arguments, stdin, stdout, stderr)
     create_args = {
@@ -17,9 +19,11 @@ module Puppet::Util::Windows::Process
         :stdout => stdout,
         :stderr => stderr
       },
-      :close_handles => false
+      :close_handles => false,
     }
-
+    if arguments[:suppress_window]
+      create_args[:creation_flags] = CREATE_NO_WINDOW
+    end
     cwd = arguments[:cwd]
     if cwd
       Dir.chdir(cwd) { Process.create(create_args) }

--- a/spec/unit/provider/package/windows/exe_package_spec.rb
+++ b/spec/unit/provider/package/windows/exe_package_spec.rb
@@ -76,7 +76,7 @@ describe Puppet::Provider::Package::Windows::ExePackage do
     it 'should install using the source' do
       cmd = subject.install_command({:source => source})
 
-      expect(cmd).to eq(['cmd.exe', '/c', 'start', '"puppet-install"', '/w', source])
+      expect(cmd).to eq(source)
     end
   end
 
@@ -84,7 +84,7 @@ describe Puppet::Provider::Package::Windows::ExePackage do
     ['C:\uninstall.exe', 'C:\Program Files\uninstall.exe'].each do |exe|
       it "should quote #{exe}" do
         expect(subject.new(name, version, exe).uninstall_command).to eq(
-          ['cmd.exe', '/c', 'start', '"puppet-uninstall"', '/w', "\"#{exe}\""]
+          "\"#{exe}\""
         )
       end
     end
@@ -92,7 +92,7 @@ describe Puppet::Provider::Package::Windows::ExePackage do
     ['"C:\Program Files\uninstall.exe"', '"C:\Program Files (x86)\Git\unins000.exe" /SILENT"'].each do |exe|
       it "should not quote #{exe}" do
         expect(subject.new(name, version, exe).uninstall_command).to eq(
-          ['cmd.exe', '/c', 'start', '"puppet-uninstall"', '/w', exe]
+          exe
         )
       end
     end

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:package).provider(:windows), :if => Puppet.features.
   let (:source)      { 'E:\Rando\Directory\mysql-5.1.58-win-x64.msi' }
   let (:resource)    {  Puppet::Type.type(:package).new(:name => name, :provider => :windows, :source => source) }
   let (:provider)    { resource.provider }
-  let (:execute_options) do {:failonfail => false, :combine => true} end
+  let (:execute_options) do {:failonfail => false, :combine => true, :suppress_window => true} end
 
   before :each do
     # make sure we never try to execute anything
@@ -86,7 +86,7 @@ describe Puppet::Type.type(:package).provider(:windows), :if => Puppet.features.
   context '#install' do
     let(:command) { 'blarg.exe /S' }
     let(:klass) { mock('installer', :install_command => ['blarg.exe', '/S'] ) }
-    let(:execute_options) do {:failonfail => false, :combine => true, :cwd => 'E:\Rando\Directory'} end
+    let(:execute_options) do {:failonfail => false, :combine => true, :cwd => 'E:\Rando\Directory', :suppress_window => true} end
     before :each do
       Puppet::Provider::Package::Windows::Package.expects(:installer_class).returns(klass)
     end

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -168,8 +168,26 @@ describe Puppet::Util::Execution do
             },
             :close_handles => false
           )
-  
+
           call_exec_windows('test command', { :cwd => cwd }, @stdin, @stdout, @stderr)
+        end
+      end
+
+      context 'suppress_window option' do
+        let(:cwd) { 'cwd' }
+        it "should execute the command in the specified working directory" do
+          Process.expects(:create).with(
+            :command_line => "test command",
+            :startup_info => {
+              :stdin => @stdin,
+              :stdout => @stdout,
+              :stderr => @stderr
+            },
+            :close_handles => false,
+            :creation_flags => Puppet::Util::Windows::Process::CREATE_NO_WINDOW
+          )
+
+          call_exec_windows('test command', { :suppress_window => true }, @stdin, @stdout, @stderr)
         end
       end
 


### PR DESCRIPTION
Previously, the windows package provider for exe packages would ignore the
exit code from the installation because cmd.exe would return the exit code
from the cmd.exe executable and not the installer executable.

This commit removes the use of cmd.exe to execute install/uninstall commands
We now ensure that processes don't open a new window by using the
CREATE_NO_WINDOW flag passed to Process.create (which in turn will send that
flag to CreateProcessW in the windows API).

This should solve all our problems: the process will wait for execution to
finish, not open a new console, and exit with the correct exit code