### PR TITLE
(PUP-9247) Update the pidlock process name check for posix platforms

### DIFF
--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -62,7 +62,7 @@ class Puppet::Util::Pidlock
     # POSIX and Windows platforms (PUP-9247).
     if Puppet.features.posix?
       procname = Puppet::Util::Execution.execute(["ps", "-p", lock_pid, "-o", "comm="]).strip
-      @lockfile.unlock unless procname =~ /puppet$/
+      @lockfile.unlock unless procname =~ /puppet(-.*)?$/
     elsif Puppet.features.microsoft_windows?
       # On Windows, we're checking if the filesystem path name of the running
       # process is our vendored ruby:


### PR DESCRIPTION
PE's puppet-infrastructure backup and restore system uses
Puppet::Agent::Locker to avoid conflicts with normal runs of the node's
agent. Due to this, the pidlock process name check needs to be expanded
to include process names such as puppet-infrastucture. This loosens the
regex slightly to ensure the lock is still valid when these maintenance
tasks are run.