### PR TITLE
(PUP-10016) Confine systemd based on proc/1/comm

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "systemctl"
 
-  confine :true => Puppet::FileSystem.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd')
+  confine :true => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8"]

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -7,18 +7,19 @@ describe test_title, unless: Puppet::Util::Platform.jruby? do
 
   # TODO: Unfortunately there does not seem a way to stub the executable
   #       checks in the systemd provider because they happen at load time.
-  it "should be considered suitable if /proc/1/exe is present and points to 'systemd'",
-    :if => File.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
+
+  it "should be considered suitable if /proc/1/comm is present and contains 'systemd'",
+    :if => File.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd') do
     expect(provider_class).to be_suitable
   end
 
-  it "should not be considered suitable if /proc/1/exe is present it does not point to 'systemd'",
-    :if => File.exist?('/proc/1/exe') && !Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
+  it "should not be considered suitable if /proc/1/comm is present it does not contain 'systemd'",
+    :if => File.exist?('/proc/1/comm') && !Puppet::FileSystem.read('/proc/1/comm').include?('systemd') do
     expect(provider_class).not_to be_suitable
   end
 
-  it "should not be considered suitable if /proc/1/exe is absent",
-    :if => !File.exist?('/proc/1/exe') do
+  it "should not be considered suitable if /proc/1/comm is absent",
+    :if => !File.exist?('/proc/1/comm') do
     expect(provider_class).not_to be_suitable
   end
 end


### PR DESCRIPTION
Reading the symlink of `proc/1/exe` is not the most reliable way
to determine if systemd is the correct service provider
because non root users might not have access to read the symlink:
```
$ ls -l /proc/1/exe
ls: cannot read symbolic link '/proc/1/exe': Permission denied
```

This is causing issues when Puppet is not run as root.

Confine systemd provider based on the content of `proc/1/comm`

```
/proc/[pid]/comm (since Linux 2.6.33)
              This file exposes the process's comm value—that is, the com‐
              mand name associated with the process.  Different threads in
              the same process may have different comm values, accessible
              via /proc/[pid]/task/[tid]/comm.  A thread may modify its comm
              value, or that of any of other thread in the same thread group
              (see the discussion of CLONE_THREAD in clone(2)), by writing
              to the file /proc/self/task/[tid]/comm.  Strings longer than
              TASK_COMM_LEN (16) characters are silently truncated.

              This file provides a superset of the prctl(2) PR_SET_NAME and
              PR_GET_NAME operations, and is employed by
              pthread_setname_np(3) when used to rename threads other than
              the caller.
```