### PR TITLE
(maint) PA-2344 update tests to work across multiple version of solaris

### DIFF
--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -41,7 +41,7 @@ agents.each do |agent|
 
   step "IPS: check it was created"
   on(agent, puppet("resource package mypkg")) do
-    assert_match( /ensure => '0\.0\.1.*'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure\s+=> '0\.0\.1[,:]?.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: do not upgrade until latest is mentioned"
@@ -52,7 +52,7 @@ agents.each do |agent|
 
   step "IPS: verify it was not upgraded"
   on(agent, puppet("resource package mypkg")) do
-    assert_match( /ensure => '0\.0\.1.*'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure\s+=> '0\.0\.1[,:]?.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: ask to be latest"
@@ -60,7 +60,7 @@ agents.each do |agent|
 
   step "IPS: ensure it was upgraded"
   on(agent, puppet("resource package mypkg")) do
-    assert_match( /ensure => '0\.0\.2.*'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure\s+=> '0\.0\.2[,:]?.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: when there are more than one option, choose latest."
@@ -68,7 +68,7 @@ agents.each do |agent|
   send_pkg agent,:pkg => 'mypkg@0.0.4'
   apply_manifest_on(agent, 'package {mypkg : ensure=>latest}')
   on(agent, puppet("resource package mypkg")) do
-    assert_match( /ensure => '0\.0\.4.*'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure\s+=> '0\.0\.4[,:]?.*'/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: ensure removed."

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -32,7 +32,7 @@ agents.each do |agent|
   end
   step "IPS: check it was created"
   on(agent, puppet("resource package mypkg")) do
-    assert_match( /ensure => '0\.0\.1.*'/, result.stdout, "err: #{agent}")
+    assert_match( /ensure\s+=> '0\.0\.1[,:]?.*'/, result.stdout, "err: #{agent}")
   end
   on agent, "pkg list -v mypkg" do
     assert_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")


### PR DESCRIPTION
In adding Solaris 11.4, we discovered that output from 'resource package'
had subtly different output, which resulted in test failures due to cosmetic
changes. This updates the matching regex to accomodate all current variations.