### PR TITLE
(PUP-9579) Use device specific ssl_context

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -270,7 +270,15 @@ Licensed under the Apache 2.0 License
           Puppet[:certname] = device.name
 
           unless options[:resource] || options[:facts] || options[:apply] || options[:libdir]
-            Puppet::Configurer::PluginHandler.new.download_plugins(env)
+            # this will reload and recompute default settings and create the devices sub vardir
+            Puppet.settings.use :main, :agent, :ssl
+            # ask for a ssl cert if needed, but at least
+            # setup the ssl system for this device.
+            ssl_context = setup_host
+
+            Puppet.override(ssl_context: ssl_context) do
+              Puppet::Configurer::PluginHandler.new.download_plugins(env)
+            end
           end
           # this init the device singleton, so that the facts terminus
           # and the various network_device provider can use it
@@ -319,15 +327,12 @@ Licensed under the Apache 2.0 License
             end
           else
             Puppet.info _("starting applying configuration to %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
-            # this will reload and recompute default settings and create the devices sub vardir
-            Puppet.settings.use :main, :agent, :ssl
-            # ask for a ssl cert if needed, but at least
-            # setup the ssl system for this device.
-            setup_host(device.name)
 
-            require 'puppet/configurer'
-            configurer = Puppet::Configurer.new
-            configurer.run(:network_device => true, :pluginsync => Puppet::Configurer.should_pluginsync? && !options[:libdir])
+            Puppet.override(ssl_context: ssl_context) do
+              require 'puppet/configurer'
+              configurer = Puppet::Configurer.new
+              configurer.run(:network_device => true, :pluginsync => Puppet::Configurer.should_pluginsync? && !options[:libdir])
+            end
           end
         rescue => detail
           Puppet.log_exception(detail)
@@ -372,9 +377,9 @@ Licensed under the Apache 2.0 License
     end
   end
 
-  def setup_host(name)
+  def setup_host
     waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : Puppet[:waitforcert])
-    sm = Puppet::SSL::StateMachine.new(certname: name, waitforcert: waitforcert)
+    sm = Puppet::SSL::StateMachine.new(waitforcert: waitforcert)
     sm.ensure_client_certificate
   end
 

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -331,7 +331,7 @@ Licensed under the Apache 2.0 License
             Puppet.override(ssl_context: ssl_context) do
               require 'puppet/configurer'
               configurer = Puppet::Configurer.new
-              configurer.run(:network_device => true, :pluginsync => Puppet::Configurer.should_pluginsync? && !options[:libdir])
+              configurer.run(:network_device => true, :pluginsync => false)
             end
           end
         rescue => detail

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -417,7 +417,10 @@ describe Puppet::Application::Device do
         @configurer = double('configurer')
         allow(@configurer).to receive(:run)
         allow(Puppet::Configurer).to receive(:new).and_return(@configurer)
+        allow_any_instance_of(Puppet::SSL::StateMachine).to receive(:ensure_client_certificate).and_return(ssl_context)
       end
+
+      let(:ssl_context) { Puppet::SSL::SSLContext.new }
 
       it "should set vardir to the device vardir" do
         expect(Puppet).to receive(:[]=).with(:vardir, make_absolute("/dummy/devices/device1"))
@@ -532,8 +535,8 @@ describe Puppet::Application::Device do
         expect { @device.main }.to exit_with 0
       end
 
-      it "should make the Puppet::Pops::Loaaders available" do
-        expect(@configurer).to receive(:run).with(:network_device => true, :pluginsync => true) do
+      it "should make the Puppet::Pops::Loaders available" do
+        expect(@configurer).to receive(:run).with(:network_device => true, :pluginsync => false) do
           fail('Loaders not available') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
           true
         end.and_return(6, 2)

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -59,6 +59,7 @@ describe Puppet::Application::Device do
 
   describe "when handling options" do
     before do
+      Puppet[:certname] = 'device.example.com'
       allow(@device.command_line).to receive(:args).and_return([])
     end
 
@@ -77,7 +78,7 @@ describe Puppet::Application::Device do
       Puppet[:onetime] = true
       expect(Puppet::SSL::StateMachine).to receive(:new).with(hash_including(waitforcert: 0)).and_return(state_machine)
 
-      @device.setup_host('device.example.com')
+      @device.setup_host
     end
 
     it "should use supplied waitforcert when --onetime is specified" do
@@ -85,19 +86,20 @@ describe Puppet::Application::Device do
       @device.handle_waitforcert(60)
       expect(Puppet::SSL::StateMachine).to receive(:new).with(hash_including(waitforcert: 60)).and_return(state_machine)
 
-      @device.setup_host('device.example.com')
+      @device.setup_host
     end
 
     it "should use a default value for waitforcert when --onetime and --waitforcert are not specified" do
       expect(Puppet::SSL::StateMachine).to receive(:new).with(hash_including(waitforcert: 120)).and_return(state_machine)
 
-      @device.setup_host('device.example.com')
+      @device.setup_host
     end
 
     it "should use the waitforcert setting when checking for a signed certificate" do
       Puppet[:waitforcert] = 10
       expect(Puppet::SSL::StateMachine).to receive(:new).with(hash_including(waitforcert: 10)).and_return(state_machine)
-      @device.setup_host('device.example.com')
+
+      @device.setup_host
     end
 
     it "should set the log destination with --logdest" do
@@ -265,17 +267,21 @@ describe Puppet::Application::Device do
   end
 
   describe "when initializing each devices SSL" do
-    it "should create a new ssl host" do
-      expect(Puppet::SSL::StateMachine).to receive(:new).with(hash_including(certname: 'device.example.com')).and_return(state_machine)
+    before :each do
+      Puppet[:certname] = 'device.example.com'
+    end
 
-      @device.setup_host('device.example.com')
+    it "should create a new ssl host" do
+      expect(Puppet::SSL::StateMachine).to receive(:new).and_return(state_machine)
+
+      @device.setup_host
     end
 
     it "should wait for a certificate" do
       allow(@device.options).to receive(:[]).with(:waitforcert).and_return(123)
       expect(Puppet::SSL::StateMachine).to receive(:new).with(hash_including(waitforcert: 123)).and_return(state_machine)
 
-      @device.setup_host('device.example.com')
+      @device.setup_host
     end
   end
 


### PR DESCRIPTION
Previously the device application failed when trying to download a
catalog for a device, because the SSL statemachine doesn't take a
`certname` keyword argument.

Also, we have to push the device specific `ssl_context` onto the context
before making network connections on behalf of the device. Otherwise, we
end up using the node's normal ssl cert.

Also don't pluginsync twice per device.