### PR TITLE
(PUP-9586) Preserve error showing callback failed

### DIFF
--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -155,6 +155,7 @@ class Puppet::Transaction::EventManager
     return true
   rescue => detail
     resource_error_message = _("Failed to call %{callback}: %{detail}") % { callback: callback, detail: detail }
+    resource.err(resource_error_message)
     transaction.resource_status(resource).failed_to_restart = true
     transaction.resource_status(resource).fail_with_event(resource_error_message)
     resource.log_exception(detail)

--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -284,8 +284,12 @@ describe Puppet::Transaction::EventManager do
         expect(@manager).to receive(:queued_events).and_yield(:callback1, [@event])
       end
 
-      it "should log but not fail" do
-        expect { @manager.process_events(@resource) }.not_to raise_error
+      it "should emit an error and log but not fail" do
+        expect(@resource).to receive(:err).with('Failed to call callback1: a failure').and_call_original
+        expect(@resource).to receive(:err).with('a failure').and_call_original
+
+        @manager.process_events(@resource)
+
         expect(@logs).to include(an_object_having_attributes(level: :err, message: 'a failure'))
       end
 


### PR DESCRIPTION
Preserve the original behavior of emitting an error message that the
callback failed, followed by the exception that caused the issue:

    Error: /Stage[main]/Main/Exec[exec]: Failed to call refresh: '/usr/bin/false' returned 1 instead of one of [0]
    Error: /Stage[main]/Main/Exec[exec]: '/usr/bin/false' returned 1 instead of one of [0]`