### PR TITLE
(PUP-7808) Fix for --to_yaml producing invalid YAML

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -315,10 +315,10 @@ Licensed under the Apache 2.0 License
               Puppet.info _("retrieving resource: %{resource} from %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { resource: type, target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
               resources = find_resources(type, name)
               if options[:to_yaml]
-                text = resources.map do |resource|
-                  resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml.force_encoding(Encoding.default_external)
-                end.join("\n")
-                text.prepend("#{type.downcase}:\n")
+                data = resources.map do |resource|
+                  resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_yaml_hash
+                end.inject(:merge!)
+                text = YAML.dump(type.downcase => data)
               else
                 text = resources.map do |resource|
                   resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest.force_encoding(Encoding.default_external)

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -142,10 +142,10 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       resources = find_or_save_resources(type, name, params)
 
     if options[:to_yaml]
-      text = resources.map do |resource|
-        resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml.force_encoding(Encoding.default_external)
-      end.join("\n")
-      text.prepend("#{type.downcase}:\n")
+      data = resources.map do |resource|
+        resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_yaml_hash
+      end.inject(:merge!)
+      text = YAML.dump(type.downcase => data)
     else
       text = resources.map do |resource|
         resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest.force_encoding(Encoding.default_external)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -451,6 +451,38 @@ class Puppet::Resource
     "  %s:\n%s" % [self.title, attributes]
   end
 
+  def hiera_yaml_serialize(data)
+    case data
+    when Array
+      data.map { |v| hiera_yaml_serialize(v) }
+    when Hash
+      data.map do |k, v|
+        { k.to_s => hiera_yaml_serialize(v) }
+      end.inject(:merge)
+    when Time, Symbol
+      data.to_s
+    when String
+      # Malformed strings cause trouble when building the YAML document, scrub
+      # all strings to ensure they are valid.
+      data.scrub
+      data
+    else
+      data
+    end
+  end
+
+  # Convert our resource to a hash suitable for YAML serialization.
+  def to_hiera_yaml_hash
+    res = {}
+
+    if parameters.include?(:ensure)
+      res['ensure'] = parameters.delete(:ensure).to_s
+    end
+    res.merge!(hiera_yaml_serialize(Hash[parameters.sort]) || {})
+
+    return { self.title.to_s => res }
+  end
+
   # Convert our resource to Puppet code.
   def to_manifest
     # Collect list of attributes to align => and move ensure first

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -460,11 +460,12 @@ describe Puppet::Application::Device do
         it "outputs resources as YAML" do
           resources = [
             Puppet::Type.type(:user).new(:name => "title").to_resource,
+            Puppet::Type.type(:user).new(:name => "other").to_resource,
           ]
           allow(device.options).to receive(:[]).with(:to_yaml).and_return(true)
           allow(device.command_line).to receive(:args).and_return(['user'])
           expect(Puppet::Resource.indirection).to receive(:search).with('user/', {}).and_return(resources)
-          expect(device).to receive(:puts).with("user:\n  title:\n")
+          expect(device).to receive(:puts).with("---\nuser:\n  title: {}\n  other: {}\n")
           expect { device.main }.to exit_with 0
         end
       end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -747,25 +747,26 @@ describe Puppet::Resource do
       @resource = Puppet::Resource.new("one::two", "/my/file",
         :parameters => {
           :noop => true,
-          :foo => %w{one two},
+          :foo => [:one, "two"],
           :bar => 'a\'b',
           :ensure => 'present',
         }
       )
     end
 
-    it "should align and sort attributes with ensure first" do
-      expect(@resource.to_hierayaml).to eq(<<-'HEREDOC'.gsub(/^\s{8}/, ''))
-          /my/file:
-            ensure: 'present'
-            bar   : 'a\'b'
-            foo   : ['one', 'two']
-            noop  : true
-      HEREDOC
+    it "should sort attributes with ensure first" do
+      expect(@resource.to_hiera_yaml_hash['/my/file'].keys).to eq(['ensure', 'bar', 'foo', 'noop'])
     end
 
-    it "should produce a parsable YAML output" do
-      expect {YAML.parse(@resource.to_hierayaml)}.to_not raise_exception
+    it "should convert some types to String" do
+      expect(@resource.to_hiera_yaml_hash).to eq(
+        "/my/file" => {
+          'ensure' => "present",
+          'bar'    => "a'b",
+          'foo'    => ["one", "two"],
+          'noop'   => true
+        }
+      )
     end
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -748,18 +748,24 @@ describe Puppet::Resource do
         :parameters => {
           :noop => true,
           :foo => %w{one two},
+          :bar => 'a\'b',
           :ensure => 'present',
         }
       )
     end
 
-    it "should align and sort to attributes with ensure first" do
-      expect(@resource.to_hierayaml).to eq(<<-HEREDOC.gsub(/^\s{8}/, ''))
+    it "should align and sort attributes with ensure first" do
+      expect(@resource.to_hierayaml).to eq(<<-'HEREDOC'.gsub(/^\s{8}/, ''))
           /my/file:
             ensure: 'present'
+            bar   : 'a\'b'
             foo   : ['one', 'two']
             noop  : true
       HEREDOC
+    end
+
+    it "should produce a parsable YAML output" do
+      expect {YAML.parse(@resource.to_hierayaml)}.to_not raise_exception
     end
   end
 


### PR DESCRIPTION
When using `--to_yaml`, Puppet sometimes produce invalid YAML output.  This PR add a unit test that ensures the produced YAML is valid and can be parsed, and rework the way this YAML is produced so that the output can be successfully used in scripts.