### PR TITLE
(PUP-9295) Redact sensitive notify messages

### DIFF
--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -11,11 +11,12 @@ module Puppet
     newproperty(:message, :idempotent => false) do
       desc "The message to be sent to the log."
       def sync
+        message = @sensitive ? 'Sensitive [value redacted]' : self.should
         case @resource["withpath"]
         when :true
-          send(@resource[:loglevel], self.should)
+          send(@resource[:loglevel], message)
         else
-          Puppet.send(@resource[:loglevel], self.should)
+          Puppet.send(@resource[:loglevel], message)
         end
         return
       end

--- a/spec/integration/type/notify_spec.rb
+++ b/spec/integration/type/notify_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+describe Puppet::Type.type(:notify) do
+  include PuppetSpec::Compiler
+
+  it "logs the title at notice level" do
+    apply_compiled_manifest(<<-MANIFEST)
+      notify { 'hi': }
+    MANIFEST
+
+    expect(@logs).to include(an_object_having_attributes(level: :notice, message: 'hi'))
+  end
+
+  it "logs the message property" do
+    apply_compiled_manifest(<<-MANIFEST)
+      notify { 'title':
+        message => 'hello'
+      }
+    MANIFEST
+
+    expect(@logs).to include(an_object_having_attributes(level: :notice, message: "defined 'message' as 'hello'"))
+  end
+
+  it "redacts sensitive message properties" do
+    apply_compiled_manifest(<<-MANIFEST)
+      $message = Sensitive('secret')
+      notify { 'notify1':
+        message => $message
+      }
+    MANIFEST
+
+    expect(@logs).to include(an_object_having_attributes(level: :notice, message: 'changed [redacted] to [redacted]'))
+  end
+
+  it "redacts sensitive interpolated message properties" do
+    apply_compiled_manifest(<<-MANIFEST)
+      $message = Sensitive('secret')
+      notify { 'notify2':
+        message => "${message}"
+      }
+    MANIFEST
+
+    expect(@logs).to include(an_object_having_attributes(level: :notice, message: "defined 'message' as 'Sensitive [value redacted]'"))
+  end
+end


### PR DESCRIPTION
Previously, puppet redacted sensitive notify messages, but not if the sensitive
value was interpolated in another string. This commit redacts the message in
both cases, and adds tests.