### PR TITLE
(maint) cleanup rspec requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group(:test) do
   gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2')
   gem "rspec", "~> 3.1", require: false
   gem "rspec-its", "~> 1.1", require: false
-  gem "rspec-collection_matchers", "~> 1.1", require: false
   gem 'vcr', '~> 2.9', require: false
   gem 'webmock', '~> 1.24', require: false
   gem 'yard', require: false

--- a/spec/lib/puppet_spec/matchers.rb
+++ b/spec/lib/puppet_spec/matchers.rb
@@ -1,19 +1,6 @@
 require 'stringio'
 
 ########################################################################
-# Backward compatibility for Jenkins outdated environment.
-module RSpec
-  module Matchers
-    module BlockAliases
-      alias_method :to,     :should      unless method_defined? :to
-      alias_method :to_not, :should_not  unless method_defined? :to_not
-      alias_method :not_to, :should_not  unless method_defined? :not_to
-    end
-  end
-end
-
-
-########################################################################
 # Custom matchers...
 RSpec::Matchers.define :have_matching_element do |expected|
   match do |actual|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,6 @@ require 'puppet/gettext/stubs'
 
 require 'rspec'
 require 'rspec/its'
-require 'rspec/collection_matchers'
 
 # So everyone else doesn't have to include this base constant.
 module PuppetSpec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,7 @@ require 'puppet'
 # FastGettext's implementation of these methods.
 require 'puppet/gettext/stubs'
 
-gem 'rspec', '>=3.1.0'
-require 'rspec/expectations'
+require 'rspec'
 require 'rspec/its'
 require 'rspec/collection_matchers'
 

--- a/spec/unit/face/help_spec.rb
+++ b/spec/unit/face/help_spec.rb
@@ -155,7 +155,7 @@ describe Puppet::Face[:help, '0.0.1'] do
     # If we don't, these tests are ... less than useful, because they assume
     # it.  When this breaks you should consider ditching the entire feature
     # and tests, but if not work out how to fake one. --daniel 2011-04-11
-    it { is_expected.to have_at_least(1).item }
+    it { expect(subject.count).to be > 1 }
 
     # Meh.  This is nasty, but we can't control the other list; the specific
     # bug that caused these to be listed is annoyingly subtle and has a nasty

--- a/spec/unit/functions/contain_spec.rb
+++ b/spec/unit/functions/contain_spec.rb
@@ -192,7 +192,7 @@ describe 'The "contain" function' do
     contained = catalog.resource("Class", "contained")
     container = catalog.resource("Class", "container")
 
-    expect(catalog.edges_between(container, contained)).to have(1).item
+    expect(catalog.edges_between(container, contained).count).to eq 1
   end
 
   context "when a containing class has a dependency order" do

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::Node::Environment do
 
         expect(hash[base]).to eq("same env")
         expect(hash[different]).to eq("different env")
-        expect(hash).to have(2).item
+        expect(hash.count).to eq 2
       end
 
       it "is equal when name, modules, and manifests are the same" do

--- a/spec/unit/provider/package/pkgin_spec.rb
+++ b/spec/unit/provider/package/pkgin_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::Type.type(:package).provider(:pkgin) do
 
     it "returns an array of providers for each package" do
       instances = described_class.instances
-      expect(instances).to have(2).items
+      expect(instances.count).to eq 2
       instances.each do |instance|
         expect(instance).to be_a(described_class)
       end

--- a/spec/unit/type/schedule_spec.rb
+++ b/spec/unit/type/schedule_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::Type.type(:schedule) do
     it "should not produce default schedules when default_schedules is false"  do
       Puppet[:default_schedules] = false
       schedules = Puppet::Type.type(:schedule).mkdefaultschedules
-      expect(schedules).to have_exactly(0).items
+      expect(schedules).to be_empty
     end
 
     it "should produce a schedule named puppet with a period of hourly and a repeat of 2" do

--- a/spec/unit/util/inifile_spec.rb
+++ b/spec/unit/util/inifile_spec.rb
@@ -132,7 +132,7 @@ describe Puppet::Util::IniConfig::PhysicalFile do
 
         subject.parse(text)
 
-        expect(subject.contents).to have(1).items
+        expect(subject.contents.count).to eq 1
         sect = subject.contents[0]
         expect(sect.name).to eq "mysect"
       end
@@ -171,7 +171,7 @@ describe Puppet::Util::IniConfig::PhysicalFile do
         text = "[main]\nkey=val\n"
 
         subject.parse(text)
-        expect(subject.contents).to have(1).items
+        expect(subject.contents.count).to eq 1
         sect = subject.contents[0]
         expect(sect['key']).to eq 'val'
       end
@@ -186,7 +186,7 @@ white_space_after_equals= value3
 white_space_after_value=value4\t
 INIFILE
           subject.parse(text)
-          expect(subject.contents).to have(1).items
+          expect(subject.contents.count).to eq 1
           subject.contents[0]
         end
 
@@ -213,7 +213,7 @@ INIFILE
         text = "[main]\nkey=val\n moreval"
 
         subject.parse(text)
-        expect(subject.contents).to have(1).items
+        expect(subject.contents.count).to eq 1
         sect = subject.contents[0]
         expect(sect['key']).to eq "val\n moreval"
       end
@@ -261,7 +261,7 @@ INIFILE
     subject.parse(text)
 
     sections = subject.sections
-    expect(sections).to have(2).items
+    expect(sections.count).to eq 2
     expect(sections[0].name).to eq "first"
     expect(sections[1].name).to eq "second"
   end


### PR DESCRIPTION
* Remove `gem` annotation from spec_helper.rb
* replace last usages of rspec2 collection matchers