### PR TITLE
(PUP-10057) User resource on Windows confuses domain and local accounts

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -1,6 +1,23 @@
 module Puppet::Util::Windows::ADSI
   require 'ffi'
 
+  # https://docs.microsoft.com/en-us/windows/win32/api/dsrole/ne-dsrole-dsrole_machine_role
+  STANDALONE_WORKSTATION = 0
+  MEMBER_WORKSTATION = 1
+  STANDALONE_SERVER = 2
+  MEMBER_SERVER = 3
+  BACKUP_DOMAIN_CONTROLLER = 4
+  PRIMARY_DOMAIN_CONTROLLER = 5
+
+  DOMAIN_ROLES = {
+    STANDALONE_WORKSTATION => :STANDALONE_WORKSTATION,
+    MEMBER_WORKSTATION => :MEMBER_WORKSTATION,
+    STANDALONE_SERVER => :STANDALONE_SERVER,
+    MEMBER_SERVER => :MEMBER_SERVER,
+    BACKUP_DOMAIN_CONTROLLER => :BACKUP_DOMAIN_CONTROLLER,
+    PRIMARY_DOMAIN_CONTROLLER => :PRIMARY_DOMAIN_CONTROLLER,
+  }
+
   class << self
     extend FFI::Library
 
@@ -94,6 +111,14 @@ module Puppet::Util::Windows::ADSI
       wmi_connection.execquery(query)
     end
 
+    def domain_role
+      unless @domain_role
+        query_result = Puppet::Util::Windows::ADSI.execquery('select DomainRole from Win32_ComputerSystem').to_enum.first
+        @domain_role = DOMAIN_ROLES[query_result.DomainRole] if query_result
+      end
+      @domain_role
+    end
+
     ffi_convention :stdcall
 
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724295(v=vs.85).aspx
@@ -126,24 +151,24 @@ module Puppet::Util::Windows::ADSI
           Puppet::Util::Windows::SID.name_to_principal('SYSTEM').domain.upcase
         ]
       end
-  
+
       def uri(name, host = '.')
         host = '.' if (localized_domains << Socket.gethostname.upcase).include?(host.upcase)
         Puppet::Util::Windows::ADSI.uri(name, @object_class, host)
       end
-  
+
       def parse_name(name)
         if name =~ /\//
           raise Puppet::Error.new( _("Value must be in DOMAIN\\%{object_class} style syntax") % { object_class: @object_class } )
         end
-  
+
         matches = name.scan(/((.*)\\)?(.*)/)
         domain = matches[0][1] || '.'
         account = matches[0][2]
-  
+
         return account, domain
       end
-  
+
       # returns Puppet::Util::Windows::SID::Principal[]
       # may contain objects that represent unresolvable SIDs
       def get_sids(adsi_child_collection)
@@ -151,19 +176,19 @@ module Puppet::Util::Windows::ADSI
         adsi_child_collection.each do |m|
           sids << Puppet::Util::Windows::SID.ads_to_principal(m)
         end
-  
+
         sids
       end
-  
+
       def name_sid_hash(names)
         return {} if names.nil? || names.empty?
-  
+
         sids = names.map do |name|
           sid = Puppet::Util::Windows::SID.name_to_principal(name)
           raise Puppet::Error.new( _("Could not resolve name: %{name}") % { name: name } ) if !sid
           [sid.sid, sid]
         end
-  
+
         Hash[ sids ]
       end
 
@@ -176,8 +201,12 @@ module Puppet::Util::Windows::ADSI
         well_known = false
         if (sid = Puppet::Util::Windows::SID.name_to_principal(name_or_sid))
           # Examples of SidType include SidTypeUser, SidTypeGroup
-          return true if sid.account_type == "SidType#{@object_class.capitalize}".to_sym
-  
+          if sid.account_type == "SidType#{@object_class.capitalize}".to_sym
+            # Check if we're getting back a local user when domain-joined
+            return true unless [:MEMBER_WORKSTATION, :MEMBER_SERVER].include?(Puppet::Util::Windows::ADSI.domain_role)
+            return sid.domain == Puppet::Util::Windows::ADSI.computer_name
+          end
+
           # 'well known group' is special as it can be a group like Everyone OR a user like SYSTEM
           # so try to resolve it
           # https://msdn.microsoft.com/en-us/library/cc234477.aspx
@@ -388,23 +417,23 @@ module Puppet::Util::Windows::ADSI
       ADS_UF_SCRIPT:                                 0x0001,
       ADS_UF_ACCOUNTDISABLE:                         0x0002,
       ADS_UF_HOMEDIR_REQUIRED:                       0x0008,
-      ADS_UF_LOCKOUT:                                0x0010,                          
-      ADS_UF_PASSWD_NOTREQD:                         0x0020,                   
-      ADS_UF_PASSWD_CANT_CHANGE:                     0x0040,               
-      ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED:        0x0080,       
-      ADS_UF_TEMP_DUPLICATE_ACCOUNT:                 0x0100,           
-      ADS_UF_NORMAL_ACCOUNT:                         0x0200,                   
-      ADS_UF_INTERDOMAIN_TRUST_ACCOUNT:              0x0800,        
-      ADS_UF_WORKSTATION_TRUST_ACCOUNT:              0x1000,        
-      ADS_UF_SERVER_TRUST_ACCOUNT:                   0x2000,             
-      ADS_UF_DONT_EXPIRE_PASSWD:                     0x10000,            
-      ADS_UF_MNS_LOGON_ACCOUNT:                      0x20000,               
-      ADS_UF_SMARTCARD_REQUIRED:                     0x40000,              
-      ADS_UF_TRUSTED_FOR_DELEGATION:                 0x80000,          
-      ADS_UF_NOT_DELEGATED:                          0x100000,                  
-      ADS_UF_USE_DES_KEY_ONLY:                       0x200000,               
-      ADS_UF_DONT_REQUIRE_PREAUTH:                   0x400000,               
-      ADS_UF_PASSWORD_EXPIRED:                       0x800000,               
+      ADS_UF_LOCKOUT:                                0x0010,
+      ADS_UF_PASSWD_NOTREQD:                         0x0020,
+      ADS_UF_PASSWD_CANT_CHANGE:                     0x0040,
+      ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED:        0x0080,
+      ADS_UF_TEMP_DUPLICATE_ACCOUNT:                 0x0100,
+      ADS_UF_NORMAL_ACCOUNT:                         0x0200,
+      ADS_UF_INTERDOMAIN_TRUST_ACCOUNT:              0x0800,
+      ADS_UF_WORKSTATION_TRUST_ACCOUNT:              0x1000,
+      ADS_UF_SERVER_TRUST_ACCOUNT:                   0x2000,
+      ADS_UF_DONT_EXPIRE_PASSWD:                     0x10000,
+      ADS_UF_MNS_LOGON_ACCOUNT:                      0x20000,
+      ADS_UF_SMARTCARD_REQUIRED:                     0x40000,
+      ADS_UF_TRUSTED_FOR_DELEGATION:                 0x80000,
+      ADS_UF_NOT_DELEGATED:                          0x100000,
+      ADS_UF_USE_DES_KEY_ONLY:                       0x200000,
+      ADS_UF_DONT_REQUIRE_PREAUTH:                   0x400000,
+      ADS_UF_PASSWORD_EXPIRED:                       0x800000,
       ADS_UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION: 0x1000000
     }
 

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -41,6 +41,19 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
     end
   end
 
+  describe ".domain_role" do
+    DOMAIN_ROLES = Puppet::Util::Platform.windows? ? Puppet::Util::Windows::ADSI::DOMAIN_ROLES : {}
+
+    DOMAIN_ROLES.each do |id, role|
+      it "should be able to return #{role} as the domain role of the computer" do
+        Puppet::Util::Windows::ADSI.instance_variable_set(:@domain_role, nil)
+        domain_role = [double('WMI', :DomainRole => id)]
+        allow(Puppet::Util::Windows::ADSI).to receive(:execquery).with('select DomainRole from Win32_ComputerSystem').and_return(domain_role)
+        expect(Puppet::Util::Windows::ADSI.domain_role).to eq(role)
+      end
+    end
+  end
+
   describe ".sid_uri" do
     it "should raise an error when the input is not a SID Principal" do
       [Object.new, {}, 1, :symbol, '', nil].each do |input|
@@ -53,6 +66,25 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
     it "should return a SID uri for a well-known SID (SYSTEM)" do
       sid = Puppet::Util::Windows::SID::Principal.lookup_account_name('SYSTEM')
       expect(Puppet::Util::Windows::ADSI.sid_uri(sid)).to eq('WinNT://S-1-5-18')
+    end
+  end
+
+  shared_examples 'a local only resource query' do |klass, account_type|
+    before(:each) do
+      allow(Puppet::Util::Windows::ADSI).to receive(:domain_role).and_return(:MEMBER_SERVER)
+    end
+
+    it "should be able to check for a local resource" do
+      local_domain = 'testcomputername'
+      principal = double('Principal', :account => resource_name, :domain => local_domain, :account_type => account_type)
+      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with(resource_name).and_return(principal)
+      expect(klass.exists?(resource_name)).to eq(true)
+    end
+
+    it "should return false if no local resource exists" do
+      principal = double('Principal', :account => resource_name, :domain => 'AD_DOMAIN', :account_type => account_type)
+      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with(resource_name).and_return(principal)
+      expect(klass.exists?(resource_name)).to eq(false)
     end
   end
 
@@ -101,6 +133,12 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
       expect(user).to be_a(Puppet::Util::Windows::ADSI::User)
       expect(user.native_object).to eq(adsi_user)
+    end
+
+    context "when domain-joined" do
+      it_should_behave_like 'a local only resource query', Puppet::Util::Windows::ADSI::User, :SidTypeUser do
+        let(:resource_name) { username }
+      end
     end
 
     it "should be able to check the existence of a user" do
@@ -541,6 +579,12 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
 
     it "should generate the correct URI for a NT AUTHORITY group" do
       expect(Puppet::Util::Windows::ADSI::Group.uri(groupname, ntauthority_localized)).to eq("WinNT://./#{groupname},group")
+    end
+
+    context "when domain-joined" do
+      it_should_behave_like 'a local only resource query', Puppet::Util::Windows::ADSI::Group, :SidTypeGroup do
+        let(:resource_name) { groupname }
+      end
     end
 
     it "should be able to create a group" do


### PR DESCRIPTION
Behavior of the user resource goes wonky when an AD account exists with
the same name as the local user account you’re trying to manage on a
domain-joined Windows server.

This commit queries the WMI database for the computer's Domain Role. If
it's domain-joined, it will compare the found user's domain with the
computer name to confirm the account exists locally.

This issue is caused by the LookupAccountNameW function automatically
trying to resolve the name using domain controllers trusted by the local
system if the name cannot be resolved on the local system.

Still needs tests.