### PR TITLE
(BOLT-1433) Load resource types for bolt plan execution

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -38,8 +38,9 @@ class StaticLoader < Loader
   attr_reader :loaded
   def initialize
     @loaded = {}
-    @runtime_3_initialized = false
     create_built_in_types
+    create_resource_type_references
+    register_aliases
   end
 
   def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
@@ -77,14 +78,6 @@ class StaticLoader < Loader
 
   def loaded_entry(typed_name, check_dependencies = false)
     @loaded[typed_name]
-  end
-
-  def runtime_3_init
-    unless @runtime_3_initialized
-      @runtime_3_initialized = true
-      create_resource_type_references
-    end
-    nil
   end
 
   def register_aliases

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -380,20 +380,15 @@ class Loaders
     env_conf = Puppet.lookup(:environments).get_conf(environment.name)
     env_path = env_conf.nil? || !env_conf.is_a?(Puppet::Settings::EnvironmentConf) ? nil : env_conf.path_to_env
 
-    if Puppet[:tasks]
-      loader = Loader::ModuleLoaders.environment_loader_from(parent_loader, self, env_path)
-    else
-      # Create the 3.x resource type loader
-      static_loader.runtime_3_init
-      @runtime3_type_loader = add_loader_by_name(Loader::Runtime3TypeLoader.new(parent_loader, self, environment, env_conf.nil? ? nil : env_path))
+    # Create the 3.x resource type loader
+    @runtime3_type_loader = add_loader_by_name(Loader::Runtime3TypeLoader.new(puppet_system_loader, self, environment, env_conf.nil? ? nil : env_path))
 
-      if env_path.nil?
-        # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?
-        loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, Loader::ENVIRONMENT))
-      else
-        # View the environment as a module to allow loading from it - this module is always called 'environment'
-        loader = Loader::ModuleLoaders.environment_loader_from(@runtime3_type_loader, self, env_path)
-      end
+    if env_path.nil?
+      # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?
+      loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, Loader::ENVIRONMENT))
+    else
+      # View the environment as a module to allow loading from it - this module is always called 'environment'
+      loader = Loader::ModuleLoaders.environment_loader_from(@runtime3_type_loader, self, env_path)
     end
 
     # An environment has a module path even if it has a null loader

--- a/spec/unit/pops/loaders/loader_spec.rb
+++ b/spec/unit/pops/loaders/loader_spec.rb
@@ -459,14 +459,12 @@ describe 'The Loader' do
               let(:environments_dir) { tmpdir('loader_spec') }
               let(:env) { Puppet::Node::Environment.create(:none_such, [modules_dir]) }
 
-              it 'an EmptyLoader is used and module loader finds types' do
-                expect_any_instance_of(Puppet::Pops::Loader::ModuleLoaders::EmptyLoader).to receive(:find).and_return(nil)
+              it 'a module loader finds types' do
                 expect(Loaders.find_loader('a').discover(:type) { |t| t.name =~ /^.::.*\z/ }).to(
                   contain_exactly(tn(:type, 'a::atype')))
               end
 
-              it 'an EmptyLoader is used and module loader finds tasks' do
-                expect_any_instance_of(Puppet::Pops::Loader::ModuleLoaders::EmptyLoader).to receive(:find).and_return(nil)
+              it 'a module loader finds tasks' do
                 expect(Loaders.find_loader('a').discover(:task) { |t| t.name =~ /^.::.*\z/ }).to(
                   contain_exactly(tn(:task, 'a::atask')))
               end

--- a/spec/unit/pops/loaders/static_loader_spec.rb
+++ b/spec/unit/pops/loaders/static_loader_spec.rb
@@ -3,22 +3,17 @@ require 'puppet/pops'
 require 'puppet/loaders'
 
 describe 'the static loader' do
-  let(:loader) do
-    loader = Puppet::Pops::Loader::StaticLoader.new()
-    loader.runtime_3_init
-    loader
-  end
-
   it 'has no parent' do
-    expect(loader.parent).to be(nil)
+    expect(Puppet::Pops::Loader::StaticLoader.new.parent).to be(nil)
   end
 
   it 'identifies itself in string form' do
-    expect(loader.to_s).to be_eql('(StaticLoader)')
+    expect(Puppet::Pops::Loader::StaticLoader.new.to_s).to be_eql('(StaticLoader)')
   end
 
   it 'support the Loader API' do
     # it may produce things later, this is just to test that calls work as they should - now all lookups are nil.
+    loader = Puppet::Pops::Loader::StaticLoader.new()
     a_typed_name = typed_name(:function, 'foo')
     expect(loader[a_typed_name]).to be(nil)
     expect(loader.load_typed(a_typed_name)).to be(nil)
@@ -26,6 +21,8 @@ describe 'the static loader' do
   end
 
   context 'provides access to resource types built into puppet' do
+    let(:loader) { Puppet::Pops::Loader::StaticLoader.new() }
+
     %w{
       Component
       Exec
@@ -49,16 +46,10 @@ describe 'the static loader' do
   end
 
   context 'provides access to app-management specific resource types built into puppet' do
-    it "such that Node is available" do
-      expect(loader.load(:type, 'node')).to be_the_type(resource_type('Node'))
-    end
-  end
-
-  context 'without init_runtime3 initialization' do
     let(:loader) { Puppet::Pops::Loader::StaticLoader.new() }
 
-    it 'does not provide access to resource types built into puppet' do
-      expect(loader.load(:type, 'file')).to be_nil
+    it "such that Node is available" do
+      expect(loader.load(:type, 'node')).to be_the_type(resource_type('Node'))
     end
   end
 


### PR DESCRIPTION
This commit enables loading resource types for bolt plan execution to support bolt plans being more resource aware. Loading resource types was originally disabled for two reasons:
1) Prevent name conflicts between type names and task names
2) prevent errors from manifest code being loaded that had types that depend on the concept of a 'Catalog' which is missing in 'script/bolt' mode

The naming conflics (1) appear to be solved because tasks are not types (and therefore will not have naming conflicts)
The Catalog dependent type issue is a bit trickier, an experimental workaround is included in https://github.com/puppetlabs/bolt/pull/1102 whereby a `squelch_parse_errors` override is included in bolt's puppet environment.

This reverts commit 4f45edfae91fd27a2dfe4eb17fce132cb61912aa