### PR TITLE
(PUP-10013) Update minitar to 0.9

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -45,7 +45,7 @@ gem_platform_dependencies:
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'
-      minitar: '~> 0.6.1'
+      minitar: '~> 0.9'
   x64-mingw32:
     gem_runtime_dependencies:
       # ffi is pinned due to PUP-8438
@@ -56,7 +56,7 @@ gem_platform_dependencies:
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'
-      minitar: '~> 0.6.1'
+      minitar: '~> 0.9'
 bundle_platforms:
   universal-darwin: all
   x86-mingw32: mingw

--- a/lib/puppet/module_tool/tar/mini.rb
+++ b/lib/puppet/module_tool/tar/mini.rb
@@ -1,7 +1,7 @@
 class Puppet::ModuleTool::Tar::Mini
   def unpack(sourcefile, destdir, _)
     Zlib::GzipReader.open(sourcefile) do |reader|
-      Archive::Tar::Minitar.unpack(reader, destdir, find_valid_files(reader)) do |action, name, stats|
+      Archive::Tar::Minitar.unpack(reader, destdir, find_valid_files(reader), :fsync => false) do |action, name, stats|
         case action
         when :dir
           validate_entry(destdir, name)

--- a/spec/unit/module_tool/tar/mini_spec.rb
+++ b/spec/unit/module_tool/tar/mini_spec.rb
@@ -82,7 +82,7 @@ describe Puppet::ModuleTool::Tar::Mini, :if => (Puppet.features.minitar? and Pup
     expect(Zlib::GzipReader).to receive(:open).with(sourcefile).and_yield(reader)
     expect(minitar).to receive(:find_valid_files).with(reader).and_return([name])
     entry = MockFileStatEntry.new(mode)
-    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, [name]).
+    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, [name], :fsync => false).
         and_yield(type, name, {:entry => entry})
     entry
   end


### PR DESCRIPTION
We added an options hash to minitar so that we could turn off fsync and avoid redundancy when unpacking tars. This is adding the option.