### PR TITLE
(PUP-9720) Restore puppet agent --fingerprint

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -358,6 +358,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
   end
 
   def fingerprint
+    Puppet::Util::Log.newdestination(:console)
     cert_provider = Puppet::X509::CertProvider.new
     client_cert = cert_provider.load_client_cert(Puppet[:certname])
     if client_cert

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -358,13 +358,21 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
   end
 
   def fingerprint
-    sm = Puppet::SSL::StateMachine.new(onetime: true)
-    ssl_context = sm.ensure_client_certificate
-    if ssl_context
-      puts Puppet::SSL::Digest.new(options[:digest].to_s, ssl_context.client_cert.to_der).to_s
+    cert_provider = Puppet::X509::CertProvider.new
+    client_cert = cert_provider.load_client_cert(Puppet[:certname])
+    if client_cert
+      puts Puppet::SSL::Digest.new(options[:digest].to_s, client_cert.to_der).to_s
+    else
+      csr = cert_provider.load_request(Puppet[:certname])
+      if csr
+        puts Puppet::SSL::Digest.new(options[:digest].to_s, csr.to_der).to_s
+      else
+        $stderr.puts _("Fingerprint asked but no certificate nor certificate request have yet been issued")
+        exit(1)
+      end
     end
-  rescue
-    $stderr.puts _("Fingerprint asked but no certificate nor certificate request have yet been issued")
+  rescue => e
+    Puppet.log_exception(e, _("Failed to generate fingerprint: %{message}") % {message: e.message})
     exit(1)
   end
 

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -368,7 +368,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       if csr
         puts Puppet::SSL::Digest.new(options[:digest].to_s, csr.to_der).to_s
       else
-        $stderr.puts _("Fingerprint asked but no certificate nor certificate request have yet been issued")
+        $stderr.puts _("Fingerprint asked but neither the certificate, nor the certificate request have been issued")
         exit(1)
       end
     end

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -360,7 +360,9 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
   def fingerprint
     sm = Puppet::SSL::StateMachine.new(onetime: true)
     ssl_context = sm.ensure_client_certificate
-    puts Puppet::SSL::Digest.new(options[:digest].to_s, ssl_context.client_cert.to_der).to_s
+    if ssl_context
+      puts Puppet::SSL::Digest.new(options[:digest].to_s, ssl_context.client_cert.to_der).to_s
+    end
   rescue
     $stderr.puts _("Fingerprint asked but no certificate nor certificate request have yet been issued")
     exit(1)

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -549,22 +549,20 @@ describe Puppet::Application::Agent do
       end
 
       it "should fingerprint the certificate if it exists" do
-        certificate = double('certificate')
-        allow(certificate).to receive(:to_der).and_return('ABCDE')
-        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(certificate)
+        cert = cert_fixture('signed.pem')
+        allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(cert)
 
-        expect(@puppetd).to receive(:puts).with('(MD5) 2E:CD:DE:39:59:05:1D:91:3F:61:B1:45:79:EA:13:6D')
+        expect(@puppetd).to receive(:puts).with('(MD5) A6:00:3E:C1:DF:CF:E8:44:A6:4F:8D:92:E8:B2:D9:47')
 
         @puppetd.fingerprint
       end
 
       it "should fingerprint the request if it exists" do
-        request = double('request')
-        allow(request).to receive(:to_der).and_return('FGHIJK')
+        request = request_fixture('request.pem')
         allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_client_cert).and_return(nil)
         allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_request).and_return(request)
 
-        expect(@puppetd).to receive(:puts).with('(MD5) CF:08:B5:D3:25:84:CC:A0:00:CC:B2:6D:5F:62:34:9D')
+        expect(@puppetd).to receive(:puts).with('(MD5) 04:D0:69:23:32:2F:48:77:FE:2F:F2:0C:4E:90:BE:AC')
 
         @puppetd.fingerprint
       end

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -575,7 +575,7 @@ describe Puppet::Application::Agent do
           expect {
             @puppetd.fingerprint
           }.to exit_with(1)
-        }.to output(/Fingerprint asked but no certificate nor certificate request have yet been issued/).to_stderr
+        }.to output(/Fingerprint asked but neither the certificate, nor the certificate request have been issued/).to_stderr
       end
 
       it "should log an error if an exception occurs" do


### PR DESCRIPTION
PR https://github.com/puppetlabs/puppet/pull/7560 must be merged first

This restores the pre-6.4 behavior of printing the CSR fingerprint if the client
cert doesn't exist. It only looks in the local file system and doesn't change
system state as one would expect when running `puppet agent --fingerprint`.

It does not restore the behavior of downloading the CA/CRL bundle, generating a
key (if missing) or attempting to download the client cert.

If an exception occurs, such as the client cert is invalid, then the exception
is logged instead of using writing to stderr so that the backtrace can be
displayed when running with --trace.