### PR TITLE
(PUP-1537) add hold attribute

### DIFF
--- a/acceptance/tests/provider/package/dpkg_hold_true_package_is_latest.rb
+++ b/acceptance/tests/provider/package/dpkg_hold_true_package_is_latest.rb
@@ -1,0 +1,26 @@
+test_name "dpkg ensure held package is latest installed"
+confine :to, :platform => /debian-8-amd64/
+tag 'audit:low'
+
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::PackageUtils
+extend Puppet::Acceptance::ManifestUtils
+
+
+package = "nginx"
+
+agents.each do |agent|
+  teardown do
+    package_absent(agent, package, '--force-yes')
+  end
+end
+
+step"Ensure that package is installed first if not present" do
+  expected_package_version = on(agent.name, "apt-cache policy #{package} | sed -n -e 's/Candidate: //p'").stdout
+  package_manifest = resource_manifest('package', package, hold: "true")
+
+  apply_manifest_on(agent, package_manifest) do |result|
+    installed_package_version = on(agent.name, "apt-cache policy #{package} | sed -n -e 's/Installed: //p'").stdout
+    assert_match(expected_package_version, installed_package_version)
+  end
+end

--- a/acceptance/tests/provider/package/dpkg_hold_true_should_preserve_version.rb
+++ b/acceptance/tests/provider/package/dpkg_hold_true_should_preserve_version.rb
@@ -1,0 +1,21 @@
+test_name "dpkg ensure held package should preserve version if package is allready installed"
+confine :to, :platform => /debian-8-amd64/
+tag 'audit:low'
+
+require 'puppet/acceptance/common_utils'
+extend Puppet::Acceptance::PackageUtils
+extend Puppet::Acceptance::ManifestUtils
+
+package = "openssl"
+
+step "Ensure held should lock to specific installed version" do
+  existing_installed_version = on(agent.name, "dpkg -s #{package} | sed -n -e 's/Version: //p'").stdout
+  existing_installed_version.delete!(' ')
+
+  package_manifest_held = resource_manifest('package', package, hold: true)
+  apply_manifest_on(agent, package_manifest_held) do
+    installed_version = on(agent.name, "apt-cache policy #{package} | sed -n -e 's/Installed: //p'").stdout
+    installed_version.delete!(' ')
+    assert_match(existing_installed_version, installed_version)
+  end
+end

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   # Note: self:: is required here to keep these constants in the context of what will
   # eventually become this Puppet::Type::Package::ProviderDpkg class.
   self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package} ${Version}\\n'}
-  self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+) (\S*)$}
+  self::FIELDS_REGEX = %r{^'?(\S+) +(\S+) +(\S+) (\S+) (\S*)$}
   self::FIELDS= [:desired, :error, :status, :name, :ensure]
 
   # @param line [String] one line of dpkg-query output
@@ -67,7 +67,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
       elsif ['config-files', 'half-installed', 'unpacked', 'half-configured'].include?(hash[:status])
         hash[:ensure] = :absent
       end
-      hash[:ensure] = :held if hash[:desired] == 'hold'
+      hash[:hold] = true if hash[:desired] == 'hold'
     else
       Puppet.debug("Failed to match dpkg-query line #{line.inspect}")
     end
@@ -83,8 +83,6 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     end
     args = []
 
-    # We always unhold when installing to remove any prior hold.
-    self.unhold
 
     if @resource[:configfiles] == :keep
       args << '--force-confold'
@@ -93,7 +91,12 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     end
     args << '-i' << file
 
-    dpkg(*args)
+    self.unhold if self.properties[:hold]
+    begin
+      dpkg(*args)
+    ensure
+      self.hold if @resource[:hold] == :true
+    end
   end
 
   def update
@@ -137,17 +140,33 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   end
 
   def uninstall
-    dpkg "-r", @resource[:name]
+    self.unhold if self.properties[:hold]
+    begin
+      dpkg "-r", @resource[:name]
+    rescue StandardError, LoadError => e
+      self.hold if self.properties[:hold]
+      raise e
+    end
   end
 
   def purge
-    dpkg "--purge", @resource[:name]
+    self.unhold if self.properties[:hold]
+    begin
+      dpkg "--purge", @resource[:name]
+    rescue StandardError, LoadError => e
+      self.hold if self.properties[:hold]
+      raise e
+    end
   end
 
-  def hold
+  def deprecated_hold
     if package_not_installed?
       self.install
     end
+    hold
+  end
+
+  def hold
     Tempfile.open('puppet_dpkg_set_selection') do |tmpfile|
       tmpfile.write("#{@resource[:name]} hold\n")
       tmpfile.flush

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     ).merge(
       case flags[1..1]
       when 'f'
-        {:ensure => 'held'}
+        {:hold => true}
       when '-'
         {}
       else
@@ -105,6 +105,10 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     else
       raise ArgumentError, _('Unknown line format %{resource_name}: %{parse_line}') % { resource_name: self.name, parse_line: line }
     end).merge({:provider => self.name})
+  end
+
+  def deprecated_hold
+    hold
   end
 
   def hold
@@ -201,8 +205,6 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
   def install(nofail = false)
     name = @resource[:name]
     should = @resource[:ensure]
-    # always unhold if explicitly told to install/update
-    self.unhold
     is = self.query
     if is[:ensure].to_sym == :absent
       command = 'install'
@@ -216,7 +218,12 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
     unless should.is_a? Symbol
       name += "@#{should}"
     end
-    r = exec_cmd(command(:pkg), command, *args, name)
+    self.unhold if self.properties[:hold]
+    begin
+      r = exec_cmd(command(:pkg), command, *args, name)
+    ensure
+      self.hold if @resource[:hold] == :true
+    end
     return r if nofail
     raise Puppet::Error, _("Unable to update %{package}") % { package: r[:out] } if r[:exit] != 0
   end
@@ -230,7 +237,13 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       cmd << '-r'
     end
     cmd << @resource[:name]
-    pkg cmd
+    self.unhold if self.properties[:hold]
+    begin
+      pkg cmd
+    rescue StandardError, LoadError => e
+      self.hold if self.properties[:hold]
+      raise e
+    end
   end
 
   # update the package to the latest version available

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -32,12 +32,14 @@ describe Puppet::Type.type(:package).provider(:apt) do
 
   it "should use 'apt-get remove' to uninstall" do
     expect(provider).to receive(:aptget).with("-y", "-q", :remove, name)
+    expect(provider).to receive(:properties).and_return({:hold => false})
     provider.uninstall
   end
 
   it "should use 'apt-get purge' and 'dpkg purge' to purge" do
     expect(provider).to receive(:aptget).with("-y", "-q", :remove, "--purge", name)
     expect(provider).to receive(:dpkg).with("--purge", name)
+    expect(provider).to receive(:properties).and_return({:hold => false}).twice
     provider.purge
   end
 
@@ -88,12 +90,14 @@ Version table:
     it "should preseed if a responsefile is provided" do
       resource[:responsefile] = "/my/file"
       expect(provider).to receive(:run_preseed)
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       allow(provider).to receive(:aptget)
       provider.install
     end
 
     it "should check for a cdrom" do
+      expect(provider).to receive(:properties).and_return({:hold => false})
       expect(provider).to receive(:checkforcdrom)
 
       allow(provider).to receive(:aptget)
@@ -106,6 +110,7 @@ Version table:
         expect(command[-1]).to eq(name)
         expect(command[-2]).to eq(:install)
       end
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -115,6 +120,7 @@ Version table:
       expect(provider).to receive(:aptget) do |*command|
         expect(command[-1]).to eq("#{name}=1.0")
       end
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -124,6 +130,7 @@ Version table:
       expect(provider).to receive(:aptget) do |*command|
         expect(command).to include("--force-yes")
       end
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -132,6 +139,7 @@ Version table:
       expect(provider).to receive(:aptget) do |*command|
         expect(command).to include("-q")
       end
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -140,6 +148,7 @@ Version table:
       expect(provider).to receive(:aptget) do |*command|
         expect(command).to include("-y")
       end
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -149,6 +158,7 @@ Version table:
       expect(provider).to receive(:aptget) do |*command|
         expect(command).to include("DPkg::Options::=--force-confold")
       end
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -158,6 +168,7 @@ Version table:
       expect(provider).to receive(:aptget) do |*command|
         expect(command).to include("DPkg::Options::=--force-confnew")
       end
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -165,6 +176,7 @@ Version table:
     it 'should support string install options' do
       resource[:install_options] = ['--foo', '--bar']
       expect(provider).to receive(:aptget).with('-q', '-y', '-o', 'DPkg::Options::=--force-confold', '--foo', '--bar', :install, name)
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end
@@ -172,6 +184,7 @@ Version table:
     it 'should support hash install options' do
       resource[:install_options] = ['--foo', { '--bar' => 'baz', '--baz' => 'foo' }]
       expect(provider).to receive(:aptget).with('-q', '-y', '-o', 'DPkg::Options::=--force-confold', '--foo', '--bar=baz', '--baz=foo', :install, name)
+      expect(provider).to receive(:properties).and_return({:hold => false})
 
       provider.install
     end

--- a/spec/unit/provider/package/aptitude_spec.rb
+++ b/spec/unit/provider/package/aptitude_spec.rb
@@ -33,6 +33,7 @@ describe Puppet::Type.type(:package).provider(:aptitude) do
     expect(pkg.provider).to receive(:aptitude).
       with('-y', '-o', 'DPkg::Options::=--force-confold', :install, 'faff').
       and_return(0)
+    expect(pkg.provider).to receive(:properties).and_return({:hold => false})
 
     pkg.provider.install
   end

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -126,7 +126,10 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
 
     it "considers the package held if its state is 'hold'" do
       dpkg_query_execution_returns(bash_installed_output.gsub("install","hold"))
-      expect(provider.query[:ensure]).to eq(:held)
+      query=provider.query
+      expect(query[:ensure]).to eq("4.2-5ubuntu3")
+      expect(query[:hold]).to eq(true)
+
     end
 
     context "parsing tests" do
@@ -184,14 +187,15 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
 
     it "uses 'dpkg -i' to install the package" do
       expect(resource).to receive(:[]).with(:source).and_return("mypackagefile")
+      expect(provider).to receive(:properties).and_return({:hold => true})
       expect(provider).to receive(:unhold)
       expect(provider).to receive(:dpkg).with(any_args, "-i", "mypackagefile")
-
       provider.install
     end
 
     it "keeps old config files if told to do so" do
       expect(resource).to receive(:[]).with(:configfiles).and_return(:keep)
+      expect(provider).to receive(:properties).and_return({:hold => true})
       expect(provider).to receive(:unhold)
       expect(provider).to receive(:dpkg).with("--force-confold", any_args)
 
@@ -200,6 +204,7 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
 
     it "replaces old config files if told to do so" do
       expect(resource).to receive(:[]).with(:configfiles).and_return(:replace)
+      expect(provider).to receive(:properties).and_return({:hold => true})
       expect(provider).to receive(:unhold)
       expect(provider).to receive(:dpkg).with("--force-confnew", any_args)
 
@@ -207,6 +212,7 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
     end
 
     it "ensures any hold is removed" do
+      expect(provider).to receive(:properties).and_return({:hold => true})
       expect(provider).to receive(:unhold).once
       expect(provider).to receive(:dpkg)
       provider.install
@@ -222,18 +228,28 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
     end
 
     it "installs first if package is not present and ensure holding" do
-
       allow(provider).to receive(:execute)
       allow(provider).to receive(:package_not_installed?).and_return(true)
       expect(provider).to receive(:install).once
-      provider.hold
+      expect(provider).to receive(:hold)
+      provider.deprecated_hold
+    end
+
+
+    it "skips install new package if hold is true" do
+      allow(provider).to receive(:execute)
+      allow(provider).to receive(:package_not_installed?).and_return(true)
+      expect(provider).to receive(:install).once
+      expect(provider).to receive(:hold)
+      provider.deprecated_hold
     end
 
     it "skips install new package if package is allready installed" do
       allow(provider).to receive(:execute)
       allow(provider).to receive(:package_not_installed?).and_return(false)
       expect(provider).not_to receive(:install)
-      provider.hold
+      expect(provider).to receive(:hold)
+      provider.deprecated_hold
     end
 
     it "executes dpkg --set-selections when holding" do
@@ -279,11 +295,13 @@ describe Puppet::Type.type(:package).provider(:dpkg) do
 
   it "uses 'dpkg -r' to uninstall" do
     expect(provider).to receive(:dpkg).with("-r", resource_name)
+    expect(provider).to receive(:properties).and_return({:hold => false})
     provider.uninstall
   end
 
   it "uses 'dpkg --purge' to purge" do
     expect(provider).to receive(:dpkg).with("--purge", resource_name)
+    expect(provider).to receive(:properties).and_return({:hold => false})
     provider.purge
   end
 

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -90,7 +90,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
 
       {
         'pkg://omnios/SUNWcs@0.5.11,5.11-0.151006:20130506T161045Z    i--' => {:name => 'SUNWcs', :ensure => '0.5.11,5.11-0.151006:20130506T161045Z', :status => 'installed', :provider => :pkg, :publisher => 'omnios'},
-        'pkg://omnios/incorporation/jeos/illumos-gate@11,5.11-0.151006:20130506T183443Z if-' => {:name => 'incorporation/jeos/illumos-gate', :ensure => 'held', :status => 'installed', :provider => :pkg, :publisher => 'omnios'},
+        'pkg://omnios/incorporation/jeos/illumos-gate@11,5.11-0.151006:20130506T183443Z if-' => {:name => 'incorporation/jeos/illumos-gate', :ensure => "11,5.11-0.151006:20130506T183443Z", :hold => true, :status => 'installed', :provider => :pkg, :publisher => 'omnios'},
         'pkg://solaris/SUNWcs@0.5.11,5.11-0.151.0.1:20101105T001108Z      installed  -----' => {:name => 'SUNWcs', :ensure => '0.5.11,5.11-0.151.0.1:20101105T001108Z', :status => 'installed', :provider => :pkg, :publisher => 'solaris'},
        }.each do |k, v|
         it "[#{k}] should correctly parse" do
@@ -251,6 +251,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
 
           it "should accept all licenses" do
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => :absent})
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(Puppet::Util::Execution).to receive(:execute)
               .with(['/bin/pkg', 'install', *hash[:flags], 'dummy'], {:failonfail => false, :combine => true})
               .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
@@ -265,6 +266,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             # Should install also check if the version installed is the same version we are asked to install? or should we rely on puppet for that?
             resource[:ensure] = '0.0.7,5.11-0.151006:20131230T130000Z'
             allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
             expect(Puppet::Util::Execution).to receive(:execute)
               .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
@@ -277,6 +279,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
 
           it "should install specific version(2)" do
             resource[:ensure] = '0.0.8'
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
             expect(Puppet::Util::Execution).to receive(:execute)
               .with(['/bin/pkg', 'list', '-Hv', 'dummy'], {:failonfail => false, :combine => true})
@@ -290,6 +293,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
 
           it "should downgrade to specific version" do
             resource[:ensure] = '0.0.7'
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => '0.0.8,5.11-0.151106:20131230T130000Z'})
             allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
@@ -301,6 +305,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
 
           it "should install any if version is not specified" do
             resource[:ensure] = :present
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => :absent})
             expect(Puppet::Util::Execution).to receive(:execute)
               .with(['/bin/pkg', 'install', *hash[:flags], 'dummy'], {:failonfail => false, :combine => true})
@@ -312,6 +317,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
 
           it "should install if no version was previously installed, and a specific version was requested" do
             resource[:ensure] = '0.0.7'
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => :absent})
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'unfreeze', 'dummy'], {:failonfail => false, :combine => true})
             expect(Puppet::Util::Execution).to receive(:execute)
@@ -325,6 +331,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             resource[:ensure] = '1.0-0.151006'
             is = :absent
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => is})
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(described_class).to receive(:pkg)
               .with(:list, '-Hvfa', 'dummy@1.0-0.151006')
               .and_return(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('dummy_implicit_version')), 0))
@@ -340,6 +347,7 @@ describe Puppet::Type.type(:package).provider(:pkg) do
             resource[:ensure] = '1.0-0.151006'
             is = '1.0,5.11-0.151006:20140219T191204Z'
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => is})
+            expect(provider).to receive(:properties).and_return({:hold => true})
             expect(described_class).to receive(:pkg).with(:list, '-Hvfa', 'dummy@1.0-0.151006').and_return(File.read(my_fixture('dummy_implicit_version')))
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'update', '-n', 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
             expect(provider).to receive(:unhold).with(no_args)
@@ -398,12 +406,16 @@ describe Puppet::Type.type(:package).provider(:pkg) do
       it "should support current pkg version" do
         expect(described_class).to receive(:pkg).with(:version).and_return('630e1ffc7a19')
         expect(described_class).to receive(:pkg).with([:uninstall, resource[:name]])
+        expect(provider).to receive(:properties).and_return({:hold => false})
+
         provider.uninstall
       end
 
       it "should support original pkg commands" do
         expect(described_class).to receive(:pkg).with(:version).and_return('052adf36c3f4')
         expect(described_class).to receive(:pkg).with([:uninstall, '-r', resource[:name]])
+        expect(provider).to receive(:properties).and_return({:hold => false})
+
         provider.uninstall
       end
     end


### PR DESCRIPTION
This commit adds `hold` property for package providers on
Debian(dpkg/apt/fink/aptitude) and Solaris(pgk) as
alternative of using "held" value for `ensure`.

Using "held" value for `ensure` works as before, but it shows
deprecation warning and will be removed in further release.

Allowed values for `hold` are "yes"/"true"/"no"/"false",
default to "false". Hold can be specified with or without `ensure`,
if `ensure` is missing will default to "present".

Hold cannot be specified together with "purged", "absent" or "held"
values for `ensure`.