### PR TITLE
(PUP-9717) Retry the state machine when exceptions occur

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -248,7 +248,7 @@ class Puppet::SSL::StateMachine
       else
         Puppet.info(_("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Will try again in %{time} seconds.") % {name: Puppet[:certname], time: time})
 
-        sleep(time)
+        Kernel.sleep(time)
 
         # our ssl directory may have been cleaned while we were
         # sleeping, start over from the top

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -315,6 +315,9 @@ class Puppet::SSL::StateMachine
         state = state.next_state
 
         break if state.is_a?(stop)
+      rescue => e
+        Puppet.log_exception(e)
+        state = Wait.new(self, state.ssl_context)
       end
     end
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -28,6 +28,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     allow_any_instance_of(Net::HTTP).to receive(:finish)
 
     Puppet[:ssl_lockfile] = tmpfile('ssllock')
+
+    allow(Kernel).to receive(:sleep)
   end
 
   context 'when ensuring CA certs and CRLs' do
@@ -645,7 +647,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         machine = described_class.new(waitforcert: 15)
 
         state = Puppet::SSL::StateMachine::Wait.new(machine, ssl_context)
-        expect(state).to receive(:sleep).with(15)
+        expect(Kernel).to receive(:sleep).with(15)
 
         expect(Puppet).to receive(:info).with(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Will try again in 15 seconds./)
 
@@ -656,7 +658,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         machine = described_class.new(waitforcert: 15, maxwaitforcert: 30)
 
         state = Puppet::SSL::StateMachine::Wait.new(machine, ssl_context)
-        expect(state).to receive(:sleep).with(15)
+        expect(Kernel).to receive(:sleep).with(15)
 
         expect(Puppet).to receive(:info).with(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Will try again in 15 seconds./)
 


### PR DESCRIPTION
Prior to 6.4, if an exception occurred, such as failing to connect to the
puppetserver because it's wasn't running yet, then the agent would wait and
retry.

Puppet 6.4 introduced a regression, causing the agent to exit. This commit fixes
the regression. If a StandardError is raised while running the state machine,
then we will wait up to waitforcert seconds and retry the state machine, or exit
if waitforcert is 0.