### PR TITLE
(PUP-9750) optionally add pe_serverversion to server_facts

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -390,6 +390,14 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   def set_server_facts
     @server_facts = {}
 
+    # Add our server Puppet Enterprise version, if available.
+    pe_version_file = '/opt/puppetlabs/server/pe_version'
+    if File.readable?(pe_version_file) and !File.zero?(pe_version_file)
+      pe_version_data = File.read(pe_version_file).chomp
+      pe_serverversion = pe_version_data.match(/(\d+\.\d+\.\d+)/)
+      @server_facts['pe_serverversion'] = pe_serverversion[1] if pe_serverversion
+    end
+
     # Add our server version to the fact list
     @server_facts["serverversion"] = Puppet.version.to_s
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -414,6 +414,35 @@ describe Puppet::Resource::Catalog::Compiler do
     end
   end
 
+  describe "after finding nodes when checking for a PE version" do
+    include PuppetSpec::Compiler
+
+    let(:pe_version_file) { '/opt/puppetlabs/server/pe_version' }
+    let(:request) { Puppet::Indirector::Request.new(:catalog, :find, node_name, nil) }
+
+    before :each do
+      Puppet[:code] = 'notify { "PE Version: $pe_serverversion": }'
+    end
+
+    it "should not add 'pe_serverversion' when FOSS" do
+      allow(Puppet::Node.indirection).to receive(:find).with(node_name, anything).and_return(node)
+      catalog = compiler.find(request)
+
+      expect(catalog.resource('notify', 'PE Version: 2019.2.0')).to be_nil
+    end
+
+    it "should add 'pe_serverversion' when PE" do
+      allow(File).to receive(:readable?).with(pe_version_file).and_return(true)
+      allow(File).to receive(:zero?).with(pe_version_file).and_return(false)
+      allow(File).to receive(:read).with(pe_version_file).and_return('2019.2.0')
+
+      allow(Puppet::Node.indirection).to receive(:find).with(node_name, anything).and_return(node)
+      catalog = compiler.find(request)
+
+      expect(catalog.resource('notify', 'PE Version: 2019.2.0')).to be
+    end
+  end
+
   describe "when filtering resources" do
     before :each do
       allow(Facter).to receive(:value)


### PR DESCRIPTION
Since PE 3,x, there is no concept of a "PE" Puppet Agent, and therefore
the 'pe_version' fact in 'puppetlabs-stdlib' is nil on platforms > PE 3.x.

Code that varies based upon FOSS vs PE platforms requires a consistent method
to determe whether the platform is FOSS or PE.

Calling a function like 'pe_compiling_server_version' in FOSS will generate an
error in FOSS, and the `is_function_available` function is deprecated,

The concept of a "PE" Puppet Server is valid.

With this commit, Puppet Server sets a 'peserverversion' key in the 'server_facts'
hash of server-side facts for direct inspection, and for use by a future version
of 'puppetlabs-stdlib' that can inspect this key in a best-practice function.