### PR TITLE
(PUP-9185) Fix logging exceptions at debug level

### DIFF
--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -64,7 +64,7 @@ class Puppet::Transaction::Persistence
       begin
         result = Puppet::Util::Yaml.safe_load_file(filename, [Symbol])
       rescue Puppet::Util::Yaml::YamlLoadError => detail
-        Puppet.log_exception(detail, _("Transaction store file %{filename} is corrupt (%{detail}); replacing") % { filename: filename, detail: detail }, { :level => :warning })
+        Puppet.log_exception(detail, _("Transaction store file %{filename} is corrupt (%{detail}); replacing") % { filename: filename, detail: detail })
 
         begin
           File.rename(filename, filename + ".bad")

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -49,12 +49,13 @@ module Logging
   #    to take advantage of the backtrace logging.
   def log_exception(exception, message = :default, options = {})
     trace = Puppet[:trace] || options[:trace]
+    level = options[:level] || :err
     if message == :default && exception.is_a?(Puppet::ParseErrorWithIssue)
       # Retain all detailed info and keep plain message and stacktrace separate
       backtrace = []
       build_exception_trace(backtrace, exception, trace)
       Puppet::Util::Log.create({
-          :level => options[:level] || :err,
+          :level => level,
           :source => log_source,
           :message => exception.basic_message,
           :issue_code => exception.issue_code,
@@ -66,7 +67,7 @@ module Logging
           :node => exception.node
         }.merge(log_metadata))
     else
-      err(format_exception(exception, message, trace))
+      send_log(level, format_exception(exception, message, trace))
     end
   end
 

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -138,7 +138,7 @@ describe Puppet::Agent do
 
     it "should not fail if a client class instance cannot be created" do
       AgentTestClient.expects(:new).raises "eh"
-      Puppet.expects(:err)
+      Puppet.expects(:log_exception)
       @agent.run
     end
 
@@ -146,7 +146,7 @@ describe Puppet::Agent do
       client = AgentTestClient.new
       AgentTestClient.expects(:new).returns client
       client.expects(:run).raises "eh"
-      Puppet.expects(:err)
+      Puppet.expects(:log_exception)
       @agent.run
     end
 

--- a/spec/unit/application/face_base_spec.rb
+++ b/spec/unit/application/face_base_spec.rb
@@ -416,7 +416,7 @@ EOT
       # it, but this helps us fail if that slips up and all. --daniel 2011-04-27
       Puppet::Face[:help, :current].expects(:help).never
 
-      Puppet.expects(:err).with("Could not parse application options: I don't know how to render 'interpretive-dance'")
+      Puppet.expects(:send_log).with(:err, "Could not parse application options: I don't know how to render 'interpretive-dance'")
 
       expect { app.run }.to exit_with(1)
     end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Application do
   describe "application defaults" do
     it "should fail if required app default values are missing" do
       @app.stubs(:app_defaults).returns({ :foo => 'bar' })
-      Puppet.expects(:err).with(regexp_matches(/missing required app default setting/))
+      Puppet.expects(:send_log).with(:err, regexp_matches(/missing required app default setting/))
       expect {
         @app.run
       }.to exit_with(1)
@@ -55,10 +55,10 @@ describe Puppet::Application do
     end
 
     it "should error if it can't find a class" do
-      Puppet.expects(:err).with do |value|
-        value =~ /Unable to find application 'ThisShallNeverEverEverExist'/ and
-          value =~ /puppet\/application\/thisshallneverevereverexist/ and
-          value =~ /no such file to load|cannot load such file/
+      Puppet.expects(:send_log).with do |_level, message|
+        message =~ /Unable to find application 'ThisShallNeverEverEverExist'/ and
+          message =~ /puppet\/application\/thisshallneverevereverexist/ and
+          message =~ /no such file to load|cannot load such file/
       end
 
       expect {
@@ -553,19 +553,19 @@ describe Puppet::Application do
     end
 
     it "should warn and exit if no command can be called" do
-      Puppet.expects(:err)
+      Puppet.expects(:send_log).with(:err, "Could not run: No valid command or main")
       expect { @app.run }.to exit_with 1
     end
 
     it "should raise an error if dispatch returns no command" do
       @app.stubs(:get_command).returns(nil)
-      Puppet.expects(:err)
+      Puppet.expects(:send_log).with(:err, "Could not run: No valid command or main")
       expect { @app.run }.to exit_with 1
     end
 
     it "should raise an error if dispatch returns an invalid command" do
       @app.stubs(:get_command).returns(:this_function_doesnt_exist)
-      Puppet.expects(:err)
+      Puppet.expects(:send_log).with(:err, "Could not run: No valid command or main")
       expect { @app.run }.to exit_with 1
     end
   end

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -222,7 +222,7 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should catch and log exceptions" do
-      Puppet.expects(:err)
+      Puppet.expects(:log_exception)
       # The downloader creates a new catalog for each apply, and really the only object
       # that it is possible to stub for the purpose of generating a puppet error
       Puppet::Resource::Catalog.any_instance.stubs(:apply).raises(Puppet::Error, "testing")

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -551,8 +551,8 @@ describe Puppet::Configurer do
 
       Puppet::Transaction::Report.indirection.expects(:save).raises("whatever")
 
-      Puppet.expects(:err)
-      expect { @configurer.send_report(@report) }.not_to raise_error
+      Puppet.expects(:send_log).with(:err, 'Could not send report: whatever')
+      @configurer.send_report(@report)
     end
   end
 
@@ -590,8 +590,8 @@ describe Puppet::Configurer do
 
       Puppet::Util.expects(:replace_file).yields(fh)
 
-      Puppet.expects(:err)
-      expect { @configurer.save_last_run_summary(@report) }.to_not raise_error
+      Puppet.expects(:send_log).with(:err, 'Could not save last run local report: failed to do print')
+      @configurer.save_last_run_summary(@report)
     end
 
     it "should create the last run file with the correct mode" do
@@ -609,7 +609,7 @@ describe Puppet::Configurer do
 
     it "should report invalid last run file permissions" do
       Puppet.settings.setting(:lastrunfile).expects(:mode).returns('892')
-      Puppet.expects(:err).with(regexp_matches(/Could not save last run local report.*892 is invalid/))
+      Puppet.expects(:send_log).with(:err, regexp_matches(/Could not save last run local report.*892 is invalid/))
       @configurer.save_last_run_summary(@report)
     end
   end

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -601,7 +601,7 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       @host.stubs(:generate)
       @host.stubs(:sleep)
 
-      Puppet.expects(:err)
+      Puppet.expects(:log_exception)
 
       @host.wait_for_cert(1)
     end

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -73,7 +73,7 @@ describe Puppet::Transaction::Persistence do
       it "should initialize with a clear internal state if the file does not contain valid YAML" do
         write_state_file('{ invalid')
 
-        Puppet.expects(:err).with(regexp_matches(/Transaction store file .* is corrupt/))
+        Puppet.expects(:send_log).with(:err, regexp_matches(/Transaction store file .* is corrupt/))
 
         persistence = Puppet::Transaction::Persistence.new
         persistence.load
@@ -97,8 +97,8 @@ describe Puppet::Transaction::Persistence do
 
         File.expects(:rename).raises(SystemCallError)
 
-        Puppet.expects(:err).with(regexp_matches(/Transaction store file .* is corrupt/))
-        Puppet.expects(:err).with(regexp_matches(/Unable to rename/))
+        Puppet.expects(:send_log).with(:err, regexp_matches(/Transaction store file .* is corrupt/))
+        Puppet.expects(:send_log).with(:err, regexp_matches(/Unable to rename/))
 
         persistence = Puppet::Transaction::Persistence.new
         expect { persistence.load }.to raise_error(Puppet::Error, /Could not rename/)
@@ -109,7 +109,7 @@ describe Puppet::Transaction::Persistence do
 
         File.expects(:rename).at_least_once
 
-        Puppet.expects(:err).with(regexp_matches(/Transaction store file .* is corrupt/))
+        Puppet.expects(:send_log).with(:err, regexp_matches(/Transaction store file .* is corrupt/))
 
         persistence = Puppet::Transaction::Persistence.new
         persistence.load

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -99,6 +99,64 @@ describe Puppet::Util::Logging do
     end
   end
 
+  describe "log_exception" do
+    context "when requesting a debug level it is logged at debug" do
+      it "the exception is a ParseErrorWithIssue and message is :default" do
+        Puppet::Util::Log.expects(:create).with do |args|
+          expect(args[:message]).to eq("Test")
+          expect(args[:level]).to eq(:debug)
+        end
+
+        begin
+          raise Puppet::ParseErrorWithIssue, "Test"
+        rescue Puppet::ParseErrorWithIssue => err
+          Puppet.log_exception(err, :default, level: :debug)
+        end
+      end
+
+      it "the exception is something else" do
+        Puppet::Util::Log.expects(:create).with do |args|
+          expect(args[:message]).to eq("Test")
+          expect(args[:level]).to eq(:debug)
+        end
+
+        begin
+          raise Puppet::Error, "Test"
+        rescue Puppet::Error => err
+          Puppet.log_exception(err, :default, level: :debug)
+        end
+      end
+    end
+
+    context "no log level is requested it defaults to err" do
+      it "the exception is a ParseErrorWithIssue and message is :default" do
+        Puppet::Util::Log.expects(:create).with do |args|
+          expect(args[:message]).to eq("Test")
+          expect(args[:level]).to eq(:err)
+        end
+
+        begin
+          raise Puppet::ParseErrorWithIssue, "Test"
+        rescue Puppet::ParseErrorWithIssue => err
+          Puppet.log_exception(err)
+        end
+      end
+
+      it "the exception is something else" do
+        Puppet::Util::Log.expects(:create).with do |args|
+          expect(args[:message]).to eq("Test")
+          expect(args[:level]).to eq(:err)
+        end
+
+        begin
+          raise Puppet::Error, "Test"
+        rescue Puppet::Error => err
+          Puppet.log_exception(err)
+        end
+      end
+    end
+  end
+
   describe "when sending a deprecation warning" do
     it "does not log a message when deprecation warnings are disabled" do
       Puppet.expects(:[]).with(:disable_warnings).returns %w[deprecations]


### PR DESCRIPTION
Puppet.log_exception had an option to change the log level which only
worked in a very specific case (where the exception is a
Puppet::ParseErrorWithIssue and the message argument is `:default`).
This makes the argument work consistently.