### PR TITLE
(PUP-9293) Update error message when decoding read_wide_string

### DIFF
--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -58,7 +58,7 @@ module Puppet::Util::Windows::APITypes
       str = get_bytes(0, char_length * 2).force_encoding('UTF-16LE')
       str.encode(dst_encoding, str.encoding, encode_options)
     rescue Exception => e
-      Puppet.debug "Unable to convert value #{str.dump} to encoding #{dst_encoding} due to #{e.inspect}"
+      Puppet.debug "Unable to convert value #{str.nil? ? 'nil' : str.dump} to encoding #{dst_encoding} due to #{e.inspect}"
       raise
     end
 


### PR DESCRIPTION
Previously it was possible for UTF-16LE forced encoding to fail and generate an
error, however the error handler always expected the string to not be nil.  This
commit modifies the error message to guard when the string is nil and therefore
raise the correct error message up to Puppet