### PR TITLE
(PUP-9324) Ensure logs denote corrective changes

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -161,6 +161,7 @@ class Puppet::Transaction::ResourceHarness
         name = param.name.to_s
         event.message ||= _("could not create change error message for %{name}") % { name: name }
         event.calculate_corrective_change(@persistence.get_system_value(context.resource.ref, name))
+        event.message << ' (corrective)' if event.corrective_change
         context.record(event)
         event.send_log
         context.synced_params << param.name


### PR DESCRIPTION
Prior to this PR, the log messages for intentional and corrective
changes were identical. This PR changes the logging to append
'(corrective)' to log messages for a corrective change. Intentional
change logs are not affected by this change.