### PR TITLE
(PUP-9270) Fix broken raised error in legacy function loader

### DIFF
--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -33,10 +33,11 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
 
       # Validate what was loaded
       unless func_info.is_a?(Hash)
-        raise ArgumentError, _("The code loaded from %{source_ref} did not produce the expected 3x function info Hash when evaluated. Got '%{klass}'") % { source_ref: source_ref, klass: created.class }
+        # TRANSLATORS - the word 'newfunction' shoud not be translated as it is a method name.
+        raise ArgumentError, _("Illegal legacy function definition! The code loaded from %{source_ref} did not return the result of calling 'newfunction'. Got '%{klass}'") % { source_ref: source_ref, klass: func_info.class }
       end
       unless func_info[:name] == "function_#{typed_name.name()}"
-        raise ArgumentError, _("The code loaded from %{source_ref} produced mis-matched name, expected 'function_%{type_name}', got %{created_name}") % { 
+        raise ArgumentError, _("The code loaded from %{source_ref} produced mis-matched name, expected 'function_%{type_name}', got '%{created_name}'") % { 
           source_ref: source_ref, type_name: typed_name.name, created_name: func_info[:name] }
       end
     end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  newfunction(:bad_func_load, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    "the returned value"
+  end
+
+  def method_here_is_illegal()
+  end
+end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -429,6 +429,24 @@ describe 'loaders' do
     let(:scope) { compiler.topscope }
     let(:loader) { compiler.loaders.private_loader_for_module('user') }
 
+    before(:each) do
+      Puppet.push_context(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders)
+    end
+    after(:each) do
+      Puppet.pop_context
+    end
+
+    it "a 3x function with code outside body is reported as an error" do
+      expect { loader.load_typed(typed_name(:function, 'bad_func_load')) }.to raise_error(/Illegal legacy function definition/)
+    end
+  end
+
+  context 'when causing a 3x load followed by a 4x load' do
+    let(:env) { environment_for(mix_4x_and_3x_functions) }
+    let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
+    let(:scope) { compiler.topscope }
+    let(:loader) { compiler.loaders.private_loader_for_module('user') }
+
 
     before(:each) do
       Puppet.push_context(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders)


### PR DESCRIPTION
This fixes an error in ruby_legacy_function_instantiator when it
detects that a loaded 3x function is not the expected "func_info" hash.
Instead of getting a hash, something else is returned, and the raised
error should have reported the class name of what it got instead of a
hash, but it was copy pasted from elsewhere and ended up referencing
something that was not yet instantiated.

This fixes the error so that it reports the class name of the func_info
that it got.

The problem arises when someone has mocked functions in a way that makes
them not work as functions.