### PR TITLE
(PUP-8319) Skip Failing Windows/French tests

### DIFF
--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -12,6 +12,7 @@ tag 'audit:medium',
   app_type = File.basename(__FILE__, '.*')
 
   agents.each do |agent|
+    skip_test('this test fails on windows French due to Cygwin/UTF Issues - PUP-8319,IMAGES-492') if agent['platform'] =~ /windows/ && agent['locale'] == 'fr'
 
     step 'manifest with parser function call' do
       if agent.platform !~ /windows/

--- a/acceptance/tests/resource/group/should_query.rb
+++ b/acceptance/tests/resource/group/should_query.rb
@@ -9,6 +9,8 @@ tag 'audit:high',
 name = "pl#{rand(999999).to_i}"
 
 agents.each do |agent|
+  skip_test('this test fails on windows French due to Cygwin/UTF Issues - PUP-8319,IMAGES-492') if agent['platform'] =~ /windows/ && agent['locale'] == 'fr'
+
   step "ensure that our test group exists"
   agent.group_present(name)
 

--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -5,7 +5,9 @@ tag 'audit:high',
     'audit:integration' # Does not modify system running test
 
 agents.each do |agent|
+  skip_test('this test fails on windows French due to Cygwin/UTF Issues - PUP-8319,IMAGES-492') if agent['platform'] =~ /windows/ && agent['locale'] == 'fr'
   step "query natively"
+
   groups = agent.group_list
 
   fail_test("No groups found") unless groups

--- a/acceptance/tests/resource/user/should_purge.rb
+++ b/acceptance/tests/resource/user/should_purge.rb
@@ -46,7 +46,8 @@ test_name "should purge a user" do
 
     step "verify system user is not purged" do
       if agent['platform'] =~ /windows/
-        assert(agent.user_list.include?("Administrator"), "System user (Administrator) was purged")
+        win_admin_user = agent['locale'] == 'fr' ? "Administrateur" : "Administrator"
+        assert(agent.user_list.include?(win_admin_user), "System user (Administrator) was purged")
       else
         assert(agent.user_list.include?("root"), "System user (root) was purged")
       end

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -6,6 +6,7 @@ tag 'audit:medium',
 
 agents.each do |agent|
   next if agent == master
+  skip_test('this test fails on windows French due to Cygwin/UTF Issues - PUP-8319,IMAGES-492') if agent['platform'] =~ /windows/ && agent['locale'] == 'fr'
 
   step "query natively"
   users = agent.user_list


### PR DESCRIPTION
All of these test fails because of Cygwin/UTF handling issues. So going to skip these tests completely on Windows/French locale platform similar to what was done for Japanese.

If we ever get off Cygwin as a test/ssh platform, this should be revisited.