### PR TITLE
(maint) Change osx user gid check

### DIFF
--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -30,6 +30,7 @@ agents.each do |host|
     if host['platform'] =~ /osx/
         match = result.stdout.match(/gid: (\d+)/)
         user_gid = match ? match[1] : nil
+        user_gid ||= result.stdout.split(':')[3]
     elsif host['platform'] =~ /aix/
         match = result.stdout.match(/pgrp=([^\s\\]+)/)
         user_gid = match ? host.group_gid(match[1]) : nil

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -28,6 +28,7 @@ agents.each do |host|
     if host['platform'] =~ /osx/
         match = result.stdout.match(/gid: (\d+)/)
         user_gid1 = match ? match[1] : nil
+        user_gid1 ||= result.stdout.split(':')[3]
     else
         user_gid1 = result.stdout.split(':')[3]
     end
@@ -44,6 +45,7 @@ agents.each do |host|
     if host['platform'] =~ /osx/
         match = result.stdout.match(/gid: (\d+)/)
         user_gid2 = match ? match[1] : nil
+        user_gid2 ||= result.stdout.split(':')[3]
     else
         user_gid2 = result.stdout.split(':')[3]
     end


### PR DESCRIPTION
Beaker 4 changes how we get the user gid. In earlier versions of beaker,
we run `dscacheutil -q user -a name #{name}`, but in beaker 4 we switch
to `id -P #{name}`. Since this test is currently run with beaker 3, and
we're getting ready to switch it to beaker 4, we need this test to be
able to handle both methods of parsing the user gid.