### PR TITLE
(PUP-9556) Add puppet ssl bootstrap action 

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -166,10 +166,10 @@ class Puppet::SSL::StateMachine
       @cert_provider.delete_request(Puppet[:certname])
       Done.new(@machine, next_ctx)
     rescue Puppet::SSL::SSLError => e
-      Puppet.log_exception(e, _("Failed to verify downloaded client certificate"))
+      Puppet.log_exception(e)
       Wait.new(@machine, @ssl_context)
     rescue OpenSSL::X509::CertificateError => e
-      Puppet.log_exception(e, _("Failed to parse downloaded client certificate"))
+      Puppet.log_exception(e, _("Failed to parse certificate: %{message}") % {message: e.message})
       Wait.new(@machine, @ssl_context)
     rescue Puppet::Rest::ResponseError => e
       if e.response.code.to_i == 404

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -358,6 +358,20 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
         File.open(device_cert_file, 'w') { |f| f.write('device.example.com') }
         expects_command_to_pass(%r{Removed certificate #{device_cert_file}})
      end
+    end
   end
+
+  context 'when bootstrapping' do
+    before do
+      ssl.command_line.args << 'bootstrap'
+    end
+
+    it 'returns an SSLContext with the loaded CA certs, CRLs, private key and client cert' do
+      Puppet::SSL::StateMachine.any_instance.expects(:ensure_client_certificate).returns(
+        stub('ssl_context')
+      )
+
+      expects_command_to_pass
+    end
   end
 end


### PR DESCRIPTION
Run the SSL state machine to ensure we have a CA bundle, CRL bundle (if
revocation is enabled), and a private key and signed client cert. This makes it
possible to bootstrap an agent without having to apply a catalog. The bootstrap
command behaves like the agent command, waiting every `waitforcert` seconds if
the cert is not signed. The wait interval can be changed via the setting of the
same name, or disabled by setting it to 0:

    puppet ssl bootstrap --waitforcert 0

In order to see any useful information, set the log level to :info. But don't
lower the log level from :debug, if that's what the user requested.