### PR TITLE
(PUP-9706) Solaris userdel does not properly implement :manages_homedir feature.

### DIFF
--- a/acceptance/tests/resource/user/should_destroy_with_managehome.rb
+++ b/acceptance/tests/resource/user/should_destroy_with_managehome.rb
@@ -1,0 +1,25 @@
+test_name "should delete a user with managehome=true"
+confine :except, :platform => /^eos-/ # See ARISTA-37
+confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  step "ensure the user is present"
+  agent.user_present(name)
+
+  step "delete the user with managehome=true"
+  on agent, puppet_resource('user', name, ['ensure=absent', 'managehome=true'])
+
+  step "verify the user was deleted"
+  fail_test "User #{name} was not deleted" if agent.user_list.include? name
+
+  step "delete the user, if any"
+  agent.user_absent(name)
+end

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -203,7 +203,10 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     else
       cmd = [command(:delete)]
     end
-    cmd += @resource.managehome? ? ['-r'] : []
+    # Solaris `userdel -r` will fail if the homedir does not exist.
+    if @resource.managehome? and ('Solaris' != Facter.value(:operatingsystem) or Dir.exist?(Dir.home(@resource[:name])))
+      cmd << '-r'
+    end
     cmd << @resource[:name]
   end
 

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -105,11 +105,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     # because by default duplicates are allowed.  This check is
     # to ensure consistent behaviour of the useradd provider when
     # using both useradd and luseradd
-    if not @resource.allowdupe? and @resource.forcelocal?
-       if @resource.should(:uid) and finduser('uid', @resource.should(:uid).to_s)
+    if (!@resource.allowdupe?) && @resource.forcelocal?
+       if @resource.should(:uid) && finduser('uid', @resource.should(:uid).to_s)
            raise(Puppet::Error, "UID #{@resource.should(:uid).to_s} already exists, use allowdupe to force user creation")
        end
-    elsif @resource.allowdupe? and not @resource.forcelocal?
+    elsif @resource.allowdupe? && (!@resource.forcelocal?)
        return ["-o"]
     end
     []
@@ -126,16 +126,16 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
 
   def check_manage_home
     cmd = []
-    if @resource.managehome? and not @resource.forcelocal?
+    if @resource.managehome? && (!@resource.forcelocal?)
       cmd << "-m"
-    elsif not @resource.managehome? and Facter.value(:osfamily) == 'RedHat'
+    elsif (!@resource.managehome?) && Facter.value(:osfamily) == 'RedHat'
       cmd << "-M"
     end
     cmd
   end
 
   def check_system_users
-    if self.class.system_users? and resource.system?
+    if self.class.system_users? && resource.system?
       ["-r"]
     else
       []
@@ -149,11 +149,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     Puppet::Type.type(:user).validproperties.sort.each do |property|
       next if property == :ensure
       next if property_manages_password_age?(property)
-      next if property == :groups and @resource.forcelocal?
-      next if property == :expiry and @resource.forcelocal?
+      next if (property == :groups) && @resource.forcelocal?
+      next if (property == :expiry) && @resource.forcelocal?
       # the value needs to be quoted, mostly because -c might
       # have spaces in it
-      if value = @resource.should(property) and value != ""
+      if (value = @resource.should(property)) && (value != "")
         cmd << flag(property) << munge(property, value)
       end
     end
@@ -167,7 +167,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     else
       cmd = [command(:add)]
     end
-    if not @resource.should(:gid) and Puppet::Util.gid(@resource[:name])
+    if (!@resource.should(:gid)) && Puppet::Util.gid(@resource[:name])
       cmd += ["-g", @resource[:name]]
     end
     cmd += add_properties
@@ -204,7 +204,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       cmd = [command(:delete)]
     end
     # Solaris `userdel -r` will fail if the homedir does not exist.
-    if @resource.managehome? and ('Solaris' != Facter.value(:operatingsystem) or Dir.exist?(Dir.home(@resource[:name])))
+    if @resource.managehome? && (('Solaris' != Facter.value(:operatingsystem)) || Dir.exist?(Dir.home(@resource[:name])))
       cmd << '-r'
     end
     cmd << @resource[:name]
@@ -242,10 +242,10 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       check_valid_shell
     end
      super
-     if @resource.forcelocal? and self.groups?
+     if @resource.forcelocal? && self.groups?
        set(:groups, @resource[:groups])
      end
-     if @resource.forcelocal? and @resource[:expiry]
+     if @resource.forcelocal? && @resource[:expiry]
        set(:expiry, @resource[:expiry])
      end
   end


### PR DESCRIPTION
See https://tickets.puppetlabs.com/browse/PUP-9706

> *Puppet Version: 6.4.2*
> *Puppet Server Version: N/A*
> *OS Name/Version: Solaris 11*
> 
> *Desired Behavior: Able to remove a user without any errors*
> 
> *Actual Behavior:*
> 
> When applying the following an error occurs:
>```
> root@yz4rr58lsjdxqz3:~# puppet apply -e 'user { "testuser": ensure => "present", managehome => false }'
> Notice: /File[/etc/puppetlabs/code/environments/production]/ensure: created
> Notice: Compiled catalog for yz4rr58lsjdxqz3.delivery.puppetlabs.net in environment production in 0.03 seconds
> Notice: /Stage[main]/Main/User[testuser]/ensure: created
> Notice: Applied catalog in 0.06 seconds
> root@yz4rr58lsjdxqz3:~# puppet apply -e 'user { "testuser": ensure => "absent",  managehome => true  }'
> Notice: Compiled catalog for yz4rr58lsjdxqz3.delivery.puppetlabs.net in environment production in 0.03 seconds
> Error: Could not delete user testuser: Execution of '/usr/sbin/userdel -r testuser' returned 12: UX: /usr/sbin/userdel: ERROR: Unable to remove home directory. No such file or directory
> Error: /Stage[main]/Main/User[testuser]/ensure: change from 'present' to 'absent' failed: Could not delete user testuser: Execution of '/usr/sbin/userdel -r testuser' returned 12: UX: /usr/sbin/userdel: ERROR: Unable to remove home directory. No such file or directory
> Notice: Applied catalog in 0.12 seconds// code placeholder
>```
>
> We are seeing this issue in puppetlabs-accounts in [https://github.com/puppetlabs/puppetlabs- accounts/pulls/222] when running adhoc against Solaris 11.

