### PR TITLE
(PUP-9942) Allow puppet to skip a proxy

### DIFF
--- a/lib/puppet/network/http/factory.rb
+++ b/lib/puppet/network/http/factory.rb
@@ -27,7 +27,7 @@ class Puppet::Network::HTTP::Factory
 
     args = [site.host, site.port]
 
-    unless Puppet::Util::HttpProxy.no_proxy?(site)
+    unless Puppet::Util::HttpProxy.no_proxy?(site.addr)
       if Puppet[:http_proxy_host] == "none"
         args << nil << nil
       else

--- a/spec/unit/network/http/factory_spec.rb
+++ b/spec/unit/network/http/factory_spec.rb
@@ -45,7 +45,6 @@ describe Puppet::Network::HTTP::Factory do
 
     it "should not set a proxy if the value is 'none'" do
       Puppet[:http_proxy_host] = 'none'
-      expect(Puppet::Util::HttpProxy).to receive(:no_proxy?).and_return(false)
       conn = create_connection(site)
 
       expect(conn.proxy_address).to be_nil
@@ -54,16 +53,16 @@ describe Puppet::Network::HTTP::Factory do
     it 'should not set a proxy if a no_proxy env var matches the destination' do
       Puppet[:http_proxy_host] = proxy_host
       Puppet[:http_proxy_port] = proxy_port
-      expect(Puppet::Util::HttpProxy).to receive(:no_proxy?).and_return(true)
-      conn = create_connection(site)
+      Puppet::Util.withenv('NO_PROXY' => site.host) do
+        conn = create_connection(site)
 
-      expect(conn.proxy_address).to be_nil
-      expect(conn.proxy_port).to be_nil
+        expect(conn.proxy_address).to be_nil
+        expect(conn.proxy_port).to be_nil
+      end
     end
 
     it 'sets proxy_address' do
       Puppet[:http_proxy_host] = proxy_host
-      expect(Puppet::Util::HttpProxy).to receive(:no_proxy?).and_return(false)
       conn = create_connection(site)
 
       expect(conn.proxy_address).to eq(proxy_host)
@@ -72,7 +71,6 @@ describe Puppet::Network::HTTP::Factory do
     it 'sets proxy address and port' do
       Puppet[:http_proxy_host] = proxy_host
       Puppet[:http_proxy_port] = proxy_port
-      expect(Puppet::Util::HttpProxy).to receive(:no_proxy?).and_return(false)
       conn = create_connection(site)
 
       expect(conn.proxy_port).to eq(proxy_port)


### PR DESCRIPTION
Commit 90560edf0f was supposed to allow puppet to skip a proxy if the host we're
trying to connect to matched an entry in the `NO_PROXY` environment variable.
However, it didn't actually work, because it passed the `Site` object instead of
a String or URI to `no_proxy?`.

Pass a string representation of the site URI and update tests to not stub
`no_proxy?` behavior.