### PR TITLE
(maint) Omit --server <hostname> from `puppet agent -t`

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -13,7 +13,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || ["~>1.0", ">= 1.0.1"])
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || ["~>1.0", ">= 1.18.4"])
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")

--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -169,7 +169,7 @@ module Puppet
             agents.each do |agent|
               next if agent == master && agent.is_using_passenger?
               step "Agents: Run agent --test once to obtain auto-signed cert" do
-                on agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => [0,2]
+                on agent, puppet('agent', "--test"), :acceptable_exit_codes => [0,2]
               end
             end
           end

--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -72,53 +72,6 @@ module Puppet
 
     module CAUtils
 
-      def initialize_ssl
-        hostname = on(master, 'facter hostname').stdout.strip
-        fqdn = on(master, 'facter fqdn').stdout.strip
-
-        if master.use_service_scripts?
-          step "Ensure puppet is stopped"
-          # Passenger, in particular, must be shutdown for the cert setup steps to work,
-          # but any running puppet master will interfere with webrick starting up and
-          # potentially ignore the puppet.conf changes.
-          on(master, puppet('resource', 'service', master['puppetservice'], "ensure=stopped"))
-        end
-
-        step "Clear SSL on all hosts"
-        hosts.each do |host|
-          ssldir = on(host, puppet('agent --configprint ssldir')).stdout.chomp
-          on(host, "rm -rf '#{ssldir}'")
-        end
-
-        step "Master: Start Puppet Master" do
-          master_opts = {
-            :main => {
-              :dns_alt_names => "puppet,#{hostname},#{fqdn}",
-            },
-            :__service_args__ => {
-              # apache2 service scripts can't restart if we've removed the ssl dir
-              :bypass_service_script => true,
-            },
-          }
-          with_puppet_running_on(master, master_opts) do
-
-            hosts.each do |host|
-              next if host['roles'].include? 'master'
-
-              step "Agents: Run agent --test first time to gen CSR"
-              on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
-            end
-
-            # Sign all waiting certs
-            step "Master: sign all certs"
-            on master, puppet("cert --sign --all"), :acceptable_exit_codes => [0,24]
-
-            step "Agents: Run agent --test second time to obtain signed cert"
-            on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]
-          end
-        end
-      end
-
       def clean_cert(host, cn, check = true)
         if host == master && master[:is_puppetserver]
             on master, puppet_resource("service", master['puppetservice'], "ensure=stopped")

--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -68,7 +68,7 @@ with_puppet_running_on(master, {}) do
 
     step "attempt to run the agent (message: '#{expected_message}')" do
       agents.each do |agent|
-        on(agent, puppet('agent', "--test --server #{master}"),
+        on(agent, puppet('agent', "--test"),
                      :acceptable_exit_codes => [1]) do
           disabled_regex = /administratively disabled.*'#{expected_message}'/
           unless result.stdout =~ disabled_regex
@@ -91,7 +91,7 @@ with_puppet_running_on(master, {}) do
 
     step "verify that we can run the agent (message: '#{expected_message}')" do
       agents.each do |agent|
-        on(agent, puppet('agent', "--test --server #{master}"))
+        on(agent, puppet('agent', "--test"))
       end
     end
   end # tuples block

--- a/acceptance/tests/agent/agent_parses_json_catalog.rb
+++ b/acceptance/tests/agent/agent_parses_json_catalog.rb
@@ -15,7 +15,7 @@ step "Agent parses a JSON catalog" do
     ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
   
     # Refresh the catalog
-    on(agent, puppet("agent --test --server #{master}"))
+    on(agent, puppet("agent --test"))
 
     # The catalog file should be parseable JSON
     json_catalog = File.join(agent.puppet['client_datadir'], 'catalog',
@@ -23,6 +23,6 @@ step "Agent parses a JSON catalog" do
     on(agent, "cat #{json_catalog} | #{ruby} -rjson -e 'JSON.parse(STDIN.read)'")
 
     # Can the agent parse it as JSON?
-    on(agent, puppet("catalog find --terminus json --server #{master} > /dev/null"))
+    on(agent, puppet("catalog find --terminus json > /dev/null"))
   end
 end

--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -6,7 +6,7 @@ tag 'audit:medium',
 
 step "run agents once to cache the catalog" do
   with_puppet_running_on master, {} do
-    on(agents, puppet("agent -t --server #{master}"))
+    on(agents, puppet("agent -t"))
   end
 end
 

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -18,7 +18,7 @@ test_name "aix package provider should work correctly" do
   end
 
   def get_package_manifest(package, version, sourcedir)
-    manifest = <<-MANIFEST
+    <<-MANIFEST
     package { '#{package}':
       ensure   => '#{version}',
       provider => aix,

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -176,7 +176,7 @@ step "Ensure nodes are classified based on the node name fact" do
   }
 
   with_puppet_running_on(master, master_opts, testdir) do
-    on(agents, puppet('agent', "--no-daemonize --verbose --onetime --node_name_fact kernel --server #{master}")) do
+    on(agents, puppet('agent', "--no-daemonize --verbose --onetime --node_name_fact kernel")) do
       assert_match(/defined 'message'.*#{success_message}/, stdout)
     end
   end

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -154,7 +154,7 @@ step "Ensure nodes are classified based on the node name fact" do
     },
   }
   with_puppet_running_on(master, master_opts, testdir) do
-    on(agents, puppet('agent', "-t --node_name_value specified_node_name --server #{master}"), :acceptable_exit_codes => [0,2]) do
+    on(agents, puppet('agent', "-t --node_name_value specified_node_name"), :acceptable_exit_codes => [0,2]) do
       assert_match(/defined 'message'.*#{success_message}/, stdout)
     end
   end

--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -63,7 +63,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
 
       step "run puppet and ensure that binary data was correctly applied" do
         agents.each do |agent|
-          on(agent, puppet('agent', '--test', "--environment '#{tmp_environment}'", "--server #{master.hostname}"), :acceptable_exit_codes => 2)
+          on(agent, puppet('agent', '--test', "--environment '#{tmp_environment}'"), :acceptable_exit_codes => 2)
           on(agent, "#{Puppet::Acceptance::CommandUtils::ruby_command(agent)} -e 'puts File.binread(\"#{agent_tmp_dirs[agent_to_fqdn(agent)]}/#{test_num}\").bytes.map {|b| b.to_s(16)}'") do |res|
             assert_match(/c0\nff/, res.stdout, 'Binary file did not contain originally specified data')
           end

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -82,7 +82,7 @@ MANIFEST
       end
 
       step "agent: #{agent}: Initial run: create the file with code version 1 and cache the catalog"
-      on(agent, puppet("agent", "-t", "--server #{master}"), :acceptable_exit_codes => [0,2])
+      on(agent, puppet("agent", "-t"), :acceptable_exit_codes => [0,2])
 
       # When there is no drift, there should be no request made to the server
       # for file metadata or file content.  A puppet run depending on
@@ -123,7 +123,7 @@ file { "#{module_dir}/foo/files/foo.txt" :
 MANIFEST
 
       step "Run agent again using --use_cached_catalog and ensure content from the first code_id is used"
-      on(agent, puppet("agent", "-t", "--use_cached_catalog", "--server #{master}"), :acceptable_exit_codes => [0,2])
+      on(agent, puppet("agent", "-t", "--use_cached_catalog"), :acceptable_exit_codes => [0,2])
       on(agent, "cat #{agent_test_file_path}") do
         assert_equal('code_version_1', stdout)
       end

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -13,7 +13,6 @@ test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri
 
   basedir = master.tmpdir(File.basename(__FILE__, '.*'))
   module_dir = "#{basedir}/environments/production/modules"
-  modulepath = "#{module_dir}"
 
   master_opts = {
    'main' => {

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -32,7 +32,7 @@ test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
       agent_vardir = agent.tmpdir(File.basename(__FILE__, '.*'))
 
       step "agent: #{agent}: Initial run to retrieve a catalog and generate the first report" do
-        on(agent, puppet("agent", "-t", "--vardir #{agent_vardir}", "--server #{master}"), :acceptable_exit_codes => [0,2])
+        on(agent, puppet("agent", "-t", "--vardir #{agent_vardir}"), :acceptable_exit_codes => [0,2])
       end
 
       cache_catalog_uuid = get_catalog_uuid_from_cached_catalog(agent, agent_vardir, agent.node_name)
@@ -47,7 +47,7 @@ test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
       end
 
       step "Run with --use_cached_catalog and ensure catalog_uuid in the new report matches the cached catalog" do
-        on(agent, puppet("agent", "--onetime", "--no-daemonize", "--use_cached_catalog", "--vardir #{agent_vardir}", "--server #{master}"), :acceptance_exit_codes => [0,2])
+        on(agent, puppet("agent", "--onetime", "--no-daemonize", "--use_cached_catalog", "--vardir #{agent_vardir}"), :acceptance_exit_codes => [0,2])
         report_catalog_uuid = get_catalog_uuid_from_report(master_reportdir, agent.node_name)
         assert_equal(cache_catalog_uuid, report_catalog_uuid, "catalog_uuid found in cached catalog, #{cache_catalog_uuid} did not match report #{report_catalog_uuid}")
       end

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -197,8 +197,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
       puppet(
         'agent',
         '-t',
-        '--environment', 'production',
-        '--server', master.node_name
+        '--environment', 'production'
       ),
       :acceptable_exit_codes => [0, 2]
     )
@@ -224,8 +223,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
       puppet(
         'agent',
         '-t',
-        '--environment', 'canary',
-        '--server', master.node_name
+        '--environment', 'canary'
       ),
       :acceptable_exit_codes => [0, 2]
     )
@@ -283,8 +281,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
       puppet(
         'agent',
         '-t',
-        '--environment', 'production',
-        '--server', master.node_name
+        '--environment', 'production'
       ),
       :acceptable_exit_codes => [0, 2]
     )
@@ -310,8 +307,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
       puppet(
         'agent',
         '-t',
-        '--environment', 'canary',
-        '--server', master.node_name
+        '--environment', 'canary'
       ),
       :acceptable_exit_codes => [0, 2]
     )

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -51,7 +51,7 @@ MANIFEST
       agents.each do |agent|
         config_version = ''
         config_version_matcher = /configuration version '(\d+)'/
-        on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"),
+        on(agent, puppet("agent -t --environment '#{tmp_environment}'"),
            :acceptable_exit_codes => 2).stdout do |result|
           config_version = result.match(config_version_matcher)[1]
         end
@@ -60,7 +60,7 @@ MANIFEST
         end
 
         on(agent, "rm -f '#{tmp_file[agent_to_fqdn(agent)]}'")
-        on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname} --use_cached_catalog"),
+        on(agent, puppet("agent -t --environment '#{tmp_environment}' --use_cached_catalog"),
            :acceptable_exit_codes => 2).stdout do |result|
           assert_match(config_version_matcher, result, 'agent did not use cached catalog')
           second_config_version = result.match(config_version_matcher)[1]

--- a/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
+++ b/acceptance/tests/environment/3x_forbidden_environment_names_allowed.rb
@@ -65,7 +65,7 @@ with_puppet_running_on(master, master_opts, testdir) do
   agents.each do |agent|
     environments.each do |environment|
       on(agent, puppet('agent',
-                       "--test --server #{master} --environment #{environment}"),
+                       "--test --environment #{environment}"),
       :acceptable_exit_codes => 2)
     end
   end

--- a/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
+++ b/acceptance/tests/environment/agent_runs_pluginsync_with_proper_environment.rb
@@ -61,7 +61,7 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet("agent", "-t", "--server #{master}"))
+    on(agent, puppet("agent", "-t"))
     on(agent, "cat \"#{agent.puppet['vardir']}/lib/puppet/foo.rb\"")
     assert_match(/#correct_version/, stdout, "The plugin from environment 'correct' was not synced")
     on(agent, "rm -rf \"#{agent.puppet['vardir']}/lib\"")

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -51,7 +51,7 @@ master_opts = {
 with_puppet_running_on(master, master_opts, testdir) do
   agents.each do |agent|
     on(agent, puppet('agent',
-                     "--test --server #{master} --environment #{environment}"),
+                     "--test --environment #{environment}"),
        :acceptable_exit_codes => (0..255)) do
       assert_match(/you win/, stdout,
                    'agent did not pickup newly classified environment.')

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -100,7 +100,7 @@ MANIFEST
   step "run agent in #{tmp_environment}, ensure it finds the correct provider" do
     with_puppet_running_on(master,{}) do
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet("agent -t --environment #{tmp_environment}"),
           :accept_all_exit_codes => true) do |result|
           assert_equal(2, result.exit_code, 'agent did not exit with the correct code of 2')
           assert_match(/#{file_correct}/, result.stdout, 'agent did not ensure the correct file')

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -40,7 +40,7 @@ with_puppet_running_on(master, master_opts, testdir) do
 
   step 'ensure catalog returned from production env with no changes'
   agents.each do |agent|
-    on(agent, puppet("agent -t --server #{master} --environment production --detailed-exitcodes")) do
+    on(agent, puppet("agent -t --environment production --detailed-exitcodes")) do
       # detailed-exitcodes produces a 0 when no changes are made.
       assert_equal(0, exit_code)
     end

--- a/acceptance/tests/environment/directory_environment_with_environment_conf.rb
+++ b/acceptance/tests/environment/directory_environment_with_environment_conf.rb
@@ -106,7 +106,7 @@ end
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
     on(agent,
-       puppet("agent", "-t", "--server", master, "--environment", "direnv"),
+       puppet("agent", "-t", "--environment", "direnv"),
        :acceptable_exit_codes => [2]) do |result|
 
       unless agent['locale'] == 'ja'

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -60,7 +60,7 @@ file {
 
   with_puppet_running_on(master, master_opts, testdir) do
     agents.each do |agent|
-      on(agent, puppet("agent -t --server #{master} --verbose"), :acceptable_exit_codes => [1]) do |result|
+      on(agent, puppet("agent -t --verbose"), :acceptable_exit_codes => [1]) do |result|
         unless agent['locale'] == 'ja'
           assert_match(/Could not find a directory environment named 'doesnotexist'/, result.stderr, "Errors when nonexistent environment is specified")
         end

--- a/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
+++ b/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
@@ -46,7 +46,7 @@ test_name "C97899 - Agent run should fail if environment is unreadable" do
     }
     with_puppet_running_on master, master_opts, testdir do
       agents.each do |agent|
-        on(agent, puppet("agent --test --server #{master} --environment testing"), :accept_all_exit_codes => true) do |result|
+        on(agent, puppet("agent --test --environment testing"), :accept_all_exit_codes => true) do |result|
           refute_equal(2, result.exit_code, 'agent run should not apply changes')
           expect_failure('expected to fail until PUP-6241 is resolved') do
             refute_equal(0, result.exit_code, 'agent run should not succeed')

--- a/acceptance/tests/environment/negative/agent_run_should_fail_if_site_pp_unreadable.rb
+++ b/acceptance/tests/environment/negative/agent_run_should_fail_if_site_pp_unreadable.rb
@@ -40,7 +40,7 @@ test_name "C98160 - Agent run should fail if an environment's site.pp is unreada
     }
     with_puppet_running_on master, master_opts, testdir do
       agents.each do |agent|
-        on(agent, puppet("agent --test --server #{master} --environment testing"), :accept_all_exit_codes => true) do |result|
+        on(agent, puppet("agent --test --environment testing"), :accept_all_exit_codes => true) do |result|
           refute_equal(2, result.exit_code, 'agent run should not apply changes')
           refute_equal(0, result.exit_code, 'agent run should not succeed')
           refute_empty(result.stderr, 'an appropriate error is expected')

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -55,7 +55,7 @@ END
   with_puppet_running_on(master, master_opts, testdir) do
 
     agents.each do |agent|
-      run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
+      run_agent_on(agent, "--no-daemonize --onetime --verbose --environment more_different") do |result|
         assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
       end
     end

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -45,7 +45,7 @@ test_name "Agent should use agent environment if there is no enc-specified envir
   with_puppet_running_on(master, master_opts, testdir) do
 
     agents.each do |agent|
-      run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --environment more_different") do |result|
+      run_agent_on(agent, "--no-daemonize --onetime --verbose --environment more_different") do |result|
         assert_match(/more_different_string/, result.stdout, "Did not find more_different_string from \"more_different\" environment")
       end
     end

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -68,7 +68,7 @@ END
   with_puppet_running_on(master, master_opts, testdir) do
 
     agents.each do |agent|
-      run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose") do |result|
+      run_agent_on(agent, "--no-daemonize --onetime --verbose") do |result|
         assert_match(/expected_string/, result.stdout, "Did not find expected_string from \"special\" environment")
         caching_catalog_message_count = result.stdout.split(/Info: Caching catalog for/).length - 1
         assert_equal(caching_catalog_message_count, 1, 'Should only compile and cache the catalog once during the run')

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -66,7 +66,7 @@ file { "#{atmp}/special_testy":
 END
       on(master, "chmod 644 '#{testdir}/environments/special/manifests/different.pp'")
 
-      run_agent_on(agent, "--no-daemonize --onetime --server #{master} --verbose --trace")
+      run_agent_on(agent, "--no-daemonize --onetime --verbose --trace")
 
       on(agent, "cat '#{atmp}/special_testy'") do |result|
         assert_match(/special_environment/,

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -57,7 +57,7 @@ END
         on(agent, "rm -rf '#{agent_vardir}/lib'")
       end
 
-      run_agent_on(agent, "--no-daemonize --onetime --server #{master}")
+      run_agent_on(agent, "--no-daemonize --onetime")
       on(agent, "cat '#{agent_vardir}/lib/puppet/foo.rb'") do |result|
         assert_match(/#special_version/, result.stdout, "The plugin from environment 'special' was not synced")
       end

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -11,7 +11,7 @@ test_name "Use environments from the environmentpath" do
   testdir = create_tmpdir_for_user(master, 'use_environmentpath')
 
   def generate_environment(path_to_env, environment)
-    env_content = <<-EOS
+    <<-EOS
   "#{path_to_env}/#{environment}":;
   "#{path_to_env}/#{environment}/manifests":;
   "#{path_to_env}/#{environment}/modules":;
@@ -27,7 +27,7 @@ test_name "Use environments from the environmentpath" do
     module_info    = "module-#{module_name}"
     module_info << "-from-#{environment}" if environment
 
-    module_content = <<-EOS
+    <<-EOS
   "#{path_to_module}/#{module_name}":;
   "#{path_to_module}/#{module_name}/manifests":;
   "#{path_to_module}/#{module_name}/files":;
@@ -62,7 +62,7 @@ test_name "Use environments from the environmentpath" do
   end
 
   def generate_site_manifest(path_to_manifest, *modules_to_include)
-    manifest_content = <<-EOS
+    <<-EOS
   "#{path_to_manifest}/site.pp":
     ensure => file,
     mode => "0640",
@@ -116,7 +116,6 @@ file {
 
   def run_with_environment(agent, environment, options = {})
     expected_exit_code = options[:expected_exit_code] || 2
-    expected_strings   = options[:expected_strings]
 
     step "running an agent in environment '#{environment}'"
     atmp = agent.tmpdir("use_environmentpath_#{environment}")

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -126,8 +126,7 @@ file {
     end
 
     agent_config = [
-        "-t",
-        "--server", master,
+        "-t"
     ]
     agent_config << '--environment' << environment if environment
     # This to test how the agent behaves when using the directory environment

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -2,6 +2,8 @@ test_name 'C98115 compilation should get new values in variables on each compila
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
 
+  confine :except, :platform => /^(aix|osx|solaris)/
+
   tag 'audit:medium',
       'audit:integration',
       'server'

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -65,13 +65,13 @@ echo "custom_time=$(get-date -format HHmmssffffff)"
       agents.each do |agent|
         # ensure our custom facts have been synced
         on(agent,
-           puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"),
+           puppet("agent -t --environment '#{tmp_environment}'"),
            :accept_all_exit_codes => true)
 
         local_custom_time1 = module_custom_time1 = nil
         local_custom_time2 = module_custom_time2 = nil
 
-        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"),
+        on(agent, puppet("agent -t --environment '#{tmp_environment}'"),
            :accept_all_exit_codes => [2]) do |result|
           assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'first custom time was not as expected')
           assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'first module uptime was not as expected')
@@ -82,7 +82,7 @@ echo "custom_time=$(get-date -format HHmmssffffff)"
 
         sleep 1
 
-        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"),
+        on(agent, puppet("agent -t --environment '#{tmp_environment}'"),
            :accept_all_exit_codes => [2]) do |result|
           assert_match(/Notice: #{local_custom_time_pattern}/, result.stdout, 'second custom time was not as expected')
           assert_match(/Notice: #{module_custom_time_pattern}/, result.stdout, 'second module uptime was not as expected')

--- a/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
+++ b/acceptance/tests/external_ca_support/jetty_external_root_ca.rb
@@ -128,11 +128,11 @@ with_puppet_running_on(master, master_opts) do
   # Now, try and run the agent on the master against itself.
   step "Successfully run the puppet agent on the master"
   on master, puppet_agent("#{agent_cmd_prefix} --test"), :acceptable_exit_codes => (0..255) do
-    assert_no_match /Creating a new SSL key/, stdout
-    assert_no_match /\Wfailed\W/i, stderr
-    assert_no_match /\Wfailed\W/i, stdout
-    assert_no_match /\Werror\W/i, stderr
-    assert_no_match /\Werror\W/i, stdout
+    assert_no_match(/Creating a new SSL key/, stdout)
+    assert_no_match(/\Wfailed\W/i, stderr)
+    assert_no_match(/\Wfailed\W/i, stdout)
+    assert_no_match(/\Werror\W/i, stderr)
+    assert_no_match(/\Werror\W/i, stdout)
     # Assert the exit code so we get a "Failed test" instead of an "Errored test"
     assert exit_code == 0
   end
@@ -141,10 +141,10 @@ with_puppet_running_on(master, master_opts) do
   on master, "cp #{testdir}/etc/agent/puppet.conf{,.no_email}"
   on master, "cp #{testdir}/etc/agent/puppet.conf{.email,}"
   on master, puppet_agent("#{agent_cmd_prefix} --test"), :acceptable_exit_codes => (0..255) do
-    assert_no_match /\Wfailed\W/i, stdout
-    assert_no_match /\Wfailed\W/i, stderr
-    assert_no_match /\Werror\W/i, stdout
-    assert_no_match /\Werror\W/i, stderr
+    assert_no_match(/\Wfailed\W/i, stdout)
+    assert_no_match(/\Wfailed\W/i, stderr)
+    assert_no_match(/\Werror\W/i, stdout)
+    assert_no_match(/\Werror\W/i, stderr)
     # Assert the exit code so we get a "Failed test" instead of an "Errored test"
     assert exit_code == 0
   end
@@ -155,7 +155,7 @@ with_puppet_running_on(master, master_opts) do
 
   revoke_opts = "--hostcrl #{testdir}/ca_master.crl"
   on master, puppet_agent("#{agent_cmd_prefix} #{revoke_opts} --test"), :acceptable_exit_codes => (0..255) do
-    assert_match /certificate revoked.*?example.org/, stderr
+    assert_match(/certificate revoked.*?example.org/, stderr)
     assert exit_code == 1
   end
 end
@@ -166,9 +166,9 @@ create_remote_file master, "#{jetty_confdir}/webserver.conf",
 with_puppet_running_on(master, master_opts) do
   step "Agent refuses to connect to a rogue master"
   on master, puppet_agent("#{agent_cmd_prefix} --ssl_client_ca_auth=#{testdir}/ca_master.crt --test"), :acceptable_exit_codes => (0..255) do
-    assert_no_match /Creating a new SSL key/, stdout
-    assert_match /certificate verify failed/i, stderr
-    assert_match /The server presented a SSL certificate chain which does not include a CA listed in the ssl_client_ca_auth file/i, stderr
+    assert_no_match(/Creating a new SSL key/, stdout)
+    assert_match(/certificate verify failed/i, stderr)
+    assert_match(/The server presented a SSL certificate chain which does not include a CA listed in the ssl_client_ca_auth file/i, stderr)
     assert exit_code == 1
   end
 end

--- a/acceptance/tests/face/help_test.rb
+++ b/acceptance/tests/face/help_test.rb
@@ -34,8 +34,8 @@ test_name 'Test `puppet help` workflow' do
       step "Use `puppet help #{face}`"
 
       on agent, puppet("help #{face} | grep USAGE") do
-        assert_match /^USAGE:/, stdout,
-          "There is NO usage section for 'puppet help #{face}'"
+        assert_match(/^USAGE:/, stdout,
+          "There is NO usage section for 'puppet help #{face}'")
       end
     end
   end

--- a/acceptance/tests/i18n/check_puppet_run_message.rb
+++ b/acceptance/tests/i18n/check_puppet_run_message.rb
@@ -20,7 +20,7 @@ test_name 'C100559: puppet agent run output with a supported language should be 
     end
 
     step "Run Puppet apply with language #{language} and check the output" do
-      on(agent, puppet("agent -t --server #{master}", 'ENV' => {'LANGUAGE' => language})) do |apply_result|
+      on(agent, puppet("agent -t", 'ENV' => {'LANGUAGE' => language})) do |apply_result|
         # Info: Applying configuration version '1505773208'
         assert_match(/設定バージョン'[^']*'を適用しています。/, apply_result.stdout, "agent run does not contain 'Applying configuration version' translation")
         # Notice: Applied catalog in 0.03 seconds

--- a/acceptance/tests/i18n/enable_option_disable_i18n.rb
+++ b/acceptance/tests/i18n/enable_option_disable_i18n.rb
@@ -15,18 +15,6 @@ test_name 'C100561: verify that disable_i18n can be set to true and have transla
 
   with_puppet_running_on master, 'master' => { 'disable_i18n' => true } do
     agents.each do |agent|
-
-      puppet_conf = agent.tmpfile('puppet_conf_test')
-      config      = <<-EOM
-    [user]
-    disable_i18n = true
-      EOM
-      create_remote_file(agent, puppet_conf, config)
-
-      teardown do
-        on(agent, "rm -f '#{puppet_conf}'")
-      end
-
       step("ensure #{language} locale is configured") do
         language = enable_locale_language(agent, language)
         # fall back to ja_JP since we're expecting english fallback for this test anyways
@@ -34,7 +22,7 @@ test_name 'C100561: verify that disable_i18n can be set to true and have transla
       end
 
       step "Run Puppet agent with language #{language} and check the output" do
-        on(agent, puppet("agent -t --config '#{puppet_conf}'", 'ENV' => {'LANGUAGE' => language})) do |agent_result|
+        on(agent, puppet("agent -t --disable_i18n", 'ENV' => {'LANGUAGE' => language})) do |agent_result|
           assert_match(/Applying configuration version '[^']*'/, agent_result.stdout, "agent run does not contain english 'Applying configuration version'")
           assert_match(/Applied catalog in\s+[0-9.]*\s+seconds/, agent_result.stdout, "agent run does not contain english 'Applied catalog in' ")
         end

--- a/acceptance/tests/i18n/enable_option_disable_i18n.rb
+++ b/acceptance/tests/i18n/enable_option_disable_i18n.rb
@@ -34,7 +34,7 @@ test_name 'C100561: verify that disable_i18n can be set to true and have transla
       end
 
       step "Run Puppet agent with language #{language} and check the output" do
-        on(agent, puppet("agent -t --config '#{puppet_conf}' --server '#{master}'", 'ENV' => {'LANGUAGE' => language})) do |agent_result|
+        on(agent, puppet("agent -t --config '#{puppet_conf}'", 'ENV' => {'LANGUAGE' => language})) do |agent_result|
           assert_match(/Applying configuration version '[^']*'/, agent_result.stdout, "agent run does not contain english 'Applying configuration version'")
           assert_match(/Applied catalog in\s+[0-9.]*\s+seconds/, agent_result.stdout, "agent run does not contain english 'Applied catalog in' ")
         end

--- a/acceptance/tests/i18n/modules/puppet_agent.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent.rb
@@ -63,7 +63,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
           }
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_1)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
           assert_match(/.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
         end
       end
@@ -76,7 +76,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
         #   }
         # PP
         # create_sitepp(master, tmp_environment_1, site_pp_content_3)
-        # on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => { 'LANGUAGE' => '', 'LANG' => language }), :acceptable_exit_codes => 1) do |result|
+        # on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => { 'LANGUAGE' => '', 'LANG' => language }), :acceptable_exit_codes => 1) do |result|
         #   assert_match(/Error: リモートサーバからカタログを取得できませんでした: SERVERのエラー500 : サーバエラー: Evaluation/, result.stderr, 'missing translation for Server Error')
         #   assert_match(/Error:.*の検証中にエラーが生じました。.*ファイルの作成に失敗しました/, result.stderr, 'missing translation for fail from init.pp')
         # end
@@ -90,7 +90,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
         PP
 
         create_sitepp(master, tmp_environment_1, site_pp_content_4)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 1) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 1) do |result|
           assert_match(/Warning:.*\w+-i18ndemo type: 良い値/, result.stderr, 'missing warning from custom type')
         end
 
@@ -100,7 +100,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
           }
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_5)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 1) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 1) do |result|
           assert_match(/Error: .* \w+-i18ndemo type: 値は有12345効な値ではありません/, result.stderr, 'missing error from invalid value for custom type param')
         end
       end
@@ -115,7 +115,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
           }
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_6)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language)) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language)) do |result|
           assert_match(/Warning:.*\w+-i18ndemo provider: i18ndemo_typeは存在しますか/, result.stderr, 'missing translated provider message')
         end
       end
@@ -129,7 +129,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
           }
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_7)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 2) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 2) do |result|
           assert_match(/Notice: --\*\w+-i18ndemo function: それは楽しい時間です\*--/, result.stdout, 'missing translated notice message')
         end
       end

--- a/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
@@ -64,7 +64,7 @@ test_name 'C100566: puppet agent with module should translate messages when usin
           }
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_1)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
           assert_match(/.*\w+-i18ndemo fact: これは\w+-i18ndemoからのカスタムファクトからのレイズです/, result.stderr, 'missing translation for raise from ruby fact')
         end
         on(agent, puppet("agent -t --environment #{tmp_environment_1} --use_cached_catalog", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
@@ -82,7 +82,7 @@ test_name 'C100566: puppet agent with module should translate messages when usin
           }
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_6)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
           assert_match(/Warning:.*\w+-i18ndemo provider: i18ndemo_typeは存在しますか/, result.stderr, 'missing translated provider message')
         end
         on(agent, puppet("agent -t --server #{unresolved_server} --environment #{tmp_environment_1} --use_cached_catalog", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
@@ -99,7 +99,7 @@ test_name 'C100566: puppet agent with module should translate messages when usin
           }
         PP
         create_sitepp(master, tmp_environment_1, site_pp_content_7)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|
           assert_match(/Notice: --\*\w+-i18ndemo function: それは楽しい時間です\*--/, result.stdout, 'missing translated notice message')
         end
         on(agent, puppet("agent -t --server #{unresolved_server} --environment #{tmp_environment_1} --use_cached_catalog", 'ENV' => shell_env_language), :acceptable_exit_codes => [0, 2]) do |result|

--- a/acceptance/tests/i18n/modules/puppet_agent_with_multiple_environments.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_with_multiple_environments.rb
@@ -70,12 +70,12 @@ test_name 'C100575: puppet agent with different modules in different environment
           }
       PP
       create_sitepp(master, tmp_environment_1, site_pp_content)
-      on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 2) do |result|
+      on(agent, puppet("agent -t --environment #{tmp_environment_1}", 'ENV' => shell_env_language), :acceptable_exit_codes => 2) do |result|
         assert_match(/Notice: --\*(ENV_1:)?ENV_1:\w+-i18ndemo function: それは楽しい時間です\*--/, result.stdout, 'missing translated notice message for environment 1')
       end
 
       create_sitepp(master, tmp_environment_2, site_pp_content)
-      on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment_2}", 'ENV' => shell_env_language), :acceptable_exit_codes => 2) do |result|
+      on(agent, puppet("agent -t --environment #{tmp_environment_2}", 'ENV' => shell_env_language), :acceptable_exit_codes => 2) do |result|
         assert_match(/Notice: --\*(ENV_2:)?ENV_2:\w+-i18ndemo function: それは楽しい時間です\*--/, result.stdout, 'missing translated notice message for environment 2')
       end
     end

--- a/acceptance/tests/i18n/translation_fallback.rb
+++ b/acceptance/tests/i18n/translation_fallback.rb
@@ -7,7 +7,7 @@ test_name 'C100560: puppet agent run output falls back to english when language 
   agents.each do |agent|
     step 'Run Puppet apply with language Hungarian and check the output' do
       unsupported_language='hu_HU'
-      on(agent, puppet("agent -t --server #{master}",
+      on(agent, puppet("agent -t",
                        'ENV' => {'LANG' => unsupported_language, 'LANGUAGE' => ''})) do |apply_result|
         assert_match(/Applying configuration version '[^']*'/, apply_result.stdout,
                      'agent run should default to english translation')

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -10,7 +10,6 @@ test_name 'C98346: Binary data type' do
 
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
-  fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"
 
   tmp_filename_win = tmp_filename_else = ''
   agents.each do |agent|
@@ -21,11 +20,6 @@ test_name 'C98346: Binary data type' do
       tmp_filename_win = "C:\\cygwin64\\tmp\\#{tmp_environment}.txt"
     end
     tmp_filename_else = "/tmp/#{tmp_environment}.txt"
-    if agent.platform =~ /windows/
-      tmp_filename = tmp_filename_win
-    else
-      tmp_filename = tmp_filename_else
-    end
     on(agent, "echo 'old content' > '/tmp/#{tmp_environment}.txt'")
   end
   # create a fake module files... file for binary_file()

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -70,7 +70,7 @@ test_name 'C98346: Binary data type' do
   step "run agent in #{tmp_environment}, run all assertions" do
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"), :acceptable_exit_codes => [2]) do |result|
+        on(agent, puppet("agent -t --environment '#{tmp_environment}'"), :acceptable_exit_codes => [2]) do |result|
           run_assertions(assertion_code, result)
         end
       end

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -160,12 +160,12 @@ MANIFEST
     on(master, puppet("config set storeconfigs_backend #{storeconfigs_backend_name} --section main"))
     on(master, "service #{master['puppetservice']} restart")
     step 'run the master agent to export the resources' do
-      on(master, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"))
+      on(master, puppet("agent -t --environment #{tmp_environment}"))
     end
     agents.each do |agent|
       next if agent == master
       step 'run the agents to collect exported resources' do
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet("agent -t --environment #{tmp_environment}"),
            :acceptable_exit_codes => 2)
         on(agent, puppet_resource("user #{exported_username}"), :accept_all_exit_codes => true) do |result|
           assert_match(/present/, result.stdout, 'collected resource not found')

--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -10,7 +10,6 @@ tag 'audit:high',
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
-  fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
 
   manifest = <<-PP
 type Mod::Foo = Object[{

--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -37,7 +37,7 @@ include mod
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step "run the agent on #{agent.hostname} and assert notify output" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent didn't exit properly: (#{result.exit_code})")
           assert_match(/A foo/, result.stdout, 'agent didn\'t notify correctly')

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -47,10 +47,10 @@ tag 'audit:medium',
 
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
-      on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+      on(agent, puppet("agent -t --environment #{tmp_environment}"),
          :acceptable_exit_codes => 2)
       step 'run agent in environment with type with an extra parameter. try to use this parameter' do
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment2}"),
+        on(agent, puppet("agent -t --environment #{tmp_environment2}"),
            :accept_all_exit_codes => true) do |result|
           unless agent['locale'] == 'ja'
             assert_match("Error: no parameter named 'other'", result.output,
@@ -67,9 +67,9 @@ tag 'audit:medium',
 
     agents.each do |agent|
       step 'rerun agents after generate, ensure proper runs' do
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet("agent -t --environment #{tmp_environment}"),
            :acceptable_exit_codes => 2)
-        on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment2}"),
+        on(agent, puppet("agent -t --environment #{tmp_environment2}"),
            :acceptable_exit_codes => 2)
       end
     end

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -102,7 +102,7 @@ tag 'audit:high',
     with_puppet_running_on(master,{}) do
       agents.each do |agent|
         # redirect logging to a temp location to avoid platform specific syslogs
-        on(agent, puppet("agent -t --debug --trace --show_diff --server #{master.hostname} --environment #{tmp_environment}"), :accept_all_exit_codes => true) do |result|
+        on(agent, puppet("agent -t --debug --trace --show_diff --environment #{tmp_environment}"), :accept_all_exit_codes => true) do |result|
           assert_equal(result.exit_code, 2,'puppet agent run failed')
 
           run_assertions(assertion_code, result) unless agent['locale'] == 'ja'

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -18,7 +18,7 @@ tag 'audit:medium',
     master_opts = {}
     with_puppet_running_on(master, master_opts) do
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master} --environment #{tmp_environment}"),
+        on(agent, puppet("agent -t --environment #{tmp_environment}"),
            :acceptable_exit_codes => 2) do |result|
           assert_match(/abc{serverversion/, result.stdout,
                        "#{agent}: $server_facts should have some stuff" )
@@ -29,7 +29,7 @@ tag 'audit:medium',
 
   step 'ensure puppet issues a warning if an agent overwrites a server fact' do
     agents.each do |agent|
-      on(agent, puppet("agent -t --server #{master}",
+      on(agent, puppet("agent -t",
                        'ENV' => { 'FACTER_server_facts' => 'overwrite' }),
         :acceptable_exit_codes => 1) do |result|
           # Do not perform this check on non-English hosts

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -8,7 +8,6 @@ tag 'audit:medium',
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
-  fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
 
   step 'ensure $server_facts exist' do
     create_sitepp(master, tmp_environment, <<-SITE)

--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -75,7 +75,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
       empty_execution_log_file(master, execution_log[agent_to_fqdn(master)])
       empty_execution_log_file(agent, execution_log[agent_to_fqdn(agent)])
 
-      on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'")) do |puppet_result|
+      on(agent, puppet("agent -t --environment '#{tmp_environment}'")) do |puppet_result|
         assert_match(/\/File\[.*\/type_tst.rb\]\/ensure: defined content as/, puppet_result.stdout,
                      'Expected to see defined content message for type: type_tst')
         assert_match(/Notice: found_type_tst/, puppet_result.stdout, 'Expected to see the notice from the new type: type_tst')
@@ -130,7 +130,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
     # Compilation should now work using the generated types,
     # so we should only see a log entry on the agent node and nothing on the master node
     with_puppet_running_on(master, {}) do
-      on(agent, puppet("agent -t --server #{master.hostname} --environment '#{tmp_environment}'"),
+      on(agent, puppet("agent -t --environment '#{tmp_environment}'"),
          :acceptable_exit_codes => 0) do |puppet_result|
         assert_match(/Notice: found_type_tst/, puppet_result.stdout, 'Expected to see output from new type: type_tst')
       end

--- a/acceptance/tests/loader/resource_triggers_autoload.rb
+++ b/acceptance/tests/loader/resource_triggers_autoload.rb
@@ -39,7 +39,7 @@ test_name 'C100296: can auto-load defined types using a Resource statement' do
 
   with_puppet_running_on(master, {}) do
     agents.each do |agent|
-      on(agent, puppet("agent -t --server #{master.hostname} --environment #{tmp_environment}"),
+      on(agent, puppet("agent -t --environment #{tmp_environment}"),
          :acceptable_exit_codes => 2) do |puppet_result|
         assert_match(/Notice: tst1: Define found one::tst1/, puppet_result.stdout, 'Expected to see output from define notify')
         assert_match(/Notice: tst2: Define found one::tst2/, puppet_result.stdout, 'Expected to see output from define notify')

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -64,7 +64,7 @@ include some_mod
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step "agent lookup" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment} --debug"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment} --debug"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup didn't exit properly: (#{result.exit_code})")
           assert_match(/env value/, result.stdout,

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -25,8 +25,6 @@ tag 'audit:medium',
   end
 
   step "create hiera configs in #{tmp_environment} and global" do
-    codedir = master.puppet('master')['codedir']
-
     step "create global hiera.yaml and module data" do
       create_remote_file(master, "#{master_confdir}/hiera.yaml", <<-HIERA)
 ---

--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -95,7 +95,7 @@ notify{"hiera_array_data2: ${hiera_array_data2}":}
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step "agent lookups: #{agent.hostname}, hiera5" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup didn't exit properly: (#{result.exit_code})")
           assert_match(/data: \[from global, from test1/, result.stdout,

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -74,7 +74,7 @@ end
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step "agent manifest lookup on #{agent.hostname}" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup didn't exit properly: (#{result.exit_code})")
           assert_match(/custom value/, result.stdout,

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -82,7 +82,7 @@ PP
 
   def mod_manifest_metadata_json(module_name = nil, testdir)
     if module_name
-      metadata_manifest = <<PPmetadata
+      <<PPmetadata
       file { '#{testdir}/environments/production/modules/#{module_name}/metadata.json':
         ensure => file,
         content => '

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -306,7 +306,7 @@ PP
   with_puppet_running_on master, master_opts, testdir do
     step "Lookup string data, binding specified in metadata.json" do
       agents.each do |agent|
-        on(agent, puppet('agent', "-t --server #{master}"), :acceptable_exit_codes => [0, 2])
+        on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [0, 2])
         assert_match("#{env_data_implied_key} #{env_data_implied_value}", stdout)
         assert_match("#{env_data_key} #{env_data_value}", stdout)
 

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -98,7 +98,7 @@ function rich_data_test3($options, $context) {
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step "agent lookup in ruby function" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup using ruby function didn't exit properly: (#{result.exit_code})")
           assert_match(sensitive_value_rb, result.stdout,

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -169,7 +169,7 @@ notify { "lookup-array: ${lookup ('array')}": }
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step "agent lookups #{agent.hostname}, hiera3" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup didn't exit properly: (#{result.exit_code})")
           # hiera_hash will honor old global merge strategies, which were a bad idea
@@ -193,7 +193,7 @@ notify { "lookup-array: ${lookup ('array')}": }
         end
       end
       step "agent lookups #{agent.hostname}, hiera5" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment2}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment2}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup didn't exit properly: (#{result.exit_code})")
           assert_match(/hiera_hash: \[auth_kerb, authnz_ldap, cgid, php, status, mpm_prefork, ssl\]/, result.stdout,

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -105,7 +105,7 @@ notify { "${lookup('environment_key4')}": }
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step "agent lookup" do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup didn't exit properly: (#{result.exit_code})")
           assert_match(/env value1/, result.stdout,

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -10,14 +10,11 @@ tag 'audit:medium',
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
-  tmp_environment2 = mk_tmp_environment_with_teardown(master, app_type)
-  fq_tmp_environmentpath2  = "#{environmentpath}/#{tmp_environment2}"
 
   hiera_conf_backup = master.tmpfile('C99629-hiera-yaml')
 
   step "create hiera v3 global config and data" do
     confdir = master.puppet('master')['confdir']
-    codedir = master.puppet('master')['codedir']
 
     step "backup global hiera.yaml" do
       on(master, "cp -a #{confdir}/hiera.yaml #{hiera_conf_backup}", :acceptable_exit_codes => [0,1])

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -109,7 +109,7 @@ environment_key2 = "hocon value",
   with_puppet_running_on(master,{}) do
     agents.each do |agent|
       step 'agent lookup' do
-        on(agent, puppet('agent', "-t --server #{master.hostname} --environment #{tmp_environment}"),
+        on(agent, puppet('agent', "-t --environment #{tmp_environment}"),
            :accept_all_exit_codes => true) do |result|
           assert(result.exit_code == 2, "agent lookup didn't exit properly: (#{result.exit_code})")
           assert_match(/global_key-common_file/m, result.stdout,

--- a/acceptance/tests/modules/build/build_ignore_module_file.rb
+++ b/acceptance/tests/modules/build/build_ignore_module_file.rb
@@ -1,7 +1,7 @@
 test_name 'PUP-3981 - C63215 - Build Module Should Ignore Module File'
 
 tag 'audit:low',
-    'audit:acceptance'
+    'audit:acceptance',
     'audit:refactor'   # Wrap steps in blocks in accordance with Beaker style guide
 
 #Init

--- a/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
+++ b/acceptance/tests/modules/build/build_should_not_allow_symlinks.rb
@@ -7,8 +7,6 @@ confine :except, :platform => 'windows'
 
 modauthor = 'foo'
 modname = 'bar'
-defaultversion = '0.1.0'
-buildpath = "#{modname}/pkg/#{modname}-#{defaultversion}"
 
 agents.each do |agent|
 

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -16,5 +16,5 @@ step 'Run module changes to check an unmodified module'
 on( master, puppet("module changes #{testdir}/nginx"),
     :acceptable_exit_codes => [0] ) do
 
-  assert_match /No modified files/, stdout
+  assert_match(/No modified files/, stdout)
 end

--- a/acceptance/tests/modules/generate/basic_generate.rb
+++ b/acceptance/tests/modules/generate/basic_generate.rb
@@ -7,7 +7,6 @@ tag 'audit:medium',
 
 module_author = "pmtacceptance"
 module_name   = "nginx"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/already_installed.rb
+++ b/acceptance/tests/modules/install/already_installed.rb
@@ -10,7 +10,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/already_installed_elsewhere.rb
+++ b/acceptance/tests/modules/install/already_installed_elsewhere.rb
@@ -10,7 +10,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/already_installed_with_local_changes.rb
+++ b/acceptance/tests/modules/install/already_installed_with_local_changes.rb
@@ -10,7 +10,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 module_author = "pmtacceptance"
 module_name   = "nginx"
 module_reference = "#{module_author}-#{module_name}"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/basic_install.rb
+++ b/acceptance/tests/modules/install/basic_install.rb
@@ -10,7 +10,6 @@ confine :except, :platform => /centos-4|el-4/ # PUP-5226
 
 module_author = "pmtacceptance"
 module_name   = "nginx"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/nonexistent_directory.rb
+++ b/acceptance/tests/modules/install/nonexistent_directory.rb
@@ -9,7 +9,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "nginx"
-module_dependencies = []
 
 default_moduledir = get_default_modulepath_for_host(master)
 

--- a/acceptance/tests/modules/install/nonexistent_module.rb
+++ b/acceptance/tests/modules/install/nonexistent_module.rb
@@ -9,7 +9,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "nonexistent"
-module_dependencies  = []
 
 default_moduledir = get_default_modulepath_for_host(master)
 

--- a/acceptance/tests/modules/install/with_debug.rb
+++ b/acceptance/tests/modules/install/with_debug.rb
@@ -7,7 +7,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "java"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/with_existing_module_directory.rb
+++ b/acceptance/tests/modules/install/with_existing_module_directory.rb
@@ -7,7 +7,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "nginx"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/with_modulepath.rb
+++ b/acceptance/tests/modules/install/with_modulepath.rb
@@ -12,7 +12,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 codedir = master.puppet('master')['codedir']
 module_author = "pmtacceptance"
 module_name   = "nginx"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/with_necessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_necessary_upgrade.rb
@@ -9,7 +9,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "java"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/with_no_dependencies.rb
+++ b/acceptance/tests/modules/install/with_no_dependencies.rb
@@ -9,7 +9,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "nginx"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
+++ b/acceptance/tests/modules/install/with_unnecessary_upgrade.rb
@@ -9,7 +9,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "java"
-module_dependencies   = ["stdlub"]
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
+++ b/acceptance/tests/modules/install/with_unsatisfied_constraints.rb
@@ -9,8 +9,6 @@ tag 'audit:low',       # Install via pmt is not the primary support workflow
 
 module_author = "pmtacceptance"
 module_name   = "git"
-module_reference = "#{module_author}-#{module_name}"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/list/with_circular_dependencies.rb
+++ b/acceptance/tests/modules/list/with_circular_dependencies.rb
@@ -50,12 +50,12 @@ on master, "[ -d #{master['sitemoduledir']}/crakorn ]"
 
 step "List the installed modules"
 on master, puppet("module list") do
-  assert_match /jimmy-crakorn/, stdout, 'Could not find jimmy crakorn'
-  assert_match /jimmy-appleseed/, stdout, 'Could not find jimmy appleseed, but then again... wasnt it johnny appleseed?'
+  assert_match(/jimmy-crakorn/, stdout, 'Could not find jimmy crakorn')
+  assert_match(/jimmy-appleseed/, stdout, 'Could not find jimmy appleseed, but then again... wasnt it johnny appleseed?')
 end
 
 step "List the installed modules as a dependency tree"
 on master, puppet("module list --tree") do
-  assert_match /jimmy-crakorn.*\[#{master['sitemoduledir']}\]/, stdout, 'Could not find jimmy crakorn'
-  assert_match /jimmy-appleseed.*\[#{master['distmoduledir']}\]/, stdout, 'Could not find jimmy appleseed, but then again... wasnt it johnny appleseed?'
+  assert_match(/jimmy-crakorn.*\[#{master['sitemoduledir']}\]/, stdout, 'Could not find jimmy crakorn')
+  assert_match(/jimmy-appleseed.*\[#{master['distmoduledir']}\]/, stdout, 'Could not find jimmy appleseed, but then again... wasnt it johnny appleseed?')
 end

--- a/acceptance/tests/modules/list/with_invalid_dependencies.rb
+++ b/acceptance/tests/modules/list/with_invalid_dependencies.rb
@@ -81,7 +81,7 @@ on master, puppet("module list") do |res|
   ].join("\n"), Regexp::MULTILINE)
   assert_match(pattern, result.stderr)
 
-  assert_match /jimmy-crakorn.*invalid/, res.stdout, 'Did not find module jimmy-crick in module site path'
+  assert_match(/jimmy-crakorn.*invalid/, res.stdout, 'Did not find module jimmy-crick in module site path')
 end
 
 step "List the installed modules as a dependency tree"
@@ -93,5 +93,5 @@ on master, puppet("module list --tree") do |res|
   ].join("\n"), Regexp::MULTILINE)
   assert_match(pattern, result.stderr)
 
-  assert_match /jimmy-crakorn.*\[#{master['distmoduledir']}\].*invalid/, res.stdout
+  assert_match(/jimmy-crakorn.*\[#{master['distmoduledir']}\].*invalid/, res.stdout)
 end

--- a/acceptance/tests/modules/list/with_missing_dependencies.rb
+++ b/acceptance/tests/modules/list/with_missing_dependencies.rb
@@ -85,7 +85,7 @@ on master, puppet('module list --tree') do
   ].join("\n"), Regexp::MULTILINE)
   assert_match(pattern, result.stderr)
 
-  assert_match /UNMET DEPENDENCY.*jimmy-sprinkles/, stdout, 'Did not find unmeet dependency for jimmy-sprinkles warning'
+  assert_match(/UNMET DEPENDENCY.*jimmy-sprinkles/, stdout, 'Did not find unmeet dependency for jimmy-sprinkles warning')
 
-  assert_match /UNMET DEPENDENCY.*jimmy-crakorn/, stdout, 'Did not find unmeet dependency for jimmy-crakorn warning'
+  assert_match(/UNMET DEPENDENCY.*jimmy-crakorn/, stdout, 'Did not find unmeet dependency for jimmy-crakorn warning')
 end

--- a/acceptance/tests/modules/search/communication_error.rb
+++ b/acceptance/tests/modules/search/communication_error.rb
@@ -13,7 +13,7 @@ on master, puppet("module search yup"), :acceptable_exit_codes => [1] do
 \e[mNotice: Searching https://forgeapi.puppet.com ...\e[0m
 STDOUT
 
-assert_no_match /yup/,
+assert_no_match(/yup/,
   stdout,
-  'Found a reference to a fake module when errors should have prevented us from getting here'
+  'Found a reference to a fake module when errors should have prevented us from getting here')
 end

--- a/acceptance/tests/modules/uninstall/using_version_filter.rb
+++ b/acceptance/tests/modules/uninstall/using_version_filter.rb
@@ -9,7 +9,6 @@ tag 'audit:low',       # Module management via pmt is not the primary support wo
 
 module_author = "jimmy"
 module_name   = "crakorn"
-module_dependencies = []
 
 orig_installed_modules = get_installed_modules_for_hosts hosts
 teardown do

--- a/acceptance/tests/modules/upgrade/with_environment.rb
+++ b/acceptance/tests/modules/upgrade/with_environment.rb
@@ -11,7 +11,6 @@ tmpdir = master.tmpdir('module-upgrade-withenv')
 
 module_author = "pmtacceptance"
 module_name   = "java"
-module_dependencies = ["stdlub"]
 
 step 'Setup'
 

--- a/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
+++ b/acceptance/tests/modules/upgrade/with_scattered_dependencies.rb
@@ -23,7 +23,7 @@ on master, puppet("module install pmtacceptance-stdlub --version 0.0.2 --target-
 on master, puppet("module install pmtacceptance-java --version 1.6.0 --target-dir #{master['distmoduledir']} --ignore-dependencies")
 on master, puppet("module install pmtacceptance-postql --version 0.0.1 --target-dir #{master['distmoduledir']} --ignore-dependencies")
 on master, puppet("module list") do
-  assert_match /pmtacceptance-java.*1\.6\.0/, stdout, 'Could not find pmtacceptance/java'
-  assert_match /pmtacceptance-postql.*0\.0\.1/, stdout, 'Could not find pmtacceptance/postql'
-  assert_match /pmtacceptance-stdlub.*0\.0\.2/, stdout, 'Could not find pmtacceptance/stdlub'
+  assert_match(/pmtacceptance-java.*1\.6\.0/, stdout, 'Could not find pmtacceptance/java')
+  assert_match(/pmtacceptance-postql.*0\.0\.1/, stdout, 'Could not find pmtacceptance/postql')
+  assert_match(/pmtacceptance-stdlub.*0\.0\.2/, stdout, 'Could not find pmtacceptance/stdlub')
 end

--- a/acceptance/tests/node/check_woy_cache_works.rb
+++ b/acceptance/tests/node/check_woy_cache_works.rb
@@ -131,7 +131,7 @@ master_opts = {
 with_puppet_running_on master, master_opts do
 
   # only one agent is needed because we only care about the file written on the master
-  run_agent_on(agents[0], "--no-daemonize --verbose --onetime --node_name_value #{node_name} --server #{master}")
+  run_agent_on(agents[0], "--no-daemonize --verbose --onetime --node_name_value #{node_name}")
 
   yamldir = on(master, puppet('master', '--configprint', 'yamldir')).stdout.chomp
   on master, puppet('node', 'search', '"*"', '--node_terminus', 'yaml', '--clientyamldir', yamldir, '--render-as', 'json') do

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -42,7 +42,7 @@ master_opts = {
 
 with_puppet_running_on(master, master_opts) do
   agents.each do |agent|
-    on(agent, puppet('agent', "--no-daemonize --onetime --verbose --server #{master} --ordering manifest"))
+    on(agent, puppet('agent', "--no-daemonize --onetime --verbose --ordering manifest"))
     if stdout !~ /Notice: first.*Notice: second.*Notice: third.*Notice: fourth.*Notice: fifth.*Notice: sixth.*Notice: seventh.*Notice: eighth/m
       fail_test "Output did not include the notify resources in the correct order"
     end

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -25,14 +25,13 @@ def manifest_call_each_function_from_array(functions)
 end
 
 
-generator = ''
 agents.each do |agent|
   testdir = agent.tmpdir('calling_all_functions')
-  if agent["platform"] =~ /win/
-    generator = {:args => '"c:/windows/system32/tasklist.exe"', :expected => /\nImage Name/}
-  else
-    generator = {:args => '"/bin/date"',                        :expected => /\w\w\w.*?\d\d:\d\d\:\d\d/}
-  end
+  # if agent["platform"] =~ /win/
+  #   generator = {:args => '"c:/windows/system32/tasklist.exe"', :expected => /\nImage Name/}
+  # else
+  #   generator = {:args => '"/bin/date"',                        :expected => /\w\w\w.*?\d\d:\d\d\:\d\d/}
+  # end
 
   # create list of 3x functions and args
   # notes: hiera functions are well tested elsewhere, included for completeness

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -89,7 +89,7 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t --server #{master}"), :acceptable_exit_codes => [2])
+    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2])
 
     assert_match("apache server port: 8080", stdout)
   end

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -101,7 +101,7 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t --server #{master}"), :acceptable_exit_codes => [2])
+    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2])
 
     assert_match("ntpserver global.ntp.puppetlabs.com", stdout)
     assert_match("ntpserver production.ntp.puppetlabs.com", stdout)

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -99,7 +99,7 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t --server #{master}"), :acceptable_exit_codes => [2])
+    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2])
 
     assert_match("name: postgres shell: /bin/bash", stdout)
   end

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -68,7 +68,6 @@ hash_value:
 NEW_YAML
     osfamily_yamls += new_yaml
   end
-  osfamily_yamls
   environ = <<ENV
 
 File {
@@ -276,7 +275,7 @@ def find_osfamilies
     osf = res.stdout.chomp
     family_hash[osf] = 1
   end
-  osfamilies = family_hash.keys
+  family_hash.keys
 end
 
 def find_tmp_dirs

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -309,7 +309,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
     step "Applying catalog to agent: #{agent}. result files in #{resultdir}"
     on(
       agent,
-      puppet('agent', "-t --server #{master}"),
+      puppet('agent', "-t"),
       :acceptable_exit_codes => [2]
     )
 

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -55,7 +55,7 @@ SITEPP
 
   with_puppet_running_on(master, {}) do
     agents.each do |agent|
-      on(agent, puppet("agent -t --environment #{tmp_environment} --server #{master.hostname}"))
+      on(agent, puppet("agent -t --environment #{tmp_environment}"))
     end
   end
 

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -41,7 +41,7 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, basedir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t --server #{master}"))
+    on(agent, puppet('agent', "-t"))
       assert_no_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/pluginfacts/, stderr)
       assert_no_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/plugins/, stderr)
   end

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -90,12 +90,12 @@ MANIFEST
       end
 
       step "Pluginsync the external fact to the agent and ensure it resolves correctly" do
-        on(agent, puppet('agent', '-t', '--server', master, '--pluginfactdest', factsd), :acceptable_exit_codes => [2]) do |result|
+        on(agent, puppet('agent', '-t', '--pluginfactdest', factsd), :acceptable_exit_codes => [2]) do |result|
           assert_match(/foo is bar/, result.stdout)
         end
       end
       step "Use plugin face to download to the agent" do
-        on(agent, puppet('plugin', 'download', '--server', master, '--pluginfactdest', pluginfactdest)) do |result|
+        on(agent, puppet('plugin', 'download', '--pluginfactdest', pluginfactdest)) do |result|
           assert_match(/Downloaded these plugins: .*external_fact/, result.stdout) unless agent['locale'] == 'ja'
         end
       end

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -81,8 +81,6 @@ MANIFEST
     agents.each do |agent|
       factsd         = agent.tmpdir('facts.d')
       pluginfactdest = agent.tmpdir('facts.d')
-      tmpdir         = agent.tmpdir('tmpdir')
-      testfile       = File.join(tmpdir, 'testfile')
 
       teardown do
         on(master, "rm -rf '#{codedir}'")

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -53,7 +53,7 @@ test_name "Pluginsync'ed custom facts should be resolvable during application ru
 
   with_puppet_running_on(master, {}) do
     agents.each do |agent|
-      on(agent, puppet("agent -t --server #{master} --environment #{tmp_environment}"))
+      on(agent, puppet("agent -t --environment #{tmp_environment}"))
       on(agent, puppet('resource test4847')) do |result|
         assert_match(/fact foo=bar/, result.stderr)
       end

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -71,7 +71,7 @@ end
         end
 
         step "run the agent" do
-          on(agent, puppet("agent --libdir='#{agent_lib_dir}' --test --server #{master} --environment '#{tmp_environment}'")) do |result|
+          on(agent, puppet("agent --libdir='#{agent_lib_dir}' --test --environment '#{tmp_environment}'")) do |result|
             assert_no_match(
               /The \`source_permissions\` parameter is deprecated/,
               result.stderr,

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -115,7 +115,7 @@ begin
         agents.each do |agent|
           on(agent, puppet('agent',
                            "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\" ",
-                           "--trace --test --server #{master}")
+                           "--trace --test")
           )
         end
       end

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -33,9 +33,6 @@ app_name = "superbogus"
 app_desc = "a simple %1$s for testing %1$s delivery via plugin sync"
 app_output = "Hello from the #{app_name} %s"
 
-master_module_file_content = {}
-
-
 master_module_face_content = <<-HERE
 Puppet::Face.define(:#{app_name}, '0.0.1') do
   copyright "Puppet Labs", 2011

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -82,7 +82,7 @@ test_name "the pluginsync functionality should sync feature definitions" do
         end
 
         step 'run the agent and verify that it loaded the feature' do
-          on(agent, puppet("agent -t --libdir='#{agent_lib_dir}' --server #{master} --environment '#{tmp_environment}'"),
+          on(agent, puppet("agent -t --libdir='#{agent_lib_dir}' --environment '#{tmp_environment}'"),
              :acceptable_exit_codes => [2]) do |result|
             assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
                          "Expected agent stdout to include confirmation that the feature was 'true'")
@@ -98,7 +98,7 @@ test_name "the pluginsync functionality should sync feature definitions" do
         end
 
         step 'run the agent again' do
-          on(agent, puppet("agent -t --libdir='#{agent_lib_dir}' --server #{master} --environment '#{tmp_environment}'"),
+          on(agent, puppet("agent -t --libdir='#{agent_lib_dir}' --environment '#{tmp_environment}'"),
              :acceptable_exit_codes => [2]) do |result|
             assert_match(/The value of the #{module_name} feature is: true/, result.stdout,
                          "Expected agent stdout to include confirmation that the feature was 'true'")

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -61,7 +61,7 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, basedir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t --server #{master}"))
+    on(agent, puppet('agent', "-t"))
     on agent, "cat \"#{agent.puppet['vardir']}/lib/foo.rb\"" do
       assert_match(/from the first module/, stdout, "The synced plugin was not found or the wrong version was synced")
     end

--- a/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
+++ b/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
@@ -11,14 +11,13 @@ test_name "C100533: Agent sends json report for cached catalog" do
 
     step "Perform agent run to ensure that catalog is cached" do
       agents.each do |agent|
-        on(agent, puppet('agent', '-t', "--server #{master}"), :acceptable_exit_codes => [0,2])
+        on(agent, puppet('agent', '-t'), :acceptable_exit_codes => [0,2])
       end
     end
 
     step "Ensure agent sends #{expected_format} report for cached catalog" do
       agents.each do |agent|
         on(agent, puppet('agent', '-t',
-                         "--server #{master}",
                          '--http_debug'), :acceptable_exit_codes => [0,2]) do |res|
           # Expected content-type should be in the headers of the
           # HTTP report payload being PUT to the server by the agent.

--- a/acceptance/tests/reports/cached_catalog_status_in_report.rb
+++ b/acceptance/tests/reports/cached_catalog_status_in_report.rb
@@ -17,11 +17,11 @@ test_name "PUP-5867: The report specifies whether a cached catalog was used, and
     agents.each do |agent|
       step "cached_catalog_status should be 'not used' when a new catalog is retrieved" do
         step "Initial run: cache a newly retrieved catalog" do
-          on(agent, puppet("agent", "-t", "--server #{master}"), :acceptable_exit_codes => [0,2])
+          on(agent, puppet("agent", "-t"), :acceptable_exit_codes => [0,2])
         end
 
         step "Run again and ensure report indicates that the cached catalog was not used" do
-          on(agent, puppet("agent", "--onetime", "--no-daemonize", "--server #{master}"), :acceptable_exit_codes => [0, 2])
+          on(agent, puppet("agent", "--onetime", "--no-daemonize"), :acceptable_exit_codes => [0, 2])
           on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do
             assert_match(/cached_catalog_status: not_used/, stdout, "expected to find 'cached_catalog_status: not_used' in the report")
           end
@@ -30,7 +30,7 @@ test_name "PUP-5867: The report specifies whether a cached catalog was used, and
       end
 
       step "Run with --use_cached_catalog and ensure report indicates cached catalog was explicitly requested" do
-        on(agent, puppet("agent", "--onetime", "--no-daemonize", "--use_cached_catalog", "--server #{master}"), :acceptable_exit_codes => [0, 2])
+        on(agent, puppet("agent", "--onetime", "--no-daemonize", "--use_cached_catalog"), :acceptable_exit_codes => [0, 2])
         on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do
           assert_match(/cached_catalog_status: explicitly_requested/, stdout, "expected to find 'cached_catalog_status: explicitly_requested' in the report")
         end

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -53,7 +53,7 @@ test_name "C98092 - a new resource should not be reported as a corrective change
       agents.each do |agent|
         #Run agent once to create new File resource
         step 'Run agent once to create new File resource' do
-          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}'"), :acceptable_exit_codes => 2)
         end
 
         #Verify the file resource is created

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -54,7 +54,7 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
       agents.each do |agent|
         #Run agent once to create new File resource
         step 'Run agent once to create new File resource' do
-          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}'"), :acceptable_exit_codes => 2)
         end
 
         #Verify the file resource is created
@@ -71,7 +71,7 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
 
         #Run agent to correct the file's absence
         step 'Run agent to correct the files absence' do
-          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}'"), :acceptable_exit_codes => 2)
         end
 
         #Verify the file resource is created

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -62,7 +62,7 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
         step 'Run agent once to create new File resource' do
-          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}'"), :acceptable_exit_codes => 2)
         end
 
         step 'Verify the file resource is created' do
@@ -78,7 +78,7 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
 
       agents.each do |agent|
         step 'Run agent a 2nd time to change the File resource' do
-          on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
+          on(agent, puppet("agent -t --environment '#{tmp_environment}'"), :acceptable_exit_codes => 2)
         end
 
         step 'Verify the file resource is created' do

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -51,7 +51,7 @@ if master.is_pe?
 
   with_puppet_running_on(master, {}) do
     agents.each do |agent|
-      on(agent, puppet('agent', "-t --server #{master}"))
+      on(agent, puppet('agent', "-t"))
 
       sleep_until_queue_empty
 
@@ -72,7 +72,7 @@ else
 
   with_puppet_running_on(master, :main => { :reportdir => testdir, :reports => 'store' }) do
     agents.each do |agent|
-      on(agent, puppet('agent', "-t --server #{master}"))
+      on(agent, puppet('agent', "-t"))
 
       on master, "grep -q #{agent.node_name} #{testdir}/*/*"
     end

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -7,7 +7,7 @@ tag 'audit:high',
 
 def before(agent)
   step "file to be touched should not exist."
-  touched = agent.tmpfile('test-exec')
+  agent.tmpfile('test-exec')
 end
 
 def after(agent, touched)

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -162,7 +162,7 @@ test_name "The source attribute" do
     agents.each do |agent|
       # accept an exit code of 2 which is returned if there are changes
       step "create file the first run"
-      on(agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => [0,2]) do
+      on(agent, puppet('agent', "--test"), :acceptable_exit_codes => [0,2]) do
         file_to_check = agent['platform'] =~ /windows/ ? @target_file_on_windows : @target_file_on_nix
         dir_to_check = agent['platform'] =~ /windows/ ? @target_dir_on_windows : @target_dir_on_nix
 
@@ -178,7 +178,7 @@ test_name "The source attribute" do
       end
 
       step "second run should not update file"
-      on(agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => [0,2]) do
+      on(agent, puppet('agent', "--test"), :acceptable_exit_codes => [0,2]) do
         assert_no_match(/content changed.*(md5|sha256)/, stdout, "Shouldn't have overwritten any files")
 
         # When using ctime/mtime, the agent compares the values from its
@@ -210,7 +210,7 @@ test_name "The source attribute" do
 
     on master, "touch #{mod_source_file} #{mod_source_dir_file}"
     agents.each do |agent|
-      on(agent, puppet('agent', "--test --server #{master}"), :acceptable_exit_codes => [0,2]) do
+      on(agent, puppet('agent', "--test"), :acceptable_exit_codes => [0,2]) do
         file_to_check = agent['platform'] =~ /windows/ ? @target_file_on_windows : @target_file_on_nix
         dir_to_check = agent['platform'] =~ /windows/ ? @target_dir_on_windows : @target_dir_on_nix
         ['ctime', 'mtime'].each do |time_type|

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -76,7 +76,7 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
 
     with_puppet_running_on(master, {}) do
       agents.each do |agent|
-        on(agent, puppet("agent -t --environment '#{tmp_environment}' --server #{master.hostname}"), :acceptable_exit_codes => 2)
+        on(agent, puppet("agent -t --environment '#{tmp_environment}'"), :acceptable_exit_codes => 2)
 
         on(agent, "cat '#{agent_tmp_dirs[agent_to_fqdn(agent)]}/\uff72\uff67\u30d5\u30eb'") do |result|
           assert_match("\u2603", result.stdout, "managed UTF-8 file contents '#{result.stdout}' did not match expected value '\u2603'")

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -38,7 +38,7 @@ agents.each do |agent|
   apply_manifest_on(agent, manifest, :trace => true)
 
   on agent, "cat #{dest}" do
-    assert_match /This is the real content/, stdout
+    assert_match(/This is the real content/, stdout)
   end
 
   step "Cleanup"

--- a/acceptance/tests/resource/mount/modify.rb
+++ b/acceptance/tests/resource/mount/modify.rb
@@ -17,7 +17,6 @@ require 'puppet/acceptance/mount_utils'
 extend Puppet::Acceptance::MountUtils
 
 name = "pl#{rand(999999).to_i}"
-new_name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
   fs_file = filesystem_file(agent)

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -26,9 +26,9 @@ agents.each do |agent|
 
   step "list running services and make sure ssh reports running"
   on(agent, puppet('resource service'))
-  assert_match /service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is not running"
+  assert_match(/service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is not running")
 
   step "list running services again and make sure ssh is still running"
   on(agent, puppet('resource service'))
-  assert_match /service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is no longer running"
+  assert_match(/service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is no longer running")
 end

--- a/acceptance/tests/security/cve-2013-1640_facter_string.rb
+++ b/acceptance/tests/security/cve-2013-1640_facter_string.rb
@@ -13,7 +13,7 @@ test_name "CVE 2013-1640 Remote Code Execution" do
              %q[ puppet apply -e ] +
              %q[ 'notice(inline_template("<%= \"I am Safe\" %>"))' ] do |test|
 
-    assert_match /I am Safe/, test.stdout
-    assert_no_match /hax0rd/, test.stdout
+    assert_match(/I am Safe/, test.stdout)
+    assert_no_match(/hax0rd/, test.stdout)
   end
 end

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -11,7 +11,7 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
 
   with_puppet_running_on master, {} do
     # Ensure each agent has a signed cert
-    on agents, puppet('agent', "-t --server #{master}" )
+    on agents, puppet('agent', "-t")
 
     agents.each do |agent|
       next if agent['roles'].include?( 'master' )

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -11,7 +11,7 @@ test_name "CVE 2013-1652 Poison node cache" do
 
   with_puppet_running_on( master, {} ) do
     # Ensure agent has a signed cert
-    on master, puppet('agent', '-t', "--server #{master}" )
+    on master, puppet('agent', '-t' )
 
     certname = on(
       master, puppet('agent', "--configprint certname")).stdout.chomp

--- a/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
+++ b/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
@@ -39,7 +39,7 @@ include $enc_data
       next if agent['roles'].include?('master')
 
       step "Request a catalog to trigger the exploit" do
-        on agent, puppet('agent', '-t', "--server #{master}"), :acceptable_exit_codes => [1]
+        on agent, puppet('agent', '-t'), :acceptable_exit_codes => [1]
       end
 
       step "Check that the exploit marker was not created" do

--- a/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
+++ b/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
@@ -13,7 +13,6 @@ test_name "C100532: Server returns expected format when --preferred_serializatio
         agents.each do |agent|
           on(agent, puppet('agent', '-t',
                            "--preferred_serialization_format #{expected_format}",
-                           "--server #{master}",
                            '--http_debug'), :acceptable_exit_codes => [0,2]) do |res|
             found_format = false
             started = false

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -65,7 +65,6 @@ EOF
 
         test_certnames << (certname = "#{agent}-autosign")
         on(agent, puppet("agent --test",
-                  "--server #{master}",
                   "--waitforcert 0",
                   "--ssldir", "'#{testdirs[agent]}/ssldir-autosign'",
                   "--certname #{certname}"), :acceptable_exit_codes => [0,2])
@@ -106,7 +105,6 @@ EOF
 
         test_certnames << (certname = "#{agent}-reject")
         on(agent, puppet("agent --test",
-                        "--server #{master}",
                         "--waitforcert 0",
                         "--ssldir", "'#{testdirs[agent]}/ssldir-reject'",
                         "--certname #{certname}"), :acceptable_exit_codes => [1])
@@ -175,7 +173,6 @@ custom_attributes:
         step "attempting to obtain cert for #{agent}"
         test_certnames << (certname = "#{agent}-attrs")
         on(agent, puppet("agent --test",
-                         "--server #{master}",
                          "--waitforcert 0",
                          "--ssldir", "'#{testdirs[agent]}/ssldir-attrs'",
                          "--csr_attributes '#{agent_csr_attributes[agent]}'",

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -87,7 +87,6 @@ test_name "certificate extensions available as trusted data" do
 
       step "Check in as #{agent_certname}"
       on(agent, puppet("agent", "--test",
-                       "--server", master,
                        "--waitforcert", 0,
                        "--csr_attributes", agent_csr_attributes,
                        "--certname", agent_certname,

--- a/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
+++ b/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
@@ -33,10 +33,6 @@ class in_three {
 class { "in_three": stage => "three" }
 HERE
 
-  expected_results = "in_one
-in_two
-in_three
-"
   apply_manifest_on agent, test_manifest
 
   on(agent, "cat #{temp_file_name}") do

--- a/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
+++ b/acceptance/tests/stages/ticket_4655_default_stage_for_classes.rb
@@ -37,6 +37,6 @@ HERE
 
   on(agent, "cat #{temp_file_name}") do
     # echo on windows adds \r\n, so do dotall regexp match
-    assert_match(/in_one\s*in_two\s*\in_three/m, stdout, "Unexpected result for host '#{agent}'")
+    assert_match(/in_one\s*in_two\s*in_three/m, stdout, "Unexpected result for host '#{agent}'")
   end
 end

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -118,7 +118,7 @@ begin
           on(agent, puppet('agent',
                            "--vardir=\"#{get_test_file_path(agent, agent_var_dir)}\" ",
                            "--ssldir=\"#{agent_ssldir}\" ",
-                           "--trace  --test --server #{master}")
+                           "--trace  --test")
           )
         end
       end

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -25,8 +25,6 @@ app_name = "superbogus"
 app_desc = "a simple %1$s for testing %1$s delivery via plugin sync"
 app_output = "Hello from the #{app_name} %s"
 
-master_module_file_content = {}
-
 master_module_face_content = <<-HERE
 Puppet::Face.define(:#{app_name}, '0.0.1') do
   copyright "Puppet Labs", 2011

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -1,6 +1,5 @@
 test_name "#3360: Allow duplicate CSR when allow_duplicate_certs is on"
 
-agent_hostnames = agents.map {|a| a.to_s}
 tag 'audit:medium',  # CA functionality
     'audit:refactor', # Use block style `test_name`
     'audit:unit',

--- a/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
+++ b/acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb
@@ -17,7 +17,7 @@ with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true,
 
   agents_with_cert_name.each do |fqdn, agent|
     step "Generate a certificate request for the agent"
-    on(agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}"))
+    on(agent, puppet("certificate generate #{fqdn} --ca-location remote"))
   end
 
   step "Collect the original certs"
@@ -37,7 +37,7 @@ with_puppet_running_on(master, {'master' => {'allow_duplicate_certs' => true,
 
   agents_with_cert_name.each do |fqdn, agent|
     step "Make another request with the same certname"
-    on(agent, puppet("certificate generate #{fqdn} --ca-location remote --server #{master}"))
+    on(agent, puppet("certificate generate #{fqdn} --ca-location remote"))
   end
 
   step "Collect the new certs"

--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -34,7 +34,7 @@ step "Master: Start Puppet Master" do
       end
 
       tmpfile = agent.tmpfile('testfile')
-      remote_str = "--remote --server #{master}"
+      remote_str = "--remote"
       local_str = "--local"
 
       teardown do

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -40,7 +40,7 @@ master_opts = {
 with_puppet_running_on master, master_opts, testdir do
   # Run test on Agents
   step "Agent: agent --test"
-  on(agents, puppet('agent', "-t --server #{master}"), :acceptable_exit_codes => [0,2])
+  on(agents, puppet('agent', "-t"), :acceptable_exit_codes => [0,2])
 
   # Create a new site.pp
   step "Master: create basic site.pp file"
@@ -53,7 +53,7 @@ with_puppet_running_on master, master_opts, testdir do
   step "Agent: puppet agent --test"
 
   agents.each do |host|
-    on(host, puppet('agent', "-t --server #{master}"), :acceptable_exit_codes => [2]) do
+    on(host, puppet('agent', "-t"), :acceptable_exit_codes => [2]) do
       assert_match(/ticket_5477_notify/, stdout, "#{host}: Site.pp not detected on Puppet Master")
     end
   end

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -8,7 +8,7 @@ require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils
 
 hosts_to_test = agents.reject do |agent|
-  if agent['platform'].match /(?:ubuntu|centos|debian|el-|fedora)/
+  if agent['platform'].match(/(?:ubuntu|centos|debian|el-|fedora)/)
     result = on(agent, "#{ruby_command(agent)} -e \"require 'shadow' or raise\"", :acceptable_exit_codes => [0,1])
     result.exit_code != 0
   else

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -64,7 +64,7 @@ PP
 
     with_puppet_running_on(master, master_opts, codedir) do
       step "apply utf-8 catalog" do
-        on(agent, puppet("agent -t --vardir '#{agent_vardir}' --server #{master.hostname}"),
+        on(agent, puppet("agent -t --vardir '#{agent_vardir}'"),
            { :acceptable_exit_codes => [2], :environment => { :LANG => "en_US.UTF-8" } })
       end
 

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -4,7 +4,6 @@ test_name 'utf-8 characters in cached catalog' do
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
       'audit:refactor' # use mk_temp_environment_with_teardown
 
-  utf8chars_lit = "€‰ㄘ万竹ÜÖ"
   utf8chars     = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
   file_content  = "This is the file content. file #{utf8chars}"
   codedir       = master.tmpdir("code")

--- a/acceptance/tests/utf8/utf8-in-puppet-describe.rb
+++ b/acceptance/tests/utf8/utf8-in-puppet-describe.rb
@@ -71,7 +71,7 @@ MASTER_MANIFEST
       puts "agent name: #{agent.hostname}, platform: #{agent.platform}"
       step "Run puppet agent for plugin sync" do 
         on(
-          agent, puppet("agent", "-t", "--server #{master.node_name}"),
+          agent, puppet("agent", "-t"),
           :acceptable_exit_codes => [0, 2]
         )
       end


### PR DESCRIPTION
beaker-puppet 1.18.4 will automatically set the `server` setting for every host. Require at least that version, so that each test doesn't need to.