### PR TITLE
(PUP-9943) Remove user type's custom retrieve()

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -493,25 +493,6 @@ module Puppet
       provider.exists?
     end
 
-    def retrieve
-      absent = false
-      properties.inject({}) { |prophash, property|
-        current_value = :absent
-
-        if absent
-          prophash[property] = :absent
-        else
-          current_value = property.retrieve
-          prophash[property] = current_value
-        end
-
-        if property.name == :ensure and current_value == :absent
-          absent = true
-        end
-        prophash
-      }
-    end
-
     newproperty(:roles, :parent => Puppet::Property::List, :required_features => :manages_solaris_rbac) do
       desc "The roles the user has.  Multiple roles should be
         specified as an array."

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -453,7 +453,7 @@ describe Puppet::Application::Device do
           resource = Puppet::Type.type(:user).new(:name => "jim").to_resource
           allow(device.command_line).to receive(:args).and_return(['user', 'jim'])
           expect(Puppet::Resource.indirection).to receive(:find).with('user/jim').and_return(resource)
-          expect(device).to receive(:puts).with("user { 'jim':\n}")
+          expect(device).to receive(:puts).with("user { 'jim':\n  ensure => 'absent',\n}")
           expect { device.main }.to exit_with 0
         end
 
@@ -464,7 +464,7 @@ describe Puppet::Application::Device do
           allow(device.options).to receive(:[]).with(:to_yaml).and_return(true)
           allow(device.command_line).to receive(:args).and_return(['user'])
           expect(Puppet::Resource.indirection).to receive(:search).with('user/', {}).and_return(resources)
-          expect(device).to receive(:puts).with("---\nuser:\n  title: {}\n")
+          expect(device).to receive(:puts).with("---\nuser:\n  title:\n    ensure: absent\n")
           expect { device.main }.to exit_with 0
         end
       end

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -408,7 +408,6 @@ describe Puppet::Type.type(:user) do
       Puppet::Resource::Catalog.new :testing do |conf|
         [testuser, testrole].each { |resource| conf.add_resource resource }
       end
-      allow(Puppet::Type::User::ProviderDirectoryservice).to receive(:get_macosx_version_major).and_return("10.5")
 
       rel = testuser.autorequire[0]
       expect(rel.source.ref).to eq(testrole.ref)


### PR DESCRIPTION
The user type has a long-standing custom retrieve() method which
returns values not in keeping with the standard retrieve() from
Puppet::Type.retrieve(). This patch removes the custom method
and adjusts the tests dependent on the particular behavior from
it.