### PR TITLE
(PUP-9973) Always stringify execute array arguments

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -162,14 +162,15 @@ module Puppet::Util::Execution
 
     options = default_options.merge(options)
 
-    if options[:sensitive]
-      command_str = '[redacted]'
-    elsif command.is_a?(Array)
+    if command.is_a?(Array)
       command = command.flatten.map(&:to_s)
       command_str = command.join(" ")
     elsif command.is_a?(String)
       command_str = command
     end
+
+    # do this after processing 'command' array or string
+    command_str = '[redacted]' if options[:sensitive]
 
     user_log_s = ''
     if options[:uid]


### PR DESCRIPTION
Previously, calling execute with an array of arguments and `sensitive: true`
options would fail to stringify the array. If one of the arguments wasn't a
string, such as the useradd provider passing a `uid`, then the call to
Kernel.exec would generate a "no implicit conversion of Integer into String"
error.

Commit e1dd1301003 added the `sensitive` option handling, but it wasn't until
commit 70d20329012 that it caused a problem for user providers.

Change the redaction logic so that we always process the `command` string or
argument as before, and afterwards decide whether to redact the command
displayed in debug output.

# Conflicts:
#	spec/integration/util/execution_spec.rb