### PR TITLE
(PUP-1542) Ensure errors during sync have some kind of error message

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -158,7 +158,9 @@ class Puppet::Transaction::ResourceHarness
       raise
     ensure
       if event
-        event.calculate_corrective_change(@persistence.get_system_value(context.resource.ref, param.name.to_s))
+        name = param.name.to_s
+        event.message ||= _("could not create change error message for %{name}") % { name: name }
+        event.calculate_corrective_change(@persistence.get_system_value(context.resource.ref, name))
         context.record(event)
         event.send_log
         context.synced_params << param.name


### PR DESCRIPTION
Without this change, Puppet will fail to log any message for some errors during sync.  With this change, there will be a minimal log message and the rest of the information will be preserved.