### PR TITLE
(PUP-10095) Better error handling for loading task metadata

### DIFF
--- a/lib/puppet/pops/loader/task_instantiator.rb
+++ b/lib/puppet/pops/loader/task_instantiator.rb
@@ -18,6 +18,10 @@ class TaskInstantiator
     task = { 'name' => name, 'metadata' => metadata, 'files' => files }
 
     begin
+      unless metadata['parameters'].is_a?(Hash) || metadata['parameters'].nil?
+        msg = _('Failed to load metadata for task %{name}: \'parameters\' must be a hash') % { name: name }
+        raise Puppet::ParseError.new(msg, metadata_file)
+      end
       task['parameters'] = convert_types(metadata['parameters'])
 
       Types::TypeFactory.task.from_hash(task)


### PR DESCRIPTION
This commit adds some error handling around loading task metadata where previously cryptic errors would be raised when the user specified metadata had the wrong shape.