### PR TITLE
(PUP-2958) Protect the ssl state machine with the agent lock

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -1,4 +1,5 @@
 require 'puppet/ssl'
+require 'puppet/agent'
 
 # This class implements a state machine for bootstrapping a host's CA and CRL
 # bundles, private key and signed client certificate. Each state has a frozen
@@ -11,6 +12,8 @@ require 'puppet/ssl'
 #
 # @private
 class Puppet::SSL::StateMachine
+  include Puppet::Agent::Locker
+
   class SSLState
     attr_reader :ssl_context
 
@@ -302,10 +305,12 @@ class Puppet::SSL::StateMachine
   private
 
   def run_machine(state, stop)
-    loop do
-      state = state.next_state
+    lock do
+      loop do
+        state = state.next_state
 
-      return state if state.is_a?(stop)
+        return state if state.is_a?(stop)
+      end
     end
   end
 end

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -20,8 +20,8 @@ class Puppet::SSL::StateMachine
     def initialize(machine, ssl_context)
       @machine = machine
       @ssl_context = ssl_context
-      @cert_provider = Puppet::X509::CertProvider.new
-      @ssl_provider = Puppet::SSL::SSLProvider.new
+      @cert_provider = machine.cert_provider
+      @ssl_provider = machine.ssl_provider
     end
   end
 
@@ -264,11 +264,14 @@ class Puppet::SSL::StateMachine
   #
   class Done < SSLState; end
 
-  attr_reader :waitforcert, :wait_deadline
+  attr_reader :waitforcert, :wait_deadline, :cert_provider, :ssl_provider
 
-  def initialize(waitforcert: Puppet[:waitforcert], maxwaitforcert: Puppet[:maxwaitforcert])
+  def initialize(waitforcert: Puppet[:waitforcert], maxwaitforcert: Puppet[:maxwaitforcert],
+                 cert_provider: Puppet::X509::CertProvider.new, ssl_provider: Puppet::SSL::SSLProvider.new)
     @waitforcert = waitforcert
     @wait_deadline = Time.now.to_i + maxwaitforcert
+    @cert_provider = cert_provider
+    @ssl_provider = ssl_provider
   end
 
   # Run the state machine for CA certs and CRLs

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -314,5 +314,7 @@ class Puppet::SSL::StateMachine
     end
 
     state
+  rescue Puppet::LockError
+    raise Puppet::Error, 'Another puppet instance is already running; exiting'
   end
 end

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -309,8 +309,10 @@ class Puppet::SSL::StateMachine
       loop do
         state = state.next_state
 
-        return state if state.is_a?(stop)
+        break if state.is_a?(stop)
       end
     end
+
+    state
   end
 end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -60,10 +60,9 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
   context 'when locking' do
     it "should lock prior to running the state machine" do
-      allow(cert_provider).to receive(:load_crls).and_return(crls)
-      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
-
-      expect_any_instance_of(Puppet::Util::Pidlock).to receive(:lock).and_return(true)
+      expect(machine).to receive(:lock).and_call_original.ordered
+      expect(cert_provider).to receive(:load_cacerts).and_return(cacerts).ordered
+      expect(cert_provider).to receive(:load_crls).and_return(crls).ordered
 
       machine.ensure_ca_certificates
     end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -66,10 +66,12 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       machine.ensure_ca_certificates
     end
 
-    it "should raise LockError if it fails to lock" do
+    it "should raise a meaningful exception if it fails to lock" do
       allow_any_instance_of(Puppet::Util::Pidlock).to receive(:lock).and_return(false)
 
-      expect { machine.ensure_ca_certificates }.to raise_error(Puppet::LockError)
+      expect {
+        machine.ensure_ca_certificates
+      }.to raise_error(Puppet::Error, /Another puppet instance is already running; exiting/)
     end
   end
 


### PR DESCRIPTION
Prevent multiple puppet processes from running the state machine
concurrently, as it can cause the second process to overwrite the
private key saved by the first process.