### PR TITLE
(PUP-9251) Deprecate application orchestration constructs

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -917,5 +917,10 @@ module Issues
   LOADER_FAILURE = issue :LOADER_FAILURE, :type do
     _('Failed to load: %{type_name}') % { type: type }
   end
+
+  DEPRECATED_APP_ORCHESTRATION = issue :DEPRECATED_APP_ORCHESTRATION, :klass do
+    _("Use of the application-orchestration %{expr} is deprecated. See http://links.puppet.com/tbd-app-orchestration-deprecation" % { expr: label(klass) })
+  end
+
 end
 end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -199,6 +199,11 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     end
   end
 
+  def check_Application(o)
+    check_NamedDefinition(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
+  end
+
   def check_AssignmentExpression(o)
     case o.operator
     when '='
@@ -296,6 +301,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   end
 
   def check_CapabilityMapping(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
     ok =
     case o.component
     when Model::QualifiedReference
@@ -861,6 +867,10 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   def check_SelectorEntry(o)
     rvalue(o.matching_expr)
+  end
+
+  def check_SiteDefinition(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
   end
 
   def check_UnaryExpression(o)

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -31,6 +31,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::RT_NO_STORECONFIGS]             = Puppet[:storeconfigs] ? :ignore : :warning
 
     p[Issues::FUTURE_RESERVED_WORD]           = :deprecation
+    p[Issues::DEPRECATED_APP_ORCHESTRATION]   = :deprecation
 
     p[Issues::DUPLICATE_KEY]                  = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]               = :error

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -367,6 +367,13 @@ EOS
       }.to raise_error(/'Cap\[cap\]' is exported by both 'Prod\[one\]' and 'Prod\[two\]'/)
     end
 
+    it "issues deprecation warnings" do
+      expect {compile_collect_log(MANIFEST_WO_NODE)}.not_to raise_error
+      expect(warnings).to include(/Capability Mapping is deprecated/) # there are two of these
+      expect(warnings).to include(/Application is deprecated/)
+      expect(warnings).to include(/Site Definition is deprecated/)
+    end
+
     context "for producing node" do
       let(:compiled_node) { Puppet::Node.new('first', :environment => env) }
       let(:compiled_catalog) { compile_to_catalog(MANIFEST, compiled_node)}


### PR DESCRIPTION
This adds deprecation warnings for the application orchestration
constructs site, application and capability mappings
(produces/consumes).