### PR TITLE
(maint) Restructure unit tests to use built-in RSpec facilities

### DIFF
--- a/spec/unit/provider/group/ldap_spec.rb
+++ b/spec/unit/provider/group/ldap_spec.rb
@@ -1,54 +1,51 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:group).provider(:ldap)
-
-describe provider_class do
+describe Puppet::Type.type(:group).provider(:ldap) do
   it "should have the Ldap provider class as its baseclass" do
-    expect(provider_class.superclass).to equal(Puppet::Provider::Ldap)
+    expect(described_class.superclass).to equal(Puppet::Provider::Ldap)
   end
 
   it "should manage :posixGroup objectclass" do
-    expect(provider_class.manager.objectclasses).to eq([:posixGroup])
+    expect(described_class.manager.objectclasses).to eq([:posixGroup])
   end
 
   it "should use 'ou=Groups' as its relative base" do
-    expect(provider_class.manager.location).to eq("ou=Groups")
+    expect(described_class.manager.location).to eq("ou=Groups")
   end
 
   it "should use :cn as its rdn" do
-    expect(provider_class.manager.rdn).to eq(:cn)
+    expect(described_class.manager.rdn).to eq(:cn)
   end
 
   it "should map :name to 'cn'" do
-    expect(provider_class.manager.ldap_name(:name)).to eq('cn')
+    expect(described_class.manager.ldap_name(:name)).to eq('cn')
   end
 
   it "should map :gid to 'gidNumber'" do
-    expect(provider_class.manager.ldap_name(:gid)).to eq('gidNumber')
+    expect(described_class.manager.ldap_name(:gid)).to eq('gidNumber')
   end
 
   it "should map :members to 'memberUid', to be used by the user ldap provider" do
-    expect(provider_class.manager.ldap_name(:members)).to eq('memberUid')
+    expect(described_class.manager.ldap_name(:members)).to eq('memberUid')
   end
 
   describe "when being created" do
     before do
       # So we don't try to actually talk to ldap
       @connection = mock 'connection'
-      provider_class.manager.stubs(:connect).yields @connection
+      described_class.manager.stubs(:connect).yields @connection
     end
 
     describe "with no gid specified" do
       it "should pick the first available GID after the largest existing GID" do
         low = {:name=>["luke"], :gid=>["600"]}
         high = {:name=>["testing"], :gid=>["640"]}
-        provider_class.manager.expects(:search).returns([low, high])
+        described_class.manager.expects(:search).returns([low, high])
 
         resource = stub 'resource', :should => %w{whatever}
         resource.stubs(:should).with(:gid).returns nil
         resource.stubs(:should).with(:ensure).returns :present
-        instance = provider_class.new(:name => "luke", :ensure => :absent)
+        instance = described_class.new(:name => "luke", :ensure => :absent)
         instance.stubs(:resource).returns resource
 
         @connection.expects(:add).with { |dn, attrs| attrs["gidNumber"] == ["641"] }
@@ -58,12 +55,12 @@ describe provider_class do
       end
 
       it "should pick '501' as its GID if no groups are found" do
-        provider_class.manager.expects(:search).returns nil
+        described_class.manager.expects(:search).returns nil
 
         resource = stub 'resource', :should => %w{whatever}
         resource.stubs(:should).with(:gid).returns nil
         resource.stubs(:should).with(:ensure).returns :present
-        instance = provider_class.new(:name => "luke", :ensure => :absent)
+        instance = described_class.new(:name => "luke", :ensure => :absent)
         instance.stubs(:resource).returns resource
 
         @connection.expects(:add).with { |dn, attrs| attrs["gidNumber"] == ["501"] }
@@ -75,27 +72,27 @@ describe provider_class do
   end
 
   it "should have a method for converting group names to GIDs" do
-    expect(provider_class).to respond_to(:name2id)
+    expect(described_class).to respond_to(:name2id)
   end
 
   describe "when converting from a group name to GID" do
     it "should use the ldap manager to look up the GID" do
-      provider_class.manager.expects(:search).with("cn=foo")
-      provider_class.name2id("foo")
+      described_class.manager.expects(:search).with("cn=foo")
+      described_class.name2id("foo")
     end
 
     it "should return nil if no group is found" do
-      provider_class.manager.expects(:search).with("cn=foo").returns nil
-      expect(provider_class.name2id("foo")).to be_nil
-      provider_class.manager.expects(:search).with("cn=bar").returns []
-      expect(provider_class.name2id("bar")).to be_nil
+      described_class.manager.expects(:search).with("cn=foo").returns nil
+      expect(described_class.name2id("foo")).to be_nil
+      described_class.manager.expects(:search).with("cn=bar").returns []
+      expect(described_class.name2id("bar")).to be_nil
     end
 
     # We shouldn't ever actually have more than one gid, but it doesn't hurt
     # to test for the possibility.
     it "should return the first gid from the first returned group" do
-      provider_class.manager.expects(:search).with("cn=foo").returns [{:name => "foo", :gid => [10, 11]}, {:name => :bar, :gid => [20, 21]}]
-      expect(provider_class.name2id("foo")).to eq(10)
+      described_class.manager.expects(:search).with("cn=foo").returns [{:name => "foo", :gid => [10, 11]}, {:name => :bar, :gid => [20, 21]}]
+      expect(described_class.name2id("foo")).to eq(10)
     end
   end
 end

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:group).provider(:pw)
-
-describe provider_class do
+describe Puppet::Type.type(:group).provider(:pw) do
   let :resource do
     Puppet::Type.type(:group).new(:name => "testgroup", :provider => :pw)
   end
@@ -20,8 +17,8 @@ describe provider_class do
     end
 
     it "should run pw with no additional flags when no properties are given" do
-      expect(provider.addcmd).to eq([provider_class.command(:pw), "groupadd", "testgroup"])
-      provider.expects(:execute).with([provider_class.command(:pw), "groupadd", "testgroup"], kind_of(Hash))
+      expect(provider.addcmd).to eq([described_class.command(:pw), "groupadd", "testgroup"])
+      provider.expects(:execute).with([described_class.command(:pw), "groupadd", "testgroup"], kind_of(Hash))
       provider.create
     end
 
@@ -53,16 +50,16 @@ describe provider_class do
   describe "when deleting groups" do
     it "should run pw with no additional flags" do
       provider.expects(:exists?).returns true
-      expect(provider.deletecmd).to eq([provider_class.command(:pw), "groupdel", "testgroup"])
-      provider.expects(:execute).with([provider_class.command(:pw), "groupdel", "testgroup"], has_entry(:custom_environment, {}))
+      expect(provider.deletecmd).to eq([described_class.command(:pw), "groupdel", "testgroup"])
+      provider.expects(:execute).with([described_class.command(:pw), "groupdel", "testgroup"], has_entry(:custom_environment, {}))
       provider.delete
     end
   end
 
   describe "when modifying groups" do
     it "should run pw with the correct arguments" do
-      expect(provider.modifycmd("gid", 12345)).to eq([provider_class.command(:pw), "groupmod", "testgroup", "-g", 12345])
-      provider.expects(:execute).with([provider_class.command(:pw), "groupmod", "testgroup", "-g", 12345], has_entry(:custom_environment, {}))
+      expect(provider.modifycmd("gid", 12345)).to eq([described_class.command(:pw), "groupmod", "testgroup", "-g", 12345])
+      provider.expects(:execute).with([described_class.command(:pw), "groupmod", "testgroup", "-g", 12345], has_entry(:custom_environment, {}))
       provider.gid = 12345
     end
 

--- a/spec/unit/provider/host/parsed_spec.rb
+++ b/spec/unit/provider/host/parsed_spec.rb
@@ -1,12 +1,9 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
-require 'shared_behaviours/all_parsedfile_providers'
 
+require 'shared_behaviours/all_parsedfile_providers'
 require 'puppet_spec/files'
 
-provider_class = Puppet::Type.type(:host).provider(:parsed)
-
-describe provider_class do
+describe Puppet::Type.type(:host).provider(:parsed) do
   include PuppetSpec::Files
 
   before do
@@ -46,7 +43,6 @@ describe provider_class do
   end
 
   describe "when parsing on incomplete line" do
-
     it "should work for only ip" do
       expect(@provider.parse_line("127.0.0.1")[:line]).to eq("127.0.0.1")
     end
@@ -78,11 +74,9 @@ describe provider_class do
     it "should work for crazy incomplete lines" do
       expect(@provider.parse_line("%th1s is a\t cr$zy    !incompl1t line")[:line]).to eq("%th1s is a\t cr$zy    !incompl1t line")
     end
-
   end
 
   describe "when parsing a line with ip and hostname" do
-
     it "should parse an ipv4 from the first field" do
       expect(@provider.parse_line("127.0.0.1    localhost")[:ip]).to eq("127.0.0.1")
     end
@@ -102,7 +96,6 @@ describe provider_class do
     it "should set host_aliases to :absent" do
       expect(@provider.parse_line("::1     localhost")[:host_aliases]).to eq(:absent)
     end
-
   end
 
   describe "when parsing a line with ip, hostname and comment" do
@@ -121,11 +114,9 @@ describe provider_class do
     it "should parse the comment after the first '#' character" do
       expect(@provider.parse_line(@testline)[:comment]).to eq('A comment with a #-char')
     end
-
   end
 
   describe "when parsing a line with ip, hostname and aliases" do
-
     it "should parse alias from the third field" do
       expect(@provider.parse_line("127.0.0.1   localhost   localhost.localdomain")[:host_aliases]).to eq("localhost.localdomain")
     end
@@ -135,11 +126,9 @@ describe provider_class do
       expect(@provider.parse_line("127.0.0.1 host alias1\talias2")[:host_aliases]).to eq('alias1 alias2')
       expect(@provider.parse_line("127.0.0.1 host alias1\talias2   alias3")[:host_aliases]).to eq('alias1 alias2 alias3')
     end
-
   end
 
   describe "when parsing a line with ip, hostname, aliases and comment" do
-
     before do
       # Just playing with a few different delimiters
       @testline = "127.0.0.1\t   host  alias1\talias2   alias3   #   A comment with a #-char"
@@ -160,12 +149,11 @@ describe provider_class do
     it "should parse the comment after the first '#' character" do
       expect(@provider.parse_line(@testline)[:comment]).to eq('A comment with a #-char')
     end
-
   end
 
   describe "when operating on /etc/hosts like files" do
     it_should_behave_like "all parsedfile providers",
-      provider_class, my_fixtures('valid*')
+      described_class, my_fixtures('valid*')
 
     it "should be able to generate a simple hostfile entry" do
       host = mkhost(
@@ -227,7 +215,5 @@ describe provider_class do
       )
       expect(genhost(host)).to eq("192.0.0.1\thost\ta1 a2 a3 a4\t# Bazinga!\n")
     end
-
   end
-
 end

--- a/spec/unit/provider/nameservice/directoryservice_spec.rb
+++ b/spec/unit/provider/nameservice/directoryservice_spec.rb
@@ -1,4 +1,3 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
 module Puppet::Util::Plist
@@ -6,13 +5,11 @@ end
 
 # We use this as a reasonable way to obtain all the support infrastructure.
 [:group].each do |type_for_this_round|
-  provider_class = Puppet::Type.type(type_for_this_round).provider(:directoryservice)
-
-  describe provider_class do
+  describe Puppet::Type.type(type_for_this_round).provider(:directoryservice) do
     before do
       @resource = stub("resource")
       @resource.stubs(:[]).with(:name)
-      @provider = provider_class.new(@resource)
+      @provider = described_class.new(@resource)
     end
 
     it "[#6009] should handle nested arrays of members" do
@@ -40,125 +37,122 @@ end
   end
 end
 
-describe 'DirectoryService.single_report' do
-  it 'should use plist data' do
-    Puppet::Provider::NameService::DirectoryService.stubs(:get_ds_path).returns('Users')
-    Puppet::Provider::NameService::DirectoryService.stubs(:list_all_present).returns(
-      ['root', 'user1', 'user2', 'resource_name']
-    )
-    Puppet::Provider::NameService::DirectoryService.stubs(:generate_attribute_hash)
-    Puppet::Provider::NameService::DirectoryService.stubs(:execute)
-    Puppet::Provider::NameService::DirectoryService.expects(:parse_dscl_plist_data)
+describe Puppet::Provider::NameService::DirectoryService do
+  context '.single_report' do
+    it 'should use plist data' do
+      Puppet::Provider::NameService::DirectoryService.stubs(:get_ds_path).returns('Users')
+      Puppet::Provider::NameService::DirectoryService.stubs(:list_all_present).returns(
+        ['root', 'user1', 'user2', 'resource_name']
+      )
+      Puppet::Provider::NameService::DirectoryService.stubs(:generate_attribute_hash)
+      Puppet::Provider::NameService::DirectoryService.stubs(:execute)
+      Puppet::Provider::NameService::DirectoryService.expects(:parse_dscl_plist_data)
 
-    Puppet::Provider::NameService::DirectoryService.single_report('resource_name')
+      Puppet::Provider::NameService::DirectoryService.single_report('resource_name')
+    end
+  end
+
+  context '.get_exec_preamble' do
+    it 'should use plist data' do
+      Puppet::Provider::NameService::DirectoryService.stubs(:get_ds_path).returns('Users')
+
+      expect(Puppet::Provider::NameService::DirectoryService.get_exec_preamble('-list')).to include("-plist")
+    end
+  end
+
+  context 'password behavior' do
+    # The below is a binary plist containing a ShadowHashData key which CONTAINS
+    # another binary plist. The nested binary plist contains a 'SALTED-SHA512'
+    # key that contains a base64 encoded salted-SHA512 password hash...
+    let (:binary_plist) { "bplist00\324\001\002\003\004\005\006\a\bXCRAM-MD5RNT]SALTED-SHA512[RECOVERABLEO\020 \231k2\3360\200GI\201\355J\216\202\215y\243\001\206J\300\363\032\031\022\006\2359\024\257\217<\361O\020\020F\353\at\377\277\226\276c\306\254\031\037J(\235O\020D\335\006{\3744g@\377z\204\322\r\332t\021\330\n\003\246K\223\356\034!P\261\305t\035\346\352p\206\003n\247MMA\310\301Z<\366\246\023\0161W3\340\357\000\317T\t\301\311+\204\246L7\276\370\320*\245O\021\002\000k\024\221\270x\353\001\237\346D}\377?\265]\356+\243\v[\350\316a\340h\376<\322\266\327\016\306n\272r\t\212A\253L\216\214\205\016\241 [\360/\335\002#\\A\372\241a\261\346\346\\\251\330\312\365\016\n\341\017\016\225&;\322\\\004*\ru\316\372\a \362?8\031\247\231\030\030\267\315\023\v\343{@\227\301s\372h\212\000a\244&\231\366\nt\277\2036,\027bZ+\223W\212g\333`\264\331N\306\307\362\257(^~ b\262\247&\231\261t\341\231%\244\247\203eOt\365\271\201\273\330\350\363C^A\327F\214!\217hgf\e\320k\260n\315u~\336\371M\t\235k\230S\375\311\303\240\351\037d\273\321y\335=K\016`_\317\230\2612_\023K\036\350\v\232\323Y\310\317_\035\227%\237\v\340\023\016\243\233\025\306:\227\351\370\364x\234\231\266\367\016w\275\333-\351\210}\375x\034\262\272kRuHa\362T/F!\347B\231O`K\304\037'k$$\245h)e\363\365mT\b\317\\2\361\026\351\254\375Jl1~\r\371\267\352\2322I\341\272\376\243^Un\266E7\230[VocUJ\220N\2116D/\025f=\213\314\325\vG}\311\360\377DT\307m\261&\263\340\272\243_\020\271rG^BW\210\030l\344\0324\335\233\300\023\272\225Im\330\n\227*Yv[\006\315\330y'\a\321\373\273A\240\305F{S\246I#/\355\2425\031\031GGF\270y\n\331\004\023G@\331\000\361\343\350\264$\032\355_\210y\000\205\342\375\212q\024\004\026W:\205 \363v?\035\270L-\270=\022\323\2003\v\336\277\t\237\356\374\n\267n\003\367\342\330;\371S\326\016`B6@Njm>\240\021%\336\345\002(P\204Yn\3279l\0228\264\254\304\2528t\372h\217\347sA\314\345\245\337)]\000\b\000\021\000\032\000\035\000+\0007\000Z\000m\000\264\000\000\000\000\000\000\002\001\000\000\000\000\000\000\000\t\000\000\000\000\000\000\000\000\000\000\000\000\000\000\002\270" }
+
+    # The below is a base64 encoded salted-SHA512 password hash.
+    let (:pw_string) { "\335\006{\3744g@\377z\204\322\r\332t\021\330\n\003\246K\223\356\034!P\261\305t\035\346\352p\206\003n\247MMA\310\301Z<\366\246\023\0161W3\340\357\000\317T\t\301\311+\204\246L7\276\370\320*\245" }
+
+    # The below is a salted-SHA512 password hash in hex.
+    let (:sha512_hash) { 'dd067bfc346740ff7a84d20dda7411d80a03a64b93ee1c2150b1c5741de6ea7086036ea74d4d41c8c15a3cf6a6130e315733e0ef00cf5409c1c92b84a64c37bef8d02aa5' }
+
+    let :plist_path do
+      '/var/db/dslocal/nodes/Default/users/jeff.plist'
+    end
+
+    let :ds_provider do
+      described_class
+    end
+
+    let :shadow_hash_data do
+      {'ShadowHashData' => [binary_plist]}
+    end
+
+    it 'should execute convert_binary_to_hash once when getting the password' do
+      described_class.expects(:convert_binary_to_hash).returns({'SALTED-SHA512' => pw_string})
+      Puppet::FileSystem.expects(:exist?).with(plist_path).once.returns(true)
+      Puppet::Util::Plist.expects(:read_plist_file).returns(shadow_hash_data)
+      described_class.get_password('uid', 'jeff')
+    end
+
+    it 'should fail if a salted-SHA512 password hash is not passed in' do
+      expect {
+        described_class.set_password('jeff', 'uid', 'badpassword')
+      }.to raise_error(RuntimeError, /OS X 10.7 requires a Salted SHA512 hash password of 136 characters./)
+    end
+
+    it 'should convert xml-to-binary and binary-to-xml when setting the pw on >= 10.7' do
+      described_class.expects(:convert_binary_to_hash).returns({'SALTED-SHA512' => pw_string})
+      described_class.expects(:convert_hash_to_binary).returns(binary_plist)
+      Puppet::FileSystem.expects(:exist?).with(plist_path).once.returns(true)
+      Puppet::Util::Plist.expects(:read_plist_file).returns(shadow_hash_data)
+      Puppet::Util::Plist.expects(:write_plist_file).with(shadow_hash_data, plist_path, :binary)
+      described_class.set_password('jeff', 'uid', sha512_hash)
+    end
+
+    it '[#13686] should handle an empty ShadowHashData field in the users plist' do
+      described_class.expects(:convert_hash_to_binary).returns(binary_plist)
+      Puppet::FileSystem.expects(:exist?).with(plist_path).once.returns(true)
+      Puppet::Util::Plist.expects(:read_plist_file).returns({'ShadowHashData' => nil})
+      Puppet::Util::Plist.expects(:write_plist_file)
+      described_class.set_password('jeff', 'uid', sha512_hash)
+    end
+  end
+
+  context '(#4855) directoryservice group resource failure' do
+    let :provider_class do
+      Puppet::Type.type(:group).provider(:directoryservice)
+    end
+
+    let :group_members do
+      ['root','jeff']
+    end
+
+    let :user_account do
+      ['root']
+    end
+
+    let :stub_resource do
+      stub('resource')
+    end
+
+    subject do
+      provider_class.new(stub_resource)
+    end
+
+    before :each do
+      @resource = stub("resource")
+      @resource.stubs(:[]).with(:name)
+      @provider = provider_class.new(@resource)
+    end
+
+    it 'should delete a group member if the user does not exist' do
+      stub_resource.stubs(:[]).with(:name).returns('fake_group')
+      stub_resource.stubs(:name).returns('fake_group')
+      subject.expects(:execute).with([:dseditgroup, '-o', 'edit', '-n', '.',
+                                    '-d', 'jeff',
+                                    'fake_group']).raises(Puppet::ExecutionFailure,
+                                    'it broke')
+      subject.expects(:execute).with([:dscl, '.', '-delete',
+                                    '/Groups/fake_group', 'GroupMembership',
+                                    'jeff'])
+      subject.remove_unwanted_members(group_members, user_account)
+    end
   end
 end
-
-describe 'DirectoryService.get_exec_preamble' do
-  it 'should use plist data' do
-    Puppet::Provider::NameService::DirectoryService.stubs(:get_ds_path).returns('Users')
-
-    expect(Puppet::Provider::NameService::DirectoryService.get_exec_preamble('-list')).to include("-plist")
-  end
-end
-
-describe 'DirectoryService password behavior' do
-  # The below is a binary plist containing a ShadowHashData key which CONTAINS
-  # another binary plist. The nested binary plist contains a 'SALTED-SHA512'
-  # key that contains a base64 encoded salted-SHA512 password hash...
-  let (:binary_plist) { "bplist00\324\001\002\003\004\005\006\a\bXCRAM-MD5RNT]SALTED-SHA512[RECOVERABLEO\020 \231k2\3360\200GI\201\355J\216\202\215y\243\001\206J\300\363\032\031\022\006\2359\024\257\217<\361O\020\020F\353\at\377\277\226\276c\306\254\031\037J(\235O\020D\335\006{\3744g@\377z\204\322\r\332t\021\330\n\003\246K\223\356\034!P\261\305t\035\346\352p\206\003n\247MMA\310\301Z<\366\246\023\0161W3\340\357\000\317T\t\301\311+\204\246L7\276\370\320*\245O\021\002\000k\024\221\270x\353\001\237\346D}\377?\265]\356+\243\v[\350\316a\340h\376<\322\266\327\016\306n\272r\t\212A\253L\216\214\205\016\241 [\360/\335\002#\\A\372\241a\261\346\346\\\251\330\312\365\016\n\341\017\016\225&;\322\\\004*\ru\316\372\a \362?8\031\247\231\030\030\267\315\023\v\343{@\227\301s\372h\212\000a\244&\231\366\nt\277\2036,\027bZ+\223W\212g\333`\264\331N\306\307\362\257(^~ b\262\247&\231\261t\341\231%\244\247\203eOt\365\271\201\273\330\350\363C^A\327F\214!\217hgf\e\320k\260n\315u~\336\371M\t\235k\230S\375\311\303\240\351\037d\273\321y\335=K\016`_\317\230\2612_\023K\036\350\v\232\323Y\310\317_\035\227%\237\v\340\023\016\243\233\025\306:\227\351\370\364x\234\231\266\367\016w\275\333-\351\210}\375x\034\262\272kRuHa\362T/F!\347B\231O`K\304\037'k$$\245h)e\363\365mT\b\317\\2\361\026\351\254\375Jl1~\r\371\267\352\2322I\341\272\376\243^Un\266E7\230[VocUJ\220N\2116D/\025f=\213\314\325\vG}\311\360\377DT\307m\261&\263\340\272\243_\020\271rG^BW\210\030l\344\0324\335\233\300\023\272\225Im\330\n\227*Yv[\006\315\330y'\a\321\373\273A\240\305F{S\246I#/\355\2425\031\031GGF\270y\n\331\004\023G@\331\000\361\343\350\264$\032\355_\210y\000\205\342\375\212q\024\004\026W:\205 \363v?\035\270L-\270=\022\323\2003\v\336\277\t\237\356\374\n\267n\003\367\342\330;\371S\326\016`B6@Njm>\240\021%\336\345\002(P\204Yn\3279l\0228\264\254\304\2528t\372h\217\347sA\314\345\245\337)]\000\b\000\021\000\032\000\035\000+\0007\000Z\000m\000\264\000\000\000\000\000\000\002\001\000\000\000\000\000\000\000\t\000\000\000\000\000\000\000\000\000\000\000\000\000\000\002\270" }
-
-  # The below is a base64 encoded salted-SHA512 password hash.
-  let (:pw_string) { "\335\006{\3744g@\377z\204\322\r\332t\021\330\n\003\246K\223\356\034!P\261\305t\035\346\352p\206\003n\247MMA\310\301Z<\366\246\023\0161W3\340\357\000\317T\t\301\311+\204\246L7\276\370\320*\245" }
-
-  # The below is a salted-SHA512 password hash in hex.
-  let (:sha512_hash) { 'dd067bfc346740ff7a84d20dda7411d80a03a64b93ee1c2150b1c5741de6ea7086036ea74d4d41c8c15a3cf6a6130e315733e0ef00cf5409c1c92b84a64c37bef8d02aa5' }
-
-  let :plist_path do
-    '/var/db/dslocal/nodes/Default/users/jeff.plist'
-  end
-
-  let :ds_provider do
-    Puppet::Provider::NameService::DirectoryService
-  end
-
-  let :shadow_hash_data do
-    {'ShadowHashData' => [binary_plist]}
-  end
-
-  subject do
-    Puppet::Provider::NameService::DirectoryService
-  end
-
-  it 'should execute convert_binary_to_hash once when getting the password' do
-    subject.expects(:convert_binary_to_hash).returns({'SALTED-SHA512' => pw_string})
-    Puppet::FileSystem.expects(:exist?).with(plist_path).once.returns(true)
-    Puppet::Util::Plist.expects(:read_plist_file).returns(shadow_hash_data)
-    subject.get_password('uid', 'jeff')
-  end
-
-  it 'should fail if a salted-SHA512 password hash is not passed in' do
-    expect {
-      subject.set_password('jeff', 'uid', 'badpassword')
-    }.to raise_error(RuntimeError, /OS X 10.7 requires a Salted SHA512 hash password of 136 characters./)
-  end
-
-  it 'should convert xml-to-binary and binary-to-xml when setting the pw on >= 10.7' do
-    subject.expects(:convert_binary_to_hash).returns({'SALTED-SHA512' => pw_string})
-    subject.expects(:convert_hash_to_binary).returns(binary_plist)
-    Puppet::FileSystem.expects(:exist?).with(plist_path).once.returns(true)
-    Puppet::Util::Plist.expects(:read_plist_file).returns(shadow_hash_data)
-    Puppet::Util::Plist.expects(:write_plist_file).with(shadow_hash_data, plist_path, :binary)
-    subject.set_password('jeff', 'uid', sha512_hash)
-  end
-
-  it '[#13686] should handle an empty ShadowHashData field in the users plist' do
-    subject.expects(:convert_hash_to_binary).returns(binary_plist)
-    Puppet::FileSystem.expects(:exist?).with(plist_path).once.returns(true)
-    Puppet::Util::Plist.expects(:read_plist_file).returns({'ShadowHashData' => nil})
-    Puppet::Util::Plist.expects(:write_plist_file)
-    subject.set_password('jeff', 'uid', sha512_hash)
-  end
-end
-
-describe '(#4855) directoryservice group resource failure' do
-  let :provider_class do
-    Puppet::Type.type(:group).provider(:directoryservice)
-  end
-
-  let :group_members do
-    ['root','jeff']
-  end
-
-  let :user_account do
-    ['root']
-  end
-
-  let :stub_resource do
-    stub('resource')
-  end
-
-  subject do
-    provider_class.new(stub_resource)
-  end
-
-  before :each do
-    @resource = stub("resource")
-    @resource.stubs(:[]).with(:name)
-    @provider = provider_class.new(@resource)
-  end
-
-  it 'should delete a group member if the user does not exist' do
-    stub_resource.stubs(:[]).with(:name).returns('fake_group')
-    stub_resource.stubs(:name).returns('fake_group')
-    subject.expects(:execute).with([:dseditgroup, '-o', 'edit', '-n', '.',
-                                   '-d', 'jeff',
-                                   'fake_group']).raises(Puppet::ExecutionFailure,
-                                   'it broke')
-    subject.expects(:execute).with([:dscl, '.', '-delete',
-                                   '/Groups/fake_group', 'GroupMembership',
-                                   'jeff'])
-    subject.remove_unwanted_members(group_members, user_account)
-  end
-end
-

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:aix)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:aix) do
   before(:each) do
     # Create a mock resource
     @resource = Puppet::Type.type(:package).new(:name => 'mypackage', :ensure => :installed, :source => 'mysource', :provider => :aix)
@@ -23,7 +20,7 @@ describe provider_class do
     @provider.uninstall
   end
 
-  describe "when installing" do
+  context "when installing" do
     it "should install a package" do
       @provider.expects(:installp).with('-acgwXY', '-d', 'mysource', 'mypackage')
       @provider.install
@@ -86,7 +83,7 @@ mypackage                 1.2.3.3         Already superseded by 1.2.3.4
     end
   end
 
-  describe "when finding the latest version" do
+  context "when finding the latest version" do
     it "should return the current version when no later version is present" do
       @provider.stubs(:latest_info).returns(nil)
       @provider.stubs(:properties).returns( { :ensure => "1.2.3.4" } )
@@ -126,7 +123,7 @@ END
     latest = Puppet::Type.type(:package).new(:name => 'mypackage', :ensure => :latest, :source => 'mysource', :provider => :aix)
     absent = Puppet::Type.type(:package).new(:name => 'otherpackage', :ensure => :absent, :provider => :aix)
     Process.stubs(:euid).returns(0)
-    provider_class.expects(:execute).returns 'mypackage:mypackage.rte:1.8.6.4::I:T:::::N:A Super Cool Package::::0::\n'
-    provider_class.prefetch({ 'mypackage' => latest, 'otherpackage' => absent })
+    described_class.expects(:execute).returns 'mypackage:mypackage.rte:1.8.6.4::I:T:::::N:A Super Cool Package::::0::\n'
+    described_class.prefetch({ 'mypackage' => latest, 'otherpackage' => absent })
   end
 end

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:apt)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:apt) do
   let(:name) { 'asdf' }
 
   let(:resource) do
@@ -14,7 +11,7 @@ describe provider_class do
   end
 
   let(:provider) do
-    provider = provider_class.new
+    provider = subject()
     provider.resource = resource
     provider
   end
@@ -25,7 +22,7 @@ describe provider_class do
   end
 
   it "should be versionable" do
-    expect(provider_class).to be_versionable
+    expect(described_class).to be_versionable
   end
 
   it "should use :install to update" do

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -3,43 +3,41 @@ require 'spec_helper'
 # Note that much of the functionality of the dnf provider is already tested with yum provider tests,
 # as yum is the parent provider.
 
-provider_class = Puppet::Type.type(:package).provider(:dnf)
-
-context 'default' do
-  (19..21).each do |ver|
-    it "should not be the default provider on fedora#{ver}" do
-      Facter.stubs(:value).with(:osfamily).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
-      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
-      expect(provider_class).to_not be_default
+describe Puppet::Type.type(:package).provider(:dnf) do
+  context 'default' do
+    (19..21).each do |ver|
+      it "should not be the default provider on fedora#{ver}" do
+        Facter.stubs(:value).with(:osfamily).returns(:redhat)
+        Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+        expect(described_class).to_not be_default
+      end
     end
-  end
 
-  (22..26).each do |ver|
-    it "should be the default provider on fedora#{ver}" do
-      Facter.stubs(:value).with(:osfamily).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
-      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
-      expect(provider_class).to be_default
+    (22..26).each do |ver|
+      it "should be the default provider on fedora#{ver}" do
+        Facter.stubs(:value).with(:osfamily).returns(:redhat)
+        Facter.stubs(:value).with(:operatingsystem).returns(:fedora)
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+        expect(described_class).to be_default
+      end
     end
+
+    it "should not be the default provider on rhel7" do
+        Facter.stubs(:value).with(:osfamily).returns(:redhat)
+        Facter.stubs(:value).with(:operatingsystem).returns(:redhat)
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns("7")
+        expect(described_class).to_not be_default
+    end
+
+    it "should be the default provider on rhel8" do
+        Facter.stubs(:value).with(:osfamily).returns(:redhat)
+        Facter.stubs(:value).with(:operatingsystem).returns(:redhat)
+        Facter.stubs(:value).with(:operatingsystemmajrelease).returns("8")
+        expect(described_class).to be_default
+    end
+
   end
 
-  it "should not be the default provider on rhel7" do
-      Facter.stubs(:value).with(:osfamily).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystem).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("7")
-      expect(provider_class).to_not be_default
-  end
-
-  it "should be the default provider on rhel8" do
-      Facter.stubs(:value).with(:osfamily).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystem).returns(:redhat)
-      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("8")
-      expect(provider_class).to be_default
-  end
-
-end
-
-describe provider_class do
-  it_behaves_like 'RHEL package provider', provider_class, 'dnf'
+  it_behaves_like 'RHEL package provider', described_class, 'dnf'
 end

--- a/spec/unit/provider/package/freebsd_spec.rb
+++ b/spec/unit/provider/package/freebsd_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:freebsd)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:freebsd) do
   before :each do
     # Create a mock resource
     @resource = stub 'resource'
@@ -15,16 +12,16 @@ describe provider_class do
     @resource.stubs(:[]).with(:name).returns   "mypackage"
     @resource.stubs(:[]).with(:ensure).returns :installed
 
-    @provider = provider_class.new
+    @provider = subject()
     @provider.resource = @resource
   end
 
   it "should have an install method" do
-    @provider = provider_class.new
+    @provider = subject()
     expect(@provider).to respond_to(:install)
   end
 
-  describe "when installing" do
+  context "when installing" do
     before :each do
       @resource.stubs(:should).with(:ensure).returns(:installed)
     end

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -1,10 +1,7 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:gem)
-
-context 'installing myresource' do
-  describe provider_class do
+context Puppet::Type.type(:package).provider(:gem) do
+  context 'installing myresource' do
     let(:resource) do
       Puppet::Type.type(:package).new(
         :name     => 'myresource',
@@ -13,7 +10,7 @@ context 'installing myresource' do
     end
 
     let(:provider) do
-      provider = provider_class.new
+      provider = described_class.new
       provider.resource = resource
       provider
     end
@@ -22,9 +19,9 @@ context 'installing myresource' do
       resource.provider = provider
     end
 
-    describe "when installing" do
+    context "when installing" do
       it "should use the path to the gem" do
-        provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
         provider.expects(:execute).with { |args| args[0] == "/my/gem" }.returns ""
         provider.install
       end
@@ -60,42 +57,47 @@ context 'installing myresource' do
         provider.install
       end
 
-      describe "when a source is specified" do
-        describe "as a normal file" do
+      context "when a source is specified" do
+        context "as a normal file" do
           it "should use the file name instead of the gem name" do
             resource[:source] = "/my/file"
             provider.expects(:execute).with { |args| args[2] == "/my/file" }.returns ""
             provider.install
           end
         end
-        describe "as a file url" do
+
+        context "as a file url" do
           it "should use the file name instead of the gem name" do
             resource[:source] = "file:///my/file"
             provider.expects(:execute).with { |args| args[2] == "/my/file" }.returns ""
             provider.install
           end
         end
-        describe "as a puppet url" do
+
+        context "as a puppet url" do
           it "should fail" do
             resource[:source] = "puppet://my/file"
             expect { provider.install }.to raise_error(Puppet::Error)
           end
         end
-        describe "as a non-file and non-puppet url" do
+
+        context "as a non-file and non-puppet url" do
           it "should treat the source as a gem repository" do
             resource[:source] = "http://host/my/file"
             provider.expects(:execute).with { |args| args[2..4] == ["--source", "http://host/my/file", "myresource"] }.returns ""
             provider.install
           end
         end
-        describe "as a windows path on windows", :if => Puppet.features.microsoft_windows? do
+
+        context "as a windows path on windows", :if => Puppet.features.microsoft_windows? do
           it "should treat the source as a local path" do
             resource[:source] = "c:/this/is/a/path/to/a/gem.gem"
             provider.expects(:execute).with { |args| args[2] == "c:/this/is/a/path/to/a/gem.gem" }.returns ""
             provider.install
           end
         end
-        describe "with an invalid uri" do
+
+        context "with an invalid uri" do
           it "should fail" do
             URI.expects(:parse).raises(ArgumentError)
             resource[:source] = "http:::::uppet:/:/my/file"
@@ -105,7 +107,7 @@ context 'installing myresource' do
       end
     end
 
-    describe "#latest" do
+    context "#latest" do
       it "should return a single value for 'latest'" do
         #gemlist is used for retrieving both local and remote version numbers, and there are cases
         # (particularly local) where it makes sense for it to return an array.  That doesn't make
@@ -131,55 +133,55 @@ context 'installing myresource' do
       end
     end
 
-    describe "#instances" do
+    context "#instances" do
       before do
-        provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
       end
 
       it "should return an empty array when no gems installed" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns("\n")
-        expect(provider_class.instances).to eq([])
+        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns("\n")
+        expect(described_class.instances).to eq([])
       end
 
       it "should return ensure values as an array of installed versions" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
+        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         vagrant (0.8.7, 0.6.9)
         HEREDOC
 
-        expect(provider_class.instances.map {|p| p.properties}).to eq([
+        expect(described_class.instances.map {|p| p.properties}).to eq([
           {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
           {:ensure => ["0.8.7", "0.6.9"], :provider => :gem, :name => 'vagrant'}
         ])
       end
 
       it "should ignore platform specifications" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
+        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         nokogiri (1.6.1 ruby java x86-mingw32 x86-mswin32-60, 1.4.4.1 x86-mswin32)
         HEREDOC
 
-        expect(provider_class.instances.map {|p| p.properties}).to eq([
+        expect(described_class.instances.map {|p| p.properties}).to eq([
           {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
           {:ensure => ["1.6.1", "1.4.4.1"], :provider => :gem, :name => 'nokogiri'}
         ])
       end
 
       it "should not list 'default: ' text from rubygems''" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}, anything).returns <<-HEREDOC.gsub(/        /, '')
+        described_class.expects(:execute).with(%w{/my/gem list --local}, anything).returns <<-HEREDOC.gsub(/        /, '')
         bundler (1.16.1, default: 1.16.0, 1.15.1)
         HEREDOC
 
-        expect(provider_class.instances.map {|p| p.properties}).to eq([
+        expect(described_class.instances.map {|p| p.properties}).to eq([
           {:name => 'bundler', :ensure => ["1.16.1", "1.16.0", "1.15.1"], :provider => :gem}
         ])
       end
 
       it "should not fail when an unmatched line is returned" do
-        provider_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).
+        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).
           returns(File.read(my_fixture('line-with-1.8.5-warning')))
 
-        expect(provider_class.instances.map {|p| p.properties}).
+        expect(described_class.instances.map {|p| p.properties}).
           to eq([{:provider=>:gem, :ensure=>["0.3.2"], :name=>"columnize"},
                  {:provider=>:gem, :ensure=>["1.1.3"], :name=>"diff-lcs"},
                  {:provider=>:gem, :ensure=>["0.0.1"], :name=>"metaclass"},
@@ -193,18 +195,18 @@ context 'installing myresource' do
       end
     end
 
-    describe "listing gems" do
-      describe "searching for a single package" do
+    context "listing gems" do
+      context "searching for a single package" do
         it "searches for an exact match" do
-          provider_class.expects(:execute).with(includes('\Abundler\z'), {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns(File.read(my_fixture('gem-list-single-package')))
+          described_class.expects(:execute).with(includes('\Abundler\z'), {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns(File.read(my_fixture('gem-list-single-package')))
           expected = {:name => 'bundler', :ensure => %w[1.6.2], :provider => :gem}
-          expect(provider_class.gemlist({:justme => 'bundler'})).to eq(expected)
+          expect(described_class.gemlist({:justme => 'bundler'})).to eq(expected)
         end
       end
     end
 
-    describe 'insync?' do
-      describe 'for array of versions' do
+    context 'insync?' do
+      context 'for array of versions' do
         let(:is) { ['1.3.4', '3.6.1', '5.1.2'] }
 
         it 'returns true for ~> 1.3' do
@@ -233,7 +235,7 @@ context 'installing myresource' do
         end
       end
 
-      describe 'for string version' do
+      context 'for string version' do
         let(:is) { '1.3.4' }
 
         it 'returns true for ~> 1.3' do
@@ -273,10 +275,8 @@ context 'installing myresource' do
       end
     end
   end
-end
 
-context 'uninstalling myresource' do
-  describe provider_class do
+  context 'uninstalling myresource' do
     let(:resource) do
       Puppet::Type.type(:package).new(
         :name     => 'myresource',
@@ -285,7 +285,7 @@ context 'uninstalling myresource' do
     end
 
     let(:provider) do
-      provider = provider_class.new
+      provider = described_class.new
       provider.resource = resource
       provider
     end
@@ -294,9 +294,9 @@ context 'uninstalling myresource' do
       resource.provider = provider
     end
 
-    describe "when uninstalling" do
+    context "when uninstalling" do
       it "should use the path to the gem" do
-        provider_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
         provider.expects(:execute).with { |args| args[0] == "/my/gem" }.returns ""
         provider.uninstall
       end

--- a/spec/unit/provider/package/hpux_spec.rb
+++ b/spec/unit/provider/package/hpux_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:hpux)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:hpux) do
   before(:each) do
     # Create a mock resource
     @resource = stub 'resource'
@@ -16,33 +13,33 @@ describe provider_class do
     @resource.stubs(:[]).with(:source).returns "mysource"
     @resource.stubs(:[]).with(:ensure).returns :installed
 
-    @provider = provider_class.new
+    @provider = subject()
     @provider.stubs(:resource).returns @resource
   end
 
   it "should have an install method" do
-    @provider = provider_class.new
+    @provider = subject()
     expect(@provider).to respond_to(:install)
   end
 
   it "should have an uninstall method" do
-    @provider = provider_class.new
+    @provider = subject()
     expect(@provider).to respond_to(:uninstall)
   end
 
   it "should have a swlist method" do
-    @provider = provider_class.new
+    @provider = subject()
     expect(@provider).to respond_to(:swlist)
   end
 
-  describe "when installing" do
+  context "when installing" do
     it "should use a command-line like 'swinstall -x mount_all_filesystems=false -s SOURCE PACKAGE-NAME'" do
       @provider.expects(:swinstall).with('-x', 'mount_all_filesystems=false', '-s', 'mysource', 'mypackage')
       @provider.install
     end
   end
 
-  describe "when uninstalling" do
+  context "when uninstalling" do
     it "should use a command-line like 'swremove -x mount_all_filesystems=false PACKAGE-NAME'" do
       @provider.expects(:swremove).with('-x', 'mount_all_filesystems=false', 'mypackage')
       @provider.uninstall

--- a/spec/unit/provider/package/macports_spec.rb
+++ b/spec/unit/provider/package/macports_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:macports)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:macports) do
   let :resource_name do
     "foo"
   end
@@ -21,7 +19,7 @@ describe provider_class do
     {:name => resource_name, :ensure => "1.2.3", :revision => "1", :provider => :macports}
   end
 
-  describe "provider features" do
+  context "provider features" do
     subject { provider }
 
     it { is_expected.to be_installable }
@@ -30,30 +28,30 @@ describe provider_class do
     it { is_expected.to be_versionable }
   end
 
-  describe "when listing all instances" do
+  context "when listing all instances" do
     it "should call port -q installed" do
-      provider_class.expects(:port).with("-q", :installed).returns("")
-      provider_class.instances
+      described_class.expects(:port).with("-q", :installed).returns("")
+      described_class.instances
     end
 
     it "should create instances from active ports" do
-      provider_class.expects(:port).returns("foo @1.234.5_2 (active)")
-      expect(provider_class.instances.size).to eq(1)
+      described_class.expects(:port).returns("foo @1.234.5_2 (active)")
+      expect(described_class.instances.size).to eq(1)
     end
 
     it "should ignore ports that aren't activated" do
-      provider_class.expects(:port).returns("foo @1.234.5_2")
-      expect(provider_class.instances.size).to eq(0)
+      described_class.expects(:port).returns("foo @1.234.5_2")
+      expect(described_class.instances.size).to eq(0)
     end
 
     it "should ignore variants" do
-      expect(provider_class.parse_installed_query_line("bar @1.0beta2_38_1+x11+java (active)")).
+      expect(described_class.parse_installed_query_line("bar @1.0beta2_38_1+x11+java (active)")).
         to eq({:provider=>:macports, :revision=>"1", :name=>"bar", :ensure=>"1.0beta2_38"})
     end
 
   end
 
-  describe "when installing" do
+  context "when installing" do
    it "should not specify a version when ensure is set to latest" do
      resource[:ensure] = :latest
      provider.expects(:port).with { |flag, method, name, version|
@@ -79,7 +77,7 @@ describe provider_class do
    end
   end
 
-  describe "when querying for the latest version" do
+  context "when querying for the latest version" do
     let :new_info_line do
       "1.2.3 2"
     end
@@ -120,7 +118,7 @@ describe provider_class do
     end
   end
 
-  describe "when updating a port" do
+  context "when updating a port" do
     it "should execute port install if the port is installed" do
       resource[:name] = resource_name
       resource[:ensure] = :present

--- a/spec/unit/provider/package/nim_spec.rb
+++ b/spec/unit/provider/package/nim_spec.rb
@@ -1,10 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:nim)
-
-describe provider_class do
-
+describe Puppet::Type.type(:package).provider(:nim) do
   before(:each) do
     # Create a mock resource
     @resource = stub 'resource'
@@ -17,12 +13,12 @@ describe provider_class do
     @resource.stubs(:[]).with(:source).returns "mysource"
     @resource.stubs(:[]).with(:ensure).returns :installed
 
-    @provider = provider_class.new
+    @provider = subject()
     @provider.resource = @resource
   end
 
   it "should have an install method" do
-    @provider = provider_class.new
+    @provider = subject()
     expect(@provider).to respond_to(:install)
   end
 
@@ -48,7 +44,6 @@ END
 
   context "when installing" do
     it "should install a package" do
-
       @resource.stubs(:should).with(:ensure).returns(:installed)
       Puppet::Util::Execution.expects(:execute).with("/usr/sbin/nimclient -o showres -a resource=mysource |/usr/bin/grep -p -E 'mypackage\\.foo'").returns(bff_showres_output)
       @provider.expects(:nimclient).with("-o", "cust", "-a", "installp_flags=acgwXY", "-a", "lpp_source=mysource", "-a", "filesets=mypackage.foo 1.2.3.8")
@@ -56,7 +51,6 @@ END
     end
 
     context "when installing versioned packages" do
-
       it "should fail if the package is not available on the lpp source" do
         nimclient_showres_output = ""
 
@@ -130,7 +124,6 @@ OUTPUT
 
         expect { @provider.install }.to raise_error(Puppet::Error, "NIM package provider is unable to downgrade packages")
     end
-
 
     it "should succeed if an RPM package is available on the lpp source" do
         nimclient_sequence = sequence('nimclient')

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:pip3)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:pip3) do
 
   it { is_expected.to be_installable }
   it { is_expected.to be_uninstallable }
@@ -12,11 +9,11 @@ describe provider_class do
   it { is_expected.to be_install_options }
 
   it "should inherit most things from pip provider" do
-    expect(provider_class < Puppet::Type.type(:package).provider(:pip))
+    expect(described_class < Puppet::Type.type(:package).provider(:pip))
   end
 
   it "should use pip3 command" do
-    expect(provider_class.cmd).to eq(["pip3"])
+    expect(described_class.cmd).to eq(["pip3"])
   end
 
 end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -1,23 +1,19 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:pip)
 osfamilies = { 'windows' => ['pip.exe'], 'other' => ['pip', 'pip-python'] }
 
-describe provider_class do
-
+describe Puppet::Type.type(:package).provider(:pip) do
   before do  
     @resource = Puppet::Resource.new(:package, "fake_package")
-    @provider = provider_class.new(@resource)
+    @provider = described_class.new(@resource)
     @client = stub_everything('client')
     @client.stubs(:call).with('package_releases', 'real_package').returns(["1.3", "1.2.5", "1.2.4"])
     @client.stubs(:call).with('package_releases', 'fake_package').returns([])
   end
 
-  describe "parse" do
-
+  context "parse" do
     it "should return a hash on valid input" do
-      expect(provider_class.parse("real_package==1.2.5")).to eq({
+      expect(described_class.parse("real_package==1.2.5")).to eq({
         :ensure   => "1.2.5",
         :name     => "real_package",
         :provider => :pip,
@@ -25,48 +21,43 @@ describe provider_class do
     end
 
     it "should return nil on invalid input" do
-      expect(provider_class.parse("foo")).to eq(nil)
+      expect(described_class.parse("foo")).to eq(nil)
     end
-
   end
 
-  describe "cmd" do
-
+  context "cmd" do
     it "should return 'pip.exe' by default on Windows systems" do
       Puppet.features.stubs(:microsoft_windows?).returns true
-      expect(provider_class.cmd[0]).to eq('pip.exe')
+      expect(described_class.cmd[0]).to eq('pip.exe')
     end
 
     it "could return pip-python on legacy redhat systems which rename pip" do
       Puppet.features.stubs(:microsoft_windows?).returns false
-      expect(provider_class.cmd[1]).to eq('pip-python')
+      expect(described_class.cmd[1]).to eq('pip-python')
     end
 
     it "should return pip by default on other systems" do
       Puppet.features.stubs(:microsoft_windows?).returns false
-      expect(provider_class.cmd[0]).to eq('pip')
+      expect(described_class.cmd[0]).to eq('pip')
     end
-
   end
 
-  describe "instances" do
-
+  context "instances" do
     osfamilies.each do |osfamily, pip_cmds|
-
       it "should return an array on #{osfamily} systems when #{pip_cmds.join(' or ')} is present" do
         Puppet.features.stubs(:microsoft_windows?).returns (osfamily == 'windows')
         pip_cmds.each do |pip_cmd|  
           pip_cmds.each do |cmd|
             unless cmd == pip_cmd
-              provider_class.expects(:which).with(cmd).returns(nil)
+              described_class.expects(:which).with(cmd).returns(nil)
             end
           end
-          provider_class.stubs(:pip_version).returns('8.0.1')
-          provider_class.expects(:which).with(pip_cmd).returns("/fake/bin/#{pip_cmd}")
+          described_class.stubs(:pip_version).returns('8.0.1')
+          described_class.expects(:which).with(pip_cmd).returns("/fake/bin/#{pip_cmd}")
           p = stub("process")
           p.expects(:collect).yields("real_package==1.2.5")
-          provider_class.expects(:execpipe).with(["/fake/bin/#{pip_cmd}", "freeze"]).yields(p)
-          provider_class.instances
+          described_class.expects(:execpipe).with(["/fake/bin/#{pip_cmd}", "freeze"]).yields(p)
+          described_class.instances
         end
       end
 
@@ -75,12 +66,12 @@ describe provider_class do
         versions.each do |version|
           it "should use the --all option when version is '#{version}'" do
             Puppet.features.stubs(:microsoft_windows?).returns (osfamily == 'windows')
-            provider_class.stubs(:pip_cmd).returns('/fake/bin/pip')
-            provider_class.stubs(:pip_version).returns(version)
+            described_class.stubs(:pip_cmd).returns('/fake/bin/pip')
+            described_class.stubs(:pip_version).returns(version)
             p = stub("process")
             p.expects(:collect).yields("real_package==1.2.5")
-            provider_class.expects(:execpipe).with(["/fake/bin/pip", "freeze", "--all"]).yields(p)
-            provider_class.instances
+            described_class.expects(:execpipe).with(["/fake/bin/pip", "freeze", "--all"]).yields(p)
+            described_class.instances
           end
         end
       end
@@ -88,23 +79,20 @@ describe provider_class do
       it "should return an empty array on #{osfamily} systems when #{pip_cmds.join(' and ')} are missing" do
         Puppet.features.stubs(:microsoft_windows?).returns (osfamily == 'windows')
         pip_cmds.each do |cmd|
-          provider_class.expects(:which).with(cmd).returns nil
+          described_class.expects(:which).with(cmd).returns nil
         end
-        expect(provider_class.instances).to eq([])
+        expect(described_class.instances).to eq([])
       end
-
     end
-
   end
 
-  describe "query" do
-
+  context "query" do
     before do
       @resource[:name] = "real_package"
     end
 
     it "should return a hash when pip and the package are present" do
-      provider_class.expects(:instances).returns [provider_class.new({
+      described_class.expects(:instances).returns [described_class.new({
         :ensure   => "1.2.5",
         :name     => "real_package",
         :provider => :pip,
@@ -118,14 +106,14 @@ describe provider_class do
     end
 
     it "should return nil when the package is missing" do
-      provider_class.expects(:instances).returns []
+      described_class.expects(:instances).returns []
       expect(@provider.query).to eq(nil)
     end
 
     it "should be case insensitive" do
       @resource[:name] = "Real_Package"
 
-      provider_class.expects(:instances).returns [provider_class.new({
+      described_class.expects(:instances).returns [described_class.new({
         :ensure   => "1.2.5",
         :name     => "real_package",
         :provider => :pip,
@@ -137,16 +125,15 @@ describe provider_class do
         :provider => :pip,
       })
     end
-
   end
 
-  describe "latest" do
+  context "latest" do
     context "with pip version < 1.5.4" do
       before :each do
-        provider_class.stubs(:pip_version).returns('1.0.1')
-        provider_class.stubs(:which).with('pip').returns("/fake/bin/pip")
-        provider_class.stubs(:which).with('pip-python').returns("/fake/bin/pip")
-        provider_class.stubs(:which).with('pip.exe').returns("/fake/bin/pip")
+        described_class.stubs(:pip_version).returns('1.0.1')
+        described_class.stubs(:which).with('pip').returns("/fake/bin/pip")
+        described_class.stubs(:which).with('pip-python').returns("/fake/bin/pip")
+        described_class.stubs(:which).with('pip.exe').returns("/fake/bin/pip")
       end
 
       it "should find a version number for new_pip_package" do
@@ -198,12 +185,11 @@ describe provider_class do
     context "with pip version >= 1.5.4" do
       # For Pip 1.5.4 and above, you can get a version list from CLI - which allows for native pip behavior
       # with regards to custom repositories, proxies and the like
-
       before :each do
-        provider_class.stubs(:pip_version).returns('1.5.4')
-        provider_class.stubs(:which).with('pip').returns("/fake/bin/pip")
-        provider_class.stubs(:which).with('pip-python').returns("/fake/bin/pip")
-        provider_class.stubs(:which).with('pip.exe').returns("/fake/bin/pip")
+        described_class.stubs(:pip_version).returns('1.5.4')
+        described_class.stubs(:which).with('pip').returns("/fake/bin/pip")
+        described_class.stubs(:which).with('pip-python').returns("/fake/bin/pip")
+        described_class.stubs(:which).with('pip.exe').returns("/fake/bin/pip")
       end
 
       it "should find a version number for real_package" do
@@ -247,11 +233,9 @@ describe provider_class do
         expect(latest).to eq('15.0.2')
       end
     end
-
   end
 
-  describe "install" do
-
+  context "install" do
     before do
       @resource[:name] = "fake_package"
       @url = "git+https://example.com/fake_package.git"
@@ -314,48 +298,40 @@ describe provider_class do
         with("install", "-q", "--timeout=10", "--no-index", "fake_package")
       @provider.install
     end
-
   end
 
-  describe "uninstall" do
-
+  context "uninstall" do
     it "should uninstall" do
       @resource[:name] = "fake_package"
       @provider.expects(:lazy_pip).
         with('uninstall', '-y', '-q', 'fake_package')
       @provider.uninstall
     end
-
   end
 
-  describe "update" do
-
+  context "update" do
     it "should just call install" do
       @provider.expects(:install).returns(nil)
       @provider.update
     end
-
   end
 
-  describe "pip_version" do
-
+  context "pip_version" do
     it "should return nil on missing pip" do
-      provider_class.stubs(:pip_cmd).returns(nil)
-      expect(provider_class.pip_version).to eq(nil)
+      described_class.stubs(:pip_cmd).returns(nil)
+      expect(described_class.pip_version).to eq(nil)
     end
 
     it "should look up version if pip is present" do
-      provider_class.stubs(:pip_cmd).returns('/fake/bin/pip')
+      described_class.stubs(:pip_cmd).returns('/fake/bin/pip')
       p = stub("process")
       p.expects(:collect).yields('pip 8.0.2 from /usr/local/lib/python2.7/dist-packages (python 2.7)')
-      provider_class.expects(:execpipe).with(['/fake/bin/pip', '--version']).yields(p)
-      expect(provider_class.pip_version).to eq('8.0.2')
+      described_class.expects(:execpipe).with(['/fake/bin/pip', '--version']).yields(p)
+      expect(described_class.pip_version).to eq('8.0.2')
     end
-
   end
 
-  describe "lazy_pip" do
-
+  context "lazy_pip" do
     after(:each) do
       Puppet::Type::Package::ProviderPip.instance_variable_set(:@confine_collection, nil)
     end
@@ -366,7 +342,6 @@ describe provider_class do
     end
 
     osfamilies.each do |osfamily, pip_cmds|
-
       pip_cmds.each do |pip_cmd|
         it "should retry on #{osfamily} systems if #{pip_cmd} has not yet been found" do
           Puppet.features.stubs(:microsoft_windows?).returns (osfamily == 'windows')
@@ -399,9 +374,6 @@ describe provider_class do
         expect { @provider.method(:lazy_pip).call("freeze") }.
           to raise_error(NoMethodError, "Could not locate command #{pip_cmds.join(' and ')}.")
       end
-
     end
-
   end
-
 end

--- a/spec/unit/provider/package/pkgin_spec.rb
+++ b/spec/unit/provider/package/pkgin_spec.rb
@@ -1,19 +1,16 @@
 require "spec_helper"
 
-provider_class = Puppet::Type.type(:package).provider(:pkgin)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:pkgin) do
   let(:resource) { Puppet::Type.type(:package).new(:name => "vim", :provider => :pkgin) }
   subject        { resource.provider }
 
   describe "Puppet provider interface" do
     it "can return the list of all packages" do
-      expect(provider_class).to respond_to(:instances)
+      expect(described_class).to respond_to(:instances)
     end
   end
 
   describe "#install" do
-
    describe "a package not installed" do
     before { resource[:ensure] = :absent }
     it "uses pkgin install to install" do
@@ -29,7 +26,6 @@ describe provider_class do
       subject.install
     end
    end
-
   end
 
   describe "#uninstall" do
@@ -45,19 +41,19 @@ describe provider_class do
     end
 
     before do
-      provider_class.stubs(:pkgin).with(:list).returns(pkgin_ls_output)
+      described_class.stubs(:pkgin).with(:list).returns(pkgin_ls_output)
     end
 
     it "returns an array of providers for each package" do
-      instances = provider_class.instances
+      instances = described_class.instances
       expect(instances).to have(2).items
       instances.each do |instance|
-        expect(instance).to be_a(provider_class)
+        expect(instance).to be_a(described_class)
       end
     end
 
     it "populates each provider with an installed package" do
-      zlib_provider, zziplib_provider = provider_class.instances
+      zlib_provider, zziplib_provider = described_class.instances
       expect(zlib_provider.get(:name)).to eq("zlib")
       expect(zlib_provider.get(:ensure)).to eq("1.2.3")
       expect(zziplib_provider.get(:name)).to eq("zziplib")
@@ -67,7 +63,7 @@ describe provider_class do
 
   describe "#latest" do
     before do
-      provider_class.stubs(:pkgin).with(:search, "vim").returns(pkgin_search_output)
+      described_class.stubs(:pkgin).with(:search, "vim").returns(pkgin_search_output)
     end
 
     context "when the package is installed" do
@@ -119,7 +115,7 @@ SEARCH
       end
 
       it "returns the newest available version" do
-        provider_class.stubs(:pkgin).with(:search, "vim").returns(pkgin_search_output)
+        described_class.stubs(:pkgin).with(:search, "vim").returns(pkgin_search_output)
         expect(subject.latest).to eq("7.3")
       end
     end
@@ -140,7 +136,7 @@ SEARCH
       let(:package) { "vim-7.2.446;=;Vim editor (vi clone) without GUI" }
 
       it "extracts the name and status" do
-        expect(provider_class.parse_pkgin_line(package)).to eq({ :name => "vim" ,
+        expect(described_class.parse_pkgin_line(package)).to eq({ :name => "vim" ,
                                                              :status => "=" ,
                                                              :ensure => "7.2.446" })
       end
@@ -150,7 +146,7 @@ SEARCH
       let(:package) { "ruby18-puppet-0.25.5nb1;>;Configuration management framework written in Ruby" }
 
       it "extracts the name and status" do
-        expect(provider_class.parse_pkgin_line(package)).to eq({ :name =>  "ruby18-puppet",
+        expect(described_class.parse_pkgin_line(package)).to eq({ :name =>  "ruby18-puppet",
                                                              :status => ">" ,
                                                              :ensure => "0.25.5nb1" })
       end
@@ -160,7 +156,7 @@ SEARCH
       let(:package) { "ruby200-facter-2.4.3nb1;=;Cross-platform Ruby library for retrieving facts from OS" }
 
       it "extracts the name and status" do
-        expect(provider_class.parse_pkgin_line(package)).to eq({ :name =>  "ruby200-facter",
+        expect(described_class.parse_pkgin_line(package)).to eq({ :name =>  "ruby200-facter",
                                                              :status => "=" ,
                                                              :ensure => "2.4.3nb1" })
       end
@@ -170,18 +166,17 @@ SEARCH
       let(:package) { "vim-7.2.446;Vim editor (vi clone) without GUI" }
 
       it "extracts the name and status" do
-        expect(provider_class.parse_pkgin_line(package)).to eq({ :name => "vim" ,
+        expect(described_class.parse_pkgin_line(package)).to eq({ :name => "vim" ,
                                                              :status => nil ,
                                                              :ensure => "7.2.446" })
       end
-
     end
 
     context "with an invalid package" do
       let(:package) { "" }
 
       it "returns nil" do
-        expect(provider_class.parse_pkgin_line(package)).to be_nil
+        expect(described_class.parse_pkgin_line(package)).to be_nil
       end
     end
   end

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -1,10 +1,7 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/provider/package/pkgng'
 
-provider_class = Puppet::Type.type(:package).provider(:pkgng)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:pkgng) do
   let(:name) { 'bash' }
   let(:installed_name) { 'zsh' }
   let(:pkgng) { 'pkgng' }
@@ -38,41 +35,41 @@ describe provider_class do
   end
 
   before do
-    provider_class.stubs(:command).with(:pkg) { '/usr/local/sbin/pkg' }
+    described_class.stubs(:command).with(:pkg) { '/usr/local/sbin/pkg' }
 
     info = File.read(my_fixture('pkg.info'))
-    provider_class.stubs(:get_query).returns(info)
+    described_class.stubs(:get_query).returns(info)
 
     version_list = File.read(my_fixture('pkg.version'))
-    provider_class.stubs(:get_version_list).returns(version_list)
+    described_class.stubs(:get_version_list).returns(version_list)
   end
 
   context "#instances" do
     it "should return the empty set if no packages are listed" do
-      provider_class.stubs(:get_query).returns('')
-      provider_class.stubs(:get_version_list).returns('')
-      expect(provider_class.instances).to be_empty
+      described_class.stubs(:get_query).returns('')
+      described_class.stubs(:get_version_list).returns('')
+      expect(described_class.instances).to be_empty
     end
 
     it "should return all packages when invoked" do
-      expect(provider_class.instances.map(&:name).sort).to eq(
+      expect(described_class.instances.map(&:name).sort).to eq(
         %w{ca_root_nss curl nmap pkg gnupg mcollective zsh tac_plus}.sort)
     end
 
     it "should set latest to current version when no upgrade available" do
-      nmap = provider_class.instances.find {|i| i.properties[:origin] == 'security/nmap' }
+      nmap = described_class.instances.find {|i| i.properties[:origin] == 'security/nmap' }
 
       expect(nmap.properties[:version]).to eq(nmap.properties[:latest])
     end
 
     it "should return an empty array when pkg calls raise an exception" do
-      provider_class.stubs(:get_query).raises(Puppet::ExecutionFailure, 'An error occurred.')
-      expect(provider_class.instances).to eq([])
+      described_class.stubs(:get_query).raises(Puppet::ExecutionFailure, 'An error occurred.')
+      expect(described_class.instances).to eq([])
     end
 
     describe "version" do
       it "should retrieve the correct version of the current package" do
-        zsh = provider_class.instances.find {|i| i.properties[:origin] == 'shells/zsh' }
+        zsh = described_class.instances.find {|i| i.properties[:origin] == 'shells/zsh' }
         expect( zsh.properties[:version]).to eq('5.0.2_1')
       end
     end
@@ -118,32 +115,32 @@ describe provider_class do
 
   context "#prefetch" do
     it "should fail gracefully when " do
-      provider_class.stubs(:instances).returns([])
-      expect{ provider_class.prefetch({}) }.to_not raise_error
+      described_class.stubs(:instances).returns([])
+      expect{ described_class.prefetch({}) }.to_not raise_error
     end
   end
 
   context "#query" do
     it "should return the installed version if present" do
-      provider_class.prefetch({installed_name => installed_resource})
+      described_class.prefetch({installed_name => installed_resource})
       expect(installed_provider.query).to eq({:version=>'5.0.2_1'})
     end
 
     it "should return nil if not present" do
       fixture = File.read(my_fixture('pkg.query_absent'))
-      provider_class.stubs(:get_resource_info).with('bash').returns(fixture)
+      described_class.stubs(:get_resource_info).with('bash').returns(fixture)
       expect(provider.query).to equal(nil)
     end
   end
 
   describe "latest" do
     it "should retrieve the correct version of the latest package" do
-      provider_class.prefetch( { installed_name => installed_resource })
+      described_class.prefetch( { installed_name => installed_resource })
       expect(installed_provider.latest).not_to be_nil
     end
 
     it "should set latest to newer package version when available" do
-      instances = provider_class.instances
+      instances = described_class.instances
       curl = instances.find {|i| i.properties[:origin] == 'ftp/curl' }
       expect(curl.properties[:latest]).to eq('7.33.0_2')
     end
@@ -164,13 +161,13 @@ describe provider_class do
   describe "get_latest_version" do
     it "should rereturn nil when the current package is the latest" do
       version_list = File.read(my_fixture('pkg.version'))
-      nmap_latest_version = provider_class.get_latest_version('security/nmap', version_list)
+      nmap_latest_version = described_class.get_latest_version('security/nmap', version_list)
       expect(nmap_latest_version).to be_nil
     end
 
     it "should match the package name exactly" do
       version_list = File.read(my_fixture('pkg.version'))
-      bash_comp_latest_version = provider_class.get_latest_version('shells/bash-completion', version_list)
+      bash_comp_latest_version = described_class.get_latest_version('shells/bash-completion', version_list)
       expect(bash_comp_latest_version).to eq('2.1_3')
     end
   end
@@ -179,7 +176,7 @@ describe provider_class do
     context "on FreeBSD" do
       it "should be the default provider" do
         Facter.expects(:value).with(:operatingsystem).at_least_once.returns :freebsd
-        expect(provider_class).to be_default
+        expect(described_class).to be_default
       end
     end
   end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:puppet_gem)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:puppet_gem) do
   let(:resource) do
     Puppet::Type.type(:package).new(
       :name     => 'myresource',
@@ -12,7 +9,7 @@ describe provider_class do
   end
 
   let(:provider) do
-    provider = provider_class.new
+    provider = described_class.new
     provider.resource = resource
     provider
   end
@@ -27,9 +24,9 @@ describe provider_class do
     resource.provider = provider
   end
 
-  describe "when installing" do
+  context "when installing" do
     it "should use the path to the gem" do
-      provider_class.expects(:which).with(puppet_gem).returns(puppet_gem)
+      described_class.expects(:which).with(puppet_gem).returns(puppet_gem)
       provider.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
       provider.install
     end
@@ -46,9 +43,9 @@ describe provider_class do
     end
   end
 
-  describe "when uninstalling" do
+  context "when uninstalling" do
     it "should use the path to the gem" do
-      provider_class.expects(:which).with(puppet_gem).returns(puppet_gem)
+      described_class.expects(:which).with(puppet_gem).returns(puppet_gem)
       provider.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
       provider.install
     end

--- a/spec/unit/provider/package/tdnf_spec.rb
+++ b/spec/unit/provider/package/tdnf_spec.rb
@@ -2,17 +2,14 @@ require 'spec_helper'
 
 # Note that much of the functionality of the tdnf provider is already tested with yum provider tests,
 # as yum is the parent provider, via dnf
+describe Puppet::Type.type(:package).provider(:tdnf) do
+  it_behaves_like 'RHEL package provider', described_class, 'tdnf'
 
-provider_class = Puppet::Type.type(:package).provider(:tdnf)
-
-context 'default' do
-  it 'should be the default provider on PhotonOS' do
-    Facter.stubs(:value).with(:osfamily).returns(:redhat)
-    Facter.stubs(:value).with(:operatingsystem).returns("PhotonOS")
-    expect(provider_class).to be_default
+  context 'default' do
+    it 'should be the default provider on PhotonOS' do
+      Facter.stubs(:value).with(:osfamily).returns(:redhat)
+      Facter.stubs(:value).with(:operatingsystem).returns("PhotonOS")
+      expect(described_class).to be_default
+    end
   end
-end
-
-describe provider_class do
-  it_behaves_like 'RHEL package provider', provider_class, 'tdnf'
 end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -1,11 +1,9 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:yum)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:yum) do
   include PuppetSpec::Fixtures
-  it_behaves_like 'RHEL package provider', provider_class, 'yum'
+
+  it_behaves_like 'RHEL package provider', described_class, 'yum'
 
   describe "when supplied the source param" do
     let(:name) { 'baz' }
@@ -18,12 +16,12 @@ describe provider_class do
     end
 
     let(:provider) do
-      provider = provider_class.new
+      provider = described_class.new
       provider.resource = resource
       provider
     end
 
-    before { provider_class.stubs(:command).with(:cmd).returns("/usr/bin/yum") }
+    before { described_class.stubs(:command).with(:cmd).returns("/usr/bin/yum") }
 
     context "when installing" do
       it "should use the supplied source as the explicit path to a package to install" do
@@ -51,16 +49,18 @@ describe provider_class do
     end
   end
 
-  describe "parsing the output of check-update" do
-    describe "with no multiline entries" do
+  context "parsing the output of check-update" do
+    context "with no multiline entries" do
       let(:check_update) { File.read(my_fixture("yum-check-update-simple.txt")) }
       let(:output) { described_class.parse_updates(check_update) }
+
       it 'creates an entry for each package keyed on the package name' do
         expect(output['curl']).to eq([{:name => 'curl', :epoch => '0', :version => '7.32.0', :release => '10.fc20', :arch => 'i686'}, {:name => 'curl', :epoch => '0', :version => '7.32.0', :release => '10.fc20', :arch => 'x86_64'}])
         expect(output['gawk']).to eq([{:name => 'gawk', :epoch => '0', :version => '4.1.0', :release => '3.fc20', :arch => 'i686'}])
         expect(output['dhclient']).to eq([{:name => 'dhclient', :epoch => '12', :version => '4.1.1', :release => '38.P1.fc20', :arch => 'i686'}])
         expect(output['selinux-policy']).to eq([{:name => 'selinux-policy', :epoch => '0', :version => '3.12.1', :release => '163.fc20', :arch => 'noarch'}])
       end
+
       it 'creates an entry for each package keyed on the package name and package architecture' do
         expect(output['curl.i686']).to eq([{:name => 'curl', :epoch => '0', :version => '7.32.0', :release => '10.fc20', :arch => 'i686'}])
         expect(output['curl.x86_64']).to eq([{:name => 'curl', :epoch => '0', :version => '7.32.0', :release => '10.fc20', :arch => 'x86_64'}])
@@ -70,55 +70,69 @@ describe provider_class do
         expect(output['java-1.8.0-openjdk.x86_64']).to eq([{:name => 'java-1.8.0-openjdk', :epoch => '1', :version => '1.8.0.131', :release => '2.b11.el7_3', :arch => 'x86_64'}])
       end
     end
-    describe "with multiline entries" do
+
+    context "with multiline entries" do
       let(:check_update) { File.read(my_fixture("yum-check-update-multiline.txt")) }
       let(:output) { described_class.parse_updates(check_update) }
+
       it "parses multi-line values as a single package tuple" do
         expect(output['libpcap']).to eq([{:name => 'libpcap', :epoch => '14', :version => '1.4.0', :release => '1.20130826git2dbcaa1.el6', :arch => 'x86_64'}])
       end
     end
-    describe "with obsoleted packages" do
+
+    context "with obsoleted packages" do
       let(:check_update) { File.read(my_fixture("yum-check-update-obsoletes.txt")) }
       let(:output) { described_class.parse_updates(check_update) }
+
       it "ignores all entries including and after 'Obsoleting Packages'" do
         expect(output).not_to include("Obsoleting")
         expect(output).not_to include("NetworkManager-bluetooth.x86_64")
         expect(output).not_to include("1:1.0.0-14.git20150121.b4ea599c.el7")
       end
     end
-    describe "with security notifications" do
+
+    context "with security notifications" do
       let(:check_update) { File.read(my_fixture("yum-check-update-security.txt")) }
       let(:output) { described_class.parse_updates(check_update) }
+
       it "ignores all entries including and after 'Security'" do
         expect(output).not_to include("Security")
       end
+
       it "includes updates before 'Security'" do
         expect(output).to include("yum-plugin-fastestmirror.noarch")
       end
     end
-    describe "with broken update notices" do
+
+    context "with broken update notices" do
       let(:check_update) { File.read(my_fixture("yum-check-update-broken-notices.txt")) }
       let(:output) { described_class.parse_updates(check_update) }
+
       it "ignores all entries including and after 'Update'" do
         expect(output).not_to include("Update")
       end
+
       it "includes updates before 'Update'" do
         expect(output).to include("yum-plugin-fastestmirror.noarch")
       end
     end
-    describe "with improper package names in output" do
+
+    context "with improper package names in output" do
       it "raises an exception parsing package name" do
         expect {
           described_class.update_to_hash('badpackagename', '1')
         }.to raise_exception(Exception, /Failed to parse/)
       end
     end
-    describe "with trailing plugin output" do
+
+    context "with trailing plugin output" do
       let(:check_update) { File.read(my_fixture("yum-check-update-plugin-output.txt")) }
       let(:output) { described_class.parse_updates(check_update) }
+
       it "parses correctly formatted entries" do
         expect(output['bash']).to eq([{:name => 'bash', :epoch => '0', :version => '4.2.46', :release => '12.el7', :arch => 'x86_64'}])
       end
+
       it "ignores all mentions of plugin output" do
         expect(output).not_to include("Random plugin")
       end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -1,9 +1,6 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:package).provider(:zypper)
-
-describe provider_class do
+describe Puppet::Type.type(:package).provider(:zypper) do
   before(:each) do
     # Create a mock resource
     @resource = stub 'resource'
@@ -16,35 +13,35 @@ describe provider_class do
     @resource.stubs(:[]).with(:ensure).returns :installed
     @resource.stubs(:command).with(:zypper).returns "/usr/bin/zypper"
 
-    @provider = provider_class.new(@resource)
+    @provider = described_class.new(@resource)
   end
 
   it "should have an install method" do
-    @provider = provider_class.new
+    @provider = described_class.new
     expect(@provider).to respond_to(:install)
   end
 
   it "should have an uninstall method" do
-    @provider = provider_class.new
+    @provider = described_class.new
     expect(@provider).to respond_to(:uninstall)
   end
 
   it "should have an update method" do
-    @provider = provider_class.new
+    @provider = described_class.new
     expect(@provider).to respond_to(:update)
   end
 
   it "should have a latest method" do
-    @provider = provider_class.new
+    @provider = described_class.new
     expect(@provider).to respond_to(:latest)
   end
 
   it "should have a install_options method" do
-    @provider = provider_class.new
+    @provider = described_class.new
     expect(@provider).to respond_to(:install_options)
   end
 
-  describe "when installing with zypper version >= 1.0" do
+  context "when installing with zypper version >= 1.0" do
     it "should use a command-line with versioned package'" do
       @resource.stubs(:should).with(:ensure).returns "1.2.3-4.5.6"
       @resource.stubs(:allow_virtual?).returns false
@@ -65,7 +62,7 @@ describe provider_class do
     end
   end
 
-  describe "when installing with zypper version = 0.6.104" do
+  context "when installing with zypper version = 0.6.104" do
     it "should use a command-line with versioned package'" do
       @resource.stubs(:should).with(:ensure).returns "1.2.3-4.5.6"
       @resource.stubs(:allow_virtual?).returns false
@@ -86,7 +83,7 @@ describe provider_class do
     end
   end
 
-  describe "when installing with zypper version = 0.6.13" do
+  context "when installing with zypper version = 0.6.13" do
     it "should use a command-line with versioned package'" do
       @resource.stubs(:should).with(:ensure).returns "1.2.3-4.5.6"
       @resource.stubs(:allow_virtual?).returns false
@@ -107,15 +104,16 @@ describe provider_class do
     end
   end
 
-  describe "when updating" do
+  context "when updating" do
     it "should call install method of instance" do
       @provider.expects(:install)
       @provider.update
     end
   end
 
-  describe "when getting latest version" do
-    after do described_class.reset! end
+  context "when getting latest version" do
+    after { described_class.reset! }
+
     context "when the package has available update" do
       it "should return a version string with valid list-updates data from SLES11sp1" do
         fake_data = File.read(my_fixture('zypper-list-updates-SLES11sp1.out'))
@@ -144,7 +142,7 @@ describe provider_class do
     end
   end
 
-  describe "should install a virtual package" do
+  context "should install a virtual package" do
     it "when zypper version = 0.6.13" do
       @resource.stubs(:should).with(:ensure).returns :installed
       @resource.stubs(:allow_virtual?).returns true
@@ -164,7 +162,7 @@ describe provider_class do
     end
   end
 
-  describe "when installing with zypper install options" do
+  context "when installing with zypper install options" do
     it "should install the package without checking keys" do
       @resource.stubs(:[]).with(:name).returns "php5"
       @resource.stubs(:[]).with(:install_options).returns ['--no-gpg-check', {'-p' => '/vagrant/files/localrepo/'}]
@@ -215,7 +213,7 @@ describe provider_class do
     end
   end
 
-  describe 'when uninstalling' do
+  context 'when uninstalling' do
     it 'should use remove to uninstall on zypper version 1.6 and above' do
       @provider.stubs(:zypper_version).returns '1.6.308'
       @provider.expects(:zypper).with(:remove, '--no-confirm', 'mypackage')

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -1,20 +1,16 @@
-#!/usr/bin/env ruby
-
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:bsd)
-
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:service).provider(:bsd), :unless => Puppet.features.microsoft_windows? do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     Facter.stubs(:value).with(:operatingsystem).returns :netbsd
     Facter.stubs(:value).with(:osfamily).returns 'NetBSD'
     described_class.stubs(:defpath).returns('/etc/rc.conf.d')
-    @provider = provider_class.new
+    @provider = subject()
     @provider.stubs(:initscript)
   end
 
-  describe "#instances" do
+  context "#instances" do
     it "should have an instances method" do
       expect(described_class).to respond_to :instances
     end
@@ -24,7 +20,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#disable" do
+  context "#disable" do
     it "should have a disable method" do
       expect(@provider).to respond_to(:disable)
     end
@@ -45,7 +41,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#enable" do
+  context "#enable" do
     it "should have an enable method" do
       expect(@provider).to respond_to(:enable)
     end
@@ -70,7 +66,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#enabled?" do
+  context "#enabled?" do
     it "should have an enabled? method" do
       expect(@provider).to respond_to(:enabled?)
     end
@@ -90,7 +86,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#startcmd" do
+  context "#startcmd" do
     it "should have a startcmd method" do
       expect(@provider).to respond_to(:startcmd)
     end
@@ -109,7 +105,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#stopcmd" do
+  context "#stopcmd" do
     it "should have a stopcmd method" do
       expect(@provider).to respond_to(:stopcmd)
     end

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -1,14 +1,6 @@
-#! /usr/bin/env ruby
-#
-# Unit testing for the debian service provider
-#
-
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:debian)
-
-describe provider_class do
-
+describe Puppet::Type.type(:service).provider(:debian) do
   if Puppet.features.microsoft_windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
@@ -19,7 +11,7 @@ describe provider_class do
     # Create a mock resource
     @resource = stub 'resource'
 
-    @provider = provider_class.new
+    @provider = subject()
 
     # A catch all; no parameters set
     @resource.stubs(:[]).returns(nil)
@@ -43,14 +35,14 @@ describe provider_class do
     it "should be the default provider on CumulusLinux #{version}" do
       Facter.expects(:value).with(:operatingsystem).at_least_once.returns('CumulusLinux')
       Facter.expects(:value).with(:operatingsystemmajrelease).returns(version)
-      expect(provider_class.default?).to be_truthy
+      expect(described_class.default?).to be_truthy
     end
   end
 
   it "should be the default provider on Debian" do
     Facter.expects(:value).with(:operatingsystem).at_least_once.returns('Debian')
     Facter.expects(:value).with(:operatingsystemmajrelease).returns('7')
-    expect(provider_class.default?).to be_truthy
+    expect(described_class.default?).to be_truthy
   end
 
   it "should have an enabled? method" do
@@ -65,14 +57,14 @@ describe provider_class do
     expect(@provider).to respond_to(:disable)
   end
 
-  describe "when enabling" do
+  context "when enabling" do
     it "should call update-rc.d twice" do
       @provider.expects(:update_rc).twice
       @provider.enable
     end
   end
 
-  describe "when disabling" do
+  context "when disabling" do
     it "should be able to disable services with newer sysv-rc versions" do
       @provider.stubs(:`).with("dpkg --compare-versions $(dpkg-query -W --showformat '${Version}' sysv-rc) ge 2.88 ; echo $?").returns "0"
 
@@ -91,7 +83,7 @@ describe provider_class do
     end
   end
 
-  describe "when checking whether it is enabled" do
+  context "when checking whether it is enabled" do
     it "should call Kernel.system() with the appropriate parameters" do
       @provider.expects(:system).with("/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start").once
       $CHILD_STATUS.stubs(:exitstatus).returns(0)
@@ -151,7 +143,7 @@ describe provider_class do
     end
   end
 
-  describe "when checking service status" do
+  context "when checking service status" do
     it "should use the service command" do
       Facter.stubs(:value).with(:operatingsystem).returns('Debian')
       Facter.stubs(:value).with(:operatingsystemmajrelease).returns('8')

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -1,11 +1,8 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:freebsd)
-
-describe provider_class do
+describe Puppet::Type.type(:service).provider(:freebsd) do
   before :each do
-    @provider = provider_class.new
+    @provider = subject()
     @provider.stubs(:initscript)
     Facter.stubs(:value).with(:osfamily).returns 'FreeBSD'
   end

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -1,12 +1,6 @@
-#!/usr/bin/env ruby
-#
-# Unit testing for the OpenBSD service provider
-
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:openbsd)
-
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:service).provider(:openbsd), :unless => Puppet.features.microsoft_windows? do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     Facter.stubs(:value).with(:operatingsystem).returns :openbsd
@@ -15,7 +9,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     FileTest.stubs(:executable?).with('/usr/sbin/rcctl').returns true
   end
 
-  describe "#instances" do
+  context "#instances" do
     it "should have an instances method" do
       expect(described_class).to respond_to :instances
     end
@@ -28,7 +22,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#start" do
+  context "#start" do
     it "should use the supplied start command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
       provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
@@ -42,7 +36,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#stop" do
+  context "#stop" do
     it "should use the supplied stop command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
       provider.expects(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
@@ -56,7 +50,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#status" do
+  context "#status" do
     it "should use the status command from the resource" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
       provider.expects(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :failonfail => true, :override_locale => false, :squelch => false, :combine => true).never
@@ -81,7 +75,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#restart" do
+  context "#restart" do
     it "should use the supplied restart command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
       provider.expects(:execute).with(['/usr/sbin/rcctl', '-f', :restart, 'sshd'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true).never
@@ -104,7 +98,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#enabled?" do
+  context "#enabled?" do
     it "should return :true if the service is enabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
       described_class.stubs(:rcctl).with(:get, 'sshd', :status)
@@ -120,7 +114,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#enable" do
+  context "#enable" do
     it "should run rcctl enable to enable the service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
       described_class.stubs(:rcctl).with(:enable, 'sshd').returns('')
@@ -138,7 +132,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#disable" do
+  context "#disable" do
     it "should run rcctl disable to disable the service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
       described_class.stubs(:rcctl).with(:disable, 'sshd').returns('')
@@ -147,7 +141,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#running?" do
+  context "#running?" do
     it "should run rcctl check to check the service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
       described_class.stubs(:rcctl).with(:check, 'sshd').returns('sshd(ok)')
@@ -170,7 +164,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#flags" do
+  context "#flags" do
     it "should return flags when set" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :flags => '-6'))
       described_class.stubs(:rcctl).with('get', 'sshd', 'flags').returns('-6')
@@ -193,7 +187,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
   end
 
-  describe "#flags=" do
+  context "#flags=" do
     it "should run rcctl to set flags" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
       described_class.stubs(:rcctl).with(:set, 'sshd', :flags, '-4').returns('')

--- a/spec/unit/provider/service/rcng_spec.rb
+++ b/spec/unit/provider/service/rcng_spec.rb
@@ -1,20 +1,16 @@
-#!/usr/bin/env ruby
-
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:rcng)
-
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:service).provider(:rcng), :unless => Puppet.features.microsoft_windows? do
   before :each do
     Puppet::Type.type(:service).stubs(:defaultprovider).returns described_class
     Facter.stubs(:value).with(:operatingsystem).returns :netbsd
     Facter.stubs(:value).with(:osfamily).returns 'NetBSD'
     described_class.stubs(:defpath).returns('/etc/rc.d')
-    @provider = provider_class.new
+    @provider = subject()
     @provider.stubs(:initscript)
   end
 
-  describe "#enable" do
+  context "#enable" do
     it "should have an enable method" do
       expect(@provider).to respond_to(:enable)
     end

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -1,19 +1,12 @@
-#! /usr/bin/env ruby
-#
-# Unit testing for the RedHat service Provider
-#
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:redhat)
-
-describe provider_class, :if => Puppet.features.posix? do
-
+describe Puppet::Type.type(:service).provider(:redhat), :if => Puppet.features.posix? do
   before :each do
     @class = Puppet::Type.type(:service).provider(:redhat)
     @resource = stub 'resource'
     @resource.stubs(:[]).returns(nil)
     @resource.stubs(:[]).with(:name).returns "myservice"
-    @provider = provider_class.new
+    @provider = subject()
     @resource.stubs(:provider).returns @provider
     @provider.resource = @resource
     @provider.stubs(:get).with(:hasstatus).returns false
@@ -28,7 +21,7 @@ describe provider_class, :if => Puppet.features.posix? do
   osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
       Facter.expects(:value).with(:osfamily).returns(osfamily)
-      expect(provider_class.default?).to be_truthy
+      expect(described_class.default?).to be_truthy
     end
   end
 
@@ -40,7 +33,7 @@ describe provider_class, :if => Puppet.features.posix? do
   end
 
   # test self.instances
-  describe "when getting all service instances" do
+  context "when getting all service instances" do
     before :each do
       @services = ['one', 'two', 'three', 'four', 'kudzu', 'functions', 'halt', 'killall', 'single', 'linuxconf', 'boot', 'reboot']
       @not_services = ['functions', 'halt', 'killall', 'single', 'linuxconf', 'reboot', 'boot']
@@ -64,13 +57,13 @@ describe provider_class, :if => Puppet.features.posix? do
   end
 
   it "should use '--add' and 'on' when calling enable" do
-    provider_class.expects(:chkconfig).with("--add", @resource[:name])
-    provider_class.expects(:chkconfig).with(@resource[:name], :on)
+    described_class.expects(:chkconfig).with("--add", @resource[:name])
+    described_class.expects(:chkconfig).with(@resource[:name], :on)
     @provider.enable
   end
 
   it "(#15797) should explicitly turn off the service in all run levels" do
-    provider_class.expects(:chkconfig).with("--level", "0123456", @resource[:name], :off)
+    described_class.expects(:chkconfig).with("--level", "0123456", @resource[:name], :off)
     @provider.disable
   end
 
@@ -78,28 +71,28 @@ describe provider_class, :if => Puppet.features.posix? do
     expect(@provider).to respond_to(:enabled?)
   end
 
-  describe "when checking enabled? on Suse" do
+  context "when checking enabled? on Suse" do
     before :each do
       Facter.expects(:value).with(:osfamily).returns 'Suse'
     end
 
     it "should check for on" do
-      provider_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  on"
+      described_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  on"
       expect(@provider.enabled?).to eq(:true)
     end
 
     it "should check for B" do
-      provider_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  B"
+      described_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  B"
       expect(@provider.enabled?).to eq(:true)
     end
 
     it "should check for off" do
-      provider_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  off"
+      described_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}  off"
       expect(@provider.enabled?).to eq(:false)
     end
 
     it "should check for unknown service" do
-      provider_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}: unknown service"
+      described_class.stubs(:chkconfig).with(@resource[:name]).returns "#{@resource[:name]}: unknown service"
       expect(@provider.enabled?).to eq(:false)
     end
   end
@@ -132,20 +125,23 @@ describe provider_class, :if => Puppet.features.posix? do
     end
   end
 
-  describe "when checking status" do
-    describe "when hasstatus is :true" do
+  context "when checking status" do
+    context "when hasstatus is :true" do
       before :each do
         @resource.stubs(:[]).with(:hasstatus).returns :true
       end
+
       it "should execute the service script with fail_on_failure false" do
         @provider.expects(:texecute).with(:status, ['/sbin/service', 'myservice', 'status'], false)
         @provider.status
       end
+
       it "should consider the process running if the command returns 0" do
         @provider.expects(:texecute).with(:status, ['/sbin/service', 'myservice', 'status'], false)
         $CHILD_STATUS.stubs(:exitstatus).returns(0)
         expect(@provider.status).to eq(:running)
       end
+
       [-10,-1,1,10].each { |ec|
         it "should consider the process stopped if the command returns something non-0" do
           @provider.expects(:texecute).with(:status, ['/sbin/service', 'myservice', 'status'], false)
@@ -154,11 +150,13 @@ describe provider_class, :if => Puppet.features.posix? do
         end
       }
     end
-    describe "when hasstatus is not :true" do
+
+    context "when hasstatus is not :true" do
       it "should consider the service :running if it has a pid" do
         @provider.expects(:getpid).returns "1234"
         expect(@provider.status).to eq(:running)
       end
+
       it "should consider the service :stopped if it doesn't have a pid" do
         @provider.expects(:getpid).returns nil
         expect(@provider.status).to eq(:stopped)
@@ -166,7 +164,7 @@ describe provider_class, :if => Puppet.features.posix? do
     end
   end
 
-  describe "when restarting and hasrestart is not :true" do
+  context "when restarting and hasrestart is not :true" do
     it "should stop and restart the process with the server script" do
       @provider.expects(:texecute).with(:stop,  ['/sbin/service', 'myservice', 'stop'],  true)
       @provider.expects(:texecute).with(:start, ['/sbin/service', 'myservice', 'start'], true)

--- a/spec/unit/provider/service/runit_spec.rb
+++ b/spec/unit/provider/service/runit_spec.rb
@@ -1,20 +1,11 @@
-#! /usr/bin/env ruby
-#
-# Unit testing for the Runit service Provider
-#
-# author Brice Figureau
-#
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:runit)
-
-describe provider_class do
-
+describe Puppet::Type.type(:service).provider(:runit) do
   before(:each) do
     # Create a mock resource
     @resource = stub 'resource'
 
-    @provider = provider_class.new
+    @provider = subject()
     @servicedir = "/etc/service"
     @provider.servicedir=@servicedir
     @daemondir = "/etc/sv"
@@ -63,7 +54,7 @@ describe provider_class do
     expect(@provider).to respond_to(:disable)
   end
 
-  describe "when starting" do
+  context "when starting" do
     it "should enable the service if it is not enabled" do
       @provider.stubs(:sv)
 
@@ -81,21 +72,21 @@ describe provider_class do
     end
   end
 
-  describe "when stopping" do
+  context "when stopping" do
     it "should execute external command 'sv stop /etc/service/myservice'" do
       @provider.expects(:sv).with("stop", "/etc/service/myservice")
       @provider.stop
     end
   end
 
-  describe "when restarting" do
+  context "when restarting" do
     it "should call 'sv restart /etc/service/myservice'" do
       @provider.expects(:sv).with("restart","/etc/service/myservice")
       @provider.restart
     end
   end
 
-  describe "when enabling" do
+  context "when enabling" do
     it "should create a symlink between daemon dir and service dir", :if => Puppet.features.manages_symlinks? do
       daemon_path = File.join(@daemondir,"myservice")
       service_path = File.join(@servicedir,"myservice")
@@ -105,7 +96,7 @@ describe provider_class do
     end
   end
 
-  describe "when disabling" do
+  context "when disabling" do
     it "should remove the '/etc/service/myservice' symlink" do
       path = File.join(@servicedir,"myservice")
 #      mocked_file = mock(path, :symlink? => true)
@@ -116,14 +107,14 @@ describe provider_class do
     end
   end
 
-  describe "when checking status" do
+  context "when checking status" do
     it "should call the external command 'sv status /etc/sv/myservice'" do
       @provider.expects(:sv).with('status',File.join(@daemondir,"myservice"))
       @provider.status
     end
   end
 
-  describe "when checking status" do
+  context "when checking status" do
     it "and sv status fails, properly raise a Puppet::Error" do
       @provider.expects(:sv).with('status',File.join(@daemondir,"myservice")).raises(Puppet::ExecutionFailure, "fail: /etc/sv/myservice: file not found")
       expect { @provider.status }.to raise_error(Puppet::Error, 'Could not get status for service Service[myservice]: fail: /etc/sv/myservice: file not found')
@@ -141,5 +132,4 @@ describe provider_class do
       expect(@provider.status).to eq(:stopped)
     end
   end
-
 end

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -1,14 +1,6 @@
-#! /usr/bin/env ruby
-#
-# Unit testing for the AIX System Resource Controller (src) provider
-#
-
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:service).provider(:src)
-
-describe provider_class do
-
+describe Puppet::Type.type(:service).provider(:src) do
   if Puppet.features.microsoft_windows?
     # Get a pid for $CHILD_STATUS to latch on to
     command = "cmd.exe /c \"exit 0\""
@@ -20,7 +12,7 @@ describe provider_class do
     @resource.stubs(:[]).returns(nil)
     @resource.stubs(:[]).with(:name).returns "myservice"
 
-    @provider = provider_class.new
+    @provider = subject()
     @provider.resource = @resource
 
     @provider.stubs(:command).with(:stopsrc).returns "/usr/bin/stopsrc"
@@ -42,9 +34,9 @@ describe provider_class do
     @provider.stubs(:chitab)
   end
 
-  describe ".instances" do
+  context ".instances" do
     it "should have a .instances method" do
-      expect(provider_class).to respond_to :instances
+      expect(described_class).to respond_to :instances
     end
 
     it "should get a list of running services" do
@@ -55,8 +47,8 @@ myservice.2:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-
 myservice.3:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-K:0:0:20:0:0:-d:20:tcpip:
 myservice.4:::/usr/sbin/inetd:0:0:/dev/console:/dev/console:/dev/console:-O:-Q:-K:0:0:20:0:0:-d:20:tcpip:
 _EOF_
-      provider_class.stubs(:lssrc).returns sample_output
-      expect(provider_class.instances.map(&:name)).to eq([
+      described_class.stubs(:lssrc).returns sample_output
+      expect(described_class.instances.map(&:name)).to eq([
         'myservice.1',
         'myservice.2',
         'myservice.3',
@@ -66,7 +58,7 @@ _EOF_
 
   end
 
-  describe "when starting a service" do
+  context "when starting a service" do
     it "should execute the startsrc command" do
       @provider.expects(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:override_locale => false, :squelch => false, :combine => true, :failonfail => true})
       @provider.expects(:status).returns :running
@@ -80,7 +72,7 @@ _EOF_
     end
   end
 
-  describe "when stopping a service" do
+  context "when stopping a service" do
     it "should execute the stopsrc command" do
       @provider.expects(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:override_locale => false, :squelch => false, :combine => true, :failonfail => true})
       @provider.expects(:status).returns :stopped
@@ -94,7 +86,7 @@ _EOF_
     end
   end
 
-  describe "should have a set of methods" do
+  context "should have a set of methods" do
     [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
       it "should have a #{method} method" do
         expect(@provider).to respond_to(method)
@@ -102,21 +94,21 @@ _EOF_
     end
   end
 
-  describe "when enabling" do
+  context "when enabling" do
     it "should execute the mkitab command" do
       @provider.expects(:mkitab).with("myservice:2:once:/usr/bin/startsrc -s myservice").once
       @provider.enable
     end
   end
 
-  describe "when disabling" do
+  context "when disabling" do
     it "should execute the rmitab command" do
       @provider.expects(:rmitab).with("myservice")
       @provider.disable
     end
   end
 
-  describe "when checking if it is enabled" do
+  context "when checking if it is enabled" do
     it "should execute the lsitab command" do
       @provider.expects(:execute).with(['/usr/sbin/lsitab', 'myservice'], {:combine => true, :failonfail => false})
       $CHILD_STATUS.stubs(:exitstatus).returns(0)
@@ -136,8 +128,7 @@ _EOF_
     end
   end
 
-
-  describe "when checking a subsystem's status" do
+  context "when checking a subsystem's status" do
     it "should execute status and return running if the subsystem is active" do
       sample_output = <<_EOF_
   Subsystem         Group            PID          Status
@@ -174,7 +165,7 @@ _EOF_
     end
   end
 
-  describe "when restarting a service" do
+  context "when restarting a service" do
     it "should execute restart which runs refresh" do
       sample_output = <<_EOF_
 #subsysname:synonym:cmdargs:path:uid:auditid:standin:standout:standerr:action:multi:contact:svrkey:svrmtype:priority:signorm:sigforce:display:waittime:grpname:

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -1,10 +1,7 @@
-#!/usr/bin/env ruby
 require 'spec_helper'
 require 'etc'
 
-provider_class = Puppet::Type.type(:user).provider(:hpuxuseradd)
-
-describe provider_class, :unless => Puppet.features.microsoft_windows? do
+describe Puppet::Type.type(:user).provider(:hpuxuseradd), :unless => Puppet.features.microsoft_windows? do
   let :resource do
     Puppet::Type.type(:user).new(
       :title => 'testuser',
@@ -38,7 +35,7 @@ describe provider_class, :unless => Puppet.features.microsoft_windows? do
     end
 
     it "should have feature manages_passwords" do
-      expect(provider_class).to be_manages_passwords
+      expect(described_class).to be_manages_passwords
     end
 
     it "should return nil if user does not exist" do

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -1,14 +1,11 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:user).provider(:pw)
-
-describe provider_class do
+describe Puppet::Type.type(:user).provider(:pw) do
   let :resource do
     Puppet::Type.type(:user).new(:name => "testuser", :provider => :pw)
   end
 
-  describe "when creating users" do
+  context "when creating users" do
     let :provider do
       prov = resource.provider
       prov.expects(:exists?).returns nil
@@ -16,8 +13,8 @@ describe provider_class do
     end
 
     it "should run pw with no additional flags when no properties are given" do
-      expect(provider.addcmd).to eq([provider_class.command(:pw), "useradd", "testuser"])
-      provider.expects(:execute).with([provider_class.command(:pw), "useradd", "testuser"], kind_of(Hash))
+      expect(provider.addcmd).to eq([described_class.command(:pw), "useradd", "testuser"])
+      provider.expects(:execute).with([described_class.command(:pw), "useradd", "testuser"], kind_of(Hash))
       provider.create
     end
 
@@ -104,12 +101,12 @@ describe provider_class do
     end
   end
 
-  describe "when deleting users" do
+  context "when deleting users" do
     it "should run pw with no additional flags" do
       provider = resource.provider
       provider.expects(:exists?).returns true
-      expect(provider.deletecmd).to eq([provider_class.command(:pw), "userdel", "testuser"])
-      provider.expects(:execute).with([provider_class.command(:pw), "userdel", "testuser"], has_entry(:custom_environment, {}))
+      expect(provider.deletecmd).to eq([described_class.command(:pw), "userdel", "testuser"])
+      provider.expects(:execute).with([described_class.command(:pw), "userdel", "testuser"], has_entry(:custom_environment, {}))
       provider.delete
     end
 
@@ -133,14 +130,14 @@ describe provider_class do
     end
   end
 
-  describe "when modifying users" do
+  context "when modifying users" do
     let :provider do
       resource.provider
     end
 
     it "should run pw with the correct arguments" do
-      expect(provider.modifycmd("uid", 12345)).to eq([provider_class.command(:pw), "usermod", "testuser", "-u", 12345])
-      provider.expects(:execute).with([provider_class.command(:pw), "usermod", "testuser", "-u", 12345], has_entry(:custom_environment, {}))
+      expect(provider.modifycmd("uid", 12345)).to eq([described_class.command(:pw), "usermod", "testuser", "-u", 12345])
+      provider.expects(:execute).with([described_class.command(:pw), "usermod", "testuser", "-u", 12345], has_entry(:custom_environment, {}))
       provider.uid = 12345
     end
 


### PR DESCRIPTION
Rather than manually keeping track of the class that is under test, we can tell RSpec what class we're describing, and use the built in `subject` to get a default instance of the class, and `described_class` to refer to the class itself.

This does not update test files that have been removed in the master branch.