### PR TITLE
(PUP-9477) Make call() load functions from any loader

### DIFF
--- a/lib/puppet/functions/call.rb
+++ b/lib/puppet/functions/call.rb
@@ -37,6 +37,7 @@ Puppet::Functions.create_function(:call, Puppet::Functions::InternalFunction) do
   end
 
   def call_impl_block(scope, function_name, *args, &block)
-    call_function_with_scope(scope, function_name, *args, &block)
+    # The call function must be able to call functions loaded by any loader visible from the calling scope.
+    Puppet::Pops::Parser::EvaluatingParser.new.evaluator.external_call_function(function_name, args, scope, &block)
   end
 end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -409,6 +409,11 @@ describe 'loaders' do
       expect(function.call(scope, 'passed in scope')).to eql("usee::callee_ws() got 'passed in scope'")
     end
 
+    it 'calls can be made to a non core function via the call() function' do
+      call_function = loader.load_typed(typed_name(:function, 'call')).value
+      expect(call_function.call(scope, 'user::puppetcaller4')).to eql("usee::callee() got 'first' - usee::callee() got 'second'")
+    end
+
   end
 
   context 'loading' do


### PR DESCRIPTION
Before this the call() function was only capable of calling functions defined in puppet core.