### PR TITLE
(PUP-9297) Use file system permissions when storing reports on Windows

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -422,7 +422,10 @@ class Puppet::Configurer
   end
 
   def save_last_run_summary(report)
-    mode = Puppet.settings.setting(:lastrunfile).mode
+    # Pass nil to use file system inherited permissions, set by the Puppet Agent package.
+    mode = Puppet::Util::Platform.windows? ?
+      nil :
+      Puppet.settings.setting(:lastrunfile).mode
     Puppet::Util.replace_file(Puppet[:lastrunfile], mode) do |fh|
       fh.print YAML.dump(report.raw_summary)
     end

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -250,7 +250,9 @@ module Puppet::FileBucketFile
     # @return [void]
     # @api private
     def copy_bucket_file_to_contents_file(contents_file, bucket_file)
-      Puppet::Util.replace_file(contents_file, 0440) do |of|
+      # Pass nil to use file system inherited permissions, set by the Puppet Agent package.
+      mode = Puppet::Util::Platform.windows? ? nil : 0440
+      Puppet::Util.replace_file(contents_file, mode) do |of|
         # PUP-1044 writes all of the contents
         bucket_file.stream() do |src|
           FileUtils.copy_stream(src, of)

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -14,7 +14,9 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     filename = path(request.key)
     FileUtils.mkdir_p(File.dirname(filename))
 
-    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::BINARY) }
+    # Pass nil to use file system inherited permissions, set by the Puppet Agent package.
+    mode = Puppet::Util::Platform.windows? ? nil : 0660
+    Puppet::Util.replace_file(filename, mode) {|f| f.print to_json(request.instance).force_encoding(Encoding::BINARY) }
   rescue TypeError => detail
     Puppet.log_exception(detail, _("Could not save %{json} %{request}: %{detail}") % { json: self.name, request: request.key, detail: detail })
   end

--- a/lib/puppet/indirector/msgpack.rb
+++ b/lib/puppet/indirector/msgpack.rb
@@ -21,7 +21,9 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
     filename = path(request.key)
     FileUtils.mkdir_p(File.dirname(filename))
 
-    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_msgpack(request.instance) }
+    # Pass nil to use file system inherited permissions, set by the Puppet Agent package.
+    mode = Puppet::Util::Platform.windows? ? nil : 0660
+    Puppet::Util.replace_file(filename, mode) {|f| f.print to_msgpack(request.instance) }
   rescue TypeError => detail
     Puppet.log_exception(detail, _("Could not save %{name} %{request}: %{detail}") % { name: self.name, request: request.key, detail: detail })
   end

--- a/lib/puppet/reports/store.rb
+++ b/lib/puppet/reports/store.rb
@@ -32,7 +32,11 @@ Puppet::Reports.register_report(:store) do
     file = File.join(dir, name)
 
     begin
-      Puppet::Util.replace_file(file, 0640) do |fh|
+      # Mode 640 has known issues on Windows when the owner and group of the report file are SYSTEM
+      # which can occur when Puppet is running on a service.  Instead by passing nil we can use the
+      # file system inherited permissions, which are set by the Puppet Agent package.
+      mode = Puppet::Util::Platform.windows? ? nil: 0640
+      Puppet::Util.replace_file(file, mode) do |fh|
         fh.print to_yaml
       end
     rescue => detail

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -29,7 +29,9 @@ module Puppet::Util::Yaml
   end
 
   def self.dump(structure, filename)
-    Puppet::Util.replace_file(filename, 0660) do |fh|
+    # Pass nil to use file system inherited permissions, set by the Puppet Agent package.
+    mode = Puppet::Util::Platform.windows? ? nil : 0660
+    Puppet::Util.replace_file(filename, mode) do |fh|
       YAML.dump(structure, fh)
     end
   end

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -47,7 +47,8 @@ describe Puppet::Configurer do
       t2 = Time.now.tv_sec
 
       # sticky bit only applies to directories in windows
-      file_mode = Puppet.features.microsoft_windows? ? '666' : '100666'
+      # windows uses inherited permissions for this file
+      file_mode = Puppet.features.microsoft_windows? ? '2000700' : '100666'
 
       expect(Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode.to_s(8)).to eq(file_mode)
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -595,10 +595,11 @@ describe Puppet::Configurer do
       if Puppet::Util::Platform.windows?
         require 'puppet/util/windows/security'
         mode = Puppet::Util::Windows::Security.get_mode(Puppet[:lastrunfile])
+        expect(mode & 0777).to eq(0700)
       else
         mode = Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode
+        expect(mode & 0777).to eq(0664)
       end
-      expect(mode & 0777).to eq(0664)
     end
 
     it "should report invalid last run file permissions" do

--- a/spec/unit/reports/store_spec.rb
+++ b/spec/unit/reports/store_spec.rb
@@ -35,6 +35,30 @@ describe processor do
       Puppet::FileSystem.expects(:exist?).never
       expect { @report.process }.to raise_error(ArgumentError, /Invalid node/)
     end
+
+    context "when storing the report" do
+      context "and on Windows" do
+        before :each do
+          Puppet::Util::Platform.stubs(:windows?).returns(true)
+        end
+
+        it "does not set mode" do
+          Puppet::Util.expects(:replace_file).with() { |_path, mode| mode.nil? }
+          @report.process
+        end
+      end
+
+      context "and not on Windows" do
+        before :each do
+          Puppet::Util::Platform.stubs(:windows?).returns(false)
+        end
+
+        it "uses mode 640" do
+          Puppet::Util.expects(:replace_file).with() { |_path, mode| mode == 0640 }
+          @report.process
+        end
+      end
+    end
   end
 
   describe "::destroy" do


### PR DESCRIPTION
Previously when storing reports on Windows it tried to set mode 640.  Due to
PUP-9106 being merged, this was causing warnings to be emitted when the owner
and group were both SYSTEM.  This is because mode 640 doesn't make sense on
Windows when both the owner and group are SYSTEM and SYSTEM should always have
Full Control (770).  This commit modifies the report storing to use mode 640
when not on Windows, and when on Windows use a mode of nil, which indicates that
the default File System permissions will be used i.e. not explicitly set.  The
permissions for this file will normally come from the Puppet Agent package which
is now set to Administrators and SYSTEM full control by default.

- [x] Tests