### PR TITLE
(maint) Fix tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,49 +11,33 @@ script:
   - "bundle exec rake $CHECK"
 notifications:
   email: false
-rvm:
-  - 2.4
-  - 2.3
-  - 2.2
-  - 2.1
-  - 2.0
-  - 1.9.3
-
-env:
-  - "CHECK=parallel:spec\\[2\\]"
-  - "CHECK=rubocop"
-  - "CHECK=commits"
-  - "CHECK=warnings"
 
 matrix:
-  exclude:
-    - rvm: 2.4
-      env: "CHECK=rubocop"
-    - rvm: 2.3
-      env: "CHECK=rubocop"
-    - rvm: 2.2
-      env: "CHECK=rubocop"
-    - rvm: 2.0
-      env: "CHECK=rubocop"
+  include:
     - rvm: 1.9.3
-      env: "CHECK=rubocop"
-    - rvm: 2.4
-      env: "CHECK=commits"
-    - rvm: 2.3
-      env: "CHECK=commits"
-    - rvm: 2.2
-      env: "CHECK=commits"
+      dist: trusty
+      env: "CHECK=parallel:spec\\[2\\]"
+
     - rvm: 2.0
-      env: "CHECK=commits"
-    - rvm: 1.9.3
-      env: "CHECK=commits"
-    - rvm: 2.3
-      env: "CHECK=warnings"
-    - rvm: 2.2
-      env: "CHECK=warnings"
+      env: "CHECK=parallel:spec\\[2\\]"
+
     - rvm: 2.1
-      env: "CHECK=warnings"
-    - rvm: 2.0
-      env: "CHECK=warnings"
-    - rvm: 1.9.3
+      env: "CHECK=parallel:spec\\[2\\]"
+
+    - rvm: 2.1
+      env: "CHECK=rubocop"
+
+    - rvm: 2.1
+      env: "CHECK=commits"
+
+    - rvm: 2.2
+      env: "CHECK=parallel:spec\\[2\\]"
+
+    - rvm: 2.3
+      env: "CHECK=parallel:spec\\[2\\]"
+
+    - rvm: 2.4
+      env: "CHECK=parallel:spec\\[2\\]"
+
+    - rvm: 2.4
       env: "CHECK=warnings"

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -3,13 +3,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:service).provider(:systemd), '(integration)' do
   # TODO: Unfortunately there does not seem a way to stub the executable
   #       checks in the systemd provider because they happen at load time.
-  it "should be considered suitable if /bin/systemctl is present", :if => File.executable?('/bin/systemctl') do
-    expect(described_class).to be_suitable
-  end
-
-  it "should be considered suitable if /usr/bin/systemctl is present", :if => File.executable?('/usr/bin/systemctl')  do
-    expect(described_class).to be_suitable
-  end
 
   it "should be considered suitable if /proc/1/exe is present and points to 'systemd'",
     :if => File.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
@@ -23,11 +16,6 @@ describe Puppet::Type.type(:service).provider(:systemd), '(integration)' do
 
   it "should not be considered suitable if /proc/1/exe is absent",
     :if => !File.exist?('/proc/1/exe') do
-    expect(described_class).not_to be_suitable
-  end
-
-  it "should not be cosidered suitable if systemctl is absent",
-    :unless => (File.executable?('/bin/systemctl') or File.executable?('/usr/bin/systemctl')) do
     expect(described_class).not_to be_suitable
   end
 end


### PR DESCRIPTION
- reworked the travis matrix config to run the checks for ruby
1.9.3 on trusty due to https://github.com/puppetlabs/puppet/pull/7649#issuecomment-516851032
- removed the not needed tests from `spec/integration/provider/service/systemd_spec.rb`
due to https://github.com/puppetlabs/puppet/pull/7649#issue-302942712