### PR TITLE
(PUP-9310) Make time datatypes work with integer and float

### DIFF
--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -67,7 +67,7 @@ module Types
       when Integer
         impl_class.new(arg * Time::NSECS_PER_SEC)
       when Float
-        (min ? -Float::INFINITY : Float::INFINITY) ? arg : impl_class.new(arg * Time::NSECS_PER_SEC)
+        impl_class.new(arg * Time::NSECS_PER_SEC)
       else
         raise ArgumentError, "Unable to create a #{impl_class.name} from a #{arg.class.name}" unless arg.nil? || arg == :default
         nil

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -65,9 +65,9 @@ module Types
       when String
         impl_class.parse(arg)
       when Integer
-        arg = impl_class.new(arg * Time::NSECS_PER_SEC)
+        impl_class.new(arg * Time::NSECS_PER_SEC)
       when Float
-        arg = (min ? -Float::INFINITY : Float::INFINITY) ? arg : impl_class.new(arg * Time::NSECS_PER_SEC)
+        (min ? -Float::INFINITY : Float::INFINITY) ? arg : impl_class.new(arg * Time::NSECS_PER_SEC)
       else
         raise ArgumentError, "Unable to create a #{impl_class.name} from a #{arg.class.name}" unless arg.nil? || arg == :default
         nil

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -65,9 +65,9 @@ module Types
       when String
         impl_class.parse(arg)
       when Integer
-        arg == impl_class.new(arg * Time::NSECS_PER_SEC)
+        arg = impl_class.new(arg * Time::NSECS_PER_SEC)
       when Float
-        arg == (min ? -Float::INFINITY : Float::INFINITY) ? arg : impl_class.new(arg * Time::NSECS_PER_SEC)
+        arg = (min ? -Float::INFINITY : Float::INFINITY) ? arg : impl_class.new(arg * Time::NSECS_PER_SEC)
       else
         raise ArgumentError, "Unable to create a #{impl_class.name} from a #{arg.class.name}" unless arg.nil? || arg == :default
         nil

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -74,8 +74,10 @@ describe 'Timespan type' do
             notice(Timespan(1) =~ Timespan[1, 2])
             notice(Timespan(3) =~ Timespan[1])
             notice(Timespan(0) =~ Timespan[default, 2])
+            notice(Timespan(0) =~ Timespan[1, 2])
+            notice(Timespan(3) =~ Timespan[1, 2])
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(true true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true true true false false))
       end
 
       it 'accepts float values when specifying the range' do
@@ -83,8 +85,10 @@ describe 'Timespan type' do
             notice(Timespan(1.0) =~ Timespan[1.0, 2.0])
             notice(Timespan(3.0) =~ Timespan[1.0])
             notice(Timespan(0.0) =~ Timespan[default, 2.0])
+            notice(Timespan(0.0) =~ Timespan[1.0, 2.0])
+            notice(Timespan(3.0) =~ Timespan[1.0, 2.0])
         CODE
-        expect(eval_and_collect_notices(code)).to eq(%w(true true true))
+        expect(eval_and_collect_notices(code)).to eq(%w(true true true false false))
       end
     end
 

--- a/spec/unit/pops/types/p_timespan_type_spec.rb
+++ b/spec/unit/pops/types/p_timespan_type_spec.rb
@@ -68,6 +68,24 @@ describe 'Timespan type' do
         CODE
         expect(eval_and_collect_notices(code)).to eq(%w(true false))
       end
+
+      it 'accepts integer values when specifying the range' do
+        code = <<-CODE
+            notice(Timespan(1) =~ Timespan[1, 2])
+            notice(Timespan(3) =~ Timespan[1])
+            notice(Timespan(0) =~ Timespan[default, 2])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true true))
+      end
+
+      it 'accepts float values when specifying the range' do
+        code = <<-CODE
+            notice(Timespan(1.0) =~ Timespan[1.0, 2.0])
+            notice(Timespan(3.0) =~ Timespan[1.0])
+            notice(Timespan(0.0) =~ Timespan[default, 2.0])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true true))
+      end
     end
 
     context 'a Timespan instance' do

--- a/spec/unit/pops/types/p_timestamp_type_spec.rb
+++ b/spec/unit/pops/types/p_timestamp_type_spec.rb
@@ -74,6 +74,25 @@ describe 'Timestamp type' do
         CODE
         expect(eval_and_collect_notices(code)).to eq(%w(true false))
       end
+
+      it 'accepts integer values when specifying the range' do
+        code = <<-CODE
+            notice(Timestamp(1) =~ Timestamp[1, 2])
+            notice(Timestamp(3) =~ Timestamp[1])
+            notice(Timestamp(0) =~ Timestamp[default, 2])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true true))
+      end
+
+      it 'accepts float values when specifying the range' do
+        code = <<-CODE
+            notice(Timestamp(1.0) =~ Timestamp[1.0, 2.0])
+            notice(Timestamp(3.0) =~ Timestamp[1.0])
+            notice(Timestamp(0.0) =~ Timestamp[default, 2.0])
+        CODE
+        expect(eval_and_collect_notices(code)).to eq(%w(true true true))
+      end
+
     end
 
     context 'a Timestamp instance' do


### PR DESCRIPTION
There were typos (`==` instead of `=`) in the logic that converted type parameters for `Timestamp` and `Timespan`. This corrects both of them and adds tests.