### PR TITLE
(PUP-7113) Document AIX local resource functionality

### DIFF
--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -175,7 +175,8 @@ module Puppet
     end
 
     newparam(:ia_load_module, :required_features => :manages_aix_lam) do
-      desc "The name of the I&A module to use to manage this user"
+      desc "The name of the I&A module to use to manage this group.
+        This should be set to `files` if managing local groups."
     end
 
     newproperty(:attributes, :parent => Puppet::Property::KeyValue, :required_features => :manages_aix_lam) do
@@ -216,7 +217,8 @@ module Puppet
              :required_features => :libuser,
              :parent => Puppet::Parameter::Boolean) do
       desc "Forces the management of local accounts when accounts are also
-            being managed by some other NSS"
+            being managed by some other NSS. For AIX, refer to the
+            `ia_load_module` parameter."
       defaultto false
     end
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -614,7 +614,8 @@ module Puppet
     end
 
     newparam(:ia_load_module, :required_features => :manages_aix_lam) do
-      desc "The name of the I&A module to use to manage this user."
+      desc "The name of the I&A module to use to manage this user.
+        This should be set to `files` if managing local users."
     end
 
     newproperty(:attributes, :parent => Puppet::Property::KeyValue, :required_features => :manages_aix_lam) do
@@ -665,7 +666,8 @@ module Puppet
             :required_features => :libuser,
             :parent => Puppet::Parameter::Boolean) do
       desc "Forces the management of local accounts when accounts are also
-            being managed by some other NSS"
+            being managed by some other NSS. For AIX, refer to the
+            `ia_load_module` parameter."
       defaultto false
     end
 


### PR DESCRIPTION
To manage a local user/group resource on AIX, the `ia_load_module`
parameter needs to be set to `files`. This has the same effect as
`forcelocal` on Linux.

Since the `forcelocal` parameter is linked to the `libuser` feature
which is platform-specific, we cannot use it on AIX.

Extend the documentation on these flags to reflect this use case.