### PR TITLE
(PUP-9509) Puppet 3 API functions should be loaded from cache

### DIFF
--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -33,7 +33,7 @@ module ModuleLoaders
       NAMESPACE_WILDCARD,
       Puppet[:libdir],
       'cached_puppet_lib',
-      [:func_4x, :datatype]
+      [:func_4x, :func_3x, :datatype]
     )
   end
 

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -100,6 +100,13 @@ describe 'loaders' do
     expect(loaders.puppet_cache_loader()).to be_a(Puppet::Pops::Loader::ModuleLoaders::LibRootedFileBased)
   end
 
+  it 'creates a cached_puppet loader that can load version 3 functions, version 4 functions, and data types' do
+    loaders = Puppet::Pops::Loaders.new(empty_test_env, true)
+    expect(loaders.puppet_cache_loader.loadables).to include(:func_3x)
+    expect(loaders.puppet_cache_loader.loadables).to include(:func_4x)
+    expect(loaders.puppet_cache_loader.loadables).to include(:datatype)
+  end
+
   it 'does not create a cached_puppet loader when for_agent is the default false value' do
     loaders = Puppet::Pops::Loaders.new(empty_test_env)
     expect(loaders.puppet_cache_loader()).to be(nil)
@@ -487,7 +494,7 @@ describe 'loaders' do
     end
 
     it "to self inside function body is reported as an error" do
-      expect { 
+      expect {
         f = loader.load_typed(typed_name(:function, 'bad_func_load4')).value
         f.call(scope)
       }.to raise_error(/Illegal method definition.*'bad_func_load4_illegal_method'/)


### PR DESCRIPTION
Previously in PUP-6964 [1] the system loader was modified to to be able to load
Puppet 3 API functions:

Note that https://github.com/puppetlabs/puppet/pull/7019/files#diff-83a8daf215ff39828e0e3758c2e5a866R34
has loadables of `[:func_4x, :func_3x, :datatype]`.

However when the system cache loader was introduced in PUP-9035 [2]the loadables
specified did not include the Puppet 3 API functions:

Note that https://github.com/puppetlabs/puppet/pull/6963/files#diff-83a8daf215ff39828e0e3758c2e5a866R30
has loadables of `[:func_4x, :datatype]`

The comment at https://github.com/puppetlabs/puppet/pull/6963/files#diff-83a8daf215ff39828e0e3758c2e5a866R22
says they should be the same but is clear they are not.

This commit updates the loadables for the cache system loader to include
`:func_3x` as per the system loader.

[1] https://github.com/puppetlabs/puppet/pull/7019
[2] https://github.com/puppetlabs/puppet/pull/6963

----

- [x] Needs tests.  There are acceptance tests, but this seems like something that could be in integration instead.