### PR TITLE
(maint) Merge 5.5.x into 6.4.x

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   commands :systemctl => "systemctl"
 
-  confine :true => Puppet::FileSystem.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd')
+  confine :true => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
   defaultfor :osfamily => [:archlinux]
   defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8"]

--- a/spec/integration/provider/service/systemd_spec.rb
+++ b/spec/integration/provider/service/systemd_spec.rb
@@ -7,18 +7,19 @@ describe test_title, unless: Puppet::Util::Platform.jruby? do
 
   # TODO: Unfortunately there does not seem a way to stub the executable
   #       checks in the systemd provider because they happen at load time.
-  it "should be considered suitable if /proc/1/exe is present and points to 'systemd'",
-    :if => File.exist?('/proc/1/exe') && Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
+
+  it "should be considered suitable if /proc/1/comm is present and contains 'systemd'",
+    :if => File.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd') do
     expect(provider_class).to be_suitable
   end
 
-  it "should not be considered suitable if /proc/1/exe is present it does not point to 'systemd'",
-    :if => File.exist?('/proc/1/exe') && !Puppet::FileSystem.readlink('/proc/1/exe').include?('systemd') do
+  it "should not be considered suitable if /proc/1/comm is present it does not contain 'systemd'",
+    :if => File.exist?('/proc/1/comm') && !Puppet::FileSystem.read('/proc/1/comm').include?('systemd') do
     expect(provider_class).not_to be_suitable
   end
 
-  it "should not be considered suitable if /proc/1/exe is absent",
-    :if => !File.exist?('/proc/1/exe') do
+  it "should not be considered suitable if /proc/1/comm is absent",
+    :if => !File.exist?('/proc/1/comm') do
     expect(provider_class).not_to be_suitable
   end
 end


### PR DESCRIPTION

* upstream/5.5.x:
  (packaging) Updating manpage file for 5.5.x
  (PUP-10016) Confine systemd based on proc/1/comm

 Conflicts:
	man/man8/puppet-ca.8
	man/man8/puppet-cert.8
	man/man8/puppet-certificate.8
	man/man8/puppet-certificate_request.8
	man/man8/puppet-certificate_revocation_list.8
	man/man8/puppet-lookup.8
	man/man8/puppet-master.8
	spec/integration/provider/service/systemd_spec.rb