### PR TITLE
(PUP-9455) Ensure dummy passphrase is 4 bytes

### DIFF
--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -133,7 +133,9 @@ class Puppet::X509::CertProvider
   # @api private
   def load_private_key_from_pem(pem)
     # set a non-nil passphrase to ensure openssl doesn't prompt
-    OpenSSL::PKey::RSA.new(pem, '')
+    # but ruby 2.4.0 & 2.4.1 require at least 4 bytes, see
+    # https://github.com/ruby/ruby/commit/f012932218fd609f75f9268812df61fb26e2d0f1#diff-40e4270ec386990ac60d7ab5ff8045a4
+    OpenSSL::PKey::RSA.new(pem, '    ')
   end
 
   # Save a named client cert to the configured `certdir`.


### PR DESCRIPTION
Commit 568c900038c45463fe11cbe29fb3e73f35f5d461 specified an empty
passphrase when loading an rsa private key so that ruby does not prompt
and hang if the key is encrypted. However, ruby 2.4.0 and 2.4.1[1] have
a bug which requires the passphrase to be at least 4 bytes. This was
fixed in 2.4.2[2]. Since we don't actually care about the passphrase,
specify a 4 byte empty string, so it works on all ruby versions.

[1] https://github.com/ruby/ruby/commit/f52ab6e4940f9095c4fc5e2f7860bd56747f1c7c#diff-40e4270ec386990ac60d7ab5ff80454aR166
[2] https://github.com/ruby/ruby/commit/f012932218fd609f75f9268812df61fb26e2d0f1#diff-40e4270ec386990ac60d7ab5ff80454a