### PR TITLE
(maint) Reset language for every agent 

### DIFF
--- a/acceptance/tests/i18n/check_puppet_run_message.rb
+++ b/acceptance/tests/i18n/check_puppet_run_message.rb
@@ -11,8 +11,8 @@ test_name 'C100559: puppet agent run output with a supported language should be 
   require 'puppet/acceptance/i18n_utils'
   extend Puppet::Acceptance::I18nUtils
 
-  language = 'ja_JP'
   agents.each do |agent|
+    language = 'ja_JP'
 
     step("ensure #{language} locale is configured") do
       language = enable_locale_language(agent, language)


### PR DESCRIPTION
We want to make sure we're resetting the language for every host. If we
have multiple servers classified as an agent, there's a potential we
reset what `language` is. So instead of `ja_JP`, we could have
`ja_JP.uft8`. This isn't so ideal on ubuntu, for example, where
`locale-gen` doesn't recognize `ja_JP.uft8` as a language, where it
would recognize `ja_JP`. Generating `ja_JP` will then fail, and the test
itself will also fail.