### PR TITLE
(PUP-9693) add call function to hiera wrapping scope

### DIFF
--- a/lib/hiera/scope.rb
+++ b/lib/hiera/scope.rb
@@ -1,5 +1,8 @@
+require 'forwardable'
 class Hiera
   class Scope
+    extend Forwardable
+
     CALLING_CLASS = 'calling_class'.freeze
     CALLING_CLASS_PATH = 'calling_class_path'.freeze
     CALLING_MODULE = 'calling_module'.freeze
@@ -79,5 +82,9 @@ class Hiera
       end
     end
     private :find_hostclass
+
+    # This is needed for type conversion to work
+    def_delegators :@real, :call_function
+
   end
 end

--- a/spec/unit/hiera/scope_spec.rb
+++ b/spec/unit/hiera/scope_spec.rb
@@ -90,4 +90,11 @@ describe Hiera::Scope do
       expect(scope.include?("calling_module")).to eq(true)
     end
   end
+
+  describe "#call_function" do
+    it "should delegate a call to call_function to the real scope" do
+      expect(real).to receive(:call_function).once
+      scope.call_function('some_function', [1,2,3])
+    end
+  end
 end


### PR DESCRIPTION
Before this, interpolating keys into a hiera 3 backend managed value where the key specified a `convert_to` would fails because the `convert_to` makes a call to `call_function` on the scope that is passed in. This did not work because in Hiera 3 there is a special `Hiera::Scope` wrapper around the real scope, and the hiera wrapping scope is passed around. This PR makes the Hiera::Scope delegate `call_function` to the real scope.