### PR TITLE
(PUP-9956) Suppress exec output when sensitive

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -455,9 +455,13 @@ module Puppet
           return false
         end
 
-        output.split(/\n/).each { |line|
-          self.debug(line)
-        }
+        if sensitive
+          self.debug("[output redacted]")
+        else
+          output.split(/\n/).each { |line|
+            self.debug(line)
+          }
+        end
 
         status.exitstatus != 0
       end
@@ -507,9 +511,13 @@ module Puppet
           return false
         end
 
-        output.split(/\n/).each { |line|
-          self.debug(line)
-        }
+        if sensitive
+          self.debug("[output redacted]")
+        else
+          output.split(/\n/).each { |line|
+            self.debug(line)
+          }
+        end
 
         status.exitstatus == 0
       end

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -755,6 +755,15 @@ RSpec.describe Puppet::Type.type(:exec) do
           expect(@test.check_all_attributes).to eq(true)
           expect(@logs.shift.message).to eq("test output")
         end
+
+        it "should not emit output to debug if sensitive is true" do
+          Puppet::Util::Log.level = :debug
+          @test[param] = @fail
+          allow(@test.parameters[param]).to receive(:sensitive).and_return(true)
+          expect(@test.check_all_attributes).to eq(true)
+          expect(@logs).not_to include(an_object_having_attributes(level: :debug, message: "test output"))
+          expect(@logs).to include(an_object_having_attributes(level: :debug, message: "[output redacted]"))
+        end
       end
     end
   end


### PR DESCRIPTION
When unless or onlyif checks are sensitive, don't log check output to debug