### PR TITLE
(PUP-10017) coalesce resource dependency failures into class failures

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -154,6 +154,19 @@ module Puppet
         end
       end
     },
+    :merge_dependency_warnings => {
+      :default => false,
+      :type    => :boolean,
+      :desc    => "Whether to merge class-level dependency failure warnings.
+
+        When a class has a failed dependency, every resource in the class
+        generates a notice level message about the dependency failure,
+        and a warning level message about skipping the resource.
+
+        If true, all messages caused by a class dependency failure are merged
+        into one message associated with the class.
+        ",
+    },
     :strict => {
       :default    => :warning,
       :type       => :symbolic_enum,

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -3,6 +3,7 @@ require 'matchers/include_in_order'
 require 'puppet_spec/compiler'
 
 require 'puppet/transaction'
+require 'puppet/type/exec'
 require 'puppet/type/notify'
 require 'fileutils'
 
@@ -965,6 +966,51 @@ describe Puppet::Transaction do
         notify { ['notify1', 'notify2', 'notify3']: }
       MANIFEST
       expect(times_send_log_with_skipping_called).to eq(3)
+    end
+  end
+
+  describe "failed dependency is depended on multiple times" do
+    it "notifies and warns the failed class dependency once" do
+      Puppet.settings[:merge_dependency_warnings] = true
+
+      command_string = File.expand_path('/my/command')
+      allow(Puppet::Util::Execution).to receive(:execute).with([command_string]).and_raise(Puppet::ExecutionFailure, "Failed")
+
+      # Exec['exec1'] is outside of a class, so it's warning is not subject to being coalesced.
+      times_send_log_with_skipping_called = 0
+      allow_any_instance_of(Puppet::Type::Exec).to receive(:send_log) {times_send_log_with_skipping_called += 1; nil}.with(:warning, "Skipping because of failed dependencies")
+
+      # Class['declared_class'] depends upon Class['required_class'] which contains a resource with a failure.
+      times_send_log_with_class_dependency_called = 0
+      allow_any_instance_of(Puppet::Type).to receive(:send_log) {times_send_log_with_class_dependency_called += 1; nil}.with(:notice, "Class dependency Exec[exec2] has failures: true")
+      times_send_log_with_class_skipping_called = 0
+      allow_any_instance_of(Puppet::Type).to receive(:send_log) {times_send_log_with_class_skipping_called += 1; nil}.with(:warning, "Skipping resources in class because of failed class dependencies")
+
+      apply_compiled_manifest(<<-MANIFEST)
+        class required_class {
+          exec { 'exec2':
+            command => '#{command_string}'
+          }
+        }
+        class declared_class {
+          require required_class
+          exec { 'exec3':
+            command => '#{command_string}'
+          }
+          exec { 'exec4':
+            command => '#{command_string}'
+          }
+        }
+        exec { 'exec1':
+          command => '#{command_string}',
+          require => Exec['exec2']
+        }
+        include declared_class
+      MANIFEST
+
+      expect(times_send_log_with_skipping_called).to eq(1)
+      expect(times_send_log_with_class_dependency_called).to eq(1)
+      expect(times_send_log_with_class_skipping_called).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Merge (n) resource dependency failures into (1) class failure.

When a class has a failed dependency, every individual resource in the class
generates a notice level message about the dependency failure,
and a warning level message about skipping the resource.

At large-code and/or large-node scale, one class dependency failure can create
an overwhelming number of messages ... obscuring the root cause and increasing
the use of system resources required to process and store the resulting reports.

With this commit (and 'merge_dependency_warnings' set to true) ...

All messages caused by a class dependency failure are coalesced into one message
associated with the class.