### PR TITLE
(PUP-9292) Write windows service queries to ruby memory

### DIFF
--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -5,6 +5,9 @@ module Puppet::Util::Windows::File
   extend FFI::Library
   extend Puppet::Util::Windows::String
 
+  # https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
+  MAX_PATH = 260
+
   FILE_ATTRIBUTE_READONLY      = 0x00000001
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379607(v=vs.85).aspx


### PR DESCRIPTION
This commit updates the private query functions in the windows service util
module to write the contents of the query returns to ruby memory and returning
that instead of the actual query return.

It turns out the actual query return is freed before the functions were
exiting and we had a use-after-free scenario