### PR TITLE
(PUP-1153) force group removal

### DIFF
--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -105,7 +105,15 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
       @custom_environment = Puppet::Util::Libuser.getenv
       [command(:localdelete), @resource[:name]]
     else
-      [command(:delete), @resource[:name]]
+      # Use force flag if available in order to remove groups which are still
+      # used as the GID for an existing user.
+      groupdel_help = execute([command(:delete), '-h'])
+      has_force_flag = !!(groupdel_help =~ /^\s+-f, --force/)
+      if has_force_flag
+        [command(:delete), '-f', @resource[:name]]
+      else
+        [command(:delete), @resource[:name]]
+      end
     end
   end
 end

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -136,6 +136,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
       end
 
       it "should use groupdel" do
+        expect(provider).to receive(:execute).with(["/usr/sbin/groupdel", "-h"])
         expect(provider).to receive(:execute).with(['/usr/sbin/groupdel', 'mygroup'], hash_including({:failonfail => true, :combine => true, :custom_environment => {}}))
         provider.delete
       end


### PR DESCRIPTION
The groupdel command from https://github.com/shadow-maint/shadow refuses
to remove groups which are set as the primary GID for a user.  This
effects operating systems such as Debian which uses the shadow codebase.

This is problematic in a Puppet managed world, where it is difficult
to ensure that any dependent users are removed prior to removing the
group.

I added a force option to the groupdel command to force the removal even
when a user has the group set as their GID, so use that flag if it is
available.