### PR TITLE
(PUP-10026) document skip_tags option for the puppet agent

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -160,6 +160,9 @@ the master, the certificate request the master received is the same as
 the one the client sent (to prevent against man-in-the-middle attacks
 when signing certificates).
 
+'--skip_tags' is a flag used to filter resources. If this is set, then
+only resources not tagged with the specified tags will be applied.
+Values must be comma-separated.
 
 OPTIONS
 -------


### PR DESCRIPTION
Documented --skip_tags option for the Puppet agent with wording from official documentation referenced in this ticket.