### PR TITLE
(PUP-10177) Fixes scan_options parser with yum package provider

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -286,12 +286,16 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   # @param key [String] The key to look for in all contained hashes
   # @return [Array<String>] All hash values with the given key.
   def scan_options(options, key)
-    return [] if options.nil?
-    options.inject([]) do |repos, opt|
-      if opt.is_a? Hash and opt[key]
-        repos << opt[key]
+    return [] unless options.is_a?(Enumerable)
+    values = options.map do | repo |
+      value = if repo.is_a?(String)
+        next unless repo.include?('=')
+        Hash[*repo.strip.split('=')] # make it a hash
+      else
+        repo
       end
-      repos
+      value[key]
     end
+    values.compact.uniq
   end
 end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -54,6 +54,56 @@ describe Puppet::Type.type(:package).provider(:yum) do
         provider.install
       end
     end
+
+    describe 'with install_options' do 
+      it 'can parse disable-repo with array of strings' do
+          resource[:install_options] = ['--disable-repo=dev*', '--disable-repo=prod*']
+          expect(provider).to receive(:execute) do | arr|
+            expect(arr[-3]).to eq(["--disable-repo=dev*", "--disable-repo=prod*"])
+          end
+          provider.install
+      end
+
+      it 'can parse disable-repo with array of hashes' do
+        resource[:install_options] = [{'--disable-repo' => 'dev*'}, {'--disable-repo' => 'prod*'}]
+        expect(provider).to receive(:execute) do | arr|
+          expect(arr[-3]).to eq(["--disable-repo=dev*", "--disable-repo=prod*"])
+        end
+        provider.install
+      end
+
+      it 'can parse enable-repo with array of strings' do
+          resource[:install_options] = ['--enable-repo=dev*', '--enable-repo=prod*']
+          expect(provider).to receive(:execute) do | arr|
+            expect(arr[-3]).to eq(["--enable-repo=dev*", "--enable-repo=prod*"])
+          end
+          provider.install
+      end
+
+      it 'can parse enable-repo with array of hashes' do
+        resource[:install_options] = [{'--enable-repo' => 'dev*'}, {'--disable-repo' => 'prod*'}]
+        expect(provider).to receive(:execute) do | arr|
+          expect(arr[-3]).to eq(["--enable-repo=dev*", "--disable-repo=prod*"])
+        end
+        provider.install
+      end
+
+      it 'can parse enable-repo with single hash' do
+        resource[:install_options] = [{'--enable-repo' => 'dev*','--disable-repo' => 'prod*'}]
+        expect(provider).to receive(:execute) do | arr|
+          expect(arr[-3]).to eq(["--disable-repo=prod*", "--enable-repo=dev*"])
+        end
+        provider.install
+      end
+
+      it 'can parse enable-repo with empty array' do
+        resource[:install_options] = []
+        expect(provider).to receive(:execute) do | arr|
+          expect(arr[-3]).to eq([])
+        end
+        provider.install
+      end
+    end
   end
 
   context "parsing the output of check-update" do


### PR DESCRIPTION
  * previously the parsing of install_options only
    worked with a hash.  This fixes the code to also
    work with a array of strings as it was originally
    intended to.

  * This bug has been present since 2014!

Current issue when using an array of strings 
```
  package{'nginx':
             ensure => latest,
             install_options => ['--disable-repo=dev*'],
             provider => yum,
           }
```

* This fix may have unintended changes to users since they are used to the current implementation. However, if a user is not seeing the results with the current implementation prior to this patch they can work around the bug by using an array of hashes instead of an array of strings. 

Workaround with hashes:

```
  package{'nginx':
             ensure => latest,
             install_options => [{'--disable-repo' =>'dev*'}],
             provider => yum,
           }
```