### PR TITLE
(maint) Don't run test on AIX, Solaris or OSX

### DIFF
--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -2,6 +2,8 @@ test_name 'C98115 compilation should get new values in variables on each compila
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
 
+  confine :except, :platform => /^(aix|osx|solaris)/
+
   tag 'audit:medium',
       'audit:integration',
       'server'


### PR DESCRIPTION
The test relies on nanosecond resolution, but `date` on AIX and OSX don't
support that. Since this is a server test, just skip the test for those agents.

This supersedes the change made in 87083b13ab233a152fdbb07a490a06c613180814