### PR TITLE
(maint) Test fix: reference host not agent

### DIFF
--- a/acceptance/tests/apply/hashes/should_not_reassign.rb
+++ b/acceptance/tests/apply/hashes/should_not_reassign.rb
@@ -12,6 +12,6 @@ $my_hash['one']='1.5'
 agents.each do |host|
   apply_manifest_on(host, manifest, :acceptable_exit_codes => [1]) do
     expected_error_message = "Illegal attempt to assign via [index/key]. Not an assignable reference"
-    fail_test("didn't find the failure") unless stderr.include?(expected_error_message) || agent['locale'] == 'ja'
+    fail_test("didn't find the failure") unless stderr.include?(expected_error_message) || host['locale'] == 'ja'
   end
 end


### PR DESCRIPTION
In this loop, though we're only acting on our hosts classified as
`agent`, we're assigning each agent host the name `host`, not `agent`.
So the test needs to be updated to reflect that assignment.