### PR TITLE
(maint) Adjust scoping of setup in loader_spec to be able to run all tests

### DIFF
--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -475,8 +475,7 @@ describe 'The Loader' do
           end
 
           context 'with no explicit dependencies' do
-
-            let(:modules) {
+            let(:modules) do
               {
                 'a' => {
                   'functions' => a_functions,
@@ -496,12 +495,12 @@ describe 'The Loader' do
                   'types' => c_types,
                 },
               }
+            end
 
-              it 'discover is only called once on dependent loader' do
-                ModuleLoaders::FileBased.any_instance.expects(:discover).times(4).with(:type, Pcore::RUNTIME_NAME_AUTHORITY).returns([])
-                expect(loader.private_loader.discover(:type) { |t| t.name =~ /^.::.*\z/ }).to(contain_exactly())
-              end
-            }
+            it 'discover is only called once on dependent loader' do
+              ModuleLoaders::FileBased.any_instance.expects(:discover).times(4).with(:type, nil, Pcore::RUNTIME_NAME_AUTHORITY).returns([])
+              expect(loader.private_loader.discover(:type) { |t| t.name =~ /^.::.*\z/ }).to(contain_exactly())
+            end
           end
         end
       end


### PR DESCRIPTION
One of the tests in `spec/unit/pops/loaders/loader_spec.rb` was accidentally inside the set up block for its test data, so it wasn't actually being run.