### PR TITLE
(PUP-9909) Prefer SHA-256 for forge downloads

### DIFF
--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -51,9 +51,6 @@ module Puppet::ModuleTool
       end
 
       def run
-        # Disallow anything that invokes md5 to avoid un-friendly termination due to FIPS
-        raise _("Module install is prohibited in FIPS mode.") if Facter.value(:fips_enabled)
-
         name = @name.tr('/', '-')
         version = options[:version] || '>= 0.0.0'
 

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -365,14 +365,5 @@ describe Puppet::ModuleTool::Applications::Installer, :unless => RUBY_PLATFORM =
         end
       end
     end
-
-    context 'when in FIPS mode...' do
-      it 'module installer refuses to run' do
-        allow(Facter).to receive(:value).with(:fips_enabled).and_return(true)
-        expect {application.run}.to raise_error(/Module install is prohibited in FIPS mode./)
-      end 
-    end
-
   end
-
 end


### PR DESCRIPTION
The forge API recently added `file_sha256` to the fetch module release
response[1] containing the SHA-256 checksum of the module release tarball. This
commit modifies the `puppet module install` command to prefer SHA-256, or
fallback to MD5 as it did before. If the PMT falls back to MD5 and FIPS is
enabled, then raise an exception like we did before. If both checksums are
missing, raise an exception.

We cannot drop MD5 yet, because some 3rd party forge implementations like
Artifactory haven't been updated to respond with `file_sha256`.

[1] https://forgeapi.puppetlabs.com/#operation/getRelease