### PR TITLE
(PUP-9076) Puppet should fail when it cannot find a functional server

### DIFF
--- a/acceptance/tests/reports/failover_master.rb
+++ b/acceptance/tests/reports/failover_master.rb
@@ -37,9 +37,8 @@ test_name "The report specifies which master was contacted during failover" do
         end
 
         step "master_field should not appear when no master could be conatacted" do
-          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list=badmaster:1","--http_connect_timeout=5s", "--report_server=#{master}"), :acceptable_exit_codes => [1])
-          on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do
-            assert_no_match(/master_used:/, stdout, "did not expect master_used to be in the report")
+          on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server_list=badmaster:1","--http_connect_timeout=5s", "--report_server=#{master}"), :acceptable_exit_codes => [1]) do
+            assert_match(/Could not select a functional puppet master from server_list:/, stderr)
           end
           remove_reports_on_master(master_reportdir, agent.node_name)
         end


### PR DESCRIPTION
When `server_list` is set, rather than fall back to the default `server`
setting, puppet should just fail.

This commit updates the acceptance tests, which were missed when this
change was originally made.