### PR TITLE
(PUP-9915) service provider: sync defaultfor :debian

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -24,8 +24,8 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
-  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
-
+  defaultfor :operatingsystem => :debian
+  notdefaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["5", "6", "7"] # These are using the "debian" method
   defaultfor :operatingsystem => :LinuxMint
   notdefaultfor :operatingsystem => :LinuxMint, :operatingsystemmajrelease => ["10", "11", "12", "13", "14", "15", "16", "17"] # These are using upstart
   defaultfor :operatingsystem => :ubuntu

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -120,6 +120,20 @@ describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platf
     expect(provider_class).to be_default
   end
 
+  it "should be the default provider on debian11" do
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("11")
+    expect(provider_class).to be_default
+  end
+
+  it "should be the default provider on debian bookworm/sid" do
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("bookworm/sid")
+    expect(provider_class).to be_default
+  end
+
   it "should not be the default provider on ubuntu14.04" do
     allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
     allow(Facter).to receive(:value).with(:operatingsystem).and_return(:ubuntu)


### PR DESCRIPTION
Make the systemd defaultfor the opposite of debian defaultfor. This
should avoid the need for updates with every future Debian release.
