### PR TITLE
(PUP-9994) implement $trusted['external'] facts

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -306,7 +306,7 @@ module Puppet
         :default  => ! Puppet::Util::Platform.windows?,
         :type     => :boolean,
         :desc     => "Whether Puppet should manage the owner, group, and mode of files it uses internally.
-        
+
           **Note**: For Windows agents, the default is `false` for versions 4.10.13 and greater, versions 5.5.6 and greater, and versions 6.0 and greater.",
     },
     :onetime => {
@@ -535,6 +535,16 @@ module Puppet
     :facts_terminus => {
       :default => 'facter',
       :desc => "The node facts terminus.",
+    },
+    :trusted_external_command => {
+      :default  => nil,
+      :desc     => "The external trusted facts script to use.
+        This setting's value can be set to the path to an executable command that
+        can produce external trusted facts. The command must:
+
+        * Take the name of a node as a command-line argument.
+        * Return a JSON hash with the external trusted facts for this node.
+        * For unknown or invalid nodes, exit with a non-zero exit code.",
     },
     :default_file_terminus => {
       :type       => :terminus,

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -135,7 +135,7 @@ module Puppet::Test
       Puppet.push_context(
         {
           trusted_information:
-            Puppet::Context::TrustedInformation.new('local', 'testing', {}),
+            Puppet::Context::TrustedInformation.new('local', 'testing', {}, { "trusted_testhelper" => true }),
           ssl_context: Puppet::SSL::SSLContext.new(cacerts: []).freeze
         },
         "Context for specs")

--- a/lib/puppet/trusted_external.rb
+++ b/lib/puppet/trusted_external.rb
@@ -1,0 +1,13 @@
+# A method for retrieving external trusted facts
+module Puppet::TrustedExternal
+  def retrieve(certname)
+    command = Puppet[:trusted_external_command]
+    return nil unless command
+    result = Puppet::Util::Execution.execute([command, certname], {
+      :combine => false,
+      :failonfail => true,
+    })
+    JSON.parse(result)
+  end
+  module_function :retrieve
+end

--- a/spec/unit/context/trusted_information_spec.rb
+++ b/spec/unit/context/trusted_information_spec.rb
@@ -98,7 +98,8 @@ describe Puppet::Context::TrustedInformation, :unless => RUBY_PLATFORM == 'java'
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
       },
       'hostname' => 'cert name',
-      'domain' => nil
+      'domain' => nil,
+      'external' => nil,
     })
   end
 
@@ -113,7 +114,8 @@ describe Puppet::Context::TrustedInformation, :unless => RUBY_PLATFORM == 'java'
         '1.3.6.1.4.1.34380.1.2.2' => 'more CSR specific info',
       },
       'hostname' => 'hostname',
-      'domain' => 'domain.long'
+      'domain' => 'domain.long',
+      'external' => nil,
     })
   end
 


### PR DESCRIPTION
These facts are supplied through a new external lookup. They can be used
for injecting additional facts from third-party databases like asset
management or service-now.

To configure a lookup, provide the name of your lookup command to
`trusted_external_command`. The lookup script will receive the certname
as first and only argument and is expected to return the external facts
as a JSON hash on stdout.