### PR TITLE
(PUP-9589) Ignore onetime in state machine

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -190,7 +190,7 @@ class Puppet::SSL::StateMachine
   #
   class Wait < SSLState
     def next_state
-      time = @machine.onetime ? 0 : @machine.waitforcert
+      time = @machine.waitforcert
       if time < 1
         puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Exiting now because the waitforcert setting is set to 0.") % { name: Puppet[:certname] }
         exit(1)
@@ -211,10 +211,9 @@ class Puppet::SSL::StateMachine
   #
   class Done < SSLState; end
 
-  attr_reader :onetime, :waitforcert
+  attr_reader :waitforcert
 
-  def initialize(onetime: Puppet[:onetime], waitforcert: Puppet[:waitforcert])
-    @onetime = onetime
+  def initialize(waitforcert: Puppet[:waitforcert])
     @waitforcert = waitforcert
   end
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -469,16 +469,6 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     context 'in state Wait' do
       let(:ssl_context) { Puppet::SSL::SSLContext.new(cacerts: cacerts, crls: crls)}
 
-      it 'exits with 1 if only running once' do
-        machine = described_class.new(onetime: true)
-
-        expect {
-          expect {
-            Puppet::SSL::StateMachine::Wait.new(machine, ssl_context).next_state
-          }.to exit_with(1)
-        }.to output(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Exiting now because the waitforcert setting is set to 0./).to_stdout
-      end
-
       it 'exits with 1 if waitforcert is 0' do
         machine = described_class.new(waitforcert: 0)
 


### PR DESCRIPTION
Previously, `puppet agent -t --waitforcert N` ignored `waitforcert`. This was
because `-t` implies `--onetime`, and the state machine would always exit when
`onetime` was set, regardless of `waitforcert`.

This commit simplifies the state machine to only observe the `waitforcert`
setting. The `puppet agent` application already maps `onetime=true` to
`waitforcert=0`, so it doesn't need to be repeated in the state machine.

The `puppet device` application doesn't have the same problem, because
it doesn't have a `--test` option, nor does it automagically map options
to `onetime`.