### PR TITLE
(PUP-10040) Print resolution exceptions when routing fails

### DIFF
--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -37,7 +37,7 @@ describe Puppet::HTTP::Session do
       resolved = session.route_to(:ca)
 
       expect(resolved).to eq(good_service)
-      expect(@logs).to include(an_object_having_attributes(level: :debug, message: "Connection to #{uri} failed whoops, trying next route"))
+      expect(@logs).to include(an_object_having_attributes(level: :debug, message: "Connection to #{uri} failed, trying next route: whoops"))
     end
 
     it 'only resolves once per session' do


### PR DESCRIPTION
Previously, if an agent couldn't connect to the CA to bootstrap its SSL certs,
it only printed "No more routes to ca" while the actual connection failure was
logged at :debug level. This caused the windows eventlog acceptance test to
fail, since "puppet agent -t" sets the log level to :info, preventing the
expected message from being logged.

This commit continues to log each individual connection failures at debug as is
done in Puppet::Configurer#find_functional_server and Puppet::Rest::Routes when
using SRV records, but if we exhaust all resolvers, then we log each exception
at error level, and raise the "no more routes" error as we did before:

    C:\> puppet agent -t
    ...
    Error: Failed to connect to https://127.0.0.1:8140/puppet-ca/v1: Failed to open TCP connection to 127.0.0.1:8140 (Connection refused - connect(2) for "127.0.0.1" port 8140)
    Wrapped exception:
    Failed to open TCP connection to 127.0.0.1:8140 (Connection refused - connect(2) for "127.0.0.1" port 8140)
    Error: No more routes to ca
    Error: Could not run: No more routes to ca