### PR TITLE
(PUP-9647) Quote pip executable

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -29,7 +29,10 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   def self.provider_command
     # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
-    self.cmd.map { |c| which(c) }.find { |c| c != nil }
+    cmd = self.cmd.map { |c| which(c) }.find { |c| c != nil }
+    # Quote the command, to protect against spaces:
+    cmd = '"' + cmd + '"' unless cmd.nil?
+    cmd
   end
 
   def self.cmd

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -61,11 +61,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
               expect(described_class).to receive(:which).with(cmd).and_return(nil)
             end
           end
-          allow(described_class).to receive(:pip_version).with(pip_cmd).and_return('8.0.1')
+          pip_cmd_path = '"' + pip_cmd + '"'
+          allow(described_class).to receive(:pip_version).with(pip_cmd_path).and_return('8.0.1')
           expect(described_class).to receive(:which).with(pip_cmd).and_return(pip_cmd)
           p = double("process")
           expect(p).to receive(:collect).and_yield("real_package==1.2.5")
-          expect(described_class).to receive(:execpipe).with([pip_cmd, ["freeze"]]).and_yield(p)
+          expect(described_class).to receive(:execpipe).with([pip_cmd_path, ["freeze"]]).and_yield(p)
           described_class.instances
         end
       end


### PR DESCRIPTION
On Windows, quote the pip executable path as it is not uncommon
for those paths to contain spaces, which unquoted will cause
parts of the path to be treated as arguments to a partial path
to the command.