### PR TITLE
(maint) Call expect with a block

### DIFF
--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -38,19 +38,27 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if there is no environment specified" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {}) }).to raise_error(bad_request_error)
+      expect {
+        handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {})
+      }.to raise_error(bad_request_error)
     end
 
     it "should fail if the environment is not alphanumeric" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {:environment => "env ness"}) }).to raise_error(bad_request_error)
+      expect {
+        handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", {:environment => "env ness"})
+      }.to raise_error(bad_request_error)
     end
 
     it "should fail if the indirection does not match the prefix" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/certificate/foo", params) }).to raise_error(bad_request_error)
+      expect {
+        handler.uri2indirection("GET", "#{master_url_prefix}/certificate/foo", params)
+      }.to raise_error(bad_request_error)
     end
 
     it "should fail if the indirection does not have the correct version" do
-      expect(lambda { handler.uri2indirection("GET", "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v3/certificate/foo", params) }).to raise_error(bad_request_error)
+      expect {
+        handler.uri2indirection("GET", "#{Puppet::Network::HTTP::CA_URL_PREFIX}/v3/certificate/foo", params)
+      }.to raise_error(bad_request_error)
     end
 
     it "should not pass a buck_path parameter through (See Bugs #13553, #13518, #13511)" do
@@ -74,7 +82,9 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if the indirection name is not alphanumeric" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/foo ness/bar", params) }).to raise_error(bad_request_error)
+      expect {
+        handler.uri2indirection("GET", "#{master_url_prefix}/foo ness/bar", params)
+      }.to raise_error(bad_request_error)
     end
 
     it "should use the remainder of the URI as the indirection key" do
@@ -86,7 +96,9 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if no indirection key is specified" do
-      expect(lambda { handler.uri2indirection("GET", "#{master_url_prefix}/node", params) }).to raise_error(bad_request_error)
+      expect {
+        handler.uri2indirection("GET", "#{master_url_prefix}/node", params)
+      }.to raise_error(bad_request_error)
     end
 
     it "should choose 'find' as the indirection method if the http method is a GET and the indirection name is singular" do
@@ -126,7 +138,9 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "should fail if an indirection method cannot be picked" do
-      expect(lambda { handler.uri2indirection("UPDATE", "#{master_url_prefix}/node/bar", params) }).to raise_error(method_not_allowed_error)
+      expect {
+        handler.uri2indirection("UPDATE", "#{master_url_prefix}/node/bar", params)
+      }.to raise_error(method_not_allowed_error)
     end
 
     it "should not URI unescape the indirection key" do
@@ -146,9 +160,11 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(handler).to receive(:check_authorization) do |_, _, arg|
         expect(arg).not_to include(:environment)
       end
-      expect(lambda { handler.uri2indirection("GET",
-                                              "#{master_url_prefix}/node/bar",
-                                              {:environment => 'bogus'}) }).to raise_error(not_found_error)
+      expect {
+        handler.uri2indirection("GET",
+                                "#{master_url_prefix}/node/bar",
+                                {:environment => 'bogus'})
+      }.to raise_error(not_found_error)
     end
 
     it "should not URI unescape the indirection key as passed through to a call to check_authorization" do

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -34,11 +34,11 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
     it "should fail if the set values are not URLs" do
       expect(URI).to receive(:parse).with('foo').and_raise(RuntimeError)
 
-      expect(lambda { resource[:source] = %w{foo} }).to raise_error(Puppet::Error)
+      expect { resource[:source] = %w{foo} }.to raise_error(Puppet::Error)
     end
 
     it "should fail if the URI is not a local file, file URI, or puppet URI" do
-      expect(lambda { resource[:source] = %w{ftp://foo/bar} }).to raise_error(Puppet::Error, /Cannot use URLs of type 'ftp' as source for fileserving/)
+      expect { resource[:source] = %w{ftp://foo/bar} }.to raise_error(Puppet::Error, /Cannot use URLs of type 'ftp' as source for fileserving/)
     end
 
     it "should strip trailing forward slashes", :unless => Puppet.features.microsoft_windows? do
@@ -61,11 +61,11 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
     end
 
     it "should reject relative URI sources" do
-      expect(lambda { resource[:source] = 'foo/bar' }).to raise_error(Puppet::Error)
+      expect { resource[:source] = 'foo/bar' }.to raise_error(Puppet::Error)
     end
 
     it "should reject opaque sources" do
-      expect(lambda { resource[:source] = 'mailto:foo@com' }).to raise_error(Puppet::Error)
+      expect { resource[:source] = 'mailto:foo@com' }.to raise_error(Puppet::Error)
     end
 
     it "should accept URI authority component" do

--- a/spec/unit/type/schedule_spec.rb
+++ b/spec/unit/type/schedule_spec.rb
@@ -446,7 +446,9 @@ describe Puppet::Type.type(:schedule) do
 
     it "should fail if the periodmatch is 'number'" do
       @schedule[:periodmatch] = :number
-      expect(proc { @schedule[:repeat] = 2 }).to raise_error(Puppet::Error)
+      expect {
+        @schedule[:repeat] = 2
+      }.to raise_error(Puppet::Error)
     end
 
     it "should match if the previous run was further away than the distance divided by the repeat" do


### PR DESCRIPTION
Previously, some tests were passing a lambda or proc as the matcher to the
`expect` method. Since rspec-expecations 3.8.5 this is not allowed. Instead pass
it as an implicit block.