### PR TITLE
(PUP-9320) Generate function docs include whitespace warning

### DIFF
--- a/lib/puppet/parser/functions/generate.rb
+++ b/lib/puppet/parser/functions/generate.rb
@@ -1,15 +1,16 @@
 # Runs an external command and returns the results
 Puppet::Parser::Functions::newfunction(:generate, :arity => -2, :type => :rvalue,
     :doc => "Calls an external command on the Puppet master and returns
-    the results of the command.  Any arguments are passed to the external command as
-    arguments.  If the generator does not exit with return code of 0,
+    the results of the command. Any arguments are passed to the external command as
+    arguments. If the generator does not exit with return code of 0,
     the generator is considered to have failed and a parse error is
-    thrown.  Generators can only have file separators, alphanumerics, dashes,
-    and periods in them.  This function will attempt to protect you from
+    thrown. Generators can only have file separators, alphanumerics, dashes,
+    and periods in them. This function will attempt to protect you from
     malicious generator calls (e.g., those with '..' in them), but it can
-    never be entirely safe.  No subshell is used to execute
+    never be entirely safe. No subshell is used to execute
     generators, so all shell metacharacters are passed directly to
-    the generator.") do |args|
+    the generator, and all metacharacters are returned by the function.
+    Consider cleaning white space from any string generated.") do |args|
 
       #TRANSLATORS "fully qualified" refers to a fully qualified file system path
       raise Puppet::ParseError, _("Generators must be fully qualified") unless Puppet::Util.absolute_path?(args[0])


### PR DESCRIPTION
This adds an additional caveat to the docs for the generate()
parser function to suggest cleaning whitespace from returned values.