### PR TITLE
(PUP-2310) Allow agent to refresh CRL periodically

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1085,6 +1085,23 @@ EOT
       :desc       => "The default TTL for new certificates.
       #{AS_DURATION}",
     },
+    :crl_refresh_interval => {
+      :type       => :duration,
+      :desc       => "How often the Puppet agent refreshes its local CRL. By
+         default the CRL is only downloaded once, and never refreshed. If a
+         duration is specified, then the agent will refresh its CRL whenever it
+         next runs and the elapsed time since the CRL was last refreshed exceeds
+         the duration.
+
+         In general, the duration should be greater than the `runinterval`.
+         Setting it to an equal or lesser value will cause the CRL to be
+         refreshed on every run.
+
+         If the agent downloads a new CRL, the agent will use it for subsequent
+         network requests. If the refresh request fails or if the CRL is
+         unchanged on the server, then the agent run will continue using the
+         local CRL it already has.#{AS_DURATION}",
+    },
     :keylength => {
       :default    => 4096,
       :desc       => "The bit length of keys.",

--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -214,10 +214,12 @@ module Puppet::FileSystem
 
   # Touches the file. On most systems this updates the mtime of the file.
   #
+  # @param mtime [Time] The last modified time or nil to use the current time
+  #
   # @api public
   #
-  def self.touch(path)
-    @impl.touch(assert_path(path))
+  def self.touch(path, mtime: nil)
+    @impl.touch(assert_path(path), mtime: mtime)
   end
 
   # Creates directories for all parts of the given path.

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -108,8 +108,8 @@ class Puppet::FileSystem::FileImpl
     path.writable?
   end
 
-  def touch(path)
-    ::FileUtils.touch(path)
+  def touch(path, mtime: nil)
+    ::FileUtils.touch(path, mtime: mtime)
   end
 
   def mkpath(path)

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -16,6 +16,10 @@ module Puppet::Rest
                         srv_service: :ca)
     end
 
+    def self.clear
+      @ca = nil
+    end
+
     # Make an HTTP request to fetch the named certificate
     # @param [String] name the name of the certificate to fetch
     # @param [Puppet::SSL::SSLContext] ssl_context the ssl content to use when making the request

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -1,3 +1,4 @@
+require 'time'
 require 'puppet/rest/route'
 require 'puppet/network/http_pool'
 require 'puppet/network/http/compression'
@@ -50,9 +51,11 @@ module Puppet::Rest
     # @param [Puppet::SSL::SSLContext] ssl_context the ssl content to use when making the request
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM-encoded crl
-    def self.get_crls(name, ssl_context)
+    def self.get_crls(name, ssl_context, if_modified_since: nil)
       ca.with_base_url(Puppet::Network::Resolver.new) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }
+        header['If-Modified-Since'] = if_modified_since.httpdate if if_modified_since
+
         url.path += "certificate_revocation_list/#{name}"
 
         use_ssl = url.is_a? URI::HTTPS

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -5,7 +5,6 @@ require 'puppet/network/http/compression'
 
 module Puppet::Rest
   module Routes
-
     extend Puppet::Network::HTTP::Compression.module
 
     ACCEPT_ENCODING = 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
@@ -21,9 +20,10 @@ module Puppet::Rest
       @ca = nil
     end
 
-    # Make an HTTP request to fetch the named certificate
-    # @param [String] name the name of the certificate to fetch
-    # @param [Puppet::SSL::SSLContext] ssl_context the ssl content to use when making the request
+    # Make an HTTP request to fetch the named certificate.
+    #
+    # @param name [String] the name of the certificate to fetch
+    # @param ssl_context [Puppet::SSL::SSLContext] the ssl content to use when making the request
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM-encoded certificate or certificate bundle
     def self.get_certificate(name, ssl_context)
@@ -46,9 +46,12 @@ module Puppet::Rest
       end
     end
 
-    # Make an HTTP request to fetch the named crl
-    # @param [String] name the crl to fetch
-    # @param [Puppet::SSL::SSLContext] ssl_context the ssl content to use when making the request
+    # Make an HTTP request to fetch the named crl.
+    #
+    # @param name [String] name of the crl to fetch
+    # @param ssl_context [Puppet::SSL::SSLContext] the ssl content to use when making the request
+    # @param if_modified_since [Time, nil] If non-nil, then only download the CRL if it has been
+    #   modified since the specified time.
     # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM-encoded crl
     def self.get_crls(name, ssl_context, if_modified_since: nil)
@@ -73,11 +76,12 @@ module Puppet::Rest
       end
     end
 
-    # Make an HTTP request to send the named CSR
-    # @param [String] csr_pem the contents of the CSR to sent to the CA
-    # @param [String] name the name of the host whose CSR is being submitted
-    # @param [Puppet::SSL::SSLContext] ssl_context the ssl content to use when making the request
-    # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
+    # Make an HTTP request to send the named CSR.
+    #
+    # @param csr_pem [String] the contents of the CSR to sent to the CA
+    # @param name [String] the name of the host whose CSR is being submitted
+    # @param ssl_context [Puppet::SSL::SSLContext] the ssl content to use when making the request
+    # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     def self.put_certificate_request(csr_pem, name, ssl_context)
       ca.with_base_url(Puppet::Network::Resolver.new) do |url|
         header = { 'Accept' => 'text/plain',
@@ -98,11 +102,13 @@ module Puppet::Rest
       end
     end
 
-    # Make an HTTP request to get the named CSR
-    # @param [String] name the name of the host whose CSR is being queried
-    # @param [Puppet::SSL::SSLContext] ssl_context the ssl content to use when making the request
-    # @rasies [Puppet::Rest::ResponseError] if the response status is not OK
+    # Make an HTTP request to get the named CSR.
+    #
+    # @param name [String] the name of the host whose CSR is being queried
+    # @param ssl_context [Puppet::SSL::SSLContext] the ssl content to use when making the request
+    # @raise [Puppet::Rest::ResponseError] if the response status is not OK
     # @return [String] the PEM encoded certificate request
+    # @deprecated
     def self.get_certificate_request(name, ssl_context)
       ca.with_base_url(Puppet::Network::Resolver.new) do |url|
         header = { 'Accept' => 'text/plain', 'Accept-Encoding' => ACCEPT_ENCODING }

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -145,6 +145,7 @@ module Puppet::Test
       Puppet::Util::Profiler.clear
 
       Puppet::SSL::Host.reset
+      Puppet::Rest::Routes.clear
 
       Puppet.clear_deprecation_warnings
     end

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -109,6 +109,25 @@ class Puppet::X509::CertProvider
     end
   end
 
+  # Return the time when the CRL was last updated.
+  #
+  # @return [Time, nil] Time when the CRL was last updated, or nil if we don't
+  #   have a CRL
+  def crl_last_update
+    stat = Puppet::FileSystem.stat(@crlpath)
+    Time.at(stat.mtime)
+  rescue Errno::ENOENT
+    nil
+  end
+
+  # Set the CRL last updated time.
+  #
+  # @param time [Time] The last updated time
+  #
+  def crl_last_update=(time)
+    Puppet::FileSystem.touch(@crlpath, mtime: time)
+  end
+
   # Save named private key in the configured `privatekeydir`. For
   # historical reasons, names are case insensitive.
   #

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -1089,4 +1089,33 @@ describe "Puppet::FileSystem" do
       end
     end
   end
+
+  context '#touch' do
+    let(:dest) { tmpfile('touch_file') }
+
+    it 'creates a file' do
+      Puppet::FileSystem.touch(dest)
+
+      expect(File).to be_file(dest)
+    end
+
+    it 'updates the mtime for an existing file' do
+      Puppet::FileSystem.touch(dest)
+
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      Puppet::FileSystem.touch(dest)
+
+      expect(File.mtime(dest)).to be_within(1).of(now)
+    end
+
+    it 'allows the mtime to be passed in' do
+      tomorrow = Time.now + (24 * 60 * 60)
+
+      Puppet::FileSystem.touch(dest, mtime: tomorrow)
+
+      expect(File.mtime(dest)).to be_within(1).of(tomorrow)
+    end
+  end
 end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -7,13 +7,6 @@ require 'puppet/ssl'
 describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
 
-  before(:each) do
-    WebMock.disable_net_connect!
-
-    allow_any_instance_of(Net::HTTP).to receive(:start)
-    allow_any_instance_of(Net::HTTP).to receive(:finish)
-  end
-
   let(:machine) { described_class.new }
   let(:cacert_pem) { cacert.to_pem }
   let(:cacert) { cert_fixture('ca.pem') }

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -524,4 +524,30 @@ describe Puppet::X509::CertProvider do
       end
     end
   end
+
+  context 'CRL last update time' do
+    let(:crl_path) { tmpfile('pem_crls') }
+
+    it 'returns nil if the CRL does not exist' do
+      provider = create_provider(crlpath: '/does/not/exist')
+
+      expect(provider.crl_last_update).to be_nil
+    end
+
+    it 'returns the last update time' do
+      time = Time.now - 30
+      Puppet::FileSystem.touch(crl_path, mtime: time)
+      provider = create_provider(crlpath: crl_path)
+
+      expect(provider.crl_last_update).to be_within(1).of(time)
+    end
+
+    it 'sets the last update time' do
+      time = Time.now - 30
+      provider = create_provider(crlpath: crl_path)
+      provider.crl_last_update = time
+
+      expect(Puppet::FileSystem.stat(crl_path).mtime).to be_within(1).of(time)
+    end
+  end
 end


### PR DESCRIPTION
Allow the agent to periodically refresh its CRL using `If-Modified-Since`
header support added in PUP-8913.

By default, the agent will never refresh its CRL. However, a refresh interval
can be specified in `Puppet[:crl_refresh_interval]`. If set, the agent will
refresh at most once within that interval, eg once every '8h'.

If the refresh request succeeds, then the agent will use the newly downloaded
CRL for subsequent requests.

If the refresh request fails, then the agent will ignore the error and continue
running with the existing set of CRLs. However, if the failure occurs when
downloading the initial CRL, then the agent run will fail.