### PR TITLE
(PUP-4651) Enable services before starting them

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -111,14 +111,12 @@ module Puppet
       end
 
       def sync
-        event = super()
-
         if property = @resource.property(:enable)
           val = property.retrieve
           property.sync unless property.safe_insync?(val)
         end
 
-        event
+        super
       end
     end
 


### PR DESCRIPTION
Without this, puppet will try to start services before enabling
them. While this was probably fine for sysvinit-style service
managers, some more complex ones (notably systemd) can misbehave when
this is done.

This swaps the order of syncing the enabled property and starting the
service, so that services are enabled before they are started.