### PR TITLE
(PUP-9372) Add group_by and partition functions on iterables

### DIFF
--- a/lib/puppet/functions/group_by.rb
+++ b/lib/puppet/functions/group_by.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Groups the collection by result of the block. Returns a hash where the keys are the evaluated result from the block
+# and the values are arrays of elements in the collection that correspond to the key.
+Puppet::Functions.create_function(:group_by) do
+  # @param collection A collection of things to group.
+  # @example Group array of strings by length, results in e.g. { 1 => [a, b], 2 => [ab] }
+  #   [a, b, ab].group_by |$s| { $s.length }
+  # @example Group array of strings by length and index, results in e.g. {1 => ['a'], 2 => ['b', 'ab']}
+  #   [a, b, ab].group_by |$i, $s| { $i%2 + $s.length }
+  # @example Group hash iterating by key-value pair, results in e.g. { 2 => [['a', [1, 2]]], 1 => [['b', [1]]] }
+  #   { a => [1, 2], b => [1] }.group_by |$kv| { $kv[1].length }
+  # @example Group hash iterating by key and value, results in e.g. { 2 => [['a', [1, 2]]], 1 => [['b', [1]]] }
+  #   { a => [1, 2], b => [1] }.group_by |$k, $v| { $v.length }
+  dispatch :group_by_1 do
+    required_param 'Collection', :collection
+    block_param 'Callable[1,1]', :block
+    return_type 'Hash'
+  end
+
+  dispatch :group_by_2a do
+    required_param 'Array', :array
+    block_param 'Callable[2,2]', :block
+    return_type 'Hash'
+  end
+
+  dispatch :group_by_2 do
+    required_param 'Collection', :collection
+    block_param 'Callable[2,2]', :block
+    return_type 'Hash'
+  end
+
+  def group_by_1(collection)
+    collection.group_by do |item|
+      yield(item)
+    end.freeze
+  end
+
+  def group_by_2a(array)
+    grouped = array.size.times.zip(array).group_by do |k, v|
+      yield(k, v)
+    end
+
+    grouped.each_with_object({}) do |(k, v), hsh|
+      hsh[k] = v.map { |item| item[1] }
+    end.freeze
+  end
+
+  def group_by_2(collection)
+    collection.group_by do |k, v|
+      yield(k, v)
+    end.freeze
+  end
+end

--- a/lib/puppet/functions/partition.rb
+++ b/lib/puppet/functions/partition.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Returns two arrays, the first containing the elements of enum for which the block evaluates to true,
+# the second containing the rest.
+Puppet::Functions.create_function(:partition) do
+  # @param collection A collection of things to partition.
+  # @example Partition array of empty strings, results in e.g. [[''], [b, c]]
+  #   ['', b, c].partition |$s| { $s.empty }
+  # @example Partition array of strings using index, results in e.g. [['', 'ab'], ['b']]
+  #   ['', b, ab].partition |$i, $s| { $i == 2 or $s.empty }
+  # @example Partition hash of strings by key-value pair, results in e.g. [[['b', []]], [['a', [1, 2]]]]
+  #   { a => [1, 2], b => [] }.partition |$kv| { $kv[1].empty }
+  # @example Partition hash of strings by key and value, results in e.g. [[['b', []]], [['a', [1, 2]]]]
+  #   { a => [1, 2], b => [] }.partition |$k, $v| { $v.empty }
+  dispatch :partition_1 do
+    required_param 'Collection', :collection
+    block_param 'Callable[1,1]', :block
+    return_type 'Tuple[Array, Array]'
+  end
+
+  dispatch :partition_2a do
+    required_param 'Array', :array
+    block_param 'Callable[2,2]', :block
+    return_type 'Tuple[Array, Array]'
+  end
+
+  dispatch :partition_2 do
+    required_param 'Collection', :collection
+    block_param 'Callable[2,2]', :block
+    return_type 'Tuple[Array, Array]'
+  end
+
+  def partition_1(collection)
+    collection.partition do |item|
+      yield(item)
+    end.freeze
+  end
+
+  def partition_2a(array)
+    partitioned = array.size.times.zip(array).partition do |k, v|
+      yield(k, v)
+    end
+
+    partitioned.map do |part|
+      part.map { |item| item[1] }
+    end.freeze
+  end
+
+  def partition_2(collection)
+    collection.partition do |k, v|
+      yield(k, v)
+    end.freeze
+  end
+end

--- a/spec/unit/functions/group_by_spec.rb
+++ b/spec/unit/functions/group_by_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the group_by function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  context 'for an array' do
+    it 'groups by item' do
+      manifest = "notify { String(group_by([a, b, ab]) |$s| { $s.length }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[{1 => ['a', 'b'], 2 => ['ab']}]")
+    end
+
+    it 'groups by index, item' do
+      manifest = "notify { String(group_by([a, b, ab]) |$i, $s| { $i%2 + $s.length }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[{1 => ['a'], 2 => ['b', 'ab']}]")
+    end
+  end
+
+  context 'for a hash' do
+    it 'groups by key-value pair' do
+      manifest = "notify { String(group_by(a => [1, 2], b => [1]) |$kv| { $kv[1].length }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[{2 => [['a', [1, 2]]], 1 => [['b', [1]]]}]")
+    end
+
+    it 'groups by key, value' do
+      manifest = "notify { String(group_by(a => [1, 2], b => [1]) |$k, $v| { $v.length }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[{2 => [['a', [1, 2]]], 1 => [['b', [1]]]}]")
+    end
+  end
+
+  context 'for a string' do
+    it 'fails' do
+      manifest = "notify { String(group_by('something') |$s| { $s.length }): }"
+      expect { compile_to_catalog(manifest) }.to raise_error(Puppet::PreformattedError)
+    end
+  end
+end

--- a/spec/unit/functions/partition_spec.rb
+++ b/spec/unit/functions/partition_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+describe 'the partition function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+
+  context 'for an array' do
+    it 'partitions by item' do
+      manifest = "notify { String(partition(['', b, ab]) |$s| { $s.empty }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[[[''], ['b', 'ab']]]")
+    end
+
+    it 'partitions by index, item' do
+      manifest = "notify { String(partition(['', b, ab]) |$i, $s| { $i == 2 or $s.empty }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[[['', 'ab'], ['b']]]")
+    end
+  end
+
+  context 'for a hash' do
+    it 'partitions by key-value pair' do
+      manifest = "notify { String(partition(a => [1, 2], b => []) |$kv| { $kv[1].empty }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[[[['b', []]], [['a', [1, 2]]]]]")
+    end
+
+    it 'partitions by key, value' do
+      manifest = "notify { String(partition(a => [1, 2], b => []) |$k, $v| { $v.empty }): }"
+      expect(compile_to_catalog(manifest)).to have_resource("Notify[[[['b', []]], [['a', [1, 2]]]]]")
+    end
+  end
+
+  context 'for a string' do
+    it 'fails' do
+      manifest = "notify { String(partition('something') |$s| { $s.empty }): }"
+      expect { compile_to_catalog(manifest) }.to raise_error(Puppet::PreformattedError)
+    end
+  end
+end


### PR DESCRIPTION
Add functions for operating on iterables to easily separate their
contents based on a block.