### PR TITLE
(PUP-9467) Fix problem with Optional without type

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -753,7 +753,7 @@ module Types
     end
 
     def describe_POptionalType(expected, original, actual, path)
-      return EMPTY_ARRAY if actual.is_a?(PUndefType)
+      return EMPTY_ARRAY if actual.is_a?(PUndefType) || expected.optional_type.nil?
       internal_describe(expected.optional_type, original.is_a?(PTypeAliasType) ? original : expected, actual, path)
     end
 

--- a/spec/unit/pops/types/type_mismatch_describer_spec.rb
+++ b/spec/unit/pops/types/type_mismatch_describer_spec.rb
@@ -244,6 +244,15 @@ describe 'the type mismatch describer' do
     expect { eval_and_collect_notices(code) }.to(raise_error(Puppet::Error,
       /Class\[Test\]: parameter 'opts' expects size to be 1, got 0/))
   end
+
+  it "treats Optional as Optional[Any]" do
+    code = <<-PUPPET
+      class test(Optional $var=undef) {}
+      class { 'test': var => 'hello' }
+    PUPPET
+    expect { eval_and_collect_notices(code) }.not_to raise_error
+  end
+
 end
 end
 end


### PR DESCRIPTION
Before this, puppet could crash when an `Optional` type was used without a subtype. It really means `Optional[Any]`, but this is represented internally with a `nil` type parameter.
The TypeMismatchDescriber (involved in type checking and forming of type errors) did not take the `nil` into account.

This PR fixes this and adds a test.