### PR TITLE
(maint) More rubocop improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -253,9 +253,6 @@ Lint/HandleExceptions:
 Lint/InheritException:
   Enabled: false
 
-Lint/LiteralInInterpolation:
-  Enabled: false
-
 Lint/NestedMethodDefinition:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -213,14 +213,6 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Enabled: false
 
-# DISABLED since the instances do not seem to indicate any specific errors.
-Lint/AmbiguousOperator:
-  Enabled: false
-
-# DISABLED - the offender is just haskell envy
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
 # DISABLED since for all the checked, we are basically checking nil
 # TODO: Change the checking so that if the variable being assigned to has
 # a value ALREADY, then raise an error.
@@ -229,10 +221,6 @@ Lint/AssignmentInCondition:
 
 # DISABLED
 Lint/BlockAlignment:
-  Enabled: false
-
-# DISABLED
-Lint/DefEndAlignment:
   Enabled: false
 
 Lint/EmptyWhen:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,96 +17,19 @@ AllCops:
     - 'lib/puppet/external/nagios/parser.rb'
     - 'lib/puppet/module_tool/skeleton/**/*'
 
-# MAYBE useful - no return inside ensure block.
-Lint/EnsureReturn:
+Bundler/OrderedGems:
   Enabled: false
 
-# MAYBE useful - errors when rescue {} happens.
-Lint/HandleExceptions:
+GetText/DecorateFunctionMessage:
   Enabled: false
 
-# DISABLED really useless. Detects return as last statement.
-Style/RedundantReturn:
+GetText/DecorateString:
   Enabled: false
 
-# Disabled. Throws an error trying to run.
-Style/RedundantParentheses:
-  Enabled: false
-
-# DISABLED since the instances do not seem to indicate any specific errors.
-Lint/AmbiguousOperator:
-  Enabled: false
-
-# DISABLED since for all the checked, we are basically checking nil
-# TODO: Change the checking so that if the variable being assigned to has
-# a value ALREADY, then raise an error.
-Lint/AssignmentInCondition:
-  Enabled: false
-
-# DISABLED - not useful
-Layout/SpaceBeforeComment:
-  Enabled: false
-
-# DISABLED - not useful
-Style/HashSyntax:
-  Enabled: false
-
-# USES: as shortcut for non nil&valid checking a = x() and a.empty?
-# DISABLED - not useful
-Style/AndOr:
-  Enabled: false
-
-# DISABLED - not useful
-Style/RedundantSelf:
-  Enabled: false
-
-# DISABLED - not useful
-Metrics/MethodLength:
-  Enabled: false
-
-# DISABLED - not useful
-Style/WhileUntilModifier:
-  Enabled: false
-
-# DISABLED - the offender is just haskell envy
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
-# DISABLED
-Security/Eval:
-  Enabled: false
-# DISABLED
-Lint/BlockAlignment:
-  Enabled: false
-
-# DISABLED
-Lint/DefEndAlignment:
-  Enabled: false
-
-# DISABLED
-Lint/EndAlignment:
-  Enabled: false
-
-# DISABLED
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
-
-Lint/RescueException:
-  Enabled: false
-
-Lint/UnusedBlockArgument:
-  Enabled: false
-
-Lint/UnusedMethodArgument:
+GetText/DecorateStringFormattingUsingPercent:
   Enabled: false
 
 Layout/AccessModifierIndentation:
-  Enabled: false
-
-Style/AccessorMethodName:
-  Enabled: false
-
-Style/Alias:
   Enabled: false
 
 Layout/AlignArray:
@@ -118,63 +41,146 @@ Layout/AlignHash:
 Layout/AlignParameters:
   Enabled: false
 
-Metrics/BlockNesting:
-  Enabled: false
-
-Style/AsciiComments:
-  Enabled: false
-
-Style/Attr:
-  Enabled: false
-
-Style/BracesAroundHashParameters:
-  Enabled: false
-
-Style/CaseEquality:
-  Enabled: false
-
 Layout/CaseIndentation:
   Enabled: false
 
-Style/CharacterLiteral:
+Layout/ClosingParenthesisIndentation:
   Enabled: false
 
-Style/ClassAndModuleCamelCase:
+Layout/CommentIndentation:
   Enabled: false
 
-Style/ClassAndModuleChildren:
+Layout/DotPosition:
   Enabled: false
 
-Style/ClassCheck:
+Layout/ElseAlignment:
   Enabled: false
 
-Metrics/ClassLength:
+Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
-Style/ClassMethods:
+Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Style/ClassVars:
+Layout/EmptyLines:
   Enabled: false
 
-Style/WhenThen:
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
 
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentAssignment:
+  Enabled: false
+
+Layout/IndentHash:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/IndentationConsistency:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false
+
+Layout/InitialIndentation:
+  Enabled: false
+
+Layout/LeadingCommentSpace:
+  Enabled: false
+
+Layout/MultilineArrayBraceLayout:
+  Enabled: false
+
+Layout/MultilineBlockLayout:
+  Enabled: false
+
+Layout/MultilineHashBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/RescueEnsureAlignment:
+  Enabled: false
+
+Layout/SpaceAfterColon:
+  Enabled: false
+
+Layout/SpaceAfterComma:
+  Enabled: false
+
+Layout/SpaceAfterMethodName:
+  Enabled: false
+
+Layout/SpaceAfterNot:
+  Enabled: false
+
+Layout/SpaceAfterSemicolon:
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: false
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Layout/SpaceAroundKeyword:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Enabled: false
 
 # DISABLED - not useful
-Style/WordArray:
+Layout/SpaceBeforeComment:
   Enabled: false
 
-Style/UnneededPercentQ:
-  Enabled: false
-
-Layout/Tab:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
 
 Layout/SpaceBeforeSemicolon:
-  Enabled: false
-
-Layout/TrailingBlankLines:
   Enabled: false
 
 Layout/SpaceInsideBlockBraces:
@@ -189,68 +195,211 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/SpaceInsideParens:
   Enabled: false
 
-Layout/LeadingCommentSpace:
+Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 
-Layout/SpaceAfterColon:
+Layout/SpaceInsideRangeLiteral:
   Enabled: false
 
-Layout/SpaceAfterComma:
+Layout/SpaceInsideStringInterpolation:
   Enabled: false
 
-Layout/SpaceAroundKeyword:
+Layout/Tab:
   Enabled: false
 
-Layout/SpaceAfterMethodName:
+Layout/TrailingBlankLines:
   Enabled: false
 
-Layout/SpaceAfterNot:
+Layout/TrailingWhitespace:
   Enabled: false
 
-Layout/SpaceAfterSemicolon:
+# DISABLED since the instances do not seem to indicate any specific errors.
+Lint/AmbiguousOperator:
   Enabled: false
 
-Layout/SpaceAroundEqualsInParameterDefault:
+# DISABLED - the offender is just haskell envy
+Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-Layout/SpaceAroundOperators:
+# DISABLED since for all the checked, we are basically checking nil
+# TODO: Change the checking so that if the variable being assigned to has
+# a value ALREADY, then raise an error.
+Lint/AssignmentInCondition:
   Enabled: false
 
-Layout/SpaceBeforeBlockBraces:
+# DISABLED
+Lint/BlockAlignment:
   Enabled: false
 
-Layout/SpaceBeforeComma:
+# DISABLED
+Lint/DefEndAlignment:
   Enabled: false
 
-
-Style/CollectionMethods:
+Lint/EmptyWhen:
   Enabled: false
 
-Layout/CommentIndentation:
+# DISABLED
+Lint/EndAlignment:
   Enabled: false
 
-Style/ColonMethodCall:
+# MAYBE useful - no return inside ensure block.
+Lint/EnsureReturn:
   Enabled: false
 
-Style/CommentAnnotation:
+# MAYBE useful - errors when rescue {} happens.
+Lint/HandleExceptions:
+  Enabled: false
+
+Lint/InheritException:
+  Enabled: false
+
+Lint/LiteralInInterpolation:
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+# DISABLED
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RequireParentheses:
+  Enabled: false
+
+Lint/RescueException:
+  Enabled: false
+
+Lint/ScriptPermission:
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
   Enabled: false
 
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Style/ConstantName:
+Metrics/LineLength:
   Enabled: false
 
-Style/Documentation:
+# DISABLED - not useful
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+# TODO PUP-8003
+Performance/Caller:
+  Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false
+
+# DISABLED
+Security/Eval:
+  Enabled: false
+
+# TODO PUP-8004
+Security/JSONLoad:
+  Enabled: false
+
+# TODO PUP-8004
+Security/YAMLLoad:
+  Enabled: false
+
+Style/AccessorMethodName:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
+# USES: as shortcut for non nil&valid checking a = x() and a.empty?
+# DISABLED - not useful
+Style/AndOr:
+  Enabled: false
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Attr:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/CharacterLiteral:
+  Enabled: false
+
+Style/ClassAndModuleCamelCase:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ClassMethods:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Style/CollectionMethods:
+  Enabled: false
+
+Style/ColonMethodCall:
+  Enabled: false
+
+Style/CommandLiteral:
+  Enabled: false
+
+Style/CommentAnnotation:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/ConstantName:
   Enabled: false
 
 Style/DefWithParentheses:
   Enabled: false
 
-Style/PreferredHashMethods:
-  Enabled: false
-
-Layout/DotPosition:
+Style/Documentation:
   Enabled: false
 
 # DISABLED - used for converting to bool
@@ -260,98 +409,19 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Enabled: false
 
-Layout/EmptyLineBetweenDefs:
+Style/EmptyCaseCondition:
   Enabled: false
 
-Layout/IndentArray:
-  Enabled: false
-
-Layout/IndentHash:
-  Enabled: false
-
-Layout/IndentationConsistency:
-  Enabled: false
-
-Layout/IndentationWidth:
-  Enabled: false
-
-Layout/EmptyLines:
-  Enabled: false
-
-Layout/EmptyLinesAroundAccessModifier:
+Style/EmptyElse:
   Enabled: false
 
 Style/EmptyLiteral:
   Enabled: false
 
-Metrics/LineLength:
+Style/EmptyMethod:
   Enabled: false
 
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: false
-
-Style/MethodDefParentheses:
-  Enabled: false
-
-Style/LineEndConcatenation:
-  Enabled: false
-
-Layout/TrailingWhitespace:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Style/TrailingCommaInLiteral:
-  Enabled: false
-
-Style/TrailingCommaInArguments:
-  Enabled: false
-
-Style/GlobalVars:
-  Enabled: false
-
-Style/GuardClause:
-  Enabled: false
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-Style/MultilineIfThen:
-  Enabled: false
-
-Style/NegatedIf:
-  Enabled: false
-
-Style/NegatedWhile:
-  Enabled: false
-
-Style/Next:
-  Enabled: false
-
-Style/SingleLineBlockParams:
-  Enabled: false
-
-Style/SingleLineMethods:
-  Enabled: false
-
-Style/SpecialGlobalVars:
-  Enabled: false
-
-
-Style/TrivialAccessors:
-  Enabled: false
-
-Style/UnlessElse:
-  Enabled: false
-
-Style/VariableInterpolation:
-  Enabled: false
-
-Style/VariableName:
-  Enabled: false
-
-Style/WhileUntilDo:
+Style/Encoding:
   Enabled: false
 
 Style/EvenOdd:
@@ -363,31 +433,110 @@ Style/FileName:
 Style/For:
   Enabled: false
 
+Style/FormatString:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/GlobalVars:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+# DISABLED - not useful
+Style/HashSyntax:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/IfInsideElse:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/IfWithSemicolon:
+  Enabled: false
+
+Style/InfiniteLoop:
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: false
+
 Style/Lambda:
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Enabled: false
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: false
+
+Style/MethodDefParentheses:
+  Enabled: false
+
+Style/MethodMissing:
   Enabled: false
 
 Style/MethodName:
   Enabled: false
 
-Style/MultilineTernaryOperator:
+Style/MixinGrouping:
   Enabled: false
 
-Style/NestedTernaryOperator:
-  Enabled: false
-
-Style/NilComparison:
-  Enabled: false
-
-Style/FormatString:
+Style/ModuleFunction:
   Enabled: false
 
 Style/MultilineBlockChain:
   Enabled: false
 
-Style/Semicolon:
+Style/MultilineIfModifier:
   Enabled: false
 
-Style/SignalException:
+Style/MultilineIfThen:
+  Enabled: false
+
+Style/MultilineMemoization:
+  Enabled: false
+
+Style/MultilineTernaryOperator:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NegatedIf:
+  Enabled: false
+
+Style/NegatedWhile:
+  Enabled: false
+
+Style/NestedModifier:
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Enabled: false
+
+Style/NestedTernaryOperator:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/NilComparison:
   Enabled: false
 
 Style/NonNilCheck:
@@ -396,7 +545,13 @@ Style/NonNilCheck:
 Style/Not:
   Enabled: false
 
+Style/NumericLiteralPrefix:
+  Enabled: false
+
 Style/NumericLiterals:
+  Enabled: false
+
+Style/NumericPredicate:
   Enabled: false
 
 Style/OneLineConditional:
@@ -405,10 +560,16 @@ Style/OneLineConditional:
 Style/OpMethod:
   Enabled: false
 
+Style/ParallelAssignment:
+  Enabled: false
+
 Style/ParenthesesAroundCondition:
   Enabled: false
 
 Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/PercentQLiterals:
   Enabled: false
 
 Style/PerlBackrefs:
@@ -417,10 +578,7 @@ Style/PerlBackrefs:
 Style/PredicateName:
   Enabled: false
 
-Style/RedundantException:
-  Enabled: false
-
-Style/SelfAssignment:
+Style/PreferredHashMethods:
   Enabled: false
 
 Style/Proc:
@@ -432,272 +590,111 @@ Style/RaiseArgs:
 Style/RedundantBegin:
   Enabled: false
 
-Style/RescueModifier:
+Style/RedundantException:
+  Enabled: false
+
+# Disabled. Throws an error trying to run.
+Style/RedundantParentheses:
+  Enabled: false
+
+# DISABLED really useless. Detects return as last statement.
+Style/RedundantReturn:
+  Enabled: false
+
+# DISABLED - not useful
+Style/RedundantSelf:
   Enabled: false
 
 Style/RegexpLiteral:
   Enabled: false
 
-Lint/UnderscorePrefixedVariableName:
+Style/RescueModifier:
   Enabled: false
 
-Metrics/ParameterLists:
+Style/SafeNavigation:
   Enabled: false
 
-Lint/RequireParentheses:
+Style/SelfAssignment:
   Enabled: false
 
-Layout/SpaceBeforeFirstArg:
+Style/Semicolon:
   Enabled: false
 
-Style/ModuleFunction:
+Style/SignalException:
   Enabled: false
 
-Style/IfWithSemicolon:
+Style/SingleLineBlockParams:
   Enabled: false
 
-Style/Encoding:
+Style/SingleLineMethods:
   Enabled: false
 
-Metrics/PerceivedComplexity:
+Style/SpecialGlobalVars:
   Enabled: false
 
-Style/SymbolProc:
-  Enabled: false
-
-Layout/SpaceInsideRangeLiteral:
-  Enabled: false
-
-Style/InfiniteLoop:
-  Enabled: false
-
-Style/BarePercentLiterals:
-  Enabled: false
-
-Style/PercentQLiterals:
-  Enabled: false
-
-Layout/MultilineBlockLayout:
-  Enabled: false
-
-Metrics/AbcSize:
-  Enabled: false
-
-Style/MutableConstant:
-  Enabled: false
-
-Style/BlockDelimiters:
-  Enabled: false
-
-Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
-Style/ConditionalAssignment:
-  Enabled: false
-
-Layout/ExtraSpacing:
-  Enabled: false
-
-Layout/EmptyLinesAroundBlockBody:
-  Enabled: false
-
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: false
-
-Layout/MultilineOperationIndentation:
-  Enabled: false
-
-Style/EmptyElse:
+Style/StringLiterals:
   Enabled: false
 
 Style/StringLiteralsInInterpolation:
   Enabled: false
 
-Layout/MultilineMethodCallIndentation:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Layout/EmptyLinesAroundMethodBody:
-  Enabled: false
-
-Layout/ClosingParenthesisIndentation:
-  Enabled: false
-
-Style/UnneededInterpolation:
-  Enabled: false
-
-Layout/ElseAlignment:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Layout/FirstParameterIndentation:
-  Enabled: false
-
-Style/IfInsideElse:
-  Enabled: false
-
-Layout/IndentAssignment:
-  Enabled: false
-
-Layout/SpaceAroundBlockParameters:
-  Enabled: false
-
-Style/ParallelAssignment:
-  Enabled: false
-
-Performance/RedundantBlockCall:
-  Enabled: false
-
-Style/IdenticalConditionalBranches:
-  Enabled: false
-
-Style/CommandLiteral:
-  Enabled: false
-
-Lint/NestedMethodDefinition:
-  Enabled: false
-
-Layout/SpaceInsideStringInterpolation:
-  Enabled: false
-
-Style/NestedModifier:
-  Enabled: false
-
-Style/NestedParenthesizedCalls:
-  Enabled: false
-
-Layout/RescueEnsureAlignment:
-  Enabled: false
-
-Style/TrailingUnderscoreVariable:
-  Enabled: false
-
-Lint/LiteralInInterpolation:
-  Enabled: false
-
-Layout/InitialIndentation:
-  Enabled: false
-
 Style/StructInheritance:
-  Enabled: false
-
-Style/SymbolLiteral:
-  Enabled: false
-
-Style/IfUnlessModifierOfIfUnless:
-  Enabled: false
-
-Style/ZeroLengthPredicate:
-  Enabled: false
-
-Bundler/OrderedGems:
-  Enabled: false
-
-Layout/EmptyLineAfterMagicComment:
-  Enabled: false
-
-Layout/EmptyLinesAroundBeginBody:
-  Enabled: false
-
-Layout/EmptyLinesAroundExceptionHandlingKeywords:
-  Enabled: false
-
-Layout/IndentHeredoc:
-  Enabled: false
-
-Layout/MultilineArrayBraceLayout:
-  Enabled: false
-
-Layout/MultilineHashBraceLayout:
-  Enabled: false
-
-Layout/MultilineMethodCallBraceLayout:
-  Enabled: false
-
-Layout/MultilineMethodDefinitionBraceLayout:
-  Enabled: false
-
-Layout/SpaceInsidePercentLiteralDelimiters:
-  Enabled: false
-
-Lint/EmptyWhen:
-  Enabled: false
-
-Lint/InheritException:
-  Enabled: false
-
-Lint/ScriptPermission:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
-# TODO PUP-8003
-Performance/Caller:
-  Enabled: false
-
-# TODO PUP-8004
-Security/JSONLoad:
-  Enabled: false
-
-# TODO PUP-8004
-Security/YAMLLoad:
-  Enabled: false
-
-Style/EmptyCaseCondition:
-  Enabled: false
-
-Style/EmptyMethod:
-  Enabled: false
-
-Style/FormatStringToken:
-  Enabled: false
-
-Style/InverseMethods:
-  Enabled: false
-
-Style/MethodMissing:
-  Enabled: false
-
-Style/MixinGrouping:
-  Enabled: false
-
-Style/MultilineIfModifier:
-  Enabled: false
-
-Style/MultilineMemoization:
-  Enabled: false
-
-Style/MultipleComparison:
-  Enabled: false
-
-Style/NumericLiteralPrefix:
-  Enabled: false
-
-Style/NumericPredicate:
   Enabled: false
 
 Style/SymbolArray:
   Enabled: false
 
+Style/SymbolLiteral:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
 Style/TernaryParentheses:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Style/TrivialAccessors:
+  Enabled: false
+
+Style/UnlessElse:
+  Enabled: false
+
+Style/UnneededInterpolation:
+  Enabled: false
+
+Style/UnneededPercentQ:
+  Enabled: false
+
+Style/VariableInterpolation:
+  Enabled: false
+
+Style/VariableName:
+  Enabled: false
+
+Style/WhenThen:
+  Enabled: false
+
+Style/WhileUntilDo:
+  Enabled: false
+
+# DISABLED - not useful
+Style/WhileUntilModifier:
+  Enabled: false
+
+Style/WordArray:
   Enabled: false
 
 Style/YodaCondition:
   Enabled: false
 
-GetText/DecorateFunctionMessage:
-  Enabled: false
-
-GetText/DecorateString:
-  Enabled: false
-
-GetText/DecorateStringFormattingUsingPercent:
-  Enabled: false
-
-Style/SafeNavigation:
+Style/ZeroLengthPredicate:
   Enabled: false

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -171,7 +171,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
         operation = update_command
         self.debug "Ensuring latest, so using #{operation}"
       else
-        self.debug "Ensuring latest, but package is absent, so using #{:install}"
+        self.debug "Ensuring latest, but package is absent, so using install"
         operation = :install
       end
       should = nil

--- a/lib/puppet/type/component.rb
+++ b/lib/puppet/type/component.rb
@@ -62,7 +62,7 @@ Puppet::Type.newtype(:component) do
     catalog.adjacent(self).each do |child|
       if child.respond_to?(:refresh)
         child.refresh
-        child.log "triggering #{:refresh}"
+        child.log "triggering refresh"
       end
     end
   end


### PR DESCRIPTION
Sort disabled cops by group/name so it's easier to visualize the important `Lint` cops vs less important `Style` cops. Remove some unneeded exclusions, and fix `LiteralInInterpolation` cop.