### PR TITLE
(PUP-10033) HTTP Client

### DIFF
--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -3,6 +3,7 @@ module Puppet::HTTP
   require 'puppet/ssl'
   require 'puppet/x509'
 
+  require 'puppet/http/errors'
   require 'puppet/http/response'
   require 'puppet/http/client'
 end

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -6,4 +6,5 @@ module Puppet::HTTP
   require 'puppet/http/errors'
   require 'puppet/http/response'
   require 'puppet/http/client'
+  require 'puppet/http/redirector'
 end

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -1,0 +1,7 @@
+module Puppet::HTTP
+  require 'puppet/network/http'
+  require 'puppet/ssl'
+  require 'puppet/x509'
+
+  require 'puppet/http/client'
+end

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -7,4 +7,5 @@ module Puppet::HTTP
   require 'puppet/http/response'
   require 'puppet/http/client'
   require 'puppet/http/redirector'
+  require 'puppet/http/retry_after_handler'
 end

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -3,5 +3,6 @@ module Puppet::HTTP
   require 'puppet/ssl'
   require 'puppet/x509'
 
+  require 'puppet/http/response'
   require 'puppet/http/client'
 end

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -16,7 +16,27 @@ class Puppet::HTTP::Client
     end
   end
 
+  def get(url, headers: {}, params: {})
+    connect(url) do |http|
+      query = encode_params(params)
+      path = "#{url.path}?#{query}"
+
+      request = Net::HTTP::Get.new(path, @default_headers.merge(headers))
+      resp = http.request(request)
+      Puppet.info("HTTP GET #{url} returned #{resp.code} #{resp.message}")
+      resp
+    end
+  end
+
   def close
     @pool.close
+  end
+
+  private
+
+  def encode_params(params)
+    params.map do |key, value|
+      "#{key}=#{Puppet::Util.uri_query_encode(value.to_s)}"
+    end.join('&')
   end
 end

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -28,6 +28,21 @@ class Puppet::HTTP::Client
     end
   end
 
+  def put(url, headers: {}, params: {}, content_type:, body:)
+    connect(url) do |http|
+      query = encode_params(params)
+      path = "#{url.path}?#{query}"
+
+      request = Net::HTTP::Put.new(path, @default_headers.merge(headers))
+      request.body = body
+      request['Content-Length'] = body.bytesize
+      request['Content-Type'] = content_type
+      resp = http.request(request)
+      Puppet.info("HTTP PUT #{url} returned #{resp.code} #{resp.message}")
+      resp
+    end
+  end
+
   def close
     @pool.close
   end

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -1,0 +1,22 @@
+class Puppet::HTTP::Client
+  def initialize(pool: Puppet::Network::HTTP::Pool.new, ssl_context:)
+    @pool = pool
+    @default_headers = {
+      'X-Puppet-Version' => Puppet.version,
+      'User-Agent' => Puppet[:http_user_agent],
+    }.freeze
+    @ssl_context = ssl_context
+  end
+
+  def connect(uri, &block)
+    site = Puppet::Network::HTTP::Site.from_uri(uri)
+    verifier = Puppet::SSL::Verifier.new(uri.host, @ssl_context)
+    @pool.with_connection(site, verifier) do |http|
+      yield http if block_given?
+    end
+  end
+
+  def close
+    @pool.close
+  end
+end

--- a/lib/puppet/http/errors.rb
+++ b/lib/puppet/http/errors.rb
@@ -2,4 +2,12 @@ module Puppet::HTTP
   class HTTPError < Puppet::Error; end
 
   class ConnectionError < HTTPError; end
+
+  class ProtocolError < HTTPError; end
+
+  class TooManyRedirects < HTTPError
+    def initialize(addr)
+      super(_("Too many HTTP redirections for %{addr}") % { addr: addr})
+    end
+  end
 end

--- a/lib/puppet/http/errors.rb
+++ b/lib/puppet/http/errors.rb
@@ -10,4 +10,12 @@ module Puppet::HTTP
       super(_("Too many HTTP redirections for %{addr}") % { addr: addr})
     end
   end
+
+  class TooManyRetryAfters < HTTPError
+    def initialize(addr)
+      super(_("Too many HTTP retries for %{addr}") % { addr: addr})
+    end
+  end
+
+
 end

--- a/lib/puppet/http/errors.rb
+++ b/lib/puppet/http/errors.rb
@@ -1,0 +1,5 @@
+module Puppet::HTTP
+  class HTTPError < Puppet::Error; end
+
+  class ConnectionError < HTTPError; end
+end

--- a/lib/puppet/http/redirector.rb
+++ b/lib/puppet/http/redirector.rb
@@ -1,0 +1,48 @@
+class Puppet::HTTP::Redirector
+  def initialize(redirect_limit)
+    @redirect_limit = redirect_limit
+  end
+
+  def redirect?(request, response)
+    # Net::HTTPRedirection is not used because historically puppet
+    # has only handled these, and we're not a browser
+    case response.code
+    when 301, 302, 307
+      true
+    else
+      false
+    end
+  end
+
+  def redirect_to(request, response, redirects)
+    raise Puppet::HTTP::TooManyRedirects.new(request.uri) if redirects >= @redirect_limit
+
+    location = parse_location(response)
+    if location.relative?
+      url = request.uri.dup
+      url.path = location.path
+    else
+      url = location.dup
+    end
+    url.query = request.uri.query
+
+    new_request = request.class.new(url)
+    new_request.body = request.body
+    request.each do |header, value|
+      new_request[header] = value
+    end
+
+    new_request
+  end
+
+  private
+
+  def parse_location(response)
+    location = response['location']
+    raise Puppet::HTTP::ProtocolError.new(_("Location response header is missing")) unless location
+
+    URI.parse(location)
+  rescue URI::InvalidURIError => e
+    raise Puppet::HTTP::ProtocolError.new(_("Location URI is invalid: %{detail}") % { detail: e.message}, e)
+  end
+end

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -1,0 +1,25 @@
+class Puppet::HTTP::Response
+  def initialize(nethttp)
+    @nethttp = nethttp
+  end
+
+  def code
+    @nethttp.code.to_i
+  end
+
+  def reason
+    @nethttp.message
+  end
+
+  def body
+    @nethttp.body
+  end
+
+  def read_body(&block)
+    @nethttp.read_body(&block)
+  end
+
+  def success?
+    @nethttp.is_a?(Net::HTTPSuccess)
+  end
+end

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -22,4 +22,13 @@ class Puppet::HTTP::Response
   def success?
     @nethttp.is_a?(Net::HTTPSuccess)
   end
+
+  def [](name)
+    @nethttp[name]
+  end
+
+  def drain
+    body
+    true
+  end
 end

--- a/lib/puppet/http/retry_after_handler.rb
+++ b/lib/puppet/http/retry_after_handler.rb
@@ -1,0 +1,47 @@
+require 'date'
+require 'time'
+
+class Puppet::HTTP::RetryAfterHandler
+  def initialize(retry_limit, max_sleep)
+    @retry_limit = retry_limit
+    @max_sleep = max_sleep
+  end
+
+  def retry_after?(request, response)
+    case response.code
+    when 429, 503
+      true
+    else
+      false
+    end
+  end
+
+  def retry_after_interval(request, response, retries)
+    raise Puppet::HTTP::TooManyRetryAfters.new(request.uri) if retries >= @retry_limit
+
+    retry_after = response['Retry-After']
+    return nil unless retry_after
+
+    seconds = parse_retry_after(retry_after)
+
+    # if retry-after is far in the future, we could end up sleeping repeatedly
+    # for 30 minutes, effectively waiting indefinitely, seems like we should wait
+    # in total for 30 minutes, in which case this upper limit needs to be enforced
+    # by the client.
+    [seconds, @max_sleep].min
+  end
+
+  private
+
+  def parse_retry_after(retry_after)
+    Integer(retry_after)
+  rescue TypeError, ArgumentError
+    begin
+      tm = DateTime.rfc2822(retry_after)
+      seconds = (tm.to_time - DateTime.now.to_time).to_i
+      [seconds, 0].max
+    rescue ArgumentError
+      raise Puppet::HTTP::ProtocolError.new(_("Failed to parse Retry-After header '%{retry_after}' as an integer or RFC 2822 date") % { retry_after: retry_after })
+    end
+  end
+end

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -89,6 +89,8 @@ class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
   #
   # @api private
   def setsockopts(netio)
+    return unless netio
+
     socket = netio.io
     socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
   end

--- a/lib/puppet/network/http/site.rb
+++ b/lib/puppet/network/http/site.rb
@@ -8,6 +8,10 @@
 class Puppet::Network::HTTP::Site
   attr_reader :scheme, :host, :port
 
+  def self.from_uri(uri)
+    self.new(uri.scheme, uri.host, uri.port)
+  end
+
   def initialize(scheme, host, port)
     @scheme = scheme
     @host = host

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -749,6 +749,7 @@ describe Puppet::Configurer do
       end
 
       it "should not make a node request" do
+        expects_new_catalog_only(@catalog)
         expect(Puppet::Node.indirection).not_to receive(:find)
 
         @agent.run

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -5,12 +5,7 @@ require 'puppet/http'
 describe Puppet::HTTP::Client do
   let(:ssl_context) { Puppet::SSL::SSLContext.new }
   let(:client) { described_class.new(ssl_context: ssl_context) }
-
-  before :each do
-    WebMock.disable_net_connect!
-    allow_any_instance_of(Net::HTTP).to receive(:start)
-    allow_any_instance_of(Net::HTTP).to receive(:finish)
-  end
+  let(:uri) { URI.parse('https://www.example.com') }
 
   context "when connecting" do
     it 'connects to HTTP URLs' do
@@ -24,8 +19,6 @@ describe Puppet::HTTP::Client do
     end
 
     it 'connects to HTTPS URLs' do
-      uri = URI.parse('https://www.example.com')
-
       client.connect(uri) do |http|
         expect(http.address).to eq('www.example.com')
         expect(http.port).to eq(443)
@@ -41,6 +34,34 @@ describe Puppet::HTTP::Client do
 
       client = described_class.new(pool: pool, ssl_context: ssl_context)
       client.close
+    end
+  end
+
+  context "for GET requests" do
+    it "includes default HTTP headers" do
+      stub_request(:get, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./})
+
+      client.get(uri)
+    end
+
+    it "stringifies keys and encodes values in the query" do
+      stub_request(:get, uri).with(query: "foo=bar%3Dbaz")
+
+      client.get(uri, params: {:foo => "bar=baz"})
+    end
+
+    it "includes custom headers" do
+      stub_request(:get, uri).with(headers: { 'X-Foo' => 'Bar' })
+
+      client.get(uri, headers: {'X-Foo' => 'Bar'})
+    end
+
+    it "returns the response" do
+      stub_request(:get, uri)
+
+      response = client.get(uri)
+      expect(response).to be_an_instance_of(Net::HTTPOK)
+      expect(response.code).to eq("200")
     end
   end
 end

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -3,9 +3,8 @@ require 'webmock/rspec'
 require 'puppet/http'
 
 describe Puppet::HTTP::Client do
-  let(:ssl_context) { Puppet::SSL::SSLContext.new }
-  let(:client) { described_class.new(ssl_context: ssl_context) }
   let(:uri) { URI.parse('https://www.example.com') }
+  let(:client) { described_class.new }
 
   context "when connecting" do
     it 'connects to HTTP URLs' do
@@ -66,7 +65,7 @@ describe Puppet::HTTP::Client do
       pool = double('pool')
       expect(pool).to receive(:close)
 
-      client = described_class.new(pool: pool, ssl_context: ssl_context)
+      client = described_class.new(pool: pool)
       client.close
     end
   end

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -60,8 +60,28 @@ describe Puppet::HTTP::Client do
       stub_request(:get, uri)
 
       response = client.get(uri)
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
+      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_success
+      expect(response.code).to eq(200)
+    end
+
+    it "returns the entire response body" do
+      stub_request(:get, uri).to_return(body: "abc")
+
+      expect(client.get(uri).body).to eq("abc")
+    end
+
+    it "streams the response body when a block is given" do
+      stub_request(:get, uri).to_return(body: "abc")
+
+      io = StringIO.new
+      client.get(uri) do |response|
+        response.read_body do |data|
+          io.write(data)
+        end
+      end
+
+      expect(io.string).to eq("abc")
     end
   end
 
@@ -88,8 +108,9 @@ describe Puppet::HTTP::Client do
       stub_request(:put, uri)
 
       response = client.put(uri, content_type: 'text/plain', body: "")
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
+      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_success
+      expect(response.code).to eq(200)
     end
 
     it "sets content-length and content-type for the body" do

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'puppet/http'
+
+describe Puppet::HTTP::Client do
+  let(:ssl_context) { Puppet::SSL::SSLContext.new }
+  let(:client) { described_class.new(ssl_context: ssl_context) }
+
+  before :each do
+    WebMock.disable_net_connect!
+    allow_any_instance_of(Net::HTTP).to receive(:start)
+    allow_any_instance_of(Net::HTTP).to receive(:finish)
+  end
+
+  context "when connecting" do
+    it 'connects to HTTP URLs' do
+      uri = URI.parse('http://www.example.com')
+
+      client.connect(uri) do |http|
+        expect(http.address).to eq('www.example.com')
+        expect(http.port).to eq(80)
+        expect(http).to_not be_use_ssl
+      end
+    end
+
+    it 'connects to HTTPS URLs' do
+      uri = URI.parse('https://www.example.com')
+
+      client.connect(uri) do |http|
+        expect(http.address).to eq('www.example.com')
+        expect(http.port).to eq(443)
+        expect(http).to be_use_ssl
+      end
+    end
+  end
+
+  context "when closing" do
+    it "closes all connections in the pool" do
+      pool = double('pool')
+      expect(pool).to receive(:close)
+
+      client = described_class.new(pool: pool, ssl_context: ssl_context)
+      client.close
+    end
+  end
+end

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -64,4 +64,38 @@ describe Puppet::HTTP::Client do
       expect(response.code).to eq("200")
     end
   end
+
+  context "for PUT requests" do
+    it "includes default HTTP headers" do
+      stub_request(:put, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./})
+
+      client.put(uri, content_type: 'text/plain', body: "")
+    end
+
+    it "stringifies keys and encodes values in the query" do
+      stub_request(:put, "https://www.example.com").with(query: "foo=bar%3Dbaz")
+
+      client.put(uri, params: {:foo => "bar=baz"}, content_type: 'text/plain', body: "")
+    end
+
+    it "includes custom headers" do
+      stub_request(:put, "https://www.example.com").with(headers: { 'X-Foo' => 'Bar' })
+
+      client.put(uri, headers: {'X-Foo' => 'Bar'}, content_type: 'text/plain', body: "")
+    end
+
+    it "returns the response" do
+      stub_request(:put, uri)
+
+      response = client.put(uri, content_type: 'text/plain', body: "")
+      expect(response).to be_an_instance_of(Net::HTTPOK)
+      expect(response.code).to eq("200")
+    end
+
+    it "sets content-length and content-type for the body" do
+      stub_request(:put, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
+
+      client.put(uri, content_type: 'text/plain', body: "hello")
+    end
+  end
 end

--- a/spec/unit/network/http/site_spec.rb
+++ b/spec/unit/network/http/site_spec.rb
@@ -86,4 +86,11 @@ describe Puppet::Network::HTTP::Site do
     expect(new_site.host).to eq('host2')
     expect(new_site.port).to eq(443)
   end
+
+  it 'creates a site from a URI' do
+    site = create_site('https', 'rubygems.org', 443)
+    uri = URI.parse('https://rubygems.org/gems/puppet/')
+
+    expect(described_class.from_uri(uri)).to eq(site)
+  end
 end


### PR DESCRIPTION
Implements an HTTP client:

- [x] GET & PUT
- [x] Return Puppet responses
- [x] Raise Puppet exceptions
- [x] Connect & read timeouts
- [x] Proxy settings & environment variables
- [x] User-Agent
- [x] X-Puppet-Version
- [x] Follow Redirects
- [x] Retry After
- [x] Compression
- [x] Default SSLContext
- [x] Allow SSLContext to be specified
- [x] HTTP Basic Auth
- [x] Proxy Auth
- [x] Persistent connections