### PR TITLE
Test fixes

### DIFF
--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -2,6 +2,10 @@ test_name 'puppet module list (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+
 tmpdir = master.tmpdir('module-list-with-environment')
 
 step 'Setup'

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -1,6 +1,8 @@
 test_name "autosign command and csr attributes behavior (#7243,#7244)" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
+  skip_test "Test requires at least one non-master agent" if hosts.length == 1
+
   tag 'audit:high',        # cert/ca core behavior
       'audit:integration',
       'server'             # Ruby implementation is deprecated

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -5,9 +5,11 @@ initialize_temp_dirs
 test_name "certificate extensions available as trusted data" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
+  skip_test "Test requires at least one non-master agent" if hosts.length == 1
+
   tag 'audit:high',        # ca/cert core functionality
       'audit:integration',
-      'server'             # Ruby implimentation is deprecated
+      'server'             # Ruby implementation is deprecated
 
   agent_certnames = []
   hostname = master.execute('facter hostname')


### PR DESCRIPTION
I found these while running `server` tests on the FIPS platform. It turns out they're not exactly FIPS related, but are still good cleanup.

Once these are cleaned up, all `server` tests passed on the FIPS platform, with the caveat that we are not yet using the FIPS version of BouncyCastle. However, with these fixes (notably the tag-related one), we should be able to enable testing on redhatfips in the server pipeline.