### PR TITLE
(PUP-9316) implement no_proxy in puppet.conf

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -550,6 +550,10 @@ module Puppet
         contains any characters with special meanings in URLs (as specified by RFC 3986
         section 2.2), they must be URL-encoded. (For example, `#` would become `%23`.)",
     },
+    :no_proxy => {
+      :default    => "none",
+      :desc       => "List of domain names that should not go through `http_proxy_host`. Environment variable no_proxy or NO_PROXY will override this value.",
+    },
     :http_keepalive_timeout => {
       :default    => "4s",
       :type       => :duration,

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -33,7 +33,7 @@ module Puppet::Util::HttpProxy
   #   .example.com
   # We'll accommodate both here.
   def self.no_proxy?(dest)
-    unless no_proxy_env = ENV["no_proxy"] || ENV["NO_PROXY"]
+    unless no_proxy = self.no_proxy
       return false
     end
 
@@ -45,7 +45,7 @@ module Puppet::Util::HttpProxy
       end
     end
 
-    no_proxy_env.split(/\s*,\s*/).each do |d|
+    no_proxy.split(/\s*,\s*/).each do |d|
       host, port = d.split(':')
       host = Regexp.escape(host).gsub('\*', '.*')
 
@@ -125,6 +125,20 @@ module Puppet::Util::HttpProxy
     end
 
     return Puppet.settings[:http_proxy_password]
+  end
+
+  def self.no_proxy
+    no_proxy_env = ENV["no_proxy"] || ENV["NO_PROXY"]
+
+    if no_proxy_env
+      return no_proxy_env
+    end
+
+    if Puppet.settings[:no_proxy] == 'none'
+      return nil
+    end
+
+    return Puppet.settings[:no_proxy]
   end
 
   # Return a Net::HTTP::Proxy object.

--- a/spec/unit/network/http/factory_spec.rb
+++ b/spec/unit/network/http/factory_spec.rb
@@ -43,7 +43,7 @@ describe Puppet::Network::HTTP::Factory do
     let(:proxy_host) { 'myhost' }
     let(:proxy_port) { 432 }
 
-    it "should not set a proxy if the value is 'none'" do
+    it "should not set a proxy if the http_proxy_host setting is 'none'" do
       Puppet[:http_proxy_host] = 'none'
       conn = create_connection(site)
 
@@ -59,6 +59,16 @@ describe Puppet::Network::HTTP::Factory do
         expect(conn.proxy_address).to be_nil
         expect(conn.proxy_port).to be_nil
       end
+    end
+
+    it 'should not set a proxy if the no_proxy setting matches the destination' do
+      Puppet[:http_proxy_host] = proxy_host
+      Puppet[:http_proxy_port] = proxy_port
+      Puppet[:no_proxy] = site.host
+      conn = create_connection(site)
+
+      expect(conn.proxy_address).to be_nil
+      expect(conn.proxy_port).to be_nil
     end
 
     it 'sets proxy_address' do

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -129,9 +129,32 @@ describe Puppet::Util::HttpProxy do
 
   end
 
+  describe ".no_proxy" do
+    no_proxy = '127.0.0.1, localhost'
+    it "should use a no_proxy list if set in environment" do
+      Puppet::Util.withenv('NO_PROXY' => no_proxy) do
+        expect(subject.no_proxy).to eq(no_proxy)
+      end
+    end
+
+    it "should use a no_proxy list if set in config" do
+      Puppet.settings[:no_proxy] = no_proxy
+      expect(subject.no_proxy).to eq(no_proxy)
+    end
+
+    it "should use environment variable before puppet settings" do
+      no_proxy_puppet_setting = '10.0.0.1, localhost'
+      Puppet::Util.withenv('NO_PROXY' => no_proxy) do
+        Puppet.settings[:no_proxy] = no_proxy_puppet_setting
+        expect(subject.no_proxy).to eq(no_proxy)
+      end
+    end
+  end
+
   describe ".no_proxy?" do
     no_proxy = '127.0.0.1, localhost, mydomain.com, *.otherdomain.com, oddport.com:8080, *.otheroddport.com:8080, .anotherdomain.com, .anotheroddport.com:8080'
-    it "should return false if no_proxy does not exist in env" do
+
+    it "should return false if no_proxy does not exist in environment or puppet settings" do
       Puppet::Util.withenv('no_proxy' => nil) do
         dest = 'https://puppetlabs.com'
         expect(subject.no_proxy?(dest)).to be false


### PR DESCRIPTION
Prior to this commit, puppet implemented http_proxy* settings in
puppet.conf or as ENV variables, if set; but only implemented the
no_proxy setting as an ENV variable.

With this commit, puppet also implements no_proxy as a setting,
and continues to implement it as an ENV variable, if set.