### PR TITLE
(PUP-9978) Support for DNF modules

### DIFF
--- a/acceptance/tests/provider/package/dnfmodule_ensure_versionable.rb
+++ b/acceptance/tests/provider/package/dnfmodule_ensure_versionable.rb
@@ -1,0 +1,32 @@
+test_name "dnfmodule is versionable" do
+  confine :to, :platform => /el-8-x86_64/  # only el/centos 8 have the appstream repo
+  tag 'audit:low'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::PackageUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+
+  package = "postgresql"
+
+  agents.each do |agent|
+    skip_test('appstream repo not present') unless on(agent, 'dnf repolist').stdout.include?('appstream')
+    teardown do
+      apply_manifest_on(agent, resource_manifest('package', package, ensure: 'absent', provider: 'dnfmodule'))
+    end
+  end
+
+  step "Ensure we get the newer version by default" do
+    apply_manifest_on(agent, resource_manifest('package', package, ensure: 'present', provider: 'dnfmodule'))
+    on(agent, 'postgres --version') do |version|
+      assert_match('postgres (PostgreSQL) 10', version.stdout, 'package version not correct')
+    end
+  end
+
+  step "Ensure we get a specific version if we want it" do
+    apply_manifest_on(agent, resource_manifest('package', package, ensure: '9.6', provider: 'dnfmodule'))
+    on(agent, 'postgres --version') do |version|
+      assert_match('postgres (PostgreSQL) 9.6', version.stdout, 'package version not correct')
+    end
+  end
+end

--- a/lib/puppet/provider/package/dnfmodule.rb
+++ b/lib/puppet/provider/package/dnfmodule.rb
@@ -1,0 +1,87 @@
+# dnfmodule - A puppet package provider for DNF modules
+#
+# Installing a module:
+#  package { 'postgresql':
+#   provider => 'dnfmodule',
+#   ensure   => '9.6',  # install a specific stream
+#   flavor   => 'client',  # install a specific profile
+# }
+
+
+require 'puppet/provider/package'
+
+Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
+
+  has_feature :installable, :uninstallable, :versionable
+  #has_feature :upgradeable
+  # it's not (yet) feasible to make this upgradeable since module streams don't
+  # always have matching version types (i.e. idm has streams DL1 and client,
+  # other modules have semver streams, others have string streams... we cannot
+  # programatically determine a latest version for ensure => 'latest'
+
+  commands :dnf => '/usr/bin/dnf'
+
+  def self.current_version
+    @current_version ||= dnf('--version').split.first
+  end
+
+  def self.prefetch(packages)
+    if Puppet::Util::Package.versioncmp(current_version, '3.0.1') < 0
+      raise Puppet::Error, _("Modules are not supported on DNF versions lower than 3.0.1")
+    end
+    super
+  end
+
+  def self.instances
+    packages = []
+    cmd = "#{command(:dnf)} module list --installed -d 0 -e #{error_level}"
+    execute(cmd).each_line do |line|
+      next unless line =~ /\[i\][, ]/  # get rid of non-package lines (including last Hint line)
+      line.gsub!(/\[[de]\]/, '')  # we don't care about default/enabled flags
+      packages << new(
+        name: line.split[0],
+        ensure: line.split[1],
+        flavor: line.split('[i]').first.split.last,  # this is nasty
+        provider: name
+      )
+    end
+    packages
+  end
+
+  def query
+    pkg = self.class.instances.find do |package|
+            @resource[:name] == package.name
+          end
+    pkg ? pkg.properties : nil
+  end
+
+  def reset
+    execute([command(:dnf), 'module', 'reset', '-d', '0', '-e', self.class.error_level, '-y', @resource[:name]])
+  end
+
+  # to install specific streams and profiles:
+  # $ dnf module install module-name:stream/profile
+  # $ dnf module install perl:5.24/minimal
+  # if unspecified, they will be defaulted (see [d] param in dnf module list output)
+  def install
+    args = @resource[:name]
+    # ensure we start fresh (remove existing stream)
+    uninstall unless [:absent, :purged].include?(@property_hash[:ensure])
+    case @resource[:ensure]
+    when true, false, Symbol
+      # pass
+    else
+      args << ":#{@resource[:ensure]}"
+    end
+    if @resource[:flavor]
+      args << "/#{@resource[:flavor]}"
+    end
+    execute([command(:dnf), 'module', 'install', '-d', '0', '-e', self.class.error_level, '-y', args])
+  end
+
+  def uninstall
+    execute([command(:dnf), 'module', 'remove', '-d', '0', '-e', self.class.error_level, '-y', @resource[:name]])
+    reset  # reset module to the default stream
+  end
+end
+

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -481,8 +481,8 @@ module Puppet
     end
 
     newparam(:flavor) do
-      desc "OpenBSD supports 'flavors', which are further specifications for
-        which type of package you want."
+      desc "OpenBSD and DNF modules support 'flavors', which are
+        further specifications for which type of package you want."
     end
 
     newparam(:install_only, :boolean => false, :parent => Puppet::Parameter::Boolean, :required_features => :install_only) do

--- a/spec/fixtures/unit/provider/package/dnfmodule/dnf-module-list-installed.txt
+++ b/spec/fixtures/unit/provider/package/dnfmodule/dnf-module-list-installed.txt
@@ -1,0 +1,11 @@
+localmirror-appstream
+Name         Stream       Profiles                                  Summary                                                            
+gimp         2.8 [d][e]   common [d], devel [i]                     gimp module                                                        
+mariadb      10.3 [d][e]  client [i], server [d], galera            MariaDB Module                                                     
+nodejs       10 [d][e]    common [d], development, minimal [i], s2i Javascript runtime                                                 
+perl         5.26 [d][e]  common [d], minimal [i]                   Practical Extraction and Report Language                           
+postgresql   10 [d][e]    client, server [d] [i]                    PostgreSQL server and client module                                
+rust-toolset rhel8 [d][e] common [d] [i]                            Rust                                                               
+subversion   1.10 [d][e]  common [d], server [i]                    Apache Subversion                                                  
+
+Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled

--- a/spec/unit/provider/package/dnfmodule_spec.rb
+++ b/spec/unit/provider/package/dnfmodule_spec.rb
@@ -1,0 +1,186 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:package).provider(:dnfmodule) do
+  include PuppetSpec::Fixtures
+
+  let(:dnf_version) do
+    <<-DNF_OUTPUT
+    4.0.9
+      Installed: dnf-0:4.0.9.2-5.el8.noarch at Wed 29 May 2019 07:05:05 AM GMT
+      Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Thu 14 Feb 2019 12:04:07 PM GMT
+
+      Installed: rpm-0:4.14.2-9.el8.x86_64 at Wed 29 May 2019 07:04:33 AM GMT
+      Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Thu 20 Dec 2018 01:30:03 PM GMT
+    DNF_OUTPUT
+  end
+
+  let(:execute_options) do
+    {:failonfail => true, :combine => true, :custom_environment => {}}
+  end
+
+  let(:packages) { File.read(my_fixture("dnf-module-list-installed.txt")) }
+  let(:dnf_path) { '/usr/bin/dnf' }
+
+  before(:each) { allow(Puppet::Util).to receive(:which).with('/usr/bin/dnf').and_return(dnf_path) }
+
+  it "should have lower specificity" do
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('8')
+    expect(described_class.specificity).to be < 200
+  end
+
+  describe "should be an opt-in provider" do
+    Array(4..8).each do |ver|
+      it "should not be default for redhat #{ver}" do
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return('redhat')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver.to_s)
+        expect(described_class).not_to be_default
+      end
+    end
+  end
+
+  describe "handling dnf versions" do
+    before(:each) do
+      expect(Puppet::Type::Package::ProviderDnfmodule).to receive(:execute)
+          .with(["/usr/bin/dnf", "--version"])
+          .and_return(dnf_version).at_most(:once)
+      expect(Puppet::Util::Execution).to receive(:execute)
+          .with(["/usr/bin/dnf", "--version"], execute_options)
+          .and_return(Puppet::Util::Execution::ProcessOutput.new(dnf_version, 0))
+    end
+
+    describe "with a supported dnf version" do
+      it "correctly parses the version" do
+        expect(described_class.current_version).to eq('4.0.9')
+      end
+    end
+
+    describe "with an unsupported dnf version" do
+      let(:dnf_version) do
+        <<-DNF_OUTPUT
+        2.7.5
+          Installed: dnf-0:2.7.5-12.fc28.noarch at Mon 13 Aug 2018 11:05:27 PM GMT
+          Built    : Fedora Project at Wed 18 Apr 2018 02:29:51 PM GMT
+
+          Installed: rpm-0:4.14.1-7.fc28.x86_64 at Mon 13 Aug 2018 11:05:25 PM GMT
+          Built    : Fedora Project at Mon 19 Feb 2018 09:29:01 AM GMT
+        DNF_OUTPUT
+      end
+
+      before(:each) { described_class.instance_variable_set("@current_version", nil) }
+
+      it "correctly parses the version" do
+        expect(described_class.current_version).to eq('2.7.5')
+      end
+
+      it "raises an error when attempting prefetch" do
+        expect { described_class.prefetch('anything') }.to raise_error(Puppet::Error, "Modules are not supported on DNF versions lower than 3.0.1")
+      end
+    end
+  end
+
+  describe "when installing a module" do
+    let(:name) { 'baz' }
+
+    let(:resource) do
+      Puppet::Type.type(:package).new(
+        :name => name,
+        :provider => 'dnfmodule',
+      )
+    end
+
+    let(:provider) do
+      provider = described_class.new
+      provider.resource = resource
+      provider
+    end
+
+    describe 'provider features' do
+      it { is_expected.to be_versionable }
+      it { is_expected.to be_installable }
+      it { is_expected.to be_uninstallable }
+    end
+
+    context "when installing a new module" do
+      before do
+        provider.instance_variable_get('@property_hash')[:ensure] = :absent
+      end
+
+      it "should not reset the module stream when package is absent" do
+        resource[:ensure] = :present
+        expect(provider).not_to receive(:uninstall)
+        expect(provider).to receive(:execute)
+        provider.install
+      end
+
+      it "should not reset the module stream when package is purged" do
+        provider.instance_variable_get('@property_hash')[:ensure] = :purged
+        resource[:ensure] = :present
+        expect(provider).not_to receive(:uninstall)
+        expect(provider).to receive(:execute)
+        provider.install
+      end
+
+      it "should install the default stream and flavor" do
+        resource[:ensure] = :present
+        expect(provider).to receive(:execute).with(array_including('baz'))
+        provider.install
+      end
+
+      it "should install a specific stream" do
+        resource[:ensure] = '9.6'
+        expect(provider).to receive(:execute).with(array_including('baz:9.6'))
+        provider.install
+      end
+
+      it "should install a specific flavor" do
+        resource[:ensure] = :present
+        resource[:flavor] = 'minimal'
+        expect(provider).to receive(:execute).with(array_including('baz/minimal'))
+        provider.install
+      end
+
+      it "should install a specific flavor and stream" do
+        resource[:ensure] = '9.6'
+        resource[:flavor] = 'minimal'
+        expect(provider).to receive(:execute).with(array_including('baz:9.6/minimal'))
+        provider.install
+      end
+    end
+
+    context "when ensuring a specific version on top of another stream" do
+      before do
+        provider.instance_variable_get('@property_hash')[:ensure] = '9.6'
+      end
+
+      it "should remove existing packages and reset the module stream before installing" do
+        resource[:ensure] = '10'
+        expect(provider).to receive(:execute).thrice.with(array_including(/remove|reset|install/))
+        provider.install
+      end
+    end
+  end
+
+  context "parsing the output of module list --installed" do
+    before { allow(described_class).to receive(:command).with(:dnf).and_return(dnf_path) }
+
+    it "returns an array of installed modules" do
+      allow(Puppet::Util::Execution).to receive(:execute)
+        .with("/usr/bin/dnf module list --installed -d 0 -e 1")
+        .and_return(packages)
+
+      installed_packages = described_class.instances.map { |package| package.properties }
+      expected_packages = [{name: "gimp", ensure: "2.8", flavor: "devel", :provider => :dnfmodule},
+                           {name: "mariadb", ensure: "10.3", flavor: "client", :provider => :dnfmodule},
+                           {name: "nodejs", ensure: "10", flavor: "minimal", :provider => :dnfmodule},
+                           {name: "perl", ensure: "5.26", flavor: "minimal", :provider => :dnfmodule},
+                           {name: "postgresql", ensure: "10", flavor: "server", :provider => :dnfmodule},
+                           {name: "rust-toolset", ensure: "rhel8", flavor: "common", :provider => :dnfmodule},
+                           {name: "subversion", ensure: "1.10", flavor: "server", :provider => :dnfmodule}]
+
+      expect(installed_packages).to eql(expected_packages)
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces support for managing DNF/YUM modules through the `module` subcommand. Modules are groups of packages that represent an application, a language runtime, or any logical group.

Modules can be available in multiple streams, usually representing a major version of the software they include. Profiles are package subsets representing a specific use case of the module (these are handled by the `flavor` parameter of the package type).

A sample module installation using all applicable flags would be:

```puppet
package { 'postgresql':
  ensure   => '9.6' # stream
  flavor   => 'client' # profile
  provider => 'dnfmodule'
}
```

Due to the significant difference between a package and a module, `dnfmodule` is an opt-in provider and should be explicitly specified in the manifest.

More information: https://docs.pagure.org/modularity/