### PR TITLE
(PUP-9294) Fix error when 3x func has illegal constructs

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1948,6 +1948,16 @@ EOT
       referencing variables that are explicitly set to undef).
     EOT
     },
+   :func3x_check => {
+     :default => true,
+     :type => :boolean,
+     :desc => <<-'EOT'
+       Causes validation of loaded legacy Ruby functions (3x API) to raise errors about illegal constructs that
+       could cause harm or that simply does not work. This flag is on by default. This flag is made available
+       so that the validation can be turned off in case the method of validation is faulty - if encountered, please
+       file a bug report.
+     EOT
+     },
   :tasks => {
     :default => false,
     :type => :boolean,

--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -1,6 +1,7 @@
 # The RubyLegacyFunctionInstantiator instantiates a Puppet::Functions::Function given the ruby source
 # that calls Puppet::Functions.create_function.
 #
+require 'ripper'
 class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
   # Produces an instance of the Function class with the given typed_name, or fails with an error if the
   # given ruby source does not produce this instance when evaluated.
@@ -13,7 +14,9 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
   # @return [Puppet::Pops::Functions.Function] - an instantiated function with global scope closure associated with the given loader
   #
   def self.create(loader, typed_name, source_ref, ruby_code_string)
-    unless ruby_code_string.is_a?(String) && ruby_code_string =~ /Puppet\:\:Parser\:\:Functions.*newfunction/m
+    assertion_result = []
+    assert_code(ruby_code_string, assertion_result)
+    unless ruby_code_string.is_a?(String) && assertion_result.include?(:found_newfunction)
       raise ArgumentError, _("The code loaded from %{source_ref} does not seem to be a Puppet 3x API function - no 'newfunction' call.") % { source_ref: source_ref }
     end
     # make the private loader available in a binding to allow it to be passed on
@@ -60,4 +63,41 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
     binding
   end
   private_class_method :get_binding
+
+  def self.assert_code(code_string, result)
+    ripped = Ripper.sexp(code_string)
+    return if ripped.nil?  # Let the next real parse crash and tell where and what is wrong
+    ripped.each {|x| walk(x, result) }
+  end
+  private_class_method :assert_code
+
+  def self.walk(x, result)
+    return unless x.is_a?(Array)
+    first = x[0]
+    case first
+    when :fcall, :call
+      # Ripper returns a :fcall for a function call in a module (want to know there is a call to newfunction()).
+      # And it returns :call for a qualified named call
+      identity_part = find_identity(x)
+      result << :found_newfunction if identity_part.is_a?(Array) && identity_part[1] == 'newfunction'
+    when :def, :defs
+      # There should not be any calls to def in a 3x function
+      # Ripper returns an array [:def, ...] for a regular def name, and a [:defs ...] for a def self.name
+      identity_part = find_identity(x)
+      # assume there is nothing fancy and that there is always an array with name/line to use (or get nothing)
+      mname, mline = (identity_part.is_a?(Array) ? [identity_part[1], identity_part[2][1]] : [nil, nil]).map {|v| v.nil? ? '<unknown>' : v }
+      raise SecurityError, _("Illegal method definition of method '%{method_name}' on line %{line}' in legacy function. See %{url} for more information") % { 
+        method_name: mname,
+        line: mline,
+        url: "https://puppet.com/docs/puppet/latest/functions_refactor_legacy.html"
+      }
+    end
+    x.each {|v| walk(v, result) }
+  end
+  private_class_method :walk
+
+  def self.find_identity(rast)
+    rast.find{|x| x.is_a?(Array) && x[0] == :@ident }
+  end
+  private_class_method :find_identity
 end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load2.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load2.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  x = newfunction(:bad_func_load2, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    "some return value"
+  end
+end
+def illegal_method_here
+end
+x

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load3.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load3.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  newfunction(:bad_func_load3, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    def bad_func_load3_illegal_method
+      "some return value from illegal method"
+    end
+    "some return value"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load4.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load4.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  newfunction(:bad_func_load4, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    def self.bad_func_load4_illegal_method
+      "some return value from illegal method"
+    end
+    "some return value"
+  end
+end

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load5.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/bad_func_load5.rb
@@ -1,0 +1,12 @@
+x = module Puppet::Parser::Functions
+  newfunction(:bad_func_load5, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    "some return value"
+  end
+end
+def self.bad_func_load5_illegal_method
+end
+# Attempt to get around problem of not returning what newfunction returns
+x

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/good_func_load.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/good_func_load.rb
@@ -1,0 +1,9 @@
+module Puppet::Parser::Functions
+  newfunction(:good_func_load, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API
+  EOS
+  ) do |arguments|
+    # This is not illegal
+    Float("3.14")
+  end
+end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -468,7 +468,7 @@ describe 'loaders' do
     end
 
     it "inside function body is reported as an error" do
-      expect { 
+      expect {
         f = loader.load_typed(typed_name(:function, 'bad_func_load3')).value
         f.call(scope)
       }.to raise_error(/Illegal method definition.*'bad_func_load3_illegal_method'/)
@@ -481,6 +481,27 @@ describe 'loaders' do
       }.to raise_error(/Illegal method definition.*'bad_func_load4_illegal_method'/)
     end
   end
+
+context 'when a 3x load has illegal construct and --func3x_check is false' do
+  let(:env) { environment_for(mix_4x_and_3x_functions) }
+  let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
+  let(:scope) { compiler.topscope }
+  let(:loader) { compiler.loaders.private_loader_for_module('user') }
+
+  before(:each) do
+    Puppet.push_context(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders)
+    Puppet[:func3x_check] = false
+  end
+  after(:each) do
+    Puppet.pop_context
+    Puppet[:func3x_check] = true
+  end
+
+  it "an illegal function is loaded" do
+      f = loader.load_typed(typed_name(:function, 'bad_func_load3')).value
+      expect(f.call(scope)).to eql("some return value")
+  end
+end
 
   context 'when causing a 3x load followed by a 4x load' do
     let(:env) { environment_for(mix_4x_and_3x_functions) }

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -423,7 +423,7 @@ describe 'loaders' do
 
   end
 
-  context 'when causing a 3x load followed by a 4x load' do
+  context 'when a 3x load takes place' do
     let(:env) { environment_for(mix_4x_and_3x_functions) }
     let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
     let(:scope) { compiler.topscope }
@@ -436,8 +436,49 @@ describe 'loaders' do
       Puppet.pop_context
     end
 
-    it "a 3x function with code outside body is reported as an error" do
-      expect { loader.load_typed(typed_name(:function, 'bad_func_load')) }.to raise_error(/Illegal legacy function definition/)
+    it "a function with no illegal constructs can be loaded" do
+      function = loader.load_typed(typed_name(:function, 'good_func_load')).value
+      expect(function.call(scope)).to eql(Float("3.14"))
+    end
+  end
+
+  context 'when a 3x load has illegal method added' do
+    let(:env) { environment_for(mix_4x_and_3x_functions) }
+    let(:compiler) { Puppet::Parser::Compiler.new(Puppet::Node.new("test", :environment => env)) }
+    let(:scope) { compiler.topscope }
+    let(:loader) { compiler.loaders.private_loader_for_module('user') }
+
+    before(:each) do
+      Puppet.push_context(:current_environment => scope.environment, :global_scope => scope, :loaders => compiler.loaders)
+    end
+    after(:each) do
+      Puppet.pop_context
+    end
+
+    it "outside function body is reported as an error" do
+      expect { loader.load_typed(typed_name(:function, 'bad_func_load')) }.to raise_error(/Illegal method definition/)
+    end
+
+    it "to self outside function body is reported as an error" do
+      expect { loader.load_typed(typed_name(:function, 'bad_func_load5')) }.to raise_error(/Illegal method definition.*'bad_func_load5_illegal_method'/)
+    end
+
+    it "outside body is reported as an error even if returning the right func_info" do
+      expect { loader.load_typed(typed_name(:function, 'bad_func_load2'))}.to raise_error(/Illegal method definition/)
+    end
+
+    it "inside function body is reported as an error" do
+      expect { 
+        f = loader.load_typed(typed_name(:function, 'bad_func_load3')).value
+        f.call(scope)
+      }.to raise_error(/Illegal method definition.*'bad_func_load3_illegal_method'/)
+    end
+
+    it "to self inside function body is reported as an error" do
+      expect { 
+        f = loader.load_typed(typed_name(:function, 'bad_func_load4')).value
+        f.call(scope)
+      }.to raise_error(/Illegal method definition.*'bad_func_load4_illegal_method'/)
     end
   end
 


### PR DESCRIPTION
Before this, methods added in a legacy function implementation file
could reside a) inside the body given to `newfunction` or b) before or
after the call to `newfunction` in the `Puppet::Parser::Functions`
module. In both a) and b) the method could be added with a `def mname`
or `def self.mname` neither defining a method where the user expects it
to be added.

This commit adds protection against these method definitions by raising
an error if found in the parsed Ruby source by using the "Ripper" to
generate a Ruby AST that is then walked and checked for illegal constructs.

This also introduces a new setting `--func3x_check` (default `true`) to
enable users to switch of the Ripper parsing and subsequent assertions;
thus making the system behave in the same undefined way as it did before
the logic in the PR was added. This was added as a precaution if the
experimental Ripper API changes (and we have not updated the logic), or
if the logic making use of the Ripper result is faulty for some real world
3x function.
