### PR TITLE
(PUP-5934) Add optional fact refresh after applying catalog

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -372,6 +372,14 @@ class Puppet::Configurer
       execute_postrun_command or return nil
     end
   ensure
+    if Puppet[:resubmit_facts]
+      # TODO: Should mark the report as "failed" if an error occurs and
+      #       resubmit_facts returns false. There is currently no API for this.
+      resubmit_facts_time = thinmark { resubmit_facts }
+
+      report.add_times(:resubmit_facts, resubmit_facts_time)
+    end
+
     report.cached_catalog_status ||= @cached_catalog_status
     report.add_times(:total, Time.now - start)
     report.finalize_report
@@ -416,6 +424,40 @@ class Puppet::Configurer
     end
   rescue => detail
     Puppet.log_exception(detail, _("Could not save last run local report: %{detail}") % { detail: detail })
+  end
+
+  # Submit updated facts to the Puppet Server
+  #
+  # This method will clear all current fact values, load a fresh set of
+  # fact data, and then submit it to the Puppet Server.
+  #
+  # @return [true] If fact submission succeeds.
+  # @return [false] If an exception is raised during fact generation or
+  #   submission.
+  def resubmit_facts
+    ::Facter.clear
+    facts = find_facts
+
+    saved_fact_terminus = Puppet::Node::Facts.indirection.terminus_class
+    begin
+      Puppet::Node::Facts.indirection.terminus_class = :rest
+
+      server = Puppet::Node::Facts::Rest.server
+      Puppet.notice(_("Uploading facts for '%{node}' to: '%{server}'") % {
+                    node: facts.name,
+                    server: server})
+
+      Puppet::Node::Facts.indirection.save(facts, nil, :environment => Puppet::Node::Environment.remote(@environment))
+
+      return true
+    ensure
+      Puppet::Node::Facts.indirection.terminus_class = saved_fact_terminus
+    end
+  rescue => detail
+    Puppet.log_exception(detail, _("Failed to submit facts: %{detail}") %
+                                 { detail: detail })
+
+    return false
   end
 
   private

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1730,6 +1730,11 @@ EOT
       :type     => :boolean,
       :desc     => "Whether to send reports after every transaction.",
     },
+    :resubmit_facts => {
+      :default  => false,
+      :type     => :boolean,
+      :desc     => "Whether to send updated facts after every transaction.",
+    },
     :lastrunfile =>  {
       :default  => "$statedir/last_run_summary.yaml",
       :type     => :file,

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -62,5 +62,61 @@ describe Puppet::Configurer do
       expect(summary["time"]).to be_key("notify")
       expect(summary["time"]["last_run"]).to be_between(t1, t2)
     end
+
+    describe 'resubmitting facts' do
+      context 'when resubmit_facts is set to false' do
+        before(:each) { Puppet[:resubmit_facts] = false }
+
+        it 'should not send data' do
+          expect(@configurer).to receive(:resubmit_facts).never
+
+          @configurer.run(catalog: @catalog)
+        end
+      end
+
+      context 'when resubmit_facts is set to true' do
+        let(:test_facts) { Puppet::Node::Facts.new('configurer.test') }
+        let(:fact_rest_terminus) { Puppet::Node::Facts.indirection.terminus(:rest) }
+
+        before(:each) do
+          Puppet[:resubmit_facts] = true
+
+          allow(@configurer).to receive(:find_facts).and_return(test_facts)
+          allow(fact_rest_terminus).to receive(:save)
+        end
+
+        it 'sends fact data using the rest terminus' do
+          expect(fact_rest_terminus).to receive(:save)
+
+          @configurer.run(catalog: @catalog)
+        end
+
+        it 'logs errors that occur during fact generation' do
+          allow(@configurer).to receive(:find_facts).and_raise('error generating facts')
+          expect(Puppet).to receive(:log_exception).with(instance_of(RuntimeError),
+                                                         /^Failed to submit facts/)
+
+          @configurer.run(catalog: @catalog)
+        end
+
+        it 'logs errors that occur during fact submission' do
+          allow(fact_rest_terminus).to receive(:save).and_raise('error sending facts')
+          expect(Puppet).to receive(:log_exception).with(instance_of(RuntimeError),
+                                                         /^Failed to submit facts/)
+
+          @configurer.run(catalog: @catalog)
+        end
+
+        it 'records time spent resubmitting facts' do
+          report = Puppet::Transaction::Report.new
+
+          allow(report).to receive(:add_times)
+          expect(report).to receive(:add_times).with(:resubmit_facts,
+                                                     kind_of(Numeric))
+
+          @configurer.run(catalog: @catalog, report: report)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds a `report_facts` option to Puppet's settings.
When set to `true`, this option causes the agent to reload facts
after applying a catalog and then report the updated data to the
Puppet Server. This has the following benefits:

  - Changes in facts due to resources that were enforced during
    the run are reported immediately.

  - Agents that are running off cached catalogs can still submit
    regular updates to facts.

Note that enabling `report_facts` will increase the load on
backend services such as Puppet Server and PuppetDB and is
therefore a change that should be monitored closely in
large environments.