### PR TITLE
(PUP-10095) Better error handling for loading task metadata

### DIFF
--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -154,6 +154,10 @@ class Puppet::Module
         end
 
         implementations = metadata['implementations'].map do |impl|
+          unless impl['requirements'].is_a?(Array) || impl['requirements'].nil?
+            msg = _("Task metadata for task %{name} does not specify requirements as an array" % { name: name })
+            raise InvalidMetadata.new(msg, 'puppet.tasks/invalid-metadata')
+          end
           path = executables.find { |real_impl| File.basename(real_impl) == impl['name'] }
           unless path
             msg = _("Task metadata for task %{name} specifies missing implementation %{implementation}" % { name: name, implementation: impl['name'] })

--- a/spec/unit/pops/loaders/module_loaders_spec.rb
+++ b/spec/unit/pops/loaders/module_loaders_spec.rb
@@ -173,6 +173,16 @@ describe 'FileBased module loader' do
         .to raise_error(Puppet::ParseError, /Failed to load metadata for task testmodule::foo: 'parameters' must be a hash/)
     end
 
+    it 'raises and error when `implementations` `requirements` key is not an array' do
+      metadata = { 'implementations' => { 'name' => 'foo.py', 'requirements' => 'foo'} }
+      module_dir = dir_containing('testmodule', 'tasks' => {'foo.py' => '', 'foo.json' => metadata.to_json})
+
+      module_loader = Puppet::Pops::Loader::ModuleLoaders.module_loader_from(static_loader, loaders, 'testmodule', module_dir)
+      expect{module_loader.load_typed(typed_name(:task, 'testmodule::foo'))}
+        .to raise_error(Puppet::Module::Task::InvalidMetadata,
+        /Task metadata for task testmodule::foo does not specify implementations as an array/)
+    end
+
     it 'raises and error when top-level `files` is not an array' do
       metadata = { 'files' => 'foo' }
       module_dir = dir_containing('testmodule', 'tasks' => {'foo.py' => '', 'foo.json' => metadata.to_json})


### PR DESCRIPTION
This commit adds some error handling when loading task metadata. Specifically it raises an error when the `requirments` key for a tasks `implementations` hash is not an array.