### PR TITLE
(PUP-9564) Fix package update on resource held

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -60,6 +60,16 @@ module Puppet
       end
     end
 
+    module PackageUtils
+      def package_present(host, package, version = nil)
+          host.install_package(package, '', version)
+      end
+
+      def package_absent(host, package, cmdline_args = '', opts = {})
+          host.uninstall_package(package, cmdline_args, opts)
+      end
+    end
+
     module CAUtils
 
       def initialize_ssl
@@ -199,10 +209,10 @@ module Puppet
         end.join(",\n")
 
         <<-MANIFEST
-#{resource} { '#{title}':
-  #{params_str}
-}
-MANIFEST
+        #{resource} { '#{title}':
+          #{params_str}
+        }
+        MANIFEST
       end
 
       def file_manifest(path, params = {})

--- a/acceptance/tests/provider/package/dpkg_ensure_held_package_is_latest.rb
+++ b/acceptance/tests/provider/package/dpkg_ensure_held_package_is_latest.rb
@@ -1,0 +1,26 @@
+test_name "dpkg ensure held package is latest installed"
+confine :to, :platform => /debian-8-amd64/
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::PackageUtils
+extend Puppet::Acceptance::ManifestUtils
+
+
+package = "nginx"
+
+agents.each do |agent|
+  teardown do
+    package_absent(agent, package, '--force-yes')
+  end
+end
+
+step"Ensure that package is installed first if not present" do
+  info = on(agent.name, "apt-cache policy #{package} | grep Candidate:").stdout
+  expected_package_version = info.split.first
+  package_manifest = resource_manifest('package', package, ensure: "held")
+
+  apply_manifest_on(agent, package_manifest) do |result|
+    info = on(agent.name, "apt-cache policy #{package} | grep Installed").stdout
+    installed_package_version = info.split.first
+    assert_match(expected_package_version, installed_package_version)
+  end
+end

--- a/acceptance/tests/provider/package/dpkg_ensure_held_package_should_preserve_version.rb
+++ b/acceptance/tests/provider/package/dpkg_ensure_held_package_should_preserve_version.rb
@@ -1,0 +1,19 @@
+test_name "dpkg ensure held package should preserve version if package is allready installed"
+confine :to, :platform => /debian-8-amd64/
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::PackageUtils
+extend Puppet::Acceptance::ManifestUtils
+
+package = "openssl"
+
+step "Ensure held should lock to specific installed version" do
+  existing_installed_version = on(agent.name, "dpkg -s #{package} | sed -n -e 's/Version: //p'").stdout
+  existing_installed_version.delete!(' ')
+
+  package_manifest_held = resource_manifest('package', package, ensure: 'held')
+  apply_manifest_on(agent, package_manifest_held) do
+    installed_version = on(agent.name, "apt-cache policy #{package} | sed -n -e 's/Installed: //p'").stdout
+    installed_version.delete!(' ')
+    assert_match(existing_installed_version, installed_version)
+  end
+end

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -221,19 +221,30 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
       allow(Tempfile).to receive(:new).and_return(tempfile)
     end
 
-    it "installs first if holding" do
+    it "installs first if package is not present and ensure holding" do
+
       allow(provider).to receive(:execute)
+      allow(provider).to receive(:package_not_installed?).and_return(false)
       expect(provider).to receive(:install).once
       provider.hold
     end
 
+    it "skips install new package if package is allready installed" do
+      allow(provider).to receive(:execute)
+      allow(provider).to receive(:package_not_installed?).and_return(true)
+      expect(provider).not_to receive(:install)
+      provider.hold
+    end
+
     it "executes dpkg --set-selections when holding" do
+      allow(provider).to receive(:package_not_installed?).and_return(false)
       allow(provider).to receive(:install)
       expect(provider).to receive(:execute).with([:dpkg, '--set-selections'], {:failonfail => false, :combine => false, :stdinfile => tempfile.path}).once
       provider.hold
     end
 
     it "executes dpkg --set-selections when unholding" do
+      allow(provider).to receive(:package_not_installed?).and_return(false)
       allow(provider).to receive(:install)
       expect(provider).to receive(:execute).with([:dpkg, '--set-selections'], {:failonfail => false, :combine => false, :stdinfile => tempfile.path}).once
       provider.hold
@@ -275,4 +286,10 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
     expect(provider).to receive(:dpkg).with("--purge", resource_name)
     provider.purge
   end
+
+  it "raises error if package name is nil" do
+    expect {provider.package_not_installed?(nil)}.to raise_error(ArgumentError,"Package name is nil or empty")
+    expect {provider.package_not_installed?("")}.to raise_error(ArgumentError,"Package name is nil or empty")
+  end
 end
+


### PR DESCRIPTION
This PR fixes the following bug:

When setting a package to held first it checks if the package is installed on the system, if true then it only sets it's state to held, if false then it installs the latest package and after it sets it's state to held.

Before this it would install the latest package and after that the state would change to held.