### PR TITLE
(PUP-9323) Change resolution of Deferred to be on demand

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -215,6 +215,7 @@ class Puppet::Configurer
   # This just passes any options on to the catalog,
   # which accepts :tags and :ignoreschedules.
   def run(options = {})
+    require 'byebug'; debugger
     pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
     # We create the report pre-populated with default settings for
     # environment and transaction_uuid very early, this is to ensure
@@ -261,6 +262,7 @@ class Puppet::Configurer
   end
 
   def run_internal(options)
+    require 'byebug'; debugger
     start = Time.now
     report = options[:report]
 
@@ -270,6 +272,7 @@ class Puppet::Configurer
       Puppet::GettextConfig.reset_text_domain('agent')
       Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
 
+      # TODO: Needs deferred resolver around this
       if catalog = prepare_and_retrieve_catalog_from_cache(options)
         options[:catalog] = catalog
         @cached_catalog_status = 'explicitly_requested'
@@ -344,7 +347,7 @@ class Puppet::Configurer
                                          current_environment.config_version)
       end
       Puppet.push_context({
-        :current_environment => local_node_environment, 
+        :current_environment => local_node_environment,
         :loaders => Puppet::Pops::Loaders.new(local_node_environment, true)
       }, "Local node environment for configurer transaction")
 
@@ -377,6 +380,7 @@ class Puppet::Configurer
         query_options = get_facts(options)
         query_options[:configured_environment] = configured_environment
 
+        # TODO: Needs deferred_resolver
         return nil unless catalog = prepare_and_retrieve_catalog(options, query_options)
         tries += 1
       end

--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -70,10 +70,19 @@ class Puppet::Transaction::ResourceHarness
   def perform_changes(resource, context)
     cache(resource, :checked, Time.now)
 
+    # The validation may have been delayed - make sure validation has taken place as it may
+    # set the ensure value based on validated input which could cause no action to be taken
+    # if the ensure value is derived. It is also important that any other validation processing
+    # has been performed as the logic here assumes all parameters/properties have been validated.
+    # This call does nothing when the resource is already validated.
+    #
+    resource.do_validation
+
     # Record the current state in state.yml.
     context.audited_params.each do |param|
       cache(resource, param, context.current_values[param])
     end
+
 
     ensure_param = resource.parameter(:ensure)
     if ensure_param && ensure_param.should

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -391,6 +391,18 @@ Puppet::Type.newtype(:file) do
     self.warning _("Checksum value is ignored unless content or source are specified") if self[:checksum_value] && !self[:content] && !self[:source]
 
     provider.validate if provider.respond_to?(:validate)
+
+    # Configure derived values
+    # If they've specified a source, we get our 'should' values
+    # from it.
+    unless self[:ensure]
+      if self[:target]
+        self[:ensure] = :link
+      elsif self[:content]
+        self[:ensure] = :file
+      end
+    end
+
   end
 
   def self.[](path)
@@ -488,16 +500,6 @@ Puppet::Type.newtype(:file) do
     @clients = {}
 
     super
-
-    # If they've specified a source, we get our 'should' values
-    # from it.
-    unless self[:ensure]
-      if self[:target]
-        self[:ensure] = :link
-      elsif self[:content]
-        self[:ensure] = :file
-      end
-    end
 
     @stat = :needs_stat
   end

--- a/spec/integration/application/apply_deferred_spec.rb
+++ b/spec/integration/application/apply_deferred_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+require 'puppet_spec/compiler'
+
+describe "apply with deferred values" do
+  include PuppetSpec::Files
+  include PuppetSpec::Compiler
+
+  before :each do
+    Puppet[:reports] = "none"
+    # Let exceptions be raised instead of exiting
+    Puppet::Application.any_instance.stubs(:exit_on_fail).yields
+  end
+
+  let(:env_name) { 'spec' }
+  let(:libdir_puppet) {{
+    'functions' => {
+      'counter.rb' => <<-PP
+        Puppet::Functions.create_function(:counter) do
+          # returns +1 each call starting with 1
+          def counter()
+            @value ||= 0
+            @value = @value + 1
+          end
+        end
+      PP
+    }
+  }}
+
+  let(:env) { Puppet::Node::Environment.create(:'spec', []) }
+  let(:node) { Puppet::Node.new('test', :environment => env) }
+
+  context 'in a configured environment' do
+    before(:each) do
+      # Test harness does not create the leaf libdir, but the rest of the path is a tmp directory
+      # The below simulates a pluginsync to libdir - which is needed to make apply (using an "for agent" loader)
+      # find the counter() function.
+      #
+      unless Dir.exist?(Puppet[:libdir])
+        Dir.mkdir(Puppet[:libdir])
+        dir_contained_in(Puppet[:libdir], 'puppet' => libdir_puppet)
+      end
+    end
+
+    it 'apply resolves deferred values in dependency order' do
+      # 1. Compile
+      catalog = compile_to_catalog(<<-PP, node)
+        notify { 'b': message => Deferred('sprintf', ['b=%d', Deferred('counter')]) }
+        notify { 'a': message => Deferred('sprintf', ['a=%d', Deferred('counter')]) }
+        Notify[a] -> Notify[b]
+      PP
+
+      # 2. Serialize
+      serialized_catalog = Puppet.override(rich_data: true) do
+        catalog.to_json
+      end
+
+      # 3. Apply
+      Puppet[:environment] = 'spec' 
+      apply = Puppet::Application[:apply]
+      # needed as apply otherwise finds a mismatch catalog.environment vs. actual and tries to get a new catalog
+      apply.options[:catalog] = file_containing('catalog.json', serialized_catalog)
+      expect { apply.run_command; exit(0) }.to exit_with(0)
+
+      # 4. Assert count()  was called in expected order
+      expect(@logs.map(&:to_s)).to include('a=1')
+      expect(@logs.map(&:to_s)).to include('b=2')
+    end
+
+  end
+end


### PR DESCRIPTION
Before this, all Deferred values were resolved upfront when a catalog
was read - via a REST request to a master, or read from disk.

In PUP-9323 it is requested that the resolution of deferred values
should instead occur as late as possible to enable additional use cases;
mainly that deferred functions are guaranteed to be resolved at a time
when all of a resource's dependencies have been processed. For example,
if a resource "a" writes a file, and resource "b" depends on it, then a
deferred function call for a parameter/property in "b" will be
guaranteed to run after "a" has written the file.

This is done by modifying the Parameter and Property classes such that
the first "read" of a `value` / `should` triggers a resolution of
Deferred and Binary values (what was done upfront before this).

To support this, an instance of DeferredResolver is bound in the puppet
context by the `apply` application. This is required since resolution
takes place lazily throughout the entire apply cycle and it would be too
costly to set up a resolver per Deferred value.