### PR TITLE
(PUP-9816) Fix `puppet parser validate` handling of STDIN

### DIFF
--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -89,7 +89,7 @@ Puppet::Face.define(:parser, '0.0.1') do
           [file, file_errors]
         end.to_h
 
-        puts Puppet::Util::Json.dump(Puppet::Pops::Serialization::ToDataConverter.convert(data, rich_data: false), :pretty => true)
+        puts Puppet::Util::Json.dump(Puppet::Pops::Serialization::ToDataConverter.convert(data, rich_data: false, symbol_as_string: true), :pretty => true)
 
         exit(1)
       end

--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -42,7 +42,8 @@ Puppet::Face.define(:parser, '0.0.1') do
       if files.empty?
         if not STDIN.tty?
           Puppet[:code] = STDIN.read
-          parse_errors['STDIN'] = validate_manifest(nil)
+          error = validate_manifest(nil)
+          parse_errors['STDIN'] = error if error
         else
           manifest = Puppet.lookup(:current_environment).manifest
           files << manifest

--- a/spec/unit/face/parser_spec.rb
+++ b/spec/unit/face/parser_spec.rb
@@ -105,13 +105,25 @@ describe Puppet::Face[:parser, :current] do
       end
     end
 
-    it "validates the contents of STDIN when no files given and STDIN is not a tty" do
-      from_a_piped_input_of("{ invalid =>")
+    context "when no files given and STDIN is not a tty" do
+      it "validates the contents of STDIN" do
+        from_a_piped_input_of("{ invalid =>")
 
-      Puppet.override(:current_environment => Puppet::Node::Environment.create(:special, [])) do
-        parse_errors = parser.validate()
+        Puppet.override(:current_environment => Puppet::Node::Environment.create(:special, [])) do
+          parse_errors = parser.validate()
 
-        expect(parse_errors['STDIN']).to be_a_kind_of(Puppet::ParseErrorWithIssue)
+          expect(parse_errors['STDIN']).to be_a_kind_of(Puppet::ParseErrorWithIssue)
+        end
+      end
+
+      it "runs error free when contents of STDIN is valid" do
+        from_a_piped_input_of("notify { valid: }")
+
+        Puppet.override(:current_environment => Puppet::Node::Environment.create(:special, [])) do
+          parse_errors = parser.validate()
+
+          expect(parse_errors).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
In PUP-8984 the `puppet parser validate` face was refactored to
support the `--render-as json` option and also support validating
multiple files with parse errors in a single execution. (Previously it
would exit immediately on the first parse error.)

The implementation of PUP-8984 introduced a data structure to collect each
file that contained a parse error as well as the error itself.
Unfortunately a bug was introduced where when a manifest with no parse
errors was passed to `puppet parser validate` via the STDIN pipe (e.g.
`puppet parser validate < good.pp`) an entry in the "files with errors"
data structure was still created for "STDIN" but with a value of `nil`
instead of a parse error object. This empty entry caused the output renderer
to pass `nil` to the formatting methods resulting in `Error: undefined method
`message' for nil:NilClass`.

The fix for this issue adds a conditional so that the error collection
data structure entry for "STDIN" is only created if an actual parse
error was encountered, which mirrors the behavior when parsing manifests
from filename arguments.

A new unit test is also added to cover this scenario.