### PR TITLE
(PUP-10139) Add find_template function

### DIFF
--- a/lib/puppet/functions/find_template.rb
+++ b/lib/puppet/functions/find_template.rb
@@ -1,0 +1,63 @@
+# Finds an existing template from a module and returns its path.
+#
+# This function accepts an argument that is a String as a `<MODULE NAME>/<TEMPLATE>`
+# reference, which searches for `<TEMPLATE>` relative to a module's `templates`
+# directory on the master. (For example, the reference `mymod/secret.conf.epp`
+# will search for the file `<MODULES DIRECTORY>/mymod/templates/secret.conf.epp`.)
+#
+# The primary use case is for agent-side template rendering with late-bound variables
+# resolved, such as from secret stores inaccessible to the master, such as
+#
+# ```
+# $variables = {
+#   'password' => Deferred('vault_lookup::lookup',
+#                   ['secret/mymod', 'https://vault.example.com:8200']),
+# }
+#
+# # compile the template source into the catalog
+# file { '/etc/secrets.conf':
+#   ensure  => file,
+#   content => Deferred('inline_epp',
+#                [find_template('mymod/secret.conf.epp').file, $variables]),
+# }
+# ```
+#
+#
+#
+# This function can also accept:
+#
+# * An absolute String path, which checks for the existence of a template from anywhere on disk.
+# * Multiple String arguments, which returns the path of the **first** template
+#   found, skipping nonexistent files.
+# * An array of string paths, which returns the path of the **first** template
+#   found from the given paths in the array, skipping nonexistent files.
+#
+# The function returns `undef` if none of the given paths were found.
+#
+# @since 6.x
+#
+Puppet::Functions.create_function(:find_template, Puppet::Functions::InternalFunction) do
+  dispatch :find_template do
+    scope_param
+    repeated_param 'String', :paths
+  end
+
+  dispatch :find_template_array do
+    scope_param
+    repeated_param 'Array[String]', :paths_array
+  end
+
+  def find_template_array(scope, array)
+    find_template(scope, *array)
+  end
+
+  def find_template(scope, *args)
+    args.each do |file|
+      found = Puppet::Parser::Files.find_template(file, scope.compiler.environment)
+      if found && Puppet::FileSystem.exist?(found)
+        return found
+      end
+    end
+    nil
+  end
+end

--- a/spec/unit/functions/find_template_spec.rb
+++ b/spec/unit/functions/find_template_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+require 'puppet_spec/files'
+
+describe 'the find_template function' do
+  include PuppetSpec::Compiler
+  include Matchers::Resource
+  include PuppetSpec::Files
+
+  def with_file_content(content)
+    path = tmpfile('find-file-function')
+    file = File.new(path, 'wb')
+    file.sync = true
+    file.print content
+    yield path
+  end
+
+  it 'finds an existing absolute file when given arguments individually' do
+    with_file_content('one') do |one|
+      with_file_content('two') do |two|
+        expect(compile_to_catalog("notify { find_template('#{one}', '#{two}'):}")).to have_resource("Notify[#{one}]")
+      end
+    end
+  end
+
+  it 'skips non existing files' do
+    with_file_content('one') do |one|
+      with_file_content('two') do |two|
+        expect(compile_to_catalog("notify { find_template('#{one}/nope', '#{two}'):}")).to have_resource("Notify[#{two}]")
+      end
+    end
+  end
+
+  it 'accepts arguments given as an array' do
+    with_file_content('one') do |one|
+      with_file_content('two') do |two|
+        expect(compile_to_catalog("notify { find_template(['#{one}', '#{two}']):}")).to have_resource("Notify[#{one}]")
+      end
+    end
+  end
+
+  it 'finds an existing file in a module' do
+    with_file_content('file content') do |name|
+      mod = double('module')
+      allow(mod).to receive(:template).with('myfile').and_return(name)
+      Puppet[:code] = "notify { find_template('mymod/myfile'):}"
+      node = Puppet::Node.new('localhost')
+      compiler = Puppet::Parser::Compiler.new(node)
+      allow(compiler.environment).to receive(:module).with('mymod').and_return(mod)
+
+      expect(compiler.compile().filter { |r| r.virtual? }).to have_resource("Notify[#{name}]")
+    end
+  end
+
+  it 'returns undef when none of the paths were found' do
+    mod = double('module')
+    allow(mod).to receive(:template).with('myfile').and_return(nil)
+    Puppet[:code] = "notify { String(type(find_template('mymod/myfile', 'nomod/nofile'))):}"
+    node = Puppet::Node.new('localhost')
+    compiler = Puppet::Parser::Compiler.new(node)
+    # For a module that does not have the file
+    allow(compiler.environment).to receive(:module).with('mymod').and_return(mod)
+    # For a module that does not exist
+    allow(compiler.environment).to receive(:module).with('nomod').and_return(nil)
+
+    expect(compiler.compile().filter { |r| r.virtual? }).to have_resource("Notify[Undef]")
+  end
+end


### PR DESCRIPTION
This makes it easier users to render templates on the agent, meaning that
they can use secret values resolved by deferred functions directly with
e.g. Vault. That means that the master no longer needs keys to the kingdom.