### PR TITLE
(PUP-9435) Return member names for Windows groups, not SIDs

### DIFF
--- a/acceptance/tests/resource/group/should_manage_members.rb
+++ b/acceptance/tests/resource/group/should_manage_members.rb
@@ -150,6 +150,8 @@ RUBY
     # we should consider placing them in a separate file.
     case agent['platform']
     when /windows/
+      domain = on(agent, 'hostname').stdout.chomp.upcase
+
       step "(Windows) Verify that Puppet prints each group member as DOMAIN\\<user>" do
         new_members = [users[3]]
 
@@ -159,9 +161,18 @@ RUBY
 
           stdout = result.stdout.chomp
 
-          domain = on(agent, 'hostname').stdout.chomp.upcase
           group_members.each do |user|
             assert_match(/#{domain}\\#{user}/, stdout, "Puppet fails to print the group member #{user} as #{domain}\\#{user}")
+          end
+        end
+      end
+
+      step "(Windows) Verify that `puppet resource` prints each group member as DOMAIN\\<user>" do
+        on(agent, puppet('resource', 'group', group)) do |result|
+          stdout = result.stdout.chomp
+
+          group_members.each do |user|
+            assert_match(/#{domain}\\#{user}/, stdout, "`puppet resource` fails to print the group member #{user} as #{domain}\\#{user}")
           end
         end
       end

--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -67,7 +67,10 @@ Puppet::Type.type(:group).provide :windows_adsi do
 
   def members
     @members ||= Puppet::Util::Windows::ADSI::Group.name_sid_hash(group.members)
-    @members.keys
+
+    # @members.keys returns an array of SIDs. We need to convert those SIDs into
+    # names so that `puppet resource` prints the right output.
+    members_to_s(@members.keys).split(',')
   end
 
   def members=(members)

--- a/spec/unit/provider/group/windows_adsi_spec.rb
+++ b/spec/unit/provider/group/windows_adsi_spec.rb
@@ -251,7 +251,13 @@ describe Puppet::Type.type(:group).provider(:windows_adsi), :if => Puppet.featur
         'user3',
       ]
 
-      expect(provider.members).to match_array([user1.sid, user2.sid, user3.sid])
+      expected_member_sids = [user1.sid, user2.sid, user3.sid]
+      expected_members = ['user1', 'user2', 'user3']
+      provider.stubs(:members_to_s)
+        .with(expected_member_sids)
+        .returns(expected_members.join(','))
+
+      expect(provider.members).to match_array(expected_members)
     end
 
     it "should be able to set group members" do


### PR DESCRIPTION
PUP-9265 fixed the Group resource's members property to print the
right change notifications for a given Puppet run. Part of that work
improved the parity between how the Windows group provider handles
group members with how the Windows user provider handles user groups.
However, that work introduced a regression to `puppet resource`'s
output, which now printed member SIDs instead of member names.

This commit modifies the Windows group provider to return member names
instead of member SIDs, which fixes the `puppet resource` regression.