### PR TITLE
(maint) Remove --server option

### DIFF
--- a/acceptance/tests/modulepath.rb
+++ b/acceptance/tests/modulepath.rb
@@ -108,7 +108,7 @@ END
   with_puppet_running_on(master, {}) do
     step "agent doesn't pluginsync the vendored module, instead using its local vendored module" do
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [0,2]) do |result|
+        on(agent, puppet("agent -t"), :acceptable_exit_codes => [0,2]) do |result|
           assert_match(/defined 'message' as 'vendored module from #{agent}'/, result.stdout)
         end
       end
@@ -121,7 +121,7 @@ END
       on(master, "chown -R puppet:puppet #{global_dir}")
 
       agents.each do |agent|
-        on(agent, puppet("agent -t --server #{master}"), :acceptable_exit_codes => [0,2]) do |result|
+        on(agent, puppet("agent -t"), :acceptable_exit_codes => [0,2]) do |result|
           assert_match(/defined 'message' as 'server module from #{master}'/, result.stdout)
         end
       end

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -66,7 +66,6 @@ EOF
         on(agent, puppet("agent --test",
                   "--waitforcert 0",
                   "--ssldir", "'#{testdirs[agent]}/ssldir-autosign'",
-                  "--server", fqdn,
                   "--certname #{certname}"), :acceptable_exit_codes => [0,2])
         unless agent['locale'] == 'ja'
           assert_key_generated(agent)
@@ -107,7 +106,6 @@ EOF
         on(agent, puppet("agent --test",
                         "--waitforcert 0",
                         "--ssldir", "'#{testdirs[agent]}/ssldir-reject'",
-                        "--server", fqdn,
                         "--certname #{certname}"), :acceptable_exit_codes => [1])
         unless agent['locale'] == 'ja'
           assert_key_generated(agent)
@@ -176,7 +174,6 @@ custom_attributes:
         on(agent, puppet("agent --test",
                          "--waitforcert 0",
                          "--ssldir", "'#{testdirs[agent]}/ssldir-attrs'",
-                         "--server", fqdn,
                          "--csr_attributes '#{agent_csr_attributes[agent]}'",
                          "--certname #{certname}"), :acceptable_exit_codes => [0,2])
         assert_key_generated(agent) unless agent['locale'] == 'ja'

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -91,7 +91,6 @@ test_name "certificate extensions available as trusted data" do
                        "--csr_attributes", agent_csr_attributes,
                        "--certname", agent_certname,
                        "--ssldir", agent_ssldir,
-                       "--server", fqdn,
                        'ENV' => { "FACTER_test_dir" => get_test_file_path(agent, "") }),
         :acceptable_exit_codes => [0, 2])
 


### PR DESCRIPTION
When running beaker tests it's no longer necessary to specify the master,
unless it needs to be overridden, such as to test failover, or if the agent
is using a non-default puppet.conf.