### PR TITLE
(PUP-8002) Use new resource initialization methods when realizing

### DIFF
--- a/lib/puppet/pops/evaluator/collectors/abstract_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/abstract_collector.rb
@@ -51,7 +51,9 @@ class Puppet::Pops::Evaluator::Collectors::AbstractCollector
 
       objects.each do |res|
         unless @collected.include?(res.ref)
-          newres = Puppet::Parser::Resource.new(res.type, res.title, @overrides)
+          t = res.type
+          t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t)
+          newres = Puppet::Parser::Resource.new(t, res.title, @overrides)
           scope.compiler.add_override(newres)
         end
       end


### PR DESCRIPTION
Prior to this commit, the resource collection code used a pre-pops
API for finding resource types. This triggered the same error as
exported/collected resources ran into in PDB-3734.

This patch updates the code to use the new pops-related API for
finding resources, similar to the fix for the puppetdb terminus,
but without the conditions excluding classes and nodes since they
could be valid in this context.