### PR TITLE
(PUP-9211) Don't emit location error with subsr path

### DIFF
--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -623,9 +623,9 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   def is_parent_dir_of(parent_dir, child_dir)
     parent_dir_path = Pathname.new(parent_dir)
-    clean_parent = parent_dir_path.cleanpath
+    clean_parent = parent_dir_path.cleanpath.to_s + File::SEPARATOR
 
-    return child_dir.to_s.start_with?(clean_parent.to_s)
+    return child_dir.to_s.start_with?(clean_parent)
   end
 
   def dir_to_names(relative_path)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -113,6 +113,18 @@ describe "validating 4x" do
     end
   end
 
+  it 'should not raise error when one modulepath is a substring of another' do
+    with_environment(environment, modulepath: ['path', 'pathplus']) do
+      expect(validate(parse('class aaa::ccc() {}', 'pathplus/aaa/manifests/ccc.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
+  end
+
+  it 'should not raise error when a modulepath ends with a file separator' do
+    with_environment(environment, modulepath: ['path/']) do
+      expect(validate(parse('class aaa::ccc() {}', 'pathplus/aaa/manifests/ccc.pp'))).not_to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_LOCATION)
+    end
+  end
+
   it 'should raise error for illegal type names' do
     expect(validate(parse('type ::Aaa = Any'))).to have_issue(Puppet::Pops::Issues::ILLEGAL_DEFINITION_NAME)
   end


### PR DESCRIPTION
Before this change, when an earlier module path is a substring of a later module path, puppet would give a location deprecation warning for items in the later path.
This change prevents those incorrect warnings from being created.
