### PR TITLE
(PUP-4470) Observe http proxy user/password

### DIFF
--- a/lib/puppet/network/http/factory.rb
+++ b/lib/puppet/network/http/factory.rb
@@ -25,17 +25,7 @@ class Puppet::Network::HTTP::Factory
   def create_connection(site)
     Puppet.debug("Creating new connection for #{site}")
 
-    args = [site.host, site.port]
-
-    unless Puppet::Util::HttpProxy.no_proxy?(site.addr)
-      if Puppet[:http_proxy_host] == "none"
-        args << nil << nil
-      else
-        args << Puppet[:http_proxy_host] << Puppet[:http_proxy_port]
-      end
-    end
-
-    http = Net::HTTP.new(*args)
+    http = Puppet::Util::HttpProxy.proxy(URI(site.addr))
     http.use_ssl = site.use_ssl?
     http.read_timeout = Puppet[:http_read_timeout]
     http.open_timeout = Puppet[:http_connect_timeout]

--- a/spec/unit/network/http/factory_spec.rb
+++ b/spec/unit/network/http/factory_spec.rb
@@ -42,6 +42,8 @@ describe Puppet::Network::HTTP::Factory do
   context "proxy settings" do
     let(:proxy_host) { 'myhost' }
     let(:proxy_port) { 432 }
+    let(:proxy_user) { 'mo' }
+    let(:proxy_pass) { 'password' }
 
     it "should not set a proxy if the http_proxy_host setting is 'none'" do
       Puppet[:http_proxy_host] = 'none'
@@ -84,6 +86,18 @@ describe Puppet::Network::HTTP::Factory do
       conn = create_connection(site)
 
       expect(conn.proxy_port).to eq(proxy_port)
+    end
+
+    it 'sets proxy user and password' do
+      Puppet[:http_proxy_host] = proxy_host
+      Puppet[:http_proxy_port] = proxy_port
+      Puppet[:http_proxy_user] = proxy_user
+      Puppet[:http_proxy_password] = proxy_pass
+
+      conn = create_connection(site)
+
+      expect(conn.proxy_user).to eq(proxy_user)
+      expect(conn.proxy_pass).to eq(proxy_pass)
     end
   end
 


### PR DESCRIPTION
Previously, puppet couldn't connect to an authenticating http proxy for REST
requests.

The Puppet::Util::HttpProxy.proxy method will return a connection object of
class Net::HTTP or the subclass Net::HTTP::Proxy based on the currently
configured proxy host, port, user and password.