### PR TITLE
(PUP-6488) targetable package command

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -2,10 +2,10 @@
 # <http://pip.pypa.io/>
 
 require 'puppet/provider/package'
+require 'puppet/provider/package_targetable'
 require 'puppet/util/http_proxy'
 
-Puppet::Type.type(:package).provide :pip,
-  :parent => ::Puppet::Provider::Package do
+Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package::Targetable do
 
   desc "Python packages via `pip`.
 
@@ -13,43 +13,14 @@ Puppet::Type.type(:package).provide :pip,
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
-  # Parse lines of output from `pip freeze`, which are structured as
-  # _package_==_version_.
-  def self.parse(line)
-    if line.chomp =~ /^([^=]+)==([^=]+)$/
-      {:ensure => $2, :name => $1, :provider => name}
-    else
-      nil
-    end
-  end
+  # Define the default provider package command name when the provider is targetable.
+  # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command
 
-  # Return an array of structured information about every installed package
-  # that's managed by `pip` or an empty array if `pip` is not available.
-  def self.instances
-    packages = []
-    pip_cmd = self.pip_cmd
-    return [] unless pip_cmd
-    command = [pip_cmd, 'freeze']
-    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') >= 0 # a >= b
-      command << '--all'
-    end
-    execpipe command do |process|
-      process.collect do |line|
-        next unless options = parse(line)
-        packages << new(options)
-      end
-    end
-
-    # Pip can also upgrade pip, but it's not listed in freeze so need to special case it
-    # Pip list would also show pip installed version, but "pip list" doesn't exist for older versions of pip (E.G v1.0)
-    # Not needed when "pip freeze --all" is available
-    if Puppet::Util::Package.versioncmp(self.pip_version, '8.1.0') == -1 && version = self.pip_version
-      packages << new({:ensure => version, :name => File.basename(pip_cmd), :provider => name})
-    end
-
-    packages
+  def self.provider_command
+    # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
+    self.cmd.map { |c| which(c) }.find { |c| c != nil }
   end
 
   def self.cmd
@@ -60,104 +31,95 @@ Puppet::Type.type(:package).provide :pip,
     end
   end
 
-  def self.pip_cmd
-    self.cmd.map { |c| which(c) }.find { |c| c != nil }
-  end
-
-  def self.pip_version
-    pip_cmd = self.pip_cmd
-    return nil unless pip_cmd
-
-    execpipe [pip_cmd, '--version'] do |process|
+  def self.pip_version(command)
+    execpipe [command, '--version'] do |process|
       process.collect do |line|
         return line.strip.match(/^pip (\d+\.\d+\.?\d*).*$/)[1]
       end
     end
   end
 
-  # Return structured information about a particular package or `nil` if
-  # it is not installed or `pip` itself is not available.
+  # Return an array of structured information about every installed package
+  # that's managed by `pip` or an empty array if `pip` is not available.
+
+  def self.instances(target_command = nil)
+    if target_command
+      command = target_command
+      self.validate_command(command)
+    else
+      command = provider_command
+    end
+
+    packages = []
+    return packages unless command
+
+    command_options = ['freeze']
+    command_version = self.pip_version(command)
+    if Puppet::Util::Package.versioncmp(command_version, '8.1.0') >= 0
+      command_options << '--all'
+    end
+
+    execpipe [command, command_options] do |process|
+      process.collect do |line|
+        next unless pkg = parse(line)
+        pkg[:command] = command
+        packages << new(pkg)
+      end
+    end
+
+    # Pip can also upgrade pip, but it's not listed in freeze so need to special case it
+    # Pip list would also show pip installed version, but "pip list" doesn't exist for older versions of pip (E.G v1.0)
+    # Not needed when "pip freeze --all" is available.
+    if Puppet::Util::Package.versioncmp(command_version, '8.1.0') == -1
+      packages << new({:ensure => command_version, :name => File.basename(command), :provider => name, :command => command})
+    end
+
+    packages
+  end
+
+  # Parse lines of output from `pip freeze`, which are structured as:
+  # _package_==_version_
+
+  def self.parse(line)
+    if line.chomp =~ /^([^=]+)==([^=]+)$/
+      {:ensure => $2, :name => $1, :provider => name}
+    end
+  end
+
+  # Return structured information about a particular package or `nil`
+  # if the package is not installed or `pip` itself is not available.
+
   def query
-    self.class.instances.each do |provider_pip|
-      return provider_pip.properties if @resource[:name].downcase == provider_pip.name.downcase
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
+    self.class.instances(command).each do |pkg|
+      return pkg.properties if @resource[:name].downcase == pkg.name.downcase
     end
     return nil
   end
 
-  # Use pip CLI to look up versions from PyPI repositories, honoring local pip config such as custom repositories
+  # Use pip CLI to look up versions from PyPI repositories,
+  # honoring local pip config such as custom repositories.
+
   def latest
-    return nil unless self.class.pip_cmd
-    if Puppet::Util::Package.versioncmp(self.class.pip_version, '1.5.4') == -1 # a < b
-      return latest_with_old_pip
-    end
-    latest_with_new_pip
-  end
+    command = resource_or_provider_command
+    self.class.validate_command(command)
 
-  # Install a package.  The ensure parameter may specify installed,
-  # latest, a version number, or, in conjunction with the source
-  # parameter, an SCM revision.  In that case, the source parameter
-  # gives the fully-qualified URL to the repository.
-  def install
-    args = %w{install -q}
-    args +=  install_options if @resource[:install_options]
-    if @resource[:source]
-      if String === @resource[:ensure]
-        args << "#{@resource[:source]}@#{@resource[:ensure]}#egg=#{
-          @resource[:name]}"
-      else
-        args << "#{@resource[:source]}#egg=#{@resource[:name]}"
-      end
+    command_version = self.pip_version(command)
+    if Puppet::Util::Package.versioncmp(command_version, '1.5.4') == -1
+      latest_with_old_pip
     else
-      case @resource[:ensure]
-      when String
-        args << "#{@resource[:name]}==#{@resource[:ensure]}"
-      when :latest
-        args << "--upgrade" << @resource[:name]
-      else
-        args << @resource[:name]
-      end
+      latest_with_new_pip
     end
-    lazy_pip(*args)
-  end
-
-  # Uninstall a package.  Uninstall won't work reliably on Debian/Ubuntu
-  # unless this issue gets fixed.
-  # <http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562544>
-  def uninstall
-    lazy_pip "uninstall", "-y", "-q", @resource[:name]
-  end
-
-  def update
-    install
-  end
-
-  # Execute a `pip` command.  If Puppet doesn't yet know how to do so,
-  # try to teach it and if even that fails, raise the error.
-  private
-  def lazy_pip(*args)
-    pip(*args)
-  rescue NoMethodError => e
-    # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
-    # The path to pip needs to be looked up again in the subsequent request. Using the preferred approach as noted
-    # in provider.rb ensures this (copied below for reference)
-    #
-    # @note From provider.rb; It is preferred if the commands are not entered with absolute paths as this allows puppet
-    # to search for them using the PATH variable.
-    if pathname = self.class.cmd.map { |c| which(c) }.find { |c| c != nil }
-      self.class.commands :pip => File.basename(pathname)
-      pip(*args)
-    else
-      raise e, "Could not locate command #{self.class.cmd.join(' and ')}.", e.backtrace
-    end
-  end
-
-  def install_options
-    join_options(@resource[:install_options])
   end
 
   def latest_with_new_pip
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
     # Less resource intensive approach for pip version 1.5.4 and above
-    execpipe ["#{self.class.pip_cmd}", "install", "#{@resource[:name]}==versionplease"] do |process|
+    execpipe [command, "install", "#{@resource[:name]}==versionplease"] do |process|
       process.collect do |line|
         # PIP OUTPUT: Could not find a version that satisfies the requirement Django==versionplease (from versions: 1.1.3, 1.8rc1)
         if line =~ /from versions: /
@@ -173,8 +135,11 @@ Puppet::Type.type(:package).provide :pip,
   end
 
   def latest_with_old_pip
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
     Dir.mktmpdir("puppet_pip") do |dir|
-      execpipe ["#{self.class.pip_cmd}", "install", "#{@resource[:name]}", "-d", "#{dir}", "-v"] do |process|
+      execpipe [command, "install", "#{@resource[:name]}", "-d", "#{dir}", "-v"] do |process|
         process.collect do |line|
           # PIP OUTPUT: Using version 0.10.1 (newest of versions: 0.10.1, 0.10, 0.9, 0.8.1, 0.8, 0.7.2, 0.7.1, 0.7, 0.6.1, 0.6, 0.5.2, 0.5.1, 0.5, 0.4, 0.3.1, 0.3, 0.2, 0.1)
           if line =~ /Using version (.+?) \(newest of versions/
@@ -184,5 +149,56 @@ Puppet::Type.type(:package).provide :pip,
         return nil
       end
     end
+  end
+
+  # Install a package.  The ensure parameter may specify installed,
+  # latest, a version number, or, in conjunction with the source
+  # parameter, an SCM revision.  In that case, the source parameter
+  # gives the fully-qualified URL to the repository.
+
+  def install
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
+    command_options = %w{install -q}
+    command_options +=  install_options if @resource[:install_options]
+    if @resource[:source]
+      if String === @resource[:ensure]
+        command_options << "#{@resource[:source]}@#{@resource[:ensure]}#egg=#{@resource[:name]}"
+      else
+        command_options << "#{@resource[:source]}#egg=#{@resource[:name]}"
+      end
+    else
+      case @resource[:ensure]
+      when String
+        command_options << "#{@resource[:name]}==#{@resource[:ensure]}"
+      when :latest
+        command_options << "--upgrade" << @resource[:name]
+      else
+        command_options << @resource[:name]
+      end
+    end
+
+    execute([command, command_options])
+  end
+
+  # Uninstall a package. Uninstall won't work reliably on Debian/Ubuntu unless this issue gets fixed.
+  # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562544
+
+  def uninstall
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
+    command_options = ["uninstall", "-y", "-q", @resource[:name]]
+
+    execute([command, command_options])
+  end
+
+  def update
+    install
+  end
+
+  def install_options
+    join_options(@resource[:install_options])
   end
 end

--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:package).provide :pip3,
   These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
   or an array where each element is either a string or a hash."
 
-  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
   def self.cmd
     ["pip3"]

--- a/lib/puppet/provider/package_targetable.rb
+++ b/lib/puppet/provider/package_targetable.rb
@@ -1,0 +1,66 @@
+# Targetable package providers implement a `command` attribute.
+#
+# The `packages` hash passed to `Puppet::Provider::Package::prefetch` is deduplicated,
+# as it is keyed only by name in `Puppet::Transaction::prefetch_if_necessary`.
+#
+# (The `packages` hash passed to ``Puppet::Provider::Package::prefetch`` should be keyed by all namevars,
+# possibly via a `prefetchV2` method that could take a better data structure.)
+#
+# In addition, `Puppet::Provider::Package::properties` calls `query` in the provider.
+# But `query` in the provider depends upon whether a `command` attribute is defined for the resource.
+# This is a Catch-22.
+#
+# Instead ...
+#
+# Inspect any package to access the catalog (every package includes a reference to the catalog).
+# Inspect the catalog to find all of the `command` attributes for all of the packages of this class.
+# Find all of the package instances using each package `command`, including the default provider command.
+# Assign each instance's `provider` by selecting it from the `packages` hash passed to `prefetch`, based upon `name` and `command`.
+#
+# The original `command` parameter in the catalog is not populated by the default (`:default`) for the parameter in type/package.rb.
+# Rather, the result of the `original_parameters` is `nil` when the `command` parameter is undefined in the catalog.
+
+class Puppet::Provider::Package::Targetable < Puppet::Provider::Package
+  # Prefetch our package list, yo.
+  def self.prefetch(packages)
+    catalog_packages = packages.first[1]::catalog::resources.select{ |p| p.provider.class == self }
+    package_commands = catalog_packages.map { |catalog_package| catalog_package::original_parameters[:command] }.uniq
+    package_commands.each do |command|
+      instances(command).each do |instance|
+        catalog_packages.each do |catalog_package|
+          if catalog_package[:name] == instance.name && catalog_package::original_parameters[:command] == command
+            catalog_package.provider = instance
+            self.debug "Prefetched instance: %{name} via command: %{command}" % { name: instance.name, cmd: (command || :default)}
+          end
+        end
+      end
+    end
+  end
+
+  # Returns the resource command or provider command.
+
+  def resource_or_provider_command
+    resource::original_parameters[:command] || self.class.provider_command
+  end
+
+  # Targetable providers use has_command/is_optional to defer validation of provider suitability.
+  # Evaluate provider suitability here and now by validating that the command is defined and exists.
+  #
+  # cmd: the full path to the package command.
+
+  def self.validate_command(cmd)
+    unless cmd
+      raise Puppet::Error, _("Provider %{name} package command is not functional on this host") % { name: name }
+    end
+    unless File.file?(cmd)
+      raise Puppet::Error, _("Provider %{name} package command '%{cmd}' does not exist on this host") % { name: name, cmd: cmd }
+    end
+  end
+
+  # Return information about the package, its provider, and its (optional) command.
+
+  def to_s
+    cmd = resource[:command] || :default
+    "#{@resource}(provider=#{self.class.name})(command=#{cmd})"
+  end
+end

--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -100,7 +100,7 @@ describe Puppet::Type.type(:package), "when packages with the same name are sour
       provider_name = Puppet::Type.type(:package).defaultprovider.name
       expect {
         @catalog.add_resource(@alt_package)
-      }.to raise_error ArgumentError, "Cannot alias Package[gem-yay] to [\"yay\", :#{provider_name}]; resource [\"Package\", \"yay\", :#{provider_name}] already declared"
+      }.to raise_error ArgumentError, "Cannot alias Package[gem-yay] to [nil, \"yay\", :#{provider_name}]; resource [\"Package\", nil, \"yay\", :#{provider_name}] already declared"
     end
   end
 

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -2,7 +2,15 @@ require 'spec_helper'
 
 context Puppet::Type.type(:package).provider(:gem) do
 
+  it { is_expected.to be_installable }
+  it { is_expected.to be_uninstallable }
+  it { is_expected.to be_upgradeable }
+  it { is_expected.to be_versionable }
+  it { is_expected.to be_install_options }
+  it { is_expected.to be_targetable }
+
   let(:provider_gem_cmd) { '/provider/gem' }
+  let(:execute_options) { {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}} }
 
   context 'installing myresource' do
     let(:resource) do
@@ -18,8 +26,6 @@ context Puppet::Type.type(:package).provider(:gem) do
       provider
     end
 
-    let(:execute_options) { {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}} }
-
     before :each do
       resource.provider = provider
       allow(described_class).to receive(:command).with(:gemcmd).and_return(provider_gem_cmd)
@@ -31,45 +37,45 @@ context Puppet::Type.type(:package).provider(:gem) do
       end
 
       it "should use the path to the gem command" do
-        allow(described_class).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+        allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
         expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return("")
         provider.install
       end
 
       it "should specify that the gem is being installed" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[0]).to eq("install") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[0]).to eq("install") }.and_return("")
         provider.install
       end
 
       it "should specify that --rdoc should not be included when gem version is < 2.0.0" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[1]).to eq("--no-rdoc") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[1]).to eq("--no-rdoc") }.and_return("")
         provider.install
       end
 
       it "should specify that --ri should not be included when gem version is < 2.0.0" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[2]).to eq("--no-ri") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[2]).to eq("--no-ri") }.and_return("")
         provider.install
       end
 
       it "should specify that --document should not be included when gem version is >= 2.0.0" do
         allow(provider).to receive(:rubygem_version).and_return('2.0.0')
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[1]).to eq("--no-document") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[1]).to eq("--no-document") }.and_return("")
         provider.install
       end
 
       it "should specify the package name" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[3]).to eq("myresource") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[3]).to eq("myresource") }.and_return("")
         provider.install
       end
 
       it "should not append install_options by default" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args.length).to eq(4) }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args.length).to eq(4) }.and_return("")
         provider.install
       end
 
       it "should allow setting an install_options parameter" do
         resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) do |args|
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) do |cmd, args|
           expect(args[1]).to eq('--force')
           expect(args[2]).to eq('--bindir=/usr/bin')
         end.and_return("")
@@ -80,7 +86,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a normal file" do
           it "should use the file name instead of the gem name" do
             resource[:source] = "/my/file"
-            expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[3]).to eq("/my/file") }.and_return("")
+            expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, array_including("/my/file")).and_return("")
             provider.install
           end
         end
@@ -88,7 +94,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a file url" do
           it "should use the file name instead of the gem name" do
             resource[:source] = "file:///my/file"
-            expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[3]).to eq("/my/file") }.and_return("")
+            expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, array_including("/my/file")).and_return("")
             provider.install
           end
         end
@@ -103,7 +109,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a non-file and non-puppet url" do
           it "should treat the source as a gem repository" do
             resource[:source] = "http://host/my/file"
-            expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[3..5]).to eq(["--source", "http://host/my/file", "myresource"]) }.and_return("")
+            expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[3..5]).to eq(["--source", "http://host/my/file", "myresource"]) }.and_return("")
             provider.install
           end
         end
@@ -111,7 +117,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         context "as a windows path on windows", :if => Puppet.features.microsoft_windows? do
           it "should treat the source as a local path" do
             resource[:source] = "c:/this/is/a/path/to/a/gem.gem"
-            expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[3]).to eq("c:/this/is/a/path/to/a/gem.gem") }.and_return("")
+            expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, array_including("c:/this/is/a/path/to/a/gem.gem")).and_return("")
             provider.install
           end
         end
@@ -131,7 +137,7 @@ context Puppet::Type.type(:package).provider(:gem) do
         #gemlist is used for retrieving both local and remote version numbers, and there are cases
         # (particularly local) where it makes sense for it to return an array.  That doesn't make
         # sense for '#latest', though.
-        expect(provider.class).to receive(:gemlist).with({:justme => 'myresource'}).and_return({
+        expect(provider.class).to receive(:gemlist).with({:command => provider_gem_cmd, :justme => 'myresource'}).and_return({
           :name     => 'myresource',
           :ensure   => ["3.0"],
           :provider => :gem,
@@ -142,7 +148,7 @@ context Puppet::Type.type(:package).provider(:gem) do
       it "should list from the specified source repository" do
         resource[:source] = "http://foo.bar.baz/gems"
         expect(provider.class).to receive(:gemlist).
-          with({:justme => 'myresource', :source => "http://foo.bar.baz/gems"}).
+          with({:command => provider_gem_cmd, :justme => 'myresource', :source => "http://foo.bar.baz/gems"}).
           and_return({
             :name     => 'myresource',
             :ensure   => ["3.0"],
@@ -158,67 +164,67 @@ context Puppet::Type.type(:package).provider(:gem) do
       end
 
       it "should return an empty array when no gems installed" do
-        expect(described_class).to receive(:execute_gem_command).with(%w{list --local}).and_return("\n")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{list --local}).and_return("\n")
         expect(described_class.instances).to eq([])
       end
 
       it "should return ensure values as an array of installed versions" do
-        expect(described_class).to receive(:execute_gem_command).with(%w{list --local}).and_return(<<-HEREDOC.gsub(/        /, ''))
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{list --local}).and_return(<<-HEREDOC.gsub(/        /, ''))
         systemu (1.2.0)
         vagrant (0.8.7, 0.6.9)
         HEREDOC
 
         expect(described_class.instances.map {|p| p.properties}).to eq([
-          {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
-          {:ensure => ["0.8.7", "0.6.9"], :provider => :gem, :name => 'vagrant'}
+          {:name => "systemu", :provider => :gem, :command => provider_gem_cmd, :ensure => ["1.2.0"]},
+          {:name => "vagrant", :provider => :gem, :command => provider_gem_cmd, :ensure => ["0.8.7", "0.6.9"]}
         ])
       end
 
       it "should ignore platform specifications" do
-        expect(described_class).to receive(:execute_gem_command).with(%w{list --local}).and_return(<<-HEREDOC.gsub(/        /, ''))
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{list --local}).and_return(<<-HEREDOC.gsub(/        /, ''))
         systemu (1.2.0)
         nokogiri (1.6.1 ruby java x86-mingw32 x86-mswin32-60, 1.4.4.1 x86-mswin32)
         HEREDOC
 
         expect(described_class.instances.map {|p| p.properties}).to eq([
-          {:ensure => ["1.2.0"],          :provider => :gem, :name => 'systemu'},
-          {:ensure => ["1.6.1", "1.4.4.1"], :provider => :gem, :name => 'nokogiri'}
+          {:name => "systemu",  :provider => :gem, :command => provider_gem_cmd, :ensure => ["1.2.0"]},
+          {:name => "nokogiri", :provider => :gem, :command => provider_gem_cmd, :ensure => ["1.6.1", "1.4.4.1"]}
         ])
       end
 
       it "should not list 'default: ' text from rubygems''" do
-        expect(described_class).to receive(:execute_gem_command).with(%w{list --local}).and_return(<<-HEREDOC.gsub(/        /, ''))
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{list --local}).and_return(<<-HEREDOC.gsub(/        /, ''))
         bundler (1.16.1, default: 1.16.0, 1.15.1)
         HEREDOC
 
         expect(described_class.instances.map {|p| p.properties}).to eq([
-          {:name => 'bundler', :ensure => ["1.16.1", "1.16.0", "1.15.1"], :provider => :gem}
+          {:name => "bundler", :provider => :gem, :command => provider_gem_cmd, :ensure => ["1.16.1", "1.16.0", "1.15.1"]}
         ])
       end
 
       it "should not fail when an unmatched line is returned" do
-        expect(described_class).to receive(:execute_gem_command).with(%w{list --local}).and_return(File.read(my_fixture('line-with-1.8.5-warning')))
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{list --local}).and_return(File.read(my_fixture('line-with-1.8.5-warning')))
 
         expect(described_class.instances.map {|p| p.properties}).
-          to eq([{provider: :gem, ensure: ["0.3.2"],    name: "columnize"},
-                 {provider: :gem, ensure: ["1.1.3"],    name: "diff-lcs"},
-                 {provider: :gem, ensure: ["0.0.1"],    name: "metaclass"},
-                 {provider: :gem, ensure: ["0.10.5"],   name: "mocha"},
-                 {provider: :gem, ensure: ["0.8.7"],    name: "rake"},
-                 {provider: :gem, ensure: ["2.9.0"],    name: "rspec-core"},
-                 {provider: :gem, ensure: ["2.9.1"],    name: "rspec-expectations"},
-                 {provider: :gem, ensure: ["2.9.0"],    name: "rspec-mocks"},
-                 {provider: :gem, ensure: ["0.9.0"],    name: "rubygems-bundler"},
-                 {provider: :gem, ensure: ["1.11.3.3"], name: "rvm"}])
+          to eq([{:name=>"columnize",          :provider=>:gem, :command => provider_gem_cmd, :ensure=>["0.3.2"]},
+                 {:name=>"diff-lcs",           :provider=>:gem, :command => provider_gem_cmd, :ensure=>["1.1.3"]},
+                 {:name=>"metaclass",          :provider=>:gem, :command => provider_gem_cmd, :ensure=>["0.0.1"]},
+                 {:name=>"mocha",              :provider=>:gem, :command => provider_gem_cmd, :ensure=>["0.10.5"]},
+                 {:name=>"rake",               :provider=>:gem, :command => provider_gem_cmd, :ensure=>["0.8.7"]},
+                 {:name=>"rspec-core",         :provider=>:gem, :command => provider_gem_cmd, :ensure=>["2.9.0"]},
+                 {:name=>"rspec-expectations", :provider=>:gem, :command => provider_gem_cmd, :ensure=>["2.9.1"]},
+                 {:name=>"rspec-mocks",        :provider=>:gem, :command => provider_gem_cmd, :ensure=>["2.9.0"]},
+                 {:name=>"rubygems-bundler",   :provider=>:gem, :command => provider_gem_cmd, :ensure=>["0.9.0"]},
+                 {:name=>"rvm",                :provider=>:gem, :command => provider_gem_cmd, :ensure=>["1.11.3.3"]}])
       end
     end
 
     context "listing gems" do
       context "searching for a single package" do
         it "searches for an exact match" do
-          expect(described_class).to receive(:execute_gem_command).with(include('\Abundler\z')).and_return(File.read(my_fixture('gem-list-single-package')))
-          expected = {:name => 'bundler', :ensure => %w[1.6.2], :provider => :gem}
-          expect(described_class.gemlist({:justme => 'bundler'})).to eq(expected)
+          expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, array_including('\Abundler\z')).and_return(File.read(my_fixture('gem-list-single-package')))
+          expected = {:name=>"bundler", :provider=>:gem, :ensure=>["1.6.2"]}
+          expect(described_class.gemlist({:command => provider_gem_cmd, :justme => 'bundler'})).to eq(expected)
         end
       end
     end
@@ -294,6 +300,39 @@ context Puppet::Type.type(:package).provider(:gem) do
     end
   end
 
+  context 'installing myresource with a target command' do
+    let(:resource_gem_cmd) { '/resource/gem' }
+
+    let(:resource) do
+      Puppet::Type.type(:package).new(
+        :name     => "myresource",
+        :ensure   => :installed,
+      )
+    end
+
+    let(:provider) do
+      provider = described_class.new
+      provider.resource = resource
+      provider
+    end
+
+    before :each do
+      resource.provider = provider
+    end
+
+    context "when installing with a target command" do
+      before :each do
+        allow(described_class).to receive(:which).with(resource_gem_cmd).and_return(resource_gem_cmd)
+      end
+
+      it "should use the path to the other gem" do
+        resource::original_parameters[:command] = resource_gem_cmd
+        expect(described_class).to receive(:execute_gem_command).with(resource_gem_cmd, be_a(Array)).twice.and_return("")
+        provider.install
+      end
+    end
+  end
+
   context 'uninstalling myresource' do
     let(:resource) do
       Puppet::Type.type(:package).new(
@@ -308,8 +347,6 @@ context Puppet::Type.type(:package).provider(:gem) do
       provider
     end
 
-    let(:execute_options) { {:failonfail => true, :combine => true, :custom_environment => {"HOME"=>ENV["HOME"]}} }
-
     before :each do
       resource.provider = provider
       allow(described_class).to receive(:command).with(:gemcmd).and_return(provider_gem_cmd)
@@ -317,39 +354,39 @@ context Puppet::Type.type(:package).provider(:gem) do
 
     context "when uninstalling" do
       it "should use the path to the gem command" do
-        allow(described_class).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+        allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
         expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return("")
         provider.uninstall
       end
 
       it "should specify that the gem is being uninstalled" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[0]).to eq("uninstall") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[0]).to eq("uninstall") }.and_return("")
         provider.uninstall
       end
 
       it "should specify that the relevant executables should be removed without confirmation" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[1]).to eq("--executables") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[1]).to eq("--executables") }.and_return("")
         provider.uninstall
       end
 
       it "should specify that all the matching versions should be removed" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[2]).to eq("--all") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[2]).to eq("--all") }.and_return("")
         provider.uninstall
       end
 
       it "should specify the package name" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args[3]).to eq("myresource") }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args[3]).to eq("myresource") }.and_return("")
         provider.uninstall
       end
 
       it "should not append uninstall_options by default" do
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) { |args| expect(args.length).to eq(4) }.and_return("")
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) { |cmd, args| expect(args.length).to eq(4) }.and_return("")
         provider.uninstall
       end
 
       it "should allow setting an uninstall_options parameter" do
         resource[:uninstall_options] = [ '--ignore-dependencies', {'--version' => '0.1.1' } ]
-        expect(described_class).to receive(:execute_gem_command).with(be_a(Array)) do |args|
+        expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, be_a(Array)) do |cmd, args|
           expect(args[4]).to eq('--ignore-dependencies')
           expect(args[5]).to eq('--version=0.1.1')
         end.and_return('')

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -7,6 +7,7 @@ describe Puppet::Type.type(:package).provider(:pip3) do
   it { is_expected.to be_upgradeable }
   it { is_expected.to be_versionable }
   it { is_expected.to be_install_options }
+  it { is_expected.to be_targetable }
 
   it "should inherit most things from pip provider" do
     expect(described_class < Puppet::Type.type(:package).provider(:pip))

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -3,8 +3,17 @@ require 'spec_helper'
 osfamilies = { 'windows' => ['pip.exe'], 'other' => ['pip', 'pip-python'] }
 
 describe Puppet::Type.type(:package).provider(:pip) do
-  before do  
+
+  it { is_expected.to be_installable }
+  it { is_expected.to be_uninstallable }
+  it { is_expected.to be_upgradeable }
+  it { is_expected.to be_versionable }
+  it { is_expected.to be_install_options }
+  it { is_expected.to be_targetable }
+
+  before do
     @resource = Puppet::Resource.new(:package, "fake_package")
+    allow(@resource).to receive(:original_parameters).and_return({})
     @provider = described_class.new(@resource)
     @client = double('client')
     allow(@client).to receive(:call).with('package_releases', 'real_package').and_return(["1.3", "1.2.5", "1.2.4"])
@@ -46,17 +55,17 @@ describe Puppet::Type.type(:package).provider(:pip) do
     osfamilies.each do |osfamily, pip_cmds|
       it "should return an array on #{osfamily} systems when #{pip_cmds.join(' or ')} is present" do
         allow(Puppet.features).to receive(:microsoft_windows?).and_return(osfamily == 'windows')
-        pip_cmds.each do |pip_cmd|  
+        pip_cmds.each do |pip_cmd|
           pip_cmds.each do |cmd|
             unless cmd == pip_cmd
               expect(described_class).to receive(:which).with(cmd).and_return(nil)
             end
           end
-          allow(described_class).to receive(:pip_version).and_return('8.0.1')
-          expect(described_class).to receive(:which).with(pip_cmd).and_return("/fake/bin/#{pip_cmd}")
+          allow(described_class).to receive(:pip_version).with(pip_cmd).and_return('8.0.1')
+          expect(described_class).to receive(:which).with(pip_cmd).and_return(pip_cmd)
           p = double("process")
           expect(p).to receive(:collect).and_yield("real_package==1.2.5")
-          expect(described_class).to receive(:execpipe).with(["/fake/bin/#{pip_cmd}", "freeze"]).and_yield(p)
+          expect(described_class).to receive(:execpipe).with([pip_cmd, ["freeze"]]).and_yield(p)
           described_class.instances
         end
       end
@@ -66,11 +75,11 @@ describe Puppet::Type.type(:package).provider(:pip) do
         versions.each do |version|
           it "should use the --all option when version is '#{version}'" do
             allow(Puppet.features).to receive(:microsoft_windows?).and_return(osfamily == 'windows')
-            allow(described_class).to receive(:pip_cmd).and_return('/fake/bin/pip')
-            allow(described_class).to receive(:pip_version).and_return(version)
+            allow(described_class).to receive(:provider_command).and_return('/fake/bin/pip')
+            allow(described_class).to receive(:pip_version).with('/fake/bin/pip').and_return(version)
             p = double("process")
             expect(p).to receive(:collect).and_yield("real_package==1.2.5")
-            expect(described_class).to receive(:execpipe).with(["/fake/bin/pip", "freeze", "--all"]).and_yield(p)
+            expect(described_class).to receive(:execpipe).with(["/fake/bin/pip", ["freeze", "--all"]]).and_yield(p)
             described_class.instances
           end
         end
@@ -89,6 +98,8 @@ describe Puppet::Type.type(:package).provider(:pip) do
   context "query" do
     before do
       @resource[:name] = "real_package"
+      allow(described_class).to receive(:provider_command).and_return('/fake/bin/pip')
+      allow(described_class).to receive(:validate_command).with('/fake/bin/pip')
     end
 
     it "should return a hash when pip and the package are present" do
@@ -96,12 +107,14 @@ describe Puppet::Type.type(:package).provider(:pip) do
         :ensure   => "1.2.5",
         :name     => "real_package",
         :provider => :pip,
+        :command  => '/fake/bin/pip',
       })])
 
       expect(@provider.query).to eq({
         :ensure   => "1.2.5",
         :name     => "real_package",
         :provider => :pip,
+        :command  => '/fake/bin/pip',
       })
     end
 
@@ -117,12 +130,14 @@ describe Puppet::Type.type(:package).provider(:pip) do
         :ensure   => "1.2.5",
         :name     => "real_package",
         :provider => :pip,
+        :command  => '/fake/bin/pip',
       })])
 
       expect(@provider.query).to eq({
         :ensure   => "1.2.5",
         :name     => "real_package",
         :provider => :pip,
+        :command  => '/fake/bin/pip',
       })
     end
   end
@@ -130,10 +145,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
   context "latest" do
     context "with pip version < 1.5.4" do
       before :each do
-        allow(described_class).to receive(:pip_version).and_return('1.0.1')
+        allow(@provider).to receive(:pip_version).with("/fake/bin/pip").and_return('1.0.1')
         allow(described_class).to receive(:which).with('pip').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip-python').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip.exe').and_return("/fake/bin/pip")
+        allow(described_class).to receive(:provider_command).and_return('/fake/bin/pip')
+        allow(described_class).to receive(:validate_command).with('/fake/bin/pip')
       end
 
       it "should find a version number for new_pip_package" do
@@ -186,10 +203,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
       # For Pip 1.5.4 and above, you can get a version list from CLI - which allows for native pip behavior
       # with regards to custom repositories, proxies and the like
       before :each do
-        allow(described_class).to receive(:pip_version).and_return('1.5.4')
         allow(described_class).to receive(:which).with('pip').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip-python').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip.exe').and_return("/fake/bin/pip")
+        allow(described_class).to receive(:provider_command).and_return('/fake/bin/pip')
+        allow(described_class).to receive(:validate_command).with('/fake/bin/pip')
+        allow(@provider).to receive(:pip_version).with("/fake/bin/pip").and_return('1.5.4')
       end
 
       it "should find a version number for real_package" do
@@ -239,12 +258,14 @@ describe Puppet::Type.type(:package).provider(:pip) do
     before do
       @resource[:name] = "fake_package"
       @url = "git+https://example.com/fake_package.git"
+      allow(described_class).to receive(:provider_command).and_return('/fake/bin/pip')
+      allow(described_class).to receive(:validate_command).with('/fake/bin/pip')
     end
 
     it "should install" do
       @resource[:ensure] = :installed
       @resource[:source] = nil
-      expect(@provider).to receive(:lazy_pip).with("install", '-q', "fake_package")
+      expect(@provider).to receive(:execute).with(["/fake/bin/pip", ["install", "-q", "fake_package"]])
       @provider.install
     end
 
@@ -252,7 +273,8 @@ describe Puppet::Type.type(:package).provider(:pip) do
       # The -e flag makes the provider non-idempotent
       @resource[:ensure] = :installed
       @resource[:source] = @url
-      expect(@provider).to receive(:lazy_pip) do |*args|
+      # TJK
+      expect(@provider).to receive(:execute) do |*args|
         expect(args).not_to include("-e")
       end
       @provider.install
@@ -261,28 +283,31 @@ describe Puppet::Type.type(:package).provider(:pip) do
     it "should install from SCM" do
       @resource[:ensure] = :installed
       @resource[:source] = @url
-      expect(@provider).to receive(:lazy_pip).with("install", '-q', "#{@url}#egg=fake_package")
+      expect(@provider).to receive(:execute).with(["/fake/bin/pip", ["install", "-q", "#{@url}#egg=fake_package"]])
       @provider.install
     end
 
     it "should install a particular SCM revision" do
       @resource[:ensure] = "0123456"
       @resource[:source] = @url
-      expect(@provider).to receive(:lazy_pip).with("install", "-q", "#{@url}@0123456#egg=fake_package")
+      # TJK
+      expect(@provider).to receive(:execute).with(["/fake/bin/pip", ["install", "-q", "#{@url}@0123456#egg=fake_package"]])
       @provider.install
     end
 
     it "should install a particular version" do
       @resource[:ensure] = "0.0.0"
       @resource[:source] = nil
-      expect(@provider).to receive(:lazy_pip).with("install", "-q", "fake_package==0.0.0")
+      # TJK
+      expect(@provider).to receive(:execute).with(["/fake/bin/pip", ["install", "-q", "fake_package==0.0.0"]])
       @provider.install
     end
 
     it "should upgrade" do
       @resource[:ensure] = :latest
       @resource[:source] = nil
-      expect(@provider).to receive(:lazy_pip).with("install", "-q", "--upgrade", "fake_package")
+      # TJK
+      expect(@provider).to receive(:execute).with(["/fake/bin/pip", ["install", "-q", "--upgrade", "fake_package"]])
       @provider.install
     end
 
@@ -290,15 +315,20 @@ describe Puppet::Type.type(:package).provider(:pip) do
       @resource[:ensure] = :installed
       @resource[:source] = nil
       @resource[:install_options] = [{"--timeout" => "10"}, "--no-index"]
-      expect(@provider).to receive(:lazy_pip).with("install", "-q", "--timeout=10", "--no-index", "fake_package")
+      expect(@provider).to receive(:execute).with(["/fake/bin/pip", ["install", "-q", "--timeout=10", "--no-index", "fake_package"]])
       @provider.install
     end
   end
 
   context "uninstall" do
+    before do
+      allow(described_class).to receive(:provider_command).and_return('/fake/bin/pip')
+      allow(described_class).to receive(:validate_command).with('/fake/bin/pip')
+    end
+
     it "should uninstall" do
       @resource[:name] = "fake_package"
-      expect(@provider).to receive(:lazy_pip).with('uninstall', '-y', '-q', 'fake_package')
+      expect(@provider).to receive(:execute).with(["/fake/bin/pip", ["uninstall", "-y", "-q", "fake_package"]])
       @provider.uninstall
     end
   end
@@ -311,67 +341,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
   end
 
   context "pip_version" do
-    it "should return nil on missing pip" do
-      allow(described_class).to receive(:pip_cmd).and_return(nil)
-      expect(described_class.pip_version).to eq(nil)
-    end
-
     it "should look up version if pip is present" do
       allow(described_class).to receive(:pip_cmd).and_return('/fake/bin/pip')
       p = double("process")
       expect(p).to receive(:collect).and_yield('pip 8.0.2 from /usr/local/lib/python2.7/dist-packages (python 2.7)')
       expect(described_class).to receive(:execpipe).with(['/fake/bin/pip', '--version']).and_yield(p)
-      expect(described_class.pip_version).to eq('8.0.2')
-    end
-  end
-
-  context "lazy_pip" do
-    after(:each) do
-      Puppet::Type::Package::ProviderPip.instance_variable_set(:@confine_collection, nil)
-    end
-
-    it "should succeed if pip is present" do
-      allow(@provider).to receive(:pip).and_return(nil)
-      @provider.method(:lazy_pip).call "freeze"
-    end
-
-    osfamilies.each do |osfamily, pip_cmds|
-      pip_cmds.each do |pip_cmd|
-        it "should retry on #{osfamily} systems if #{pip_cmd} has not yet been found" do
-          allow(Puppet.features).to receive(:microsoft_windows?).and_return(osfamily == 'windows')
-          times_called = 0
-          expect(@provider).to receive(:pip).twice.with('freeze') do
-            times_called += 1
-            raise NoMethodError if times_called == 1
-          end
-          pip_cmds.each do |cmd|
-            unless cmd == pip_cmd
-              expect(@provider).to receive(:which).with(cmd).and_return(nil)
-            end
-          end
-          expect(@provider).to receive(:which).with(pip_cmd).and_return("/fake/bin/#{pip_cmd}")
-          @provider.method(:lazy_pip).call "freeze"
-        end
-      end
-
-      it "should fail on #{osfamily} systems if #{pip_cmds.join(' and ')} are missing" do
-        allow(Puppet.features).to receive(:microsoft_windows?).and_return(osfamily == 'windows')
-        expect(@provider).to receive(:pip).with('freeze').and_raise(NoMethodError)
-        pip_cmds.each do |pip_cmd|
-          expect(@provider).to receive(:which).with(pip_cmd).and_return(nil)
-        end
-        expect { @provider.method(:lazy_pip).call("freeze") }.to raise_error(NoMethodError)
-      end
-
-      it "should output a useful error message on #{osfamily} systems if #{pip_cmds.join(' and ')} are missing" do
-        allow(Puppet.features).to receive(:microsoft_windows?).and_return(osfamily == 'windows')
-        expect(@provider).to receive(:pip).with('freeze').and_raise(NoMethodError)
-        pip_cmds.each do |pip_cmd|
-          expect(@provider).to receive(:which).with(pip_cmd).and_return(nil)
-        end
-        expect { @provider.method(:lazy_pip).call("freeze") }.
-          to raise_error(NoMethodError, "Could not locate command #{pip_cmds.join(' and ')}.")
-      end
+      expect(described_class.pip_version('/fake/bin/pip')).to eq('8.0.2')
     end
   end
 end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -33,38 +33,38 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     end
 
     it "should use the path to the gem command" do
-      allow(described_class).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+      allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
       expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
       provider.install
     end
 
     it "should not append install_options by default" do
-      expect(described_class).to receive(:execute_gem_command).with(%w{install --no-rdoc --no-ri myresource}).and_return('')
+      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{install --no-rdoc --no-ri myresource}).and_return('')
       provider.install
     end
 
     it "should allow setting an install_options parameter" do
       resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      expect(described_class).to receive(:execute_gem_command).with(%w{install --force --bindir=/usr/bin --no-rdoc --no-ri myresource}).and_return('')
+      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{install --force --bindir=/usr/bin --no-rdoc --no-ri myresource}).and_return('')
       provider.install
     end
   end
 
   context "when uninstalling" do
     it "should use the path to the gem command" do
-      allow(described_class).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+      allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
       expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
       provider.uninstall
     end
 
     it "should not append uninstall_options by default" do
-      expect(described_class).to receive(:execute_gem_command).with(%w{uninstall --executables --all myresource}).and_return('')
+      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{uninstall --executables --all myresource}).and_return('')
       provider.uninstall
     end
 
     it "should allow setting an uninstall_options parameter" do
       resource[:uninstall_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      expect(described_class).to receive(:execute_gem_command).with(%w{uninstall --executables --all myresource --force --bindir=/usr/bin}).and_return('')
+      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{uninstall --executables --all myresource --force --bindir=/usr/bin}).and_return('')
       provider.uninstall
     end
   end


### PR DESCRIPTION
With this commit ...

Package providers can implement a targetable `command`.
The gem (and puppet_gem) package provider implements a targetable `command`.
The pip (and pip3) package provider implements a targetable `command`.