### PR TITLE
(PUP-8736) Symlink puppet device certs to /etc

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -265,6 +265,14 @@ module Puppet
       :group    => "service",
       :desc     => "Where Puppet PID files are kept."
     },
+    :deviceconfdir => {
+      :default  => "$confdir/devices",
+      :type     => :directory,
+      :mode     => "0750",
+      :owner    => "service",
+      :group    => "service",
+      :desc     => "The root directory of devices' $confdir.",
+    },
     :genconfig => {
         :default  => false,
         :type     => :boolean,

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -382,7 +382,17 @@ describe Puppet::Application::Device do
         allow(configurer).to receive(:run)
         allow(Puppet::Configurer).to receive(:new).and_return(configurer)
 
+        allow(Puppet::FileSystem).to receive(:exist?)
+        allow(Puppet::FileSystem).to receive(:symlink)
+        allow(Puppet::FileSystem).to receive(:dir_mkpath).and_return(true)
+        allow(Puppet::FileSystem).to receive(:dir_exist?).and_return(true)
+
         allow(plugin_handler).to receive(:download_plugins)
+      end
+
+      it "sets ssldir relative to the global confdir" do
+        expect(Puppet).to receive(:[]=).with(:ssldir, make_absolute("/dummy/devices/device1/ssl"))
+        expect { device.main }.to exit_with 1
       end
 
       it "sets vardir to the device vardir" do
@@ -402,6 +412,22 @@ describe Puppet::Application::Device do
       end
 
       context 'with --target=device1' do
+        it "symlinks the ssl directory if it doesn't exist" do
+          allow(device.options).to receive(:[]).with(:target).and_return('device1')
+          allow(Puppet::FileSystem).to receive(:exist?).and_return(false)
+
+          expect(Puppet::FileSystem).to receive(:symlink).with(Puppet[:ssldir], File.join(Puppet[:confdir], 'ssl')).and_return(true)
+          expect { device.main }.to exit_with 1
+        end
+
+        it "creates the device confdir under the global confdir" do
+          allow(device.options).to receive(:[]).with(:target).and_return('device1')
+          allow(Puppet::FileSystem).to receive(:dir_exist?).and_return(false)
+
+          expect(Puppet::FileSystem).to receive(:dir_mkpath).with(Puppet[:ssldir]).and_return(true)
+          expect { device.main }.to exit_with 1
+        end
+
         it "manages the specified target" do
           allow(device.options).to receive(:[]).with(:target).and_return('device1')
 


### PR DESCRIPTION
Prior to this commit, SSL certificates, along with the rest of the Puppet device configuration were stored under cache.

When the proxy Puppet agent for a device is the master, and the user executes a backup and restore (manually, or as automated in OpsWorks), the certificate and keys in the `ssldir` in each `devicedir` are lost, requiring certificate regeneration for those devices.

This commit symlinks the `ssl` directory from `/opt/puppetlabs/puppet/cache/devices/DEVICE/ssl` to `/etc/puppetlabs/puppet/devices/ssl/DEVICE`, ensuring that SSL certificates are not lost when cache is deleted.