### PR TITLE
(PUP-6571) Raise error when setting logdest fails

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -418,7 +418,7 @@ class Application
       Puppet::Util::Log.newdestination(arg)
       options[:setdest] = true
     rescue => detail
-      Puppet.log_exception(detail)
+      Puppet.log_and_raise(detail, _("Could not set logdest to %{dest}.") % { dest: arg })
     end
   end
 

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -60,7 +60,7 @@ class Puppet::Util::Log
   end
 
   def self.close_all
-    destinations.keys.each { |dest|
+    @destinations.keys.each { |dest|
       close(dest)
     }
     #TRANSLATORS "Log.close_all" is a method name and should not be translated
@@ -147,7 +147,12 @@ class Puppet::Util::Log
       Puppet.log_exception(detail)
 
       # If this was our only destination, then add the console back in.
-      newdestination(:console) if @destinations.empty? and (dest != :console and dest != "console")
+      if destinations.empty? && dest.intern != :console
+        newdestination(:console)
+      end
+
+      # Re-raise (end exit Puppet) because we could not set up logging correctly.
+      raise detail
     end
   end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -640,8 +640,15 @@ describe Puppet::Application do
     it "should log an exception that is raised" do
       our_exception = Puppet::DevError.new("test exception")
       Puppet::Util::Log.expects(:newdestination).with(test_arg).raises(our_exception)
-      Puppet.expects(:log_exception).with(our_exception)
+      Puppet.expects(:log_and_raise).with(our_exception, anything)
       @app.handle_logdest_arg(test_arg)
+    end
+
+    it "should exit when an exception is raised" do
+      our_exception = Puppet::DevError.new("test exception")
+      Puppet::Util::Log.expects(:newdestination).with(test_arg).raises(our_exception)
+      Puppet.expects(:log_and_raise).with(our_exception, anything).raises(our_exception)
+      expect { @app.handle_logdest_arg(test_arg) }.to raise_error(Puppet::DevError)
     end
 
     it "should set the new log destination" do

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -88,6 +88,21 @@ describe Puppet::Util::Log do
     expect(logs.last.source).to eq(utf_8_msg)
   end
 
+  require 'puppet/util/log/destinations'
+
+  it "raises an error when it has no successful logging destinations" do
+    # spec_helper.rb redirects log output away from the console,
+    # so we have to stop that here, or else the logic we are testing
+    # will not be reached.
+    Puppet::Util::Log.stubs(:destinations).returns({})
+
+    our_exception = Puppet::DevError.new("test exception")
+    Puppet::FileSystem.expects(:dir).raises(our_exception)
+    bad_file = tmpfile("bad_file")
+
+    expect { Puppet::Util::Log.newdestination(bad_file) }.to raise_error(Puppet::DevError)
+  end
+
   describe ".setup_default" do
     it "should default to :syslog" do
       Puppet.features.stubs(:syslog?).returns(true)


### PR DESCRIPTION
If setting logdest fails, we should raise an exception, and if there are no successful log destinations, we should exit.