### PR TITLE
(maint) Improve Kernel.caller() usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -728,10 +728,6 @@ Metrics/BlockLength:
   Enabled: false
 
 # TODO PUP-8003
-Performance/Caller:
-  Enabled: false
-
-# TODO PUP-8003
 Performance/CompareWithBlock:
   Enabled: false
 

--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -624,8 +624,7 @@ module Puppet::Functions
       # Get location to use in case of error - this produces ruby filename and where call to 'type' occurred
       # but strips off the rest of the internal "where" as it is not meaningful to user.
       #
-      rb_location = caller[0]
-
+      rb_location = caller(1, 1).first
       begin
         result = parser.parse_string("type #{assignment_string}", nil)
       rescue StandardError => e

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -175,7 +175,7 @@ class Puppet::Util::Log
     # We only select the last 10 callers in the stack to avoid being spammy
     message = _("Received a Log attribute with invalid encoding:%{log_message}") %
         { log_message: Puppet::Util::CharacterEncoding.convert_to_utf_8(str.dump)}
-    message += '\n' + _("Backtrace:\n%{backtrace}") % { backtrace: caller[0..10].join("\n") }
+    message += '\n' + _("Backtrace:\n%{backtrace}") % { backtrace: caller(1, 10).join("\n") }
     message
   end
   private_class_method :coerce_string

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -194,9 +194,9 @@ module Logging
     # let's find the offending line;  we need to jump back up the stack a few steps to find the method that called
     #  the deprecated method
     if Puppet[:trace]
-      caller()[2..-1]
+      caller(3)
     else
-      [caller()[2]]
+      [caller(3, 1).first]
     end
   end
 


### PR DESCRIPTION
In Ruby 2, and JRuby 9k, `Kernel#caller` got a new optional argument that
controls how many frames to go back when constructing the call stack.

In most cases where we call `caller` we also throw away most of the
call stack. This has performance implications for every Ruby environment
and especially for JRuby.

Most of the time this doesn't matter because we are getting the call
stack for error reporting, however in at least one case this
information is used for non-fatal warnings.