### PR TITLE
(PUP-9156) Add puppet ssl clean action

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -113,7 +113,7 @@ HELP
       name: host.name, server: Puppet[:ca_server], port: Puppet[:ca_port]
     }
   rescue => e
-    raise Puppet::Error, _("Failed to submit certificate request: %{message}") % { message: e.message }
+    raise Puppet::Error.new(_("Failed to submit certificate request: %{message}") % { message: e.message }, e)
   end
 
   def download_cert(host)
@@ -130,7 +130,7 @@ HELP
     }
     cert
   rescue => e
-    raise Puppet::Error, _("Failed to download certificate: %{message}") % { message: e.message }
+    raise Puppet::Error.new(_("Failed to download certificate: %{message}") % { message: e.message }, e)
   end
 
   def verify(host)
@@ -161,7 +161,7 @@ HELP
     #   Puppet.notice "#{indent}#{issuer.subject.to_s}"
     # end
   rescue => e
-    raise Puppet::Error, _("Verify failed: %{message}") % { message: e.message }
+    raise Puppet::Error.new(_("Verify failed: %{message}") % { message: e.message }, e)
   end
 
   def clean(host)
@@ -170,8 +170,8 @@ HELP
       cert =
         begin
           host.download_certificate_from_ca(Puppet[:certname])
-        rescue
-          raise Puppet::Error, _("Failed to connect to the CA to determine if certificate %{certname} has been cleaned") % { certname: Puppet[:certname] }
+        rescue => e
+          raise Puppet::Error.new(_("Failed to connect to the CA to determine if certificate %{certname} has been cleaned") % { certname: Puppet[:certname] }, e)
         end
 
       if cert

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -71,7 +71,7 @@ HELP
     when 'clean'
       clean(host)
     else
-      puts "Unknown action '#{action}'"
+      puts _("Unknown action '%{action}'") % { action: action }
       exit(1)
     end
 
@@ -82,23 +82,29 @@ HELP
     host.ensure_ca_certificate
 
     host.submit_request
-    puts "Submitted certificate request for '#{host.name}' to https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
+    puts _("Submitted certificate request for '%{name}' to https://%{server}:%{port}") % {
+      name: host.name, server: Puppet[:ca_server], port: Puppet[:ca_port]
+    }
   rescue => e
-    puts "Failed to submit certificate request: #{e.message}"
+    puts _("Failed to submit certificate request: %{message}") % { message: e.message }
     exit(1)
   end
 
   def download_cert(host)
     host.ensure_ca_certificate
 
-    puts "Downloading certificate '#{host.name}' from https://#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
+    puts _("Downloading certificate '%{name}' from https://%{server}:%{port}") % {
+      name: host.name, server: Puppet[:ca_server], port: Puppet[:ca_port]
+    }
     if cert = host.download_host_certificate
-      puts "Downloaded certificate '#{host.name}' with fingerprint #{cert.fingerprint}"
+      puts _("Downloaded certificate '%{name}' with fingerprint %{fingerprint}") % {
+        name: host.name, fingerprint: cert.fingerprint
+      }
     else
-      puts "No certificate for '#{host.name}' on CA"
+      puts _("No certificate for '%{name}' on CA") % { name: host.name }
     end
   rescue => e
-    puts "Failed to download certificate: #{e.message}"
+    puts _("Failed to download certificate: %{message}") % { message: e.message }
     exit(1)
   end
 
@@ -107,35 +113,39 @@ HELP
 
     key = host.key
     unless key
-      puts "The host's private key is missing"
+      puts _("The host's private key is missing")
       exit(1)
     end
 
     cert = host.check_for_certificate_on_disk(host.name)
     unless cert
-      puts "The host's certificate is missing"
+      puts _("The host's certificate is missing")
       exit(1)
     end
 
     if cert.content.public_key.to_pem != key.content.public_key.to_pem
-      puts "The host's key does not match the certificate"
+      puts _("The host's key does not match the certificate")
       exit(1)
     end
 
     store = host.ssl_store
     unless store.verify(cert.content)
-      puts "Failed to verify certificate '#{host.name}': #{store.error_string} (#{store.error})"
+      puts _("Failed to verify certificate '%{name}': %{message} (%{error})") % {
+        name: host.name, message: store.error_string, error: store.error
+      }
       exit(1)
     end
 
-    puts "Verified certificate '#{host.name}'"
+    puts _("Verified certificate '%{name}'") % {
+      name: host.name
+    }
     # store.chain.reverse.each_with_index do |issuer, i|
     #   indent = "  " * (i+1)
     #   puts "#{indent}#{issuer.subject.to_s}"
     # end
     exit(0)
   rescue => e
-    puts "Verify failed: #{e.message}"
+    puts _("Verify failed: %{message}") % { message: e.message }
     exit(1)
   end
 
@@ -146,7 +156,7 @@ HELP
       path = Puppet[setting]
       if Puppet::FileSystem.exist?(path)
         Puppet::FileSystem.unlink(path)
-        puts "Deleted #{path}"
+        puts _("Deleted %{path}") % { path: path }
       end
     end
   end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -37,6 +37,9 @@ ACTIONS
 * verify:
   Verify the private key and certificate are present and match, verify the certificate is
   issued by a trusted CA, and check revocation status.
+
+* clean:
+  Delete the private key and certificate related files for this host.
 HELP
   end
 
@@ -62,6 +65,8 @@ HELP
       download_cert(host)
     when 'verify'
       verify(host)
+    when 'clean'
+      clean(host)
     else
       puts "Unknown action '#{action}'"
       exit(1)
@@ -129,5 +134,15 @@ HELP
   rescue => e
     puts "Verify failed: #{e.message}"
     exit(1)
+  end
+
+  def clean(host)
+    %w[hostprivkey hostpubkey hostcsr hostcert passfile].each do |setting|
+      path = Puppet[setting]
+      if Puppet::FileSystem.exist?(path)
+        Puppet::FileSystem.unlink(path)
+        puts "Deleted #{path}"
+      end
+    end
   end
 end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -165,9 +165,15 @@ HELP
   end
 
   def clean(host)
+    # make sure cert has been removed from the CA
     if Puppet[:certname] == Puppet[:ca_server]
-      # make sure cert has been removed from the CA
-      cert = host.download_certificate_from_ca(Puppet[:certname])
+      cert =
+        begin
+          host.download_certificate_from_ca(Puppet[:certname])
+        rescue
+          raise Puppet::Error, _("Failed to connect to the CA to determine if certificate %{certname} has been cleaned") % { certname: Puppet[:certname] }
+        end
+
       if cert
         raise Puppet::Error, _(<<END) % { certname: Puppet[:certname] }
 The certificate %{certname} must be cleaned from the CA first. To fix this,

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -2,6 +2,9 @@ require 'puppet/application'
 require 'puppet/ssl/oids'
 
 class Puppet::Application::Ssl < Puppet::Application
+
+  run_mode :agent
+
   def summary
     _("Manage SSL keys and certificates for puppet SSL clients")
   end
@@ -162,9 +165,7 @@ HELP
   end
 
   def clean(host)
-    # resolve the `ca_server` setting using `agent` run mode
-    ca_server = Puppet.settings.values(Puppet[:environment].to_sym, :agent).interpolate(:ca_server)
-    if Puppet[:certname] == ca_server
+    if Puppet[:certname] == Puppet[:ca_server]
       # make sure cert has been removed from the CA
       cert = host.download_certificate_from_ca(Puppet[:certname])
       if cert

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -39,8 +39,8 @@ ACTIONS
   issued by a trusted CA, and check revocation status.
 
 * clean:
-  Delete the private key and certificate related files for this host. If `--localca` is
-  specified, then also delete this host's local copy of the CA certificate(s) and CRL bundle.
+  Remove the private key and certificate related files for this host. If `--localca` is
+  specified, then also remove this host's local copy of the CA certificate(s) and CRL bundle.
 HELP
   end
 
@@ -150,13 +150,19 @@ HELP
   end
 
   def clean(host)
-    settings = %w[hostprivkey hostpubkey hostcsr hostcert passfile]
-    settings.concat(%w[localcacert hostcrl]) if options[:localca]
-    settings.each do |setting|
+    settings = {
+      hostprivkey: 'private key',
+      hostpubkey: 'public key',
+      hostcsr: 'certificate request',
+      hostcert: 'certificate',
+      passfile: 'private key password file'
+    }
+    settings.merge!(localcacert: 'local CA certificate', hostcrl: 'local CRL') if options[:localca]
+    settings.each_pair do |setting, label|
       path = Puppet[setting]
       if Puppet::FileSystem.exist?(path)
         Puppet::FileSystem.unlink(path)
-        puts _("Deleted %{path}") % { path: path }
+        puts _("Removed %{label} %{path}") % { label: label, path: path }
       end
     end
   end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -18,7 +18,7 @@ to communicate with a puppet infrastructure.
 
 USAGE
 -----
-puppet ssl <action> [--certname <NAME>]
+puppet ssl <action> [--certname <NAME>] [--localca]
 
 ACTIONS
 -------
@@ -39,13 +39,16 @@ ACTIONS
   issued by a trusted CA, and check revocation status.
 
 * clean:
-  Delete the private key and certificate related files for this host.
+  Delete the private key and certificate related files for this host. If `--localca` is
+  specified, then also delete this host's local copy of the CA certificate(s) and CRL bundle.
 HELP
   end
 
   option('--certname NAME') do |arg|
     options[:certname] = arg
   end
+
+  option('--localca')
 
   def main
     if command_line.args.empty?
@@ -137,7 +140,9 @@ HELP
   end
 
   def clean(host)
-    %w[hostprivkey hostpubkey hostcsr hostcert passfile].each do |setting|
+    settings = %w[hostprivkey hostpubkey hostcsr hostcert passfile]
+    settings.concat(%w[localcacert hostcrl]) if options[:localca]
+    settings.each do |setting|
       path = Puppet[setting]
       if Puppet::FileSystem.exist?(path)
         Puppet::FileSystem.unlink(path)

--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -59,7 +59,6 @@ Puppet::Face.define(:node, '0.0.1') do
   # clean signed cert for +host+
   def clean_cert(node)
     if Puppet.features.puppetserver_ca?
-      require 'puppetserver/ca/action/clean'
       Puppetserver::Ca::Action::Clean.new(LoggerIO.new).run({ 'certnames' => [node] })
     else
       Puppet.info _("Not managing %{node} certs as this host is not a CA") % { node: node }

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -73,4 +73,4 @@ Puppet.features.add(:manages_symlinks) do
   end
 end
 
-Puppet.features.add(:puppetserver_ca, libs: ['puppetserver/ca'])
+Puppet.features.add(:puppetserver_ca, libs: ['puppetserver/ca', 'puppetserver/ca/action/clean'])

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -573,6 +573,7 @@ ERROR_STRING
       end
     end
   end
+  public :download_certificate_from_ca
 
   # Returns the file path for the named certificate, based on this host's
   # configuration.

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -154,15 +154,14 @@ class Puppet::SSL::Host
     raise Puppet::Error, _("No certificate to validate.") unless cert
     raise Puppet::Error, _("No private key with which to validate certificate with fingerprint: %{fingerprint}") % { fingerprint: cert.fingerprint } unless key
     unless cert.content.check_private_key(key.content)
-      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: cert.fingerprint, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
+      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: cert.fingerprint, cert_name: Puppet[:certname] }
 The certificate retrieved from the master does not match the agent's private key. Did you forget to run as root?
 Certificate fingerprint: %{fingerprint}
 To fix this, remove the certificate from both the master and the agent and then start a puppet run, which will automatically regenerate a certificate.
 On the master:
   puppetserver ca clean --certname %{cert_name}
 On the agent:
-  1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
-  1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f
+  1. puppet ssl clean
   2. puppet agent -t
 ERROR_STRING
     end
@@ -237,15 +236,14 @@ ERROR_STRING
 
   def validate_local_csr_with_key(csr, key)
     if key.content.public_key.to_s != csr.content.public_key.to_s
-      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: csr.fingerprint, csr_public_key: csr.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
+      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: csr.fingerprint, csr_public_key: csr.content.public_key.to_text, agent_public_key: key.content.public_key.to_text }
 The local CSR does not match the agent's public key.
 CSR fingerprint: %{fingerprint}
 CSR public key: %{csr_public_key}
 Agent public key: %{agent_public_key}
 To fix this, remove the CSR from the agent and then start a puppet run, which will automatically regenerate a CSR.
 On the agent:
-  1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
-  1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f
+  1. puppet ssl clean
   2. puppet agent -t
 ERROR_STRING
     end
@@ -254,7 +252,7 @@ ERROR_STRING
 
   def validate_csr_with_key(csr, key)
     if key.content.public_key.to_s != csr.content.public_key.to_s
-      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: csr.fingerprint, csr_public_key: csr.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname], ssl_dir: Puppet[:ssldir], cert_dir: Puppet[:certdir].gsub('/', '\\') }
+      raise Puppet::Error, _(<<ERROR_STRING) % { fingerprint: csr.fingerprint, csr_public_key: csr.content.public_key.to_text, agent_public_key: key.content.public_key.to_text, cert_name: Puppet[:certname] }
 The CSR retrieved from the master does not match the agent's public key.
 CSR fingerprint: %{fingerprint}
 CSR public key: %{csr_public_key}
@@ -263,8 +261,7 @@ To fix this, remove the CSR from both the master and the agent and then start a 
 On the master:
   puppetserver ca clean --certname %{cert_name}
 On the agent:
-  1a. On most platforms: find %{ssl_dir} -name %{cert_name}.pem -delete
-  1b. On Windows: del "%{cert_dir}\\%{cert_name}.pem" /f
+  1. puppet ssl clean
   2. puppet agent -t
 ERROR_STRING
     end

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -49,16 +49,10 @@ module Puppet
       @crl.add_revoked(revoked)
     end
 
-    def generate_client(name, opts)
-      host_key = OpenSSL::PKey::RSA.new(1024)
-      csr = create_csr(name, host_key)
-      { private_key: host_key, csr: csr, cert: sign(csr, opts).content }
-    end
-
     def generate(name, opts)
       host_key = OpenSSL::PKey::RSA.new(1024)
       csr = create_csr(name, host_key)
-      sign(csr, opts)
+      { private_key: host_key, csr: csr, cert: sign(csr, opts).content }
     end
 
     private

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -49,6 +49,12 @@ module Puppet
       @crl.add_revoked(revoked)
     end
 
+    def generate_client(name, opts)
+      host_key = OpenSSL::PKey::RSA.new(1024)
+      csr = create_csr(name, host_key)
+      { private_key: host_key, csr: csr, cert: sign(csr, opts).content }
+    end
+
     def generate(name, opts)
       host_key = OpenSSL::PKey::RSA.new(1024)
       csr = create_csr(name, host_key)

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -292,5 +292,24 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
         }.to exit_with(0)
       }.to_not output(%r{Deleted #{Puppet[:hostprivkey]}}).to_stdout
     end
+
+    context 'when deleting local CA' do
+      before do
+        ssl.command_line.args << '--localca'
+        ssl.parse_options
+      end
+
+      it 'deletes the local CA cert' do
+        File.open(Puppet[:localcacert], 'w') { |f| f.write(@ca_cert.to_pem) }
+
+        expects_command_to_output(%r{Deleted #{Puppet[:localcacert]}}, 0)
+      end
+
+      it 'deletes the local CRL' do
+        File.open(Puppet[:hostcrl], 'w') { |f| f.write(@crl.to_pem) }
+
+        expects_command_to_output(%r{Deleted #{Puppet[:hostcrl]}}, 0)
+      end
+    end
   end
 end

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     @ca = Puppet::TestCa.new
     @ca_cert = @ca.ca_cert
     @crl = @ca.ca_crl
-    @host = @ca.generate_client('ssl-client', {})
+    @host = @ca.generate('ssl-client', {})
   end
 
   before do

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -312,6 +312,15 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       }.to_not output(%r{Removed private key #{Puppet[:hostprivkey]}}).to_stdout
     end
 
+    it "raises if we fail to retrieve server's cert that we're about to clean" do
+      Puppet[:certname] = name
+      Puppet[:server] = name
+
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_raise(Errno::ECONNREFUSED)
+
+      expects_command_to_fail(%r{Failed to connect to the CA to determine if certificate #{name} has been cleaned})
+    end
+
     context 'when deleting local CA' do
       before do
         ssl.command_line.args << '--localca'

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -75,6 +75,12 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     end
   end
 
+  it 'uses the agent run mode' do
+    # make sure the ssl app resolves certname, server, etc
+    # the same way the agent application does
+    expect(ssl.class.run_mode.name).to eq(:agent)
+  end
+
   context 'when generating help' do
     it 'prints a message when an unknown action is specified' do
       ssl.command_line.args << 'whoops'

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -256,31 +256,31 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     it 'deletes the hostcert' do
       File.open(Puppet[:hostcert], 'w') { |f| f.write(@host[:cert].to_pem) }
 
-      expects_command_to_output(%r{Deleted #{Puppet[:cert]}}, 0)
+      expects_command_to_output(%r{Removed certificate #{Puppet[:cert]}}, 0)
     end
 
     it 'deletes the private key' do
       File.open(Puppet[:hostprivkey], 'w') { |f| f.write(@host[:private_key].to_pem) }
 
-      expects_command_to_output(%r{Deleted #{Puppet[:hostprivkey]}}, 0)
+      expects_command_to_output(%r{Removed private key #{Puppet[:hostprivkey]}}, 0)
     end
 
     it 'deletes the public key' do
       File.open(Puppet[:hostpubkey], 'w') { |f| f.write(@host[:private_key].public_key.to_pem) }
 
-      expects_command_to_output(%r{Deleted #{Puppet[:hostpubkey]}}, 0)
+      expects_command_to_output(%r{Removed public key #{Puppet[:hostpubkey]}}, 0)
     end
 
     it 'deletes the request' do
       File.open(Puppet[:hostcsr], 'w') { |f| f.write(@host[:csr].to_pem) }
 
-      expects_command_to_output(%r{Deleted #{Puppet[:hostcsr]}}, 0)
+      expects_command_to_output(%r{Removed certificate request #{Puppet[:hostcsr]}}, 0)
     end
 
     it 'deletes the passfile' do
       File.open(Puppet[:passfile], 'w') { |_| }
 
-      expects_command_to_output(%r{Deleted #{Puppet[:passfile]}}, 0)
+      expects_command_to_output(%r{Removed private key password file #{Puppet[:passfile]}}, 0)
     end
 
     it 'skips files that do not exist' do
@@ -290,7 +290,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
         expect {
           ssl.run_command
         }.to exit_with(0)
-      }.to_not output(%r{Deleted #{Puppet[:hostprivkey]}}).to_stdout
+      }.to_not output(%r{Removed private key #{Puppet[:hostprivkey]}}).to_stdout
     end
 
     context 'when deleting local CA' do
@@ -302,13 +302,13 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       it 'deletes the local CA cert' do
         File.open(Puppet[:localcacert], 'w') { |f| f.write(@ca_cert.to_pem) }
 
-        expects_command_to_output(%r{Deleted #{Puppet[:localcacert]}}, 0)
+        expects_command_to_output(%r{Removed local CA certificate #{Puppet[:localcacert]}}, 0)
       end
 
       it 'deletes the local CRL' do
         File.open(Puppet[:hostcrl], 'w') { |f| f.write(@crl.to_pem) }
 
-        expects_command_to_output(%r{Deleted #{Puppet[:hostcrl]}}, 0)
+        expects_command_to_output(%r{Removed local CRL #{Puppet[:hostcrl]}}, 0)
       end
     end
   end

--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -2,8 +2,6 @@
 require 'spec_helper'
 require 'puppet/face'
 
-require 'puppetserver/ca/cli'
-
 describe Puppet::Face[:node, '0.0.1'] do
   describe '#cleanup' do
     it "should clean everything" do
@@ -90,7 +88,7 @@ describe Puppet::Face[:node, '0.0.1'] do
         end
       end
 
-      describe "when cleaning certificate" do
+      describe "when cleaning certificate", :if => Puppet.features.puppetserver_ca? do
         it "should call the CA CLI gem's clean action" do
           Puppetserver::Ca::Action::Clean.any_instance.expects(:run).with({ 'certnames' => ['hostname'] }).returns(0)
           subject.clean_cert('hostname')

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -97,7 +97,7 @@ describe Puppet::Network::HTTP::Connection do
       :verify => ConstantErrorValidator.new(
         :fails_with => 'hostname was not match with server certificate',
         :peer_certs => [Puppet::TestCa.new.generate('not_my_server',
-                                                    :subject_alt_names => 'DNS:foo,DNS:bar,DNS:baz,DNS:not_my_server').content]))
+                                                    :subject_alt_names => 'DNS:foo,DNS:bar,DNS:baz,DNS:not_my_server')[:cert]]))
 
       expect do
         connection.get('request')
@@ -120,7 +120,7 @@ describe Puppet::Network::HTTP::Connection do
     it "should check all peer certificates for upcoming expiration", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       Puppet[:confdir] = tmpdir('conf')
       cert = Puppet::TestCa.new.generate('server',
-                                         :subject_alt_names => 'DNS:foo,DNS:bar,DNS:baz,DNS:server')
+                                         :subject_alt_names => 'DNS:foo,DNS:bar,DNS:baz,DNS:server')[:cert]
 
       connection = Puppet::Network::HTTP::Connection.new(
         host, port,


### PR DESCRIPTION
Adds a `puppet ssl clean` action to delete a host's client cert, private key, public key, CSR and private key password file. Only the current host's files are deleted based on the `$certname` setting.

If the `--localca` option is specified, then the host's local copy of the CA certificate and CRL bundle are deleted.