### PR TITLE
(PUP-9499) Add FileSystem.replace_file

### DIFF
--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -404,4 +404,21 @@ module Puppet::FileSystem
   def self.chmod(mode, path)
     @impl.chmod(mode, path)
   end
+
+  # Replace the contents of a file atomically, creating the file if necessary.
+  # If a `mode` is specified, then it will always be applied to the file. If
+  # a `mode` is not specified and the file exists, its mode will be preserved.
+  # If the file doesn't exist, the mode will be set to a platform-specific
+  # default.
+  #
+  # @param path [String] The path to the file, can also accept [PathName]
+  # @param mode [Integer] Optional mode for the file.
+  #
+  # @raise [Errno::EISDIR]: path is a directory
+  #
+  # @api public
+  #
+  def self.replace_file(path, mode = nil, &block)
+    @impl.replace_file(assert_path(path), mode, &block)
+  end
 end

--- a/lib/puppet/file_system/jruby.rb
+++ b/lib/puppet/file_system/jruby.rb
@@ -10,4 +10,14 @@ class Puppet::FileSystem::JRuby < Puppet::FileSystem::Posix
     # See https://github.com/jruby/jruby/issues/5617
     stat(*paths)
   end
+
+  def replace_file(path, mode = nil, &block)
+    # MRI Ruby rename checks if destination is a directory and raises, while
+    # JRuby removes the directory and replaces the file.
+    if Puppet::FileSystem.directory?(path)
+      raise Errno::EISDIR, _("Is a directory: %{directory}") % { directory: path }
+    end
+
+    super
+  end
 end

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -2,6 +2,8 @@ require 'puppet/file_system/posix'
 require 'puppet/util/windows'
 
 class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
+  FULL_CONTROL = Puppet::Util::Windows::File::FILE_ALL_ACCESS
+  FILE_READ = Puppet::Util::Windows::File::FILE_GENERIC_READ
 
   def open(path, mode, options, &block)
     # PUP-6959 mode is explicitly ignored until it can be implemented
@@ -114,7 +116,77 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
     contents
   end
 
+  def replace_file(path, mode = nil)
+    if Puppet::FileSystem.directory?(path)
+      raise Errno::EISDIR, _("Is a directory: %{directory}") % { directory: path }
+    end
+
+    current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
+    dacl = case mode
+           when 0644
+             dacl = secure_dacl(current_sid)
+             dacl.allow(Puppet::Util::Windows::SID::BuiltinUsers, FILE_READ)
+             dacl
+           when 0640, 0600
+             secure_dacl(current_sid)
+           when nil
+             get_dacl_from_file(path) || secure_dacl(current_sid)
+           else
+             raise ArgumentError, "Only modes 0644, 0640 and 0600 are allowed"
+           end
+
+
+    tempfile = Puppet::FileSystem::Uniquefile.new(Puppet::FileSystem.basename_string(path), Puppet::FileSystem.dir_string(path))
+    begin
+      tempdacl = Puppet::Util::Windows::AccessControlList.new
+      tempdacl.allow(current_sid, FULL_CONTROL)
+      set_dacl(tempfile.path, tempdacl)
+
+      begin
+        yield tempfile
+        tempfile.flush
+        tempfile.fsync
+      ensure
+        tempfile.close
+      end
+
+      set_dacl(tempfile.path, dacl) if dacl
+      File.rename(tempfile.path, Puppet::FileSystem.path_string(path))
+    ensure
+      tempfile.close!
+    end
+  end
+
   private
+
+  def set_dacl(path, dacl)
+    sd = Puppet::Util::Windows::Security.get_security_descriptor(path)
+    new_sd = Puppet::Util::Windows::SecurityDescriptor.new(sd.owner, sd.group, dacl, true)
+    Puppet::Util::Windows::Security.set_security_descriptor(path, new_sd)
+  end
+
+  def secure_dacl(current_sid)
+    dacl = Puppet::Util::Windows::AccessControlList.new
+    [
+     Puppet::Util::Windows::SID::LocalSystem,
+     Puppet::Util::Windows::SID::BuiltinAdministrators,
+     current_sid
+    ].uniq.map do |sid|
+      dacl.allow(sid, FULL_CONTROL)
+    end
+    dacl
+  end
+
+  def get_dacl_from_file(path)
+    sd = Puppet::Util::Windows::Security.get_security_descriptor(Puppet::FileSystem.path_string(path))
+    sd.dacl
+  rescue Puppet::Util::Windows::Error => e
+    if e.code == 2 # ERROR_FILE_NOT_FOUND
+      nil
+    else
+      raise e
+    end
+  end
 
   def raise_if_symlinks_unsupported
     if ! Puppet.features.manages_symlinks?

--- a/lib/puppet/x509/pem_store.rb
+++ b/lib/puppet/x509/pem_store.rb
@@ -30,10 +30,9 @@ module Puppet::X509::PemStore
   # @raise [Errno::EPERM] if the operation cannot be completed
   # @api private
   def save_pem(pem, path)
-    if Puppet::Util::Platform.windows?
-      save_pem_win32(pem, path)
-    else
-      save_pem_posix(pem, path)
+    Puppet::FileSystem.replace_file(path, 0644) do |f|
+      f.set_encoding('UTF-8')
+      f.write(pem.encode('UTF-8'))
     end
   end
 
@@ -48,32 +47,5 @@ module Puppet::X509::PemStore
     true
   rescue Errno::ENOENT
     false
-  end
-
-  private
-
-  def save_pem_posix(pem, path)
-    Puppet::Util.replace_file(path, 0644) do |f|
-      f.set_encoding('UTF-8')
-      f.write(pem.encode('UTF-8'))
-    end
-  end
-
-  # https://docs.microsoft.com/en-us/windows/desktop/debug/system-error-codes--0-499-
-  ACCESS_DENIED = 5
-  SHARING_VIOLATION = 32
-  LOCK_VIOLATION = 33
-
-  def save_pem_win32(pem, path)
-    # Puppet::Util.replace_file should be implemented in Puppet::FileSystem
-    # and raise Errno-based exceptions
-    save_pem_posix(pem, path)
-  rescue Puppet::Util::Windows::Error => e
-    case e.code
-    when ACCESS_DENIED, SHARING_VIOLATION, LOCK_VIOLATION
-      raise Errno::EACCES.new(path, e)
-    else
-      raise SystemCallError.new(e.message, e)
-    end
   end
 end

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -7,6 +7,12 @@ describe Puppet::FileSystem::Uniquefile do
     end
   end
 
+  it "ensures the file has permissions 0600", unless: Puppet::Util::Platform.windows? do
+    Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|
+      expect(Puppet::FileSystem.stat(file.path).mode & 07777).to eq(0600)
+    end
+  end
+
   it "provides a writeable file" do
     Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|
       file.write("stuff")

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -1061,6 +1061,22 @@ describe "Puppet::FileSystem" do
             an_object_having_attributes(sid: 'S-1-5-32-545', mask: 0x120089)
           )
         end
+
+        it 'raises Errno::EACCES if access is denied' do
+          Puppet::Util::Windows::Security.stubs(:get_security_descriptor).raises(Puppet::Util::Windows::Error.new('access denied', 5))
+
+          expect {
+            Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+          }.to raise_error(Errno::EACCES, /Access is denied/)
+        end
+
+        it 'raises SystemCallError otherwise' do
+          Puppet::Util::Windows::Security.stubs(:get_security_descriptor).raises(Puppet::Util::Windows::Error.new('arena is trashed', 7))
+
+          expect {
+            Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+          }.to raise_error(SystemCallError, /The storage control blocks were destroyed/)
+        end
       end
     end
   end

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -942,6 +942,39 @@ describe "Puppet::FileSystem" do
           expect(mode & 07777).to eq(0400)
         end
       end
+
+      context 'on windows', if: Puppet::Util::Platform.windows? do
+        it 'does not grant users access by default' do
+          Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+
+          current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
+          sd = Puppet::Util::Windows::Security.get_security_descriptor(dest)
+          expect(sd.dacl).to contain_exactly(
+            an_object_having_attributes(sid: 'S-1-5-18', mask: 0x1f01ff),
+            an_object_having_attributes(sid: 'S-1-5-32-544', mask: 0x1f01ff),
+            an_object_having_attributes(sid: current_sid, mask: 0x1f01ff)
+          )
+        end
+
+        it 'applies the specified mode' do
+          Puppet::FileSystem.replace_file(dest, 0644) { |f| f.write(content) }
+
+          current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
+          sd = Puppet::Util::Windows::Security.get_security_descriptor(dest)
+          expect(sd.dacl).to contain_exactly(
+            an_object_having_attributes(sid: 'S-1-5-18', mask: 0x1f01ff),
+            an_object_having_attributes(sid: 'S-1-5-32-544', mask: 0x1f01ff),
+            an_object_having_attributes(sid: current_sid, mask: 0x1f01ff),
+            an_object_having_attributes(sid: 'S-1-5-32-545', mask: 0x120089)
+          )
+        end
+
+        it 'rejects unsupported modes' do
+          expect {
+            Puppet::FileSystem.replace_file(dest, 0755) { |_| }
+          }.to raise_error(ArgumentError, /Only modes 0644, 0640 and 0600 are allowed/)
+        end
+      end
     end
 
     context "when overwriting" do
@@ -956,7 +989,6 @@ describe "Puppet::FileSystem" do
       end
 
       it 'raises ISDIR if the destination is a directory' do
-        pending("Need windows filesystem impl") if Puppet::Util::Platform.windows?
         dir = tmpdir('file_system')
 
         expect {
@@ -1000,6 +1032,34 @@ describe "Puppet::FileSystem" do
 
           mode = Puppet::FileSystem.stat(dest).mode
           expect(mode & 07777).to eq(0400)
+        end
+      end
+
+      context 'on windows', if: Puppet::Util::Platform.windows? do
+        it 'preserves the existing mode' do
+          old_sd = Puppet::Util::Windows::Security.get_security_descriptor(dest)
+
+          Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+
+          new_sd = Puppet::Util::Windows::Security.get_security_descriptor(dest)
+          expect(old_sd.owner).to eq(new_sd.owner)
+          expect(old_sd.group).to eq(new_sd.group)
+          old_sd.dacl.each do |ace|
+            expect(new_sd.dacl).to include(an_object_having_attributes(sid: ace.sid, mask: ace.mask))
+          end
+        end
+
+        it 'applies the specified mode' do
+          Puppet::FileSystem.replace_file(dest, 0644) { |f| f.write(content) }
+
+          current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
+          sd = Puppet::Util::Windows::Security.get_security_descriptor(dest)
+          expect(sd.dacl).to contain_exactly(
+            an_object_having_attributes(sid: 'S-1-5-18', mask: 0x1f01ff),
+            an_object_having_attributes(sid: 'S-1-5-32-544', mask: 0x1f01ff),
+            an_object_having_attributes(sid: current_sid, mask: 0x1f01ff),
+            an_object_having_attributes(sid: 'S-1-5-32-545', mask: 0x120089)
+          )
         end
       end
     end


### PR DESCRIPTION
Add a `FileSystem.replace_file` method to supersede `Puppet::Util.replace_file`, as the latter only applies the specified mode if it needs to create the file, but not overwrite it.