### PR TITLE
(maint) Remove translation from Ruby version error

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,7 +1,7 @@
 require 'puppet/version'
 
 if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("1.9.3")
-  raise LoadError, _("Puppet %{version} requires ruby 1.9.3 or greater.") % { version: Puppet.version }
+  raise LoadError, "Puppet #{Puppet.version} requires Ruby 1.9.3 or greater, found Ruby #{RUBY_VERSION.dup}."
 end
 
 Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.3.0'


### PR DESCRIPTION
The error messaging that occurs when you attempt to load Puppet with an
invalid Ruby version occurs before the i18n machinery is initialized, so
it can't be translated. This commit removes the translation method from
that error.