### PR TITLE
(PUP-9461) Use new http connection method

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -211,8 +211,10 @@ module Puppet
         begin
           build_ssl_context
         rescue => e
-          Puppet.log_exception(e, "Failed to initialize SSL: #{e.message}")
-          Puppet.err("Run `puppet agent -t`")
+          # TRANSLATORS: `message` is an already translated string of why SSL failed to initialize
+          Puppet.log_exception(e, _("Failed to initialize SSL: %{message}") % { message: e.message })
+          # TRANSLATORS: `puppet agent -t` is a command and should not be translated
+          Puppet.err(_("Run `puppet agent -t`"))
           raise e
         end
       },
@@ -225,16 +227,20 @@ module Puppet
   def self.build_ssl_context
     cert = Puppet::X509::CertProvider.new
     cacerts = cert.load_cacerts
-    raise Puppet::Error, "The CA certificate is missing from '#{Puppet[:localcacert]}'" unless cacerts
+    # TRANSLATORS: localcacert is the path to the CA certificate file
+    raise Puppet::Error, _("The CA certificate is missing from '%{localcacert}'") % { localcacert: Puppet[:localcacert] } unless cacerts
 
     crls = cert.load_crls
-    raise Puppet::Error, "The CRL is missing from '#{Puppet[:hostcrl]}'" unless crls
+    # TRANSLATORS: hostcrl is the path to the CRL file
+    raise Puppet::Error, _("The CRL is missing from '%{hostcrl}'") % { hostcrl: Puppet[:hostcrl] } unless crls
 
     private_key = cert.load_private_key(Puppet[:certname])
-    raise Puppet::Error, "The private key is missing from '#{Puppet[:hostprivkey]}'" unless private_key
+    # TRANSLATORS: hostprivkey is the path to the host's private key
+    raise Puppet::Error, _("The private key is missing from '%{hostprivkey}'") % { hostprivkey: Puppet[:hostprivkey] } unless private_key
 
     client_cert = cert.load_client_cert(Puppet[:certname])
-    raise Puppet::Error, "The client certificate is missing from '#{Puppet[:hostcert]}'" unless client_cert
+    # TRANSLATORS: hostcert is the path to the host's certificate
+    raise Puppet::Error, _("The client certificate is missing from '%{hostcert}'") % { hostcert: Puppet[:hostcert] } unless client_cert
 
     ssl = Puppet::SSL::SSLProvider.new
     ssl.create_context(cacerts: cacerts, crls: crls,  private_key: private_key, client_cert: client_cert)

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -207,6 +207,16 @@ module Puppet
         require 'puppet/network/http'
         Puppet::Network::HTTP::NoCachePool.new
       },
+      :ssl_context => proc {
+        cert = Puppet::X509::CertProvider.new
+        ssl = Puppet::SSL::SSLProvider.new
+        ssl.create_context(
+          cacerts: cert.load_cacerts,
+          crls: cert.load_crls,
+          private_key: cert.load_private_key(Puppet[:certname]),
+          client_cert: cert.load_client_cert(Puppet[:certname])
+        )
+      },
       :ssl_host => proc { Puppet::SSL::Host.localhost },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins },
       :rich_data => false

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -395,7 +395,7 @@ class Puppet::Configurer
       host = server[0]
       port = server[1] || Puppet[:masterport]
       begin
-        http = Puppet::Network::HttpPool.http_ssl_instance(host, port)
+        http = Puppet::Network::HttpPool.http_ssl_instance(host, port.to_i)
         response = http.get('/status/v1/simple/master')
         return [host, port] if response.is_a?(Net::HTTPOK)
 

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -395,7 +395,8 @@ class Puppet::Configurer
       host = server[0]
       port = server[1] || Puppet[:masterport]
       begin
-        http = Puppet::Network::HttpPool.http_ssl_instance(host, port.to_i)
+        ssl_context = Puppet.lookup(:ssl_context)
+        http = Puppet::Network::HttpPool.connection(host, port.to_i, ssl_context: ssl_context)
         response = http.get('/status/v1/simple/master')
         return [host, port] if response.is_a?(Net::HTTPOK)
 

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -73,8 +73,10 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   end
 
   def network(request)
-    Puppet::Network::HttpPool.http_instance(request.server || self.class.server,
-                                            request.port || self.class.port)
+    ssl_context = Puppet.lookup(:ssl_context)
+    Puppet::Network::HttpPool.connection(request.server || self.class.server,
+                                         request.port || self.class.port,
+                                         ssl_context: ssl_context)
   end
 
   def http_get(request, path, headers = nil, *args)

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -28,7 +28,8 @@ Puppet::Reports.register_report(:http) do
       }
     end
     use_ssl = url.scheme == 'https'
-    conn = Puppet::Network::HttpPool.http_instance(url.host, url.port, use_ssl)
+    ssl_context = use_ssl ? Puppet.lookup(:ssl_context) : nil
+    conn = Puppet::Network::HttpPool.connection(url.host, url.port, use_ssl: use_ssl, ssl_context: ssl_context)
     response = conn.post(url.path, self.to_yaml, headers, options)
     unless response.kind_of?(Net::HTTPSuccess)
       Puppet.err _("Unable to submit report to %{url} [%{code}] %{message}") % { url: Puppet[:reporturl].to_s, code: response.code, message: response.msg }

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -62,10 +62,10 @@ class Puppet::SSL::SSLProvider
   #   `private_key`.
   # @api private
   def create_context(cacerts:, crls:, private_key:, client_cert:, revocation: Puppet[:certificate_revocation])
-    raise ArgumentError, "CA certs are missing" unless cacerts
-    raise ArgumentError, "CRLs are missing" unless crls
-    raise ArgumentError, "Private key is missing" unless private_key
-    raise ArgumentError, "Client cert is missing" unless client_cert
+    raise ArgumentError, _("CA certs are missing") unless cacerts
+    raise ArgumentError, _("CRLs are missing") unless crls
+    raise ArgumentError, _("Private key is missing") unless private_key
+    raise ArgumentError, _("Client cert is missing") unless client_cert
 
     store = create_x509_store(cacerts, crls, revocation)
     client_chain = verify_cert_with_store(store, client_cert)

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -62,8 +62,10 @@ class Puppet::SSL::SSLProvider
   #   `private_key`.
   # @api private
   def create_context(cacerts:, crls:, private_key:, client_cert:, revocation: Puppet[:certificate_revocation])
-    raise ArgumentError, "Private key is required" unless private_key
-    raise ArgumentError, "Client cert is required" unless client_cert
+    raise ArgumentError, "CA certs are missing" unless cacerts
+    raise ArgumentError, "CRLs are missing" unless crls
+    raise ArgumentError, "Private key is missing" unless private_key
+    raise ArgumentError, "Client cert is missing" unless client_cert
 
     store = create_x509_store(cacerts, crls, revocation)
     client_chain = verify_cert_with_store(store, client_cert)

--- a/lib/puppet/ssl/verifier.rb
+++ b/lib/puppet/ssl/verifier.rb
@@ -123,7 +123,12 @@ class Puppet::SSL::Verifier
       end
     end
 
-    @last_error = Puppet::SSL::CertVerifyError.new("certificate verify failed [#{store_context.error_string} for #{peer_cert.subject}]", store_context.error, peer_cert)
+    # TRANSLATORS: `error` is an untranslated message from openssl describing why a certificate in the server's chain is invalid, and `subject` is the identity/name of the failed certificate
+    @last_error = Puppet::SSL::CertVerifyError.new(
+      _("certificate verify failed [%{error} for %{subject}]") %
+      { error: store_context.error_string, subject: peer_cert.subject },
+      store_context.error, peer_cert
+    )
     false
   end
 end

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -134,8 +134,9 @@ module Puppet::Test
 
       Puppet.push_context(
         {
-          :trusted_information =>
+          trusted_information:
             Puppet::Context::TrustedInformation.new('local', 'testing', {}),
+          ssl_context: Puppet::SSL::SSLContext.new
         },
         "Context for specs")
 

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -302,7 +302,8 @@ module Puppet
       end
 
       request.do_request(:fileserver) do |req|
-        connection = Puppet::Network::HttpPool.http_instance(req.server, req.port)
+        ssl_context = Puppet.lookup(:ssl_context)
+        connection = Puppet::Network::HttpPool.connection(req.server, req.port, ssl_context: ssl_context)
         connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => BINARY_MIME_TYPES}), &block)
       end
     end

--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -47,7 +47,7 @@ module Puppet::Util
     # failover-selected port.
     # @param [Symbol] port_setting The preferred port setting to use
     # @param [Symbol] server_setting The server setting assoicated with this route.
-    # @return [String] the port to use for use in the request
+    # @return [Integer] the port to use for use in the request
     def self.determine_port(port_setting, server_setting)
       if (port_setting && port_setting != :masterport && Puppet.settings.set_by_config?(port_setting)) ||
          (server_setting && server_setting != :server && Puppet.settings.set_by_config?(server_setting))

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -54,6 +54,9 @@ class Puppet::X509::CertProvider
   # @raise [OpenSSL::X509::CertificateError] The `pem` text does not contain a valid cert
   # @api private
   def load_cacerts_from_pem(pem)
+    # TRANSLATORS 'PEM' is an acronym and shouldn't be translated
+    raise OpenSSL::X509::CertificateError, _("Failed to parse CA certificates as PEM") if pem !~ CERT_DELIMITERS
+
     pem.scan(CERT_DELIMITERS).map do |text|
       OpenSSL::X509::Certificate.new(text)
     end
@@ -90,6 +93,9 @@ class Puppet::X509::CertProvider
   # @raise [OpenSSL::X509::CRLError] The `pem` text does not contain a valid CRL
   # @api private
   def load_crls_from_pem(pem)
+    # TRANSLATORS 'PEM' is an acronym and shouldn't be translated
+    raise OpenSSL::X509::CRLError, _("Failed to parse CRLs as PEM") if pem !~ CRL_DELIMITERS
+
     pem.scan(CRL_DELIMITERS).map do |text|
       OpenSSL::X509::CRL.new(text)
     end

--- a/spec/integration/network/http_pool_spec.rb
+++ b/spec/integration/network/http_pool_spec.rb
@@ -125,7 +125,7 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
     let(:ssl_context) { ssl.create_root_context(cacerts: [server.ca_cert], crls: [server.ca_crl]) }
 
     def connection(host, port)
-      Puppet::Network::HttpPool.connection(URI("https://#{host}:#{port}"), ssl_context: ssl_context)
+      Puppet::Network::HttpPool.connection(host, port, ssl_context: ssl_context)
     end
 
     it "connects over SSL" do
@@ -155,7 +155,7 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
       server.start_server do |port|
         ssl_context = ssl.create_root_context(cacerts: [OpenSSL::X509::Certificate.new(PuppetSpec::HTTPSServer::UNKNOWN_CA)],
                                               crls: [server.ca_crl])
-        http = Puppet::Network::HttpPool.connection(URI("https://#{hostname}:#{port}"), ssl_context: ssl_context)
+        http = Puppet::Network::HttpPool.connection(hostname, port, ssl_context: ssl_context)
         expect {
           http.get('/')
         }.to raise_error(Puppet::Error,

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1011,7 +1011,7 @@ describe Puppet::Configurer do
     it "should select a server when provided" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPOK.new(nil, 200, 'OK')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(mock('request', get: response))
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: response))
       @agent.stubs(:run_internal)
 
       options = {}
@@ -1024,7 +1024,7 @@ describe Puppet::Configurer do
       response = Net::HTTPOK.new(nil, 200, 'OK')
       http = mock('request')
       http.expects(:get).with('/status/v1/simple/master').returns(response)
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(http)
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(http)
       @agent.stubs(:run_internal)
 
       @agent.run
@@ -1033,7 +1033,7 @@ describe Puppet::Configurer do
     it "should report when a server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPInternalServerError.new(nil, 500, 'Internal Server Error')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(mock('request', get: response))
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: response))
 
       Puppet.expects(:debug).with("Puppet server myserver:123 is unavailable: 500 Internal Server Error")
       expect{ @agent.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list/)
@@ -1042,17 +1042,17 @@ describe Puppet::Configurer do
     it "should error when no servers in 'server_list' are reachable" do
       Puppet.settings[:server_list] = ["myserver:123"]
       error = Net::HTTPError.new(400, 'dummy server communication error')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(mock('request', get: error))
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: error))
 
       options = {}
       expect{ @agent.run(options) }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list/)
       expect(options[:report].master_used).to be_nil
     end
 
-    it "should not make multiple node requets when the server is found" do
+    it "should not make multiple node requests when the server is found" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPOK.new(nil, 200, 'OK')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', '123').returns(mock('request', get: response))
+      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: response))
       @agent.stubs(:run_internal)
 
       @agent.run

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1011,7 +1011,7 @@ describe Puppet::Configurer do
     it "should select a server when provided" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPOK.new(nil, 200, 'OK')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: response))
+      Puppet::Network::HttpPool.stubs(:connection).with('myserver', 123, anything).returns(mock('request', get: response))
       @agent.stubs(:run_internal)
 
       options = {}
@@ -1024,7 +1024,7 @@ describe Puppet::Configurer do
       response = Net::HTTPOK.new(nil, 200, 'OK')
       http = mock('request')
       http.expects(:get).with('/status/v1/simple/master').returns(response)
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(http)
+      Puppet::Network::HttpPool.stubs(:connection).with('myserver', 123, anything).returns(http)
       @agent.stubs(:run_internal)
 
       @agent.run
@@ -1033,7 +1033,7 @@ describe Puppet::Configurer do
     it "should report when a server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPInternalServerError.new(nil, 500, 'Internal Server Error')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: response))
+      Puppet::Network::HttpPool.stubs(:connection).with('myserver', 123, anything).returns(mock('request', get: response))
 
       Puppet.expects(:debug).with("Puppet server myserver:123 is unavailable: 500 Internal Server Error")
       expect{ @agent.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list/)
@@ -1042,7 +1042,7 @@ describe Puppet::Configurer do
     it "should error when no servers in 'server_list' are reachable" do
       Puppet.settings[:server_list] = ["myserver:123"]
       error = Net::HTTPError.new(400, 'dummy server communication error')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: error))
+      Puppet::Network::HttpPool.stubs(:connection).with('myserver', 123, anything).returns(mock('request', get: error))
 
       options = {}
       expect{ @agent.run(options) }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list/)
@@ -1052,7 +1052,8 @@ describe Puppet::Configurer do
     it "should not make multiple node requests when the server is found" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPOK.new(nil, 200, 'OK')
-      Puppet::Network::HttpPool.stubs(:http_ssl_instance).with('myserver', 123).returns(mock('request', get: response))
+
+      Puppet::Network::HttpPool.expects(:connection).with('myserver', 123, anything).returns(mock('request', get: response))
       @agent.stubs(:run_internal)
 
       @agent.run

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -335,21 +335,21 @@ describe Puppet::Indirector::REST do
       @request = stub 'request', :key => "foo", :server => nil, :port => nil
       terminus.class.expects(:port).returns 321
       terminus.class.expects(:server).returns "myserver"
-      Puppet::Network::HttpPool.expects(:http_instance).with("myserver", 321).returns "myconn"
+      Puppet::Network::HttpPool.expects(:connection).with('myserver', 321, anything).returns "myconn"
       expect(terminus.network(@request)).to eq("myconn")
     end
 
     it "should use the server from the indirection request if one is present" do
       @request = stub 'request', :key => "foo", :server => "myserver", :port => nil
       terminus.class.stubs(:port).returns 321
-      Puppet::Network::HttpPool.expects(:http_instance).with("myserver", 321).returns "myconn"
+      Puppet::Network::HttpPool.expects(:connection).with('myserver', 321, anything).returns "myconn"
       expect(terminus.network(@request)).to eq("myconn")
     end
 
     it "should use the port from the indirection request if one is present" do
       @request = stub 'request', :key => "foo", :server => nil, :port => 321
       terminus.class.stubs(:server).returns "myserver"
-      Puppet::Network::HttpPool.expects(:http_instance).with("myserver", 321).returns "myconn"
+      Puppet::Network::HttpPool.expects(:connection).with('myserver', 321, anything).returns "myconn"
       expect(terminus.network(@request)).to eq("myconn")
     end
   end

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -18,18 +18,18 @@ describe processor do
     it "configures the connection for ssl when using https" do
       Puppet[:reporturl] = 'https://testing:8080/the/path'
 
-      Puppet::Network::HttpPool.expects(:http_instance).with(
-        'testing', 8080, true
+      Puppet::Network::HttpPool.expects(:connection).with(
+        'testing', 8080, has_entry(ssl_context: instance_of(Puppet::SSL::SSLContext))
       ).returns http
 
       subject.process
     end
 
-    it "does not configure the connectino for ssl when using http" do
-      Puppet[:reporturl] = "http://testing:8080/the/path"
+    it "does not configure the connection for ssl when using http" do
+      Puppet[:reporturl] = 'http://testing:8080/the/path'
 
-      Puppet::Network::HttpPool.expects(:http_instance).with(
-        'testing', 8080, false
+      Puppet::Network::HttpPool.expects(:connection).with(
+        'testing', 8080, use_ssl: false, ssl_context: nil
       ).returns http
 
       subject.process
@@ -42,7 +42,7 @@ describe processor do
     let(:options) { {:metric_id => [:puppet, :report, :http]} }
 
     before :each do
-      Puppet::Network::HttpPool.expects(:http_instance).returns(connection)
+      Puppet::Network::HttpPool.expects(:connection).returns(connection)
     end
 
     it "should use the path specified by the 'reporturl' setting" do

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -113,6 +113,30 @@ describe Puppet::SSL::SSLProvider do
     let(:private_key) { key('signed-key.pem') }
     let(:config) { { cacerts: global_cacerts, crls: global_crls, client_cert: client_cert, private_key: private_key } }
 
+    it 'raises if CA certs are missing' do
+      expect {
+        subject.create_context(config.merge(cacerts: nil))
+      }.to raise_error(ArgumentError, /CA certs are missing/)
+    end
+
+    it 'raises if CRLs are are missing' do
+      expect {
+        subject.create_context(config.merge(crls: nil))
+      }.to raise_error(ArgumentError, /CRLs are missing/)
+    end
+
+    it 'raises if private key is missing' do
+      expect {
+        subject.create_context(config.merge(private_key: nil))
+      }.to raise_error(ArgumentError, /Private key is missing/)
+    end
+
+    it 'raises if client cert is missing' do
+      expect {
+        subject.create_context(config.merge(client_cert: nil))
+      }.to raise_error(ArgumentError, /Client cert is missing/)
+    end
+
     it 'accepts RSA keys' do
       sslctx = subject.create_context(config)
       expect(sslctx.private_key).to eq(private_key)

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -594,7 +594,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
       it 'should use an explicit fileserver if source starts with puppet://' do
         response.stubs(:code).returns('200')
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet://somehostname/test/foo', :ftype => 'file')
-        Puppet::Network::HttpPool.expects(:http_instance).with('somehostname', anything).returns(conn)
+        Puppet::Network::HttpPool.expects(:connection).with('somehostname', 8140, anything).returns(conn)
 
         resource.write(source)
       end
@@ -602,14 +602,14 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
       it 'should use the default fileserver if source starts with puppet:///' do
         response.stubs(:code).returns('200')
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo', :ftype => 'file')
-        Puppet::Network::HttpPool.expects(:http_instance).with(Puppet.settings[:server], anything).returns(conn)
+        Puppet::Network::HttpPool.expects(:connection).with(Puppet[:server], 8140, anything).returns(conn)
 
         resource.write(source)
       end
 
       it 'should percent encode reserved characters' do
         response.stubs(:code).returns('200')
-        Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)
+        Puppet::Network::HttpPool.stubs(:connection).returns(conn)
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
 
         conn.unstub(:request_get)
@@ -620,7 +620,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
 
       it 'should request binary content' do
         response.stubs(:code).returns('200')
-        Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)
+        Puppet::Network::HttpPool.stubs(:connection).returns(conn)
         source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file')
 
         conn.unstub(:request_get)
@@ -637,7 +637,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         end
 
         before(:each) do
-          Puppet::Network::HttpPool.stubs(:http_instance).returns(conn)
+          Puppet::Network::HttpPool.stubs(:connection).returns(conn)
           source.stubs(:metadata).returns stub_everything('metadata', :source => 'puppet:///test/foo', :ftype => 'file')
         end
 


### PR DESCRIPTION
Load an `ssl_context` based on available cert and keys, and make it
available in puppet's global context. Update call sites to use the new
`HttpPool.connection` method.

This doesn't change the certificate related rest methods as they are
called during SSL bootstrapping, before we have a complete SSL context.

If certs, private key, or CRL are not available, then raise an error telling
users which file is missing and to run `puppet agent -t` to bootstrap the SSL
process. For example, if the agent has never run, so there's no CA cert:

    $ puppet filebucket backup file.txt
    Error: Failed to initialize SSL: The CA certificate is missing from '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
    Error: Run `puppet agent -t`

If all of the prerequisite files exist, but we fail to load the SSL context,
such as a mismatched key and cert, then we display why it failed:

    $ puppet catalog find --terminus rest
    Error: Failed to initialize SSL: The certificate for '/CN=chard' does not match its private key
    Error: Run `puppet agent -t`

The user will need to run `puppet agent -t` to complete the bootstrap process.
