### PR TITLE
(maint) Update acceptance Gemfile for beaker 4

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,6 +16,7 @@ gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
 gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 1")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
+gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,8 +12,8 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.33')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 0.12")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 1")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
 gem "rake", "~> 10.1"

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,6 +16,7 @@ gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
 gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 1")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false


### PR DESCRIPTION
Nightly acceptance tests are already using beaker 4, but the default wasn't updated in the gemfile. This sets beaker 4 as the default, and adds beaker-vmpooler explicitly, since it's not included as part of beaker anymore.