### PR TITLE
(maint) Make facts upload environment explicit

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -81,7 +81,7 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
                     node: Puppet[:node_name_value],
                     server: server})
 
-      Puppet::Node::Facts.indirection.save(facts)
+      Puppet::Node::Facts.indirection.save(facts, nil, :environment => Puppet.lookup(:current_environment))
     end
   end
 end

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -45,6 +45,15 @@ CONF
       subject.upload
     end
 
+    it "passes the current environment" do
+      env = Puppet::Node::Environment.remote('qa')
+      expect(model.indirection).to receive(:save).with(anything, nil, :environment => env)
+
+      Puppet.override(:current_environment => env) do
+        subject.upload
+      end
+    end
+
     it "uses settings from the agent section of puppet.conf" do
       expect(facter_terminus).to receive(:find).with(have_attributes(key: 'puppet.node.test')).and_return(test_data)
 


### PR DESCRIPTION
This adds a test to verify `puppet facts upload` passes the current environment and it makes the environment passing explicit. It doesn't result in a functional change, because the indirector request [defaults to the current environment](https://github.com/puppetlabs/puppet/blob/57492210f3b93f7709ea2ad9b6ccc00839a98b70/lib/puppet/indirector/request.rb#L32). 