### PR TITLE
(PUP-7331) Don't chown existing files when added as a log

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -77,9 +77,10 @@ Puppet::Util::Log.newdesttype :file do
 
     # create the log file, if it doesn't already exist
     need_array_start = false
+    file_exists = File.exists?(path)
     if @json == 1
       need_array_start = true
-      if File.exists?(path)
+      if file_exists
         sz = File.size(path)
         need_array_start = sz == 0
 
@@ -93,7 +94,7 @@ Puppet::Util::Log.newdesttype :file do
     file.puts('[') if need_array_start
 
     # Give ownership to the user and group puppet will run as
-    if Puppet.features.root? && !Puppet::Util::Platform.windows?
+    if Puppet.features.root? && !Puppet::Util::Platform.windows? && !file_exists
       begin
         FileUtils.chown(Puppet[:user], Puppet[:group], path)
       rescue ArgumentError, Errno::EPERM

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -54,6 +54,7 @@ describe Puppet::Util::Log.desttypes[:file] do
         it_behaves_like "file destination"
 
         it "logs an error if it can't chown the file owner & group" do
+          File.expects(:exists?).with(abspath).returns(false)
           FileUtils.expects(:chown).with(Puppet[:user], Puppet[:group], abspath).raises(Errno::EPERM)
           Puppet.features.expects(:root?).returns(true)
           Puppet.expects(:err).with("Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{abspath}")
@@ -62,8 +63,17 @@ describe Puppet::Util::Log.desttypes[:file] do
         end
 
         it "doesn't attempt to chown when running as non-root" do
+          File.expects(:exists?).with(abspath).returns(false)
           FileUtils.expects(:chown).with(Puppet[:user], Puppet[:group], abspath).never
           Puppet.features.expects(:root?).returns(false)
+
+          @class.new(abspath)
+        end
+
+        it "doesn't attempt to chown when file already exists" do
+          File.expects(:exists?).with(abspath).returns(true)
+          FileUtils.expects(:chown).with(Puppet[:user], Puppet[:group], abspath).never
+          Puppet.features.expects(:root?).returns(true)
 
           @class.new(abspath)
         end


### PR DESCRIPTION
Before this change, if Puppet was run as root, it would (attempt to) chown any file added as a log destination to the Puppet user/group from the settings.  On some systems, this caused errors when the user or group did not exist.
With this change, Puppet will not chown pre-existing log files when they are added as logging destinations.
