### PR TITLE
(maint) attempt to fix travis

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://puppetlabs.com"
   s.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
   s.require_paths = ["lib"]
-  s.rubyforge_project = "puppet"
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
   s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 4"])

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 bundler_args: --jobs 4 --retry 2 --without packaging documentation
 before_install:
-  - gem update --system && gem install bundler --no-document
+  - yes | gem update --system
 script:
   - "bundle exec rake $CHECK"
 notifications:


### PR DESCRIPTION
The last bundler update cause `gem update --system` to become interactive causing our travis builds to get stuck.

This PR attempts to provide a temporary workaround until upstream fixes it.
More info here: https://github.com/rubygems/rubygems/issues/3030
