### PR TITLE
(PUP-9495) formatting server_list output

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -222,7 +222,7 @@ class Puppet::Configurer
           found = find_functional_server()
           server = found[:server]
           if server.nil?
-            raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: Puppet[:server_list] }
+            raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: Puppet.settings.value(:server_list, Puppet[:environment].to_sym, true) }
           else
             #TRANSLATORS 'server_list' is the name of a setting and should not be translated
             Puppet.debug _("Selected server from the `server_list` setting: %{server}:%{port}") % {server: server[0], port: server[1]}

--- a/lib/puppet/settings/server_list_setting.rb
+++ b/lib/puppet/settings/server_list_setting.rb
@@ -5,7 +5,12 @@ class Puppet::Settings::ServerListSetting < Puppet::Settings::ArraySetting
   end
 
   def print(value)
-    value
+    if value.is_a?(Array)
+      #turn into a string
+      value.map {|item| item.join(":") }.join(",")
+    else
+      value
+    end
   end
   
   def munge(value)

--- a/lib/puppet/settings/server_list_setting.rb
+++ b/lib/puppet/settings/server_list_setting.rb
@@ -4,6 +4,10 @@ class Puppet::Settings::ServerListSetting < Puppet::Settings::ArraySetting
     :server_list
   end
 
+  def print(value)
+    value
+  end
+  
   def munge(value)
     servers = super 
     servers.map! { |server| 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1025,14 +1025,15 @@ describe Puppet::Configurer do
     end
 
     it "should error when no servers in 'server_list' are reachable" do
-      Puppet.settings[:server_list] = ["myserver:123"]
+      Puppet.settings[:server_list] = "myserver:123,someotherservername"
       pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
-      expect(Puppet::Network::HTTP::Pool).to receive(:new).and_return(pool)
-      expect(Puppet).to receive(:override).with({:http_pool => pool}).and_yield
-      expect(Puppet).to receive(:override).with({:server => "myserver", :serverport => '123'}).and_yield
+      allow(Puppet::Network::HTTP::Pool).to receive(:new).and_return(pool)
+      allow(Puppet).to receive(:override).with({:http_pool => pool}).and_yield
+      allow(Puppet).to receive(:override).with({:server => "myserver", :serverport => '123'}).and_yield
+      allow(Puppet).to receive(:override).with({:server => "someotherservername", :serverport => 8140}).and_yield
       error = Net::HTTPError.new(400, 'dummy server communication error')
-      expect(Puppet::Node.indirection).to receive(:find).and_raise(error)
-      expect{ @agent.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list/)
+      allow(Puppet::Node.indirection).to receive(:find).and_raise(error)
+      expect{ @agent.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list: 'myserver:123,someotherservername'/)
     end
 
     it "should not make multiple node requets when the server is found" do

--- a/spec/unit/settings/server_list_setting_spec.rb
+++ b/spec/unit/settings/server_list_setting_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'puppet/settings/server_list_setting'
+
+describe Puppet::Settings::ServerListSetting do
+
+    it "prints items in the same format as the original list" do
+      settings = Puppet::Settings.new
+      settings.define_settings(:main, neptune: {type: :server_list, desc: 'list of servers'})
+      server_list_setting = settings.setting(:neptune)
+      expect(server_list_setting.print("jupiter,mars")).to eq("jupiter,mars")
+    end
+
+end

--- a/spec/unit/settings/server_list_setting_spec.rb
+++ b/spec/unit/settings/server_list_setting_spec.rb
@@ -3,11 +3,19 @@ require 'puppet/settings/server_list_setting'
 
 describe Puppet::Settings::ServerListSetting do
 
-    it "prints items in the same format as the original list" do
+    it "prints strings as strings" do
       settings = Puppet::Settings.new
       settings.define_settings(:main, neptune: {type: :server_list, desc: 'list of servers'})
       server_list_setting = settings.setting(:neptune)
       expect(server_list_setting.print("jupiter,mars")).to eq("jupiter,mars")
+    end
+
+    it "prints arrays as strings" do
+      settings = Puppet::Settings.new
+      settings.define_settings(:main, neptune: {type: :server_list, desc: 'list of servers'})
+      server_list_setting = settings.setting(:neptune)
+      expect(server_list_setting.print([["main", 1234],["production", 8140]])).to eq("main:1234,production:8140")
+      expect(server_list_setting.print([])).to eq("")
     end
 
 end


### PR DESCRIPTION
This PR changes the output of server_list when using `config print` as well as in error messages when no server could be reached. It also changes and adds tests to ensure this change.