### PR TITLE
(PUP-9463) Set mode when saving private keys

### DIFF
--- a/lib/puppet/x509/pem_store.rb
+++ b/lib/puppet/x509/pem_store.rb
@@ -29,10 +29,14 @@ module Puppet::X509::PemStore
   # @raise [Errno::EACCES] if permission is denied
   # @raise [Errno::EPERM] if the operation cannot be completed
   # @api private
-  def save_pem(pem, path)
-    Puppet::FileSystem.replace_file(path, 0644) do |f|
+  def save_pem(pem, path, owner: nil, group: nil, mode: 0644)
+    Puppet::FileSystem.replace_file(path, mode) do |f|
       f.set_encoding('UTF-8')
       f.write(pem.encode('UTF-8'))
+    end
+
+    if !Puppet::Util::Platform.windows? && Puppet.features.root? && (owner || group)
+      FileUtils.chown(owner, group, path)
     end
   end
 


### PR DESCRIPTION
Set the mode, and optionally owner & group when saving PEM files, based on the corresponding puppet setting, eg `:hostprivkey`. The private key mode is 0640, the other PEM files are 0644. If the service user & group accounts are available, then also chown/chgrp the files. This is necessary when puppet is running on the puppetserver host, since the jetty process shares the agents private key, and must be readable by that process.

PR https://github.com/puppetlabs/puppet/pull/7426 must be merged first