### PR TITLE
(maint) Rescue NameError when checking JRuby OpenSSL

### DIFF
--- a/lib/puppet/util/platform.rb
+++ b/lib/puppet/util/platform.rb
@@ -41,7 +41,7 @@ module Puppet
                            begin
                              require 'openssl'
                              false
-                           rescue LoadError
+                           rescue LoadError, NameError
                              true
                            end
                          else


### PR DESCRIPTION
In unit/integration testing and at the repl (in instances when JRuby is
interpreting the Ruby code and dynamically loading its Java
dependencies) attempting to load 'openssl' in a FIPS environment raises
a Ruby LoadError.

In a packaged environment where all of our java dependencies and JRuby
itself have been compiled, requiring openssl causes a NameError when
JRuby's OpenSSL implementation actually attempts to reference the
non-existant BouncyCastle classes.

Rescue both LoadError and NameError to provide the same behavior
regardless of runtime environment.