### PR TITLE
(maint) test Travis on Ruby >= 2.0

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.version = mdata ? mdata[1] : version
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
-  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.0")
   s.authors = ["Puppet Labs"]
   s.date = "2012-08-17"
   s.description = "Puppet, an automated configuration management tool"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ rvm:
   - 2.2
   - 2.1
   - 2.0
-  - 1.9.3
 
 env:
   - "CHECK=parallel:spec\\[2\\]"
@@ -35,8 +34,6 @@ matrix:
       env: "CHECK=rubocop"
     - rvm: 2.0
       env: "CHECK=rubocop"
-    - rvm: 1.9.3
-      env: "CHECK=rubocop"
     - rvm: 2.4
       env: "CHECK=commits"
     - rvm: 2.3
@@ -45,8 +42,6 @@ matrix:
       env: "CHECK=commits"
     - rvm: 2.0
       env: "CHECK=commits"
-    - rvm: 1.9.3
-      env: "CHECK=commits"
     - rvm: 2.3
       env: "CHECK=warnings"
     - rvm: 2.2
@@ -54,6 +49,4 @@ matrix:
     - rvm: 2.1
       env: "CHECK=warnings"
     - rvm: 2.0
-      env: "CHECK=warnings"
-    - rvm: 1.9.3
       env: "CHECK=warnings"

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -3,14 +3,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:service).provider(:systemd), '(integration)' do
   # TODO: Unfortunately there does not seem a way to stub the executable
   #       checks in the systemd provider because they happen at load time.
-  it "should be considered suitable if /bin/systemctl is present", :if => File.executable?('/bin/systemctl') do
-    expect(described_class).to be_suitable
-  end
-
-  it "should be considered suitable if /usr/bin/systemctl is present", :if => File.executable?('/usr/bin/systemctl')  do
-    expect(described_class).to be_suitable
-  end
-
   it "should be considered suitable if /proc/1/exe is present and points to 'systemd'",
     :if => File.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
     expect(described_class).to be_suitable


### PR DESCRIPTION
Travis has changed the base docker container used for "ruby" based builds.
A few days ago they changed from Ubuntu 14.04.5 LTS to Ubuntu 16.04.6 LTS. 

Even thou Ubuntu 16.04.6 LTS has /bin/systemctl executable, it is not suitable for the systemd provider because systemd is not started as pid 1.

Test for testing if a platform is suitable for systemd provider were added here: https://github.com/puppetlabs/puppet/pull/7628

This PR removes old tests.