### PR TITLE
(PUP-9586) Remove Duplicate Failed Event

### DIFF
--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -155,11 +155,6 @@ class Puppet::Transaction::EventManager
     return true
   rescue => detail
     resource_error_message = _("Failed to call %{callback}: %{detail}") % { callback: callback, detail: detail }
-    resource.err resource_error_message
-    if not resource.is_a?(Puppet::Type.type(:whit))
-      add_callback_status_event(resource, callback, resource_error_message, "failure")
-    end
-
     transaction.resource_status(resource).failed_to_restart = true
     transaction.resource_status(resource).fail_with_event(resource_error_message)
     resource.log_exception(detail)

--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -304,7 +304,7 @@ describe Puppet::Transaction::EventManager do
       it "should record a failed event on the resource status" do
         @manager.process_events(@resource)
 
-        expect(@transaction.resource_status(@resource).events.length).to eq(2)
+        expect(@transaction.resource_status(@resource).events.length).to eq(1)
         expect(@transaction.resource_status(@resource).events[0].status).to eq('failure')
       end
 


### PR DESCRIPTION
Having both add_callback_status_event and fail_with_event created two almost identical events.  These events were causing problems with checks in PuppetDB.  After this change, only one event is generated.