### PR TITLE
(PUP-9727) Reduce specificity of gem, pip providers

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -17,6 +17,16 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
 
   has_feature :versionable, :install_options, :uninstall_options, :targetable
 
+  # Override the specificity method to return 1 if gem is not set as default provider
+  def self.specificity
+    match = default_match
+    length = match ? match.length : 0
+
+    return 1 if length == 0
+
+    super
+  end
+
   # Define the default provider package command name when the provider is targetable.
   # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command
 

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -15,6 +15,16 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
+  # Override the specificity method to return 1 if pip is not set as default provider
+  def self.specificity
+    match = default_match
+    length = match ? match.length : 0
+
+    return 1 if length == 0
+
+    super
+  end
+
   # Define the default provider package command name when the provider is targetable.
   # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command
 

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -107,7 +107,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   end
 
   def self.update_to_hash(pkgname, pkgversion)
-    
+
     # The pkgname string has two parts: name, and architecture. Architecture
     # is the portion of the string following the last "." character. All
     # characters preceding the final dot are the package name. Parse out

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -394,4 +394,20 @@ context Puppet::Type.type(:package).provider(:gem) do
       end
     end
   end
+
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
 end

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -17,4 +17,20 @@ describe Puppet::Type.type(:package).provider(:pip3) do
     expect(described_class.cmd).to eq(["pip3"])
   end
 
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
+
 end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -349,4 +349,20 @@ describe Puppet::Type.type(:package).provider(:pip) do
       expect(described_class.pip_version('/fake/bin/pip')).to eq('8.0.2')
     end
   end
+
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
 end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -69,4 +69,20 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     end
   end
 
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
+
 end


### PR DESCRIPTION
Due to the recent changes on package providers, when
no default package provider is explicitly set it will
always fallback to gem/puppet_gem/pip/pip3 because of the way
that specificity is calculated for a system which does
not have a default(the match expresion and number of ancestors)

Since those are specific language package managers,
their specificity was lowered to 1 if none of those providers
are set as default provider, otherwise the specficity
is calculated like it was before.