### PR TITLE
(PUP-3905) Disable ruby's http retry

### DIFF
--- a/lib/puppet/network/http/factory.rb
+++ b/lib/puppet/network/http/factory.rb
@@ -41,6 +41,11 @@ class Puppet::Network::HTTP::Factory
     http.open_timeout = Puppet[:http_connect_timeout]
     http.keep_alive_timeout = KEEP_ALIVE_TIMEOUT if http.respond_to?(:keep_alive_timeout=)
 
+    if http.respond_to?(:max_retries)
+      # 0 means make one request and never retry
+      http.max_retries = 0
+    end
+
     if Puppet[:sourceaddress]
       if http.respond_to?(:local_host)
         Puppet.debug("Using source IP #{Puppet[:sourceaddress]}")

--- a/spec/unit/network/http/factory_spec.rb
+++ b/spec/unit/network/http/factory_spec.rb
@@ -103,6 +103,12 @@ describe Puppet::Network::HTTP::Factory do
     expect(conn.keep_alive_timeout).to eq(2147483647)
   end
 
+  it "disables ruby's max retry on 2.5 and up", if: RUBY_VERSION.to_f >= 2.5 do
+    conn = create_connection(site)
+
+    expect(conn.max_retries).to eq(0)
+  end
+
   context 'source address' do
     it 'defaults to system-defined' do
       skip "Requires Ruby >= 2.0" unless RUBY_VERSION.to_i >= 2


### PR DESCRIPTION
Ruby 2.1.5 introduced automatic retry for idempotent HTTP methods
which ruby defines as: GET HEAD PUT DELETE OPTIONS TRACE. In order to
be idempotent, resending the same request should produce the same
effect as if the request was only sent once.

However, puppetserver processes each report, producing multiple entries in
puppetdb. The latest report doesn't overwrite the earlier report.

Also when puppet submits a report, it will block waiting for the HTTP response
until all report processors are finished. If the connection is dropped, eg load
balancer kills the idle connection, then the agent will retry the request,
causing another instance of the report to be processed.

Ruby 2.5 added an `Net::HTTP#max_retries=` method which defaults to 1, which
means the request will be made once, and retried at most once.

This commit changes the max retry to 0, to disable retry.

In the future, we can add retry logic, but it needs to be done at a higher level
so we can take into account the current REST request and method, such as it's
ok to retry GET file downloads, but not submitting reports.