### PR TITLE
(DOCS) Correct the name of a function in docs

### DIFF
--- a/lib/puppet/functions/camelcase.rb
+++ b/lib/puppet/functions/camelcase.rb
@@ -23,8 +23,8 @@
 #
 # @example Camelcase of strings in an Array
 # ```puppet
-# ['abc_def', 'bcd_xyz'].capitalize()
-# capitalize(['abc_def', 'bcd_xyz'])
+# ['abc_def', 'bcd_xyz'].camelcase()
+# camelcase(['abc_def', 'bcd_xyz'])
 # ```
 # Would both result in `['AbcDef', 'BcdXyz']`
 #


### PR DESCRIPTION
It looks like this was copy & pasted from the `capitalize()` function
and this was left over.