### PR TITLE
(docs) Use fully qualified docs URLs

### DIFF
--- a/lib/puppet/functions/epp.rb
+++ b/lib/puppet/functions/epp.rb
@@ -6,12 +6,12 @@
 # The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 # reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 # directory. In most cases, the last argument is optional; if used, it should be a
-# [hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+# [hash](https://puppet.com/docs/puppet/latest/lang_data_hash.html) that contains parameters to
 # pass to the template.
 #
-# - See the [template](/puppet/latest/reference/lang_template.html) documentation
-# for general template usage information.
-# - See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+# - See the [template](https://puppet.com/docs/puppet/latest/lang_template.html)
+# documentation for general template usage information.
+# - See the [EPP syntax](https://puppet.com/docs/puppet/latest/lang_template_epp.html)
 # documentation for examples of EPP.
 #
 # For example, to call the apache module's `templates/vhost/_docroot.epp`

--- a/lib/puppet/functions/inline_epp.rb
+++ b/lib/puppet/functions/inline_epp.rb
@@ -5,12 +5,12 @@
 #
 # The first argument to this function should be a string containing an EPP
 # template. In most cases, the last argument is optional; if used, it should be a
-# [hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+# [hash](https://puppet.com/docs/puppet/latest/lang_data_hash.html) that contains parameters to
 # pass to the template.
 #
-# - See the [template](/puppet/latest/reference/lang_template.html) documentation
-# for general template usage information.
-# - See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+# - See the [template](https://puppet.com/docs/puppet/latest/lang_template.html)
+# documentation for general template usage information.
+# - See the [EPP syntax](https://puppet.com/docs/puppet/latest/lang_template_epp.html)
 # documentation for examples of EPP.
 #
 # For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -28,7 +28,7 @@
 # `inline_epp` function fails to pass any required parameter.
 #
 # An inline EPP template should be written as a single-quoted string or
-# [heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+# [heredoc](https://puppet.com/docs/puppet/latest/lang_data_string.html#heredocs).
 # A double-quoted string is subject to expression interpolation before the string
 # is parsed as an EPP template.
 #

--- a/lib/puppet/parser/functions/epp.rb
+++ b/lib/puppet/parser/functions/epp.rb
@@ -7,12 +7,12 @@ result as a String.
 The first argument to this function should be a `<MODULE NAME>/<TEMPLATE FILE>`
 reference, which loads `<TEMPLATE FILE>` from `<MODULE NAME>`'s `templates`
 directory. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](https://puppet.com/docs/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](https://puppet.com/docs/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](https://puppet.com/docs/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to call the apache module's `templates/vhost/_docroot.epp`

--- a/lib/puppet/parser/functions/inline_epp.rb
+++ b/lib/puppet/parser/functions/inline_epp.rb
@@ -6,12 +6,12 @@ text result as a String.
 
 The first argument to this function should be a string containing an EPP
 template. In most cases, the last argument is optional; if used, it should be a
-[hash](/puppet/latest/reference/lang_data_hash.html) that contains parameters to
+[hash](https://puppet.com/docs/puppet/latest/lang_data_hash.html) that contains parameters to
 pass to the template.
 
-- See the [template](/puppet/latest/reference/lang_template.html) documentation
+- See the [template](https://puppet.com/docs/puppet/latest/lang_template.html) documentation
 for general template usage information.
-- See the [EPP syntax](/puppet/latest/reference/lang_template_epp.html)
+- See the [EPP syntax](https://puppet.com/docs/puppet/latest/lang_template_epp.html)
 documentation for examples of EPP.
 
 For example, to evaluate an inline EPP template and pass it the `docroot` and
@@ -29,7 +29,7 @@ parameter tag without default values. Puppet produces an error if the
 `inline_epp` function fails to pass any required parameter.
 
 An inline EPP template should be written as a single-quoted string or
-[heredoc](/puppet/latest/reference/lang_data_string.html#heredocs).
+[heredoc](https://puppet.com/docs/puppet/latest/lang_data_string.html#heredocs).
 A double-quoted string is subject to expression interpolation before the string
 is parsed as an EPP template.
 
@@ -45,7 +45,7 @@ END
 ~~~
 
 - Since 3.5
-- Requires [future parser](/puppet/3.8/reference/experiments_future.html) in Puppet 3.5 to 3.8") do |arguments|
+- Requires [future parser](https://puppet.com/docs/puppet/3.8/experiments_future.html) in Puppet 3.5 to 3.8") do |arguments|
 
   Puppet::Parser::Functions::Error.is4x('inline_epp')
 end

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1447,7 +1447,7 @@ class Type
           }
 
       Tags are useful for things like applying a subset of a host's configuration
-      with [the `tags` setting](/puppet/latest/configuration.html#tags)
+      with [the `tags` setting](https://puppet.com/docs/puppet/latest/configuration.html#tags)
       (e.g. `puppet agent --test --tags bootstrap`)."
 
     munge do |tags|


### PR DESCRIPTION
Changes to the docs site structure resulted in changed or removed
redirects for absolute URLs (ie. `/puppet/latest/...`) as well as
for URLs referring to the `references` subdirectory.

Update Markdown docs in comments and heredocs to use fully
qualified URLs (`https://puppet.com/docs/...`) and update their
targets to avoid relying on redirects that no longer exist.