### PR TITLE
(Docs) Adding note to manage_internal_file_permissions

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -305,7 +305,9 @@ module Puppet
     :manage_internal_file_permissions => {
         :default  => ! Puppet::Util::Platform.windows?,
         :type     => :boolean,
-        :desc     => "Whether Puppet should manage the owner, group, and mode of files it uses internally",
+        :desc     => "Whether Puppet should manage the owner, group, and mode of files it uses internally.
+        
+          **Note**: For Windows agents, the default is `false` for versions 4.10.13 and greater, versions 5.5.6 and greater, and versions 6.0 and greater.",
     },
     :onetime => {
         :default  => false,


### PR DESCRIPTION
For Windows agents, the default is false for versions 4.10.13+, 5.5.6+, and 6.0+