### PR TITLE
(PUP-9698) Request status of the master service

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -387,8 +387,9 @@ class Puppet::Configurer
       port = server[1] || Puppet[:masterport]
       begin
         http = Puppet::Network::HttpPool.http_ssl_instance(host, port)
-        response = http.get('/status/v1/simple')
+        response = http.get('/status/v1/simple/master')
         return [host, port] if response.is_a?(Net::HTTPOK) || response.is_a?(Net::HTTPForbidden)
+
         Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %
                      { host: host, port: port, code: response.code, reason: response.message })
       rescue => detail

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1035,6 +1035,17 @@ describe Puppet::Configurer do
       expect(options[:report].master_used).to eq('myserver:123')
     end
 
+    it "queries the simple status for the 'master' service" do
+      Puppet.settings[:server_list] = ["myserver:123"]
+      response = Net::HTTPOK.new(nil, 200, 'OK')
+      http = double('request')
+      expect(http).to receive(:get).with('/status/v1/simple/master').and_return(response)
+      allow(Puppet::Network::HttpPool).to receive(:http_ssl_instance).with('myserver', '123').and_return(http)
+      allow(@agent).to receive(:run_internal)
+
+      @agent.run
+    end
+
     it "should report when a server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPInternalServerError.new(nil, 500, 'Internal Server Error')


### PR DESCRIPTION
The 'simple' status includes the status of all trapperkeeper services
such as the broker and filesync services. Request status for the 'master'
service specifically.

Backports commit 604212978 from PUP-9159