### PR TITLE
(PUP-10040) Use http client for cert related requests

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -296,10 +296,18 @@ module Puppet
     @context.rollback(name)
   end
 
+  def self.runtime
+    @runtime
+  end
+
   require 'puppet/node'
 
   # The single instance used for normal operation
   @context = Puppet::Context.new(bootstrap_context)
+
+  require 'puppet/runtime'
+  @runtime = Puppet::Runtime.instance
+  @runtime['http'] = proc { Puppet::HTTP::Client.new }
 end
 
 # This feels weird to me; I would really like for us to get to a state where there is never a "require" statement

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -1,18 +1,29 @@
-module Puppet::HTTP
-  require 'puppet/network/http'
-  require 'puppet/network/resolver'
-  require 'puppet/ssl'
-  require 'puppet/x509'
+module Puppet
+  module Network
+    module HTTP
+      require 'puppet/network/http/site'
+      require 'puppet/network/http/session'
+      require 'puppet/network/http/factory'
+      require 'puppet/network/http/base_pool'
+      require 'puppet/network/http/nocache_pool'
+      require 'puppet/network/http/pool'
+      require 'puppet/network/resolver'
+    end
+  end
 
-  require 'puppet/http/errors'
-  require 'puppet/http/response'
-  require 'puppet/http/service'
-  require 'puppet/http/service/ca'
-  require 'puppet/http/session'
-  require 'puppet/http/resolver'
-  require 'puppet/http/resolver/settings'
-  require 'puppet/http/resolver/srv'
-  require 'puppet/http/client'
-  require 'puppet/http/redirector'
-  require 'puppet/http/retry_after_handler'
+  module HTTP
+    ACCEPT_ENCODING = "gzip;q=1.0,deflate;q=0.6,identity;q=0.3".freeze
+
+    require 'puppet/http/errors'
+    require 'puppet/http/response'
+    require 'puppet/http/service'
+    require 'puppet/http/service/ca'
+    require 'puppet/http/session'
+    require 'puppet/http/resolver'
+    require 'puppet/http/resolver/settings'
+    require 'puppet/http/resolver/srv'
+    require 'puppet/http/client'
+    require 'puppet/http/redirector'
+    require 'puppet/http/retry_after_handler'
+  end
 end

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -1,10 +1,11 @@
 class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   HEADERS = { 'Accept' => 'text/plain' }.freeze
 
-  def get_certificate(name)
+  def get_certificate(name, ssl_context: nil)
     response = @client.get(
       with_base_url("/certificate/#{name}"),
-      headers: HEADERS
+      headers: HEADERS,
+      ssl_context: ssl_context
     )
 
     return response.body.to_s if response.success?
@@ -12,7 +13,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     raise Puppet::HTTP::ResponseError.new(response)
   end
 
-  def get_certificate_revocation_list(if_modified_since: nil)
+  def get_certificate_revocation_list(if_modified_since: nil, ssl_context: nil)
     request_headers = if if_modified_since
                         h = HEADERS.dup
                         h['If-Modified-Since'] = if_modified_since.httpdate
@@ -23,7 +24,8 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
 
     response = @client.get(
       with_base_url("/certificate_revocation_list/ca"),
-      headers: request_headers
+      headers: request_headers,
+      ssl_context: ssl_context
     )
 
     return response.body.to_s if response.success?
@@ -31,12 +33,13 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     raise Puppet::HTTP::ResponseError.new(response)
   end
 
-  def put_certificate_request(name, csr)
+  def put_certificate_request(name, csr, ssl_context: nil)
     response = @client.put(
       with_base_url("/certificate_request/#{name}"),
       headers: HEADERS,
       content_type: 'text/plain',
-      body: csr.to_pem
+      body: csr.to_pem,
+      ssl_context: ssl_context
     )
 
     return response.body.to_s if response.success?

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -19,12 +19,12 @@ class Puppet::HTTP::Session
     return cached if cached
 
     @resolvers.each do |resolver|
-      Puppet.info("Resolving service '#{name}' using #{resolver.class}")
+      Puppet.debug("Resolving service '#{name}' using #{resolver.class}")
       resolver.resolve(self, name) do |service|
         begin
           service.connect(ssl_context: ssl_context)
           @resolved_services[name] = service
-          Puppet.info("Resolved service '#{name}' to #{service.url}")
+          Puppet.debug("Resolved service '#{name}' to #{service.url}")
           return service
         rescue Puppet::HTTP::ConnectionError => e
           Puppet.debug("Connection to #{service.url} failed #{e.message}, trying next route")

--- a/lib/puppet/network/http.rb
+++ b/lib/puppet/network/http.rb
@@ -18,12 +18,8 @@ module Puppet::Network::HTTP
   require 'puppet/network/http/handler'
   require 'puppet/network/http/response'
   require 'puppet/network/http/request'
-  require 'puppet/network/http/site'
-  require 'puppet/network/http/session'
-  require 'puppet/network/http/factory'
-  require 'puppet/network/http/base_pool'
-  require 'puppet/network/http/nocache_pool'
-  require 'puppet/network/http/pool'
   require 'puppet/network/http/memory_response'
   require 'puppet/network/http/compression'
+
+  require 'puppet/http'
 end

--- a/lib/puppet/rest/errors.rb
+++ b/lib/puppet/rest/errors.rb
@@ -1,3 +1,4 @@
+# @deprecated Use {Puppet::HTTP::Client} instead.
 module Puppet::Rest
   class ResponseError < Puppet::Error
     attr_reader :response

--- a/lib/puppet/rest/response.rb
+++ b/lib/puppet/rest/response.rb
@@ -1,3 +1,4 @@
+# @deprecated Use {Puppet::HTTP::Client} instead.
 module Puppet::Rest
   # This is a wrapper for the HTTP::Message class of the HTTPClient
   # gem. It is designed to wrap a message sent as an HTTP response.

--- a/lib/puppet/rest/route.rb
+++ b/lib/puppet/rest/route.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'puppet/util/connection'
 
+# @deprecated Use {Puppet::HTTP::Client} instead.
 module Puppet::Rest
   class Route
     attr_reader :server

--- a/lib/puppet/rest/routes.rb
+++ b/lib/puppet/rest/routes.rb
@@ -3,6 +3,7 @@ require 'puppet/rest/route'
 require 'puppet/network/http_pool'
 require 'puppet/network/http/compression'
 
+# @deprecated Use {Puppet::HTTP::Client} instead.
 module Puppet::Rest
   module Routes
     extend Puppet::Network::HTTP::Compression.module
@@ -10,6 +11,8 @@ module Puppet::Rest
     ACCEPT_ENCODING = 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
 
     def self.ca
+      Puppet.deprecation_warning("Puppet::Rest::Routes is deprecated, use Puppet::HTTP::Client instead")
+
       @ca ||= Route.new(api: '/puppet-ca/v1/',
                         server_setting: :ca_server,
                         port_setting: :ca_port,

--- a/lib/puppet/runtime.rb
+++ b/lib/puppet/runtime.rb
@@ -1,0 +1,25 @@
+require 'puppet/http'
+
+class Puppet::Runtime
+  include Singleton
+
+  def initialize
+    @runtime_services = {}
+  end
+  private :initialize
+
+  def [](name)
+    service = @runtime_services[name]
+    raise ArgumentError, "Unknown service #{name}" unless service
+
+    if service.is_a?(Proc)
+      @runtime_services[name] = service.call
+    else
+      service
+    end
+  end
+
+  def []=(name, impl)
+    @runtime_services[name] = impl
+  end
+end

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -44,7 +44,8 @@ class Puppet::SSL::StateMachine
       if cacerts
         next_ctx = @ssl_provider.create_root_context(cacerts: cacerts, revocation: false)
       else
-        pem = Puppet::Rest::Routes.get_certificate(Puppet::SSL::CA_NAME, @ssl_context)
+        route = @machine.session.route_to(:ca, ssl_context: @ssl_context)
+        pem = route.get_certificate(Puppet::SSL::CA_NAME, ssl_context: @ssl_context)
         if @machine.ca_fingerprint
           actual_digest = Puppet::SSL::Digest.new(@machine.digest, pem).to_hex
           expected_digest = @machine.ca_fingerprint.scan(/../).join(':').upcase
@@ -66,8 +67,8 @@ class Puppet::SSL::StateMachine
       NeedCRLs.new(@machine, next_ctx)
     rescue OpenSSL::X509::CertificateError => e
       Error.new(@machine, e.message, e)
-    rescue Puppet::Rest::ResponseError => e
-      if e.response.code.to_i == 404
+    rescue Puppet::HTTP::ResponseError => e
+      if e.response.code == 404
         to_error(_('CA certificate is missing from the server'), e)
       else
         to_error(_('Could not download CA certificate: %{message}') % { message: e.message }, e)
@@ -112,8 +113,8 @@ class Puppet::SSL::StateMachine
       NeedKey.new(@machine, next_ctx)
     rescue OpenSSL::X509::CRLError => e
       Error.new(@machine, e.message, e)
-    rescue Puppet::Rest::ResponseError => e
-      if e.response.code.to_i == 404
+    rescue Puppet::HTTP::ResponseError => e
+      if e.response.code == 404
         to_error(_('CRL is missing from the server'), e)
       else
         to_error(_('Could not download CRLs: %{message}') % { message: e.message }, e)
@@ -127,8 +128,8 @@ class Puppet::SSL::StateMachine
 
       # return the next_ctx containing the updated crl
       download_crl(ssl_ctx, last_update)
-    rescue Puppet::Rest::ResponseError => e
-      if e.response.code.to_i == 304
+    rescue Puppet::HTTP::ResponseError => e
+      if e.response.code == 304
         Puppet.info(_("CRL is unmodified, using existing CRL"))
       else
         Puppet.info(_("Failed to refresh CRL, using existing CRL: %{message}") % {message: e.message})
@@ -136,7 +137,7 @@ class Puppet::SSL::StateMachine
 
       # return the original ssl_ctx
       ssl_ctx
-    rescue SystemCallError => e
+    rescue Puppet::HTTP::HTTPError => e
       Puppet.warning(_("Failed to refresh CRL, using existing CRL: %{message}") % {message: e.message})
 
       # return the original ssl_ctx
@@ -144,7 +145,8 @@ class Puppet::SSL::StateMachine
     end
 
     def download_crl(ssl_ctx, last_update)
-      pem = Puppet::Rest::Routes.get_crls(Puppet::SSL::CA_NAME, ssl_ctx, if_modified_since: last_update)
+      route = @machine.session.route_to(:ca, ssl_context: ssl_ctx)
+      pem = route.get_certificate_revocation_list(if_modified_since: last_update, ssl_context: ssl_ctx)
       crls = @cert_provider.load_crls_from_pem(pem)
       # verify crls before saving
       next_ctx = @ssl_provider.create_root_context(cacerts: ssl_ctx[:cacerts], crls: crls)
@@ -211,11 +213,12 @@ class Puppet::SSL::StateMachine
       Puppet.debug(_("Generating and submitting a CSR"))
 
       csr = @cert_provider.create_request(Puppet[:certname], @private_key)
-      Puppet::Rest::Routes.put_certificate_request(csr.to_pem, Puppet[:certname], @ssl_context)
+      route = @machine.session.route_to(:ca, ssl_context: @ssl_context)
+      route.put_certificate_request(Puppet[:certname], csr, ssl_context: @ssl_context)
       @cert_provider.save_request(Puppet[:certname], csr)
       NeedCert.new(@machine, @ssl_context, @private_key)
-    rescue Puppet::Rest::ResponseError => e
-      if e.response.code.to_i == 400
+    rescue Puppet::HTTP::ResponseError => e
+      if e.response.code == 400
         NeedCert.new(@machine, @ssl_context, @private_key)
       else
         to_error(_("Failed to submit the CSR, HTTP response was %{code}") % { code: e.response.code }, e)
@@ -229,8 +232,9 @@ class Puppet::SSL::StateMachine
     def next_state
       Puppet.debug(_("Downloading client certificate"))
 
+      route = @machine.session.route_to(:ca, ssl_context: @ssl_context)
       cert = OpenSSL::X509::Certificate.new(
-        Puppet::Rest::Routes.get_certificate(Puppet[:certname], @ssl_context)
+        route.get_certificate(Puppet[:certname], ssl_context: @ssl_context)
       )
       # verify client cert before saving
       next_ctx = @ssl_provider.create_context(
@@ -243,8 +247,8 @@ class Puppet::SSL::StateMachine
       Error.new(@machine, e.message, e)
     rescue OpenSSL::X509::CertificateError => e
       Error.new(@machine, _("Failed to parse certificate: %{message}") % {message: e.message}, e)
-    rescue Puppet::Rest::ResponseError => e
-      if e.response.code.to_i == 404
+    rescue Puppet::HTTP::ResponseError => e
+      if e.response.code == 404
         Puppet.info(_("Certificate for %{certname} has not been signed yet") % {certname: Puppet[:certname]})
         $stdout.puts _("Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (%{name}).") % { name: Puppet[:certname] }
         Wait.new(@machine)
@@ -277,6 +281,7 @@ class Puppet::SSL::StateMachine
 
         # our ssl directory may have been cleaned while we were
         # sleeping, start over from the top
+        @machine.session = Puppet.runtime['http'].create_session
         NeedCACerts.new(@machine)
       end
     end
@@ -305,6 +310,7 @@ class Puppet::SSL::StateMachine
   class Done < SSLState; end
 
   attr_reader :waitforcert, :wait_deadline, :cert_provider, :ssl_provider, :ca_fingerprint, :digest
+  attr_accessor :session
 
   # Construct a state machine to manage the SSL initialization process. By
   # default, if the state machine encounters an exception, it will log the
@@ -343,6 +349,7 @@ class Puppet::SSL::StateMachine
     @lockfile = lockfile
     @digest = digest
     @ca_fingerprint = ca_fingerprint
+    @session = Puppet.runtime['http'].create_session
   end
 
   # Run the state machine for CA certs and CRLs.

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -236,6 +236,7 @@ class Puppet::SSL::StateMachine
       cert = OpenSSL::X509::Certificate.new(
         route.get_certificate(Puppet[:certname], ssl_context: @ssl_context)
       )
+      Puppet.info _("Downloaded certificate for %{name} from %{url}") % { name: Puppet[:certname], url: route.url }
       # verify client cert before saving
       next_ctx = @ssl_provider.create_context(
         cacerts: @ssl_context.cacerts, crls: @ssl_context.crls, private_key: @private_key, client_cert: cert

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -1,6 +1,6 @@
 require 'uri'
 require 'puppet/ssl/openssl_loader'
-require 'puppet/network/http'
+require 'puppet/http'
 
 module Puppet::Util::HttpProxy
   def self.proxy(uri)
@@ -187,7 +187,7 @@ module Puppet::Util::HttpProxy
 
       headers = { 'Accept' => '*/*', 'User-Agent' => Puppet[:http_user_agent] }
       if Puppet.features.zlib?
-        headers["Accept-Encoding"] = Puppet::Network::HTTP::Compression::ACCEPT_ENCODING
+        headers["Accept-Encoding"] = Puppet::HTTP::ACCEPT_ENCODING
       end
 
       response = proxy.send(:head, current_uri, headers)

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -298,9 +298,12 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 200, body: cacert_pem)
       allow(cert_provider).to receive(:save_cacerts)
 
-      expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+      receive_count = 0
+      allow_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE) { receive_count += 1 }
 
       state.next_state
+
+      expect(receive_count).to eq(2)
     end
 
     it 'returns an Error if the server returns 404' do
@@ -410,9 +413,12 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: crl_pem)
       allow(cert_provider).to receive(:save_crls)
 
-      expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+      receive_count = 0
+      allow_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER) { receive_count += 1 }
 
       state.next_state
+
+      expect(receive_count).to eq(2)
     end
 
     it 'returns an Error if the server returns 404' do
@@ -724,9 +730,12 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       it "verifies the server's certificate when submitting the CSR" do
         stub_request(:put, %r{puppet-ca/v1/certificate_request/#{Puppet[:certname]}}).to_return(status: 200)
 
-        expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+        receive_count = 0
+        allow_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER) { receive_count += 1 }
 
         state.next_state
+
+        expect(receive_count).to eq(2)
       end
     end
 
@@ -774,9 +783,12 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         allow(cert_provider).to receive(:save_client_cert)
         allow(cert_provider).to receive(:save_request)
 
-        expect_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+        receive_count = 0
+        allow_any_instance_of(Net::HTTP).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER) { receive_count += 1 }
 
         state.next_state
+
+        expect(receive_count).to eq(2)
       end
 
       it 'does not save an invalid client cert' do


### PR DESCRIPTION
Change the `puppet ssl` application and the ssl state machine to use the http client, and deprecate the `Puppet::Rest`.

Depends on PR https://github.com/puppetlabs/puppet/pull/7825