### PR TITLE
(PUP-9555) Relax FFI dependency to support Ruby 2.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ matrix:
 
 # Ruby versions under test
 platform:
+  - Ruby26-x64
   - Ruby25-x64
   - Ruby24-x64
   - Ruby23-x64

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -37,7 +37,7 @@ gem_platform_dependencies:
       CFPropertyList: '~> 2.2'
   x86-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.25'
+      ffi: ['> 1.9.24', '< 2']
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-process: '= 0.7.5'
@@ -47,7 +47,7 @@ gem_platform_dependencies:
       minitar: '~> 0.6.1'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.25'
+      ffi: ['> 1.9.24', '< 2']
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
       win32-process: '= 0.7.5'


### PR DESCRIPTION
- Per the FFI CHANGELOG, Ruby 2.6 compatible Windows binaries were not
   added until FFI 1.10.

   See ffi/ffi:CHANGELOG.md@master

 - Relax Puppets dependency to set a minimum of 1.9.25 and a maximum
   of 2.0.

   1.9.21 was necessary to support Ruby 2.5, but newer versions are
   preferred due to fixing CVE-2018-10000201

 - Loosens restriction from c483351
   where FFI dependency was last set to < 1.10.

 - Now that FFI restriction has been loosened, run tests against
   Ruby 2.6 in AppVeyor