### PR TITLE
Revert "(PUP-9217) Change swallow_prefetch_errors => raise_prefetch_errors"

### DIFF
--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/parsedfile'
 
-Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :raise_prefetch_errors => true) do
+Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :swallow_prefetch_errors => false) do
   commands :crontab => "crontab"
 
   text_line :comment, :match => %r{^\s*#}, :post_parse => proc { |record|

--- a/lib/puppet/provider/parsedfile.rb
+++ b/lib/puppet/provider/parsedfile.rb
@@ -13,14 +13,14 @@ require 'puppet/util/fileparsing'
 #
 # NOTE: The prefetch method swallows FileReadErrors by treating the
 # corresponding target as an empty file. If you would like to turn this
-# behavior off, then set the raise_prefetch_errors class variable to
-# true. Doing so will error all resources associated with the failed
+# behavior off, then set the swallow_prefetch_errors class variable to
+# false. Doing so will error all resources associated with the failed
 # target.
 class Puppet::Provider::ParsedFile < Puppet::Provider
   extend Puppet::Util::FileParsing
 
   class << self
-    attr_accessor :default_target, :target, :raise_prefetch_errors
+    attr_accessor :default_target, :target, :swallow_prefetch_errors
   end
 
   attr_accessor :property_hash
@@ -95,7 +95,7 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
 
   # Flush all of the records relating to a specific target.
   def self.flush_target(target)
-    if @raise_prefetch_errors && @failed_prefetch_targets.key?(target)
+    if ! @swallow_prefetch_errors && @failed_prefetch_targets.key?(target)
       raise Puppet::Error, _("Failed to read %{target}'s records when prefetching them. Reason: %{detail}") % { target: target, detail: @failed_prefetch_targets[target] }
     end
 
@@ -154,7 +154,7 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
 
     # Hash of <target> => <failure reason>.
     @failed_prefetch_targets = {}
-    @raise_prefetch_errors = false
+    @swallow_prefetch_errors = true
 
     @target = nil
 
@@ -277,7 +277,7 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
     begin
       target_records = retrieve(target)
     rescue Puppet::Util::FileType::FileReadError => detail
-      if @raise_prefetch_errors
+      if ! @swallow_prefetch_errors
         # We will raise an error later in flush_target. This way,
         # only the resources linked to our target will fail
         # evaluation.


### PR DESCRIPTION
This is a public API, so unfortunately we can't do these sorts of
cleanups until Puppet 7.

This reverts commit c53697c5d358edc072a4aa01073dd0ec7d0eedb5.