### PR TITLE
(PUP-9513) Deprecate ssl_{server,client}_ca_auth settings

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -929,17 +929,20 @@ EOT
       :desc  => "Certificate authorities who issue server certificates.  SSL servers will not be
         considered authentic unless they possess a certificate issued by an authority
         listed in this file.  If this setting has no value then the Puppet master's CA
-        certificate (localcacert) will be used."
+        certificate (localcacert) will be used.",
+      :hook => proc do |val|
+        Puppet.deprecation_warning(_("Setting 'ssl_client_ca_auth' is deprecated."))
+      end
     },
     :ssl_server_ca_auth => {
       :type  => :file,
       :mode  => "0644",
       :owner => "service",
       :group => "service",
-      :desc  => "Certificate authorities who issue client certificates.  SSL clients will not be
-        considered authentic unless they possess a certificate issued by an authority
-        listed in this file.  If this setting has no value then the Puppet master's CA
-        certificate (localcacert) will be used."
+      :deprecated  => :completely,
+      :desc => "The setting is deprecated and has no effect. Ensure all root and
+        intermediate certificate authorities used to issue client certificates are
+        contained in the server's `cacert` file on the server."
     },
     :hostcrl => {
       :default => "$ssldir/crl.pem",


### PR DESCRIPTION
The `ssl_server_ca_auth` setting is dead and has been since the ruby webrick
puppet master was removed. Any attempt to get or set the setting will generate a
deprecation warning.

The `ssl_client_ca_auth` setting was created in 3.x to support certificate
chains back when `ca.pem` could only contain a single root CA. The setting is
read whenever `Puppet::Network::HttpPool.http*instance` is called. To prevent
deprecation spamming, only warn if the value is set, as that may indicate the
`ca.pem` does not contain all of the CA certificates that the agent needs to
verify the server's SSL chain.