### PR TITLE
(packaging) Bump to version '6.11.0' [no-promote]

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -13,7 +13,7 @@
 
 Gem::Specification.new do |s|
   s.name = "puppet"
-  version = "6.10.1"
+  version = "6.11.0"
   mdata = version.match(/(\d+\.\d+\.\d+)/)
   s.version = mdata ? mdata[1] : version
 

--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -6,7 +6,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 
 module Puppet
-  PUPPETVERSION = '6.10.1'
+  PUPPETVERSION = '6.11.0'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This PR sets the version for the next agent release