### PR TITLE
(PUP-9689) Make Integer.new accept leading 0 for explicit base 10 conv

### DIFF
--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -843,14 +843,16 @@ INTEGER_HEX = '(?:0[xX][0-9A-Fa-f]+)'
 INTEGER_OCT = '(?:0[0-7]+)'
 INTEGER_BIN = '(?:0[bB][01]+)'
 INTEGER_DEC = '(?:0|[1-9]\d*)'
+INTEGER_DEC_OR_OCT = '(?:\d+)'
 SIGN_PREFIX = '[+-]?\s*'
 
 OPTIONAL_FRACTION = '(?:\.\d+)?'
 OPTIONAL_EXPONENT = '(?:[eE]-?\d+)?'
 FLOAT_DEC = '(?:' + INTEGER_DEC + OPTIONAL_FRACTION + OPTIONAL_EXPONENT + ')'
 
-INTEGER_PATTERN = '\A' + SIGN_PREFIX + '(?:' + INTEGER_DEC + '|' + INTEGER_HEX + '|' + INTEGER_OCT + '|' + INTEGER_BIN + ')\z'
-FLOAT_PATTERN = '\A' + SIGN_PREFIX + '(?:' + FLOAT_DEC + '|' + INTEGER_HEX + '|' + INTEGER_OCT + '|' + INTEGER_BIN + ')\z'
+INTEGER_PATTERN          = '\A' + SIGN_PREFIX + '(?:' + INTEGER_DEC + '|' + INTEGER_HEX + '|' + INTEGER_OCT + '|' + INTEGER_BIN + ')\z'
+INTEGER_PATTERN_LENIENT = '\A' + SIGN_PREFIX + '(?:' + INTEGER_DEC_OR_OCT + '|' + INTEGER_HEX + '|' + INTEGER_BIN + ')\z'
+FLOAT_PATTERN            = '\A' + SIGN_PREFIX + '(?:' + FLOAT_DEC + '|' + INTEGER_HEX + '|' + INTEGER_OCT + '|' + INTEGER_BIN + ')\z'
 
 # @api public
 #
@@ -1089,7 +1091,7 @@ class PIntegerType < PNumericType
     @@new_function ||= Puppet::Functions.create_loaded_function(:new, loader) do
       local_types do
         type 'Radix       = Variant[Default, Integer[2,2], Integer[8,8], Integer[10,10], Integer[16,16]]'
-        type "Convertible = Variant[Numeric, Boolean, Pattern[/#{INTEGER_PATTERN}/], Timespan, Timestamp]"
+        type "Convertible = Variant[Numeric, Boolean, Pattern[/#{INTEGER_PATTERN_LENIENT}/], Timespan, Timestamp]"
         type 'NamedArgs   = Struct[{from => Convertible, Optional[radix] => Radix, Optional[abs] => Boolean}]'
       end
 

--- a/spec/unit/functions/new_spec.rb
+++ b/spec/unit/functions/new_spec.rb
@@ -174,6 +174,19 @@ describe 'the new function' do
           )).to have_resource("Notify[Integer, #{result}]")
         end
       end
+
+      { '0x0G'  => :error,
+        '08'    => :error,
+        '10F'   => :error,
+        '0B2'   => :error,
+      }.each do |str, result|
+        it "errors when given a non Integer compliant string '#{str}'" do
+          expect{compile_to_catalog(<<-"MANIFEST"
+            $x = Integer.new("#{str}")
+          MANIFEST
+        )}.to raise_error(Puppet::Error, /invalid value|cannot be converted to Integer/)
+        end
+      end
     end
 
     context "when radix is explicitly set to 'default' it" do
@@ -307,6 +320,8 @@ describe 'the new function' do
       { "10"     => 10,
         "010"    => 10,
         "00010"  => 10,
+        "08"     => 8,
+        "0008"   => 8,
       }.each do |str, result|
         it "produces #{result} from the string '#{str}'" do
           expect(compile_to_catalog(<<-"MANIFEST"


### PR DESCRIPTION
Before this, the input to Integer.new was checked with a regexp such
that if a value started with a leading zero it must also be a valid
octal number. That was bad because it prevented an explicit conversion
from for example "08" with radix 10.

This is now changes so that leading zeros are accepted by the function,
and that any error is instead triggered when the conversion takes place.

Additional test cases added.