### PR TITLE
(PUP-9638) Verify CA fingerprint 

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -913,6 +913,14 @@ EOT
       :group => "service",
       :desc => "Where each client stores the CA certificate."
     },
+    :ca_fingerprint => {
+      :default => nil,
+      :type   => :string,
+      :desc => "The expected fingerprint of the CA certificate. If specified, the agent
+        will compare the CA certificate fingerprint that it downloads against this value
+        and reject the CA certificate if the values do not match. This only applies
+        during the first download of the CA certificate."
+    },
     :ssl_client_ca_auth => {
       :type  => :file,
       :mode  => "0644",

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -367,7 +367,7 @@ class Puppet::SSL::StateMachine
       chain = ssl_context.client_chain
       # print from root to client
       chain.reverse.each_with_index do |cert, i|
-        digest = Puppet::SSL::Digest.new('SHA256', cert.to_der)
+        digest = Puppet::SSL::Digest.new(@digest, cert.to_der)
         if i == chain.length - 1
           Puppet.debug(_("Verified client certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
         else

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -334,8 +334,7 @@ class Puppet::SSL::StateMachine
                  ssl_provider: Puppet::SSL::SSLProvider.new,
                  lockfile: Puppet::Util::Pidlock.new(Puppet[:ssl_lockfile]),
                  digest: 'SHA256',
-                 ca_fingerprint: nil
-                )
+                 ca_fingerprint: Puppet[:ca_fingerprint])
     @waitforcert = waitforcert
     @wait_deadline = Time.now.to_i + maxwaitforcert
     @onetime = onetime

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -45,6 +45,18 @@ class Puppet::SSL::StateMachine
         next_ctx = @ssl_provider.create_root_context(cacerts: cacerts, revocation: false)
       else
         pem = Puppet::Rest::Routes.get_certificate(Puppet::SSL::CA_NAME, @ssl_context)
+        if @machine.ca_fingerprint
+          actual_digest = Puppet::SSL::Digest.new(@machine.digest, pem).to_hex
+          expected_digest = @machine.ca_fingerprint.scan(/../).join(':').upcase
+          if actual_digest == expected_digest
+            Puppet.info(_("Verified CA bundle with digest (%{digest_type}) %{actual_digest}") %
+                        { digest_type: @machine.digest, actual_digest: actual_digest })
+          else
+            e = Puppet::Error.new(_("CA bundle with digest (%{digest_type}) %{actual_digest} did not match expected digest %{expected_digest}") % { digest_type: @machine.digest, actual_digest: actual_digest, expected_digest: expected_digest })
+            return Error.new(@machine, e.message, e)
+          end
+        end
+
         cacerts = @cert_provider.load_cacerts_from_pem(pem)
         # verify cacerts before saving
         next_ctx = @ssl_provider.create_root_context(cacerts: cacerts, revocation: false)
@@ -292,7 +304,7 @@ class Puppet::SSL::StateMachine
   #
   class Done < SSLState; end
 
-  attr_reader :waitforcert, :wait_deadline, :cert_provider, :ssl_provider
+  attr_reader :waitforcert, :wait_deadline, :cert_provider, :ssl_provider, :ca_fingerprint, :digest
 
   # Construct a state machine to manage the SSL initialization process. By
   # default, if the state machine encounters an exception, it will log the
@@ -312,18 +324,26 @@ class Puppet::SSL::StateMachine
   #   to load and save X509 objects.
   # @param ssl_provider [Puppet::SSL::SSLProvider] ssl provider to use
   #   to construct ssl contexts.
+  # @param digest [String] digest algorithm to use for certificate fingerprinting
+  # @param ca_fingerprint [String] optional fingerprint to verify the
+  #   downloaded CA bundle
   def initialize(waitforcert: Puppet[:waitforcert],
                  maxwaitforcert: Puppet[:maxwaitforcert],
                  onetime: Puppet[:onetime],
                  cert_provider: Puppet::X509::CertProvider.new,
                  ssl_provider: Puppet::SSL::SSLProvider.new,
-                 lockfile: Puppet::Util::Pidlock.new(Puppet[:ssl_lockfile]))
+                 lockfile: Puppet::Util::Pidlock.new(Puppet[:ssl_lockfile]),
+                 digest: 'SHA256',
+                 ca_fingerprint: nil
+                )
     @waitforcert = waitforcert
     @wait_deadline = Time.now.to_i + maxwaitforcert
     @onetime = onetime
     @cert_provider = cert_provider
     @ssl_provider = ssl_provider
     @lockfile = lockfile
+    @digest = digest
+    @ca_fingerprint = ca_fingerprint
   end
 
   # Run the state machine for CA certs and CRLs.

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -38,6 +38,16 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     allow(Kernel).to receive(:sleep)
   end
 
+  context 'when passing keyword arguments' do
+    it "accepts digest" do
+      expect(described_class.new(digest: 'SHA512').digest).to eq('SHA512')
+    end
+
+    it "accepts ca_fingerprint" do
+      expect(described_class.new(ca_fingerprint: 'CAFE').ca_fingerprint).to eq('CAFE')
+    end
+  end
+
   context 'when ensuring CA certs and CRLs' do
     it 'returns an SSLContext with the loaded CA certs and CRLs' do
       allow(cert_provider).to receive(:load_cacerts).and_return(cacerts)
@@ -317,6 +327,41 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       state.next_state rescue OpenSSL::X509::CertificateError
 
       expect(File).to_not exist(Puppet[:localcacert])
+    end
+
+    context 'when verifying CA cert bundle' do
+      before :each do
+        allow(cert_provider).to receive(:load_cacerts).and_return(nil)
+        stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: cacert_pem)
+        allow(cert_provider).to receive(:save_cacerts)
+      end
+
+      it 'verifies CA cert bundle if a ca_fingerprint is given case-insensitively' do
+        Puppet[:log_level] = :info
+        machine = described_class.new(digest: 'SHA256', ca_fingerprint: 'caacf69bbbcdad9dbcda92dd2da3608b639d1aea4c314d6cc6823cdb32d8e0f8')
+        state = Puppet::SSL::StateMachine::NeedCACerts.new(machine)
+        state.next_state
+
+        expect(@logs).to include(an_object_having_attributes(message: "Verified CA bundle with digest (SHA256) CA:AC:F6:9B:BB:CD:AD:9D:BC:DA:92:DD:2D:A3:60:8B:63:9D:1A:EA:4C:31:4D:6C:C6:82:3C:DB:32:D8:E0:F8"))
+      end
+
+      it 'verifies CA cert bundle using non-default fingerprint' do
+        Puppet[:log_level] = :info
+        machine = described_class.new(digest: 'SHA512', ca_fingerprint: '3c9d1482b878913ad95c9631feac5090cb05c6eab9496178d6fd5c14a023da3b1a8650a3cbaac516d9a48caf0b0742e1ed7eebf55105c024c74834a45056a9d9')
+        state = Puppet::SSL::StateMachine::NeedCACerts.new(machine)
+        state.next_state
+
+        expect(@logs).to include(an_object_having_attributes(message: "Verified CA bundle with digest (SHA512) 3C:9D:14:82:B8:78:91:3A:D9:5C:96:31:FE:AC:50:90:CB:05:C6:EA:B9:49:61:78:D6:FD:5C:14:A0:23:DA:3B:1A:86:50:A3:CB:AA:C5:16:D9:A4:8C:AF:0B:07:42:E1:ED:7E:EB:F5:51:05:C0:24:C7:48:34:A4:50:56:A9:D9"))
+      end
+
+      it 'returns an error if verification fails' do
+        machine = described_class.new(digest: 'SHA256', ca_fingerprint: 'wrong!')
+        state = Puppet::SSL::StateMachine::NeedCACerts.new(machine)
+
+        st = state.next_state
+        expect(st).to be_an_instance_of(Puppet::SSL::StateMachine::Error)
+        expect(st.message).to eq("CA bundle with digest (SHA256) CA:AC:F6:9B:BB:CD:AD:9D:BC:DA:92:DD:2D:A3:60:8B:63:9D:1A:EA:4C:31:4D:6C:C6:82:3C:DB:32:D8:E0:F8 did not match expected digest WR:ON:G!")
+      end
     end
   end
 


### PR DESCRIPTION
If `ca_fingerprint` puppet setting is specified, then the agent will verify the downloaded CA certificate and reject it if its fingerprint does not match.