### PR TITLE
(PUP-9496) Allow MSI packages to install without setting CWD

### DIFF
--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -63,7 +63,11 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
     installer = Puppet::Provider::Package::Windows::Package.installer_class(resource)
 
     command = [installer.install_command(resource), install_options].flatten.compact.join(' ')
-    output = execute(command, :failonfail => false, :combine => true, :cwd => File.dirname(resource[:source]), :suppress_window => true)
+    working_dir = File.dirname(resource[:source])
+    if !Puppet::FileSystem.exist?(working_dir) && resource[:source] =~ /\.msi"?\Z/i
+      working_dir = nil
+    end
+    output = execute(command, :failonfail => false, :combine => true, :cwd => working_dir, :suppress_window => true)
 
     check_result(output.exitstatus)
   end

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -86,7 +86,7 @@ describe Puppet::Type.type(:package).provider(:windows), :if => Puppet.features.
   context '#install' do
     let(:command) { 'blarg.exe /S' }
     let(:klass) { mock('installer', :install_command => ['blarg.exe', '/S'] ) }
-    let(:execute_options) do {:failonfail => false, :combine => true, :cwd => 'E:\Rando\Directory', :suppress_window => true} end
+    let(:execute_options) do {:failonfail => false, :combine => true, :cwd => nil, :suppress_window => true} end
     before :each do
       Puppet::Provider::Package::Windows::Package.expects(:installer_class).returns(klass)
     end
@@ -134,6 +134,17 @@ describe Puppet::Type.type(:package).provider(:windows), :if => Puppet.features.
       end.to raise_error do |error|
         expect(error).to be_a(Puppet::Util::Windows::Error)
         expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
+      end
+    end
+
+    context 'With a real working dir' do
+      let(:execute_options) do {:failonfail => false, :combine => true, :cwd => 'E:\Rando\Directory', :suppress_window => true} end
+
+      it 'should not try to set the working directory' do
+        Puppet::FileSystem.expects(:exist?).with('E:\Rando\Directory').returns(true)
+        expect_execute(command, 0)
+
+        provider.install
       end
     end
   end


### PR DESCRIPTION
After PUP-6920, the Windows package provider requires the "directory"
part of the source path to be something which can be set to the
working directory. Unfortunately, for http sources of MSI files, chdir
doesn't work. This has broken installing those packages.

This change allows MSIs to be installed without setting the working
directory if it does not exist. It still prefers to set the directory
when possible, just in case any MSIs out there are as badly-behaved as
legacy exe installers are.