### PR TITLE
(PUP-9294) Report illegal 3x function defining methods

### DIFF
--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -1,6 +1,7 @@
 # The RubyLegacyFunctionInstantiator instantiates a Puppet::Functions::Function given the ruby source
 # that calls Puppet::Functions.create_function.
 #
+require 'ripper'
 class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
   # Produces an instance of the Function class with the given typed_name, or fails with an error if the
   # given ruby source does not produce this instance when evaluated.
@@ -13,6 +14,7 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
   # @return [Puppet::Pops::Functions.Function] - an instantiated function with global scope closure associated with the given loader
   #
   def self.create(loader, typed_name, source_ref, ruby_code_string)
+    assert_code(ruby_code_string)
     unless ruby_code_string.is_a?(String) && ruby_code_string =~ /Puppet\:\:Parser\:\:Functions.*newfunction/m
       raise ArgumentError, _("The code loaded from %{source_ref} does not seem to be a Puppet 3x API function - no 'newfunction' call.") % { source_ref: source_ref }
     end
@@ -60,4 +62,27 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
     binding
   end
   private_class_method :get_binding
+
+  def self.assert_code(code_string)
+    ripped = Ripper.sexp(code_string)
+    return if ripped.nil?  # Let the next real parse crash and tell where and what is wrong
+    ripped.each {|x| walk(x) }
+  end
+
+  def self.walk(x)
+    return unless x.is_a?(Array)
+    # There should not be any calls to def in a 3x function
+    # Ripper returns an array [:def, ...] for a regular def name, and a [:defs ...] for a def self.name
+    if x[0] == :def || x[0] == :defs
+      identity_part = find_identity(x)
+      # assume there is nothing fancy and that there is always an array with name/line to use (or get nothing)
+      mname, mline = (identity_part.is_a?(Array) ? [identity_part[1], identity_part[2]] : [nil, nil]).map {|x| x.nil? ? '<unknown>' : x }
+      raise SecurityError, _("Illegal method definition of method '%{method_name}' on line %{line}' in legacy function") % { method_name: mname, line: mline }
+    end
+    x.each {|x| walk(x) }
+  end
+
+  def self.find_identity(rast)
+    rast.find{|x| x.is_a?(Array) && x[0] == :@ident }
+  end
 end

--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -85,7 +85,11 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
       identity_part = find_identity(x)
       # assume there is nothing fancy and that there is always an array with name/line to use (or get nothing)
       mname, mline = (identity_part.is_a?(Array) ? [identity_part[1], identity_part[2][1]] : [nil, nil]).map {|v| v.nil? ? '<unknown>' : v }
-      raise SecurityError, _("Illegal method definition of method '%{method_name}' on line %{line}' in legacy function") % { method_name: mname, line: mline }
+      raise SecurityError, _("Illegal method definition of method '%{method_name}' on line %{line}' in legacy function. See %{url} for more information") % { 
+        method_name: mname,
+        line: mline,
+        url: "https://puppet.com/docs/puppet/latest/functions_refactor_legacy.html"
+      }
     end
     x.each {|v| walk(v, result) }
   end

--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -84,10 +84,10 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
       # Ripper returns an array [:def, ...] for a regular def name, and a [:defs ...] for a def self.name
       identity_part = find_identity(x)
       # assume there is nothing fancy and that there is always an array with name/line to use (or get nothing)
-      mname, mline = (identity_part.is_a?(Array) ? [identity_part[1], identity_part[2]] : [nil, nil]).map {|x| x.nil? ? '<unknown>' : x }
+      mname, mline = (identity_part.is_a?(Array) ? [identity_part[1], identity_part[2][1]] : [nil, nil]).map {|v| v.nil? ? '<unknown>' : v }
       raise SecurityError, _("Illegal method definition of method '%{method_name}' on line %{line}' in legacy function") % { method_name: mname, line: mline }
     end
-    x.each {|x| walk(x, result) }
+    x.each {|v| walk(v, result) }
   end
   private_class_method :walk
 

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load2.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load2.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  x = newfunction(:bad_func_load2, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    "some return value"
+  end
+end
+def illegal_method_here
+end
+x

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load3.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load3.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  newfunction(:bad_func_load3, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    def bad_func_load3_illegal_method
+      "some return value from illegal method"
+    end
+    "some return value"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load4.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load4.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  newfunction(:bad_func_load4, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    def self.bad_func_load4_illegal_method
+      "some return value from illegal method"
+    end
+    "some return value"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load5.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load5.rb
@@ -1,0 +1,12 @@
+x = module Puppet::Parser::Functions
+  newfunction(:bad_func_load5, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    "some return value"
+  end
+end
+def self.bad_func_load5_illegal_method
+end
+# Attempt to get around problem of not returning what newfunction returns
+x

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -423,7 +423,7 @@ describe 'loaders' do
 
   end
 
-  context 'when causing a 3x load followed by a 4x load' do
+  context 'when a 3x load has illegal method added' do
     let(:env) { environment_for(mix_4x_and_3x_functions) }
     let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
     let(:scope) { compiler.topscope }
@@ -436,8 +436,30 @@ describe 'loaders' do
       Puppet.pop_context
     end
 
-    it "a 3x function with code outside body is reported as an error" do
-      expect { loader.load_typed(typed_name(:function, 'bad_func_load')) }.to raise_error(/Illegal legacy function definition/)
+    it "outside function body is reported as an error" do
+      expect { loader.load_typed(typed_name(:function, 'bad_func_load')) }.to raise_error(/Illegal method definition/)
+    end
+
+    it "to self outside function body is reported as an error" do
+      expect { loader.load_typed(typed_name(:function, 'bad_func_load5')) }.to raise_error(/Illegal method definition.*'bad_func_load5_illegal_method'/)
+    end
+
+    it "outside body is reported as an error even if returning the right func_info" do
+      expect { loader.load_typed(typed_name(:function, 'bad_func_load2'))}.to raise_error(/Illegal method definition/)
+    end
+
+    it "inside function body is reported as an error" do
+      expect { 
+        f = loader.load_typed(typed_name(:function, 'bad_func_load3')).value
+        f.call(scope)
+      }.to raise_error(/Illegal method definition.*'bad_func_load3_illegal_method'/)
+    end
+
+    it "to self inside function body is reported as an error" do
+      expect { 
+        f = loader.load_typed(typed_name(:function, 'bad_func_load4')).value
+        f.call(scope)
+      }.to raise_error(/Illegal method definition.*'bad_func_load4_illegal_method'/)
     end
   end
 


### PR DESCRIPTION
Before this, methods added in a legacy function implementation file
could reside a) inside the body given to `newfunction` or b) before or
after the call to `newfunction` in the `Puppet::Parser::Functions`
module. or c) outside the module, In all three cases the method could be added with a `def mname`
or `def self.mname` neither defining a method where the user expects it
to be added. 

This commit adds protection against these method definitions by raising
an error when they are added.