### PR TITLE
(Do Not Merge) Show rake spec issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage/
 *.iml
 .rakeTasks
 .idea/
+spec_order.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - _JAVA_OPTIONS="-Xmx1024m -Xms512m"
   matrix:
     - "CHECK=parallel:spec\\[2\\]"
+    - "CHECK=spec"
     - "CHECK=rubocop"
     - "CHECK=commits"
     - "CHECK=warnings"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   matrix:
     - "CHECK=parallel:spec\\[2\\]"
     - "CHECK=spec"
+    - "CHECK=parallel:spec[1,25000]"
     - "CHECK=rubocop"
     - "CHECK=commits"
     - "CHECK=warnings"


### PR DESCRIPTION
While doing some testing I ran into the oddity that `rake spec` and `rake parallel:spec[1,2500]` fail when the plain old `rake parallel:spec` passes.  

Seems this also applies to 5.5.x but, of course, the failures are different there.  

For clarity, I'm not suggesting we actually add these to travis but I'm just adding them here for demonstration purposes.  