### PR TITLE
(PUP-9248) add support for devices to puppet ssl clean

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -305,7 +305,7 @@ Licensed under the Apache 2.0 License
             Puppet.settings.use :main, :agent, :ssl
             # ask for a ssl cert if needed, but at least
             # setup the ssl system for this device.
-            setup_host
+            setup_host(device.name)
 
             require 'puppet/configurer'
             configurer = Puppet::Configurer.new
@@ -354,8 +354,8 @@ Licensed under the Apache 2.0 License
     end
   end
 
-  def setup_host
-    @host = Puppet::SSL::Host.new
+  def setup_host(name)
+    @host = Puppet::SSL::Host.new(name, true)
     waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : Puppet[:waitforcert])
     @host.wait_for_cert(waitforcert)
   end

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -75,25 +75,25 @@ describe Puppet::Application::Device do
     it "should set waitforcert to 0 with --onetime and if --waitforcert wasn't given" do
       Puppet[:onetime] = true
       Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(0)
-      @device.setup_host
+      @device.setup_host('device.example.com')
     end
 
     it "should use supplied waitforcert when --onetime is specified" do
       Puppet[:onetime] = true
       @device.handle_waitforcert(60)
       Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(60)
-      @device.setup_host
+      @device.setup_host('device.example.com')
     end
 
     it "should use a default value for waitforcert when --onetime and --waitforcert are not specified" do
       Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(120)
-      @device.setup_host
+      @device.setup_host('device.example.com')
     end
 
     it "should use the waitforcert setting when checking for a signed certificate" do
       Puppet[:waitforcert] = 10
       Puppet::SSL::Host.any_instance.expects(:wait_for_cert).with(10)
-      @device.setup_host
+      @device.setup_host('device.example.com')
     end
 
     it "should set the log destination with --logdest" do
@@ -271,14 +271,14 @@ describe Puppet::Application::Device do
 
     it "should create a new ssl host" do
       Puppet::SSL::Host.expects(:new).returns(@host)
-      @device.setup_host
+      @device.setup_host('device.example.com')
     end
 
     it "should wait for a certificate" do
       @device.options.stubs(:[]).with(:waitforcert).returns(123)
       @host.expects(:wait_for_cert).with(123)
 
-      @device.setup_host
+      @device.setup_host('device.example.com')
     end
   end
 


### PR DESCRIPTION
Prior to this commit ...

  An SSL error involving a device prompts the user to run the 'puppet ssl clean'
  command which cleans agent ssl files instead of the device ssl files,
  and prompts the user to run 'puppet agent' instead of 'puppet device'.

With this commit ...

  An SSL error involving a device outputs valid commands for devices.
  Puppet::SSL::Host implements a 'device' parameter to specify it is a device.
  The 'puppet ssl clean' command implements a '--device CERTNAME' parameter.