### PR TITLE
(PUP-10144) Add method for loading system ssl context

### DIFF
--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'puppet_spec/https'
+require 'puppet_spec/files'
+
+describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
+  include PuppetSpec::Files
+
+  before :all do
+    WebMock.disable!
+  end
+
+  after :all do
+    WebMock.enable!
+  end
+
+  before :each do
+    # make sure we don't take too long
+    Puppet[:http_connect_timeout] = '5s'
+  end
+
+  let(:hostname) { '127.0.0.1' }
+  let(:wrong_hostname) { 'localhost' }
+  let(:server) { PuppetSpec::HTTPSServer.new }
+  let(:client) { Puppet::HTTP::Client.new }
+  let(:ssl_provider) { Puppet::SSL::SSLProvider.new }
+  let(:root_context) { ssl_provider.create_root_context(cacerts: [server.ca_cert], crls: [server.ca_crl]) }
+
+  context "when verifying an HTTPS server" do
+    it "connects over SSL" do
+      server.start_server do |port|
+        res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: root_context)
+        expect(res).to be_success
+      end
+    end
+
+    it "raises if the server's cert doesn't match the hostname we connected to" do
+      server.start_server do |port|
+        expect {
+          client.get(URI("https://#{wrong_hostname}:#{port}"), ssl_context: root_context)
+        }.to raise_error { |err|
+          expect(err).to be_instance_of(Puppet::HTTP::ConnectionError)
+          expect(err.message).to match(/Server hostname '#{wrong_hostname}' did not match server certificate; expected one of (.+)/)
+
+          md = err.message.match(/expected one of (.+)/)
+          expect(md[1].split(', ')).to contain_exactly('127.0.0.1', 'DNS:127.0.0.1', 'DNS:127.0.0.2')
+        }
+      end
+    end
+
+    it "raises if the server's CA is unknown" do
+      wrong_ca = cert_fixture('netlock-arany-utf8.pem')
+      alt_context = ssl_provider.create_root_context(cacerts: [wrong_ca], revocation: false)
+
+      server.start_server do |port|
+        expect {
+          client.get(URI("https://127.0.0.1:#{port}"), ssl_context: alt_context)
+        }.to raise_error(Puppet::HTTP::ConnectionError,
+                         %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
+      end
+    end
+  end
+
+  context "with client certs" do
+    let(:ctx_proc) {
+      -> ctx {
+        # configures the server to require the client to present a client cert
+        ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+      }
+    }
+
+    it "mutually authenticates the connection" do
+      client_context = ssl_provider.create_context(
+        cacerts: [server.ca_cert], crls: [server.ca_crl],
+        client_cert: server.server_cert, private_key: server.server_key
+      )
+
+      server.start_server(ctx_proc: ctx_proc) do |port|
+        res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: client_context)
+        expect(res).to be_success
+      end
+    end
+  end
+end

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -80,4 +80,42 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       end
     end
   end
+
+  context "with a system trust store" do
+    it "connects when the client trusts the server's CA" do
+      system_context = ssl_provider.create_system_context(cacerts: [server.ca_cert])
+
+      server.start_server do |port|
+        res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: system_context)
+        expect(res).to be_success
+      end
+    end
+
+    it "connects when the server's CA is in the system store" do
+      # create a temp cacert bundle
+      ssl_file = tmpfile('systemstore')
+      File.write(ssl_file, server.ca_cert)
+
+      # override path to system cacert bundle, this must be done before
+      # the SSLContext is created and the call to X509::Store.set_default_paths
+      Puppet::Util.withenv("SSL_CERT_FILE" => ssl_file) do
+        system_context = ssl_provider.create_system_context(cacerts: [])
+        server.start_server do |port|
+          res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: system_context)
+          expect(res).to be_success
+        end
+      end
+    end
+
+    it "raises if the server's CA is not in the context or system store" do
+      system_context = ssl_provider.create_system_context(cacerts: [cert_fixture('netlock-arany-utf8.pem')])
+
+      server.start_server do |port|
+        expect {
+          client.get(URI("https://127.0.0.1:#{port}"), ssl_context: system_context)
+        }.to raise_error(Puppet::HTTP::ConnectionError,
+                         %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
+      end
+    end
+  end
 end

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -73,6 +73,11 @@ describe Puppet::SSL::SSLProvider do
         sslctx.verify_peer = false
       }.to raise_error(/can't modify frozen/)
     end
+
+    it 'verifies peer' do
+      sslctx = subject.create_root_context(config)
+      expect(sslctx.verify_peer).to eq(true)
+    end
   end
 
   context 'when creating a system ssl context' do
@@ -114,6 +119,11 @@ describe Puppet::SSL::SSLProvider do
       subject.create_system_context(cacerts: [])
     end
 
+    it 'verifies peer' do
+      sslctx = subject.create_system_context(cacerts: [])
+      expect(sslctx.verify_peer).to eq(true)
+    end
+
     it 'disable revocation' do
       sslctx = subject.create_system_context(cacerts: [])
       expect(sslctx.revocation).to eq(false)
@@ -149,6 +159,11 @@ describe Puppet::SSL::SSLProvider do
 
       sslctx = subject.create_root_context(config.merge(crls: expired))
       expect(sslctx.crls).to eq(expired)
+    end
+
+    it 'verifies peer' do
+      sslctx = subject.create_root_context(config)
+      expect(sslctx.verify_peer).to eq(true)
     end
   end
 
@@ -395,6 +410,11 @@ describe Puppet::SSL::SSLProvider do
       expect {
         sslctx.verify_peer = false
       }.to raise_error(/can't modify frozen/)
+    end
+
+    it 'verifies peer' do
+      sslctx = subject.create_context(config)
+      expect(sslctx.verify_peer).to eq(true)
     end
   end
 


### PR DESCRIPTION
Add SSLProvider#create_system_context which returns an SSLContext configured to
trust the specified cacerts and any certs in OpenSSL's default verify path
location. This is necessary so that puppet can make HTTPS connections to servers
whose certs are not issued by puppet's PKI.
