### PR TITLE
(PUP-10021) fix net user /add prompt in tests

### DIFF
--- a/acceptance/tests/windows/enable_password_changes_special_users.rb
+++ b/acceptance/tests/windows/enable_password_changes_special_users.rb
@@ -13,12 +13,12 @@ test_name 'Puppet should change passwords for disabled, expired, or locked out W
     return <<-MANIFEST
     user { '#{username}':
       ensure   => 'present',
-      password => '#{NEW_PASSWORD}' 
+      password => '#{NEW_PASSWORD}'
     }
     MANIFEST
   end
 
-  INITIAL_PASSWORD='1nitialP@ssword'
+  INITIAL_PASSWORD='iP@ssword'
   NEW_PASSWORD="Password-#{rand(999999).to_i}"
 
   agents.each do |host|


### PR DESCRIPTION
Windows has a password policy, where it prompts the
user based on password complexity, password length
and history. In our case, it is prompting since password
exceeds the limit of 14 characters. This is to enable
using the user accounts on Windows versions older
than Windows 2000, since they don't support long passwords.

Since we are using `net user /add` only in tests,
it is safe to use a shorter password for this test.