### PR TITLE
(PUP-9566) Add extra_headers setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -306,7 +306,7 @@ module Puppet
         :default  => ! Puppet::Util::Platform.windows?,
         :type     => :boolean,
         :desc     => "Whether Puppet should manage the owner, group, and mode of files it uses internally.
-        
+
           **Note**: For Windows agents, the default is `false` for versions 4.10.13 and greater, versions 5.5.6 and greater, and versions 6.0 and greater.",
     },
     :onetime => {
@@ -1469,6 +1469,12 @@ EOT
     :srv_domain => {
       :default    => lambda { Puppet::Settings.domain_fact },
       :desc       => "The domain which will be queried to find the SRV records of servers to use.",
+    },
+    :http_extra_headers => {
+      :default    => [],
+      :type       => :http_extra_headers,
+      :desc       => "The list of extra headers that will be sent with every HTTP request.
+        The header definition consists of a name and a value separated by a colon."
     },
     :ignoreschedules => {
       :default    => false,

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -2,6 +2,7 @@ require 'net/https'
 require 'puppet/ssl/host'
 require 'puppet/ssl/validator'
 require 'puppet/network/http'
+require 'puppet/util/connection'
 require 'uri'
 require 'date'
 require 'time'
@@ -197,6 +198,7 @@ module Puppet::Network::HTTP
 
         with_connection(current_site) do |connection|
           apply_options_to(current_request, options)
+          Puppet::Util::Connection.add_extra_headers(current_request)
 
           current_response = execute_request(connection, current_request)
 

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -30,6 +30,7 @@ class Puppet::Settings
   require 'puppet/settings/value_translator'
   require 'puppet/settings/environment_conf'
   require 'puppet/settings/server_list_setting'
+  require 'puppet/settings/http_extra_headers_setting'
   require 'puppet/settings/certificate_revocation_setting'
 
   # local reference for convenience
@@ -683,6 +684,7 @@ class Puppet::Settings
       :priority   => PrioritySetting,
       :autosign   => AutosignSetting,
       :server_list => ServerListSetting,
+      :http_extra_headers => HttpExtraHeadersSetting,
       :certificate_revocation => CertificateRevocationSetting
   }
 

--- a/lib/puppet/settings/http_extra_headers_setting.rb
+++ b/lib/puppet/settings/http_extra_headers_setting.rb
@@ -1,0 +1,20 @@
+class Puppet::Settings::HttpExtraHeadersSetting < Puppet::Settings::ArraySetting
+
+  def type
+    :http_extra_headers
+  end
+
+  def munge(value)
+    headers = super
+    headers.map! { |header|
+      case header
+      when String
+        header.split(':')
+      when Array
+        header
+      else
+        raise ArgumentError, _("Expected an Array of String, got a %{klass}") % { klass: value.class }
+      end
+    }
+  end
+end

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -304,7 +304,9 @@ module Puppet
       request.do_request(:fileserver) do |req|
         ssl_context = Puppet.lookup(:ssl_context)
         connection = Puppet::Network::HttpPool.connection(req.server, req.port, ssl_context: ssl_context)
-        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => BINARY_MIME_TYPES}), &block)
+        headers = add_accept_encoding({"Accept" => BINARY_MIME_TYPES})
+        headers = Puppet::Util::Connection.add_extra_headers(headers)
+        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), headers, &block)
       end
     end
 

--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -79,7 +79,7 @@ module Puppet::Util
     # Adds extra headers to a given hash if http_extra_headers option was set.
     # @param [Hash] headers The headers to be modified
     # @return [Hash] the modified headers hash
-    def self.add_extra_headers(headers)
+    def self.add_extra_headers(headers={})
       Puppet[:http_extra_headers].each do |name, value|
         if headers.key?(name)
           Puppet.warning(_('Ignoring extra header "%{name}" as it was previously set.') %

--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -76,19 +76,19 @@ module Puppet::Util
       end
     end
 
-    # Adds extra headers to a given request if http_extra_headers option was set.
-    # @param [Hash] request The request to be modified
-    # @return [Hash] the modified request
-    def self.add_extra_headers(request)
-      Puppet[:http_extra_headers].each do |header, value|
-        if request.key?(header)
-          Puppet.warning(_('Ignoring extra header "%{header}" as it was previously set.') %
-                         {header: header})
+    # Adds extra headers to a given hash if http_extra_headers option was set.
+    # @param [Hash] headers The headers to be modified
+    # @return [Hash] the modified headers hash
+    def self.add_extra_headers(headers)
+      Puppet[:http_extra_headers].each do |name, value|
+        if headers.key?(name)
+          Puppet.warning(_('Ignoring extra header "%{name}" as it was previously set.') %
+                         {name: name})
         else
-          request[header] = value
+          headers[name] = value
         end
       end
-      request
+      headers
     end
   end
 end

--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -75,5 +75,20 @@ module Puppet::Util
         port.to_i
       end
     end
+
+    # Adds extra headers to a given request if http_extra_headers option was set.
+    # @param [Hash] request The request to be modified
+    # @return [Hash] the modified request
+    def self.add_extra_headers(request)
+      Puppet[:http_extra_headers].each do |header, value|
+        if request.key?(header)
+          Puppet.warning(_('Ignoring extra header "%{header}" as it was previously set.') %
+                         {header: header})
+        else
+          request[header] = value
+        end
+      end
+      request
+    end
   end
 end

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'openssl'
 require 'puppet/network/http'
+require 'puppet/util/connection'
 
 module Puppet::Util::HttpProxy
   def self.proxy(uri)
@@ -180,6 +181,7 @@ module Puppet::Util::HttpProxy
       if Puppet.features.zlib?
         headers.merge!({"Accept-Encoding" => Puppet::Network::HTTP::Compression::ACCEPT_ENCODING})
       end
+      Puppet::Util::Connection.add_extra_headers(headers)
 
       response = proxy.send(:head, current_uri.path, headers)
       Puppet.debug("HTTP HEAD request to #{current_uri} returned #{response.code} #{response.message}")

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -298,4 +298,25 @@ describe Puppet::Network::HTTP::Connection do
 
     subject.get('/path')
   end
+
+  it "sets extra headers specified in http_extra_headers" do
+    Puppet[:http_extra_headers] = ["foo:bar"]
+
+    Net::HTTP.any_instance.expects(:request).with do |request|
+      expect(request['foo']).to eq("bar")
+    end.returns(httpok)
+
+    subject.get('/path')
+  end
+
+  it "doesn't change headers already specified" do
+    puppet_ua = "Puppet/#{Puppet.version} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})"
+    Puppet[:http_extra_headers] = ["User-Agent:foo"]
+
+    Net::HTTP.any_instance.expects(:request).with do |request|
+      expect(request['User-Agent']).to eq(puppet_ua)
+    end.returns(httpok)
+
+    subject.get('/path')
+  end
 end

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -232,6 +232,33 @@ describe Puppet::Util::HttpProxy do
       subject.request_with_redirects(dest, :get, 0)
     end
 
+    it 'add extra headers specified in http_extra_headers' do
+      Puppet[:http_extra_headers] = ["foo:bar", "baz:qux"]
+
+      Net::HTTP.any_instance.stubs(:head).returns(http_ok)
+      Net::HTTP.any_instance.expects(:get).with do |_, headers|
+        expect(headers)
+          .to include({'foo' => 'bar',
+                     'baz' => 'qux'})
+      end.returns(http_ok)
+
+      subject.request_with_redirects(dest, :get, 0)
+    end
+
+    it "doesn't change headers already specified" do
+      Puppet[:http_extra_headers] = ["User-Agent:foo"]
+
+      Net::HTTP.any_instance.stubs(:head).returns(http_ok)
+      Net::HTTP.any_instance.expects(:get).with do |_, headers|
+        expect(headers)
+          .to include({'Accept' => '*/*',
+                     'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'User-Agent' => /Puppet/})
+      end.returns(http_ok)
+
+      subject.request_with_redirects(dest, :get, 0)
+    end
+
     it 'can return a compressed response body' do
       Net::HTTP.any_instance.stubs(:head).returns(http_ok)
 


### PR DESCRIPTION
This new setting allows to pass a list of headers in every HTTP request when running `puppet agent`. These headers can be used, for example, to redirect the traffic to specific Puppet Servers in a load balancer.

An example of how to use it would be the following one:
```
puppet agent -t --extra_headers foo:bar,baz:qux
```