### PR TITLE
(maint) Set server in main section of conf

### DIFF
--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -21,8 +21,14 @@ test_name "autosign command and csr attributes behavior (#7243,#7244)" do
 
   teardown do
     step "clear test certs"
-    test_certnames.each do |cn|
-      on(master, "puppetserver ca clean --certname #{cn}", :acceptable_exit_codes => [0,24])
+    master_opts = {
+      'main' => { 'server' => fqdn },
+      'master' => { 'dns_alt_names' => "puppet,#{hostname},#{fqdn}" }
+    }
+    with_puppet_running_on(master, master_opts) do
+      on(master,
+         "puppetserver ca clean --certname #{test_certnames.join(',')}",
+         :acceptable_exit_codes => [0,24])
     end
   end
 
@@ -47,10 +53,10 @@ EOF
     on(master, "chmod 777 #{autosign_true_script_path}")
 
     master_opts = {
+      'main' => { 'server' => fqdn },
       'master' => {
         'autosign' => autosign_true_script_path,
-        'dns_alt_names' => "puppet,#{hostname},#{fqdn}",
-        'server' => fqdn
+        'dns_alt_names' => "puppet,#{hostname},#{fqdn}"
       }
     }
     with_puppet_running_on(master, master_opts) do
@@ -88,10 +94,10 @@ EOF
     on(master, "chmod 777 #{autosign_false_script_path}")
 
     master_opts = {
+      'main' => { 'server' => fqdn },
       'master' => {
         'autosign' => autosign_false_script_path,
-        'dns_alt_names' => "puppet,#{hostname},#{fqdn}",
-        'server' => fqdn
+        'dns_alt_names' => "puppet,#{hostname},#{fqdn}"
       }
     }
     with_puppet_running_on(master, master_opts) do
@@ -156,10 +162,10 @@ custom_attributes:
 
   step "Step 5: successfully obtain a cert" do
     master_opts = {
+      'main' => { 'server' => fqdn },
       'master' => {
         'autosign' => autosign_inspect_csr_path,
-        'dns_alt_names' => "puppet,#{hostname},#{fqdn}",
-        'server' => fqdn
+        'dns_alt_names' => "puppet,#{hostname},#{fqdn}"
       },
     }
     with_puppet_running_on(master, master_opts) do

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -13,8 +13,15 @@ test_name "certificate extensions available as trusted data" do
 
   teardown do
     step "Cleanup the test agent certs"
-    agent_certnames.each do |cn|
-      on(master, "puppetserver ca clean --certname #{cn}", :acceptable_exit_codes => [0,24])
+    master_config = {
+      'main' => { 'server' => fqdn },
+      'master' => { 'dns_alt_names' => "puppet,#{hostname},#{fqdn}" }
+    }
+
+    with_puppet_running_on(master, master_config) do
+      on(master,
+         "puppetserver ca clean --certname #{agent_certnames.join(',')}",
+         :acceptable_exit_codes => [0,24])
     end
   end
 
@@ -24,11 +31,11 @@ test_name "certificate extensions available as trusted data" do
   master_config = {
     'main' => {
       'environmentpath' => environments_dir,
+      'server' => fqdn
     },
     'master' => {
       'autosign' => true,
       'dns_alt_names' => "puppet,#{hostname},#{fqdn}",
-      'server' => fqdn
     }
   }
 


### PR DESCRIPTION
The puppetserver ca cli tool needs the value of the server set in "main"
or "master" sections of the puppet.conf to function correctly.

Previously we updated the main portions of the autosign and certificate
extension tests to set server in the master section and removed our
passing of --server to the agent.

The agent however will not see the server setting in the master
section. This moves the server setting to the main section. It
additionally wraps the teardown calls to puppetserver ca in a
with_puppet_running to with server set.