### PR TITLE
(docs) Fix markdown markup

### DIFF
--- a/lib/puppet/functions/abs.rb
+++ b/lib/puppet/functions/abs.rb
@@ -28,7 +28,7 @@
 # Integer($strval, 10, true) # Converts to absolute Integer using base 10 (decimal)
 # Integer($strval, 16, true) # Converts to absolute Integer using base 16 (hex)
 # Float($strval, true)       # Converts to absolute Float
-# ```puppet
+# ```
 #
 Puppet::Functions.create_function(:abs) do
   dispatch :on_numeric do


### PR DESCRIPTION
Documentation is partially broken here: the `alert` and `all` functions documentation appears under the `abs` section:
https://puppet.com/docs/puppet/6.0/function.html

![Screenshot](https://screenshotscdn.firefoxusercontent.com/images/d62415af-8c99-4070-9ba5-eae3c854cf9e.png)

This should fix the issue.