### PR TITLE
(PUP-9055) Expose function similar to `puppet master --compile`

### DIFF
--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -83,6 +83,25 @@ Puppet::Indirector::Face.define(:catalog, '0.0.1') do
     end
   end
 
+  action(:compile) do
+    summary _("Compile a catalog.")
+    description <<-'EOT'
+      Compiles a catalog locally for a node, requiring access to modules, node classifier, etc.
+    EOT
+    examples <<-'EOT'
+      Compile catalog for node 'mynode':
+
+      $ puppet catalog compile mynode --codedir ...
+    EOT
+    returns <<-'EOT'
+      A serialized catalog.
+    EOT
+    when_invoked do |*args|
+      Puppet.settings.preferred_run_mode = :master
+      Puppet::Face[:catalog, :current].find(*args)
+    end
+  end
+
   action(:download) do
     summary "Download this node's catalog from the puppet master server."
     description <<-'EOT'


### PR DESCRIPTION
The `master` subcommand was removed in Puppet v6 but is still in use by
users to compile catalogs without a server (e.g. `puppet master
--compile ...`).

Setting `run_mode` to `master` for the Catalog face effectively makes
`puppet catalog compile` behave the same way that `puppet master --compile` did. 
This is due to how "run mode" is used inside Puppet (changes default
config paths and which config option names are used).

Unfortunately I cannot find a way to get the `run_mode` override in
`Puppet::Application`, where it's used before the face options are
parsed, _and_ provide a help message for it.