### PR TITLE
[DOCUMENT-1004] Improve docstring for the fail() function.

### DIFF
--- a/lib/puppet/parser/functions/fail.rb
+++ b/lib/puppet/parser/functions/fail.rb
@@ -1,4 +1,11 @@
-Puppet::Parser::Functions::newfunction(:fail, :arity => -1, :doc => "Fail with a parse error.") do |vals|
+Puppet::Parser::Functions::newfunction(
+    :fail,
+    :arity => -1,
+    :doc   => <<DOC
+Fail with a parse error. Any parameters will be stringified,
+concatenated, and passed to the exception-handler.
+DOC
+) do |vals|
     vals = vals.collect { |s| s.to_s }.join(" ") if vals.is_a? Array
     raise Puppet::ParseError, vals.to_s
 end


### PR DESCRIPTION
#fixes: https://tickets.puppetlabs.com/browse/DOCUMENT-1004

The [documentation](https://puppet.com/docs/puppet/latest/function.html#fail)  for the [`fail()`](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/parser/functions/fail.rb) function should mention what it does with its parameters.