### PR TITLE
(DOCS) PDOC-265 fix example formatting

### DIFF
--- a/lib/puppet/functions/regsubst.rb
+++ b/lib/puppet/functions/regsubst.rb
@@ -27,14 +27,14 @@
 # @return [Array[String], String] The result of the substitution. Result type is the same as for the target parameter.
 #
 # @example Get the third octet from the node's IP address:
-# ```puppet
-# $i3 = regsubst($ipaddress,'^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$','\\3')
-# ```
+#   ```puppet
+#   $i3 = regsubst($ipaddress,'^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$','\\3')
+#   ```
 #
 # @example Put angle brackets around each octet in the node's IP address:
-# ```puppet
-# $x = regsubst($ipaddress, /([0-9]+)/, '<\\1>', 'G')
-# ```
+#   ```puppet
+#   $x = regsubst($ipaddress, /([0-9]+)/, '<\\1>', 'G')
+#   ```
 #
 Puppet::Functions.create_function(:regsubst) do
   dispatch :regsubst_string do

--- a/lib/puppet/functions/regsubst.rb
+++ b/lib/puppet/functions/regsubst.rb
@@ -27,13 +27,11 @@
 # @return [Array[String], String] The result of the substitution. Result type is the same as for the target parameter.
 #
 # @example Get the third octet from the node's IP address:
-#
 # ```puppet
 # $i3 = regsubst($ipaddress,'^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$','\\3')
 # ```
 #
 # @example Put angle brackets around each octet in the node's IP address:
-#
 # ```puppet
 # $x = regsubst($ipaddress, /([0-9]+)/, '<\\1>', 'G')
 # ```


### PR DESCRIPTION
Generated docs for these examples is not showing up, and it might be an issue with the empty line in between the @ tag and the example.