### PR TITLE
PUP-6488 alternative package command as target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: ruby
 sudo: false
+
+before_install:
+  - gem update --system
+  - gem install bundler
 bundler_args: --jobs 4 --retry 2 --without packaging documentation
+cache: bundler
+
 script:
   - "bundle exec rake $CHECK"
 notifications:

--- a/lib/puppet/provider/package.rb
+++ b/lib/puppet/provider/package.rb
@@ -1,10 +1,95 @@
 class Puppet::Provider::Package < Puppet::Provider
   # Prefetch our package list, yo.
   def self.prefetch(packages)
-    instances.each do |prov|
-      if pkg = packages[prov.name]
-        pkg.provider = prov
+    # Packages resources are deduplicated as they are stored in a hash by name.
+    # A unique key would include name, provider, and target. See transaction.rb.
+
+    # Collect providers and targets from all package resources with a target.
+    default_targets = false
+    targets = {}
+    packages.each do |name, package|
+      if package[:target]
+        if package[:target] == :default
+          default_targets = true
+        else
+          targets[package[:target]] = package.provider.class
+        end
       end
+    end
+
+    # Instances for each package provider without a targeted package command.
+    if default_targets == true || (default_targets == false && targets.empty?)
+      instances.each do |instance|
+        self.debug "Prefetched instance: #{instance.name}"
+        # * See above comment regarding uniqueness.
+        # if package = packages[instance.key]
+          # if package[:target] && package[:target] == :default
+          #  package.provider = instance
+          # end
+        # end
+      end
+    end
+
+    # Instances for each package provider with a targeted package command.
+    targets.each do |target, provider|
+      provider::instances(target).each do |instance|
+        self.debug "Prefetched via: #{target}, instance: #{instance.name}"
+        # * See above comment regarding uniqueness.
+        # if package = packages[instance.key]
+          # if package[:target] && package[:target] == target
+          #   package.provider = instance
+          # end
+        # end
+      end
+    end
+  end
+
+  # Returns a human readable string with information about the package, provider, and target.
+  def to_s
+    "#{@resource}(provider=#{self.class.name})(target=#{resource_target})"
+  end
+
+  # Not all providers are targetable, not all targetable packages have a target.
+  def resource_target
+    resource[:target] || :default
+  end
+
+  # Instance method to determine the package command of a targetable package resource.
+  #
+  # key: the symbol for the default package command in the commands hash
+  def resource_or_default_package_command(key)
+    if resource[:target] && resource[:target] != :default
+      self.class.validate_package_command(resource[:target])
+      resource[:target]
+    else
+      self.class.validate_package_command(command(key))
+      command(key)
+    end
+  end
+
+  # Class method to determine the package command of a targetable package provider.
+  #
+  # cmd: the full path to the target package command
+  # key: the symbol for the default package command in the commands hash
+  def self.command_or_default_package_command(cmd, key)
+    if cmd
+      validate_package_command(cmd)
+      cmd
+    else
+      validate_package_command(command(key))
+      command(key)
+    end
+  end
+
+  # Targetable providers use has_command/is_optional to defer evaluation of provider suitability.
+  #
+  # cmd: the full path to the package command
+  def self.validate_package_command(cmd)
+    unless cmd
+      raise Puppet::Error, _('package command not specified')
+    end
+    unless File.file?(cmd)
+      raise Puppet::Error, _("package command '%{cmd}' does not exist") % { cmd: cmd }
     end
   end
 

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -13,44 +13,9 @@ Puppet::Type.type(:package).provide :pip,
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
-  # Parse lines of output from `pip freeze`, which are structured as
-  # _package_==_version_.
-  def self.parse(line)
-    if line.chomp =~ /^([^=]+)==([^=]+)$/
-      {:ensure => $2, :name => $1, :provider => name}
-    else
-      nil
-    end
-  end
-
-  # Return an array of structured information about every installed package
-  # that's managed by `pip` or an empty array if `pip` is not available.
-  def self.instances
-    packages = []
-    pip_cmd = self.pip_cmd
-    return [] unless pip_cmd
-    command = [pip_cmd, 'freeze']
-    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') >= 0 # a >= b
-      command << '--all'
-    end
-    execpipe command do |process|
-      process.collect do |line|
-        next unless options = parse(line)
-        packages << new(options)
-      end
-    end
-
-    # Pip can also upgrade pip, but it's not listed in freeze so need to special case it
-    # Pip list would also show pip installed version, but "pip list" doesn't exist for older versions of pip (E.G v1.0)
-    # Not needed when "pip freeze --all" is available
-    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') == -1 && version = self.pip_version
-      packages << new({:ensure => version, :name => File.basename(pip_cmd), :provider => name})
-    end
-
-    packages
-  end
+  # Command(s)!
 
   def self.cmd
     if Puppet::Util::Platform.windows?
@@ -60,43 +25,113 @@ Puppet::Type.type(:package).provide :pip,
     end
   end
 
-  def self.pip_cmd
+  def self.default_pip_cmd
     self.cmd.map { |c| which(c) }.find { |c| c != nil }
   end
 
-  def self.pip_version
-    pip_cmd = self.pip_cmd
-    return nil unless pip_cmd
+  # Class method to determine the package command of this targetable package provider.
+  #
+  # cmd: the full path to the target package command.
+  def self.command_or_default_package_command(cmd)
+    if cmd
+      validate_package_command(cmd)
+      cmd
+    else
+      # Do not validate yet, as per lazy_pip below.
+      default_pip_cmd
+    end
+  end
 
-    execpipe [pip_cmd, '--version'] do |process|
+  # Instance method to determine the package command of this targetable package resource.
+  def resource_or_default_package_command
+    if resource[:target] && resource[:target] != :default
+      self.class.validate_package_command(resource[:target])
+      resource[:target]
+    else
+      # Do not validate yet, as per lazy_pip below.
+      self.class.default_pip_cmd
+    end
+  end
+
+  # Instances!
+
+  # Return an array of structured information about every installed package
+  # that's managed by `pip` or an empty array if `pip` is not available.
+  def self.instances(cmd = nil)
+    cmd = command_or_default_package_command(cmd)
+    packages = []
+    return packages unless cmd
+
+    command = [cmd, 'freeze']
+    command_version = self.pip_version(cmd)
+    if Puppet::Util::Package.versioncmp(command_version, '8.1.0') >= 0
+      command << '--all'
+    end
+
+    execpipe command do |process|
+      process.collect do |line|
+        if pkg = parse(line)
+          # Track the package command when the provider is targetable.
+          pkg[:target] = cmd
+          packages << new(pkg)
+        end
+      end
+    end
+
+    # Pip can also upgrade pip, but it's not listed in freeze so need to special case it
+    # Pip list would also show pip installed version, but "pip list" doesn't exist for older versions of pip (E.G v1.0)
+    # Not needed when "pip freeze --all" is available
+    if Puppet::Util::Package.versioncmp(command_version, '8.1.0') == -1 && version = command_version
+      # Track the package command when the provider is targetable.
+      packages << new({:ensure => version, :name => File.basename(cmd), :provider => name, :target => cmd})
+    end
+
+    packages
+  end
+
+  # Parse lines of output from `pip freeze`, which are structured as:
+  # _package_==_version_.
+  def self.parse(line)
+    if line.chomp =~ /^([^=]+)==([^=]+)$/
+      {:ensure => $2, :name => $1, :provider => name}
+    else
+      nil
+    end
+  end
+
+  def self.pip_version(cmd)
+    return nil unless cmd
+    execpipe [cmd, '--version'] do |process|
       process.collect do |line|
         return line.strip.match(/^pip (\d+\.\d+\.?\d*).*$/)[1]
       end
     end
   end
 
-  # Return structured information about a particular package or `nil` if
-  # it is not installed or `pip` itself is not available.
+  # Return structured information about a particular package
+  # or `nil` if it is not installed or `pip` itself is not available.
   def query
-    self.class.instances.each do |provider_pip|
+    self.class.instances(resource_or_default_package_command).each do |provider_pip|
       return provider_pip.properties if @resource[:name].downcase == provider_pip.name.downcase
     end
     return nil
   end
 
-  # Use pip CLI to look up versions from PyPI repositories, honoring local pip config such as custom repositories
+  # Use pip CLI to look up versions from PyPI repositories,
+  # honoring local pip config such as custom repositories.
   def latest
-    return nil unless self.class.pip_cmd
-    if Puppet::Util::Package.versioncmp(self.class.pip_version, '1.5.4') == -1 # a < b
-      return latest_with_old_pip
+    command_version = self.pip_version(resource_or_default_package_command)
+    if Puppet::Util::Package.versioncmp(command_version, '1.5.4') == -1
+      latest_with_old_pip
+    else
+      latest_with_new_pip
     end
-    latest_with_new_pip
   end
 
-  # Install a package.  The ensure parameter may specify installed,
-  # latest, a version number, or, in conjunction with the source
-  # parameter, an SCM revision.  In that case, the source parameter
-  # gives the fully-qualified URL to the repository.
+  # Install a package.
+  # The ensure parameter may specify installed, latest, a version number, or,
+  # in conjunction with the source parameter, an SCM revision.
+  # In that case, the source parameter gives the fully-qualified URL to the repository.
   def install
     args = %w{install -q}
     args +=  install_options if @resource[:install_options]
@@ -117,38 +152,19 @@ Puppet::Type.type(:package).provide :pip,
         args << @resource[:name]
       end
     end
+
     lazy_pip(*args)
   end
 
-  # Uninstall a package.  Uninstall won't work reliably on Debian/Ubuntu
-  # unless this issue gets fixed.
-  # <http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562544>
+  # Uninstall a package.
+  # Uninstall won't work reliably on Debian/Ubuntu unless this issue gets fixed:
+  # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562544
   def uninstall
-    lazy_pip "uninstall", "-y", "-q", @resource[:name]
+    lazy_pip("uninstall", "-y", "-q", @resource[:name])
   end
 
   def update
     install
-  end
-
-  # Execute a `pip` command.  If Puppet doesn't yet know how to do so,
-  # try to teach it and if even that fails, raise the error.
-  private
-  def lazy_pip(*args)
-    pip(*args)
-  rescue NoMethodError => e
-    # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
-    # The path to pip needs to be looked up again in the subsequent request. Using the preferred approach as noted
-    # in provider.rb ensures this (copied below for reference)
-    #
-    # @note From provider.rb; It is preferred if the commands are not entered with absolute paths as this allows puppet
-    # to search for them using the PATH variable.
-    if pathname = self.class.cmd.map { |c| which(c) }.find { |c| c != nil }
-      self.class.commands :pip => File.basename(pathname)
-      pip(*args)
-    else
-      raise e, "Could not locate command #{self.class.cmd.join(' and ')}.", e.backtrace
-    end
   end
 
   def install_options
@@ -156,8 +172,9 @@ Puppet::Type.type(:package).provide :pip,
   end
 
   def latest_with_new_pip
-    # Less resource intensive approach for pip version 1.5.4 and above
-    execpipe ["#{self.class.pip_cmd}", "install", "#{@resource[:name]}==versionplease"] do |process|
+    # Less resource intensive approach for pip version 1.5.4 and above.
+
+    execpipe [resource_or_default_package_command, "install", "#{@resource[:name]}==versionplease"] do |process|
       process.collect do |line|
         # PIP OUTPUT: Could not find a version that satisfies the requirement Django==versionplease (from versions: 1.1.3, 1.8rc1)
         if line =~ /from versions: /
@@ -174,7 +191,7 @@ Puppet::Type.type(:package).provide :pip,
 
   def latest_with_old_pip
     Dir.mktmpdir("puppet_pip") do |dir|
-      execpipe ["#{self.class.pip_cmd}", "install", "#{@resource[:name]}", "-d", "#{dir}", "-v"] do |process|
+      execpipe [resource_or_default_package_command, "install", "#{@resource[:name]}", "-d", "#{dir}", "-v"] do |process|
         process.collect do |line|
           # PIP OUTPUT: Using version 0.10.1 (newest of versions: 0.10.1, 0.10, 0.9, 0.8.1, 0.8, 0.7.2, 0.7.1, 0.7, 0.6.1, 0.6, 0.5.2, 0.5.1, 0.5, 0.4, 0.3.1, 0.3, 0.2, 0.1)
           if line =~ /Using version (.+?) \(newest of versions/
@@ -183,6 +200,26 @@ Puppet::Type.type(:package).provide :pip,
         end
         return nil
       end
+    end
+  end
+
+  # Execute a `pip` command.
+  # If Puppet doesn't yet know how to do so, try to teach it and if even that fails, raise the error.
+  private
+  def lazy_pip(*args)
+    pip(*args)
+  rescue NoMethodError
+    # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
+    # The path to pip needs to be looked up again in the subsequent request.
+    # Using the preferred approach as noted in provider.rb ensures this (copied below for reference)
+    #
+    # @note From provider.rb; It is preferred if the commands are not entered with absolute paths as this allows puppet
+    # to search for them using the PATH variable.
+    if command = resource_or_default_package_command
+      self.class.commands :pip => command
+      pip(*args)
+    else
+      raise Puppet::Error, _('pip package command not specified or does not exist')
     end
   end
 end

--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:package).provide :pip3,
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
   def self.cmd
     ["pip3"]

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -6,12 +6,13 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
 
   has_feature :versionable, :install_options, :uninstall_options
 
+  # Puppet on Windows prepends its paths to PATH, including Puppet's RUBY_DIR.
+  # This means that we do not need to specify the absolute path.
   if Puppet::Util::Platform.windows?
-    # On windows, we put our ruby ahead of anything that already
-    # existed on the system PATH. This means that we do not need to
-    # sort out the absolute path.
-    commands :gemcmd => "gem"
+    gem_cmd = 'gem.bat'
   else
-    commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
+    gem_cmd = '/opt/puppetlabs/puppet/bin/gem'
   end
+
+  commands :gemcmd => gem_cmd
 end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -20,8 +20,8 @@ module Puppet
       requires in order to function, and you must meet those requirements
       to use a given provider.
 
-      You can declare multiple package resources with the same `name`, as long
-      as they specify different providers and have unique titles.
+      You can declare multiple package resources with the same `name` as long
+      as they have unique titles, and specify different providers and targets.
 
       Note that you must use the _title_ to make a reference to a package
       resource; `Package[<NAME>]` is not a synonym for `Package[<TITLE>]` like
@@ -65,6 +65,8 @@ module Puppet
       provider-specific.",
       :methods => [:package_settings_insync?, :package_settings, :package_settings=]
     feature :virtual_packages, "The provider accepts virtual package names for install and uninstall."
+
+    feature :targetable, "The provider accepts a targeted package management command."
 
     ensurable do
       desc <<-EOT
@@ -271,24 +273,55 @@ module Puppet
     providify
     paramclass(:provider).isnamevar
 
-    def self.parameters_to_include
-      [:provider]
+    # Specify a targeted package management command.
+    newparam(:target, :required_features => :targetable) do
+      desc <<-EOT
+        The targeted command to use when managing a package:
+
+          package { 'mysql':
+            provider => gem,
+          }
+
+          package { 'mysql-opt':
+            name     => 'mysql',
+            provider => gem,
+            target   => '/opt/ruby/bin/gem',
+          }
+
+        Each provider defines a package management command; and uses the first
+        instance of the command found in the PATH.
+
+        Providers supporting the targetable feature allow you to specify the
+        absolute path of the package management command; useful when multiple
+        instances of the command are installed, or the command is not in the PATH.
+      EOT
+
+      isnamevar
+      defaultto :default
     end
 
-    # We have more than one namevar, so we need title_patterns. However, we
-    # cheat and set the patterns to map to name only and completely ignore
-    # provider. So far, the logic that determines uniqueness appears to just
-    # "Do The Right Thing™" when the provider is explicitly set by the user.
+    # We have more than one namevar, so we need title_patterns.
+    # However, we cheat and set the patterns to map to name only
+    # and completely ignore provider (and target, for targetable providers).
+    # So far, the logic that determines uniqueness appears to just
+    # "Do The Right Thing™" when provider (and target) are explicitly set.
     #
     # The following resources will be seen as unique by puppet:
     #
     #     # Uniqueness Key: ['mysql', nil]
-    #     package{'mysql': }
+    #     package {'mysql': }
     #
-    #     # Uniqueness Key: ['mysql', 'gem']
-    #     package{'gem-mysql':
+    #     # Uniqueness Key: ['mysql', 'gem', nil]
+    #     package {'gem-mysql':
+    #       name     => 'mysql,
+    #       provider => gem,
+    #     }
+    #
+    #     # Uniqueness Key: ['mysql', 'gem', '/opt/ruby/bin/gem']
+    #     package {'gem-mysql-opt':
     #       name     => 'mysql,
     #       provider => gem
+    #       target   => '/opt/ruby/bin/gem',
     #     }
     #
     # This does not handle the case where providers like 'yum' and 'rpm' should

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -7,6 +7,7 @@ describe Puppet::Type.type(:package).provider(:pip3) do
   it { is_expected.to be_upgradeable }
   it { is_expected.to be_versionable }
   it { is_expected.to be_install_options }
+  it { is_expected.to be_targetable }
 
   it "should inherit most things from pip provider" do
     expect(described_class < Puppet::Type.type(:package).provider(:pip))

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   if Puppet::Util::Platform.windows?
-    let(:puppet_gem) { 'gem' }
+    let(:puppet_gem) { 'gem.bat' }
   else
     let(:puppet_gem) { '/opt/puppetlabs/puppet/bin/gem' }
   end
@@ -25,40 +25,11 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   context "when installing" do
-    it "should use the path to the gem" do
-      described_class.expects(:which).with(puppet_gem).returns(puppet_gem)
+    it "should use the path to the puppet gem" do
+      described_class.stubs(:command).with(:gemcmd).returns puppet_gem
+      described_class.stubs(:validate_package_command).returns puppet_gem
       provider.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
       provider.install
-    end
-
-    it "should not append install_options by default" do
-      provider.expects(:execute).with { |args| args.length == 5 }.returns ''
-      provider.install
-    end
-
-    it "should allow setting an install_options parameter" do
-      resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      provider.expects(:execute).with { |args| args[2] == '--force' && args[3] == '--bindir=/usr/bin' }.returns ''
-      provider.install
-    end
-  end
-
-  context "when uninstalling" do
-    it "should use the path to the gem" do
-      described_class.expects(:which).with(puppet_gem).returns(puppet_gem)
-      provider.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
-      provider.install
-    end
-
-    it "should not append uninstall_options by default" do
-      provider.expects(:execute).with { |args| args.length == 5 }.returns ''
-      provider.uninstall
-    end
-
-    it "should allow setting an uninstall_options parameter" do
-      resource[:uninstall_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      provider.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
-      provider.uninstall
     end
   end
 end


### PR DESCRIPTION
With this commit ...

The package type and provider accept a 'target' parameter / feature,
allowing for management of packages when multiple installations of
a package management command are present on a system, but not in the PATH.

The gem, pip, and pip3 providers implement the target parameter / feature.

Changes to the gem also addresses PUP-6134.