### PR TITLE
(maint) Bump minimum Facter gem version & remove obsolete tests

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "puppet"
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
-  s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])
+  s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
   # PUP-7115 - return to a gem dependency in Puppet 5
   # s.add_runtime_dependency(%q<semantic_puppet>, ['>= 0.1.3', '< 2'])

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -289,21 +289,6 @@ original
       Facter.unstub(:debugging)
     end
 
-    describe 'does not support debugging' do
-      before :each do
-        Facter.stubs(:respond_to?).with(:debugging).returns false
-        Facter.stubs(:debugging).never
-      end
-
-      it 'does not enable Facter debugging for debug level' do
-        Puppet::Util::Log.level = :debug
-      end
-
-      it 'does not enable Facter debugging non-debug level' do
-        Puppet::Util::Log.level = :info
-      end
-    end
-
     describe 'does support debugging' do
       before :each do
         Facter.stubs(:respond_to?).with(:debugging).returns true
@@ -320,21 +305,6 @@ original
       end
     end
 
-    describe 'does not support trace' do
-      before :each do
-        Facter.stubs(:respond_to?).with(:trace).returns false
-        Facter.stubs(:trace).never
-      end
-
-      it 'does not enable Facter trace when enabled' do
-        Puppet[:trace] = true
-      end
-
-      it 'does not enable Facter trace when disabled' do
-        Puppet[:trace] = false
-      end
-    end
-
     describe 'does support trace' do
       before :each do
         Facter.stubs(:respond_to?).with(:trace).returns true
@@ -348,17 +318,6 @@ original
       it 'disables Facter trace when disabled' do
         Facter.stubs(:trace).with(false)
         Puppet[:trace] = false
-      end
-    end
-
-    describe 'does not support on_message' do
-      before :each do
-        Facter.stubs(:respond_to?).with(:on_message).returns false
-        Facter.stubs(:on_message).never
-      end
-
-      it 'does not call Facter.on_message' do
-        expect(Puppet::Util::Logging::setup_facter_logging!).to be_falsey
       end
     end
 


### PR DESCRIPTION
Facter 2.4.0 has been out since Jan 22, 2015, and is the minimum version to contain all of the Facter.debuggin, Facter.trace, and Facter.on_message methods. By requiring at least version 2.4.0 of the Ruby Facter, we no longer have to carry along tests with fragile setup to test for Puppet working if the version of Facter is too old to have any of these methods.