### PR TITLE
(PUP-9718) Create plan information service

### DIFF
--- a/lib/puppet/info_service.rb
+++ b/lib/puppet/info_service.rb
@@ -2,6 +2,7 @@
 module Puppet::InfoService
   require 'puppet/info_service/class_information_service'
   require 'puppet/info_service/task_information_service'
+  require 'puppet/info_service/plan_information_service'
 
   def self.classes_per_environment(env_file_hash)
     Puppet::InfoService::ClassInformationService.new.classes_per_environment(env_file_hash)
@@ -13,5 +14,13 @@ module Puppet::InfoService
 
   def self.task_data(environment_name, module_name, task_name)
     Puppet::InfoService::TaskInformationService.task_data(environment_name, module_name, task_name)
+  end
+
+  def self.plans_per_environment(environment_name)
+    Puppet::InfoService::PlanInformationService.plans_per_environment(environment_name)
+  end
+
+  def self.plan_data(environment_name, module_name, plan_name)
+    Puppet::InfoService::PlanInformationService.plan_data(environment_name, module_name, plan_name)
   end
 end

--- a/lib/puppet/info_service/plan_information_service.rb
+++ b/lib/puppet/info_service/plan_information_service.rb
@@ -1,0 +1,36 @@
+class Puppet::InfoService::PlanInformationService
+  require 'puppet/module'
+
+  def self.plans_per_environment(environment_name)
+    # get the actual environment object, raise error if the named env doesn't exist
+    env = Puppet.lookup(:environments).get!(environment_name)
+    env.modules.map do |mod|
+      mod.plans.map do |plan|
+        {:module => {:name => plan.module.name}, :name => plan.name}
+      end
+    end.flatten
+  end
+
+  def self.plan_data(environment_name, module_name, plan_name)
+    # raise EnvironmentNotFound if applicable
+    Puppet.lookup(:environments).get!(environment_name)
+
+    pup_module = Puppet::Module.find(module_name, environment_name)
+    if pup_module.nil?
+      raise Puppet::Module::MissingModule, _("Module %{module_name} not found in environment %{environment_name}.") %
+                                            {module_name: module_name, environment_name: environment_name}
+    end
+
+    plan = pup_module.plans.find { |t| t.name == plan_name }
+    if plan.nil?
+      raise Puppet::Module::Plan::PlanNotFound.new(plan_name, module_name)
+    end
+
+    begin
+      plan.validate
+      {:metadata => plan.metadata, :files => plan.files}
+    rescue Puppet::Module::Plan::Error => err
+      { :metadata => nil, :files => [], :error => err.to_h }
+    end
+  end
+end

--- a/lib/puppet/module/plan.rb
+++ b/lib/puppet/module/plan.rb
@@ -1,0 +1,160 @@
+require 'puppet/util/logging'
+
+class Puppet::Module
+  class Plan
+    class Error < Puppet::Error
+      attr_accessor :kind, :details
+      def initialize(message, kind, details = nil)
+        super(message)
+        @details = details || {}
+        @kind = kind
+      end
+
+      def to_h
+        {
+          msg: message,
+          kind: kind,
+          details: details
+        }
+      end
+    end
+
+    class InvalidName < Error
+      def initialize(name, msg)
+        super(msg, 'puppet.plans/invalid-name')
+      end
+    end
+
+    class InvalidFile < Error
+      def initialize(msg)
+        super(msg, 'puppet.plans/invalid-file')
+      end
+    end
+
+    class InvalidPlan < Error
+    end
+    class InvalidMetadata < Error
+    end
+    class PlanNotFound < Error
+      def initialize(plan_name, module_name)
+        msg = _("Plan %{plan_name} not found in module %{module_name}.") %
+          {plan_name: plan_name, module_name: module_name}
+        super(msg, 'puppet.plans/plan-not-found', { 'name' => plan_name })
+      end
+    end
+
+    ALLOWED_EXTENSIONS = %w{.pp .yaml}
+    RESERVED_WORDS = %w{and application attr case class consumes default else
+        elsif environment false function if import in inherits node or private
+        produces site true type undef unless}
+    RESERVED_DATA_TYPES = %w{any array boolean catalogentry class collection
+        callable data default enum float hash integer numeric optional pattern
+        resource runtime scalar string struct tuple type undef variant}
+    MOUNTS = %w[lib files plans]
+
+    def self.is_plan_name?(name)
+      return true if name =~ /^[a-z][a-z0-9_]*$/
+      return false
+    end
+
+    # Determine whether a plan file has a legal name and extension
+    def self.is_plans_filename?(path)
+      name = File.basename(path, '.*')
+      ext = File.extname(path)
+      return [false, _("Plan names must start with a lowercase letter and be composed of only lowercase letters, numbers, and underscores")] unless is_plan_name?(name)
+      unless ALLOWED_EXTENSIONS.include? ext
+        return [false, _("Plan name cannot have extension %{ext}, must be .pp or .yaml") % { ext: ext }]
+      end
+      if RESERVED_WORDS.include?(name)
+        return [false, _("Plan name cannot be a reserved word, but was '%{name}'") % { name: name }]
+      end
+      if RESERVED_DATA_TYPES.include?(name)
+        return [false, _("Plan name cannot be a Puppet data type, but was '%{name}'") % { name: name }]
+      end
+      return [true]
+    end
+
+    # Executables list should contain the full path of all possible implementation files
+    def self.find_implementations(name, plan_files)
+      basename = name.split('::')[1] || 'init'
+
+      # If implementations isn't defined, then we use executables matching the
+      # plan name, and only one may exist.
+      implementations = plan_files.select { |impl| File.basename(impl, '.*') == basename }
+
+      # Select .pp before .yaml, since .pp comes before .yaml alphabetically.
+      chosen = implementations.sort.first
+
+      [{ "name" => File.basename(chosen), "path" => chosen }]
+    end
+    private_class_method :find_implementations
+
+    def self.find_files(name, plan_files)
+      find_implementations(name, plan_files)
+    end
+
+    def self.plans_in_module(pup_module)
+      # Search e.g. 'modules/<pup_module>/plans' for all plans
+      plan_files = Dir.glob(File.join(pup_module.plans_directory, '*'))
+        .keep_if { |f| valid, _ = is_plans_filename?(f); valid }
+
+      plans = plan_files.group_by { |f| plan_name_from_path(f) }
+
+      plans.map do |plan, plan_filenames|
+        new_with_files(pup_module, plan, plan_filenames)
+      end
+    end
+
+    attr_reader :name, :module, :metadata_file, :metadata
+
+    # file paths must be relative to the modules plan directory
+    def initialize(pup_module, plan_name, plan_files)
+      valid, reason = Puppet::Module::Plan.is_plans_filename?(plan_files.first)
+      unless valid
+        raise InvalidName.new(plan_name, reason)
+      end
+
+      name = plan_name == "init" ? pup_module.name : "#{pup_module.name}::#{plan_name}"
+
+      @module = pup_module
+      @name = name
+      @metadata_file = metadata_file
+      @plan_files = plan_files || []
+    end
+
+    def metadata
+      # Nothing to go here unless plans eventually support metadata.
+      @metadata ||= {}
+    end
+
+    def files
+      @files ||= self.class.find_files(@name, @plan_files)
+    end
+
+    def validate
+      files
+      true
+    end
+
+    def ==(other)
+      self.name == other.name &&
+      self.module == other.module
+    end
+
+    def environment_name
+      @module.environment.respond_to?(:name) ? @module.environment.name : 'production'
+    end
+    private :environment_name
+
+    def self.new_with_files(pup_module, name, plan_files)
+      Puppet::Module::Plan.new(pup_module, name, plan_files)
+    end
+    private_class_method :new_with_files
+
+    # Abstracted here so we can add support for subdirectories later
+    def self.plan_name_from_path(path)
+      return File.basename(path, '.*')
+    end
+    private_class_method :plan_name_from_path
+  end
+end

--- a/spec/lib/puppet_spec/modules.rb
+++ b/spec/lib/puppet_spec/modules.rb
@@ -34,6 +34,18 @@ module PuppetSpec::Modules
         end
       end
 
+      if plans = options[:plans]
+        plans_dir = File.join(module_dir, 'plans')
+        FileUtils.mkdir_p(plans_dir)
+        plans.each do |plan_file|
+          if plan_file.is_a?(String)
+            # default content to acceptable metadata
+            plan_file = { :name => plan_file, :content => "{}" }
+          end
+          File.write(File.join(plans_dir, plan_file[:name]), plan_file[:content])
+        end
+      end
+
       (options[:files] || {}).each do |fname, content|
         path = File.join(module_dir, fname)
         FileUtils.mkdir_p(File.dirname(path))

--- a/spec/unit/plan_spec.rb
+++ b/spec/unit/plan_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+require 'puppet_spec/modules'
+require 'puppet/module/plan'
+
+describe Puppet::Module::Plan do
+  include PuppetSpec::Files
+
+  let(:modpath) { tmpdir('plan_modpath') }
+  let(:mymodpath) { File.join(modpath, 'mymod') }
+  let(:othermodpath) { File.join(modpath, 'othermod') }
+  let(:mymod) { Puppet::Module.new('mymod', mymodpath, nil) }
+  let(:othermod) { Puppet::Module.new('othermod', othermodpath, nil) }
+  let(:plans_path) { File.join(mymodpath, 'plans') }
+  let(:other_plans_path) { File.join(othermodpath, 'plans') }
+  let(:plans_glob) { File.join(mymodpath, 'plans', '*') }
+
+  describe :naming do
+    word = (Puppet::Module::Plan::RESERVED_WORDS - Puppet::Module::Plan::RESERVED_DATA_TYPES).sample
+    datatype = (Puppet::Module::Plan::RESERVED_DATA_TYPES - Puppet::Module::Plan::RESERVED_WORDS).sample
+    test_cases = { 'iLegal.pp'  => 'Plan names must start with a lowercase letter and be composed of only lowercase letters, numbers, and underscores',
+                   'name.md'    => 'Plan name cannot have extension .md, must be .pp or .yaml',
+                   "#{word}.pp"     => "Plan name cannot be a reserved word, but was '#{word}'",
+                   "#{datatype}.pp" => "Plan name cannot be a Puppet data type, but was '#{datatype}'",
+                   'test_1.pp'    => nil,
+                   'test_2.yaml'  => nil }
+    test_cases.each do |filename, error|
+      it "constructs plans when needed with #{filename}" do
+        name = File.basename(filename, '.*')
+        if error
+          expect { Puppet::Module::Plan.new(mymod, name, [File.join(plans_path, filename)]) }
+            .to raise_error(Puppet::Module::Plan::InvalidName,
+                            error)
+        else
+          expect { Puppet::Module::Plan.new(mymod, name, [filename]) }
+            .not_to raise_error
+        end
+      end
+    end
+  end
+
+  it "finds all plans in module" do
+    og_files = %w{plan1.pp plan2.yaml not-a-plan.ok}.map { |bn| "#{plans_path}/#{bn}" }
+    expect(Dir).to receive(:glob).with(plans_glob).and_return(og_files)
+
+    plans = Puppet::Module::Plan.plans_in_module(mymod)
+
+    expect(plans.count).to eq(2)
+  end
+
+  it "selects .pp file before .yaml" do
+    og_files = %w{plan1.pp plan1.yaml}.map { |bn| "#{plans_path}/#{bn}" }
+    expect(Dir).to receive(:glob).with(plans_glob).and_return(og_files)
+
+    plans = Puppet::Module::Plan.plans_in_module(mymod)
+
+    expect(plans.count).to eq(1)
+    expect(plans.first.files.count).to eq(1)
+    expect(plans.first.files.first['name']).to eq('plan1.pp')
+  end
+
+  it "gives the 'init' plan a name that is just the module's name" do
+    expect(Puppet::Module::Plan.new(mymod, 'init', ["#{plans_path}/init.pp"]).name).to eq('mymod')
+  end
+end


### PR DESCRIPTION
This extends the information service to supply information about plans.
Given a module and environment, this code will return all valid plan
files in the `/modules/<name>/plans` directory.

It works similarly to the tasks information service, just without
metadata and multiple implementations.