### PR TITLE
(PUP-10080) Stop Exec defaulting its cwd parameter

### DIFF
--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -52,7 +52,11 @@ class Puppet::Provider::Exec < Puppet::Provider
     # This is backwards compatible all the way to Ruby 1.8.7.
     Timeout::timeout(resource[:timeout], Timeout::Error) do
       cwd = resource[:cwd]
-      cwd ||= Dir.pwd
+      # It's ok if cwd is nil. In that case Puppet::Util::Execution.execute() simply will not attempt to
+      # change the working directory, which is exactly the right behavior when no cwd parameter is
+      # expressed on the resource.  Moreover, attempting to change to the directory that is already
+      # the working directory can fail under some circumstances, so avoiding the directory change attempt
+      # is preferable to defaulting cwd to that directory.
 
       # note that we are passing "false" for the "override_locale" parameter, which ensures that the user's
       # default/system locale will be respected.  Callers may override this behavior by setting locale-related


### PR DESCRIPTION
Without this patch, the base Exec provider defaults the cwd parameter to
Puppet's working directory.  As a result, in the event that no cwd is
explicitly specified, Puppet attempts to change to the directory that is
already its working directory when it runs the Exec's command.  In most
cases that's merely wasteful, but under some circumstances it causes the
Exec to fail needlessly.

With the defaulting removed, the provider's
Puppet::Util::Execution.execute() call just does the right thing.
That is, it avoids attempting a working-directory change in the event
that no value was specified for the cwd parameter.