### PR TITLE
(maint) Update for bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: ruby
 sudo: false
 bundler_args: --without development extra packaging
 before_install:
-  - if [[ $TRAVIS_RUBY_VERSION == "1.9.3" ]]; then gem update bundler; bundler -v; fi
+  - if [[ $TRAVIS_RUBY_VERSION =~ ^(1.9|2.0|2.1|2.2) ]]; then
+      gem update --system 2.7.8 && gem install bundler -v '< 2' --no-document;
+    else
+      gem update --system && gem install bundler --no-document;
+    fi
 script:
   - "bundle exec rake $CHECK"
 notifications:


### PR DESCRIPTION
When running on ruby < 2.3, use bundler 1.x and rubygems 2.7.8.
When running on ruby >= 2.3, use bundler 2 and rubygems 3.

This is necessary because bundler 2 requires rubygems 3 and ruby 2.3.

This also uses the `--no-document` option as `--no-rdoc` and
`--no-ri` were removed in bundler 2.