### PR TITLE
(maint) Default Amazon Linux to yum

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -22,6 +22,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       end
   end
 
+defaultfor :operatingsystem => :amazon
 defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
 
   def self.prefetch(packages)

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -12,6 +12,40 @@ describe Puppet::Type.type(:package).provider(:yum) do
     expect(described_class.specificity).to be < 200
   end
 
+  describe "should have logical defaults" do
+    [2, 2018].each do |ver|
+      it "should be the default provider on Amazon Linux #{ver}" do
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return('amazon')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver)
+        expect(described_class).to be_default
+      end
+    end
+
+    Array(4..7).each do |ver|
+      it "should be default for redhat #{ver}" do
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return('redhat')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver.to_s)
+        expect(described_class).to be_default
+      end
+    end
+
+    it "should not be default for redhat 8" do
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('redhat')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('8')
+      expect(described_class).not_to be_default
+    end
+
+    it "should not be default for Ubuntu 16.04" do
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('ubuntu')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('ubuntu')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('16.04')
+      expect(described_class).not_to be_default
+    end
+  end
+
   describe "when supplied the source param" do
     let(:name) { 'baz' }
 


### PR DESCRIPTION
Prior to this commit, Amazon Linux did not have a default package provider set. This commit ensures that all versions of Amazon Linux will default to using the yum package provider.

Users will no longer get a warning about multiple default package providers.