### PR TITLE
(PUP-9959) Add plugin to puppet help command

### DIFF
--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -195,7 +195,7 @@ Puppet::Face.define(:help, '0.0.1') do
   #private :horribly_extract_summary_from
 
   def exclude_from_docs?(appname)
-    %w{face_base indirection_base cert key man plugin report status}.include? appname
+    %w{face_base indirection_base cert key man report status}.include? appname
   end
   # This should absolutely be a private method, but for some reason it appears
   #  that you can't use the 'private' keyword inside of a Face definition.


### PR DESCRIPTION
Executing puppet help does not show the plugin subcommand, even if the
subcommand is available and working.
Now puppet help includes the plugin subcommand.