### PR TITLE
(PUP-10015) Add support for arbitrary equality to pip provider

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -87,9 +87,9 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
   end
 
   # Parse lines of output from `pip freeze`, which are structured as:
-  # _package_==_version_
+  # _package_==_version_ or _package_===_version_
   def self.parse(line)
-    if line.chomp =~ /^([^=]+)==([^=]+)$/
+    if line.chomp =~ /^([^=]+)===?([^=]+)$/
       {:ensure => $2, :name => $1, :provider => name}
     end
   end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -29,6 +29,14 @@ describe Puppet::Type.type(:package).provider(:pip) do
       })
     end
 
+    it "should correctly parse arbitrary equality" do
+      expect(described_class.parse("real_package===1.2.5")).to eq({
+        :ensure   => "1.2.5",
+        :name     => "real_package",
+        :provider => :pip,
+      })
+    end
+
     it "should return nil on invalid input" do
       expect(described_class.parse("foo")).to eq(nil)
     end


### PR DESCRIPTION
Without this patch the pip provider doesn't correctly parse pip freeze
output specified with arbitrary equality.

https://www.python.org/dev/peps/pep-0440/#arbitrary-equality

This is manifest with triple === separating the package name from the
package version, e.g.

$ pip freeze | grep pytz
pytz===2012f

By not correctly parsing this output, puppet tries to continually
install this package on each run.

The patch updates the regex to handle arbitrary equality.