### PR TITLE
(PUP-10037) Add CA service

### DIFF
--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -8,6 +8,7 @@ module Puppet::HTTP
   require 'puppet/http/service'
   require 'puppet/http/service/ca'
   require 'puppet/http/session'
+  require 'puppet/http/resolver'
   require 'puppet/http/client'
   require 'puppet/http/redirector'
   require 'puppet/http/retry_after_handler'

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -5,6 +5,7 @@ module Puppet::HTTP
 
   require 'puppet/http/errors'
   require 'puppet/http/response'
+  require 'puppet/http/service'
   require 'puppet/http/client'
   require 'puppet/http/redirector'
   require 'puppet/http/retry_after_handler'

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -9,6 +9,7 @@ module Puppet::HTTP
   require 'puppet/http/service/ca'
   require 'puppet/http/session'
   require 'puppet/http/resolver'
+  require 'puppet/http/resolver/settings'
   require 'puppet/http/client'
   require 'puppet/http/redirector'
   require 'puppet/http/retry_after_handler'

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -1,5 +1,6 @@
 module Puppet::HTTP
   require 'puppet/network/http'
+  require 'puppet/network/resolver'
   require 'puppet/ssl'
   require 'puppet/x509'
 
@@ -10,6 +11,7 @@ module Puppet::HTTP
   require 'puppet/http/session'
   require 'puppet/http/resolver'
   require 'puppet/http/resolver/settings'
+  require 'puppet/http/resolver/srv'
   require 'puppet/http/client'
   require 'puppet/http/redirector'
   require 'puppet/http/retry_after_handler'

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -7,6 +7,7 @@ module Puppet::HTTP
   require 'puppet/http/response'
   require 'puppet/http/service'
   require 'puppet/http/service/ca'
+  require 'puppet/http/session'
   require 'puppet/http/client'
   require 'puppet/http/redirector'
   require 'puppet/http/retry_after_handler'

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -6,6 +6,7 @@ module Puppet::HTTP
   require 'puppet/http/errors'
   require 'puppet/http/response'
   require 'puppet/http/service'
+  require 'puppet/http/service/ca'
   require 'puppet/http/client'
   require 'puppet/http/redirector'
   require 'puppet/http/retry_after_handler'

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -8,7 +8,7 @@ class Puppet::HTTP::Client
     @default_ssl_context = ssl_context
     @redirector = Puppet::HTTP::Redirector.new(redirect_limit)
     @retry_after_handler = Puppet::HTTP::RetryAfterHandler.new(retry_limit, Puppet[:runinterval])
-    @resolvers = [].freeze
+    @resolvers = [Puppet::HTTP::Resolver::Settings.new].freeze
   end
 
   def create_session

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -83,7 +83,7 @@ class Puppet::HTTP::Client
         http.request(request) do |nethttp|
           response = Puppet::HTTP::Response.new(nethttp)
           begin
-            Puppet.info("HTTP #{request.method.upcase} returned #{response.code} #{response.reason}")
+            Puppet.debug("HTTP #{request.method.upcase} #{request.uri} returned #{response.code} #{response.reason}")
 
             if @redirector.redirect?(request, response)
               request = @redirector.redirect_to(request, response, redirects)

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -8,6 +8,11 @@ class Puppet::HTTP::Client
     @default_ssl_context = ssl_context
     @redirector = Puppet::HTTP::Redirector.new(redirect_limit)
     @retry_after_handler = Puppet::HTTP::RetryAfterHandler.new(retry_limit, Puppet[:runinterval])
+    @resolvers = [].freeze
+  end
+
+  def create_session
+    Puppet::HTTP::Session.new(self, @resolvers)
   end
 
   def connect(uri, ssl_context: nil, &block)

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -8,7 +8,7 @@ class Puppet::HTTP::Client
     @default_ssl_context = ssl_context
     @redirector = Puppet::HTTP::Redirector.new(redirect_limit)
     @retry_after_handler = Puppet::HTTP::RetryAfterHandler.new(retry_limit, Puppet[:runinterval])
-    @resolvers = [Puppet::HTTP::Resolver::Settings.new].freeze
+    @resolvers = build_resolvers
   end
 
   def create_session
@@ -141,5 +141,16 @@ class Puppet::HTTP::Client
     if user && password
       request.basic_auth(user, password)
     end
+  end
+
+  def build_resolvers
+    resolvers = []
+
+    if Puppet[:use_srv_records]
+      resolvers << Puppet::HTTP::Resolver::SRV.new(domain: Puppet[:srv_domain])
+    end
+
+    resolvers << Puppet::HTTP::Resolver::Settings.new
+    resolvers.freeze
   end
 end

--- a/lib/puppet/http/errors.rb
+++ b/lib/puppet/http/errors.rb
@@ -3,6 +3,8 @@ module Puppet::HTTP
 
   class ConnectionError < HTTPError; end
 
+  class RouteError < HTTPError; end
+
   class ProtocolError < HTTPError; end
 
   class ResponseError < HTTPError

--- a/lib/puppet/http/errors.rb
+++ b/lib/puppet/http/errors.rb
@@ -5,6 +5,15 @@ module Puppet::HTTP
 
   class ProtocolError < HTTPError; end
 
+  class ResponseError < HTTPError
+    attr_reader :response
+
+    def initialize(response)
+      super(response.reason)
+      @response = response
+    end
+  end
+
   class TooManyRedirects < HTTPError
     def initialize(addr)
       super(_("Too many HTTP redirections for %{addr}") % { addr: addr})
@@ -16,6 +25,4 @@ module Puppet::HTTP
       super(_("Too many HTTP retries for %{addr}") % { addr: addr})
     end
   end
-
-
 end

--- a/lib/puppet/http/resolver.rb
+++ b/lib/puppet/http/resolver.rb
@@ -1,0 +1,5 @@
+class Puppet::HTTP::Resolver
+  def resolve(session, name, &block)
+    raise NotImplementedError
+  end
+end

--- a/lib/puppet/http/resolver/settings.rb
+++ b/lib/puppet/http/resolver/settings.rb
@@ -1,0 +1,5 @@
+class Puppet::HTTP::Resolver::Settings < Puppet::HTTP::Resolver
+  def resolve(session, name, &block)
+    yield session.create_service(name)
+  end
+end

--- a/lib/puppet/http/resolver/srv.rb
+++ b/lib/puppet/http/resolver/srv.rb
@@ -1,0 +1,13 @@
+class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
+  def initialize(domain: srv_domain, dns: Resolv::DNS.new)
+    @srv_domain = domain
+    @delegate = Puppet::Network::Resolver.new(dns)
+  end
+
+  def resolve(session, name, &block)
+    # This assumes the route name is the same as the DNS SRV name
+    @delegate.each_srv_record(@srv_domain, name) do |server, port|
+      yield session.create_service(name, server, port)
+    end
+  end
+end

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -1,0 +1,18 @@
+class Puppet::HTTP::Service
+  attr_reader :url
+
+  def initialize(client, url)
+    @client = client
+    @url = url
+  end
+
+  def with_base_url(path)
+    u = @url.dup
+    u.path += path
+    u
+  end
+
+  def connect(ssl_context: nil)
+    @client.connect(@url, ssl_context: ssl_context)
+  end
+end

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -1,0 +1,46 @@
+class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
+  HEADERS = { 'Accept' => 'text/plain' }.freeze
+
+  def get_certificate(name)
+    response = @client.get(
+      with_base_url("/certificate/#{name}"),
+      headers: HEADERS
+    )
+
+    return response.body.to_s if response.success?
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
+
+  def get_certificate_revocation_list(if_modified_since: nil)
+    request_headers = if if_modified_since
+                        h = HEADERS.dup
+                        h['If-Modified-Since'] = if_modified_since.httpdate
+                        h
+                      else
+                        HEADERS
+                      end
+
+    response = @client.get(
+      with_base_url("/certificate_revocation_list/ca"),
+      headers: request_headers
+    )
+
+    return response.body.to_s if response.success?
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
+
+  def put_certificate_request(name, csr)
+    response = @client.put(
+      with_base_url("/certificate_request/#{name}"),
+      headers: HEADERS,
+      content_type: 'text/plain',
+      body: csr.to_pem
+    )
+
+    return response.body.to_s if response.success?
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
+end

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -1,0 +1,37 @@
+class Puppet::HTTP::Session
+  Route = Struct.new(:service_class, :api, :server_setting, :port_setting)
+
+  ROUTES = {
+    ca: Route.new(Puppet::HTTP::Service::Ca, '/puppet-ca/v1', :ca_server, :ca_port),
+  }.freeze
+
+  def initialize(client, resolvers)
+    @client = client
+    @resolvers = resolvers
+    @resolved_services = {}
+  end
+
+  def route_to(name, ssl_context: nil)
+    route = ROUTES[name]
+    raise ArgumentError, "Unknown service #{name}" unless route
+
+    cached = @resolved_services[name]
+    return cached if cached
+
+    @resolvers.each do |resolver|
+      Puppet.info("Resolving service '#{name}' using #{resolver.class}")
+      resolver.resolve(self, name) do |service|
+        begin
+          service.connect(ssl_context: ssl_context)
+          @resolved_services[name] = service
+          Puppet.info("Resolved service '#{name}' to #{service.url}")
+          return service
+        rescue Puppet::HTTP::ConnectionError => e
+          Puppet.err("Connection to #{service.url} failed #{e.message}, trying next route")
+        end
+      end
+    end
+
+    raise Puppet::HTTP::RouteError, "No more routes to #{name}"
+  end
+end

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -27,7 +27,7 @@ class Puppet::HTTP::Session
           Puppet.info("Resolved service '#{name}' to #{service.url}")
           return service
         rescue Puppet::HTTP::ConnectionError => e
-          Puppet.err("Connection to #{service.url} failed #{e.message}, trying next route")
+          Puppet.debug("Connection to #{service.url} failed #{e.message}, trying next route")
         end
       end
     end

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -34,4 +34,17 @@ class Puppet::HTTP::Session
 
     raise Puppet::HTTP::RouteError, "No more routes to #{name}"
   end
+
+  def create_service(name, server = nil, port = nil)
+    route = ROUTES[name]
+    raise ArgumentError, "Unknown service #{name}" unless route
+
+    server ||= Puppet[route.server_setting]
+    port   ||= Puppet[route.port_setting]
+    url = URI::HTTPS.build(host: server,
+                           port: port,
+                           path: route.api
+                          ).freeze
+    route.service_class.new(@client, url)
+  end
 end

--- a/lib/puppet/network/resolver.rb
+++ b/lib/puppet/network/resolver.rb
@@ -23,8 +23,8 @@ module Puppet::Network
       end
     end
 
-    def initialize
-      @resolver = Resolv::DNS.new
+    def initialize(resolver = Resolv::DNS.new)
+      @resolver = resolver
 
       # Stores DNS records per service, along with their TTL
       # and the time at which they were resolved, for cache

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -6,6 +6,10 @@ describe Puppet::HTTP::Client do
   let(:uri) { URI.parse('https://www.example.com') }
   let(:client) { described_class.new }
 
+  it 'creates unique sessions' do
+    expect(client.create_session).to_not eq(client.create_session)
+  end
+
   context "when connecting" do
     it 'connects to HTTP URLs' do
       uri = URI.parse('http://www.example.com')

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'puppet/http'
+
+describe Puppet::HTTP::Resolver do
+  let(:ssl_context) { Puppet::SSL::SSLContext.new }
+  let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:session) { client.create_session }
+  let(:uri) { URI.parse('https://www.example.com') }
+
+  context 'when resolving using settings' do
+    let(:subject) { Puppet::HTTP::Resolver::Settings.new }
+
+    it 'yields a service based on the current ca_server and ca_port settings' do
+      Puppet[:ca_server] = 'ca.example.com'
+      Puppet[:ca_port] = 8141
+
+      subject.resolve(session, :ca) do |service|
+        expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
+        expect(service.url.to_s).to eq("https://ca.example.com:8141/puppet-ca/v1")
+      end
+    end
+  end
+end

--- a/spec/unit/http/service/ca_spec.rb
+++ b/spec/unit/http/service/ca_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'puppet/http'
+
+describe Puppet::HTTP::Service::Ca do
+  let(:ssl_context) { Puppet::SSL::SSLContext.new }
+  let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:base_url) { URI.parse('https://www.example.com') }
+  let(:subject) { described_class.new(client, base_url) }
+
+  context 'when getting certificates' do
+    let(:cert) { cert_fixture('ca.pem') }
+    let(:pem) { cert.to_pem }
+    let(:url) { "https://www.example.com/certificate/ca" }
+
+    it 'gets a certificate from the "certificate" endpoint' do
+      stub_request(:get, url).to_return(body: pem)
+
+      expect(subject.get_certificate('ca')).to eq(pem)
+    end
+
+    it 'accepts text/plain responses' do
+      stub_request(:get, url).with(headers: {'Accept' => 'text/plain'})
+
+      subject.get_certificate('ca')
+    end
+
+    it 'raises a response error if unsuccessful' do
+      stub_request(:get, url).to_return(status: [404, 'Not Found'])
+
+      expect {
+        subject.get_certificate('ca')
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq("Not Found")
+        expect(err.response.code).to eq(404)
+      end
+    end
+  end
+
+  context 'when getting CRLs' do
+    let(:crl) { crl_fixture('crl.pem') }
+    let(:pem) { crl.to_pem }
+    let(:url) { "https://www.example.com/certificate_revocation_list/ca" }
+
+    it 'gets a CRL from "certificate_revocation_list" endpoint' do
+      stub_request(:get, url).to_return(body: pem)
+
+      expect(subject.get_certificate_revocation_list).to eq(pem)
+    end
+
+    it 'accepts text/plain responses' do
+      stub_request(:get, url).with(headers: {'Accept' => 'text/plain'})
+
+      subject.get_certificate_revocation_list
+    end
+
+    it 'raises a response error if unsuccessful' do
+      stub_request(:get, url).to_return(status: [404, 'Not Found'])
+
+      expect {
+        subject.get_certificate_revocation_list
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq("Not Found")
+        expect(err.response.code).to eq(404)
+      end
+    end
+
+    it 'raises a 304 response error if it is unmodified' do
+      stub_request(:get, url).to_return(status: [304, 'Not Modified'])
+
+      expect {
+        subject.get_certificate_revocation_list(if_modified_since: Time.now)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq("Not Modified")
+        expect(err.response.code).to eq(304)
+      end
+    end
+  end
+
+  context 'when submitting a CSR' do
+    let(:request) { request_fixture('request.pem') }
+    let(:pem) { request.to_pem }
+    let(:url) { "https://www.example.com/certificate_request/infinity" }
+
+    it 'submits a CSR to the "certificate_request" endpoint' do
+      stub_request(:put, url).with(body: pem, headers: { 'Content-Type' => 'text/plain' })
+
+      subject.put_certificate_request('infinity', request)
+    end
+
+    it 'raises response error if unsuccessful' do
+      stub_request(:put, url).to_return(status: [400, 'Bad Request'])
+
+      expect {
+        subject.put_certificate_request('infinity', request)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq('Bad Request')
+        expect(err.response.code).to eq(400)
+      end
+    end
+  end
+end

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'puppet/http'
+
+describe Puppet::HTTP::Service do
+  let(:ssl_context) { Puppet::SSL::SSLContext.new }
+  let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:url) { URI.parse('https://www.example.com') }
+  let(:service) { described_class.new(client, url) }
+
+  it "returns a URI containing the base URL and path" do
+    expect(service.with_base_url('/puppet/v3')).to eq(URI.parse("https://www.example.com/puppet/v3"))
+  end
+
+  it "doesn't modify frozen the base URL" do
+    service = described_class.new(client, url.freeze)
+    service.with_base_url('/puppet/v3')
+  end
+
+  it "connects to the base URL with a nil ssl context" do
+    expect(client).to receive(:connect).with(url, ssl_context: nil)
+
+    service.connect
+  end
+
+  it "accepts an optional ssl_context" do
+    other_ctx = Puppet::SSL::SSLContext.new
+    expect(client).to receive(:connect).with(url, ssl_context: other_ctx)
+
+    service.connect(ssl_context: other_ctx)
+  end
+end

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -31,12 +31,13 @@ describe Puppet::HTTP::Session do
 
   context 'when routing' do
     it 'returns the first resolved service' do
+      Puppet[:log_level] = :debug
       resolvers = [DummyResolver.new(bad_service), DummyResolver.new(good_service)]
       session = described_class.new(client, resolvers)
       resolved = session.route_to(:ca)
 
       expect(resolved).to eq(good_service)
-      expect(@logs).to include(an_object_having_attributes(level: :err, message: "Connection to #{uri} failed whoops, trying next route"))
+      expect(@logs).to include(an_object_having_attributes(level: :debug, message: "Connection to #{uri} failed whoops, trying next route"))
     end
 
     it 'only resolves once per session' do

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'puppet/http'
+
+describe Puppet::HTTP::Session do
+  let(:ssl_context) { Puppet::SSL::SSLContext.new }
+  let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:uri) { URI.parse('https://www.example.com') }
+  let(:good_service) {
+    double('good', url: uri, connect: nil)
+  }
+  let(:bad_service) {
+    service = double('good', url: uri)
+    allow(service).to receive(:connect).and_raise(Puppet::HTTP::ConnectionError, 'whoops')
+    service
+  }
+
+  class DummyResolver
+    attr_reader :count
+
+    def initialize(service)
+      @service = service
+      @count = 0
+    end
+
+    def resolve(session, name, &block)
+      @count += 1
+      yield @service
+    end
+  end
+
+  context 'when routing' do
+    it 'returns the first resolved service' do
+      resolvers = [DummyResolver.new(bad_service), DummyResolver.new(good_service)]
+      session = described_class.new(client, resolvers)
+      resolved = session.route_to(:ca)
+
+      expect(resolved).to eq(good_service)
+      expect(@logs).to include(an_object_having_attributes(level: :err, message: "Connection to #{uri} failed whoops, trying next route"))
+    end
+
+    it 'only resolves once per session' do
+      resolver = DummyResolver.new(good_service)
+      session = described_class.new(client, [resolver])
+      session.route_to(:ca)
+      session.route_to(:ca)
+
+      expect(resolver.count).to eq(1)
+    end
+
+    it 'raises if there are no more routes' do
+      resolvers = [DummyResolver.new(bad_service)]
+      session = described_class.new(client, resolvers)
+
+      expect {
+        session.route_to(:ca)
+      }.to raise_error(Puppet::HTTP::RouteError, 'No more routes to ca')
+    end
+
+    it 'accepts an ssl context to use when connecting' do
+      alt_context = Puppet::SSL::SSLContext.new
+      expect(good_service).to receive(:connect).with(ssl_context: alt_context)
+
+      resolvers = [DummyResolver.new(good_service)]
+      session = described_class.new(client, resolvers)
+      session.route_to(:ca, ssl_context: alt_context)
+    end
+
+    it 'raises for unknown service names' do
+      expect {
+        session = described_class.new(client, [])
+        session.route_to(:westbound)
+      }.to raise_error(ArgumentError, "Unknown service westbound")
+    end
+  end
+end

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -73,4 +73,29 @@ describe Puppet::HTTP::Session do
       }.to raise_error(ArgumentError, "Unknown service westbound")
     end
   end
+
+  context 'when creating services' do
+    let(:session) { described_class.new(client, []) }
+
+    it 'defaults the server and port based on settings' do
+      Puppet[:ca_server] = 'ca.example.com'
+      Puppet[:ca_port] = 8141
+      service = session.create_service(:ca)
+
+      expect(service.url.to_s).to eq("https://ca.example.com:8141/puppet-ca/v1")
+    end
+
+    it 'accepts server and port arguments' do
+      service = session.create_service(:ca, 'ca2.example.com', 8142)
+
+      expect(service.url.to_s).to eq("https://ca2.example.com:8142/puppet-ca/v1")
+    end
+
+    it 'raises for unknown service names' do
+      expect {
+        session = described_class.new(client, [])
+        session.create_service(:westbound)
+      }.to raise_error(ArgumentError, "Unknown service westbound")
+    end
+  end
 end


### PR DESCRIPTION
Adds a CA service to the http client:

```
client = Puppet::HTTP::Client.new
session = client.create_session
ca = session.route_to(:ca)
crl = ca.get_certificate_revocation_list(if_modified_since: Time.now)
```

The client will use SRV records (if enabled) or puppet settings to route to the CA service. Routing will only be performed once per session. The CA service provides methods for interacting with the puppetserver's CA REST API. The methods either return the entity (eg pem encoded crl), or raise one of the `Puppet::HTTP::HTTPError` exceptions.

- [x] Abstract Service 
- [x] CA Service
- [x] Session
- [x] Abstract Resolver
- [x] Settings Resolver
- [x] SRV Resolver