### PR TITLE
(PUP-9465) Add libuser provider to group type

### DIFF
--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -6,6 +6,9 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
 
   "
 
+  # is there a better way to default this (or make sure libuser is never defaulted)?
+  defaultfor :kernel => :Linux
+
   commands :add => "groupadd", :delete => "groupdel", :modify => "groupmod"
 
   has_feature :system_groups unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
@@ -69,6 +72,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     if @resource.forcelocal?
       cmd = [command(:localadd)]
       @custom_environment = Puppet::Util::Libuser.getenv
+      Puppet.deprecation_warning _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider.")
     else
       cmd = [command(:add)]
     end
@@ -89,6 +93,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     if @resource.forcelocal?
       cmd = [command(:localmodify)]
       @custom_environment = Puppet::Util::Libuser.getenv
+      Puppet.deprecation_warning _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider.")
     else
       cmd = [command(:modify)]
     end
@@ -104,6 +109,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
   def deletecmd
     if @resource.forcelocal?
       @custom_environment = Puppet::Util::Libuser.getenv
+      Puppet.deprecation_warning _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider.")
       [command(:localdelete), @resource[:name]]
     else
       [command(:delete), @resource[:name]]

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -72,7 +72,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     if @resource.forcelocal?
       cmd = [command(:localadd)]
       @custom_environment = Puppet::Util::Libuser.getenv
-      Puppet.deprecation_warning _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider.")
+      Puppet.warn_once('deprecations', 'forcelocal', _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider."))
     else
       cmd = [command(:add)]
     end
@@ -93,7 +93,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     if @resource.forcelocal?
       cmd = [command(:localmodify)]
       @custom_environment = Puppet::Util::Libuser.getenv
-      Puppet.deprecation_warning _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider.")
+      Puppet.warn_once('deprecations', 'forcelocal', _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider."))
     else
       cmd = [command(:modify)]
     end
@@ -109,7 +109,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
   def deletecmd
     if @resource.forcelocal?
       @custom_environment = Puppet::Util::Libuser.getenv
-      Puppet.deprecation_warning _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider.")
+      Puppet.warn_once('deprecations', 'forcelocal', _("`forcelocal` is deprecated and will be removed in a future release. This property has been replaced by the `libuser` provider."))
       [command(:localdelete), @resource[:name]]
     else
       [command(:delete), @resource[:name]]

--- a/lib/puppet/provider/group/libuser.rb
+++ b/lib/puppet/provider/group/libuser.rb
@@ -1,0 +1,86 @@
+require 'puppet/provider/nameservice/objectadd'
+
+Puppet::Type.type(:group).provide :libuser, :parent => Puppet::Provider::NameService::ObjectAdd do
+  desc "Group management via `libuser`. Available on most RedHat-based platforms."
+
+  commands :add => "lgroupadd", :delete => "lgroupdel", :modify => "lgroupmod"
+
+  has_feature :system_groups, :manages_members
+
+  options :members, :flag => '-M', :method => :mem
+
+  # TODO maybe move this closer? I'm open to suggestions
+  ENV['LIBUSER_CONF'] = File.expand_path("../../../util/libuser.conf", __FILE__)
+
+  def create
+    super
+    if @resource['members']
+      set(:members, @resource[:members])
+    end
+  end
+
+  def gid_exists?
+    begin
+      !!Etc.getgrgid(@resource.should(:gid))
+    rescue ArgumentError
+      nil
+    end
+  end
+
+  def check_allow_dup
+    # We have to manually check for duplicates when using libuser
+    # because by default duplicates are allowed.
+    if gid_exists? && !@resource.allowdupe?
+      raise(Puppet::Error, _("GID %{resource} already exists, use allowdupe to force this change") % { resource: @resource.should(:gid).to_s })
+    end
+  end
+
+  def addcmd
+    cmd = [command(:add)]
+    gid = @resource.should(:gid)
+    if gid
+      cmd << flag(:gid) << gid
+      check_allow_dup
+    end
+    cmd << "-r" if @resource.system?
+    cmd << @resource[:name]
+    cmd
+  end
+
+  def purge_members
+    modify('-m', members_to_s(members), @resource.name)
+  end
+
+  def modifycmd(param, value)
+    cmd = [command(:modify)]
+    if param == :members
+      value = members_to_s(value)
+      purge_members if @resource[:auth_membership] && !members.empty?
+    end
+    check_allow_dup if param == :gid
+    cmd << flag(param) << value
+    cmd << @resource[:name]
+    cmd
+  end
+
+  def deletecmd
+    [command(:delete), @resource[:name]]
+  end
+
+  def members_insync?(current, should)
+    current.sort == @resource.parameter(:members).actual_should(current, should)
+  end
+
+  def members_to_s(current)
+    return '' if current.nil? or !current.kind_of?(Array)
+    current.join(',')
+  end
+
+  def member_valid?(user)
+    begin
+      !!Etc.getpwnam(user)
+    rescue ArgumentError
+      raise Puppet::Error, _("User %{user} does not exist") % { user: user }
+    end
+  end
+end

--- a/lib/puppet/provider/group/libuser.rb
+++ b/lib/puppet/provider/group/libuser.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:group).provide :libuser, :parent => Puppet::Provider::NameSer
   end
 
   def members_insync?(current, should)
-    current.sort == @resource.parameter(:members).actual_should(current, should)
+    current.uniq.sort == @resource.parameter(:members).actual_should(current, should)
   end
 
   def members_to_s(current)

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -96,7 +96,7 @@ module Puppet
 
       def insync?(current)
         if provider.respond_to?(:members_insync?)
-          return provider.members_insync?(current, munge_members_value(@should))
+          return provider.members_insync?(current, @should)
         end
 
         super(current)
@@ -136,7 +136,6 @@ module Puppet
       def munge_members_value(value)
         return [] if value == :absent
         return value.split(',') if value.is_a?(String)
-        return value.first.split(',') if value.is_a?(Array) && value.size == 1
 
         value
       end

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -96,7 +96,7 @@ module Puppet
 
       def insync?(current)
         if provider.respond_to?(:members_insync?)
-          return provider.members_insync?(current, @should)
+          return provider.members_insync?(current, munge_members_value(@should))
         end
 
         super(current)
@@ -136,6 +136,7 @@ module Puppet
       def munge_members_value(value)
         return [] if value == :absent
         return value.split(',') if value.is_a?(String)
+        return value.first.split(',') if value.is_a?(Array) && value.size == 1
 
         value
       end

--- a/spec/unit/provider/group/libuser_spec.rb
+++ b/spec/unit/provider/group/libuser_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+
+RSpec::Matchers.define_negated_matcher :excluding, :include
+
+describe Puppet::Type.type(:group).provider(:libuser) do
+  before do
+    allow(described_class).to receive(:command).with(:add).and_return('/usr/sbin/lgroupadd')
+    allow(described_class).to receive(:command).with(:delete).and_return('/usr/sbin/lgroupdel')
+    allow(described_class).to receive(:command).with(:modify).and_return('/usr/sbin/lgroupmod')
+  end
+
+  let!(:resource) { Puppet::Type.type(:group).new(:name => 'mygroup', :provider => provider) }
+  let(:provider) { described_class.new(:name => 'mygroup') }
+
+  describe "#create" do
+    before do
+       allow(provider).to receive(:exists?).and_return(false)
+       allow(provider).to receive(:member_valid?).and_return(true)
+    end
+
+    it "should support allowdupe when the group is being created" do
+      resource[:allowdupe] = :true
+      expect(provider).to receive(:execute).with(['/usr/sbin/lgroupadd', 'mygroup'], kind_of(Hash))
+      provider.create
+    end
+
+    it "should execute both add and modify when a list of members is passed and the group is being created" do
+      resource[:members] = ['user1', 'user2', 'user3']
+      expect(provider).to receive(:execute).with(['/usr/sbin/lgroupadd', 'mygroup'], kind_of(Hash))
+      expect(provider).to receive(:execute).with(['/usr/sbin/lgroupmod', '-M', 'user1,user2,user3', 'mygroup'], kind_of(Hash))
+      provider.create
+    end
+
+    it "should add -r when system_groups is enabled and the group is being created" do
+      resource[:system] = :true
+      expect(provider).to receive(:execute).with(['/usr/sbin/lgroupadd', '-r', 'mygroup'], kind_of(Hash))
+      provider.create
+    end
+
+    it "should raise an exception for duplicate GID if allowdupe is not set and duplicate GIDs exist" do
+      resource[:gid] = 505
+      allow(provider).to receive(:gid_exists?).and_return(true)
+      expect { provider.create }.to raise_error(Puppet::Error, "GID 505 already exists, use allowdupe to force this change")
+    end
+  end
+
+  describe "#modify" do
+    before do
+       allow(provider).to receive(:exists?).and_return(true)
+    end
+
+    it "should raise an exception for duplicate GID if allowdupe is not set and duplicate GIDs exist" do
+      resource[:gid] = 150
+      allow(provider).to receive(:gid_exists?).and_return(true)
+      expect { provider.gid = 150 }.to raise_error(Puppet::Error, "GID 150 already exists, use allowdupe to force this change")
+    end
+
+    describe "if auth_membership is true" do
+      before :each do
+        resource[:auth_membership] = true
+      end
+
+      it "should execute purge_members if the group has members" do
+        allow(provider).to receive(:members).and_return(['user1', 'user2'])
+        expect(provider).to receive(:purge_members).and_return(true)
+        provider.modifycmd(:members, ['user3'])
+      end
+
+      it "should not execute purge_members if the group has no members" do
+        allow(provider).to receive(:members).and_return([])
+        expect(provider).not_to receive(:purge_members)
+        provider.modifycmd(:members, ['user3'])
+      end
+    end
+
+    describe "if auth_membership is false" do
+      before :each do
+        resource[:auth_membership] = false
+      end
+
+      it "should not execute purge_members" do
+        allow(provider).to receive(:members).and_return(['user1', 'user2'])
+        expect(provider).not_to receive(:purge_members)
+        provider.modifycmd(:members, ['user3'])
+      end
+
+      it "should add an user to the existing ones" do
+        allow(provider).to receive(:members).and_return(['user1', 'user2'])
+        expect(provider).to receive(:modifycmd).with(:members, ['user3']).and_return(['/usr/sbin/lgroupmod', '-M', 'user3', 'mygroup'])
+        provider.modifycmd(:members, ['user3'])
+      end
+    end
+  end
+
+  describe "#delete" do
+    before do
+      allow(provider).to receive(:exists?).and_return(true)
+    end
+
+    it "should remove a group" do
+      expect(provider).to receive(:execute).with(['/usr/sbin/lgroupdel', 'mygroup'], kind_of(Hash))
+      provider.delete
+    end
+  end
+
+  describe "group type :members property helpers" do
+    describe "#member_valid?" do
+      it "should return true if a member exists" do
+        passwd = Struct::Passwd.new('existinguser', nil, 1100)
+        allow(Etc).to receive(:getpwnam).with('existinguser').and_return(passwd)
+        expect(provider.member_valid?('existinguser')).to eq(true)
+      end
+
+      it "should raise an exception if a member does not exist" do
+        allow(Etc).to receive(:getpwnam).with('invaliduser').and_raise(ArgumentError)
+        expect { provider.member_valid?('invaliduser') }.to raise_error(Puppet::Error, "User invaliduser does not exist")
+      end
+    end
+
+    describe "#members_to_s" do
+      it "should return an empty string on non-array input" do
+        [Object.new, {}, 1, :symbol, ''].each do |input|
+          expect(provider.members_to_s(input)).to be_empty
+        end
+      end
+
+      it "should return an empty string on empty or nil users" do
+        expect(provider.members_to_s([])).to be_empty
+        expect(provider.members_to_s(nil)).to be_empty
+      end
+
+      it "should return a user string for a single user" do
+        expect(provider.members_to_s(['user1'])).to eq('user1')
+      end
+
+      it "should return a user string for multiple users" do
+        expect(provider.members_to_s(['user1', 'user2'])).to eq('user1,user2')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, group provider `groupadd` uses two separate packages for managing groups. The (groupadd, groupmod, groupdel) programs belong to the shadow project. These utilities explicitly operate on local files (/etc/passwd, /etc/shadow, /etc/group, /etc/gshadow) only.

The (lgroupadd, lgroupmod, lgroupdel) programs belong to the libuser project. Per its documentation, libuser is a library that implements a standardized interface for manipulating and administering user and group accounts, using pluggable back-ends to interface to data sources.

To fix this mis-engineering, we separate the two providers and deprecate the `forcelocal` parameter which is only used in conjunction with the `libuser` commands. We also make use of libuser's ability of directly managing group members in order to benefit from Puppet's `manages_members` feature.

However, we avoid defaulting the libuser provider since it does not have the same set of features as the groupadd provider, hence it should be an opt-in provider. For example, libuser doesn't support NIS accounts.

Still needs proper tests.