### PR TITLE
(PUP-9818) PAL updates

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -141,17 +141,16 @@ module Puppet::Environments
   class StaticDirectory < Static
     # Accepts a single environment in the given directory having the given name (not required to be reflected as the name
     # of the directory)
-    # 
     def initialize(env_name, env_dir, environment)
       super(environment)
       @env_dir = env_dir
-      @env_name = env_name
+      @env_name = env_name.intern
     end
 
     # @!macro loader_get_conf
     def get_conf(name)
-      return nil unless name == @env_name
-      Puppet::Settings::EnvironmentConf.load_from(@env_dir, '')
+      return nil unless name.intern == @env_name
+      Puppet::Settings::EnvironmentConf.load_from(@env_dir, [])
     end
   end
 

--- a/lib/puppet/pal/catalog_compiler.rb
+++ b/lib/puppet/pal/catalog_compiler.rb
@@ -9,11 +9,9 @@ module Pal
   # @api public
   class CatalogCompiler < Compiler
 
-    # @api private
     def catalog
       internal_compiler.catalog
     end
-    private :catalog
 
     # Returns true if this is a compiler that compiles a catalog.
     # This implementation returns `true`

--- a/lib/puppet/pal/catalog_compiler.rb
+++ b/lib/puppet/pal/catalog_compiler.rb
@@ -9,9 +9,11 @@ module Pal
   # @api public
   class CatalogCompiler < Compiler
 
+    # @api private
     def catalog
       internal_compiler.catalog
     end
+    private :catalog
 
     # Returns true if this is a compiler that compiles a catalog.
     # This implementation returns `true`
@@ -25,7 +27,7 @@ module Pal
     # @example Get resulting catalog as pretty printed Json
     #   Puppet::Pal.in_environment(...) do |pal|
     #     pal.with_catalog_compiler(...) do |compiler|
-    #       compiler.with_json_encoding {| encoder | encoder.encode
+    #       compiler.with_json_encoding { |encoder| encoder.encode }
     #     end
     #   end
     #
@@ -33,6 +35,13 @@ module Pal
     #
     def with_json_encoding(pretty: true, exclude_virtual: true)
       yield JsonCatalogEncoder.new(catalog, pretty: pretty, exclude_virtual: exclude_virtual)
+    end
+
+    # Returns a hash representation of the compiled catalog.
+    #
+    # @api public
+    def catalog_data_hash
+      catalog.to_data_hash
     end
 
     # Evaluates an AST obtained from `parse_string` or `parse_file` in topscope.

--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -176,6 +176,10 @@ module Pal
       end
     end
 
+    # We need to make sure to set these back when we're done
+    previous_tasks_value = Puppet[:tasks]
+    previous_code_value = Puppet[:code]
+
     Puppet[:tasks] = false
     # After the assertions, if code_string is non nil - it has the highest precedence
     Puppet[:code] = code_string unless code_string.nil?
@@ -183,6 +187,10 @@ module Pal
     # If manifest_file is nil, the #main method will use the env configured manifest
     # to do things in the block while a Script Compiler is in effect
     main(manifest_file, facts, variables, :catalog, &block)
+  ensure
+    # Clean up after ourselves
+    Puppet[:tasks] = previous_tasks_value
+    Puppet[:code] = previous_code_value
   end
 
   # Defines the context in which to perform puppet operations (evaluation, etc)

--- a/spec/unit/puppet_pal_catalog_spec.rb
+++ b/spec/unit/puppet_pal_catalog_spec.rb
@@ -111,6 +111,18 @@ describe 'Puppet Pal' do
           expect(resource.title).to eq('test')
         end
 
+        context 'catalog_data_hash' do
+          it 'produces a data_hash encoding of a catalog' do
+            result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |pal|
+              pal.with_catalog_compiler {|c|
+                c.evaluate_string("notify {'test': message => /a regexp/}")
+                c.catalog_data_hash
+              }
+            end
+            expect(result['resources']).to include(include('type' => 'Notify'))
+          end
+        end
+
         context 'the with_json_encoding()' do
 
           it 'produces json for a catalog' do


### PR DESCRIPTION
I have so far found two updates needed to PAL to support adding an AST parsing endpoint to Puppet Server (see https://github.com/puppetlabs/puppetserver/pull/2082).

1) Allow retrieval of the catalog object
2) State cleanup from catalog compiler block