### PR TITLE
(PUP-9554) Add ability to create Regexp with boolean to control escape

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1684,10 +1684,11 @@ class PRegexpType < PScalarType
     @new_function ||= Puppet::Functions.create_loaded_function(:new_float, type.loader) do
       dispatch :from_string do
         param 'String', :pattern
+        optional_param 'Boolean', :escape
       end
 
-      def from_string(pattern)
-        Regexp.new(pattern)
+      def from_string(pattern, escape = false)
+        Regexp.new(escape ? Regexp.escape(pattern) : pattern)
       end
     end
   end

--- a/spec/unit/pops/types/types_spec.rb
+++ b/spec/unit/pops/types/types_spec.rb
@@ -219,6 +219,33 @@ describe 'Puppet Type System' do
     end
   end
 
+  context 'Regexp type' do
+    it 'parameterized type is assignable to base type' do
+      code = <<-CODE
+        notice(Regexp[a] < Regexp)
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true'])
+    end
+
+    it 'new function creates a new regexp' do
+      code = <<-CODE
+        $r = Regexp('abc')
+        notice('abc' =~ $r)
+        notice(type($r) =~ Type[Regexp])
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true', 'true'])
+    end
+
+    it 'special characters are escaped with second parameter to Regexp.new set to true' do
+      code = <<-CODE
+        $r = Regexp('.[]', true)
+        notice('.[]' =~ $r)
+        notice(String($r) == "\\.\\[\\]")
+      CODE
+      expect(eval_and_collect_notices(code)).to eq(['true', 'true'])
+    end
+  end
+
   context 'Iterable type' do
     it 'can be parameterized with element type' do
       code = <<-CODE


### PR DESCRIPTION
Before this it was not possible to conveniently create a regular
expression with all regexp special characters escaped.

With this commit, an optional boolean flag is added to `Regexp.new` such
that if set to true, the created regexp will have all special characters
in the input escaped.