### PR TITLE
(maint) Bump travis to latest ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ script:
 notifications:
   email: false
 rvm:
-  - 2.4.0
-  - 2.3.6
-  - 2.2.9
-  - 2.1.9
-  - 2.0.0
+  - 2.4
+  - 2.3
+  - 2.2
+  - 2.1
+  - 2.0
   - 1.9.3
 
 env:
@@ -21,33 +21,33 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.4.0
+    - rvm: 2.4
       env: "CHECK=rubocop"
-    - rvm: 2.3.6
+    - rvm: 2.3
       env: "CHECK=rubocop"
-    - rvm: 2.2.9
+    - rvm: 2.2
       env: "CHECK=rubocop"
-    - rvm: 2.0.0
+    - rvm: 2.0
       env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
-    - rvm: 2.4.0
+    - rvm: 2.4
       env: "CHECK=commits"
-    - rvm: 2.3.6
+    - rvm: 2.3
       env: "CHECK=commits"
-    - rvm: 2.2.9
+    - rvm: 2.2
       env: "CHECK=commits"
-    - rvm: 2.0.0
+    - rvm: 2.0
       env: "CHECK=commits"
     - rvm: 1.9.3
       env: "CHECK=commits"
-    - rvm: 2.3.6
+    - rvm: 2.3
       env: "CHECK=warnings"
-    - rvm: 2.2.9
+    - rvm: 2.2
       env: "CHECK=warnings"
-    - rvm: 2.1.9
+    - rvm: 2.1
       env: "CHECK=warnings"
-    - rvm: 2.0.0
+    - rvm: 2.0
       env: "CHECK=warnings"
     - rvm: 1.9.3
       env: "CHECK=warnings"


### PR DESCRIPTION
Travis is having issues with ruby 2.4.0p0. Bump to latest 2.4 version.