### PR TITLE
(maint) Prefer stub_request over any_instance_of(Net::HTTP)

### DIFF
--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -250,7 +250,7 @@ describe Puppet::Network::HTTP::Connection do
   describe 'connection request errors' do
     it "logs and raises generic http errors" do
       generic_error = Net::HTTPError.new('generic error', double("response"))
-      expect_any_instance_of(Net::HTTP).to receive(:request).and_raise(generic_error)
+      stub_request(:get, url).to_raise(generic_error)
 
       expect(Puppet).to receive(:log_exception).with(anything, /^.*failed: generic error$/)
       expect { subject.get('/foo') }.to raise_error(generic_error)
@@ -258,7 +258,7 @@ describe Puppet::Network::HTTP::Connection do
 
     it "logs and raises timeout errors" do
       timeout_error = Timeout::Error.new
-      expect_any_instance_of(Net::HTTP).to receive(:request).and_raise(timeout_error)
+      stub_request(:get, url).to_raise(timeout_error)
 
       expect(Puppet).to receive(:log_exception).with(anything, /^.*timed out after .* seconds$/)
       expect { subject.get('/foo') }.to raise_error(timeout_error)
@@ -266,7 +266,7 @@ describe Puppet::Network::HTTP::Connection do
 
     it "logs and raises eof errors" do
       eof_error = EOFError
-      expect_any_instance_of(Net::HTTP).to receive(:request).and_raise(eof_error)
+      stub_request(:get, url).to_raise(eof_error)
 
       expect(Puppet).to receive(:log_exception).with(anything, /^.*interrupted after .* seconds$/)
       expect { subject.get('/foo') }.to raise_error(eof_error)


### PR DESCRIPTION
Use stub_request in puppet 6.x instead of Net::HTTP, so we're not tied to a
specific http implementation. T