### PR TITLE
(PUP-9650) ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - rvm: 2.5
       env: "CHECK=parallel:spec\\[2\\]"
 
+    - rvm: 2.6
+      env: "CHECK=parallel:spec\\[2\\]"
+
     - rvm: jruby-9.2.0.0
       jdk: openjdk8
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ matrix:
 
 # Ruby versions under test
 platform:
+  - Ruby26-x64
   - Ruby25-x64
   - Ruby24-x64
   - Ruby23-x64

--- a/lib/puppet/indirector/request.rb
+++ b/lib/puppet/indirector/request.rb
@@ -272,7 +272,7 @@ class Puppet::Indirector::Request
       return
     end
 
-    @server = uri.host if uri.host
+    @server = uri.host if uri.host && !uri.host.empty?
 
     # If the URI class can look up the scheme, it will provide a port,
     # otherwise it will default to '0'.

--- a/lib/puppet/pops/types/p_uri_type.rb
+++ b/lib/puppet/pops/types/p_uri_type.rb
@@ -175,7 +175,7 @@ class PURIType < PAnyType
       result[SCHEME] = scheme
     end
     result[USERINFO] = uri.userinfo unless uri.userinfo.nil?
-    result[HOST] = uri.host.downcase unless uri.host.nil?
+    result[HOST] = uri.host.downcase unless uri.host.nil? || uri.host.empty?
     result[PORT] = uri.port.to_s unless uri.port.nil? || uri.port == 80 && 'http' == scheme || uri.port == 443 && 'https' == scheme
     result[PATH] = uri.path unless uri.path.nil? || uri.path.empty?
     result[QUERY] = uri.query unless uri.query.nil?

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -220,11 +220,11 @@ module Puppet
     end
 
     def server?
-       uri and uri.host
+       uri && uri.host && !uri.host.empty?
     end
 
     def server
-      (uri and uri.host) or Puppet.settings[:server]
+      server? ? uri.host : Puppet.settings[:server]
     end
 
     def port

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -359,7 +359,7 @@ module Util
     path = URI.unescape(uri.path.encode(Encoding::UTF_8))
 
     if Puppet::Util::Platform.windows? && uri.scheme == 'file'
-      if uri.host
+      if uri.host && !uri.host.empty?
         path = "//#{uri.host}" + path # UNC
       else
         path.sub!(/^\//, '')

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -459,7 +459,9 @@ describe 'loaders' do
     end
 
     it "a function with syntax error has helpful error message" do
-      expect { loader.load_typed(typed_name(:function, 'func_with_syntax_error')) }.to raise_error(/syntax error, unexpected keyword_end/)
+      expect {
+        loader.load_typed(typed_name(:function, 'func_with_syntax_error'))
+      }.to raise_error(/syntax error, unexpected (keyword_)?end/)
     end
   end
 

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -52,6 +52,10 @@ describe 'loaders' do
 
   # Loaders caches the puppet_system_loader, must reset between tests
 
+  before :each do
+    allow(File).to receive(:read).and_call_original
+  end
+
   context 'when loading pp resource types using auto loading' do
     let(:pp_resources) { config_dir('pp_resources') }
     let(:environments) { Puppet::Environments::Directories.new(my_fixture_dir, []) }


### PR DESCRIPTION
* Run Travis & Appveyor specs on ruby 2.6
* Address behavior changes in 2.6
  * `Pathname#read` now calls `File.read` instead of `IO.read`
  * Syntax error message changed when `end` keyword is missing
  * `URI#host` returns an empty string instead of `nil` for file URIs.
