### PR TITLE
Merge 5.5.x to 6.0.x

### DIFF
--- a/lib/puppet/util/ssl.rb
+++ b/lib/puppet/util/ssl.rb
@@ -70,7 +70,11 @@ module Puppet::Util::SSL
     # can be nil
     peer_cert = verifier.peer_certs.last
 
-    if peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert, host)
+    if error.message.include? "certificate verify failed"
+      msg = error.message
+      msg << ": [" + verifier.verify_errors.join('; ') + "]"
+      raise Puppet::Error, msg, error.backtrace
+    elsif peer_cert && !OpenSSL::SSL.verify_certificate_identity(peer_cert, host)
       valid_certnames = [peer_cert.subject.to_s.sub(/.*=/, ''),
                          *Puppet::SSL::Certificate.subject_alt_names_for(peer_cert)].uniq
       if valid_certnames.size > 1
@@ -80,10 +84,6 @@ module Puppet::Util::SSL
       end
 
       msg = _("Server hostname '%{host}' did not match server certificate; %{expected_certnames}") % { host: host, expected_certnames: expected_certnames }
-      raise Puppet::Error, msg, error.backtrace
-    elsif !verifier.verify_errors.empty?
-      msg = error.message
-      msg << ": [" + verifier.verify_errors.join('; ') + "]"
       raise Puppet::Error, msg, error.backtrace
     else
       raise error

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -78,7 +78,7 @@ describe Puppet::Network::HTTP::Connection do
       WebMock.enable!
     end
 
-    it "should provide a useful error message when one is available and certificate validation fails in ruby 2.4 and up" do
+    it "should provide a useful error message when one is available and certificate validation fails", :unless => Puppet::Util::Platform.windows? do
       connection = Puppet::Network::HTTP::Connection.new(
         host, port,
         :verify => ConstantErrorValidator.new(:fails_with => 'certificate verify failed',
@@ -89,32 +89,16 @@ describe Puppet::Network::HTTP::Connection do
       end.to raise_error(Puppet::Error, /certificate verify failed: \[shady looking signature\]/)
     end
 
-    it "should provide a helpful error message when hostname does not match server certificate before ruby 2.4", :unless => RUBY_PLATFORM == 'java' do
+    it "should provide a helpful error message when hostname was not match with server certificate", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       Puppet[:confdir] = tmpdir('conf')
 
       connection = Puppet::Network::HTTP::Connection.new(
       host, port,
       :verify => ConstantErrorValidator.new(
-        :fails_with => "hostname 'myserver' does not match the server certificate",
+        :fails_with => 'hostname was not match with server certificate',
         :peer_certs => [Puppet::TestCa.new.generate('not_my_server',
                                                     :subject_alt_names => 'DNS:foo,DNS:bar,DNS:baz,DNS:not_my_server')[:cert]]))
-      expect do
-        connection.get('request')
-      end.to raise_error(Puppet::Error) do |error|
-        error.message =~ /\AServer hostname 'my_server' did not match server certificate; expected one of (.+)/
-        expect($1.split(', ')).to match_array(%w[DNS:foo DNS:bar DNS:baz DNS:not_my_server not_my_server])
-      end
-    end
 
-    it "should provide a helpful error message when hostname does not match server certificate in ruby 2.4 or greater" do
-      Puppet[:confdir] = tmpdir('conf')
-
-      connection = Puppet::Network::HTTP::Connection.new(
-        host, port,
-        :verify => ConstantErrorValidator.new(
-          :fails_with => "certificate verify failed",
-          :peer_certs => [Puppet::TestCa.new.generate('not_my_server',
-                                                      :subject_alt_names => 'DNS:foo,DNS:bar,DNS:baz,DNS:not_my_server')[:cert]]))
       expect do
         connection.get('request')
       end.to raise_error(Puppet::Error) do |error|
@@ -133,7 +117,7 @@ describe Puppet::Network::HTTP::Connection do
       end.to raise_error(/some other message/)
     end
 
-    it "should check all peer certificates for upcoming expiration", :unless => RUBY_PLATFORM == 'java' do
+    it "should check all peer certificates for upcoming expiration", :unless => Puppet::Util::Platform.windows? || RUBY_PLATFORM == 'java' do
       Puppet[:confdir] = tmpdir('conf')
       cert = Puppet::TestCa.new.generate('server',
                                          :subject_alt_names => 'DNS:foo,DNS:bar,DNS:baz,DNS:server')[:cert]


### PR DESCRIPTION
Restore the previous behavior of checking for "certificate verify failed" message first, expecting `hostname was not match with server certificate` (sic), and skipping some tests on windows and jruby.