### PR TITLE
Revert "(PUP-9824) Allow virtual packages for debian"

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     These options should be specified as an array where each element is either a
      string or a hash."
 
-  has_feature :versionable, :install_options, :virtual_packages
+  has_feature :versionable, :install_options
 
   commands :aptget => "/usr/bin/apt-get"
   commands :aptcache => "/usr/bin/apt-cache"

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     and not `apt`, you must specify the source of any packages you want
     to manage."
 
-  has_feature :holdable, :virtual_packages 
+  has_feature :holdable
 
   commands :dpkg => "/usr/bin/dpkg"
   commands :dpkg_deb => "/usr/bin/dpkg-deb"
@@ -45,18 +45,16 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   # Note: self:: is required here to keep these constants in the context of what will
   # eventually become this Puppet::Type::Package::ProviderDpkg class.
   self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package} ${Version}\\n'}
-  self::DPKG_QUERY_PROVIDES_FORMAT_STRING = %Q{'${Status} ${Package} ${Version} [${Provides}]\\n'}
   self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*)$}
-  self::FIELDS_REGEX_WITH_PROVIDES = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*) \[.*\]$} 
   self::FIELDS= [:desired, :error, :status, :name, :ensure]
 
   # @param line [String] one line of dpkg-query output
   # @return [Hash,nil] a hash of FIELDS or nil if we failed to match
   # @api private
-  def self.parse_line(line, regex=self::FIELDS_REGEX)
+  def self.parse_line(line)
     hash = nil
 
-    match = regex.match(line)
+    match = self::FIELDS_REGEX.match(line)
     if match
       hash = {}
 
@@ -118,18 +116,6 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
 
     # list out our specific package
     begin
-      if @resource.allow_virtual?
-        output = dpkgquery(
-          "-W",
-          "--showformat",
-          self.class::DPKG_QUERY_PROVIDES_FORMAT_STRING
-        ).lines.find {|package| package.match(/\[.*#{@resource[:name]}.*\]/)}
-        if output          
-          hash = self.class.parse_line(output,self.class::FIELDS_REGEX_WITH_PROVIDES)
-          Puppet.info("Package #{@resource[:name]} is virtual, defaulting to #{hash[:name]}")
-          @resource[:name] = hash[:name]
-        end
-      end
       output = dpkgquery(
         "-W",
         "--showformat",


### PR DESCRIPTION
This reverts commit f33a531d71a960360c519e38e977b37112fc99b3.

# Conflicts:
#	lib/puppet/provider/package/dpkg.rb