### PR TITLE
(maint) Don't reload the upstart provider for 5.5.x

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -27,14 +27,14 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   # We only want to use upstart as our provider if the upstart daemon is running.
   # This can be checked by running `initctl version --quiet` on a machine that has
   # upstart installed.
-  confine :true => lambda {
-    begin
-      initctl('version', '--quiet')
-      true
-    rescue
-      false
-    end
-  }
+  confine :true => lambda { has_initctl? }
+
+  def self.has_initctl?
+    initctl('version', '--quiet')
+    true
+  rescue
+    false
+  end
 
   # upstart developer haven't implemented initctl enable/disable yet:
   # http://www.linuxplanet.com/linuxplanet/tutorials/7033/2/

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -33,32 +33,16 @@ describe Puppet::Type.type(:service).provider(:upstart) do
   end
 
   context "upstart daemon existence confine" do
-    # We have a separate method here because our search for the upstart daemon
-    # confine expects it to be the last confine declared in the upstart provider.
-    # If in the future we add other confines below it or change its order, these
-    # unit tests will fail. Placing knowledge of where this confine is located
-    # in one place makes updating it less painful in case we ever need to do this.
-    def assert_upstart_daemon_existence_confine_is(expected_value)
-      upstart_daemon_existence_confine = provider_class.confine_collection.instance_variable_get(:@confines)[-1]
-      expect(upstart_daemon_existence_confine.valid?).to be(expected_value)
-    end
-
     let(:initctl_version) { ['/sbin/initctl', 'version', '--quiet'] }
 
     before(:each) do
-      # Stub out /sbin/initctl
       allow(Puppet::Util).to receive(:which).with('/sbin/initctl').and_return('/sbin/initctl')
-
-      # Both of our tests are asserting the confine :true block that shells out to
-      # `initctl version --quiet`. Its expression is evaluated at provider load-time.
-      # Hence before each test, we want to reload the upstart provider so that the
-      # confine is re-evaluated.
-      Puppet::Type.type(:service).unprovide(:upstart)
     end
 
     it "should return true when the daemon is running" do
       expect(Puppet::Util::Execution).to receive(:execute).with(initctl_version, instance_of(Hash))
-      assert_upstart_daemon_existence_confine_is(true)
+
+      expect(provider_class).to be_has_initctl
     end
 
     it "should return false when the daemon is not running" do
@@ -66,7 +50,7 @@ describe Puppet::Type.type(:service).provider(:upstart) do
         .with(initctl_version, instance_of(Hash))
         .and_raise(Puppet::ExecutionFailure, "initctl failed!")
 
-      assert_upstart_daemon_existence_confine_is(false)
+      expect(provider_class).to_not be_has_initctl
     end
   end
 


### PR DESCRIPTION
Previously, the upstart service tests called `unprovide` to force the confine
logic to be re-evaluated for another test. This causes warnings due to constants
being redefined:

    warning: already initialized constant START_ON

This commit moves the confine logic to a class method, which allows the
different cases to be tested without unproviding the provider.