### PR TITLE
(PUP-9562) User resource should respect forcelocal for the comment parameter

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -55,6 +55,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
      get(:uid)
   end
 
+  def comment
+     return localcomment if @resource.forcelocal?
+     get(:comment)
+  end
+
   def finduser(key, value)
     passwd_file = "/etc/passwd"
     passwd_keys = ['account', 'password', 'uid', 'gid', 'gecos', 'directory', 'shell']
@@ -64,7 +69,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
          user = line.split(":")
          if user[index] == value
              f.close
-             return user
+             return Hash[passwd_keys.zip(user)]
          end
       end
     end
@@ -77,8 +82,13 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
 
   def localuid
     user = finduser('account', resource[:name])
-    return user[2] if user
+    return user['uid'] if user
     false
+  end
+
+  def localcomment
+    user = finduser('account', resource[:name])
+    user['gecos']
   end
 
   def shell=(value)

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -62,38 +62,37 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
 
   def finduser(key, value)
     passwd_file = "/etc/passwd"
-    passwd_keys = ['account', 'password', 'uid', 'gid', 'gecos', 'directory', 'shell']
+    passwd_keys = [:account, :password, :uid, :gid, :gecos, :directory, :shell]
     index = passwd_keys.index(key)
     File.open(passwd_file) do |f|
       f.each_line do |line|
-         user = line.split(":")
-         if user[index] == value
-             f.close
-             return Hash[passwd_keys.zip(user)]
-         end
+        user = line.split(":")
+        if user[index] == value
+          return Hash[passwd_keys.zip(user)]
+        end
       end
     end
     false
   end
 
   def local_username
-    finduser('uid', @resource.uid)
+    finduser(:uid, @resource.uid)
   end
 
   def localuid
-    user = finduser('account', resource[:name])
-    return user['uid'] if user
+    user = finduser(:account, resource[:name])
+    return user[:uid] if user
     false
   end
 
   def localcomment
-    user = finduser('account', resource[:name])
-    user['gecos']
+    user = finduser(:account, resource[:name])
+    user[:gecos]
   end
 
   def shell=(value)
     check_valid_shell
-    set("shell", value)
+    set(:shell, value)
   end
 
   verify :gid, "GID must be an integer" do |value|
@@ -116,7 +115,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     # to ensure consistent behaviour of the useradd provider when
     # using both useradd and luseradd
     if (!@resource.allowdupe?) && @resource.forcelocal?
-       if @resource.should(:uid) && finduser('uid', @resource.should(:uid).to_s)
+       if @resource.should(:uid) && finduser(:uid, @resource.should(:uid).to_s)
            raise(Puppet::Error, "UID #{@resource.should(:uid)} already exists, use allowdupe to force user creation")
        end
     elsif @resource.allowdupe? && (!@resource.forcelocal?)

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -317,6 +317,28 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
   end
 
+  describe "#comment" do
+    before do
+      described_class.has_feature :libuser
+    end
+
+    let(:passwd_line) { "myuser:x:1492:1000:local comment:/home/myuser:/bin/bash" }
+
+    it "should return the local comment string when forcelocal is true" do
+      resource[:forcelocal] = true
+      allow(provider).to receive(:finduser).with('account', 'myuser').and_return(passwd_line)
+      expect(provider).to receive(:localcomment).and_return('local comment')
+      provider.comment
+    end
+
+    it "should fall back to nameservice comment string when forcelocal is false" do
+      resource[:forcelocal] = false
+      allow(provider).to receive(:get).with(:comment).and_return('remote comment')
+      expect(provider).not_to receive(:localcomment)
+      provider.comment
+    end
+  end
+
   describe "#check_allow_dup" do
     it "should return an array with a flag if dup is allowed" do
       resource[:allowdupe] = :true


### PR DESCRIPTION
A user resource configured with `forcelocal` will still try to sync the comment with the external directory services. It does use `lusermod` to modify the local `/etc/passwd` to the comment specified in the user resource, but it compares the `in_sync` with the external directory
services, meaning that it always updates the comment on catalog compilation.

This commit queries the comment from the local `/etc/passwd` if the `forcelocal` parameter is set. It also modifies the `finduser` method to return a hash of parameter/value type, since returning numbered elements is more error-prone.