### PR TITLE
(PUP-10117) Read passwd and group files once per resource

### DIFF
--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -32,13 +32,11 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     group_file = "/etc/group"
     group_keys = [:group_name, :password, :gid, :user_list]
     index = group_keys.index(key)
-    File.open(group_file) do |f|
-      f.each_line do |line|
-         group = line.split(":")
-         if group[index] == value
-             f.close
-             return Hash[group_keys.zip(group)]
-         end
+    @group_content ||= File.read(group_file)
+    @group_content.each_line do |line|
+      group = line.split(":")
+      if group[index] == value
+        return Hash[group_keys.zip(group)]
       end
     end
     false

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -30,14 +30,14 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
 
   def findgroup(key, value)
     group_file = "/etc/group"
-    group_keys = ['group_name', 'password', 'gid', 'user_list']
+    group_keys = [:group_name, :password, :gid, :user_list]
     index = group_keys.index(key)
     File.open(group_file) do |f|
       f.each_line do |line|
          group = line.split(":")
          if group[index] == value
              f.close
-             return group
+             return Hash[group_keys.zip(group)]
          end
       end
     end
@@ -45,8 +45,8 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
   end
 
   def localgid
-    group = findgroup('group_name', resource[:name])
-    return group[2] if group
+    group = findgroup(:group_name, resource[:name])
+    return group[:gid] if group
     false
   end
 
@@ -56,7 +56,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     # to ensure consistent behaviour of the useradd provider when
     # using both useradd and luseradd
     if not @resource.allowdupe? and @resource.forcelocal?
-       if @resource.should(:gid) and findgroup('gid', @resource.should(:gid).to_s)
+       if @resource.should(:gid) and findgroup(:gid, @resource.should(:gid).to_s)
            raise(Puppet::Error, _("GID %{resource} already exists, use allowdupe to force group creation") % { resource: @resource.should(:gid).to_s })
        end
     elsif @resource.allowdupe? and not @resource.forcelocal?

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -28,20 +28,6 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     get(:gid)
   end
 
-  def findgroup(key, value)
-    group_file = "/etc/group"
-    group_keys = [:group_name, :password, :gid, :user_list]
-    index = group_keys.index(key)
-    @group_content ||= File.read(group_file)
-    @group_content.each_line do |line|
-      group = line.split(":")
-      if group[index] == value
-        return Hash[group_keys.zip(group)]
-      end
-    end
-    false
-  end
-
   def localgid
     group = findgroup(:group_name, resource[:name])
     return group[:gid] if group
@@ -105,5 +91,21 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     else
       [command(:delete), @resource[:name]]
     end
+  end
+
+  private
+
+  def findgroup(key, value)
+    group_file = "/etc/group"
+    group_keys = [:group_name, :password, :gid, :user_list]
+    index = group_keys.index(key)
+    @group_content ||= File.read(group_file)
+    @group_content.each_line do |line|
+      group = line.split(":")
+      if group[index] == value
+        return Hash[group_keys.zip(group)]
+      end
+    end
+    false
   end
 end

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -64,12 +64,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     passwd_file = "/etc/passwd"
     passwd_keys = [:account, :password, :uid, :gid, :gecos, :directory, :shell]
     index = passwd_keys.index(key)
-    File.open(passwd_file) do |f|
-      f.each_line do |line|
-        user = line.split(":")
-        if user[index] == value
-          return Hash[passwd_keys.zip(user)]
-        end
+    @passwd_content ||= File.read(passwd_file)
+    @passwd_content.each_line do |line|
+      user = line.split(":")
+      if user[index] == value
+        return Hash[passwd_keys.zip(user)]
       end
     end
     false

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -47,7 +47,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
         described_class.has_feature(:libuser)
         resource[:forcelocal] = :true
       end
- 
+
       it "should use lgroupadd instead of groupadd" do
         expect(provider).to receive(:execute).with(including('/usr/sbin/lgroupadd'), hash_including(:custom_environment => hash_including('LIBUSER_CONF')))
         provider.create
@@ -121,6 +121,35 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
       resource[:allowdupe] = :true
       expect(provider).to receive(:execute).with(['/usr/sbin/groupmod', '-g', 150, '-o', 'mygroup'], hash_including({:failonfail => true, :combine => true, :custom_environment => {}}))
       provider.gid = 150
+    end
+  end
+
+  describe "#findgroup" do
+    before { allow(File).to receive(:read).with('/etc/group').and_return(content) }
+
+    let(:content) { "sample_group_name:sample_password:sample_gid:sample_user_list" }
+    let(:output) do
+      {
+        group_name: 'sample_group_name',
+        password: 'sample_password',
+        gid: 'sample_gid',
+        user_list: 'sample_user_list',
+      }
+    end
+
+    [:group_name, :password, :gid, :user_list].each do |key|
+      it "finds a group by #{key} when asked" do
+        expect(provider.findgroup(key, "sample_#{key}")).to eq(output)
+      end
+    end
+
+    it "returns false when specified key/value pair is not found" do
+      expect(provider.findgroup(:group_name, 'invalid_group_name')).to eq(false)
+    end
+
+    it "reads the group file only once per resource" do
+      expect(File).to receive(:read).with('/etc/group').once
+      5.times { provider.findgroup(:group_name, 'sample_group_name') }
     end
   end
 

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -139,17 +139,17 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
 
     [:group_name, :password, :gid, :user_list].each do |key|
       it "finds a group by #{key} when asked" do
-        expect(provider.findgroup(key, "sample_#{key}")).to eq(output)
+        expect(provider.send(:findgroup, key, "sample_#{key}")).to eq(output)
       end
     end
 
     it "returns false when specified key/value pair is not found" do
-      expect(provider.findgroup(:group_name, 'invalid_group_name')).to eq(false)
+      expect(provider.send(:findgroup, :group_name, 'invalid_group_name')).to eq(false)
     end
 
     it "reads the group file only once per resource" do
       expect(File).to receive(:read).with('/etc/group').once
-      5.times { provider.findgroup(:group_name, 'sample_group_name') }
+      5.times { provider.send(:findgroup, :group_name, 'sample_group_name') }
     end
   end
 

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -324,7 +324,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
 
     it "should return the local comment string when forcelocal is true" do
       resource[:forcelocal] = true
-      allow(File).to receive(:open).with('/etc/passwd').and_yield(content)
+      allow(File).to receive(:read).with('/etc/passwd').and_return(content)
       expect(provider.comment).to eq('local comment')
     end
 
@@ -337,7 +337,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
   end
 
   describe "#finduser" do
-    before { allow(File).to receive(:open).with('/etc/passwd').and_yield(content) }
+    before { allow(File).to receive(:read).with('/etc/passwd').and_return(content) }
 
     let(:content) { "sample_account:sample_password:sample_uid:sample_gid:sample_gecos:sample_directory:sample_shell" }
     let(:output) do
@@ -360,6 +360,11 @@ describe Puppet::Type.type(:user).provider(:useradd) do
 
     it "returns false when specified key/value pair is not found" do
       expect(provider.finduser(:account, 'invalid_account')).to eq(false)
+    end
+
+    it "reads the user file only once per resource" do
+      expect(File).to receive(:read).with('/etc/passwd').once
+      5.times { provider.finduser(:account, 'sample_account') }
     end
   end
 


### PR DESCRIPTION
This adds memoization to the `finduser` and `findgroup` methods to avoid reading the `/etc/passwd` or `/etc/group` file multiple times per resource. 

I need to write some specs for this.

