### PR TITLE
(PUP-9470) Document which settings the value of server originates

### DIFF
--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -16,7 +16,7 @@ test_name "Priority of server_list setting over server setting" do
           on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
              :acceptable_exit_codes => [0, 2]) do |result|
             unless agent['locale'] == 'ja'
-              assert_match(/Selected master: #{master}:#{master_port}/,
+              assert_match(/Selected server from the `server_list` setting: #{master}:#{master_port}/,
                            result.stdout, "should have selected the working master")
             end
           end

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -289,11 +289,15 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       else
         if Puppet[:server_list] && !Puppet[:server_list].empty?
           server = Puppet[:server_list].first
+          #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+          Puppet.debug _("Selected server from first entry of the `server_list` setting: %{server}:%{port}") % {server: server[0], port: server[1]}
           @client = Puppet::FileBucket::Dipper.new(
             :Server => server[0],
             :Port => server[1]
           )
         else
+          #TRANSLATORS 'server' is the name of a setting and should not be translated
+          Puppet.debug _("Selected server from the `server` setting: %{server}") % {server: Puppet[:server]}
           @client = Puppet::FileBucket::Dipper.new(:Server => Puppet[:server])
         end
       end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -224,7 +224,8 @@ class Puppet::Configurer
           if server.nil?
             raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: Puppet[:server_list] }
           else
-            Puppet.debug "Selected master: #{server[0]}:#{server[1]}"
+            #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+            Puppet.debug _("Selected server from the `server_list` setting: %{server}:%{port}") % {server: server[0], port: server[1]}
             report.master_used = "#{server[0]}:#{server[1]}"
           end
           Puppet.override(:server => server[0], :serverport => server[1]) do
@@ -405,6 +406,10 @@ class Puppet::Configurer
         end
       end
       found
+    end
+    unless selected_server.nil?
+      #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+      Puppet.debug _("Selected functional server from the `server_list` setting: %{server}") % {server: selected_server}
     end
     { :node => node,
       :server => selected_server }

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -196,26 +196,37 @@ class Puppet::Indirector::Request
       end
     end
 
-    # ... Fall back onto the default server.
-     bound_server = Puppet.lookup(:server) do
-      if primary_server = Puppet.settings[:server_list][0]
-        primary_server[0]
-      else
-        Puppet.settings[:server]
+    if default_server
+      self.server = default_server
+    else
+      self.server = Puppet.lookup(:server) do
+        if primary_server = Puppet.settings[:server_list][0]
+          #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+          Puppet.debug _("Selected server from first entry of the `server_list` setting: %{server}") % {server: primary_server[0]}
+          primary_server[0]
+        else
+          #TRANSLATORS 'server' is the name of a setting and should not be translated
+          Puppet.debug _("Selected server from the `server` setting: %{server}") % {server: Puppet.settings[:server]}
+          Puppet.settings[:server]
+        end
       end
     end
 
-    bound_port = Puppet.lookup(:serverport) do
-      if primary_server = Puppet.settings[:server_list][0]
-        primary_server[1]
-      else
-        Puppet.settings[:masterport]
+    if default_port
+      self.port = default_port
+    else
+      self.port = Puppet.lookup(:serverport) do
+        if primary_server = Puppet.settings[:server_list][0]
+          #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+          Puppet.debug _("Selected port from the first entry of the `server_list` setting: %{port}") % {port: primary_server[1]}
+          primary_server[1]
+        else
+          #TRANSLATORS 'masterport' is the name of a setting and should not be translated
+          Puppet.debug _("Selected port from the `masterport` setting: %{port}") % {port: Puppet.settings[:masterport]}
+          Puppet.settings[:masterport]
+        end
       end
     end
-    self.server = default_server || bound_server
-    self.port   = default_port || bound_port
-
-    Puppet.debug "No more servers left, falling back to #{self.server}:#{self.port}" if Puppet.settings[:use_srv_records]
 
     return yield(self)
   end

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -55,15 +55,17 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   def self.server
     setting = server_setting()
     if setting && setting != :server && Puppet.settings.set_by_config?(setting)
+      Puppet.debug _("Selected server from the %{setting} setting: %{server}") % {setting: setting, server: Puppet.settings[setting]}
       Puppet.settings[setting]
     else
       server = Puppet.lookup(:server) do
         if primary_server = Puppet.settings[:server_list][0]
-          Puppet.debug "Dynamically-bound server lookup failed; using first entry"
+          #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+          Puppet.debug _("Dynamically-bound server lookup failed; using first entry from the `server_list` setting: %{server}") % {server: primary_server[0]}
           primary_server[0]
         else
           setting ||= :server
-          Puppet.debug "Dynamically-bound server lookup failed, falling back to #{setting} setting"
+          Puppet.debug _("Dynamically-bound server lookup failed, falling back to %{setting} setting: %{server}") % {setting: setting, server: Puppet.settings[setting]}
           Puppet.settings[setting]
         end
       end
@@ -80,20 +82,27 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     setting = port_setting()
     srv_setting = server_setting()
     if (setting && setting != :masterport && Puppet.settings.set_by_config?(setting)) ||
-       (srv_setting && srv_setting != :server && Puppet.settings.set_by_config?(srv_setting))
+        (srv_setting && srv_setting != :server && Puppet.settings.set_by_config?(srv_setting))
+      Puppet.debug _("Selected port from the %{setting} setting: %{port}") % {setting: setting, port: Puppet.settings[setting].to_i}
       Puppet.settings[setting].to_i
     else
       port = Puppet.lookup(:serverport) do
         if primary_server = Puppet.settings[:server_list][0]
-          Puppet.debug "Dynamically-bound port lookup failed; using first entry"
-
           # Port might not be set, so we want to fallback in that
           # case. We know we don't need to use `setting` here, since
           # the default value of every port setting is `masterport`
-          (primary_server[1] || Puppet.settings[:masterport])
+          if primary_server[1]
+            #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+            Puppet.debug _("Dynamically-bound port lookup failed; using first entry from the `server_list` setting: %{port}") % {port: primary_server[1]}
+            primary_server[1]
+          else
+            #TRANSLATORS 'masterport' is the name of a setting and should not be translated
+            Puppet.debug _("Dynamically-bound port lookup failed; falling back to `masterport` setting: %{port}") % {port: Puppet.settings[:masterport]}
+            Puppet.settings[:masterport]
+          end
         else
           setting ||= :masterport
-          Puppet.debug "Dynamically-bound port lookup failed; falling back to #{setting} setting"
+          Puppet.debug _("Dynamically-bound port lookup failed; falling back to %{setting} setting: %{port}") % {setting: setting, port: Puppet.settings[setting]}
           Puppet.settings[setting]
         end
       end


### PR DESCRIPTION
This commits adds additional debug statements to show exactly where the
server setting is being defined. This hopefully will help elucidate some
of the confusion around the `server` and `server_list` settings.