### PR TITLE
(PUP-9746) Add registration of OIDs to SSL Context initialization

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -112,6 +112,8 @@ HELP
       Puppet.settings.use(:main, :agent)
     end
 
+    Puppet::SSL::Oids.register_puppet_oids
+
     certname = Puppet[:certname]
     action = command_line.args.first
     case action

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -146,6 +146,13 @@ describe Puppet::Application::Agent do
       execute_agent
     end
 
+    it "should register ssl OIDs" do
+      expect(Puppet::SSL::StateMachine).to receive(:new).with(waitforcert: 120).and_return(double(ensure_client_certificate: nil))
+      expect(Puppet::SSL::Oids).to receive(:register_puppet_oids)
+
+      execute_agent
+    end
+
     it "should use the waitforcert setting when checking for a signed certificate" do
       Puppet[:waitforcert] = 10
 

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -366,6 +366,14 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       ssl.command_line.args << 'bootstrap'
     end
 
+    it 'registers the OIDs' do
+      expect_any_instance_of(Puppet::SSL::StateMachine).to receive(:ensure_client_certificate).and_return(
+        double('ssl_context')
+      )
+      expect(Puppet::SSL::Oids).to receive(:register_puppet_oids)
+      expects_command_to_pass
+    end
+
     it 'returns an SSLContext with the loaded CA certs, CRLs, private key and client cert' do
       expect_any_instance_of(Puppet::SSL::StateMachine).to receive(:ensure_client_certificate).and_return(
         double('ssl_context')


### PR DESCRIPTION
This will enable puppet ssl tool to work for tasks that need the OIDs.  We are leaving the registration in the agent, and registration is cached so there is minimal extra cost.