### PR TITLE
(PUP-6885) Remove server and server_list conflict warning

### DIFF
--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -11,52 +11,13 @@ test_name "Priority of server_list setting over server setting" do
     agents.each do |agent|
       tmpconf = agent.tmpfile('puppet_conf_test')
 
-      step "Should emit a warning when trying to set both server and server_list" do
-        step "when server is set first" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server #{master}", "--server_list #{master}:#{master_port},another:123"),
-            :acceptable_exit_codes => [0, 2]) do |result|
+      step "Server_list setting takes priority over server" do
+        step "Invalid server setting with valid server_list setting should successfully contact master" do
+          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
+             :acceptable_exit_codes => [0, 2]) do |result|
             unless agent['locale'] == 'ja'
-              assert_match(/Attempted to set both server and server_list/,
-                           result.stderr, "a warning should have been issued because both server setttings were used")
-            end
-          end
-        end
-
-        step "when server_list is set first" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list #{master}:#{master_port},another:123", "--server #{master}"),
-            :acceptable_exit_codes => [0, 2]) do |result|
-            unless agent['locale'] == 'ja'
-              assert_match(/Attempted to set both server and server_list/,
-                           result.stderr, "a warning should have been issued because both server setttings were used")
-            end
-          end
-        end
-      end
-
-      step "Should not emit a warning when only one setting is used" do
-        step "only server_list" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list #{master}:#{master_port},another:123"),
-            :acceptable_exit_codes => [0, 2]) do |result|
-              assert_no_match(/Attempted to set both server and server_list/,
-                              result.stderr, "a warning should not have been issued because only one settting was used")
-          end
-        end
-
-        step "only server" do
-          on(agent, puppet("agent", "--config #{tmpconf}", "-t", "--server #{master}"),
-            :acceptable_exit_codes => [0, 2]) do |result|
-              assert_no_match(/Attempted to set both server and server_list/, result.stderr, "a warning should not have been issued because only one settting was used")
-          end
-        end
-
-        step "Server_list setting takes priority over server" do
-          step "Invalid server setting with valid server_list setting should successfully contact master" do
-            on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
-               :acceptable_exit_codes => [0, 2]) do |result|
-              unless agent['locale'] == 'ja'
-                assert_match(/Selected master: #{master}:#{master_port}/,
-                             result.stdout, "should have selected the working master")
-              end
+              assert_match(/Selected master: #{master}:#{master_port}/,
+                           result.stdout, "should have selected the working master")
             end
           end
         end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1535,30 +1535,12 @@ EOT
     :server => {
       :default => "puppet",
       :desc => "The puppet master server to which the puppet agent should connect.",
-      :call_hook => :on_initialize_and_write,
-      :hook => proc { |value|
-        if Puppet.settings.set_by_config?(:server) && Puppet.settings.set_by_config?(:server_list)
-          #TRANSLATOR 'server' and 'server_list' are setting names and should not be translated
-          message = _('Attempted to set both server and server_list.')
-          message += ' ' + _('Server setting will not be used.')
-          Puppet.deprecation_warning(message, :SERVER_DUPLICATION)
-        end
-      }
     },
     :server_list => {
       :default => [],
       :type => :server_list,
       :desc => "The list of puppet master servers to which the puppet agent should connect,
         in the order that they will be tried.",
-      :call_hook => :on_initialize_and_write,
-      :hook => proc { |value|
-        if Puppet.settings.set_by_config?(:server) && Puppet.settings.set_by_config?(:server_list)
-          #TRANSLATOR 'server' and 'server_list' are setting names and should not be translated
-          message = _('Attempted to set both server and server_list.')
-          message += ' ' + _('Server setting will not be used.')
-          Puppet.deprecation_warning(message, :SERVER_DUPLICATION)
-        end
-      }
     },
     :use_srv_records => {
       :default    => false,

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -110,20 +110,6 @@ describe "Defaults" do
     end
   end
 
-  describe 'server vs server_list' do
-    it 'should warn when both settings are set in code' do
-      Puppet.expects(:deprecation_warning).with('Attempted to set both server and server_list. Server setting will not be used.', :SERVER_DUPLICATION)
-      Puppet.settings[:server] = 'test_server'
-      Puppet.settings[:server_list] = ['one', 'two']
-    end
-
-    it 'should warn when both settings are set by command line' do
-      Puppet.expects(:deprecation_warning).with('Attempted to set both server and server_list. Server setting will not be used.', :SERVER_DUPLICATION)
-      Puppet.settings.handlearg("--server_list", "one,two")
-      Puppet.settings.handlearg("--server", "test_server")
-    end
-  end
-
   describe 'manage_internal_file_permissions' do
     describe 'on windows', :if => Puppet::Util::Platform.windows? do
       it 'should default to false' do


### PR DESCRIPTION
From the ticket description, when we added `server_list`, it was with
the idea that it would be used in place of `server` for all things. We
never really made strides with that, and now have a mixture of code that
uses `server` or `server_list` or just the first entry from
`server_list`.

Generally, `agent` is the only puppet application that knows about both
`server` and `server_list`.