### PR TITLE
(maint) Account for new OpenSSL 1.1.1 behavior

### DIFF
--- a/spec/integration/ssl/key_spec.rb
+++ b/spec/integration/ssl/key_spec.rb
@@ -41,8 +41,6 @@ describe Puppet::SSL::Key do
     end
 
     it "should be able to read an existing private key given the correct password" do
-      Puppet[:keylength] = '50'
-
       key_name = 'test'
       # use OpenSSL APIs to generate a private key
       private_key = OpenSSL::PKey::RSA.generate(512)
@@ -69,8 +67,6 @@ describe Puppet::SSL::Key do
     end
 
     it 'should export the private key to PEM using the password' do
-      Puppet[:keylength] = '50'
-
       key_name = 'test'
 
       # uses specified :passfile when writing the private key

--- a/spec/unit/ssl/key_spec.rb
+++ b/spec/unit/ssl/key_spec.rb
@@ -129,8 +129,8 @@ describe Puppet::SSL::Key do
     end
 
     it "should create the private key with the keylength specified in the settings" do
-      Puppet[:keylength] = "50"
-      OpenSSL::PKey::RSA.expects(:new).with(50).returns(@key)
+      Puppet[:keylength] = 513
+      OpenSSL::PKey::RSA.expects(:new).with(513).returns(@key)
 
       @instance.generate
     end
@@ -172,8 +172,6 @@ describe Puppet::SSL::Key do
       end
 
       it "should export the private key to text using the password" do
-        Puppet[:keylength] = "50"
-
         @instance.password_file = "/path/to/pass"
         @instance.stubs(:password).returns "my password"
 

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -102,13 +102,26 @@ describe OpenSSL::X509::Store, :if => Puppet::Util::Platform.windows? do
     store.set_default_paths
   end
 
-  it "warns when adding a certificate that already exists" do
-    with_root_certs([cert])
-    store.add_cert(cert)
+  # openssl 1.1.1 ignores duplicate certs
+  # https://github.com/openssl/openssl/commit/c0452248ea1a59a41023a4765ef7d9825e80a62b
+  if OpenSSL::OPENSSL_VERSION_NUMBER < 0x10101000
+    it "warns when adding a certificate that already exists" do
+      with_root_certs([cert])
+      store.add_cert(cert)
 
-    store.expects(:warn).with('Failed to add /DC=com/DC=microsoft/CN=Microsoft Root Certificate Authority')
+      store.expects(:warn).with('Failed to add /DC=com/DC=microsoft/CN=Microsoft Root Certificate Authority')
 
-    store.set_default_paths
+      store.set_default_paths
+    end
+  else
+    it "doesn't warn when adding a duplicate cert" do
+      with_root_certs([cert])
+      store.add_cert(cert)
+
+      store.expects(:warn).never
+
+      store.set_default_paths
+    end
   end
 
   it "raises when adding an invalid certificate" do


### PR DESCRIPTION
OpenSSL 1.1.1 now enforces a minimum of 512 bit RSA keys and it performs a noop if the same cert is added to an X509 store. This PR updates the tests accordingly.

Note we're currently only testing openssl 1.1.1 in the puppet 6.0.x branch with ruby 2.5 on appveyor, but it seems like a good thing to fix in 5.5.x.