### PR TITLE
(PUP-9312) Whitelist registry reads for Windows package providers

### DIFF
--- a/lib/puppet/provider/package/windows/exe_package.rb
+++ b/lib/puppet/provider/package/windows/exe_package.rb
@@ -4,6 +4,19 @@ class Puppet::Provider::Package::Windows
   class ExePackage < Puppet::Provider::Package::Windows::Package
     attr_reader :uninstall_string
 
+    # registry values to load under each product entry in
+    # HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
+    # for this provider
+    REG_VALUE_NAMES = [
+      'DisplayVersion',
+      'UninstallString',
+      'ParentKeyName',
+      'Security Update',
+      'Update Rollup',
+      'Hotfix',
+      'WindowsInstaller',
+    ]
+
     # Return an instance of the package from the registry, or nil
     def self.from_registry(name, values)
       if valid?(name, values)

--- a/lib/puppet/provider/package/windows/msi_package.rb
+++ b/lib/puppet/provider/package/windows/msi_package.rb
@@ -8,6 +8,14 @@ class Puppet::Provider::Package::Windows
     INSTALLSTATE_DEFAULT = 5 # product is installed for the current user
     INSTALLUILEVEL_NONE  = 2 # completely silent installation
 
+    # registry values to load under each product entry in
+    # HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
+    # for this provider
+    REG_VALUE_NAMES = [
+      'DisplayVersion',
+      'WindowsInstaller'
+    ]
+
     # Get the COM installer object, it's in a separate method for testing
     def self.installer
       # REMIND: when does the COM release happen?

--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -11,6 +11,14 @@ class Puppet::Provider::Package::Windows
 
     attr_reader :name, :version
 
+    REG_DISPLAY_VALUE_NAMES = [ 'DisplayName', 'QuietDisplayName' ]
+
+    def self.reg_value_names_to_load
+      REG_DISPLAY_VALUE_NAMES |
+      MsiPackage::REG_VALUE_NAMES |
+      ExePackage::REG_VALUE_NAMES
+    end
+
     # Enumerate each package. The appropriate package subclass
     # will be yielded.
     def self.each(&block)
@@ -37,7 +45,7 @@ class Puppet::Provider::Package::Windows
             open(hive, 'Software\Microsoft\Windows\CurrentVersion\Uninstall', mode) do |uninstall|
               each_key(uninstall) do |name, wtime|
                 open(hive, "#{uninstall.keyname}\\#{name}", mode) do |key|
-                  yield key, values(key)
+                  yield key, values_by_name(key, reg_value_names_to_load)
                 end
               end
             end

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -247,7 +247,9 @@ module Puppet::Util::Windows
               buffer_ptr, length_ptr)
 
             if result != FFI::ERROR_SUCCESS
-              msg = _("Failed to read registry value %{value} at %{key}") % { value: name_ptr.read_wide_string, key: key.keyname }
+              # buffer is raw bytes, *not* chars - less a NULL terminator
+              name_length = (name_ptr.size / FFI.type_size(:wchar)) - 1 if name_ptr.size > 0
+              msg = _("Failed to read registry value %{value} at %{key}") % { value: name_ptr.read_wide_string(name_length), key: key.keyname }
               raise Puppet::Util::Windows::Error.new(msg)
             end
 

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -104,7 +104,7 @@ module Puppet::Util::Windows
 
             if result != FFI::ERROR_SUCCESS
               msg = _("Failed to enumerate %{key} registry keys at index %{index}") % { key: key.keyname, index: index }
-              raise Puppet::Util::Windows::Error.new(msg)
+              raise Puppet::Util::Windows::Error.new(msg, result)
             end
 
             filetime = FFI::WIN32::FILETIME.new(filetime_ptr)
@@ -135,7 +135,7 @@ module Puppet::Util::Windows
 
           if result != FFI::ERROR_SUCCESS
             msg = _("Failed to enumerate %{key} registry values at index %{index}") % { key: key.keyname, index: index }
-            raise Puppet::Util::Windows::Error.new(msg)
+            raise Puppet::Util::Windows::Error.new(msg, result)
           end
 
           subkey_length = subkey_length_ptr.read_dword
@@ -165,7 +165,7 @@ module Puppet::Util::Windows
 
           if status != FFI::ERROR_SUCCESS
             msg = _("Failed to query registry %{key} for sizes") % { key: key.keyname }
-            raise Puppet::Util::Windows::Error.new(msg)
+            raise Puppet::Util::Windows::Error.new(msg, status)
           end
 
           result = [
@@ -250,7 +250,7 @@ module Puppet::Util::Windows
               # buffer is raw bytes, *not* chars - less a NULL terminator
               name_length = (name_ptr.size / FFI.type_size(:wchar)) - 1 if name_ptr.size > 0
               msg = _("Failed to read registry value %{value} at %{key}") % { value: name_ptr.read_wide_string(name_length), key: key.keyname }
-              raise Puppet::Util::Windows::Error.new(msg)
+              raise Puppet::Util::Windows::Error.new(msg, result)
             end
 
             # allows caller to use FFI MemoryPointer helpers to read / shape


### PR DESCRIPTION
Previously, the Windows package provider would enumerate all
   registry values affiliated with a given product.

   Products are enumerated under
   HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall

   Where each individual product resides in a subkey, like 7-Zip

   This could result in reading quite a bit of extraneous data.

 - In reality, there are only 9 key values that the package provider
   is interested in, so whitelist those values when enumerating
   for a given product.

 - This also fixes an issue where some products may install bad data
   into registry values (one such product stores binary data inside
   of a REG_SZ which breaks Puppets abiliy to interpret the value
   as a string).

   While this is really the fault of the product and not of Puppet,
   Puppet must be resilient to such bad data.

---

Alternate approach to #7244 