### PR TITLE
(PUP-9719) Fix Administrators Group Windows Permissions

### DIFF
--- a/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
+++ b/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
@@ -1,58 +1,57 @@
 test_name "PUP-9719 Windows First Agent run as SYSTEM sets cache file permissions correctly" do
 
-    tag 'risk:medium',
-        'audit:medium',
-        'audit:refactor',   # Use block style `test_name`
-        'audit:integration' # exec resource succeeds when the `exit_code` parameter
-                            # is given a windows specific exit code and a exec
-                            # returns that exit code, ie. it either correctly matches
-                            # exit_code parameter to returned exit code, or ignores both (;
+  tag 'risk:medium',
+    'audit:medium',
+    'audit:integration' # exec resource succeeds when the `exit_code` parameter
+  # is given a windows specific exit code and a exec
+  # returns that exit code, ie. it either correctly matches
+  # exit_code parameter to returned exit code, or ignores both (;
 
-    confine :to, :platform => 'windows'
+  confine :to, :platform => 'windows'
 
-    require 'puppet/acceptance/temp_file_utils'
-    extend Puppet::Acceptance::TempFileUtils
+  require 'puppet/acceptance/temp_file_utils'
+  extend Puppet::Acceptance::TempFileUtils
 
-    agents.each do |agent|
-        statedir = on(agent, puppet('config print statedir')).stdout.chomp
-        client_datadir = on(agent, puppet('config print client_datadir')).stdout.chomp
+  agents.each do |agent|
+    statedir = on(agent, puppet('config print statedir')).stdout.chomp
+    client_datadir = on(agent, puppet('config print client_datadir')).stdout.chomp
 
-        teardown do
-            on agent, "schtasks /delete /tn PuppetSystemRun /F"
-            on agent, "rm -rf #{statedir}/*"
-            on agent, "rm -rf #{client_datadir}/catalog/*"
-        end
-
-        step "Clean the ProgramData cache directory first" do
-            on agent, "rm -rf #{statedir}/*"
-            on agent, "rm -rf #{client_datadir}/catalog/*"
-        end
-
-        step "Create and run a scheduled task on System Account." do
-            on agent, "schtasks /create /tn PuppetSystemRun /RL HIGHEST /RU SYSTEM /F /SC ONCE /ST 23:59 /TR 'cmd /c \"%ProgramFiles%\\Puppet Labs\\Puppet\\bin\\puppet.bat\" agent -t >> c:\\Windows\\Temp\\Puppet-System-Run.log 2>&1'"
-            on agent, "schtasks /run /tn PuppetSystemRun"
-        end
-
-        step "Wait for Puppet Agent run to complete" do
-            last_puppet_run = statedir + "/last_run_summary.yaml"
-            (trymax, try, last_wait, wait) = 10,1,2,3
-            file_found = false
-            while try <= trymax
-                if file_exists?(agent, last_puppet_run)
-                    logger.info("Puppet run has completed")
-                    file_found = true
-                    break
-                end
-                @logger.warn "Wait for Puppet (SYSTEM) run to complete, Try #{try}, Trying again in #{wait} seconds"
-                sleep wait
-                (last_wait, wait) = wait, last_wait + wait
-                try += 1
-            end
-            fail_test("Puppet Run (SYSTEM) didn't complete") unless file_found
-        end
-
-        step "Test that normal PA run under Administrator doesn't fail." do
-            on agent, "cmd /c puppet agent -t"
-        end
+    teardown do
+      on agent, "schtasks /delete /tn PuppetSystemRun /F"
+      on agent, "rm -rf #{statedir}/*"
+      on agent, "rm -rf #{client_datadir}/catalog/*"
     end
+
+    step "Clean the ProgramData cache directory first" do
+      on agent, "rm -rf #{statedir}/*"
+      on agent, "rm -rf #{client_datadir}/catalog/*"
+    end
+
+    step "Create and run a scheduled task on System Account." do
+      on agent, "schtasks /create /tn PuppetSystemRun /RL HIGHEST /RU SYSTEM /F /SC ONCE /ST 23:59 /TR 'cmd /c \"%ProgramFiles%\\Puppet Labs\\Puppet\\bin\\puppet.bat\" agent -t >> c:\\Windows\\Temp\\Puppet-System-Run.log 2>&1'"
+      on agent, "schtasks /run /tn PuppetSystemRun"
+    end
+
+    step "Wait for Puppet Agent run to complete" do
+      last_puppet_run = statedir + "/last_run_summary.yaml"
+      (trymax, try, last_wait, wait) = 10,1,2,3
+      file_found = false
+      while try <= trymax
+        if file_exists?(agent, last_puppet_run)
+          logger.info("Puppet run has completed")
+          file_found = true
+          break
+        end
+        @logger.warn "Wait for Puppet (SYSTEM) run to complete, Try #{try}, Trying again in #{wait} seconds"
+        sleep wait
+        (last_wait, wait) = wait, last_wait + wait
+        try += 1
+      end
+      fail_test("Puppet Run (SYSTEM) didn't complete") unless file_found
+    end
+
+    step "Test that normal PA run under Administrator doesn't fail." do
+      on agent, "cmd /c puppet agent -t", acceptable_exit_codes: [0]
+    end
+  end
 end

--- a/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
+++ b/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
@@ -1,0 +1,58 @@
+test_name "PUP-9719 Windows First Agent run as SYSTEM sets cache file permissions correctly" do
+
+    tag 'risk:medium',
+        'audit:medium',
+        'audit:refactor',   # Use block style `test_name`
+        'audit:integration' # exec resource succeeds when the `exit_code` parameter
+                            # is given a windows specific exit code and a exec
+                            # returns that exit code, ie. it either correctly matches
+                            # exit_code parameter to returned exit code, or ignores both (;
+
+    confine :to, :platform => 'windows'
+
+    require 'puppet/acceptance/temp_file_utils'
+    extend Puppet::Acceptance::TempFileUtils
+
+    agents.each do |agent|
+        statedir = on(agent, puppet('config print statedir')).stdout.chomp
+        client_datadir = on(agent, puppet('config print client_datadir')).stdout.chomp
+
+        teardown do
+            on agent, "schtasks /delete /tn PuppetSystemRun /F"
+            on agent, "rm -rf #{statedir}/*"
+            on agent, "rm -rf #{client_datadir}/catalog/*"
+        end
+
+        step "Clean the ProgramData cache directory first" do
+            on agent, "rm -rf #{statedir}/*"
+            on agent, "rm -rf #{client_datadir}/catalog/*"
+        end
+
+        step "Create and run a scheduled task on System Account." do
+            on agent, "schtasks /create /tn PuppetSystemRun /RL HIGHEST /RU SYSTEM /F /SC ONCE /ST 23:59 /TR 'cmd /c \"%ProgramFiles%\\Puppet Labs\\Puppet\\bin\\puppet.bat\" agent -t >> c:\\Windows\\Temp\\Puppet-System-Run.log 2>&1'"
+            on agent, "schtasks /run /tn PuppetSystemRun"
+        end
+
+        step "Wait for Puppet Agent run to complete" do
+            last_puppet_run = statedir + "/last_run_summary.yaml"
+            (trymax, try, last_wait, wait) = 10,1,2,3
+            file_found = false
+            while try <= trymax
+                if file_exists?(agent, last_puppet_run)
+                    logger.info("Puppet run has completed")
+                    file_found = true
+                    break
+                end
+                @logger.warn "Wait for Puppet (SYSTEM) run to complete, Try #{try}, Trying again in #{wait} seconds"
+                sleep wait
+                (last_wait, wait) = wait, last_wait + wait
+                try += 1
+            end
+            fail_test("Puppet Run (SYSTEM) didn't complete") unless file_found
+        end
+
+        step "Test that normal PA run under Administrator doesn't fail." do
+            on agent, "cmd /c puppet agent -t"
+        end
+    end
+end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -410,7 +410,7 @@ class Puppet::Configurer
   end
 
   def save_last_run_summary(report)
-    mode = Puppet.settings.setting(:lastrunfile).mode
+    mode = Integer(Puppet.settings.setting(:lastrunfile).mode,8)
     Puppet::FileSystem.replace_file(Puppet[:lastrunfile], mode) do |fh|
       fh.print YAML.dump(report.raw_summary)
     end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -410,7 +410,14 @@ class Puppet::Configurer
   end
 
   def save_last_run_summary(report)
-    mode = Integer(Puppet.settings.setting(:lastrunfile).mode,8)
+    mode = Puppet.settings.setting(:lastrunfile).mode
+
+    if !Puppet::Util.valid_symbolic_mode?(mode)
+      raise Puppet::DevError, _("invalid file mode: %{mode}") % { mode: mode }
+    end
+
+    mode = Integer(mode, 8)
+
     Puppet::FileSystem.replace_file(Puppet[:lastrunfile], mode) do |fh|
       fh.print YAML.dump(report.raw_summary)
     end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -411,7 +411,7 @@ class Puppet::Configurer
 
   def save_last_run_summary(report)
     mode = Puppet.settings.setting(:lastrunfile).mode
-    Puppet::Util.replace_file(Puppet[:lastrunfile], mode) do |fh|
+    Puppet::FileSystem.replace_file(Puppet[:lastrunfile], mode) do |fh|
       fh.print YAML.dump(report.raw_summary)
     end
   rescue => detail

--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -401,4 +401,21 @@ module Puppet::FileSystem
   def self.chmod(mode, path)
     @impl.chmod(mode, path)
   end
+
+  # Replace the contents of a file atomically, creating the file if necessary.
+  # If a `mode` is specified, then it will always be applied to the file. If
+  # a `mode` is not specified and the file exists, its mode will be preserved.
+  # If the file doesn't exist, the mode will be set to a platform-specific
+  # default.
+  #
+  # @param path [String] The path to the file, can also accept [PathName]
+  # @param mode [Integer] Optional mode for the file.
+  #
+  # @raise [Errno::EISDIR]: path is a directory
+  #
+  # @api public
+  #
+  def self.replace_file(path, mode = nil, &block)
+    @impl.replace_file(assert_path(path), mode, &block)
+  end
 end

--- a/lib/puppet/file_system/jruby.rb
+++ b/lib/puppet/file_system/jruby.rb
@@ -1,0 +1,23 @@
+require 'puppet/file_system/posix'
+
+class Puppet::FileSystem::JRuby < Puppet::FileSystem::Posix
+  def unlink(*paths)
+    File.unlink(*paths)
+  rescue Errno::ENOENT
+    # JRuby raises ENOENT if the path doesn't exist or the parent directory
+    # doesn't allow execute/traverse. If it's the former, `stat` will raise
+    # ENOENT, if it's the later, it'll raise EACCES
+    # See https://github.com/jruby/jruby/issues/5617
+    stat(*paths)
+  end
+
+  def replace_file(path, mode = nil, &block)
+    # MRI Ruby rename checks if destination is a directory and raises, while
+    # JRuby removes the directory and replaces the file.
+    if Puppet::FileSystem.directory?(path)
+      raise Errno::EISDIR, _("Is a directory: %{directory}") % { directory: path }
+    end
+
+    super
+  end
+end

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -4,6 +4,8 @@ require 'puppet/util/windows'
 class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
   FULL_CONTROL = Puppet::Util::Windows::File::FILE_ALL_ACCESS
   FILE_READ = Puppet::Util::Windows::File::FILE_GENERIC_READ
+  FILE_WRITE = Puppet::Util::Windows::File::FILE_GENERIC_WRITE
+  FILE_RW = (FILE_READ | FILE_WRITE)
 
   def open(path, mode, options, &block)
     # PUP-6959 mode is explicitly ignored until it can be implemented

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -184,14 +184,22 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
     Puppet::Util::Windows::Security.set_security_descriptor(path, new_sd)
   end
 
-  def secure_dacl(current_sid)
+  def secure_dacl(current_sid, owner_permission = FULL_CONTROL, group_permission = FULL_CONTROL)
     dacl = Puppet::Util::Windows::AccessControlList.new
     [
      Puppet::Util::Windows::SID::LocalSystem,
      Puppet::Util::Windows::SID::BuiltinAdministrators,
      current_sid
     ].uniq.map do |sid|
-      dacl.allow(sid, FULL_CONTROL)
+        permission = case sid
+                     when Puppet::Util::Windows::SID::LocalSystem
+                       owner_permission
+                     when Puppet::Util::Windows::SID::BuiltinAdministrators
+                       group_permission
+                     else
+                       owner_permission
+                     end
+        dacl.allow(sid, permission)
     end
     dacl
   end

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -2,6 +2,8 @@ require 'puppet/file_system/posix'
 require 'puppet/util/windows'
 
 class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
+  FULL_CONTROL = Puppet::Util::Windows::File::FILE_ALL_ACCESS
+  FILE_READ = Puppet::Util::Windows::File::FILE_GENERIC_READ
 
   def open(path, mode, options, &block)
     # PUP-6959 mode is explicitly ignored until it can be implemented
@@ -114,7 +116,77 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
     contents
   end
 
+  def replace_file(path, mode = nil)
+    if Puppet::FileSystem.directory?(path)
+      raise Errno::EISDIR, _("Is a directory: %{directory}") % { directory: path }
+    end
+
+    current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
+    dacl = case mode
+           when 0644
+             dacl = secure_dacl(current_sid)
+             dacl.allow(Puppet::Util::Windows::SID::BuiltinUsers, FILE_READ)
+             dacl
+           when 0640, 0600
+             secure_dacl(current_sid)
+           when nil
+             get_dacl_from_file(path) || secure_dacl(current_sid)
+           else
+             raise ArgumentError, "Only modes 0644, 0640 and 0600 are allowed"
+           end
+
+
+    tempfile = Puppet::FileSystem::Uniquefile.new(Puppet::FileSystem.basename_string(path), Puppet::FileSystem.dir_string(path))
+    begin
+      tempdacl = Puppet::Util::Windows::AccessControlList.new
+      tempdacl.allow(current_sid, FULL_CONTROL)
+      set_dacl(tempfile.path, tempdacl)
+
+      begin
+        yield tempfile
+        tempfile.flush
+        tempfile.fsync
+      ensure
+        tempfile.close
+      end
+
+      set_dacl(tempfile.path, dacl) if dacl
+      File.rename(tempfile.path, Puppet::FileSystem.path_string(path))
+    ensure
+      tempfile.close!
+    end
+  end
+
   private
+
+  def set_dacl(path, dacl)
+    sd = Puppet::Util::Windows::Security.get_security_descriptor(path)
+    new_sd = Puppet::Util::Windows::SecurityDescriptor.new(sd.owner, sd.group, dacl, true)
+    Puppet::Util::Windows::Security.set_security_descriptor(path, new_sd)
+  end
+
+  def secure_dacl(current_sid)
+    dacl = Puppet::Util::Windows::AccessControlList.new
+    [
+     Puppet::Util::Windows::SID::LocalSystem,
+     Puppet::Util::Windows::SID::BuiltinAdministrators,
+     current_sid
+    ].uniq.map do |sid|
+      dacl.allow(sid, FULL_CONTROL)
+    end
+    dacl
+  end
+
+  def get_dacl_from_file(path)
+    sd = Puppet::Util::Windows::Security.get_security_descriptor(Puppet::FileSystem.path_string(path))
+    sd.dacl
+  rescue Puppet::Util::Windows::Error => e
+    if e.code == 2 # ERROR_FILE_NOT_FOUND
+      nil
+    else
+      raise e
+    end
+  end
 
   def raise_if_symlinks_unsupported
     if ! Puppet.features.manages_symlinks?

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -250,7 +250,7 @@ module Puppet::FileBucketFile
     # @return [void]
     # @api private
     def copy_bucket_file_to_contents_file(contents_file, bucket_file)
-      Puppet::Util.replace_file(contents_file, 0440) do |of|
+      Puppet::FileSystem.replace_file(contents_file, 0440) do |of|
         # PUP-1044 writes all of the contents
         bucket_file.stream() do |src|
           FileUtils.copy_stream(src, of)

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -14,7 +14,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
     filename = path(request.key)
     FileUtils.mkdir_p(File.dirname(filename))
 
-    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::BINARY) }
+    Puppet::FileSystem.replace_file(filename, 0660) {|f| f.print to_json(request.instance).force_encoding(Encoding::BINARY) }
   rescue TypeError => detail
     Puppet.log_exception(detail, _("Could not save %{json} %{request}: %{detail}") % { json: self.name, request: request.key, detail: detail })
   end

--- a/lib/puppet/indirector/msgpack.rb
+++ b/lib/puppet/indirector/msgpack.rb
@@ -21,7 +21,7 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
     filename = path(request.key)
     FileUtils.mkdir_p(File.dirname(filename))
 
-    Puppet::Util.replace_file(filename, 0660) {|f| f.print to_msgpack(request.instance) }
+    Puppet::FileSystem.replace_file(filename, 0660) {|f| f.print to_msgpack(request.instance) }
   rescue TypeError => detail
     Puppet.log_exception(detail, _("Could not save %{name} %{request}: %{detail}") % { name: self.name, request: request.key, detail: detail })
   end

--- a/lib/puppet/reports/store.rb
+++ b/lib/puppet/reports/store.rb
@@ -32,7 +32,7 @@ Puppet::Reports.register_report(:store) do
     file = File.join(dir, name)
 
     begin
-      Puppet::Util.replace_file(file, 0640) do |fh|
+      Puppet::FileSystem.replace_file(file, 0640) do |fh|
         fh.print to_yaml
       end
     rescue => detail

--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -29,7 +29,7 @@ module Puppet::Util::Yaml
   end
 
   def self.dump(structure, filename)
-    Puppet::Util.replace_file(filename, 0660) do |fh|
+    Puppet::FileSystem.replace_file(filename, 0660) do |fh|
       YAML.dump(structure, fh)
     end
   end

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -45,10 +45,12 @@ describe Puppet::Configurer do
       @configurer.run :catalog => @catalog, :report => report
       t2 = Time.now.tv_sec
 
-      # sticky bit only applies to directories in windows
-      file_mode = Puppet.features.microsoft_windows? ? '666' : '100666'
-
-      expect(Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode.to_s(8)).to eq(file_mode)
+      if Puppet.features.microsoft_windows?
+        require 'puppet/util/windows/security'
+        expect(Puppet::Util::Windows::Security.get_mode(Puppet[:lastrunfile])).to eq(02000666)
+      else
+        expect(Puppet::FileSystem.stat(Puppet[:lastrunfile]).mode).to eq(0100666)
+      end
 
       summary = nil
       File.open(Puppet[:lastrunfile], "r") do |fd|

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Configurer do
       allow(Puppet::Transaction::Report.indirection).to receive(:save)
 
       Puppet[:lastrunfile] = tmpfile("lastrunfile")
-      Puppet.settings.setting(:lastrunfile).mode = 0666
+      Puppet.settings.setting(:lastrunfile).mode = '666'
       Puppet[:report] = true
 
       # We only record integer seconds in the timestamp, and truncate

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -589,7 +589,6 @@ describe Puppet::Configurer do
       expect(Puppet.settings.setting(:lastrunfile)).to receive(:mode).and_return('664')
       @configurer.save_last_run_summary(@report)
 
-      # Copy/Pasta from file_system_spec to see if we can get this working.
       SYSTEM_SID_BYTES = [1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0]
 
       def is_current_user_system?
@@ -609,16 +608,15 @@ describe Puppet::Configurer do
       end
     end
 
-    it "should report invalid last run file permissions with invalid mode", :if => Puppet.features.microsoft_windows? do
-      # Needs some additional work for non-windows so filtered out.
+    it "should report invalid last run file permissions with invalid mode" do
       expect(Puppet.settings.setting(:lastrunfile)).to receive(:mode).and_return('33333')
-      expect(Puppet).to receive(:err).with(/Could not save last run local report:.* is invalid:.*/)
+      expect(Puppet).to receive(:err).with("Could not save last run local report: invalid file mode: 33333")
       @configurer.save_last_run_summary(@report)
     end
 
     it "should report invalid last run file permissions with octal mode" do
       expect(Puppet.settings.setting(:lastrunfile)).to receive(:mode).and_return('892')
-      expect(Puppet).to receive(:err).with("Could not save last run local report: invalid value for Integer(): \"892\"")
+      expect(Puppet).to receive(:err).with("Could not save last run local report: invalid file mode: 892")
       @configurer.save_last_run_summary(@report)
     end
   end
@@ -1089,7 +1087,7 @@ describe Puppet::Configurer do
     it "should not make multiple node requets when the server is found" do
       response = Net::HTTPOK.new(nil, 200, 'OK')
       allow(Puppet::Network::HttpPool).to receive(:http_ssl_instance).with('myserver', '123').and_return(double('request', get: response))
-      
+
       Puppet.settings[:server_list] = ["myserver:123"]
       expect(Puppet::Node.indirection).to receive(:find).and_return("mynode").once
       expect(@agent).to receive(:prepare_and_retrieve_catalog).and_return(nil)

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -7,6 +7,12 @@ describe Puppet::FileSystem::Uniquefile do
     end
   end
 
+  it "ensures the file has permissions 0600", unless: Puppet::Util::Platform.windows? do
+    Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|
+      expect(Puppet::FileSystem.stat(file.path).mode & 07777).to eq(0600)
+    end
+  end
+
   it "provides a writeable file" do
     Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|
       file.write("stuff")

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -1046,7 +1046,7 @@ describe "Puppet::FileSystem" do
         end
 
         it 'raises Errno::EACCES if access is denied' do
-          Puppet::Util::Windows::Security.stubs(:get_security_descriptor).raises(Puppet::Util::Windows::Error.new('access denied', 5))
+          allow(Puppet::Util::Windows::Security).to receive(:get_security_descriptor).and_raise(Puppet::Util::Windows::Error.new('access denied', 5))
 
           expect {
             Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
@@ -1054,7 +1054,7 @@ describe "Puppet::FileSystem" do
         end
 
         it 'raises SystemCallError otherwise' do
-          Puppet::Util::Windows::Security.stubs(:get_security_descriptor).raises(Puppet::Util::Windows::Error.new('arena is trashed', 7))
+          allow(Puppet::Util::Windows::Security).to receive(:get_security_descriptor).and_raise(Puppet::Util::Windows::Error.new('arena is trashed', 7))
 
           expect {
             Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -872,4 +872,119 @@ describe "Puppet::FileSystem" do
       end
     end
   end
+
+  describe '#replace_file' do
+    let(:dest) { tmpfile('replace_file') }
+    let(:content) { "some data" }
+
+    context 'when creating' do
+      it 'writes the data' do
+        Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+
+        expect(Puppet::FileSystem.binread(dest)).to eq(content)
+      end
+
+      it 'writes in binary mode' do
+        Puppet::FileSystem.replace_file(dest) { |f| f.write("\x00\x01\x02") }
+
+        expect(Puppet::FileSystem.binread(dest)).to eq("\x00\x01\x02")
+      end
+
+      context 'on posix', unless: Puppet::Util::Platform.windows? do
+        it 'applies the default mode 0640' do
+          Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+
+          mode = Puppet::FileSystem.stat(dest).mode
+          expect(mode & 07777).to eq(0640)
+        end
+
+        it 'applies the specified mode' do
+          Puppet::FileSystem.replace_file(dest, 0777) { |f| f.write(content) }
+
+          mode = Puppet::FileSystem.stat(dest).mode
+          expect(mode & 07777).to eq(0777)
+        end
+
+        it 'raises EACCES if we do not have permission' do
+          dir = tmpdir('file_system')
+          dest = File.join(dir, 'unwritable')
+
+          Puppet::FileSystem.chmod(0600, dir)
+
+          expect {
+            Puppet::FileSystem.replace_file(dest) { |_| }
+          }.to raise_error(Errno::EACCES, /Permission denied/)
+        end
+
+        it 'creates a read-only file' do
+          Puppet::FileSystem.replace_file(dest, 0400) { |f| f.write(content) }
+
+          expect(Puppet::FileSystem.binread(dest)).to eq(content)
+
+          mode = Puppet::FileSystem.stat(dest).mode
+          expect(mode & 07777).to eq(0400)
+        end
+      end
+    end
+
+    context "when overwriting" do
+      before :each do
+        FileUtils.touch(dest)
+      end
+
+      it 'overwrites the content' do
+        Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+
+        expect(Puppet::FileSystem.binread(dest)).to eq(content)
+      end
+
+      it 'raises ISDIR if the destination is a directory' do
+        pending("Need windows filesystem impl") if Puppet::Util::Platform.windows?
+        dir = tmpdir('file_system')
+
+        expect {
+          Puppet::FileSystem.replace_file(dir) { |f| f.write(content) }
+        }.to raise_error(Errno::EISDIR, /Is a directory/)
+      end
+
+      it 'preserves the existing content if an error is raised' do
+        File.write(dest, 'existing content')
+
+        Puppet::FileSystem.replace_file(dest) { |f| raise 'whoops' } rescue nil
+
+        expect(Puppet::FileSystem.binread(dest)).to eq('existing content')
+      end
+
+      context 'on posix', unless: Puppet::Util::Platform.windows? do
+        it 'preserves the existing mode' do
+          Puppet::FileSystem.chmod(0600, dest)
+
+          Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+
+          mode = Puppet::FileSystem.stat(dest).mode
+          expect(mode & 07777).to eq(0600)
+        end
+
+        it 'applies the specified mode' do
+          Puppet::FileSystem.chmod(0600, dest)
+
+          Puppet::FileSystem.replace_file(dest, 0777) { |f| f.write(content) }
+
+          mode = Puppet::FileSystem.stat(dest).mode
+          expect(mode & 07777).to eq(0777)
+        end
+
+        it 'updates a read-only file' do
+          Puppet::FileSystem.chmod(0400, dest)
+
+          Puppet::FileSystem.replace_file(dest) { |f| f.write(content) }
+
+          expect(Puppet::FileSystem.binread(dest)).to eq(content)
+
+          mode = Puppet::FileSystem.stat(dest).mode
+          expect(mode & 07777).to eq(0400)
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -956,8 +956,6 @@ describe "Puppet::FileSystem" do
           )
         end
 
-        # TBD - this begs for a helper function?
-
         it 'applies the specified mode' do
           Puppet::FileSystem.replace_file(dest, 0640) { |f| f.write(content) }
 
@@ -1128,7 +1126,6 @@ describe "Puppet::FileSystem" do
           end
         end
 
-        # TBD - as noted earlier - Helper function for this ?
         it 'applies the specified mode' do
           Puppet::FileSystem.replace_file(dest, 0644) { |f| f.write(content) }
 

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -146,16 +146,7 @@ describe Puppet::Transaction::Persistence do
       Dir.mkdir(Puppet[:transactionstorefile])
       persistence = Puppet::Transaction::Persistence.new
 
-      if Puppet.features.microsoft_windows?
-        expect do
-          persistence.save
-        end.to raise_error do |error|
-          expect(error).to be_a(Puppet::Util::Windows::Error)
-          expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
-        end
-      else
-        expect { persistence.save }.to raise_error(Errno::EISDIR, /Is a directory/)
-      end
+      expect { persistence.save }.to raise_error(Errno::EISDIR, /Is a directory/)
 
       Dir.rmdir(Puppet[:transactionstorefile])
     end

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -189,15 +189,8 @@ describe Puppet::Util::Storage do
       Dir.mkdir(Puppet[:statefile])
       Puppet::Util::Storage.cache(:yayness)
 
-      if Puppet.features.microsoft_windows?
-        expect { Puppet::Util::Storage.store }.to raise_error do |error|
-          expect(error).to be_a(Puppet::Util::Windows::Error)
-          expect(error.code).to eq(5) # ERROR_ACCESS_DENIED
-        end
-      else
-        expect { Puppet::Util::Storage.store }.to raise_error(Errno::EISDIR, /Is a directory/)
-      end
-
+      expect { Puppet::Util::Storage.store }.to raise_error(Errno::EISDIR, /Is a directory/)
+      
       Dir.rmdir(Puppet[:statefile])
     end
 


### PR DESCRIPTION
Several files under C:\ProgramData are not saved correctly with Administrator permissions if the first Puppet Agent run is under the SYSTEM Account.

Use Puppet::FileSystem.replace_file instead of Puppet::Util.replace_file as this caters better for Windows situations where we need to ensure both SYSTEM and Administrator need access to the created files.

The structure of the PR is as follows:
1. Cherry-picked initial commits from PUP-9499 (see #7426) to add the FileSystem::replace_file method and associated.
2. Manual change of some rspec to cover recent rspec->mocha changes
3. Single commit to replace all the necessary ```Puppet::Util.replace_file``` calls with ```Puppet::FileSystem.replace_file```
4. Configure mode handling changes
5. Handle additional permission modes in windows.rb
6. Spec tests changes broken down into multiple commits separating obvious and "controversial" changes.
