### PR TITLE
(PUP-9697) Updated crontab read path for Solaris

### DIFF
--- a/lib/puppet/provider/cron/crontab.rb
+++ b/lib/puppet/provider/cron/crontab.rb
@@ -258,7 +258,7 @@ Puppet::Type.type(:cron).provide(:crontab, :parent => Puppet::Provider::ParsedFi
   end
 
   CRONTAB_DIR = case Facter.value("osfamily")
-  when "Debian", "HP-UX"
+  when "Debian", "HP-UX", "Solaris"
     "/var/spool/cron/crontabs"
   when /BSD/
     "/var/cron/tabs"


### PR DESCRIPTION
Solaris lists all the crontabs in the same place as Debian, without this, only current user's crontabs will be listed.