### PR TITLE
(maint) i18n tests should only test translations

### DIFF
--- a/acceptance/tests/i18n/modules/puppet_agent.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent.rb
@@ -64,7 +64,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_1)
         on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
-          assert_match(/Error:.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
+          assert_match(/.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
         end
       end
 

--- a/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
@@ -65,10 +65,10 @@ test_name 'C100566: puppet agent with module should translate messages when usin
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_1)
         on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
-          assert_match(/Error:.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
+          assert_match(/.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
         end
         on(agent, puppet("agent -t --environment #{tmp_environment_1} --use_cached_catalog", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
-          assert_match(/Error:.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact when using cached catalog')
+          assert_match(/.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact when using cached catalog')
         end
       end
 

--- a/acceptance/tests/i18n/modules/puppet_apply.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply.rb
@@ -46,7 +46,7 @@ test_name 'C100567: puppet apply of module should translate messages' do
     step "Run puppet apply of a module with language #{agent_language} and verify the translations" do
       step 'verify custom fact translations' do
         on(agent, puppet("apply -e \"class { 'i18ndemo': filename => '#{type_path}' }\"", 'ENV' => shell_env_language)) do |apply_result|
-          assert_match(/Error:.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, apply_result.stderr, 'missing translation for raise from ruby fact')
+          assert_match(/.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, apply_result.stderr, 'missing translation for raise from ruby fact')
         end
       end
 

--- a/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
@@ -43,7 +43,7 @@ test_name 'C100574: puppet apply using a module should translate messages in a l
     step "Run puppet apply of a module with language #{agent_language} and verify default english returned" do
       step 'verify custom fact message translated and applied catalog message not translatated' do
         on(agent, puppet("apply -e \"class { 'i18ndemo': filename => '#{type_path}' }\"", 'ENV' => shell_env_language)) do |apply_result|
-          assert_match(/Error: Facter: error while resolving custom fact "i18ndemo_fact": i18ndemo_fact: tämä on korotus mukautetusta tosiasiasta \w+-i18ndemo/,
+          assert_match(/i18ndemo_fact: tämä on korotus mukautetusta tosiasiasta \w+-i18ndemo/,
                        apply_result.stderr, 'missing translated message for raise from ruby fact')
           assert_match(/Notice: Applied catalog in [0-9.]+ seconds/, apply_result.stdout, 'missing untranslated message for catalog applied')
         end

--- a/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
@@ -34,7 +34,7 @@ test_name 'C100568: puppet apply of module for an unsupported language should fa
     step "Run puppet apply of a module with language #{unsupported_language} and verify default english returned" do
       step 'verify custom fact messages not translatated' do
         on(agent, puppet("apply -e \"class { 'i18ndemo': filename => '#{type_path}' }\"", 'ENV' => shell_env_language)) do |apply_result|
-          assert_match(/Error:.*i18ndemo_fact: this is a raise from a custom fact from \w+-i18ndemo/, apply_result.stderr, 'missing untranslated message for raise from ruby fact')
+          assert_match(/.*i18ndemo_fact: this is a raise from a custom fact from \w+-i18ndemo/, apply_result.stderr, 'missing untranslated message for raise from ruby fact')
         end
       end
 

--- a/acceptance/tests/i18n/modules/puppet_facts.rb
+++ b/acceptance/tests/i18n/modules/puppet_facts.rb
@@ -42,7 +42,7 @@ test_name 'C100564: puppet facts translates the fact error message' do
 
     step "Run puppet fact with a module and language #{agent_language} and verify the translations" do
       on(agent, puppet("facts", 'ENV' => shell_env_language)) do |result|
-        assert_match(/Error:.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
+        assert_match(/.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
       end
     end
   end


### PR DESCRIPTION
It seems there may be something about testing with facter 2 that these
tests aren't working. We're still getting translations, but the failure
is that it's expecting an error and getting a warning. Rather than
checking warning vs. error, we should only be checking that translations
are present/absent.