### PR TITLE
(PUP-9792) Refresh lookup_options on config change

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -196,6 +196,7 @@ class HieraConfig
   # @return [Array<DataProvider>] the data providers
   def configured_data_providers(lookup_invocation, parent_data_provider, use_default_hierarchy = false)
     unless @data_providers && scope_interpolations_stable?(lookup_invocation)
+      lookup_invocation.lookup_adapter.clear_lookup_options
       if @data_providers
         lookup_invocation.report_text { _('Hiera configuration recreated due to change of scope variables used in interpolation expressions') }
       end

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -287,6 +287,13 @@ class LookupAdapter < DataAdapter
     self
   end
 
+  def clear_lookup_options
+    @lookup_options = {}
+    @global_lookup_options = nil
+    @env_only_lookup_options = nil
+    @env_lookup_options = nil
+  end
+
   private
 
   PROVIDER_STACK = [:lookup_global, :lookup_in_environment, :lookup_in_module].freeze


### PR DESCRIPTION
If `lookup_options` is found in Hiera levels that utilise top scope variables as opposed to facts then unless all top scope variables are set before the first lookup, `lookup_options` gets cached once and is never refreshed.

This change removes all caching so `lookup_options` is refreshed every time.