### PR TITLE
(PUP-9586) Account for different Puppet.err behavior

### DIFF
--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -286,7 +286,6 @@ describe Puppet::Transaction::EventManager do
 
       it "should emit an error and log but not fail" do
         expect(@resource).to receive(:err).with('Failed to call callback1: a failure').and_call_original
-        expect(@resource).to receive(:err).with('a failure').and_call_original
 
         @manager.process_events(@resource)
 


### PR DESCRIPTION
In 6.x, puppet's `log_exception` no longer calls `Puppet.err`, instead
using `send_log(:err, 'message')`, which breaks our expectation. Since
the expectation is already handled by examining the collected logs, just
do that.