### PR TITLE
(maint) Add beaker-docker to acceptance gemfile

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -17,6 +17,7 @@ gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || ["~>1.0", ">=
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")
+gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || "~> 0.5")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false


### PR DESCRIPTION
Since we have the ability to run acceptance tests with the docker
hypervisor, we should make it easily available for users