### PR TITLE
Revert "(maint) Add support for Fedora 30"

### DIFF
--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -1,6 +1,6 @@
 test_name 'SysV on default Systemd Service Provider Validation' do
 
-  confine :to, :platform => /el-|centos|fedora-(2[0-9])/ do |h|
+  confine :to, :platform => /el-|centos|fedora/ do |h|
     on h, 'which systemctl', :acceptable_exit_codes => [0, 1]
     stdout =~ /systemctl/
   end
@@ -19,7 +19,7 @@ test_name 'SysV on default Systemd Service Provider Validation' do
 
   # Some scripts don't have status command.
   def initd_file(svc, pidfile, initd_location, status)
-    <<INITD
+    initd = <<INITD
 #!/bin/bash
 # #{svc} daemon
 # chkconfig: 2345 20 80


### PR DESCRIPTION
Reverts puppetlabs/puppet#7543. Should be committed to 5.5.x instead of master.