### PR TITLE
(PUP-9175) Use modern version of Rake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,9 @@ group(:development, :test) do
   # be removed here *yet* due to TravisCI / AppVeyor which call:
   # bundle install --without development
   # PUP-7433 describes work necessary to restructure this
-  gem "rake", '~> 12.2.1', :require => false
+  gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2.1') if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2') if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0') # rubocop:disable Bundler/DuplicatedGem
+
   gem "rspec", "~> 3.1", :require => false
   gem "rspec-its", "~> 1.1", :require => false
   gem "rspec-collection_matchers", "~> 1.1", :require => false


### PR DESCRIPTION
Previously the version of Rake was pinned to an old Ruby 1.9 compatible version
however this is beginning to cause issues with compatibility in other gems,
for example the packaging gem.  This commit changes the rake requirement in the
gemfile to use the older version for old versions of Ruby (< 2.0) and uses a
more relaxed pin, protecting on major version, for newer Ruby versions (>= 2.0).

This commit also adds a RAKE_LOCATION environment variable which can be used in
any instance to specify the the version of Rake required, much like the FACTER
and HIERA variables.