### PR TITLE
(PUP-9574) Reword allow_duplicate_certs setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1055,7 +1055,9 @@ EOT
     :allow_duplicate_certs => {
       :default    => false,
       :type       => :boolean,
-      :desc       => "Whether to allow a new certificate request to overwrite an existing certificate.",
+      :desc       => "Whether to allow a new certificate request to overwrite an existing
+        certificate request. If true, then the old certificate must be cleaned using
+        `puppetserver ca clean`, and the new request signed using `puppetserver ca sign`."
     },
     :ca_ttl => {
       :default    => "5y",


### PR DESCRIPTION
The setting does not allow a cert request to overwrite a certificate. It's more
that the CA will accept a CSR while there is already a pending CSR or a signed
cert with that name. If it's the former, then the new CSR will overwrite the old
one. If it's the latter, then the CSR will be saved, but the user must still
clean (revoke+delete) the old cert, and sign the new CSR.