### PR TITLE
(maint) Create man directories before manpage generation

### DIFF
--- a/tasks/manpages.rake
+++ b/tasks/manpages.rake
@@ -35,7 +35,7 @@ task :gen_manpages do
 #   IO.popen("#{ronn} #{ronn_args} > ./man/man5/puppet.conf.5", 'w') do |fh|
 #     fh.write %x{RUBYLIB=./lib:$RUBYLIB bin/puppetdoc --reference configuration}
 #   end
-  %x{mkdir -p ./man/man{5,8}}
+  %x{mkdir -p ./man/man5 ./man/man8}
   %x{RUBYLIB=./lib:$RUBYLIB bin/puppet doc --reference configuration > ./man/man5/puppetconf.5.ronn}
   %x{#{ronn} #{ronn_args} ./man/man5/puppetconf.5.ronn}
   FileUtils.mv("./man/man5/puppetconf.5", "./man/man5/puppet.conf.5")


### PR DESCRIPTION
Running `mkdir -p man/man{5,8}` makes `/bin/sh` (which is the default
shell for rake) create a single directory titled `man{5,8}`, since this
type of grouping is bash-specific.

The previous implementation might work on most modern systems where
`/bin/sh` is a symlink to `bash`, but to be safe we create the
directories individually.