### PR TITLE
(PUP-9579) Push device specific ssl_context

### DIFF
--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -410,40 +410,6 @@ describe Puppet::Application::Device do
         end
       end
 
-      context 'when running --apply' do
-        before do
-          allow(device.options).to receive(:[]).with(:apply).and_return('file.pp')
-          allow(device.options).to receive(:[]).with(:target).and_return('device1')
-          allow(Puppet::Util::NetworkDevice).to receive(:init)
-          allow(File).to receive(:file?).with('file.pp').and_return(true)
-          allow(Puppet).to receive(:[]).and_call_original
-          allow(Puppet).to receive(:[]).with(:statedir).and_return('/tmp/statedir')
-          allow(::File).to receive(:directory?).and_return(false)
-        end
-
-        it "does not try to recreate the state folder" do
-          allow(File).to receive(:directory?).with('/tmp/statedir').and_return(true)
-          expect(FileUtils).not_to receive(:mkdir_p).with('/tmp/statedir')
-
-          expect(Puppet::Util::CommandLine).to receive(:new).once
-          expect(Puppet::Application::Apply).to receive(:new).once
-
-          expect(Puppet::Configurer).not_to receive(:new)
-          expect { device.main }.to exit_with 1
-        end
-
-        it "creates the missing state folder" do
-          allow(File).to receive(:directory?).with('/tmp/statedir').and_return(false)
-          expect(FileUtils).to receive(:mkdir_p).with('/tmp/statedir').once
-
-          expect(Puppet::Util::CommandLine).to receive(:new).once
-          expect(Puppet::Application::Apply).to receive(:new).once
-
-          expect(Puppet::Configurer).not_to receive(:new)
-          expect { device.main }.to exit_with 1
-        end
-      end
-
       context 'when running --resource' do
         before do
           allow(device.options).to receive(:[]).with(:resource).and_return(true)

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -71,6 +71,7 @@ describe Puppet::Application::Device do
 
   describe "when handling options" do
     before do
+      Puppet[:certname] = 'device.example.com'
       allow(device.command_line).to receive(:args).and_return([])
     end
 

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -514,7 +514,7 @@ describe Puppet::Application::Device do
         end
 
         it "makes the Puppet::Pops::Loaders available" do
-          expect(configurer).to receive(:run).with(:network_device => true, :pluginsync => true) do
+          expect(configurer).to receive(:run).with(:network_device => true, :pluginsync => false) do
             fail('Loaders not available') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
             true
           end.and_return(6, 2)


### PR DESCRIPTION
Previously the device application failed when trying to download a
catalog for a device, because the SSL statemachine doesn't take a
`certname` keyword argument.

If `--libdir` is specified, then we want to continue skipping pluginsync, but we
still need to ensure the per-device ssl_context is initialized before requesting
a catalog on behalf of the device. If we created a per-device ssl_context, then
push that on the context stack so we don't accidentally fall back to the
non-device one.
