### PR TITLE
RFC (PUP-9247) Check process name when clearing pidlock

### DIFF
--- a/spec/unit/util/pidlock_spec.rb
+++ b/spec/unit/util/pidlock_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'puppet/util/pidlock'
 
-describe Puppet::Util::Pidlock do
+describe Puppet::Util::Pidlock, if: !Puppet::Util::Platform.jruby? do
   require 'puppet_spec/files'
   include PuppetSpec::Files
 
@@ -23,6 +23,7 @@ describe Puppet::Util::Pidlock do
 
     it "should become locked" do
       @lock.lock
+      Puppet::Util::Execution.stubs(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'comm=']).returns('puppet')
       expect(@lock).to be_locked
     end
 
@@ -101,6 +102,7 @@ describe Puppet::Util::Pidlock do
   describe "#locked?" do
     it "should return true if locked" do
       @lock.lock
+      Puppet::Util::Execution.stubs(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'comm=']).returns('puppet')
       expect(@lock).to be_locked
     end
 
@@ -146,6 +148,7 @@ describe Puppet::Util::Pidlock do
       end
 
       it "should replace with new locks" do
+        Puppet::Util::Execution.stubs(:execute).with(['ps', '-p', 6789, '-o', 'comm=']).returns('puppet')
         @lock.lock
         expect(Puppet::FileSystem.exist?(@lockfile)).to be_truthy
         expect(@lock.lock_pid).to eq(6789)
@@ -170,6 +173,7 @@ describe Puppet::Util::Pidlock do
     before(:each) do
       # fake our pid to be 1234
       Process.stubs(:pid).returns(1234)
+      Puppet::Util::Execution.stubs(:execute).with(['ps', '-p', 1234, '-o', 'comm=']).returns('puppet')
       # lock the file
       @lock.lock
       # fake our pid to be a different pid, to simulate someone else


### PR DESCRIPTION
Under rare but possible conditions, a stale Puppet pidlock file may
exist which contains a pid that refers to another (non-puppet) process.
This adds a check of the process name to avoid locking issues under these
circumstances.

Due to the complexities of cross-platform process management, this
additional check is currently limited to POSIX platforms only.