### PR TITLE
(PUP-9344) Add alt # flag to String %p formatting rule

### DIFF
--- a/lib/puppet/functions/new.rb
+++ b/lib/puppet/functions/new.rb
@@ -608,7 +608,7 @@
 # | Format | String
 # | ------ | ------
 # | s      | Unquoted string, verbatim output of control chars.
-# | p      | Programmatic representation - strings are quoted, interior quotes and control chars are escaped.
+# | p      | Programmatic representation - strings are quoted, interior quotes and control chars are escaped. Selects single or double quotes based on content, or uses double quotes if alternative flag `#` is used.
 # | C      | Each `::` name segment capitalized, quoted if alternative flag `#` is used.
 # | c      | Capitalized string, quoted if alternative flag `#` is used.
 # | d      | Downcased string, quoted if alternative flag `#` is used.

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -804,7 +804,7 @@ class StringConverter
       Kernel.format(f.orig_fmt, val)
 
     when :p
-      apply_string_flags(f, puppet_quote(val))
+      apply_string_flags(f, puppet_quote(val, f.alt?))
 
     when :c
       c_val = val.capitalize
@@ -836,10 +836,15 @@ class StringConverter
   # strings will be quoted using double quotes.
   #
   # @param [String] str the string that should be formatted
+  # @param [Boolean] enforce_double_quotes if true the result will be double quoted (even if single quotes would be possible)
   # @return [String] the formatted string
   #
   # @api public
-  def puppet_quote(str)
+  def puppet_quote(str, enforce_double_quotes = false)
+    if enforce_double_quotes
+      return puppet_double_quote(str)
+    end
+
     # Assume that the string can be single quoted
     bld = '\''
     bld.force_encoding(str.encoding)

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -128,8 +128,12 @@ describe 'The string converter' do
          expect(converter.convert("hello\tworld.\r\nSun is brigth today.", string_formats)).to eq('"hello\\tworld.\\r\\nSun is brigth today."')
       end
 
-      it 'singe quoted result for string that is plain ascii without \\, $ or control characters' do
+      it 'single quoted result for string that is plain ascii without \\, $ or control characters' do
         expect(converter.convert('hello world', string_formats)).to eq("'hello world'")
+      end
+
+      it 'double quoted result when using %#p if it would otherwise be single quoted' do
+        expect(converter.convert('hello world', '%#p')).to eq('"hello world"')
       end
 
       it 'quoted 5-byte unicode chars' do


### PR DESCRIPTION
This adds support for the alternative flag # when using the %p
String formatting rule. By default it selects single or double
quotes around the string based on its content. Single quoted
output may sometimes not be desired.

Thus `String("hello world", '%#p')` will produce `"hello world"` and
`String("hello world", '%p')` will produce `'hello world'` since it can
be expressed as a single quoted string.