### PR TITLE
(PUP-9931) Make Puppet::Context thread local

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   s.add_runtime_dependency(%q<httpclient>, "~> 2.8")
+  s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
 
   # loads platform specific gems like ffi, win32 platform gems
   # as additional runtime dependencies

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -25,6 +25,7 @@ gem_runtime_dependencies:
   multi_json: '~> 1.10'
   httpclient: '~> 2.8'
   puppet-resource_api: '~>1.5'
+  concurrent-ruby: '~> 1.0'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -148,7 +148,7 @@ module Puppet
     Puppet.settings.initialize_global_settings(args, require_config)
     run_mode = Puppet::Util::RunMode[run_mode]
     Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(run_mode))
-    Puppet.push_context(Puppet.base_context(Puppet.settings), "Initial context after settings initialization")
+    @context.unsafe_push_global(Puppet.base_context(Puppet.settings), "Initial context after settings initialization")
     Puppet::Parser::Functions.reset
   end
   private_class_method :do_initialize_settings_for_run_mode

--- a/spec/unit/context_spec.rb
+++ b/spec/unit/context_spec.rb
@@ -3,33 +3,9 @@ require 'spec_helper'
 describe Puppet::Context do
   let(:context) { Puppet::Context.new({ :testing => "value" }) }
 
-  context "with the implicit test_helper.rb pushed context" do
-    it "fails to lookup a value that does not exist" do
-      expect { context.lookup("a") }.to raise_error(Puppet::Context::UndefinedBindingError)
-    end
-
-    it "calls a provided block for a default value when none is found" do
-      expect(context.lookup("a") { "default" }).to eq("default")
-    end
-
-    it "behaves as if pushed a {} if you push nil" do
-      context.push(nil)
-      expect(context.lookup(:testing)).to eq("value")
-      context.pop
-    end
-
-    it "fails if you try to pop off the top of the stack" do
-      expect { context.pop }.to raise_error(Puppet::Context::StackUnderflow)
-    end
-  end
-
   describe "with additional context" do
     before :each do
       context.push("a" => 1)
-    end
-
-    it "holds values for later lookup" do
-      expect(context.lookup("a")).to eq(1)
     end
 
     it "allows rebinding values in a nested context" do
@@ -111,26 +87,131 @@ describe Puppet::Context do
     end
   end
 
-  context 'support lazy entries' do
-    it 'by evaluating a bound proc' do
-      result = nil
-      context.override(:a => lambda {|| 'yay'}) do
-        result = context.lookup(:a)
+  context "with multiple threads" do
+    it "a value pushed in another thread is not seen in the original thread" do
+      context.push(a: 1)
+      t = Thread.new do
+        context.push(a: 2, b: 5)
       end
-      expect(result).to eq('yay')
+      t.join
+
+      expect(context.lookup(:a)).to eq(1)
+      expect{ context.lookup(:b) }.to raise_error(Puppet::Context::UndefinedBindingError)
+    end
+
+    it "pops on a different thread do not interfere" do
+      context.push(a: 1)
+      t = Thread.new do
+        context.pop
+      end
+      t.join
+
+      # Raises exception if the binding we pushed has already been popped
+      context.pop
+    end
+
+    it "a mark in one thread is not seen in another thread" do
+      t = Thread.new do
+        context.push(b: 2)
+        context.mark('point b')
+      end
+      t.join
+
+      expect { context.rollback('point b') }.to raise_error(Puppet::Context::UnknownRollbackMarkError)
+    end
+  end
+end
+
+
+describe Puppet::Context::EmptyStack do
+  let(:empty_stack) { Puppet::Context::EmptyStack.new }
+
+  it "raises undefined binding on lookup" do
+    expect { empty_stack.lookup("a") }.to raise_error(Puppet::Context::UndefinedBindingError)
+  end
+
+  it "calls a provided block for a default value when none is found" do
+    expect(empty_stack.lookup("a") { "default" }).to eq("default")
+  end
+
+  it "raises an error when trying to pop" do
+    expect { empty_stack.pop }.to raise_error(Puppet::Context::StackUnderflow)
+  end
+
+  it "returns a stack when something is pushed" do
+    stack = empty_stack.push(a: 1)
+    expect(stack).to be_a(Puppet::Context::Stack)
+  end
+
+  it "returns a new stack with no bindings when pushed nil" do
+    stack = empty_stack.push(nil)
+    expect(stack).not_to be(empty_stack)
+    expect(stack.pop).to be(empty_stack)
+  end
+end
+
+describe Puppet::Context::Stack do
+  let(:empty_stack) { Puppet::Context::EmptyStack.new }
+
+  context "a stack with depth of 1" do
+    let(:stack) { empty_stack.push(a: 1) }
+
+    it "returns the empty stack when popped" do
+      expect(stack.pop).to be(empty_stack)
+    end
+
+    it "calls a provided block for a default value when none is found" do
+      expect(stack.lookup("a") { "default" }).to eq("default")
+    end
+
+    it "returns a new but equivalent stack when pushed nil" do
+      stackier = stack.push(nil)
+      expect(stackier).not_to be(stack)
+      expect(stackier.pop).to be(stack)
+      expect(stackier.bindings).to eq(stack.bindings)
+    end
+  end
+
+  context "a stack with more than 1 element" do
+    let(:level_one) { empty_stack.push(a: 1, c: 4) }
+    let(:level_two) { level_one.push(b: 2, c: 3) }
+
+    it "falls back to lower levels on lookup" do
+      expect(level_two.lookup(:c)).to eq(3)
+      expect(level_two.lookup(:a)).to eq(1)
+      expect{ level_two.lookup(:d) }.to raise_error(Puppet::Context::UndefinedBindingError)
+    end
+
+    it "the parent is immutable" do
+      expect(level_one.lookup(:c)).to eq(4)
+      expect{ level_one.lookup(:b) }.to raise_error(Puppet::Context::UndefinedBindingError)
+    end
+  end
+
+  context 'supports lazy entries' do
+    it 'by evaluating a bound proc' do
+      stack = empty_stack.push(a: lambda { || 'yay' })
+      expect(stack.lookup(:a)).to eq('yay')
     end
 
     it 'by memoizing the bound value' do
-      result1 = nil
-      result2 = nil
       original = 'yay'
-      context.override(:a => lambda {|| tmp = original; original = 'no'; tmp}) do
-        result1 = context.lookup(:a)
-        result2 = context.lookup(:a)
-      end
-      expect(result1).to eq('yay')
+      stack = empty_stack.push(:a => lambda {|| tmp = original; original = 'no'; tmp})
+      expect(stack.lookup(:a)).to eq('yay')
       expect(original).to eq('no')
-      expect(result2).to eq('yay')
+      expect(stack.lookup(:a)).to eq('yay')
+    end
+
+    it 'the bound value is memoized only at the top level of the stack' do
+      # I'm just characterizing the current behavior here
+
+      original = 'yay'
+      stack = empty_stack.push(:a => lambda {|| tmp = original; original = 'no'; tmp})
+      stack_two = stack.push({})
+      expect(stack.lookup(:a)).to eq('yay')
+      expect(original).to eq('no')
+      expect(stack.lookup(:a)).to eq('yay')
+      expect(stack_two.lookup(:a)).to eq('no')
     end
   end
 end


### PR DESCRIPTION
Make Puppet::Context thread local so that we can do one compilation per thread without needing separate JRuby instances.

This refactors Puppet::Context to use an immutable Stack data structure so that it's easy to put into a single ThreadLocalVar.

This does not address the thread safety of any objects stored within the Context, only the Context itself.

I've removed the ignore feature of Context for now as it appears to be unused and was marked as private api. I can reimplement that if it turns out to be necessary.