### PR TITLE
(PUP-9250) Use the STDIN, STDOUT, STDERR constants in safe_posix_fork

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -479,9 +479,13 @@ module Util
 
   def safe_posix_fork(stdin=$stdin, stdout=$stdout, stderr=$stderr, &block)
     child_pid = Kernel.fork do
-      $stdin.reopen(stdin)
-      $stdout.reopen(stdout)
-      $stderr.reopen(stderr)
+      STDIN.reopen(stdin)
+      STDOUT.reopen(stdout)
+      STDERR.reopen(stderr)
+
+      $stdin = STDIN
+      $stdout = STDOUT
+      $stderr = STDERR
 
       begin
         Dir.foreach('/proc/self/fd') do |f|


### PR DESCRIPTION
Previously, safe_posix_fork would reference the child process' stdin,
stdout, and stderr streams via. the global variables $stdin, $stdout,
and $stderr. This was not good because these are mutable variables;
they may not always point to the right thing. However the STDIN, STDOUT
and STDERR constants do point to the child process' stdin, stdout and
stderr streams. This commit uses these constants instead of the global
variables.