### PR TITLE
(PUP-8986) Parse multiple lines of pip --version output

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -41,11 +41,20 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
   end
 
   def self.pip_version(command)
+    version = nil
     execpipe [command, '--version'] do |process|
       process.collect do |line|
-        return line.strip.match(/^pip (\d+\.\d+\.?\d*).*$/)[1]
+        md = line.strip.match(/^pip (\d+\.\d+\.?\d*).*$/)
+        if md
+          version = md[1]
+          break
+        end
       end
     end
+
+    raise Puppet::Error, _("Cannot resolve pip version") unless version
+
+    version
   end
 
   # Return an array of structured information about every installed package


### PR DESCRIPTION
Previously the `pip --version` command failed if the version string
wasn't the first line of output. This could occur when `pip --version`
generated a warning on stderr, since `execpipe` redirects stderr to
stdout.

Check if the regex matches before grabbing the first capture group.