### PR TITLE
(PUP-2958) Protect the SSL state machine with an ssl lockfile

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -826,6 +826,11 @@ EOT
       :group => "service",
       :desc => "Where SSL certificates are kept."
     },
+    :ssl_lockfile => {
+      :default => "$ssldir/ssl.lock",
+      :type    => :string,
+      :desc    => "A lock file to indicate that the ssl bootstrap process is currently in progress.",
+    },
     :publickeydir => {
       :default => "$ssldir/public_keys",
       :type   => :directory,

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -61,7 +61,7 @@ class Puppet::FileSystem::FileImpl
           timeout -= wait
           wait *= 2
           if timeout < 0
-            raise Timeout::Error, _("Timeout waiting for exclusive lock on %{path}") % { path: @path }
+            raise Timeout::Error, _("Timeout waiting for exclusive lock on %{path}") % { path: path }
           end
         end
       end

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -54,9 +54,12 @@ class Puppet::FileSystem::FileImpl
     while !written
       ::File.open(path, options, mode) do |rf|
         if rf.flock(::File::LOCK_EX|::File::LOCK_NB)
+          Puppet.debug(_("Locked '%{path}'") % { path: path })
           yield rf
           written = true
+          Puppet.debug(_("Unlocked '%{path}'") % { path: path })
         else
+          Puppet.debug("Failed to lock '%s' retrying in %.2f milliseconds" % [path, wait * 1000])
           sleep wait
           timeout -= wait
           wait *= 2

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -308,7 +308,9 @@ class Puppet::SSL::StateMachine
     loop do
       state = state.next_state
 
-      return state if state.is_a?(stop)
+      break if state.is_a?(stop)
     end
+
+    state
   end
 end

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -17,8 +17,8 @@ class Puppet::SSL::StateMachine
     def initialize(machine, ssl_context)
       @machine = machine
       @ssl_context = ssl_context
-      @cert_provider = Puppet::X509::CertProvider.new
-      @ssl_provider = Puppet::SSL::SSLProvider.new
+      @cert_provider = machine.cert_provider
+      @ssl_provider = machine.ssl_provider
     end
   end
 
@@ -261,11 +261,14 @@ class Puppet::SSL::StateMachine
   #
   class Done < SSLState; end
 
-  attr_reader :waitforcert, :wait_deadline
+  attr_reader :waitforcert, :wait_deadline, :cert_provider, :ssl_provider
 
-  def initialize(waitforcert: Puppet[:waitforcert], maxwaitforcert: Puppet[:maxwaitforcert])
+  def initialize(waitforcert: Puppet[:waitforcert], maxwaitforcert: Puppet[:maxwaitforcert],
+                 cert_provider: Puppet::X509::CertProvider.new, ssl_provider: Puppet::SSL::SSLProvider.new)
     @waitforcert = waitforcert
     @wait_deadline = Time.now.to_i + maxwaitforcert
+    @cert_provider = cert_provider
+    @ssl_provider = ssl_provider
   end
 
   # Run the state machine for CA certs and CRLs

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -223,7 +223,7 @@ describe "Puppet::FileSystem" do
       expect do
         Puppet::FileSystem.exclusive_open(file, 0666, 'a', 0.1) do |f|
         end
-      end.to raise_error(Timeout::Error)
+      end.to raise_error(Timeout::Error, /Timeout waiting for exclusive lock on #{file}/)
 
       Process.kill(9, child)
     end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -7,7 +7,9 @@ require 'puppet/ssl'
 describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
 
-  let(:machine) { described_class.new }
+  let(:cert_provider) { Puppet::X509::CertProvider.new }
+  let(:ssl_provider) { Puppet::SSL::SSLProvider.new }
+  let(:machine) { described_class.new(cert_provider: cert_provider, ssl_provider: ssl_provider) }
   let(:cacert_pem) { cacert.to_pem }
   let(:cacert) { cert_fixture('ca.pem') }
   let(:cacerts) { [cacert] }
@@ -28,8 +30,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
   context 'when ensuring CA certs and CRLs' do
     it 'returns an SSLContext with the loaded CA certs and CRLs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
 
       ssl_context = machine.ensure_ca_certificates
 
@@ -41,10 +43,10 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
   context 'when ensuring a client cert' do
     it 'returns an SSLContext with the loaded CA certs, CRLs, private key and client cert' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(client_cert)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_private_key).and_return(private_key)
+      allow(cert_provider).to receive(:load_client_cert).and_return(client_cert)
 
       ssl_context = machine.ensure_client_certificate
 
@@ -64,20 +66,20 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'transitions to NeedCRLs state' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
 
       expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedCRLs)
     end
 
     it 'loads existing CA certs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
 
       st = state.next_state
       expect(st.ssl_context[:cacerts]).to eq(cacerts)
     end
 
     it 'fetches and saves CA certs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(nil)
+      allow(cert_provider).to receive(:load_cacerts).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: cacert_pem)
 
       st = state.next_state
@@ -86,9 +88,9 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it "does not verify the server's cert if there are no local CA certs" do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(nil)
+      allow(cert_provider).to receive(:load_cacerts).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: cacert_pem)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_cacerts)
+      allow(cert_provider).to receive(:save_cacerts)
 
       expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
 
@@ -112,7 +114,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'raises if CA certs are invalid' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(nil)
+      allow(cert_provider).to receive(:load_cacerts).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: '')
 
       expect {
@@ -141,20 +143,20 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'transitions to NeedKey state' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
 
       expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedKey)
     end
 
     it 'loads existing CRLs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
 
       st = state.next_state
       expect(st.ssl_context[:crls]).to eq(crls)
     end
 
     it 'fetches and saves CRLs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(nil)
+      allow(cert_provider).to receive(:load_crls).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: crl_pem)
 
       st = state.next_state
@@ -163,9 +165,9 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it "verifies the server's certificate when fetching the CRL" do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(nil)
+      allow(cert_provider).to receive(:load_crls).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: crl_pem)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_crls)
+      allow(cert_provider).to receive(:save_crls)
 
       expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
 
@@ -189,7 +191,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'raises if CRLs are invalid' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(nil)
+      allow(cert_provider).to receive(:load_crls).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: '')
 
       expect {
@@ -211,7 +213,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     it 'skips CRL download when revocation is disabled' do
       Puppet[:certificate_revocation] = false
 
-      expect_any_instance_of(Puppet::X509::CertProvider).not_to receive(:load_crls)
+      expect(cert_provider).not_to receive(:load_crls)
       expect(Puppet::Rest::Routes).not_to receive(:get_crls)
 
       state.next_state
@@ -289,7 +291,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       let(:state) { Puppet::SSL::StateMachine::NeedKey.new(machine, ssl_context) }
 
       it 'loads an existing private key and passes it to the next state' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
+        allow(cert_provider).to receive(:load_private_key).and_return(private_key)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
@@ -297,16 +299,16 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       end
 
       it 'loads a matching private key and cert' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(client_cert)
+        allow(cert_provider).to receive(:load_private_key).and_return(private_key)
+        allow(cert_provider).to receive(:load_client_cert).and_return(client_cert)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::Done)
       end
 
       it 'raises if the client cert is mismatched' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(cert_fixture('tampered-cert.pem'))
+        allow(cert_provider).to receive(:load_private_key).and_return(private_key)
+        allow(cert_provider).to receive(:load_client_cert).and_return(cert_fixture('tampered-cert.pem'))
 
         expect {
           state.next_state
@@ -314,8 +316,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       end
 
       it 'generates a new RSA private key, saves it and passes it to the next state' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
-        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_private_key)
+        allow(cert_provider).to receive(:load_private_key).and_return(nil)
+        expect(cert_provider).to receive(:save_private_key)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
@@ -325,8 +327,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
       it 'generates a new EC private key, saves it and passes it to the next state' do
         Puppet[:key_type] = 'ec'
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
-        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_private_key)
+        allow(cert_provider).to receive(:load_private_key).and_return(nil)
+        expect(cert_provider).to receive(:save_private_key)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
@@ -338,8 +340,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       it 'generates a new EC private key with curve `secp384r1`, saves it and passes it to the next state' do
         Puppet[:key_type] = 'ec'
         Puppet[:named_curve] = 'secp384r1'
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
-        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_private_key)
+        allow(cert_provider).to receive(:load_private_key).and_return(nil)
+        expect(cert_provider).to receive(:save_private_key)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
@@ -351,7 +353,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       it 'raises if the named curve is unsupported' do
         Puppet[:key_type] = 'ec'
         Puppet[:named_curve] = 'infiniteloop'
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
+        allow(cert_provider).to receive(:load_private_key).and_return(nil)
 
         expect {
           state.next_state
@@ -359,7 +361,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       end
 
       it 'raises an error if it fails to load the key' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_raise(OpenSSL::PKey::RSAError)
+        allow(cert_provider).to receive(:load_private_key).and_raise(OpenSSL::PKey::RSAError)
 
         expect {
           state.next_state
@@ -376,7 +378,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       end
 
       before :each do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request)
+        allow(cert_provider).to receive(:save_request)
       end
 
       it 'submits the CSR and transitions to NeedCert' do
@@ -388,7 +390,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       it 'saves the CSR and transitions to NeedCert' do
         stub_request(:put, %r{puppet-ca/v1/certificate_request/#{Puppet[:certname]}}).to_return(status: 200)
 
-        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request).with(Puppet[:certname], instance_of(OpenSSL::X509::Request))
+        expect(cert_provider).to receive(:save_request).with(Puppet[:certname], instance_of(OpenSSL::X509::Request))
 
         state.next_state
       end
@@ -492,8 +494,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       let(:state) { Puppet::SSL::StateMachine::NeedCert.new(machine, ssl_context, private_key) }
 
       it 'transitions to Done if the cert is signed and matches our private key' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_client_cert)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request)
+        allow(cert_provider).to receive(:save_client_cert)
+        allow(cert_provider).to receive(:save_request)
 
         stub_request(:get, %r{puppet-ca/v1/certificate/#{Puppet[:certname]}}).to_return(status: 200, body: client_cert.to_pem)
 
@@ -515,8 +517,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
       it "verifies the server's certificate when getting the client cert" do
         stub_request(:get, %r{puppet-ca/v1/certificate/#{Puppet[:certname]}}).to_return(status: 200, body: client_cert.to_pem)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_client_cert)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request)
+        allow(cert_provider).to receive(:save_client_cert)
+        allow(cert_provider).to receive(:save_request)
 
         expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
 


### PR DESCRIPTION
Commit 926e0e6436 locked the agent lockfile before running the SSL state machine, but had to be reverted in 3e82d0f860 due to `puppet infrastructure` locking the agent lock and running `puppet ssl bootstrap`.

These commits introduce a new ssl lockfile so that the ssl and catalog application lock files have different scopes.