### PR TITLE
(maint) Only autorequire groups if it's managed

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -445,6 +445,7 @@ module Puppet
     autorequire(:group) do
       autos = []
 
+      # autorequire primary group, if managed
       obj = @parameters[:gid]
       groups = obj.shouldorig if obj
       if groups
@@ -468,10 +469,13 @@ module Puppet
         }
       end
 
+      # autorequire groups, excluding primary group, if managed
       obj = @parameters[:groups]
-      groups = obj.should if obj
-      if groups
-        autos += groups.split(",")
+      if obj
+        groups = obj.should
+        if groups
+          autos += groups.split(",")
+        end
       end
 
       autos


### PR DESCRIPTION
If the `gid` user property is managed, but the `groups` property is not, then
the `groups` variable will already be set to an Array. Ensure we only split the
comma delimited string if we're managing the `groups` property.