### PR TITLE
(PUP-9714) Add support for nested hiera interpolation

### DIFF
--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -874,6 +874,10 @@ module Issues
     _('Interpolation using method syntax is not allowed in this context')
   end
 
+  HIERA_INTERPOLATION_TRIPLE_NESTING = hard_issue :HIERA_INTERPOLATION_TRIPLE_NESTING do
+    _('Only two levels of hiera interpolation nesting is allowed')
+  end
+
   SERIALIZATION_ENDLESS_RECURSION = hard_issue :SERIALIZATION_ENDLESS_RECURSION, :type_name do
     _('Endless recursion detected when attempting to serialize value of class %{type_name}') % { :type_name => type_name }
   end


### PR DESCRIPTION
This commit adds support for two levels of nested hiera interpolations. For example, given a fact called `hostgroup` with value `group1`, the following hiera data would have `local_users::add::users.root.password` set to `$6$....`
```yaml
---
group1_root_password: $6$....
local_users::add::users:
  root:
    password: '%{lookup("%{facts.hostgroup}_root_password")}'
```

If this is useful for merging, I would be glad to update any necessary documentation.