### PR TITLE
(PUP-9927) Don't call OpenSSL::PKey.read

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -99,22 +99,6 @@ unless OpenSSL::X509::Name.instance_methods.include?(:to_utf8)
   end
 end
 
-if RUBY_VERSION =~ /^2\.3/
-  module OpenSSL::PKey
-    alias __original_read read
-    def read(*args)
-      __original_read(*args)
-    rescue ArgumentError => e
-      # ruby <= 2.3 raises ArgumentError if it can't decrypt
-      # passphrase protected private keys, fixed in 2.4.0
-      # see https://bugs.ruby-lang.org/issues/11774
-      raise OpenSSL::PKey::PKeyError, e.message
-    end
-    module_function :read
-    module_function :__original_read
-  end
-end
-
 unless OpenSSL::PKey::EC.instance_methods.include?(:private?)
   class OpenSSL::PKey::EC
     # Added in ruby 2.4.0 in https://github.com/ruby/ruby/commit/7c971e61f04

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -307,7 +307,7 @@ describe Puppet::X509::CertProvider do
           # password is 74695716c8b6
           expect {
             provider.load_private_key('encrypted-ec-key')
-          }.to raise_error(OpenSSL::PKey::PKeyError, /Could not parse PKey: no start line/)
+          }.to raise_error(OpenSSL::PKey::PKeyError, /(unknown|invalid) curve name|Could not parse PKey: no start line/)
         end
       end
     end


### PR DESCRIPTION
The method is broken in MRI 2.3, doesn't exist in JRuby 9.1, and is broken in
JRuby 9.2. Just call the appropriate key subclass based on the PEM header. Also
remove our monkey patch since it's no longer used.

As a result of this change, the exception message is different when trying to
read an EC password protected private key, and providing the wrong password,
and the wording is different for MRI 2.3 vs 2.4+.