### PR TITLE
(PUP-10013) Update minitar in Gemfile in 6.4 and newer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group(:features) do
   gem 'hocon', '~> 1.0', require: false
   # requires native libshadow headers/libs
   #gem 'ruby-shadow', '~> 2.5', require: false, platforms: [:ruby]
-  gem 'minitar', '~> 0.6', require: false
+  gem 'minitar', '~> 0.9', require: false
   gem 'msgpack', '~> 1.2', require: false
   gem 'rdoc', '~> 6.0', require: false, platforms: [:ruby]
   # requires native augeas headers/libs


### PR DESCRIPTION
We updated this in project_yaml.yaml but in 6.4 and newer branches we're also specifying this in `Gemfile` (thanks @glennsarti for pointing this out!)