### PR TITLE
(PUP-9330) Add tmpfs to SELinux filesystem whitelist

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -190,7 +190,7 @@ module Puppet::Util::SELinux
   def selinux_label_support?(file)
     fstype = find_fs(file)
     return false if fstype.nil?
-    filesystems = ['ext2', 'ext3', 'ext4', 'gfs', 'gfs2', 'xfs', 'jfs', 'btrfs']
+    filesystems = ['ext2', 'ext3', 'ext4', 'gfs', 'gfs2', 'xfs', 'jfs', 'btrfs', 'tmpfs']
     filesystems.include?(fstype)
   end
 

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -73,6 +73,10 @@ describe Puppet::Util::SELinux do
       expect(selinux_label_support?('/etc/puppetlabs/puppet/testfile')).to be_truthy
     end
 
+    it "should return true if tmpfs" do
+      expect(selinux_label_support?('/dev/shm/testfile')).to be_truthy
+    end
+
     it "should return false for a noncapable filesystem" do
       expect(selinux_label_support?('/mnt/nfs/testfile')).to be_falsey
     end


### PR DESCRIPTION
Tracking Ticket: https://tickets.puppetlabs.com/browse/PUP-9330

Add tmpfs as a SELinux supported filesystem type. 

Currently, Puppet managed directories/files on a `tmpfs` are unable to have their SELinux attributed managed. By adding tmpfs to this array, Puppet will now be able to enforce and configure the SELinux attributes for files and directories on a tmpfs filesystem.

