### PR TITLE
(PUP-9565) Allow specifying --logdest multiple times on the command line

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -388,7 +388,7 @@ class Application
   end
 
   def setup_logs
-    handle_logdest_arg(Puppet[:logdest])
+    handle_logdest_arg(Puppet[:logdest]) if !options[:setdest]
 
     unless options[:setdest]
       if options[:debug] || options[:verbose]
@@ -411,7 +411,7 @@ class Application
   end
 
   def handle_logdest_arg(arg)
-    return if options[:setdest] || arg.nil?
+    return if arg.nil?
 
     begin
       Puppet[:logdest] = arg

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -6,7 +6,6 @@ require 'getoptlong'
 require 'timeout'
 
 describe Puppet::Application do
-
   before(:each) do
     @app = Class.new(Puppet::Application).new
     @appclass = @app.class
@@ -326,7 +325,6 @@ describe Puppet::Application do
   end
 
   describe "when parsing command-line options" do
-
     before :each do
       allow(@app.command_line).to receive(:args).and_return([])
 
@@ -650,13 +648,6 @@ describe Puppet::Application do
       allow(Puppet::Util::Log).to receive(:newdestination).with(test_arg)
       @app.handle_logdest_arg(test_arg)
       expect(@app.options[:setdest]).to be_truthy
-    end
-
-    it "does not set the log destination if setdest is true" do
-      expect(Puppet::Util::Log).not_to receive(:newdestination)
-      @app.options[:setdest] = true
-
-      @app.handle_logdest_arg(test_arg)
     end
 
     it "does not set the log destination if arg is nil" do


### PR DESCRIPTION
Before PUP-2997 (dbf0ac4f3d) it was possible to specify multiple log destinations on the command line by repeating the --logdest arg. In order to restore this ability, we're still setting a flag that lets us know that we've already set a log destination whenever we handle_logdest_arg, but handle_logdest_arg no longer bails out early if this flag has been set. We now use the flag to avoid calling handle_logdest_arg with the "default" log destination if we've already set the log destination based on command line arguments.