### PR TITLE
(PUP-9329) Fix short form format rule for Array/Hash in string converter

### DIFF
--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -484,8 +484,17 @@ class StringConverter
 
     value_type = TypeCalculator.infer_set(value)
     if string_formats.is_a?(String)
-      # add the format given for the exact type
-      string_formats = { value_type => string_formats }
+      # For Array and Hash, the format is given as a Hash where 'format' key is the format for the collection itself
+      if Puppet::Pops::Types::PArrayType::DEFAULT.assignable?(value_type)
+        # add the format given for the exact type
+        string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => {'format' => string_formats }}
+      elsif Puppet::Pops::Types::PHashType::DEFAULT.assignable?(value_type)
+          # add the format given for the exact type
+          string_formats = { Puppet::Pops::Types::PHashType::DEFAULT => {'format' => string_formats }}
+      else
+        # add the format given for the exact type
+        string_formats = { value_type => string_formats }
+      end
     end
 
     case string_formats

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -698,6 +698,15 @@ describe 'The string converter' do
      expect(formatted).to eq(result)
     end
 
+    it 'applies a short form format' do
+      result = [
+        "[1,",
+        "  [2, 3],",
+        "  4]"
+        ].join("\n")
+      expect(converter.convert([1, [2,3], 4], '%#a')).to eq(result)
+    end
+
     it 'treats hashes as nested arrays wrt indentation' do
       string_formats = { Puppet::Pops::Types::PArrayType::DEFAULT => { 'format' => '%#a', 'separator' =>", " } }
       # formatting matters here
@@ -844,6 +853,17 @@ describe 'The string converter' do
        ].join("\n")
 
       expect(converter.convert({1 => "hello", 2 => {3=> "world"}}, string_formats)).to eq(result)
+    end
+
+    it 'applies a short form format' do
+      result = [
+        "{",
+        "  1 => {",
+        "    2 => 3",
+        "  },",
+        "  4 => 5",
+        "}"].join("\n")
+      expect(converter.convert({1 => {2 => 3}, 4 => 5}, '%#h')).to eq(result)
     end
 
     context "containing an array" do


### PR DESCRIPTION
Before this, if specifying a short format (e.g. "%#a") for an
Array or similar for a Hash, the rule would not be applied as
a collection format.

This commit adds the special processing to take the simplified form
when given for a top level Array or Hash to be applied as a format
specification of `{ BASE_TYPE => { 'format' => GIVEN }`.