### PR TITLE
(PUP-9642) explicitly set the confdir permissions

### DIFF
--- a/acceptance/tests/puppet_device_test.rb
+++ b/acceptance/tests/puppet_device_test.rb
@@ -1,0 +1,68 @@
+test_name "puppet device is able to run and configure a node"
+
+teardown do
+  # revert permission changes to reset state for other tests
+  on(master, "puppet agent -td --server #{master}")
+end
+
+codedir = "#{master.puppet['codedir']}/modules"
+confdir = master.puppet['confdir']
+common_options="--config /tmp/puppet.conf --debug --trace -w0 --server #{master}"
+
+on(master, puppet("module install --target-dir #{codedir} puppetlabs-test_device"))
+on(master, puppet("module install --target-dir #{codedir} puppetlabs-device_manager"))
+on(master, puppet("module install --target-dir #{codedir} puppetlabs-resource_api"))
+
+apply_manifest_on(master, <<MANIFEST, :catch_failures => true)
+# create and configure test user to trigger PUP-9642
+user {
+  'test':
+    ensure => 'present',
+}
+
+# testfile for --apply
+file {
+  '/tmp/spinner.pp':
+    content => "spinner { '999': ensure => 'absent' }"
+}
+
+# install and configure the Resource API
+service { 'puppetserver': }
+include 'resource_api::server', 'resource_api::agent'
+MANIFEST
+
+on(master, "cp -v #{confdir}/puppet.conf /tmp/puppet.conf")
+on(master, "echo \"#{<<-CONF}\" >> /tmp/puppet.conf")
+[main]
+user = test
+CONF
+
+# configure device credentials
+on(master, puppet("apply -e 'device_manager { [\"spinny1.example.com\", \"spinny2.example.com\", \"spinny3.example.com\"]: type => 'spinner', credentials => { facts_cpu_time => 1 }, include_module => false }'"))
+
+# run operation without certificate
+on(master, "umask 077; puppet device #{common_options} --target spinny1.example.com --facts")
+
+# request cert, or fall through
+on(master, "umask 077; puppet device #{common_options} --target spinny1.example.com", acceptable_exit_codes: [0, 1]) do |result|
+  assert_no_match(/Permission denied/, result.stderr, 'cert requesting failed')
+end
+on(master, "umask 077; puppet ca sign spinny1.example.com")
+
+# test catalog application
+on(master, "umask 077; puppet device #{common_options} --target spinny1.example.com")
+
+# test --resource
+on(master, "umask 077; puppet device  #{common_options} --target spinny1.example.com --resource spinner")
+
+# test --apply
+on(master, "umask 077; puppet device  #{common_options} --target spinny1.example.com --apply /tmp/spinner.pp")
+
+# test development runmode
+common_options += " --libdir #{codedir}/test_device/lib"
+on(master, "umask 077; puppet device #{common_options} --target spinny2.example.com --facts")
+on(master, "umask 077; puppet device #{common_options} --target spinny2.example.com", acceptable_exit_codes: [0, 1]) do |result|
+  assert_no_match(/Permission denied/, result.stderr, 'cert requesting failed with --libdir')
+end
+on(master, puppet("ca sign spinny2.example.com"))
+on(master, "umask 077; puppet device #{common_options} --target spinny2.example.com")

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -266,15 +266,29 @@ Licensed under the Apache 2.0 License
           Puppet[:vardir] = ::File.join(Puppet[:devicedir], device.name)
           Puppet[:certname] = device.name
 
-          unless options[:resource] || options[:facts] || options[:apply] || options[:libdir]
+          unless options[:resource] || options[:facts] || options[:apply]
             # this will reload and recompute default settings and create the devices sub vardir
             Puppet.settings.use :main, :agent, :ssl
+
+            # Since it's too complicated to fix properly in the default settings, we workaround for PUP-9642 here.
+            # See https://github.com/puppetlabs/puppet/pull/7483#issuecomment-483455997 for details.
+            # This has to happen after `settings.use` above, so the directory is created and before `setup_host` below, where the SSL
+            # routines would fail with access errors
+            if Puppet.features.root? && !Puppet::Util::Platform.windows?
+              user = Puppet::Type.type(:user).new(name: Puppet[:user]).exists? ? Puppet[:user] : nil
+              group = Puppet::Type.type(:group).new(name: Puppet[:group]).exists? ? Puppet[:group] : nil
+              Puppet.debug("Fixing perms for #{user}:#{group} on #{Puppet[:confdir]}")
+              FileUtils.chown(user, group, Puppet[:confdir]) if user || group
+            end
+
             # ask for a ssl cert if needed, and setup the ssl system for this device.
             setup_host
 
-            Puppet::Configurer::PluginHandler.new.download_plugins(env)
+            # only pluginsync if we do not have a libdir specified on the command line
+            Puppet::Configurer::PluginHandler.new.download_plugins(env) unless options[:libdir]
           end
-          # this init the device singleton, so that the facts terminus
+
+          # this inits the device singleton, so that the facts terminus
           # and the various network_device provider can use it
           Puppet::Util::NetworkDevice.init(device)
 

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -267,6 +267,11 @@ Licensed under the Apache 2.0 License
           Puppet[:certname] = device.name
 
           unless options[:resource] || options[:facts] || options[:apply] || options[:libdir]
+            # this will reload and recompute default settings and create the devices sub vardir
+            Puppet.settings.use :main, :agent, :ssl
+            # ask for a ssl cert if needed, and setup the ssl system for this device.
+            setup_host
+
             Puppet::Configurer::PluginHandler.new.download_plugins(env)
           end
           # this init the device singleton, so that the facts terminus
@@ -316,12 +321,6 @@ Licensed under the Apache 2.0 License
             end
           else
             Puppet.info _("starting applying configuration to %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
-            # this will reload and recompute default settings and create the devices sub vardir
-            Puppet.settings.use :main, :agent, :ssl
-            # ask for a ssl cert if needed, and setup the ssl system for this device.
-            setup_host
-
-            require 'puppet/configurer'
             configurer = Puppet::Configurer.new
             configurer.run(:network_device => true, :pluginsync => Puppet::Configurer.should_pluginsync? && !options[:libdir])
           end

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -318,8 +318,7 @@ Licensed under the Apache 2.0 License
             Puppet.info _("starting applying configuration to %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
             # this will reload and recompute default settings and create the devices sub vardir
             Puppet.settings.use :main, :agent, :ssl
-            # ask for a ssl cert if needed, but at least
-            # setup the ssl system for this device.
+            # ask for a ssl cert if needed, and setup the ssl system for this device.
             setup_host
 
             require 'puppet/configurer'


### PR DESCRIPTION
The `puppet device` application is using the `confdir` setting to have
puppet create a new private directory for the device's use. This causes
the directory to be created for each new device through the magic of
`Puppet.settings.use`.

* The defaults do not specify a filemode for `confdir`.
  Therefore any environmental markers, like `umask`, get propagated
  through to the file system.
* The settings subsystem switches to the configured `user`/`group` before
  writing files, and PE is setting those configuration values to non-root
  values.
  Therefore any filesystem operation has to pass through filesystem
  permissions.

With `umask 0027` the `$devicedir/$devicename` directory gets created as
`root/root` with `drwxr-x---` permissions, and the subsequent attempt to
write the private key into a subdirectory fails.

This commit adds an explicit chown for the newly created confdir that
allows access, thereby allowing the subsequent SSL key operations to
succeed.

Since the SSL keys are independently protected in their directories,
this change has no effect on the overall security.