### PR TITLE
(PUP-9789) Guard Windows Constants

### DIFF
--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -3,10 +3,10 @@ require 'puppet/util/windows/string'
 
 module Puppet::Util::Windows::APITypes
   module ::FFI
-    WIN32_FALSE = 0
+    WIN32_FALSE ||= 0
 
     # standard Win32 error codes
-    ERROR_SUCCESS = 0
+    ERROR_SUCCESS ||= 0
   end
 
   module ::FFI::Library


### PR DESCRIPTION
When running tests under Litmus acceptance testing work flows, the
Puppet::Util::Windows::APITypes::FFI module
from lib/puppet/util/windows/api_types.rb is loaded via the puppet gem.

Unfortunately this module always gets loaded twice and a warning is
returned to the commandline.

This change guards two constants against previous assignment to avoid
the error messages being sent to the console.