### PR TITLE
(PUP-9936) Change deviceconfdir section to agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,39 +7,29 @@ script:
   - "bundle exec rake $CHECK"
 notifications:
   email: false
-rvm:
-  - 2.5
-  - 2.4
-  - 2.3
-  - jruby-9.2.0.0
-jdk: openjdk8
-
-env:
-  global:
-    - _JAVA_OPTIONS="-Xmx1024m -Xms512m"
-  matrix:
-    - "CHECK=parallel:spec\\[2\\]"
-    - "CHECK=rubocop"
-    - "CHECK=commits"
-    - "CHECK=warnings"
 
 matrix:
-  exclude:
-    - rvm: 2.4
-      env: "CHECK=rubocop"
+  include:
     - rvm: 2.3
-      env: "CHECK=rubocop"
-    - rvm: jruby-9.2.0.0
-      env: "CHECK=rubocop"
+      env: "CHECK=parallel:spec\\[2\\]"
+
     - rvm: 2.4
-      env: "CHECK=commits"
-    - rvm: 2.3
-      env: "CHECK=commits"
+      env: "CHECK=parallel:spec\\[2\\]"
+
+    - rvm: 2.5
+      env: "CHECK=parallel:spec\\[2\\]"
+
     - rvm: jruby-9.2.0.0
+      jdk: openjdk8
+      env:
+        - "_JAVA_OPTIONS='-Xmx1024m -Xms512m'"
+        - "CHECK=parallel:spec\\[2\\]"
+
+    - rvm: 2.5
+      env: "CHECK=rubocop"
+
+    - rvm: 2.5
       env: "CHECK=commits"
-    - rvm: 2.4
-      env: "CHECK=warnings"
-    - rvm: 2.3
-      env: "CHECK=warnings"
-    - rvm: jruby-9.2.0.0
+
+    - rvm: 2.5
       env: "CHECK=warnings"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.4
   - 2.3
   - jruby-9.2.0.0
+jdk: openjdk8
 
 env:
   global:

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -265,14 +265,6 @@ module Puppet
       :group    => "service",
       :desc     => "Where Puppet PID files are kept."
     },
-    :deviceconfdir => {
-      :default  => "$confdir/devices",
-      :type     => :directory,
-      :mode     => "0750",
-      :owner    => "service",
-      :group    => "service",
-      :desc     => "The root directory of devices' $confdir.",
-    },
     :genconfig => {
         :default  => false,
         :type     => :boolean,
@@ -1476,6 +1468,14 @@ EOT
         option in the manual pages for puppet master, puppet agent, and puppet
         apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
         or read them online at https://puppet.com/docs/puppet/latest/man/."
+    },
+    :deviceconfdir => {
+      :default  => "$confdir/devices",
+      :type     => :directory,
+      :mode     => "0750",
+      :owner    => "service",
+      :group    => "service",
+      :desc     => "The root directory of devices' $confdir.",
     },
     :server => {
       :default => "puppet",

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -1,37 +1,21 @@
 require 'spec_helper'
 
-test_title = 'Integration Tests for Puppet::Type::Service::Provider::Systemd'
-
-describe test_title, unless: Puppet::Util::Platform.jruby? do
-  let(:provider_class) { Puppet::Type.type(:service).provider(:systemd) }
-
+describe Puppet::Type.type(:service).provider(:systemd), '(integration)' do
   # TODO: Unfortunately there does not seem a way to stub the executable
   #       checks in the systemd provider because they happen at load time.
-  it "should be considered suitable if /bin/systemctl is present", :if => File.executable?('/bin/systemctl') do
-    expect(provider_class).to be_suitable
-  end
-
-  it "should be considered suitable if /usr/bin/systemctl is present", :if => File.executable?('/usr/bin/systemctl')  do
-    expect(provider_class).to be_suitable
-  end
 
   it "should be considered suitable if /proc/1/exe is present and points to 'systemd'",
     :if => File.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
-    expect(provider_class).to be_suitable
+    expect(described_class).to be_suitable
   end
 
   it "should not be considered suitable if /proc/1/exe is present it does not point to 'systemd'",
     :if => File.exist?('/proc/1/exe') && !Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
-    expect(provider_class).not_to be_suitable
+    expect(described_class).not_to be_suitable
   end
 
   it "should not be considered suitable if /proc/1/exe is absent",
     :if => !File.exist?('/proc/1/exe') do
-    expect(provider_class).not_to be_suitable
-  end
-
-  it "should not be cosidered suitable if systemctl is absent",
-    :unless => (File.executable?('/bin/systemctl') or File.executable?('/usr/bin/systemctl')) do
-    expect(provider_class).not_to be_suitable
+    expect(described_class).not_to be_suitable
   end
 end

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -1,21 +1,24 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:service).provider(:systemd), '(integration)' do
+test_title = 'Integration Tests for Puppet::Type::Service::Provider::Systemd'
+
+describe test_title, unless: Puppet::Util::Platform.jruby? do
+  let(:provider_class) { Puppet::Type.type(:service).provider(:systemd) }
+
   # TODO: Unfortunately there does not seem a way to stub the executable
   #       checks in the systemd provider because they happen at load time.
-
   it "should be considered suitable if /proc/1/exe is present and points to 'systemd'",
     :if => File.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
-    expect(described_class).to be_suitable
+    expect(provider_class).to be_suitable
   end
 
   it "should not be considered suitable if /proc/1/exe is present it does not point to 'systemd'",
     :if => File.exist?('/proc/1/exe') && !Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
-    expect(described_class).not_to be_suitable
+    expect(provider_class).not_to be_suitable
   end
 
   it "should not be considered suitable if /proc/1/exe is absent",
     :if => !File.exist?('/proc/1/exe') do
-    expect(described_class).not_to be_suitable
+    expect(provider_class).not_to be_suitable
   end
 end


### PR DESCRIPTION
Setting `$deviceconfdir` in the main section makes puppetserver want to create it, which it shouldn't.

Starting puppetserver with an affected puppet version fails because of this. Changing the section of `$deviceconfdir` to `agent` fixes the issue.