### PR TITLE
(PUP-9586) Fix spec failure

### DIFF
--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -280,15 +280,13 @@ describe Puppet::Transaction::EventManager do
     describe "and the callback fails" do
       before do
         expect(@resource).to receive(:callback1).and_raise("a failure")
-        allow(@resource).to receive(:err)
 
         expect(@manager).to receive(:queued_events).and_yield(:callback1, [@event])
       end
 
       it "should log but not fail" do
-        expect(@resource).to receive(:err)
-
         expect { @manager.process_events(@resource) }.not_to raise_error
+        expect(@logs).to include(an_object_having_attributes(level: :err, message: 'a failure'))
       end
 
       it "should set the 'failed_restarts' state on the resource status" do


### PR DESCRIPTION
Though 5.5.x tests were passing, this change is required for 6.0.x