### PR TITLE
Un-revert PUP-9336

### DIFF
--- a/lib/puppet/confine/boolean.rb
+++ b/lib/puppet/confine/boolean.rb
@@ -1,0 +1,45 @@
+require 'puppet/confine'
+
+# Common module for the Boolean confines. It currently
+# contains just enough code to implement PUP-9336.
+class Puppet::Confine
+  module Boolean
+    # Returns the passing value for the Boolean confine.
+    def passing_value
+      raise NotImplementedError, "The Boolean confine %{confine} must provide the passing value." % { confine: self.class.name }
+    end
+
+    # The Boolean confines 'true' and 'false' let the user specify
+    # two types of values:
+    #     * A lambda for lazy evaluation. This would be something like
+    #         confine :true => lambda { true }
+    #
+    #     * A single Boolean value, or an array of Boolean values. This would
+    #     be something like
+    #         confine :true => true OR confine :true => [true, false, false, true]
+    #
+    # This override distinguishes between the two cases.
+    def values
+      # Note that Puppet::Confine's constructor ensures that @values
+      # will always be an array, even if a lambda's passed in. This is
+      # why we have the length == 1 check.
+      unless @values.length == 1 && @values.first.respond_to?(:call)
+        return @values
+      end
+
+      # We have a lambda. Here, we want to enforce "cache positive"
+      # behavior, which is to cache the result _if_ it evaluates to
+      # the passing value (i.e. the class name).
+
+      return @cached_value unless @cached_value.nil?
+
+      # Double negate to coerce the value into a Boolean
+      calculated_value = !! @values.first.call
+      if calculated_value == passing_value
+        @cached_value = [calculated_value]
+      end
+
+      [calculated_value]
+    end
+  end
+end

--- a/lib/puppet/confine/false.rb
+++ b/lib/puppet/confine/false.rb
@@ -1,6 +1,12 @@
-require 'puppet/confine'
+require 'puppet/confine/boolean'
 
 class Puppet::Confine::False < Puppet::Confine
+  include Puppet::Confine::Boolean
+
+  def passing_value
+    false
+  end
+
   def self.summarize(confines)
     confines.inject(0) { |count, confine| count + confine.summary }
   end

--- a/lib/puppet/confine/true.rb
+++ b/lib/puppet/confine/true.rb
@@ -1,6 +1,12 @@
-require 'puppet/confine'
+require 'puppet/confine/boolean'
 
 class Puppet::Confine::True < Puppet::Confine
+  include Puppet::Confine::Boolean
+
+  def passing_value
+    true
+  end
+
   def self.summarize(confines)
     confines.inject(0) { |count, confine| count + confine.summary }
   end

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -28,12 +28,14 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   # We only want to use upstart as our provider if the upstart daemon is running.
   # This can be checked by running `initctl version --quiet` on a machine that has
   # upstart installed.
-  confine :true => begin
-    initctl('version', '--quiet')
-    true
-  rescue
-    false
-  end
+  confine :true => lambda {
+    begin
+      initctl('version', '--quiet')
+      true
+    rescue
+      false
+    end
+  }
 
   # upstart developer haven't implemented initctl enable/disable yet:
   # http://www.linuxplanet.com/linuxplanet/tutorials/7033/2/

--- a/spec/unit/confine/false_spec.rb
+++ b/spec/unit/confine/false_spec.rb
@@ -12,6 +12,33 @@ describe Puppet::Confine::False do
     expect { Puppet::Confine.new }.to raise_error(ArgumentError)
   end
 
+  describe "when passing in a lambda as a value for lazy evaluation" do
+    it "should accept it" do
+      confine = Puppet::Confine::False.new(lambda { false })
+      expect(confine.values).to eql([false])
+    end
+
+    describe "when enforcing cache-positive behavior" do
+      def cached_value_of(confine)
+        confine.instance_variable_get(:@cached_value)
+      end
+
+      it "should cache a false value" do
+        confine = Puppet::Confine::False.new(lambda { false })
+        confine.values
+
+        expect(cached_value_of(confine)).to eql([false])
+      end
+
+      it "should not cache a true value" do
+        confine = Puppet::Confine::False.new(lambda { true })
+        confine.values
+
+        expect(cached_value_of(confine)).to be_nil
+      end
+    end
+  end
+
   describe "when testing values" do
     before { @confine = Puppet::Confine::False.new("foo") }
 

--- a/spec/unit/confine/true_spec.rb
+++ b/spec/unit/confine/true_spec.rb
@@ -12,6 +12,33 @@ describe Puppet::Confine::True do
     expect { Puppet::Confine::True.new }.to raise_error(ArgumentError)
   end
 
+  describe "when passing in a lambda as a value for lazy evaluation" do
+    it "should accept it" do
+      confine = Puppet::Confine::True.new(lambda { true })
+      expect(confine.values).to eql([true])
+    end
+
+    describe "when enforcing cache-positive behavior" do
+      def cached_value_of(confine)
+        confine.instance_variable_get(:@cached_value)
+      end
+
+      it "should cache a true value" do
+        confine = Puppet::Confine::True.new(lambda { true })
+        confine.values
+
+        expect(cached_value_of(confine)).to eql([true])
+      end
+
+      it "should not cache a false value" do
+        confine = Puppet::Confine::True.new(lambda { false })
+        confine.values
+
+        expect(cached_value_of(confine)).to be_nil
+      end
+    end
+  end
+
   describe "when testing values" do
     before do
       @confine = Puppet::Confine::True.new("foo")


### PR DESCRIPTION
We reverted this work during the 6.2.0 release so that we could have a little more time to resolve the jruby spec failures in the 6.0.x branch. Here's the un-revert.