### PR TITLE
(PUP-10124) fix slot for portage package provider

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -70,7 +70,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     name = qatom[:pfx] + name if qatom[:pfx]
     name = name + '-' + qatom[:pv] if qatom[:pv]
     name = name + '-' + qatom[:pr] if qatom[:pr]
-    name = name + qatom[:slot] if qatom[:slot]
+    name = name + ':' + qatom[:slot] if qatom[:slot]
     cmd << '--update' if [:latest].include?(should)
     cmd += install_options if @resource[:install_options]
     cmd << name
@@ -84,7 +84,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     name = qatom[:pfx] + name if qatom[:pfx]
     name = name + '-' + qatom[:pv] if qatom[:pv]
     name = name + '-' + qatom[:pr] if qatom[:pr]
-    name = name + qatom[:slot] if qatom[:slot]
+    name = name + ':' + qatom[:slot] if qatom[:slot]
     cmd += uninstall_options if @resource[:uninstall_options]
     cmd << name
     if [:purged].include?(should)
@@ -247,7 +247,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     # [2.7.12: 2.7
     #  3.4.5:  3.4
     #  3.5.2:  3.5]
-    version_for_slot = versions_and_slots.find { |version_and_slot| version_and_slot.last == slot[1..-1] }
+    version_for_slot = versions_and_slots.find { |version_and_slot| version_and_slot.last == slot }
     # [3.5.2:  3.5]
     version_for_slot.first if version_for_slot
     # 3.5.2

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -42,13 +42,13 @@ describe Puppet::Type.type(:package).provider(:portage) do
     allow(@unslotted_provider).to receive(:qatom).and_return({:category=>"dev-lang", :pn=>"ruby", :pv=>nil, :pr=>nil, :slot=>nil, :pfx=>nil, :sfx=>nil})
     allow(@unslotted_provider.class).to receive(:emerge).with('--list-sets').and_return(package_sets)
     @slotted_provider = described_class.new(@slotted_resource)
-    allow(@slotted_provider).to receive(:qatom).and_return({:category=>"dev-lang", :pn=>"ruby", :pv=>nil, :pr=>nil, :slot=>":2.1", :pfx=>nil, :sfx=>nil})
+    allow(@slotted_provider).to receive(:qatom).and_return({:category=>"dev-lang", :pn=>"ruby", :pv=>nil, :pr=>nil, :slot=>"2.1", :pfx=>nil, :sfx=>nil})
     allow(@slotted_provider.class).to receive(:emerge).with('--list-sets').and_return(package_sets)
     @versioned_provider = described_class.new(@versioned_resource)
     allow(@versioned_provider).to receive(:qatom).and_return({:category=>"dev-lang", :pn=>"ruby", :pv=>"1.9.3", :pr=>nil, :slot=>nil, :pfx=>nil, :sfx=>nil})
     allow(@versioned_provider.class).to receive(:emerge).with('--list-sets').and_return(package_sets)
     @versioned_slotted_provider = described_class.new(@versioned_slotted_resource)
-    allow(@versioned_slotted_provider).to receive(:qatom).and_return({:category=>"dev-lang", :pn=>"ruby", :pv=>"1.9.3", :pr=>nil, :slot=>":1.9", :pfx=>"=", :sfx=>nil})
+    allow(@versioned_slotted_provider).to receive(:qatom).and_return({:category=>"dev-lang", :pn=>"ruby", :pv=>"1.9.3", :pr=>nil, :slot=>"1.9", :pfx=>"=", :sfx=>nil})
     allow(@versioned_slotted_provider.class).to receive(:emerge).with('--list-sets').and_return(package_sets)
     @set_provider = described_class.new(@set_resource)
     allow(@set_provider).to receive(:qatom).and_return({:category=>nil, :pn=>"@system", :pv=>nil, :pr=>nil, :slot=>nil, :pfx=>nil, :sfx=>nil})
@@ -166,7 +166,7 @@ describe Puppet::Type.type(:package).provider(:portage) do
   end
 
   it "can extract the slot from the package name" do
-    expect(@slotted_provider.qatom[:slot]).to eq(':2.1')
+    expect(@slotted_provider.qatom[:slot]).to eq('2.1')
   end
 
   it "returns nil for as the slot when no slot is specified" do
@@ -182,7 +182,7 @@ describe Puppet::Type.type(:package).provider(:portage) do
     expect(@versioned_slotted_provider.qatom[:category]).to eq('dev-lang')
     expect(@versioned_slotted_provider.qatom[:pn]).to eq('ruby')
     expect(@versioned_slotted_provider.qatom[:pv]).to eq('1.9.3')
-    expect(@versioned_slotted_provider.qatom[:slot]).to eq(':1.9')
+    expect(@versioned_slotted_provider.qatom[:slot]).to eq('1.9')
   end
 
   it "can handle search output with slots for unslotted packages" do


### PR DESCRIPTION
until now slot was expected to contain `:` which is not the case in current Linux Gentoo