### PR TITLE
(PUP-9395) specify version-specific documentation params with install

### DIFF
--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -25,9 +25,13 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   context "when installing" do
+    before :each do
+      allow(described_class).to receive(:command).with(:gemcmd).and_return(puppet_gem)
+      allow(provider).to receive(:gem_version).with(puppet_gem).and_return('1.9.9')
+    end
+
     it "should use the path to the gem" do
-      expect(described_class).to receive(:which).with(puppet_gem).and_return(puppet_gem)
-      expect(provider).to receive(:execute) do |args|
+      expect(provider).to receive(:execute).at_least(:once) do |args|
         expect(args[0]).to eq(puppet_gem)
         ''
       end
@@ -35,7 +39,7 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     end
 
     it "should not append install_options by default" do
-      expect(provider).to receive(:execute) do |args|
+      expect(provider).to receive(:execute).with(array_including(puppet_gem, 'install'), be_a(Hash)).at_least(:once) do |args|
         expect(args.length).to eq(5)
         ''
       end
@@ -44,7 +48,7 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
 
     it "should allow setting an install_options parameter" do
       resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      expect(provider).to receive(:execute) do |args|
+      expect(provider).to receive(:execute).with(array_including(puppet_gem, 'install'), be_a(Hash)).at_least(:once) do |args|
         expect(args[2]).to eq('--force')
         expect(args[3]).to eq('--bindir=/usr/bin')
         ''
@@ -60,7 +64,7 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
         expect(args[0]).to eq(puppet_gem)
         ''
       end
-      provider.install
+      provider.uninstall
     end
 
     it "should not append uninstall_options by default" do

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -15,74 +15,58 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   if Puppet.features.microsoft_windows?
-    let(:puppet_gem) { 'gem' }
+    let(:provider_gem_cmd) { 'gem' }
   else
-    let(:puppet_gem) { '/opt/puppetlabs/puppet/bin/gem' }
+    let(:provider_gem_cmd) { '/opt/puppetlabs/puppet/bin/gem' }
   end
+
+  let(:execute_options) { {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}} }
 
   before :each do
     resource.provider = provider
+    allow(described_class).to receive(:command).with(:gemcmd).and_return(provider_gem_cmd)
   end
 
   context "when installing" do
     before :each do
-      allow(described_class).to receive(:command).with(:gemcmd).and_return(puppet_gem)
-      allow(provider).to receive(:gem_version).with(puppet_gem).and_return('1.9.9')
+      allow(provider).to receive(:rubygem_version).and_return('1.9.9')
     end
 
-    it "should use the path to the gem" do
-      expect(provider).to receive(:execute).at_least(:once) do |args|
-        expect(args[0]).to eq(puppet_gem)
-        ''
-      end
+    it "should use the path to the gem command" do
+      allow(described_class).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+      expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
       provider.install
     end
 
     it "should not append install_options by default" do
-      expect(provider).to receive(:execute).with(array_including(puppet_gem, 'install'), be_a(Hash)).at_least(:once) do |args|
-        expect(args.length).to eq(5)
-        ''
-      end
+      expect(described_class).to receive(:execute_gem_command).with(%w{install --no-rdoc --no-ri myresource}).and_return('')
       provider.install
     end
 
     it "should allow setting an install_options parameter" do
       resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      expect(provider).to receive(:execute).with(array_including(puppet_gem, 'install'), be_a(Hash)).at_least(:once) do |args|
-        expect(args[2]).to eq('--force')
-        expect(args[3]).to eq('--bindir=/usr/bin')
-        ''
-      end
+      expect(described_class).to receive(:execute_gem_command).with(%w{install --force --bindir=/usr/bin --no-rdoc --no-ri myresource}).and_return('')
       provider.install
     end
   end
 
   context "when uninstalling" do
-    it "should use the path to the gem" do
-      expect(described_class).to receive(:which).with(puppet_gem).and_return(puppet_gem)
-      expect(provider).to receive(:execute) do |args|
-        expect(args[0]).to eq(puppet_gem)
-        ''
-      end
+    it "should use the path to the gem command" do
+      allow(described_class).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+      expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
       provider.uninstall
     end
 
     it "should not append uninstall_options by default" do
-      expect(provider).to receive(:execute) do |args|
-        expect(args.length).to eq(5)
-        ''
-      end
+      expect(described_class).to receive(:execute_gem_command).with(%w{uninstall --executables --all myresource}).and_return('')
       provider.uninstall
     end
 
     it "should allow setting an uninstall_options parameter" do
       resource[:uninstall_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      expect(provider).to receive(:execute) do |args|
-        expect(args[5]).to eq('--force')
-        expect(args[6]).to eq('--bindir=/usr/bin')
-        ''
-      end
+      expect(described_class).to receive(:execute_gem_command).with(%w{uninstall --executables --all myresource --force --bindir=/usr/bin}).and_return('')
       provider.uninstall
     end
   end
+
 end


### PR DESCRIPTION
With this commit, install specifies version-specific parameters to not install
documentation, and specify those parameters independent of the source parameter.