### PR TITLE
WIP targetable package command

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -19,23 +19,30 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
 
   commands :gemcmd => "gem"
 
+  def self.execute_gem_command(command_options)
+    cmd = [command(:gemcmd)]
+    cmd += command_options
+
+    execute(cmd, { :failonfail => true, :combine => true, :custom_environment => { 'HOME' => ENV['HOME'] } })
+  end
+
   def self.gemlist(options)
-    gem_list_command = [command(:gemcmd), "list"]
+    command_options = ['list']
 
     if options[:local]
-      gem_list_command << "--local"
+      command_options << "--local"
     else
-      gem_list_command << "--remote"
+      command_options << "--remote"
     end
     if options[:source]
-      gem_list_command << "--source" << options[:source]
+      command_options << "--source" << options[:source]
     end
     if name = options[:justme]
-      gem_list_command << '\A' + name + '\z'
+      command_options << '\A' + name + '\z'
     end
 
     begin
-      list = execute(gem_list_command, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).lines.
+      list = execute_gem_command(command_options).lines.
         map {|set| gemsplit(set) }.
         reject {|x| x.nil? }
     rescue Puppet::ExecutionFailure => detail
@@ -92,14 +99,27 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
     is.any? { |version| dependency.match?('', version) }
   end
 
+  def rubygem_version
+    command_options = ['--version']
+
+    self.class.execute_gem_command(command_options)
+  end
+
   def install(useversion = true)
-    command = [command(:gemcmd), "install"]
-    command += install_options if resource[:install_options]
+    command_options = ['install']
+    command_options += install_options if resource[:install_options]
+
     if Puppet.features.microsoft_windows?
       version = resource[:ensure]
-      command << "-v" << %Q["#{version}"] if (! resource[:ensure].is_a? Symbol) and useversion
+      command_options << "-v" << %Q["#{version}"] if (! resource[:ensure].is_a? Symbol) and useversion
     else
-      command << "-v" << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
+      command_options << "-v" << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
+    end
+
+    if Puppet::Util::Package.versioncmp(rubygem_version, '2.0.0') == -1
+      command_options << '--no-rdoc' << '--no-ri'
+    else
+      command_options << '--no-document'
     end
 
     if source = resource[:source]
@@ -112,35 +132,35 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
       case uri.scheme
       when nil
         # no URI scheme => interpret the source as a local file
-        command << source
+        command_options << source
       when /file/i
-        command << uri.path
+        command_options << uri.path
       when 'puppet'
         # we don't support puppet:// URLs (yet)
         raise Puppet::Error.new(_("puppet:// URLs are not supported as gem sources"))
       else
         # check whether it's an absolute file path to help Windows out
         if Puppet::Util.absolute_path?(source)
-          command << source
+          command_options << source
         else
           # interpret it as a gem repository
-          command << "--source" << "#{source}" << resource[:name]
+          command_options << "--source" << "#{source}" << resource[:name]
         end
       end
     else
-      command << "--no-rdoc" << "--no-ri" << resource[:name]
+      command_options << resource[:name]
     end
 
-    output = execute(command, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}})
+    output = self.class.execute_gem_command(command_options)
     # Apparently some stupid gem versions don't exit non-0 on failure
     self.fail _("Could not install: %{output}") % { output: output.chomp } if output.include?("ERROR")
   end
 
   def latest
     # This always gets the latest version available.
-    gemlist_options = {:justme => resource[:name]}
-    gemlist_options.merge!({:source => resource[:source]}) unless resource[:source].nil?
-    hash = self.class.gemlist(gemlist_options)
+    options = {:justme => resource[:name]}
+    options.merge!({:source => resource[:source]}) unless resource[:source].nil?
+    hash = self.class.gemlist(options)
 
     hash[:ensure][0]
   end
@@ -150,13 +170,11 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package d
   end
 
   def uninstall
-    command = [command(:gemcmd), "uninstall"]
-    command << "--executables" << "--all" << resource[:name]
+    command_options = ['uninstall']
+    command_options << "--executables" << "--all" << resource[:name]
+    command_options += uninstall_options if resource[:uninstall_options]
 
-    command += uninstall_options if resource[:uninstall_options]
-
-    output = execute(command, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}})
-
+    output = self.class.execute_gem_command(command_options)
     # Apparently some stupid gem versions don't exit non-0 on failure
     self.fail _("Could not uninstall: %{output}") % { output: output.chomp } if output.include?("ERROR")
   end

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -13,10 +13,76 @@ Puppet::Type.type(:package).provide :pip,
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
-  # Parse lines of output from `pip freeze`, which are structured as
-  # _package_==_version_.
+  def self.cmd
+    if Puppet::Util::Platform.windows?
+      ["pip.exe"]
+    else
+      ["pip", "pip-python"]
+    end
+  end
+
+  def self.default_pip_cmd
+    self.cmd.map { |c| which(c) }.find { |c| c != nil }
+  end
+
+  # Return an array of structured information about every installed package
+  # that's managed by `pip` or an empty array if `pip` is not available.
+  def self.instances(cmd = nil)
+    cmd = command_or_default_package_command(cmd)
+    packages = []
+    return packages unless cmd
+
+    command = [cmd, 'freeze']
+    command_version = self.pip_version(cmd)
+    if Puppet::Util::Package.versioncmp(command_version, '8.1.0') >= 0
+      command << '--all'
+    end
+
+    execpipe command do |process|
+      process.collect do |line|
+        next unless pkg = parse(line)
+        pkg[:command] = cmd
+        packages << new(pkg)
+      end
+    end
+
+    # Pip can also upgrade pip, but it's not listed in freeze so need to special case it
+    # Pip list would also show pip installed version, but "pip list" doesn't exist for older versions of pip (E.G v1.0)
+    # Not needed when "pip freeze --all" is available
+    if Puppet::Util::Package.versioncmp(command_version, '8.1.0') == -1 && version = command_version
+      packages << new({:ensure => version, :name => File.basename(cmd), :provider => name, :command => cmd})
+    end
+
+    packages
+  end
+
+  # Determine the package command of this targetable package provider.
+  #
+  # cmd: the full path to the target package command.
+  def self.command_or_default_package_command(cmd)
+    if cmd
+      validate_package_command(cmd)
+      cmd
+    else
+      default_pip_cmd
+    end
+  end
+
+  # Determine the package command of this targetable package resource.
+  # Redefined from the parent class, as this class implements default_pip_cmd and lazy_pip.
+  def resource_or_default_package_command
+    if resource[:command] && resource[:command] != :default
+      self.class.validate_package_command(resource[:command])
+      resource[:command]
+    else
+      self.class.default_pip_cmd
+    end
+  end
+
+  # Parse lines of output from `pip freeze`, which are structured as:
+  #   _package_==_version_
   def self.parse(line)
     if line.chomp =~ /^([^=]+)==([^=]+)$/
       {:ensure => $2, :name => $1, :provider => name}
@@ -25,78 +91,39 @@ Puppet::Type.type(:package).provide :pip,
     end
   end
 
-  # Return an array of structured information about every installed package
-  # that's managed by `pip` or an empty array if `pip` is not available.
-  def self.instances
-    packages = []
-    pip_cmd = self.pip_cmd
-    return [] unless pip_cmd
-    command = [pip_cmd, 'freeze']
-    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') >= 0 # a >= b
-      command << '--all'
-    end
-    execpipe command do |process|
-      process.collect do |line|
-        next unless options = parse(line)
-        packages << new(options)
-      end
-    end
-
-    # Pip can also upgrade pip, but it's not listed in freeze so need to special case it
-    # Pip list would also show pip installed version, but "pip list" doesn't exist for older versions of pip (E.G v1.0)
-    # Not needed when "pip freeze --all" is available
-    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') == -1 && version = self.pip_version
-      packages << new({:ensure => version, :name => File.basename(pip_cmd), :provider => name})
-    end
-
-    packages
-  end
-
-  def self.cmd
-    if Puppet.features.microsoft_windows?
-      ["pip.exe"]
-    else
-      ["pip", "pip-python"]
-    end
-  end
-
-  def self.pip_cmd
-    self.cmd.map { |c| which(c) }.find { |c| c != nil }
-  end
-
-  def self.pip_version
-    pip_cmd = self.pip_cmd
-    return nil unless pip_cmd
-
-    execpipe [pip_cmd, '--version'] do |process|
+  def self.pip_version(cmd)
+    return nil unless cmd
+    execpipe [cmd, '--version'] do |process|
       process.collect do |line|
         return line.strip.match(/^pip (\d+\.\d+\.?\d*).*$/)[1]
       end
     end
   end
 
-  # Return structured information about a particular package or `nil` if
-  # it is not installed or `pip` itself is not available.
+  # Return structured information about a particular package
+  # or `nil` if it is not installed or `pip` itself is not available.
   def query
-    self.class.instances.each do |provider_pip|
+    self.class.instances(resource_or_default_package_command).each do |provider_pip|
       return provider_pip.properties if @resource[:name].downcase == provider_pip.name.downcase
     end
     return nil
   end
 
-  # Use pip CLI to look up versions from PyPI repositories, honoring local pip config such as custom repositories
+  # Use pip CLI to look up versions from PyPI repositories,
+  # honoring local pip config such as custom repositories.
   def latest
-    return nil unless self.class.pip_cmd
-    if Puppet::Util::Package.versioncmp(self.class.pip_version, '1.5.4') == -1 # a < b
-      return latest_with_old_pip
+    command_version = self.pip_version(resource_or_default_package_command)
+    if Puppet::Util::Package.versioncmp(command_version, '1.5.4') == -1
+      latest_with_old_pip
+    else
+      latest_with_new_pip
     end
-    latest_with_new_pip
   end
 
-  # Install a package.  The ensure parameter may specify installed,
-  # latest, a version number, or, in conjunction with the source
-  # parameter, an SCM revision.  In that case, the source parameter
-  # gives the fully-qualified URL to the repository.
+  # Install a package.
+  # The ensure parameter may specify installed, latest, a version number, or,
+  # in conjunction with the source parameter, an SCM revision.
+  # In that case, the source parameter gives the fully-qualified URL to the repository.
   def install
     args = %w{install -q}
     args +=  install_options if @resource[:install_options]
@@ -117,38 +144,19 @@ Puppet::Type.type(:package).provide :pip,
         args << @resource[:name]
       end
     end
+
     lazy_pip(*args)
   end
 
-  # Uninstall a package.  Uninstall won't work reliably on Debian/Ubuntu
-  # unless this issue gets fixed.
-  # <http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562544>
+  # Uninstall a package.
+  # Uninstall won't work reliably on Debian/Ubuntu unless this issue gets fixed:
+  # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562544
   def uninstall
-    lazy_pip "uninstall", "-y", "-q", @resource[:name]
+    lazy_pip("uninstall", "-y", "-q", @resource[:name])
   end
 
   def update
     install
-  end
-
-  # Execute a `pip` command.  If Puppet doesn't yet know how to do so,
-  # try to teach it and if even that fails, raise the error.
-  private
-  def lazy_pip(*args)
-    pip(*args)
-  rescue NoMethodError => e
-    # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
-    # The path to pip needs to be looked up again in the subsequent request. Using the preferred approach as noted
-    # in provider.rb ensures this (copied below for reference)
-    #
-    # @note From provider.rb; It is preferred if the commands are not entered with absolute paths as this allows puppet
-    # to search for them using the PATH variable.
-    if pathname = self.class.cmd.map { |c| which(c) }.find { |c| c != nil }
-      self.class.commands :pip => File.basename(pathname)
-      pip(*args)
-    else
-      raise e, "Could not locate command #{self.class.cmd.join(' and ')}.", e.backtrace
-    end
   end
 
   def install_options
@@ -156,8 +164,8 @@ Puppet::Type.type(:package).provide :pip,
   end
 
   def latest_with_new_pip
-    # Less resource intensive approach for pip version 1.5.4 and above
-    execpipe ["#{self.class.pip_cmd}", "install", "#{@resource[:name]}==versionplease"] do |process|
+    # Less resource intensive approach for pip version 1.5.4 and above.
+    execpipe [resource_or_default_package_command, "install", "#{@resource[:name]}==versionplease"] do |process|
       process.collect do |line|
         # PIP OUTPUT: Could not find a version that satisfies the requirement Django==versionplease (from versions: 1.1.3, 1.8rc1)
         if line =~ /from versions: /
@@ -174,7 +182,7 @@ Puppet::Type.type(:package).provide :pip,
 
   def latest_with_old_pip
     Dir.mktmpdir("puppet_pip") do |dir|
-      execpipe ["#{self.class.pip_cmd}", "install", "#{@resource[:name]}", "-d", "#{dir}", "-v"] do |process|
+      execpipe [resource_or_default_package_command, "install", "#{@resource[:name]}", "-d", "#{dir}", "-v"] do |process|
         process.collect do |line|
           # PIP OUTPUT: Using version 0.10.1 (newest of versions: 0.10.1, 0.10, 0.9, 0.8.1, 0.8, 0.7.2, 0.7.1, 0.7, 0.6.1, 0.6, 0.5.2, 0.5.1, 0.5, 0.4, 0.3.1, 0.3, 0.2, 0.1)
           if line =~ /Using version (.+?) \(newest of versions/
@@ -183,6 +191,27 @@ Puppet::Type.type(:package).provide :pip,
         end
         return nil
       end
+    end
+  end
+
+  # Execute a `pip` command.
+  # If Puppet doesn't yet know how to do so, try to teach it and if even that fails, raise the error.
+  private
+  def lazy_pip(*args)
+    pip(*args)
+  rescue NoMethodError
+    # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
+    # The path to pip needs to be looked up again in the subsequent request.
+    # Using the preferred approach as noted in provider.rb ensures this (copied below for reference)
+    #
+    # @note From provider.rb; It is preferred if the commands are not entered with absolute paths as this allows puppet
+    # to search for them using the PATH variable.
+    command = resource_or_default_package_command
+    if command
+      self.class.commands :pip => command
+      pip(*args)
+    else
+      raise Puppet::Error, _('pip package command not specified or does not exist')
     end
   end
 end

--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:package).provide :pip3,
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
   def self.cmd
     ["pip3"]

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -10,8 +10,8 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
     # On windows, we put our ruby ahead of anything that already
     # existed on the system PATH. This means that we do not need to
     # sort out the absolute path.
-    commands :gemcmd => "gem"
+    commands :gemcmd => 'gem'
   else
-    commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
+    commands :gemcmd => '/opt/puppetlabs/puppet/bin/gem'
   end
 end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -20,8 +20,8 @@ module Puppet
       requires in order to function, and you must meet those requirements
       to use a given provider.
 
-      You can declare multiple package resources with the same `name`, as long
-      as they specify different providers and have unique titles.
+      You can declare multiple package resources with the same `name` as long
+      as they have unique titles, and specify different providers and commands.
 
       Note that you must use the _title_ to make a reference to a package
       resource; `Package[<NAME>]` is not a synonym for `Package[<TITLE>]` like
@@ -65,6 +65,8 @@ module Puppet
       provider-specific.",
       :methods => [:package_settings_insync?, :package_settings, :package_settings=]
     feature :virtual_packages, "The provider accepts virtual package names for install and uninstall."
+
+    feature :targetable, "The provider accepts a targeted package management command."
 
     ensurable do
       desc <<-EOT
@@ -271,20 +273,55 @@ module Puppet
     providify
     paramclass(:provider).isnamevar
 
-    # We have more than one namevar, so we need title_patterns. However, we
-    # cheat and set the patterns to map to name only and completely ignore
-    # provider. So far, the logic that determines uniqueness appears to just
-    # "Do The Right Thing™" when the provider is explicitly set by the user.
+    # Specify a targeted package management command.
+    newparam(:command, :required_features => :targetable) do
+      desc <<-EOT
+        The targeted command to use when managing a package:
+
+          package { 'mysql':
+            provider => gem,
+          }
+
+          package { 'mysql-opt':
+            name     => 'mysql',
+            provider => gem,
+            command  => '/opt/ruby/bin/gem',
+          }
+
+        Each provider defines a package management command; and uses the first
+        instance of the command found in the PATH.
+
+        Providers supporting the targetable feature allow you to specify the
+        absolute path of the package management command; useful when multiple
+        instances of the command are installed, or the command is not in the PATH.
+      EOT
+
+      isnamevar
+      defaultto 'default'
+    end
+
+    # We have more than one namevar, so we need title_patterns.
+    # However, we cheat and set the patterns to map to name only
+    # and completely ignore provider (and command, for targetable providers).
+    # So far, the logic that determines uniqueness appears to just
+    # "Do The Right Thing™" when provider (and command) are explicitly set.
     #
     # The following resources will be seen as unique by puppet:
     #
     #     # Uniqueness Key: ['mysql', nil]
-    #     package{'mysql': }
+    #     package {'mysql': }
     #
-    #     # Uniqueness Key: ['mysql', 'gem']
-    #     package{'gem-mysql':
+    #     # Uniqueness Key: ['mysql', 'gem', nil]
+    #     package {'gem-mysql':
+    #       name     => 'mysql,
+    #       provider => gem,
+    #     }
+    #
+    #     # Uniqueness Key: ['mysql', 'gem', '/opt/ruby/bin/gem']
+    #     package {'gem-mysql-opt':
     #       name     => 'mysql,
     #       provider => gem
+    #       command  => '/opt/ruby/bin/gem',
     #     }
     #
     # This does not handle the case where providers like 'yum' and 'rpm' should

--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -93,23 +93,23 @@ describe Puppet::Type.type(:package), "when packages with the same name are sour
   end
 
   describe "with different title" do
-    before :each do
-      @alt_package = Puppet::Type.type(:package).new(:name => "yay", :title => "gem-yay", :ensure => :present)
-    end
+    before {
+      @alt_package = Puppet::Type.type(:package).new(:name => "yay", :title => "different-yay", :ensure => :present)
+    }
 
     it "should give an error" do
       provider_name = Puppet::Type.type(:package).defaultprovider.name
       expect {
         @catalog.add_resource(@alt_package)
-      }.to raise_error ArgumentError, "Cannot alias Package[gem-yay] to [\"yay\", :#{provider_name}]; resource [\"Package\", \"yay\", :#{provider_name}] already declared"
+      }.to raise_error ArgumentError, "Cannot alias Package[different-yay] to [nil, \"yay\", :#{provider_name}]; resource [\"Package\", nil, \"yay\", :#{provider_name}] already declared"
     end
   end
 
-  describe "from multiple providers" do
-    provider_class = Puppet::Type.type(:package).provider(:gem)
+  describe "from multiple providers" do # unless: Puppet::Util::Platform.jruby? do
+    alt_provider_class = Puppet::Type.type(:package).provider(:gem)
 
     before :each do
-      @alt_provider = provider_class.new
+      @alt_provider = alt_provider_class.new
       @alt_package = Puppet::Type.type(:package).new(:name => "yay", :title => "gem-yay", :provider => @alt_provider, :ensure => :present)
       @catalog.add_resource(@alt_package)
     end
@@ -132,6 +132,29 @@ describe Puppet::Type.type(:package), "when packages with the same name are sour
           @catalog.apply
         end
       end
+    end
+  end
+
+  describe "from one provider with multiple targets" do # unless: Puppet::Util::Platform.jruby? do
+    alt_provider_class = Puppet::Type.type(:package).provider(:gem)
+
+    before :each do
+      alt_provider_class.stubs(:validate_gem_command).with("/other/gem2").returns "/other/gem2"
+      alt_provider_class.stubs(:validate_gem_command).with("/other/gem3").returns "/other/gem3"
+      alt_provider_class.stubs(:instances).returns([])
+      @alt_provider = alt_provider_class.new
+      @alt_package1 = Puppet::Type.type(:package).new(:name => "yay", :title => "gem-default", :provider => @alt_provider, :ensure => :absent)
+      @alt_package2 = Puppet::Type.type(:package).new(:name => "yay", :title => "gem-other-2", :provider => @alt_provider, :command => '/other/gem2', :ensure => :absent)
+      @alt_package3 = Puppet::Type.type(:package).new(:name => "yay", :title => "gem-other-3", :provider => @alt_provider, :command => '/other/gem3', :ensure => :absent)
+      @catalog.add_resource(@alt_package1)
+      @catalog.add_resource(@alt_package2)
+    end
+
+    it "it should not error" do
+      @alt_provider.stubs(:properties).returns(:ensure => :absent)
+      @provider.stubs(:properties).returns(:ensure => :absent)
+      @provider.expects(:install)
+      @catalog.apply
     end
   end
 end
@@ -201,4 +224,3 @@ describe Puppet::Type.type(:package), 'logging package state transitions' do
     end
   end
 end
-

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -1,10 +1,18 @@
 require 'spec_helper'
 
 context Puppet::Type.type(:package).provider(:gem) do
+
+  it { is_expected.to be_installable }
+  it { is_expected.to be_uninstallable }
+  it { is_expected.to be_upgradeable }
+  it { is_expected.to be_versionable }
+  it { is_expected.to be_install_options }
+  it { is_expected.to be_targetable }
+
   context 'installing myresource' do
     let(:resource) do
       Puppet::Type.type(:package).new(
-        :name     => 'myresource',
+        :name     => "myresource",
         :ensure   => :installed
       )
     end
@@ -22,48 +30,50 @@ context Puppet::Type.type(:package).provider(:gem) do
     context "when installing" do
       before :each do
         described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
-        provider.stubs(:rubygem_version).returns '1.9.9'
+        described_class.stubs(:which).with("gem").returns("/my/gem")
+        described_class.stubs(:validate_package_command).with("/my/gem").returns "/my/gem"
+        provider.stubs(:rubygem_version).with(:gemcmd).returns "1.9.9"
       end
 
       it "should use the path to the gem" do
-        described_class.expects(:execute).with { |args| args[0] == "/my/gem" }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, any_parameters).returns ""
         provider.install
       end
 
       it "should specify that the gem is being installed" do
-        described_class.expects(:execute).with { |args| args[1] == "install" }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("install")).returns ""
         provider.install
       end
 
-      it "should specify that --rdoc should not be included when gem version is < 2.0.0" do
-        described_class.expects(:execute).with { |args| args[2] == "--no-rdoc" }.returns ""
+      it "should specify that --rdoc should be negated when gem version is < 2.0.0" do
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("--no-rdoc")).returns ""
         provider.install
       end
 
-      it "should specify that --ri should not be included when gem version is < 2.0.0" do
-        described_class.expects(:execute).with { |args| args[3] == "--no-ri" }.returns ""
+      it "should specify that --ri should be negated when gem version is < 2.0.0" do
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("--no-ri")).returns ""
         provider.install
       end
 
-      it "should specify that --document should not be included when gem version is >= 2.0.0" do
-        provider.stubs(:rubygem_version).returns '2.0.0'
-        described_class.expects(:execute).with { |args| args[2] == "--no-document" }.returns ""
+      it "should specify that --document should be negated when gem version is >= 2.0.0" do
+        provider.stubs(:rubygem_version).with(:gemcmd).returns "2.0.0"
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("--no-document")).returns ""
         provider.install
       end
 
       it "should specify the package name" do
-        described_class.expects(:execute).with { |args| args[4] == "myresource" }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("myresource")).returns ""
         provider.install
       end
 
       it "should not append install_options by default" do
-        described_class.expects(:execute).with { |args| args.length == 5 }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["install", "--no-rdoc", "--no-ri", "myresource"]).returns ""
         provider.install
       end
 
       it "should allow setting an install_options parameter" do
-        resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-        described_class.expects(:execute).with { |args| args[2] == '--force' && args[3] == '--bindir=/usr/bin' }.returns ''
+        resource[:install_options] = [ "--force", {"--bindir" => "/usr/bin" } ]
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["install", "--force", "--bindir=/usr/bin", "--no-rdoc", "--no-ri", "myresource"]).returns ""
         provider.install
       end
 
@@ -71,7 +81,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a normal file" do
           it "should use the file name instead of the gem name" do
             resource[:source] = "/my/file"
-            described_class.expects(:execute).with { |args| args[4] == "/my/file" }.returns ""
+            described_class.expects(:execute_gem_command).with(:gemcmd, includes("/my/file")).returns ""
             provider.install
           end
         end
@@ -79,7 +89,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a file url" do
           it "should use the file name instead of the gem name" do
             resource[:source] = "file:///my/file"
-            described_class.expects(:execute).with { |args| args[4] == "/my/file" }.returns ""
+            described_class.expects(:execute_gem_command).with(:gemcmd, includes("/my/file")).returns ""
             provider.install
           end
         end
@@ -94,7 +104,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a non-file and non-puppet url" do
           it "should treat the source as a gem repository" do
             resource[:source] = "http://host/my/file"
-            described_class.expects(:execute).with { |args| args[4..5] == ["--source", "http://host/my/file"] }.returns ""
+            described_class.expects(:execute_gem_command).with(:gemcmd, ["install", "--no-rdoc", "--no-ri", "--source", "http://host/my/file", "myresource"]).returns ""
             provider.install
           end
         end
@@ -102,7 +112,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a windows path on windows", :if => Puppet.features.microsoft_windows? do
           it "should treat the source as a local path" do
             resource[:source] = "c:/this/is/a/path/to/a/gem.gem"
-            described_class.expects(:execute).with { |args| args[4] == "c:/this/is/a/path/to/a/gem.gem" }.returns ""
+            described_class.expects(:execute_gem_command).with(:gemcmd, includes("c:/this/is/a/path/to/a/gem.gem")).returns ""
             provider.install
           end
         end
@@ -119,98 +129,106 @@ context Puppet::Type.type(:package).provider(:gem) do
 
     context "#latest" do
       it "should return a single value for 'latest'" do
-        #gemlist is used for retrieving both local and remote version numbers, and there are cases
+        described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        described_class.stubs(:validate_package_command).with("/my/gem").returns "/my/gem"
+        # gemlist is used for retrieving both local and remote version numbers, and there are cases
         # (particularly local) where it makes sense for it to return an array.  That doesn't make
         # sense for '#latest', though.
-        provider.class.expects(:gemlist).with({ :justme => 'myresource'}).returns({
-          :name     => 'myresource',
-          :ensure   => ["3.0"],
-          :provider => :gem,
+        provider.class.expects(:gemlist).with({:command => :gemcmd, :justme => "myresource"}).
+          returns({
+            :name     => "myresource",
+            :ensure   => ["3.0"],
+            :provider => :gem,
         })
         expect(provider.latest).to eq("3.0")
       end
 
       it "should list from the specified source repository" do
+        described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        described_class.stubs(:validate_package_command).with("/my/gem").returns "/my/gem"
         resource[:source] = "http://foo.bar.baz/gems"
-        provider.class.expects(:gemlist).
-          with({:justme => 'myresource', :source => "http://foo.bar.baz/gems"}).
+        provider.class.expects(:gemlist).with({:command => :gemcmd, :justme => "myresource", :source => "http://foo.bar.baz/gems"}).
           returns({
-            :name     => 'myresource',
+            :name     => "myresource",
             :ensure   => ["3.0"],
             :provider => :gem,
           })
-          expect(provider.latest).to eq("3.0")
+        expect(provider.latest).to eq("3.0")
       end
     end
 
     context "#instances" do
       before do
         described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+        described_class.stubs(:validate_package_command).with("/my/gem").returns "/my/gem"
       end
 
       it "should return an empty array when no gems installed" do
-        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns("\n")
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["list", "--local"]).returns "\n"
         expect(described_class.instances).to eq([])
       end
 
       it "should return ensure values as an array of installed versions" do
-        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["list", "--local"]).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         vagrant (0.8.7, 0.6.9)
         HEREDOC
 
         expect(described_class.instances.map {|p| p.properties}).to eq([
-          {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
-          {:ensure => ["0.8.7", "0.6.9"], :provider => :gem, :name => 'vagrant'}
+          {:name => "systemu", :provider => :gem, :command => "/my/gem", :ensure => ["1.2.0"]},
+          {:name => "vagrant", :provider => :gem, :command => "/my/gem", :ensure => ["0.8.7", "0.6.9"]}
         ])
       end
 
       it "should ignore platform specifications" do
-        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns <<-HEREDOC.gsub(/        /, '')
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["list", "--local"]).returns <<-HEREDOC.gsub(/        /, '')
         systemu (1.2.0)
         nokogiri (1.6.1 ruby java x86-mingw32 x86-mswin32-60, 1.4.4.1 x86-mswin32)
         HEREDOC
 
         expect(described_class.instances.map {|p| p.properties}).to eq([
-          {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
-          {:ensure => ["1.6.1", "1.4.4.1"], :provider => :gem, :name => 'nokogiri'}
+          {:name => "systemu",  :provider => :gem, :command => "/my/gem", :ensure => ["1.2.0"]},
+          {:name => "nokogiri", :provider => :gem, :command => "/my/gem", :ensure => ["1.6.1", "1.4.4.1"]}
         ])
       end
 
       it "should not list 'default: ' text from rubygems''" do
-        described_class.expects(:execute).with(%w{/my/gem list --local}, anything).returns <<-HEREDOC.gsub(/        /, '')
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["list", "--local"]).returns <<-HEREDOC.gsub(/        /, '')
         bundler (1.16.1, default: 1.16.0, 1.15.1)
         HEREDOC
 
         expect(described_class.instances.map {|p| p.properties}).to eq([
-          {:name => 'bundler', :ensure => ["1.16.1", "1.16.0", "1.15.1"], :provider => :gem}
+          {:name => "bundler", :provider => :gem, :command => "/my/gem", :ensure => ["1.16.1", "1.16.0", "1.15.1"]}
         ])
       end
 
       it "should not fail when an unmatched line is returned" do
-        described_class.expects(:execute).with(%w{/my/gem list --local}, {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).
-          returns(File.read(my_fixture('line-with-1.8.5-warning')))
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["list", "--local"]).returns(File.read(my_fixture('line-with-1.8.5-warning')))
 
         expect(described_class.instances.map {|p| p.properties}).
-          to eq([{:provider=>:gem, :ensure=>["0.3.2"], :name=>"columnize"},
-                 {:provider=>:gem, :ensure=>["1.1.3"], :name=>"diff-lcs"},
-                 {:provider=>:gem, :ensure=>["0.0.1"], :name=>"metaclass"},
-                 {:provider=>:gem, :ensure=>["0.10.5"], :name=>"mocha"},
-                 {:provider=>:gem, :ensure=>["0.8.7"], :name=>"rake"},
-                 {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-core"},
-                 {:provider=>:gem, :ensure=>["2.9.1"], :name=>"rspec-expectations"},
-                 {:provider=>:gem, :ensure=>["2.9.0"], :name=>"rspec-mocks"},
-                 {:provider=>:gem, :ensure=>["0.9.0"], :name=>"rubygems-bundler"},
-                 {:provider=>:gem, :ensure=>["1.11.3.3"], :name=>"rvm"}])
+          to eq([{:name=>"columnize",          :provider=>:gem, :command => "/my/gem", :ensure=>["0.3.2"]},
+                 {:name=>"diff-lcs",           :provider=>:gem, :command => "/my/gem", :ensure=>["1.1.3"]},
+                 {:name=>"metaclass",          :provider=>:gem, :command => "/my/gem", :ensure=>["0.0.1"]},
+                 {:name=>"mocha",              :provider=>:gem, :command => "/my/gem", :ensure=>["0.10.5"]},
+                 {:name=>"rake",               :provider=>:gem, :command => "/my/gem", :ensure=>["0.8.7"]},
+                 {:name=>"rspec-core",         :provider=>:gem, :command => "/my/gem", :ensure=>["2.9.0"]},
+                 {:name=>"rspec-expectations", :provider=>:gem, :command => "/my/gem", :ensure=>["2.9.1"]},
+                 {:name=>"rspec-mocks",        :provider=>:gem, :command => "/my/gem", :ensure=>["2.9.0"]},
+                 {:name=>"rubygems-bundler",   :provider=>:gem, :command => "/my/gem", :ensure=>["0.9.0"]},
+                 {:name=>"rvm",                :provider=>:gem, :command => "/my/gem", :ensure=>["1.11.3.3"]}])
       end
     end
 
     context "listing gems" do
       context "searching for a single package" do
         it "searches for an exact match" do
-          described_class.expects(:execute).with(includes('\Abundler\z'), {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}}).returns(File.read(my_fixture('gem-list-single-package')))
-          expected = {:name => 'bundler', :ensure => %w[1.6.2], :provider => :gem}
-          expect(described_class.gemlist({:justme => 'bundler'})).to eq(expected)
+          described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
+          described_class.stubs(:validate_package_command).with("/my/gem").returns "/my/gem"
+          described_class.expects(:execute_gem_command).with(:gemcmd, ["list", "--local", '\Abundler\z']).
+            returns(File.read(my_fixture('gem-list-single-package')))
+
+          expected = {:name => "bundler", :ensure => ["1.6.2"], :provider => :gem}
+          expect(described_class.gemlist({:command => :gemcmd, :local => :true, :justme => "bundler"})).to eq(expected)
         end
       end
     end
@@ -286,10 +304,45 @@ context Puppet::Type.type(:package).provider(:gem) do
     end
   end
 
+  context 'installing myresource with a target command' do
+
+    let(:resource) do
+      Puppet::Type.type(:package).new(
+        :name     => "myresource",
+        :ensure   => :installed,
+      )
+    end
+
+    let(:provider) do
+      provider = described_class.new
+      provider.resource = resource
+      provider
+    end
+
+    before :each do
+      resource.provider = provider
+    end
+
+    context "when installing with a target command" do
+      before :each do
+        resource.provider = provider
+        described_class.stubs(:which).with("/other/gem").returns("/other/gem")
+        described_class.stubs(:validate_package_command).with("/other/gem").returns "/other/gem"
+        provider.stubs(:rubygem_version).with(:"/other/gem").returns "1.9.9"
+      end
+
+      it "should use the path to the other gem" do
+        resource[:command] = "/other/gem"
+        described_class.expects(:execute_gem_command).with(:"/other/gem", any_parameters).returns ""
+        provider.install
+      end
+    end
+  end
+
   context 'uninstalling myresource' do
     let(:resource) do
       Puppet::Type.type(:package).new(
-        :name     => 'myresource',
+        :name     => "myresource",
         :ensure   => :absent
       )
     end
@@ -307,38 +360,39 @@ context Puppet::Type.type(:package).provider(:gem) do
     context "when uninstalling" do
       it "should use the path to the gem" do
         described_class.stubs(:command).with(:gemcmd).returns "/my/gem"
-        described_class.expects(:execute).with { |args| args[0] == "/my/gem" }.returns ""
+        described_class.stubs(:validate_package_command).with("/my/gem").returns "/my/gem"
+        described_class.expects(:execute_gem_command).with(:gemcmd, any_parameters).returns ""
         provider.uninstall
       end
 
       it "should specify that the gem is being uninstalled" do
-        described_class.expects(:execute).with { |args| args[1] == "uninstall" }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("uninstall")).returns ""
         provider.uninstall
       end
 
       it "should specify that the relevant executables should be removed without confirmation" do
-        described_class.expects(:execute).with { |args| args[2] == "--executables" }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("--executables")).returns ""
         provider.uninstall
       end
 
       it "should specify that all the matching versions should be removed" do
-        described_class.expects(:execute).with { |args| args[3] == "--all" }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("--all")).returns ""
         provider.uninstall
       end
 
       it "should specify the package name" do
-        described_class.expects(:execute).with { |args| args[4] == "myresource" }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, includes("myresource")).returns ""
         provider.uninstall
       end
 
       it "should not append uninstall_options by default" do
-        described_class.expects(:execute).with { |args| args.length == 5 }.returns ""
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["uninstall", "--executables", "--all", "myresource"]).returns ""
         provider.uninstall
       end
 
       it "should allow setting an uninstall_options parameter" do
-        resource[:uninstall_options] = [ '--ignore-dependencies', {'--version' => '0.1.1' } ]
-        described_class.expects(:execute).with { |args| args[5] == '--ignore-dependencies' && args[6] == '--version=0.1.1' }.returns ''
+        resource[:uninstall_options] = [ "--ignore-dependencies", {"--version" => "0.1.1" } ]
+        described_class.expects(:execute_gem_command).with(:gemcmd, ["uninstall", "--executables", "--all", "myresource", "--ignore-dependencies", "--version=0.1.1"]).returns ""
         provider.uninstall
       end
     end

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -2,12 +2,6 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:package).provider(:pip3) do
 
-  it { is_expected.to be_installable }
-  it { is_expected.to be_uninstallable }
-  it { is_expected.to be_upgradeable }
-  it { is_expected.to be_versionable }
-  it { is_expected.to be_install_options }
-
   it "should inherit most things from pip provider" do
     expect(described_class < Puppet::Type.type(:package).provider(:pip))
   end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -25,20 +25,24 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   context "when installing" do
+    before :each do
+      described_class.stubs(:command).with(:gemcmd).returns puppet_gem
+      provider.stubs(:rubygem_version).returns '1.9.9'
+    end
+
     it "should use the path to the gem" do
-      described_class.expects(:which).with(puppet_gem).returns(puppet_gem)
-      provider.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
+      described_class.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
       provider.install
     end
 
     it "should not append install_options by default" do
-      provider.expects(:execute).with { |args| args.length == 5 }.returns ''
+      described_class.expects(:execute).with { |args| args.length == 5 }.returns ''
       provider.install
     end
 
     it "should allow setting an install_options parameter" do
       resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      provider.expects(:execute).with { |args| args[2] == '--force' && args[3] == '--bindir=/usr/bin' }.returns ''
+      described_class.expects(:execute).with { |args| args[2] == '--force' && args[3] == '--bindir=/usr/bin' }.returns ''
       provider.install
     end
   end
@@ -46,18 +50,18 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   context "when uninstalling" do
     it "should use the path to the gem" do
       described_class.expects(:which).with(puppet_gem).returns(puppet_gem)
-      provider.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
-      provider.install
+      described_class.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
+      provider.uninstall
     end
 
     it "should not append uninstall_options by default" do
-      provider.expects(:execute).with { |args| args.length == 5 }.returns ''
+      described_class.expects(:execute).with { |args| args.length == 5 }.returns ''
       provider.uninstall
     end
 
     it "should allow setting an uninstall_options parameter" do
       resource[:uninstall_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      provider.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
+      described_class.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
       provider.uninstall
     end
   end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Puppet::Type.type(:package).provider(:puppet_gem) do
   let(:resource) do
     Puppet::Type.type(:package).new(
-      :name     => 'myresource',
+      :name     => "myresource",
       :ensure   => :installed
     )
   end
@@ -15,9 +15,9 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   if Puppet.features.microsoft_windows?
-    let(:puppet_gem) { 'gem' }
+    let(:puppet_gem) { "gem.bat" }
   else
-    let(:puppet_gem) { '/opt/puppetlabs/puppet/bin/gem' }
+    let(:puppet_gem) { "/opt/puppetlabs/puppet/bin/gem" }
   end
 
   before :each do
@@ -27,41 +27,47 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   context "when installing" do
     before :each do
       described_class.stubs(:command).with(:gemcmd).returns puppet_gem
-      provider.stubs(:rubygem_version).returns '1.9.9'
+      described_class.stubs(:validate_package_command).with(puppet_gem).returns puppet_gem
+      provider.stubs(:rubygem_version).with(:gemcmd).returns "1.9.9"
     end
 
     it "should use the path to the gem" do
-      described_class.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
+      described_class.expects(:execute_gem_command).with(:gemcmd, any_parameters).returns ""
       provider.install
     end
 
     it "should not append install_options by default" do
-      described_class.expects(:execute).with { |args| args.length == 5 }.returns ''
+      described_class.expects(:execute_gem_command).with(:gemcmd, ["install", "--no-rdoc", "--no-ri", "myresource"]).returns ""
       provider.install
     end
 
     it "should allow setting an install_options parameter" do
-      resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      described_class.expects(:execute).with { |args| args[2] == '--force' && args[3] == '--bindir=/usr/bin' }.returns ''
+      resource[:install_options] = [ "--force", {"--bindir" => "/usr/bin" } ]
+      described_class.expects(:execute_gem_command).with(:gemcmd, ["install", "--force", "--bindir=/usr/bin", "--no-rdoc", "--no-ri", "myresource"]).returns ""
       provider.install
     end
   end
 
   context "when uninstalling" do
+    before :each do
+      described_class.stubs(:command).with(:gemcmd).returns puppet_gem
+      described_class.stubs(:validate_package_command).with(puppet_gem).returns puppet_gem
+      provider.stubs(:rubygem_version).with(:gemcmd).returns "1.9.9"
+    end
+
     it "should use the path to the gem" do
-      described_class.expects(:which).with(puppet_gem).returns(puppet_gem)
-      described_class.expects(:execute).with { |args| args[0] == puppet_gem }.returns ''
+      described_class.expects(:execute_gem_command).with(:gemcmd, any_parameters).returns ""
       provider.uninstall
     end
 
     it "should not append uninstall_options by default" do
-      described_class.expects(:execute).with { |args| args.length == 5 }.returns ''
+      described_class.expects(:execute_gem_command).with(:gemcmd, ["uninstall", "--executables", "--all", "myresource"]).returns ""
       provider.uninstall
     end
 
     it "should allow setting an uninstall_options parameter" do
-      resource[:uninstall_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      described_class.expects(:execute).with { |args| args[5] == '--force' && args[6] == '--bindir=/usr/bin' }.returns ''
+      resource[:uninstall_options] = [ "--ignore-dependencies", {"--version" => "0.1.1" } ]
+      described_class.expects(:execute_gem_command).with(:gemcmd, ["uninstall", "--executables", "--all", "myresource", "--ignore-dependencies", "--version=0.1.1"]).returns ""
       provider.uninstall
     end
   end


### PR DESCRIPTION
With this commit ...

The package type and provider implement a :targetable feature, allowing
:targetable package providers to manage packages when multiple instances of a
package management command are present on a system, and/or are not in the PATH.

The gem, pip, and pip3 package providers implement the :targetable feature,
allowing for the use of the `command` parameter with those providers:

```
package { 'colorize':
  provider => gem,
}

package { 'colorize-opt':
  name     => 'colorize',
  provider => gem,
  command  => '/opt/ruby/bin/gem',
}
```