### PR TITLE
(PUP-10136) premature facts loading under facter -p

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -35,7 +35,7 @@ module Puppet
   def self.default_basemodulepath
     if Puppet::Util::Platform.windows?
       path = ['$codedir/modules']
-      installdir = Facter.value(:env_windows_installdir)
+      installdir = ENV["FACTER_env_windows_installdir"]
       if installdir
         path << "#{installdir}/puppet/modules"
       end
@@ -47,7 +47,7 @@ module Puppet
 
   def self.default_vendormoduledir
     if Puppet::Util::Platform.windows?
-      installdir = Facter.value(:env_windows_installdir)
+      installdir = ENV["FACTER_env_windows_installdir"]
       if installdir
         "#{installdir}\\puppet\\vendor_modules"
       else

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -139,7 +139,7 @@ describe "Defaults" do
       let(:installdir) { 'C:\Program Files\Puppet Labs\Puppet' }
 
       it 'includes user and system modules' do
-        allow(Facter).to receive(:value).with(:env_windows_installdir).and_return(installdir)
+        allow(ENV).to receive(:[]).with("FACTER_env_windows_installdir").and_return(installdir)
 
         expect(
           Puppet.default_basemodulepath
@@ -147,7 +147,7 @@ describe "Defaults" do
       end
 
       it 'includes user modules if installdir fact is missing' do
-        allow(Facter).to receive(:value).with(:env_windows_installdir).and_return(nil)
+        allow(ENV).to receive(:[]).with("FACTER_env_windows_installdir").and_return(nil)
 
         expect(
           Puppet.default_basemodulepath
@@ -167,7 +167,7 @@ describe "Defaults" do
       let(:installdir) { 'C:\Program Files\Puppet Labs\Puppet' }
 
       it 'includes the default vendormoduledir' do
-        allow(Facter).to receive(:value).with(:env_windows_installdir).and_return(installdir)
+        allow(ENV).to receive(:[]).with("FACTER_env_windows_installdir").and_return(installdir)
 
         expect(
           Puppet.default_vendormoduledir
@@ -175,7 +175,7 @@ describe "Defaults" do
       end
 
       it 'is nil if installdir fact is missing' do
-        allow(Facter).to receive(:value).with(:env_windows_installdir).and_return(nil)
+        allow(ENV).to receive(:[]).with("FACTER_env_windows_installdir").and_return(nil)
 
         expect(Puppet.default_vendormoduledir).to be_nil
       end


### PR DESCRIPTION
When running facter -p on windows, if there are custom facts or module
facts that require some additional files that that are not yet present
in $LOAD_PATH, it will cause an error.

This error is caused by the way base modules/vendor paths are generated.
When running facter -p, puppet needs to set $LOAD_PATH so that facter
will know where to check for module facts. When loading the module path,
puppet will call Facter.value of a non core fact, and this will start
the re-evaluation of all custom/plugin facts without setting the
$LOAD_PATH. This step fails if a fact requires some additional files not
yet in $LOAD_PATH.

Now the $LOAD_PATH will be set  without using Facter, getting it
directly from the system environment.