### PR TITLE
(PUP-9914) Fixed ParsedFile behaviour for records

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -256,11 +256,11 @@ class Puppet::Transaction::Report
     @time = data['time']
     @corrective_change = data['corrective_change']
 
-    if data['master_used'] 
+    if data['master_used']
       @master_used = data['master_used']
     end
 
-    if data['catalog_uuid'] 
+    if data['catalog_uuid']
       @catalog_uuid = data['catalog_uuid']
     end
 

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -573,7 +573,7 @@ module Puppet
     autorequire(:user) do
       # Autorequire users if they are specified by name
       user = self[:user]
-      if user !~ /^\d+$/
+      if user && user !~ /^\d+$/
         user
       end
     end

--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -201,7 +201,7 @@ module Puppet::Util::FileParsing
       else
         ret = {}
         sep = record.separator
-  
+
         # String "helpfully" replaces ' ' with /\s+/ in splitting, so we
         # have to work around it.
         if sep == " "
@@ -216,20 +216,20 @@ module Puppet::Util::FileParsing
             ret[param] = :absent
           end
         end
-  
+
         if record.rollup and ! line_fields.empty?
           last_field = record.fields[-1]
           val = ([ret[last_field]] + line_fields).join(record.joiner)
           ret[last_field] = val
         end
       end
-  
-      if ret
-        ret[:record_type] = record.name
-        return ret
-      else
-        return nil
-      end
+    end
+
+    if ret
+      ret[:record_type] = record.name
+      return ret
+    else
+      return nil
     end
   end
 
@@ -373,7 +373,7 @@ module Puppet::Util::FileParsing
 
   def valid_attr?(type, attr)
     type = type.intern
-    record = record_type(type) 
+    record = record_type(type)
     if record && record.fields.include?(attr.intern)
       return true
     else

--- a/spec/fixtures/unit/provider/parsedfile/aliases.txt
+++ b/spec/fixtures/unit/provider/parsedfile/aliases.txt
@@ -1,0 +1,2 @@
+manager:  root
+dumper:   postmaster

--- a/spec/unit/provider/parsedfile_spec.rb
+++ b/spec/unit/provider/parsedfile_spec.rb
@@ -224,4 +224,30 @@ describe "A very basic provider based on ParsedFile" do
       end
     end
   end
+
+  context 'parsing a record type' do
+    let(:input_text) { File.read(my_fixture('aliases.txt')) }
+    let(:target) { tmpfile('parsedfile_spec') }
+    let(:provider) do
+      example_provider_class = Class.new(Puppet::Provider::ParsedFile)
+      example_provider_class.default_target = target
+      # Setup some record rules
+      example_provider_class.instance_eval do
+        record_line :aliases, :fields =>  %w{manager alias}, :separator => ':'
+      end
+      example_provider_class.initvars
+      example_provider_class.prefetch
+      example_provider_class
+    end
+    let(:expected_result) do
+      [
+        {:manager=>"manager", :alias=>"  root", :record_type=>:aliases},
+        {:manager=>"dumper", :alias=>"   postmaster", :record_type=>:aliases}
+      ]
+    end
+
+    subject { provider.parse(input_text) }
+
+    it { is_expected.to  match_array(expected_result) }
+  end
 end


### PR DESCRIPTION
Also:
 - remove whitespaces in: lib/puppet/transaction/report.rb
 - do an extra check in: lib/puppet/type/exec.rb:576