### PR TITLE
(PUP-7218) systemd service provider missing double dash

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   # in the provider's believed state of the service and the actual state.
   # @param action [String,Symbol] One of 'enable', 'disable', 'mask' or 'unmask'
   def systemctl_change_enable(action)
-    output = systemctl(action, @resource[:name])
+    output = systemctl(action, '--', @resource[:name])
   rescue
     raise Puppet::Error, "Could not #{action} #{self.name}: #{output}", $!.backtrace
   ensure
@@ -64,7 +64,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   def cached_enabled?
     return @cached_enabled if @cached_enabled
-    cmd = [command(:systemctl), 'is-enabled', @resource[:name]]
+    cmd = [command(:systemctl), 'is-enabled', '--', @resource[:name]]
     @cached_enabled = execute(cmd, :failonfail => false).strip
   end
 
@@ -131,20 +131,20 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def restartcmd
-    [command(:systemctl), "restart", @resource[:name]]
+    [command(:systemctl), "restart", '--', @resource[:name]]
   end
 
   def startcmd
     self.unmask
-    [command(:systemctl), "start", @resource[:name]]
+    [command(:systemctl), "start", '--', @resource[:name]]
   end
 
   def stopcmd
-    [command(:systemctl), "stop", @resource[:name]]
+    [command(:systemctl), "stop", '--', @resource[:name]]
   end
 
   def statuscmd
-    [command(:systemctl), "is-active", @resource[:name]]
+    [command(:systemctl), "is-active", '--', @resource[:name]]
   end
 
   def restart

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -164,15 +164,15 @@ describe Puppet::Type.type(:service).provider(:systemd) do
 
     it "should start the service with systemctl start otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:systemctl).with(:unmask, 'sshd.service')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','start','sshd.service'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:systemctl).with(:unmask, '--', 'sshd.service')
+      expect(provider).to receive(:execute).with(['/bin/systemctl','start', '--', 'sshd.service'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.start
     end
 
     it "should show journald logs on failure" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:systemctl).with(:unmask, 'sshd.service')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','start','sshd.service'],{:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:systemctl).with(:unmask, '--', 'sshd.service')
+      expect(provider).to receive(:execute).with(['/bin/systemctl','start', '--', 'sshd.service'],{:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
         .and_raise(Puppet::ExecutionFailure, "Failed to start sshd.service: Unit sshd.service failed to load: Invalid argument. See system logs and 'systemctl status sshd.service' for details.")
       journalctl_logs = <<-EOS
 -- Logs begin at Tue 2016-06-14 11:59:21 UTC, end at Tue 2016-06-14 21:45:02 UTC. --
@@ -194,13 +194,13 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
 
     it "should stop the service with systemctl stop otherwise" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','stop','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','stop', '--', 'sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
       provider.stop
     end
 
     it "should show journald logs on failure" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','stop','sshd.service'],{:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/bin/systemctl','stop', '--', 'sshd.service'],{:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
         .and_raise(Puppet::ExecutionFailure, "Failed to stop sshd.service: Unit sshd.service failed to load: Invalid argument. See system logs and 'systemctl status sshd.service' for details.")
       journalctl_logs = <<-EOS
 -- Logs begin at Tue 2016-06-14 11:59:21 UTC, end at Tue 2016-06-14 21:45:02 UTC. --
@@ -216,42 +216,42 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#enabled?" do
     it "should return :true if the service is enabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).and_return("enabled\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("enabled\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :true if the service is static" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).and_return("static\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','--', 'sshd.service'], :failonfail => false).and_return("static\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :false if the service is disabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).and_return("disabled\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("disabled\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :false if the service is indirect" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).and_return("indirect\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("indirect\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :false if the service is masked and the resource is attempting to be disabled" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).and_return("masked\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("masked\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :mask if the service is masked and the resource is attempting to be masked" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => 'mask'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','sshd.service'], :failonfail => false).and_return("masked\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("masked\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
       expect(provider.enabled?).to eq(:mask)
     end
@@ -260,8 +260,8 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#enable" do
     it "should run systemctl enable to enable a service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:systemctl).with(:unmask, 'sshd.service')
-      expect(provider).to receive(:systemctl).with(:enable, 'sshd.service')
+      expect(provider).to receive(:systemctl).with(:unmask, '--', 'sshd.service')
+      expect(provider).to receive(:systemctl).with(:enable, '--', 'sshd.service')
       provider.enable
     end
   end
@@ -269,7 +269,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#disable" do
     it "should run systemctl disable to disable a service" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:systemctl).with(:disable, 'sshd.service')
+      expect(provider).to receive(:systemctl).with(:disable, '--', 'sshd.service')
       provider.disable
     end
   end
@@ -280,8 +280,8 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
       # :disable is the only call in the provider that uses a symbol instead of
       # a string.
       # This should be made consistent in the future and all tests updated.
-      expect(provider).to receive(:systemctl).with(:disable, 'sshd.service')
-      expect(provider).to receive(:systemctl).with(:mask, 'sshd.service')
+      expect(provider).to receive(:systemctl).with(:disable, '--', 'sshd.service')
+      expect(provider).to receive(:systemctl).with(:mask, '--', 'sshd.service')
       provider.mask
     end
   end
@@ -291,7 +291,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#status" do
     it "should return running if if the command returns 0" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','sshd.service'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true).and_return("active\n")
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','--','sshd.service'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true).and_return("active\n")
       allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
       expect(provider.status).to eq(:running)
     end
@@ -299,7 +299,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     [-10,-1,3,10].each { |ec|
       it "should return stopped if the command returns something non-0" do
         provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-        expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','sshd.service'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true).and_return("inactive\n")
+        expect(provider).to receive(:execute).with(['/bin/systemctl','is-active','--','sshd.service'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true).and_return("inactive\n")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(ec)
         expect(provider.status).to eq(:stopped)
       end
@@ -317,20 +317,20 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/bin/systemctl','restart','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/bin/systemctl','restart','--','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
       expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
       provider.restart
     end
 
     it "should restart the service with systemctl restart" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','--','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
       provider.restart
     end
 
     it "should show journald logs on failure" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','sshd.service'],{:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/bin/systemctl','restart', '--', 'sshd.service'],{:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
         .and_raise(Puppet::ExecutionFailure, "Failed to restart sshd.service: Unit sshd.service failed to load: Invalid argument. See system logs and 'systemctl status sshd.service' for details.")
       journalctl_logs = <<-EOS
 -- Logs begin at Tue 2016-06-14 11:59:21 UTC, end at Tue 2016-06-14 21:45:02 UTC. --


### PR DESCRIPTION
Without applying this page any service beging with a '-' (dash) cannot
be started by systemd. This is a problem because it's conventional in
systemd services to do so. This patch allows users to run commands
systemctl enable [service] and systemctl disable [service] by
appending a -- (em dash) between the command and service name. Tests
have been updated to verify corrected output.