### PR TITLE
(PUP-9724) Use yum as default provider for Amazon

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -23,6 +23,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       end
   end
 
+defaultfor :operatingsystem => :amazon
 defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
 
   def self.prefetch(packages)
@@ -107,7 +108,7 @@ defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
   end
 
   def self.update_to_hash(pkgname, pkgversion)
-    
+
     # The pkgname string has two parts: name, and architecture. Architecture
     # is the portion of the string following the last "." character. All
     # characters preceding the final dot are the package name. Parse out


### PR DESCRIPTION
Amazon machines should use `yum` as their default
package provider.

Due to the recent changes on package providers, when
no default package provider is explicitly set it will
always fallback to puppet_gem/pip/pip3/gem because of the way
that specificity is calculated for a system which does
not have a default(number of ancestors)

Their specificity was lowered to 1 If none of those providers are set as defaults on any operating system.

Code output on an amazon machine: https://gist.github.com/gimmyxd/301a2d38daa6d1e852a117662d18892e