### PR TITLE
(PUP-9639) Sanitize Windows Registry read strings

### DIFF
--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -232,7 +232,7 @@ module Puppet::Util::Windows
         begin
           case type
             when Win32::Registry::REG_SZ, Win32::Registry::REG_EXPAND_SZ
-              result = [ type, data_ptr.read_wide_string(string_length) ]
+              result = [ type, sanitize(data_ptr.read_wide_string(string_length)) ]
             when Win32::Registry::REG_MULTI_SZ
               result = [ type, data_ptr.read_wide_string(string_length).split(/\0/) ]
             when Win32::Registry::REG_BINARY
@@ -310,6 +310,12 @@ module Puppet::Util::Windows
       end
 
       result
+    end
+
+    def sanitize(value)
+      # Replace null bytes with a space
+      value.gsub!("\x00", ' ')
+      value
     end
 
     ffi_convention :stdcall


### PR DESCRIPTION
Sanitize the values after they are read from the windows registry.