### PR TITLE
(PUP-10021) Allow password change for disabled users

### DIFF
--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -125,14 +125,13 @@ Puppet::Type.type(:user).provide :windows_adsi do
 
   def password=(value)
     if user.disabled?
-      warning _("The user account '%s' is disabled; puppet will not reset the password" % @resource[:name])
+      warning _("The user account '%s' is disabled; The password will still be changed" % @resource[:name])
     elsif user.locked_out?
-      warning _("The user account '%s' is locked out; puppet will not reset the password" % @resource[:name])
+      warning _("The user account '%s' is locked out; The password will still be changed" % @resource[:name])
     elsif user.expired?
-      warning _("The user account '%s' is expired; puppet will not reset the password" % @resource[:name])
-    else
-      user.password = value
+      warning _("The user account '%s' is expired; The password will still be changed" % @resource[:name])
     end
+      user.password = value
   end
 
   def uid


### PR DESCRIPTION
This commit enables puppet to change the passwords of disabled, locked
out and expired users.

Before this commit puppet will not change the password of
disabled,locked or expired users, even is this operation is supported in
windows.