### PR TITLE
(PUP-9790) restore class to pip_version in latest

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -116,7 +116,7 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     command = resource_or_provider_command
     self.class.validate_command(command)
 
-    command_version = self.pip_version(command)
+    command_version = self.class.pip_version(command)
     if Puppet::Util::Package.versioncmp(command_version, '1.5.4') == -1
       latest_with_old_pip
     else

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -145,7 +145,7 @@ describe Puppet::Type.type(:package).provider(:pip) do
   context "latest" do
     context "with pip version < 1.5.4" do
       before :each do
-        allow(@provider).to receive(:pip_version).with("/fake/bin/pip").and_return('1.0.1')
+        allow(described_class).to receive(:pip_version).with("/fake/bin/pip").and_return('1.0.1')
         allow(described_class).to receive(:which).with('pip').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip-python').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip.exe').and_return("/fake/bin/pip")
@@ -203,12 +203,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
       # For Pip 1.5.4 and above, you can get a version list from CLI - which allows for native pip behavior
       # with regards to custom repositories, proxies and the like
       before :each do
+        allow(described_class).to receive(:pip_version).with("/fake/bin/pip").and_return('1.5.4')
         allow(described_class).to receive(:which).with('pip').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip-python').and_return("/fake/bin/pip")
         allow(described_class).to receive(:which).with('pip.exe').and_return("/fake/bin/pip")
         allow(described_class).to receive(:provider_command).and_return('/fake/bin/pip')
         allow(described_class).to receive(:validate_command).with('/fake/bin/pip')
-        allow(@provider).to receive(:pip_version).with("/fake/bin/pip").and_return('1.5.4')
       end
 
       it "should find a version number for real_package" do


### PR DESCRIPTION
PUP-1082 introduced an error by dropping '.class' from
'self.class.pip_version' in the 'latest' class method.

This commit restores that reference, and updates the spec test stubs.