### PR TITLE
(test) Don't merge - testing jenkins defaults

### DIFF
--- a/lib/puppet/pops/evaluator/collectors/abstract_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/abstract_collector.rb
@@ -53,6 +53,7 @@ class Puppet::Pops::Evaluator::Collectors::AbstractCollector
         unless @collected.include?(res.ref)
           t = res.type
           t = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, t)
+          t = "foo"
           newres = Puppet::Parser::Resource.new(t, res.title, @overrides)
           scope.compiler.add_override(newres)
         end


### PR DESCRIPTION
This is a test to see if Jenkins picks up the 5.5.x target, and what happens if you forget the 'a' at the end of the testing platforms.