### PR TITLE
(PUP-7312) Confine systemd provider in chroot-compatible manner.

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -1,5 +1,7 @@
 # Manage systemd services using systemctl
 
+require 'puppet/file_system'
+
 Puppet::Type.type(:service).provide :systemd, :parent => :base do
   desc "Manages `systemd` services using `systemctl`.
 
@@ -9,14 +11,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "systemctl"
 
-  if Facter.value(:osfamily).downcase == 'debian'
-    # With multiple init systems on Debian, it is possible to have
-    # pieces of systemd around (e.g. systemctl) but not really be
-    # using systemd.  We do not do this on other platforms as it can
-    # cause issues when running in a chroot without /run mounted
-    # (PUP-5577)
-    confine :exists => "/run/systemd/system"
-  end
+  confine :true => Puppet::FileSystem.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd')
 
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8"]


### PR DESCRIPTION
/run/systemd/system does not exist when running Puppet in a chroot environment
but /proc/1/exe is a symlink to /lib/systemd/system or /usr/lib/systemd/system.