### PR TITLE
(PUP-4687) Print warning message when setting home on Windows

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -423,7 +423,10 @@ module Puppet
         resource at the same time. For instance, Puppet creates a home directory for a managed
         user if `ensure => present` and the user does not exist at the time of the Puppet run.
         If the home directory is then deleted manually, Puppet will not recreate it on the next
-        run."
+        run.
+
+        Note that on Windows, this manages creation/deletion of the user profile instead of the
+        home directory."
 
       defaultto false
 


### PR DESCRIPTION
Previously, the home property on Windows was implemented by
getting/setting the HomeDirectory property of an ADSI user.
It turns out that the HomeDirectory property does not do
anything meaningful. It does not, for example, create the home
directory if it does not exist or even return the current home
directory (it was, for example, returning an empty string for a
user whose profile's been created and is located in C:\Users\<username>
instead of the C:\Users\<username> path).

All of this means that the current implementation of the home
property did not do anything meaningful for Windows users. In
fact, the home property does not make a lot of sense on Windows
because the user profile, which is effectively the home directory
for a Windows user, is created in C:\Users and is very rarely
moved outside of this location.

Thus, there is no practical reason to support the home property
on Windows. We will rip this support out in the future. For now,
we print a warning message when the user attempts to set the
home directory on Windows in order to preserve backwards
compatibility.