### PR TITLE
EL8 provider fix

### DIFF
--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -30,8 +30,7 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
 
   defaultfor :operatingsystem => :fedora
   notdefaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => (19..21).to_a
-  defaultfor :osfamily => :redhat
-  notdefaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
+  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (1..3).to_a
 
   def self.update_command
     # In DNF, update is deprecated for upgrade

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -23,7 +23,8 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   end
 
 defaultfor :operatingsystem => :amazon
-defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
+defaultfor :osfamily => :redhat
+notdefaultfor :osfamily => :redhat, :operatingsystemmajrelease => (1..3).to_a
 
   def self.prefetch(packages)
     raise Puppet::Error, _("The yum provider can only be used as root") if Process.euid != 0


### PR DESCRIPTION
The dnf.rb and yum.rb providers were incorrectly scoped, causing the `yum` provider to not automatically get used for EL versions higher than 7. As we now officially support RHEL8, this should be fixed. This PR switched the logic, which ensures the default provider for EL versions over 3 is `yum`, not `dnf`.