### PR TITLE
(PUP-9646) Return parsed yaml plan without instantiating

### DIFF
--- a/lib/puppet/pal/script_compiler.rb
+++ b/lib/puppet/pal/script_compiler.rb
@@ -15,6 +15,12 @@ module Pal
       nil
     end
 
+    def parse_plan(plan_name)
+      typed_name = Puppet::Pops::Loader::TypedName.new(:plan, plan_name)
+      loader = internal_compiler.loaders.private_environment_loader
+      loader.parse_plan(typed_name)
+    end
+
     # Returns an array of TypedName objects for all plans, optionally filtered by a regular expression.
     # The returned array has more information than just the leaf name - the typical thing is to just get
     # the name as showing the following example.

--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -32,14 +32,14 @@ class BaseLoader < Loader
 
   # @api public
   #
-  def load_typed(typed_name)
+  def load_typed(typed_name, action = nil)
     # The check for "last queried name" is an optimization when a module searches. First it checks up its parent
     # chain, then itself, and then delegates to modules it depends on.
     # These modules are typically parented by the same
     # loader as the one initiating the search. It is inefficient to again try to search the same loader for
     # the same name.
     if @last_result.nil? || typed_name != @last_result.typed_name
-      @last_result = internal_load(typed_name)
+      @last_result = internal_load(typed_name, action)
     else
       @last_result
     end
@@ -145,11 +145,12 @@ class BaseLoader < Loader
   # 3. find it here
   # 4. give up
   #
-  def internal_load(typed_name)
+  def internal_load(typed_name, action = nil)
     # avoid calling get_entry by looking it up
     te = @named_values[typed_name]
     return te unless te.nil? || te.value.nil?
 
+    # TODO do we need to pass action here?
     te = parent.load_typed(typed_name)
     return te unless te.nil? || te.value.nil?
 
@@ -158,7 +159,11 @@ class BaseLoader < Loader
     # recursive call into this loader. This means that the entry might be present now, so a new
     # check must be made.
     te = @named_values[typed_name]
-    te.nil? || te.value.nil? ? find(typed_name) : te
+    if action
+      te.nil? || te.value.nil? ? find(typed_name, action) : te
+    else
+      te.nil? || te.value.nil? ? find(typed_name) : te
+    end
   end
 end
 end

--- a/lib/puppet/pops/loader/generic_plan_instantiator.rb
+++ b/lib/puppet/pops/loader/generic_plan_instantiator.rb
@@ -23,6 +23,20 @@ class GenericPlanInstantiator
 
     instantiator.create(loader, typed_name, source_ref, code_string)
   end
+
+  def self.parse_plan(typed_name, source_refs)
+    if source_refs.length > 1
+      raise ArgumentError, _("Found multiple files for plan '%{plan_name}' but only one is allowed") % { plan_name: typed_name.name }
+    end
+
+    source_ref = source_refs[0]
+    code_string = Puppet::FileSystem.read(source_ref, :encoding => 'utf-8')
+
+    loader = Puppet.lookup(:yaml_plan_instantiator) do
+      raise Puppet::DevError, _("No instantiator is available to load plan from %{source_ref}") % { source_ref: source_ref }
+    end
+    loader.parse_plan(code_string, source_ref)
+  end
 end
 end
 end

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -86,6 +86,10 @@ class Loader
     raise NotImplementedError, "Class #{self.class.name} must implement method #load_typed"
   end
 
+  def parse_plan(typed_name, action)
+    raise NotImplementedError, "Class #{self.class.name} must implement method #parse_plan"
+  end
+
   # Returns an already loaded entry if one exists, or nil. This does not trigger loading
   # of the given type/name.
   #


### PR DESCRIPTION
This returns a parsed yaml plan from the generic plan instantiator without actually instantiating the function. This supports returning a parsed plan to Bolt to be converted into a Puppet plan (see BOLT-1195). It includes loading the plan with a new optional arguments `action` to the relevant loading methods, since we still need to find and load the plan, then uses the action key to determine whether to instantiate or parse the plan. It does not check for whether the plan is a yaml plan or a Puppet plan - should that validation be here or in bolt?