### PR TITLE
(PUP-9752) defaultfor for released Debian 10 and bullseye/sid

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
-  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid", "10", "bullseye/sid"]
 
   defaultfor :operatingsystem => :LinuxMint
   notdefaultfor :operatingsystem => :LinuxMint, :operatingsystemmajrelease => ["10", "11", "12", "13", "14", "15", "16", "17"] # These are using upstart


### PR DESCRIPTION
With the release of buster planned for July 6, it might be time to set the defaultfor for it (current testing branch reports 10); when the release  is done it will report "bullseye/sid" so set that too.