### PR TITLE
(maint) Do not set SSL related termini in JRUBY_FIPS

### DIFF
--- a/lib/puppet/ssl/openssl_loader.rb
+++ b/lib/puppet/ssl/openssl_loader.rb
@@ -21,8 +21,4 @@ else
       class Certificate; end
     end
   end
-
-  Puppet::SSL::Certificate.indirection.terminus = :none
-  Puppet::SSL::CertificateRequest.indirection.terminus = :none
-  Puppet::SSL::Key.indirection.terminus = :none
 end


### PR DESCRIPTION
Previously, we were setting the termini for Certificate,
CertificateRequest, and Key to ensure these indirections that assumed a
working OpenSSL could not be used when JRuby was in FIPS mode (JRuby
does not support its OpenSSL library in FIPS mode).

This seemed to work in Puppet Server integration tests, however when
deployed to servers the load order appears to have changed and now the
openssl_loader is being loaded prior to the Puppet::SSL namespace being
defined causing a NameError.

This simply removes the terminus setting code because:
1) A non-cyclical way to declare this is non-obvious
2) These indirections are deprecated anyway
3) This will cause an ugly error message but it's not clear if that's
   a worse UX then not being able to find an appropriate terminus if a
   user is unaware of FIPS caveats.