### PR TITLE
(docs) update ca v1 http api section

### DIFF
--- a/api/docs/http_api_index.md
+++ b/api/docs/http_api_index.md
@@ -2,13 +2,9 @@ A Puppet master server provides several services via HTTP API, and the Puppet
 agent application uses those services to resolve a node's credentials, retrieve
 a configuration catalog, retrieve file data, and submit reports.
 
-In general, these APIs aren't designed for use by tools other than Puppet agent,
-and they've historically relied on a lot of shared code to work correctly.
+In general, these APIs aren't designed for use by tools other than Puppet agent.
 This is gradually changing, although we expect external use of these APIs to
-remain low for the foreseeable future.
-
-Puppet will often send garbage URL parameters, such as `fail_on_404` and
-`ignore_cache`. The server will ignore any parameters it isn't expecting.
+remain low for the foreseeable future. The server ignores any parameters it isn't expecting.
 
 V1/V2 HTTP APIs (Removed)
 ---------------
@@ -31,7 +27,7 @@ and a separate one for the certificate authority (CA).
 
 All configuration endpoints are prefixed with `/puppet`, while all CA endpoints are
 prefixed with `/puppet-ca`. All endpoints are explicitly versioned: the prefix
-is always immediately followed by a string like `/v3` (a directory separator,
+is always immediately followed by a string such as `/v3` (a directory separator,
 the letter `v`, and the version number of the API).
 
 ### Authorization
@@ -41,11 +37,10 @@ authorization system.
 
 Puppet Server ignores `auth.conf` for `/puppet-ca` endpoints. Access to the
 `certificate_status` endpoint is configured in Puppet Server's `ca.conf` file,
-and the remaining CA endpoints are always accessible. Rack Puppet master servers
-still use `auth.conf` for `/puppet-ca`.
+and the remaining CA endpoints are always accessible.
 
 When specifying authorization in `auth.conf`, the prefix and the version number
-(e.g. `/puppet/v3`) on the paths must be retained, since Puppet matches
+(such as `/puppet/v3`) on the paths must be retained, since Puppet matches
 authorization rules against the full request path.
 
 Puppet V3 HTTP API
@@ -144,34 +139,7 @@ A [JSON schema for the error objects](../schemas/error.json) is also available.
 CA V1 HTTP API
 --------------
 
-The CA API contains all of the endpoints used in support of Puppet's PKI
-system.
-
-The CA V1 endpoints share the same basic format as the Puppet V3 API, since
-they are also based off of Puppet's internal "indirector". However, they have
-a different prefix and version. The endpoints thus follow the form:
-`/puppet-ca/v1/:indirection/:key?environment=:environment` where:
-
-* `:environment` is an arbitrary placeholder word, required for historical
-  reasons. No CA endpoints actually use an environment, but the query parameter
-  must always be specified.
-* `:indirection` is the indirection to dispatch the request to.
-* `:key` is the "key" portion of the indirection call.
-
-As with the Puppet V3 API, using this API requires a significant amount of
-understanding of how Puppet's internal services are structured. The following
-documents provide additional specification.
-
-### SSL Certificate Related Services
-
-These endpoints only accept plain text payload formats. Historically, Puppet has
-used the MIME type `s` to mean `text/plain`. In Puppet 5, it will always use
-`text/plain`, but will continue to accept `s` to mean the same thing.
-
-* [Certificate](./http_certificate.md)
-* [Certificate Signing Requests](./http_certificate_request.md)
-* [Certificate Status](./http_certificate_status.md)
-* [Certificate Revocation List](./http_certificate_revocation_list.md)
+The certificate authority (CA) API contains all of the endpoints supporting Puppet's public key infrastructure (PKI) system. This endpoint is now handled entirely through Puppet Server. See Puppet Server's [HTTP API](https://puppet.com/docs/puppetserver/latest/http_api_index.md) docs for detailed information.
 
 Serialization Formats
 ---------------------


### PR DESCRIPTION
CA V1 docs have been removed from this repo and now exist in puppetserver docs. This PR updates the CA V1 HTTP API section of the docs to address 404ing links. This fix should be applied to this file in versions 6.0 or later