### PR TITLE
(PUP-9699) Add recording of all looked up (hiera) keys

### DIFF
--- a/lib/puppet/pops/lookup.rb
+++ b/lib/puppet/pops/lookup.rb
@@ -94,3 +94,4 @@ end
 end
 
 require_relative 'lookup/lookup_adapter'
+require_relative 'lookup/key_recorder'

--- a/lib/puppet/pops/lookup/key_recorder.rb
+++ b/lib/puppet/pops/lookup/key_recorder.rb
@@ -1,0 +1,18 @@
+# This class defines the private API of the Lookup Key Recorder support.
+# @api private
+#
+class Puppet::Pops::Lookup::KeyRecorder
+
+  def initialize()
+  end
+
+  def self.singleton
+    @null_recorder ||= self.new
+  end
+
+  # Records a key
+  # (This implementation does nothing)
+  #
+  def record(key)
+  end
+end

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -27,6 +27,8 @@ class LookupAdapter < DataAdapter
     super()
     @compiler = compiler
     @lookup_options = {}
+    # Get a KeyRecorder from context, and set a "null recorder" if not defined
+    @key_recorder = Puppet.lookup(:lookup_key_recorder) { KeyRecorder.singleton }
   end
 
   # Performs a lookup using global, environment, and module data providers. Merge the result using the given
@@ -47,6 +49,11 @@ class LookupAdapter < DataAdapter
         throw :no_such_key
       end
     end
+
+    # Record that the key was looked up. This will record all keys for which a lookup is performed
+    # except 'lookup_options' (since that is illegal from a user perspective,
+    # and from an impact perspective is always looked up).
+    @key_recorder.record(key)
 
     key = LookupKey.new(key)
     lookup_invocation.lookup(key, key.module_name) do


### PR DESCRIPTION
This adds an API for recording all looked up hiera keys (except the
always implicitly looked up `lookup_options` key built into hiera).