### PR TITLE
(PUP-9326) Adds Systemd support for LinuxMint 18 & 19

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -26,6 +26,8 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
 
+  defaultfor :operatingsystem => :LinuxMint
+  notdefaultfor :operatingsystem => :LinuxMint, :operatingsystemmajrelease => ["10", "11", "12", "13", "14", "15", "16", "17"] # These are using upstart
   defaultfor :operatingsystem => :ubuntu
   notdefaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"] # These are using upstart
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -17,6 +17,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   ]
 
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
+  defaultfor :operatingsystem => :LinuxMint, :operatingsystemmajrelease => ["10", "11", "12", "13", "14", "15", "16", "17"]
 
   commands :start   => "/sbin/start",
            :stop    => "/sbin/stop",

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -143,6 +143,24 @@ describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platf
     end
   end
 
+  [ '10', '11', '12', '13', '14', '15', '16', '17' ].each do |ver|
+    it "should not be the default provider on LinuxMint#{ver}" do
+      Facter.stubs(:value).with(:osfamily).returns(:debian)
+      Facter.stubs(:value).with(:operatingsystem).returns(:LinuxMint)
+      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+      expect(provider_class).not_to be_default
+    end
+  end
+
+  [ '18', '19' ].each do |ver|
+    it "should be the default provider on LinuxMint#{ver}" do
+      Facter.stubs(:value).with(:osfamily).returns(:debian)
+      Facter.stubs(:value).with(:operatingsystem).returns(:LinuxMint)
+      Facter.stubs(:value).with(:operatingsystemmajrelease).returns("#{ver}")
+      expect(provider_class).to be_default
+    end
+  end
+
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
     it "should have a #{method} method" do
       expect(provider).to respond_to(method)


### PR DESCRIPTION
LinuxMint switched to using Systemd as it's init system with the release of version 18. Currently, Puppet runs will fail on LinuxMint 18 and LinuxMint 19 machines when using the `service` resource as Puppet tries to use upstart to manage the services. This PR adds support for Systemd on LinuxMint 18 & 19 as well as updates the `systemd_spec.rb` unit test to reflect the changes.