### PR TITLE
(PUP-9991) Allow module uninstall in FIPS

### DIFF
--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -15,9 +15,6 @@ module Puppet::ModuleTool
       end
 
       def run
-        # Disallow anything that invokes md5 to avoid un-friendly termination due to FIPS
-        raise _("Module uninstall is prohibited in FIPS mode.") if Facter.value(:fips_enabled)
-
         results = {
           :module_name       => @name,
           :requested_version => @version,
@@ -92,6 +89,8 @@ module Puppet::ModuleTool
         mod = @installed.first
 
         unless @ignore_changes
+          raise _("Either the `--ignore_changes` or `--force` argument must be specified to uninstall modules when running in FIPS mode.") if Facter.value(:fips_enabled)
+
           changes = begin
             Puppet::ModuleTool::Applications::Checksummer.run(mod.path)
           rescue ArgumentError


### PR DESCRIPTION
The `uninstall` action detects if there are local modifications to a module
before deleting it. Since module checksum metadata is hardcoded to use MD5, the
entire uninstall action was disallowed in FIPS mode.

This commit relaxes the restriction so that uninstall is allowed provided
`--ignore_changes` or `--force` are specified, since they both skip the check
for local modifications.