### PR TITLE
(PUP-10149) Fix regression in systemd daemon-reload

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -127,10 +127,10 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   # This function is called only on start & restart unit options.
   # Reference: (PUP-3483) Systemd provider doesn't scan for changed units
   def daemon_reload?
-    cmd = [command(:systemctl), 'show', '--', @resource[:name], '--property=NeedDaemonReload']
+    cmd = [command(:systemctl), 'show', '--property=NeedDaemonReload', '--', @resource[:name]]
     daemon_reload = execute(cmd, :failonfail => false).strip.split('=').last
     if daemon_reload == 'yes'
-      daemon_reload_cmd = [command(:systemctl), '--', 'daemon-reload']
+      daemon_reload_cmd = [command(:systemctl), 'daemon-reload']
       execute(daemon_reload_cmd, :failonfail => false)
     end
   end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -255,13 +255,13 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#daemon_reload?" do
     it "should skip the systemctl daemon_reload if not required by the service" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','show', '--', 'sshd.service','--property=NeedDaemonReload'], :failonfail => false).and_return("no")
+      expect(provider).to receive(:execute).with(['/bin/systemctl', 'show', '--property=NeedDaemonReload', '--', 'sshd.service'], :failonfail => false).and_return("no")
       provider.daemon_reload?
     end
     it "should run a systemctl daemon_reload if the service has been modified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','show', '--', 'sshd.service','--property=NeedDaemonReload'], :failonfail => false).and_return("yes")
-      expect(provider).to receive(:execute).with(['/bin/systemctl', '--', 'daemon-reload'], :failonfail => false)
+      expect(provider).to receive(:execute).with(['/bin/systemctl', 'show', '--property=NeedDaemonReload', '--', 'sshd.service'], :failonfail => false).and_return("yes")
+      expect(provider).to receive(:execute).with(['/bin/systemctl', 'daemon-reload'], :failonfail => false)
       provider.daemon_reload?
     end
   end


### PR DESCRIPTION
This commit restores the functionality of
https://tickets.puppetlabs.com/browse/PUP-3483

It was broken my the merge-up of the PR for
https://tickets.puppetlabs.com/browse/PUP-7218

Without this change

```
systemctl show -- some.service --property=NeedDaemonReload
```

shows *all* properties and the `.strip.split('=').last` doesn't work.
The option `--property=NeedDaemonReload` is not being treated as an
option, but a very obscurely named service.

The fix is trivial.  By moving the `--property=NeedDaemonReload` to be
before the `--`, it works again.