### PR TITLE
(PUP-9362) Remove redundant tests

### DIFF
--- a/spec/unit/util/ldap/manager_spec.rb
+++ b/spec/unit/util/ldap/manager_spec.rb
@@ -532,21 +532,6 @@ describe Puppet::Util::Ldap::Manager, :if => Puppet.features.ldap? do
         @manager.update(@name, @is, @should)
       end
 
-      it "should convert the property names to strings" do
-        expect(@manager).to receive(:create).with(anything, hash_including("uno" => ["yay"]))
-        @manager.update(@name, @is, @should)
-      end
-
-      it "should convert the property values to arrays if necessary" do
-        expect(@manager).to receive(:create).with(anything, hash_including("uno" => ["yay"]))
-        @manager.update(@name, @is, @should)
-      end
-
-      it "should convert the property values to strings if necessary" do
-        expect(@manager).to receive(:create).with(anything, hash_including("uno" => ["yay"]))
-        @manager.update(@name, @is, @should)
-      end
-
       it "should not include :ensure in the properties sent" do
         expect(@manager).to receive(:create).with(anything, hash_excluding(:ensure))
         @manager.update(@name, @is, @should)


### PR DESCRIPTION
The setup data for the test preceding the ones removed structured things in such a way that all four tests (including the one not removed) had identical content, and expectations. Rather than run the exact same data through the exact same process, and expect the exact same results, we only do this once now, even though it's not (and never was) individually testing each aspect of the transformation.