### PR TITLE
(PUP-10112) Use Net::HTTP.new instead of Net::HTTP::Proxy

### DIFF
--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -10,7 +10,7 @@ module Puppet::Util::HttpProxy
       http = Net::HTTP.new(uri.host, uri.port, nil, nil, nil, nil)
       # Net::HTTP defaults the proxy port even though we said not to
       # use one. Set it to nil so caller is not surprised
-      http.proxy_port = nil
+      http.proxy_port = nil if http.respond_to?(:proxy_port=)
       http
     end
   end

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -4,13 +4,15 @@ require 'puppet/network/http'
 
 module Puppet::Util::HttpProxy
   def self.proxy(uri)
-    if self.no_proxy?(uri)
-      proxy_class = Net::HTTP::Proxy(nil)
+    if http_proxy_host && !no_proxy?(uri)
+      Net::HTTP.new(uri.host, uri.port, self.http_proxy_host, self.http_proxy_port, self.http_proxy_user, self.http_proxy_password)
     else
-      proxy_class = Net::HTTP::Proxy(self.http_proxy_host, self.http_proxy_port, self.http_proxy_user, self.http_proxy_password)
+      http = Net::HTTP.new(uri.host, uri.port, nil, nil, nil, nil)
+      # Net::HTTP defaults the proxy port even though we said not to
+      # use one. Set it to nil so caller is not surprised
+      http.proxy_port = nil
+      http
     end
-
-    return proxy_class.new(uri.host, uri.port)
   end
 
   def self.http_proxy_env

--- a/spec/unit/forge/forge_spec.rb
+++ b/spec/unit/forge/forge_spec.rb
@@ -97,10 +97,8 @@ describe Puppet::Forge do
   def mock_proxy(port, proxy_args, result, &block)
     http = double("http client")
     proxy = double("http proxy")
-    proxy_class = double("http proxy class")
 
-    expect(Net::HTTP).to receive(:Proxy).with(*proxy_args).and_return(proxy_class)
-    expect(proxy_class).to receive(:new).with(host, port).and_return(proxy)
+    expect(Net::HTTP).to receive(:new).with(host, port, *proxy_args).and_return(proxy)
 
     expect(proxy).to receive(:open_timeout=)
     expect(proxy).to receive(:read_timeout=)

--- a/spec/unit/forge/repository_spec.rb
+++ b/spec/unit/forge/repository_spec.rb
@@ -234,10 +234,8 @@ describe Puppet::Forge::Repository do
   def mock_proxy(port, proxy_args, result, &block)
     http = double("http client")
     proxy = double("http proxy")
-    proxy_class = double("http proxy class")
 
-    expect(Net::HTTP).to receive(:Proxy).with(*proxy_args).and_return(proxy_class)
-    expect(proxy_class).to receive(:new).with("fake.com", port).and_return(proxy)
+    expect(Net::HTTP).to receive(:new).with("fake.com", port, *proxy_args).and_return(proxy)
 
     expect(proxy).to receive(:open_timeout=)
     expect(proxy).to receive(:read_timeout=)

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -50,12 +50,53 @@ describe Puppet::Util::HttpProxy do
       expects_direct_connection_to(http, www)
     end
 
-    it 'connects directly to the server when HTTP_PROXY environment variable is set, but server matches no_proxy setting' do
-      Puppet[:http_proxy_host] = host
-      Puppet[:http_proxy_port] = port
-      Puppet[:no_proxy] = www.host
+    context 'when setting no_proxy' do
+      before :each do
+        Puppet[:http_proxy_host] = host
+        Puppet[:http_proxy_port] = port
+      end
 
-      Puppet::Util.withenv('HTTP_PROXY' => "http://#{host}:#{port}") do
+      it 'connects directly to the server when HTTP_PROXY environment variable is set, but server matches no_proxy setting' do
+        Puppet[:no_proxy] = www.host
+
+        Puppet::Util.withenv('HTTP_PROXY' => "http://#{host}:#{port}") do
+          http = subject.proxy(www)
+          expects_direct_connection_to(http, www)
+        end
+      end
+
+      it 'connects directly to the server when no_proxy matches wildcard domain' do
+        Puppet[:no_proxy] = '*.example.com'
+
+        http = subject.proxy(www)
+        expects_direct_connection_to(http, www)
+      end
+
+      it 'connects directly to the server when no_proxy matches dotted domain' do
+        Puppet[:no_proxy] = '.example.com'
+
+        http = subject.proxy(www)
+        expects_direct_connection_to(http, www)
+      end
+
+      it 'connects directly to the server when no_proxy matches domain like ruby does' do
+        pending("PUP-10106 Puppet doesn't match domains like ruby")
+        Puppet[:no_proxy] = 'example.com'
+
+        http = subject.proxy(www)
+        expects_direct_connection_to(http, www)
+      end
+
+      it 'connects directly to the server when it is a subdomain of no_proxy' do
+        Puppet[:no_proxy] = '*.com'
+
+        http = subject.proxy(www)
+        expects_direct_connection_to(http, www)
+      end
+
+      it 'connects directly to the server when no_proxy is *' do
+        Puppet[:no_proxy] = '*'
+
         http = subject.proxy(www)
         expects_direct_connection_to(http, www)
       end


### PR DESCRIPTION
Backports PUP-9990 to 5.5.x

Previously puppet would attempt to connect via a proxy if the HTTP_PROXY
environment variable was set, but the destination server matched the
Puppet[:no_proxy] setting. The confusion occurred because ruby's Net::HTTP
automagically resolved proxy settings from the environment, after puppet had
already decided not to use one.

The disconnect is due to ruby 2.0 changing the default behavior of
Net::HTTP.new, which is called by Net::HTTP::Proxy[1]. If the third argument to
the initialize method (`p_addr`) is not specified, then it defaults to :ENV
causing ruby to lookup proxy configuration from the environment. In ruby 1.9 and
before, `p_addr` defaulted to nil.

Net::HTTP::Proxy is also marked as obsolete, so this commit switches to
Net::HTTP.new instead. If puppet decides not to use a proxy, it explicitly
passes nil arguments.

[1] https://github.com/ruby/ruby/commit/9416becda4592f7884460a054fe12b7761f6f055