### PR TITLE
(maint) fix pip tests on centos-8

### DIFF
--- a/acceptance/tests/provider/package/pip.rb
+++ b/acceptance/tests/provider/package/pip.rb
@@ -9,11 +9,13 @@ test_name "pip provider should install, use install_options with latest, and uni
   package = 'colorize'
 
   agents.each do |agent|
+    pip_command = 'pip'
     step "Setup: Install EPEL Repository, Python and Pip" do
       package_present(agent, 'epel-release')
       if agent.platform =~ /el-8/
         package_present(agent, 'python2')
         package_present(agent, 'python2-pip')
+        pip_command = 'pip2'
       else
         package_present(agent, 'python')
         package_present(agent, 'python-pip')
@@ -23,25 +25,25 @@ test_name "pip provider should install, use install_options with latest, and uni
     step "Install a pip package" do
       package_manifest = resource_manifest('package', package, { ensure: 'present', provider: 'pip' } )
       apply_manifest_on(agent, package_manifest, :catch_failures => true) do
-        list = on(agent, 'pip list --disable-pip-version-check').stdout
+        list = on(agent, "#{pip_command} list --disable-pip-version-check").stdout
         assert_match(/#{package} \(/, list)
       end
-      on(agent, "pip uninstall #{package} --disable-pip-version-check --yes")
+      on(agent, "#{pip_command} uninstall #{package} --disable-pip-version-check --yes")
     end
 
     step "Ensure latest with pip uses install_options" do
-      on(agent, "pip install #{package} --disable-pip-version-check")
+      on(agent, "#{pip_command} install #{package} --disable-pip-version-check")
       package_manifest = resource_manifest('package', package, { ensure: 'latest', provider: 'pip', install_options: { '--index' => 'https://pypi.python.org/simple' } } )
       result = apply_manifest_on(agent, package_manifest, { :catch_failures => true, :debug => true } )
       assert_match(/--index=https:\/\/pypi.python.org\/simple/, result.stdout)
-      on(agent, "pip uninstall #{package} --disable-pip-version-check --yes")
+      on(agent, "#{pip_command} uninstall #{package} --disable-pip-version-check --yes")
     end
 
     step "Uninstall a pip package" do
-      on(agent, "pip install #{package} --disable-pip-version-check")
+      on(agent, "#{pip_command} install #{package} --disable-pip-version-check")
       package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'pip' } )
       apply_manifest_on(agent, package_manifest, :catch_failures => true) do
-        list = on(agent, 'pip list --disable-pip-version-check').stdout
+        list = on(agent, "#{pip_command} list --disable-pip-version-check").stdout
         assert_no_match(/#{package} \(/, list)
       end
     end

--- a/acceptance/tests/provider/package/pip.rb
+++ b/acceptance/tests/provider/package/pip.rb
@@ -11,8 +11,13 @@ test_name "pip provider should install, use install_options with latest, and uni
   agents.each do |agent|
     step "Setup: Install EPEL Repository, Python and Pip" do
       package_present(agent, 'epel-release')
-      package_present(agent, 'python')
-      package_present(agent, 'python-pip')
+      if agent.platform =~ /el-8/
+        package_present(agent, 'python2')
+        package_present(agent, 'python2-pip')
+      else
+        package_present(agent, 'python')
+        package_present(agent, 'python-pip')
+      end
     end
 
     step "Install a pip package" do

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     if Puppet.features.microsoft_windows?
       ["pip.exe"]
     else
-      ["pip", "pip-python"]
+      ["pip", "pip-python", "pip2", "pip-2"]
     end
   end
 

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-osfamilies = { 'windows' => ['pip.exe'], 'other' => ['pip', 'pip-python'] }
+osfamilies = { 'windows' => ['pip.exe'], 'other' => ['pip', 'pip-python', 'pip2', 'pip-2'] }
 
 describe Puppet::Type.type(:package).provider(:pip) do
 


### PR DESCRIPTION
CentOS 8 does not come with the python package:

```
[root@rmql4g2dj6dsuwv ~]# yum install python
Last metadata expiration check: 0:12:38 ago on Fri 01 Nov 2019 11:37:30 AM UTC.
No match for argument: python
There are following alternatives for "python": python2, python36
Error: Unable to find a match
```
thus causing the pip test to fail.

On centos-7 the `python` package installs python2:
```
[root@ix0x69pe3wfm16j ~]# yum install python
........
  Updating   : python-libs-2.7.5-86.el7.x86_64                                                                                                                      1/4
  Updating   : python-2.7.5-86.el7.x86_64                                                                                                                           2/4
  Cleanup    : python-2.7.5-34.el7.x86_64                                                                                                                           3/4
  Cleanup    : python-libs-2.7.5-34.el7.x86_64                                                                                                                      4/4
  Verifying  : python-2.7.5-86.el7.x86_64                                                                                                                           1/4
  Verifying  : python-libs-2.7.5-86.el7.x86_64                                                                                                                      2/4
  Verifying  : python-libs-2.7.5-34.el7.x86_64                                                                                                                      3/4
  Verifying  : python-2.7.5-34.el7.x86_64                                                                                                                           4/4

Updated:
  python.x86_64 0:2.7.5-86.el7

Dependency Updated:
  python-libs.x86_64 0:2.7.5-86.el7

Complete!
[root@ix0x69pe3wfm16j ~]# python --version
Python 2.7.5
```
This PR is setting the test to install python2 on CentOS 8
