### PR TITLE
(maint) Select the correct item in info split to fix assert_match

### DIFF
--- a/acceptance/tests/provider/package/dpkg_ensure_held_package_is_latest.rb
+++ b/acceptance/tests/provider/package/dpkg_ensure_held_package_is_latest.rb
@@ -13,14 +13,14 @@ agents.each do |agent|
   end
 end
 
-step"Ensure that package is installed first if not present" do
+step "Ensure that package is installed first if not present" do
   info = on(agent.name, "apt-cache policy #{package} | grep Candidate:").stdout
-  expected_package_version = info.split.first
+  expected_package_version = info.split[1]
   package_manifest = resource_manifest('package', package, ensure: "held")
 
   apply_manifest_on(agent, package_manifest) do |result|
     info = on(agent.name, "apt-cache policy #{package} | grep Installed").stdout
-    installed_package_version = info.split.first
+    installed_package_version = info.split[1]
     assert_match(expected_package_version, installed_package_version)
   end
 end


### PR DESCRIPTION
Previously, assert_match was selecting the first item in info.split, which
included the grep'd text "Candidate:" or "Installed" which meant a match could
never be made, causing the test suite to fail.

This PR changes it to use the next item so package names can match.