### PR TITLE
(maint) Print TLS connection info at debug level

### DIFF
--- a/lib/puppet/network/http/base_pool.rb
+++ b/lib/puppet/network/http/base_pool.rb
@@ -8,11 +8,24 @@ class Puppet::Network::HTTP::BasePool
       verifier.setup_connection(http)
       begin
         http.start
+        print_ssl_info(http) if Puppet::Util::Log.sendlevel?(:debug)
       rescue OpenSSL::SSL::SSLError => error
         verifier.handle_connection_error(http, error)
       end
     else
       http.start
     end
+  end
+
+  private
+
+  def print_ssl_info(http)
+    buffered_io = http.instance_variable_get(:@socket)
+    return unless buffered_io
+
+    socket = buffered_io.io
+    return unless socket
+
+    Puppet.debug("Using #{socket.ssl_version} with cipher #{socket.cipher.first}")
   end
 end

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -58,6 +58,17 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
                          %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
       end
     end
+
+    it "prints TLS protocol and ciphersuite in debug" do
+      Puppet[:log_level] = 'debug'
+      server.start_server do |port|
+        client.get(URI("https://127.0.0.1:#{port}"), ssl_context: root_context)
+        # TLS version string can be TLSv1 or TLSv1.[1-3], but not TLSv1.0
+        expect(@logs).to include(
+          an_object_having_attributes(level: :debug, message: /Using TLSv1(\.[1-3])? with cipher .*/),
+        )
+      end
+    end
   end
 
   context "with client certs" do


### PR DESCRIPTION
If debugging is enabled, print TLS protocol and ciphersuites.

```
$ bx puppet agent -t
Debug: Creating new connection for https://crested-pursuer.delivery.puppetlabs.net:8140
Debug: Starting connection for https://crested-pursuer.delivery.puppetlabs.net:8140
Debug: Using TLSv1.2 with cipher DHE-RSA-AES128-SHA256
```