### PR TITLE
(maint) Don't call Facter.reset under JRuby

### DIFF
--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -375,7 +375,8 @@ module Pal
 
     # Puppet requires Facter, which initializes its lookup paths. Reset Facter to
     # pickup the new $LOAD_PATH.
-    Facter.reset
+    # This fails under JRuby, where Facter does not make `reset` available.
+    Facter.reset unless RUBY_PLATFORM == 'java'
 
     node = Puppet.lookup(:pal_current_node)
     pal_facts = Puppet.lookup(:pal_facts)


### PR DESCRIPTION
When running in JRuby, PAL's call to Facter.reset produces an error,
since `reset` it isn't exposed there. Skip that step in JRuby, since
$LOAD_PATH is controlled in other ways there.