### PR TITLE
(PUP-9359) Fix error when 3x function contains calls not based on id

### DIFF
--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -78,7 +78,8 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
     when :fcall, :call
       # Ripper returns a :fcall for a function call in a module (want to know there is a call to newfunction()).
       # And it returns :call for a qualified named call
-      result << :found_newfunction if find_identity(x)[1] == 'newfunction'
+      identity_part = find_identity(x)
+      result << :found_newfunction if identity_part.is_a?(Array) && identity_part[1] == 'newfunction'
     when :def, :defs
       # There should not be any calls to def in a 3x function
       # Ripper returns an array [:def, ...] for a regular def name, and a [:defs ...] for a def self.name

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -423,6 +423,25 @@ describe 'loaders' do
 
   end
 
+  context 'when a 3x load takes place' do
+    let(:env) { environment_for(mix_4x_and_3x_functions) }
+    let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
+    let(:scope) { compiler.topscope }
+    let(:loader) { compiler.loaders.private_loader_for_module('user') }
+
+    before(:each) do
+      Puppet.push_context(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders)
+    end
+    after(:each) do
+      Puppet.pop_context
+    end
+
+    it "a function with no illegal constructs can be loaded" do
+      function = loader.load_typed(typed_name(:function, 'good_func_load')).value
+      expect(function.call(scope)).to eql(Float("3.14"))
+    end
+  end
+
   context 'when a 3x load has illegal method added' do
     let(:env) { environment_for(mix_4x_and_3x_functions) }
     let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }


### PR DESCRIPTION
Before this, when the ruby_legacy_function_loader loaded a 3x function
it scanned the ruby parse tree for calls for the purpose of finding
a call to "newfunction". When doing so, the code did not anticipate
that there are other forms of calls where there is no method name e.g.
Float("3.14"). This resulted in return of `nil` from find_identity.
A subsequent lookup of [1] in that array failed.

This is now fixed by checking if there is an identity (i.e. method
name). And if not, it cannot possibly be the expected "newfunction"
call.

A unit test is added that a Float("3.14") works inside a 3x function.