### PR TITLE
(PUP-10140) fix puppet service on windows

### DIFF
--- a/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_mcollective_service_management.rb
@@ -1,6 +1,5 @@
 test_name "Puppet and Mcollective services should be manageable with Puppet"
 
-confine :except, :platform => 'windows' # See MCO-727
 confine :except, :platform => /centos-4|el-4/ # PUP-5257
 
 tag 'audit:medium',
@@ -30,6 +29,9 @@ end
 agents.each do |agent|
 
   ['puppet', 'mcollective'].each do |service|
+    # skip mcollective on windows: MCO-727
+    next if service == 'mcollective' && agent.platform =~ /windows/
+
     # --- service management using `puppet apply` --- #
     step "#{service} service management using `puppet apply`"
     set_service_initial_status(agent, service, 'stopped')


### PR DESCRIPTION
puppet-agent 5.5.x fails to start, because if ENV['RUBYLIB']
is not defined, then daemon.rb tries to append nil to a string.
This raises an exception "TypeError (no implicit conversion of nil into String)".