### PR TITLE
(PUP-9340) Update test to account for differently-ordered search results

### DIFF
--- a/spec/unit/indirector/yaml_spec.rb
+++ b/spec/unit/indirector/yaml_spec.rb
@@ -124,7 +124,7 @@ describe Puppet::Indirector::Yaml do
       Dir.expects(:glob).with(:glob).returns(%w{one.yaml two.yaml})
       YAML.expects(:load_file).with("one.yaml").returns @one;
       YAML.expects(:load_file).with("two.yaml").returns @two;
-      expect(@store.search(@request)).to eq([@one, @two])
+      expect(@store.search(@request)).to contain_exactly(@one, @two)
     end
 
     it "should return an array containing a single instance of fact when globbing 'one*'" do


### PR DESCRIPTION
The search results aren't guaranteed to come back in a specific order, so now the test looks to make sure that the set contains the right number of items, and that it also contains the items we're looking for.