### PR TITLE
(PUP-7580) Don't show the namevar to protect sensitive data.

### DIFF
--- a/lib/puppet/resource/catalog.rb
+++ b/lib/puppet/resource/catalog.rb
@@ -559,11 +559,7 @@ class Puppet::Resource::Catalog < Puppet::Graph::SimpleGraph
     Puppet::FileSystem.open(resourcefile.value, resourcefile.mode.to_i(8), "w:UTF-8") do |f|
       to_print = resources.map do |resource|
         next unless resource.managed?
-        if resource.name_var
-          "#{resource.type}[#{resource[resource.name_var]}]"
-        else
-          "#{resource.ref.downcase}"
-        end
+        "#{resource.ref.downcase}"
       end.compact
       f.puts to_print.join("\n")
     end

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -48,8 +48,8 @@ describe Puppet::Resource::Catalog, "when compiling" do
     catalog.add_resource(res, res2, res3, res4, comp_res)
     catalog.write_resource_file
     expect(File.readlines(resourcefile).map(&:chomp)).to match_array([
-      "file[#{File.expand_path('/tmp/sam')}]",
-      "exec[#{File.expand_path('/bin/rm')} -rf /]"
+      "file[#{res.title.downcase}]",
+      "exec[#{res2.title.downcase}]"
     ])
   end
 


### PR DESCRIPTION
Checking this in with a non-working unit test (and no code fix) so that I can collaborate with the team.
I was able to manually reproduce this with this short test.pp file:

$secret = Sensitive('cat /tmp/secret_file_name.txt')
exec { 'do it':
  command => $secret,
  path    => '/bin/'
}

However, I have not been able to reproduce with a unit test.