### PR TITLE
(maint) Relax fast_gettext gem constraint

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
   s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
-  s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1.2")
+  s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   s.add_runtime_dependency(%q<httpclient>, "~> 2.8")

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -20,7 +20,7 @@ gem_runtime_dependencies:
   facter: ['> 2.0.1', '< 4']
   hiera: ['>= 3.2.1', '< 4']
   semantic_puppet: '~> 1.0'
-  fast_gettext: '~> 1.1.2'
+  fast_gettext: '~> 1.1'
   locale: '~> 2.1'
   multi_json: '~> 1.10'
   httpclient: '~> 2.8'


### PR DESCRIPTION
When fast_gettext was added as a dependency back in 2dffc4eab942e987dbf9d365b4c3c3e2448cfafa, fast_gettext-1.2 required Ruby 2.1 and it was decided to use fast_gettext-1.1.x (probably an old legacy version of Puppet was using an older Ruby?).

Now that all supported releases of Puppet are shipped with Ruby 2.1+, fast_gettext constraint can be relaxed.

`~> major.minor` dependencies make it easier to maintain he Puppet stack in an non-AIO system-wide environment.