### PR TITLE
(PUP-9647) Quote pip path when calling execpipe

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -42,7 +42,7 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   def self.pip_version(command)
     version = nil
-    execpipe [command, '--version'] do |process|
+    execpipe [quote(command), '--version'] do |process|
       process.collect do |line|
         md = line.strip.match(/^pip (\d+\.\d+\.?\d*).*$/)
         if md
@@ -219,4 +219,13 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
   def install_options
     join_options(@resource[:install_options])
   end
+
+  def self.quote(path)
+    if path.include?(" ")
+      "\"#{path}\""
+    else
+      path
+    end
+  end
+  private_class_method :quote
 end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -369,6 +369,15 @@ describe Puppet::Type.type(:package).provider(:pip) do
         described_class.pip_version('/fake/bin/pip')
       }.to raise_error(Puppet::Error, 'Cannot resolve pip version')
     end
+
+    it "quotes commands with spaces" do
+      pip = 'C:\Program Files\Python27\Scripts\pip.exe'
+      allow(described_class).to receive(:pip_cmd).and_return(pip)
+      p = double("process")
+      expect(p).to receive(:collect).and_yield("pip 18.1 from c:\program files\python27\lib\site-packages\pip (python 2.7)\r\n")
+      expect(described_class).to receive(:execpipe).with(["\"#{pip}\"", '--version']).and_yield(p)
+      expect(described_class.pip_version(pip)).to eq('18.1')
+    end
   end
 
   context 'calculated specificity' do


### PR DESCRIPTION
If the resolved pip path contains a space, then calls to `execute` will work,
but `execpipe` will not, because `execute` calls into `CreateProcess` which
handles a command with spaces, while `execpipe` calls `Kernel.open` which does
not.

If the path contains a space, wrap in quotes before calling `execpipe`. This
change is less risky then switching everything to `execute` due to the different
ways that they handle environment variables like `LC_ALL`.

Thanks to Sean Millichamp <sean@bruenor.org> for identifying why this
was failing on Windows.