### PR TITLE
PUP-8949 use install_options with 'latest' methods

### DIFF
--- a/acceptance/tests/provider/package/pip.rb
+++ b/acceptance/tests/provider/package/pip.rb
@@ -1,0 +1,44 @@
+test_name "pip provider should install, use install_options with latest, and uninstall" do
+  confine :to, :template => /centos/
+  tag 'audit:low'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::PackageUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  package = 'colorize'
+
+  agents.each do |agent|
+    step "Setup: Install EPEL Repository, Python and Pip" do
+      package_present(agent, 'epel-release')
+      package_present(agent, 'python')
+      package_present(agent, 'python-pip')
+    end
+
+    step "Install a pip package" do
+      package_manifest = resource_manifest('package', package, { ensure: 'present', provider: 'pip' } )
+      apply_manifest_on(agent, package_manifest, :catch_failures => true) do
+        list = on(agent, 'pip list --disable-pip-version-check').stdout
+        assert_match(/#{package} \(/, list)
+      end
+      on(agent, "pip uninstall #{package} --disable-pip-version-check --yes")
+    end
+
+    step "Ensure latest with pip uses install_options" do
+      on(agent, "pip install #{package} --disable-pip-version-check")
+      package_manifest = resource_manifest('package', package, { ensure: 'latest', provider: 'pip', install_options: { '--index' => 'https://pypi.python.org/simple' } } )
+      result = apply_manifest_on(agent, package_manifest, { :catch_failures => true, :debug => true } )
+      assert_match(/--index=https:\/\/pypi.python.org\/simple/, result.stdout)
+      on(agent, "pip uninstall #{package} --disable-pip-version-check --yes")
+    end
+
+    step "Uninstall a pip package" do
+      on(agent, "pip install #{package} --disable-pip-version-check")
+      package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'pip' } )
+      apply_manifest_on(agent, package_manifest, :catch_failures => true) do
+        list = on(agent, 'pip list --disable-pip-version-check').stdout
+        assert_no_match(/#{package} \(/, list)
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -123,14 +123,17 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     end
   end
 
+  # Less resource-intensive approach for pip version 1.5.4 and newer.
+
   def latest_with_new_pip
     command = resource_or_provider_command
     self.class.validate_command(command)
 
-    # Less resource intensive approach for pip version 1.5.4 and above
-    execpipe [command, "install", "#{@resource[:name]}==versionplease"] do |process|
+    command_and_options = [command, 'install', "#{@resource[:name]}==versionplease"]
+    command_and_options << install_options if @resource[:install_options]
+    execpipe command_and_options do |process|
       process.collect do |line|
-        # PIP OUTPUT: Could not find a version that satisfies the requirement Django==versionplease (from versions: 1.1.3, 1.8rc1)
+        # PIP OUTPUT: Could not find a version that satisfies the requirement example==versionplease (from versions: 1.2.3, 4.5.6)
         if line =~ /from versions: /
           textAfterLastMatch = $'.chomp(")\n")
           versionList = textAfterLastMatch.split(', ').sort do |x,y|
@@ -143,14 +146,18 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     end
   end
 
+  # More resource-intensive approach for pip version 1.5.3 and older.
+
   def latest_with_old_pip
     command = resource_or_provider_command
     self.class.validate_command(command)
 
     Dir.mktmpdir("puppet_pip") do |dir|
-      execpipe [command, "install", "#{@resource[:name]}", "-d", "#{dir}", "-v"] do |process|
+      command_and_options = [command, 'install', "#{@resource[:name]}", '-d', "#{dir}", '-v']
+      command_and_options << install_options if @resource[:install_options]
+      execpipe command_and_options do |process|
         process.collect do |line|
-          # PIP OUTPUT: Using version 0.10.1 (newest of versions: 0.10.1, 0.10, 0.9, 0.8.1, 0.8, 0.7.2, 0.7.1, 0.7, 0.6.1, 0.6, 0.5.2, 0.5.1, 0.5, 0.4, 0.3.1, 0.3, 0.2, 0.1)
+          # PIP OUTPUT: Using version 0.10.1 (newest of versions: 1.2.3, 4.5.6)
           if line =~ /Using version (.+?) \(newest of versions/
             return $1
           end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -197,6 +197,13 @@ describe Puppet::Type.type(:package).provider(:pip) do
         @resource[:name] = "fake_package"
         expect(@provider.latest).to eq(nil)
       end
+
+      it "should use 'install_options' when specified" do
+        expect(Puppet::Util::Execution).to receive(:execpipe).with(array_including([["--index=https://fake.example.com"]])).once
+        @resource[:name] = "fake_package"
+        @resource[:install_options] = ['--index' => 'https://fake.example.com']
+        expect(@provider.latest).to eq(nil)
+      end
     end
 
     context "with pip version >= 1.5.4" do
@@ -250,6 +257,13 @@ describe Puppet::Type.type(:package).provider(:pip) do
         @resource[:name] = "real_package"
         latest = @provider.latest
         expect(latest).to eq('15.0.2')
+      end
+
+      it "should use 'install_options' when specified" do
+        expect(Puppet::Util::Execution).to receive(:execpipe).with(array_including([["--index=https://fake.example.com"]])).once
+        @resource[:name] = "fake_package"
+        @resource[:install_options] = ['--index' => 'https://fake.example.com']
+        expect(@provider.latest).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
Prior to this commit ...

The 'latest_with_new_pip' and 'latest_with_old_pip methods' (called by the
'latest' method) failed to execute `pip install` with the resource's
`install_options` attribute, potentially resulting in a lack of idempotency.

With this commit ...

Any 'install_options' are applied whenever 'install' is executed.