### PR TITLE
(docs) Clarify `period => never`

### DIFF
--- a/lib/puppet/type/schedule.rb
+++ b/lib/puppet/type/schedule.rb
@@ -271,6 +271,10 @@ module Puppet
 
         See the `periodmatch` attribute for tuning whether to match
         times by their distance apart or by their specific value.
+        
+        > **Tip**: You can use `period => never,` to prevent a resource from being applied
+        in the given `range`. This is useful if you need to create a blackout window to
+        perform sensitive operations without interruption.
       EOT
 
       newvalues(:hourly, :daily, :weekly, :monthly, :never)


### PR DESCRIPTION
A Puppet docs site feedback provider asked for clarification on this attribute.