### PR TITLE
(maint) FreeBSD package provider improvements (pkgng)

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -16,12 +16,16 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
     pkg(['query', '-a', '%n %v %o'])
   end
 
-  def self.get_version_list
-    pkg(['version', '-voRL='])
+  def self.cached_version_list
+    @version_list ||= get_version_list
   end
 
-  def self.get_latest_version(origin, version_list)
-    if latest_version = version_list.lines.find { |l| l =~ /^#{origin} / }
+  def self.get_version_list
+    @version_list = pkg(['version', '-voRL='])
+  end
+
+  def self.get_latest_version(origin)
+    if latest_version = cached_version_list.lines.find { |l| l =~ /^#{origin} / }
       latest_version = latest_version.split(' ').last.split(')').first
       return latest_version
     end
@@ -32,7 +36,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
     packages = []
     begin
       info = self.get_query
-      version_list = self.get_version_list
+      get_version_list
 
       unless info
         return packages
@@ -41,7 +45,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
       info.lines.each do |line|
 
         name, version, origin = line.chomp.split(" ", 3)
-        latest_version  = get_latest_version(origin, version_list) || version
+        latest_version  = get_latest_version(origin) || version
 
         pkg = {
           :ensure   => version,

--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -137,6 +137,10 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
     @property_hash[:version]
   end
 
+  def version=
+    pkg(['install', '-qfy', "#{resource[:name]}-#{resource[:version]}"])
+  end
+
   # Upgrade to the latest version
   def update
     install

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.info
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.info
@@ -1,7 +1,0 @@
-ca_root_nss 3.15.3.1 security/ca_root_nss
-curl 7.33.0 ftp/curl
-gnupg 2.0.22 security/gnupg
-nmap 6.40 security/nmap
-pkg 1.2.4_1 ports-mgmt/pkg
-zsh 5.0.2_1 shells/zsh
-tac_plus F4.0.4.27a net/tac_plus4

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.query
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.query
@@ -1,1 +1,7 @@
-zsh-5.0.2                      The Z shell
+ca_root_nss 3.15.3.1 security/ca_root_nss
+curl 7.33.0 ftp/curl
+gnupg 2.0.22 security/gnupg
+nmap 6.40 security/nmap
+pkg 1.2.4_1 ports-mgmt/pkg
+zsh 5.0.2_1 shells/zsh
+tac_plus F4.0.4.27a net/tac_plus4

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.query.zsh
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.query.zsh
@@ -1,0 +1,1 @@
+zsh 5.0.2_1 shells/zsh

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.query_absent
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.query_absent
@@ -1,1 +1,0 @@
-pkg: No package(s) matching bash

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -164,13 +164,15 @@ describe provider_class do
   describe "get_latest_version" do
     it "should rereturn nil when the current package is the latest" do
       version_list = File.read(my_fixture('pkg.version'))
-      nmap_latest_version = provider_class.get_latest_version('security/nmap', version_list)
+      provider_class.stubs(:get_version_list).returns(version_list)
+      nmap_latest_version = provider_class.get_latest_version('security/nmap')
       expect(nmap_latest_version).to be_nil
     end
 
     it "should match the package name exactly" do
       version_list = File.read(my_fixture('pkg.version'))
-      bash_comp_latest_version = provider_class.get_latest_version('shells/bash-completion', version_list)
+      provider_class.stubs(:get_version_list).returns(version_list)
+      bash_comp_latest_version = provider_class.get_latest_version('shells/bash-completion')
       expect(bash_comp_latest_version).to eq('2.1_3')
     end
   end

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -40,7 +40,7 @@ describe provider_class do
   before do
     provider_class.stubs(:command).with(:pkg) { '/usr/local/sbin/pkg' }
 
-    info = File.read(my_fixture('pkg.info'))
+    info = File.read(my_fixture('pkg.query'))
     provider_class.stubs(:get_query).returns(info)
 
     version_list = File.read(my_fixture('pkg.version'))

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -125,13 +125,14 @@ describe provider_class do
 
   context "#query" do
     it "should return the installed version if present" do
+      pkg_query_zsh = File.read(my_fixture('pkg.query.zsh'))
+      provider_class.stubs(:get_resource_info).with('zsh').returns(pkg_query_zsh)
       provider_class.prefetch({installed_name => installed_resource})
-      expect(installed_provider.query).to eq({:version=>'5.0.2_1'})
+      expect(installed_provider.query).to be >= {:version=>'5.0.2_1'}
     end
 
     it "should return nil if not present" do
-      fixture = File.read(my_fixture('pkg.query_absent'))
-      provider_class.stubs(:get_resource_info).with('bash').returns(fixture)
+      provider_class.stubs(:get_resource_info).with('bash').raises(Puppet::ExecutionFailure, 'An error occurred')
       expect(provider.query).to equal(nil)
     end
   end

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -150,6 +150,8 @@ describe provider_class do
     end
 
     it "should call update to upgrade the version" do
+      provider_class.stubs(:get_resource_info).with('ftp/curl').returns('curl 7.61.1 ftp/curl')
+
       resource = Puppet::Type.type(:package).new(
         :name     => 'ftp/curl',
         :provider => pkgng,


### PR DESCRIPTION
These commits improve the pkgng provider used on FreeBSD.  The initial goal was to unbreak the mcollective_package_agent which was broken with the provider because the `#query` method itself was not working as expected.

While here, a few more minor improvements where introduced (unused fixtures removed, misnamed fixtures renamed).