### PR TITLE
(PUP-1353) Start Posix based services with a 0 priority

### DIFF
--- a/lib/puppet/provider/service/service.rb
+++ b/lib/puppet/provider/service/service.rb
@@ -21,8 +21,19 @@ Puppet::Type.type(:service).provide :service do
 
   # A simple wrapper so execution failures are a bit more informative.
   def texecute(type, command, fof = true, squelch = false, combine = true)
+    # Set the process priority to 0 (or normal in Windows) so that services
+    # which are started as children of puppet will start with normal priority,
+    # rather than the priority of the puppet process itself.
+    priority = Puppet::Util::Platform.windows? ? Process::NORMAL_PRIORITY_CLASS : 0
     begin
-      execute(command, :failonfail => fof, :override_locale => false, :squelch => squelch, :combine => combine)
+      opts = {
+        :combine => combine,
+        :failonfail => fof,
+        :override_locale => false,
+        :priority => priority,
+        :squelch => squelch,
+      }
+      execute(command, opts)
     rescue Puppet::ExecutionFailure => detail
       @resource.fail Puppet::Error, "Could not #{type} #{@resource.ref}: #{detail}", detail
     end

--- a/lib/puppet/provider/service/service.rb
+++ b/lib/puppet/provider/service/service.rb
@@ -24,13 +24,12 @@ Puppet::Type.type(:service).provide :service do
     # Set the process priority to 0 (or normal in Windows) so that services
     # which are started as children of puppet will start with normal priority,
     # rather than the priority of the puppet process itself.
-    priority = Puppet::Util::Platform.windows? ? Process::NORMAL_PRIORITY_CLASS : 0
     begin
       opts = {
         :combine => combine,
         :failonfail => fof,
         :override_locale => false,
-        :priority => priority,
+        :priority => :normal,
         :squelch => squelch,
       }
       execute(command, opts)

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -134,7 +134,7 @@ module Puppet::Util::Execution
   #   Passing in a value of false for this option will allow the command to be executed using the user/system locale.
   # @option options [Hash<{String => String}>] :custom_environment ({}) a hash of key/value pairs to set as environment variables for the duration
   #   of the command.
-  # @option options [Integer] :priority (nil) The priority of child process, aka the nice value in Posix operatingsystems.
+  # @option options [Symbol] :priority (nil) The priority of child process, see Puppet::Settings::PrioritySetting::PRIORITY_MAP for values.
   # @return [Puppet::Util::Execution::ProcessOutput] output as specified by options
   # @raise [Puppet::ExecutionFailure] if the executed chiled process did not exit with status == 0 and `failonfail` is
   #   `true`.
@@ -341,7 +341,7 @@ module Puppet::Util::Execution
       Process.setsid
       if options[:priority]
         if Puppet.features.root?
-          setpriority(options[:priority])
+          setpriority(Puppet::Settings::PrioritySetting::PRIORITY_MAP[options[:priority]])
         end
       end
       begin

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -24,9 +24,13 @@ module Puppet::Util::Windows::Process
         :stderr => stderr
       },
       :close_handles => false,
+      :creation_flags => 0,
     }
     if arguments[:suppress_window]
-      create_args[:creation_flags] = CREATE_NO_WINDOW
+      create_args[:creation_flags] |= CREATE_NO_WINDOW
+    end
+    if arguments[:priority]
+      create_args[:creation_flags] |= Puppet::Settings::PrioritySetting::PRIORITY_MAP[arguments[:priority]]
     end
     if arguments[:cwd]
       create_args[:cwd] = arguments[:cwd]

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -94,13 +94,13 @@ describe 'Puppet::Type::Service::Provider::Bsd',
 
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.start
     end
 
     it "should start the serviced directly otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestart], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/rc.d/sshd')
       provider.start
     end
@@ -113,13 +113,13 @@ describe 'Puppet::Type::Service::Provider::Bsd',
 
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.stop
     end
 
     it "should stop the serviced directly otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestop], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/rc.d/sshd')
       provider.stop
     end

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -94,13 +94,13 @@ describe 'Puppet::Type::Service::Provider::Bsd',
 
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.start
     end
 
     it "should start the serviced directly otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/rc.d/sshd')
       provider.start
     end
@@ -113,13 +113,13 @@ describe 'Puppet::Type::Service::Provider::Bsd',
 
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.stop
     end
 
     it "should stop the serviced directly otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/rc.d/sshd')
       provider.stop
     end

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -79,13 +79,13 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.start
     end
 
     it "should start the service with <initscript> start otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
       provider.start
     end
@@ -94,13 +94,13 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.stop
     end
 
     it "should stop the service with <initscript> stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
       provider.stop
     end
@@ -160,24 +160,24 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
     describe "when a special status command is specified" do
       it "should use the status command from the resource" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.status
       end
 
       it "should return :stopped when the status command returns with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
 
       it "should return :running when the status command returns with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -186,14 +186,14 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         expect(provider).to receive(:getpid).and_return(1000)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if no pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         expect(provider).to receive(:getpid).and_return(nil)
         expect(provider.status).to eq(:stopped)
       end
@@ -203,7 +203,7 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
       it "should return running if <initscript> status exits with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -211,7 +211,7 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
       it "should return stopped if <initscript> status exits with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
@@ -221,24 +221,24 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with <initscript> restart if hasrestart is true" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with <initscript> stop/start if hasrestart is false" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
   end

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -79,13 +79,13 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.start
     end
 
     it "should start the service with <initscript> start otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
       provider.start
     end
@@ -94,13 +94,13 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.stop
     end
 
     it "should stop the service with <initscript> stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
       provider.stop
     end
@@ -160,24 +160,24 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
     describe "when a special status command is specified" do
       it "should use the status command from the resource" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.status
       end
 
       it "should return :stopped when the status command returns with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
 
       it "should return :running when the status command returns with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -186,14 +186,14 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         expect(provider).to receive(:getpid).and_return(1000)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if no pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         expect(provider).to receive(:getpid).and_return(nil)
         expect(provider.status).to eq(:stopped)
       end
@@ -203,7 +203,7 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
       it "should return running if <initscript> status exits with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -211,7 +211,7 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
       it "should return stopped if <initscript> status exits with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
@@ -221,24 +221,24 @@ describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platfo
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with <initscript> restart if hasrestart is true" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with <initscript> stop/start if hasrestart is false" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.restart
     end
   end

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -242,7 +242,7 @@ describe 'Puppet::Type::Service::Provider::Init', unless: Puppet::Util::Platform
     describe "when starting a service on Solaris" do
       it "should use ctrun" do
         allow(Facter).to receive(:value).with(:osfamily).and_return('Solaris')
-        expect(provider).to receive(:execute).with('/usr/bin/ctrun -l child /service/path/myservice start', {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).and_return("")
+        expect(provider).to receive(:execute).with('/usr/bin/ctrun -l child /service/path/myservice start', {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false}).and_return("")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.start
       end
@@ -251,7 +251,7 @@ describe 'Puppet::Type::Service::Provider::Init', unless: Puppet::Util::Platform
     describe "when starting a service on RedHat" do
       it "should not use ctrun" do
         allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-        expect(provider).to receive(:execute).with(['/service/path/myservice', :start], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).and_return("")
+        expect(provider).to receive(:execute).with(['/service/path/myservice', :start], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false}).and_return("")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.start
       end

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -242,7 +242,7 @@ describe 'Puppet::Type::Service::Provider::Init', unless: Puppet::Util::Platform
     describe "when starting a service on Solaris" do
       it "should use ctrun" do
         allow(Facter).to receive(:value).with(:osfamily).and_return('Solaris')
-        expect(provider).to receive(:execute).with('/usr/bin/ctrun -l child /service/path/myservice start', {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false}).and_return("")
+        expect(provider).to receive(:execute).with('/usr/bin/ctrun -l child /service/path/myservice start', {:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false}).and_return("")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.start
       end
@@ -251,7 +251,7 @@ describe 'Puppet::Type::Service::Provider::Init', unless: Puppet::Util::Platform
     describe "when starting a service on RedHat" do
       it "should not use ctrun" do
         allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-        expect(provider).to receive(:execute).with(['/service/path/myservice', :start], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false}).and_return("")
+        expect(provider).to receive(:execute).with(['/service/path/myservice', :start], {:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false}).and_return("")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.start
       end

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -28,7 +28,7 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.start
     end
 
@@ -42,7 +42,7 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.stop
     end
 
@@ -56,23 +56,23 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#status" do
     it "should use the status command from the resource" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
       provider.status
     end
 
     it "should return :stopped when status command returns with a non-zero exitcode" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
       expect(provider.status).to eq(:stopped)
     end
 
     it "should return :running when status command returns with a zero exitcode" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
       expect(provider.status).to eq(:running)
     end
@@ -81,8 +81,8 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', '-f', :restart, 'sshd'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', '-f', :restart, 'sshd'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
 

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -28,7 +28,7 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.start
     end
 
@@ -42,7 +42,7 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.stop
     end
 
@@ -56,23 +56,23 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#status" do
     it "should use the status command from the resource" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
       provider.status
     end
 
     it "should return :stopped when status command returns with a non-zero exitcode" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
       expect(provider.status).to eq(:stopped)
     end
 
     it "should return :running when status command returns with a zero exitcode" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
       expect(provider.status).to eq(:running)
     end
@@ -81,8 +81,8 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', '-f', :restart, 'sshd'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', '-f', :restart, 'sshd'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.restart
     end
 

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -42,13 +42,15 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.start
     end
 
     it "should start the service with rc-service start otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.start
     end
   end
@@ -56,13 +58,15 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.stop
     end
 
     it "should stop the service with rc-service stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.stop
     end
   end
@@ -150,24 +154,27 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
     describe "when a special status command if specified" do
       it "should use the status command from the resource" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.status
       end
 
       it "should return :stopped when status command returns with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
 
       it "should return :running when status command returns with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -176,14 +183,14 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         expect(provider).to receive(:getpid).and_return(1000)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if no pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         expect(provider).to receive(:getpid).and_return(nil)
         expect(provider.status).to eq(:stopped)
       end
@@ -192,14 +199,16 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
     describe "when hasstatus is true" do
       it "should return running if rc-service status exits with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
-        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if rc-service status exits with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
-        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
@@ -209,22 +218,26 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with rc-service restart if hasrestart is true" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with rc-service stop/start if hasrestart is false" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
-      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
       provider.restart
     end
   end

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -42,15 +42,13 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.start
     end
 
     it "should start the service with rc-service start otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.start
     end
   end
@@ -58,15 +56,13 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.stop
     end
 
     it "should stop the service with rc-service stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.stop
     end
   end
@@ -154,27 +150,24 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
     describe "when a special status command if specified" do
       it "should use the status command from the resource" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.status
       end
 
       it "should return :stopped when status command returns with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
 
       it "should return :running when status command returns with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -183,14 +176,14 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         expect(provider).to receive(:getpid).and_return(1000)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if no pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         expect(provider).to receive(:getpid).and_return(nil)
         expect(provider.status).to eq(:stopped)
       end
@@ -199,16 +192,14 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
     describe "when hasstatus is true" do
       it "should return running if rc-service status exits with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if rc-service status exits with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:status], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(3)
         expect(provider.status).to eq(:stopped)
       end
@@ -218,26 +209,22 @@ describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platfo
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with rc-service restart if hasrestart is true" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with rc-service stop/start if hasrestart is false" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
-      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
-      expect(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
   end

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -62,15 +62,13 @@ _EOF_
 
   context "when starting a service" do
     it "should execute the startsrc command" do
-      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
-      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
       expect(@provider).to receive(:status).and_return(:running)
       @provider.start
     end
 
     it "should error if timeout occurs while stopping the service" do
-      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
-      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
       expect(Timeout).to receive(:timeout).with(60).and_raise(Timeout::Error)
       expect { @provider.start }.to raise_error Puppet::Error, ('Timed out waiting for myservice to transition states')
     end
@@ -78,15 +76,13 @@ _EOF_
 
   context "when stopping a service" do
     it "should execute the stopsrc command" do
-      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
-      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
       expect(@provider).to receive(:status).and_return(:stopped)
       @provider.stop
     end
 
     it "should error if timeout occurs while stopping the service" do
-      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
-      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
       expect(Timeout).to receive(:timeout).with(60).and_raise(Timeout::Error)
       expect { @provider.stop }.to raise_error Puppet::Error, ('Timed out waiting for myservice to transition states')
     end

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -62,13 +62,15 @@ _EOF_
 
   context "when starting a service" do
     it "should execute the startsrc command" do
-      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:override_locale => false, :squelch => false, :combine => true, :failonfail => true})
+      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
+      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
       expect(@provider).to receive(:status).and_return(:running)
       @provider.start
     end
 
     it "should error if timeout occurs while stopping the service" do
-      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:override_locale => false, :squelch => false, :combine => true, :failonfail => true})
+      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
+      expect(@provider).to receive(:execute).with(['/usr/bin/startsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
       expect(Timeout).to receive(:timeout).with(60).and_raise(Timeout::Error)
       expect { @provider.start }.to raise_error Puppet::Error, ('Timed out waiting for myservice to transition states')
     end
@@ -76,13 +78,15 @@ _EOF_
 
   context "when stopping a service" do
     it "should execute the stopsrc command" do
-      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:override_locale => false, :squelch => false, :combine => true, :failonfail => true})
+      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
+      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
       expect(@provider).to receive(:status).and_return(:stopped)
       @provider.stop
     end
 
     it "should error if timeout occurs while stopping the service" do
-      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:override_locale => false, :squelch => false, :combine => true, :failonfail => true})
+      expect(Facter).to receive(:value).with(:osfamily).and_return('AIX')
+      expect(@provider).to receive(:execute).with(['/usr/bin/stopsrc', '-s', "myservice"], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
       expect(Timeout).to receive(:timeout).with(60).and_raise(Timeout::Error)
       expect { @provider.stop }.to raise_error Puppet::Error, ('Timed out waiting for myservice to transition states')
     end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -181,8 +181,7 @@ describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platf
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :start => '/bin/foo'))
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.start
     end
 
@@ -190,8 +189,7 @@ describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platf
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       expect(provider).to receive(:systemctl).with(:unmask, 'sshd.service')
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','start','sshd.service'], {:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(provider).to receive(:execute).with(['/bin/systemctl','start','sshd.service'], {:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
       provider.start
     end
 
@@ -199,8 +197,7 @@ describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platf
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       expect(provider).to receive(:systemctl).with(:unmask, 'sshd.service')
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','start','sshd.service'],{:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(provider).to receive(:execute).with(['/bin/systemctl','start','sshd.service'],{:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
         .and_raise(Puppet::ExecutionFailure, "Failed to start sshd.service: Unit sshd.service failed to load: Invalid argument. See system logs and 'systemctl status sshd.service' for details.")
       journalctl_logs = <<-EOS
 -- Logs begin at Tue 2016-06-14 11:59:21 UTC, end at Tue 2016-06-14 21:45:02 UTC. --
@@ -216,22 +213,19 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :stop => '/bin/foo'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.stop
     end
 
     it "should stop the service with systemctl stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','stop','sshd.service'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','stop','sshd.service'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.stop
     end
 
     it "should show journald logs on failure" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','stop','sshd.service'],{:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(provider).to receive(:execute).with(['/bin/systemctl','stop','sshd.service'],{:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
         .and_raise(Puppet::ExecutionFailure, "Failed to stop sshd.service: Unit sshd.service failed to load: Invalid argument. See system logs and 'systemctl status sshd.service' for details.")
       journalctl_logs = <<-EOS
 -- Logs begin at Tue 2016-06-14 11:59:21 UTC, end at Tue 2016-06-14 21:45:02 UTC. --
@@ -336,8 +330,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#status" do
     it "should return running if if the command returns 0" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','sshd.service'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false).and_return("active\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','sshd.service'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false).and_return("active\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
       expect(provider.status).to eq(:running)
     end
@@ -345,8 +338,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     [-10,-1,3,10].each { |ec|
       it "should return stopped if the command returns something non-0" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-        expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-        expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','sshd.service'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false).and_return("inactive\n")
+        expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','sshd.service'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false).and_return("inactive\n")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(ec)
         expect(provider.status).to eq(:stopped)
       end
@@ -354,8 +346,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
 
     it "should use the supplied status command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :status => '/bin/foo'))
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
       provider.status
     end
   end
@@ -366,25 +357,22 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false).never
-      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false).never
+      expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
 
     it "should restart the service with systemctl restart" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'], :combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
       provider.restart
     end
 
     it "should show journald logs on failure" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'],{:combine => true, :failonfail => true, :override_locale => false, :priority => 0, :squelch => false})
+      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'],{:combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false})
         .and_raise(Puppet::ExecutionFailure, "Failed to restart sshd.service: Unit sshd.service failed to load: Invalid argument. See system logs and 'systemctl status sshd.service' for details.")
       journalctl_logs = <<-EOS
 -- Logs begin at Tue 2016-06-14 11:59:21 UTC, end at Tue 2016-06-14 21:45:02 UTC. --

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -153,7 +153,8 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow_any_instance_of(Process::Status).to receive(:exitstatus).and_return(0)
         provider.status
       end
@@ -164,7 +165,8 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
         expect(provider.status).to eq(:stopped)
       end
@@ -175,7 +177,8 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -210,7 +213,8 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow_any_instance_of(Process::Status).to receive(:exitstatus).and_return(0)
         provider.status
       end
@@ -221,7 +225,8 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
         expect(provider.status).to eq(:stopped)
       end
@@ -232,7 +237,8 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -153,8 +153,7 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow_any_instance_of(Process::Status).to receive(:exitstatus).and_return(0)
         provider.status
       end
@@ -165,8 +164,7 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
         expect(provider.status).to eq(:stopped)
       end
@@ -177,8 +175,7 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end
@@ -213,8 +210,7 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow_any_instance_of(Process::Status).to receive(:exitstatus).and_return(0)
         provider.status
       end
@@ -225,8 +221,7 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
         expect(provider.status).to eq(:stopped)
       end
@@ -237,8 +232,7 @@ describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platf
         allow(provider).to receive(:is_upstart?).and_return(true)
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
-        expect(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => 0, :squelch => false)
+        expect(provider).to receive(:execute).with(['/bin/foo'], :combine => true, :failonfail => false, :override_locale => false, :priority => :normal, :squelch => false)
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         expect(provider.status).to eq(:running)
       end

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -125,8 +125,7 @@ describe 'Puppet::Type::Service::Provider::Windows',
     it "should use the supplied restart command if specified" do
       resource[:restart] = 'c:/bin/foo'
 
-      expect(Facter).to receive(:value).with(:osfamily).and_return('windows')
-      expect(provider).to receive(:execute).with(['c:/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => Process::NORMAL_PRIORITY_CLASS, :squelch => false)
+      expect(provider).to receive(:execute).with(['c:/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => :normal, :squelch => false)
 
       provider.restart
     end

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -125,7 +125,8 @@ describe 'Puppet::Type::Service::Provider::Windows',
     it "should use the supplied restart command if specified" do
       resource[:restart] = 'c:/bin/foo'
 
-      expect(provider).to receive(:execute).with(['c:/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(Facter).to receive(:value).with(:osfamily).and_return('windows')
+      expect(provider).to receive(:execute).with(['c:/bin/foo'], :combine => true, :failonfail => true, :override_locale => false, :priority => Process::NORMAL_PRIORITY_CLASS, :squelch => false)
 
       provider.restart
     end

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -149,7 +149,8 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
         expect(Process).to receive(:create).with(
           :command_line => "test command",
           :startup_info => {:stdin => @stdin, :stdout => @stdout, :stderr => @stderr},
-          :close_handles => false
+          :close_handles => false,
+          :creation_flags => 0
         ).and_return(proc_info_stub)
 
         call_exec_windows('test command', {}, @stdin, @stdout, @stderr)
@@ -166,7 +167,8 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
               :stderr => @stderr
             },
             :close_handles => false,
-            :cwd => cwd
+            :cwd => cwd,
+            :creation_flags => 0
           )
 
           call_exec_windows('test command', { :cwd => cwd }, @stdin, @stdout, @stderr)


### PR DESCRIPTION
Puppet's base service provider starts services as a child process of the
Puppet process. On Posix systems the child process inherits the priority
or nice value of the parent process. The result is that services which
are started as child processes of Puppet have their priority set to
Puppet's priority. This behavior is undesirable as services expect to
be started with a 0 or normal priority. This commit ensures services are
started with a normal priority by changing the priority of the child
process when starting a service.

Example of old & new behavior on Debian Wheezy:

  ; git checkout master
  Switched to branch 'master'
  Your branch is up-to-date with 'origin/master'.

  ; sudo /etc/init.d/ntp stop
  Stopping NTP server: ntpd.

  ; nice -n 13 sudo bundle exec puppet apply -e 'service { "ntp": ensure => "running" }'
  Notice: Compiled catalog for foo in environment production in 0.12 seconds
  Notice: /Stage[main]/Main/Service[ntp]/ensure: ensure changed 'stopped' to 'running'
  Notice: Applied catalog in 0.05 seconds

  ; ps -C ntpd -o pid,tid,class,rtprio,ni,pri,psr,pcpu,stat,wchan:14,comm
    PID   TID CLS RTPRIO  NI PRI PSR %CPU STAT WCHAN          COMMAND
  30269 30269 TS       -  13   6   6  0.0 SNs  -              ntpd

  ; git checkout service_priority
  Switched to branch 'service_priority'
  Your branch is up-to-date with 'origin/service_priority'.

  ; sudo /etc/init.d/ntp stop
  Stopping NTP server: ntpd.

  ; nice -n 13 sudo bundle exec puppet apply -e 'service { "ntp": ensure => "running" }'
  Notice: Compiled catalog for foo in environment production in 0.11 seconds
  Notice: /Stage[main]/Main/Service[ntp]/ensure: ensure changed 'stopped' to 'running'
  Notice: Applied catalog in 0.04 seconds

  ; ps -C ntpd -o pid,tid,class,rtprio,ni,pri,psr,pcpu,stat,wchan:14,comm
    PID   TID CLS RTPRIO  NI PRI PSR %CPU STAT WCHAN          COMMAND
  30536 30536 TS       -   0  19  10  0.0 Ss   -              ntpd