### PR TITLE
(PUP-3237) Accept maximum time to wait for cert

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1698,8 +1698,17 @@ EOT
       Puppet agent cannot apply configurations until its approved certificate is
       available. Since the certificate may or may not be available immediately,
       puppet agent will repeatedly try to fetch it at this interval. You can
-      turn off waiting for certificates by specifying a time of 0, in which case
+      turn off waiting for certificates by specifying a time of 0, or a maximum
+      amount of time to wait in the `maxwaitforcert` setting, in which case
       puppet agent will exit if it cannot get a cert.
+      #{AS_DURATION}",
+    },
+    :maxwaitforcert => {
+      :default  => "unlimited",
+      :type     => :ttl,
+      :desc     => "The maximum amount of time the Puppet agent should wait for its
+      certificate request to be signed. A value of `unlimited` will cause puppet agent
+      to ask for a signed certificate indefinitely.
       #{AS_DURATION}",
     }
   )

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -194,6 +194,9 @@ class Puppet::SSL::StateMachine
       if time < 1
         puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Exiting now because the waitforcert setting is set to 0.") % { name: Puppet[:certname] }
         exit(1)
+      elsif Time.now.to_i > @machine.wait_deadline
+        puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Exiting now because the maxwaitforcert timeout has been exceeded.") % {name: Puppet[:certname] }
+        exit(1)
       else
         Puppet.info(_("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Will try again in %{time} seconds.") % {name: Puppet[:certname], time: time})
 
@@ -211,10 +214,11 @@ class Puppet::SSL::StateMachine
   #
   class Done < SSLState; end
 
-  attr_reader :waitforcert
+  attr_reader :waitforcert, :wait_deadline
 
-  def initialize(waitforcert: Puppet[:waitforcert])
+  def initialize(waitforcert: Puppet[:waitforcert], maxwaitforcert: Puppet[:maxwaitforcert])
     @waitforcert = waitforcert
+    @wait_deadline = Time.now.to_i + maxwaitforcert
   end
 
   # Run the state machine for CA certs and CRLs

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -489,6 +489,36 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
         expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedCACerts)
       end
+
+      it 'sleeps and transitions to NeedCACerts when maxwaitforcert is set' do
+        machine = described_class.new(waitforcert: 15, maxwaitforcert: 30)
+
+        state = Puppet::SSL::StateMachine::Wait.new(machine, ssl_context)
+        expect(state).to receive(:sleep).with(15)
+
+        expect(Puppet).to receive(:info).with(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Will try again in 15 seconds./)
+
+        expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedCACerts)
+      end
+
+      it 'waits indefinitely by default' do
+        machine = described_class.new
+        expect(machine.wait_deadline).to eq(Float::INFINITY)
+      end
+
+      it 'exits with 1 if maxwaitforcert is exceeded' do
+        machine = described_class.new(maxwaitforcert: 1)
+
+        # 5 minutes in the future
+        future = Time.now + (5 * 60)
+        allow(Time).to receive(:now).and_return(future)
+
+        expect {
+          expect {
+            Puppet::SSL::StateMachine::Wait.new(machine, ssl_context).next_state
+          }.to exit_with(1)
+        }.to output(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Exiting now because the maxwaitforcert timeout has been exceeded./).to_stdout
+      end
     end
   end
 end


### PR DESCRIPTION
If `waitforcert` is specified, such as when using `puppet agent -t`, then the
agent will wait indefinitely for its cert to be signed, which can be a problem
if there's an infrastructure issue.

This commit adds a `maxwaitforcert` setting of type `ttl`. Acceptable values are
`unlimited` or a duration, such as `5m`, `1h`, etc. The default value is
`unlimited`, so the new behavior must be opted into.