### PR TITLE
(PUP-9824) Allow virtual packages for debian

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
     or an array where each element is either a string or a hash."
 
-  has_feature :versionable, :install_options
+  has_feature :versionable, :install_options, :virtual_packages
 
   commands :aptget => "/usr/bin/apt-get"
   commands :aptcache => "/usr/bin/apt-cache"

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     and not `apt`, you must specify the source of any packages you want
     to manage."
 
-  has_feature :holdable
+  has_feature :holdable, :virtual_packages 
 
   commands :dpkg => "/usr/bin/dpkg"
   commands :dpkg_deb => "/usr/bin/dpkg-deb"
@@ -44,16 +44,18 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   # Note: self:: is required here to keep these constants in the context of what will
   # eventually become this Puppet::Type::Package::ProviderDpkg class.
   self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package} ${Version}\\n'}
+  self::DPKG_QUERY_PROVIDES_FORMAT_STRING = %Q{'${Status} ${Package} ${Version} [${Provides}]\\n'}
   self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*)$}
+  self::FIELDS_REGEX_WITH_PROVIDES = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*) \[.*\]$} 
   self::FIELDS= [:desired, :error, :status, :name, :ensure]
 
   # @param line [String] one line of dpkg-query output
   # @return [Hash,nil] a hash of FIELDS or nil if we failed to match
   # @api private
-  def self.parse_line(line)
+  def self.parse_line(line, regex=self::FIELDS_REGEX)
     hash = nil
 
-    if match = self::FIELDS_REGEX.match(line)
+    if match = regex.match(line)
       hash = {}
 
       self::FIELDS.zip(match.captures) do |field,value|
@@ -113,6 +115,18 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
 
     # list out our specific package
     begin
+      if @resource.allow_virtual?
+        output = dpkgquery(
+          "-W",
+          "--showformat",
+          self.class::DPKG_QUERY_PROVIDES_FORMAT_STRING
+        ).lines.find {|package| package.match(/\[.*#{@resource[:name]}.*\]/)}
+        if output          
+          hash = self.class.parse_line(output,self.class::FIELDS_REGEX_WITH_PROVIDES)
+          Puppet.info("Package #{@resource[:name]} is virtual, defaulting to #{hash[:name]}")
+          @resource[:name] = hash[:name]
+        end
+      end
       output = dpkgquery(
         "-W",
         "--showformat",

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -8,6 +8,7 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
   let(:vim_installed_output) { "install ok installed vim 2:7.3.547-6ubuntu5\n" }
   let(:all_installed_io) { StringIO.new([bash_installed_output, vim_installed_output].join) }
   let(:args) { ['-W', '--showformat', %Q{'${Status} ${Package} ${Version}\\n'}] }
+  let(:args_with_provides) { ['/bin/dpkg-query','-W', '--showformat', %Q{'${Status} ${Package} ${Version} [${Provides}]\\n'}]}
   let(:execute_options) do
     {:failonfail => true, :combine => true, :custom_environment => {}}
   end
@@ -31,7 +32,6 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
 
       installed = double('bash')
       expect(described_class).to receive(:new).with(:ensure => "4.2-5ubuntu3", :error => "ok", :desired => "install", :name => "bash", :status => "installed", :provider => :dpkg).and_return(installed)
-
       expect(described_class.instances).to eq([installed])
     end
 
@@ -68,31 +68,59 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
       expect(Puppet::Util::Execution).to receive(:execute).with(query_args, execute_options).and_return(Puppet::Util::Execution::ProcessOutput.new(output, 0))
     end
 
+    def dpkg_query_execution_with_multiple_args_returns(output, *args)
+      args.each do |arg|
+        expect(Puppet::Util::Execution).to receive(:execute).with(arg, execute_options).ordered.and_return(Puppet::Util::Execution::ProcessOutput.new(output, 0))
+      end
+    end
+
     before do
       allow(Puppet::Util).to receive(:which).with('/usr/bin/dpkg-query').and_return(dpkgquery_path)
+      allow(resource).to receive(:allow_virtual?).and_return(false)
     end
 
     it "considers the package purged if dpkg-query fails" do
       allow(Puppet::Util::Execution).to receive(:execute).with(query_args, execute_options).and_raise(Puppet::ExecutionFailure.new("eh"))
+      expect(provider.query[:ensure]).to eq(:purged)
+    end
 
+    it "considers the package purged if dpkg-query fails  with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      allow(Puppet::Util::Execution).to receive(:execute).with(args_with_provides, execute_options).and_raise(Puppet::ExecutionFailure.new("eh"))
       expect(provider.query[:ensure]).to eq(:purged)
     end
 
     it "returns a hash of the found package status for an installed package" do
       dpkg_query_execution_returns(bash_installed_output)
+      expect(provider.query).to eq({:ensure => "4.2-5ubuntu3", :error => "ok", :desired => "install", :name => "bash", :status => "installed", :provider => :dpkg})
+    end
 
+    it "returns a hash of the found package status for an installed package with allo_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns(bash_installed_output,args_with_provides,query_args)
       expect(provider.query).to eq({:ensure => "4.2-5ubuntu3", :error => "ok", :desired => "install", :name => "bash", :status => "installed", :provider => :dpkg})
     end
 
     it "considers the package absent if the dpkg-query result cannot be interpreted" do
+      allow(resource).to receive(:allow_virtual?).and_return(false)
       dpkg_query_execution_returns('some-bad-data')
+      expect(provider.query[:ensure]).to eq(:absent)
+    end
 
+    it "considers the package absent if the dpkg-query result cannot be interpreted  with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns('some-bad-data',args_with_provides,query_args)
       expect(provider.query[:ensure]).to eq(:absent)
     end
 
     it "fails if an error is discovered" do
       dpkg_query_execution_returns(bash_installed_output.gsub("ok","error"))
+      expect { provider.query }.to raise_error(Puppet::Error)
+    end
 
+    it "fails if an error is discovered with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns(bash_installed_output.gsub("ok","error"),args_with_provides,query_args)
       expect { provider.query }.to raise_error(Puppet::Error)
     end
 
@@ -100,12 +128,26 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
       not_installed_bash = bash_installed_output.gsub("installed", "not-installed")
       not_installed_bash.gsub!(bash_version, "")
       dpkg_query_execution_returns(not_installed_bash)
-
       expect(provider.query[:ensure]).to eq(:purged)
     end
 
+    it "considers the package purged if it is marked 'not-installed' with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      not_installed_bash = bash_installed_output.gsub("installed", "not-installed")
+      not_installed_bash.gsub!(bash_version, "")
+      dpkg_query_execution_with_multiple_args_returns(not_installed_bash,args_with_provides,query_args)
+      expect(provider.query[:ensure]).to eq(:purged)
+    end
+
+
     it "considers the package absent if it is marked 'config-files'" do
       dpkg_query_execution_returns(bash_installed_output.gsub("installed","config-files"))
+      expect(provider.query[:ensure]).to eq(:absent)
+    end
+
+    it "considers the package absent if it is marked 'config-files' with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns(bash_installed_output.gsub("installed","config-files"),args_with_provides,query_args)
       expect(provider.query[:ensure]).to eq(:absent)
     end
 
@@ -114,8 +156,21 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
       expect(provider.query[:ensure]).to eq(:absent)
     end
 
+    it "considers the package absent if it is marked 'half-installed' with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns(bash_installed_output.gsub("installed","half-installed"),args_with_provides,query_args)
+      expect(provider.query[:ensure]).to eq(:absent)
+    end
+
     it "considers the package absent if it is marked 'unpacked'" do
       dpkg_query_execution_returns(bash_installed_output.gsub("installed","unpacked"))
+      expect(provider.query[:ensure]).to eq(:absent)
+    end
+
+
+    it "considers the package absent if it is marked 'unpacked' with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns(bash_installed_output.gsub("installed","unpacked"),args_with_provides,query_args)
       expect(provider.query[:ensure]).to eq(:absent)
     end
 
@@ -124,8 +179,20 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
       expect(provider.query[:ensure]).to eq(:absent)
     end
 
+    it "considers the package absent if it is marked 'half-configured' with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns(bash_installed_output.gsub("installed","half-configured"),args_with_provides,query_args)      
+      expect(provider.query[:ensure]).to eq(:absent)
+    end
+
     it "considers the package held if its state is 'hold'" do
       dpkg_query_execution_returns(bash_installed_output.gsub("install","hold"))
+      expect(provider.query[:ensure]).to eq(:held)
+    end
+
+    it "considers the package held if its state is 'hold' with allow_virtual enabled" do
+      allow(resource).to receive(:allow_virtual?).and_return(true)
+      dpkg_query_execution_with_multiple_args_returns(bash_installed_output.gsub("install","hold"),args_with_provides,query_args)
       expect(provider.query[:ensure]).to eq(:held)
     end
 
@@ -144,6 +211,7 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
       let(:package_not_found_hash) do
         {:ensure => :purged, :status => 'missing', :name => resource_name, :error => 'ok'}
       end
+      let(:output) {'an unexpected dpkg msg with an exit code of 0'}
 
       def parser_test(dpkg_output_string, gold_hash, number_of_debug_logs = 0)
         dpkg_query_execution_returns(dpkg_output_string)
@@ -157,20 +225,33 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
         no_ensure = 'desired ok status name '
         parser_test(no_ensure, package_hash.merge(:ensure => ''))
       end
+      it "provides debug logging of unparsable lines with allow_virtual enabled" do
+        allow(resource).to receive(:allow_virtual?).and_return(true)
+        dpkg_query_execution_with_multiple_args_returns(output, args_with_provides, query_args)
+        expect(Puppet).not_to receive(:warning)
+        expect(Puppet).to receive(:debug).exactly(1).times
+        expect(provider.query).to eq(package_not_found_hash.merge(:ensure => :absent))
+      end
+      
 
       it "provides debug logging of unparsable lines" do
         parser_test('an unexpected dpkg msg with an exit code of 0', package_not_found_hash.merge(:ensure => :absent), 1)
+      end
+      
+      it "does not log if execution returns with non-zero exit code with allow_virtual enabled" do
+        allow(resource).to receive(:allow_virtual?).and_return(true)
+        expect(Puppet::Util::Execution).to receive(:execute).with(args_with_provides, execute_options).ordered.and_raise(Puppet::ExecutionFailure.new("failed"))
+        expect(Puppet).not_to receive(:debug)
+        expect(provider.query).to eq(package_not_found_hash)
       end
 
       it "does not log if execution returns with non-zero exit code" do
         expect(Puppet::Util::Execution).to receive(:execute).with(query_args, execute_options).and_raise(Puppet::ExecutionFailure.new("failed"))
         expect(Puppet).not_to receive(:debug)
-
         expect(provider.query).to eq(package_not_found_hash)
       end
     end
   end
-
   context "when installing" do
     before do
       allow(resource).to receive(:[]).with(:source).and_return("mypkg")
@@ -218,7 +299,7 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
 
     before do
       allow(tempfile).to receive(:write)
-      allow(Tempfile).to receive(:new).and_return(tempfile)
+      allow(Tempfile).to receive(:open).and_yield(tempfile)
     end
 
     it "installs first if package is not present and ensure holding" do
@@ -292,4 +373,3 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
     expect {provider.package_not_installed?("")}.to raise_error(ArgumentError,"Package name is nil or empty")
   end
 end
-


### PR DESCRIPTION
Implementation for apt and dpkg to allow virtual packages to be installed on the system.