### PR TITLE
(PUP-2175) Include the package provider in puppet resource's output

### DIFF
--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -6,15 +6,11 @@ test_name "Puppet returns only resource package declaration when querying an uni
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.
 
-  resource_declaration_regex = %r@package \{ 'not-installed-on-this-host':
-  ensure => '(?:purged|absent)',
-\}@m
-
   agents.each do |agent|
 
     step "test puppet resource package" do
       on(agent, puppet('resource', 'package', 'not-installed-on-this-host')) do
-        assert_match(resource_declaration_regex, stdout)
+        assert_match(/package.*not-installed-on-this-host.*\n.*ensure.*(?:absent|purged).*\n.*provider/, stdout)
       end
     end
 

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -583,7 +583,9 @@ class Puppet::Resource
         delete(attribute)
       end
 
-      parameters_to_include = options[:parameters_to_include] || []
+      parameters_to_include = resource_type.parameters_to_include
+      parameters_to_include += options[:parameters_to_include] || []
+
       delete(attribute) unless properties.include?(attribute) || parameters_to_include.include?(attribute)
     end
     self

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -391,6 +391,12 @@ class Type
     @key_attributes_cache ||= key_attribute_parameters.collect { |p| p.name }
   end
 
+  # Returns any parameters that should be included by default in puppet resource's output
+  # @return [Array<Symbol>] the parameters to include
+  def self.parameters_to_include
+    []
+  end
+
   # Returns a mapping from the title string to setting of attribute values.
   # This default implementation provides a mapping of title to the one and only _namevar_ present
   # in the type's definition.

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -271,6 +271,10 @@ module Puppet
     providify
     paramclass(:provider).isnamevar
 
+    def self.parameters_to_include
+      [:provider]
+    end
+
     # We have more than one namevar, so we need title_patterns. However, we
     # cheat and set the patterns to map to name only and completely ignore
     # provider. So far, the logic that determines uniqueness appears to just

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1082,6 +1082,18 @@ describe Puppet::Resource do
         newparam(:admits_to_age)
         newparam(:name)
       end
+
+      Puppet::Type.newtype('brown') do
+        newproperty(:ensure)
+        newparam(:admits_to_dying_hair)
+        newparam(:admits_to_age)
+        newparam(:hair_length)
+        newparam(:name)
+
+        def self.parameters_to_include
+          [:admits_to_dying_hair, :admits_to_age]
+        end
+      end
     end
 
     it "should strip all parameters and strip properties that are nil, empty or absent except for ensure" do
@@ -1123,6 +1135,25 @@ describe Puppet::Resource do
         :friends         => ['Oprah'],
       })
       )
+    end
+
+    context "when the resource type has a default set of parameters it wants to include" do
+      it "should leave those parameters alone" do
+        resource = Puppet::Resource.new("brown", "Esmeralda", :parameters => {
+          :admits_to_age        => true,
+          :admits_to_dying_hair => false,
+          :hair_length          => 10
+        })
+
+        pruned_resource = resource.prune_parameters
+        expected_resource = Puppet::Resource.new(
+          "brown",
+          "Esmeralda",
+          :parameters => { :admits_to_age => true, :admits_to_dying_hair => false }
+        )
+  
+        expect(pruned_resource).to eq(expected_resource)
+      end
     end
   end
 end


### PR DESCRIPTION
Knowing the provider of a given package resource is useful when it
differs from the operating system default.

Note that this commit also introduces a generic way for types to
specify any parameters they want included in puppet resource's
default output. All they need to do is override parameters_to_include
to return these parameters.