### PR TITLE
(PUP-9722) File mode change on every puppet run

### DIFF
--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -200,6 +200,7 @@ module Puppet::Util::Windows::Security
     well_known_world_sid = Puppet::Util::Windows::SID::Everyone
     well_known_nobody_sid = Puppet::Util::Windows::SID::Nobody
     well_known_system_sid = Puppet::Util::Windows::SID::LocalSystem
+    well_known_app_packages_sid = Puppet::Util::Windows::SID::AllAppPackages
 
     mode = S_ISYSTEM_MISSING
 
@@ -234,6 +235,7 @@ module Puppet::Util::Windows::Security
         if (ace.mask & FILE::FILE_APPEND_DATA).nonzero?
           mode |= S_ISVTX
         end
+      when well_known_app_packages_sid
       when well_known_system_sid
       else
         #puts "Warning, unable to map SID into POSIX mode: #{ace.sid}"

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -46,6 +46,7 @@ module Puppet::Util::Windows
     PrintOperators              = 'S-1-5-32-550'
     BackupOperators             = 'S-1-5-32-551'
     Replicators                 = 'S-1-5-32-552'
+    AllAppPackages              = 'S-1-15-2-1'
 
     # Convert an account name, e.g. 'Administrators' into a SID string,
     # e.g. 'S-1-5-32-544'. The name can be specified as 'Administrators',


### PR DESCRIPTION
Files present in a system protected filder, like C:\Windows or
C:\Program Files will inherit some additional ACE(Access Control Entries) from the
protected dir. So the file ACL(Access Control List) that stores ACEs will have
additional entries.

The ACE added is "APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES"
with a SID(Security Identifier) of "S-1-15-2-1".
"S-1-15-2-1” is not identified by security.rb as a well known SID,
as it was added in windows 8 to the list of well known SIDs
(https://msdn.microsoft.com/en-us/library/cc980032.aspx), and it is used for
execution of sandboxed applications.

Since it was unable to match to a well known SID, it was unable to map the SID
into POSIX mode, so when getting the mode, it added the S_IEXTRA bit flag indicating
that an access control entry was found whose SID is neither the owner, group, or other.

After the SID was added to the list of well known SIDs, it won't add the S_IEXTRA
bit when getting the file mode, so the desired mode matches the actual
mode and there is no need to apply the mode on every run.