### PR TITLE
(maint) Update dev dep of puppetserver-ca to 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group(:features) do
   # gem 'ruby-augeas', require: false, platforms: [:ruby]
   # requires native ldap headers/libs
   # gem 'ruby-ldap', '~> 0.9', require: false, platforms: [:ruby]
-  gem 'puppetserver-ca', '~> 0.5', require: false
+  gem 'puppetserver-ca', '~> 1.1', require: false
 end
 
 group(:test) do


### PR DESCRIPTION
Previously we pulled in a pre-1.0 version of puppetserver-ca as a
development dependency. With Puppet Server 6.0.0 we shipped 1.0.0 and
consequently developers should have a 1+ version available during
development.

This updates to the latest y release of puppetserver-ca and ensures the
bundle installs should receive the latest y release of the 1 major
series.