### PR TITLE
(maint) Remove duplicate rubocop, commits and warnings checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,20 @@ env:
 
 matrix:
   exclude:
+    - rvm: 2.4.0
+      env: "CHECK=rubocop"
     - rvm: 2.3.6
       env: "CHECK=rubocop"
     - rvm: jruby-9.2.0.0
       env: "CHECK=rubocop"
+    - rvm: 2.4.0
+      env: "CHECK=commits"
     - rvm: 2.3.6
       env: "CHECK=commits"
     - rvm: jruby-9.2.0.0
       env: "CHECK=commits"
+    - rvm: 2.4.0
+      env: "CHECK=warnings"
     - rvm: 2.3.6
       env: "CHECK=warnings"
     - rvm: jruby-9.2.0.0


### PR DESCRIPTION
We were running the same checks against ruby 2.4.0 and 2.5.1. Targeting
6.0.x, because 5.5.x doesn't test against 2.5.1. Also appveyor doesn't
have this issue.