### PR TITLE
(PUP-9691) Puppet pidlock incorrectly clears lock when running under bundler

### DIFF
--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -54,7 +54,21 @@ class Puppet::Util::Pidlock
     begin
       Process.kill(0, lock_pid)
     rescue *errors
-      @lockfile.unlock
+      return @lockfile.unlock
+    end
+
+    # Ensure the process associated with this pid is our process. If
+    # not, we can unlock the lockfile. For now this is only done on
+    # POSIX and Windows platforms (PUP-9247).
+    if Puppet.features.posix?
+      procname = Puppet::Util::Execution.execute(["ps", "-p", lock_pid, "-o", "comm="]).strip
+      args     = Puppet::Util::Execution.execute(["ps", "-p", lock_pid, "-o", "args="]).strip
+      @lockfile.unlock unless procname =~ /ruby/ && args =~ /puppet/ || procname =~ /puppet(-.*)?$/
+    elsif Puppet.features.microsoft_windows?
+      # On Windows, we're checking if the filesystem path name of the running
+      # process is our vendored ruby:
+      exe_path = Puppet::Util::Windows::Process::get_process_image_name_by_pid(lock_pid)
+      @lockfile.unlock unless exe_path =~ /\\bin\\ruby.exe$/
     end
   end
   private :clear_if_stale

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -10,6 +10,10 @@ module Puppet::Util::Windows::Process
   WAIT_INTERVAL = 200
   # https://docs.microsoft.com/en-us/windows/desktop/ProcThread/process-creation-flags
   CREATE_NO_WINDOW = 0x08000000
+  #https://docs.microsoft.com/en-us/windows/desktop/ProcThread/process-security-and-access-rights
+  PROCESS_QUERY_INFORMATION = 0x0400
+  # https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation
+  MAX_PATH_LENGTH = 32767
 
   def execute(command, arguments, stdin, stdout, stderr)
     create_args = {
@@ -62,6 +66,26 @@ module Puppet::Util::Windows::Process
   end
   module_function :get_current_process
 
+  def open_process(desired_access, inherit_handle, process_id, &block)
+    phandle = nil
+    inherit = inherit_handle ? FFI::WIN32_TRUE : FFI::WIN32_FALSE
+    begin
+      phandle = OpenProcess(desired_access, inherit, process_id)
+      if phandle == FFI::Pointer::NULL_HANDLE
+        raise Puppet::Util::Windows::Error.new(
+          "OpenProcess(#{desired_access.to_s(8)}, #{inherit}, #{process_id})")
+      end
+
+      yield phandle
+    ensure
+      FFI::WIN32.CloseHandle(phandle) if phandle
+    end
+
+    # phandle has had CloseHandle called against it, so nothing to return
+    nil
+  end
+  module_function :open_process
+
   def open_process_token(handle, desired_access, &block)
     token_handle = nil
     begin
@@ -96,6 +120,32 @@ module Puppet::Util::Windows::Process
     nil
   end
   module_function :with_process_token
+
+  def get_process_image_name_by_pid(pid)
+    image_name = ""
+
+     open_process(PROCESS_QUERY_INFORMATION, false, pid) do |phandle|
+
+       FFI::MemoryPointer.new(:dword, 1) do |exe_name_length_ptr|
+        # UTF is 2 bytes/char:
+        max_chars = MAX_PATH_LENGTH + 1
+        exe_name_length_ptr.write_dword(max_chars)
+        FFI::MemoryPointer.new(:wchar, max_chars) do |exe_name_ptr|
+          use_win32_path_format = 0
+          result = QueryFullProcessImageNameW(phandle, use_win32_path_format, exe_name_ptr, exe_name_length_ptr)
+          if result == FFI::WIN32_FALSE
+            raise Puppet::Util::Windows::Error.new(
+              "QueryFullProcessImageNameW(phandle, #{use_win32_path_format}, " +
+              "exe_name_ptr, #{max_chars}")
+          end
+          image_name = exe_name_ptr.read_wide_string(exe_name_length_ptr.read_dword)
+        end
+      end
+    end
+
+     image_name
+  end
+  module_function :get_process_image_name_by_pid
 
   def lookup_privilege_value(name, system_name = '', &block)
     FFI::MemoryPointer.new(LUID.size) do |luid_ptr|
@@ -366,6 +416,16 @@ module Puppet::Util::Windows::Process
   attach_function_private :SetEnvironmentVariableW,
     [:lpcwstr, :lpcwstr], :win32_bool
 
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684320(v=vs.85).aspx
+  # HANDLE WINAPI OpenProcess(
+  #   _In_   DWORD DesiredAccess,
+  #   _In_   BOOL InheritHandle,
+  #   _In_   DWORD ProcessId
+  # );
+  ffi_lib :kernel32
+  attach_function_private :OpenProcess,
+    [:dword, :win32_bool, :dword], :handle
+
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379295(v=vs.85).aspx
   # BOOL WINAPI OpenProcessToken(
   #   _In_   HANDLE ProcessHandle,
@@ -376,6 +436,16 @@ module Puppet::Util::Windows::Process
   attach_function_private :OpenProcessToken,
     [:handle, :dword, :phandle], :win32_bool
 
+  # https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-queryfullprocessimagenamew
+  # BOOL WINAPI QueryFullProcessImageName(
+  #   _In_   HANDLE hProcess,
+  #   _In_   DWORD dwFlags,
+  #   _Out_  LPWSTR lpExeName,
+  #   _In_   PDWORD lpdwSize,
+  # );
+  ffi_lib :kernel32
+  attach_function_private :QueryFullProcessImageNameW,
+    [:handle, :dword, :lpwstr, :pdword], :win32_bool
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379261(v=vs.85).aspx
   # typedef struct _LUID {


### PR DESCRIPTION
Applying changes from  PUP-9247 on 5.5.x and also fixing the case when puppet runs as a gem. 
This will fix PA-2669 also.