### PR TITLE
(PUP-9106) Output mode warning using octal number

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -329,13 +329,13 @@ module Puppet::Util::Windows::Security
       # should not be done.  We can trap these instances and correct them before being applied.
       if (sd.owner == well_known_system_sid) && (owner_allow != FILE::FILE_ALL_ACCESS)
         #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the owner, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode, path: path }
+        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the owner, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
         owner_allow = FILE::FILE_ALL_ACCESS
       end
 
       if (sd.group == well_known_system_sid) && (group_allow != FILE::FILE_ALL_ACCESS)
         #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the group, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode, path: path }
+        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the group, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
         group_allow = FILE::FILE_ALL_ACCESS
       end
     end


### PR DESCRIPTION
Previously when SYSTEM was being set to lower than Full Control a warning was
emitted however the mode in the warning was the base 10 representation of the
mode, not the octal version.  This commit changes the warning message to emit
the octal representation of the proposed mode.