### PR TITLE
(PUP-9327) Delete CSR relative to requestdir

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -199,16 +199,15 @@ END
       end
     end
 
-    settings = {
-      hostprivkey: 'private key',
-      hostpubkey: 'public key',
-      hostcsr: 'certificate request',
-      hostcert: 'certificate',
-      passfile: 'private key password file'
+    paths = {
+      'private key' => Puppet[:hostprivkey],
+      'public key'  => Puppet[:hostpubkey],
+      'certificate request' => File.join(Puppet[:requestdir], "#{Puppet[:certname]}.pem"),
+      'certificate' => Puppet[:hostcert],
+      'private key password file' => Puppet[:passfile]
     }
-    settings.merge!(localcacert: 'local CA certificate', hostcrl: 'local CRL') if options[:localca]
-    settings.each_pair do |setting, label|
-      path = Puppet[setting]
+    paths.merge!('local CA certificate' => Puppet[:localcacert], 'local CRL' => Puppet[:hostcrl]) if options[:localca]
+    paths.each_pair do |label, path|
       if Puppet::FileSystem.exist?(path)
         Puppet::FileSystem.unlink(path)
         Puppet.notice _("Removed %{label} %{path}") % { label: label, path: path }

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -851,7 +851,8 @@ EOT
       :mode => "0644",
       :owner => "service",
       :group => "service",
-      :desc => "Where individual hosts store and look for their certificate requests."
+      :deprecated  => :completely,
+      :desc => "This setting is deprecated."
     },
     :hostcert => {
       :default => "$certdir/$certname.pem",

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -296,9 +296,10 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'deletes the request' do
-      File.open(Puppet[:hostcsr], 'w') { |f| f.write(@host[:csr].to_pem) }
+      path = File.join(Puppet[:requestdir], "#{Puppet[:certname]}.pem")
+      File.open(path, 'w') { |f| f.write(@host[:csr].to_pem) }
 
-      expects_command_to_pass(%r{Removed certificate request #{Puppet[:hostcsr]}})
+      expects_command_to_pass(%r{Removed certificate request #{path}})
     end
 
     it 'deletes the passfile' do


### PR DESCRIPTION
Previously, `puppet ssl clean` did not delete local CSRs which could lead
to the "The local CSR does not match the agent's public key" error the
next time the agent was run.

This commit modifies the `ssl` application to delete the CSR relative to
the `:requestdir` setting, instead of `:hostcsr`. The latter was last
used in the legacy SSLCertificates code circa 2011. The indirector based
implementation stores CSR in the `:requestdir` based on the `:certname`.
See commit de1986196b when the legacy implementation was removed.

This commit also completely deprecates the hostcsr to avoid future
confusion.