### PR TITLE
(PUP-9512) Allow discovering and loading of YAML plans

### DIFF
--- a/lib/puppet/loaders.rb
+++ b/lib/puppet/loaders.rb
@@ -21,6 +21,7 @@ module Puppet
       require 'puppet/pops/loader/loader_paths'
       require 'puppet/pops/loader/simple_environment_loader'
       require 'puppet/pops/loader/predefined_loader'
+      require 'puppet/pops/loader/generic_plan_instantiator'
       require 'puppet/pops/loader/puppet_plan_instantiator'
     end
   end

--- a/lib/puppet/pops/loader/generic_plan_instantiator.rb
+++ b/lib/puppet/pops/loader/generic_plan_instantiator.rb
@@ -1,0 +1,28 @@
+module Puppet::Pops
+module Loader
+# The GenericPlanInstantiator dispatches to either PuppetPlanInstantiator or a
+# yaml_plan_instantiator injected through the Puppet context, depending on
+# the type of the plan.
+#
+class GenericPlanInstantiator
+  def self.create(loader, typed_name, source_refs)
+    if source_refs.length > 1
+      raise ArgumentError, _("Found multiple files for plan '%{plan_name}' but only one is allowed") % { plan_name: typed_name.name }
+    end
+
+    source_ref = source_refs[0]
+    code_string = Puppet::FileSystem.read(source_ref, :encoding => 'utf-8')
+
+    instantiator = if source_ref.end_with?('.pp')
+                     Puppet::Pops::Loader::PuppetPlanInstantiator
+                   else
+                     Puppet.lookup(:yaml_plan_instantiator) do
+                       raise Puppet::DevError, _("No instantiator is available to load plan from %{source_ref}") % { source_ref: source_ref }
+                     end
+                   end
+
+    instantiator.create(loader, typed_name, source_ref, code_string)
+  end
+end
+end
+end

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -316,7 +316,17 @@ module LoaderPaths
     PLAN_PATH = File.join('plans')
     PP_EXT = '.pp'.freeze
     YAML_EXT = '.yaml'.freeze
-    INIT_FILENAMES = %w[init.pp init.yaml].freeze
+
+    def initialize(loader)
+      super
+
+      if Puppet.lookup(:yaml_plan_instantiator) { nil }
+        @extensions = [PP_EXT, YAML_EXT]
+      else
+        @extensions = [PP_EXT]
+      end
+      @init_filenames = @extensions.map { |ext| "init#{ext}" }
+    end
 
     def extension
       EMPTY_STRING
@@ -327,7 +337,7 @@ module LoaderPaths
     end
 
     def instantiator()
-      Puppet::Pops::Loader::PuppetPlanInstantiator
+      Puppet::Pops::Loader::GenericPlanInstantiator
     end
 
     def fuzzy_matching?
@@ -335,20 +345,17 @@ module LoaderPaths
     end
 
     def valid_path?(path)
-      (path.end_with?(PP_EXT) || path.end_with?(YAML_EXT)) && path.start_with?(generic_path)
+      @extensions.any? { |ext| path.end_with?(ext) } && path.start_with?(generic_path)
     end
 
     def typed_name(type, name_authority, relative_path, module_name)
-      if INIT_FILENAMES.include?(relative_path) && !(module_name.nil? || module_name.empty?)
+      if @init_filenames.include?(relative_path) && !(module_name.nil? || module_name.empty?)
         TypedName.new(type, module_name, name_authority)
       else
         n = ''
         n << module_name unless module_name.nil?
-        if relative_path.end_with?(PP_EXT)
-          relative_path = relative_path[0..-(PP_EXT.length+1)]
-        else
-          relative_path = relative_path[0..-(YAML_EXT.length+1)]
-        end
+        ext = @extensions.find { |extension| relative_path.end_with?(extension) }
+        relative_path = relative_path[0..-(ext.length+1)]
 
         relative_path.split('/').each do |segment|
           n << '::' if n.size > 0
@@ -367,7 +374,7 @@ module LoaderPaths
         parts = parts[start_index_in_name..-1]
       end
       basename = File.join(generic_path, parts)
-      ["#{basename}#{PP_EXT}", "#{basename}#{YAML_EXT}"]
+      @extensions.map { |ext| "#{basename}#{ext}" }
     end
   end
 

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -30,6 +30,7 @@ module LoaderPaths
         end
     when :plan
       result << PlanPathPP.new(loader)
+      result << PlanPathYaml.new(loader)
     when :task
       result << TaskPath.new(loader) if Puppet[:tasks] && loader.loadables.include?(:task)
     when :type
@@ -324,7 +325,7 @@ module LoaderPaths
     end
 
     def typed_name(type, name_authority, relative_path, module_name)
-      if relative_path == 'init.pp' && !(module_name.nil? || module_name.empty?)
+      if relative_path == "init#{extension}" && !(module_name.nil? || module_name.empty?)
         TypedName.new(type, module_name, name_authority)
       else
         n = ''
@@ -339,6 +340,18 @@ module LoaderPaths
         end
         TypedName.new(type, n, name_authority)
       end
+    end
+  end
+
+  class PlanPathYaml < PlanPathPP
+    EXTENSION = '.yaml'.freeze
+
+    def instantiator()
+      Puppet.lookup(:yaml_plan_instantiator)
+    end
+
+    def extension
+      EXTENSION
     end
   end
 

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -407,9 +407,16 @@ module ModuleLoaders
         origin = sp.effective_path(typed_name, is_global ? 0 : 1)
         unless origin.nil?
           if sp.fuzzy_matching?
-            # Find all paths that might be related to origin
-            origins = candidate_paths(origin)
-            return [origins, sp] unless origins.empty?
+            # If there are multiple *specific* paths for the file, find
+            # whichever ones exist. Otherwise, find all paths that *might* be
+            # related to origin
+            if origin.is_a?(Array)
+              origins = origin.map { |ori| existing_path(ori) }.compact
+              return [origins, sp] unless origins.empty?
+            else
+              origins = candidate_paths(origin)
+              return [origins, sp] unless origins.empty?
+            end
           else
             existing = existing_path(origin)
             return [origin, sp] unless existing.nil?

--- a/lib/puppet/pops/loader/puppet_plan_instantiator.rb
+++ b/lib/puppet/pops/loader/puppet_plan_instantiator.rb
@@ -9,26 +9,16 @@ class PuppetPlanInstantiator
   #
   # @param loader [Loader] The loader the function is associated with
   # @param typed_name [TypedName] the type / name of the function to load
-  # @param source_ref [Array] a references to the source / origin of the puppet code to evaluate
+  # @param source_ref [URI, String] a reference to the source / origin of the puppet code to evaluate
+  # @param pp_code_string [String] puppet code in a string
   #
   # @return [Functions::Function] - an instantiated function with global scope closure associated with the given loader
   #
-  def self.create(loader, typed_name, source_refs)
-    if source_refs.length > 1
-      raise ArgumentError, _("Found both a .pp and .yaml version of plan '%{plan_name}' - only one is allowed") % { plan_name: typed_name.name }
-    end
-
-    source_ref = source_refs[0]
-    code_string = Puppet::FileSystem.read(source_ref, :encoding => 'utf-8')
-
-    if source_ref.end_with?('.yaml')
-      return Puppet.lookup(:yaml_plan_instantiator).create(loader, typed_name, source_ref, code_string)
-    end
-
+  def self.create(loader, typed_name, source_ref, pp_code_string)
     parser = Parser::EvaluatingParser.new()
 
     # parse and validate
-    result = parser.parse_string(code_string, source_ref)
+    result = parser.parse_string(pp_code_string, source_ref)
     # Only one function is allowed (and no other definitions)
     case result.definitions.size
     when 0


### PR DESCRIPTION
This adds a second loader for plans which will find plans with a .yaml
extension. Because plans in general, and YAML plans especially, aren't a
meaningful concept in Puppet proper, this loader just calls out to an
injected `yaml_plan_instantiator` to handle actual creation of the plan
once it's been loaded.

This will prefer .pp plans over .yaml when two files with the same name
exist.