### PR TITLE
(maint) Update Rakefile warnings task to not check generated egrammar.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -103,6 +103,8 @@ task(:warnings) do
   puts "Checking modified files #{commit_range}"
   %x{git diff --diff-filter=ACM --name-only #{commit_range}}.each_line do |modified_file|
     modified_file.chomp!
+    # Skip racc generated file as it can have many warnings that cannot be manually fixed
+    next if modified_file.end_with?("pops/parser/eparser.rb")
     next if modified_file.start_with?('spec/fixtures/', 'acceptance/fixtures/') || File.extname(modified_file) != '.rb'
     puts modified_file
 


### PR DESCRIPTION
Before this, whenever the grammar was regenerated, the warnings rake
task would find warnings in it related to indentation. Unfortunately it
is not possible to fix those without modifying racc as it produces many
lines with inconsistent indentation.

This makes the rake warnings task simply skip the generated file
puppet/pops/parser/eparser.rb