### PR TITLE
(PUP-1401) use execute instead of execpipe

### DIFF
--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -82,12 +82,10 @@ Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Pr
 
     # list out all of the packages
     begin
-      execpipe("#{command(:rpm)} -qa #{nosignature} #{nodigest} --qf '#{self::NEVRA_FORMAT}' | sort") { |process|
-        # now turn each returned line into a package object
-        nevra_to_multiversion_hash(process).each { |hash| packages << new(hash) }
-      }
+      results = execute([command(:rpm), "-qa", nosignature, nodigest, "--qf", self::NEVRA_FORMAT].delete_if(&:nil?)).lines.sort.join
+      nevra_to_multiversion_hash(results).each { |hash| packages << new(hash) }
     rescue Puppet::ExecutionFailure
-      raise Puppet::Error, _("Failed to list packages"), $!.backtrace
+      raise Puppet::Error, _("Failed to list packages"), results
     end
 
     packages


### PR DESCRIPTION
 Some package providers use `execpipe` which does not set LC_ALL or LANG.
    
With this commit the `pip` and `rpm` package provider use `execute` instead of `execpipe`.
    
If this does not address the issue, at least execute accepts a hash with 'override_locale' and 'custom_environment' which would address locale.