### PR TITLE
(maint) Update more beaker tests for FIPS mode

### DIFF
--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -15,9 +15,9 @@ test_name "The source attribute" do
   # common denominator.
   checksums_fips = [nil, 'sha256', 'sha256lite', 'ctime', 'mtime']
   checksums_no_fips = [nil, 'md5', 'md5lite', 'sha256', 'sha256lite', 'ctime', 'mtime']
- 
+
   fips_host_present = hosts.any? { |host| on(host, facter("fips_enabled")).stdout =~ /true/ }
-  
+
   if fips_host_present
     checksums = checksums_fips
   else
@@ -263,8 +263,8 @@ test_name "The source attribute" do
     byte_after_md5lite = 513
     source_content[byte_after_md5lite] = 'z'
     create_remote_file agent, source, source_content
-    
-    if fips_host_present == 1
+
+    if fips_host_present
       apply_manifest_on agent, "file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }" do
         assert_no_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
       end
@@ -272,7 +272,7 @@ test_name "The source attribute" do
       apply_manifest_on agent, "file { '#{localsource_testdir}/targetmd5lite': source => '#{source}', ensure => present, checksum => md5lite } file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }" do
         assert_no_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
       end
-    end 
+    end
 
     local_module_manifest = ""
     checksums.each do |checksum_type|

--- a/acceptance/tests/ticket_4622_filebucket_diff_test.rb
+++ b/acceptance/tests/ticket_4622_filebucket_diff_test.rb
@@ -1,6 +1,8 @@
 test_name "ticket 4622 filebucket diff test."
 confine :except, :platform => 'windows'
 skip_test 'skip test, no non-Windows agents specified' if agents.empty?
+# Filebucket is not supported in PE, the only context in which FIPS is expected to work
+skip_test 'skip test if any host is in FIPS mode' if hosts.any? { |host| host.fips_mode? }
 
 tag 'audit:medium',
     'audit:integration',


### PR DESCRIPTION
This commit skips a filebucket test when running in FIPS mode because we
only support FIPS in PE, which disables filebucket. It also fixes up a
typo around FIPS detection logic, to avoid testing md5 sums when
running in FIPS mode.