### PR TITLE
(PUP-9513) Deprecate Puppet::SSL::Host

### DIFF
--- a/lib/puppet/indirector/certificate/file.rb
+++ b/lib/puppet/indirector/certificate/file.rb
@@ -1,6 +1,7 @@
 require 'puppet/indirector/ssl_file'
 require 'puppet/ssl/certificate'
 
+# @deprecated
 class Puppet::SSL::Certificate::File < Puppet::Indirector::SslFile
   desc "Manage SSL certificates on disk."
 

--- a/lib/puppet/indirector/certificate/rest.rb
+++ b/lib/puppet/indirector/certificate/rest.rb
@@ -1,6 +1,7 @@
 require 'puppet/ssl/certificate'
 require 'puppet/indirector/rest'
 
+# @deprecated
 class Puppet::SSL::Certificate::Rest < Puppet::Indirector::REST
   desc "Find certificates over HTTP via REST."
 

--- a/lib/puppet/indirector/certificate_request/file.rb
+++ b/lib/puppet/indirector/certificate_request/file.rb
@@ -1,6 +1,7 @@
 require 'puppet/indirector/ssl_file'
 require 'puppet/ssl/certificate_request'
 
+# @deprecated
 class Puppet::SSL::CertificateRequest::File < Puppet::Indirector::SslFile
   desc "Manage the collection of certificate requests on disk."
 

--- a/lib/puppet/indirector/certificate_request/memory.rb
+++ b/lib/puppet/indirector/certificate_request/memory.rb
@@ -1,6 +1,7 @@
 require 'puppet/ssl/certificate_request'
 require 'puppet/indirector/memory'
 
+# @deprecated
 class Puppet::SSL::CertificateRequest::Memory < Puppet::Indirector::Memory
   desc "Store certificate requests in memory. This is used for testing puppet."
 end

--- a/lib/puppet/indirector/certificate_request/rest.rb
+++ b/lib/puppet/indirector/certificate_request/rest.rb
@@ -1,6 +1,7 @@
 require 'puppet/ssl/certificate_request'
 require 'puppet/indirector/rest'
 
+# @deprecated
 class Puppet::SSL::CertificateRequest::Rest < Puppet::Indirector::REST
   desc "Find and save certificate requests over HTTP via REST."
 

--- a/lib/puppet/indirector/key/file.rb
+++ b/lib/puppet/indirector/key/file.rb
@@ -1,6 +1,7 @@
 require 'puppet/indirector/ssl_file'
 require 'puppet/ssl/key'
 
+# @deprecated
 class Puppet::SSL::Key::File < Puppet::Indirector::SslFile
   desc "Manage SSL private and public keys on disk."
 

--- a/lib/puppet/indirector/key/memory.rb
+++ b/lib/puppet/indirector/key/memory.rb
@@ -1,6 +1,7 @@
 require 'puppet/ssl/key'
 require 'puppet/indirector/memory'
 
+# @deprecated
 class Puppet::SSL::Key::Memory < Puppet::Indirector::Memory
   desc "Store keys in memory. This is used for testing puppet."
 end

--- a/lib/puppet/ssl/certificate.rb
+++ b/lib/puppet/ssl/certificate.rb
@@ -5,6 +5,8 @@ require 'puppet/ssl/base'
 # for turning CSRs into certificates; we can only
 # retrieve them from the CA (or not, as is often
 # the case).
+#
+# @deprecated Use {Puppet::SSL::SSLProvider} instead.
 class Puppet::SSL::Certificate < Puppet::SSL::Base
   # This is defined from the base class
   wraps OpenSSL::X509::Certificate

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -9,6 +9,8 @@ require 'puppet/rest/routes'
 
 # The class that manages all aspects of our SSL certificates --
 # private keys, public keys, requests, etc.
+#
+# @deprecated Use {Puppet::SSL::SSLProvider} instead.
 class Puppet::SSL::Host
   # Yay, ruby's strange constant lookups.
   Key = Puppet::SSL::Key
@@ -230,6 +232,7 @@ ERROR_STRING
     @key = @certificate = @certificate_request = nil
     @crl_usage = Puppet.settings[:certificate_revocation]
     @crl_path = Puppet.settings[:hostcrl]
+    Puppet.deprecation_warning(_("Puppet::SSL::Host is deprecated and will be removed in a future release of Puppet."));
   end
 
   # Extract the public key from the private key.

--- a/lib/puppet/ssl/key.rb
+++ b/lib/puppet/ssl/key.rb
@@ -2,6 +2,8 @@ require 'puppet/ssl/base'
 require 'puppet/indirector'
 
 # Manage private and public keys as a pair.
+#
+# @deprecated Use {Puppet::SSL::SSLProvider} instead.
 class Puppet::SSL::Key < Puppet::SSL::Base
   wraps OpenSSL::PKey::RSA
 


### PR DESCRIPTION
Generate a deprecation warning if `Puppet::SSL::Host` is created. Add `@deprecated` tag to SSL related models and termini.