### PR TITLE
(PUP-9254) add eval function

### DIFF
--- a/lib/puppet/functions/eval.rb
+++ b/lib/puppet/functions/eval.rb
@@ -1,0 +1,47 @@
+# Evaluates a string containing Puppet Language source.
+# The primary intended use case is to combine eval with
+# Deferred to enable evaluating arbitrary code on the agent side
+# when applying a catalog.
+#
+# @example Using `eval`
+#
+# ```puppet
+# eval("\$x + \$y", { 'x' => 10, 'y' => 20}) # produces 30
+# ```
+#
+# Note the escaped `$` characters since interpolation is unwanted.
+#
+# ```puppet
+# Deferred('eval' ["$x + $y", { 'x' => 10, 'y' => 20})] # produces 30 on the agent
+# ```
+#
+# This function can be used when there is the need to format or transform deferred
+# values since doing that with only deferred values can be difficult to construct
+# or impossible to achieve when a lambda is needed.
+#
+# @example Evaluating logic on agent requiring use of "filter"
+#
+# ```puppet
+# Deferred('eval', "local_lookup('key').filter |\$x| { \$x =~ Integer }")
+# ```
+#
+# To assert the return type - this is simply done by calling `assert_type`
+# as part of the string to evaluate.
+#
+# @example
+# ```puppet
+# eval("assert_type(Integer, \$x + \$y))", { 'x' => 10, 'y' => 20})
+# ```
+# @since 6.1.0
+#
+Puppet::Functions.create_function(:eval, Puppet::Functions::InternalFunction) do
+  dispatch :eval_puppet do
+    compiler_param
+    param 'String', :code
+    optional_param 'Hash[String, Any]', :variables
+  end
+
+  def eval_puppet(compiler, code, variables = {})
+    compiler.in_local_scope(variables) { compiler.evaluate_string(code) }
+  end
+end

--- a/lib/puppet/functions/eval.rb
+++ b/lib/puppet/functions/eval.rb
@@ -12,7 +12,7 @@
 # Note the escaped `$` characters since interpolation is unwanted.
 #
 # ```puppet
-# Deferred('eval' ["$x + $y", { 'x' => 10, 'y' => 20})] # produces 30 on the agent
+# Deferred('eval' ["\$x + \$y", { 'x' => 10, 'y' => 20})] # produces 30 on the agent
 # ```
 #
 # This function can be used when there is the need to format or transform deferred

--- a/lib/puppet/pal/catalog_compiler.rb
+++ b/lib/puppet/pal/catalog_compiler.rb
@@ -37,7 +37,7 @@ module Pal
       yield JsonCatalogEncoder.new(catalog, pretty: pretty, exclude_virtual: exclude_virtual)
     end
 
-    # Evaluates an AST obtained from `parse_string` or `parse_file` in topscope.
+    # Evaluates an AST obtained from `parse_string` or `parse_file` in current scope.
     # If the ast is a `Puppet::Pops::Model::Program` (what is returned from the `parse` methods, any definitions
     # in the program (that is, any function, plan, etc. that is defined will be made available for use).
     #
@@ -49,9 +49,9 @@ module Pal
         bridged = Puppet::Parser::AST::PopsBridge::Program.new(ast)
         # define all catalog types
         internal_compiler.environment.known_resource_types.import_ast(bridged, "")
-        bridged.evaluate(internal_compiler.topscope)
+        bridged.evaluate(current_scope)
       else
-        internal_evaluator.evaluate(topscope, ast)
+        internal_evaluator.evaluate(current_scope, ast)
       end
     end
 

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -65,8 +65,6 @@ class Dispatch < Evaluator::CallableSignature
 
   # @api private
   def weave(scope, args)
-    # Must be done late as PAL cannot be initialized until after all of puppet, and requiring PAL means also requiring puppet
-    require 'puppet_pal'
     # no need to weave if there are no injections
     if @injections.empty?
       args

--- a/spec/unit/functions/eval_spec.rb
+++ b/spec/unit/functions/eval_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the eval function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  it 'evaluates a string with puppet logic' do
+    notices = eval_and_collect_notices(<<-PUPPET)
+      $x = '1+2'
+      notice(['result is ', eval($x)].join)
+    PUPPET
+    expect(notices).to include('result is 3')
+  end
+
+  it 'sets variables in a local scope from a hash' do
+    notices = eval_and_collect_notices(<<-PUPPET)
+      $x = 'shadowed value'
+      notice(['result is ', eval('$x', {'x' => 42})].join)
+    PUPPET
+    expect(notices).to include('result is 42')
+  end
+
+  it 'variables set in the evaluated string are set in a local scope' do
+    notices = eval_and_collect_notices(<<-PUPPET)
+        $y = '$x = 42; $x'
+        notice(['result is ', eval($y)].join)
+        notice(['defined is ', defined('$x')].join)
+        PUPPET
+     expect(notices).to include('result is 42')
+     expect(notices).to include('defined is false')
+  end
+
+  it 'definitions in evaluated string are made available inside and after the eval' do
+    notices = eval_and_collect_notices(<<-PUPPET)
+        $y = 'function foo(Integer $x) { $x * 2 } foo(30)'
+        notice(['inside result is ', eval($y)].join)
+        notice(['after result is ', foo(10)].join)
+        PUPPET
+     expect(notices).to include('inside result is 60')
+     expect(notices).to include('after result is 20')
+  end
+
+end


### PR DESCRIPTION
This adds the function `eval(String $source_code, Optional[Hash[String[1], Any] $variables)` which evaluates the given `source_code` in a local scope after first having set any variables as given in the `variables` hash.