### PR TITLE
(maint) file_spec, fix path to test command on Debian

### DIFF
--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1681,7 +1681,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
   describe "when using validate_cmd" do
     test_cmd = '/bin/test'
-    if Facter.value(:operatingsystem) == 'Ubuntu'
+    if Facter.value(:osfamily) == 'Debian'
       test_cmd = '/usr/bin/test'
     end
 


### PR DESCRIPTION
The test command is found in /usr/bin rather than /bin on Debian, as it
is on Ubuntu. Use :osfamily rather than :operatingsystem to set the
correct value for any Debian flavor.

This fixes this test when run on Debian.