### PR TITLE
(PUP-9717) Retry state machine on errors

### DIFF
--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -121,7 +121,7 @@ class Puppet::SSL::Host
       generate_key unless key
 
       # get CA and optional CRL
-      sm = Puppet::SSL::StateMachine.new
+      sm = Puppet::SSL::StateMachine.new(onetime: true)
       sm.ensure_ca_certificates
 
       cert = get_host_certificate

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -238,8 +238,10 @@ class Puppet::SSL::StateMachine
   attr_reader :waitforcert,  :cert_provider, :ssl_provider
 
   def initialize(waitforcert: Puppet[:waitforcert],
+                 onetime: Puppet[:onetime],
                  cert_provider: Puppet::X509::CertProvider.new, ssl_provider: Puppet::SSL::SSLProvider.new)
     @waitforcert = waitforcert
+    @onetime = onetime
     @cert_provider = cert_provider
     @ssl_provider = ssl_provider
   end
@@ -285,8 +287,10 @@ class Puppet::SSL::StateMachine
       when stop
         break
       when Error
-        # always raise for now pending PUP-9717
-        raise state.error
+        if @onetime
+          Puppet.log_exception(state.error)
+          raise state.error
+        end
       else
         # fall through
       end

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -185,7 +185,7 @@ class Puppet::SSL::StateMachine
       if e.response.code.to_i == 404
         Puppet.info(_("Certificate for %{certname} has not been signed yet") % {certname: Puppet[:certname]})
         $stdout.puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}).") % { name: Puppet[:certname] }
-        Wait.new(@machine, @ssl_context)
+        Wait.new(@machine)
       else
         to_error(_("Failed to retrieve certificate for %{certname}: %{message}") %
                  {certname: Puppet[:certname], message: e.response.message}, e)
@@ -196,6 +196,10 @@ class Puppet::SSL::StateMachine
   # We cannot make progress, so wait if allowed to do so, or exit.
   #
   class Wait < SSLState
+    def initialize(machine)
+      super(machine, nil)
+    end
+
     def next_state
       time = @machine.waitforcert
       if time < 1
@@ -226,7 +230,7 @@ class Puppet::SSL::StateMachine
 
     def next_state
       Puppet.log_exception(@error, @message)
-      Wait.new(@machine, nil)
+      Wait.new(@machine)
     end
   end
 

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -258,7 +258,9 @@ class Puppet::SSL::StateMachine
     loop do
       state = state.next_state
 
-      return state if state.is_a?(stop)
+      break if state.is_a?(stop)
     end
+
+    state
   end
 end

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -17,8 +17,8 @@ class Puppet::SSL::StateMachine
     def initialize(machine, ssl_context)
       @machine = machine
       @ssl_context = ssl_context
-      @cert_provider = Puppet::X509::CertProvider.new
-      @ssl_provider = Puppet::SSL::SSLProvider.new
+      @cert_provider = machine.cert_provider
+      @ssl_provider = machine.ssl_provider
     end
   end
 
@@ -211,10 +211,14 @@ class Puppet::SSL::StateMachine
   #
   class Done < SSLState; end
 
-  attr_reader :waitforcert
+  attr_reader :waitforcert,  :cert_provider, :ssl_provider
 
-  def initialize(waitforcert: Puppet[:waitforcert])
+
+  def initialize(waitforcert: Puppet[:waitforcert],
+                 cert_provider: Puppet::X509::CertProvider.new, ssl_provider: Puppet::SSL::SSLProvider.new)
     @waitforcert = waitforcert
+    @cert_provider = cert_provider
+    @ssl_provider = ssl_provider
   end
 
   # Run the state machine for CA certs and CRLs

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -197,7 +197,7 @@ class Puppet::SSL::StateMachine
       else
         Puppet.info(_("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Will try again in %{time} seconds.") % {name: Puppet[:certname], time: time})
 
-        sleep(time)
+        Kernel.sleep(time)
 
         # our ssl directory may have been cleaned while we were
         # sleeping, start over from the top

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -184,6 +184,7 @@ class Puppet::SSL::StateMachine
     rescue Puppet::Rest::ResponseError => e
       if e.response.code.to_i == 404
         Puppet.info(_("Certificate for %{certname} has not been signed yet") % {certname: Puppet[:certname]})
+        $stdout.puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}).") % { name: Puppet[:certname] }
         Wait.new(@machine, @ssl_context)
       else
         to_error(_("Failed to retrieve certificate for %{certname}: %{message}") %
@@ -198,10 +199,10 @@ class Puppet::SSL::StateMachine
     def next_state
       time = @machine.waitforcert
       if time < 1
-        puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Exiting now because the waitforcert setting is set to 0.") % { name: Puppet[:certname] }
+        puts _("Exiting now because the waitforcert setting is set to 0.")
         exit(1)
       else
-        Puppet.info(_("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}). Will try again in %{time} seconds.") % {name: Puppet[:certname], time: time})
+        Puppet.info(_("Will try again in %{time} seconds.") % {time: time})
 
         Kernel.sleep(time)
 

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -22,7 +22,9 @@ class Puppet::SSL::StateMachine
     end
 
     def to_error(message, cause)
-      Error.new(@machine, message, Puppet::Error.new(message, cause))
+      detail = Puppet::Error.new(message)
+      detail.set_backtrace(cause.backtrace)
+      Error.new(@machine, message, detail)
     end
   end
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -8,6 +8,9 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
 
   let(:machine) { described_class.new }
+  let(:cert_provider) { Puppet::X509::CertProvider.new }
+  let(:ssl_provider) { Puppet::SSL::SSLProvider.new }
+  let(:machine) { described_class.new(cert_provider: cert_provider, ssl_provider: ssl_provider) }
   let(:cacert_pem) { cacert.to_pem }
   let(:cacert) { cert_fixture('ca.pem') }
   let(:cacerts) { [cacert] }
@@ -28,8 +31,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
   context 'when ensuring CA certs and CRLs' do
     it 'returns an SSLContext with the loaded CA certs and CRLs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
 
       ssl_context = machine.ensure_ca_certificates
 
@@ -41,10 +44,10 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
   context 'when ensuring a client cert' do
     it 'returns an SSLContext with the loaded CA certs, CRLs, private key and client cert' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(client_cert)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_private_key).and_return(private_key)
+      allow(cert_provider).to receive(:load_client_cert).and_return(client_cert)
 
       ssl_context = machine.ensure_client_certificate
 
@@ -64,20 +67,20 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'transitions to NeedCRLs state' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
 
       expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedCRLs)
     end
 
     it 'loads existing CA certs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(cacerts)
+      allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
 
       st = state.next_state
       expect(st.ssl_context[:cacerts]).to eq(cacerts)
     end
 
     it 'fetches and saves CA certs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(nil)
+      allow(cert_provider).to receive(:load_cacerts).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: cacert_pem)
 
       st = state.next_state
@@ -86,9 +89,9 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it "does not verify the server's cert if there are no local CA certs" do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(nil)
+      allow(cert_provider).to receive(:load_cacerts).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: cacert_pem)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_cacerts)
+      allow(cert_provider).to receive(:save_cacerts)
 
       expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
 
@@ -112,7 +115,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'raises if CA certs are invalid' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_cacerts).and_return(nil)
+      allow(cert_provider).to receive(:load_cacerts).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: '')
 
       expect {
@@ -141,20 +144,20 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'transitions to NeedKey state' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
 
       expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedKey)
     end
 
     it 'loads existing CRLs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
+      allow(cert_provider).to receive(:load_crls).and_return(crls)
 
       st = state.next_state
       expect(st.ssl_context[:crls]).to eq(crls)
     end
 
     it 'fetches and saves CRLs' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(nil)
+      allow(cert_provider).to receive(:load_crls).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: crl_pem)
 
       st = state.next_state
@@ -163,9 +166,9 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it "verifies the server's certificate when fetching the CRL" do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(nil)
+      allow(cert_provider).to receive(:load_crls).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: crl_pem)
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_crls)
+      allow(cert_provider).to receive(:save_crls)
 
       expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
 
@@ -189,7 +192,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'raises if CRLs are invalid' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(nil)
+      allow(cert_provider).to receive(:load_crls).and_return(nil)
       stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: '')
 
       expect {
@@ -211,7 +214,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     it 'skips CRL download when revocation is disabled' do
       Puppet[:certificate_revocation] = false
 
-      expect_any_instance_of(Puppet::X509::CertProvider).not_to receive(:load_crls)
+      expect(cert_provider).not_to receive(:load_crls)
       expect(Puppet::Rest::Routes).not_to receive(:get_crls)
 
       state.next_state
@@ -226,7 +229,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       let(:state) { Puppet::SSL::StateMachine::NeedKey.new(machine, ssl_context) }
 
       it 'loads an existing private key and passes it to the next state' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
+        allow(cert_provider).to receive(:load_private_key).and_return(private_key)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
@@ -234,16 +237,16 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       end
 
       it 'loads a matching private key and cert' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(client_cert)
+        allow(cert_provider).to receive(:load_private_key).and_return(private_key)
+        allow(cert_provider).to receive(:load_client_cert).and_return(client_cert)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::Done)
       end
 
       it 'raises if the client cert is mismatched' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(private_key)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(cert_fixture('tampered-cert.pem'))
+        allow(cert_provider).to receive(:load_private_key).and_return(private_key)
+        allow(cert_provider).to receive(:load_client_cert).and_return(cert_fixture('tampered-cert.pem'))
 
         expect {
           state.next_state
@@ -251,16 +254,17 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       end
 
       it 'generates a new private key, saves it and passes it to the next state' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_return(nil)
-        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_private_key)
+        allow(cert_provider).to receive(:load_private_key).and_return(nil)
+        expect(cert_provider).to receive(:save_private_key)
 
         st = state.next_state
         expect(st).to be_instance_of(Puppet::SSL::StateMachine::NeedSubmitCSR)
         expect(st.private_key).to be_instance_of(OpenSSL::PKey::RSA)
+        expect(st.private_key).to be_private
       end
 
       it 'raises an error if it fails to load the key' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_private_key).and_raise(OpenSSL::PKey::RSAError)
+        allow(cert_provider).to receive(:load_private_key).and_raise(OpenSSL::PKey::RSAError)
 
         expect {
           state.next_state
@@ -279,7 +283,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       end
 
       before :each do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request)
+        allow(cert_provider).to receive(:save_request)
       end
 
       it 'submits the CSR and transitions to NeedCert' do
@@ -291,7 +295,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       it 'saves the CSR and transitions to NeedCert' do
         stub_request(:put, %r{puppet-ca/v1/certificate_request/#{Puppet[:certname]}}).to_return(status: 200)
 
-        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request).with(Puppet[:certname], instance_of(OpenSSL::X509::Request))
+        expect(cert_provider).to receive(:save_request).with(Puppet[:certname], instance_of(OpenSSL::X509::Request))
 
         state.next_state
       end
@@ -395,8 +399,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       let(:state) { Puppet::SSL::StateMachine::NeedCert.new(machine, ssl_context, private_key) }
 
       it 'transitions to Done if the cert is signed and matches our private key' do
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_client_cert)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request)
+        allow(cert_provider).to receive(:save_client_cert)
+        allow(cert_provider).to receive(:save_request)
 
         stub_request(:get, %r{puppet-ca/v1/certificate/#{Puppet[:certname]}}).to_return(status: 200, body: client_cert.to_pem)
 
@@ -418,8 +422,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
       it "verifies the server's certificate when getting the client cert" do
         stub_request(:get, %r{puppet-ca/v1/certificate/#{Puppet[:certname]}}).to_return(status: 200, body: client_cert.to_pem)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_client_cert)
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:save_request)
+        allow(cert_provider).to receive(:save_client_cert)
+        allow(cert_provider).to receive(:save_request)
 
         expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -590,7 +590,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
         expect {
           expect {
-            Puppet::SSL::StateMachine::Wait.new(machine, ssl_context).next_state
+            Puppet::SSL::StateMachine::Wait.new(machine).next_state
           }.to exit_with(1)
         }.to output(/Exiting now because the waitforcert setting is set to 0./).to_stdout
       end
@@ -598,7 +598,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       it 'sleeps and transitions to NeedCACerts' do
         machine = described_class.new(waitforcert: 15)
 
-        state = Puppet::SSL::StateMachine::Wait.new(machine, ssl_context)
+        state = Puppet::SSL::StateMachine::Wait.new(machine)
         expect(Kernel).to receive(:sleep).with(15)
 
         expect(Puppet).to receive(:info).with(/Will try again in 15 seconds./)

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -7,13 +7,6 @@ require 'puppet/ssl'
 describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
 
-  before(:each) do
-    WebMock.disable_net_connect!
-
-    allow_any_instance_of(Net::HTTP).to receive(:start)
-    allow_any_instance_of(Net::HTTP).to receive(:finish)
-  end
-
   let(:machine) { described_class.new }
   let(:cacert_pem) { cacert.to_pem }
   let(:cacert) { cert_fixture('ca.pem') }

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -27,6 +27,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
     allow_any_instance_of(Net::HTTP).to receive(:start)
     allow_any_instance_of(Net::HTTP).to receive(:finish)
+
+    allow(Kernel).to receive(:sleep)
   end
 
   context 'when ensuring CA certs and CRLs' do
@@ -480,7 +482,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         machine = described_class.new(waitforcert: 15)
 
         state = Puppet::SSL::StateMachine::Wait.new(machine, ssl_context)
-        expect(state).to receive(:sleep).with(15)
+        expect(Kernel).to receive(:sleep).with(15)
 
         expect(Puppet).to receive(:info).with(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Will try again in 15 seconds./)
 


### PR DESCRIPTION
Backports several commits from master: 81e2668, 5c7bfb7, c487c2f 

Updates the state machine to retry when exceptions occur, not just when the CSR hasn't been signed yet. By default the state machine will either reach the Done state or keep retrying, waiting every `waitforcert` seconds in between.

Preserves the behavior where if we ever try to wait, but `waitforcert < 1`, then exit.

Adds a `onetime` option to the state machine so it will raise if an error occurs, and never retry. This is needed for things like `puppet agent --test/--onetime`, which don't retry on errors. It is also needed to preserve the legacy `Puppet::SSL::Host#certificate` behavior.