### PR TITLE
Add missing require: singleton

### DIFF
--- a/lib/puppet/runtime.rb
+++ b/lib/puppet/runtime.rb
@@ -1,4 +1,5 @@
 require 'puppet/http'
+require 'singleton'
 
 class Puppet::Runtime
   include Singleton


### PR DESCRIPTION
This file use the Singleton pattern implemented by Ruby's Singleton class in the singleton module.  Require the singleton module before using the Singleton class.

Problem was spotted while updating the puppetserver ports on FreeBSD:

```
[...]
Caused by: org.jruby.exceptions.NameError: (NameError) uninitialized constant Puppet::Runtime::Singleton
        at org.jruby.RubyModule.const_missing(org/jruby/RubyModule.java:3746)
        at RUBY.<class:Runtime>(/usr/local/lib/ruby/site_ruby/2.6/puppet/runtime.rb:4)
[...]
```

Cc @joshcooper who authored this file recently.