### PR TITLE
(PUP-10102) fix service crash

### DIFF
--- a/lib/puppet/provider/service/daemontools.rb
+++ b/lib/puppet/provider/service/daemontools.rb
@@ -107,7 +107,9 @@ Puppet::Type.type(:service).provide :daemontools, :parent => :base do
   # note that this path can be overridden in the resource
   # definition
   def daemon
-    File.join(resource[:path], resource[:name])
+    path = resource[:path]
+    raise Puppet::Error.new("#{self.class.name} must specify a path for daemon directory") unless path
+    File.join(path, resource[:name])
   end
 
   def status

--- a/lib/puppet/provider/service/runit.rb
+++ b/lib/puppet/provider/service/runit.rb
@@ -40,14 +40,8 @@ Puppet::Type.type(:service).provide :runit, :parent => :daemontools do
     # this is necessary to autodetect a valid resource
     # default path, since there is no standard for such directory.
     def defpath
-      unless @defpath
-        ["/etc/sv", "/var/lib/service"].each do |path|
-          if Puppet::FileSystem.exist?(path)
-            @defpath = path
-            break
-          end
-        end
-        raise "Could not find the daemon directory (tested [/etc/sv,/var/lib/service])" unless @defpath
+      @defpath ||= ["/var/lib/service", "/etc/sv"].find do |path|
+        Puppet::FileSystem.exist?(path) && FileTest.directory?(path)
       end
       @defpath
     end

--- a/spec/unit/provider/service/daemontools_spec.rb
+++ b/spec/unit/provider/service/daemontools_spec.rb
@@ -160,4 +160,28 @@ describe Puppet::Type.type(:service).provider(:daemontools) do
       expect(@provider.status).to  eq(:stopped)
     end
   end
+
+  context '.instances' do
+    before do
+      allow(described_class).to receive(:defpath).and_return(path)
+    end
+
+    context 'when defpath is nil' do
+      let(:path) { nil }
+
+      it 'returns info message' do
+        expect(Puppet).to receive(:info).with(/daemontools is unsuitable because service directory is nil/)
+        described_class.instances
+      end
+    end
+
+    context 'when defpath does not exist' do
+      let(:path) { '/inexistent_path' }
+
+      it 'returns notice about missing path' do
+        expect(Puppet).to receive(:notice).with(/Service path #{path} does not exist/)
+        described_class.instances
+      end
+    end
+  end
 end

--- a/spec/unit/provider/service/runit_spec.rb
+++ b/spec/unit/provider/service/runit_spec.rb
@@ -134,4 +134,28 @@ describe Puppet::Type.type(:service).provider(:runit) do
       expect(@provider.status).to eq(:stopped)
     end
   end
+
+  context '.instances' do
+    before do
+      allow(described_class).to receive(:defpath).and_return(path)
+    end
+
+    context 'when defpath is nil' do
+      let(:path) { nil }
+
+      it 'returns info message' do
+        expect(Puppet).to receive(:info).with(/runit is unsuitable because service directory is nil/)
+        described_class.instances
+      end
+    end
+
+    context 'when defpath does not exist' do
+      let(:path) { '/inexistent_path' }
+
+      it 'returns notice about missing path' do
+        expect(Puppet).to receive(:notice).with(/Service path #{path} does not exist/)
+        described_class.instances
+      end
+    end
+  end
 end


### PR DESCRIPTION
When running on distributions that do not have a
default service provider puppet will try to
evaluate `runit` and set `defpath` default
before verifying that `runit` is suitable. Raising an
error when setting defpath results in a state that should
not be reached.

This commit removes the raise exception from defpath
and let puppet decide if the provide is suitable or not.