### PR TITLE
(maint) fix lookup option spelling to be consistent

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -33,7 +33,7 @@ class Puppet::Application::Lookup < Puppet::Application
     options[:prefix] = arg
   end
 
-  option('--sort-merge-arrays')
+  option('--sort-merged-arrays')
 
   option('--merge-hash-arrays')
 


### PR DESCRIPTION
fix lookup option spelling to be consistent with code and documentation