### PR TITLE
(maint) Merge 5.5.x to 6.0.x

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,7 +1,7 @@
 require 'puppet/version'
 
 if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3.0")
-  raise LoadError, _("Puppet %{version} requires ruby 2.3.0 or greater.") % { version: Puppet.version }
+  raise LoadError, "Puppet #{Puppet.version} requires Ruby 2.3.0 or greater, found Ruby #{RUBY_VERSION.dup}."
 end
 
 Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.3.0'

--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -395,7 +395,7 @@ class Puppet::Provider
   # @raise [Puppet::DevError] Error indicating that the method should have been implemented by subclass.
   # @see prefetch
   def self.instances
-    raise Puppet::DevError, _("Provider %{provider} has not defined the 'instances' class method") % { provider: self.name }
+    raise Puppet::DevError, _("To support listing resources of this type the '%{provider}' provider needs to implement an 'instances' class method returning the current set of resources. We recommend porting your module to the simpler Resource API instead: https://puppet.com/search/docs?keys=resource+api") % { provider: self.name }
   end
 
   # Creates getter- and setter- methods for each property supported by the resource type.
@@ -621,4 +621,3 @@ class Puppet::Provider
   # @return [void]
   # @api public
 end
-


### PR DESCRIPTION
Preserve the changes made in f942554, but puppet 6.0.x requires ruby 2.3 or greater.