### PR TITLE
(PUP-10157) Observe ServerList Resolver

### DIFF
--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -1,21 +1,25 @@
 class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
-  def initialize(client, server_list:, default_port:)
+  def initialize(client, server_list_setting:, default_port:, services: )
     @client = client
-    @server_list = server_list
+    @server_list_setting = server_list_setting
     @default_port = default_port
+    @services = services
   end
 
   def resolve(session, name, ssl_context: nil)
-    @server_list.each do |server|
-      host = server[0]
-      port = server[1] || @default_port
-      uri = URI("https://#{host}:#{port}/status/v1/simple/master")
-      if get_success?(uri, session, ssl_context: ssl_context)
-        return Puppet::HTTP::Service.create_service(@client, name, host, port)
+    if @services.include?(name)
+      @server_list_setting.value.each do |server|
+        host = server[0]
+        port = server[1] || @default_port
+        uri = URI("https://#{host}:#{port}/status/v1/simple/master")
+        if get_success?(uri, session, ssl_context: ssl_context)
+          return Puppet::HTTP::Service.create_service(@client, name, host, port)
+        end
       end
+      raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: @server_list_setting.print(@server_list_setting.value) }
+    else
+      return nil
     end
-
-    raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: Puppet.settings.value(:server_list, Puppet[:environment].to_sym, true) }
   end
 
   def get_success?(uri, session, ssl_context: nil)

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -22,9 +22,10 @@ describe Puppet::HTTP::Resolver do
   end
 
   context 'when resolving using server_list' do
-    let(:server_list) { [["ca.example.com", "8141"], ["apple.example.com"]] }
-    let(:default_port) { '8142' }
-    let(:subject) { Puppet::HTTP::Resolver::ServerList.new(client, server_list: server_list, default_port: default_port) }
+    before :each do
+      Puppet[:server_list] = 'ca.example.com:8141,apple.example.com'
+    end
+    let(:subject) { Puppet::HTTP::Resolver::ServerList.new(client, server_list_setting: Puppet.settings.setting(:server_list), default_port: 8142, services: [:puppet, :ca]) }
 
     it 'returns a service based on the current server_list setting' do
       stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 200)


### PR DESCRIPTION
This commit enables the ServerList resolver for the ca service and adds
tests to ensure a consistent flow when resolving the route to the
server.