### PR TITLE
(PUP-3122) Improve message when cert hasn't been signed yet

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -192,10 +192,10 @@ class Puppet::SSL::StateMachine
     def next_state
       time = @machine.onetime ? 0 : @machine.waitforcert
       if time < 1
-        puts _("Exiting; no certificate found and waitforcert is disabled")
+        puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Exiting now because the waitforcert setting is set to 0.") % { name: Puppet[:certname] }
         exit(1)
       else
-        Puppet.debug(_("Waiting %{time} seconds for cert to be signed") % {time: time})
+        Puppet.info(_("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Will try again in %{time} seconds.") % {name: Puppet[:certname], time: time})
 
         sleep(time)
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -475,8 +475,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         expect {
           expect {
             Puppet::SSL::StateMachine::Wait.new(machine, ssl_context).next_state
-          }.to output("Exiting; no certificate found and waitforcert is disabled").to_stdout
-        }.to exit_with(1)
+          }.to exit_with(1)
+        }.to output(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Exiting now because the waitforcert setting is set to 0./).to_stdout
       end
 
       it 'exits with 1 if waitforcert is 0' do
@@ -485,8 +485,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         expect {
           expect {
             Puppet::SSL::StateMachine::Wait.new(machine, ssl_context).next_state
-          }.to output("Exiting; no certificate found and waitforcert is disabled").to_stdout
-        }.to exit_with(1)
+          }.to exit_with(1)
+        }.to output(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Exiting now because the waitforcert setting is set to 0./).to_stdout
       end
 
       it 'sleeps and transitions to NeedCACerts' do
@@ -494,6 +494,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
         state = Puppet::SSL::StateMachine::Wait.new(machine, ssl_context)
         expect(state).to receive(:sleep).with(15)
+
+        expect(Puppet).to receive(:info).with(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Will try again in 15 seconds./)
 
         expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedCACerts)
       end


### PR DESCRIPTION
Improve message when cert can't be downloaded, so it's clear the agent
is waiting for the cert to be signed on the CA.

Previously the stdout expectation wasn't testing anything due to the
SystemExit. Switch the order of expectations so we rescue the SystemExit
first, and then assert the expected output.