### PR TITLE
(PUP-9400) Fix problem with PNTransformerer crashing on nil

### DIFF
--- a/lib/puppet/pops/model/pn_transformer.rb
+++ b/lib/puppet/pops/model/pn_transformer.rb
@@ -200,6 +200,11 @@ class PNTransformer
     PN::Call.new('nop')
   end
 
+  # Some elements may have a nil element instead of a Nop Expression
+  def transform_NilClass(e)
+    PN::Call.new('nop')
+  end
+
   def transform_NotExpression(e)
     PN::Call.new('!', transform(e.expr))
   end

--- a/spec/unit/pops/model/pn_transformer_spec.rb
+++ b/spec/unit/pops/model/pn_transformer_spec.rb
@@ -42,6 +42,10 @@ describe 'Puppet::Pops::Model::PNTransformer' do
       expect(Puppet::Pops::Model::PNTransformer.transform(x.model)).to eq(
         call('hash', call('=>', 'a', 1), call('=>', 'b', 2)))
     end
+
+    it 'replaces empty/nil body with a Nop' do
+      expect(Puppet::Pops::Model::PNTransformer.transform(nil)).to eq(call('nop'))
+    end
   end
 
   def lit(value)


### PR DESCRIPTION
This makes a transformation of AST containing a nil body produce a Nop
PN call instead of crashing.

This is important since PN should be able to represent code that is not
100% semantically valid.