### PR TITLE
(maint) init_spec, expect :osfamily as well

### DIFF
--- a/spec/integration/provider/service/init_spec.rb
+++ b/spec/integration/provider/service/init_spec.rb
@@ -8,6 +8,7 @@ describe test_title, unless: Puppet::Util::Platform.jruby? do
   describe "when running on FreeBSD" do
     before :each do
       allow(Facter).to receive(:value).with(:operatingsystem).and_return('FreeBSD')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('FreeBSD')
     end
 
     it "should set its default path to include /etc/rc.d and /usr/local/etc/rc.d" do


### PR DESCRIPTION
The init provider also asks Facter for the :osfamily, so add that to the
spec.

This fixes the init_spec.