### PR TITLE
(PUP-9794) prevent autoload superclass errors

### DIFF
--- a/lib/puppet/provider/package.rb
+++ b/lib/puppet/provider/package.rb
@@ -1,3 +1,5 @@
+require 'puppet/provider'
+
 class Puppet::Provider::Package < Puppet::Provider
   # Prefetch our package list, yo.
   def self.prefetch(packages)

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -1,7 +1,6 @@
 # Puppet package provider for Python's `pip` package management frontend.
 # <http://pip.pypa.io/>
 
-require 'puppet/provider/package'
 require 'puppet/provider/package_targetable'
 require 'puppet/util/http_proxy'
 

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/package'
+require 'puppet/provider/package/gem'
 
 Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   desc "Puppet Ruby Gem support. This provider is useful for managing

--- a/lib/puppet/provider/package_targetable.rb
+++ b/lib/puppet/provider/package_targetable.rb
@@ -7,6 +7,8 @@
 # possibly via a `prefetchV2` method that could take a better data structure.)
 #
 # In addition, `Puppet::Provider::Package::properties` calls `query` in the provider.
+require 'puppet/provider/package'
+
 # But `query` in the provider depends upon whether a `command` attribute is defined for the resource.
 # This is a Catch-22.
 #


### PR DESCRIPTION
With these commits, 'package_targetable.rb' requires 'puppet/provider/package'
avoiding errors when the gem package provider is the first provider to
be autoloaded, which varies depending on the inode order of files in
'puppet/provider/package' and which one 'Dir.entries' happens to returns first.

The 'package_provider' fact in puppetlabs-stdlib triggers this error when it
requires the 'puppet/type/package' outside the body of 'setcode'.

In between the time that 'puppet/type.rb' is required and when when providers
are loaded 'Puppet::Provider::Package' refers to the wrong object. An explicit
'require puppet/provider/package' overwrites an earlier 'Puppet::Provider::Package'
constant, resulting from a mixin of Puppet::Util and Puppet::Provider.