### PR TITLE
(PUP-8215) Don't expand skip_tags

### DIFF
--- a/lib/puppet/util/skip_tags.rb
+++ b/lib/puppet/util/skip_tags.rb
@@ -6,4 +6,8 @@ class Puppet::Util::SkipTags
   def initialize(stags)
     self.tags = stags unless defined?(@tags)
   end
+
+  def split_qualified_tags?
+    false
+  end
 end

--- a/spec/unit/util/skip_tags_spec.rb
+++ b/spec/unit/util/skip_tags_spec.rb
@@ -1,0 +1,14 @@
+# coding: utf-8
+require 'spec_helper'
+
+require 'puppet/util/skip_tags'
+
+describe Puppet::Util::SkipTags do
+  let(:tagger) { Puppet::Util::SkipTags.new([]) }
+
+  it "should add qualified classes as single tags" do
+    tagger.tag("one::two::three")
+    expect(tagger.tags).to include("one::two::three")
+    expect(tagger.tags).not_to include("one", "two", "three")
+  end
+end


### PR DESCRIPTION
Don't split tags in skip_tags on namespace separator.

I noticed this issue in Puppet 5.4.0 and I was able to reproduce it on `master` branch(`e1aee1ccb17a49798f3dae90172e7cb0b9c8518f`). My patch makes `skip_tags` behave similarly to `tags` option. Let me know, if you would like to change/add anything, before you consider merging.

# Example

Manifest:

```ruby
class l1 {
  contain l1::l2_1
  contain l1::l2_2
  file { '/home/jakub/test':
    ensure => directory,
  }
}

class l1::l2_1 {
  file { '/home/jakub/test/l2_1':
    ensure => present,
  }
}

class l1::l2_2 {
  file { '/home/jakub/test/l2_2':
    ensure => present,
  }
}

include l1
```

Running without patch:
```
$ bundle exec puppet apply test.pp --skip_tags l1::l2_1 --debug | grep 'Skipping with skip tags'
Debug: Class[L1]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: Class[L1::L2_1]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: Class[L1::L2_2]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: /Stage[main]/L1/File[/home/jakub/test]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: /Stage[main]/L1::L2_1/File[/home/jakub/test/l2_1]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: Class[L1::L2_1]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: /Stage[main]/L1::L2_2/File[/home/jakub/test/l2_2]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: Class[L1::L2_2]: Skipping with skip tags l1::l2_1, l1, l2_1
Debug: Class[L1]: Skipping with skip tags l1::l2_1, l1, l2_1
```

Running with patch:
```
$ bundle exec puppet apply test.pp --skip_tags l1::l2_1 --debug | grep 'Skipping with skip tags'
Debug: Class[L1::L2_1]: Skipping with skip tags l1::l2_1
Debug: /Stage[main]/L1::L2_1/File[/home/jakub/test/l2_1]: Skipping with skip tags l1::l2_1
Debug: Class[L1::L2_1]: Skipping with skip tags l1::l2_1
```