### PR TITLE
(maint) Do not use Ruby stacktrace for "Puppet" stack

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -298,14 +298,11 @@ module Runtime3Support
   def call_function(name, args, o, scope, &block)
     file, line = extract_file_line(o)
     loader = Adapters::LoaderAdapter.loader_for_model_object(o, file)
-    # 'ruby -wc' thinks that _func is unused, because the only reference to it
-    # is inside of the Kernel.eval string below. By prefixing it with the
-    # underscore, we let Ruby know to not worry about whether it's unused or not.
-    _func = loader.load(:function, name) if loader
-    if _func
+    func = loader.load(:function, name) if loader
+    if func
       Puppet::Util::Profiler.profile(name, [:functions, name]) do
-        # Add stack frame when calling. See Puppet::Pops::PuppetStack
-        return Kernel.eval('_func.call(scope, *args, &block)'.freeze, Kernel.binding, file || '', line)
+        # Add stack frame when calling.
+        return Puppet::Pops::PuppetStack.stack(file || '', line, func, :call, [scope, *args], &block)
       end
     end
     # Call via 3x API if function exists there without having been autoloaded


### PR DESCRIPTION
Previously, we used `Kernel.eval` to add additional information to the
Ruby call stack. That information would show that the call had come from
a Puppet manifest. We did this to interleave Puppet "function calls"
with Ruby function calls. Then when creating error or warning messages
we would retrieve the entire Ruby call stack and strip out everything
from the call stack save for the Puppet manifest files.

This moves us to use a threadsafe variable to store Puppet stack
information bypassing the performance issues that come from interacting
with the Ruby call stack.