### PR TITLE
(PUP-9643) Make syntax errors from 3x function loading surface

### DIFF
--- a/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
+++ b/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb
@@ -19,9 +19,10 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
     # When func3x turned on, assert content by parsing, when turned off continue with (legacy) undefined behavior
     if Puppet[:func3x_check]
       assertion_result = []
-      assert_code(ruby_code_string, assertion_result)
-      unless ruby_code_string.is_a?(String) && assertion_result.include?(:found_newfunction)
-        raise ArgumentError, _("The code loaded from %{source_ref} does not seem to be a Puppet 3x API function - no 'newfunction' call.") % { source_ref: source_ref }
+      if assert_code(ruby_code_string, assertion_result)
+        unless ruby_code_string.is_a?(String) && assertion_result.include?(:found_newfunction)
+          raise ArgumentError, _("The code loaded from %{source_ref} does not seem to be a Puppet 3x API function - no 'newfunction' call.") % { source_ref: source_ref }
+        end
       end
     end
 
@@ -72,8 +73,9 @@ class Puppet::Pops::Loader::RubyLegacyFunctionInstantiator
 
   def self.assert_code(code_string, result)
     ripped = Ripper.sexp(code_string)
-    return if ripped.nil?  # Let the next real parse crash and tell where and what is wrong
+    return false if ripped.nil?  # Let the next real parse crash and tell where and what is wrong
     ripped.each {|x| walk(x, result) }
+    true
   end
   private_class_method :assert_code
 

--- a/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/func_with_syntax_error.rb
+++ b/spec/fixtures/unit/pops/loaders/loaders/mix_4x_and_3x_functions/usee/lib/puppet/parser/functions/func_with_syntax_error.rb
@@ -1,0 +1,9 @@
+module Puppet::Parser::Functions
+  newfunction(:func_with_syntax_error, :type => :rvalue, :doc => <<-EOS
+    A function using the 3x API having a syntax error
+  EOS
+  ) do |arguments|
+    # this syntax error is here on purpose!
+    1+ + + +
+  end
+end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -448,6 +448,10 @@ describe 'loaders' do
       function = loader.load_typed(typed_name(:function, 'good_func_load')).value
       expect(function.call(scope)).to eql(Float("3.14"))
     end
+
+    it "a function with syntax error has helpful error message" do
+      expect { loader.load_typed(typed_name(:function, 'func_with_syntax_error')) }.to raise_error(/syntax error, unexpected keyword_end/)
+    end
   end
 
   context 'when a 3x load has illegal method added' do


### PR DESCRIPTION
Before this, if there was a syntax error in a loaded 3.x function
it would be reported as "not containing a call to newfunction" and
the syntax error information would not be shown.

This commits changes this so that syntax errors surface unchanged.

A change was made to the code assertion such that it returns boolean tru
if it was possible to parse, and false otherwise. If false it lets the
real eval of the code string take place and to produce the error.