### PR TITLE
(PUP-9466) Readd encrypted private keys

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -209,11 +209,8 @@ module Puppet
       },
       :ssl_context => proc {
         begin
-          password = begin
-                       Puppet::FileSystem.read(Puppet[:passfile], :encoding => Encoding::BINARY)
-                     rescue Errno::ENOENT
-                       nil
-                     end
+          cert = Puppet::X509::CertProvider.new
+          password = cert.load_private_key_password
           ssl = Puppet::SSL::SSLProvider.new
           ssl.load_context(certname: Puppet[:certname], password: password)
         rescue => e

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -209,8 +209,13 @@ module Puppet
       },
       :ssl_context => proc {
         begin
+          password = begin
+                       Puppet::FileSystem.read(Puppet[:passfile], :encoding => Encoding::BINARY)
+                     rescue Errno::ENOENT
+                       nil
+                     end
           ssl = Puppet::SSL::SSLProvider.new
-          ssl.load_context(certname: Puppet[:certname])
+          ssl.load_context(certname: Puppet[:certname], password: password)
         rescue => e
           # TRANSLATORS: `message` is an already translated string of why SSL failed to initialize
           Puppet.log_exception(e, _("Failed to initialize SSL: %{message}") % { message: e.message })

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -347,12 +347,12 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       # Setup signal traps immediately after daemonization so we clean up the daemon
       daemon.set_signal_traps
 
-      wait_for_certificates
-
-      if Puppet[:onetime]
-        onetime(daemon)
-      else
-        main(daemon)
+      Puppet.override(ssl_context: wait_for_certificates) do
+        if Puppet[:onetime]
+          onetime(daemon)
+        else
+          main(daemon)
+        end
       end
     end
   end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -206,11 +206,7 @@ HELP
   end
 
   def verify(certname)
-    password = begin
-                 Puppet::FileSystem.read(Puppet[:passfile], :encoding => Encoding::BINARY)
-               rescue Errno::ENOENT
-                 nil
-               end
+    password = @cert_provider.load_private_key_password
     ssl_context = @ssl_provider.load_context(certname: certname, password: password)
 
     # print from root to client

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -206,7 +206,12 @@ HELP
   end
 
   def verify(certname)
-    ssl_context = @ssl_provider.load_context(certname: certname)
+    password = begin
+                 Puppet::FileSystem.read(Puppet[:passfile], :encoding => Encoding::BINARY)
+               rescue Errno::ENOENT
+                 nil
+               end
+    ssl_context = @ssl_provider.load_context(certname: certname, password: password)
 
     # print from root to client
     ssl_context.client_chain.reverse.each_with_index do |cert, i|

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -100,7 +100,12 @@ class Puppet::SSL::StateMachine
     def next_state
       Puppet.debug(_("Loading/generating private key"))
 
-      key = @cert_provider.load_private_key(Puppet[:certname])
+      password = begin
+                   Puppet::FileSystem.read(Puppet[:passfile], :encoding => Encoding::BINARY)
+                 rescue Errno::ENOENT
+                   nil
+                 end
+      key = @cert_provider.load_private_key(Puppet[:certname], password: password)
       if key
         cert = @cert_provider.load_client_cert(Puppet[:certname])
         if cert
@@ -117,7 +122,8 @@ class Puppet::SSL::StateMachine
           Puppet.info _("Creating a new RSA SSL key for %{name}") % { name: Puppet[:certname] }
           key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
         end
-        @cert_provider.save_private_key(Puppet[:certname], key)
+
+        @cert_provider.save_private_key(Puppet[:certname], key, password: password)
       end
 
       NeedSubmitCSR.new(@machine, @ssl_context, key)

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -100,11 +100,7 @@ class Puppet::SSL::StateMachine
     def next_state
       Puppet.debug(_("Loading/generating private key"))
 
-      password = begin
-                   Puppet::FileSystem.read(Puppet[:passfile], :encoding => Encoding::BINARY)
-                 rescue Errno::ENOENT
-                   nil
-                 end
+      password = @cert_provider.load_private_key_password
       key = @cert_provider.load_private_key(Puppet[:certname], password: password)
       if key
         cert = @cert_provider.load_client_cert(Puppet[:certname])

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -190,6 +190,16 @@ class Puppet::X509::CertProvider
     end
   end
 
+  # Load the private key password.
+  #
+  # @return [String, nil] The private key password as a binary string or nil
+  #   if there is none.
+  def load_private_key_password
+    Puppet::FileSystem.read(Puppet[:passfile], :encoding => Encoding::BINARY)
+  rescue Errno::ENOENT
+    nil
+  end
+
   # Save a named client cert to the configured `certdir`.
   #
   # @param name [String] The client cert identity

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -115,11 +115,20 @@ class Puppet::X509::CertProvider
   #
   # @param name [String] The private key identity
   # @param key [OpenSSL::PKey::RSA] private key
+  # @param password [String, nil] If non-nil, derive an encryption key
+  #   from the password, and use that to encrypt the private key. If nil,
+  #   save the private key unencrypted.
   # @raise [Puppet::Error] if the private key cannot be saved
   # @api private
-  def save_private_key(name, key)
+  def save_private_key(name, key, password: nil)
+    pem = if password
+            cipher = OpenSSL::Cipher::AES.new(128, :CBC)
+            key.export(cipher, password)
+          else
+            key.to_pem
+          end
     path = to_path(@privatekeydir, name)
-    save_pem(key.to_pem, path, **permissions_for_setting(:hostprivkey))
+    save_pem(pem, path, **permissions_for_setting(:hostprivkey))
   rescue SystemCallError => e
     raise Puppet::Error.new(_("Failed to save private key for '%{name}'") % {name: name}, e)
   end
@@ -129,17 +138,20 @@ class Puppet::X509::CertProvider
   #
   # @param name [String] The private key identity
   # @param required [Boolean] If true, raise if it is missing
+  # @param password [String, nil] If the private key is encrypted, decrypt
+  #   it using the password. If the key is encrypted, but a password is
+  #   not specified, then the key cannot be loaded.
   # @return (see #load_private_key_from_pem)
   # @raise (see #load_private_key_from_pem)
   # @raise [Puppet::Error] if the private key cannot be loaded
   # @api private
-  def load_private_key(name, required: false)
+  def load_private_key(name, required: false, password: nil)
     path = to_path(@privatekeydir, name)
     pem = load_pem(path)
     if !pem && required
       raise Puppet::Error, _("The private key is missing from '%{path}'") % { path: path }
     end
-    pem ? load_private_key_from_pem(pem) : nil
+    pem ? load_private_key_from_pem(pem, password: password) : nil
   rescue SystemCallError => e
     raise Puppet::Error.new(_("Failed to load private key for '%{name}'") % {name: name}, e)
   end
@@ -147,19 +159,24 @@ class Puppet::X509::CertProvider
   # Load a PEM encoded private key.
   #
   # @param pem [String] PEM encoded private key
+  # @param password [String, nil] If the private key is encrypted, decrypt
+  #   it using the password. If the key is encrypted, but a password is
+  #   not specified, then the key cannot be loaded.
   # @return [OpenSSL::PKey::RSA, OpenSSL::PKey::EC] The private key
   # @raise [OpenSSL::PKey::PKeyError] The `pem` text does not contain a valid key
   # @api private
-  def load_private_key_from_pem(pem)
-    # set a non-nil passphrase to ensure openssl doesn't prompt
+  def load_private_key_from_pem(pem, password: nil)
+    # set a non-nil password to ensure openssl doesn't prompt
     # but ruby 2.4.0 & 2.4.1 require at least 4 bytes, see
     # https://github.com/ruby/ruby/commit/f012932218fd609f75f9268812df61fb26e2d0f1#diff-40e4270ec386990ac60d7ab5ff8045a4
+    password ||= '    '
+
     if Puppet::Util::Platform.jruby?
       begin
         if pem =~ EC_HEADER
-          OpenSSL::PKey::EC.new(pem, '    ')
+          OpenSSL::PKey::EC.new(pem, password)
         else
-          OpenSSL::PKey::RSA.new(pem, '    ')
+          OpenSSL::PKey::RSA.new(pem, password)
         end
       rescue OpenSSL::PKey::PKeyError => e
         if e.message =~ /Neither PUB key nor PRIV key/
@@ -169,7 +186,7 @@ class Puppet::X509::CertProvider
         end
       end
     else
-      OpenSSL::PKey.read(pem, '    ')
+      OpenSSL::PKey.read(pem, password)
     end
   end
 

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -167,8 +167,9 @@ class Puppet::X509::CertProvider
   # @api private
   def load_private_key_from_pem(pem, password: nil)
     # set a non-nil password to ensure openssl doesn't prompt
-    # but ruby 2.4.0 & 2.4.1 require at least 4 bytes, see
-    # https://github.com/ruby/ruby/commit/f012932218fd609f75f9268812df61fb26e2d0f1#diff-40e4270ec386990ac60d7ab5ff8045a4
+    # but ruby 2.4.0 & 2.4.1 require at least 4 bytes due to
+    # https://github.com/ruby/openssl/commit/f38501249f33bff7ca9d208670b8cde695ea8b7b
+    # and corrected in https://github.com/ruby/openssl/commit/a896c3d1dfa090e92dec1abf8ac12843af6af721
     password ||= '    '
 
     if Puppet::Util::Platform.jruby?

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -7,12 +7,6 @@ describe Puppet::SSL::SSLProvider do
   let(:global_crls) { [ crl_fixture('crl.pem'), crl_fixture('intermediate-crl.pem') ] }
   let(:wrong_key) { OpenSSL::PKey::RSA.new(512) }
 
-  def as_pem_file(x509)
-    path = tmpfile('ssl_provider_pem')
-    File.write(path, x509.to_pem)
-    path
-  end
-
   context 'when creating an insecure context' do
     let(:sslctx) { subject.create_insecure_context }
 
@@ -359,8 +353,8 @@ describe Puppet::SSL::SSLProvider do
     let(:doesnt_exist) { '/does/not/exist' }
 
     before :each do
-      Puppet[:localcacert] = as_pem_file(global_cacerts.first)
-      Puppet[:hostcrl] = as_pem_file(global_crls.first)
+      Puppet[:localcacert] = file_containing('global_cacerts', global_cacerts.first.to_pem)
+      Puppet[:hostcrl] = file_containing('global_crls', global_crls.first.to_pem)
 
       Puppet[:certname] = 'signed'
       Puppet[:privatekeydir] = tmpdir('privatekeydir')

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -316,9 +316,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       let(:state) { Puppet::SSL::StateMachine::NeedSubmitCSR.new(machine, ssl_context, private_key) }
 
       def write_csr_attributes(data)
-        csr_yaml = tmpfile('state_machine_csr')
-        File.write(csr_yaml, YAML.dump(data))
-        csr_yaml
+        file_containing('state_machine_csr', YAML.dump(data))
       end
 
       before :each do

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -8,12 +8,6 @@ describe Puppet::X509::CertProvider do
     described_class.new(options)
   end
 
-  def as_pem_file(pem)
-    path = tmpfile('cert_provider_pem')
-    File.write(path, pem)
-    path
-  end
-
   def expects_public_file(path)
     if Puppet::Util::Platform.windows?
       current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
@@ -69,7 +63,7 @@ describe Puppet::X509::CertProvider do
 
       context 'and input is invalid' do
         it 'raises when invalid input is inside BEGIN-END block' do
-          ca_path = as_pem_file(<<~END)
+          ca_path = file_containing('invalid_ca', <<~END)
             -----BEGIN CERTIFICATE-----
             whoops
             -----END CERTIFICATE-----
@@ -82,12 +76,12 @@ describe Puppet::X509::CertProvider do
 
         it 'raises if the input is empty' do
           expect {
-            create_provider(capath: as_pem_file('')).load_cacerts
+            create_provider(capath: file_containing('empty_ca', '')).load_cacerts
           }.to raise_error(OpenSSL::X509::CertificateError)
         end
 
         it 'raises if the input is malformed' do
-          ca_path = as_pem_file(<<~END)
+          ca_path = file_containing('malformed_ca', <<~END)
             -----BEGIN CERTIFICATE-----
             MIIBpDCCAQ2gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
           END
@@ -133,7 +127,7 @@ describe Puppet::X509::CertProvider do
         it 'raises when invalid input is inside BEGIN-END block' do
           pending('jruby bug: https://github.com/jruby/jruby/issues/5619') if Puppet::Util::Platform.jruby?
 
-          crl_path = as_pem_file(<<~END)
+          crl_path = file_containing('invalid_crls', <<~END)
             -----BEGIN X509 CRL-----
             whoops
             -----END X509 CRL-----
@@ -146,12 +140,12 @@ describe Puppet::X509::CertProvider do
 
         it 'raises if the input is empty' do
           expect {
-            create_provider(crlpath: as_pem_file('')).load_crls
+            create_provider(crlpath: file_containing('empty_crl', '')).load_crls
           }.to raise_error(OpenSSL::X509::CRLError, 'Failed to parse CRLs as PEM')
         end
 
         it 'raises if the input is malformed' do
-          crl_path = as_pem_file(<<~END)
+          crl_path = file_containing('malformed_crl', <<~END)
             -----BEGIN X509 CRL-----
             MIIBCjB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
           END


### PR DESCRIPTION
Historically `Puppet::SSL::Key` supported password protected private keys,
provided the password file `Puppet[:passfile]` existed prior to
`Puppet::SSL::Host` being initialized the first time. However, it has two
limitations:

 * If the private key was encrypted and the `passfile` was later deleted, then
   ruby would hang trying to prompt for the password.
 * Private keys were encrypted using 3DES-CBC, which is outdated.

This commit adds an optional `password` keyword argument to encrypt and decrypt
the private key. Decryption will use the cipher and IV specified in the PEM
header, such as `DEK-Info: AES-128-CBC,7D9CB780A5571FAC184E44E1D736A163`, and
the provided password.

Encryption will always use AES-128-CBC and save the private key in the
"traditional" PEM format, not PKCS8. GCM is not an option since it's not
available in ruby 2.3, and openssl 1.1 can't decrypt a previously GCM-encrypted
private key.