### PR TITLE
(PUP-10160) Defer catalog transformation until after environment convergence

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -369,6 +369,7 @@ class Puppet::Configurer
         indirection = Puppet::Resource::Catalog.indirection
         if !Puppet[:noop] && indirection.cache?
           request = indirection.request(:save, nil, catalog, environment: Puppet::Node::Environment.remote(catalog.environment))
+          Puppet.info("Caching catalog for #{request.key}")
           indirection.cache.save(request)
         end
       end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -356,7 +356,7 @@ class Puppet::Configurer
 
       # now that environment has converged, convert resource catalog into ral catalog
       # unless we were given a RAL catalog
-      if options[:catalog]
+      if !cached_catalog && options[:catalog]
         ral_catalog = options[:catalog]
       else
         # REMIND @duration is the time spent loading the last catalog, and doesn't

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -90,6 +90,8 @@ class Puppet::Network::HTTP::Pool
   #
   # @api private
   def setsockopts(netio)
+    return unless netio
+
     socket = netio.io
     socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
   end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -3,6 +3,8 @@ require 'puppet/configurer'
 
 describe Puppet::Configurer do
   before do
+    Puppet::Node::Facts.indirection.terminus_class = :memory
+
     allow(Puppet.settings).to receive(:use).and_return(true)
     @agent = Puppet::Configurer.new
     allow(@agent).to receive(:init_storage)
@@ -11,8 +13,8 @@ describe Puppet::Configurer do
     Puppet[:report] = true
   end
 
-  it "should include the Fact Handler module" do
-    expect(Puppet::Configurer.ancestors).to be_include(Puppet::Configurer::FactHandler)
+  after :all do
+    Puppet::Node::Facts.indirection.reset_terminus_class
   end
 
   describe "when executing a pre-run hook" do
@@ -65,7 +67,6 @@ describe Puppet::Configurer do
     before do
       allow(Puppet.settings).to receive(:use).and_return(true)
       allow(@agent).to receive(:download_plugins)
-      Puppet::Node::Facts.indirection.terminus_class = :memory
       @facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
       Puppet::Node::Facts.indirection.save(@facts)
 
@@ -80,7 +81,6 @@ describe Puppet::Configurer do
     end
 
     after :all do
-      Puppet::Node::Facts.indirection.reset_terminus_class
       Puppet::Resource::Catalog.indirection.reset_terminus_class
     end
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -4,7 +4,6 @@ require 'puppet/configurer'
 describe Puppet::Configurer do
   before do
     Puppet::Node::Facts.indirection.terminus_class = :memory
-    @agent = Puppet::Configurer.new
     Puppet[:server] = "puppetmaster"
     Puppet[:report] = true
   end
@@ -13,26 +12,28 @@ describe Puppet::Configurer do
     Puppet::Node::Facts.indirection.reset_terminus_class
   end
 
+  let(:configurer) { Puppet::Configurer.new }
+
   describe "when executing a pre-run hook" do
     it "should do nothing if the hook is set to an empty string" do
       Puppet.settings[:prerun_command] = ""
       expect(Puppet::Util).not_to receive(:exec)
 
-      @agent.execute_prerun_command
+      configurer.execute_prerun_command
     end
 
     it "should execute any pre-run command provided via the 'prerun_command' setting" do
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      @agent.execute_prerun_command
+      configurer.execute_prerun_command
     end
 
     it "should fail if the command fails" do
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@agent.execute_prerun_command).to be_falsey
+      expect(configurer.execute_prerun_command).to be_falsey
     end
   end
 
@@ -41,27 +42,27 @@ describe Puppet::Configurer do
       Puppet.settings[:postrun_command] = ""
       expect(Puppet::Util).not_to receive(:exec)
 
-      @agent.execute_postrun_command
+      configurer.execute_postrun_command
     end
 
     it "should execute any post-run command provided via the 'postrun_command' setting" do
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      @agent.execute_postrun_command
+      configurer.execute_postrun_command
     end
 
     it "should fail if the command fails" do
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@agent.execute_postrun_command).to be_falsey
+      expect(configurer.execute_postrun_command).to be_falsey
     end
   end
 
   describe "when executing a catalog run" do
     before do
-      allow(@agent).to receive(:download_plugins)
+      allow(configurer).to receive(:download_plugins)
       @facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
       Puppet::Node::Facts.indirection.save(@facts)
 
@@ -69,8 +70,8 @@ describe Puppet::Configurer do
       allow(@catalog).to receive(:to_ral).and_return(@catalog)
       Puppet::Resource::Catalog.indirection.terminus_class = :rest
       allow(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(@catalog)
-      allow(@agent).to receive(:send_report)
-      allow(@agent).to receive(:save_last_run_summary)
+      allow(configurer).to receive(:send_report)
+      allow(configurer).to receive(:save_last_run_summary)
 
       allow(Puppet::Util::Log).to receive(:close_all)
     end
@@ -80,19 +81,19 @@ describe Puppet::Configurer do
     end
 
     it "downloads plugins when told" do
-      expect(@agent).to receive(:download_plugins)
-      @agent.run(:pluginsync => true)
+      expect(configurer).to receive(:download_plugins)
+      configurer.run(:pluginsync => true)
     end
 
     it "does not download plugins when told" do
-      expect(@agent).not_to receive(:download_plugins)
-      @agent.run(:pluginsync => false)
+      expect(configurer).not_to receive(:download_plugins)
+      configurer.run(:pluginsync => false)
     end
 
     it "should carry on when it can't fetch its node definition" do
       error = Net::HTTPError.new(400, 'dummy server communication error')
       expect(Puppet::Node.indirection).to receive(:find).and_raise(error)
-      expect(@agent.run).to eq(0)
+      expect(configurer.run).to eq(0)
     end
 
     it "applies a cached catalog when it can't connect to the master" do
@@ -102,14 +103,14 @@ describe Puppet::Configurer do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(:ignore_cache => true)).and_raise(error)
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(:ignore_terminus => true)).and_return(@catalog)
 
-      expect(@agent.run).to eq(0)
+      expect(configurer.run).to eq(0)
     end
 
     it "should initialize a transaction report if one is not provided" do
       report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
-      @agent.run
+      configurer.run
     end
 
     it "should respect node_name_fact when setting the host on a report" do
@@ -118,7 +119,7 @@ describe Puppet::Configurer do
 
       report = Puppet::Transaction::Report.new
 
-      @agent.run(:report => report)
+      configurer.run(:report => report)
       expect(report.host).to eq('node_name_from_fact')
     end
 
@@ -127,14 +128,14 @@ describe Puppet::Configurer do
       allow(Puppet::Transaction::Report).to receive(:new).and_return(report)
       expect(@catalog).to receive(:apply).with(hash_including(report: report))
 
-      @agent.run
+      configurer.run
     end
 
     it "should use the provided report if it was passed one" do
       report = Puppet::Transaction::Report.new
       expect(@catalog).to receive(:apply).with(hash_including(report: report))
 
-      @agent.run(:report => report)
+      configurer.run(:report => report)
     end
 
     it "should set the report as a log destination" do
@@ -142,104 +143,104 @@ describe Puppet::Configurer do
 
       expect(report).to receive(:<<).with(instance_of(Puppet::Util::Log)).at_least(:once)
 
-      @agent.run(:report => report)
+      configurer.run(:report => report)
     end
 
     it "should retrieve the catalog" do
-      expect(@agent).to receive(:retrieve_catalog)
+      expect(configurer).to receive(:retrieve_catalog)
 
-      @agent.run
+      configurer.run
     end
 
     it "should log a failure and do nothing if no catalog can be retrieved" do
-      expect(@agent).to receive(:retrieve_catalog).and_return(nil)
+      expect(configurer).to receive(:retrieve_catalog).and_return(nil)
 
       expect(Puppet).to receive(:err).with("Could not retrieve catalog; skipping run")
 
-      @agent.run
+      configurer.run
     end
 
     it "should apply the catalog with all options to :run" do
-      expect(@agent).to receive(:retrieve_catalog).and_return(@catalog)
+      expect(configurer).to receive(:retrieve_catalog).and_return(@catalog)
 
       expect(@catalog).to receive(:apply).with(hash_including(one: true))
-      @agent.run :one => true
+      configurer.run :one => true
     end
 
     it "should accept a catalog and use it instead of retrieving a different one" do
-      expect(@agent).not_to receive(:retrieve_catalog)
+      expect(configurer).not_to receive(:retrieve_catalog)
 
       expect(@catalog).to receive(:apply)
-      @agent.run :one => true, :catalog => @catalog
+      configurer.run :one => true, :catalog => @catalog
     end
 
     it "should benchmark how long it takes to apply the catalog" do
-      expect(@agent).to receive(:benchmark).with(:notice, instance_of(String))
+      expect(configurer).to receive(:benchmark).with(:notice, instance_of(String))
 
-      expect(@agent).to receive(:retrieve_catalog).and_return(@catalog)
+      expect(configurer).to receive(:retrieve_catalog).and_return(@catalog)
 
       expect(@catalog).not_to receive(:apply) # because we're not yielding
-      @agent.run
+      configurer.run
     end
 
     it "should execute post-run hooks after the run" do
-      expect(@agent).to receive(:execute_postrun_command)
+      expect(configurer).to receive(:execute_postrun_command)
 
-      @agent.run
+      configurer.run
     end
 
     it "should create report with passed transaction_uuid and job_id" do
-      @agent = Puppet::Configurer.new("test_tuuid", "test_jid")
+      configurer = Puppet::Configurer.new("test_tuuid", "test_jid")
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).with(anything, anything, 'test_tuuid', 'test_jid').and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
-      @agent.run
+      configurer.run
     end
 
     it "should send the report" do
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
       expect(report.environment).to eq("test")
       expect(report.transaction_uuid).to eq("aaaa")
 
-      @agent.run
+      configurer.run
     end
 
     it "should send the transaction report even if the catalog could not be retrieved" do
-      expect(@agent).to receive(:retrieve_catalog).and_return(nil)
+      expect(configurer).to receive(:retrieve_catalog).and_return(nil)
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
       expect(report.environment).to eq("test")
       expect(report.transaction_uuid).to eq("aaaa")
 
-      @agent.run
+      configurer.run
     end
 
     it "should send the transaction report even if there is a failure" do
-      expect(@agent).to receive(:retrieve_catalog).and_raise("whatever")
+      expect(configurer).to receive(:retrieve_catalog).and_raise("whatever")
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
       expect(report.environment).to eq("test")
       expect(report.transaction_uuid).to eq("aaaa")
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should remove the report as a log destination when the run is finished" do
       report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
-      @agent.run
+      configurer.run
 
       expect(Puppet::Util::Log.destinations).not_to include(report)
     end
@@ -249,13 +250,13 @@ describe Puppet::Configurer do
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
       expect(report).to receive(:exit_status).and_return(1234)
 
-      expect(@agent.run).to eq(1234)
+      expect(configurer.run).to eq(1234)
     end
 
     it "should return nil if catalog application fails" do
       expect(@catalog).to receive(:apply).and_raise(Puppet::Error, 'One or more resource dependency cycles detected in graph')
       report = Puppet::Transaction::Report.new
-      expect(@agent.run(catalog: @catalog, report: report)).to be_nil
+      expect(configurer.run(catalog: @catalog, report: report)).to be_nil
     end
 
     it "should send the transaction report even if the pre-run command fails" do
@@ -264,9 +265,9 @@ describe Puppet::Configurer do
 
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should include the pre-run command failure in the report" do
@@ -276,7 +277,7 @@ describe Puppet::Configurer do
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
       expect(report.logs.find { |x| x.message =~ /Could not run command from prerun_command/ }).to be
     end
 
@@ -286,9 +287,9 @@ describe Puppet::Configurer do
 
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should include the post-run command failure in the report" do
@@ -300,7 +301,7 @@ describe Puppet::Configurer do
 
       expect(report).to receive(:<<) { |log, _| expect(log.message).to match(/Could not run command from postrun_command/) }.at_least(:once)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should execute post-run command even if the pre-run command fails" do
@@ -309,7 +310,7 @@ describe Puppet::Configurer do
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/precommand"]).and_raise(Puppet::ExecutionFailure, "Failed")
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/postcommand"])
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should finalize the report" do
@@ -317,7 +318,7 @@ describe Puppet::Configurer do
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       expect(report).to receive(:finalize_report)
-      @agent.run
+      configurer.run
     end
 
     it "should not apply the catalog if the pre-run command fails" do
@@ -328,9 +329,9 @@ describe Puppet::Configurer do
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
       expect(@catalog).not_to receive(:apply)
-      expect(@agent).to receive(:send_report)
+      expect(configurer).to receive(:send_report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should apply the catalog, send the report, and return nil if the post-run command fails" do
@@ -341,15 +342,15 @@ describe Puppet::Configurer do
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
       expect(@catalog).to receive(:apply)
-      expect(@agent).to receive(:send_report)
+      expect(configurer).to receive(:send_report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it 'includes total time metrics in the report after successfully applying the catalog' do
       report = Puppet::Transaction::Report.new
       allow(@catalog).to receive(:apply).with(:report => report)
-      @agent.run(report: report)
+      configurer.run(report: report)
 
       expect(report.metrics['time']).to be
       expect(report.metrics['time']['total']).to be_a_kind_of(Numeric)
@@ -360,7 +361,7 @@ describe Puppet::Configurer do
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
       report = Puppet::Transaction::Report.new
-      @agent.run(report: report)
+      configurer.run(report: report)
 
       expect(report.metrics['time']).to be
       expect(report.metrics['time']['total']).to be_a_kind_of(Numeric)
@@ -368,8 +369,8 @@ describe Puppet::Configurer do
 
     it 'includes total time metrics in the report even if catalog retrieval fails' do
       report = Puppet::Transaction::Report.new
-      allow(@agent).to receive(:prepare_and_retrieve_catalog_from_cache).and_raise
-      @agent.run(:report => report)
+      allow(configurer).to receive(:prepare_and_retrieve_catalog_from_cache).and_raise
+      configurer.run(:report => report)
 
       expect(report.metrics['time']).to be
       expect(report.metrics['time']['total']).to be_a_kind_of(Numeric)
@@ -377,86 +378,86 @@ describe Puppet::Configurer do
 
     it "should refetch the catalog if the server specifies a new environment in the catalog" do
       catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
-      expect(@agent).to receive(:retrieve_catalog).and_return(catalog).twice
+      expect(configurer).to receive(:retrieve_catalog).and_return(catalog).twice
 
-      @agent.run
+      configurer.run
     end
 
     it "should change the environment setting if the server specifies a new environment in the catalog" do
       allow(@catalog).to receive(:environment).and_return("second_env")
 
-      @agent.run
+      configurer.run
 
-      expect(@agent.environment).to eq("second_env")
+      expect(configurer.environment).to eq("second_env")
     end
 
     it "should fix the report if the server specifies a new environment in the catalog" do
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
       allow(@catalog).to receive(:environment).and_return("second_env")
-      allow(@agent).to receive(:retrieve_catalog).and_return(@catalog)
+      allow(configurer).to receive(:retrieve_catalog).and_return(@catalog)
 
-      @agent.run
+      configurer.run
 
       expect(report.environment).to eq("second_env")
     end
 
     it "sends the transaction uuid in a catalog request" do
-      @agent.instance_variable_set(:@transaction_uuid, 'aaa')
+      configurer.instance_variable_set(:@transaction_uuid, 'aaa')
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(transaction_uuid: 'aaa'))
-      @agent.run
+      configurer.run
     end
 
     it "sends the transaction uuid in a catalog request" do
-      @agent.instance_variable_set(:@job_id, 'aaa')
+      configurer.instance_variable_set(:@job_id, 'aaa')
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(job_id: 'aaa'))
-      @agent.run
+      configurer.run
     end
 
     it "sets the static_catalog query param to true in a catalog request" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(static_catalog: true))
-      @agent.run
+      configurer.run
     end
 
     it "sets the checksum_type query param to the default supported_checksum_types in a catalog request" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything,
         hash_including(checksum_type: 'md5.sha256.sha384.sha512.sha224'))
-      @agent.run
+      configurer.run
     end
 
     it "sets the checksum_type query param to the supported_checksum_types setting in a catalog request" do
-      # Regenerate the agent to pick up the new setting
       Puppet[:supported_checksum_types] = ['sha256']
-      @agent = Puppet::Configurer.new
-      allow(@agent).to receive(:download_plugins)
-      allow(@agent).to receive(:send_report)
-      allow(@agent).to receive(:save_last_run_summary)
+      # Regenerate the agent to pick up the new setting
+      configurer = Puppet::Configurer.new
+      allow(configurer).to receive(:download_plugins)
+      allow(configurer).to receive(:send_report)
+      allow(configurer).to receive(:save_last_run_summary)
 
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(checksum_type: 'sha256'))
-      @agent.run
+      configurer.run
     end
 
     describe "when not using a REST terminus for catalogs" do
       it "should not pass any facts when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :compiler
-        expect(@agent).not_to receive(:facts_for_uploading)
+        expect(configurer).not_to receive(:facts_for_uploading)
         expect(Puppet::Resource::Catalog.indirection).to receive(:find) do |name, options|
           options[:facts].nil?
         end.and_return(@catalog)
 
-        @agent.run
+        configurer.run
       end
     end
 
     describe "when using a REST terminus for catalogs" do
       it "should pass the prepared facts and the facts format as arguments when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :rest
-        expect(@agent).to receive(:facts_for_uploading).and_return(:facts => "myfacts", :facts_format => :foo)
+        expect(configurer).to receive(:facts_for_uploading).and_return(:facts => "myfacts", :facts_format => :foo)
         expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(facts: "myfacts", facts_format: :foo)).and_return(@catalog)
 
-        @agent.run
+        configurer.run
       end
     end
   end
@@ -473,7 +474,6 @@ describe Puppet::Configurer do
     include PuppetSpec::Files
 
     before do
-      @configurer = Puppet::Configurer.new
       Puppet[:lastrunfile] = tmpfile('last_run_file')
 
       @report = Puppet::Transaction::Report.new
@@ -485,43 +485,43 @@ describe Puppet::Configurer do
 
       expect(@report).to receive(:summary).and_return("stuff")
 
-      expect(@configurer).to receive(:puts).with("stuff")
-      @configurer.send_report(@report)
+      expect(configurer).to receive(:puts).with("stuff")
+      configurer.send_report(@report)
     end
 
     it "should not print a report summary if not configured to do so" do
       Puppet.settings[:summarize] = false
 
-      expect(@configurer).not_to receive(:puts)
-      @configurer.send_report(@report)
+      expect(configurer).not_to receive(:puts)
+      configurer.send_report(@report)
     end
 
     it "should save the report if reporting is enabled" do
       Puppet.settings[:report] = true
 
       expect(Puppet::Transaction::Report.indirection).to receive(:save).with(@report, nil, instance_of(Hash))
-      @configurer.send_report(@report)
+      configurer.send_report(@report)
     end
 
     it "should not save the report if reporting is disabled" do
       Puppet.settings[:report] = false
 
       expect(Puppet::Transaction::Report.indirection).not_to receive(:save).with(@report, nil, instance_of(Hash))
-      @configurer.send_report(@report)
+      configurer.send_report(@report)
     end
 
     it "should save the last run summary if reporting is enabled" do
       Puppet.settings[:report] = true
 
-      expect(@configurer).to receive(:save_last_run_summary).with(@report)
-      @configurer.send_report(@report)
+      expect(configurer).to receive(:save_last_run_summary).with(@report)
+      configurer.send_report(@report)
     end
 
     it "should save the last run summary if reporting is disabled" do
       Puppet.settings[:report] = false
 
-      expect(@configurer).to receive(:save_last_run_summary).with(@report)
-      @configurer.send_report(@report)
+      expect(configurer).to receive(:save_last_run_summary).with(@report)
+      configurer.send_report(@report)
     end
 
     it "should log but not fail if saving the report fails" do
@@ -530,7 +530,7 @@ describe Puppet::Configurer do
       expect(Puppet::Transaction::Report.indirection).to receive(:save).and_raise("whatever")
 
       expect(Puppet).to receive(:err)
-      expect { @configurer.send_report(@report) }.not_to raise_error
+      expect { configurer.send_report(@report) }.not_to raise_error
     end
   end
 
@@ -538,21 +538,19 @@ describe Puppet::Configurer do
     include PuppetSpec::Files
 
     before do
-      @configurer = Puppet::Configurer.new
-
       @report = double('report', :raw_summary => {})
 
       Puppet[:lastrunfile] = tmpfile('last_run_file')
     end
 
     it "should write the last run file" do
-      @configurer.save_last_run_summary(@report)
+      configurer.save_last_run_summary(@report)
       expect(Puppet::FileSystem.exist?(Puppet[:lastrunfile])).to be_truthy
     end
 
     it "should write the raw summary as yaml" do
       expect(@report).to receive(:raw_summary).and_return("summary")
-      @configurer.save_last_run_summary(@report)
+      configurer.save_last_run_summary(@report)
       expect(File.read(Puppet[:lastrunfile])).to eq(YAML.dump("summary"))
     end
 
@@ -568,12 +566,12 @@ describe Puppet::Configurer do
       expect(Puppet::Util).to receive(:replace_file).and_yield(fh)
 
       expect(Puppet).to receive(:err)
-      expect { @configurer.save_last_run_summary(@report) }.to_not raise_error
+      expect { configurer.save_last_run_summary(@report) }.to_not raise_error
     end
 
     it "should create the last run file with the correct mode" do
       expect(Puppet.settings.setting(:lastrunfile)).to receive(:mode).and_return('664')
-      @configurer.save_last_run_summary(@report)
+      configurer.save_last_run_summary(@report)
 
       if Puppet::Util::Platform.windows?
         require 'puppet/util/windows/security'
@@ -587,25 +585,25 @@ describe Puppet::Configurer do
     it "should report invalid last run file permissions" do
       expect(Puppet.settings.setting(:lastrunfile)).to receive(:mode).and_return('892')
       expect(Puppet).to receive(:err).with(/Could not save last run local report.*892 is invalid/)
-      @configurer.save_last_run_summary(@report)
+      configurer.save_last_run_summary(@report)
     end
   end
 
   describe "when requesting a node" do
     it "uses the transaction uuid in the request" do
       expect(Puppet::Node.indirection).to receive(:find).with(anything, hash_including(transaction_uuid: anything)).twice
-      @agent.run
+      configurer.run
     end
 
     it "sends an explicitly configured environment request" do
       expect(Puppet.settings).to receive(:set_by_config?).with(:environment).and_return(true)
       expect(Puppet::Node.indirection).to receive(:find).with(anything, hash_including(configured_environment: Puppet[:environment])).twice
-      @agent.run
+      configurer.run
     end
 
     it "does not send a configured_environment when using the default" do
       expect(Puppet::Node.indirection).to receive(:find).with(anything, hash_including(configured_environment: nil)).twice
-      @agent.run
+      configurer.run
     end
   end
 
@@ -636,8 +634,8 @@ describe Puppet::Configurer do
 
   describe "when retrieving a catalog" do
     before do
-      allow(@agent).to receive(:facts_for_uploading).and_return({})
-      allow(@agent).to receive(:download_plugins)
+      allow(configurer).to receive(:facts_for_uploading).and_return({})
+      allow(configurer).to receive(:download_plugins)
 
       # retrieve a catalog in the current environment, so we don't try to converge unexpectedly
       @catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
@@ -654,58 +652,58 @@ describe Puppet::Configurer do
       it "should first look in the cache for a catalog" do
         expects_cached_catalog_only(@catalog)
 
-        expect(@agent.retrieve_catalog({})).to eq(@catalog)
+        expect(configurer.retrieve_catalog({})).to eq(@catalog)
       end
 
       it "should not make a node request or pluginsync when a cached catalog is successfully retrieved" do
         expect(Puppet::Node.indirection).not_to receive(:find)
         expects_cached_catalog_only(@catalog)
-        expect(@agent).not_to receive(:download_plugins)
+        expect(configurer).not_to receive(:download_plugins)
 
-        @agent.run
+        configurer.run
       end
 
       it "should make a node request and pluginsync when a cached catalog cannot be retrieved" do
         expect(Puppet::Node.indirection).to receive(:find).and_return(nil)
         expects_fallback_to_new_catalog(@catalog)
-        expect(@agent).to receive(:download_plugins)
+        expect(configurer).to receive(:download_plugins)
 
-        @agent.run
+        configurer.run
       end
 
       it "should set its cached_catalog_status to 'explicitly_requested'" do
         expects_cached_catalog_only(@catalog)
 
-        @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('explicitly_requested')
+        configurer.retrieve_catalog({})
+        expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('explicitly_requested')
       end
 
       it "should set its cached_catalog_status to 'explicitly requested' if the cached catalog is from a different environment" do
         cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
         expects_cached_catalog_only(cached_catalog)
 
-        @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('explicitly_requested')
+        configurer.retrieve_catalog({})
+        expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('explicitly_requested')
       end
 
       it "should compile a new catalog if none is found in the cache" do
         expects_fallback_to_new_catalog(@catalog)
 
-        expect(@agent.retrieve_catalog({})).to eq(@catalog)
+        expect(configurer.retrieve_catalog({})).to eq(@catalog)
       end
 
       it "should set its cached_catalog_status to 'not_used' if no catalog is found in the cache" do
         expects_fallback_to_new_catalog(@catalog)
 
-        @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
+        configurer.retrieve_catalog({})
+        expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
       end
 
       it "should not attempt to retrieve a cached catalog again if the first attempt failed" do
         expect(Puppet::Node.indirection).to receive(:find).and_return(nil)
         expects_neither_new_or_cached_catalog
 
-        @agent.run
+        configurer.run
       end
 
       it "should return the cached catalog when the environment doesn't match" do
@@ -713,7 +711,7 @@ describe Puppet::Configurer do
         expects_cached_catalog_only(cached_catalog)
 
         expect(Puppet).to receive(:info).with("Using cached catalog from environment 'second_env'")
-        expect(@agent.retrieve_catalog({})).to eq(cached_catalog)
+        expect(configurer.retrieve_catalog({})).to eq(cached_catalog)
       end
     end
 
@@ -722,30 +720,30 @@ describe Puppet::Configurer do
         allow(@catalog).to receive(:to_ral).and_return(@catalog)
         allow(@catalog).to receive(:write_class_file)
         allow(@catalog).to receive(:write_resource_file)
-        allow(@agent).to receive(:send_report)
-        allow(@agent).to receive(:save_last_run_summary)
+        allow(configurer).to receive(:send_report)
+        allow(configurer).to receive(:save_last_run_summary)
         Puppet.settings[:strict_environment_mode] = true
       end
 
       it "should not make a node request" do
         expect(Puppet::Node.indirection).not_to receive(:find)
 
-        @agent.run
+        configurer.run
       end
 
       it "should return nil when the catalog's environment doesn't match the agent specified environment" do
-        @agent.instance_variable_set(:@environment, 'second_env')
+        configurer.instance_variable_set(:@environment, 'second_env')
         expects_new_catalog_only(@catalog)
 
         expect(Puppet).to receive(:err).with("Not using catalog because its environment 'production' does not match agent specified environment 'second_env' and strict_environment_mode is set")
-        expect(@agent.run).to be_nil
+        expect(configurer.run).to be_nil
       end
 
       it "should not return nil when the catalog's environment matches the agent specified environment" do
-        @agent.instance_variable_set(:@environment, 'production')
+        configurer.instance_variable_set(:@environment, 'production')
         expects_new_catalog_only(@catalog)
 
-        expect(@agent.run).to eq(0)
+        expect(configurer.run).to eq(0)
       end
 
       describe "and a cached catalog is explicitly requested" do
@@ -754,19 +752,19 @@ describe Puppet::Configurer do
         end
 
         it "should return nil when the cached catalog's environment doesn't match the agent specified environment" do
-          @agent.instance_variable_set(:@environment, 'second_env')
+          configurer.instance_variable_set(:@environment, 'second_env')
           expects_cached_catalog_only(@catalog)
 
           expect(Puppet).to receive(:err).with("Not using catalog because its environment 'production' does not match agent specified environment 'second_env' and strict_environment_mode is set")
-          expect(@agent.run).to be_nil
+          expect(configurer.run).to be_nil
         end
 
         it "should proceed with the cached catalog if its environment matchs the local environment" do
           Puppet.settings[:use_cached_catalog] = true
-          @agent.instance_variable_set(:@environment, 'production')
+          configurer.instance_variable_set(:@environment, 'production')
           expects_cached_catalog_only(@catalog)
 
-          expect(@agent.run).to eq(0)
+          expect(configurer.run).to eq(0)
         end
       end
     end
@@ -774,14 +772,14 @@ describe Puppet::Configurer do
     it "should use the Catalog class to get its catalog" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(@catalog)
 
-      @agent.retrieve_catalog({})
+      configurer.retrieve_catalog({})
     end
 
     it "should set its cached_catalog_status to 'not_used' when downloading a new catalog" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(@catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
+      configurer.retrieve_catalog({})
+      expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
     end
 
     it "should use its node_name_value to retrieve the catalog" do
@@ -789,48 +787,48 @@ describe Puppet::Configurer do
       Puppet.settings[:node_name_value] = "myhost.domain.com"
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with("myhost.domain.com", anything).and_return(@catalog)
 
-      @agent.retrieve_catalog({})
+      configurer.retrieve_catalog({})
     end
 
     it "should default to returning a catalog retrieved directly from the server, skipping the cache" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(@catalog)
 
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
+      expect(configurer.retrieve_catalog({})).to eq(@catalog)
     end
 
     it "should log and return the cached catalog when no catalog can be retrieved from the server" do
       expects_fallback_to_cached_catalog(@catalog)
 
       expect(Puppet).to receive(:info).with("Using cached catalog from environment 'production'")
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
+      expect(configurer.retrieve_catalog({})).to eq(@catalog)
     end
 
     it "should set its cached_catalog_status to 'on_failure' when no catalog can be retrieved from the server" do
       expects_fallback_to_cached_catalog(@catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
+      configurer.retrieve_catalog({})
+      expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
     end
 
     it "should not look in the cache for a catalog if one is returned from the server" do
       expects_new_catalog_only(@catalog)
 
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
+      expect(configurer.retrieve_catalog({})).to eq(@catalog)
     end
 
     it "should return the cached catalog when retrieving the remote catalog throws an exception" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_raise("eh")
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_terminus: true)).and_return(@catalog)
 
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
+      expect(configurer.retrieve_catalog({})).to eq(@catalog)
     end
 
     it "should set its cached_catalog_status to 'on_failure' when retrieving the remote catalog throws an exception" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_raise("eh")
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_terminus: true)).and_return(@catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
+      configurer.retrieve_catalog({})
+      expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
     end
 
     it "should log and return nil if no catalog can be retrieved from the server and :usecacheonfailure is disabled" do
@@ -839,74 +837,74 @@ describe Puppet::Configurer do
 
       expect(Puppet).to receive(:warning).with('Not using cache on failed catalog')
 
-      expect(@agent.retrieve_catalog({})).to be_nil
+      expect(configurer.retrieve_catalog({})).to be_nil
     end
 
     it "should set its cached_catalog_status to 'not_used' if no catalog can be retrieved from the server and :usecacheonfailure is disabled or fails to retrieve a catalog" do
       Puppet[:usecacheonfailure] = false
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(nil)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
+      configurer.retrieve_catalog({})
+      expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
     end
 
     it "should return nil if no cached catalog is available and no catalog can be retrieved from the server" do
       expects_neither_new_or_cached_catalog
 
-      expect(@agent.retrieve_catalog({})).to be_nil
+      expect(configurer.retrieve_catalog({})).to be_nil
     end
 
     it "should return nil if its cached catalog environment doesn't match server-specified environment" do
       cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
-      @agent.instance_variable_set(:@node_environment, 'production')
+      configurer.instance_variable_set(:@node_environment, 'production')
 
       expects_fallback_to_cached_catalog(cached_catalog)
 
       expect(Puppet).to receive(:err).with("Not using cached catalog because its environment 'second_env' does not match 'production'")
-      expect(@agent.retrieve_catalog({})).to be_nil
+      expect(configurer.retrieve_catalog({})).to be_nil
     end
 
     it "should set its cached_catalog_status to 'not_used' if the cached catalog environment doesn't match server-specified environment" do
       cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
-      @agent.instance_variable_set(:@node_environment, 'production')
+      configurer.instance_variable_set(:@node_environment, 'production')
 
       expects_fallback_to_cached_catalog(cached_catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
+      configurer.retrieve_catalog({})
+      expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
     end
 
     it "should return its cached catalog if the environment matches the server-specified environment" do
       cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment]))
-      @agent.instance_variable_set(:@node_environment, cached_catalog.environment)
+      configurer.instance_variable_set(:@node_environment, cached_catalog.environment)
 
       expects_fallback_to_cached_catalog(cached_catalog)
 
-      expect(@agent.retrieve_catalog({})).to eq(cached_catalog)
+      expect(configurer.retrieve_catalog({})).to eq(cached_catalog)
     end
 
     it "should set its cached_catalog_status to 'on_failure' if the cached catalog environment matches server-specified environment" do
       cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment]))
-      @agent.instance_variable_set(:@node_environment, cached_catalog.environment)
+      configurer.instance_variable_set(:@node_environment, cached_catalog.environment)
 
       expects_fallback_to_cached_catalog(cached_catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
+      configurer.retrieve_catalog({})
+      expect(configurer.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
     end
 
     it "should not update the cached catalog in noop mode" do
       Puppet[:noop] = true
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true, ignore_cache_save: true)).and_return(@catalog)
 
-      @agent.retrieve_catalog({})
+      configurer.retrieve_catalog({})
     end
 
     it "should update the cached catalog when not in noop mode" do
       Puppet[:noop] = false
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true, ignore_cache_save: false)).and_return(@catalog)
 
-      @agent.retrieve_catalog({})
+      configurer.retrieve_catalog({})
     end
   end
 
@@ -919,38 +917,38 @@ describe Puppet::Configurer do
     let (:ral_catalog) { Puppet::Resource::Catalog.new('tester', Puppet::Node::Environment.remote(Puppet[:environment].to_sym)) }
 
     it "should convert the catalog to a RAL-formed catalog" do
-      expect(@agent.convert_catalog(catalog, 10)).to equal(ral_catalog)
+      expect(configurer.convert_catalog(catalog, 10)).to equal(ral_catalog)
     end
 
     it "should finalize the catalog" do
       expect(ral_catalog).to receive(:finalize)
 
-      @agent.convert_catalog(catalog, 10)
+      configurer.convert_catalog(catalog, 10)
     end
 
     it "should record the passed retrieval time with the RAL catalog" do
       expect(ral_catalog).to receive(:retrieval_duration=).with(10)
 
-      @agent.convert_catalog(catalog, 10)
+      configurer.convert_catalog(catalog, 10)
     end
 
     it "should write the RAL catalog's class file" do
       expect(ral_catalog).to receive(:write_class_file)
 
-      @agent.convert_catalog(catalog, 10)
+      configurer.convert_catalog(catalog, 10)
     end
 
     it "should write the RAL catalog's resource file" do
       expect(ral_catalog).to receive(:write_resource_file)
 
-      @agent.convert_catalog(catalog, 10)
+      configurer.convert_catalog(catalog, 10)
     end
 
     it "should set catalog conversion time on the report" do
       report = Puppet::Transaction::Report.new
 
       expect(report).to receive(:add_times).with(:convert_catalog, kind_of(Numeric))
-      @agent.convert_catalog(catalog, 10, {:report => report})
+      configurer.convert_catalog(catalog, 10, {:report => report})
     end
   end
 
@@ -985,25 +983,25 @@ describe Puppet::Configurer do
   describe "when attempting failover" do
     it "should not failover if server_list is not set" do
       Puppet.settings[:server_list] = []
-      expect(@agent).not_to receive(:find_functional_server)
-      @agent.run
+      expect(configurer).not_to receive(:find_functional_server)
+      configurer.run
     end
 
     it "should not failover during an apply run" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      expect(@agent).not_to receive(:find_functional_server)
+      expect(configurer).not_to receive(:find_functional_server)
       catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
-      @agent.run :catalog => catalog
+      configurer.run :catalog => catalog
     end
 
     it "should select a server when it receives 200 OK response" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPOK.new(nil, 200, 'OK')
       allow(Puppet::Network::HttpPool).to receive(:http_ssl_instance).with('myserver', '123').and_return(double('request', get: response))
-      allow(@agent).to receive(:run_internal)
+      allow(configurer).to receive(:run_internal)
 
       options = {}
-      @agent.run(options)
+      configurer.run(options)
       expect(options[:report].master_used).to eq('myserver:123')
     end
 
@@ -1011,10 +1009,10 @@ describe Puppet::Configurer do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPForbidden.new(nil, 403, 'Forbidden')
       allow(Puppet::Network::HttpPool).to receive(:http_ssl_instance).with('myserver', '123').and_return(double('request', get: response))
-      allow(@agent).to receive(:run_internal)
+      allow(configurer).to receive(:run_internal)
 
       options = {}
-      @agent.run(options)
+      configurer.run(options)
       expect(options[:report].master_used).to eq('myserver:123')
     end
 
@@ -1024,19 +1022,19 @@ describe Puppet::Configurer do
       http = double('request')
       expect(http).to receive(:get).with('/status/v1/simple/master').and_return(response)
       allow(Puppet::Network::HttpPool).to receive(:http_ssl_instance).with('myserver', '123').and_return(http)
-      allow(@agent).to receive(:run_internal)
+      allow(configurer).to receive(:run_internal)
 
-      @agent.run
+      configurer.run
     end
 
     it "should report when a server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
       response = Net::HTTPInternalServerError.new(nil, 500, 'Internal Server Error')
       allow(Puppet::Network::HttpPool).to receive(:http_ssl_instance).with('myserver', '123').and_return(double('request', get: response))
-      allow(@agent).to receive(:run_internal)
+      allow(configurer).to receive(:run_internal)
 
       expect(Puppet).to receive(:debug).with("Puppet server myserver:123 is unavailable: 500 Internal Server Error")
-      expect { @agent.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list:/)
+      expect { configurer.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list:/)
     end
 
     it "should error when no servers in 'server_list' are reachable" do
@@ -1048,7 +1046,7 @@ describe Puppet::Configurer do
       allow(Puppet).to receive(:override).with({:server => "someotherservername", :serverport => 8140}).and_yield
       error = Net::HTTPError.new(400, 'dummy server communication error')
       allow(Puppet::Node.indirection).to receive(:find).and_raise(error)
-      expect{ @agent.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list: 'myserver:123,someotherservername'/)
+      expect{ configurer.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list: 'myserver:123,someotherservername'/)
     end
 
     it "should not make multiple node requets when the server is found" do
@@ -1057,8 +1055,8 @@ describe Puppet::Configurer do
       
       Puppet.settings[:server_list] = ["myserver:123"]
       expect(Puppet::Node.indirection).to receive(:find).and_return("mynode").once
-      expect(@agent).to receive(:prepare_and_retrieve_catalog).and_return(nil)
-      @agent.run
+      expect(configurer).to receive(:prepare_and_retrieve_catalog).and_return(nil)
+      configurer.run
     end
   end
 end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -829,6 +829,7 @@ describe Puppet::Configurer do
 
     it "should update the cached catalog when not in noop mode" do
       Puppet[:noop] = false
+      Puppet[:log_level] = 'info'
 
       stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
 
@@ -838,6 +839,8 @@ describe Puppet::Configurer do
       expect(File).to_not be_exist(cache_path)
       configurer.run
       expect(File).to be_exist(cache_path)
+
+      expect(@logs).to include(an_object_having_attributes(level: :info, message: "Caching catalog for #{Puppet[:node_name_value]}"))
     end
 
     it "successfully applies the catalog without a cache" do

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -4,8 +4,6 @@ require 'puppet/configurer'
 describe Puppet::Configurer do
   before do
     Puppet::Node::Facts.indirection.terminus_class = :memory
-
-    allow(Puppet.settings).to receive(:use).and_return(true)
     @agent = Puppet::Configurer.new
     allow(@agent).to receive(:init_storage)
     allow(Puppet::Util::Storage).to receive(:store)
@@ -65,7 +63,6 @@ describe Puppet::Configurer do
 
   describe "when executing a catalog run" do
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
       allow(@agent).to receive(:download_plugins)
       @facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
       Puppet::Node::Facts.indirection.save(@facts)
@@ -485,7 +482,6 @@ describe Puppet::Configurer do
     include PuppetSpec::Files
 
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
       @configurer = Puppet::Configurer.new
       Puppet[:lastrunfile] = tmpfile('last_run_file')
 
@@ -551,7 +547,6 @@ describe Puppet::Configurer do
     include PuppetSpec::Files
 
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
       @configurer = Puppet::Configurer.new
 
       @report = double('report', :raw_summary => {})
@@ -650,7 +645,6 @@ describe Puppet::Configurer do
 
   describe "when retrieving a catalog" do
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
       allow(@agent).to receive(:facts_for_uploading).and_return({})
       allow(@agent).to receive(:download_plugins)
 
@@ -927,8 +921,6 @@ describe Puppet::Configurer do
 
   describe "when converting the catalog" do
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
-
       allow(catalog).to receive(:to_ral).and_return(ral_catalog)
     end
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -12,10 +12,6 @@ describe Puppet::Configurer do
     catalog.add_resource(resource)
   end
 
-  after :all do
-    Puppet::Node::Facts.indirection.reset_terminus_class
-  end
-
   let(:configurer) { Puppet::Configurer.new }
   let(:report) { Puppet::Transaction::Report.new }
   let(:catalog) { Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym)) }
@@ -70,18 +66,8 @@ describe Puppet::Configurer do
 
   describe "when executing a catalog run" do
     before do
-      allow(configurer).to receive(:download_plugins)
-
       Puppet::Resource::Catalog.indirection.terminus_class = :rest
       allow(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(catalog)
-      allow(configurer).to receive(:send_report)
-      allow(configurer).to receive(:save_last_run_summary)
-
-      allow(Puppet::Util::Log).to receive(:close_all)
-    end
-
-    after :all do
-      Puppet::Resource::Catalog.indirection.reset_terminus_class
     end
 
     it "downloads plugins when told" do
@@ -381,9 +367,6 @@ describe Puppet::Configurer do
       Puppet[:supported_checksum_types] = ['sha256']
       # Regenerate the agent to pick up the new setting
       configurer = Puppet::Configurer.new
-      allow(configurer).to receive(:download_plugins)
-      allow(configurer).to receive(:send_report)
-      allow(configurer).to receive(:save_last_run_summary)
 
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(checksum_type: 'sha256'))
       configurer.run
@@ -586,9 +569,6 @@ describe Puppet::Configurer do
 
   describe "when retrieving a catalog" do
     before do
-      allow(configurer).to receive(:download_plugins)
-
-      # this is the default when using a Configurer instance
       allow(Puppet::Resource::Catalog.indirection).to receive(:terminus_class).and_return(:rest)
     end
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Configurer do
   describe "when executing a pre-run hook" do
     it "should do nothing if the hook is set to an empty string" do
       Puppet.settings[:prerun_command] = ""
-      expect(Puppet::Util).not_to receive(:exec)
+      expect(Puppet::Util::Execution).not_to receive(:execute)
 
       configurer.execute_prerun_command
     end
@@ -40,7 +40,7 @@ describe Puppet::Configurer do
   describe "when executing a post-run hook" do
     it "should do nothing if the hook is set to an empty string" do
       Puppet.settings[:postrun_command] = ""
-      expect(Puppet::Util).not_to receive(:exec)
+      expect(Puppet::Util::Execution).not_to receive(:execute)
 
       configurer.execute_postrun_command
     end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -5,8 +5,6 @@ describe Puppet::Configurer do
   before do
     Puppet::Node::Facts.indirection.terminus_class = :memory
     @agent = Puppet::Configurer.new
-    allow(@agent).to receive(:init_storage)
-    allow(Puppet::Util::Storage).to receive(:store)
     Puppet[:server] = "puppetmaster"
     Puppet[:report] = true
   end
@@ -79,11 +77,6 @@ describe Puppet::Configurer do
 
     after :all do
       Puppet::Resource::Catalog.indirection.reset_terminus_class
-    end
-
-    it "should initialize storage" do
-      expect(Puppet::Util::Storage).to receive(:load)
-      @agent.run
     end
 
     it "downloads plugins when told" do
@@ -197,7 +190,6 @@ describe Puppet::Configurer do
 
     it "should create report with passed transaction_uuid and job_id" do
       @agent = Puppet::Configurer.new("test_tuuid", "test_jid")
-      allow(@agent).to receive(:init_storage)
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).with(anything, anything, 'test_tuuid', 'test_jid').and_return(report)
@@ -438,7 +430,6 @@ describe Puppet::Configurer do
       # Regenerate the agent to pick up the new setting
       Puppet[:supported_checksum_types] = ['sha256']
       @agent = Puppet::Configurer.new
-      allow(@agent).to receive(:init_storage)
       allow(@agent).to receive(:download_plugins)
       allow(@agent).to receive(:send_report)
       allow(@agent).to receive(:save_last_run_summary)


### PR DESCRIPTION
Previously during the environment convergence loop, we downloaded a resource catalog, updated the cached catalog as a side effect of the indirector's cache class, and converted the resource catalog into a RAL catalog. However, if our current environment did not match, then we switched to the new environment, and re-requested facts and a new catalog.

The process of serializing the catalog to the cache and converting the resource catalog to a RAL catalog causes puppet to load types and providers. This is unnecessary and can lead to environment isolation problems if a type or provider loads helper code (since the helper code is not reloaded).

This commit defers the RAL catalog transformation and cached catalog update until after we've converged the environment.

From [plantuml](http://www.plantuml.com/plantuml/uml/ZLF1Qjn03BtFLwZNGiYb9nz2mfBqqYubREcX5AEEjLvJMJ8pOmV_VSVoRkAuRiZ5ZAJttZn9uzkOCAI-PVVpuo-ukhg1BuhL3ls9yZSXQrr07wdqbYhzd7CRAA-I6ka9L812qF0i-KXHUQ2zLhJ7bWhuy1x5BQhxHwevWkIWb1oLH_Hf3J6PpvIc-5u6ztAyLBvnNpSIrvNxgOSVGQM-wpeUSzfkYoaqFfKaGvDhBKagsynoBq85TFDX54yLJAOYU1Jm9vIQ5du7v7x9j7jtoam-FKmqjmoUEw6dyuZSgsZLJm4BZz0siSNaJniKQzH6lzTqnwnFLCqxiXMf7B7XFj06zG6PVwF_Sr3Z5_0Uqavbe90E-eXi9i6SKVoVjuFgLvInW1luD8_p-ZpXQt_6-j5p5bZvMUtHShP7k_GoaJNfRO_BYa6_TnKcUlLqtKREiFQIBY0BbjNylxXRagfl-Iy0)

![Configurer](http://www.plantuml.com/plantuml/png/ZLF1Qjn03BtFLwZNGiYb9nz2mfBqqYubREcX5AEEjLvJMJ8pOmV_VSVoRkAuRiZ5ZAJttZn9uzkOCAI-PVVpuo-ukhg1BuhL3ls9yZSXQrr07wdqbYhzd7CRAA-I6ka9L812qF0i-KXHUQ2zLhJ7bWhuy1x5BQhxHwevWkIWb1oLH_Hf3J6PpvIc-5u6ztAyLBvnNpSIrvNxgOSVGQM-wpeUSzfkYoaqFfKaGvDhBKagsynoBq85TFDX54yLJAOYU1Jm9vIQ5du7v7x9j7jtoam-FKmqjmoUEw6dyuZSgsZLJm4BZz0siSNaJniKQzH6lzTqnwnFLCqxiXMf7B7XFj06zG6PVwF_Sr3Z5_0Uqavbe90E-eXi9i6SKVoVjuFgLvInW1luD8_p-ZpXQt_6-j5p5bZvMUtHShP7k_GoaJNfRO_BYa6_TnKcUlLqtKREiFQIBY0BbjNylxXRagfl-Iy0)