### PR TITLE
(PUP-8662) Use persistent HTTP pool to download plugins

### DIFF
--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -41,8 +41,15 @@ Puppet::Face.define(:plugin, '0.0.1') do
     when_invoked do |options|
       remote_environment_for_plugins = Puppet::Node::Environment.remote(Puppet[:environment])
 
-      handler = Puppet::Configurer::PluginHandler.new()
-      handler.download_plugins(remote_environment_for_plugins)
+      pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
+      Puppet.override(:http_pool => pool) do
+        begin
+          handler = Puppet::Configurer::PluginHandler.new()
+          handler.download_plugins(remote_environment_for_plugins)
+        ensure
+          pool.close
+        end
+      end
     end
 
     when_rendering :console do |value|

--- a/spec/unit/face/plugin_spec.rb
+++ b/spec/unit/face/plugin_spec.rb
@@ -50,6 +50,14 @@ describe Puppet::Face[:plugin, :current] do
       expect(receive_count).to eq(3)
       expect(render(result)).to eq('Downloaded these plugins: /a, /b, /c')
     end
+
+    it "uses persistent HTTP pool" do
+      allow_any_instance_of(Puppet::Configurer::Downloader).to receive(:evaluate) do
+        expect(Puppet.lookup(:http_pool)).to be_instance_of(Puppet::Network::HTTP::Pool)
+      end.and_return([])
+
+      pluginface.download
+    end
   end
 
   context "download when server_agent_version is 5.3.3" do


### PR DESCRIPTION
Previously, `puppet plugin download` created a new TCP connection for each file
it downloaded.

Instead use the persistent HTTP pool, which should result in the same behavior
and speed as a normal agent run.