### PR TITLE
(maint) Refactor how services are created

### DIFF
--- a/lib/puppet/http/resolver/srv.rb
+++ b/lib/puppet/http/resolver/srv.rb
@@ -5,7 +5,9 @@ class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
   end
 
   def resolve(session, name, &block)
-    # This assumes the route name is the same as the DNS SRV name
+    # Here we pass our HTTP service name as the DNS SRV service name
+    # This is fine for :ca, but note that :puppet and :file are handled
+    # specially in `each_srv_record`.
     @delegate.each_srv_record(@srv_domain, name) do |server, port|
       yield session.create_service(name, server, port)
     end

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -1,6 +1,21 @@
 class Puppet::HTTP::Service
   attr_reader :url
 
+  SERVICE_NAMES = [:ca].freeze
+
+  def self.create_service(client, name, server = nil, port = nil)
+    case name
+    when :ca
+      Puppet::HTTP::Service::Ca.new(client, server, port)
+    else
+      raise ArgumentError, "Unknown service #{name}"
+    end
+  end
+
+  def self.valid_name?(name)
+    SERVICE_NAMES.include?(name)
+  end
+
   def initialize(client, url)
     @client = client
     @url = url
@@ -14,5 +29,14 @@ class Puppet::HTTP::Service
 
   def connect(ssl_context: nil)
     @client.connect(@url, ssl_context: ssl_context)
+  end
+
+  protected
+
+  def build_url(api, server, port)
+    URI::HTTPS.build(host: server,
+                     port: port,
+                     path: api
+                    ).freeze
   end
 end

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -1,5 +1,11 @@
 class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   HEADERS = { 'Accept' => 'text/plain' }.freeze
+  API = '/puppet-ca/v1'.freeze
+
+  def initialize(client, server, port)
+    url = build_url(API, server || Puppet[:ca_server], port || Puppet[:ca_port])
+    super(client, url)
+  end
 
   def get_certificate(name, ssl_context: nil)
     response = @client.get(

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -1,8 +1,8 @@
 class Puppet::HTTP::Session
-  Route = Struct.new(:service_class, :api, :server_setting, :port_setting)
+  ServiceType = Struct.new(:service_class, :api, :server_setting, :port_setting)
 
-  ROUTES = {
-    ca: Route.new(Puppet::HTTP::Service::Ca, '/puppet-ca/v1', :ca_server, :ca_port),
+  SERVICE_TYPES = {
+    ca: ServiceType.new(Puppet::HTTP::Service::Ca, '/puppet-ca/v1', :ca_server, :ca_port),
   }.freeze
 
   def initialize(client, resolvers)
@@ -12,8 +12,7 @@ class Puppet::HTTP::Session
   end
 
   def route_to(name, ssl_context: nil)
-    route = ROUTES[name]
-    raise ArgumentError, "Unknown service #{name}" unless route
+    raise ArgumentError, "Unknown service #{name}" if SERVICE_TYPES[name].nil?
 
     cached = @resolved_services[name]
     return cached if cached
@@ -41,15 +40,15 @@ class Puppet::HTTP::Session
   end
 
   def create_service(name, server = nil, port = nil)
-    route = ROUTES[name]
-    raise ArgumentError, "Unknown service #{name}" unless route
+    service_type = SERVICE_TYPES[name]
+    raise ArgumentError, "Unknown service #{name}" unless service_type
 
-    server ||= Puppet[route.server_setting]
-    port   ||= Puppet[route.port_setting]
+    server ||= Puppet[service_type.server_setting]
+    port   ||= Puppet[service_type.port_setting]
     url = URI::HTTPS.build(host: server,
                            port: port,
-                           path: route.api
+                           path: service_type.api
                           ).freeze
-    route.service_class.new(@client, url)
+    service_type.service_class.new(@client, url)
   end
 end

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -29,4 +29,24 @@ describe Puppet::HTTP::Service do
 
     service.connect(ssl_context: other_ctx)
   end
+
+  it 'raises for unknown service names' do
+    expect {
+      described_class.create_service(client, :westbound)
+    }.to raise_error(ArgumentError, "Unknown service westbound")
+  end
+
+  [:ca].each do |name|
+    it "returns true for #{name}" do
+      expect(described_class.valid_name?(name)).to eq(true)
+    end
+  end
+
+  it "returns false when the service name is a string" do
+    expect(described_class.valid_name?("ca")).to eq(false)
+  end
+
+  it "returns false for unknown service names" do
+    expect(described_class.valid_name?(:westbound)).to eq(false)
+  end
 end

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -74,29 +74,4 @@ describe Puppet::HTTP::Session do
       }.to raise_error(ArgumentError, "Unknown service westbound")
     end
   end
-
-  context 'when creating services' do
-    let(:session) { described_class.new(client, []) }
-
-    it 'defaults the server and port based on settings' do
-      Puppet[:ca_server] = 'ca.example.com'
-      Puppet[:ca_port] = 8141
-      service = session.create_service(:ca)
-
-      expect(service.url.to_s).to eq("https://ca.example.com:8141/puppet-ca/v1")
-    end
-
-    it 'accepts server and port arguments' do
-      service = session.create_service(:ca, 'ca2.example.com', 8142)
-
-      expect(service.url.to_s).to eq("https://ca2.example.com:8142/puppet-ca/v1")
-    end
-
-    it 'raises for unknown service names' do
-      expect {
-        session = described_class.new(client, [])
-        session.create_service(:westbound)
-      }.to raise_error(ArgumentError, "Unknown service westbound")
-    end
-  end
 end


### PR DESCRIPTION
Previously, information needed to create the CA service was stored in a misnamed `Routes` map. The information was used to build the URL to the CA prior to creating the CA service.

This commit moves the `api`, `server_setting` and `server_port` information into the CA service itself, eliminating the need for the `Routes` map.

It also moves the CA service tests to test at a higher level via `client.create_session.route_to(:ca)`.