### PR TITLE
(PUP-9509) Update unit tests for cache loader

### DIFF
--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -100,11 +100,9 @@ describe 'loaders' do
     expect(loaders.puppet_cache_loader()).to be_a(Puppet::Pops::Loader::ModuleLoaders::LibRootedFileBased)
   end
 
-  it 'creates a cached_puppet loader that can load version 3 functions, version 4 functions, and data types' do
+  it 'creates a cached_puppet loader that can load version 4 functions, version 3 functions, and data types, in that order' do
     loaders = Puppet::Pops::Loaders.new(empty_test_env, true)
-    expect(loaders.puppet_cache_loader.loadables).to include(:func_3x)
-    expect(loaders.puppet_cache_loader.loadables).to include(:func_4x)
-    expect(loaders.puppet_cache_loader.loadables).to include(:datatype)
+    expect(loaders.puppet_cache_loader.loadables).to eq([:func_4x, :func_3x, :datatype])
   end
 
   it 'does not create a cached_puppet loader when for_agent is the default false value' do


### PR DESCRIPTION
Previously the unit tests for the cache loader only checked that a loadable was
specified.  However order is important.  This commit updates the unit test to
confirm that all loadables are specified in the correct order.