### PR TITLE
(PUP-10170) Do not use Ruby stacktrace for "Puppet" stack

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -299,10 +299,10 @@ module Runtime3Support
     # 'ruby -wc' thinks that _func is unused, because the only reference to it
     # is inside of the Kernel.eval string below. By prefixing it with the
     # underscore, we let Ruby know to not worry about whether it's unused or not.
-    if loader && _func = loader.load(:function, name)
+    if loader && func = loader.load(:function, name)
       Puppet::Util::Profiler.profile(name, [:functions, name]) do
-        # Add stack frame when calling. See Puppet::Pops::PuppetStack
-        return Kernel.eval('_func.call(scope, *args, &block)'.freeze, Kernel.binding, file || '', line)
+        # Add stack frame when calling.
+        return Puppet::Pops::PuppetStack.stack(file || '', line, func, :call, [scope, *args], &block)
       end
     end
     # Call via 3x API if function exists there

--- a/lib/puppet/pops/puppet_stack.rb
+++ b/lib/puppet/pops/puppet_stack.rb
@@ -1,57 +1,60 @@
-module Puppet::Pops
-# Module for making a call such that there is an identifiable entry on
-# the ruby call stack enabling getting a puppet call stack
-# To use this make a call with:
-# ```
-# Puppet::Pops::PuppetStack.stack(file, line, receiver, message, args)
-# ```
-# To get the stack call:
-# ```
-# Puppet::Pops::PuppetStack.stacktrace
-#
-# When getting a backtrace in Ruby, the puppet stack frames are
-# identified as coming from "in 'stack'" and having a ".pp" file
-# name.
-# To support testing, a given file that is an empty string, or nil
-# as well as a nil line number are supported. Such stack frames
-# will be represented with the text `unknown` and `0´ respectively.
-#
-module PuppetStack
-  # Pattern matching an entry in the ruby stack that is a puppet entry
-  PP_ENTRY_PATTERN = /^(.*\.pp)?:([0-9]+):in (`stack'|`block in call_function')/
 
-  # Sends a message to an obj such that it appears to come from
-  # file, line when calling stacktrace.
-  #
-  def self.stack(file, line, obj, message, args, &block)
-    file = '' if file.nil?
-    line = 0 if line.nil?
+module Puppet
+  module Pops
+    # Utility class for keeping track of the "Puppet stack", ie the file
+    # and line numbers of Puppet Code that created the current context.
+    #
+    # To use this make a call with:
+    #
+    # ```rb
+    # Puppet::Pops::PuppetStack.stack(file, line, receiver, message, args)
+    # ```
+    #
+    # To get the stack call:
+    #
+    # ```rb
+    # Puppet::Pops::PuppetStack.stacktrace
+    # ```
+    #
+    # or
+    #
+    # ```rb
+    # Puppet::Pops::PuppetStack.top_of_stack
+    # ```
+    #
+    # To support testing, a given file that is an empty string, or nil
+    # as well as a nil line number are supported. Such stack frames
+    # will be represented with the text `unknown` and `0´ respectively.
+    module PuppetStack
+      @stack = Array.new
 
-    if block_given?
-      Kernel.eval("obj.send(message, *args, &block)", Kernel.binding(), file, line)
-    else
-      Kernel.eval("obj.send(message, *args)", Kernel.binding(), file, line)
-    end
-  end
+      def self.stack(file, line, obj, message, args, &block)
+        file = 'unknown' if (file.nil? || file == '')
+        line = 0 if line.nil?
 
-  def self.stacktrace
-    caller().reduce([]) do |memo, loc|
-      if loc =~ PP_ENTRY_PATTERN
-        memo << [$1.nil? ? 'unknown' : $1, $2.to_i]
+        result = nil
+        @stack.unshift([file, line])
+        begin
+          if block_given?
+            result = obj.send(message, *args, &block)
+          else
+            result = obj.send(message, *args)
+          end
+        ensure
+          @stack.shift()
+        end
+        result
       end
-      memo
-    end
-  end
 
-  # Returns an Array with the top of the puppet stack, or an empty Array if there was no such entry.
-  #
-  def self.top_of_stack
-    caller.each do |loc|
-      if loc =~ PP_ENTRY_PATTERN
-        return [$1.nil? ? 'unknown' : $1, $2.to_i]
+      def self.stacktrace
+        @stack.dup
+      end
+
+      # Returns an Array with the top of the puppet stack, or an empty
+      # Array if there was no such entry.
+      def self.top_of_stack
+        @stack.first || []
       end
     end
-    []
   end
-end
 end


### PR DESCRIPTION
Previously, we used `Kernel.eval` to add additional information to the
Ruby call stack. That information would show that the call had come from
a Puppet manifest. We did this to interleave Puppet "function calls"
with Ruby function calls. Then when creating error or warning messages
we would retrieve the entire Ruby call stack and strip out everything
from the call stack save for the Puppet manifest files.

This moves us to use a threadsafe variable to store Puppet stack
information bypassing the performance issues that come from interacting
with the Ruby call stack.

Conflicts:
 - lib/puppet/pops/evaluator/runtime3_support.rb
 - lib/puppet/pops/puppet_stack.rb

cherry-pick note:
  The original threadsafe class is not available in this stream. This
may be merged up to Puppet 6.5.x but not later w/o needing further
editing and/or review to ensure the threadsafety isn't compromised.