### PR TITLE
(PUP-9257) Add pp syntax check to heredoc

### DIFF
--- a/lib/puppet/plugins/configuration.rb
+++ b/lib/puppet/plugins/configuration.rb
@@ -10,6 +10,8 @@ module Puppet::Plugins
     require 'puppet/plugins/syntax_checkers'
     require 'puppet/syntax_checkers/base64'
     require 'puppet/syntax_checkers/json'
+    require 'puppet/syntax_checkers/pp'
+    require 'puppet/syntax_checkers/epp'
 
     def self.load_plugins
       # Register extensions
@@ -17,7 +19,9 @@ module Puppet::Plugins
       {
         SyntaxCheckers::SYNTAX_CHECKERS_KEY => {
           'json' => Puppet::SyntaxCheckers::Json.new,
-          'base64' => Puppet::SyntaxCheckers::Base64.new
+          'base64' => Puppet::SyntaxCheckers::Base64.new,
+          'pp' => Puppet::SyntaxCheckers::PP.new,
+          'epp' => Puppet::SyntaxCheckers::EPP.new
         }
       }
     end

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -1028,8 +1028,12 @@ class EvaluatorImpl
 
   # Evaluates Puppet DSL Heredoc
   def eval_HeredocExpression o, scope
+    expr = o.text_expr.expr # Always a SublocatedExpression with an expression
     result = evaluate(o.text_expr, scope)
-    assert_external_syntax(scope, result, o.syntax, o.text_expr)
+    unless expr.is_a?(Model::LiteralString)
+      # When expr is a LiteralString, validation has already validated this
+      assert_external_syntax(scope, result, o.syntax, o.text_expr)
+    end
     result
   end
 

--- a/lib/puppet/pops/evaluator/external_syntax_support.rb
+++ b/lib/puppet/pops/evaluator/external_syntax_support.rb
@@ -3,11 +3,11 @@
 #
 require 'puppet/plugins/syntax_checkers'
 module Puppet::Pops::Evaluator::ExternalSyntaxSupport
-  def assert_external_syntax(scope, result, syntax, reference_expr)
+  def assert_external_syntax(_, result, syntax, reference_expr)
     # ignore 'unspecified syntax'
     return if syntax.nil? || syntax == ''
 
-    checker = checker_for_syntax(scope, syntax)
+    checker = checker_for_syntax(nil, syntax)
     # ignore syntax with no matching checker
     return unless checker
 
@@ -26,7 +26,7 @@ module Puppet::Pops::Evaluator::ExternalSyntaxSupport
   # Finds the most significant checker for the given syntax (most significant is to the right).
   # Returns nil if there is no registered checker.
   #
-  def checker_for_syntax(scope, syntax)
+  def checker_for_syntax(_, syntax)
     checkers_hash = Puppet.lookup(:plugins)[Puppet::Plugins::SyntaxCheckers::SYNTAX_CHECKERS_KEY]
     checkers_hash[lookup_keys_for_syntax(syntax).find {|x| checkers_hash[x] }]
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -1,5 +1,8 @@
+require 'puppet/pops/evaluator/external_syntax_support'
+
 module Puppet::Pops
 module Validation
+
 # A Validator validates a model.
 #
 # Validation is performed on each model element in isolation. Each method should validate the model element's state
@@ -12,6 +15,8 @@ module Validation
 #       This is however mostly valuable when validating model to model transformations, and is therefore T.B.D
 #
 class Checker4_0 < Evaluator::LiteralEvaluator
+  include Puppet::Pops::Evaluator::ExternalSyntaxSupport
+
   attr_reader :acceptor
   attr_reader :migration_checker
 
@@ -321,6 +326,14 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     if p.is_a?(Model::LambdaExpression)
       internal_check_no_capture(p, o)
       internal_check_parameter_name_uniqueness(p)
+    end
+  end
+
+  def check_HeredocExpression(o)
+    # Only check static text in heredoc
+    expr = o.text_expr.expr # Always a SublocatedExpression with an expression
+    if expr.is_a?(Model::LiteralString)
+      assert_external_syntax(nil, expr.value, o.syntax, o.text_expr)
     end
   end
 

--- a/lib/puppet/syntax_checkers/epp.rb
+++ b/lib/puppet/syntax_checkers/epp.rb
@@ -1,0 +1,34 @@
+# A syntax checker for JSON.
+# @api public
+require 'puppet/syntax_checkers'
+class Puppet::SyntaxCheckers::EPP < Puppet::Plugins::SyntaxCheckers::SyntaxChecker
+
+  # Checks the text for Puppet Language EPP syntax issues and reports them to the given acceptor.
+  #
+  # Error messages from the checker are capped at 100 chars from the source text.
+  #
+  # @param text [String] The text to check
+  # @param syntax [String] The syntax identifier in mime style (only accepts 'pp')
+  # @param acceptor [#accept] A Diagnostic acceptor
+  # @param source_pos [Puppet::Pops::Adapters::SourcePosAdapter] A source pos adapter with location information
+  # @api public
+  #
+  def check(text, syntax, acceptor, source_pos)
+    raise ArgumentError.new(_("EPP syntax checker: the text to check must be a String.")) unless text.is_a?(String)
+    raise ArgumentError.new(_("EPP syntax checker: the syntax identifier must be a String, e.g. pp")) unless syntax == 'epp'
+    raise ArgumentError.new(_("EPP syntax checker: invalid Acceptor, got: '%{klass}'.") % { klass: acceptor.class.name }) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
+
+    begin
+      Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.singleton.parse_string(text)
+    rescue => e
+      # Cap the message to 100 chars and replace newlines
+      msg = _("EPP syntax checker: \"%{message}\"") % { message: e.message().slice(0,500).gsub(/\r?\n/, "\\n") }
+
+      # TODO: improve the pops API to allow simpler diagnostic creation while still maintaining capabilities
+      # and the issue code. (In this case especially, where there is only a single error message being issued).
+      #
+      issue = Puppet::Pops::Issues::issue(:ILLEGAL_EPP) { msg }
+      acceptor.accept(Puppet::Pops::Validation::Diagnostic.new(:error, issue, source_pos.file, source_pos, {}))
+    end
+  end
+end

--- a/lib/puppet/syntax_checkers/pp.rb
+++ b/lib/puppet/syntax_checkers/pp.rb
@@ -1,0 +1,34 @@
+# A syntax checker for JSON.
+# @api public
+require 'puppet/syntax_checkers'
+class Puppet::SyntaxCheckers::PP < Puppet::Plugins::SyntaxCheckers::SyntaxChecker
+
+  # Checks the text for Puppet Language syntax issues and reports them to the given acceptor.
+  #
+  # Error messages from the checker are capped at 100 chars from the source text.
+  #
+  # @param text [String] The text to check
+  # @param syntax [String] The syntax identifier in mime style (only accepts 'pp')
+  # @param acceptor [#accept] A Diagnostic acceptor
+  # @param source_pos [Puppet::Pops::Adapters::SourcePosAdapter] A source pos adapter with location information
+  # @api public
+  #
+  def check(text, syntax, acceptor, source_pos)
+    raise ArgumentError.new(_("PP syntax checker: the text to check must be a String.")) unless text.is_a?(String)
+    raise ArgumentError.new(_("PP syntax checker: the syntax identifier must be a String, e.g. pp")) unless syntax == 'pp'
+    raise ArgumentError.new(_("PP syntax checker: invalid Acceptor, got: '%{klass}'.") % { klass: acceptor.class.name }) unless acceptor.is_a?(Puppet::Pops::Validation::Acceptor)
+
+    begin
+      Puppet::Pops::Parser::EvaluatingParser.singleton.parse_string(text)
+    rescue => e
+      # Cap the message to 100 chars and replace newlines
+      msg = _("PP syntax checker: \"%{message}\"") % { message: e.message().slice(0,500).gsub(/\r?\n/, "\\n") }
+
+      # TODO: improve the pops API to allow simpler diagnostic creation while still maintaining capabilities
+      # and the issue code. (In this case especially, where there is only a single error message being issued).
+      #
+      issue = Puppet::Pops::Issues::issue(:ILLEGAL_PP) { msg }
+      acceptor.accept(Puppet::Pops::Validation::Diagnostic.new(:error, issue, source_pos.file, source_pos, {}))
+    end
+  end
+end

--- a/spec/unit/face/parser_spec.rb
+++ b/spec/unit/face/parser_spec.rb
@@ -35,6 +35,21 @@ describe Puppet::Face[:parser, :current] do
         expect { parser.validate(manifest) }.to exit_with(1)
       end
 
+      it "validates static heredoc with specified syntax" do
+        manifest = file_containing('site.pp', "@(EOT:pp)
+          { invalid =>
+          EOT
+        ")
+        expect { parser.validate(manifest) }.to exit_with(1)
+      end
+
+      it "does not validates dynamic heredoc with specified syntax" do
+        manifest = file_containing('site.pp', "@(\"EOT\":pp)
+        {invalid => ${1+1}
+        EOT")
+        expect { parser.validate(manifest) }.to_not exit_with(1)
+      end
+
       it "runs error free when there are no validation errors" do
         expect {
             manifest = file_containing('site.pp', "notify { valid: }")

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1385,6 +1385,24 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       expect(parser.evaluate_string(scope, src)).to eq('dGhlIHF1aWNrIHJlZCBmb3g=')
     end
 
+    it "parses pp syntax checked specification" do
+      src = <<-CODE
+      @(END:pp)
+        $x = 42
+        |- END
+      CODE
+      expect(parser.evaluate_string(scope, src)).to eq('$x = 42')
+    end
+
+    it "parses epp syntax checked specification" do
+      src = <<-CODE
+      @(END:epp)
+        <% $x = 42 %><%= $x %>
+        |- END
+      CODE
+      expect(parser.evaluate_string(scope, src)).to eq('<% $x = 42 %><%= $x %>')
+    end
+
     it "parses json syntax checked specification with error and reports it" do
       src = <<-CODE
       @(END:json)
@@ -1401,6 +1419,24 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
         |- END
       CODE
       expect { parser.evaluate_string(scope, src)}.to raise_error(/Cannot parse invalid Base64 string/)
+    end
+
+    it "parses pp syntax checked specification with error and reports it" do
+      src = <<-CODE
+      @(END:pp)
+        $x ==== 42
+        |- END
+      CODE
+      expect{parser.evaluate_string(scope, src)}.to raise_error(/Invalid produced text having syntax: 'pp'/)
+    end
+
+    it "parses epp syntax checked specification with error and reports it" do
+      src = <<-CODE
+      @(END:epp)
+        <% $x ==== 42 %>
+        |- END
+      CODE
+      expect{parser.evaluate_string(scope, src)}.to raise_error(/Invalid produced text having syntax: 'epp'/)
     end
 
     it "parses interpolated heredoc expression" do


### PR DESCRIPTION
This adds syntax checkers for 'pp' and 'epp' to heredoc.
This is of value when sending a heredoc to a Deferred function as it is preferable to get syntax errors when compiling as opposed to when applying a catalog.

To use `@(EOT:pp)` for puppet, and `@(EOT:epp)` for EPP.