### PR TITLE
(PUP-9399) Pass srv domain to resolver for CA routes

### DIFF
--- a/lib/puppet/rest/route.rb
+++ b/lib/puppet/rest/route.rb
@@ -50,7 +50,7 @@ module Puppet::Rest
       end
 
       if Puppet[:use_srv_records]
-        dns_resolver.each_srv_record(@srv_service) do |srv_server, srv_port|
+        dns_resolver.each_srv_record(Puppet[:srv_domain], @srv_service) do |srv_server, srv_port|
           # Try each of the servers for this service in weighted order
           # until a working one is found.
           begin

--- a/spec/unit/rest/route_spec.rb
+++ b/spec/unit/rest/route_spec.rb
@@ -91,7 +91,7 @@ describe Puppet::Rest::Route do
           @srv_records = [record]
 
           @dns_mock.expects(:getresources).
-            with("_x-puppet._tcp.test_service", Resolv::DNS::Resource::IN::SRV).
+            with("_x-puppet-test_service._tcp.example.com", Resolv::DNS::Resource::IN::SRV).
             returns(@srv_records)
         end
 


### PR DESCRIPTION
SRV resolution was broken for CA related routes because we were passing
the `ca` SRV service name as the SRV domain, and ignoring the
`srv_domain` setting. This wasn't noticed because the service name will
default to `:puppet`.

This commit passes the SRV domain name as the first argument and service
name as the second argument.