### PR TITLE
(PUP-2606) Add EC private key support

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -147,8 +147,13 @@ HELP
   def submit_request(ssl_context)
     key = @cert_provider.load_private_key(Puppet[:certname])
     unless key
-      Puppet.info _("Creating a new SSL key for %{name}") % { name: Puppet[:certname] }
-      key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+      if Puppet[:key_type] == 'ec'
+        Puppet.info _("Creating a new EC SSL key for %{name} using curve %{curve}") % { name: Puppet[:certname], curve: Puppet[:named_curve] }
+        key = OpenSSL::PKey::EC.generate(Puppet[:named_curve])
+      else
+        Puppet.info _("Creating a new SSL key for %{name}") % { name: Puppet[:certname] }
+        key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+      end
       @cert_provider.save_private_key(Puppet[:certname], key)
     end
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -961,6 +961,19 @@ EOT
           certificate revocation checking and does not attempt to download the CRL.
         EOT
     },
+    :key_type => {
+      :default => 'rsa',
+      :type    => :enum,
+      :values  => %w[rsa ec],
+      :desc    => "The type of private key. Valid values are `rsa` and `ec`. Default is `rsa`."
+    },
+    :named_curve => {
+      :default => 'prime256v1',
+      :type    => :string,
+      :desc    => "The short name for the EC curve used to generate the EC private key. Valid
+                   values must be one of the curves in `OpenSSL::PKey::EC.builtin_curves`.
+                   Default is `prime256v1`."
+    },
     :digest_algorithm => {
         :default  => lambda { default_digest_algorithm },
         :type     => :enum,

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -51,7 +51,7 @@ class Puppet::SSL::SSLProvider
   #
   # @param cacerts [Array<OpenSSL::X509::Certificate>] Array of trusted CA certs
   # @param crls [Array<OpenSSL::X509::CRL>] Array of CRLs
-  # @param private_key [OpenSSL::PKey::RSA] client's private key
+  # @param private_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC] client's private key
   # @param client_cert [OpenSSL::X509::Certificate] client's cert whose public
   #   key matches the `private_key`
   # @param revocation [:chain, :leaf, false] revocation mode
@@ -70,7 +70,7 @@ class Puppet::SSL::SSLProvider
     store = create_x509_store(cacerts, crls, revocation)
     client_chain = verify_cert_with_store(store, client_cert)
 
-    unless private_key.is_a?(OpenSSL::PKey::RSA)
+    if !private_key.is_a?(OpenSSL::PKey::RSA) && !private_key.is_a?(OpenSSL::PKey::EC)
       raise Puppet::SSL::SSLError, _("Unsupported key '%{type}'") % { type: private_key.class.name }
     end
 
@@ -116,7 +116,7 @@ class Puppet::SSL::SSLProvider
   # of the private key, and that it hasn't been tampered with since.
   #
   # @param csr [OpenSSL::X509::Request] certificate signing request
-  # @param public_key [OpenSSL::PKey::RSA] public key
+  # @param public_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC] public key
   # @raise [Puppet::SSL:SSLError] The private_key for the given `public_key` was
   #   not used to sign the CSR.
   # @api private

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -110,8 +110,13 @@ class Puppet::SSL::StateMachine
           return Done.new(@machine, next_ctx)
         end
       else
-        Puppet.info _("Creating a new SSL key for %{name}") % { name: Puppet[:certname] }
-        key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+        if Puppet[:key_type] == 'ec'
+          Puppet.info _("Creating a new EC SSL key for %{name} using curve %{curve}") % { name: Puppet[:certname], curve: Puppet[:named_curve] }
+          key = OpenSSL::PKey::EC.generate(Puppet[:named_curve])
+        else
+          Puppet.info _("Creating a new RSA SSL key for %{name}") % { name: Puppet[:certname] }
+          key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+        end
         @cert_provider.save_private_key(Puppet[:certname], key)
       end
 

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -99,6 +99,39 @@ unless OpenSSL::X509::Name.instance_methods.include?(:to_utf8)
   end
 end
 
+if RUBY_VERSION =~ /^2\.3/
+  module OpenSSL::PKey
+    alias __original_read read
+    def read(*args)
+      __original_read(*args)
+    rescue ArgumentError => e
+      # ruby <= 2.3 raises ArgumentError if it can't decrypt
+      # passphrase protected private keys, fixed in 2.4.0
+      # see https://bugs.ruby-lang.org/issues/11774
+      raise OpenSSL::PKey::PKeyError, e.message
+    end
+    module_function :read
+    module_function :__original_read
+  end
+end
+
+unless OpenSSL::PKey::EC.instance_methods.include?(:private?)
+  class OpenSSL::PKey::EC
+    # Added in ruby 2.4.0 in https://github.com/ruby/ruby/commit/7c971e61f04
+    alias :private? :private_key?
+  end
+end
+
+unless OpenSSL::PKey::EC.singleton_methods.include?(:generate)
+  class OpenSSL::PKey::EC
+    # Added in ruby 2.4.0 in https://github.com/ruby/ruby/commit/85500b66342
+    def self.generate(string)
+      ec = OpenSSL::PKey::EC.new(string)
+      ec.generate_key
+    end
+  end
+end
+
 # The Enumerable#uniq method was added in Ruby 2.4.0 (https://bugs.ruby-lang.org/issues/11090)
 # This is a backport to earlier Ruby versions.
 #

--- a/spec/fixtures/ssl/127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/127.0.0.1-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:bb:e1:47:40:df:d0:06:c2:ef:5b:0b:41:41:01:
-    f8:a3:68:fe:18:82:21:5b:97:b5:7c:25:f2:31:b9:
-    50:09:a8:56:71:4c:81:e5:fe:e0:2b:f3:8d:38:e8:
-    fd:15:c2:a3:5a:db:56:5d:29:49:4d:75:e5:ae:69:
-    a7:a3:ac:19:c6:23:cb:1a:23:57:15:aa:ca:e1:e1:
-    78:79:af:49:15:bf:7d:9a:42:16:bc:b1:18:61:68:
-    d8:e1:34:57:4e:73:a0:90:3e:1f:8a:56:fd:0c:eb:
-    f0:fb:03:fd:ec:1b:ff:15:1f:d7:3e:5c:73:09:15:
-    48:83:e5:ff:4e:b3:ea:3a:a9
+    00:98:34:bb:6c:44:52:00:23:29:ae:bb:7c:c9:91:
+    ec:6b:1c:83:b1:db:6c:b6:1b:12:fb:e3:f4:e4:20:
+    27:6c:c7:50:f9:ac:ef:f8:7a:de:00:4a:01:cb:ba:
+    9b:be:35:3c:e5:33:ef:32:79:61:1c:a6:70:23:19:
+    16:19:ae:33:e5:96:0a:70:3d:81:2f:b3:59:64:89:
+    45:ef:86:97:4d:00:9b:1d:68:9e:8d:5e:75:fb:69:
+    c0:1b:b2:06:1d:97:1a:27:30:38:3e:4f:11:04:70:
+    70:98:c1:6a:fc:93:a5:17:0f:fb:fe:42:31:af:f3:
+    6a:bc:51:dc:33:86:be:5f:c9
 publicExponent: 65537 (0x10001)
 privateExponent:
-    22:7d:7d:b6:24:20:2d:4d:95:e1:31:d4:bd:d9:5d:
-    ca:a9:d8:93:a9:37:f4:77:8a:42:8b:38:c5:f6:0e:
-    02:67:db:ce:9a:cb:f1:eb:f3:3d:3e:4d:bb:97:d1:
-    f6:2f:b0:0b:5a:de:a4:e5:92:66:5c:f1:58:2e:5f:
-    2f:05:c6:09:30:2e:77:0c:07:64:ea:9e:c2:f4:72:
-    b0:f9:31:36:af:45:7e:a5:44:bf:b8:f9:1c:0d:fc:
-    9f:8e:41:08:c4:8e:d0:8d:4e:de:2d:f3:42:c3:d0:
-    6e:ca:70:21:bb:f5:c4:e2:67:13:21:10:5a:0b:68:
-    7b:5d:9f:ea:08:f0:12:3d
+    6a:b3:cd:10:c1:74:9b:14:0b:8c:ab:73:77:fc:0c:
+    b9:aa:6b:c8:ac:03:32:47:18:af:ed:c7:28:86:42:
+    1d:48:3d:c4:4b:30:90:09:d2:c8:71:19:81:31:79:
+    2d:87:35:01:99:be:fe:ab:89:21:04:ad:68:6d:95:
+    c8:bb:0f:35:b7:84:83:ce:32:fe:9e:98:b5:71:a0:
+    67:30:e5:17:1d:d9:c3:48:9b:a7:c1:f4:17:f8:4a:
+    bb:88:1b:94:2c:cc:5d:90:92:f8:6e:93:36:eb:42:
+    63:d0:c9:6f:04:e5:c1:2f:dc:a8:1f:19:ed:e5:b0:
+    45:23:ab:82:d4:0b:69:81
 prime1:
-    00:e3:d5:5c:8e:b9:31:28:ce:d3:c0:78:0d:b2:12:
-    0e:14:95:a4:b8:48:20:82:2f:27:37:f5:b8:6e:b4:
-    ec:57:7f:92:c4:23:15:5b:d1:b6:35:20:60:49:36:
-    fb:63:8d:df:34:45:af:07:80:a7:9b:05:2f:43:5e:
-    af:9a:bc:9b:43
+    00:c8:90:0e:0f:a2:ab:82:a7:e5:3a:69:dd:3a:e7:
+    a2:80:ef:b2:12:c5:fb:4b:a2:cf:b6:9a:41:8c:d8:
+    b5:76:05:c5:d3:c6:0e:1d:c6:1e:14:9f:14:21:53:
+    15:08:42:70:12:12:36:1e:0d:be:b8:5d:ce:46:66:
+    0b:fc:1a:dd:95
 prime2:
-    00:d3:1b:70:e1:ff:2d:af:09:a9:3e:65:04:58:3d:
-    65:11:bd:98:7e:39:26:ab:33:98:37:cf:46:13:2e:
-    6f:dd:48:0e:0c:bb:ee:3a:a7:91:60:81:6f:9f:54:
-    65:2c:cd:8a:6f:27:a5:6a:72:f1:3d:44:9c:b3:eb:
-    b8:56:6f:b5:a3
+    00:c2:46:ec:9d:fc:0b:1c:e7:c4:b3:2a:eb:ff:64:
+    8e:2d:32:f7:f5:9c:bf:60:46:ca:46:db:91:33:fb:
+    47:8a:c4:2c:c7:4a:b0:34:cb:34:1b:93:bd:aa:3a:
+    3a:a4:b8:f6:4e:4b:b7:23:03:bb:07:43:6e:39:31:
+    61:ce:0c:24:65
 exponent1:
-    00:b4:ef:ca:4c:f2:98:2e:ef:6a:cd:8c:ca:5b:a3:
-    e9:18:c1:eb:0a:0b:05:fe:3d:92:68:e7:b5:2b:fe:
-    75:3f:db:e9:e3:e8:74:da:f1:c6:41:94:cf:c2:f5:
-    6e:5a:16:de:af:75:b3:d6:42:7f:59:26:99:ed:67:
-    f2:0f:f2:3f:5f
+    14:08:5f:7f:2c:4e:59:44:8f:de:df:c8:1b:24:1b:
+    d5:29:1b:ee:48:1c:2b:97:dd:8b:6d:a8:f2:7a:8a:
+    d5:79:0a:23:76:fa:dd:fa:75:f2:b5:58:fb:63:23:
+    0c:aa:26:2b:87:ea:23:e2:57:94:6e:ba:35:c9:e7:
+    94:8c:d2:69
 exponent2:
-    10:8b:45:fd:70:12:14:75:9d:5d:d6:6c:d0:bd:7e:
-    fe:34:ed:8e:76:cc:20:fe:9a:1f:45:8f:28:51:ab:
-    52:9c:22:fd:bc:7c:9e:fc:22:d8:7d:4c:52:20:3b:
-    0d:97:ce:11:87:f9:de:ad:c3:5a:19:d6:6e:03:3b:
-    1f:0b:02:21
+    50:c3:c5:68:64:38:86:7a:bf:a6:30:68:cd:d2:92:
+    dc:ad:7c:b1:c9:c9:31:90:1c:55:5a:c0:41:98:ec:
+    03:ff:4c:12:49:b5:79:2d:24:eb:75:fe:fa:3e:9c:
+    d4:8f:e4:2d:66:82:aa:f6:c9:10:da:f2:7e:aa:4d:
+    db:a7:e6:95
 coefficient:
-    00:a9:b1:a0:81:72:a1:e9:41:51:3e:32:5a:33:aa:
-    20:b1:23:bf:ff:62:53:a7:6d:e2:c1:d5:18:11:57:
-    b6:9e:fd:b2:c5:d8:d8:50:d1:5e:5c:22:ba:14:e3:
-    36:92:34:4c:29:19:dc:a3:60:a8:01:81:00:5b:c1:
-    3b:4e:0f:26:23
+    45:11:a8:a2:ab:92:a6:f2:42:b3:7f:09:8d:ae:45:
+    25:e5:c6:24:9e:80:ea:58:b5:d7:44:7f:84:47:6b:
+    4d:da:f0:f3:4c:60:5b:9d:18:64:b2:89:2c:1e:b2:
+    60:35:58:ef:90:6f:b5:12:d7:0e:d7:7b:4a:62:ac:
+    38:b4:12:80
 -----BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQC74UdA39AGwu9bC0FBAfijaP4YgiFbl7V8JfIxuVAJqFZxTIHl
-/uAr84046P0VwqNa21ZdKUlNdeWuaaejrBnGI8saI1cVqsrh4Xh5r0kVv32aQha8
-sRhhaNjhNFdOc6CQPh+KVv0M6/D7A/3sG/8VH9c+XHMJFUiD5f9Os+o6qQIDAQAB
-AoGAIn19tiQgLU2V4THUvdldyqnYk6k39HeKQos4xfYOAmfbzprL8evzPT5Nu5fR
-9i+wC1repOWSZlzxWC5fLwXGCTAudwwHZOqewvRysPkxNq9FfqVEv7j5HA38n45B
-CMSO0I1O3i3zQsPQbspwIbv1xOJnEyEQWgtoe12f6gjwEj0CQQDj1VyOuTEoztPA
-eA2yEg4UlaS4SCCCLyc39bhutOxXf5LEIxVb0bY1IGBJNvtjjd80Ra8HgKebBS9D
-Xq+avJtDAkEA0xtw4f8trwmpPmUEWD1lEb2YfjkmqzOYN89GEy5v3UgODLvuOqeR
-YIFvn1RlLM2KbyelanLxPUScs+u4Vm+1owJBALTvykzymC7vas2Myluj6RjB6woL
-Bf49kmjntSv+dT/b6ePodNrxxkGUz8L1bloW3q91s9ZCf1kmme1n8g/yP18CQBCL
-Rf1wEhR1nV3WbNC9fv407Y52zCD+mh9FjyhRq1KcIv28fJ78Ith9TFIgOw2XzhGH
-+d6tw1oZ1m4DOx8LAiECQQCpsaCBcqHpQVE+MlozqiCxI7//YlOnbeLB1RgRV7ae
-/bLF2NhQ0V5cIroU4zaSNEwpGdyjYKgBgQBbwTtODyYj
+MIICWwIBAAKBgQCYNLtsRFIAIymuu3zJkexrHIOx22y2GxL74/TkICdsx1D5rO/4
+et4ASgHLupu+NTzlM+8yeWEcpnAjGRYZrjPllgpwPYEvs1lkiUXvhpdNAJsdaJ6N
+XnX7acAbsgYdlxonMDg+TxEEcHCYwWr8k6UXD/v+QjGv82q8Udwzhr5fyQIDAQAB
+AoGAarPNEMF0mxQLjKtzd/wMuapryKwDMkcYr+3HKIZCHUg9xEswkAnSyHEZgTF5
+LYc1AZm+/quJIQStaG2VyLsPNbeEg84y/p6YtXGgZzDlFx3Zw0ibp8H0F/hKu4gb
+lCzMXZCS+G6TNutCY9DJbwTlwS/cqB8Z7eWwRSOrgtQLaYECQQDIkA4PoquCp+U6
+ad0656KA77ISxftLos+2mkGM2LV2BcXTxg4dxh4UnxQhUxUIQnASEjYeDb64Xc5G
+Zgv8Gt2VAkEAwkbsnfwLHOfEsyrr/2SOLTL39Zy/YEbKRtuRM/tHisQsx0qwNMs0
+G5O9qjo6pLj2Tku3IwO7B0NuOTFhzgwkZQJAFAhffyxOWUSP3t/IGyQb1Skb7kgc
+K5fdi22o8nqK1XkKI3b63fp18rVY+2MjDKomK4fqI+JXlG66NcnnlIzSaQJAUMPF
+aGQ4hnq/pjBozdKS3K18scnJMZAcVVrAQZjsA/9MEkm1eS0k63X++j6c1I/kLWaC
+qvbJENryfqpN26fmlQJARRGooquSpvJCs38Jja5FJeXGJJ6A6li110R/hEdrTdrw
+80xgW50YZLKJLB6yYDVY75BvtRLXDtd7SmKsOLQSgA==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/127.0.0.1.pem
+++ b/spec/fixtures/ssl/127.0.0.1.pem
@@ -6,43 +6,43 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:bb:e1:47:40:df:d0:06:c2:ef:5b:0b:41:41:01:
-                    f8:a3:68:fe:18:82:21:5b:97:b5:7c:25:f2:31:b9:
-                    50:09:a8:56:71:4c:81:e5:fe:e0:2b:f3:8d:38:e8:
-                    fd:15:c2:a3:5a:db:56:5d:29:49:4d:75:e5:ae:69:
-                    a7:a3:ac:19:c6:23:cb:1a:23:57:15:aa:ca:e1:e1:
-                    78:79:af:49:15:bf:7d:9a:42:16:bc:b1:18:61:68:
-                    d8:e1:34:57:4e:73:a0:90:3e:1f:8a:56:fd:0c:eb:
-                    f0:fb:03:fd:ec:1b:ff:15:1f:d7:3e:5c:73:09:15:
-                    48:83:e5:ff:4e:b3:ea:3a:a9
+                    00:98:34:bb:6c:44:52:00:23:29:ae:bb:7c:c9:91:
+                    ec:6b:1c:83:b1:db:6c:b6:1b:12:fb:e3:f4:e4:20:
+                    27:6c:c7:50:f9:ac:ef:f8:7a:de:00:4a:01:cb:ba:
+                    9b:be:35:3c:e5:33:ef:32:79:61:1c:a6:70:23:19:
+                    16:19:ae:33:e5:96:0a:70:3d:81:2f:b3:59:64:89:
+                    45:ef:86:97:4d:00:9b:1d:68:9e:8d:5e:75:fb:69:
+                    c0:1b:b2:06:1d:97:1a:27:30:38:3e:4f:11:04:70:
+                    70:98:c1:6a:fc:93:a5:17:0f:fb:fe:42:31:af:f3:
+                    6a:bc:51:dc:33:86:be:5f:c9
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         ba:0d:5c:ae:e4:7b:7f:ec:39:f5:e6:29:ab:6a:bf:65:26:87:
-         04:50:ca:93:f1:ee:7a:65:3a:6b:7c:b2:d7:96:f2:29:19:8a:
-         0d:ed:e3:3d:ed:d1:5d:72:c2:a6:60:bc:13:c6:c0:92:a8:a2:
-         23:3b:35:6b:58:a5:c4:7c:74:88:1a:00:bd:47:0f:c8:4b:4d:
-         f6:2c:16:61:1c:9a:b9:b6:be:28:0e:41:17:df:bc:f3:21:a8:
-         2c:a3:e2:4b:23:e0:2e:06:f3:b6:0e:90:3d:87:8c:da:a8:66:
-         14:7e:03:e2:69:85:0d:a7:a9:d9:b6:25:92:fd:13:e1:e9:71:
-         f9:da
+         a0:40:1e:cc:ed:75:47:4b:3a:a6:05:fb:a6:29:22:cd:f9:28:
+         4c:f3:3d:0c:e2:df:6c:91:68:52:1b:df:d4:9d:88:36:e9:db:
+         ca:94:a4:14:d9:2a:bb:b6:f7:a9:4a:70:f7:db:d7:86:e4:82:
+         e4:dd:08:77:03:7b:fb:99:24:fd:15:44:b5:05:dd:b3:ff:dc:
+         e0:b4:e8:92:7f:58:b3:2f:48:ba:80:c9:a6:1c:c8:8e:99:e1:
+         52:f4:52:90:ad:44:8b:89:39:a1:51:67:15:99:a2:f5:76:75:
+         b4:12:f5:5e:99:e7:8b:7b:b1:9d:04:63:31:33:36:0d:a8:67:
+         00:42
 -----BEGIN CERTIFICATE-----
 MIIBvzCCASigAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owFDESMBAGA1UEAwwJ
-MTI3LjAuMC4xMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC74UdA39AGwu9b
-C0FBAfijaP4YgiFbl7V8JfIxuVAJqFZxTIHl/uAr84046P0VwqNa21ZdKUlNdeWu
-aaejrBnGI8saI1cVqsrh4Xh5r0kVv32aQha8sRhhaNjhNFdOc6CQPh+KVv0M6/D7
-A/3sG/8VH9c+XHMJFUiD5f9Os+o6qQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcu
-MC4wLjGCCTEyNy4wLjAuMjANBgkqhkiG9w0BAQsFAAOBgQC6DVyu5Ht/7Dn15imr
-ar9lJocEUMqT8e56ZTprfLLXlvIpGYoN7eM97dFdcsKmYLwTxsCSqKIjOzVrWKXE
-fHSIGgC9Rw/IS032LBZhHJq5tr4oDkEX37zzIagso+JLI+AuBvO2DpA9h4zaqGYU
-fgPiaYUNp6nZtiWS/RPh6XH52g==
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowFDESMBAGA1UEAwwJ
+MTI3LjAuMC4xMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCYNLtsRFIAIymu
+u3zJkexrHIOx22y2GxL74/TkICdsx1D5rO/4et4ASgHLupu+NTzlM+8yeWEcpnAj
+GRYZrjPllgpwPYEvs1lkiUXvhpdNAJsdaJ6NXnX7acAbsgYdlxonMDg+TxEEcHCY
+wWr8k6UXD/v+QjGv82q8Udwzhr5fyQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcu
+MC4wLjGCCTEyNy4wLjAuMjANBgkqhkiG9w0BAQsFAAOBgQCgQB7M7XVHSzqmBfum
+KSLN+ShM8z0M4t9skWhSG9/UnYg26dvKlKQU2Sq7tvepSnD329eG5ILk3Qh3A3v7
+mST9FUS1Bd2z/9zgtOiSf1izL0i6gMmmHMiOmeFS9FKQrUSLiTmhUWcVmaL1dnW0
+EvVemeeLe7GdBGMxMzYNqGcAQg==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-basic-constraints.pem
@@ -1,26 +1,26 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 7 (0x7)
+        Serial Number: 8 (0x8)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:c8:15:08:03:7c:69:d7:4d:05:f9:81:0c:f3:f1:
-                    77:ed:4a:e8:7c:f7:ac:77:bb:5c:8b:5c:96:31:01:
-                    bf:aa:b4:16:e6:d6:b3:22:15:4b:5c:8e:3c:99:af:
-                    7b:7d:1a:e8:0d:3d:40:14:37:00:f5:37:3a:00:06:
-                    e1:0b:0e:37:b8:76:62:a3:9a:5e:47:d5:d4:2a:4e:
-                    13:50:a9:0c:7a:b1:69:e7:79:9a:30:51:66:0b:e4:
-                    b7:b9:7d:e4:5b:61:19:0b:8f:79:a9:43:b0:a1:ff:
-                    c7:a6:7a:a6:fa:2e:88:28:84:66:68:bf:bf:b6:64:
-                    9e:1e:b7:e7:fe:35:63:65:51
+                    00:d0:b3:d8:3f:2b:c0:45:8c:f0:3d:96:58:2c:5e:
+                    0e:6a:46:81:ab:10:2f:22:9c:7c:69:f0:61:b7:2d:
+                    f2:2f:46:97:d5:d9:1b:08:c8:c9:e8:18:a5:d8:89:
+                    27:a7:80:cb:0a:8e:ee:26:32:89:70:37:2b:bf:6f:
+                    7e:ee:12:7d:49:c7:0c:19:46:7c:65:99:dc:1f:1a:
+                    31:af:ab:87:01:b3:68:8a:5b:51:a7:78:ca:cc:1d:
+                    7c:26:b4:27:5f:67:75:99:7e:9f:16:ed:88:b3:8f:
+                    77:0f:b3:e8:b3:97:bc:70:8b:ec:62:b9:a2:47:4b:
+                    ef:dc:af:d4:9f:3d:17:cd:03
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +28,32 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
 
     Signature Algorithm: sha256WithRSAEncryption
-         75:cc:05:b2:d8:43:aa:99:84:5d:64:0b:ac:cc:af:07:a7:0d:
-         90:79:9f:c9:dc:09:e6:59:d8:d1:c2:0e:2a:96:ab:80:38:f8:
-         1a:1d:d1:e2:0c:c0:fa:df:c0:cf:0c:78:30:ac:d0:b7:e9:88:
-         31:d6:05:29:41:8f:2e:32:f2:98:74:fc:19:4b:d8:c5:36:c3:
-         7a:a7:ae:8c:65:b0:4b:f0:fb:f8:86:ad:08:53:43:8f:f5:52:
-         a0:9b:cf:e8:2d:60:57:4f:f3:ab:63:3c:f2:23:da:d0:5a:de:
-         2f:64:25:c3:4f:ff:51:c9:51:22:38:b4:e6:a6:87:50:a8:ea:
-         9f:f3
+         12:60:01:ec:ea:6c:bc:d6:4e:e7:40:b6:9f:cd:8c:6e:6d:42:
+         4f:d8:db:42:f8:8d:04:09:48:ad:22:50:e5:de:7f:ec:d5:19:
+         21:3f:6b:d0:85:d4:75:20:18:a7:cc:a0:7c:b2:08:6f:d6:7b:
+         a7:63:22:25:1b:f8:20:66:ea:b7:40:09:25:05:7b:61:6d:a1:
+         4f:af:72:51:c9:c8:42:87:04:ab:6e:b6:98:ed:f9:9c:98:64:
+         dc:78:e0:f1:21:16:46:93:67:89:af:a7:da:b4:8d:b7:11:a8:
+         9a:9b:66:be:a4:7f:71:84:57:b4:2b:3c:56:e0:37:f9:6a:29:
+         cd:4a
 -----BEGIN CERTIFICATE-----
-MIICLzCCAZigAwIBAgIBBzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owEjEQMA4GA1UEAwwH
-VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAyBUIA3xp100F+YEM
-8/F37UrofPesd7tci1yWMQG/qrQW5tazIhVLXI48ma97fRroDT1AFDcA9Tc6AAbh
-Cw43uHZio5peR9XUKk4TUKkMerFp53maMFFmC+S3uX3kW2EZC495qUOwof/Hpnqm
-+i6IKIRmaL+/tmSeHrfn/jVjZVECAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4G
-A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUk3BD2sCqFHEPk+uC5/WuydIaeHcwMQYJ
+MIICLzCCAZigAwIBAgIBCDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowEjEQMA4GA1UEAwwH
+VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA0LPYPyvARYzwPZZY
+LF4OakaBqxAvIpx8afBhty3yL0aX1dkbCMjJ6Bil2Iknp4DLCo7uJjKJcDcrv29+
+7hJ9SccMGUZ8ZZncHxoxr6uHAbNoiltRp3jKzB18JrQnX2d1mX6fFu2Is493D7Po
+s5e8cIvsYrmiR0vv3K/Unz0XzQMCAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4G
+A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQULCUZoWyz92n9dps6IssMVgEB8TEwMQYJ
 YIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUw
-HwYDVR0jBBgwFoAUk3BD2sCqFHEPk+uC5/WuydIaeHcwDQYJKoZIhvcNAQELBQAD
-gYEAdcwFsthDqpmEXWQLrMyvB6cNkHmfydwJ5lnY0cIOKpargDj4Gh3R4gzA+t/A
-zwx4MKzQt+mIMdYFKUGPLjLymHT8GUvYxTbDeqeujGWwS/D7+IatCFNDj/VSoJvP
-6C1gV0/zq2M88iPa0FreL2Qlw0//UclRIji05qaHUKjqn/M=
+HwYDVR0jBBgwFoAULCUZoWyz92n9dps6IssMVgEB8TEwDQYJKoZIhvcNAQELBQAD
+gYEAEmAB7OpsvNZO50C2n82Mbm1CT9jbQviNBAlIrSJQ5d5/7NUZIT9r0IXUdSAY
+p8ygfLIIb9Z7p2MiJRv4IGbqt0AJJQV7YW2hT69yUcnIQocEq262mO35nJhk3Hjg
+8SEWRpNnia+n2rSNtxGomptmvqR/cYRXtCs8VuA3+WopzUo=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-int-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-int-basic-constraints.pem
@@ -6,21 +6,21 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:e3:9e:d9:d2:f3:61:04:11:b7:41:5e:1f:4e:be:
-                    2f:27:e2:79:95:8a:15:e5:1e:31:3e:15:d9:73:7b:
-                    b5:af:3f:53:25:fd:2d:ed:d4:ef:15:b6:de:8c:34:
-                    28:3e:e8:14:86:9b:06:a8:8f:c5:c2:cf:ce:31:c1:
-                    40:4d:24:7b:4c:17:4b:9d:19:6c:57:66:a2:25:ba:
-                    26:d2:14:37:32:17:15:0c:51:2e:9d:7e:01:6a:f7:
-                    a1:3c:c9:b7:bb:00:79:82:f0:a9:c3:6f:58:a7:68:
-                    75:53:b2:fa:33:98:28:53:2e:99:d2:fb:73:63:09:
-                    51:32:df:0f:58:ee:ba:6a:19
+                    00:c2:4a:6e:07:c6:1c:8b:2f:bf:91:3e:25:dc:54:
+                    2c:02:0f:1b:6f:5b:0e:5a:69:1d:dd:52:3f:8b:f4:
+                    c8:56:c6:f3:c5:56:2c:b8:82:67:81:09:7b:0d:6f:
+                    01:26:4a:ae:42:53:95:b1:32:ba:07:d4:64:bc:79:
+                    1f:16:0a:92:07:e5:af:5d:d6:b3:4d:09:58:b1:8a:
+                    ba:2c:c0:d3:9b:95:cc:a1:0d:e5:4d:40:1a:50:2d:
+                    a4:45:ff:05:63:62:84:35:73:2c:0f:b3:f6:69:fd:
+                    9b:d3:5e:a8:12:f0:c4:a0:77:25:59:e7:81:3d:ee:
+                    c5:22:10:75:ac:ad:cc:a4:1f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +28,32 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                7A:E0:53:6E:4C:00:F4:DE:3D:74:3A:37:BA:CD:25:7A:C2:BC:44:0A
+                23:78:2F:09:81:B0:7B:C6:79:1F:30:FE:FC:5E:37:14:FF:20:A0:20
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
 
     Signature Algorithm: sha256WithRSAEncryption
-         49:f9:91:6e:e7:62:aa:f7:50:89:4e:d7:c8:b9:dd:5f:35:13:
-         1f:d8:d6:42:06:b0:71:48:47:35:77:5b:61:87:df:e3:61:45:
-         63:9d:64:14:25:d6:64:0c:9c:d0:20:97:e5:86:f8:41:ac:3c:
-         bf:a9:65:31:e7:f0:6b:19:97:6b:a2:e9:fb:e5:4a:57:90:08:
-         f5:33:5e:08:f6:1f:76:f2:7f:5d:f3:44:8f:33:5b:91:7a:f2:
-         80:c5:68:7b:2d:c6:c2:6e:1f:51:79:f4:06:ed:f9:c9:95:88:
-         41:e7:8a:eb:41:fa:7c:b4:d3:a6:42:c4:92:bf:e0:dd:89:00:
-         c6:6a
+         7a:8a:07:aa:d1:4d:7b:5b:01:cf:d3:9f:b0:3f:03:2e:ac:4b:
+         31:e8:86:4d:ca:c0:fb:cb:c2:80:73:60:ea:1e:0c:2f:7c:01:
+         fc:78:4e:3d:9b:be:16:85:bf:bc:c9:7b:41:9d:de:74:69:82:
+         97:b6:e1:e2:37:40:4b:36:ba:ad:fa:bd:c6:73:21:d9:c4:e5:
+         96:d6:6a:bf:c9:dc:0a:0e:9e:0b:44:5c:2f:b3:5a:54:75:14:
+         2b:53:a8:27:6f:8b:94:c9:27:cc:ed:8b:82:5b:09:b1:db:6d:
+         90:78:0a:e8:e2:ac:30:f6:1a:9f:77:4f:70:aa:4f:b7:61:fe:
+         49:41
 -----BEGIN CERTIFICATE-----
 MIICPDCCAaWgAwIBAgIBATANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AOOe2dLzYQQRt0FeH06+LyfieZWKFeUeMT4V2XN7ta8/UyX9Le3U7xW23ow0KD7o
-FIabBqiPxcLPzjHBQE0ke0wXS50ZbFdmoiW6JtIUNzIXFQxRLp1+AWr3oTzJt7sA
-eYLwqcNvWKdodVOy+jOYKFMumdL7c2MJUTLfD1juumoZAgMBAAGjgZQwgZEwDAYD
-VR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHrgU25MAPTePXQ6
-N7rNJXrCvEQKMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFs
-IENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFJNwQ9rAqhRxD5Prguf1rsnSGnh3MA0G
-CSqGSIb3DQEBCwUAA4GBAEn5kW7nYqr3UIlO18i53V81Ex/Y1kIGsHFIRzV3W2GH
-3+NhRWOdZBQl1mQMnNAgl+WG+EGsPL+pZTHn8GsZl2ui6fvlSleQCPUzXgj2H3by
-f13zRI8zW5F68oDFaHstxsJuH1F59Abt+cmViEHniutB+ny006ZCxJK/4N2JAMZq
+AMJKbgfGHIsvv5E+JdxULAIPG29bDlppHd1SP4v0yFbG88VWLLiCZ4EJew1vASZK
+rkJTlbEyugfUZLx5HxYKkgflr13Ws00JWLGKuizA05uVzKEN5U1AGlAtpEX/BWNi
+hDVzLA+z9mn9m9NeqBLwxKB3JVnngT3uxSIQdaytzKQfAgMBAAGjgZQwgZEwDAYD
+VR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFCN4LwmBsHvGeR8w
+/vxeNxT/IKAgMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFs
+IENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFCwlGaFss/dp/XabOiLLDFYBAfExMA0G
+CSqGSIb3DQEBCwUAA4GBAHqKB6rRTXtbAc/Tn7A/Ay6sSzHohk3KwPvLwoBzYOoe
+DC98Afx4Tj2bvhaFv7zJe0Gd3nRpgpe24eI3QEs2uq36vcZzIdnE5ZbWar/J3AoO
+ngtEXC+zWlR1FCtTqCdvi5TJJ8zti4JbCbHbbZB4CujirDD2Gp93T3CqT7dh/klB
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/ca.pem
+++ b/spec/fixtures/ssl/ca.pem
@@ -6,21 +6,21 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:c8:15:08:03:7c:69:d7:4d:05:f9:81:0c:f3:f1:
-                    77:ed:4a:e8:7c:f7:ac:77:bb:5c:8b:5c:96:31:01:
-                    bf:aa:b4:16:e6:d6:b3:22:15:4b:5c:8e:3c:99:af:
-                    7b:7d:1a:e8:0d:3d:40:14:37:00:f5:37:3a:00:06:
-                    e1:0b:0e:37:b8:76:62:a3:9a:5e:47:d5:d4:2a:4e:
-                    13:50:a9:0c:7a:b1:69:e7:79:9a:30:51:66:0b:e4:
-                    b7:b9:7d:e4:5b:61:19:0b:8f:79:a9:43:b0:a1:ff:
-                    c7:a6:7a:a6:fa:2e:88:28:84:66:68:bf:bf:b6:64:
-                    9e:1e:b7:e7:fe:35:63:65:51
+                    00:d0:b3:d8:3f:2b:c0:45:8c:f0:3d:96:58:2c:5e:
+                    0e:6a:46:81:ab:10:2f:22:9c:7c:69:f0:61:b7:2d:
+                    f2:2f:46:97:d5:d9:1b:08:c8:c9:e8:18:a5:d8:89:
+                    27:a7:80:cb:0a:8e:ee:26:32:89:70:37:2b:bf:6f:
+                    7e:ee:12:7d:49:c7:0c:19:46:7c:65:99:dc:1f:1a:
+                    31:af:ab:87:01:b3:68:8a:5b:51:a7:78:ca:cc:1d:
+                    7c:26:b4:27:5f:67:75:99:7e:9f:16:ed:88:b3:8f:
+                    77:0f:b3:e8:b3:97:bc:70:8b:ec:62:b9:a2:47:4b:
+                    ef:dc:af:d4:9f:3d:17:cd:03
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +28,32 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
 
     Signature Algorithm: sha256WithRSAEncryption
-         41:67:29:fe:f0:0a:34:21:0a:a9:f6:bc:61:d1:55:73:37:fd:
-         07:c3:8a:fc:85:44:e3:18:9d:76:d8:c3:0d:eb:52:68:54:33:
-         bc:14:a5:35:7c:9f:98:60:5c:4d:68:75:6e:57:89:45:c7:95:
-         7d:64:22:73:f6:91:46:a2:9d:a0:3d:17:29:2b:0b:98:30:b2:
-         dc:2f:21:87:20:8a:dc:49:89:81:e3:04:35:05:53:26:63:6e:
-         4c:be:00:1a:37:fc:39:e3:e0:56:04:0d:95:89:ca:0c:e8:36:
-         92:d4:8e:51:97:ae:10:9e:0e:2b:ff:f4:1d:79:8c:2b:82:4b:
-         67:6e
+         1c:a2:87:ce:19:24:db:66:41:6b:42:a9:19:85:76:5d:0f:9d:
+         30:18:6f:b7:90:7f:6a:c5:00:ce:21:73:4d:3e:c0:75:93:6d:
+         c6:d9:3b:ad:4c:4a:46:75:f3:51:96:f2:ad:c2:13:53:f0:e3:
+         f1:a6:49:0f:e7:4f:73:b6:60:9c:9d:52:c9:b6:61:4d:31:3f:
+         94:12:7f:ef:8c:f5:81:ea:7a:13:8e:11:8b:7c:83:80:65:50:
+         d2:3d:21:34:07:0a:58:25:43:8f:e6:c6:c9:30:7d:d8:8d:3d:
+         17:8b:43:78:43:0d:6b:43:ea:72:d7:84:2a:ac:f9:02:be:d1:
+         10:a0
 -----BEGIN CERTIFICATE-----
 MIICMjCCAZugAwIBAgIBADANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owEjEQMA4GA1UEAwwH
-VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAyBUIA3xp100F+YEM
-8/F37UrofPesd7tci1yWMQG/qrQW5tazIhVLXI48ma97fRroDT1AFDcA9Tc6AAbh
-Cw43uHZio5peR9XUKk4TUKkMerFp53maMFFmC+S3uX3kW2EZC495qUOwof/Hpnqm
-+i6IKIRmaL+/tmSeHrfn/jVjZVECAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/
-MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUk3BD2sCqFHEPk+uC5/WuydIaeHcw
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowEjEQMA4GA1UEAwwH
+VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA0LPYPyvARYzwPZZY
+LF4OakaBqxAvIpx8afBhty3yL0aX1dkbCMjJ6Bil2Iknp4DLCo7uJjKJcDcrv29+
+7hJ9SccMGUZ8ZZncHxoxr6uHAbNoiltRp3jKzB18JrQnX2d1mX6fFu2Is493D7Po
+s5e8cIvsYrmiR0vv3K/Unz0XzQMCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/
+MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQULCUZoWyz92n9dps6IssMVgEB8TEw
 MQYJYIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNh
-dGUwHwYDVR0jBBgwFoAUk3BD2sCqFHEPk+uC5/WuydIaeHcwDQYJKoZIhvcNAQEL
-BQADgYEAQWcp/vAKNCEKqfa8YdFVczf9B8OK/IVE4xiddtjDDetSaFQzvBSlNXyf
-mGBcTWh1bleJRceVfWQic/aRRqKdoD0XKSsLmDCy3C8hhyCK3EmJgeMENQVTJmNu
-TL4AGjf8OePgVgQNlYnKDOg2ktSOUZeuEJ4OK//0HXmMK4JLZ24=
+dGUwHwYDVR0jBBgwFoAULCUZoWyz92n9dps6IssMVgEB8TEwDQYJKoZIhvcNAQEL
+BQADgYEAHKKHzhkk22ZBa0KpGYV2XQ+dMBhvt5B/asUAziFzTT7AdZNtxtk7rUxK
+RnXzUZbyrcITU/Dj8aZJD+dPc7ZgnJ1SybZhTTE/lBJ/74z1gep6E44Ri3yDgGVQ
+0j0hNAcKWCVDj+bGyTB92I09F4tDeEMNa0PqcteEKqz5Ar7REKA=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/crl.pem
+++ b/spec/fixtures/ssl/crl.pem
@@ -3,28 +3,28 @@ Certificate Revocation List (CRL):
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /CN=Test CA
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Mar  9 21:35:53 2029 GMT
+        Next Update: Apr 19 22:31:22 2029 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
 
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         1d:22:2e:ce:86:44:d5:58:56:84:a9:98:2f:31:38:41:52:c7:
-         31:83:94:81:bd:57:8e:8c:4f:9a:58:16:2c:84:56:83:ef:34:
-         b6:d8:fb:65:f6:54:1a:7e:6c:36:5b:d3:f0:8c:65:22:fb:4a:
-         08:3c:31:c4:93:1a:f0:9c:24:97:50:e4:6f:6b:5b:33:93:c8:
-         89:f1:9f:7a:cc:cd:3a:db:0b:af:f2:2c:6b:f8:f5:a7:9d:cc:
-         1b:71:fc:03:2f:2b:f7:6b:47:7d:86:c5:ee:be:76:f6:13:9d:
-         63:ba:72:b3:ac:c4:4d:e5:84:03:25:b4:52:f9:35:ea:88:f2:
-         6f:c5
+         48:c8:b3:f8:53:4c:79:92:ea:3e:19:c4:96:14:93:90:c4:e0:
+         6f:77:26:cb:6b:12:58:35:44:e7:5e:fb:b2:13:dc:5b:be:41:
+         09:1a:08:ab:15:38:73:a7:17:48:68:d0:64:d4:77:b6:5b:b1:
+         9c:1c:f6:2c:dd:ab:d7:83:97:ac:0d:5f:af:b2:81:90:2b:5f:
+         fa:2d:cf:f3:ee:1a:76:b5:3d:d2:9e:49:8c:71:dc:fc:cc:82:
+         2a:4a:81:80:35:2c:9f:8e:df:7e:83:89:f9:62:c1:e7:5a:7f:
+         34:cd:fa:da:83:bf:c9:4b:61:fd:c0:f5:16:e5:e1:b4:b9:70:
+         af:9a
 -----BEGIN X509 CRL-----
 MIIBCjB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
-MDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1qgLzAtMB8GA1UdIwQYMBaAFJNwQ9rA
-qhRxD5Prguf1rsnSGnh3MAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4GBAB0i
-Ls6GRNVYVoSpmC8xOEFSxzGDlIG9V46MT5pYFiyEVoPvNLbY+2X2VBp+bDZb0/CM
-ZSL7Sgg8McSTGvCcJJdQ5G9rWzOTyInxn3rMzTrbC6/yLGv49aedzBtx/AMvK/dr
-R32Gxe6+dvYTnWO6crOsxE3lhAMltFL5NeqI8m/F
+MDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlqgLzAtMB8GA1UdIwQYMBaAFCwlGaFs
+s/dp/XabOiLLDFYBAfExMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4GBAEjI
+s/hTTHmS6j4ZxJYUk5DE4G93JstrElg1ROde+7IT3Fu+QQkaCKsVOHOnF0ho0GTU
+d7ZbsZwc9izdq9eDl6wNX6+ygZArX/otz/PuGna1PdKeSYxx3PzMgipKgYA1LJ+O
+336DifliwedafzTN+tqDv8lLYf3A9Rbl4bS5cK+a
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/ec-key.pem
+++ b/spec/fixtures/ssl/ec-key.pem
@@ -1,0 +1,18 @@
+Private-Key: (256 bit)
+priv:
+    7e:cc:3d:2f:ed:f2:aa:9b:a4:9d:ad:13:f1:ef:5c:
+    e3:4f:3a:81:24:63:f3:cd:07:1c:74:6a:ec:c8:97:
+    47:83
+pub:
+    04:b0:b9:7e:1e:25:44:42:3d:40:24:bb:e7:e5:34:
+    e6:16:05:b8:f0:ee:bf:0f:10:23:40:ff:af:40:7e:
+    1b:1c:3a:4b:e7:35:e4:06:98:97:ac:94:da:16:1f:
+    46:4f:72:0c:4b:08:b7:86:c0:a7:57:17:aa:57:a3:
+    1a:ba:b8:93:4e
+ASN1 OID: prime256v1
+NIST CURVE: P-256
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIH7MPS/t8qqbpJ2tE/HvXONPOoEkY/PNBxx0auzIl0eDoAoGCCqGSM49
+AwEHoUQDQgAEsLl+HiVEQj1AJLvn5TTmFgW48O6/DxAjQP+vQH4bHDpL5zXkBpiX
+rJTaFh9GT3IMSwi3hsCnVxeqV6MauriTTg==
+-----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/ec.pem
+++ b/spec/fixtures/ssl/ec.pem
@@ -1,0 +1,40 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 5 (0x5)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA Subauthority
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
+        Subject: CN=ec
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:b0:b9:7e:1e:25:44:42:3d:40:24:bb:e7:e5:34:
+                    e6:16:05:b8:f0:ee:bf:0f:10:23:40:ff:af:40:7e:
+                    1b:1c:3a:4b:e7:35:e4:06:98:97:ac:94:da:16:1f:
+                    46:4f:72:0c:4b:08:b7:86:c0:a7:57:17:aa:57:a3:
+                    1a:ba:b8:93:4e
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+    Signature Algorithm: sha256WithRSAEncryption
+         02:89:4d:ca:b0:89:38:e7:c3:ee:d8:55:76:7a:b6:b6:8c:8a:
+         a7:38:ef:62:97:3d:c6:83:5f:08:3d:39:d1:ea:50:12:32:37:
+         6d:c6:aa:42:21:8b:39:46:e7:a9:a0:16:6f:80:c0:8a:08:19:
+         4b:21:cb:14:59:49:d3:e7:f7:5b:ac:0f:ed:67:c3:b6:fa:c7:
+         7d:60:38:70:c5:6c:df:a0:3f:e5:c0:79:ce:2d:21:a5:4b:48:
+         50:a7:22:b3:71:d7:1a:44:47:8a:96:eb:e9:d3:fa:8d:dc:18:
+         7f:1e:45:86:a0:05:6e:61:8f:33:6a:ae:4e:21:60:5d:49:ee:
+         17:28
+-----BEGIN CERTIFICATE-----
+MIIBWDCBwqADAgECAgEFMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
+Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlow
+DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASwuX4eJURC
+PUAku+flNOYWBbjw7r8PECNA/69AfhscOkvnNeQGmJeslNoWH0ZPcgxLCLeGwKdX
+F6pXoxq6uJNOMA0GCSqGSIb3DQEBCwUAA4GBAAKJTcqwiTjnw+7YVXZ6traMiqc4
+72KXPcaDXwg9OdHqUBIyN23GqkIhizlG56mgFm+AwIoIGUshyxRZSdPn91usD+1n
+w7b6x31gOHDFbN+gP+XAec4tIaVLSFCnIrNx1xpER4qW6+nT+o3cGH8eRYagBW5h
+jzNqrk4hYF1J7hco
+-----END CERTIFICATE-----

--- a/spec/fixtures/ssl/encrypted-ec-key.pem
+++ b/spec/fixtures/ssl/encrypted-ec-key.pem
@@ -1,0 +1,21 @@
+Private-Key: (256 bit)
+priv:
+    7e:cc:3d:2f:ed:f2:aa:9b:a4:9d:ad:13:f1:ef:5c:
+    e3:4f:3a:81:24:63:f3:cd:07:1c:74:6a:ec:c8:97:
+    47:83
+pub:
+    04:b0:b9:7e:1e:25:44:42:3d:40:24:bb:e7:e5:34:
+    e6:16:05:b8:f0:ee:bf:0f:10:23:40:ff:af:40:7e:
+    1b:1c:3a:4b:e7:35:e4:06:98:97:ac:94:da:16:1f:
+    46:4f:72:0c:4b:08:b7:86:c0:a7:57:17:aa:57:a3:
+    1a:ba:b8:93:4e
+ASN1 OID: prime256v1
+NIST CURVE: P-256
+-----BEGIN EC PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-128-CBC,0868B9423657113886CFF18689853E85
+
+5PsfXd1EI/wHzw3qbXRnXgmbBmmtIvevJsAfC34P1sHAWRTcQnbj1R0TOiPYj65m
+GCkjLnAMNWxyHpjOtD7irdGINBEre+Puo68pmnXEOAFYIjOhjr1kQn3oQ7SQ35dV
+M8jBxhogriHr0Q7D7ab2KXJL6yBf4HrFYsg5lL97jlY=
+-----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/encrypted-key.pem
+++ b/spec/fixtures/ssl/encrypted-key.pem
@@ -1,70 +1,70 @@
 Private-Key: (1024 bit)
 modulus:
-    00:ad:cf:8f:ff:51:7a:86:cc:99:5d:14:8f:07:0c:
-    f7:e7:f7:e8:3c:46:90:38:d3:fa:71:91:57:42:3a:
-    bd:9a:80:24:e8:df:55:26:a6:8f:74:30:5c:5a:f4:
-    34:f0:db:76:24:1c:f1:cd:57:1b:80:93:2c:5c:e9:
-    b1:ea:21:c8:f6:58:52:ce:3f:b3:f6:32:6e:de:00:
-    b9:8e:a2:9f:07:08:ac:e7:32:6e:43:93:4a:eb:87:
-    d6:6c:e6:6a:4e:45:bd:f9:08:4b:71:d3:05:77:67:
-    87:26:08:12:62:37:09:5f:37:59:09:3e:80:74:b2:
-    69:43:46:32:99:b9:db:fe:05
+    00:ef:bc:2c:47:fa:12:2d:09:ef:16:96:90:8b:84:
+    45:c7:86:f1:5e:8f:58:59:23:87:df:a1:e3:be:8c:
+    2f:ad:70:96:1a:f5:67:7f:5c:9c:54:5e:82:de:05:
+    7f:8f:9d:c9:f3:24:72:39:4f:1c:b4:a6:e0:d0:19:
+    af:bd:e4:29:65:bb:d7:43:3e:66:d3:4f:74:05:0b:
+    8a:e4:d5:52:08:af:9b:f4:f4:7d:6c:92:5f:cc:bb:
+    c2:2d:ca:d0:12:28:e5:c8:fd:f6:09:90:dd:85:f9:
+    85:d9:37:a6:fe:83:c7:24:e4:af:28:e3:ff:5a:1b:
+    72:5f:29:c6:39:88:5b:48:19
 publicExponent: 65537 (0x10001)
 privateExponent:
-    25:5f:98:4b:02:2e:22:86:24:04:0b:c3:a5:74:78:
-    69:fc:b8:87:1d:75:2d:83:07:3b:1c:51:73:00:46:
-    7c:ce:49:21:79:c4:49:87:4f:19:60:bc:bb:21:ff:
-    b0:3a:c0:70:8b:78:c2:fa:94:03:55:a2:18:68:77:
-    c5:2c:76:95:86:fb:af:4d:24:d7:ab:08:65:f3:6e:
-    52:7b:cb:ec:89:74:55:e7:6c:26:93:62:ff:01:f0:
-    5f:33:1c:a2:db:78:7e:fc:fc:a0:c1:75:cd:2a:aa:
-    31:1e:03:ee:0f:a4:be:f8:aa:80:e5:c1:fe:12:67:
-    7d:8b:4a:ba:5d:bc:89:01
+    75:11:3b:c2:6e:30:60:04:00:d7:d3:f0:83:e0:b4:
+    be:89:7b:e6:84:33:4d:5c:17:66:b2:44:67:71:47:
+    7a:f7:86:a5:65:7f:03:e7:b2:83:54:9f:ad:51:9c:
+    08:02:b2:72:64:32:cf:1f:7d:d2:0d:c7:ac:77:4e:
+    a5:78:fc:69:3a:88:12:5b:81:81:19:c9:1f:9d:aa:
+    fa:35:2e:cd:df:71:ee:50:f9:59:53:99:52:22:f7:
+    48:ba:17:4f:47:b5:72:16:47:d1:1d:31:29:47:80:
+    b1:e1:3c:e0:a0:4b:ef:05:c5:ea:0a:b2:c7:4a:b9:
+    d3:06:c0:b7:7b:0a:2e:81
 prime1:
-    00:e2:de:b4:d0:ef:3c:db:51:50:0f:f5:ff:73:8e:
-    da:e2:1c:1e:46:3a:09:a0:00:e1:a4:97:90:c7:62:
-    9a:e0:84:f4:66:ff:35:be:7f:f8:98:ed:28:50:5d:
-    a5:77:eb:ab:0d:9c:f8:b1:f9:ef:d0:0e:5b:9f:da:
-    fa:44:73:3f:d5
+    00:fa:cc:b0:ba:9e:06:c5:f7:63:09:37:e7:9f:aa:
+    4d:f8:f1:b4:7f:aa:c6:8a:04:16:93:73:af:ba:1f:
+    e3:97:76:11:a9:4d:fb:42:8b:f0:51:0a:7d:6c:69:
+    fa:2f:d8:7b:ad:20:79:de:71:ea:e2:e0:a3:69:1b:
+    1e:e3:6c:9b:e9
 prime2:
-    00:c4:20:c8:8a:86:24:f5:be:20:82:73:f4:bb:43:
-    77:d7:c7:cd:de:49:a0:58:1e:c2:5e:34:e2:4e:a0:
-    fd:26:16:9a:4b:32:42:f2:08:19:93:64:13:cd:d9:
-    93:c5:63:0d:39:9f:1d:8d:20:80:02:27:75:71:25:
-    74:24:43:0d:71
+    00:f4:b4:bf:cf:56:a0:fa:94:15:5c:24:9c:45:fd:
+    54:31:72:75:7b:ef:d5:de:5b:64:c9:6a:88:42:e0:
+    0d:f0:63:c2:46:9e:59:81:be:60:ee:05:01:b0:dd:
+    e4:12:d0:5b:77:76:c0:5b:f2:21:0c:5b:42:af:f5:
+    c2:5b:c6:1c:b1
 exponent1:
-    00:b6:34:1a:8f:fa:b3:ab:88:60:7e:91:18:fa:1b:
-    ef:1a:cd:6e:5b:04:5d:9a:8d:5a:ab:2f:b6:ed:0a:
-    fa:4b:fb:3b:b6:44:9d:4b:43:c7:ca:3a:1d:b8:7d:
-    9d:58:f4:82:ca:4a:19:4a:06:eb:5c:f3:4b:0e:d5:
-    75:4d:e8:29:89
+    15:d0:1f:be:db:67:b3:68:24:d0:f4:6f:cc:cf:3f:
+    20:db:c4:db:25:bb:46:dd:bc:28:ee:f2:e5:b9:48:
+    4e:30:12:b1:2a:fb:23:7a:90:58:3c:15:54:8c:93:
+    19:fe:36:23:84:a3:94:d9:4b:98:97:f9:1e:77:21:
+    64:9e:59:a1
 exponent2:
-    1e:1d:66:8d:96:a1:70:36:5c:69:8b:82:85:8a:8b:
-    89:4f:7d:b5:e7:1a:3e:cd:a2:4c:b2:d4:18:fc:b1:
-    42:3a:f0:40:21:9c:93:eb:58:7a:00:40:e6:37:c5:
-    6f:e6:90:ae:4b:57:4f:47:31:40:a3:6c:6e:0e:31:
-    32:2c:35:91
+    00:81:96:5e:a5:5c:48:ef:aa:10:0d:b5:cd:94:3a:
+    ed:a5:29:ea:11:72:17:1e:23:e4:21:cd:ea:cf:0f:
+    7c:12:3b:a2:1c:67:ab:1a:cc:48:e4:83:7e:3b:bd:
+    a6:14:58:86:b7:a3:09:87:27:98:5c:c4:cf:72:03:
+    81:a3:bc:2c:61
 coefficient:
-    57:c8:09:23:2a:ad:d0:a4:c0:f5:5b:9c:b4:7e:36:
-    a2:b6:dd:8d:cc:9d:ac:db:e9:03:3d:32:a3:90:c3:
-    47:9d:07:69:9c:c5:97:94:96:53:b4:b6:c5:45:96:
-    56:07:e4:c6:9a:ec:56:a4:b5:c3:12:70:ee:13:ae:
-    43:bd:51:39
+    7d:b4:b6:78:c7:d3:0c:44:6f:a2:aa:83:8a:79:65:
+    69:24:b2:31:ac:59:ed:6c:bf:4c:1a:1a:27:f0:c8:
+    e9:38:ff:84:50:df:b5:10:c2:6e:4b:5c:c2:4c:c9:
+    82:2a:db:0a:6f:59:dd:12:93:8c:c1:9d:57:f3:dd:
+    66:41:9a:e0
 -----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,E9B79BAA1EF2AB76A41C5024B914E84D
+DEK-Info: AES-128-CBC,7D9CB780A5571FAC184E44E1D736A163
 
-IHS6jMaijjLaI3BZywYIdIitmDHDDRuSaUno/jeHLf3JKPTqI+wyjyE+E1u+Eu4J
-+ZGYkT0qcZf+fD0OJ9w9LdogwlsXQXTgT21gt4+uiBR0CRcbF5K4nw2k282ui+7T
-qCTm8eir6jqVbxYWVLC0rmw0zoQDS0nLaKJK7XePd4LVqFjejBRu+QXtKitBdbb5
-/kHbTCydEz1zc3NA8jgelZyl2s8pgPqIW/rLVgpaQs4zNqUmnETvdQM9JEds9InJ
-9Qd22k0+qQceUpSOh5NGoAuTpiycNhk11AL5isCok1U3pEUSi/redT+W+DVEnICZ
-QO07+6OQbOp0g6/QEsEg5v6YxFXVdMU9o7Y/kAxFc07c8NrhEFr8T23NVrLs/t5d
-Rj7DTO0wEh782dX2K7Qda8qDnTbknf0T48kFT8NGgm9LtznrGhKWRgUQawJ5ODOu
-jDAe4R1956gmIw56EpZ+Gtog5ugRHnF+YgwYRYGQ/MCYkwvuwJX0RrmaScNxbVhj
-qBwoOtD0entIfynapOgGyMqe+E0SyZUoqkbh602DPJsQ6MYgaGeDFXMJ3u5K8sD0
-OytTqb09Efg4VDCSdG4qrO+l+NueuRkCpsGZ4PtU8XZ5FDhw6MjFCVRPr3N6WIIQ
-wcMCk5Zuu6ynjGaOm0buQeNpaH9v7/7hEat8+dj0lL4PbxZ6VO/dTz1mqs/Wey9A
-B1p6RkEYHEHzrzoxso18DyTLGRTncT8GTVHVwTK+/+1z+fkcfoi3y89M2zHifKKP
-YLHhCBIMC73ClhuD0u/BsFXH4SEXoMrcsCTMEaByfq+Ws4kNU91JUzVDeQaRTwFq
+Qm1/dU9pVgWJvFbAsoTpvKsID72hLSQt9Krsoi1qzoCkCjY/9zuYcZs5IAx9rzZj
+ykULBjY9ZIBaNplQtpH1VRHl7YvrZ72oYXeTyQL0+fYyjqjC3X6SSATyOFR2yycs
+cXGE/jFvVnFdU/vmuv26laHCINhJ9KGJXLQRXoobMNxCR7uE4CVI8AKmKLxNq7jL
+GrkKUE4T9gkoWZOnck7TfYxSplc8ttSPRuaxV0eEAohkmOZBdL6vi7TXVhaEf7ym
+ZeUi5yUTByBqMBFgk6Az4Pr6U/etY0JbYRYwB0Opg+vjvAxqkmtgDKqZQkobZ7w2
+61l9a01u2fXxN1CahJKgoke1vw4FQdDtFoIbtKPxZSGFOi8G7fSFk9+L8yeombXH
+3omxcUJqtsteWFJbqHkMZYY9uK3NpZ+RifC1tmNV0h99oFpUxOkqP52T6TIJaav7
+YQaxJXqjBp8d07o+mtKLu4oggcFfXCYNdepG9L/U5TrTFeLmhf7Ep2zzr5NF1cbG
+DF1k0X4g9obOKbSVLMDD+umWmvj8FNXcKZ1joRcGfY2WZbjJtofdOhLbCD8/M4lE
+h2KyrhMbRalg0A82IFPoavGeTSmvK1iNcwSf04JYKNx2wpzjF+eTzMHpyPPv9RyV
+2fRtSXZmfQA33BmTo0QImST22WqL76auJEQTKlH4Ka6Q7OQLC+xYzyhm7CZCFBzU
+T46HRAwxjptK89yWIvawDdAUcxZ/H/TjVOGG+q/DRQYI/Gyf4IOZqKTfIVg/JlvD
+njF3wo6kRV0JLrifTnev5mQwl3y9MXW5KUsAedLcWl7tv33pkbXFy7B/7Pn1wH67
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/intermediate-agent-crl.pem
+++ b/spec/fixtures/ssl/intermediate-agent-crl.pem
@@ -3,29 +3,29 @@ Certificate Revocation List (CRL):
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /CN=Test CA Agent Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Mar  9 21:35:53 2029 GMT
+        Next Update: Apr 19 22:31:22 2029 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:4C:8D:DA:6C:26:2B:12:AF:11:85:FD:26:DF:21:F5:E4:1D:AE:CD:81
+                keyid:71:55:03:0F:DF:BC:E6:CE:3E:DE:05:DE:06:0F:E1:4F:BA:00:16:8D
 
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         15:83:8b:cc:88:0c:19:02:41:63:e5:88:7f:6c:85:8a:d9:3c:
-         0f:ad:0b:b6:c4:4d:39:76:94:7f:a8:d8:74:30:d9:22:c1:bc:
-         1e:6a:b5:7b:7c:4d:ee:ab:6f:b3:30:78:3d:cd:3a:f6:6b:fb:
-         84:d8:75:42:1e:8b:83:81:16:8e:ae:74:85:bf:5f:6a:b5:e6:
-         f7:a5:dc:5a:bf:c2:c5:1d:a3:a2:de:5a:9f:01:18:42:af:ad:
-         2a:a5:a9:fa:d9:52:95:e0:bb:8c:6d:6d:50:7b:fa:b0:eb:e0:
-         c9:2c:92:9f:fa:d0:4e:11:c6:80:70:62:12:15:9d:e6:05:c2:
-         81:58
+         07:24:a1:9d:d9:ec:57:1c:0b:68:ee:fb:59:c5:98:65:77:59:
+         49:a5:c5:51:69:9e:4c:20:94:d8:7b:f1:cb:e3:c8:4d:5e:a2:
+         58:3d:a6:6c:e1:7d:52:a3:d5:44:d5:be:95:95:c5:b8:10:86:
+         12:5a:4d:03:f2:73:d2:c9:94:a5:f5:c9:bb:78:bf:8e:7d:cf:
+         8e:5c:77:51:3b:4f:0f:bb:3b:f7:f3:00:45:00:9a:4b:4e:db:
+         3b:95:d3:cf:d5:dd:d0:78:28:b0:3a:9c:b1:2b:75:88:91:5b:
+         6e:b8:39:25:59:67:73:c1:21:6c:2b:b1:a9:da:e8:da:04:ca:
+         64:aa
 -----BEGIN X509 CRL-----
 MIIBHjCBiAIBATANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0IENBIEFn
-ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwMzA5MjEzNTUzWqAv
-MC0wHwYDVR0jBBgwFoAUTI3abCYrEq8Rhf0m3yH15B2uzYEwCgYDVR0UBAMCAQAw
-DQYJKoZIhvcNAQELBQADgYEAFYOLzIgMGQJBY+WIf2yFitk8D60LtsRNOXaUf6jY
-dDDZIsG8Hmq1e3xN7qtvszB4Pc069mv7hNh1Qh6Lg4EWjq50hb9farXm96XcWr/C
-xR2jot5anwEYQq+tKqWp+tlSleC7jG1tUHv6sOvgySySn/rQThHGgHBiEhWd5gXC
-gVg=
+ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwNDE5MjIzMTIyWqAv
+MC0wHwYDVR0jBBgwFoAUcVUDD9+85s4+3gXeBg/hT7oAFo0wCgYDVR0UBAMCAQAw
+DQYJKoZIhvcNAQELBQADgYEAByShndnsVxwLaO77WcWYZXdZSaXFUWmeTCCU2Hvx
+y+PITV6iWD2mbOF9UqPVRNW+lZXFuBCGElpNA/Jz0smUpfXJu3i/jn3Pjlx3UTtP
+D7s79/MARQCaS07bO5XTz9Xd0HgosDqcsSt1iJFbbrg5JVlnc8EhbCuxqdro2gTK
+ZKo=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate-agent.pem
+++ b/spec/fixtures/ssl/intermediate-agent.pem
@@ -1,26 +1,26 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 5 (0x5)
+        Serial Number: 6 (0x6)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=Test CA Agent Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:b5:ed:95:5b:eb:9e:9c:18:b2:6b:d6:a5:93:54:
-                    29:cd:37:90:3b:2a:ce:ad:b8:1d:44:85:6b:7c:5f:
-                    68:e4:a6:97:c0:cf:cc:f3:b5:28:cb:d5:c3:5f:f1:
-                    2b:1b:96:99:9a:05:eb:72:b9:48:6f:83:5c:12:a7:
-                    1f:14:16:db:51:6c:84:a5:64:76:89:28:53:64:61:
-                    32:02:af:3f:b8:f9:5f:66:2c:2a:b9:63:37:24:57:
-                    c2:46:8a:e7:fe:cc:14:b6:50:2b:6d:f9:4d:5f:7d:
-                    3e:68:1c:c3:11:06:01:d9:d8:31:7d:08:a5:75:b5:
-                    dd:11:10:2f:e1:e4:8a:5a:d3
+                    00:e7:30:19:5b:4d:c2:77:b0:2d:8f:54:19:8d:f5:
+                    cf:91:57:48:ae:0d:59:c0:a2:75:d0:d5:11:5b:72:
+                    97:c9:8b:45:8e:7b:91:03:1c:57:c5:08:f0:ae:00:
+                    da:b0:1b:9a:bd:c3:ee:fd:f6:c2:1d:05:9d:f5:5e:
+                    e3:91:bd:c1:80:cd:0a:45:f7:89:32:91:19:31:11:
+                    95:a9:14:d3:6b:02:a3:2d:df:68:b8:c4:0e:a3:27:
+                    18:e9:22:f1:fa:d4:e8:5a:bc:f1:11:c5:fd:e1:b6:
+                    d8:00:e4:82:60:00:37:f9:54:cb:a9:ad:fe:ea:e3:
+                    8b:c3:67:07:04:e6:70:b0:45
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,33 +28,33 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                4C:8D:DA:6C:26:2B:12:AF:11:85:FD:26:DF:21:F5:E4:1D:AE:CD:81
+                71:55:03:0F:DF:BC:E6:CE:3E:DE:05:DE:06:0F:E1:4F:BA:00:16:8D
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
 
     Signature Algorithm: sha256WithRSAEncryption
-         85:84:ab:76:ae:37:77:e7:0d:f0:6b:43:57:5a:7f:98:81:e0:
-         5d:81:3a:a6:ec:04:01:f4:e0:e1:e8:96:43:a4:f5:2f:93:9c:
-         4c:0b:e6:53:ce:c8:ff:a1:b6:0e:e5:0b:62:87:10:40:fb:bb:
-         29:a6:c9:df:ec:52:59:77:07:91:ef:cc:29:97:86:ed:5f:9f:
-         34:ad:20:33:3c:39:1d:e5:58:d7:1c:0b:91:1c:3b:b1:a7:8d:
-         bc:fb:b9:27:f9:1d:3f:f9:54:a6:63:83:73:4c:63:97:23:21:
-         62:ae:c5:a6:e6:f7:4c:24:bc:e1:e9:cb:d5:37:42:15:a3:78:
-         5d:33
+         96:88:36:03:b3:7f:ae:df:a6:58:7d:4e:3d:71:22:ab:88:95:
+         98:e2:58:45:ab:b3:c7:a6:53:91:43:61:a6:b6:07:0b:65:84:
+         3f:41:53:2f:fb:d9:07:06:7a:fe:19:52:11:e8:f0:5e:dd:04:
+         62:24:9a:a4:23:4d:58:5c:47:81:3e:e9:ab:5b:ee:92:3e:74:
+         6d:21:78:6e:2d:a8:d9:83:0d:91:b8:43:0f:94:3c:c2:47:e9:
+         04:55:cc:52:7f:95:2f:5a:21:08:56:a0:f2:88:7d:a0:82:3b:
+         6a:96:34:4d:bb:0d:7c:31:16:0f:9b:84:71:34:ee:ec:fe:bf:
+         8c:cb
 -----BEGIN CERTIFICATE-----
-MIICRTCCAa6gAwIBAgIBBTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owJTEjMCEGA1UEAwwa
+MIICRTCCAa6gAwIBAgIBBjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowJTEjMCEGA1UEAwwa
 VGVzdCBDQSBBZ2VudCBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0A
-MIGJAoGBALXtlVvrnpwYsmvWpZNUKc03kDsqzq24HUSFa3xfaOSml8DPzPO1KMvV
-w1/xKxuWmZoF63K5SG+DXBKnHxQW21FshKVkdokoU2RhMgKvP7j5X2YsKrljNyRX
-wkaK5/7MFLZQK235TV99PmgcwxEGAdnYMX0IpXW13REQL+HkilrTAgMBAAGjgZcw
-gZQwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFEyN
-2mwmKxKvEYX9Jt8h9eQdrs2BMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVy
-IEludGVybmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFJNwQ9rAqhRxD5Prguf1
-rsnSGnh3MA0GCSqGSIb3DQEBCwUAA4GBAIWEq3auN3fnDfBrQ1daf5iB4F2BOqbs
-BAH04OHolkOk9S+TnEwL5lPOyP+htg7lC2KHEED7uymmyd/sUll3B5HvzCmXhu1f
-nzStIDM8OR3lWNccC5EcO7Gnjbz7uSf5HT/5VKZjg3NMY5cjIWKuxabm90wkvOHp
-y9U3QhWjeF0z
+MIGJAoGBAOcwGVtNwnewLY9UGY31z5FXSK4NWcCiddDVEVtyl8mLRY57kQMcV8UI
+8K4A2rAbmr3D7v32wh0FnfVe45G9wYDNCkX3iTKRGTERlakU02sCoy3faLjEDqMn
+GOki8frU6Fq88RHF/eG22ADkgmAAN/lUy6mt/urji8NnBwTmcLBFAgMBAAGjgZcw
+gZQwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHFV
+Aw/fvObOPt4F3gYP4U+6ABaNMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVy
+IEludGVybmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFCwlGaFss/dp/XabOiLL
+DFYBAfExMA0GCSqGSIb3DQEBCwUAA4GBAJaINgOzf67fplh9Tj1xIquIlZjiWEWr
+s8emU5FDYaa2BwtlhD9BUy/72QcGev4ZUhHo8F7dBGIkmqQjTVhcR4E+6atb7pI+
+dG0heG4tqNmDDZG4Qw+UPMJH6QRVzFJ/lS9aIQhWoPKIfaCCO2qWNE27DXwxFg+b
+hHE07uz+v4zL
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/intermediate-crl.pem
+++ b/spec/fixtures/ssl/intermediate-crl.pem
@@ -3,34 +3,34 @@ Certificate Revocation List (CRL):
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: /CN=Test CA Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Mar  9 21:35:53 2029 GMT
+        Next Update: Apr 19 22:31:22 2029 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:7A:E0:53:6E:4C:00:F4:DE:3D:74:3A:37:BA:CD:25:7A:C2:BC:44:0A
+                keyid:23:78:2F:09:81:B0:7B:C6:79:1F:30:FE:FC:5E:37:14:FF:20:A0:20
 
             X509v3 CRL Number: 
                 0
 Revoked Certificates:
     Serial Number: 04
-        Revocation Date: Mar 12 21:35:53 2019 GMT
+        Revocation Date: Apr 22 22:31:22 2019 GMT
         CRL entry extensions:
             X509v3 CRL Reason Code: 
                 Key Compromise
     Signature Algorithm: sha256WithRSAEncryption
-         01:4f:22:9c:6d:6d:35:4a:8f:9e:44:09:a2:f8:2a:e9:85:3d:
-         cb:4d:c3:4e:9a:59:14:85:b5:1a:2b:de:d8:02:d8:56:b9:0d:
-         48:e3:5f:65:a3:33:c8:f0:72:6b:4c:33:a1:07:45:a7:b3:fd:
-         30:07:b2:5e:45:4b:82:6a:9a:d0:8e:73:51:72:6d:57:2b:5a:
-         97:fc:00:20:f4:8f:7f:1c:6e:07:f1:42:01:7f:52:24:22:28:
-         bf:99:c4:43:23:57:f7:18:68:6c:63:d8:e4:8f:57:e1:9a:41:
-         82:b0:c0:a9:c3:39:d5:9c:5b:db:33:a7:f9:f4:ad:0f:65:b0:
-         fc:8e
+         75:08:37:d8:e9:75:be:6b:8f:3e:f4:03:43:03:63:b8:26:02:
+         b3:a8:eb:fc:61:f5:0a:ab:8d:4f:59:ba:79:e4:d2:45:be:9a:
+         60:ee:ba:85:a3:0e:2e:2b:e0:6f:ac:18:0e:94:c8:76:b6:17:
+         c3:fb:55:ab:26:9c:a4:26:8b:9f:74:51:e8:33:8e:83:50:e6:
+         6e:38:04:7b:35:db:75:55:88:1b:8d:19:f3:ed:9c:18:1e:3c:
+         40:31:73:5e:4d:a7:a2:ef:55:b1:0c:70:ef:85:60:d8:d5:39:
+         32:d0:84:8d:b3:96:e6:35:93:8a:da:e6:ec:1f:37:98:9a:5c:
+         37:40
 -----BEGIN X509 CRL-----
 MIIBPDCBpgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0IENBIFN1
-YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwMzA5MjEzNTUzWjAiMCACAQQX
-DTE5MDMxMjIxMzU1M1owDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUeuBT
-bkwA9N49dDo3us0lesK8RAowCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADgYEA
-AU8inG1tNUqPnkQJovgq6YU9y03DTppZFIW1Give2ALYVrkNSONfZaMzyPBya0wz
-oQdFp7P9MAeyXkVLgmqa0I5zUXJtVytal/wAIPSPfxxuB/FCAX9SJCIov5nEQyNX
-9xhobGPY5I9X4ZpBgrDAqcM51Zxb2zOn+fStD2Ww/I4=
+YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwNDE5MjIzMTIyWjAiMCACAQQX
+DTE5MDQyMjIyMzEyMlowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUI3gv
+CYGwe8Z5HzD+/F43FP8goCAwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADgYEA
+dQg32Ol1vmuPPvQDQwNjuCYCs6jr/GH1CquNT1m6eeTSRb6aYO66haMOLivgb6wY
+DpTIdrYXw/tVqyacpCaLn3RR6DOOg1DmbjgEezXbdVWIG40Z8+2cGB48QDFzXk2n
+ou9VsQxw74Vg2NU5MtCEjbOW5jWTitrm7B83mJpcN0A=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate.pem
+++ b/spec/fixtures/ssl/intermediate.pem
@@ -6,21 +6,21 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:e3:9e:d9:d2:f3:61:04:11:b7:41:5e:1f:4e:be:
-                    2f:27:e2:79:95:8a:15:e5:1e:31:3e:15:d9:73:7b:
-                    b5:af:3f:53:25:fd:2d:ed:d4:ef:15:b6:de:8c:34:
-                    28:3e:e8:14:86:9b:06:a8:8f:c5:c2:cf:ce:31:c1:
-                    40:4d:24:7b:4c:17:4b:9d:19:6c:57:66:a2:25:ba:
-                    26:d2:14:37:32:17:15:0c:51:2e:9d:7e:01:6a:f7:
-                    a1:3c:c9:b7:bb:00:79:82:f0:a9:c3:6f:58:a7:68:
-                    75:53:b2:fa:33:98:28:53:2e:99:d2:fb:73:63:09:
-                    51:32:df:0f:58:ee:ba:6a:19
+                    00:c2:4a:6e:07:c6:1c:8b:2f:bf:91:3e:25:dc:54:
+                    2c:02:0f:1b:6f:5b:0e:5a:69:1d:dd:52:3f:8b:f4:
+                    c8:56:c6:f3:c5:56:2c:b8:82:67:81:09:7b:0d:6f:
+                    01:26:4a:ae:42:53:95:b1:32:ba:07:d4:64:bc:79:
+                    1f:16:0a:92:07:e5:af:5d:d6:b3:4d:09:58:b1:8a:
+                    ba:2c:c0:d3:9b:95:cc:a1:0d:e5:4d:40:1a:50:2d:
+                    a4:45:ff:05:63:62:84:35:73:2c:0f:b3:f6:69:fd:
+                    9b:d3:5e:a8:12:f0:c4:a0:77:25:59:e7:81:3d:ee:
+                    c5:22:10:75:ac:ad:cc:a4:1f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,33 +28,33 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                7A:E0:53:6E:4C:00:F4:DE:3D:74:3A:37:BA:CD:25:7A:C2:BC:44:0A
+                23:78:2F:09:81:B0:7B:C6:79:1F:30:FE:FC:5E:37:14:FF:20:A0:20
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:93:70:43:DA:C0:AA:14:71:0F:93:EB:82:E7:F5:AE:C9:D2:1A:78:77
+                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
 
     Signature Algorithm: sha256WithRSAEncryption
-         c3:d4:14:36:2b:f3:0b:aa:1a:eb:25:d6:fc:8c:f4:26:bc:c1:
-         a4:eb:a0:ea:91:bc:2d:3d:96:dc:4d:e0:45:af:a6:80:88:dd:
-         79:71:ee:3f:72:20:0a:e1:31:8d:9f:20:fc:64:9c:9c:5e:46:
-         6b:b4:7e:84:20:cf:18:25:14:6d:d0:b7:e2:74:c5:92:2b:86:
-         0a:d0:4a:64:2c:94:50:2d:a2:3b:1d:93:c8:dc:dc:c4:73:d6:
-         8a:92:01:05:c9:1e:29:07:c7:da:b6:3b:2b:ca:ca:18:95:13:
-         18:1f:d9:5d:11:01:77:47:23:da:b7:b3:82:3f:42:2e:52:3d:
-         05:65
+         82:ba:d5:8d:f2:d3:98:79:1a:02:15:a2:3d:b3:53:e7:79:28:
+         05:39:aa:be:2d:7c:6a:4f:c2:66:60:86:62:41:ba:eb:d5:de:
+         6e:3a:81:4a:22:33:5b:22:31:35:61:9e:d9:9c:f8:59:fa:93:
+         e7:7e:9c:f9:e7:15:60:34:f2:2a:3a:13:96:94:c8:de:24:b6:
+         bf:0d:20:aa:4a:9b:eb:c1:9c:49:be:2f:69:69:01:53:0a:06:
+         2a:1d:e7:02:6b:a8:d8:e7:95:32:7e:b5:79:e6:40:0e:72:02:
+         74:24:75:eb:3d:17:8d:75:87:2b:2a:dd:5e:98:d8:67:e3:5c:
+         2a:9d
 -----BEGIN CERTIFICATE-----
 MIICPzCCAaigAwIBAgIBATANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDMwOTIxMzU1M1owHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AOOe2dLzYQQRt0FeH06+LyfieZWKFeUeMT4V2XN7ta8/UyX9Le3U7xW23ow0KD7o
-FIabBqiPxcLPzjHBQE0ke0wXS50ZbFdmoiW6JtIUNzIXFQxRLp1+AWr3oTzJt7sA
-eYLwqcNvWKdodVOy+jOYKFMumdL7c2MJUTLfD1juumoZAgMBAAGjgZcwgZQwDwYD
-VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHrgU25MAPTe
-PXQ6N7rNJXrCvEQKMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVy
-bmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFJNwQ9rAqhRxD5Prguf1rsnSGnh3
-MA0GCSqGSIb3DQEBCwUAA4GBAMPUFDYr8wuqGusl1vyM9Ca8waTroOqRvC09ltxN
-4EWvpoCI3Xlx7j9yIArhMY2fIPxknJxeRmu0foQgzxglFG3Qt+J0xZIrhgrQSmQs
-lFAtojsdk8jc3MRz1oqSAQXJHikHx9q2OyvKyhiVExgf2V0RAXdHI9q3s4I/Qi5S
-PQVl
+AMJKbgfGHIsvv5E+JdxULAIPG29bDlppHd1SP4v0yFbG88VWLLiCZ4EJew1vASZK
+rkJTlbEyugfUZLx5HxYKkgflr13Ws00JWLGKuizA05uVzKEN5U1AGlAtpEX/BWNi
+hDVzLA+z9mn9m9NeqBLwxKB3JVnngT3uxSIQdaytzKQfAgMBAAGjgZcwgZQwDwYD
+VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFCN4LwmBsHvG
+eR8w/vxeNxT/IKAgMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVy
+bmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFCwlGaFss/dp/XabOiLLDFYBAfEx
+MA0GCSqGSIb3DQEBCwUAA4GBAIK61Y3y05h5GgIVoj2zU+d5KAU5qr4tfGpPwmZg
+hmJBuuvV3m46gUoiM1siMTVhntmc+Fn6k+d+nPnnFWA08io6E5aUyN4ktr8NIKpK
+m+vBnEm+L2lpAVMKBiod5wJrqNjnlTJ+tXnmQA5yAnQkdes9F411hysq3V6Y2Gfj
+XCqd
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/pluto-key.pem
+++ b/spec/fixtures/ssl/pluto-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:d0:24:0c:ff:0a:c3:9c:15:95:f1:38:7f:5d:be:
-    1f:d0:cc:1f:38:30:66:e7:36:a5:fd:a6:c1:52:b9:
-    34:7c:61:b6:ef:42:f9:ef:9c:cb:2e:1a:80:0f:c3:
-    45:52:2b:a7:d2:fd:32:b7:75:95:7c:63:f7:5b:98:
-    5c:4a:8d:6a:fd:ac:a7:d2:fb:1e:93:e8:39:19:22:
-    f5:78:ea:41:76:12:e9:2a:a0:66:65:2a:55:76:cd:
-    9d:7d:43:10:b7:ff:8a:e4:22:6d:35:0c:00:ff:ba:
-    8b:e1:00:20:87:9a:fd:64:0b:16:c4:e7:36:95:43:
-    ef:e9:5e:e9:50:4b:90:3e:c5
+    00:96:dd:38:6c:f5:6a:d5:c1:69:6b:81:97:91:a0:
+    05:be:53:2b:96:b5:cb:25:4c:f8:35:81:0e:aa:81:
+    66:49:10:58:cf:0c:8e:d1:01:2a:0a:38:ae:a2:e0:
+    8c:8a:7d:cf:d0:44:09:90:59:d7:02:6e:aa:fa:72:
+    6e:34:31:d8:ff:c5:69:90:f5:d9:17:b1:8d:0e:df:
+    8b:b1:2b:f8:7d:0d:7e:0b:6e:ba:05:b7:5f:da:d8:
+    2f:e5:66:11:37:f9:20:af:8e:f1:42:c3:6d:f0:00:
+    bb:72:90:08:c7:26:84:04:b1:48:dd:8e:72:20:20:
+    30:04:31:b4:71:7b:92:b7:17
 publicExponent: 65537 (0x10001)
 privateExponent:
-    78:c3:c2:0a:a4:ab:34:3f:cd:fc:e4:c3:f9:97:1b:
-    8c:a1:32:a7:fe:65:66:57:ed:dd:8b:48:75:ff:e1:
-    75:1d:98:ef:9f:d3:b6:74:29:eb:39:12:fe:92:55:
-    01:45:35:1d:95:2d:3d:06:eb:51:fe:0a:82:49:97:
-    9a:e6:0c:a1:d0:2b:70:01:0f:17:8b:77:e8:59:3c:
-    32:99:e8:35:b1:9a:4d:d3:4f:6c:68:58:9f:13:83:
-    8b:be:a1:e2:61:cb:98:e4:df:45:76:bf:db:cc:ba:
-    d5:52:e9:b9:ab:a3:ba:67:41:c5:ab:32:35:8a:a8:
-    54:25:c1:e7:6c:3c:a0:8d
+    0d:3e:44:2a:c4:6c:69:71:3e:08:d2:ea:74:3d:20:
+    e3:f1:37:1d:56:be:0b:7b:33:3a:b7:26:8b:6f:2a:
+    84:75:6b:e6:59:0a:dc:6c:06:bd:b8:f6:13:94:34:
+    a2:1f:a3:33:7c:15:7e:d7:74:19:61:8f:9e:c6:96:
+    c7:fc:2c:39:3d:21:58:1d:72:09:97:5e:07:73:39:
+    8f:e5:23:62:76:5f:16:60:be:13:1a:c2:aa:5e:da:
+    90:b2:6a:c7:55:1b:15:ba:06:47:88:6e:e4:f3:2f:
+    76:1a:0a:72:9e:f2:2f:48:e3:58:05:ee:9f:56:f0:
+    42:bd:8e:96:1f:2d:de:59
 prime1:
-    00:fa:97:c4:20:8c:42:ec:25:8d:7e:1f:9c:de:cd:
-    0a:6d:90:39:dd:f2:a1:ac:db:e1:9f:03:83:1e:ec:
-    7b:cf:25:7b:0f:ab:1b:f7:8d:d1:9d:a4:ae:fd:68:
-    7d:b0:f6:6d:cf:c4:bf:be:4a:e0:13:f3:73:3c:08:
-    77:15:25:fe:17
+    00:c4:ea:3f:6c:c8:0a:dc:98:c6:73:7e:fc:c4:73:
+    9f:53:3a:c2:2c:7e:cc:58:26:60:49:f6:38:85:fa:
+    6b:2a:17:ec:f2:7f:a6:ee:71:1c:ae:c6:0f:82:f1:
+    11:f2:13:43:c1:23:e1:d4:3f:b2:bc:66:0b:32:85:
+    20:2d:c2:fb:53
 prime2:
-    00:d4:a1:c9:62:aa:a8:1c:9e:27:54:79:3f:e4:77:
-    f8:9d:fd:29:4d:0c:fb:56:49:0d:7b:8c:7b:ce:66:
-    68:6c:54:05:d0:6c:30:ab:8c:ce:85:ab:2c:ef:a3:
-    8f:c0:88:5b:c8:95:de:b2:a2:10:4c:4f:70:94:d8:
-    20:f8:ef:2f:83
+    00:c4:21:a3:60:a7:b8:71:d4:12:f7:d1:a6:5b:2e:
+    33:65:e9:e6:58:98:0e:09:aa:02:79:b6:de:a0:1f:
+    9f:33:f0:34:58:2e:ca:a8:3f:60:d2:68:50:56:e4:
+    26:2b:48:4b:53:42:5b:35:79:41:c1:9c:10:80:09:
+    bb:0a:f9:a0:ad
 exponent1:
-    06:5b:d9:87:35:e7:f0:d4:17:1e:0f:31:4c:da:09:
-    1c:b4:9f:33:49:97:de:aa:09:b4:9e:43:32:82:af:
-    b5:96:ee:e3:7b:e5:0e:c8:13:7c:9b:94:31:2b:f8:
-    9c:87:f4:4b:64:63:b5:31:73:34:2e:66:4b:2c:af:
-    d0:e2:90:eb
+    03:9f:a3:e7:26:8f:3c:9b:fb:1a:e8:fd:51:c8:26:
+    e8:6b:2e:63:8f:39:c7:6d:7d:5c:1f:11:cf:35:5a:
+    7f:7d:cd:38:71:2c:eb:3a:5d:a2:c1:b6:4b:5c:90:
+    4d:fa:18:c7:17:17:f2:c5:f1:4e:12:3a:a6:85:58:
+    a0:3e:f4:4d
 exponent2:
-    59:f0:89:27:83:fa:12:08:cf:a8:0a:95:7d:05:46:
-    13:45:c7:57:81:1b:3a:f7:31:8d:c5:f1:84:6f:8a:
-    d1:ef:84:7a:11:99:50:a7:01:a0:46:b4:7e:34:d8:
-    14:5f:59:3b:72:31:3d:ac:11:6a:c5:db:60:0a:3f:
-    80:2c:64:13
+    00:96:6b:0d:f7:d4:e9:ba:32:e1:91:3a:32:91:7f:
+    6f:5f:db:f1:13:45:1a:8f:02:d9:ff:2a:e6:b6:7b:
+    4a:07:f5:52:cf:c6:a3:1a:41:f1:29:ad:62:e0:20:
+    fd:bc:f8:26:fc:e5:c9:39:cb:93:48:bf:3e:50:54:
+    26:25:16:a9:c9
 coefficient:
-    00:a9:aa:39:02:18:ba:e7:22:17:bd:2a:6c:90:0f:
-    bc:6f:ed:60:7c:42:b1:8a:8c:b9:03:4e:d8:d0:ec:
-    db:03:e1:42:0c:00:39:3b:d3:d2:28:1c:26:67:31:
-    71:5a:a8:92:ec:eb:c6:50:52:fb:da:03:92:43:ec:
-    fa:7f:73:b8:25
+    03:ff:60:b9:86:8a:d9:ee:79:fc:2b:01:a5:f7:7c:
+    56:f6:57:32:8e:21:18:17:37:c3:34:dc:d5:8b:ed:
+    56:fa:9f:10:34:92:fb:06:b8:87:c2:36:ce:6a:7a:
+    9f:ae:56:e0:02:e3:0c:87:57:4c:9f:5a:fe:c3:0a:
+    b0:7b:cd:e4
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQDQJAz/CsOcFZXxOH9dvh/QzB84MGbnNqX9psFSuTR8YbbvQvnv
-nMsuGoAPw0VSK6fS/TK3dZV8Y/dbmFxKjWr9rKfS+x6T6DkZIvV46kF2EukqoGZl
-KlV2zZ19QxC3/4rkIm01DAD/uovhACCHmv1kCxbE5zaVQ+/pXulQS5A+xQIDAQAB
-AoGAeMPCCqSrND/N/OTD+ZcbjKEyp/5lZlft3YtIdf/hdR2Y75/TtnQp6zkS/pJV
-AUU1HZUtPQbrUf4KgkmXmuYModArcAEPF4t36Fk8MpnoNbGaTdNPbGhYnxODi76h
-4mHLmOTfRXa/28y61VLpuaujumdBxasyNYqoVCXB52w8oI0CQQD6l8QgjELsJY1+
-H5zezQptkDnd8qGs2+GfA4Me7HvPJXsPqxv3jdGdpK79aH2w9m3PxL++SuAT83M8
-CHcVJf4XAkEA1KHJYqqoHJ4nVHk/5Hf4nf0pTQz7VkkNe4x7zmZobFQF0Gwwq4zO
-hass76OPwIhbyJXesqIQTE9wlNgg+O8vgwJABlvZhzXn8NQXHg8xTNoJHLSfM0mX
-3qoJtJ5DMoKvtZbu43vlDsgTfJuUMSv4nIf0S2RjtTFzNC5mSyyv0OKQ6wJAWfCJ
-J4P6EgjPqAqVfQVGE0XHV4EbOvcxjcXxhG+K0e+EehGZUKcBoEa0fjTYFF9ZO3Ix
-PawRasXbYAo/gCxkEwJBAKmqOQIYuuciF70qbJAPvG/tYHxCsYqMuQNO2NDs2wPh
-QgwAOTvT0igcJmcxcVqokuzrxlBS+9oDkkPs+n9zuCU=
+MIICXAIBAAKBgQCW3Ths9WrVwWlrgZeRoAW+UyuWtcslTPg1gQ6qgWZJEFjPDI7R
+ASoKOK6i4IyKfc/QRAmQWdcCbqr6cm40Mdj/xWmQ9dkXsY0O34uxK/h9DX4LbroF
+t1/a2C/lZhE3+SCvjvFCw23wALtykAjHJoQEsUjdjnIgIDAEMbRxe5K3FwIDAQAB
+AoGADT5EKsRsaXE+CNLqdD0g4/E3HVa+C3szOrcmi28qhHVr5lkK3GwGvbj2E5Q0
+oh+jM3wVftd0GWGPnsaWx/wsOT0hWB1yCZdeB3M5j+UjYnZfFmC+ExrCql7akLJq
+x1UbFboGR4hu5PMvdhoKcp7yL0jjWAXun1bwQr2Olh8t3lkCQQDE6j9syArcmMZz
+fvzEc59TOsIsfsxYJmBJ9jiF+msqF+zyf6bucRyuxg+C8RHyE0PBI+HUP7K8Zgsy
+hSAtwvtTAkEAxCGjYKe4cdQS99GmWy4zZenmWJgOCaoCebbeoB+fM/A0WC7KqD9g
+0mhQVuQmK0hLU0JbNXlBwZwQgAm7CvmgrQJAA5+j5yaPPJv7Guj9Ucgm6GsuY485
+x219XB8RzzVaf33NOHEs6zpdosG2S1yQTfoYxxcX8sXxThI6poVYoD70TQJBAJZr
+DffU6boy4ZE6MpF/b1/b8RNFGo8C2f8q5rZ7Sgf1Us/GoxpB8SmtYuAg/bz4Jvzl
+yTnLk0i/PlBUJiUWqckCQAP/YLmGitnuefwrAaX3fFb2VzKOIRgXN8M03NWL7Vb6
+nxA0kvsGuIfCNs5qep+uVuAC4wyHV0yfWv7DCrB7zeQ=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/pluto.pem
+++ b/spec/fixtures/ssl/pluto.pem
@@ -1,44 +1,44 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 6 (0x6)
+        Serial Number: 7 (0x7)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Agent Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=pluto
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:d0:24:0c:ff:0a:c3:9c:15:95:f1:38:7f:5d:be:
-                    1f:d0:cc:1f:38:30:66:e7:36:a5:fd:a6:c1:52:b9:
-                    34:7c:61:b6:ef:42:f9:ef:9c:cb:2e:1a:80:0f:c3:
-                    45:52:2b:a7:d2:fd:32:b7:75:95:7c:63:f7:5b:98:
-                    5c:4a:8d:6a:fd:ac:a7:d2:fb:1e:93:e8:39:19:22:
-                    f5:78:ea:41:76:12:e9:2a:a0:66:65:2a:55:76:cd:
-                    9d:7d:43:10:b7:ff:8a:e4:22:6d:35:0c:00:ff:ba:
-                    8b:e1:00:20:87:9a:fd:64:0b:16:c4:e7:36:95:43:
-                    ef:e9:5e:e9:50:4b:90:3e:c5
+                    00:96:dd:38:6c:f5:6a:d5:c1:69:6b:81:97:91:a0:
+                    05:be:53:2b:96:b5:cb:25:4c:f8:35:81:0e:aa:81:
+                    66:49:10:58:cf:0c:8e:d1:01:2a:0a:38:ae:a2:e0:
+                    8c:8a:7d:cf:d0:44:09:90:59:d7:02:6e:aa:fa:72:
+                    6e:34:31:d8:ff:c5:69:90:f5:d9:17:b1:8d:0e:df:
+                    8b:b1:2b:f8:7d:0d:7e:0b:6e:ba:05:b7:5f:da:d8:
+                    2f:e5:66:11:37:f9:20:af:8e:f1:42:c3:6d:f0:00:
+                    bb:72:90:08:c7:26:84:04:b1:48:dd:8e:72:20:20:
+                    30:04:31:b4:71:7b:92:b7:17
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         9f:99:01:ae:86:0a:bf:b3:03:5a:94:72:47:6e:61:97:6b:44:
-         c6:9f:c4:1e:7e:5e:41:e0:1e:11:8e:d0:68:0a:c0:bb:5d:7d:
-         9a:e4:93:ba:df:9f:77:3c:26:ee:7f:e0:2c:45:b4:17:64:af:
-         5c:92:f9:7f:b1:5d:2c:8b:25:bd:ed:3b:e3:db:ca:1a:a0:41:
-         c2:9f:9c:17:78:d2:b4:9c:83:65:f5:42:10:94:3b:81:f5:e0:
-         35:3f:6c:3e:ef:41:a9:85:9c:06:07:e5:95:0b:81:9b:92:91:
-         ab:d2:c6:fe:0f:28:4a:60:8e:dd:5b:36:58:d6:62:75:5a:47:
-         c1:30
+         57:cd:20:5c:a5:26:46:6d:88:4d:ae:5b:4d:a2:d2:37:09:0e:
+         81:6f:ed:01:9a:45:a0:ef:ac:51:33:f3:70:b6:f7:bf:1d:1e:
+         a6:e6:c3:15:bd:80:f8:01:d5:ed:a3:78:f5:56:4e:00:1f:47:
+         d9:e7:04:81:a8:bc:f0:b9:30:fa:67:02:75:0c:5c:e8:ea:71:
+         3f:36:4a:1b:39:62:eb:ab:ad:46:2d:93:74:6d:5b:b7:87:fc:
+         b3:0b:bd:d7:11:4e:2b:59:87:bc:29:31:da:a5:74:07:e2:46:
+         dc:1c:a6:cb:20:fc:4b:f0:c3:31:01:1d:f9:1a:76:c9:f2:68:
+         dd:c2
 -----BEGIN CERTIFICATE-----
-MIIBqTCCARKgAwIBAgIBBjANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
-IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDky
-MTM1NTNaMBAxDjAMBgNVBAMMBXBsdXRvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
-iQKBgQDQJAz/CsOcFZXxOH9dvh/QzB84MGbnNqX9psFSuTR8YbbvQvnvnMsuGoAP
-w0VSK6fS/TK3dZV8Y/dbmFxKjWr9rKfS+x6T6DkZIvV46kF2EukqoGZlKlV2zZ19
-QxC3/4rkIm01DAD/uovhACCHmv1kCxbE5zaVQ+/pXulQS5A+xQIDAQABMA0GCSqG
-SIb3DQEBCwUAA4GBAJ+ZAa6GCr+zA1qUckduYZdrRMafxB5+XkHgHhGO0GgKwLtd
-fZrkk7rfn3c8Ju5/4CxFtBdkr1yS+X+xXSyLJb3tO+PbyhqgQcKfnBd40rScg2X1
-QhCUO4H14DU/bD7vQamFnAYH5ZULgZuSkavSxv4PKEpgjt1bNljWYnVaR8Ew
+MIIBqTCCARKgAwIBAgIBBzANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
+IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTky
+MjMxMjJaMBAxDjAMBgNVBAMMBXBsdXRvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQCW3Ths9WrVwWlrgZeRoAW+UyuWtcslTPg1gQ6qgWZJEFjPDI7RASoKOK6i
+4IyKfc/QRAmQWdcCbqr6cm40Mdj/xWmQ9dkXsY0O34uxK/h9DX4LbroFt1/a2C/l
+ZhE3+SCvjvFCw23wALtykAjHJoQEsUjdjnIgIDAEMbRxe5K3FwIDAQABMA0GCSqG
+SIb3DQEBCwUAA4GBAFfNIFylJkZtiE2uW02i0jcJDoFv7QGaRaDvrFEz83C2978d
+HqbmwxW9gPgB1e2jePVWTgAfR9nnBIGovPC5MPpnAnUMXOjqcT82Shs5YuurrUYt
+k3RtW7eH/LMLvdcRTitZh7wpMdqldAfiRtwcpssg/EvwwzEBHfkadsnyaN3C
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/request-key.pem
+++ b/spec/fixtures/ssl/request-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:da:5a:94:fd:77:48:51:fa:2b:1e:bb:38:32:17:
-    71:5d:93:32:5b:67:fa:18:53:d2:4c:86:ea:1a:ec:
-    7c:eb:fd:64:a5:d4:04:88:6d:92:8c:5f:8a:8a:02:
-    b5:c6:8e:c9:e4:a0:26:1c:7d:62:e0:1b:37:46:de:
-    0a:e1:1d:7b:79:1c:9a:b1:71:de:e0:c7:31:1d:00:
-    a6:98:fb:6e:32:a5:9b:bf:36:30:54:7a:13:14:fe:
-    2f:f3:75:a7:0c:bb:d8:96:15:05:eb:57:63:a1:cc:
-    1b:32:67:c1:dc:dc:b2:34:7b:23:00:70:f0:9a:5e:
-    6f:31:7f:f4:d1:cc:84:5f:25
+    00:9a:61:a1:62:58:9d:04:2e:8a:53:d0:68:7a:00:
+    96:1b:2c:9b:ba:b6:d5:78:69:9f:63:51:2e:65:20:
+    bb:de:34:32:03:83:81:63:3e:5f:54:14:c1:64:66:
+    73:22:13:e0:6c:c7:4c:07:df:46:7a:cd:71:d6:4a:
+    1d:28:97:72:10:00:42:d9:3a:5e:73:ab:92:d6:e4:
+    30:59:14:89:4b:8a:58:8c:0d:ba:1e:7a:b5:fd:c5:
+    31:b2:2f:c8:37:e6:47:05:23:7a:71:db:f0:66:7f:
+    cc:0a:a8:1e:26:ca:80:2d:8c:a1:e3:af:4a:49:61:
+    8f:94:99:70:48:9b:06:26:bd
 publicExponent: 65537 (0x10001)
 privateExponent:
-    17:12:8d:3d:bf:35:f0:1b:9c:24:d2:29:9c:f9:67:
-    2c:39:1a:90:18:0b:90:38:83:37:3c:e6:4d:d4:01:
-    5b:3a:5a:41:3f:86:ff:17:7c:ed:c2:46:b4:50:96:
-    fe:95:25:f6:37:89:ef:66:bc:64:eb:db:4a:6c:b9:
-    ff:91:8a:f3:4e:39:f0:e2:bf:21:e5:4a:fe:8c:77:
-    62:c7:84:2f:ba:bd:35:e9:b5:5f:49:54:f8:02:72:
-    02:39:6b:ee:07:62:ec:bf:6a:51:17:9c:76:66:dd:
-    8b:01:d6:ab:60:49:e2:7c:4b:40:af:34:5d:2f:29:
-    67:5f:d0:23:1b:9b:52:bd
+    1f:0f:1f:49:ca:ec:24:08:3c:fa:29:c6:ab:2c:ed:
+    06:20:8e:60:1d:22:8b:6c:2c:8d:ed:aa:38:dc:42:
+    0f:ad:4e:96:98:61:72:96:fc:d4:cc:ac:2f:c7:d0:
+    c7:fd:59:bc:68:c8:2a:19:48:73:b2:5b:81:b2:3d:
+    75:8a:2a:7f:2f:9e:ae:32:e7:4a:45:fb:b1:f4:45:
+    d1:57:77:c5:a2:4e:16:30:c9:9b:a0:73:6d:64:39:
+    87:83:f1:df:0a:6c:21:5e:3f:5a:df:c6:44:9f:73:
+    8d:69:89:9a:04:70:e2:58:af:be:93:a6:ba:7e:1e:
+    5a:89:35:23:87:c3:c3:fd
 prime1:
-    00:f3:ff:bb:23:6c:56:8b:52:20:fc:e2:ce:7c:39:
-    21:09:64:57:2d:8d:87:d6:d1:6d:d2:74:cc:20:f2:
-    13:cc:ce:81:de:68:46:15:36:5b:d5:a0:11:99:79:
-    bd:75:0b:c9:b3:d8:bd:77:1d:58:df:b6:30:56:eb:
-    2f:00:30:8d:07
+    00:c9:49:17:ab:19:b4:7a:ba:98:1a:71:a0:95:de:
+    b1:f5:75:f1:43:27:51:db:36:85:aa:c4:a8:78:8c:
+    ea:aa:35:16:d4:d8:48:52:20:5e:e1:97:c4:ad:de:
+    58:b6:cf:f8:16:a2:74:3c:37:1c:92:f8:f5:f3:93:
+    8a:f9:6c:95:df
 prime2:
-    00:e5:17:f1:f4:b0:8c:36:e2:6d:a2:c3:b5:3e:83:
-    f2:c8:35:c1:76:0c:99:be:90:e6:12:ff:c7:0d:34:
-    c0:9e:db:ca:69:e3:29:a4:4e:19:96:f5:7e:cc:d0:
-    a2:c0:82:a4:12:4e:8c:f7:ca:4b:9a:cb:d6:90:d2:
-    d0:e7:f6:93:73
+    00:c4:58:9b:56:6d:ac:1e:75:57:63:86:30:53:27:
+    26:cf:e5:55:2a:ff:49:b3:25:57:d7:30:99:d9:d7:
+    c6:8a:46:3d:dd:d9:ec:33:5e:ab:e2:00:60:84:78:
+    b3:d8:55:e3:c4:48:06:d4:12:42:7a:6c:47:b6:28:
+    9a:aa:36:fe:e3
 exponent1:
-    00:d6:94:48:dc:6f:33:71:14:ca:23:fb:c6:81:a2:
-    b0:36:15:43:41:b1:5d:0c:03:64:24:98:48:c8:94:
-    7b:eb:3a:95:25:a5:e8:34:51:78:d3:d7:10:83:3b:
-    77:ed:4e:6f:95:35:7f:f2:18:22:07:a3:ae:c1:51:
-    d5:24:c2:8d:d3
+    12:9e:4e:30:27:6a:88:47:a6:36:1b:f8:8c:a4:52:
+    b5:af:b9:27:4b:05:c9:4f:1b:c2:15:fa:b7:5b:e1:
+    80:e8:f4:39:af:df:d0:a8:e9:dd:d8:19:fb:33:2b:
+    e5:8d:0b:17:9c:e3:3f:86:a1:7f:fe:c3:51:4a:7e:
+    7a:5f:ce:e5
 exponent2:
-    08:35:2f:6a:00:d9:45:2e:1f:97:71:43:91:15:d1:
-    20:f3:2c:17:3a:a4:57:7b:81:82:b4:bf:40:ed:de:
-    e8:d2:1f:12:64:1d:1d:d1:de:80:d6:12:d0:eb:b8:
-    a9:05:05:33:d2:b4:a2:3c:11:31:5e:94:35:64:18:
-    2f:f7:59:99
+    00:87:17:3b:d1:6c:65:e7:12:ef:0c:6f:d0:21:f6:
+    27:13:15:03:d3:30:90:61:ac:c8:d2:2b:03:3f:c9:
+    e1:35:53:fc:ce:fe:58:30:43:eb:d8:f4:4f:73:f5:
+    a4:2f:ad:70:a7:a4:b2:e6:08:a6:2a:9b:03:80:06:
+    51:db:d9:38:e7
 coefficient:
-    00:97:59:ca:65:4a:37:b4:5c:af:69:d6:b7:e1:45:
-    c4:73:36:50:ba:30:95:19:e0:27:5c:51:05:c0:d9:
-    e1:02:1e:ac:c1:05:2c:53:74:e9:42:4e:22:20:c3:
-    6f:ce:6c:e9:60:fd:68:1b:66:96:de:3e:5d:86:1e:
-    1b:4b:f3:e8:a6
+    52:f7:43:0b:33:a8:23:c9:fa:58:72:b1:a4:5f:f4:
+    7f:c3:6e:f5:01:69:61:e1:97:c3:99:d5:e8:3c:45:
+    51:c0:0d:41:68:0c:bf:c6:39:9c:8a:f2:19:37:8f:
+    46:90:6e:35:7a:0c:eb:eb:02:8d:e2:bd:58:43:01:
+    51:76:70:62
 -----BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQDaWpT9d0hR+iseuzgyF3FdkzJbZ/oYU9JMhuoa7Hzr/WSl1ASI
-bZKMX4qKArXGjsnkoCYcfWLgGzdG3grhHXt5HJqxcd7gxzEdAKaY+24ypZu/NjBU
-ehMU/i/zdacMu9iWFQXrV2OhzBsyZ8Hc3LI0eyMAcPCaXm8xf/TRzIRfJQIDAQAB
-AoGAFxKNPb818BucJNIpnPlnLDkakBgLkDiDNzzmTdQBWzpaQT+G/xd87cJGtFCW
-/pUl9jeJ72a8ZOvbSmy5/5GK80458OK/IeVK/ox3YseEL7q9Nem1X0lU+AJyAjlr
-7gdi7L9qURecdmbdiwHWq2BJ4nxLQK80XS8pZ1/QIxubUr0CQQDz/7sjbFaLUiD8
-4s58OSEJZFctjYfW0W3SdMwg8hPMzoHeaEYVNlvVoBGZeb11C8mz2L13HVjftjBW
-6y8AMI0HAkEA5Rfx9LCMNuJtosO1PoPyyDXBdgyZvpDmEv/HDTTAntvKaeMppE4Z
-lvV+zNCiwIKkEk6M98pLmsvWkNLQ5/aTcwJBANaUSNxvM3EUyiP7xoGisDYVQ0Gx
-XQwDZCSYSMiUe+s6lSWl6DRReNPXEIM7d+1Ob5U1f/IYIgejrsFR1STCjdMCQAg1
-L2oA2UUuH5dxQ5EV0SDzLBc6pFd7gYK0v0Dt3ujSHxJkHR3R3oDWEtDruKkFBTPS
-tKI8ETFelDVkGC/3WZkCQQCXWcplSje0XK9p1rfhRcRzNlC6MJUZ4CdcUQXA2eEC
-HqzBBSxTdOlCTiIgw2/ObOlg/WgbZpbePl2GHhtL8+im
+MIICXAIBAAKBgQCaYaFiWJ0ELopT0Gh6AJYbLJu6ttV4aZ9jUS5lILveNDIDg4Fj
+Pl9UFMFkZnMiE+Bsx0wH30Z6zXHWSh0ol3IQAELZOl5zq5LW5DBZFIlLiliMDboe
+erX9xTGyL8g35kcFI3px2/Bmf8wKqB4myoAtjKHjr0pJYY+UmXBImwYmvQIDAQAB
+AoGAHw8fScrsJAg8+inGqyztBiCOYB0ii2wsje2qONxCD61Olphhcpb81MysL8fQ
+x/1ZvGjIKhlIc7JbgbI9dYoqfy+erjLnSkX7sfRF0Vd3xaJOFjDJm6BzbWQ5h4Px
+3wpsIV4/Wt/GRJ9zjWmJmgRw4livvpOmun4eWok1I4fDw/0CQQDJSRerGbR6upga
+caCV3rH1dfFDJ1HbNoWqxKh4jOqqNRbU2EhSIF7hl8St3li2z/gWonQ8NxyS+PXz
+k4r5bJXfAkEAxFibVm2sHnVXY4YwUycmz+VVKv9JsyVX1zCZ2dfGikY93dnsM16r
+4gBghHiz2FXjxEgG1BJCemxHtiiaqjb+4wJAEp5OMCdqiEemNhv4jKRSta+5J0sF
+yU8bwhX6t1vhgOj0Oa/f0Kjp3dgZ+zMr5Y0LF5zjP4ahf/7DUUp+el/O5QJBAIcX
+O9FsZecS7wxv0CH2JxMVA9MwkGGsyNIrAz/J4TVT/M7+WDBD69j0T3P1pC+tcKek
+suYIpiqbA4AGUdvZOOcCQFL3QwszqCPJ+lhysaRf9H/DbvUBaWHhl8OZ1eg8RVHA
+DUFoDL/GOZyK8hk3j0aQbjV6DOvrAo3ivVhDAVF2cGI=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/request.pem
+++ b/spec/fixtures/ssl/request.pem
@@ -6,34 +6,34 @@ Certificate Request:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:da:5a:94:fd:77:48:51:fa:2b:1e:bb:38:32:17:
-                    71:5d:93:32:5b:67:fa:18:53:d2:4c:86:ea:1a:ec:
-                    7c:eb:fd:64:a5:d4:04:88:6d:92:8c:5f:8a:8a:02:
-                    b5:c6:8e:c9:e4:a0:26:1c:7d:62:e0:1b:37:46:de:
-                    0a:e1:1d:7b:79:1c:9a:b1:71:de:e0:c7:31:1d:00:
-                    a6:98:fb:6e:32:a5:9b:bf:36:30:54:7a:13:14:fe:
-                    2f:f3:75:a7:0c:bb:d8:96:15:05:eb:57:63:a1:cc:
-                    1b:32:67:c1:dc:dc:b2:34:7b:23:00:70:f0:9a:5e:
-                    6f:31:7f:f4:d1:cc:84:5f:25
+                    00:9a:61:a1:62:58:9d:04:2e:8a:53:d0:68:7a:00:
+                    96:1b:2c:9b:ba:b6:d5:78:69:9f:63:51:2e:65:20:
+                    bb:de:34:32:03:83:81:63:3e:5f:54:14:c1:64:66:
+                    73:22:13:e0:6c:c7:4c:07:df:46:7a:cd:71:d6:4a:
+                    1d:28:97:72:10:00:42:d9:3a:5e:73:ab:92:d6:e4:
+                    30:59:14:89:4b:8a:58:8c:0d:ba:1e:7a:b5:fd:c5:
+                    31:b2:2f:c8:37:e6:47:05:23:7a:71:db:f0:66:7f:
+                    cc:0a:a8:1e:26:ca:80:2d:8c:a1:e3:af:4a:49:61:
+                    8f:94:99:70:48:9b:06:26:bd
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         39:d7:a3:20:cb:15:ab:97:97:32:ff:64:cd:ac:47:ab:3e:c3:
-         84:1f:ed:25:f0:c5:f1:a6:88:14:c5:8c:49:dc:d2:2c:83:5a:
-         ef:59:48:f4:8c:f8:30:97:fa:0a:06:24:fd:97:92:c8:cf:cf:
-         5f:c5:8d:9f:b4:75:bc:88:da:84:94:0c:44:c0:e6:47:21:37:
-         79:35:ff:9c:78:bf:55:51:af:dc:1c:35:c0:9f:06:87:f9:63:
-         01:48:9d:0c:b4:f1:97:72:56:4b:37:9e:80:5d:19:f8:00:a1:
-         20:81:31:3c:d4:b6:6d:5c:65:bb:cd:4b:34:04:75:d6:28:04:
-         2e:db
+         21:02:1f:71:ac:e2:45:85:f7:87:b0:ee:e9:3b:c9:86:21:a7:
+         6e:2c:bd:3b:ee:69:8f:c2:97:bd:25:83:84:b0:92:58:a7:b0:
+         b5:a5:35:3e:bf:55:3e:d4:6f:28:4f:3f:1f:97:a7:f1:da:c0:
+         11:ab:85:16:cf:27:77:8e:2b:9a:de:6e:96:7c:de:49:87:e8:
+         53:14:b8:9d:c4:b8:a0:92:7f:ef:22:16:62:a5:39:72:2d:2a:
+         e7:8f:0b:31:46:62:d5:ed:7c:fb:a5:3a:5a:75:84:3c:ec:6d:
+         66:53:36:13:78:a6:71:f2:cc:fa:1c:35:5d:56:89:0e:8e:be:
+         dd:19
 -----BEGIN CERTIFICATE REQUEST-----
 MIIBUTCBuwIBAjASMRAwDgYDVQQDDAdwZW5kaW5nMIGfMA0GCSqGSIb3DQEBAQUA
-A4GNADCBiQKBgQDaWpT9d0hR+iseuzgyF3FdkzJbZ/oYU9JMhuoa7Hzr/WSl1ASI
-bZKMX4qKArXGjsnkoCYcfWLgGzdG3grhHXt5HJqxcd7gxzEdAKaY+24ypZu/NjBU
-ehMU/i/zdacMu9iWFQXrV2OhzBsyZ8Hc3LI0eyMAcPCaXm8xf/TRzIRfJQIDAQAB
-oAAwDQYJKoZIhvcNAQELBQADgYEAOdejIMsVq5eXMv9kzaxHqz7DhB/tJfDF8aaI
-FMWMSdzSLINa71lI9Iz4MJf6CgYk/ZeSyM/PX8WNn7R1vIjahJQMRMDmRyE3eTX/
-nHi/VVGv3Bw1wJ8Gh/ljAUidDLTxl3JWSzeegF0Z+AChIIExPNS2bVxlu81LNAR1
-1igELts=
+A4GNADCBiQKBgQCaYaFiWJ0ELopT0Gh6AJYbLJu6ttV4aZ9jUS5lILveNDIDg4Fj
+Pl9UFMFkZnMiE+Bsx0wH30Z6zXHWSh0ol3IQAELZOl5zq5LW5DBZFIlLiliMDboe
+erX9xTGyL8g35kcFI3px2/Bmf8wKqB4myoAtjKHjr0pJYY+UmXBImwYmvQIDAQAB
+oAAwDQYJKoZIhvcNAQELBQADgYEAIQIfcaziRYX3h7Du6TvJhiGnbiy9O+5pj8KX
+vSWDhLCSWKewtaU1Pr9VPtRvKE8/H5en8drAEauFFs8nd44rmt5ulnzeSYfoUxS4
+ncS4oJJ/7yIWYqU5ci0q548LMUZi1e18+6U6WnWEPOxtZlM2E3imcfLM+hw1XVaJ
+Do6+3Rk=
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/revoked-key.pem
+++ b/spec/fixtures/ssl/revoked-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:df:01:71:af:01:5d:b1:b6:af:81:20:06:b1:22:
-    74:12:ec:20:f6:c8:12:0f:13:ed:a4:0e:17:af:00:
-    89:7c:53:a1:5d:b7:d7:d5:3a:c0:ab:1b:2a:6d:44:
-    ea:8c:91:44:75:5e:19:4f:bd:2f:67:86:ed:78:1d:
-    67:a5:54:e3:fb:29:7d:03:2a:3a:15:59:3f:0f:8f:
-    7d:db:42:28:77:48:ae:fb:2d:8f:7c:97:31:ca:7e:
-    a4:a0:56:3c:15:73:c8:8e:45:0a:5b:16:4b:4e:d7:
-    5e:f5:75:86:dd:aa:b6:69:ed:05:98:7c:ed:94:2f:
-    05:e2:ca:33:7d:c2:e6:9b:47
+    00:ac:50:a2:73:53:48:80:77:b1:93:92:2e:8e:99:
+    f7:60:ba:41:fe:ac:a8:d6:57:88:67:25:40:a2:88:
+    66:e8:d8:0a:32:68:a2:79:41:30:76:e4:31:4b:3e:
+    28:62:6b:6d:52:db:4b:61:27:a5:44:29:4f:41:43:
+    da:5a:b4:aa:37:38:19:68:50:60:3c:35:27:ef:51:
+    55:da:7d:17:01:3a:e7:96:70:e8:12:8f:6f:ee:1c:
+    43:65:fe:e6:c7:dc:a9:0d:b9:57:a7:a2:8b:dd:ed:
+    89:08:3e:59:d1:d1:3f:39:6f:95:03:c5:e6:a2:2c:
+    cd:a3:3b:82:29:9e:35:83:1d
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:89:8a:d5:78:2f:ea:7e:e2:83:2a:ab:fb:14:a3:
-    80:5d:ef:5f:81:75:f2:95:74:20:1d:10:48:11:3a:
-    ce:91:6c:ef:58:e3:3b:ee:9a:d7:1c:71:9b:e0:5b:
-    22:22:e2:b2:0b:85:a7:2c:e4:2d:69:b7:f1:9d:24:
-    dd:b9:3e:3b:81:95:bf:3f:49:87:40:3b:af:b7:0d:
-    7a:39:32:b9:dc:6a:e2:a4:42:b5:ca:cb:13:97:f3:
-    f7:32:54:9d:9f:55:23:81:18:2c:c8:87:63:5d:f3:
-    50:7d:87:3e:b3:6e:52:c7:c9:0c:40:e3:8b:45:ff:
-    a7:54:0c:7e:bd:db:57:16:21
+    41:6b:f3:e1:79:33:43:a3:2e:06:6b:2f:c5:f0:6a:
+    dd:8c:99:d5:c9:53:e8:dd:1e:ea:9a:58:29:dd:43:
+    c5:0f:90:ff:86:7e:79:2e:e8:e9:9a:c5:a4:5d:9b:
+    13:92:d9:d4:e5:71:7f:17:80:45:9a:b1:7e:83:f6:
+    79:0d:b2:b9:d8:60:cf:92:69:7b:96:55:1c:e0:cd:
+    e8:87:06:65:19:38:d0:51:f0:71:aa:12:45:e1:54:
+    0b:c7:d0:72:b8:cd:ab:0e:5c:5e:ae:2d:21:eb:03:
+    b6:80:d2:66:0a:64:a5:5d:ae:46:2b:d8:dc:84:18:
+    3b:ca:27:74:0b:0b:26:39
 prime1:
-    00:f6:04:bd:de:d9:9e:7d:0c:54:2b:e3:eb:90:17:
-    e7:f0:6b:19:9a:01:74:6f:c5:7a:75:d4:1e:36:af:
-    dd:a2:e2:12:15:97:a2:ee:bc:e5:9d:59:b6:99:3a:
-    84:ef:98:07:0f:11:75:44:e3:fd:68:03:6d:2e:bb:
-    a2:82:8f:de:71
+    00:e2:79:5e:74:b3:46:79:2c:c6:cf:b3:85:cf:c3:
+    79:f3:bd:c2:f4:6e:a5:c7:5c:35:37:d5:ff:21:fa:
+    14:f3:97:e3:99:22:e6:16:04:34:1a:17:53:b9:21:
+    78:d6:b4:97:9e:79:ce:6b:99:33:0b:80:ef:ff:be:
+    6e:fa:63:eb:ef
 prime2:
-    00:e8:0d:ae:29:d0:22:a2:28:e5:e0:d4:27:89:76:
-    15:1e:86:11:ea:a3:4f:06:61:2d:ad:c8:cf:b8:74:
-    32:2c:ad:85:84:32:01:d4:46:04:d0:43:78:bc:7d:
-    a0:de:17:0e:ce:3f:29:a9:43:8f:9a:27:a1:b5:1c:
-    fb:c2:85:61:37
+    00:c2:c7:b0:ee:88:b3:f8:c2:3a:bd:12:c5:63:91:
+    81:65:99:0c:d8:f5:eb:ac:e5:32:a6:b7:a1:f6:40:
+    b0:6d:a4:35:ca:f0:bc:e9:d9:5f:c9:b7:08:d1:c1:
+    fa:a5:1e:6b:63:10:43:4d:83:72:00:43:ff:48:53:
+    0b:f4:a2:25:b3
 exponent1:
-    00:bc:ab:9e:41:4d:7b:72:43:06:3a:32:ac:f0:f0:
-    a4:7b:88:67:35:e8:6f:b7:58:27:36:3d:da:7d:ee:
-    19:77:55:10:b1:66:7d:19:c1:dc:05:f4:4b:48:ef:
-    cc:0b:42:f8:06:e2:48:a0:f0:87:e2:40:de:76:bc:
-    87:40:c1:bc:c1
+    48:5b:b4:c5:1e:7e:56:ba:ea:ae:73:d2:3e:06:5b:
+    91:77:c0:b1:2e:25:03:64:3f:90:9e:6b:cc:a4:45:
+    4b:6a:ed:0a:01:6f:77:fb:51:d6:40:3b:bc:bb:a8:
+    0b:19:5a:14:05:20:e1:99:ea:08:33:e2:fa:58:12:
+    c7:27:63:bb
 exponent2:
-    00:e2:1b:c2:62:77:ad:e7:78:16:55:f6:22:f8:2c:
-    18:f3:ff:0b:22:28:32:6e:32:ee:81:71:34:05:b5:
-    22:d6:a9:d5:79:34:08:d8:3f:c9:9c:ec:c1:8e:58:
-    93:11:14:42:96:f0:b0:b5:7f:61:43:81:ee:6d:3d:
-    6a:8a:e5:d0:0d
+    3c:60:a0:34:e0:c5:40:f8:1c:33:1d:cd:78:16:d3:
+    90:85:c7:d8:bd:2a:67:f6:c8:23:ab:ca:95:c5:e9:
+    aa:a2:fb:55:c4:18:1b:39:19:9b:32:94:96:48:d6:
+    04:37:10:bc:ad:7e:df:59:3e:8e:5c:85:96:8a:bf:
+    aa:fe:54:47
 coefficient:
-    68:c9:e2:ac:3e:cf:75:36:14:e2:99:87:8c:06:51:
-    95:a6:91:c3:22:df:a9:dc:03:a8:f8:0e:a7:77:e0:
-    64:e6:9e:1a:82:99:e8:e8:20:31:8e:a2:45:2b:35:
-    f9:8b:be:f9:6c:fe:b9:57:ee:11:9f:ab:b1:76:6a:
-    4e:a8:a5:57
+    07:af:dc:84:19:f0:d9:df:15:40:18:d7:bc:66:1a:
+    d1:73:29:b1:00:91:22:e5:87:f4:4f:d0:bc:b6:6f:
+    70:22:20:d3:d2:11:7d:e3:ce:0d:58:c6:80:c5:62:
+    76:c5:85:28:61:09:68:86:e1:68:7c:0f:5a:62:90:
+    d4:b5:2d:ef
 -----BEGIN RSA PRIVATE KEY-----
-MIICXgIBAAKBgQDfAXGvAV2xtq+BIAaxInQS7CD2yBIPE+2kDhevAIl8U6Fdt9fV
-OsCrGyptROqMkUR1XhlPvS9nhu14HWelVOP7KX0DKjoVWT8Pj33bQih3SK77LY98
-lzHKfqSgVjwVc8iORQpbFktO1171dYbdqrZp7QWYfO2ULwXiyjN9wuabRwIDAQAB
-AoGBAImK1Xgv6n7igyqr+xSjgF3vX4F18pV0IB0QSBE6zpFs71jjO+6a1xxxm+Bb
-IiLisguFpyzkLWm38Z0k3bk+O4GVvz9Jh0A7r7cNejkyudxq4qRCtcrLE5fz9zJU
-nZ9VI4EYLMiHY13zUH2HPrNuUsfJDEDji0X/p1QMfr3bVxYhAkEA9gS93tmefQxU
-K+PrkBfn8GsZmgF0b8V6ddQeNq/douISFZei7rzlnVm2mTqE75gHDxF1ROP9aANt
-Lruigo/ecQJBAOgNrinQIqIo5eDUJ4l2FR6GEeqjTwZhLa3Iz7h0MiythYQyAdRG
-BNBDeLx9oN4XDs4/KalDj5onobUc+8KFYTcCQQC8q55BTXtyQwY6Mqzw8KR7iGc1
-6G+3WCc2Pdp97hl3VRCxZn0ZwdwF9EtI78wLQvgG4kig8IfiQN52vIdAwbzBAkEA
-4hvCYnet53gWVfYi+CwY8/8LIigybjLugXE0BbUi1qnVeTQI2D/JnOzBjliTERRC
-lvCwtX9hQ4HubT1qiuXQDQJAaMnirD7PdTYU4pmHjAZRlaaRwyLfqdwDqPgOp3fg
-ZOaeGoKZ6OggMY6iRSs1+Yu++Wz+uVfuEZ+rsXZqTqilVw==
+MIICWwIBAAKBgQCsUKJzU0iAd7GTki6OmfdgukH+rKjWV4hnJUCiiGbo2AoyaKJ5
+QTB25DFLPihia21S20thJ6VEKU9BQ9patKo3OBloUGA8NSfvUVXafRcBOueWcOgS
+j2/uHENl/ubH3KkNuVenoovd7YkIPlnR0T85b5UDxeaiLM2jO4IpnjWDHQIDAQAB
+AoGAQWvz4XkzQ6MuBmsvxfBq3YyZ1clT6N0e6ppYKd1DxQ+Q/4Z+eS7o6ZrFpF2b
+E5LZ1OVxfxeARZqxfoP2eQ2yudhgz5Jpe5ZVHODN6IcGZRk40FHwcaoSReFUC8fQ
+crjNqw5cXq4tIesDtoDSZgpkpV2uRivY3IQYO8ondAsLJjkCQQDieV50s0Z5LMbP
+s4XPw3nzvcL0bqXHXDU31f8h+hTzl+OZIuYWBDQaF1O5IXjWtJeeec5rmTMLgO//
+vm76Y+vvAkEAwsew7oiz+MI6vRLFY5GBZZkM2PXrrOUypreh9kCwbaQ1yvC86dlf
+ybcI0cH6pR5rYxBDTYNyAEP/SFML9KIlswJASFu0xR5+VrrqrnPSPgZbkXfAsS4l
+A2Q/kJ5rzKRFS2rtCgFvd/tR1kA7vLuoCxlaFAUg4ZnqCDPi+lgSxydjuwJAPGCg
+NODFQPgcMx3NeBbTkIXH2L0qZ/bII6vKlcXpqqL7VcQYGzkZmzKUlkjWBDcQvK1+
+31k+jlyFloq/qv5URwJAB6/chBnw2d8VQBjXvGYa0XMpsQCRIuWH9E/QvLZvcCIg
+09IRfePODVjGgMVidsWFKGEJaIbhaHwPWmKQ1LUt7w==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/revoked.pem
+++ b/spec/fixtures/ssl/revoked.pem
@@ -6,39 +6,39 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=revoked
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:df:01:71:af:01:5d:b1:b6:af:81:20:06:b1:22:
-                    74:12:ec:20:f6:c8:12:0f:13:ed:a4:0e:17:af:00:
-                    89:7c:53:a1:5d:b7:d7:d5:3a:c0:ab:1b:2a:6d:44:
-                    ea:8c:91:44:75:5e:19:4f:bd:2f:67:86:ed:78:1d:
-                    67:a5:54:e3:fb:29:7d:03:2a:3a:15:59:3f:0f:8f:
-                    7d:db:42:28:77:48:ae:fb:2d:8f:7c:97:31:ca:7e:
-                    a4:a0:56:3c:15:73:c8:8e:45:0a:5b:16:4b:4e:d7:
-                    5e:f5:75:86:dd:aa:b6:69:ed:05:98:7c:ed:94:2f:
-                    05:e2:ca:33:7d:c2:e6:9b:47
+                    00:ac:50:a2:73:53:48:80:77:b1:93:92:2e:8e:99:
+                    f7:60:ba:41:fe:ac:a8:d6:57:88:67:25:40:a2:88:
+                    66:e8:d8:0a:32:68:a2:79:41:30:76:e4:31:4b:3e:
+                    28:62:6b:6d:52:db:4b:61:27:a5:44:29:4f:41:43:
+                    da:5a:b4:aa:37:38:19:68:50:60:3c:35:27:ef:51:
+                    55:da:7d:17:01:3a:e7:96:70:e8:12:8f:6f:ee:1c:
+                    43:65:fe:e6:c7:dc:a9:0d:b9:57:a7:a2:8b:dd:ed:
+                    89:08:3e:59:d1:d1:3f:39:6f:95:03:c5:e6:a2:2c:
+                    cd:a3:3b:82:29:9e:35:83:1d
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         4f:24:56:32:a9:45:7b:f2:f2:2c:29:31:ff:03:e6:da:c9:ed:
-         37:87:18:a0:b3:ff:ad:42:82:01:1a:d2:03:09:60:2d:b9:fe:
-         81:46:f7:40:90:d4:d6:17:79:93:f4:32:2a:9e:7b:29:8a:97:
-         82:d8:55:d8:39:84:6b:d0:da:65:39:de:28:09:33:83:8b:fa:
-         e2:f2:76:5f:fb:30:72:a7:28:b2:20:48:15:da:3e:87:0d:6a:
-         74:1a:c2:55:12:07:7a:2e:30:ec:e6:a6:96:78:34:1b:7d:94:
-         7b:67:54:5c:ca:06:98:e3:fb:c7:7f:48:ab:a3:e0:e5:87:2c:
-         c5:fc
+         37:b6:44:8d:06:42:a0:9f:7f:fd:61:18:04:c4:f6:ae:f9:8a:
+         14:98:63:a8:08:01:0a:7d:80:7f:4b:a5:e4:3d:27:6d:36:ef:
+         6a:99:44:bb:70:c8:1f:18:64:35:47:07:34:71:c9:96:2f:e0:
+         c7:fe:61:ce:71:2b:20:1b:2f:11:92:e3:37:51:03:f2:71:2a:
+         53:2f:94:11:41:2e:48:45:15:0a:95:71:d2:49:03:38:8e:6f:
+         ab:dd:7b:e8:77:82:4c:29:29:e8:41:4d:c9:3b:ec:08:d0:2e:
+         42:6a:26:bc:d3:a9:e8:ce:fd:5e:f4:4f:b9:ea:60:72:01:04:
+         d6:66
 -----BEGIN CERTIFICATE-----
 MIIBpTCCAQ6gAwIBAgIBBDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDkyMTM1NTNa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTkyMjMxMjJa
 MBIxEDAOBgNVBAMMB3Jldm9rZWQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AN8Bca8BXbG2r4EgBrEidBLsIPbIEg8T7aQOF68AiXxToV2319U6wKsbKm1E6oyR
-RHVeGU+9L2eG7XgdZ6VU4/spfQMqOhVZPw+PfdtCKHdIrvstj3yXMcp+pKBWPBVz
-yI5FClsWS07XXvV1ht2qtmntBZh87ZQvBeLKM33C5ptHAgMBAAEwDQYJKoZIhvcN
-AQELBQADgYEATyRWMqlFe/LyLCkx/wPm2sntN4cYoLP/rUKCARrSAwlgLbn+gUb3
-QJDU1hd5k/QyKp57KYqXgthV2DmEa9DaZTneKAkzg4v64vJ2X/swcqcosiBIFdo+
-hw1qdBrCVRIHei4w7Oamlng0G32Ue2dUXMoGmOP7x39Iq6Pg5Ycsxfw=
+AKxQonNTSIB3sZOSLo6Z92C6Qf6sqNZXiGclQKKIZujYCjJoonlBMHbkMUs+KGJr
+bVLbS2EnpUQpT0FD2lq0qjc4GWhQYDw1J+9RVdp9FwE655Zw6BKPb+4cQ2X+5sfc
+qQ25V6eii93tiQg+WdHRPzlvlQPF5qIszaM7gimeNYMdAgMBAAEwDQYJKoZIhvcN
+AQELBQADgYEAN7ZEjQZCoJ9//WEYBMT2rvmKFJhjqAgBCn2Af0ul5D0nbTbvaplE
+u3DIHxhkNUcHNHHJli/gx/5hznErIBsvEZLjN1ED8nEqUy+UEUEuSEUVCpVx0kkD
+OI5vq9176HeCTCkp6EFNyTvsCNAuQmomvNOp6M79XvRPuepgcgEE1mY=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/signed-key.pem
+++ b/spec/fixtures/ssl/signed-key.pem
@@ -1,67 +1,67 @@
 Private-Key: (1024 bit)
 modulus:
-    00:ad:cf:8f:ff:51:7a:86:cc:99:5d:14:8f:07:0c:
-    f7:e7:f7:e8:3c:46:90:38:d3:fa:71:91:57:42:3a:
-    bd:9a:80:24:e8:df:55:26:a6:8f:74:30:5c:5a:f4:
-    34:f0:db:76:24:1c:f1:cd:57:1b:80:93:2c:5c:e9:
-    b1:ea:21:c8:f6:58:52:ce:3f:b3:f6:32:6e:de:00:
-    b9:8e:a2:9f:07:08:ac:e7:32:6e:43:93:4a:eb:87:
-    d6:6c:e6:6a:4e:45:bd:f9:08:4b:71:d3:05:77:67:
-    87:26:08:12:62:37:09:5f:37:59:09:3e:80:74:b2:
-    69:43:46:32:99:b9:db:fe:05
+    00:ef:bc:2c:47:fa:12:2d:09:ef:16:96:90:8b:84:
+    45:c7:86:f1:5e:8f:58:59:23:87:df:a1:e3:be:8c:
+    2f:ad:70:96:1a:f5:67:7f:5c:9c:54:5e:82:de:05:
+    7f:8f:9d:c9:f3:24:72:39:4f:1c:b4:a6:e0:d0:19:
+    af:bd:e4:29:65:bb:d7:43:3e:66:d3:4f:74:05:0b:
+    8a:e4:d5:52:08:af:9b:f4:f4:7d:6c:92:5f:cc:bb:
+    c2:2d:ca:d0:12:28:e5:c8:fd:f6:09:90:dd:85:f9:
+    85:d9:37:a6:fe:83:c7:24:e4:af:28:e3:ff:5a:1b:
+    72:5f:29:c6:39:88:5b:48:19
 publicExponent: 65537 (0x10001)
 privateExponent:
-    25:5f:98:4b:02:2e:22:86:24:04:0b:c3:a5:74:78:
-    69:fc:b8:87:1d:75:2d:83:07:3b:1c:51:73:00:46:
-    7c:ce:49:21:79:c4:49:87:4f:19:60:bc:bb:21:ff:
-    b0:3a:c0:70:8b:78:c2:fa:94:03:55:a2:18:68:77:
-    c5:2c:76:95:86:fb:af:4d:24:d7:ab:08:65:f3:6e:
-    52:7b:cb:ec:89:74:55:e7:6c:26:93:62:ff:01:f0:
-    5f:33:1c:a2:db:78:7e:fc:fc:a0:c1:75:cd:2a:aa:
-    31:1e:03:ee:0f:a4:be:f8:aa:80:e5:c1:fe:12:67:
-    7d:8b:4a:ba:5d:bc:89:01
+    75:11:3b:c2:6e:30:60:04:00:d7:d3:f0:83:e0:b4:
+    be:89:7b:e6:84:33:4d:5c:17:66:b2:44:67:71:47:
+    7a:f7:86:a5:65:7f:03:e7:b2:83:54:9f:ad:51:9c:
+    08:02:b2:72:64:32:cf:1f:7d:d2:0d:c7:ac:77:4e:
+    a5:78:fc:69:3a:88:12:5b:81:81:19:c9:1f:9d:aa:
+    fa:35:2e:cd:df:71:ee:50:f9:59:53:99:52:22:f7:
+    48:ba:17:4f:47:b5:72:16:47:d1:1d:31:29:47:80:
+    b1:e1:3c:e0:a0:4b:ef:05:c5:ea:0a:b2:c7:4a:b9:
+    d3:06:c0:b7:7b:0a:2e:81
 prime1:
-    00:e2:de:b4:d0:ef:3c:db:51:50:0f:f5:ff:73:8e:
-    da:e2:1c:1e:46:3a:09:a0:00:e1:a4:97:90:c7:62:
-    9a:e0:84:f4:66:ff:35:be:7f:f8:98:ed:28:50:5d:
-    a5:77:eb:ab:0d:9c:f8:b1:f9:ef:d0:0e:5b:9f:da:
-    fa:44:73:3f:d5
+    00:fa:cc:b0:ba:9e:06:c5:f7:63:09:37:e7:9f:aa:
+    4d:f8:f1:b4:7f:aa:c6:8a:04:16:93:73:af:ba:1f:
+    e3:97:76:11:a9:4d:fb:42:8b:f0:51:0a:7d:6c:69:
+    fa:2f:d8:7b:ad:20:79:de:71:ea:e2:e0:a3:69:1b:
+    1e:e3:6c:9b:e9
 prime2:
-    00:c4:20:c8:8a:86:24:f5:be:20:82:73:f4:bb:43:
-    77:d7:c7:cd:de:49:a0:58:1e:c2:5e:34:e2:4e:a0:
-    fd:26:16:9a:4b:32:42:f2:08:19:93:64:13:cd:d9:
-    93:c5:63:0d:39:9f:1d:8d:20:80:02:27:75:71:25:
-    74:24:43:0d:71
+    00:f4:b4:bf:cf:56:a0:fa:94:15:5c:24:9c:45:fd:
+    54:31:72:75:7b:ef:d5:de:5b:64:c9:6a:88:42:e0:
+    0d:f0:63:c2:46:9e:59:81:be:60:ee:05:01:b0:dd:
+    e4:12:d0:5b:77:76:c0:5b:f2:21:0c:5b:42:af:f5:
+    c2:5b:c6:1c:b1
 exponent1:
-    00:b6:34:1a:8f:fa:b3:ab:88:60:7e:91:18:fa:1b:
-    ef:1a:cd:6e:5b:04:5d:9a:8d:5a:ab:2f:b6:ed:0a:
-    fa:4b:fb:3b:b6:44:9d:4b:43:c7:ca:3a:1d:b8:7d:
-    9d:58:f4:82:ca:4a:19:4a:06:eb:5c:f3:4b:0e:d5:
-    75:4d:e8:29:89
+    15:d0:1f:be:db:67:b3:68:24:d0:f4:6f:cc:cf:3f:
+    20:db:c4:db:25:bb:46:dd:bc:28:ee:f2:e5:b9:48:
+    4e:30:12:b1:2a:fb:23:7a:90:58:3c:15:54:8c:93:
+    19:fe:36:23:84:a3:94:d9:4b:98:97:f9:1e:77:21:
+    64:9e:59:a1
 exponent2:
-    1e:1d:66:8d:96:a1:70:36:5c:69:8b:82:85:8a:8b:
-    89:4f:7d:b5:e7:1a:3e:cd:a2:4c:b2:d4:18:fc:b1:
-    42:3a:f0:40:21:9c:93:eb:58:7a:00:40:e6:37:c5:
-    6f:e6:90:ae:4b:57:4f:47:31:40:a3:6c:6e:0e:31:
-    32:2c:35:91
+    00:81:96:5e:a5:5c:48:ef:aa:10:0d:b5:cd:94:3a:
+    ed:a5:29:ea:11:72:17:1e:23:e4:21:cd:ea:cf:0f:
+    7c:12:3b:a2:1c:67:ab:1a:cc:48:e4:83:7e:3b:bd:
+    a6:14:58:86:b7:a3:09:87:27:98:5c:c4:cf:72:03:
+    81:a3:bc:2c:61
 coefficient:
-    57:c8:09:23:2a:ad:d0:a4:c0:f5:5b:9c:b4:7e:36:
-    a2:b6:dd:8d:cc:9d:ac:db:e9:03:3d:32:a3:90:c3:
-    47:9d:07:69:9c:c5:97:94:96:53:b4:b6:c5:45:96:
-    56:07:e4:c6:9a:ec:56:a4:b5:c3:12:70:ee:13:ae:
-    43:bd:51:39
+    7d:b4:b6:78:c7:d3:0c:44:6f:a2:aa:83:8a:79:65:
+    69:24:b2:31:ac:59:ed:6c:bf:4c:1a:1a:27:f0:c8:
+    e9:38:ff:84:50:df:b5:10:c2:6e:4b:5c:c2:4c:c9:
+    82:2a:db:0a:6f:59:dd:12:93:8c:c1:9d:57:f3:dd:
+    66:41:9a:e0
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQCtz4//UXqGzJldFI8HDPfn9+g8RpA40/pxkVdCOr2agCTo31Um
-po90MFxa9DTw23YkHPHNVxuAkyxc6bHqIcj2WFLOP7P2Mm7eALmOop8HCKznMm5D
-k0rrh9Zs5mpORb35CEtx0wV3Z4cmCBJiNwlfN1kJPoB0smlDRjKZudv+BQIDAQAB
-AoGAJV+YSwIuIoYkBAvDpXR4afy4hx11LYMHOxxRcwBGfM5JIXnESYdPGWC8uyH/
-sDrAcIt4wvqUA1WiGGh3xSx2lYb7r00k16sIZfNuUnvL7Il0VedsJpNi/wHwXzMc
-ott4fvz8oMF1zSqqMR4D7g+kvviqgOXB/hJnfYtKul28iQECQQDi3rTQ7zzbUVAP
-9f9zjtriHB5GOgmgAOGkl5DHYprghPRm/zW+f/iY7ShQXaV366sNnPix+e/QDluf
-2vpEcz/VAkEAxCDIioYk9b4ggnP0u0N318fN3kmgWB7CXjTiTqD9JhaaSzJC8ggZ
-k2QTzdmTxWMNOZ8djSCAAid1cSV0JEMNcQJBALY0Go/6s6uIYH6RGPob7xrNblsE
-XZqNWqsvtu0K+kv7O7ZEnUtDx8o6Hbh9nVj0gspKGUoG61zzSw7VdU3oKYkCQB4d
-Zo2WoXA2XGmLgoWKi4lPfbXnGj7Nokyy1Bj8sUI68EAhnJPrWHoAQOY3xW/mkK5L
-V09HMUCjbG4OMTIsNZECQFfICSMqrdCkwPVbnLR+NqK23Y3Mnazb6QM9MqOQw0ed
-B2mcxZeUllO0tsVFllYH5Maa7FaktcMScO4TrkO9UTk=
+MIICXAIBAAKBgQDvvCxH+hItCe8WlpCLhEXHhvFej1hZI4ffoeO+jC+tcJYa9Wd/
+XJxUXoLeBX+PncnzJHI5Txy0puDQGa+95Cllu9dDPmbTT3QFC4rk1VIIr5v09H1s
+kl/Mu8ItytASKOXI/fYJkN2F+YXZN6b+g8ck5K8o4/9aG3JfKcY5iFtIGQIDAQAB
+AoGAdRE7wm4wYAQA19Pwg+C0vol75oQzTVwXZrJEZ3FHeveGpWV/A+eyg1SfrVGc
+CAKycmQyzx990g3HrHdOpXj8aTqIEluBgRnJH52q+jUuzd9x7lD5WVOZUiL3SLoX
+T0e1chZH0R0xKUeAseE84KBL7wXF6gqyx0q50wbAt3sKLoECQQD6zLC6ngbF92MJ
+N+efqk348bR/qsaKBBaTc6+6H+OXdhGpTftCi/BRCn1safov2HutIHneceri4KNp
+Gx7jbJvpAkEA9LS/z1ag+pQVXCScRf1UMXJ1e+/V3ltkyWqIQuAN8GPCRp5Zgb5g
+7gUBsN3kEtBbd3bAW/IhDFtCr/XCW8YcsQJAFdAfvttns2gk0PRvzM8/INvE2yW7
+Rt28KO7y5blITjASsSr7I3qQWDwVVIyTGf42I4SjlNlLmJf5HnchZJ5ZoQJBAIGW
+XqVcSO+qEA21zZQ67aUp6hFyFx4j5CHN6s8PfBI7ohxnqxrMSOSDfju9phRYhrej
+CYcnmFzEz3IDgaO8LGECQH20tnjH0wxEb6Kqg4p5ZWkksjGsWe1sv0waGifwyOk4
+/4RQ37UQwm5LXMJMyYIq2wpvWd0Sk4zBnVfz3WZBmuA=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/signed.pem
+++ b/spec/fixtures/ssl/signed.pem
@@ -6,39 +6,39 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:ad:cf:8f:ff:51:7a:86:cc:99:5d:14:8f:07:0c:
-                    f7:e7:f7:e8:3c:46:90:38:d3:fa:71:91:57:42:3a:
-                    bd:9a:80:24:e8:df:55:26:a6:8f:74:30:5c:5a:f4:
-                    34:f0:db:76:24:1c:f1:cd:57:1b:80:93:2c:5c:e9:
-                    b1:ea:21:c8:f6:58:52:ce:3f:b3:f6:32:6e:de:00:
-                    b9:8e:a2:9f:07:08:ac:e7:32:6e:43:93:4a:eb:87:
-                    d6:6c:e6:6a:4e:45:bd:f9:08:4b:71:d3:05:77:67:
-                    87:26:08:12:62:37:09:5f:37:59:09:3e:80:74:b2:
-                    69:43:46:32:99:b9:db:fe:05
+                    00:ef:bc:2c:47:fa:12:2d:09:ef:16:96:90:8b:84:
+                    45:c7:86:f1:5e:8f:58:59:23:87:df:a1:e3:be:8c:
+                    2f:ad:70:96:1a:f5:67:7f:5c:9c:54:5e:82:de:05:
+                    7f:8f:9d:c9:f3:24:72:39:4f:1c:b4:a6:e0:d0:19:
+                    af:bd:e4:29:65:bb:d7:43:3e:66:d3:4f:74:05:0b:
+                    8a:e4:d5:52:08:af:9b:f4:f4:7d:6c:92:5f:cc:bb:
+                    c2:2d:ca:d0:12:28:e5:c8:fd:f6:09:90:dd:85:f9:
+                    85:d9:37:a6:fe:83:c7:24:e4:af:28:e3:ff:5a:1b:
+                    72:5f:29:c6:39:88:5b:48:19
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         6a:6e:bf:67:1a:d4:05:70:ea:cb:b5:e6:8c:4e:1c:67:79:d1:
-         67:12:aa:ea:b9:7c:02:3e:8c:b5:98:bb:5c:b2:1d:74:2f:77:
-         4e:19:15:9d:6a:ae:5e:19:2b:5c:34:94:4b:88:9f:c1:08:75:
-         a0:84:94:7c:83:e5:a8:14:49:2b:e8:12:06:51:10:da:d0:69:
-         ce:55:3c:25:17:cc:2a:6b:a3:87:a8:00:2e:5a:6e:92:c4:29:
-         ed:65:6b:69:9b:aa:0c:50:5d:73:1e:0d:1d:31:5d:55:3a:a5:
-         7c:9c:e9:86:c4:f4:5e:a7:2e:4f:6b:99:de:4d:8b:4b:d3:95:
-         e3:6e
+         15:6b:ed:44:0d:41:6e:10:98:10:34:d6:c0:f8:18:38:2f:13:
+         20:19:12:54:53:9f:7c:29:50:93:0a:15:7d:50:0a:95:a0:ce:
+         e4:4f:a7:8a:d1:f6:b2:86:44:33:07:d3:1b:28:37:9d:71:21:
+         90:fe:41:06:ab:79:5a:5f:7c:bf:dc:83:8a:64:63:8b:04:81:
+         33:7e:0f:94:4a:54:7c:58:5c:68:60:b3:25:03:1d:6c:d3:f1:
+         d0:97:e0:8d:ac:75:37:76:0c:11:6c:81:fe:72:3a:90:80:c8:
+         32:c0:89:f9:6b:b9:9c:1d:06:64:42:4e:18:86:06:e2:7d:ed:
+         93:ec
 -----BEGIN CERTIFICATE-----
 MIIBpDCCAQ2gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDkyMTM1NTNa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTkyMjMxMjJa
 MBExDzANBgNVBAMMBnNpZ25lZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA
-rc+P/1F6hsyZXRSPBwz35/foPEaQONP6cZFXQjq9moAk6N9VJqaPdDBcWvQ08Nt2
-JBzxzVcbgJMsXOmx6iHI9lhSzj+z9jJu3gC5jqKfBwis5zJuQ5NK64fWbOZqTkW9
-+QhLcdMFd2eHJggSYjcJXzdZCT6AdLJpQ0Yymbnb/gUCAwEAATANBgkqhkiG9w0B
-AQsFAAOBgQBqbr9nGtQFcOrLteaMThxnedFnEqrquXwCPoy1mLtcsh10L3dOGRWd
-aq5eGStcNJRLiJ/BCHWghJR8g+WoFEkr6BIGURDa0GnOVTwlF8wqa6OHqAAuWm6S
-xCntZWtpm6oMUF1zHg0dMV1VOqV8nOmGxPRepy5Pa5neTYtL05Xjbg==
+77wsR/oSLQnvFpaQi4RFx4bxXo9YWSOH36HjvowvrXCWGvVnf1ycVF6C3gV/j53J
+8yRyOU8ctKbg0BmvveQpZbvXQz5m0090BQuK5NVSCK+b9PR9bJJfzLvCLcrQEijl
+yP32CZDdhfmF2Tem/oPHJOSvKOP/WhtyXynGOYhbSBkCAwEAATANBgkqhkiG9w0B
+AQsFAAOBgQAVa+1EDUFuEJgQNNbA+Bg4LxMgGRJUU598KVCTChV9UAqVoM7kT6eK
+0fayhkQzB9MbKDedcSGQ/kEGq3laX3y/3IOKZGOLBIEzfg+USlR8WFxoYLMlAx1s
+0/HQl+CNrHU3dgwRbIH+cjqQgMgywIn5a7mcHQZkQk4Yhgbife2T7A==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-cert.pem
+++ b/spec/fixtures/ssl/tampered-cert.pem
@@ -1,44 +1,44 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 8 (0x8)
+        Serial Number: 9 (0x9)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar  9 21:35:53 2029 GMT
+            Not After : Apr 19 22:31:22 2029 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:c8:59:04:8a:ae:1e:28:41:59:f9:0d:58:9c:11:
-                    27:30:76:f1:de:37:56:de:be:28:e2:79:4a:d0:c3:
-                    6f:73:c2:fc:77:3d:44:4b:42:aa:0e:02:43:c6:5f:
-                    52:33:a5:11:8e:65:c0:53:e8:3d:f9:a2:16:7d:1b:
-                    6c:b9:16:9d:8f:5d:a2:f8:c6:be:58:cc:4e:51:28:
-                    d6:3c:bf:9a:01:e8:b2:9d:d5:75:3c:27:6e:fa:81:
-                    e4:d5:0d:15:af:28:d2:0c:91:36:41:eb:62:32:95:
-                    65:e8:48:1c:b3:f6:de:bf:35:cd:8f:d3:74:71:d4:
-                    d3:19:4c:7b:42:04:bc:66:43
+                    00:a9:7c:f9:23:fa:ff:7d:12:60:1a:04:d0:80:0c:
+                    41:97:e0:5a:d0:b6:83:ce:1c:f1:8f:43:86:94:60:
+                    80:7d:fe:13:42:36:81:b4:31:33:01:89:0d:6d:ea:
+                    70:76:2d:6d:73:1c:24:95:48:55:62:2d:b4:99:b2:
+                    d7:6c:ea:cc:88:5e:69:83:79:01:99:59:0d:fe:93:
+                    9c:9c:5c:77:33:29:28:98:74:75:1b:f4:9b:8d:f4:
+                    42:83:55:69:b5:2b:1c:38:89:1b:c0:ba:0c:16:0c:
+                    e3:3f:8c:83:bc:ac:31:22:aa:47:03:85:c3:1b:3e:
+                    45:1b:ab:2b:3f:3c:80:c0:61
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         8b:30:32:a3:ce:74:8a:49:55:b0:c9:9d:47:b0:aa:9e:0c:8f:
-         b0:af:ef:e9:26:41:b3:bf:cb:dc:89:2a:fc:58:28:10:f8:67:
-         bd:9e:08:80:c5:77:31:63:29:34:0d:c2:5c:a7:1e:53:60:18:
-         d5:7c:88:68:18:f6:79:39:d3:1e:76:23:6a:24:4d:49:72:ed:
-         81:fc:9f:c8:08:d1:03:e7:d6:09:9c:be:00:5b:51:56:33:cd:
-         22:98:73:ec:2a:9f:1d:7b:32:bb:f5:02:46:98:8c:4e:0e:cd:
-         3e:d5:e0:2f:fe:3f:b8:f9:10:ee:da:f1:b4:44:04:21:82:81:
-         40:30
+         9f:61:e2:9b:06:b2:84:67:53:c3:da:72:3e:d6:46:d8:37:8a:
+         a1:2e:72:5f:cf:1d:cf:75:63:da:ad:0b:50:3a:71:e0:70:66:
+         23:0e:54:5d:5a:af:4e:58:20:c5:64:0c:ec:e7:ed:f8:7a:c1:
+         be:cd:fc:8d:cb:24:10:47:24:1f:b1:79:98:40:cc:37:00:15:
+         ab:7b:0b:80:89:3a:e5:e5:d5:98:d5:12:3f:a6:ac:37:7b:30:
+         1b:1b:d0:3b:72:c0:51:f7:50:e9:a1:bf:d5:06:f9:c1:c1:d7:
+         30:c4:0e:38:73:4d:06:de:52:42:cf:d1:6d:04:d0:2b:94:ef:
+         95:ff
 -----BEGIN CERTIFICATE-----
-MIIBpDCCAQ2gAwIBAgIBCDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTAzMDkyMTM1NTNa
+MIIBpDCCAQ2gAwIBAgIBCTANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTkyMjMxMjJa
 MBExDzANBgNVBAMMBnNpZ25lZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA
-yFkEiq4eKEFZ+Q1YnBEnMHbx3jdW3r4o4nlK0MNvc8L8dz1ES0KqDgJDxl9SM6UR
-jmXAU+g9+aIWfRtsuRadj12i+Ma+WMxOUSjWPL+aAeiyndV1PCdu+oHk1Q0VryjS
-DJE2QetiMpVl6Egcs/bevzXNj9N0cdTTGUx7QgS8ZkMCAwEAATANBgkqhkiG9w0B
-AQsFAAOBgQCLMDKjznSKSVWwyZ1HsKqeDI+wr+/pJkGzv8vciSr8WCgQ+Ge9ngiA
-xXcxYyk0DcJcpx5TYBjVfIhoGPZ5OdMediNqJE1Jcu2B/J/ICNED59YJnL4AW1FW
-M80imHPsKp8dezK79QJGmIxODs0+1eAv/j+4+RDu2vG0RAQhgoFAMA==
+qXz5I/r/fRJgGgTQgAxBl+Ba0LaDzhzxj0OGlGCAff4TQjaBtDEzAYkNbepwdi1t
+cxwklUhVYi20mbLXbOrMiF5pg3kBmVkN/pOcnFx3MykomHR1G/SbjfRCg1VptSsc
+OIkbwLoMFgzjP4yDvKwxIqpHA4XDGz5FG6srPzyAwGECAwEAATANBgkqhkiG9w0B
+AQsFAAOBgQCfYeKbBrKEZ1PD2nI+1kbYN4qhLnJfzx3PdWParQtQOnHgcGYjDlRd
+Wq9OWCDFZAzs5+34esG+zfyNyyQQRyQfsXmYQMw3ABWrewuAiTrl5dWY1RI/pqw3
+ezAbG9A7csBR91Dpob/VBvnBwdcwxA44c00G3lJCz9FtBNArlO+V/w==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-csr.pem
+++ b/spec/fixtures/ssl/tampered-csr.pem
@@ -6,34 +6,34 @@ Certificate Request:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (1024 bit)
                 Modulus:
-                    00:c1:cf:0a:79:46:63:ed:c2:9e:2b:a6:2a:4d:2b:
-                    9b:e6:f3:d0:cd:98:3e:55:ab:ea:be:a9:41:a6:db:
-                    ad:1e:ea:33:64:b9:18:67:b1:8b:53:5a:12:69:eb:
-                    d1:ad:a9:85:6e:7d:f0:ef:a4:4b:1a:c4:75:71:4f:
-                    3a:5c:7a:59:43:ab:b4:65:fd:75:0e:0a:6f:ac:a0:
-                    35:fc:fc:34:6c:38:9e:1d:95:26:81:cf:8b:24:d3:
-                    c1:65:d0:57:fb:e7:b1:1b:57:61:5c:40:2a:0f:a0:
-                    7d:d8:26:c6:9e:b5:bf:fd:0f:72:6a:df:2b:23:2f:
-                    01:39:21:42:a6:43:13:07:55
+                    00:e9:53:65:ee:3a:eb:2d:ab:c3:23:22:68:70:25:
+                    e8:c3:d9:1a:c6:42:82:79:98:38:75:65:39:7b:b8:
+                    67:ba:ae:5b:f0:61:05:c5:a5:ff:b2:63:b3:ce:50:
+                    30:84:61:44:ab:18:e1:85:19:c1:fa:01:a5:79:00:
+                    b7:ab:99:e5:36:7f:37:6e:c9:9e:f2:98:2a:a1:54:
+                    eb:b0:20:37:b6:97:08:62:bc:27:31:b2:af:da:59:
+                    47:e9:92:f3:ee:40:2a:75:fe:ef:ba:3a:22:70:65:
+                    32:be:4b:fb:bd:75:87:5c:3f:2f:03:cd:b6:e4:3e:
+                    4e:af:a3:f4:2a:30:17:99:6d
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         7a:96:63:e3:47:6b:3d:c2:03:79:cb:c1:98:58:b6:ec:9e:5b:
-         43:fe:0a:42:7a:fc:e6:e4:0a:fc:15:6e:b6:c5:f3:5e:fb:43:
-         ab:d3:fb:35:83:52:ba:3e:81:77:3b:f3:9d:05:24:5b:91:a6:
-         9b:90:48:13:f2:ec:2a:9d:8f:1c:c6:46:f0:a0:76:ae:fe:f9:
-         d4:16:5e:5a:9d:85:bc:ec:f1:28:86:1a:0f:ce:2a:f9:4f:ab:
-         91:84:39:10:9e:53:61:88:cc:06:5a:32:53:6e:d8:79:6b:6d:
-         3a:47:0a:5a:63:0d:73:e0:ac:96:4f:00:ea:4d:6d:44:1d:17:
-         7a:9a
+         89:dd:58:fe:dc:45:c2:52:a1:58:16:e3:59:a1:45:ab:5b:1c:
+         ae:a6:ca:63:f2:95:82:41:09:71:68:26:b3:6d:20:03:9c:c5:
+         f3:23:54:b9:a2:8a:66:3f:68:a7:c2:4a:16:81:3d:93:c5:c4:
+         10:2c:1d:20:59:9d:7c:b2:b1:1a:62:72:fd:4d:90:86:b7:8e:
+         ab:2e:05:b1:52:cb:4e:38:f0:85:e8:58:5f:64:a8:f4:5c:b3:
+         73:75:f5:bb:76:4f:93:c1:8c:e6:23:cf:e9:ff:c0:22:8f:a3:
+         09:a8:57:51:31:9b:7d:ef:97:b6:70:2e:90:d5:40:33:ca:37:
+         d3:b5
 -----BEGIN CERTIFICATE REQUEST-----
 MIIBUDCBugIBAjARMQ8wDQYDVQQDDAZzaWduZWQwgZ8wDQYJKoZIhvcNAQEBBQAD
-gY0AMIGJAoGBAMHPCnlGY+3CniumKk0rm+bz0M2YPlWr6r6pQabbrR7qM2S5GGex
-i1NaEmnr0a2phW598O+kSxrEdXFPOlx6WUOrtGX9dQ4Kb6ygNfz8NGw4nh2VJoHP
-iyTTwWXQV/vnsRtXYVxAKg+gfdgmxp61v/0PcmrfKyMvATkhQqZDEwdVAgMBAAGg
-ADANBgkqhkiG9w0BAQsFAAOBgQB6lmPjR2s9wgN5y8GYWLbsnltD/gpCevzm5Ar8
-FW62xfNe+0Or0/s1g1K6PoF3O/OdBSRbkaabkEgT8uwqnY8cxkbwoHau/vnUFl5a
-nYW87PEohhoPzir5T6uRhDkQnlNhiMwGWjJTbth5a206RwpaYw1z4KyWTwDqTW1E
-HRd6mg==
+gY0AMIGJAoGBAOlTZe466y2rwyMiaHAl6MPZGsZCgnmYOHVlOXu4Z7quW/BhBcWl
+/7Jjs85QMIRhRKsY4YUZwfoBpXkAt6uZ5TZ/N27JnvKYKqFU67AgN7aXCGK8JzGy
+r9pZR+mS8+5AKnX+77o6InBlMr5L+711h1w/LwPNtuQ+Tq+j9CowF5ltAgMBAAGg
+ADANBgkqhkiG9w0BAQsFAAOBgQCJ3Vj+3EXCUqFYFuNZoUWrWxyupspj8pWCQQlx
+aCazbSADnMXzI1S5oopmP2inwkoWgT2TxcQQLB0gWZ18srEaYnL9TZCGt46rLgWx
+UstOOPCF6FhfZKj0XLNzdfW7dk+TwYzmI8/p/8Aij6MJqFdRMZt975e2cC6Q1UAz
+yjfTtQ==
 -----END CERTIFICATE REQUEST-----

--- a/spec/lib/puppet_spec/fixtures.rb
+++ b/spec/lib/puppet_spec/fixtures.rb
@@ -42,6 +42,10 @@ module PuppetSpec::Fixtures
     OpenSSL::PKey::RSA.new(pem_content(name))
   end
 
+  def ec_key_fixture(name)
+    OpenSSL::PKey::EC.new(pem_content(name))
+  end
+
   def request_fixture(name)
     OpenSSL::X509::Request.new(pem_content(name))
   end

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -115,6 +115,16 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       expects_command_to_pass(%r{Submitted certificate request for '#{name}' to https://.*})
     end
 
+    it 'generates an EC private key' do
+      Puppet[:key_type] = 'ec'
+      File.unlink(Puppet[:hostprivkey])
+
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
+
+      expects_command_to_pass(%r{Submitted certificate request for '#{name}' to https://.*})
+    end
+
     it 'submits the CSR and saves it locally' do
       stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
       stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -106,6 +106,15 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
 
     it_behaves_like 'an ssl action'
 
+    it 'generates an RSA private key' do
+      File.unlink(Puppet[:hostprivkey])
+
+      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
+      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
+
+      expects_command_to_pass(%r{Submitted certificate request for '#{name}' to https://.*})
+    end
+
     it 'submits the CSR and saves it locally' do
       stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
       stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -141,11 +141,18 @@ describe Puppet::SSL::SSLProvider do
       expect(sslctx.private_key).to eq(private_key)
     end
 
+    it 'accepts EC keys' do
+      ec_key = ec_key_fixture('ec-key.pem')
+      ec_cert = cert_fixture('ec.pem')
+      sslctx = subject.create_context(config.merge(client_cert: ec_cert, private_key: ec_key))
+      expect(sslctx.private_key).to eq(ec_key)
+    end
+
     it 'raises if private key is unsupported' do
-      ec_key = OpenSSL::PKey::EC.new
+      dsa_key = OpenSSL::PKey::DSA.new
       expect {
-        subject.create_context(config.merge(private_key: ec_key))
-      }.to raise_error(Puppet::SSL::SSLError, /Unsupported key 'OpenSSL::PKey::EC'/)
+        subject.create_context(config.merge(private_key: dsa_key))
+      }.to raise_error(Puppet::SSL::SSLError, /Unsupported key 'OpenSSL::PKey::DSA'/)
     end
 
     it 'resolves the client chain from leaf to root' do

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -267,6 +267,41 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         expect(st.private_key).to be_private
       end
 
+      it 'generates a new EC private key, saves it and passes it to the next state' do
+        Puppet[:key_type] = 'ec'
+        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
+        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_private_key)
+
+        st = state.next_state
+        expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
+        expect(st.private_key).to be_instance_of(OpenSSL::PKey::EC)
+        expect(st.private_key).to be_private
+        expect(st.private_key.group.curve_name).to eq('prime256v1')
+      end
+
+      it 'generates a new EC private key with curve `secp384r1`, saves it and passes it to the next state' do
+        Puppet[:key_type] = 'ec'
+        Puppet[:named_curve] = 'secp384r1'
+        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
+        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_private_key)
+
+        st = state.next_state
+        expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
+        expect(st.private_key).to be_instance_of(OpenSSL::PKey::EC)
+        expect(st.private_key).to be_private
+        expect(st.private_key.group.curve_name).to eq('secp384r1')
+      end
+
+      it 'raises if the named curve is unsupported' do
+        Puppet[:key_type] = 'ec'
+        Puppet[:named_curve] = 'infiniteloop'
+        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
+
+        expect {
+          state.next_state
+        }.to raise_error(OpenSSL::PKey::ECError, /(invalid|unknown) curve name/)
+      end
+
       it 'raises an error if it fails to load the key' do
         allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_raise(OpenSSL::PKey::RSAError)
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -257,13 +257,14 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         }.to raise_error(Puppet::SSL::SSLError, %r{The certificate for 'CN=signed' does not match its private key})
       end
 
-      it 'generates a new private key, saves it and passes it to the next state' do
+      it 'generates a new RSA private key, saves it and passes it to the next state' do
         allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
         expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_private_key)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
         expect(st.private_key).to be_instance_of(OpenSSL::PKey::RSA)
+        expect(st.private_key).to be_private
       end
 
       it 'raises an error if it fails to load the key' do

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -246,10 +246,6 @@ describe Puppet::X509::CertProvider do
         }.to raise_error(Puppet::Error, %r{The private key is missing from '/does/not/exist/whatever.pem'})
       end
 
-      it 'returns an RSA key' do
-        expect(provider.load_private_key('signed-key')).to be_a(OpenSSL::PKey::RSA)
-      end
-
       it 'downcases name' do
         expect(provider.load_private_key('SIGNED-KEY')).to be_a(OpenSSL::PKey::RSA)
       end
@@ -275,12 +271,29 @@ describe Puppet::X509::CertProvider do
         }.to raise_error(Puppet::Error, "Failed to load private key for 'signed'")
       end
 
-      context 'that are encrypted' do
+      context 'using RSA' do
+        it 'returns an RSA key' do
+          expect(provider.load_private_key('signed-key')).to be_a(OpenSSL::PKey::RSA)
+        end
+
         it 'raises without a passphrase' do
           # password is 74695716c8b6
           expect {
             provider.load_private_key('encrypted-key')
-          }.to raise_error(OpenSSL::PKey::RSAError, /Neither PUB key nor PRIV key/)
+          }.to raise_error(OpenSSL::PKey::PKeyError, /Could not parse PKey: no start line/)
+        end
+      end
+
+      context 'using EC' do
+        it 'returns an EC key' do
+          expect(provider.load_private_key('ec-key')).to be_a(OpenSSL::PKey::EC)
+        end
+
+        it 'raises without a passphrase' do
+          # password is 74695716c8b6
+          expect {
+            provider.load_private_key('encrypted-ec-key')
+          }.to raise_error(OpenSSL::PKey::PKeyError, /Could not parse PKey: no start line/)
         end
       end
     end


### PR DESCRIPTION
Adds two Puppet settings `key_type` and `named_curve`. If the `key_type` is set
to `ec` then the agent will generate an elliptic curve (EC) private key, but
only if it doesn't have a key yet. If it has a previously saved RSA key, then
this commit has no effect.

Puppet defaults to the elliptic curve 'prime256v1', but alternate curves may be
specified using the `named_curve` setting, provided OpenSSL and ruby support it.
For example, ruby does not yet support X25519[1]. The list of currently
supported curves is available from `OpenSSL::PKey::EC.builtin_curves`.

The `named_curve` setting only affects how EC keys are generated (and the
resulting client certificate, since the public key is embedded in the cert), but
not the list of supported curves in TLS[2], which are configurable via
`OpenSSL::SSL::SSLContext#ecdh_curves=`.

Note it is perfectly acceptable for an agent to use EC keys, while puppetserver
uses RSA, provided the server supports `ECDHE_RSA` or `ECDH_RSA` key exchange.

Since the saved private key can be either RSA or EC, use the more
generic `OpenSSL::PKey.read` method which returns the appropriate class
of private key. However, JRuby's implementation is broken, so check for
EC or fallback to RSA.

Ruby modified the EC class extensively in 2.4 so that it followed the generic
OpenSSL::PKey interface. To ensure compatibility across different ruby versions
this commit monkey patches the `EC#private_key?` and `EC.generate` methods,
but only if the methods are not defined.

[1] https://github.com/ruby/openssl/issues/117
[2] https://tools.ietf.org/html/rfc4492#section-5.1.1