### PR TITLE
(PUP-9472) Emit X509::Name as UTF-8

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -207,9 +207,9 @@ HELP
     ssl_context.client_chain.reverse.each_with_index do |cert, i|
       digest = Puppet::SSL::Digest.new('SHA256', cert.to_der)
       if i == ssl_context.client_chain.length - 1
-        Puppet.notice("Verified client certificate '#{cert.subject.to_s}' fingerprint #{digest}")
+        Puppet.notice("Verified client certificate '#{cert.subject.to_utf8}' fingerprint #{digest}")
       else
-        Puppet.notice("Verified CA certificate '#{cert.subject.to_s}' fingerprint #{digest}")
+        Puppet.notice("Verified CA certificate '#{cert.subject.to_utf8}' fingerprint #{digest}")
       end
     end
   end

--- a/lib/puppet/ssl/certificate.rb
+++ b/lib/puppet/ssl/certificate.rb
@@ -39,7 +39,7 @@ DOC
   # This name is what gets extracted from the subject before being passed
   # to the constructor, so it's not downcased
   def unmunged_name
-    self.class.name_from_subject(content.subject)
+    self.class.name_from_subject(content.subject.to_utf8)
   end
 
   # Any extensions registered with custom OIDs as defined in module

--- a/lib/puppet/ssl/error.rb
+++ b/lib/puppet/ssl/error.rb
@@ -12,7 +12,7 @@ module Puppet::SSL
 
   class CertMismatchError < Puppet::SSL::SSLError
     def initialize(peer_cert, host)
-      valid_certnames = [peer_cert.subject.to_s.sub(/.*=/, ''),
+      valid_certnames = [peer_cert.subject.to_utf8.sub(/.*=/, ''),
                          *Puppet::SSL::Certificate.subject_alt_names_for(peer_cert)].uniq
       if valid_certnames.size > 1
         expected_certnames = _("expected one of %{certnames}") % { certnames: valid_certnames.join(', ') }

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -153,11 +153,11 @@ class Puppet::SSL::SSLProvider
   end
 
   def subject(x509)
-    x509.subject.to_s
+    x509.subject.to_utf8
   end
 
   def issuer(x509)
-    x509.issuer.to_s
+    x509.issuer.to_utf8
   end
 
   def revocation_mode(mode)

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -239,9 +239,9 @@ class Puppet::SSL::StateMachine
       chain.reverse.each_with_index do |cert, i|
         digest = Puppet::SSL::Digest.new('SHA256', cert.to_der)
         if i == chain.length - 1
-          Puppet.debug(_("Verified client certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_s, digest: digest})
+          Puppet.debug(_("Verified client certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
         else
-          Puppet.debug(_("Verified CA certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_s, digest: digest})
+          Puppet.debug(_("Verified CA certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
         end
       end
     end

--- a/lib/puppet/ssl/validator/default_validator.rb
+++ b/lib/puppet/ssl/validator/default_validator.rb
@@ -88,13 +88,13 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
             Puppet.debug("Ignoring CRL not yet valid, current time #{Time.now.utc}, CRL last updated #{crl.last_update.utc}")
             preverify_ok = true
           else
-            @verify_errors << "#{error_string} for #{crl.issuer}"
+            @verify_errors << "#{error_string} for #{crl.issuer.to_utf8}"
           end
         else
           @verify_errors << error_string
         end
       else
-        @verify_errors << "#{error_string} for #{current_cert.subject}"
+        @verify_errors << "#{error_string} for #{current_cert.subject.to_utf8}"
       end
     end
     preverify_ok
@@ -156,8 +156,8 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
     if not has_authz_peer_cert(descending_cert_chain, authz_ca_certs)
       msg = "The server presented a SSL certificate chain which does not include a " <<
         "CA listed in the ssl_client_ca_auth file.  "
-      msg << "Authorized Issuers: #{authz_ca_certs.collect {|c| c.subject}.join(', ')}  " <<
-        "Peer Chain: #{descending_cert_chain.collect {|c| c.subject}.join(' => ')}"
+      msg << "Authorized Issuers: #{authz_ca_certs.collect {|c| c.subject.to_utf8}.join(', ')}  " <<
+        "Peer Chain: #{descending_cert_chain.collect {|c| c.subject.to_utf8}.join(' => ')}"
       @verify_errors << msg
       false
     else

--- a/lib/puppet/ssl/verifier.rb
+++ b/lib/puppet/ssl/verifier.rb
@@ -126,7 +126,7 @@ class Puppet::SSL::Verifier
     # TRANSLATORS: `error` is an untranslated message from openssl describing why a certificate in the server's chain is invalid, and `subject` is the identity/name of the failed certificate
     @last_error = Puppet::SSL::CertVerifyError.new(
       _("certificate verify failed [%{error} for %{subject}]") %
-      { error: store_context.error_string, subject: peer_cert.subject },
+      { error: store_context.error_string, subject: peer_cert.subject.to_utf8 },
       store_context.error, peer_cert
     )
     false

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -70,7 +70,7 @@ if Puppet::Util::Platform.windows?
           begin
             add_cert(x509)
           rescue OpenSSL::X509::StoreError
-            warn "Failed to add #{x509.subject.to_s}"
+            warn "Failed to add #{x509.subject.to_utf8}"
           end
         end
       end

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -80,6 +80,25 @@ if Puppet::Util::Platform.windows?
   end
 end
 
+unless OpenSSL::X509::Name.instance_methods.include?(:to_utf8)
+  class OpenSSL::X509::Name
+    # https://github.com/openssl/openssl/blob/OpenSSL_1_1_0j/include/openssl/asn1.h#L362
+    ASN1_STRFLGS_ESC_MSB = 4
+
+    FLAGS = if RUBY_PLATFORM == 'java'
+              OpenSSL::X509::Name::RFC2253
+            else
+              OpenSSL::X509::Name::RFC2253 & ~ASN1_STRFLGS_ESC_MSB
+            end
+
+    def to_utf8
+      # https://github.com/ruby/ruby/blob/v2_5_5/ext/openssl/ossl_x509name.c#L317
+      str = to_s(FLAGS)
+      str.force_encoding(Encoding::UTF_8)
+    end
+  end
+end
+
 # The Enumerable#uniq method was added in Ruby 2.4.0 (https://bugs.ruby-lang.org/issues/11090)
 # This is a backport to earlier Ruby versions.
 #

--- a/spec/integration/network/http_pool_spec.rb
+++ b/spec/integration/network/http_pool_spec.rb
@@ -97,7 +97,7 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
           expect {
             http.get('/')
           }.to raise_error(Puppet::Error,
-                           %r{certificate verify failed.* .self signed certificate in certificate chain for /CN=Test CA.})
+                           %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
         end
       end
     end
@@ -166,12 +166,12 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
         expect {
           http.get('/')
         }.to raise_error(Puppet::Error,
-                         %r{certificate verify failed.* .self signed certificate in certificate chain for /CN=Test CA.})
+                         %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
       end
     end
 
     it "warns when client has an incomplete client cert chain" do
-      expect(Puppet).to receive(:warning).with("The issuer '/CN=Test CA Agent Subauthority' of certificate '/CN=pluto' cannot be found locally")
+      expect(Puppet).to receive(:warning).with("The issuer 'CN=Test CA Agent Subauthority' of certificate 'CN=pluto' cannot be found locally")
 
       pluto = cert_fixture('pluto.pem')
 

--- a/spec/integration/rest/client_spec.rb
+++ b/spec/integration/rest/client_spec.rb
@@ -50,7 +50,7 @@ describe Puppet::Rest::Client, unless: Puppet::Util::Platform.jruby? do
       expect {
         client.get(uri)
       }.to raise_error(Puppet::Error,
-                       %r{certificate verify failed.* .self signed certificate in certificate chain for /CN=Test CA.})
+                       %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
     end
   end
 

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -186,7 +186,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 200, body: @host[:cert].to_pem)
 
       expects_command_to_fail(
-        %r{^Failed to download certificate: The certificate for '/CN=ssl-client' does not match its private key}
+        %r{^Failed to download certificate: The certificate for 'CN=ssl-client' does not match its private key}
       )
     end
 
@@ -223,7 +223,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       File.open(Puppet[:hostprivkey], 'w') { |f| f.write(private_key.to_pem) }
       File.open(Puppet[:hostpubkey], 'w') { |f| f.write(public_key.to_pem) }
 
-      expects_command_to_fail(%r{The certificate for '/CN=ssl-client' does not match its private key})
+      expects_command_to_fail(%r{The certificate for 'CN=ssl-client' does not match its private key})
     end
 
     it 'reports if the cert verification fails' do
@@ -234,13 +234,13 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       # and CRL for that CA
       File.open(Puppet[:hostcrl], 'w') { |f| f.write(new_ca.ca_crl.to_pem) }
 
-      expects_command_to_fail(%r{Invalid signature for certificate '/CN=ssl-client'})
+      expects_command_to_fail(%r{Invalid signature for certificate 'CN=ssl-client'})
     end
 
     it 'reports when verification succeeds' do
       allow_any_instance_of(OpenSSL::X509::Store).to receive(:verify).and_return(true)
 
-      expects_command_to_pass(%r{Verified client certificate '/CN=ssl-client' fingerprint})
+      expects_command_to_pass(%r{Verified client certificate 'CN=ssl-client' fingerprint})
     end
   end
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -254,7 +254,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
         expect {
           state.next_state
-        }.to raise_error(Puppet::SSL::SSLError, %r{The certificate for '/CN=signed' does not match its private key})
+        }.to raise_error(Puppet::SSL::SSLError, %r{The certificate for 'CN=signed' does not match its private key})
       end
 
       it 'generates a new private key, saves it and passes it to the next state' do
@@ -451,7 +451,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
         state.next_state
 
-        expect(@logs).to include(an_object_having_attributes(message: %r{The certificate for '/CN=127.0.0.1' does not match its private key}))
+        expect(@logs).to include(an_object_having_attributes(message: %r{The certificate for 'CN=127.0.0.1' does not match its private key}))
         expect(File).to_not exist(Puppet[:hostcert])
       end
 
@@ -461,7 +461,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
         state.next_state
 
-        expect(@logs).to include(an_object_having_attributes(message: %r{Certificate '/CN=revoked' is revoked}))
+        expect(@logs).to include(an_object_having_attributes(message: %r{Certificate 'CN=revoked' is revoked}))
         expect(File).to_not exist(Puppet[:hostcert])
       end
     end

--- a/spec/unit/ssl/verifier_spec.rb
+++ b/spec/unit/ssl/verifier_spec.rb
@@ -79,7 +79,7 @@ describe Puppet::SSL::Verifier do
 
       expect {
         verifier.handle_connection_error(http, ssl_error)
-      }.to raise_error(Puppet::SSL::CertVerifyError, "certificate verify failed [unable to get local issuer certificate for /CN=127.0.0.1]")
+      }.to raise_error(Puppet::SSL::CertVerifyError, "certificate verify failed [unable to get local issuer certificate for CN=127.0.0.1]")
     end
 
     it "raises a verification error for the server cert" do
@@ -88,7 +88,7 @@ describe Puppet::SSL::Verifier do
 
       expect {
         verifier.handle_connection_error(http, ssl_error)
-      }.to raise_error(Puppet::SSL::CertVerifyError, "certificate verify failed [certificate rejected for /CN=127.0.0.1]")
+      }.to raise_error(Puppet::SSL::CertVerifyError, "certificate verify failed [certificate rejected for CN=127.0.0.1]")
     end
 
     it "raises cert mismatch error on ruby < 2.4" do

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -106,7 +106,7 @@ describe OpenSSL::X509::Store, :if => Puppet::Util::Platform.windows? do
       with_root_certs([cert])
       store.add_cert(cert)
 
-      expect(store).to receive(:warn).with('Failed to add /DC=com/DC=microsoft/CN=Microsoft Root Certificate Authority')
+      expect(store).to receive(:warn).with('Failed to add CN=Microsoft Root Certificate Authority,DC=microsoft,DC=com')
 
       store.set_default_paths
     end

--- a/spec/unit/util/windows/root_certs_spec.rb
+++ b/spec/unit/util/windows/root_certs_spec.rb
@@ -11,6 +11,6 @@ describe "Puppet::Util::Windows::RootCerts", :if => Puppet::Util::Platform.windo
   it "should return an X509 certificate with a subject" do
     x509 = x509_store.first
 
-    expect(x509.subject.to_s).to match(/CN=.*/)
+    expect(x509.subject.to_utf8).to match(/CN=.*/)
   end
 end

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -304,12 +304,12 @@ describe Puppet::X509::CertProvider do
 
       it 'returns a certificate' do
         cert = provider.load_client_cert('signed')
-        expect(cert.subject.to_s).to eq('/CN=signed')
+        expect(cert.subject.to_utf8).to eq('CN=signed')
       end
 
       it 'downcases name' do
         cert = provider.load_client_cert('SIGNED')
-        expect(cert.subject.to_s).to eq('/CN=signed')
+        expect(cert.subject.to_utf8).to eq('CN=signed')
       end
 
       it 'raises if name is invalid' do
@@ -348,7 +348,7 @@ describe Puppet::X509::CertProvider do
 
       it 'downcases name' do
         csr = provider.load_request('REQUEST')
-        expect(csr.subject.to_s).to eq('/CN=pending')
+        expect(csr.subject.to_utf8).to eq('CN=pending')
       end
 
       it 'raises if name is invalid' do


### PR DESCRIPTION
The `OpenSSL::X509::Name#to_s` method uses the default "oneline"
format, which corrupts non-ASCII characters. For example, the 𠜎 character when
UTF-8 encoded is 0xF0, 0xA0, 0x9C, 0x8E, but `Name#to_s` encodes each byte as
the 4 byte sequence `\\`, 'x', &lt;hex&gt;, &lt;hex&gt;, resulting in a 16 byte sequence.

    irb(main):006:0> name = "CN=root-ca-𠜎"
    => "CN=root-ca-𠜎"
    irb(main):007:0> OpenSSL::X509::Name.parse(name).to_s
    => "/CN=root-ca-\\xF0\\xA0\\x9C\\x8E"
    irb(main):008:0> OpenSSL::X509::Name.parse(name).to_utf8
    => "CN=root-ca-𠜎"

Use `OpenSSL::X509::Name#to_utf8` explicitly. This is mostly an issue
for CA certs, since the subject doesn't correspond to a hostname and can
be anything like:

    C=HU, L=Budapest, O=NetLock Kft., OU=Tanúsítványkiadók (Certification Services), CN=NetLock Arany (Class Gold) Főtanúsítvány
