### PR TITLE
(PUP-9706) Add acceptance test for user deletion with managehome=true.

### DIFF
--- a/acceptance/tests/resource/user/should_destroy_with_managehome.rb
+++ b/acceptance/tests/resource/user/should_destroy_with_managehome.rb
@@ -1,0 +1,25 @@
+test_name "should delete a user with managehome=true"
+confine :except, :platform => /^eos-/ # See ARISTA-37
+confine :except, :platform => /^cisco_/ # See PUP-5828
+tag 'audit:medium',
+    'audit:refactor',  # Use block style `test_run`
+    'audit:acceptance' # Could be done as integration tests, but would
+                       # require changing the system running the test
+                       # in ways that might require special permissions
+                       # or be harmful to the system running the test
+
+name = "pl#{rand(999999).to_i}"
+
+agents.each do |agent|
+  step "ensure the user is present"
+  agent.user_present(name)
+
+  step "delete the user with managehome=true"
+  on agent, puppet_resource('user', name, ['ensure=absent', 'managehome=true'])
+
+  step "verify the user was deleted"
+  fail_test "User #{name} was not deleted" if agent.user_list.include? name
+
+  step "delete the user, if any"
+  agent.user_absent(name)
+end


### PR DESCRIPTION
Tests should fail on Solaris; see #7527 for fix.