### PR TITLE
(maint) Merge 5.5.x to 6.0.x

### DIFF
--- a/acceptance/tests/provider/package/dpkg_ensure_held_package_is_latest.rb
+++ b/acceptance/tests/provider/package/dpkg_ensure_held_package_is_latest.rb
@@ -1,5 +1,7 @@
 test_name "dpkg ensure held package is latest installed"
 confine :to, :platform => /debian-8-amd64/
+tag 'audit:low'
+
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::PackageUtils
 extend Puppet::Acceptance::ManifestUtils

--- a/acceptance/tests/provider/package/dpkg_ensure_held_package_should_preserve_version.rb
+++ b/acceptance/tests/provider/package/dpkg_ensure_held_package_should_preserve_version.rb
@@ -1,5 +1,7 @@
 test_name "dpkg ensure held package should preserve version if package is allready installed"
 confine :to, :platform => /debian-8-amd64/
+tag 'audit:low'
+
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::PackageUtils
 extend Puppet::Acceptance::ManifestUtils

--- a/acceptance/tests/puppet_device_test.rb
+++ b/acceptance/tests/puppet_device_test.rb
@@ -1,5 +1,7 @@
 test_name "puppet device is able to run and configure a node"
 
+tag 'server'
+
 teardown do
   on(master, "[ -f /etc/puppetlabs/puppet/puppet.conf.bak ] && mv /etc/puppetlabs/puppet/puppet.conf.bak /etc/puppetlabs/puppet/puppet.conf")
   # revert permission changes to reset state for other tests

--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -62,12 +62,13 @@ class Puppet::Util::Pidlock
     # POSIX and Windows platforms (PUP-9247).
     if Puppet.features.posix?
       procname = Puppet::Util::Execution.execute(["ps", "-p", lock_pid, "-o", "comm="]).strip
-      @lockfile.unlock unless procname =~ /puppet(-.*)?$/
+      args     = Puppet::Util::Execution.execute(["ps", "-p", lock_pid, "-o", "args="]).strip
+      @lockfile.unlock unless procname =~ /ruby/ && args =~ /puppet/ || procname =~ /puppet(-.*)?$/
     elsif Puppet.features.microsoft_windows?
       # On Windows, we're checking if the filesystem path name of the running
       # process is our vendored ruby:
       exe_path = Puppet::Util::Windows::Process::get_process_image_name_by_pid(lock_pid)
-      @lockfile.unlock unless exe_path =~ /Puppet\\puppet\\bin\\ruby.exe/
+      @lockfile.unlock unless exe_path =~ /\\bin\\ruby.exe$/
     end
   end
   private :clear_if_stale

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -122,21 +122,21 @@ module Puppet::Util::Windows::Process
   def get_process_image_name_by_pid(pid)
     image_name = ""
 
-    open_process(PROCESS_QUERY_INFORMATION, false, pid) do |phandle|
+     open_process(PROCESS_QUERY_INFORMATION, false, pid) do |phandle|
 
-      FFI::MemoryPointer.new(:dword, 1) do |exe_name_length_ptr|
-        # Add 1 for the null terminator, and UTF is 2 bytes/char:
-        max_path_length = (MAX_PATH_LENGTH + 1) * 2
-        exe_name_length_ptr.write_dword(max_path_length)
-        FFI::MemoryPointer.new(max_path_length) do |exe_name_ptr|
+       FFI::MemoryPointer.new(:dword, 1) do |exe_name_length_ptr|
+        # UTF is 2 bytes/char:
+        max_chars = MAX_PATH_LENGTH + 1
+        exe_name_length_ptr.write_dword(max_chars)
+        FFI::MemoryPointer.new(:wchar, max_chars) do |exe_name_ptr|
           use_win32_path_format = 0
           result = QueryFullProcessImageNameW(phandle, use_win32_path_format, exe_name_ptr, exe_name_length_ptr)
           if result == FFI::WIN32_FALSE
             raise Puppet::Util::Windows::Error.new(
               "QueryFullProcessImageNameW(phandle, #{use_win32_path_format}, " +
-              "exe_name_ptr, #{max_path_length}")
+              "exe_name_ptr, #{max_chars}")
           end
-          image_name = exe_name_ptr.read_wide_string(MAX_PATH_LENGTH + 1)
+          image_name = exe_name_ptr.read_wide_string(exe_name_length_ptr.read_dword)
         end
       end
     end

--- a/spec/unit/util/pidlock_spec.rb
+++ b/spec/unit/util/pidlock_spec.rb
@@ -26,6 +26,18 @@ describe Puppet::Util::Pidlock, if: !Puppet::Util::Platform.jruby? do
         allow(Puppet::Util::Windows::Process).to receive(:get_process_image_name_by_pid).with(@lock.lock_pid).and_return('C:\Program Files\Puppet Labs\Puppet\puppet\bin\ruby.exe')
       else
         allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'comm=']).and_return('puppet')
+        allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'args=']).and_return('puppet')
+      end
+      expect(@lock).to be_locked
+    end
+
+    it "should become locked if puppet is a gem" do
+      @lock.lock
+      unless Puppet::Util::Platform.windows?
+        expect(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'comm=']).and_return('ruby')
+        expect(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'args=']).and_return('ruby /root/puppet/.bundle/ruby/2.3.0/bin/puppet agent --no-daemonize -v')
+      else
+        allow(Puppet::Util::Windows::Process).to receive(:get_process_image_name_by_pid).with(@lock.lock_pid).and_return('C:\tools\ruby25\bin\ruby.exe')
       end
       expect(@lock).to be_locked
     end
@@ -109,6 +121,18 @@ describe Puppet::Util::Pidlock, if: !Puppet::Util::Platform.jruby? do
         allow(Puppet::Util::Windows::Process).to receive(:get_process_image_name_by_pid).with(@lock.lock_pid).and_return('C:\Program Files\Puppet Labs\Puppet\puppet\bin\ruby.exe')
       else
         allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'comm=']).and_return('puppet')
+        allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'args=']).and_return('puppet')
+      end
+      expect(@lock).to be_locked
+    end
+
+    it "should return true if locked when puppet as gem" do
+      @lock.lock
+      unless Puppet::Util::Platform.windows?
+        expect(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'comm=']).and_return('ruby')
+        expect(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', @lock.lock_pid, '-o', 'args=']).and_return('ruby /root/puppet/.bundle/ruby/2.3.0/bin/puppet agent --no-daemonize -v')
+      else
+        allow(Puppet::Util::Windows::Process).to receive(:get_process_image_name_by_pid).with(@lock.lock_pid).and_return('C:\tools\ruby25\bin\ruby.exe')
       end
       expect(@lock).to be_locked
     end
@@ -159,6 +183,7 @@ describe Puppet::Util::Pidlock, if: !Puppet::Util::Platform.jruby? do
           allow(Puppet::Util::Windows::Process).to receive(:get_process_image_name_by_pid).with(6789).and_return('C:\Program Files\Puppet Labs\Puppet\puppet\bin\ruby.exe')
         else
           allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', 6789, '-o', 'comm=']).and_return('puppet')
+          allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', 6789, '-o', 'args=']).and_return('puppet')
         end
         @lock.lock
         expect(Puppet::FileSystem.exist?(@lockfile)).to be_truthy
@@ -188,6 +213,7 @@ describe Puppet::Util::Pidlock, if: !Puppet::Util::Platform.jruby? do
         allow(Puppet::Util::Windows::Process).to receive(:get_process_image_name_by_pid).with(1234).and_return('C:\Program Files\Puppet Labs\Puppet\puppet\bin\ruby.exe')
       else
         allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', 1234, '-o', 'comm=']).and_return('puppet')
+        allow(Puppet::Util::Execution).to receive(:execute).with(['ps', '-p', 1234, '-o', 'args=']).and_return('puppet')
       end
       # lock the file
       @lock.lock


### PR DESCRIPTION
Conflicts were related to pidfile lock and the following commit:
https://github.com/puppetlabs/puppet/commit/9a9a103232eeff41edc5302118044c5b09a07ec3

The conflict for puppet device test was fixed by assuming that _--allow-dns-alt-names_ flag does not exist for **puppetserver ca**