### PR TITLE
(maint) Merge 5.5.x to 6.0.x 

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -17,6 +17,16 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
 
   has_feature :versionable, :install_options, :uninstall_options, :targetable
 
+  # Override the specificity method to return 1 if gem is not set as default provider
+  def self.specificity
+    match = default_match
+    length = match ? match.length : 0
+
+    return 1 if length == 0
+
+    super
+  end
+
   # Define the default provider package command name when the provider is targetable.
   # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command
 

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -15,6 +15,16 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
 
+  # Override the specificity method to return 1 if pip is not set as default provider
+  def self.specificity
+    match = default_match
+    length = match ? match.length : 0
+
+    return 1 if length == 0
+
+    super
+  end
+
   # Define the default provider package command name when the provider is targetable.
   # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command
 

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -394,4 +394,20 @@ context Puppet::Type.type(:package).provider(:gem) do
       end
     end
   end
+
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
 end

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -17,4 +17,20 @@ describe Puppet::Type.type(:package).provider(:pip3) do
     expect(described_class.cmd).to eq(["pip3"])
   end
 
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
+
 end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -349,4 +349,20 @@ describe Puppet::Type.type(:package).provider(:pip) do
       expect(described_class.pip_version('/fake/bin/pip')).to eq('8.0.2')
     end
   end
+
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
 end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -69,4 +69,20 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     end
   end
 
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
+
 end


### PR DESCRIPTION
The only conflict was on the man files
```

❯ git merge --no-ff --log pl/5.5.x
--
Auto-merging spec/unit/provider/package/puppet_gem_spec.rb
Auto-merging spec/unit/provider/package/pip_spec.rb
Auto-merging spec/unit/provider/package/gem_spec.rb
Auto-merging man/man8/puppet.8
Auto-merging man/man8/puppet-node.8
Auto-merging man/man8/puppet-module.8
CONFLICT (modify/delete): man/man8/puppet-master.8 deleted in HEAD and modified in pl/5.5.x. Version pl/5.5.x of man/man8/puppet-master.8 left in tree.
Auto-merging man/man8/puppet-key.8
Auto-merging man/man8/puppet-config.8
CONFLICT (modify/delete): man/man8/puppet-certificate_revocation_list.8 deleted in HEAD and modified in pl/5.5.x. Version pl/5.5.x of man/man8/puppet-certificate_revocation_list.8 left in tree.
CONFLICT (modify/delete): man/man8/puppet-certificate_request.8 deleted in HEAD and modified in pl/5.5.x. Version pl/5.5.x of man/man8/puppet-certificate_request.8 left in tree.
CONFLICT (modify/delete): man/man8/puppet-certificate.8 deleted in HEAD and modified in pl/5.5.x. Version pl/5.5.x of man/man8/puppet-certificate.8 left in tree.
CONFLICT (modify/delete): man/man8/puppet-cert.8 deleted in HEAD and modified in pl/5.5.x. Version pl/5.5.x of man/man8/puppet-cert.8 left in tree.
CONFLICT (modify/delete): man/man8/puppet-ca.8 deleted in HEAD and modified in pl/5.5.x. Version pl/5.5.x of man/man8/puppet-ca.8 left in tree.
Auto-merging man/man5/puppet.conf.5
Auto-merging lib/puppet/provider/package/yum.rb
Auto-merging lib/puppet/provider/package/pip.rb
Auto-merging lib/puppet/provider/package/gem.rb
Automatic merge failed; fix conflicts and then commit the result.

```