### PR TITLE
(PUP-9813) Performance walkaround for ModuleTool::Tar::Mini, plus a perf test

### DIFF
--- a/lib/puppet/module_tool/tar.rb
+++ b/lib/puppet/module_tool/tar.rb
@@ -6,10 +6,10 @@ module Puppet::ModuleTool::Tar
   require 'puppet/module_tool/tar/mini'
 
   def self.instance
-    if Puppet.features.minitar? && Puppet.features.zlib?
-      Mini.new
-    elsif Puppet::Util.which('tar') && ! Puppet::Util::Platform.windows?
+    if Puppet::Util.which('tar') && ! Puppet::Util::Platform.windows?
       Gnu.new
+    elsif Puppet.features.minitar? && Puppet.features.zlib?
+      Mini.new
     else
       #TRANSLATORS "tar" is a program name and should not be translated
       raise RuntimeError, _('No suitable tar implementation found')

--- a/spec/unit/module_tool/tar_spec.rb
+++ b/spec/unit/module_tool/tar_spec.rb
@@ -2,27 +2,28 @@ require 'spec_helper'
 require 'puppet/module_tool/tar'
 
 describe Puppet::ModuleTool::Tar do
+  # FIXME: PUP-9813 restore minitar as a prefered impl
+
+  it "always prefers OS's tar when it's available and not on Windows" do
+    allow(Facter).to receive(:value).with('osfamily').and_return('ObscureLinuxDistro')
+    allow(Puppet::Util).to receive(:which).with('tar').and_return('/usr/bin/tar')
+    allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+
+    expect(described_class.instance).to be_a_kind_of Puppet::ModuleTool::Tar::Gnu
+  end
+
   [
-    { :name => 'ObscureLinuxDistro', :win => false }, 
-    { :name => 'Windows', :win => true }
+    { :name => 'ObscureLinuxDistro', :win => false, :title => 'it and zlib are present' },
+    { :name => 'Windows', :win => true, :title => 'on Windows' }
   ].each do |os|
-    it "always prefers minitar if it and zlib are present, even with tar available" do
+    it "falls back to minitar if #{os[:title]}" do
       allow(Facter).to receive(:value).with('osfamily').and_return(os[:name])
-      allow(Puppet::Util).to receive(:which).with('tar').and_return('/usr/bin/tar')
+      allow(Puppet::Util).to receive(:which).with('tar').and_return(nil)
       allow(Puppet::Util::Platform).to receive(:windows?).and_return(os[:win])
       allow(Puppet).to receive(:features).and_return(double(:minitar? => true, :zlib? => true))
 
       expect(described_class.instance).to be_a_kind_of Puppet::ModuleTool::Tar::Mini
     end
-  end
-
-  it "falls back to tar when minitar not present and not on Windows" do
-    allow(Facter).to receive(:value).with('osfamily').and_return('ObscureLinuxDistro')
-    allow(Puppet::Util).to receive(:which).with('tar').and_return('/usr/bin/tar')
-    allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
-    allow(Puppet).to receive(:features).and_return(double(:minitar? => false))
-
-    expect(described_class.instance).to be_a_kind_of Puppet::ModuleTool::Tar::Gnu
   end
 
   it "fails when there is no possible implementation" do


### PR DESCRIPTION
Installing modules from Puppet Forge is extremely slow. It's due to extraction of tarballs using `Puppet::ModuleTool::Tar::Mini` implementation. The unpacking is 100x times slower then executing a `tar xzvf` system command!

As a walkaround I'm switching to `Puppet::ModuleTool::Tar::Gnu` implementation as default.

Also, adding a pending performance test, that clearly shows that `Puppet::ModuleTool::Tar::Mini` is about 100x times slower then system `tar xzvf` command. Test should be unskipped if performance of `Puppet::ModuleTool::Tar::Mini` is fixed somehow.

Issue: https://tickets.puppetlabs.com/browse/PUP-9813