### PR TITLE
(PUP-9511) Log an exec's "creates" check to debug

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -198,7 +198,7 @@ module Puppet
 
     newparam(:user) do
       desc "The user to run the command as.
-      
+
         > **Note:** Puppet cannot execute commands as other users on Windows.
 
         Note that if you use this attribute, any error output is not captured
@@ -407,6 +407,8 @@ module Puppet
       # If the file exists, return false (i.e., don't run the command),
       # else return true
       def check(value)
+        #TRANSLATORS 'creates' is a parameter name and should not be translated
+        debug(_("Checking that 'creates' path '%{creates_path}' exists") % { creates_path: value })
         ! Puppet::FileSystem.exist?(value)
       end
     end
@@ -588,7 +590,7 @@ module Puppet
 
               debug(_("'%{cmd}' won't be executed because of failed check '%{check}'") % { cmd: cmdstring, check: check })
 
-              return false 
+              return false
             end
           end
         end

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -681,6 +681,22 @@ describe Puppet::Type.type(:exec) do
           @test[:creates] = [@exist] * 3
         end
       end
+
+      context "when creates is being checked" do
+        it "should be logged to debug when the path does exist" do
+          Puppet::Util::Log.level = :debug
+          @test[:creates] = @exist
+          expect(@test.check_all_attributes).to eq(false)
+          expect(@logs).to include(an_object_having_attributes(level: :debug, message: "Checking that 'creates' path '#{@exist}' exists"))
+        end
+
+        it "should be logged to debug when the path does not exist" do
+          Puppet::Util::Log.level = :debug
+          @test[:creates] = @unexist
+          expect(@test.check_all_attributes).to eq(true)
+          expect(@logs).to include(an_object_having_attributes(level: :debug, message: "Checking that 'creates' path '#{@unexist}' exists"))
+        end
+      end
     end
 
     { :onlyif => { :pass => false, :fail => true  },


### PR DESCRIPTION
Prior to this, an exec's check that the `creates` path exists was hidden from the user.

That behavior was inconsistent with the `onlyif` and `unless` checks as those log to debug when they are being checked.

After this commit, when the creates path is being checked for existence, a debug-level message will be shown to inform the user that the check is happening.

```
Checking that 'creates' path '/path/to/creates' exists
```