### PR TITLE
(PUP-2172) Don't use an http proxy for localhost

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -551,7 +551,7 @@ module Puppet
         section 2.2), they must be URL-encoded. (For example, `#` would become `%23`.)",
     },
     :no_proxy => {
-      :default    => "none",
+      :default    => "localhost, 127.0.0.1",
       :desc       => "List of domain names that should not go through `http_proxy_host`. Environment variable no_proxy or NO_PROXY will override this value.",
     },
     :http_keepalive_timeout => {


### PR DESCRIPTION
Previously if an http proxy was configured, then puppet would use it when trying
to connect to localhost or 127.0.0.1. Note HTTPS connections to localhost almost
certainly would have failed due to certname mismatch. However, HTTP connections
would unnecessarily connect via the proxy. In addition to being inefficient,
many network environments don't allow internal users to route through a proxy to
reach other internal hosts, so such requests would fail.