### PR TITLE
(maint) Add pre-suite step to register puppetres.dll

### DIFF
--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -7,5 +7,8 @@
   'use-service'                => true, # use service scripts to start/stop stuff
   'puppetservice'              => 'puppetserver',
   'puppetserver-confdir'       => '/etc/puppetlabs/puppetserver/conf.d',
-  'puppetserver-config'        => '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
+  'puppetserver-config'        => '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf',
+  :pre_suite                   => [
+    "setup/git/000_register_puppetres_dll.rb"
+  ]
 }

--- a/acceptance/setup/git/000_register_puppetres_dll.rb
+++ b/acceptance/setup/git/000_register_puppetres_dll.rb
@@ -1,0 +1,12 @@
+test_name "Register puppetres.dll on any windows agents" do
+
+  agents.each do |host|
+    next unless host['platform'] =~ /windows/
+    app_name = 'HKLM\\\\SYSTEM\\\\CurrentControlSet\\\\services\\\\eventlog\\\\Application\\\\Puppet'
+    puppetres_dll_cygpath = on(host, "find /cygdrive/c -type f -name puppetres.dll").stdout.chomp
+    puppetres_dll = on(host, "cygpath -m \"#{puppetres_dll_cygpath}\"").stdout.chomp
+    on host, "REG ADD #{app_name}"
+    on host, "REG ADD #{app_name} /v EventMessageFile /t REG_SZ /d '#{puppetres_dll.tr('/', '\\')}'"
+    on host, "REG ADD #{app_name} /v TypesSupported /t REG_DWORD /d 7"
+  end
+end


### PR DESCRIPTION
We install puppetres.dll as a part of running install.rb on windows, but
we don't want to run that file when running git-based acceptance tests.
So we need to create a pre-suite that handles registering puppetres.dll
on windows before we run any tests.