### PR TITLE
(maint) Don't reload the upstart provider for 6.0.x

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -28,14 +28,16 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   # We only want to use upstart as our provider if the upstart daemon is running.
   # This can be checked by running `initctl version --quiet` on a machine that has
   # upstart installed.
-  confine :true => lambda {
+  confine :true => lambda { has_initctl? }
+
+  def self.has_initctl?
     # Puppet::Util::Execution.execute does not currently work on jRuby.
     # Unfortunately, since this confine is invoked whenever we check for
     # provider suitability and since provider suitability is still checked
     # on the master, this confine will still be invoked on the master. Thus
     # to avoid raising an exception, we do an early return if we're running
     # on jRuby.
-    next false if Puppet::Util::Platform.jruby?
+    return false if Puppet::Util::Platform.jruby?
 
     begin
       initctl('version', '--quiet')
@@ -43,7 +45,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
     rescue
       false
     end
-  }
+  end
 
   # upstart developer haven't implemented initctl enable/disable yet:
   # http://www.linuxplanet.com/linuxplanet/tutorials/7033/2/


### PR DESCRIPTION
Previously, the upstart service tests called `unprovide` to force the confine
logic to be re-evaluated for another test. This causes warnings due to constants
being redefined:

    warning: already initialized constant START_ON

This commit moves the confine logic to a class method, which allows the
different cases to be tested without unproviding the provider.