### PR TITLE
(PUP-9244) Skip test on non-Windows

### DIFF
--- a/spec/unit/util/suidmanager_spec.rb
+++ b/spec/unit/util/suidmanager_spec.rb
@@ -121,9 +121,7 @@ describe Puppet::Util::SUIDManager do
       end
     end
 
-    it "should not get or set euid/egid on Windows" do
-      Puppet.features.stubs(:microsoft_windows?).returns true
-
+    it "should not get or set euid/egid on Windows", if: Puppet::Util::Platform.windows? do
       Puppet::Util::SUIDManager.asuser(user[:uid], user[:gid]) {}
 
       expect(xids).to be_empty


### PR DESCRIPTION
The stub was incorrect, but the test passed because we don't typically
run tests as root. Just confine the test to only run on Windows.