### PR TITLE
(PUP-10106) Don't require domain proxy exceptions to start with dot

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -524,9 +524,10 @@ module Puppet
     },
     :http_proxy_host => {
       :default    => "none",
-      :desc       => "The HTTP proxy host to use for outgoing connections.  Note: You
+      :desc       => "The HTTP proxy host to use for outgoing connections. The proxy will be bypassed if
+      the server's hostname matches the NO_PROXY environment variable or `no_proxy` setting. Note: You
       may need to use a FQDN for the server hostname when using a proxy. Environment variable
-      http_proxy or HTTP_PROXY will override this value",
+      http_proxy or HTTP_PROXY will override this value. ",
     },
     :http_proxy_port => {
       :default    => 3128,
@@ -552,7 +553,7 @@ module Puppet
     },
     :no_proxy => {
       :default    => "localhost, 127.0.0.1",
-      :desc       => "List of domain names that should not go through `http_proxy_host`. Environment variable no_proxy or NO_PROXY will override this value. Names can be specified as an FQDN `host.example.com`, wildcard `*.example.com`, dotted domain `.example.com`, or suffix `example.com`.",
+      :desc       => "List of host or domain names that should not go through `http_proxy_host`. Environment variable no_proxy or NO_PROXY will override this value. Names can be specified as an FQDN `host.example.com`, wildcard `*.example.com`, dotted domain `.example.com`, or suffix `example.com`.",
     },
     :http_keepalive_timeout => {
       :default    => "4s",

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -552,7 +552,7 @@ module Puppet
     },
     :no_proxy => {
       :default    => "localhost, 127.0.0.1",
-      :desc       => "List of domain names that should not go through `http_proxy_host`. Environment variable no_proxy or NO_PROXY will override this value.",
+      :desc       => "List of domain names that should not go through `http_proxy_host`. Environment variable no_proxy or NO_PROXY will override this value. Names can be specified as an FQDN `host.example.com`, wildcard `*.example.com`, dotted domain `.example.com`, or suffix `example.com`.",
     },
     :http_keepalive_timeout => {
       :default    => "4s",

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -51,14 +51,6 @@ module Puppet::Util::HttpProxy
       host, port = d.split(':')
       host = Regexp.escape(host).gsub('\*', '.*')
 
-      #If the host of this no_proxy value starts with '.', this entry is
-      #a domain level entry. Don't pin the regex to the beginning of the entry.
-      #If it does not start with a '.' then it is a host specific entry and
-      #should be matched to the destination starting at the beginning.
-      unless host =~ /^\\\./
-        host = "^#{host}"
-      end
-
       #If this no_proxy entry specifies a port, we want to match it against
       #the destination port.  Otherwise just match hosts.
       if port

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -79,9 +79,15 @@ describe Puppet::Util::HttpProxy do
         expects_direct_connection_to(http, www)
       end
 
-      it 'connects directly to the server when no_proxy matches domain like ruby does' do
-        pending("PUP-10106 Puppet doesn't match domains like ruby")
+      it 'connects directly to the server when no_proxy matches a domain suffix like ruby does' do
         Puppet[:no_proxy] = 'example.com'
+
+        http = subject.proxy(www)
+        expects_direct_connection_to(http, www)
+      end
+
+      it 'connects directly to the server when no_proxy matches a partial suffix like ruby does' do
+        Puppet[:no_proxy] = 'ample.com'
 
         http = subject.proxy(www)
         expects_direct_connection_to(http, www)


### PR DESCRIPTION
Previously, the `no_proxy` setting only supported domain exceptions using a
wildcard (*.example.com) or a dotted-domain (.example.com). However, curl and
ruby accept a dotted-domain and a domain suffix (example.com, ample.com), but
not wildcards.

This could lead to strange behavior if puppet executed ruby or curl during an
exec resource, and the `no_proxy` environment variable was specified as a domain
suffix -- puppet would still use the proxy, while ruby & curl would not.

This commit allows puppet to accept `no_proxy` environment variables or puppet
settings containing domain suffixes, while retaining support for wildcards and
dotted domains. As a result, it's no longer possible to force puppet to not use
a proxy for a specific host, but not any domains that happen to match that
hostname.