### PR TITLE
(PUP-9175) Allow specifying rake version from the environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 group(:test) do
   gem "json-schema", "~> 2.0", require: false
   gem "mocha", '~> 1.5.0', require: false
-  gem "rake", '~> 12.2.1', require: false
+  gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2')
   gem "rspec", "~> 3.1", require: false
   gem "rspec-its", "~> 1.1", require: false
   gem "rspec-collection_matchers", "~> 1.1", require: false


### PR DESCRIPTION
This is a cherry-pick of 6e88c554f9bcf168596f30ddeaf02b2358f73722 but
simplified because puppet 6 requires ruby 2.3 or greater.