### PR TITLE
(PA-2806) Pluginsync before running facts upload

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -64,6 +64,17 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
     render_as :json
 
     when_invoked do |options|
+
+      # Temporary change log level to display specific download/sync info
+      previous_log_level = Puppet::Util::Log.level
+      Puppet::Util::Log.level = :info
+
+      # Sync/Download plugins and facts before uploading them
+      Puppet::Face[:plugin, '0.0.1'].download
+
+      # Change log level back to previous state
+      Puppet::Util::Log.level = previous_log_level
+
       # Use `agent` sections  settings for certificates, Puppet Server URL,
       # etc. instead of `user` section settings.
       Puppet.settings.preferred_run_mode = :agent


### PR DESCRIPTION
When executing puppet facts upload, custom facts or plugin facts are not
syncronized with the master node resulting in missing facts or facts
that are not up to date.

This fix executes a plugin sync before the puppet facts upload is run.
Also temporary changes the log level to display info messages.