### PR TITLE
(PUP-9994) Make external argument optional

### DIFF
--- a/lib/puppet/context/trusted_information.rb
+++ b/lib/puppet/context/trusted_information.rb
@@ -29,12 +29,12 @@ class Puppet::Context::TrustedInformation
   # @return [String]
   attr_reader :hostname
 
-  # Additional external facts loaded through `trusted_external_terminus`.
+  # Additional external facts loaded through `trusted_external_command`.
   #
   # @return [Hash]
   attr_reader :external
 
-  def initialize(authenticated, certname, extensions, external)
+  def initialize(authenticated, certname, extensions, external = {})
     @authenticated = authenticated.freeze
     @certname = certname.freeze
     @extensions = extensions.freeze

--- a/spec/unit/context/trusted_information_spec.rb
+++ b/spec/unit/context/trusted_information_spec.rb
@@ -45,6 +45,12 @@ describe Puppet::Context::TrustedInformation, :unless => RUBY_PLATFORM == 'java'
     allow(Puppet::Util::Execution).to receive(:execute).with(['/usr/bin/generate_data.sh', certname], anything).and_return(JSON.dump(data))
   end
 
+  it "defaults external to an empty hash" do
+    trusted = Puppet::Context::TrustedInformation.new(false, 'ignored', nil)
+
+    expect(trusted.external).to eq({})
+  end
+
   context "when remote" do
     it "has no cert information when it isn't authenticated" do
       trusted = Puppet::Context::TrustedInformation.remote(false, 'ignored', nil)


### PR DESCRIPTION
rspec-puppet creates an instance of Puppet::Context::TrustedInformation
instead of using the `remote` class method[1]. To reduce compatibility issues
with rspec-puppet and any other users of trusted information, make the
`external` argument optional.

Also update docs as the setting was changed from terminus to command.

[1] https://github.com/rodjek/rspec-puppet/blob/a4749c804c820977c2f507133d01f56006b22f47/lib/rspec-puppet/support.rb#L407