### PR TITLE
(maint) Update tests requiring a yaml end of document in output

### DIFF
--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -13,7 +13,8 @@ describe Puppet::Application::Lookup do
     ensure
       $stdout = saved_stdout
     end
-    capture.string.strip
+    # Drop end of line and an optional yaml end of document
+    capture.string.gsub(/\n(\.\.\.\n)?\Z/m, '')
   end
 
   context "when running with incorrect command line options" do
@@ -74,7 +75,7 @@ describe Puppet::Application::Lookup do
         lookup.command_line.stubs(:args).returns(['atton', 'kreia'])
         lookup.stubs(:generate_scope).yields('scope')
         Puppet::Pops::Lookup.stubs(:lookup).returns('rand')
-        expect(run_lookup(lookup)).to eql("--- rand\n...")
+        expect(run_lookup(lookup)).to eql("--- rand")
       end
     end
 
@@ -85,7 +86,7 @@ describe Puppet::Application::Lookup do
 
       Puppet::Pops::Lookup.stubs(:lookup).returns('rand')
 
-      expect(run_lookup(lookup)).to eql("--- rand\n...")
+      expect(run_lookup(lookup)).to eql("--- rand")
     end
   end
 
@@ -502,14 +503,14 @@ Searching for "a"
       it "is unaffected by global variables unless '--compile' is used" do
         lookup.options[:node] = node
         lookup.command_line.stubs(:args).returns(['c'])
-        expect(run_lookup(lookup)).to eql("--- This is\n...")
+        expect(run_lookup(lookup)).to eql("--- This is")
       end
 
       it "is affected by global variables when '--compile' is used" do
         lookup.options[:node] = node
         lookup.options[:compile] = true
         lookup.command_line.stubs(:args).returns(['c'])
-        expect(run_lookup(lookup)).to eql("--- This is C from site.pp\n...")
+        expect(run_lookup(lookup)).to eql("--- This is C from site.pp")
       end
 
       it 'receives extra facts in top scope' do
@@ -523,7 +524,7 @@ Searching for "a"
         lookup.options[:node] = node
         lookup.options[:fact_file] = filename
         lookup.command_line.stubs(:args).returns(['c'])
-        expect(run_lookup(lookup)).to eql("--- This is C from facts\n...")
+        expect(run_lookup(lookup)).to eql("--- This is C from facts")
       end
 
       it 'receives extra facts in the facts hash' do
@@ -537,7 +538,7 @@ Searching for "a"
         lookup.options[:node] = node
         lookup.options[:fact_file] = filename
         lookup.command_line.stubs(:args).returns(['g'])
-        expect(run_lookup(lookup)).to eql("--- This is G from facts in facts hash\n...")
+        expect(run_lookup(lookup)).to eql("--- This is G from facts in facts hash")
       end
     end
 
@@ -547,14 +548,14 @@ Searching for "a"
       it "works OK in the absense of '--compile'" do
         lookup.options[:node] = node
         lookup.command_line.stubs(:args).returns(['c'])
-        expect(run_lookup(lookup)).to eql("--- This is C from data.pp\n...")
+        expect(run_lookup(lookup)).to eql("--- This is C from data.pp")
       end
 
       it "global scope is affected by global variables when '--compile' is used" do
         lookup.options[:node] = node
         lookup.options[:compile] = true
         lookup.command_line.stubs(:args).returns(['c'])
-        expect(run_lookup(lookup)).to eql("--- This is C from site.pp\n...")
+        expect(run_lookup(lookup)).to eql("--- This is C from site.pp")
       end
     end
   end


### PR DESCRIPTION
The behavior of dropping the yaml end of document changed between
Ruby 2.4.4p296 and 2.4.5p334. The tests regarding lookup are really
not about yaml output compatibility and this commit drops
the optional end of document at the end of the output if it is present
so that the individual tests can compare against the rest of the
produced yaml output.