### PR TITLE
(PUP-10114) Optionally include undef vars in ParameterScope to_hash method

### DIFF
--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -67,8 +67,8 @@ class Puppet::Parser::Scope
       false
     end
 
-    def add_entries_to(target = {})
-      @parent.add_entries_to(target) unless @parent.nil?
+    def add_entries_to(target = {}, include_undef = false)
+      @parent.add_entries_to(target, include_undef) unless @parent.nil?
       # do not include match data ($0-$n)
       target
     end
@@ -106,10 +106,10 @@ class Puppet::Parser::Scope
       @symbols.include?(name)
     end
 
-    def add_entries_to(target = {})
+    def add_entries_to(target = {}, include_undef = false)
       super
       @symbols.each do |k, v|
-        if v == :undef || v.nil?
+        if (v == :undef || v.nil?) && !include_undef
           target.delete(k)
         else
           target[ k ] = v
@@ -161,7 +161,7 @@ class Puppet::Parser::Scope
       raise Puppet::ParseError, _("Numerical variables cannot be deleted: Attempt to delete: $%{name}") % { name: name }
     end
 
-    def add_entries_to(target = {})
+    def add_entries_to(target = {}, include_undef = false)
       # do not include match data ($0-$n)
       super
     end
@@ -661,8 +661,9 @@ class Puppet::Parser::Scope
   # Returns a Hash containing all variables and their values, optionally (and
   # by default) including the values defined in parent. Local values
   # shadow parent values. Ephemeral scopes for match results ($0 - $n) are not included.
+  # Optionally include the variables that are explicitly set to `undef`.
   #
-  def to_hash(recursive = true)
+  def to_hash(recursive = true, include_undef = false)
     if recursive and has_enclosing_scope?
       target = enclosing_scope.to_hash(recursive)
       if !(inherited = inherited_scope).nil?
@@ -673,7 +674,7 @@ class Puppet::Parser::Scope
     end
 
     # add all local scopes
-    @ephemeral.last.add_entries_to(target)
+    @ephemeral.last.add_entries_to(target, include_undef)
     target
   end
 

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -680,5 +680,15 @@ describe Puppet::Parser::Scope do
       @scope.setvar("orange", :undef)
       expect(@scope.to_hash).to eq({'pear' => :green, 'apple' => :red })
     end
+
+    it "should not delete values that are :undef in inner scope when include_undef is true" do
+      @scope.new_ephemeral true
+      @scope.setvar("orange", :tangerine)
+      @scope.setvar("pear", :green)
+      @scope.new_ephemeral true
+      @scope.setvar("apple", :red)
+      @scope.setvar("orange", :undef)
+      expect(@scope.to_hash(true, true)).to eq({'pear' => :green, 'apple' => :red, 'orange' => :undef })
+    end
   end
 end


### PR DESCRIPTION
This commit adds an optional `include_undef` parameter to the `to_hash` method for the `Puppet::Parser::Scope::ParameterScope` class. When `include_undef` is true, variables that have been explicitly declared as `undef` will be included in the hash of variable/value pairs. This work enables passing variables from Bolt `plan` scope accross the `apply` boundry. (https://github.com/puppetlabs/bolt/blob/f5c7023ecf1fd937ca795e8168b0064b39af117a/lib/bolt/applicator.rb#L156-L157). See [Bolt issue 1288](puppetlabs/bolt#1288) for more details.