### PR TITLE
(PUP-9109) Add query parameters for HTTP request

### DIFF
--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -195,7 +195,7 @@ module Puppet::Util::HttpProxy
         headers.merge!({"Accept-Encoding" => Puppet::Network::HTTP::Compression::ACCEPT_ENCODING})
       end
 
-      response = proxy.send(:head, current_uri.path, headers)
+      response = proxy.send(:head, current_uri, headers)
       Puppet.debug("HTTP HEAD request to #{current_uri} returned #{response.code} #{response.message}")
 
       if [301, 302, 307].include?(response.code.to_i)
@@ -206,9 +206,9 @@ module Puppet::Util::HttpProxy
 
       if method != :head
         if block_given?
-          response = proxy.send("request_#{method}".to_sym, current_uri.path, headers, &block)
+          response = proxy.send("request_#{method}".to_sym, current_uri, headers, &block)
         else
-          response = proxy.send(method, current_uri.path, headers)
+          response = proxy.send(method, current_uri, headers)
         end
 
         Puppet.debug("HTTP #{method.to_s.upcase} request to #{current_uri} returned #{response.code} #{response.message}")

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -292,5 +292,21 @@ describe Puppet::Util::HttpProxy do
 
       subject.request_with_redirects(dest, :head, 0)
     end
+
+    it 'preserves query parameters' do
+      url = URI.parse('http://mydomain.com/some/path?foo=bar')
+
+      expect_any_instance_of(Net::HTTP).to receive(:head) do |_method, path, _headers|
+        expect(path).to eq(url)
+      end.and_return(http_ok)
+
+      expect_any_instance_of(Net::HTTP).to receive(:request_get) do |_http, path, _headers, &block|
+        expect(path).to eq(url)
+      end.and_return(http_ok)
+
+      subject.request_with_redirects(url, :get, 0) do
+        # unused
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds the query parameters to the HTTP request done by
`request_with_redirects`. This is needed for the `source` attribute of
the `file` resource type if the source URL contains query parameters.

The code itself was extracted from #5002, originally developed by
@mcasper. The reason for the extraction is:
* The original PR seems to be stale.
* The PR fixes another (S3) issue as well