### PR TITLE
(PUP-7808) Fix for --to_yaml producing invalid YAML

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -297,10 +297,10 @@ Licensed under the Apache 2.0 License
             Puppet.info _("retrieving resource: %{resource} from %{target} at %{scheme}%{url_host}%{port}%{url_path}") % { resource: type, target: device.name, scheme: scheme, url_host: device_url.host, port: port, url_path: device_url.path }
             resources = find_resources(type, name)
             if options[:to_yaml]
-              text = resources.map do |resource|
-                resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml.force_encoding(Encoding.default_external)
-              end.join("\n")
-              text.prepend("#{type.downcase}:\n")
+              data = resources.map do |resource|
+                resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_yaml_hash
+              end.inject(:merge!)
+              text = YAML.dump(type.downcase => data)
             else
               text = resources.map do |resource|
                 resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest.force_encoding(Encoding.default_external)

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -298,7 +298,7 @@ Licensed under the Apache 2.0 License
             resources = find_resources(type, name)
             if options[:to_yaml]
               data = resources.map do |resource|
-                resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_yaml_hash
+                resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_hash
               end.inject(:merge!)
               text = YAML.dump(type.downcase => data)
             else

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -143,7 +143,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     if options[:to_yaml]
       data = resources.map do |resource|
-        resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_yaml_hash
+        resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_hash
       end.inject(:merge!)
       text = YAML.dump(type.downcase => data)
     else

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -142,10 +142,10 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       resources = find_or_save_resources(type, name, params)
 
     if options[:to_yaml]
-      text = resources.map do |resource|
-        resource.prune_parameters(:parameters_to_include => @extra_params).to_hierayaml.force_encoding(Encoding.default_external)
-      end.join("\n")
-      text.prepend("#{type.downcase}:\n")
+      data = resources.map do |resource|
+        resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_yaml_hash
+      end.inject(:merge!)
+      text = YAML.dump(type.downcase => data)
     else
       text = resources.map do |resource|
         resource.prune_parameters(:parameters_to_include => @extra_params).to_manifest.force_encoding(Encoding.default_external)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -449,8 +449,8 @@ class Puppet::Resource
     end
   end
 
-  # Convert our resource to a hash suitable for YAML serialization.
-  def to_hiera_yaml_hash
+  # Convert our resource to a hiera hash suitable for serialization.
+  def to_hiera_hash
     res = {}
 
     if parameters.include?(:ensure)

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -481,7 +481,7 @@ describe Puppet::Application::Device do
         allow(@device.options).to receive(:[]).with(:to_yaml).and_return(true)
         allow(@device.command_line).to receive(:args).and_return(['user'])
         expect(Puppet::Resource.indirection).to receive(:search).with('user/', {}).and_return(resources)
-        expect(@device).to receive(:puts).with("user:\n  title:\n")
+        expect(@device).to receive(:puts).with("---\nuser:\n  title: {}\n")
         expect { @device.main }.to exit_with 0
       end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -765,7 +765,7 @@ describe Puppet::Resource do
     end
 
     it "should convert some types to String" do
-      expect(@resource.to_hiera_yaml_hash).to eq(
+      expect(@resource.to_hiera_hash).to eq(
         "/my/file" => {
           'ensure' => "present",
           'bar'    => "a'b",
@@ -778,13 +778,13 @@ describe Puppet::Resource do
     it "accepts symbolic titles" do
       res = Puppet::Resource.new(:file, "/my/file", :parameters => { 'ensure' => "present" })
 
-      expect(res.to_hiera_yaml_hash.keys).to eq(["/my/file"])
+      expect(res.to_hiera_hash.keys).to eq(["/my/file"])
     end
 
     it "emits an empty parameters hash" do
       res = Puppet::Resource.new(:file, "/my/file")
 
-      expect(res.to_hiera_yaml_hash).to eq({"/my/file" => {}})
+      expect(res.to_hiera_hash).to eq({"/my/file" => {}})
     end
   end
   describe "when converting to json" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -774,6 +774,18 @@ describe Puppet::Resource do
         }
       )
     end
+
+    it "accepts symbolic titles" do
+      res = Puppet::Resource.new(:file, "/my/file", :parameters => { 'ensure' => "present" })
+
+      expect(res.to_hiera_yaml_hash.keys).to eq(["/my/file"])
+    end
+
+    it "emits an empty parameters hash" do
+      res = Puppet::Resource.new(:file, "/my/file")
+
+      expect(res.to_hiera_yaml_hash).to eq({"/my/file" => {}})
+    end
   end
   describe "when converting to json" do
     # LAK:NOTE For all of these tests, we convert back to the resource so we can

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -747,7 +747,8 @@ describe Puppet::Resource do
       @resource = Puppet::Resource.new("one::two", "/my/file",
         :parameters => {
           :noop => true,
-          :foo => %w{one two},
+          :foo => [:one, "two"],
+          :bar => 'a\'b',
           :ensure => 'present',
         }
       )
@@ -757,9 +758,21 @@ describe Puppet::Resource do
       expect(@resource.to_hierayaml).to eq <<-HEREDOC.gsub(/^\s{8}/, '')
           /my/file:
             ensure: 'present'
+            bar   : 'a\\'b'
             foo   : ['one', 'two']
             noop  : true
       HEREDOC
+    end
+
+    it "should convert some types to String" do
+      expect(@resource.to_hiera_yaml_hash).to eq(
+        "/my/file" => {
+          'ensure' => "present",
+          'bar'    => "a'b",
+          'foo'    => ["one", "two"],
+          'noop'   => true
+        }
+      )
     end
   end
   describe "when converting to json" do


### PR DESCRIPTION
When using --to_yaml, Puppet sometimes produce invalid YAML output. This PR add a unit test that ensures the produced YAML is valid and can be parsed, and rework the way this YAML is produced so that the output can be successfully used in scripts.