### PR TITLE
(PUP-9640) Change user management on OS X 10.14

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -32,14 +32,13 @@ module Puppet
 
     module CronUtils
       def clean(agent, o={})
-        o = { :user => cron_user(agent) }.merge(o)
+        o = { :user => cron_user }.merge(o)
         run_cron_on(agent, :remove, o[:user])
-        return if agent[:platform] =~ /osx-10.14/ # don't try to delete osx user, it will fail
         apply_manifest_on(agent, %[user { '%s': ensure => absent, managehome => false }] % o[:user])
       end
 
       def setup(agent, o={})
-        o = { :user => cron_user(agent) }.merge(o)
+        o = { :user => cron_user }.merge(o)
         apply_manifest_on(agent, %[user { '%s': ensure => present, managehome => false }] % o[:user])
         apply_manifest_on(agent, %[case $operatingsystem {
                                      centos, redhat, fedora: {$cron = 'cronie'}
@@ -56,12 +55,7 @@ module Puppet
         crontab_contents.lines.map(&:chomp).reject { |line| line =~ /^#/ }
       end
 
-      # Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-      # that limits the operations that a OSX user can do,
-      # we can not manage users properly using puppet.
-      # We will use an already existing user('osx') to run the cron tests.
-      def cron_user(agent)
-        return 'osx' if agent[:platform] =~ /osx-10.14/
+      def cron_user
         'tstuser'
       end
     end

--- a/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
+++ b/acceptance/tests/resource/cron/should_allow_changing_parameters.rb
@@ -10,7 +10,6 @@ tag 'audit:medium',
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CronUtils
 
-
 teardown do
   step "Cron: cleanup"
   agents.each do |agent|
@@ -21,7 +20,7 @@ end
 
 agents.each do |agent|
   step "ensure the user exist via puppet"
-  user = cron_user(agent)
+  user = cron_user
   setup agent
 
   step "Cron: basic - verify that it can be created"

--- a/acceptance/tests/resource/cron/should_be_idempotent.rb
+++ b/acceptance/tests/resource/cron/should_be_idempotent.rb
@@ -17,10 +17,9 @@ teardown do
   end
 end
 
-
 agents.each do |agent|
   step "ensure the user exist via puppet"
-  user = cron_user(agent)
+  user = cron_user
   setup agent
 
   step "Cron: basic - verify that it can be created"

--- a/acceptance/tests/resource/cron/should_create_cron.rb
+++ b/acceptance/tests/resource/cron/should_create_cron.rb
@@ -19,7 +19,7 @@ end
 
 agents.each do |host|
   step "ensure the user exist via puppet"
-  user = cron_user(host)
+  user = cron_user
   setup host
 
   step "apply the resource on the host using puppet resource"

--- a/acceptance/tests/resource/cron/should_match_existing.rb
+++ b/acceptance/tests/resource/cron/should_match_existing.rb
@@ -17,7 +17,7 @@ end
 
 agents.each do |host|
   step "ensure the user exist via puppet"
-  user = cron_user(host)
+  user = cron_user
   setup host
 
 

--- a/acceptance/tests/resource/cron/should_remove_cron.rb
+++ b/acceptance/tests/resource/cron/should_remove_cron.rb
@@ -19,7 +19,7 @@ end
 
 agents.each do |host|
   step "ensure the user exist via puppet"
-  user = cron_user(host)
+  user = cron_user
   setup host
 
   step "create the existing job by hand..."

--- a/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
+++ b/acceptance/tests/resource/cron/should_remove_leading_and_trailing_whitespace.rb
@@ -17,7 +17,7 @@ end
 
 agents.each do |host|
   step "create user account for testing cron entries"
-  user = cron_user(host)
+  user = cron_user
   setup host
 
   step "apply the resource on the host using puppet resource"

--- a/acceptance/tests/resource/cron/should_remove_matching.rb
+++ b/acceptance/tests/resource/cron/should_remove_matching.rb
@@ -19,7 +19,7 @@ end
 
 agents.each do |host|
   step "ensure the user exist via puppet"
-  user = cron_user(host)
+  user = cron_user
   setup host
 
   step "create the existing job by hand..."

--- a/acceptance/tests/resource/cron/should_update_existing.rb
+++ b/acceptance/tests/resource/cron/should_update_existing.rb
@@ -19,7 +19,7 @@ end
 
 agents.each do |host|
   step "ensure the user exist via puppet"
-  user = cron_user(host)
+  user = cron_user
   setup host
 
   step "create the existing job by hand..."

--- a/acceptance/tests/resource/cron/should_write_new_users_crontab_after_puppet_creates_them.rb
+++ b/acceptance/tests/resource/cron/should_write_new_users_crontab_after_puppet_creates_them.rb
@@ -1,10 +1,6 @@
 test_name "The crontab provider should be able to write a new user's crontab after Puppet creates them" do
   confine :except, :platform => 'windows'
   confine :except, :platform => /^eos-/ # See PUP-5500
-  # Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-  # that limits the operations that a OSX user can do,
-  # we can not manage users properly using puppet.
-  confine :except, :platform => /^osx-10.14/
   tag 'audit:medium',
       'audit:unit'
 

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -2,13 +2,8 @@ test_name 'file resource: symbolic modes' do
   confine :except, :platform => /^eos-/ # See ARISTA-37
   confine :except, :platform => /^solaris-10/
   confine :except, :platform => /^windows/
-
-  # Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-  # that limits the operations that a OSX user can do,
-  # we can not manage users properly using puppet.
-  confine :except, :platform => /^osx-10.14/
-
   confine :to, {}, hosts.select {|host| !host[:roles].include?('master')}
+
   tag 'audit:high',
       'audit:acceptance'
 

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
@@ -1,0 +1,38 @@
+test_name "should not modify the home directory of an user on OS X 10.14" do
+  confine :to, :platform => /osx-10.14/
+
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::BeakerUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  user = "pl#{rand(999999).to_i}"
+
+  agents.each do |agent|
+    teardown do
+      user_absent(agent, user)
+    end
+
+    step "ensure the user is present" do
+      agent.user_present(user)
+    end
+
+    step "verify the error message is correct" do
+      expected_error = /OS X version 10\.14 does not allow changing home using puppet/
+      user_manifest = resource_manifest('user', user, ensure: 'present', home: "/opt/#{user}")
+
+      apply_manifest_on(agent, user_manifest) do |result|
+        assert_match(
+          expected_error,
+          result.stderr,
+          "Puppet fails to report an error when changing home directory on OS X 10.4"
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
@@ -1,0 +1,38 @@
+test_name "should not modify the uid of an user on OS X 10.14" do
+  confine :to, :platform => /osx-10.14/
+
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::BeakerUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  user = "pl#{rand(999999).to_i}"
+
+  agents.each do |agent|
+    teardown do
+      user_absent(agent, user)
+    end
+
+    step "ensure the user is present" do
+      agent.user_present(user)
+    end
+
+    step "verify the error message is correct" do
+      expected_error = /OS X version 10\.14 does not allow changing uid using puppet/
+      user_manifest = resource_manifest('user', user, ensure: 'present', uid: rand(999999))
+
+      apply_manifest_on(agent, user_manifest) do |result|
+        assert_match(
+          expected_error,
+          result.stderr,
+          "Puppet fails to report an error when changing uid on OS X 10.4"
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -2,11 +2,6 @@ test_name "should allow password, salt, and iteration attributes in OSX"
 
 confine :to, :platform => /osx/
 
-# Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-# that limits the operations that a OSX user can do,
-# we can not manage users properly using puppet. 
-confine :except, :platform => /^osx-10.14/
-
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -2,11 +2,6 @@ test_name "should create a user"
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
-# Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-# that limits the operations that a OSX user can do,
-# we can not manage users properly using puppet.
-confine :except, :platform => /^osx-10.14/
-
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -3,11 +3,6 @@ confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
-# Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-# that limits the operations that a OSX user can do,
-# we can not manage users properly using puppet.
-confine :except, :platform => /^osx-10.14/
-
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would

--- a/acceptance/tests/resource/user/should_manage_groups.rb
+++ b/acceptance/tests/resource/user/should_manage_groups.rb
@@ -8,11 +8,6 @@ test_name "should correctly manage the groups property for the User resource" do
   confine :except, :platform => /eos-/ # See ARISTA-37
   confine :except, :platform => /cisco_/ # See PUP-5828
 
-  # Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-  # that limits the operations that a OSX user can do,
-  # we can not manage users properly using puppet. 
-  confine :except, :platform => /^osx-10.14/
-
   tag 'audit:medium',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test

--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -13,11 +13,6 @@ confine :except, :platform => 'windows'
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
-# Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-# that limits the operations that a OSX user can do,
-# we can not manage users properly using puppet.
-confine :except, :platform => /^osx-10.14/
-
 agents.each do |agent|
   step "ensure the user and group do not exist"
   agent.user_absent(name)

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -4,11 +4,6 @@ confine :except, :platform => /aix/ # PUP-5358
 confine :except, :platform => /^eos-/ # See ARISTA-37
 confine :except, :platform => /^cisco_/ # See PUP-5828
 
-# Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-# that limits the operations that a OSX user can do,
-# we can not manage users properly using puppet.
-confine :except, :platform => /^osx-10.14/
-
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would

--- a/acceptance/tests/resource/user/should_modify_home.rb
+++ b/acceptance/tests/resource/user/should_modify_home.rb
@@ -1,0 +1,37 @@
+test_name "should modify the home directory of an user on OS X < 10.14" do
+  confine :to, :platform => /osx/
+  confine :except, :platform => /osx-10.14/
+
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::BeakerUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  user = "pl#{rand(999999).to_i}"
+
+  agents.each do |agent|
+    teardown do
+      user_absent(agent, user)
+    end
+
+    step "ensure the user is present" do
+      agent.user_present(user)
+    end
+
+    step "verify that the user has the correct home" do
+      new_home = "/opt/#{user}"
+      user_manifest = resource_manifest('user', user, ensure: 'present', home: new_home)
+      apply_manifest_on(agent, user_manifest)
+
+      agent.user_get(user) do |result|
+        user_home = result.stdout.split(':')[8]
+        assert_equal(user_home, new_home, "Expected home: #{new_home}, actual home: #{user_home}")
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/user/should_modify_uid.rb
+++ b/acceptance/tests/resource/user/should_modify_uid.rb
@@ -1,0 +1,37 @@
+test_name "should modify the uid of an user OS X < 10.14" do
+  confine :to, :platform => /osx/
+  confine :except, :platform => /osx-10.14/
+
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::BeakerUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  user = "pl#{rand(999999).to_i}"
+
+  agents.each do |agent|
+    teardown do
+      user_absent(agent, user)
+    end
+
+    step "ensure the user is present" do
+      agent.user_present(user)
+    end
+
+    step "verify that the user has the correct uid" do
+      new_uid = rand(999999)
+      user_manifest = resource_manifest('user', user, ensure: 'present', uid: new_uid)
+      apply_manifest_on(agent, user_manifest)
+
+      agent.user_get(user) do |result|
+        user_uid = Integer(result.stdout.split(':')[2])
+        assert_equal(user_uid, new_uid, "Expected uid: #{new_uid}, actual uid: #{user_uid}")
+      end
+    end
+  end
+end

--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -20,11 +20,6 @@ test_name 'PUP-6777 Manage users with UTF-8 comments' do
   # and have not been made unicode-aware yet.
   confine :except, :platform => /^(eos|aix)-/
 
-  # Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-  # that limits the operations that a OSX user can do,
-  # we can not manage users properly using puppet. 
-  confine :except, :platform => /^osx-10.14/
-
   user0 = "foo#{rand(99999).to_i}"
   user1 = "bar#{rand(99999).to_i}"
   user2 = "baz#{rand(99999).to_i}"

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -6,11 +6,6 @@ tag 'audit:medium',     # startup/configuration, high impact, low risk
                         # but changing a person running the tests users and
                         # groups can be very onerous
 
-# Due to OSX 10.14 Mojave new security feature called “Full Disk Access”
-# that limits the operations that a OSX user can do,
-# we can not manage users properly using puppet.
-confine :except, :platform => /^osx-10.14/
-
 # puppet doesn't try to manage ownership on windows.
 confine :except, :platform => 'windows'
 confine :except, :platform => /solaris-10/ # See PUP-5200


### PR DESCRIPTION
Due to FDA restrictions puppet is unable to change NFSHomeDirectory
or uid of an user using `dscl . -merge`.
Replaced `dscl . -merge` with `dscl . -create` when adding a new resource.
Added a failure message when trying to update the home/uid of an user on OS X 10.14
Added tests for home and uid.