### PR TITLE
(maint) Reset "tasks" setting after with_script_compiler

### DIFF
--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -83,6 +83,8 @@ module Pal
       end
     end
 
+    previous_tasks_value = Puppet[:tasks]
+    previous_code_value = Puppet[:code]
     Puppet[:tasks] = true
     # After the assertions, if code_string is non nil - it has the highest precedence
     Puppet[:code] = code_string unless code_string.nil?
@@ -90,6 +92,9 @@ module Pal
     # If manifest_file is nil, the #main method will use the env configured manifest
     # to do things in the block while a Script Compiler is in effect
     main(manifest_file, facts, variables, :script, &block)
+  ensure
+    Puppet[:tasks] = previous_tasks_value
+    Puppet[:code] = previous_code_value
   end
 
   # Evaluates a Puppet Language script string.


### PR DESCRIPTION
The `Puppet::Pal.with_script_compiler` method sets the
`Puppet[:tasks]` setting to true for the duration of the block, but
never sets it back to its original state. This means that the mode of
operation the process is in will be globally changed depending on
whether this method has been called. The corresponding
`with_catalog_compiler` method has similar behavior in setting
`Puppet[:tasks]` to false, but it ensures that the setting is reset to
its previous value when the method returns. We now copy that behavior in
`with_script_compiler`.