### PR TITLE
(PUP-10121) Simplify connection error handling

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -325,19 +325,17 @@ module Puppet::Network::HTTP
     rescue => exception
       elapsed = (Time.now - start).to_f.round(3)
       uri = [@site.addr, request.path.split('?')[0]].join('/')
-      eclass = exception.class
 
-      err = case exception
-            when EOFError
-              eclass.new(_('request %{uri} interrupted after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
-            when Timeout::Error
-              eclass.new(_('request %{uri} timed out after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
-            else
-              eclass.new(_('request %{uri} failed: %{msg}') % {uri: uri, msg: exception.message})
-            end
+      case exception
+      when EOFError
+        Puppet.log_exception(exception, _('request %{uri} interrupted after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
+      when Timeout::Error
+        Puppet.log_exception(exception, _('request %{uri} timed out after %{elapsed} seconds') % {uri: uri, elapsed: elapsed})
+      else
+        Puppet.log_exception(exception, _('request %{uri} failed: %{msg}') % {uri: uri, msg: exception.message})
+      end
 
-      err.set_backtrace(exception.backtrace) unless exception.backtrace.empty?
-      raise err
+      raise exception
     end
 
     def with_connection(site, &block)

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -246,4 +246,30 @@ describe Puppet::Network::HTTP::Connection do
 
     subject.get('/foo')
   end
+
+  describe 'connection request errors' do
+    it "logs and raises generic http errors" do
+      generic_error = Net::HTTPError.new('generic error', double("response"))
+      stub_request(:get, url).to_raise(generic_error)
+
+      expect(Puppet).to receive(:log_exception).with(anything, /^.*failed: generic error$/)
+      expect { subject.get('/foo') }.to raise_error(generic_error)
+    end
+
+    it "logs and raises timeout errors" do
+      timeout_error = Timeout::Error.new
+      stub_request(:get, url).to_raise(timeout_error)
+
+      expect(Puppet).to receive(:log_exception).with(anything, /^.*timed out after .* seconds$/)
+      expect { subject.get('/foo') }.to raise_error(timeout_error)
+    end
+
+    it "logs and raises eof errors" do
+      eof_error = EOFError
+      stub_request(:get, url).to_raise(eof_error)
+
+      expect(Puppet).to receive(:log_exception).with(anything, /^.*interrupted after .* seconds$/)
+      expect { subject.get('/foo') }.to raise_error(eof_error)
+    end
+  end
 end


### PR DESCRIPTION
Rather than create a new exception class when we catch connection
errors, we should raise the original exception. Previously, this rescue
block was modified to add additional contextual information to the
exceptions we were catching to give the user more information around the
context of failures. Rather than raising the original message, it would
create a new exception with the additional information.

This commit simply logs the error with Puppet with the additional
information, and raises the original caught exception. This saves us
from errors that stem from different error initializer expectations.