### PR TITLE
(PUP-9106) Change messages to debug when SYSTEM ACE is not Full Control

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -329,13 +329,13 @@ module Puppet::Util::Windows::Security
       # should not be done.  We can trap these instances and correct them before being applied.
       if (sd.owner == well_known_system_sid) && (owner_allow != FILE::FILE_ALL_ACCESS)
         #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the owner, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
+        Puppet.debug _("An attempt to set mode %{mode} on item %{path} would result in the owner, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
         owner_allow = FILE::FILE_ALL_ACCESS
       end
 
       if (sd.group == well_known_system_sid) && (group_allow != FILE::FILE_ALL_ACCESS)
         #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-        Puppet.warning _("An attempt to set mode %{mode} on item %{path} would result in the group, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
+        Puppet.debug _("An attempt to set mode %{mode} on item %{path} would result in the group, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
         group_allow = FILE::FILE_ALL_ACCESS
       end
     end


### PR DESCRIPTION
Previously in commit 2a4ba1c9f2ac1b the set_mode method was changed so that it
was not possible to set an ACL which contained an ACE with SYSTEM, without
Full Control rights.  That commit emitted a warning when the SYSTEM mode was
changed from what was requested to Full Control.  However this caused issues
with some internal Puppet settings which caused Warnings to be emitted for
things a User had no control over.

A message is still required to be emitted because Puppet is changed a requested
behaviour.  This commit changes the message from a Warning to Debug.