### PR TITLE
(PUP-9290) `puppet facts upload` always uses environment "production"…

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -81,7 +81,7 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
                     node: Puppet[:node_name_value],
                     server: server})
 
-      Puppet::Node::Facts.indirection.save(facts)
+      Puppet::Node::Facts.indirection.save(facts, nil, :environment => Puppet.lookup(:current_environment))
     end
   end
 end


### PR DESCRIPTION
… ignoring setting from puppet.conf