### PR TITLE
(PUP-9458) Download CRL explicitly

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -230,9 +230,14 @@ module Puppet
     # TRANSLATORS: localcacert is the path to the CA certificate file
     raise Puppet::Error, _("The CA certificate is missing from '%{localcacert}'") % { localcacert: Puppet[:localcacert] } unless cacerts
 
-    crls = cert.load_crls
-    # TRANSLATORS: hostcrl is the path to the CRL file
-    raise Puppet::Error, _("The CRL is missing from '%{hostcrl}'") % { hostcrl: Puppet[:hostcrl] } unless crls
+    case Puppet[:certificate_revocation]
+    when :chain, :leaf
+      crls = cert.load_crls
+      # TRANSLATORS: hostcrl is the path to the CRL file
+      raise Puppet::Error, _("The CRL is missing from '%{hostcrl}'") % { hostcrl: Puppet[:hostcrl] } unless crls
+    else
+      crls = []
+    end
 
     private_key = cert.load_private_key(Puppet[:certname])
     # TRANSLATORS: hostprivkey is the path to the host's private key

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -50,16 +50,22 @@ class Puppet::SSL::StateMachine
     def next_state
       Puppet.debug("Loading CRLs")
 
-      crls = @cert_provider.load_crls
-      if crls
-        next_ctx = @ssl_provider.create_root_context(cacerts: ssl_context[:cacerts], crls: crls)
+      case Puppet[:certificate_revocation]
+      when :chain, :leaf
+        crls = @cert_provider.load_crls
+        if crls
+          next_ctx = @ssl_provider.create_root_context(cacerts: ssl_context[:cacerts], crls: crls)
+        else
+          fetcher = Puppet::SSL::Fetcher.new(@ssl_context)
+          pem = fetcher.fetch_crls
+          crls = @cert_provider.load_crls_from_pem(pem)
+          # verify crls before saving
+          next_ctx = @ssl_provider.create_root_context(cacerts: ssl_context[:cacerts], crls: crls)
+          @cert_provider.save_crls(crls)
+        end
       else
-        fetcher = Puppet::SSL::Fetcher.new(@ssl_context)
-        pem = fetcher.fetch_crls
-        crls = @cert_provider.load_crls_from_pem(pem)
-        # verify crls before saving
-        next_ctx = @ssl_provider.create_root_context(cacerts: ssl_context[:cacerts], crls: crls)
-        @cert_provider.save_crls(crls)
+        Puppet.info("Certificate revocation is disabled, skipping CRL download")
+        next_ctx = @ssl_context
       end
 
       NeedKey.new(next_ctx)

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -86,23 +86,12 @@ class Puppet::SSL::StateMachine
 
   def run_machine(state, stop)
     loop do
-      Puppet.debug("In state #{state_name(state)}")
+      Puppet.debug("Current SSL state #{state_name(state)}")
 
-      next_state = state.next_state
-      print_transition(state, next_state) if Puppet::Util::Log.sendlevel?(:info)
-      state = next_state
+      state = state.next_state
 
-      case state
-      when stop
-        return state
-      else
-        # continue
-      end
+      return state if state.is_a?(stop)
     end
-  end
-
-  def print_transition(current_state, next_state)
-    puts "state #{state_name(current_state)} -> #{state_name(next_state)}"
   end
 
   def state_name(state)

--- a/spec/fixtures/ssl/127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/127.0.0.1-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:a8:32:0e:1d:19:fa:a6:09:3c:93:f4:99:fa:e4:
-    9d:e0:f8:69:bf:8c:b2:73:80:09:3f:6c:d3:27:12:
-    9c:7e:a2:02:8a:cf:5b:37:eb:ff:09:82:18:de:24:
-    2e:66:d3:7b:47:d8:ac:f4:0c:49:ff:b5:b8:d9:77:
-    9c:32:5b:db:93:ce:40:ff:63:67:f2:e1:53:a2:da:
-    b1:15:4b:03:62:dc:37:db:aa:66:87:aa:e5:99:2b:
-    af:b1:8e:92:c0:0d:4f:10:b2:56:09:4c:7f:cb:f4:
-    0e:c0:d8:28:62:98:7d:4d:08:be:49:7f:24:ac:ae:
-    d8:24:bc:61:92:7b:3c:da:3d
+    00:bb:e1:47:40:df:d0:06:c2:ef:5b:0b:41:41:01:
+    f8:a3:68:fe:18:82:21:5b:97:b5:7c:25:f2:31:b9:
+    50:09:a8:56:71:4c:81:e5:fe:e0:2b:f3:8d:38:e8:
+    fd:15:c2:a3:5a:db:56:5d:29:49:4d:75:e5:ae:69:
+    a7:a3:ac:19:c6:23:cb:1a:23:57:15:aa:ca:e1:e1:
+    78:79:af:49:15:bf:7d:9a:42:16:bc:b1:18:61:68:
+    d8:e1:34:57:4e:73:a0:90:3e:1f:8a:56:fd:0c:eb:
+    f0:fb:03:fd:ec:1b:ff:15:1f:d7:3e:5c:73:09:15:
+    48:83:e5:ff:4e:b3:ea:3a:a9
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:8e:6a:73:d0:e8:62:77:9c:72:92:c5:16:6c:7e:
-    8f:c0:22:17:48:7e:15:cb:fe:a9:d5:ee:8b:8c:16:
-    12:34:97:71:97:9f:a4:19:61:d6:7d:72:8f:23:e9:
-    76:f0:d2:39:1c:c8:b7:09:9e:2e:3a:3a:e0:de:22:
-    8d:3b:86:d4:10:9f:11:75:00:14:ec:57:5c:e5:70:
-    72:1e:97:8c:af:6f:02:af:10:9c:d8:a7:52:b8:e6:
-    84:01:b0:d7:4d:6e:5c:8f:3f:e8:bd:25:2d:2f:b5:
-    c9:c8:00:42:f9:03:a7:eb:e7:bc:7b:50:f2:fc:4c:
-    9f:f6:7a:19:0c:62:a1:02:01
+    22:7d:7d:b6:24:20:2d:4d:95:e1:31:d4:bd:d9:5d:
+    ca:a9:d8:93:a9:37:f4:77:8a:42:8b:38:c5:f6:0e:
+    02:67:db:ce:9a:cb:f1:eb:f3:3d:3e:4d:bb:97:d1:
+    f6:2f:b0:0b:5a:de:a4:e5:92:66:5c:f1:58:2e:5f:
+    2f:05:c6:09:30:2e:77:0c:07:64:ea:9e:c2:f4:72:
+    b0:f9:31:36:af:45:7e:a5:44:bf:b8:f9:1c:0d:fc:
+    9f:8e:41:08:c4:8e:d0:8d:4e:de:2d:f3:42:c3:d0:
+    6e:ca:70:21:bb:f5:c4:e2:67:13:21:10:5a:0b:68:
+    7b:5d:9f:ea:08:f0:12:3d
 prime1:
-    00:dc:8a:9d:5d:ac:29:fa:45:37:36:05:e8:c0:11:
-    6c:d4:3c:8c:75:5c:e0:cb:93:9e:62:5e:c0:ec:5a:
-    c8:54:88:d4:5a:d1:6b:a3:4e:ef:41:98:f2:41:ee:
-    02:14:12:65:24:0b:9e:d1:18:95:1a:69:27:b8:cf:
-    6d:06:37:ba:dd
+    00:e3:d5:5c:8e:b9:31:28:ce:d3:c0:78:0d:b2:12:
+    0e:14:95:a4:b8:48:20:82:2f:27:37:f5:b8:6e:b4:
+    ec:57:7f:92:c4:23:15:5b:d1:b6:35:20:60:49:36:
+    fb:63:8d:df:34:45:af:07:80:a7:9b:05:2f:43:5e:
+    af:9a:bc:9b:43
 prime2:
-    00:c3:3c:e7:df:c8:fa:0f:71:c9:6a:6e:c3:50:bf:
-    54:96:19:07:1d:37:13:db:0a:bf:e5:95:07:ef:9f:
-    f5:7b:34:a2:1b:cd:c7:0f:93:90:4e:53:a4:5b:4f:
-    de:77:4f:c3:69:c2:f2:5d:15:33:c2:6f:99:f7:73:
-    0a:97:43:36:e1
+    00:d3:1b:70:e1:ff:2d:af:09:a9:3e:65:04:58:3d:
+    65:11:bd:98:7e:39:26:ab:33:98:37:cf:46:13:2e:
+    6f:dd:48:0e:0c:bb:ee:3a:a7:91:60:81:6f:9f:54:
+    65:2c:cd:8a:6f:27:a5:6a:72:f1:3d:44:9c:b3:eb:
+    b8:56:6f:b5:a3
 exponent1:
-    00:a1:96:66:6a:c5:c4:13:fd:36:d0:bc:4f:a6:ba:
-    9d:b4:7b:90:a6:45:20:e7:c8:07:1a:28:36:ce:76:
-    4d:a5:b2:83:74:ef:50:20:5d:ab:6b:b2:b6:7d:9b:
-    f7:a5:e1:3c:7d:c6:8d:dc:c2:58:2c:fb:b3:00:f3:
-    e9:fb:ce:45:79
+    00:b4:ef:ca:4c:f2:98:2e:ef:6a:cd:8c:ca:5b:a3:
+    e9:18:c1:eb:0a:0b:05:fe:3d:92:68:e7:b5:2b:fe:
+    75:3f:db:e9:e3:e8:74:da:f1:c6:41:94:cf:c2:f5:
+    6e:5a:16:de:af:75:b3:d6:42:7f:59:26:99:ed:67:
+    f2:0f:f2:3f:5f
 exponent2:
-    4a:63:08:4d:c1:7b:55:2b:1b:7c:cb:da:eb:07:1b:
-    29:5d:3b:d2:ab:cb:8a:e7:9b:99:d3:a0:84:72:43:
-    cb:bf:90:0c:5b:e8:fe:4c:50:ed:26:fd:36:35:46:
-    23:db:66:2f:03:b1:e8:39:4d:d1:45:48:3a:79:c0:
-    8d:45:74:c1
+    10:8b:45:fd:70:12:14:75:9d:5d:d6:6c:d0:bd:7e:
+    fe:34:ed:8e:76:cc:20:fe:9a:1f:45:8f:28:51:ab:
+    52:9c:22:fd:bc:7c:9e:fc:22:d8:7d:4c:52:20:3b:
+    0d:97:ce:11:87:f9:de:ad:c3:5a:19:d6:6e:03:3b:
+    1f:0b:02:21
 coefficient:
-    00:a9:08:04:bd:89:a4:8d:50:b2:5d:4b:12:86:55:
-    f1:6d:8f:48:d4:1b:77:91:f7:d8:f9:d6:0c:8c:20:
-    97:69:68:7a:3d:15:34:3f:e5:58:20:7a:b3:98:b0:
-    29:17:95:ba:50:db:56:fe:ec:d9:ba:f2:50:10:2b:
-    68:23:e4:a5:21
+    00:a9:b1:a0:81:72:a1:e9:41:51:3e:32:5a:33:aa:
+    20:b1:23:bf:ff:62:53:a7:6d:e2:c1:d5:18:11:57:
+    b6:9e:fd:b2:c5:d8:d8:50:d1:5e:5c:22:ba:14:e3:
+    36:92:34:4c:29:19:dc:a3:60:a8:01:81:00:5b:c1:
+    3b:4e:0f:26:23
 -----BEGIN RSA PRIVATE KEY-----
-MIICXgIBAAKBgQCoMg4dGfqmCTyT9Jn65J3g+Gm/jLJzgAk/bNMnEpx+ogKKz1s3
-6/8JghjeJC5m03tH2Kz0DEn/tbjZd5wyW9uTzkD/Y2fy4VOi2rEVSwNi3DfbqmaH
-quWZK6+xjpLADU8QslYJTH/L9A7A2ChimH1NCL5JfySsrtgkvGGSezzaPQIDAQAB
-AoGBAI5qc9DoYneccpLFFmx+j8AiF0h+Fcv+qdXui4wWEjSXcZefpBlh1n1yjyPp
-dvDSORzItwmeLjo64N4ijTuG1BCfEXUAFOxXXOVwch6XjK9vAq8QnNinUrjmhAGw
-101uXI8/6L0lLS+1ycgAQvkDp+vnvHtQ8vxMn/Z6GQxioQIBAkEA3IqdXawp+kU3
-NgXowBFs1DyMdVzgy5OeYl7A7FrIVIjUWtFro07vQZjyQe4CFBJlJAue0RiVGmkn
-uM9tBje63QJBAMM859/I+g9xyWpuw1C/VJYZBx03E9sKv+WVB++f9Xs0ohvNxw+T
-kE5TpFtP3ndPw2nC8l0VM8JvmfdzCpdDNuECQQChlmZqxcQT/TbQvE+mup20e5Cm
-RSDnyAcaKDbOdk2lsoN071AgXatrsrZ9m/el4Tx9xo3cwlgs+7MA8+n7zkV5AkBK
-YwhNwXtVKxt8y9rrBxspXTvSq8uK55uZ06CEckPLv5AMW+j+TFDtJv02NUYj22Yv
-A7HoOU3RRUg6ecCNRXTBAkEAqQgEvYmkjVCyXUsShlXxbY9I1Bt3kffY+dYMjCCX
-aWh6PRU0P+VYIHqzmLApF5W6UNtW/uzZuvJQECtoI+SlIQ==
+MIICXQIBAAKBgQC74UdA39AGwu9bC0FBAfijaP4YgiFbl7V8JfIxuVAJqFZxTIHl
+/uAr84046P0VwqNa21ZdKUlNdeWuaaejrBnGI8saI1cVqsrh4Xh5r0kVv32aQha8
+sRhhaNjhNFdOc6CQPh+KVv0M6/D7A/3sG/8VH9c+XHMJFUiD5f9Os+o6qQIDAQAB
+AoGAIn19tiQgLU2V4THUvdldyqnYk6k39HeKQos4xfYOAmfbzprL8evzPT5Nu5fR
+9i+wC1repOWSZlzxWC5fLwXGCTAudwwHZOqewvRysPkxNq9FfqVEv7j5HA38n45B
+CMSO0I1O3i3zQsPQbspwIbv1xOJnEyEQWgtoe12f6gjwEj0CQQDj1VyOuTEoztPA
+eA2yEg4UlaS4SCCCLyc39bhutOxXf5LEIxVb0bY1IGBJNvtjjd80Ra8HgKebBS9D
+Xq+avJtDAkEA0xtw4f8trwmpPmUEWD1lEb2YfjkmqzOYN89GEy5v3UgODLvuOqeR
+YIFvn1RlLM2KbyelanLxPUScs+u4Vm+1owJBALTvykzymC7vas2Myluj6RjB6woL
+Bf49kmjntSv+dT/b6ePodNrxxkGUz8L1bloW3q91s9ZCf1kmme1n8g/yP18CQBCL
+Rf1wEhR1nV3WbNC9fv407Y52zCD+mh9FjyhRq1KcIv28fJ78Ith9TFIgOw2XzhGH
++d6tw1oZ1m4DOx8LAiECQQCpsaCBcqHpQVE+MlozqiCxI7//YlOnbeLB1RgRV7ae
+/bLF2NhQ0V5cIroU4zaSNEwpGdyjYKgBgQBbwTtODyYj
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/127.0.0.1.pem
+++ b/spec/fixtures/ssl/127.0.0.1.pem
@@ -6,43 +6,43 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:a8:32:0e:1d:19:fa:a6:09:3c:93:f4:99:fa:e4:
-                    9d:e0:f8:69:bf:8c:b2:73:80:09:3f:6c:d3:27:12:
-                    9c:7e:a2:02:8a:cf:5b:37:eb:ff:09:82:18:de:24:
-                    2e:66:d3:7b:47:d8:ac:f4:0c:49:ff:b5:b8:d9:77:
-                    9c:32:5b:db:93:ce:40:ff:63:67:f2:e1:53:a2:da:
-                    b1:15:4b:03:62:dc:37:db:aa:66:87:aa:e5:99:2b:
-                    af:b1:8e:92:c0:0d:4f:10:b2:56:09:4c:7f:cb:f4:
-                    0e:c0:d8:28:62:98:7d:4d:08:be:49:7f:24:ac:ae:
-                    d8:24:bc:61:92:7b:3c:da:3d
+                    00:bb:e1:47:40:df:d0:06:c2:ef:5b:0b:41:41:01:
+                    f8:a3:68:fe:18:82:21:5b:97:b5:7c:25:f2:31:b9:
+                    50:09:a8:56:71:4c:81:e5:fe:e0:2b:f3:8d:38:e8:
+                    fd:15:c2:a3:5a:db:56:5d:29:49:4d:75:e5:ae:69:
+                    a7:a3:ac:19:c6:23:cb:1a:23:57:15:aa:ca:e1:e1:
+                    78:79:af:49:15:bf:7d:9a:42:16:bc:b1:18:61:68:
+                    d8:e1:34:57:4e:73:a0:90:3e:1f:8a:56:fd:0c:eb:
+                    f0:fb:03:fd:ec:1b:ff:15:1f:d7:3e:5c:73:09:15:
+                    48:83:e5:ff:4e:b3:ea:3a:a9
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         74:8b:15:f1:22:66:6e:83:8f:4f:8e:d5:e6:08:b9:ed:d2:4e:
-         6d:40:ba:a6:a1:54:b2:7d:ef:f0:ec:0f:47:0c:30:51:04:f6:
-         14:12:ec:de:0d:0f:0e:a0:03:ac:41:67:6c:6f:9e:9f:19:94:
-         3d:46:2e:6b:d2:68:06:3a:d5:7b:9c:79:cc:ca:c0:e8:56:8c:
-         1a:62:1a:19:94:5c:ef:a6:73:60:f8:aa:97:9c:e7:a5:68:1a:
-         95:6f:0d:97:66:2d:79:0c:44:87:b9:7a:73:74:d7:00:8e:15:
-         b9:2b:ee:b9:12:f9:f1:f5:cf:e1:6c:be:0e:dd:25:e3:03:b7:
-         2a:ae
+         ba:0d:5c:ae:e4:7b:7f:ec:39:f5:e6:29:ab:6a:bf:65:26:87:
+         04:50:ca:93:f1:ee:7a:65:3a:6b:7c:b2:d7:96:f2:29:19:8a:
+         0d:ed:e3:3d:ed:d1:5d:72:c2:a6:60:bc:13:c6:c0:92:a8:a2:
+         23:3b:35:6b:58:a5:c4:7c:74:88:1a:00:bd:47:0f:c8:4b:4d:
+         f6:2c:16:61:1c:9a:b9:b6:be:28:0e:41:17:df:bc:f3:21:a8:
+         2c:a3:e2:4b:23:e0:2e:06:f3:b6:0e:90:3d:87:8c:da:a8:66:
+         14:7e:03:e2:69:85:0d:a7:a9:d9:b6:25:92:fd:13:e1:e9:71:
+         f9:da
 -----BEGIN CERTIFICATE-----
 MIIBvzCCASigAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwMzIwMjYyNFowFDESMBAGA1UEAwwJ
-MTI3LjAuMC4xMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCoMg4dGfqmCTyT
-9Jn65J3g+Gm/jLJzgAk/bNMnEpx+ogKKz1s36/8JghjeJC5m03tH2Kz0DEn/tbjZ
-d5wyW9uTzkD/Y2fy4VOi2rEVSwNi3DfbqmaHquWZK6+xjpLADU8QslYJTH/L9A7A
-2ChimH1NCL5JfySsrtgkvGGSezzaPQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcu
-MC4wLjGCCTEyNy4wLjAuMjANBgkqhkiG9w0BAQsFAAOBgQB0ixXxImZug49PjtXm
-CLnt0k5tQLqmoVSyfe/w7A9HDDBRBPYUEuzeDQ8OoAOsQWdsb56fGZQ9Ri5r0mgG
-OtV7nHnMysDoVowaYhoZlFzvpnNg+KqXnOelaBqVbw2XZi15DESHuXpzdNcAjhW5
-K+65Evnx9c/hbL4O3SXjA7cqrg==
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owFDESMBAGA1UEAwwJ
+MTI3LjAuMC4xMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC74UdA39AGwu9b
+C0FBAfijaP4YgiFbl7V8JfIxuVAJqFZxTIHl/uAr84046P0VwqNa21ZdKUlNdeWu
+aaejrBnGI8saI1cVqsrh4Xh5r0kVv32aQha8sRhhaNjhNFdOc6CQPh+KVv0M6/D7
+A/3sG/8VH9c+XHMJFUiD5f9Os+o6qQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcu
+MC4wLjGCCTEyNy4wLjAuMjANBgkqhkiG9w0BAQsFAAOBgQC6DVyu5Ht/7Dn15imr
+ar9lJocEUMqT8e56ZTprfLLXlvIpGYoN7eM97dFdcsKmYLwTxsCSqKIjOzVrWKXE
+fHSIGgC9Rw/IS032LBZhHJq5tr4oDkEX37zzIagso+JLI+AuBvO2DpA9h4zaqGYU
+fgPiaYUNp6nZtiWS/RPh6XH52g==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-basic-constraints.pem
@@ -1,26 +1,26 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 5 (0x5)
+        Serial Number: 7 (0x7)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:c9:47:85:44:02:d5:fa:9c:58:e6:ff:d2:f7:d7:
-                    64:d0:f6:83:90:85:a0:3b:9d:ae:81:db:9a:80:1e:
-                    70:2b:ac:d6:fc:d5:43:f9:89:8d:fe:67:b0:ba:7b:
-                    ac:40:7b:6e:6f:87:e7:38:49:3b:e6:82:90:00:10:
-                    b1:e9:d4:f1:35:64:d8:49:68:54:fc:8f:67:8d:19:
-                    87:b5:d6:de:05:69:1c:f9:42:6c:18:bd:2f:3c:b2:
-                    39:5d:7e:12:ef:c7:1e:19:6e:59:70:db:68:96:3d:
-                    93:15:7f:4f:ff:e2:43:ae:5f:9a:00:4a:d0:8c:15:
-                    3e:38:de:a4:44:c3:4f:37:eb
+                    00:c8:15:08:03:7c:69:d7:4d:05:f9:81:0c:f3:f1:
+                    77:ed:4a:e8:7c:f7:ac:77:bb:5c:8b:5c:96:31:01:
+                    bf:aa:b4:16:e6:d6:b3:22:15:4b:5c:8e:3c:99:af:
+                    7b:7d:1a:e8:0d:3d:40:14:37:00:f5:37:3a:00:06:
+                    e1:0b:0e:37:b8:76:62:a3:9a:5e:47:d5:d4:2a:4e:
+                    13:50:a9:0c:7a:b1:69:e7:79:9a:30:51:66:0b:e4:
+                    b7:b9:7d:e4:5b:61:19:0b:8f:79:a9:43:b0:a1:ff:
+                    c7:a6:7a:a6:fa:2e:88:28:84:66:68:bf:bf:b6:64:
+                    9e:1e:b7:e7:fe:35:63:65:51
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +28,32 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                5F:67:9D:DE:33:62:11:B6:CB:E0:7D:8A:5F:27:55:E0:78:C9:E2:F2
+                93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:5F:67:9D:DE:33:62:11:B6:CB:E0:7D:8A:5F:27:55:E0:78:C9:E2:F2
+                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
 
     Signature Algorithm: sha256WithRSAEncryption
-         a7:d3:09:ae:23:77:bf:4b:52:29:7b:21:44:35:1b:0b:8b:25:
-         e6:fa:68:cb:96:6c:9a:9d:34:21:7c:1f:88:90:02:50:36:ad:
-         03:3a:7b:ab:ea:26:24:4a:d7:3c:90:9d:46:a6:96:b2:cd:5c:
-         80:ec:0f:3d:86:4b:f4:15:3c:4a:d2:66:d1:73:65:2f:45:ea:
-         3c:52:4a:11:18:15:12:35:7a:b3:bb:48:35:e4:63:60:18:72:
-         9a:49:c8:d9:c1:f8:4d:cb:9c:69:db:b4:aa:df:82:c0:27:f1:
-         c3:05:bf:c8:be:65:a1:a5:c5:85:bf:0b:21:0a:ae:af:ef:a7:
-         33:e4
+         75:cc:05:b2:d8:43:aa:99:84:5d:64:0b:ac:cc:af:07:a7:0d:
+         90:79:9f:c9:dc:09:e6:59:d8:d1:c2:0e:2a:96:ab:80:38:f8:
+         1a:1d:d1:e2:0c:c0:fa:df:c0:cf:0c:78:30:ac:d0:b7:e9:88:
+         31:d6:05:29:41:8f:2e:32:f2:98:74:fc:19:4b:d8:c5:36:c3:
+         7a:a7:ae:8c:65:b0:4b:f0:fb:f8:86:ad:08:53:43:8f:f5:52:
+         a0:9b:cf:e8:2d:60:57:4f:f3:ab:63:3c:f2:23:da:d0:5a:de:
+         2f:64:25:c3:4f:ff:51:c9:51:22:38:b4:e6:a6:87:50:a8:ea:
+         9f:f3
 -----BEGIN CERTIFICATE-----
-MIICLzCCAZigAwIBAgIBBTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwMzIwMjYyNFowEjEQMA4GA1UEAwwH
-VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAyUeFRALV+pxY5v/S
-99dk0PaDkIWgO52ugduagB5wK6zW/NVD+YmN/mewunusQHtub4fnOEk75oKQABCx
-6dTxNWTYSWhU/I9njRmHtdbeBWkc+UJsGL0vPLI5XX4S78ceGW5ZcNtolj2TFX9P
-/+JDrl+aAErQjBU+ON6kRMNPN+sCAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4G
-A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUX2ed3jNiEbbL4H2KXydV4HjJ4vIwMQYJ
+MIICLzCCAZigAwIBAgIBBzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owEjEQMA4GA1UEAwwH
+VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAyBUIA3xp100F+YEM
+8/F37UrofPesd7tci1yWMQG/qrQW5tazIhVLXI48ma97fRroDT1AFDcA9Tc6AAbh
+Cw43uHZio5peR9XUKk4TUKkMerFp53maMFFmC+S3uX3kW2EZC495qUOwof/Hpnqm
++i6IKIRmaL+/tmSeHrfn/jVjZVECAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4G
+A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUk3BD2sCqFHEPk+uC5/WuydIaeHcwMQYJ
 YIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUw
-HwYDVR0jBBgwFoAUX2ed3jNiEbbL4H2KXydV4HjJ4vIwDQYJKoZIhvcNAQELBQAD
-gYEAp9MJriN3v0tSKXshRDUbC4sl5vpoy5Zsmp00IXwfiJACUDatAzp7q+omJErX
-PJCdRqaWss1cgOwPPYZL9BU8StJm0XNlL0XqPFJKERgVEjV6s7tINeRjYBhymknI
-2cH4Tcucadu0qt+CwCfxwwW/yL5loaXFhb8LIQqur++nM+Q=
+HwYDVR0jBBgwFoAUk3BD2sCqFHEPk+uC5/WuydIaeHcwDQYJKoZIhvcNAQELBQAD
+gYEAdcwFsthDqpmEXWQLrMyvB6cNkHmfydwJ5lnY0cIOKpargDj4Gh3R4gzA+t/A
+zwx4MKzQt+mIMdYFKUGPLjLymHT8GUvYxTbDeqeujGWwS/D7+IatCFNDj/VSoJvP
+6C1gV0/zq2M88iPa0FreL2Qlw0//UclRIji05qaHUKjqn/M=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-int-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-int-basic-constraints.pem
@@ -6,21 +6,21 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:b8:87:4d:ef:6e:f3:a3:fc:e6:c5:e1:f9:d6:22:
-                    f1:ed:50:ff:ba:18:8d:c7:ce:27:e3:70:40:36:9e:
-                    a1:9f:8a:cb:75:7b:3d:9f:71:04:9a:18:85:a6:30:
-                    a6:49:cb:d9:31:98:7a:f2:07:40:f2:9d:96:7b:98:
-                    73:71:a5:f6:74:9c:32:1d:0a:c6:f9:a8:df:9e:a1:
-                    f2:cd:ed:2a:2d:a3:e6:31:33:6d:a3:22:b7:ea:3f:
-                    6d:79:f7:0d:b0:45:a3:8a:25:24:7d:90:ef:a7:dd:
-                    41:e5:d2:fd:52:ab:10:fe:8d:72:64:0b:80:85:0c:
-                    24:1f:78:26:99:0f:f2:cd:31
+                    00:e3:9e:d9:d2:f3:61:04:11:b7:41:5e:1f:4e:be:
+                    2f:27:e2:79:95:8a:15:e5:1e:31:3e:15:d9:73:7b:
+                    b5:af:3f:53:25:fd:2d:ed:d4:ef:15:b6:de:8c:34:
+                    28:3e:e8:14:86:9b:06:a8:8f:c5:c2:cf:ce:31:c1:
+                    40:4d:24:7b:4c:17:4b:9d:19:6c:57:66:a2:25:ba:
+                    26:d2:14:37:32:17:15:0c:51:2e:9d:7e:01:6a:f7:
+                    a1:3c:c9:b7:bb:00:79:82:f0:a9:c3:6f:58:a7:68:
+                    75:53:b2:fa:33:98:28:53:2e:99:d2:fb:73:63:09:
+                    51:32:df:0f:58:ee:ba:6a:19
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +28,32 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                CB:B7:D8:15:1D:C0:7B:3F:1E:C8:2E:1E:32:C4:72:62:98:5E:87:49
+                7A:E0:53:6E:4C:00:F4:DE:3D:74:3A:37:BA:CD:25:7A:C2:BC:44:0A
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:5F:67:9D:DE:33:62:11:B6:CB:E0:7D:8A:5F:27:55:E0:78:C9:E2:F2
+                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
 
     Signature Algorithm: sha256WithRSAEncryption
-         2f:5e:5c:46:90:44:40:9a:ab:81:97:6e:54:d8:67:d8:23:f6:
-         5b:7e:88:6b:8f:1d:33:e8:81:b5:82:4c:00:cc:46:5f:20:3f:
-         f3:b8:68:ee:45:65:5f:bc:4c:d6:29:e2:f4:f4:f8:21:dc:d1:
-         ad:4c:af:23:ad:4b:d1:21:ca:be:37:25:a6:7b:8c:5a:ff:2c:
-         54:4a:90:57:49:0c:3c:a1:77:fc:2e:83:22:aa:e8:aa:c7:2f:
-         87:2c:e7:33:a7:6f:60:4c:91:17:4f:53:aa:6d:c1:76:39:00:
-         ce:a2:60:9f:8f:4b:c1:1d:b7:01:1a:fb:64:a5:16:6f:d1:e8:
-         58:35
+         49:f9:91:6e:e7:62:aa:f7:50:89:4e:d7:c8:b9:dd:5f:35:13:
+         1f:d8:d6:42:06:b0:71:48:47:35:77:5b:61:87:df:e3:61:45:
+         63:9d:64:14:25:d6:64:0c:9c:d0:20:97:e5:86:f8:41:ac:3c:
+         bf:a9:65:31:e7:f0:6b:19:97:6b:a2:e9:fb:e5:4a:57:90:08:
+         f5:33:5e:08:f6:1f:76:f2:7f:5d:f3:44:8f:33:5b:91:7a:f2:
+         80:c5:68:7b:2d:c6:c2:6e:1f:51:79:f4:06:ed:f9:c9:95:88:
+         41:e7:8a:eb:41:fa:7c:b4:d3:a6:42:c4:92:bf:e0:dd:89:00:
+         c6:6a
 -----BEGIN CERTIFICATE-----
 MIICPDCCAaWgAwIBAgIBATANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwMzIwMjYyNFowHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-ALiHTe9u86P85sXh+dYi8e1Q/7oYjcfOJ+NwQDaeoZ+Ky3V7PZ9xBJoYhaYwpknL
-2TGYevIHQPKdlnuYc3Gl9nScMh0Kxvmo356h8s3tKi2j5jEzbaMit+o/bXn3DbBF
-o4olJH2Q76fdQeXS/VKrEP6NcmQLgIUMJB94JpkP8s0xAgMBAAGjgZQwgZEwDAYD
-VR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFMu32BUdwHs/Hsgu
-HjLEcmKYXodJMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFs
-IENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFF9nnd4zYhG2y+B9il8nVeB4yeLyMA0G
-CSqGSIb3DQEBCwUAA4GBAC9eXEaQRECaq4GXblTYZ9gj9lt+iGuPHTPogbWCTADM
-Rl8gP/O4aO5FZV+8TNYp4vT0+CHc0a1MryOtS9Ehyr43JaZ7jFr/LFRKkFdJDDyh
-d/wugyKq6KrHL4cs5zOnb2BMkRdPU6ptwXY5AM6iYJ+PS8EdtwEa+2SlFm/R6Fg1
+AOOe2dLzYQQRt0FeH06+LyfieZWKFeUeMT4V2XN7ta8/UyX9Le3U7xW23ow0KD7o
+FIabBqiPxcLPzjHBQE0ke0wXS50ZbFdmoiW6JtIUNzIXFQxRLp1+AWr3oTzJt7sA
+eYLwqcNvWKdodVOy+jOYKFMumdL7c2MJUTLfD1juumoZAgMBAAGjgZQwgZEwDAYD
+VR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHrgU25MAPTePXQ6
+N7rNJXrCvEQKMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFs
+IENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFJNwQ9rAqhRxD5Prguf1rsnSGnh3MA0G
+CSqGSIb3DQEBCwUAA4GBAEn5kW7nYqr3UIlO18i53V81Ex/Y1kIGsHFIRzV3W2GH
+3+NhRWOdZBQl1mQMnNAgl+WG+EGsPL+pZTHn8GsZl2ui6fvlSleQCPUzXgj2H3by
+f13zRI8zW5F68oDFaHstxsJuH1F59Abt+cmViEHniutB+ny006ZCxJK/4N2JAMZq
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/ca.pem
+++ b/spec/fixtures/ssl/ca.pem
@@ -6,21 +6,21 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:c9:47:85:44:02:d5:fa:9c:58:e6:ff:d2:f7:d7:
-                    64:d0:f6:83:90:85:a0:3b:9d:ae:81:db:9a:80:1e:
-                    70:2b:ac:d6:fc:d5:43:f9:89:8d:fe:67:b0:ba:7b:
-                    ac:40:7b:6e:6f:87:e7:38:49:3b:e6:82:90:00:10:
-                    b1:e9:d4:f1:35:64:d8:49:68:54:fc:8f:67:8d:19:
-                    87:b5:d6:de:05:69:1c:f9:42:6c:18:bd:2f:3c:b2:
-                    39:5d:7e:12:ef:c7:1e:19:6e:59:70:db:68:96:3d:
-                    93:15:7f:4f:ff:e2:43:ae:5f:9a:00:4a:d0:8c:15:
-                    3e:38:de:a4:44:c3:4f:37:eb
+                    00:c8:15:08:03:7c:69:d7:4d:05:f9:81:0c:f3:f1:
+                    77:ed:4a:e8:7c:f7:ac:77:bb:5c:8b:5c:96:31:01:
+                    bf:aa:b4:16:e6:d6:b3:22:15:4b:5c:8e:3c:99:af:
+                    7b:7d:1a:e8:0d:3d:40:14:37:00:f5:37:3a:00:06:
+                    e1:0b:0e:37:b8:76:62:a3:9a:5e:47:d5:d4:2a:4e:
+                    13:50:a9:0c:7a:b1:69:e7:79:9a:30:51:66:0b:e4:
+                    b7:b9:7d:e4:5b:61:19:0b:8f:79:a9:43:b0:a1:ff:
+                    c7:a6:7a:a6:fa:2e:88:28:84:66:68:bf:bf:b6:64:
+                    9e:1e:b7:e7:fe:35:63:65:51
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +28,32 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                5F:67:9D:DE:33:62:11:B6:CB:E0:7D:8A:5F:27:55:E0:78:C9:E2:F2
+                93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:5F:67:9D:DE:33:62:11:B6:CB:E0:7D:8A:5F:27:55:E0:78:C9:E2:F2
+                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
 
     Signature Algorithm: sha256WithRSAEncryption
-         a3:52:3b:49:48:dd:b3:d6:de:5e:0b:89:ba:12:ca:88:54:c8:
-         b6:f5:0a:67:47:d7:84:b4:07:55:4f:96:57:bf:53:30:dd:41:
-         b0:be:5d:ee:0a:b4:6a:8b:85:7e:93:68:cc:c3:85:fe:3d:76:
-         7e:b9:d6:c5:c8:49:ce:40:92:e9:a4:0b:f7:ba:a5:db:c4:4e:
-         45:0f:ff:72:61:3a:88:1d:65:ad:fd:2a:49:cd:19:4a:0c:e4:
-         7a:9a:c1:0b:3b:d8:17:8c:ae:d5:58:31:2e:35:01:c2:e6:82:
-         59:f4:02:35:6e:ce:96:85:4f:74:08:e1:b0:72:ef:cf:2c:27:
-         e2:42
+         41:67:29:fe:f0:0a:34:21:0a:a9:f6:bc:61:d1:55:73:37:fd:
+         07:c3:8a:fc:85:44:e3:18:9d:76:d8:c3:0d:eb:52:68:54:33:
+         bc:14:a5:35:7c:9f:98:60:5c:4d:68:75:6e:57:89:45:c7:95:
+         7d:64:22:73:f6:91:46:a2:9d:a0:3d:17:29:2b:0b:98:30:b2:
+         dc:2f:21:87:20:8a:dc:49:89:81:e3:04:35:05:53:26:63:6e:
+         4c:be:00:1a:37:fc:39:e3:e0:56:04:0d:95:89:ca:0c:e8:36:
+         92:d4:8e:51:97:ae:10:9e:0e:2b:ff:f4:1d:79:8c:2b:82:4b:
+         67:6e
 -----BEGIN CERTIFICATE-----
 MIICMjCCAZugAwIBAgIBADANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwMzIwMjYyNFowEjEQMA4GA1UEAwwH
-VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAyUeFRALV+pxY5v/S
-99dk0PaDkIWgO52ugduagB5wK6zW/NVD+YmN/mewunusQHtub4fnOEk75oKQABCx
-6dTxNWTYSWhU/I9njRmHtdbeBWkc+UJsGL0vPLI5XX4S78ceGW5ZcNtolj2TFX9P
-/+JDrl+aAErQjBU+ON6kRMNPN+sCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/
-MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUX2ed3jNiEbbL4H2KXydV4HjJ4vIw
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owEjEQMA4GA1UEAwwH
+VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAyBUIA3xp100F+YEM
+8/F37UrofPesd7tci1yWMQG/qrQW5tazIhVLXI48ma97fRroDT1AFDcA9Tc6AAbh
+Cw43uHZio5peR9XUKk4TUKkMerFp53maMFFmC+S3uX3kW2EZC495qUOwof/Hpnqm
++i6IKIRmaL+/tmSeHrfn/jVjZVECAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/
+MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUk3BD2sCqFHEPk+uC5/WuydIaeHcw
 MQYJYIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNh
-dGUwHwYDVR0jBBgwFoAUX2ed3jNiEbbL4H2KXydV4HjJ4vIwDQYJKoZIhvcNAQEL
-BQADgYEAo1I7SUjds9beXguJuhLKiFTItvUKZ0fXhLQHVU+WV79TMN1BsL5d7gq0
-aouFfpNozMOF/j12frnWxchJzkCS6aQL97ql28RORQ//cmE6iB1lrf0qSc0ZSgzk
-eprBCzvYF4yu1VgxLjUBwuaCWfQCNW7OloVPdAjhsHLvzywn4kI=
+dGUwHwYDVR0jBBgwFoAUk3BD2sCqFHEPk+uC5/WuydIaeHcwDQYJKoZIhvcNAQEL
+BQADgYEAQWcp/vAKNCEKqfa8YdFVczf9B8OK/IVE4xiddtjDDetSaFQzvBSlNXyf
+mGBcTWh1bleJRceVfWQic/aRRqKdoD0XKSsLmDCy3C8hhyCK3EmJgeMENQVTJmNu
+TL4AGjf8OePgVgQNlYnKDOg2ktSOUZeuEJ4OK//0HXmMK4JLZ24=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/crl.pem
+++ b/spec/fixtures/ssl/crl.pem
@@ -3,28 +3,28 @@ Certificate Revocation List (CRL):
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /CN=Test CA
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Mar  3 20:26:24 2029 GMT
+        Next Update: Mar  9 21:35:53 2029 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:5F:67:9D:DE:33:62:11:B6:CB:E0:7D:8A:5F:27:55:E0:78:C9:E2:F2
+                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
 
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         28:e7:9b:37:e6:8f:af:85:a7:20:24:14:d3:e1:76:97:a5:b5:
-         d6:af:e1:84:0b:40:c8:76:a4:46:8d:bf:4b:d4:be:61:e7:fe:
-         f0:5e:27:ed:2f:90:c6:d9:a2:c2:04:a1:4f:41:0f:86:4b:9c:
-         f4:13:58:49:08:e6:e6:c4:47:3c:c7:2f:43:ee:64:62:60:fe:
-         8e:d3:a5:9d:32:ef:b0:bd:43:d4:57:91:ed:93:af:c4:11:d3:
-         d8:4b:8b:c2:73:c1:9e:de:5b:d5:e9:77:33:fd:30:aa:f8:f2:
-         01:54:8b:c4:76:f5:3a:bd:dc:ce:af:ac:01:04:b9:9a:07:e1:
-         c3:5c
+         1d:22:2e:ce:86:44:d5:58:56:84:a9:98:2f:31:38:41:52:c7:
+         31:83:94:81:bd:57:8e:8c:4f:9a:58:16:2c:84:56:83:ef:34:
+         b6:d8:fb:65:f6:54:1a:7e:6c:36:5b:d3:f0:8c:65:22:fb:4a:
+         08:3c:31:c4:93:1a:f0:9c:24:97:50:e4:6f:6b:5b:33:93:c8:
+         89:f1:9f:7a:cc:cd:3a:db:0b:af:f2:2c:6b:f8:f5:a7:9d:cc:
+         1b:71:fc:03:2f:2b:f7:6b:47:7d:86:c5:ee:be:76:f6:13:9d:
+         63:ba:72:b3:ac:c4:4d:e5:84:03:25:b4:52:f9:35:ea:88:f2:
+         6f:c5
 -----BEGIN X509 CRL-----
 MIIBCjB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
-MDEwMTAwMDAwMFoXDTI5MDMwMzIwMjYyNFqgLzAtMB8GA1UdIwQYMBaAFF9nnd4z
-YhG2y+B9il8nVeB4yeLyMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4GBACjn
-mzfmj6+FpyAkFNPhdpeltdav4YQLQMh2pEaNv0vUvmHn/vBeJ+0vkMbZosIEoU9B
-D4ZLnPQTWEkI5ubERzzHL0PuZGJg/o7TpZ0y77C9Q9RXke2Tr8QR09hLi8JzwZ7e
-W9XpdzP9MKr48gFUi8R29Tq93M6vrAEEuZoH4cNc
+MDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1qgLzAtMB8GA1UdIwQYMBaAFJNwQ9rA
+qhRxD5Prguf1rsnSGnh3MAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4GBAB0i
+Ls6GRNVYVoSpmC8xOEFSxzGDlIG9V46MT5pYFiyEVoPvNLbY+2X2VBp+bDZb0/CM
+ZSL7Sgg8McSTGvCcJJdQ5G9rWzOTyInxn3rMzTrbC6/yLGv49aedzBtx/AMvK/dr
+R32Gxe6+dvYTnWO6crOsxE3lhAMltFL5NeqI8m/F
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/encrypted-key.pem
+++ b/spec/fixtures/ssl/encrypted-key.pem
@@ -1,70 +1,70 @@
 Private-Key: (1024 bit)
 modulus:
-    00:9e:6a:e5:e9:fb:b8:29:aa:70:81:d5:55:11:34:
-    6d:21:19:77:e9:50:a5:bd:ea:e5:ac:73:71:70:1e:
-    60:c2:7a:73:34:af:99:aa:ae:67:fc:dc:06:d1:85:
-    79:93:28:31:5c:e4:60:03:4e:18:08:9e:f1:96:d0:
-    0d:5e:31:ea:a6:d1:81:ca:d5:30:d3:c2:17:62:5c:
-    30:5f:8e:26:35:34:c4:f0:ed:a5:37:98:36:cb:b5:
-    40:e7:0b:6a:ce:84:a4:5a:36:7a:61:25:00:be:e1:
-    a8:46:a7:7c:ec:ca:f4:ad:3e:a6:72:8c:a0:b0:17:
-    f0:f6:7e:af:1f:c3:ee:c5:79
+    00:ad:cf:8f:ff:51:7a:86:cc:99:5d:14:8f:07:0c:
+    f7:e7:f7:e8:3c:46:90:38:d3:fa:71:91:57:42:3a:
+    bd:9a:80:24:e8:df:55:26:a6:8f:74:30:5c:5a:f4:
+    34:f0:db:76:24:1c:f1:cd:57:1b:80:93:2c:5c:e9:
+    b1:ea:21:c8:f6:58:52:ce:3f:b3:f6:32:6e:de:00:
+    b9:8e:a2:9f:07:08:ac:e7:32:6e:43:93:4a:eb:87:
+    d6:6c:e6:6a:4e:45:bd:f9:08:4b:71:d3:05:77:67:
+    87:26:08:12:62:37:09:5f:37:59:09:3e:80:74:b2:
+    69:43:46:32:99:b9:db:fe:05
 publicExponent: 65537 (0x10001)
 privateExponent:
-    54:74:93:0c:32:19:95:84:fb:24:0c:92:a4:70:79:
-    b9:8a:b5:65:da:8b:f1:fb:17:e4:df:4a:db:c6:26:
-    39:a8:44:61:13:38:ee:48:ba:c1:90:9f:c5:f5:cd:
-    c1:c9:4c:bf:c4:34:f7:ae:1b:9c:04:f8:b1:39:4b:
-    d7:2a:ef:78:97:28:f7:63:fa:bf:a1:72:c1:96:16:
-    98:32:70:e3:b8:bd:0a:a8:a1:9f:e2:77:af:ea:ae:
-    fd:c6:d6:b1:3a:ed:f0:4f:b7:26:03:36:8e:23:ca:
-    53:c3:a1:49:bc:d8:31:f2:25:80:4f:ff:97:2e:18:
-    20:5e:be:7c:ee:b1:fb:71
+    25:5f:98:4b:02:2e:22:86:24:04:0b:c3:a5:74:78:
+    69:fc:b8:87:1d:75:2d:83:07:3b:1c:51:73:00:46:
+    7c:ce:49:21:79:c4:49:87:4f:19:60:bc:bb:21:ff:
+    b0:3a:c0:70:8b:78:c2:fa:94:03:55:a2:18:68:77:
+    c5:2c:76:95:86:fb:af:4d:24:d7:ab:08:65:f3:6e:
+    52:7b:cb:ec:89:74:55:e7:6c:26:93:62:ff:01:f0:
+    5f:33:1c:a2:db:78:7e:fc:fc:a0:c1:75:cd:2a:aa:
+    31:1e:03:ee:0f:a4:be:f8:aa:80:e5:c1:fe:12:67:
+    7d:8b:4a:ba:5d:bc:89:01
 prime1:
-    00:cf:7c:97:8a:dc:b0:7c:15:4a:ab:e0:7b:43:1d:
-    4c:fd:00:25:8d:b9:60:7e:d7:5e:fc:27:65:0a:c1:
-    36:a2:d2:f7:c1:f3:d5:38:94:61:14:f9:8f:a9:b4:
-    8a:6c:6d:2a:87:56:00:5a:14:dd:86:86:8b:bf:c0:
-    23:e4:4a:c0:ad
+    00:e2:de:b4:d0:ef:3c:db:51:50:0f:f5:ff:73:8e:
+    da:e2:1c:1e:46:3a:09:a0:00:e1:a4:97:90:c7:62:
+    9a:e0:84:f4:66:ff:35:be:7f:f8:98:ed:28:50:5d:
+    a5:77:eb:ab:0d:9c:f8:b1:f9:ef:d0:0e:5b:9f:da:
+    fa:44:73:3f:d5
 prime2:
-    00:c3:75:34:7c:2c:71:51:e0:0b:1f:bb:b8:d2:48:
-    c6:9e:62:c8:ea:4a:66:41:23:cb:57:88:82:64:65:
-    19:76:bf:14:70:70:e7:89:d3:87:5d:07:85:a1:18:
-    59:5b:23:2c:e9:eb:3f:ae:5a:26:af:58:2f:11:62:
-    cc:35:b2:95:7d
+    00:c4:20:c8:8a:86:24:f5:be:20:82:73:f4:bb:43:
+    77:d7:c7:cd:de:49:a0:58:1e:c2:5e:34:e2:4e:a0:
+    fd:26:16:9a:4b:32:42:f2:08:19:93:64:13:cd:d9:
+    93:c5:63:0d:39:9f:1d:8d:20:80:02:27:75:71:25:
+    74:24:43:0d:71
 exponent1:
-    5c:4e:6d:8c:d5:89:9e:6a:4a:82:14:a8:41:bf:73:
-    54:cb:0f:e9:f1:22:c0:cb:47:f2:9e:04:11:b8:cb:
-    79:bc:a9:84:9b:d9:ac:06:36:fa:81:dc:2b:ff:a9:
-    e5:7a:db:84:c1:f9:fe:19:72:44:3a:ef:49:2b:4d:
-    cc:6e:85:31
+    00:b6:34:1a:8f:fa:b3:ab:88:60:7e:91:18:fa:1b:
+    ef:1a:cd:6e:5b:04:5d:9a:8d:5a:ab:2f:b6:ed:0a:
+    fa:4b:fb:3b:b6:44:9d:4b:43:c7:ca:3a:1d:b8:7d:
+    9d:58:f4:82:ca:4a:19:4a:06:eb:5c:f3:4b:0e:d5:
+    75:4d:e8:29:89
 exponent2:
-    3b:b5:2e:17:50:ac:3d:4a:a7:9b:46:09:2b:93:b7:
-    b8:e2:8c:65:a5:dc:9e:c1:84:78:74:e7:00:2c:32:
-    1f:28:37:e2:31:5b:49:ab:28:8a:ae:a5:8f:94:94:
-    97:56:a3:7d:c1:b3:6e:5b:73:bd:d4:be:6c:1d:36:
-    2c:a1:25:31
+    1e:1d:66:8d:96:a1:70:36:5c:69:8b:82:85:8a:8b:
+    89:4f:7d:b5:e7:1a:3e:cd:a2:4c:b2:d4:18:fc:b1:
+    42:3a:f0:40:21:9c:93:eb:58:7a:00:40:e6:37:c5:
+    6f:e6:90:ae:4b:57:4f:47:31:40:a3:6c:6e:0e:31:
+    32:2c:35:91
 coefficient:
-    00:81:a4:13:88:2b:88:7d:36:20:00:e6:0f:a8:f6:
-    85:23:4e:e7:e0:5e:4b:13:1d:45:c0:58:98:9a:af:
-    c8:17:4d:d6:98:42:7d:c0:f8:0a:0b:a1:ee:a9:cd:
-    3e:7b:98:6e:98:39:39:19:df:ca:4d:8f:87:4a:26:
-    fc:97:76:06:c4
+    57:c8:09:23:2a:ad:d0:a4:c0:f5:5b:9c:b4:7e:36:
+    a2:b6:dd:8d:cc:9d:ac:db:e9:03:3d:32:a3:90:c3:
+    47:9d:07:69:9c:c5:97:94:96:53:b4:b6:c5:45:96:
+    56:07:e4:c6:9a:ec:56:a4:b5:c3:12:70:ee:13:ae:
+    43:bd:51:39
 -----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,30C9ECE1E9F2D5C60DDA7D6DD9F77B85
+DEK-Info: AES-128-CBC,E9B79BAA1EF2AB76A41C5024B914E84D
 
-G9Xz+3AmQwQIxSfGzl8DeS/zNKqbpSVpOq0q5JAT6BdmAz81M6Is1XBcsh5uRi8a
-3pQ/bKrIhq2HfyXqvWaFjwxG3bKEKooEdLGK7ehZYkUFh/WcClC7hra+WBahdGpw
-MY79+zsd46LBMHpWG/mylqqTSrxeHvjegT1YNJOa3vGMRSsGbLJemPsSxRUqV/YI
-5QYcwQI+WpZhZQAxT1m5qOp8k7i8GsnGQOKY0l5agq5exIRxf5kTg1BXulvoYaWv
-VkLTCLF3LkowL+oXMNn7ixFguYR4PiLpcss137SazJNTav3x0rVMBra2/gM5/hLF
-ch5vW/yccRSTZK8Wus6ElTWu5EOzEjTnxecEHP8HU6Bt+TgBX4zdiLHUpHLF7qqp
-hfpoCzbJ7HL0xY2Hns0yQKoyo2qpN0rVSqJ9UY2Ij4gaqmC279AN0Uaggfd0w71r
-JqDPNIe+9A2xyOSKZLLrO9VVkS4TiwX7ROhYii8qPdfi4L7QJFUY/rHMKVDnaRrL
-acyd1hiuvNoCbrbgTBvoCHP32+XMjD7NgknQtT2uVJqGFeiD1f6G+Os5mfEPn9Uj
-zyVkeW6F9WWSGNXfAL958QJup3Wtd9rrINhi4UtZg54Ye7wHTV5ejgGSB0SpzQau
-NZZRh+CNY9mHVattlWzi2nYg1dgaRtMbuYu1NkD/G0xYix8qWWvxhzGxmykN/Yb6
-Hw1wLnPlTTs8nNAmuFpNpbS6cYsHAjMWBhU/i4sYr7vHEYS9BnQgyiTR1/OfqnyQ
-MQLfK+nMs4H5RjO18ytmiCba8hFZGzo0FLEP2RJpLnYS6jiigTWMLBQKWDq6VEPU
+IHS6jMaijjLaI3BZywYIdIitmDHDDRuSaUno/jeHLf3JKPTqI+wyjyE+E1u+Eu4J
++ZGYkT0qcZf+fD0OJ9w9LdogwlsXQXTgT21gt4+uiBR0CRcbF5K4nw2k282ui+7T
+qCTm8eir6jqVbxYWVLC0rmw0zoQDS0nLaKJK7XePd4LVqFjejBRu+QXtKitBdbb5
+/kHbTCydEz1zc3NA8jgelZyl2s8pgPqIW/rLVgpaQs4zNqUmnETvdQM9JEds9InJ
+9Qd22k0+qQceUpSOh5NGoAuTpiycNhk11AL5isCok1U3pEUSi/redT+W+DVEnICZ
+QO07+6OQbOp0g6/QEsEg5v6YxFXVdMU9o7Y/kAxFc07c8NrhEFr8T23NVrLs/t5d
+Rj7DTO0wEh782dX2K7Qda8qDnTbknf0T48kFT8NGgm9LtznrGhKWRgUQawJ5ODOu
+jDAe4R1956gmIw56EpZ+Gtog5ugRHnF+YgwYRYGQ/MCYkwvuwJX0RrmaScNxbVhj
+qBwoOtD0entIfynapOgGyMqe+E0SyZUoqkbh602DPJsQ6MYgaGeDFXMJ3u5K8sD0
+OytTqb09Efg4VDCSdG4qrO+l+NueuRkCpsGZ4PtU8XZ5FDhw6MjFCVRPr3N6WIIQ
+wcMCk5Zuu6ynjGaOm0buQeNpaH9v7/7hEat8+dj0lL4PbxZ6VO/dTz1mqs/Wey9A
+B1p6RkEYHEHzrzoxso18DyTLGRTncT8GTVHVwTK+/+1z+fkcfoi3y89M2zHifKKP
+YLHhCBIMC73ClhuD0u/BsFXH4SEXoMrcsCTMEaByfq+Ws4kNU91JUzVDeQaRTwFq
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/intermediate-agent-crl.pem
+++ b/spec/fixtures/ssl/intermediate-agent-crl.pem
@@ -1,0 +1,31 @@
+Certificate Revocation List (CRL):
+        Version 2 (0x1)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: /CN=Test CA Agent Subauthority
+        Last Update: Jan  1 00:00:00 1970 GMT
+        Next Update: Mar  9 21:35:53 2029 GMT
+        CRL extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:4C:8D:DA:6C:26:2B:12:AF:11:85:FD:26:DF:21:F5:E4:1D:AE:CD:81
+
+            X509v3 CRL Number: 
+                0
+No Revoked Certificates.
+    Signature Algorithm: sha256WithRSAEncryption
+         15:83:8b:cc:88:0c:19:02:41:63:e5:88:7f:6c:85:8a:d9:3c:
+         0f:ad:0b:b6:c4:4d:39:76:94:7f:a8:d8:74:30:d9:22:c1:bc:
+         1e:6a:b5:7b:7c:4d:ee:ab:6f:b3:30:78:3d:cd:3a:f6:6b:fb:
+         84:d8:75:42:1e:8b:83:81:16:8e:ae:74:85:bf:5f:6a:b5:e6:
+         f7:a5:dc:5a:bf:c2:c5:1d:a3:a2:de:5a:9f:01:18:42:af:ad:
+         2a:a5:a9:fa:d9:52:95:e0:bb:8c:6d:6d:50:7b:fa:b0:eb:e0:
+         c9:2c:92:9f:fa:d0:4e:11:c6:80:70:62:12:15:9d:e6:05:c2:
+         81:58
+-----BEGIN X509 CRL-----
+MIIBHjCBiAIBATANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0IENBIEFn
+ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwMzA5MjEzNTUzWqAv
+MC0wHwYDVR0jBBgwFoAUTI3abCYrEq8Rhf0m3yH15B2uzYEwCgYDVR0UBAMCAQAw
+DQYJKoZIhvcNAQELBQADgYEAFYOLzIgMGQJBY+WIf2yFitk8D60LtsRNOXaUf6jY
+dDDZIsG8Hmq1e3xN7qtvszB4Pc069mv7hNh1Qh6Lg4EWjq50hb9farXm96XcWr/C
+xR2jot5anwEYQq+tKqWp+tlSleC7jG1tUHv6sOvgySySn/rQThHGgHBiEhWd5gXC
+gVg=
+-----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate-agent.pem
+++ b/spec/fixtures/ssl/intermediate-agent.pem
@@ -1,0 +1,60 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 5 (0x5)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
+        Subject: CN=Test CA Agent Subauthority
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (1024 bit)
+                Modulus:
+                    00:b5:ed:95:5b:eb:9e:9c:18:b2:6b:d6:a5:93:54:
+                    29:cd:37:90:3b:2a:ce:ad:b8:1d:44:85:6b:7c:5f:
+                    68:e4:a6:97:c0:cf:cc:f3:b5:28:cb:d5:c3:5f:f1:
+                    2b:1b:96:99:9a:05:eb:72:b9:48:6f:83:5c:12:a7:
+                    1f:14:16:db:51:6c:84:a5:64:76:89:28:53:64:61:
+                    32:02:af:3f:b8:f9:5f:66:2c:2a:b9:63:37:24:57:
+                    c2:46:8a:e7:fe:cc:14:b6:50:2b:6d:f9:4d:5f:7d:
+                    3e:68:1c:c3:11:06:01:d9:d8:31:7d:08:a5:75:b5:
+                    dd:11:10:2f:e1:e4:8a:5a:d3
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                4C:8D:DA:6C:26:2B:12:AF:11:85:FD:26:DF:21:F5:E4:1D:AE:CD:81
+            Netscape Comment: 
+                Puppet Server Internal Certificate
+            X509v3 Authority Key Identifier: 
+                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+
+    Signature Algorithm: sha256WithRSAEncryption
+         85:84:ab:76:ae:37:77:e7:0d:f0:6b:43:57:5a:7f:98:81:e0:
+         5d:81:3a:a6:ec:04:01:f4:e0:e1:e8:96:43:a4:f5:2f:93:9c:
+         4c:0b:e6:53:ce:c8:ff:a1:b6:0e:e5:0b:62:87:10:40:fb:bb:
+         29:a6:c9:df:ec:52:59:77:07:91:ef:cc:29:97:86:ed:5f:9f:
+         34:ad:20:33:3c:39:1d:e5:58:d7:1c:0b:91:1c:3b:b1:a7:8d:
+         bc:fb:b9:27:f9:1d:3f:f9:54:a6:63:83:73:4c:63:97:23:21:
+         62:ae:c5:a6:e6:f7:4c:24:bc:e1:e9:cb:d5:37:42:15:a3:78:
+         5d:33
+-----BEGIN CERTIFICATE-----
+MIICRTCCAa6gAwIBAgIBBTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owJTEjMCEGA1UEAwwa
+VGVzdCBDQSBBZ2VudCBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0A
+MIGJAoGBALXtlVvrnpwYsmvWpZNUKc03kDsqzq24HUSFa3xfaOSml8DPzPO1KMvV
+w1/xKxuWmZoF63K5SG+DXBKnHxQW21FshKVkdokoU2RhMgKvP7j5X2YsKrljNyRX
+wkaK5/7MFLZQK235TV99PmgcwxEGAdnYMX0IpXW13REQL+HkilrTAgMBAAGjgZcw
+gZQwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFEyN
+2mwmKxKvEYX9Jt8h9eQdrs2BMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVy
+IEludGVybmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFJNwQ9rAqhRxD5Prguf1
+rsnSGnh3MA0GCSqGSIb3DQEBCwUAA4GBAIWEq3auN3fnDfBrQ1daf5iB4F2BOqbs
+BAH04OHolkOk9S+TnEwL5lPOyP+htg7lC2KHEED7uymmyd/sUll3B5HvzCmXhu1f
+nzStIDM8OR3lWNccC5EcO7Gnjbz7uSf5HT/5VKZjg3NMY5cjIWKuxabm90wkvOHp
+y9U3QhWjeF0z
+-----END CERTIFICATE-----

--- a/spec/fixtures/ssl/intermediate-crl.pem
+++ b/spec/fixtures/ssl/intermediate-crl.pem
@@ -3,34 +3,34 @@ Certificate Revocation List (CRL):
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /CN=Test CA Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Mar  3 20:26:24 2029 GMT
+        Next Update: Mar  9 21:35:53 2029 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:CB:B7:D8:15:1D:C0:7B:3F:1E:C8:2E:1E:32:C4:72:62:98:5E:87:49
+                keyid:7A:E0:53:6E:4C:00:F4:DE:3D:74:3A:37:BA:CD:25:7A:C2:BC:44:0A
 
             X509v3 CRL Number: 
                 0
 Revoked Certificates:
     Serial Number: 04
-        Revocation Date: Mar  6 20:26:24 2019 GMT
+        Revocation Date: Mar 12 21:35:53 2019 GMT
         CRL entry extensions:
             X509v3 CRL Reason Code: 
                 Key Compromise
     Signature Algorithm: sha256WithRSAEncryption
-         93:96:a4:44:f1:4d:3c:ee:e9:76:0b:de:e9:54:59:a6:64:46:
-         63:c2:78:7a:2f:f2:2b:a7:64:2d:53:e5:ab:25:cd:11:a5:75:
-         45:78:1b:74:5c:60:d0:86:22:4a:c7:00:d2:a5:68:97:f1:3e:
-         d9:39:18:11:13:7c:f1:a4:c3:06:74:45:0d:35:d7:d2:8d:4f:
-         07:1b:93:7c:69:f4:b4:8b:f3:c1:5c:de:96:d0:e3:d0:ca:c9:
-         85:31:03:d9:69:0b:fc:df:84:8a:67:6d:79:34:31:fa:94:91:
-         0f:ec:67:62:92:3d:7b:6b:5c:e5:07:3d:08:75:ff:d3:3b:55:
-         f2:cc
+         01:4f:22:9c:6d:6d:35:4a:8f:9e:44:09:a2:f8:2a:e9:85:3d:
+         cb:4d:c3:4e:9a:59:14:85:b5:1a:2b:de:d8:02:d8:56:b9:0d:
+         48:e3:5f:65:a3:33:c8:f0:72:6b:4c:33:a1:07:45:a7:b3:fd:
+         30:07:b2:5e:45:4b:82:6a:9a:d0:8e:73:51:72:6d:57:2b:5a:
+         97:fc:00:20:f4:8f:7f:1c:6e:07:f1:42:01:7f:52:24:22:28:
+         bf:99:c4:43:23:57:f7:18:68:6c:63:d8:e4:8f:57:e1:9a:41:
+         82:b0:c0:a9:c3:39:d5:9c:5b:db:33:a7:f9:f4:ad:0f:65:b0:
+         fc:8e
 -----BEGIN X509 CRL-----
 MIIBPDCBpgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0IENBIFN1
-YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwMzAzMjAyNjI0WjAiMCACAQQX
-DTE5MDMwNjIwMjYyNFowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUy7fY
-FR3Aez8eyC4eMsRyYpheh0kwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADgYEA
-k5akRPFNPO7pdgve6VRZpmRGY8J4ei/yK6dkLVPlqyXNEaV1RXgbdFxg0IYiSscA
-0qVol/E+2TkYERN88aTDBnRFDTXX0o1PBxuTfGn0tIvzwVzeltDj0MrJhTED2WkL
-/N+EimdteTQx+pSRD+xnYpI9e2tc5Qc9CHX/0ztV8sw=
+YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwMzA5MjEzNTUzWjAiMCACAQQX
+DTE5MDMxMjIxMzU1M1owDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUeuBT
+bkwA9N49dDo3us0lesK8RAowCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADgYEA
+AU8inG1tNUqPnkQJovgq6YU9y03DTppZFIW1Give2ALYVrkNSONfZaMzyPBya0wz
+oQdFp7P9MAeyXkVLgmqa0I5zUXJtVytal/wAIPSPfxxuB/FCAX9SJCIov5nEQyNX
+9xhobGPY5I9X4ZpBgrDAqcM51Zxb2zOn+fStD2Ww/I4=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate.pem
+++ b/spec/fixtures/ssl/intermediate.pem
@@ -6,21 +6,21 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:b8:87:4d:ef:6e:f3:a3:fc:e6:c5:e1:f9:d6:22:
-                    f1:ed:50:ff:ba:18:8d:c7:ce:27:e3:70:40:36:9e:
-                    a1:9f:8a:cb:75:7b:3d:9f:71:04:9a:18:85:a6:30:
-                    a6:49:cb:d9:31:98:7a:f2:07:40:f2:9d:96:7b:98:
-                    73:71:a5:f6:74:9c:32:1d:0a:c6:f9:a8:df:9e:a1:
-                    f2:cd:ed:2a:2d:a3:e6:31:33:6d:a3:22:b7:ea:3f:
-                    6d:79:f7:0d:b0:45:a3:8a:25:24:7d:90:ef:a7:dd:
-                    41:e5:d2:fd:52:ab:10:fe:8d:72:64:0b:80:85:0c:
-                    24:1f:78:26:99:0f:f2:cd:31
+                    00:e3:9e:d9:d2:f3:61:04:11:b7:41:5e:1f:4e:be:
+                    2f:27:e2:79:95:8a:15:e5:1e:31:3e:15:d9:73:7b:
+                    b5:af:3f:53:25:fd:2d:ed:d4:ef:15:b6:de:8c:34:
+                    28:3e:e8:14:86:9b:06:a8:8f:c5:c2:cf:ce:31:c1:
+                    40:4d:24:7b:4c:17:4b:9d:19:6c:57:66:a2:25:ba:
+                    26:d2:14:37:32:17:15:0c:51:2e:9d:7e:01:6a:f7:
+                    a1:3c:c9:b7:bb:00:79:82:f0:a9:c3:6f:58:a7:68:
+                    75:53:b2:fa:33:98:28:53:2e:99:d2:fb:73:63:09:
+                    51:32:df:0f:58:ee:ba:6a:19
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,33 +28,33 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                CB:B7:D8:15:1D:C0:7B:3F:1E:C8:2E:1E:32:C4:72:62:98:5E:87:49
+                7A:E0:53:6E:4C:00:F4:DE:3D:74:3A:37:BA:CD:25:7A:C2:BC:44:0A
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:5F:67:9D:DE:33:62:11:B6:CB:E0:7D:8A:5F:27:55:E0:78:C9:E2:F2
+                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
 
     Signature Algorithm: sha256WithRSAEncryption
-         5a:d5:ce:03:93:30:02:d1:2f:2f:a4:2b:27:41:ed:05:ca:01:
-         95:98:85:e4:0a:99:5d:8a:c6:af:d8:46:81:95:c2:fc:7b:e9:
-         18:21:04:75:64:3f:c5:64:f6:fa:8d:ed:bd:d8:a4:b5:2a:69:
-         20:50:d9:8d:d1:2a:b8:fc:4b:e3:f0:ef:44:de:48:9f:e3:07:
-         8f:a3:a0:ad:fc:a5:cd:b6:cd:e4:76:be:ab:ee:c2:97:c0:44:
-         3d:d7:0f:37:48:14:9d:08:db:5f:79:ec:3d:b1:73:56:ae:15:
-         6f:e5:58:e3:7e:11:cf:a8:fd:35:f8:7d:46:54:27:41:d2:d1:
-         5e:ad
+         c3:d4:14:36:2b:f3:0b:aa:1a:eb:25:d6:fc:8c:f4:26:bc:c1:
+         a4:eb:a0:ea:91:bc:2d:3d:96:dc:4d:e0:45:af:a6:80:88:dd:
+         79:71:ee:3f:72:20:0a:e1:31:8d:9f:20:fc:64:9c:9c:5e:46:
+         6b:b4:7e:84:20:cf:18:25:14:6d:d0:b7:e2:74:c5:92:2b:86:
+         0a:d0:4a:64:2c:94:50:2d:a2:3b:1d:93:c8:dc:dc:c4:73:d6:
+         8a:92:01:05:c9:1e:29:07:c7:da:b6:3b:2b:ca:ca:18:95:13:
+         18:1f:d9:5d:11:01:77:47:23:da:b7:b3:82:3f:42:2e:52:3d:
+         05:65
 -----BEGIN CERTIFICATE-----
 MIICPzCCAaigAwIBAgIBATANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwMzIwMjYyNFowHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-ALiHTe9u86P85sXh+dYi8e1Q/7oYjcfOJ+NwQDaeoZ+Ky3V7PZ9xBJoYhaYwpknL
-2TGYevIHQPKdlnuYc3Gl9nScMh0Kxvmo356h8s3tKi2j5jEzbaMit+o/bXn3DbBF
-o4olJH2Q76fdQeXS/VKrEP6NcmQLgIUMJB94JpkP8s0xAgMBAAGjgZcwgZQwDwYD
-VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFMu32BUdwHs/
-HsguHjLEcmKYXodJMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVy
-bmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFF9nnd4zYhG2y+B9il8nVeB4yeLy
-MA0GCSqGSIb3DQEBCwUAA4GBAFrVzgOTMALRLy+kKydB7QXKAZWYheQKmV2Kxq/Y
-RoGVwvx76RghBHVkP8Vk9vqN7b3YpLUqaSBQ2Y3RKrj8S+Pw70TeSJ/jB4+joK38
-pc22zeR2vqvuwpfARD3XDzdIFJ0I21957D2xc1auFW/lWON+Ec+o/TX4fUZUJ0HS
-0V6t
+AOOe2dLzYQQRt0FeH06+LyfieZWKFeUeMT4V2XN7ta8/UyX9Le3U7xW23ow0KD7o
+FIabBqiPxcLPzjHBQE0ke0wXS50ZbFdmoiW6JtIUNzIXFQxRLp1+AWr3oTzJt7sA
+eYLwqcNvWKdodVOy+jOYKFMumdL7c2MJUTLfD1juumoZAgMBAAGjgZcwgZQwDwYD
+VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHrgU25MAPTe
+PXQ6N7rNJXrCvEQKMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVy
+bmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFJNwQ9rAqhRxD5Prguf1rsnSGnh3
+MA0GCSqGSIb3DQEBCwUAA4GBAMPUFDYr8wuqGusl1vyM9Ca8waTroOqRvC09ltxN
+4EWvpoCI3Xlx7j9yIArhMY2fIPxknJxeRmu0foQgzxglFG3Qt+J0xZIrhgrQSmQs
+lFAtojsdk8jc3MRz1oqSAQXJHikHx9q2OyvKyhiVExgf2V0RAXdHI9q3s4I/Qi5S
+PQVl
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/pluto-key.pem
+++ b/spec/fixtures/ssl/pluto-key.pem
@@ -1,0 +1,67 @@
+Private-Key: (1024 bit)
+modulus:
+    00:d0:24:0c:ff:0a:c3:9c:15:95:f1:38:7f:5d:be:
+    1f:d0:cc:1f:38:30:66:e7:36:a5:fd:a6:c1:52:b9:
+    34:7c:61:b6:ef:42:f9:ef:9c:cb:2e:1a:80:0f:c3:
+    45:52:2b:a7:d2:fd:32:b7:75:95:7c:63:f7:5b:98:
+    5c:4a:8d:6a:fd:ac:a7:d2:fb:1e:93:e8:39:19:22:
+    f5:78:ea:41:76:12:e9:2a:a0:66:65:2a:55:76:cd:
+    9d:7d:43:10:b7:ff:8a:e4:22:6d:35:0c:00:ff:ba:
+    8b:e1:00:20:87:9a:fd:64:0b:16:c4:e7:36:95:43:
+    ef:e9:5e:e9:50:4b:90:3e:c5
+publicExponent: 65537 (0x10001)
+privateExponent:
+    78:c3:c2:0a:a4:ab:34:3f:cd:fc:e4:c3:f9:97:1b:
+    8c:a1:32:a7:fe:65:66:57:ed:dd:8b:48:75:ff:e1:
+    75:1d:98:ef:9f:d3:b6:74:29:eb:39:12:fe:92:55:
+    01:45:35:1d:95:2d:3d:06:eb:51:fe:0a:82:49:97:
+    9a:e6:0c:a1:d0:2b:70:01:0f:17:8b:77:e8:59:3c:
+    32:99:e8:35:b1:9a:4d:d3:4f:6c:68:58:9f:13:83:
+    8b:be:a1:e2:61:cb:98:e4:df:45:76:bf:db:cc:ba:
+    d5:52:e9:b9:ab:a3:ba:67:41:c5:ab:32:35:8a:a8:
+    54:25:c1:e7:6c:3c:a0:8d
+prime1:
+    00:fa:97:c4:20:8c:42:ec:25:8d:7e:1f:9c:de:cd:
+    0a:6d:90:39:dd:f2:a1:ac:db:e1:9f:03:83:1e:ec:
+    7b:cf:25:7b:0f:ab:1b:f7:8d:d1:9d:a4:ae:fd:68:
+    7d:b0:f6:6d:cf:c4:bf:be:4a:e0:13:f3:73:3c:08:
+    77:15:25:fe:17
+prime2:
+    00:d4:a1:c9:62:aa:a8:1c:9e:27:54:79:3f:e4:77:
+    f8:9d:fd:29:4d:0c:fb:56:49:0d:7b:8c:7b:ce:66:
+    68:6c:54:05:d0:6c:30:ab:8c:ce:85:ab:2c:ef:a3:
+    8f:c0:88:5b:c8:95:de:b2:a2:10:4c:4f:70:94:d8:
+    20:f8:ef:2f:83
+exponent1:
+    06:5b:d9:87:35:e7:f0:d4:17:1e:0f:31:4c:da:09:
+    1c:b4:9f:33:49:97:de:aa:09:b4:9e:43:32:82:af:
+    b5:96:ee:e3:7b:e5:0e:c8:13:7c:9b:94:31:2b:f8:
+    9c:87:f4:4b:64:63:b5:31:73:34:2e:66:4b:2c:af:
+    d0:e2:90:eb
+exponent2:
+    59:f0:89:27:83:fa:12:08:cf:a8:0a:95:7d:05:46:
+    13:45:c7:57:81:1b:3a:f7:31:8d:c5:f1:84:6f:8a:
+    d1:ef:84:7a:11:99:50:a7:01:a0:46:b4:7e:34:d8:
+    14:5f:59:3b:72:31:3d:ac:11:6a:c5:db:60:0a:3f:
+    80:2c:64:13
+coefficient:
+    00:a9:aa:39:02:18:ba:e7:22:17:bd:2a:6c:90:0f:
+    bc:6f:ed:60:7c:42:b1:8a:8c:b9:03:4e:d8:d0:ec:
+    db:03:e1:42:0c:00:39:3b:d3:d2:28:1c:26:67:31:
+    71:5a:a8:92:ec:eb:c6:50:52:fb:da:03:92:43:ec:
+    fa:7f:73:b8:25
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDQJAz/CsOcFZXxOH9dvh/QzB84MGbnNqX9psFSuTR8YbbvQvnv
+nMsuGoAPw0VSK6fS/TK3dZV8Y/dbmFxKjWr9rKfS+x6T6DkZIvV46kF2EukqoGZl
+KlV2zZ19QxC3/4rkIm01DAD/uovhACCHmv1kCxbE5zaVQ+/pXulQS5A+xQIDAQAB
+AoGAeMPCCqSrND/N/OTD+ZcbjKEyp/5lZlft3YtIdf/hdR2Y75/TtnQp6zkS/pJV
+AUU1HZUtPQbrUf4KgkmXmuYModArcAEPF4t36Fk8MpnoNbGaTdNPbGhYnxODi76h
+4mHLmOTfRXa/28y61VLpuaujumdBxasyNYqoVCXB52w8oI0CQQD6l8QgjELsJY1+
+H5zezQptkDnd8qGs2+GfA4Me7HvPJXsPqxv3jdGdpK79aH2w9m3PxL++SuAT83M8
+CHcVJf4XAkEA1KHJYqqoHJ4nVHk/5Hf4nf0pTQz7VkkNe4x7zmZobFQF0Gwwq4zO
+hass76OPwIhbyJXesqIQTE9wlNgg+O8vgwJABlvZhzXn8NQXHg8xTNoJHLSfM0mX
+3qoJtJ5DMoKvtZbu43vlDsgTfJuUMSv4nIf0S2RjtTFzNC5mSyyv0OKQ6wJAWfCJ
+J4P6EgjPqAqVfQVGE0XHV4EbOvcxjcXxhG+K0e+EehGZUKcBoEa0fjTYFF9ZO3Ix
+PawRasXbYAo/gCxkEwJBAKmqOQIYuuciF70qbJAPvG/tYHxCsYqMuQNO2NDs2wPh
+QgwAOTvT0igcJmcxcVqokuzrxlBS+9oDkkPs+n9zuCU=
+-----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/pluto.pem
+++ b/spec/fixtures/ssl/pluto.pem
@@ -1,0 +1,44 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 6 (0x6)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA Agent Subauthority
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
+        Subject: CN=pluto
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (1024 bit)
+                Modulus:
+                    00:d0:24:0c:ff:0a:c3:9c:15:95:f1:38:7f:5d:be:
+                    1f:d0:cc:1f:38:30:66:e7:36:a5:fd:a6:c1:52:b9:
+                    34:7c:61:b6:ef:42:f9:ef:9c:cb:2e:1a:80:0f:c3:
+                    45:52:2b:a7:d2:fd:32:b7:75:95:7c:63:f7:5b:98:
+                    5c:4a:8d:6a:fd:ac:a7:d2:fb:1e:93:e8:39:19:22:
+                    f5:78:ea:41:76:12:e9:2a:a0:66:65:2a:55:76:cd:
+                    9d:7d:43:10:b7:ff:8a:e4:22:6d:35:0c:00:ff:ba:
+                    8b:e1:00:20:87:9a:fd:64:0b:16:c4:e7:36:95:43:
+                    ef:e9:5e:e9:50:4b:90:3e:c5
+                Exponent: 65537 (0x10001)
+    Signature Algorithm: sha256WithRSAEncryption
+         9f:99:01:ae:86:0a:bf:b3:03:5a:94:72:47:6e:61:97:6b:44:
+         c6:9f:c4:1e:7e:5e:41:e0:1e:11:8e:d0:68:0a:c0:bb:5d:7d:
+         9a:e4:93:ba:df:9f:77:3c:26:ee:7f:e0:2c:45:b4:17:64:af:
+         5c:92:f9:7f:b1:5d:2c:8b:25:bd:ed:3b:e3:db:ca:1a:a0:41:
+         c2:9f:9c:17:78:d2:b4:9c:83:65:f5:42:10:94:3b:81:f5:e0:
+         35:3f:6c:3e:ef:41:a9:85:9c:06:07:e5:95:0b:81:9b:92:91:
+         ab:d2:c6:fe:0f:28:4a:60:8e:dd:5b:36:58:d6:62:75:5a:47:
+         c1:30
+-----BEGIN CERTIFICATE-----
+MIIBqTCCARKgAwIBAgIBBjANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
+IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDky
+MTM1NTNaMBAxDjAMBgNVBAMMBXBsdXRvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDQJAz/CsOcFZXxOH9dvh/QzB84MGbnNqX9psFSuTR8YbbvQvnvnMsuGoAP
+w0VSK6fS/TK3dZV8Y/dbmFxKjWr9rKfS+x6T6DkZIvV46kF2EukqoGZlKlV2zZ19
+QxC3/4rkIm01DAD/uovhACCHmv1kCxbE5zaVQ+/pXulQS5A+xQIDAQABMA0GCSqG
+SIb3DQEBCwUAA4GBAJ+ZAa6GCr+zA1qUckduYZdrRMafxB5+XkHgHhGO0GgKwLtd
+fZrkk7rfn3c8Ju5/4CxFtBdkr1yS+X+xXSyLJb3tO+PbyhqgQcKfnBd40rScg2X1
+QhCUO4H14DU/bD7vQamFnAYH5ZULgZuSkavSxv4PKEpgjt1bNljWYnVaR8Ew
+-----END CERTIFICATE-----

--- a/spec/fixtures/ssl/request-key.pem
+++ b/spec/fixtures/ssl/request-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:d0:55:12:06:5b:e3:29:a8:4a:be:c9:46:23:58:
-    19:c4:85:fd:4d:89:99:7f:26:cb:27:ff:a2:03:16:
-    ee:52:40:1d:c5:0a:bc:0c:9b:3a:3e:88:c0:18:e9:
-    21:ff:56:e2:d7:dc:f8:c6:28:4a:c4:d1:ac:ce:97:
-    c3:94:96:cf:22:04:39:11:f6:bc:54:f3:8c:cf:d3:
-    55:5b:5c:c5:95:c7:bc:6e:3f:82:c1:2b:50:57:17:
-    cb:b6:9a:8f:6d:75:34:18:db:7a:81:ce:d8:a2:22:
-    f4:2b:8b:ae:74:df:73:91:8f:06:ef:fd:da:1a:46:
-    2a:81:fb:ee:b3:49:85:f1:2f
+    00:da:5a:94:fd:77:48:51:fa:2b:1e:bb:38:32:17:
+    71:5d:93:32:5b:67:fa:18:53:d2:4c:86:ea:1a:ec:
+    7c:eb:fd:64:a5:d4:04:88:6d:92:8c:5f:8a:8a:02:
+    b5:c6:8e:c9:e4:a0:26:1c:7d:62:e0:1b:37:46:de:
+    0a:e1:1d:7b:79:1c:9a:b1:71:de:e0:c7:31:1d:00:
+    a6:98:fb:6e:32:a5:9b:bf:36:30:54:7a:13:14:fe:
+    2f:f3:75:a7:0c:bb:d8:96:15:05:eb:57:63:a1:cc:
+    1b:32:67:c1:dc:dc:b2:34:7b:23:00:70:f0:9a:5e:
+    6f:31:7f:f4:d1:cc:84:5f:25
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:8e:25:3d:43:31:76:f1:79:6e:66:76:96:70:8f:
-    30:25:b2:f6:7d:ed:20:da:6c:f1:b8:bc:e7:22:0c:
-    87:57:7f:7f:d0:6d:de:99:0b:60:d6:42:20:2f:df:
-    01:df:62:bd:2c:64:0d:29:c7:5c:1c:a6:a3:ad:e2:
-    47:04:1f:51:fb:bc:6f:1a:04:fb:1f:24:47:58:dd:
-    d2:1c:ff:65:32:70:b3:5a:15:d0:e0:a3:ae:0d:a4:
-    2d:ed:ef:44:1c:49:d8:85:42:96:49:29:d7:65:69:
-    1b:bf:33:5a:1e:46:54:0e:19:cc:a6:55:84:9f:07:
-    d8:ed:f3:06:6a:72:03:22:61
+    17:12:8d:3d:bf:35:f0:1b:9c:24:d2:29:9c:f9:67:
+    2c:39:1a:90:18:0b:90:38:83:37:3c:e6:4d:d4:01:
+    5b:3a:5a:41:3f:86:ff:17:7c:ed:c2:46:b4:50:96:
+    fe:95:25:f6:37:89:ef:66:bc:64:eb:db:4a:6c:b9:
+    ff:91:8a:f3:4e:39:f0:e2:bf:21:e5:4a:fe:8c:77:
+    62:c7:84:2f:ba:bd:35:e9:b5:5f:49:54:f8:02:72:
+    02:39:6b:ee:07:62:ec:bf:6a:51:17:9c:76:66:dd:
+    8b:01:d6:ab:60:49:e2:7c:4b:40:af:34:5d:2f:29:
+    67:5f:d0:23:1b:9b:52:bd
 prime1:
-    00:ee:77:92:c1:41:ea:05:02:dd:b2:91:b5:57:4a:
-    d0:ae:11:76:45:01:5b:b6:12:0a:18:b5:28:40:45:
-    29:a0:3c:22:5c:31:69:3f:08:c3:4e:d6:b2:8c:cd:
-    36:3d:a2:45:77:8e:bd:fe:d9:14:88:ac:ab:46:35:
-    21:7a:14:c9:83
+    00:f3:ff:bb:23:6c:56:8b:52:20:fc:e2:ce:7c:39:
+    21:09:64:57:2d:8d:87:d6:d1:6d:d2:74:cc:20:f2:
+    13:cc:ce:81:de:68:46:15:36:5b:d5:a0:11:99:79:
+    bd:75:0b:c9:b3:d8:bd:77:1d:58:df:b6:30:56:eb:
+    2f:00:30:8d:07
 prime2:
-    00:df:a6:4c:eb:7b:43:a9:5d:c9:b3:e1:55:73:45:
-    dc:37:ee:76:4f:c4:b5:60:46:3d:51:eb:8f:7d:a8:
-    b5:1b:7f:08:5d:48:11:1e:56:c1:95:10:88:46:6f:
-    60:4a:eb:db:de:e3:fc:36:dc:ff:59:30:7e:ae:a5:
-    8b:e6:4f:65:e5
+    00:e5:17:f1:f4:b0:8c:36:e2:6d:a2:c3:b5:3e:83:
+    f2:c8:35:c1:76:0c:99:be:90:e6:12:ff:c7:0d:34:
+    c0:9e:db:ca:69:e3:29:a4:4e:19:96:f5:7e:cc:d0:
+    a2:c0:82:a4:12:4e:8c:f7:ca:4b:9a:cb:d6:90:d2:
+    d0:e7:f6:93:73
 exponent1:
-    7b:9a:fb:34:b5:27:ca:25:2c:29:0d:21:c3:f7:81:
-    a7:58:61:c7:6e:e6:cc:bf:19:00:a9:96:0d:8a:4c:
-    03:44:68:43:05:51:9a:5c:be:6f:b5:15:a3:aa:12:
-    fd:6b:89:3a:69:80:ce:02:53:84:6c:8b:f2:be:43:
-    75:f6:24:65
+    00:d6:94:48:dc:6f:33:71:14:ca:23:fb:c6:81:a2:
+    b0:36:15:43:41:b1:5d:0c:03:64:24:98:48:c8:94:
+    7b:eb:3a:95:25:a5:e8:34:51:78:d3:d7:10:83:3b:
+    77:ed:4e:6f:95:35:7f:f2:18:22:07:a3:ae:c1:51:
+    d5:24:c2:8d:d3
 exponent2:
-    6c:05:80:c5:84:25:ec:19:f6:a0:41:47:ea:83:65:
-    98:46:3f:32:cc:09:e6:d4:46:2d:d9:1e:d7:4c:b3:
-    1c:f2:c0:71:7d:ab:77:01:e4:42:41:57:f0:dd:3e:
-    9f:31:48:63:61:ae:a2:39:1f:c4:4e:5e:01:b0:c7:
-    df:97:9d:d9
+    08:35:2f:6a:00:d9:45:2e:1f:97:71:43:91:15:d1:
+    20:f3:2c:17:3a:a4:57:7b:81:82:b4:bf:40:ed:de:
+    e8:d2:1f:12:64:1d:1d:d1:de:80:d6:12:d0:eb:b8:
+    a9:05:05:33:d2:b4:a2:3c:11:31:5e:94:35:64:18:
+    2f:f7:59:99
 coefficient:
-    00:ca:d8:a7:4c:26:88:bf:1a:14:1d:26:9f:f6:99:
-    90:3f:8d:b5:da:ee:99:e6:4f:55:04:d6:70:0e:3d:
-    4f:03:95:e4:4f:bf:08:71:80:f9:8b:6e:77:35:b9:
-    1f:97:02:cf:60:e4:84:37:b3:1d:34:8a:74:3e:6f:
-    e6:95:42:ea:04
+    00:97:59:ca:65:4a:37:b4:5c:af:69:d6:b7:e1:45:
+    c4:73:36:50:ba:30:95:19:e0:27:5c:51:05:c0:d9:
+    e1:02:1e:ac:c1:05:2c:53:74:e9:42:4e:22:20:c3:
+    6f:ce:6c:e9:60:fd:68:1b:66:96:de:3e:5d:86:1e:
+    1b:4b:f3:e8:a6
 -----BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQDQVRIGW+MpqEq+yUYjWBnEhf1NiZl/Jssn/6IDFu5SQB3FCrwM
-mzo+iMAY6SH/VuLX3PjGKErE0azOl8OUls8iBDkR9rxU84zP01VbXMWVx7xuP4LB
-K1BXF8u2mo9tdTQY23qBztiiIvQri65033ORjwbv/doaRiqB++6zSYXxLwIDAQAB
-AoGBAI4lPUMxdvF5bmZ2lnCPMCWy9n3tINps8bi85yIMh1d/f9Bt3pkLYNZCIC/f
-Ad9ivSxkDSnHXBymo63iRwQfUfu8bxoE+x8kR1jd0hz/ZTJws1oV0OCjrg2kLe3v
-RBxJ2IVClkkp12VpG78zWh5GVA4ZzKZVhJ8H2O3zBmpyAyJhAkEA7neSwUHqBQLd
-spG1V0rQrhF2RQFbthIKGLUoQEUpoDwiXDFpPwjDTtayjM02PaJFd469/tkUiKyr
-RjUhehTJgwJBAN+mTOt7Q6ldybPhVXNF3Dfudk/EtWBGPVHrj32otRt/CF1IER5W
-wZUQiEZvYErr297j/Dbc/1kwfq6li+ZPZeUCQHua+zS1J8olLCkNIcP3gadYYcdu
-5sy/GQCplg2KTANEaEMFUZpcvm+1FaOqEv1riTppgM4CU4Rsi/K+Q3X2JGUCQGwF
-gMWEJewZ9qBBR+qDZZhGPzLMCebURi3ZHtdMsxzywHF9q3cB5EJBV/DdPp8xSGNh
-rqI5H8ROXgGwx9+XndkCQQDK2KdMJoi/GhQdJp/2mZA/jbXa7pnmT1UE1nAOPU8D
-leRPvwhxgPmLbnc1uR+XAs9g5IQ3sx00inQ+b+aVQuoE
+MIICXQIBAAKBgQDaWpT9d0hR+iseuzgyF3FdkzJbZ/oYU9JMhuoa7Hzr/WSl1ASI
+bZKMX4qKArXGjsnkoCYcfWLgGzdG3grhHXt5HJqxcd7gxzEdAKaY+24ypZu/NjBU
+ehMU/i/zdacMu9iWFQXrV2OhzBsyZ8Hc3LI0eyMAcPCaXm8xf/TRzIRfJQIDAQAB
+AoGAFxKNPb818BucJNIpnPlnLDkakBgLkDiDNzzmTdQBWzpaQT+G/xd87cJGtFCW
+/pUl9jeJ72a8ZOvbSmy5/5GK80458OK/IeVK/ox3YseEL7q9Nem1X0lU+AJyAjlr
+7gdi7L9qURecdmbdiwHWq2BJ4nxLQK80XS8pZ1/QIxubUr0CQQDz/7sjbFaLUiD8
+4s58OSEJZFctjYfW0W3SdMwg8hPMzoHeaEYVNlvVoBGZeb11C8mz2L13HVjftjBW
+6y8AMI0HAkEA5Rfx9LCMNuJtosO1PoPyyDXBdgyZvpDmEv/HDTTAntvKaeMppE4Z
+lvV+zNCiwIKkEk6M98pLmsvWkNLQ5/aTcwJBANaUSNxvM3EUyiP7xoGisDYVQ0Gx
+XQwDZCSYSMiUe+s6lSWl6DRReNPXEIM7d+1Ob5U1f/IYIgejrsFR1STCjdMCQAg1
+L2oA2UUuH5dxQ5EV0SDzLBc6pFd7gYK0v0Dt3ujSHxJkHR3R3oDWEtDruKkFBTPS
+tKI8ETFelDVkGC/3WZkCQQCXWcplSje0XK9p1rfhRcRzNlC6MJUZ4CdcUQXA2eEC
+HqzBBSxTdOlCTiIgw2/ObOlg/WgbZpbePl2GHhtL8+im
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/request.pem
+++ b/spec/fixtures/ssl/request.pem
@@ -6,34 +6,34 @@ Certificate Request:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:d0:55:12:06:5b:e3:29:a8:4a:be:c9:46:23:58:
-                    19:c4:85:fd:4d:89:99:7f:26:cb:27:ff:a2:03:16:
-                    ee:52:40:1d:c5:0a:bc:0c:9b:3a:3e:88:c0:18:e9:
-                    21:ff:56:e2:d7:dc:f8:c6:28:4a:c4:d1:ac:ce:97:
-                    c3:94:96:cf:22:04:39:11:f6:bc:54:f3:8c:cf:d3:
-                    55:5b:5c:c5:95:c7:bc:6e:3f:82:c1:2b:50:57:17:
-                    cb:b6:9a:8f:6d:75:34:18:db:7a:81:ce:d8:a2:22:
-                    f4:2b:8b:ae:74:df:73:91:8f:06:ef:fd:da:1a:46:
-                    2a:81:fb:ee:b3:49:85:f1:2f
+                    00:da:5a:94:fd:77:48:51:fa:2b:1e:bb:38:32:17:
+                    71:5d:93:32:5b:67:fa:18:53:d2:4c:86:ea:1a:ec:
+                    7c:eb:fd:64:a5:d4:04:88:6d:92:8c:5f:8a:8a:02:
+                    b5:c6:8e:c9:e4:a0:26:1c:7d:62:e0:1b:37:46:de:
+                    0a:e1:1d:7b:79:1c:9a:b1:71:de:e0:c7:31:1d:00:
+                    a6:98:fb:6e:32:a5:9b:bf:36:30:54:7a:13:14:fe:
+                    2f:f3:75:a7:0c:bb:d8:96:15:05:eb:57:63:a1:cc:
+                    1b:32:67:c1:dc:dc:b2:34:7b:23:00:70:f0:9a:5e:
+                    6f:31:7f:f4:d1:cc:84:5f:25
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         32:90:f1:7d:87:04:be:43:f7:ea:f9:08:04:ca:64:a8:f4:9f:
-         41:02:21:16:27:28:88:81:8d:0e:8b:19:cb:df:ff:0b:81:c1:
-         a8:8e:fb:e9:62:d6:cb:37:3d:24:bd:ce:b0:d7:d8:9d:ad:08:
-         d0:8a:81:44:64:14:4a:d6:9a:e2:bc:24:a3:a6:8d:e3:30:9d:
-         a4:f0:5b:27:68:fb:f3:16:a4:3b:3c:6b:6c:8f:17:34:27:ac:
-         cf:af:e2:43:81:83:57:71:fc:62:11:06:fa:d5:30:03:30:ea:
-         09:e7:b9:d7:1f:d9:32:09:c6:2f:6d:e9:fc:64:97:4b:6b:21:
-         11:e5
+         39:d7:a3:20:cb:15:ab:97:97:32:ff:64:cd:ac:47:ab:3e:c3:
+         84:1f:ed:25:f0:c5:f1:a6:88:14:c5:8c:49:dc:d2:2c:83:5a:
+         ef:59:48:f4:8c:f8:30:97:fa:0a:06:24:fd:97:92:c8:cf:cf:
+         5f:c5:8d:9f:b4:75:bc:88:da:84:94:0c:44:c0:e6:47:21:37:
+         79:35:ff:9c:78:bf:55:51:af:dc:1c:35:c0:9f:06:87:f9:63:
+         01:48:9d:0c:b4:f1:97:72:56:4b:37:9e:80:5d:19:f8:00:a1:
+         20:81:31:3c:d4:b6:6d:5c:65:bb:cd:4b:34:04:75:d6:28:04:
+         2e:db
 -----BEGIN CERTIFICATE REQUEST-----
 MIIBUTCBuwIBAjASMRAwDgYDVQQDDAdwZW5kaW5nMIGfMA0GCSqGSIb3DQEBAQUA
-A4GNADCBiQKBgQDQVRIGW+MpqEq+yUYjWBnEhf1NiZl/Jssn/6IDFu5SQB3FCrwM
-mzo+iMAY6SH/VuLX3PjGKErE0azOl8OUls8iBDkR9rxU84zP01VbXMWVx7xuP4LB
-K1BXF8u2mo9tdTQY23qBztiiIvQri65033ORjwbv/doaRiqB++6zSYXxLwIDAQAB
-oAAwDQYJKoZIhvcNAQELBQADgYEAMpDxfYcEvkP36vkIBMpkqPSfQQIhFicoiIGN
-DosZy9//C4HBqI776WLWyzc9JL3OsNfYna0I0IqBRGQUStaa4rwko6aN4zCdpPBb
-J2j78xakOzxrbI8XNCesz6/iQ4GDV3H8YhEG+tUwAzDqCee51x/ZMgnGL23p/GSX
-S2shEeU=
+A4GNADCBiQKBgQDaWpT9d0hR+iseuzgyF3FdkzJbZ/oYU9JMhuoa7Hzr/WSl1ASI
+bZKMX4qKArXGjsnkoCYcfWLgGzdG3grhHXt5HJqxcd7gxzEdAKaY+24ypZu/NjBU
+ehMU/i/zdacMu9iWFQXrV2OhzBsyZ8Hc3LI0eyMAcPCaXm8xf/TRzIRfJQIDAQAB
+oAAwDQYJKoZIhvcNAQELBQADgYEAOdejIMsVq5eXMv9kzaxHqz7DhB/tJfDF8aaI
+FMWMSdzSLINa71lI9Iz4MJf6CgYk/ZeSyM/PX8WNn7R1vIjahJQMRMDmRyE3eTX/
+nHi/VVGv3Bw1wJ8Gh/ljAUidDLTxl3JWSzeegF0Z+AChIIExPNS2bVxlu81LNAR1
+1igELts=
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/revoked-key.pem
+++ b/spec/fixtures/ssl/revoked-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:fd:2a:69:c6:43:ba:c8:b6:3f:7d:46:90:e2:4d:
-    0c:36:9a:1b:26:07:0c:2b:2f:40:a4:74:21:39:21:
-    c5:11:66:01:9d:80:7e:85:61:6d:bd:4b:23:d9:ac:
-    de:65:3b:94:44:d3:23:46:c0:2c:a4:fe:d2:b6:97:
-    f3:be:1a:14:52:bc:d8:da:7a:18:30:fb:f4:39:a6:
-    5d:da:7b:8e:9e:9a:b8:05:cb:21:f0:62:39:bc:a1:
-    51:ad:23:b9:45:45:6d:3d:c4:5a:ee:55:5a:fa:f9:
-    5b:f6:f3:d3:c4:26:a6:65:6e:98:1e:57:e1:a7:6c:
-    a1:a6:1d:fa:aa:7a:ef:1d:cd
+    00:df:01:71:af:01:5d:b1:b6:af:81:20:06:b1:22:
+    74:12:ec:20:f6:c8:12:0f:13:ed:a4:0e:17:af:00:
+    89:7c:53:a1:5d:b7:d7:d5:3a:c0:ab:1b:2a:6d:44:
+    ea:8c:91:44:75:5e:19:4f:bd:2f:67:86:ed:78:1d:
+    67:a5:54:e3:fb:29:7d:03:2a:3a:15:59:3f:0f:8f:
+    7d:db:42:28:77:48:ae:fb:2d:8f:7c:97:31:ca:7e:
+    a4:a0:56:3c:15:73:c8:8e:45:0a:5b:16:4b:4e:d7:
+    5e:f5:75:86:dd:aa:b6:69:ed:05:98:7c:ed:94:2f:
+    05:e2:ca:33:7d:c2:e6:9b:47
 publicExponent: 65537 (0x10001)
 privateExponent:
-    21:7d:e0:ec:67:bd:68:1c:24:1e:10:9d:ce:32:5f:
-    31:42:05:e1:6c:01:42:1d:48:31:f9:63:03:c9:e1:
-    e6:41:56:69:5d:bc:5f:2c:da:75:b6:61:11:c4:fa:
-    ce:ed:a8:d9:ca:0c:da:a9:45:be:b6:2f:6e:14:80:
-    1c:60:1a:db:eb:e0:0c:9b:b2:9d:d5:83:78:fb:3d:
-    72:de:4d:c0:48:49:76:56:b3:fe:20:5f:86:26:d0:
-    b1:77:b6:1b:e0:ce:5c:20:c9:8d:38:a0:91:28:c9:
-    e0:62:2e:63:95:db:ab:af:19:bf:36:d0:6a:ca:cf:
-    7a:63:ac:b4:a8:0c:d8:41
+    00:89:8a:d5:78:2f:ea:7e:e2:83:2a:ab:fb:14:a3:
+    80:5d:ef:5f:81:75:f2:95:74:20:1d:10:48:11:3a:
+    ce:91:6c:ef:58:e3:3b:ee:9a:d7:1c:71:9b:e0:5b:
+    22:22:e2:b2:0b:85:a7:2c:e4:2d:69:b7:f1:9d:24:
+    dd:b9:3e:3b:81:95:bf:3f:49:87:40:3b:af:b7:0d:
+    7a:39:32:b9:dc:6a:e2:a4:42:b5:ca:cb:13:97:f3:
+    f7:32:54:9d:9f:55:23:81:18:2c:c8:87:63:5d:f3:
+    50:7d:87:3e:b3:6e:52:c7:c9:0c:40:e3:8b:45:ff:
+    a7:54:0c:7e:bd:db:57:16:21
 prime1:
-    00:fe:cd:a4:34:cf:ed:e4:61:a8:79:65:25:67:57:
-    ed:fd:8c:7e:77:c0:e9:91:c4:03:1f:c8:d7:2b:32:
-    74:d9:de:4e:85:d3:40:00:9f:b3:7b:ea:fe:c4:3e:
-    54:5f:b2:ce:6c:ed:65:1d:83:49:aa:da:56:63:34:
-    f0:db:0a:e6:55
+    00:f6:04:bd:de:d9:9e:7d:0c:54:2b:e3:eb:90:17:
+    e7:f0:6b:19:9a:01:74:6f:c5:7a:75:d4:1e:36:af:
+    dd:a2:e2:12:15:97:a2:ee:bc:e5:9d:59:b6:99:3a:
+    84:ef:98:07:0f:11:75:44:e3:fd:68:03:6d:2e:bb:
+    a2:82:8f:de:71
 prime2:
-    00:fe:5a:cd:84:14:6d:22:84:9d:9d:75:03:64:64:
-    15:d4:ec:bc:4a:dd:8c:25:dc:d1:5a:97:c4:a7:ee:
-    1c:b0:f0:a4:45:45:8a:3e:5b:34:51:00:7e:e3:06:
-    d3:dd:e2:f3:39:f6:5c:d9:c4:4e:30:7f:49:f7:9f:
-    fa:cc:50:a1:99
+    00:e8:0d:ae:29:d0:22:a2:28:e5:e0:d4:27:89:76:
+    15:1e:86:11:ea:a3:4f:06:61:2d:ad:c8:cf:b8:74:
+    32:2c:ad:85:84:32:01:d4:46:04:d0:43:78:bc:7d:
+    a0:de:17:0e:ce:3f:29:a9:43:8f:9a:27:a1:b5:1c:
+    fb:c2:85:61:37
 exponent1:
-    65:cb:35:dc:bb:6c:e8:9e:73:35:fc:48:93:1e:b7:
-    bf:61:8f:6c:bc:2f:13:c2:e1:14:a3:a2:02:69:e7:
-    f0:da:35:38:95:8a:ae:35:1e:f9:54:8a:6f:50:0f:
-    59:24:0f:ff:c8:5f:6b:08:f6:37:41:7e:dd:a7:5a:
-    c9:c7:72:f9
+    00:bc:ab:9e:41:4d:7b:72:43:06:3a:32:ac:f0:f0:
+    a4:7b:88:67:35:e8:6f:b7:58:27:36:3d:da:7d:ee:
+    19:77:55:10:b1:66:7d:19:c1:dc:05:f4:4b:48:ef:
+    cc:0b:42:f8:06:e2:48:a0:f0:87:e2:40:de:76:bc:
+    87:40:c1:bc:c1
 exponent2:
-    00:b8:09:85:68:4a:cb:48:4d:82:29:9a:af:d0:a4:
-    a6:33:40:f3:60:8b:fa:ca:ae:82:80:35:0d:e2:9f:
-    e3:fc:96:b1:95:39:a2:b4:49:93:8a:04:7c:ca:d1:
-    76:dc:b6:48:5c:a9:08:37:bc:d5:02:3c:27:8d:d7:
-    20:45:53:16:09
+    00:e2:1b:c2:62:77:ad:e7:78:16:55:f6:22:f8:2c:
+    18:f3:ff:0b:22:28:32:6e:32:ee:81:71:34:05:b5:
+    22:d6:a9:d5:79:34:08:d8:3f:c9:9c:ec:c1:8e:58:
+    93:11:14:42:96:f0:b0:b5:7f:61:43:81:ee:6d:3d:
+    6a:8a:e5:d0:0d
 coefficient:
-    08:64:36:46:fd:1b:fb:9c:17:e6:b9:9d:d2:7b:76:
-    6a:46:23:1c:c4:29:49:ca:07:4a:b5:e2:44:bf:0b:
-    cd:c6:78:df:be:4a:1a:40:ba:57:ba:b7:aa:65:92:
-    d4:1e:43:97:63:9e:2f:8c:92:95:49:2e:ce:53:84:
-    7b:9f:0e:98
+    68:c9:e2:ac:3e:cf:75:36:14:e2:99:87:8c:06:51:
+    95:a6:91:c3:22:df:a9:dc:03:a8:f8:0e:a7:77:e0:
+    64:e6:9e:1a:82:99:e8:e8:20:31:8e:a2:45:2b:35:
+    f9:8b:be:f9:6c:fe:b9:57:ee:11:9f:ab:b1:76:6a:
+    4e:a8:a5:57
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQD9KmnGQ7rItj99RpDiTQw2mhsmBwwrL0CkdCE5IcURZgGdgH6F
-YW29SyPZrN5lO5RE0yNGwCyk/tK2l/O+GhRSvNjaehgw+/Q5pl3ae46emrgFyyHw
-Yjm8oVGtI7lFRW09xFruVVr6+Vv289PEJqZlbpgeV+GnbKGmHfqqeu8dzQIDAQAB
-AoGAIX3g7Ge9aBwkHhCdzjJfMUIF4WwBQh1IMfljA8nh5kFWaV28XyzadbZhEcT6
-zu2o2coM2qlFvrYvbhSAHGAa2+vgDJuyndWDePs9ct5NwEhJdlaz/iBfhibQsXe2
-G+DOXCDJjTigkSjJ4GIuY5Xbq68ZvzbQasrPemOstKgM2EECQQD+zaQ0z+3kYah5
-ZSVnV+39jH53wOmRxAMfyNcrMnTZ3k6F00AAn7N76v7EPlRfss5s7WUdg0mq2lZj
-NPDbCuZVAkEA/lrNhBRtIoSdnXUDZGQV1Oy8St2MJdzRWpfEp+4csPCkRUWKPls0
-UQB+4wbT3eLzOfZc2cROMH9J95/6zFChmQJAZcs13Lts6J5zNfxIkx63v2GPbLwv
-E8LhFKOiAmnn8No1OJWKrjUe+VSKb1APWSQP/8hfawj2N0F+3adaycdy+QJBALgJ
-hWhKy0hNgimar9CkpjNA82CL+squgoA1DeKf4/yWsZU5orRJk4oEfMrRdty2SFyp
-CDe81QI8J43XIEVTFgkCQAhkNkb9G/ucF+a5ndJ7dmpGIxzEKUnKB0q14kS/C83G
-eN++ShpAule6t6plktQeQ5djni+MkpVJLs5ThHufDpg=
+MIICXgIBAAKBgQDfAXGvAV2xtq+BIAaxInQS7CD2yBIPE+2kDhevAIl8U6Fdt9fV
+OsCrGyptROqMkUR1XhlPvS9nhu14HWelVOP7KX0DKjoVWT8Pj33bQih3SK77LY98
+lzHKfqSgVjwVc8iORQpbFktO1171dYbdqrZp7QWYfO2ULwXiyjN9wuabRwIDAQAB
+AoGBAImK1Xgv6n7igyqr+xSjgF3vX4F18pV0IB0QSBE6zpFs71jjO+6a1xxxm+Bb
+IiLisguFpyzkLWm38Z0k3bk+O4GVvz9Jh0A7r7cNejkyudxq4qRCtcrLE5fz9zJU
+nZ9VI4EYLMiHY13zUH2HPrNuUsfJDEDji0X/p1QMfr3bVxYhAkEA9gS93tmefQxU
+K+PrkBfn8GsZmgF0b8V6ddQeNq/douISFZei7rzlnVm2mTqE75gHDxF1ROP9aANt
+Lruigo/ecQJBAOgNrinQIqIo5eDUJ4l2FR6GEeqjTwZhLa3Iz7h0MiythYQyAdRG
+BNBDeLx9oN4XDs4/KalDj5onobUc+8KFYTcCQQC8q55BTXtyQwY6Mqzw8KR7iGc1
+6G+3WCc2Pdp97hl3VRCxZn0ZwdwF9EtI78wLQvgG4kig8IfiQN52vIdAwbzBAkEA
+4hvCYnet53gWVfYi+CwY8/8LIigybjLugXE0BbUi1qnVeTQI2D/JnOzBjliTERRC
+lvCwtX9hQ4HubT1qiuXQDQJAaMnirD7PdTYU4pmHjAZRlaaRwyLfqdwDqPgOp3fg
+ZOaeGoKZ6OggMY6iRSs1+Yu++Wz+uVfuEZ+rsXZqTqilVw==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/revoked.pem
+++ b/spec/fixtures/ssl/revoked.pem
@@ -6,39 +6,39 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=revoked
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:fd:2a:69:c6:43:ba:c8:b6:3f:7d:46:90:e2:4d:
-                    0c:36:9a:1b:26:07:0c:2b:2f:40:a4:74:21:39:21:
-                    c5:11:66:01:9d:80:7e:85:61:6d:bd:4b:23:d9:ac:
-                    de:65:3b:94:44:d3:23:46:c0:2c:a4:fe:d2:b6:97:
-                    f3:be:1a:14:52:bc:d8:da:7a:18:30:fb:f4:39:a6:
-                    5d:da:7b:8e:9e:9a:b8:05:cb:21:f0:62:39:bc:a1:
-                    51:ad:23:b9:45:45:6d:3d:c4:5a:ee:55:5a:fa:f9:
-                    5b:f6:f3:d3:c4:26:a6:65:6e:98:1e:57:e1:a7:6c:
-                    a1:a6:1d:fa:aa:7a:ef:1d:cd
+                    00:df:01:71:af:01:5d:b1:b6:af:81:20:06:b1:22:
+                    74:12:ec:20:f6:c8:12:0f:13:ed:a4:0e:17:af:00:
+                    89:7c:53:a1:5d:b7:d7:d5:3a:c0:ab:1b:2a:6d:44:
+                    ea:8c:91:44:75:5e:19:4f:bd:2f:67:86:ed:78:1d:
+                    67:a5:54:e3:fb:29:7d:03:2a:3a:15:59:3f:0f:8f:
+                    7d:db:42:28:77:48:ae:fb:2d:8f:7c:97:31:ca:7e:
+                    a4:a0:56:3c:15:73:c8:8e:45:0a:5b:16:4b:4e:d7:
+                    5e:f5:75:86:dd:aa:b6:69:ed:05:98:7c:ed:94:2f:
+                    05:e2:ca:33:7d:c2:e6:9b:47
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         55:ef:5d:2e:cb:40:25:9a:c3:9f:54:5e:db:76:42:09:6a:47:
-         f9:4c:7d:e6:10:38:a1:dc:71:b0:fd:20:03:c0:49:0b:0e:10:
-         9e:c9:8b:80:4f:6e:af:51:0c:80:7a:91:b5:77:bc:96:56:f5:
-         bd:d4:a3:4c:37:67:1f:70:93:39:b1:bb:87:79:4e:78:0d:8a:
-         ab:d6:41:61:80:f7:8a:5f:1d:83:cd:ef:b2:cf:50:9f:72:f7:
-         da:a7:55:9d:ea:65:c1:53:02:a1:78:f9:66:0e:a3:e1:1d:bc:
-         d0:ae:f9:5c:4a:e4:92:9c:85:57:bc:1c:d1:15:4c:31:8d:25:
-         a7:f2
+         4f:24:56:32:a9:45:7b:f2:f2:2c:29:31:ff:03:e6:da:c9:ed:
+         37:87:18:a0:b3:ff:ad:42:82:01:1a:d2:03:09:60:2d:b9:fe:
+         81:46:f7:40:90:d4:d6:17:79:93:f4:32:2a:9e:7b:29:8a:97:
+         82:d8:55:d8:39:84:6b:d0:da:65:39:de:28:09:33:83:8b:fa:
+         e2:f2:76:5f:fb:30:72:a7:28:b2:20:48:15:da:3e:87:0d:6a:
+         74:1a:c2:55:12:07:7a:2e:30:ec:e6:a6:96:78:34:1b:7d:94:
+         7b:67:54:5c:ca:06:98:e3:fb:c7:7f:48:ab:a3:e0:e5:87:2c:
+         c5:fc
 -----BEGIN CERTIFICATE-----
 MIIBpTCCAQ6gAwIBAgIBBDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDMyMDI2MjRa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDkyMTM1NTNa
 MBIxEDAOBgNVBAMMB3Jldm9rZWQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AP0qacZDusi2P31GkOJNDDaaGyYHDCsvQKR0ITkhxRFmAZ2AfoVhbb1LI9ms3mU7
-lETTI0bALKT+0raX874aFFK82Np6GDD79DmmXdp7jp6auAXLIfBiObyhUa0juUVF
-bT3EWu5VWvr5W/bz08QmpmVumB5X4adsoaYd+qp67x3NAgMBAAEwDQYJKoZIhvcN
-AQELBQADgYEAVe9dLstAJZrDn1Re23ZCCWpH+Ux95hA4odxxsP0gA8BJCw4QnsmL
-gE9ur1EMgHqRtXe8llb1vdSjTDdnH3CTObG7h3lOeA2Kq9ZBYYD3il8dg83vss9Q
-n3L32qdVneplwVMCoXj5Zg6j4R280K75XErkkpyFV7wc0RVMMY0lp/I=
+AN8Bca8BXbG2r4EgBrEidBLsIPbIEg8T7aQOF68AiXxToV2319U6wKsbKm1E6oyR
+RHVeGU+9L2eG7XgdZ6VU4/spfQMqOhVZPw+PfdtCKHdIrvstj3yXMcp+pKBWPBVz
+yI5FClsWS07XXvV1ht2qtmntBZh87ZQvBeLKM33C5ptHAgMBAAEwDQYJKoZIhvcN
+AQELBQADgYEATyRWMqlFe/LyLCkx/wPm2sntN4cYoLP/rUKCARrSAwlgLbn+gUb3
+QJDU1hd5k/QyKp57KYqXgthV2DmEa9DaZTneKAkzg4v64vJ2X/swcqcosiBIFdo+
+hw1qdBrCVRIHei4w7Oamlng0G32Ue2dUXMoGmOP7x39Iq6Pg5Ycsxfw=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/signed-key.pem
+++ b/spec/fixtures/ssl/signed-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:9e:6a:e5:e9:fb:b8:29:aa:70:81:d5:55:11:34:
-    6d:21:19:77:e9:50:a5:bd:ea:e5:ac:73:71:70:1e:
-    60:c2:7a:73:34:af:99:aa:ae:67:fc:dc:06:d1:85:
-    79:93:28:31:5c:e4:60:03:4e:18:08:9e:f1:96:d0:
-    0d:5e:31:ea:a6:d1:81:ca:d5:30:d3:c2:17:62:5c:
-    30:5f:8e:26:35:34:c4:f0:ed:a5:37:98:36:cb:b5:
-    40:e7:0b:6a:ce:84:a4:5a:36:7a:61:25:00:be:e1:
-    a8:46:a7:7c:ec:ca:f4:ad:3e:a6:72:8c:a0:b0:17:
-    f0:f6:7e:af:1f:c3:ee:c5:79
+    00:ad:cf:8f:ff:51:7a:86:cc:99:5d:14:8f:07:0c:
+    f7:e7:f7:e8:3c:46:90:38:d3:fa:71:91:57:42:3a:
+    bd:9a:80:24:e8:df:55:26:a6:8f:74:30:5c:5a:f4:
+    34:f0:db:76:24:1c:f1:cd:57:1b:80:93:2c:5c:e9:
+    b1:ea:21:c8:f6:58:52:ce:3f:b3:f6:32:6e:de:00:
+    b9:8e:a2:9f:07:08:ac:e7:32:6e:43:93:4a:eb:87:
+    d6:6c:e6:6a:4e:45:bd:f9:08:4b:71:d3:05:77:67:
+    87:26:08:12:62:37:09:5f:37:59:09:3e:80:74:b2:
+    69:43:46:32:99:b9:db:fe:05
 publicExponent: 65537 (0x10001)
 privateExponent:
-    54:74:93:0c:32:19:95:84:fb:24:0c:92:a4:70:79:
-    b9:8a:b5:65:da:8b:f1:fb:17:e4:df:4a:db:c6:26:
-    39:a8:44:61:13:38:ee:48:ba:c1:90:9f:c5:f5:cd:
-    c1:c9:4c:bf:c4:34:f7:ae:1b:9c:04:f8:b1:39:4b:
-    d7:2a:ef:78:97:28:f7:63:fa:bf:a1:72:c1:96:16:
-    98:32:70:e3:b8:bd:0a:a8:a1:9f:e2:77:af:ea:ae:
-    fd:c6:d6:b1:3a:ed:f0:4f:b7:26:03:36:8e:23:ca:
-    53:c3:a1:49:bc:d8:31:f2:25:80:4f:ff:97:2e:18:
-    20:5e:be:7c:ee:b1:fb:71
+    25:5f:98:4b:02:2e:22:86:24:04:0b:c3:a5:74:78:
+    69:fc:b8:87:1d:75:2d:83:07:3b:1c:51:73:00:46:
+    7c:ce:49:21:79:c4:49:87:4f:19:60:bc:bb:21:ff:
+    b0:3a:c0:70:8b:78:c2:fa:94:03:55:a2:18:68:77:
+    c5:2c:76:95:86:fb:af:4d:24:d7:ab:08:65:f3:6e:
+    52:7b:cb:ec:89:74:55:e7:6c:26:93:62:ff:01:f0:
+    5f:33:1c:a2:db:78:7e:fc:fc:a0:c1:75:cd:2a:aa:
+    31:1e:03:ee:0f:a4:be:f8:aa:80:e5:c1:fe:12:67:
+    7d:8b:4a:ba:5d:bc:89:01
 prime1:
-    00:cf:7c:97:8a:dc:b0:7c:15:4a:ab:e0:7b:43:1d:
-    4c:fd:00:25:8d:b9:60:7e:d7:5e:fc:27:65:0a:c1:
-    36:a2:d2:f7:c1:f3:d5:38:94:61:14:f9:8f:a9:b4:
-    8a:6c:6d:2a:87:56:00:5a:14:dd:86:86:8b:bf:c0:
-    23:e4:4a:c0:ad
+    00:e2:de:b4:d0:ef:3c:db:51:50:0f:f5:ff:73:8e:
+    da:e2:1c:1e:46:3a:09:a0:00:e1:a4:97:90:c7:62:
+    9a:e0:84:f4:66:ff:35:be:7f:f8:98:ed:28:50:5d:
+    a5:77:eb:ab:0d:9c:f8:b1:f9:ef:d0:0e:5b:9f:da:
+    fa:44:73:3f:d5
 prime2:
-    00:c3:75:34:7c:2c:71:51:e0:0b:1f:bb:b8:d2:48:
-    c6:9e:62:c8:ea:4a:66:41:23:cb:57:88:82:64:65:
-    19:76:bf:14:70:70:e7:89:d3:87:5d:07:85:a1:18:
-    59:5b:23:2c:e9:eb:3f:ae:5a:26:af:58:2f:11:62:
-    cc:35:b2:95:7d
+    00:c4:20:c8:8a:86:24:f5:be:20:82:73:f4:bb:43:
+    77:d7:c7:cd:de:49:a0:58:1e:c2:5e:34:e2:4e:a0:
+    fd:26:16:9a:4b:32:42:f2:08:19:93:64:13:cd:d9:
+    93:c5:63:0d:39:9f:1d:8d:20:80:02:27:75:71:25:
+    74:24:43:0d:71
 exponent1:
-    5c:4e:6d:8c:d5:89:9e:6a:4a:82:14:a8:41:bf:73:
-    54:cb:0f:e9:f1:22:c0:cb:47:f2:9e:04:11:b8:cb:
-    79:bc:a9:84:9b:d9:ac:06:36:fa:81:dc:2b:ff:a9:
-    e5:7a:db:84:c1:f9:fe:19:72:44:3a:ef:49:2b:4d:
-    cc:6e:85:31
+    00:b6:34:1a:8f:fa:b3:ab:88:60:7e:91:18:fa:1b:
+    ef:1a:cd:6e:5b:04:5d:9a:8d:5a:ab:2f:b6:ed:0a:
+    fa:4b:fb:3b:b6:44:9d:4b:43:c7:ca:3a:1d:b8:7d:
+    9d:58:f4:82:ca:4a:19:4a:06:eb:5c:f3:4b:0e:d5:
+    75:4d:e8:29:89
 exponent2:
-    3b:b5:2e:17:50:ac:3d:4a:a7:9b:46:09:2b:93:b7:
-    b8:e2:8c:65:a5:dc:9e:c1:84:78:74:e7:00:2c:32:
-    1f:28:37:e2:31:5b:49:ab:28:8a:ae:a5:8f:94:94:
-    97:56:a3:7d:c1:b3:6e:5b:73:bd:d4:be:6c:1d:36:
-    2c:a1:25:31
+    1e:1d:66:8d:96:a1:70:36:5c:69:8b:82:85:8a:8b:
+    89:4f:7d:b5:e7:1a:3e:cd:a2:4c:b2:d4:18:fc:b1:
+    42:3a:f0:40:21:9c:93:eb:58:7a:00:40:e6:37:c5:
+    6f:e6:90:ae:4b:57:4f:47:31:40:a3:6c:6e:0e:31:
+    32:2c:35:91
 coefficient:
-    00:81:a4:13:88:2b:88:7d:36:20:00:e6:0f:a8:f6:
-    85:23:4e:e7:e0:5e:4b:13:1d:45:c0:58:98:9a:af:
-    c8:17:4d:d6:98:42:7d:c0:f8:0a:0b:a1:ee:a9:cd:
-    3e:7b:98:6e:98:39:39:19:df:ca:4d:8f:87:4a:26:
-    fc:97:76:06:c4
+    57:c8:09:23:2a:ad:d0:a4:c0:f5:5b:9c:b4:7e:36:
+    a2:b6:dd:8d:cc:9d:ac:db:e9:03:3d:32:a3:90:c3:
+    47:9d:07:69:9c:c5:97:94:96:53:b4:b6:c5:45:96:
+    56:07:e4:c6:9a:ec:56:a4:b5:c3:12:70:ee:13:ae:
+    43:bd:51:39
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQCeauXp+7gpqnCB1VURNG0hGXfpUKW96uWsc3FwHmDCenM0r5mq
-rmf83AbRhXmTKDFc5GADThgInvGW0A1eMeqm0YHK1TDTwhdiXDBfjiY1NMTw7aU3
-mDbLtUDnC2rOhKRaNnphJQC+4ahGp3zsyvStPqZyjKCwF/D2fq8fw+7FeQIDAQAB
-AoGAVHSTDDIZlYT7JAySpHB5uYq1ZdqL8fsX5N9K28YmOahEYRM47ki6wZCfxfXN
-wclMv8Q0964bnAT4sTlL1yrveJco92P6v6FywZYWmDJw47i9Cqihn+J3r+qu/cbW
-sTrt8E+3JgM2jiPKU8OhSbzYMfIlgE//ly4YIF6+fO6x+3ECQQDPfJeK3LB8FUqr
-4HtDHUz9ACWNuWB+1178J2UKwTai0vfB89U4lGEU+Y+ptIpsbSqHVgBaFN2Ghou/
-wCPkSsCtAkEAw3U0fCxxUeALH7u40kjGnmLI6kpmQSPLV4iCZGUZdr8UcHDnidOH
-XQeFoRhZWyMs6es/rlomr1gvEWLMNbKVfQJAXE5tjNWJnmpKghSoQb9zVMsP6fEi
-wMtH8p4EEbjLebyphJvZrAY2+oHcK/+p5XrbhMH5/hlyRDrvSStNzG6FMQJAO7Uu
-F1CsPUqnm0YJK5O3uOKMZaXcnsGEeHTnACwyHyg34jFbSasoiq6lj5SUl1ajfcGz
-bltzvdS+bB02LKElMQJBAIGkE4griH02IADmD6j2hSNO5+BeSxMdRcBYmJqvyBdN
-1phCfcD4Cguh7qnNPnuYbpg5ORnfyk2Ph0om/Jd2BsQ=
+MIICXAIBAAKBgQCtz4//UXqGzJldFI8HDPfn9+g8RpA40/pxkVdCOr2agCTo31Um
+po90MFxa9DTw23YkHPHNVxuAkyxc6bHqIcj2WFLOP7P2Mm7eALmOop8HCKznMm5D
+k0rrh9Zs5mpORb35CEtx0wV3Z4cmCBJiNwlfN1kJPoB0smlDRjKZudv+BQIDAQAB
+AoGAJV+YSwIuIoYkBAvDpXR4afy4hx11LYMHOxxRcwBGfM5JIXnESYdPGWC8uyH/
+sDrAcIt4wvqUA1WiGGh3xSx2lYb7r00k16sIZfNuUnvL7Il0VedsJpNi/wHwXzMc
+ott4fvz8oMF1zSqqMR4D7g+kvviqgOXB/hJnfYtKul28iQECQQDi3rTQ7zzbUVAP
+9f9zjtriHB5GOgmgAOGkl5DHYprghPRm/zW+f/iY7ShQXaV366sNnPix+e/QDluf
+2vpEcz/VAkEAxCDIioYk9b4ggnP0u0N318fN3kmgWB7CXjTiTqD9JhaaSzJC8ggZ
+k2QTzdmTxWMNOZ8djSCAAid1cSV0JEMNcQJBALY0Go/6s6uIYH6RGPob7xrNblsE
+XZqNWqsvtu0K+kv7O7ZEnUtDx8o6Hbh9nVj0gspKGUoG61zzSw7VdU3oKYkCQB4d
+Zo2WoXA2XGmLgoWKi4lPfbXnGj7Nokyy1Bj8sUI68EAhnJPrWHoAQOY3xW/mkK5L
+V09HMUCjbG4OMTIsNZECQFfICSMqrdCkwPVbnLR+NqK23Y3Mnazb6QM9MqOQw0ed
+B2mcxZeUllO0tsVFllYH5Maa7FaktcMScO4TrkO9UTk=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/signed.pem
+++ b/spec/fixtures/ssl/signed.pem
@@ -6,39 +6,39 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:9e:6a:e5:e9:fb:b8:29:aa:70:81:d5:55:11:34:
-                    6d:21:19:77:e9:50:a5:bd:ea:e5:ac:73:71:70:1e:
-                    60:c2:7a:73:34:af:99:aa:ae:67:fc:dc:06:d1:85:
-                    79:93:28:31:5c:e4:60:03:4e:18:08:9e:f1:96:d0:
-                    0d:5e:31:ea:a6:d1:81:ca:d5:30:d3:c2:17:62:5c:
-                    30:5f:8e:26:35:34:c4:f0:ed:a5:37:98:36:cb:b5:
-                    40:e7:0b:6a:ce:84:a4:5a:36:7a:61:25:00:be:e1:
-                    a8:46:a7:7c:ec:ca:f4:ad:3e:a6:72:8c:a0:b0:17:
-                    f0:f6:7e:af:1f:c3:ee:c5:79
+                    00:ad:cf:8f:ff:51:7a:86:cc:99:5d:14:8f:07:0c:
+                    f7:e7:f7:e8:3c:46:90:38:d3:fa:71:91:57:42:3a:
+                    bd:9a:80:24:e8:df:55:26:a6:8f:74:30:5c:5a:f4:
+                    34:f0:db:76:24:1c:f1:cd:57:1b:80:93:2c:5c:e9:
+                    b1:ea:21:c8:f6:58:52:ce:3f:b3:f6:32:6e:de:00:
+                    b9:8e:a2:9f:07:08:ac:e7:32:6e:43:93:4a:eb:87:
+                    d6:6c:e6:6a:4e:45:bd:f9:08:4b:71:d3:05:77:67:
+                    87:26:08:12:62:37:09:5f:37:59:09:3e:80:74:b2:
+                    69:43:46:32:99:b9:db:fe:05
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         93:64:2b:82:9f:e6:07:31:d5:87:22:b3:37:e5:bf:86:d0:fc:
-         98:40:63:c6:69:a2:d1:0a:af:18:11:31:c0:7d:e6:a8:cb:24:
-         57:7f:14:26:5f:cd:8d:17:21:67:42:51:fa:1b:9a:8f:4b:98:
-         d8:c0:f1:5f:ff:2a:27:eb:4b:8c:d4:80:63:c3:d9:41:ea:ca:
-         e9:01:ee:42:7a:84:6e:2d:45:88:4a:6e:7b:fe:7c:df:72:9a:
-         ef:0a:41:98:69:75:4a:a1:e2:e6:03:1a:93:e6:fc:32:56:ab:
-         eb:88:3f:a1:c1:59:e8:82:85:4c:fa:73:ad:5b:64:13:cf:fa:
-         01:f1
+         6a:6e:bf:67:1a:d4:05:70:ea:cb:b5:e6:8c:4e:1c:67:79:d1:
+         67:12:aa:ea:b9:7c:02:3e:8c:b5:98:bb:5c:b2:1d:74:2f:77:
+         4e:19:15:9d:6a:ae:5e:19:2b:5c:34:94:4b:88:9f:c1:08:75:
+         a0:84:94:7c:83:e5:a8:14:49:2b:e8:12:06:51:10:da:d0:69:
+         ce:55:3c:25:17:cc:2a:6b:a3:87:a8:00:2e:5a:6e:92:c4:29:
+         ed:65:6b:69:9b:aa:0c:50:5d:73:1e:0d:1d:31:5d:55:3a:a5:
+         7c:9c:e9:86:c4:f4:5e:a7:2e:4f:6b:99:de:4d:8b:4b:d3:95:
+         e3:6e
 -----BEGIN CERTIFICATE-----
 MIIBpDCCAQ2gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDMyMDI2MjRa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDkyMTM1NTNa
 MBExDzANBgNVBAMMBnNpZ25lZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA
-nmrl6fu4KapwgdVVETRtIRl36VClverlrHNxcB5gwnpzNK+Zqq5n/NwG0YV5kygx
-XORgA04YCJ7xltANXjHqptGBytUw08IXYlwwX44mNTTE8O2lN5g2y7VA5wtqzoSk
-WjZ6YSUAvuGoRqd87Mr0rT6mcoygsBfw9n6vH8PuxXkCAwEAATANBgkqhkiG9w0B
-AQsFAAOBgQCTZCuCn+YHMdWHIrM35b+G0PyYQGPGaaLRCq8YETHAfeaoyyRXfxQm
-X82NFyFnQlH6G5qPS5jYwPFf/yon60uM1IBjw9lB6srpAe5CeoRuLUWISm57/nzf
-cprvCkGYaXVKoeLmAxqT5vwyVqvriD+hwVnogoVM+nOtW2QTz/oB8Q==
+rc+P/1F6hsyZXRSPBwz35/foPEaQONP6cZFXQjq9moAk6N9VJqaPdDBcWvQ08Nt2
+JBzxzVcbgJMsXOmx6iHI9lhSzj+z9jJu3gC5jqKfBwis5zJuQ5NK64fWbOZqTkW9
++QhLcdMFd2eHJggSYjcJXzdZCT6AdLJpQ0Yymbnb/gUCAwEAATANBgkqhkiG9w0B
+AQsFAAOBgQBqbr9nGtQFcOrLteaMThxnedFnEqrquXwCPoy1mLtcsh10L3dOGRWd
+aq5eGStcNJRLiJ/BCHWghJR8g+WoFEkr6BIGURDa0GnOVTwlF8wqa6OHqAAuWm6S
+xCntZWtpm6oMUF1zHg0dMV1VOqV8nOmGxPRepy5Pa5neTYtL05Xjbg==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-cert.pem
+++ b/spec/fixtures/ssl/tampered-cert.pem
@@ -1,44 +1,44 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 6 (0x6)
+        Serial Number: 8 (0x8)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  3 20:26:24 2029 GMT
+            Not After : Mar  9 21:35:53 2029 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:b1:3b:7a:11:44:2b:82:f8:64:3b:62:c5:e6:b5:
-                    bd:11:0e:ad:9b:44:fe:4d:3e:a1:ea:a1:5a:59:24:
-                    83:b3:e9:fa:6f:ac:99:7a:d2:03:cb:8c:93:7f:7c:
-                    d1:d4:d6:ce:c7:6e:8e:45:42:00:65:bd:a6:5e:29:
-                    05:4b:a7:f3:ae:c5:09:e6:f7:48:f4:00:8a:a1:12:
-                    3b:01:d9:08:e9:97:ef:10:10:42:94:ae:0d:20:55:
-                    f0:22:ad:bd:a9:e1:af:29:83:ba:36:80:e9:33:17:
-                    44:71:ae:ce:14:4d:61:3c:89:d0:b7:b2:9f:a2:5a:
-                    bf:bc:cd:16:68:a5:59:0d:93
+                    00:c8:59:04:8a:ae:1e:28:41:59:f9:0d:58:9c:11:
+                    27:30:76:f1:de:37:56:de:be:28:e2:79:4a:d0:c3:
+                    6f:73:c2:fc:77:3d:44:4b:42:aa:0e:02:43:c6:5f:
+                    52:33:a5:11:8e:65:c0:53:e8:3d:f9:a2:16:7d:1b:
+                    6c:b9:16:9d:8f:5d:a2:f8:c6:be:58:cc:4e:51:28:
+                    d6:3c:bf:9a:01:e8:b2:9d:d5:75:3c:27:6e:fa:81:
+                    e4:d5:0d:15:af:28:d2:0c:91:36:41:eb:62:32:95:
+                    65:e8:48:1c:b3:f6:de:bf:35:cd:8f:d3:74:71:d4:
+                    d3:19:4c:7b:42:04:bc:66:43
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         3a:d9:82:61:3b:94:fb:af:21:f5:4d:64:03:0d:b8:ef:eb:1d:
-         2a:50:c2:70:1b:e9:c7:7f:72:e1:9d:f5:0d:4e:fa:e5:10:01:
-         35:ac:1f:74:01:09:e4:f6:cb:6b:8c:5f:12:47:a1:f2:44:3f:
-         a4:b2:88:8f:1a:c3:35:4c:89:10:ef:4d:ca:0d:ba:37:ef:3b:
-         0d:c1:65:9d:68:67:88:32:fd:dc:56:8a:2e:ce:ca:34:4c:49:
-         f0:13:7b:fa:e5:a1:f5:1c:28:75:09:e1:41:ef:17:55:4e:0c:
-         ba:2f:85:a1:1a:99:ac:7a:e8:c0:c5:a3:dd:d3:3a:ca:98:16:
-         17:26
+         8b:30:32:a3:ce:74:8a:49:55:b0:c9:9d:47:b0:aa:9e:0c:8f:
+         b0:af:ef:e9:26:41:b3:bf:cb:dc:89:2a:fc:58:28:10:f8:67:
+         bd:9e:08:80:c5:77:31:63:29:34:0d:c2:5c:a7:1e:53:60:18:
+         d5:7c:88:68:18:f6:79:39:d3:1e:76:23:6a:24:4d:49:72:ed:
+         81:fc:9f:c8:08:d1:03:e7:d6:09:9c:be:00:5b:51:56:33:cd:
+         22:98:73:ec:2a:9f:1d:7b:32:bb:f5:02:46:98:8c:4e:0e:cd:
+         3e:d5:e0:2f:fe:3f:b8:f9:10:ee:da:f1:b4:44:04:21:82:81:
+         40:30
 -----BEGIN CERTIFICATE-----
-MIIBpDCCAQ2gAwIBAgIBBjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDMyMDI2MjRa
+MIIBpDCCAQ2gAwIBAgIBCDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDkyMTM1NTNa
 MBExDzANBgNVBAMMBnNpZ25lZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA
-sTt6EUQrgvhkO2LF5rW9EQ6tm0T+TT6h6qFaWSSDs+n6b6yZetIDy4yTf3zR1NbO
-x26ORUIAZb2mXikFS6fzrsUJ5vdI9ACKoRI7AdkI6ZfvEBBClK4NIFXwIq29qeGv
-KYO6NoDpMxdEca7OFE1hPInQt7Kfolq/vM0WaKVZDZMCAwEAATANBgkqhkiG9w0B
-AQsFAAOBgQA62YJhO5T7ryH1TWQDDbjv6x0qUMJwG+nHf3LhnfUNTvrlEAE1rB90
-AQnk9strjF8SR6HyRD+ksoiPGsM1TIkQ703KDbo37zsNwWWdaGeIMv3cVoouzso0
-TEnwE3v65aH1HCh1CeFB7xdVTgy6L4WhGpmseujAxaPd0zrKmBYXJg==
+yFkEiq4eKEFZ+Q1YnBEnMHbx3jdW3r4o4nlK0MNvc8L8dz1ES0KqDgJDxl9SM6UR
+jmXAU+g9+aIWfRtsuRadj12i+Ma+WMxOUSjWPL+aAeiyndV1PCdu+oHk1Q0VryjS
+DJE2QetiMpVl6Egcs/bevzXNj9N0cdTTGUx7QgS8ZkMCAwEAATANBgkqhkiG9w0B
+AQsFAAOBgQCLMDKjznSKSVWwyZ1HsKqeDI+wr+/pJkGzv8vciSr8WCgQ+Ge9ngiA
+xXcxYyk0DcJcpx5TYBjVfIhoGPZ5OdMediNqJE1Jcu2B/J/ICNED59YJnL4AW1FW
+M80imHPsKp8dezK79QJGmIxODs0+1eAv/j+4+RDu2vG0RAQhgoFAMA==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-csr.pem
+++ b/spec/fixtures/ssl/tampered-csr.pem
@@ -6,34 +6,34 @@ Certificate Request:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:e1:68:5e:47:1f:e6:18:f7:16:a3:c8:fb:50:46:
-                    4e:01:3a:29:68:65:b5:6b:ea:17:a8:1e:20:33:75:
-                    11:0e:22:7a:81:ca:ed:56:e5:8d:a0:32:52:b1:b9:
-                    41:96:7a:b2:99:cb:b4:37:df:b5:13:42:8e:e0:a8:
-                    2b:02:13:18:90:07:b6:7c:76:f4:f1:9d:22:5c:f4:
-                    ab:7e:21:8e:4c:fa:1f:cf:92:88:24:b9:f7:51:b7:
-                    37:f6:70:98:c9:91:e6:8b:aa:05:52:50:87:0f:2d:
-                    f4:27:3c:3d:f3:77:91:5d:36:8f:1b:b6:3b:57:ed:
-                    41:2e:95:7d:15:b9:27:00:1d
+                    00:c1:cf:0a:79:46:63:ed:c2:9e:2b:a6:2a:4d:2b:
+                    9b:e6:f3:d0:cd:98:3e:55:ab:ea:be:a9:41:a6:db:
+                    ad:1e:ea:33:64:b9:18:67:b1:8b:53:5a:12:69:eb:
+                    d1:ad:a9:85:6e:7d:f0:ef:a4:4b:1a:c4:75:71:4f:
+                    3a:5c:7a:59:43:ab:b4:65:fd:75:0e:0a:6f:ac:a0:
+                    35:fc:fc:34:6c:38:9e:1d:95:26:81:cf:8b:24:d3:
+                    c1:65:d0:57:fb:e7:b1:1b:57:61:5c:40:2a:0f:a0:
+                    7d:d8:26:c6:9e:b5:bf:fd:0f:72:6a:df:2b:23:2f:
+                    01:39:21:42:a6:43:13:07:55
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         6b:47:7b:d9:3a:73:cd:91:2d:6c:25:04:5c:22:a4:1f:32:56:
-         e1:e3:e2:e0:0c:12:c8:ef:3b:64:dc:52:ca:39:ac:21:ed:19:
-         33:33:32:76:d2:40:83:cf:eb:f9:14:00:9c:92:50:c1:f4:e8:
-         d5:88:2e:e0:d2:87:3a:14:95:34:c6:dc:9e:7d:67:4a:71:6d:
-         e0:2e:8e:9e:25:89:ee:4a:f9:e1:57:c2:72:c2:21:65:5b:1d:
-         0c:7d:f0:e2:49:7d:2d:96:b3:08:8d:38:a6:c2:19:53:69:16:
-         62:e1:79:88:70:4f:7a:7b:e2:20:44:9d:36:6d:b6:04:65:55:
-         81:b7
+         7a:96:63:e3:47:6b:3d:c2:03:79:cb:c1:98:58:b6:ec:9e:5b:
+         43:fe:0a:42:7a:fc:e6:e4:0a:fc:15:6e:b6:c5:f3:5e:fb:43:
+         ab:d3:fb:35:83:52:ba:3e:81:77:3b:f3:9d:05:24:5b:91:a6:
+         9b:90:48:13:f2:ec:2a:9d:8f:1c:c6:46:f0:a0:76:ae:fe:f9:
+         d4:16:5e:5a:9d:85:bc:ec:f1:28:86:1a:0f:ce:2a:f9:4f:ab:
+         91:84:39:10:9e:53:61:88:cc:06:5a:32:53:6e:d8:79:6b:6d:
+         3a:47:0a:5a:63:0d:73:e0:ac:96:4f:00:ea:4d:6d:44:1d:17:
+         7a:9a
 -----BEGIN CERTIFICATE REQUEST-----
 MIIBUDCBugIBAjARMQ8wDQYDVQQDDAZzaWduZWQwgZ8wDQYJKoZIhvcNAQEBBQAD
-gY0AMIGJAoGBAOFoXkcf5hj3FqPI+1BGTgE6KWhltWvqF6geIDN1EQ4ieoHK7Vbl
-jaAyUrG5QZZ6spnLtDfftRNCjuCoKwITGJAHtnx29PGdIlz0q34hjkz6H8+SiCS5
-91G3N/ZwmMmR5ouqBVJQhw8t9Cc8PfN3kV02jxu2O1ftQS6VfRW5JwAdAgMBAAGg
-ADANBgkqhkiG9w0BAQsFAAOBgQBrR3vZOnPNkS1sJQRcIqQfMlbh4+LgDBLI7ztk
-3FLKOawh7RkzMzJ20kCDz+v5FACcklDB9OjViC7g0oc6FJU0xtyefWdKcW3gLo6e
-JYnuSvnhV8JywiFlWx0MffDiSX0tlrMIjTimwhlTaRZi4XmIcE96e+IgRJ02bbYE
-ZVWBtw==
+gY0AMIGJAoGBAMHPCnlGY+3CniumKk0rm+bz0M2YPlWr6r6pQabbrR7qM2S5GGex
+i1NaEmnr0a2phW598O+kSxrEdXFPOlx6WUOrtGX9dQ4Kb6ygNfz8NGw4nh2VJoHP
+iyTTwWXQV/vnsRtXYVxAKg+gfdgmxp61v/0PcmrfKyMvATkhQqZDEwdVAgMBAAGg
+ADANBgkqhkiG9w0BAQsFAAOBgQB6lmPjR2s9wgN5y8GYWLbsnltD/gpCevzm5Ar8
+FW62xfNe+0Or0/s1g1K6PoF3O/OdBSRbkaabkEgT8uwqnY8cxkbwoHau/vnUFl5a
+nYW87PEohhoPzir5T6uRhDkQnlNhiMwGWjJTbth5a206RwpaYw1z4KyWTwDqTW1E
+HRd6mg==
 -----END CERTIFICATE REQUEST-----

--- a/spec/lib/puppet_spec/https.rb
+++ b/spec/lib/puppet_spec/https.rb
@@ -24,7 +24,7 @@ class PuppetSpec::HTTPSServer
     res.send_response(ssl)
   end
 
-  def start_server(&block)
+  def start_server(ctx_proc: nil, &block)
     errors = []
 
     IO.pipe {|stop_pipe_r, stop_pipe_w|
@@ -36,6 +36,7 @@ class PuppetSpec::HTTPSServer
       ctx.cert = @server_cert
       ctx.key = @server_key
       ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      ctx_proc.call(ctx) if ctx_proc
 
       Socket.do_not_reverse_lookup = true
       tcps = TCPServer.new("127.0.0.1", 0)

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -219,11 +219,10 @@ describe Puppet::SSL::SSLProvider do
                        "Certificate '/CN=revoked' is revoked")
     end
 
-    it 'raises if intermediate issuer is missing' do
-      expect {
-        subject.create_context(config.merge(cacerts: [cert_fixture('ca.pem')]))
-      }.to raise_error(Puppet::SSL::CertVerifyError,
-                       "The issuer '/CN=Test CA Subauthority' of certificate '/CN=signed' cannot be found locally")
+    it 'warns if intermediate issuer is missing' do
+      Puppet.expects(:warning).with("The issuer '/CN=Test CA Subauthority' of certificate '/CN=signed' cannot be found locally")
+
+      subject.create_context(config.merge(cacerts: [cert_fixture('ca.pem')]))
     end
 
     it 'raises if root issuer is missing' do

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -147,5 +147,16 @@ describe Puppet::SSL::StateMachine do
 
       expect(File).to_not exist(Puppet[:hostcrl])
     end
+
+    it 'skips CRL download when revocation is disabled' do
+      Puppet[:certificate_revocation] = false
+
+      Puppet::X509::CertProvider.any_instance.expects(:load_crls).never
+      Puppet::Rest::Routes.expects(:get_crls).never
+
+      state.next_state
+
+      expect(File).to_not exist(Puppet[:hostcrl])
+    end
   end
 end


### PR DESCRIPTION
Restore the ability to download a missing CRL when the agent already has a private key and cert, and the ability for the agent to use an incomplete cert chain, and have the server resolve it based on CA certs the server has locally.