### PR TITLE
(maint) Merge 6.0.x to 6.4.x

### DIFF
--- a/acceptance/tests/server_list_setting.rb
+++ b/acceptance/tests/server_list_setting.rb
@@ -16,7 +16,7 @@ test_name "Priority of server_list setting over server setting" do
             on(agent, puppet("agent", "-t", "--config #{tmpconf}", "--server notvalid", "--server_list #{master}:#{master_port}", "--debug"),
               :acceptable_exit_codes => [0, 2]) do |result|
               unless agent['locale'] == 'ja'
-                assert_match(/Selected puppet server: #{master}:#{master_port}/,
+                assert_match(/Selected puppet server from the `server_list` setting: #{master}:#{master_port}/,
                             result.stdout, "should have selected the working master")
               end
             end

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -257,89 +257,101 @@ Licensed under the Apache 2.0 License
         end
       end
       devices.collect do |devicename,device|
-        begin
-          device_url = URI.parse(device.url)
-          # Handle nil scheme & port
-          scheme = "#{device_url.scheme}://" if device_url.scheme
-          port = ":#{device_url.port}" if device_url.port
+        pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
+        Puppet.override(:http_pool => pool) do
+          # TODO when we drop support for ruby < 2.5 we can remove the extra block here
+          begin
+            device_url = URI.parse(device.url)
+            # Handle nil scheme & port
+            scheme = "#{device_url.scheme}://" if device_url.scheme
+            port = ":#{device_url.port}" if device_url.port
 
-          # override local $vardir and $certname
-          Puppet[:confdir] = ::File.join(Puppet[:devicedir], device.name)
-          Puppet[:libdir] = options[:libdir] || ::File.join(Puppet[:devicedir], device.name, 'lib')
-          Puppet[:vardir] = ::File.join(Puppet[:devicedir], device.name)
-          Puppet[:certname] = device.name
+            # override local $vardir and $certname
+            Puppet[:confdir] = ::File.join(Puppet[:devicedir], device.name)
+            Puppet[:libdir] = options[:libdir] || ::File.join(Puppet[:devicedir], device.name, 'lib')
+            Puppet[:vardir] = ::File.join(Puppet[:devicedir], device.name)
+            Puppet[:certname] = device.name
+            ssl_context = nil
 
-          unless options[:resource] || options[:facts] || options[:apply] || options[:libdir]
-            # this will reload and recompute default settings and create the devices sub vardir
+            # this will reload and recompute default settings and create device-specific sub vardir
             Puppet.settings.use :main, :agent, :ssl
-            # ask for a ssl cert if needed, but at least
-            # setup the ssl system for this device.
-            ssl_context = setup_context
 
-            Puppet.override(ssl_context: ssl_context) do
-              Puppet::Configurer::PluginHandler.new.download_plugins(env)
-            end
-          end
+            unless options[:resource] || options[:facts] || options[:apply]
+              # ask for a ssl cert if needed, but at least
+              # setup the ssl system for this device.
+              ssl_context = setup_context
 
-          # this init the device singleton, so that the facts terminus
-          # and the various network_device provider can use it
-          Puppet::Util::NetworkDevice.init(device)
-
-          if options[:resource]
-            type, name = parse_args(command_line.args)
-            Puppet.info _("retrieving resource: %{resource} from %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { resource: type, target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
-            resources = find_resources(type, name)
-            if options[:to_yaml]
-              text = resources.map do |resource|
-                resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml.force_encoding(Encoding.default_external)
-              end.join("\n")
-              text.prepend("#{type.downcase}:\n")
-            else
-              text = resources.map do |resource|
-                resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest.force_encoding(Encoding.default_external)
-              end.join("\n")
-            end
-            (puts text)
-            0
-          elsif options[:facts]
-            Puppet.info _("retrieving facts from %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { resource: type, target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
-            remote_facts = Puppet::Node::Facts.indirection.find(name, :environment => env)
-            # Give a proper name to the facts
-            remote_facts.name = remote_facts.values['clientcert']
-            renderer = Puppet::Network::FormatHandler.format(:console)
-            puts renderer.render(remote_facts)
-            0
-          elsif options[:apply]
-            # ensure we have a cache folder structure exists for the device
-            FileUtils.mkdir_p(Puppet[:statedir]) unless File.directory?(Puppet[:statedir])
-            # avoid reporting to server
-            Puppet::Transaction::Report.indirection.terminus_class = :yaml
-            Puppet::Resource::Catalog.indirection.cache_class = nil
-
-            require 'puppet/application/apply'
-            begin
-              Puppet[:node_terminus] = :plain
-              Puppet[:catalog_terminus] = :compiler
-              Puppet[:catalog_cache_terminus] = nil
-              Puppet[:facts_terminus] = :network_device
-              Puppet.override(:network_device => true) do
-                Puppet::Application::Apply.new(Puppet::Util::CommandLine.new('puppet', ["apply", options[:apply]])).run_command
+              unless options[:libdir]
+                Puppet.override(ssl_context: ssl_context) do
+                  Puppet::Configurer::PluginHandler.new.download_plugins(env) if Puppet::Configurer.should_pluginsync?
+                end
               end
             end
-          else
-            Puppet.info _("starting applying configuration to %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
-            configurer = Puppet::Configurer.new
-            configurer.run(:network_device => true, :pluginsync => Puppet::Configurer.should_pluginsync? && !options[:libdir])
+
+            # this init the device singleton, so that the facts terminus
+            # and the various network_device provider can use it
+            Puppet::Util::NetworkDevice.init(device)
+
+            if options[:resource]
+              type, name = parse_args(command_line.args)
+              Puppet.info _("retrieving resource: %{resource} from %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { resource: type, target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
+              resources = find_resources(type, name)
+              if options[:to_yaml]
+                text = resources.map do |resource|
+                  resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml.force_encoding(Encoding.default_external)
+                end.join("\n")
+                text.prepend("#{type.downcase}:\n")
+              else
+                text = resources.map do |resource|
+                  resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest.force_encoding(Encoding.default_external)
+                end.join("\n")
+              end
+              (puts text)
+              0
+            elsif options[:facts]
+              Puppet.info _("retrieving facts from %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { resource: type, target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
+              remote_facts = Puppet::Node::Facts.indirection.find(name, :environment => env)
+              # Give a proper name to the facts
+              remote_facts.name = remote_facts.values['clientcert']
+              renderer = Puppet::Network::FormatHandler.format(:console)
+              puts renderer.render(remote_facts)
+              0
+            elsif options[:apply]
+              # avoid reporting to server
+              Puppet::Transaction::Report.indirection.terminus_class = :yaml
+              Puppet::Resource::Catalog.indirection.cache_class = nil
+
+              require 'puppet/application/apply'
+              begin
+                Puppet[:node_terminus] = :plain
+                Puppet[:catalog_terminus] = :compiler
+                Puppet[:catalog_cache_terminus] = nil
+                Puppet[:facts_terminus] = :network_device
+                Puppet.override(:network_device => true) do
+                  Puppet::Application::Apply.new(Puppet::Util::CommandLine.new('puppet', ["apply", options[:apply]])).run_command
+                end
+              end
+            else
+              Puppet.info _("starting applying configuration to %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
+
+              overrides = {}
+              overrides[:ssl_context] = ssl_context if ssl_context
+              Puppet.override(overrides) do
+                configurer = Puppet::Configurer.new
+                configurer.run(:network_device => true, :pluginsync => false)
+              end
+            end
+          rescue => detail
+            Puppet.log_exception(detail)
+            # If we rescued an error, then we return 1 as the exit code
+            1
+          ensure
+            pool.close
+            Puppet[:libdir] = libdir
+            Puppet[:vardir] = vardir
+            Puppet[:confdir] = confdir
+            Puppet[:certname] = certname
           end
-        rescue => detail
-          Puppet.log_exception(detail)
-          # If we rescued an error, then we return 1 as the exit code
-          1
-        ensure
-          Puppet[:libdir] = libdir
-          Puppet[:vardir] = vardir
-          Puppet[:confdir] = confdir
-          Puppet[:certname] = certname
         end
       end
     end
@@ -382,9 +394,12 @@ Licensed under the Apache 2.0 License
 
   def setup
     setup_logs
+
+    # setup global device-specific defaults; creates all necessary directories, etc
+    Puppet.settings.use :main, :agent, :device, :ssl
+
     if options[:apply] || options[:facts] || options[:resource]
       Puppet::Util::Log.newdestination(:console)
-      Puppet.settings.use :main, :agent, :ssl
     else
       args[:Server] = Puppet[:server]
       if options[:centrallogs]
@@ -393,8 +408,6 @@ Licensed under the Apache 2.0 License
         logdest += ":" + args[:Port] if args.include?(:Port)
         Puppet::Util::Log.newdestination(logdest)
       end
-
-      Puppet.settings.use :main, :agent, :device, :ssl
 
       Puppet::Transaction::Report.indirection.terminus_class = :rest
 

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -289,11 +289,15 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       else
         if Puppet[:server_list] && !Puppet[:server_list].empty?
           server = Puppet[:server_list].first
+          #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+          Puppet.debug _("Selected server from first entry of the `server_list` setting: %{server}:%{port}") % {server: server[0], port: server[1]}
           @client = Puppet::FileBucket::Dipper.new(
             :Server => server[0],
             :Port => server[1]
           )
         else
+          #TRANSLATORS 'server' is the name of a setting and should not be translated
+          Puppet.debug _("Selected server from the `server` setting: %{server}") % {server: Puppet[:server]}
           @client = Puppet::FileBucket::Dipper.new(:Server => Puppet[:server])
         end
       end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -229,7 +229,8 @@ class Puppet::Configurer
           if server.nil?
             raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: Puppet[:server_list] }
           else
-            Puppet.debug _("Selected puppet server: %{server}:%{port}") % { server: server, port: port }
+            #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+            Puppet.debug _("Selected puppet server from the `server_list` setting: %{server}:%{port}") % { server: server, port: port }
             report.master_used = "#{server}:#{port}"
           end
           Puppet.override(server: server, serverport: port) do

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -3,12 +3,14 @@ require 'uri'
 require 'puppet/indirector'
 require 'puppet/network/resolver'
 require 'puppet/util/psych_support'
+require 'puppet/util/warnings'
 
 # This class encapsulates all of the information you need to make an
 # Indirection call, and as a result also handles REST calls.  It's somewhat
 # analogous to an HTTP Request object, except tuned for our Indirector.
 class Puppet::Indirector::Request
   include Puppet::Util::PsychSupport
+  include Puppet::Util::Warnings
 
   attr_accessor :key, :method, :options, :instance, :node, :ip, :authenticated, :ignore_cache, :ignore_cache_save, :ignore_terminus
 
@@ -200,26 +202,37 @@ class Puppet::Indirector::Request
       end
     end
 
-    # ... Fall back onto the default server.
-    bound_server = Puppet.lookup(:server) do
-      if primary_server = Puppet.settings[:server_list][0]
-        primary_server[0]
-      else
-        Puppet.settings[:server]
+    if default_server
+      self.server = default_server
+    else
+      self.server = Puppet.lookup(:server) do
+        if primary_server = Puppet.settings[:server_list][0]
+          #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+          debug_once _("Selected server from first entry of the `server_list` setting: %{server}") % {server: primary_server[0]}
+          primary_server[0]
+        else
+          #TRANSLATORS 'server' is the name of a setting and should not be translated
+          debug_once _("Selected server from the `server` setting: %{server}") % {server: Puppet.settings[:server]}
+          Puppet.settings[:server]
+        end
       end
     end
 
-    bound_port = Puppet.lookup(:serverport) do
-      if primary_server = Puppet.settings[:server_list][0]
-        primary_server[1]
-      else
-        Puppet.settings[:masterport]
+    if default_port
+      self.port = default_port
+    else
+      self.port = Puppet.lookup(:serverport) do
+        if primary_server = Puppet.settings[:server_list][0]
+          #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+          debug_once _("Selected port from the first entry of the `server_list` setting: %{port}") % {port: primary_server[1]}
+          primary_server[1]
+        else
+          #TRANSLATORS 'masterport' is the name of a setting and should not be translated
+          debug_once _("Selected port from the `masterport` setting: %{port}") % {port: Puppet.settings[:masterport]}
+          Puppet.settings[:masterport]
+        end
       end
     end
-    self.server = default_server || bound_server
-    self.port   = default_port || bound_port
-
-    Puppet.debug "No more servers left, falling back to #{self.server}:#{self.port}" if Puppet.settings[:use_srv_records]
 
     return yield(self)
   end

--- a/lib/puppet/transaction/event_manager.rb
+++ b/lib/puppet/transaction/event_manager.rb
@@ -155,11 +155,7 @@ class Puppet::Transaction::EventManager
     return true
   rescue => detail
     resource_error_message = _("Failed to call %{callback}: %{detail}") % { callback: callback, detail: detail }
-    resource.err resource_error_message
-    if not resource.is_a?(Puppet::Type.type(:whit))
-      add_callback_status_event(resource, callback, resource_error_message, "failure")
-    end
-
+    resource.err(resource_error_message)
     transaction.resource_status(resource).failed_to_restart = true
     transaction.resource_status(resource).fail_with_event(resource_error_message)
     resource.log_exception(detail)

--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -25,16 +25,17 @@ module Puppet::Util
     # @return [String] the name of the server for use in the request
     def self.determine_server(setting)
       if setting && setting != :server && Puppet.settings.set_by_config?(setting)
+        debug_once _("Selected server from the %{setting} setting: %{server}") % {setting: setting, server: Puppet.settings[setting]}
         Puppet[setting]
       else
         server = Puppet.lookup(:server) do
           if primary_server = Puppet.settings[:server_list][0]
-            debug_once('Dynamically-bound server lookup failed; using first entry')
+            #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+            debug_once _("Dynamically-bound server lookup failed; using first entry from the `server_list` setting: %{server}") % {server: primary_server[0]}
             primary_server[0]
           else
             setting ||= :server
-            debug_once('Dynamically-bound server lookup failed, falling back to %{setting} setting' %
-                       {setting: setting})
+            debug_once _("Dynamically-bound server lookup failed, falling back to %{setting} setting: %{server}") % {setting: setting, server: Puppet.settings[setting]}
             Puppet.settings[setting]
           end
         end
@@ -55,20 +56,26 @@ module Puppet::Util
     def self.determine_port(port_setting, server_setting)
       if (port_setting && port_setting != :masterport && Puppet.settings.set_by_config?(port_setting)) ||
          (server_setting && server_setting != :server && Puppet.settings.set_by_config?(server_setting))
+        debug_once _("Selected port from the %{setting} setting: %{port}") % {setting: port_setting, port: Puppet.settings[port_setting].to_i}
         Puppet.settings[port_setting].to_i
       else
         port = Puppet.lookup(:serverport) do
           if primary_server = Puppet.settings[:server_list][0]
-            debug_once('Dynamically-bound port lookup failed; using first entry')
-
             # Port might not be set, so we want to fallback in that
             # case. We know we don't need to use `setting` here, since
             # the default value of every port setting is `masterport`
-            (primary_server[1] || Puppet.settings[:masterport])
+            if primary_server[1]
+              #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+              debug_once _("Dynamically-bound port lookup failed; using first entry from the `server_list` setting: %{port}") % {port: primary_server[1]}
+              primary_server[1]
+            else
+              #TRANSLATORS 'masterport' is the name of a setting and should not be translated
+              debug_once _("Dynamically-bound port lookup failed; falling back to `masterport` setting: %{port}") % {port: Puppet.settings[:masterport]}
+              Puppet.settings[:masterport]
+            end
           else
             port_setting ||= :masterport
-            debug_once('Dynamically-bound port lookup failed; falling back to %{port_setting} setting' %
-                       {port_setting: port_setting})
+            debug_once _("Dynamically-bound port lookup failed; falling back to %{setting} setting: %{port}") % {setting: port_setting, port: Puppet.settings[port_setting]}
             Puppet.settings[port_setting]
           end
         end

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -66,6 +66,7 @@ describe Puppet::Application::Device do
 
   describe "when handling options" do
     before do
+      Puppet[:certname] = 'device.example.com'
       allow(device.command_line).to receive(:args).and_return([])
     end
 
@@ -398,40 +399,6 @@ describe Puppet::Application::Device do
         end
       end
 
-      context 'when running --apply' do
-        before do
-          allow(device.options).to receive(:[]).with(:apply).and_return('file.pp')
-          allow(device.options).to receive(:[]).with(:target).and_return('device1')
-          allow(Puppet::Util::NetworkDevice).to receive(:init)
-          allow(File).to receive(:file?).with('file.pp').and_return(true)
-          allow(Puppet).to receive(:[]).and_call_original
-          allow(Puppet).to receive(:[]).with(:statedir).and_return('/tmp/statedir')
-          allow(::File).to receive(:directory?).and_return(false)
-        end
-
-        it "does not try to recreate the state folder" do
-          allow(File).to receive(:directory?).with('/tmp/statedir').and_return(true)
-          expect(FileUtils).not_to receive(:mkdir_p).with('/tmp/statedir')
-
-          expect(Puppet::Util::CommandLine).to receive(:new).once
-          expect(Puppet::Application::Apply).to receive(:new).once
-
-          expect(Puppet::Configurer).not_to receive(:new)
-          expect { device.main }.to exit_with 1
-        end
-
-        it "creates the missing state folder" do
-          allow(File).to receive(:directory?).with('/tmp/statedir').and_return(false)
-          expect(FileUtils).to receive(:mkdir_p).with('/tmp/statedir').once
-
-          expect(Puppet::Util::CommandLine).to receive(:new).once
-          expect(Puppet::Application::Apply).to receive(:new).once
-
-          expect(Puppet::Configurer).not_to receive(:new)
-          expect { device.main }.to exit_with 1
-        end
-      end
-
       context 'when running --resource' do
         before do
           allow(device.options).to receive(:[]).with(:resource).and_return(true)
@@ -536,7 +503,7 @@ describe Puppet::Application::Device do
         end
 
         it "makes the Puppet::Pops::Loaders available" do
-          expect(configurer).to receive(:run).with(:network_device => true, :pluginsync => true) do
+          expect(configurer).to receive(:run).with(:network_device => true, :pluginsync => false) do
             fail('Loaders not available') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
             true
           end.and_return(6, 2)

--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -280,15 +280,16 @@ describe Puppet::Transaction::EventManager do
     describe "and the callback fails" do
       before do
         expect(@resource).to receive(:callback1).and_raise("a failure")
-        allow(@resource).to receive(:err)
 
         expect(@manager).to receive(:queued_events).and_yield(:callback1, [@event])
       end
 
-      it "should log but not fail" do
-        expect(@resource).to receive(:err)
+      it "should emit an error and log but not fail" do
+        expect(@resource).to receive(:err).with('Failed to call callback1: a failure').and_call_original
 
-        expect { @manager.process_events(@resource) }.not_to raise_error
+        @manager.process_events(@resource)
+
+        expect(@logs).to include(an_object_having_attributes(level: :err, message: 'a failure'))
       end
 
       it "should set the 'failed_restarts' state on the resource status" do
@@ -304,7 +305,7 @@ describe Puppet::Transaction::EventManager do
       it "should record a failed event on the resource status" do
         @manager.process_events(@resource)
 
-        expect(@transaction.resource_status(@resource).events.length).to eq(2)
+        expect(@transaction.resource_status(@resource).events.length).to eq(1)
         expect(@transaction.resource_status(@resource).events[0].status).to eq('failure')
       end
 


### PR DESCRIPTION
Had a few conflicts with device, debug_once and ssl_context:

* Use persistent http connections when pluginsyncing per device using http_pool
* If `libdir` device option is used, setup the ssl context, but don't pluginsync
* If we have a per-device `ssl_context` use that during the configurer run
* Use global `device` settings once, and then re-use `main`, etc settings per device
* Update indirector request to use `debug_once` like `puppet/util/connection`
* Emit debug showing how server/server_list was resolved
* Don't emit duplicate refreshed failed event