### PR TITLE
(PUP-8769) Print HTTP request and response

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -131,20 +131,26 @@ module Puppet::Network::HTTP
     # future we may want to refactor these so that they are funneled through
     # that method and do inherit the error handling.
     def request_get(*args, &block)
-      with_connection(@site) do |connection|
-        connection.request_get(*args, &block)
+      with_connection(@site) do |http|
+        resp = http.request_get(*args, &block)
+        Puppet.debug("HTTP GET #{@site}#{args.first.split('?').first} returned #{resp.code} #{resp.message}")
+        resp
       end
     end
 
     def request_head(*args, &block)
-      with_connection(@site) do |connection|
-        connection.request_head(*args, &block)
+      with_connection(@site) do |http|
+        resp = http.request_head(*args, &block)
+        Puppet.debug("HTTP HEAD #{@site}#{args.first.split('?').first} returned #{resp.code} #{resp.message}")
+        resp
       end
     end
 
     def request_post(*args, &block)
-      with_connection(@site) do |connection|
-        connection.request_post(*args, &block)
+      with_connection(@site) do |http|
+        resp = http.request_post(*args, &block)
+        Puppet.debug("HTTP POST #{@site}#{args.first.split('?').first} returned #{resp.code} #{resp.message}")
+        resp
       end
     end
     # end of Net::HTTP#request_* proxies
@@ -299,7 +305,9 @@ module Puppet::Network::HTTP
 
     def execute_request(connection, request)
       start = Time.now
-      connection.request(request)
+      resp = connection.request(request)
+      Puppet.debug("HTTP #{request.method.upcase} #{@site}#{request.path.split('?').first} returned #{resp.code} #{resp.message}")
+      resp
     rescue => exception
       elapsed = (Time.now - start).to_f.round(3)
       uri = [@site.addr, request.path.split('?')[0]].join('/')

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -320,7 +320,6 @@ module Puppet
       end
     end
 
-
     def chunk_file_from_source
       get_from_source do |response|
         case response.code

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -182,6 +182,7 @@ module Puppet::Util::HttpProxy
       end
 
       response = proxy.send(:head, current_uri.path, headers)
+      Puppet.debug("HTTP HEAD request to #{current_uri} returned #{response.code} #{response.message}")
 
       if [301, 302, 307].include?(response.code.to_i)
         # handle the redirection
@@ -195,9 +196,9 @@ module Puppet::Util::HttpProxy
         else
           response = proxy.send(method, current_uri.path, headers)
         end
-      end
 
-      Puppet.debug("HTTP #{method.to_s.upcase} request to #{current_uri} returned #{response.code} #{response.message}")
+        Puppet.debug("HTTP #{method.to_s.upcase} request to #{current_uri} returned #{response.code} #{response.message}")
+      end
 
       return response
     end


### PR DESCRIPTION
Print HTTP request and response info when running with debug:

    Debug: HTTP GET https://puppet.delivery.puppetlabs.net:8140/puppet/v3/file_metadatas/pluginfacts returned 200 OK

Unfortunately there isn't a single place where all connections route through, so
we have to account for the three different cases:

 * Puppet::Network::HTTP::Connection.request_* Used to stream file sources with
   scheme 'puppet'
 * Puppet::Util::HttpProxy.request_with_redirects Used to stream file sources
   with 'http(s)' schemes.
 * Puppet::Network::HTTP::Connection.{get,post,etc} Used in REST termini,
   configurer, etc.