### PR TITLE
(PUP-9217) Rename property to raise prefetch errors

### DIFF
--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/parsedfile'
 
-Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :swallow_prefetch_errors => false) do
+Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :raise_prefetch_errors => true) do
   commands :crontab => "crontab"
 
   text_line :comment, :match => %r{^\s*#}, :post_parse => proc { |record|


### PR DESCRIPTION
The property formerly called `swallow_prefetch_errors` is better suited
renamed to `raise_prefetch_errors`, so this renames that property before
it is used anywhere.