### PR TITLE
(maint) Do not create exceptions for optional warnings

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -33,7 +33,7 @@ module Runtime3Support
   # @raise [Puppet::ParseError] an evaluation error initialized from the arguments (TODO: Change to EvaluationError?)
   #
   def optionally_fail(issue, semantic, options={}, except=nil)
-    if except.nil?
+    if except.nil? && diagnostic_producer.severity_producer[issue] == :error
       # Want a stacktrace, and it must be passed as an exception
       begin
        raise EvaluationError.new()

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'spec_helper'
 
 require 'puppet/pops'
@@ -478,21 +479,26 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       }.each do |source, coerced_val|
           it "should warn about numeric coercion in '#{source}' when strict = warning" do
             Puppet[:strict] = :warning
+            expect(Puppet::Pops::Evaluator::Runtime3Support::EvaluationError).not_to receive(:new)
             collect_notices(source)
             expect(warnings).to include(/The string '#{coerced_val}' was automatically coerced to the numerical value #{coerced_val}/)
           end
 
           it "should not warn about numeric coercion in '#{source}' if strict = off" do
             Puppet[:strict] = :off
+            expect(Puppet::Pops::Evaluator::Runtime3Support::EvaluationError).not_to receive(:new)
             collect_notices(source)
             expect(warnings).to_not include(/The string '#{coerced_val}' was automatically coerced to the numerical value #{coerced_val}/)
           end
 
         it "should error when finding numeric coercion in '#{source}' if strict = error" do
           Puppet[:strict] = :error
-          expect { parser.evaluate_string(scope, source, __FILE__) }.to raise_error(
-            /The string '#{coerced_val}' was automatically coerced to the numerical value #{coerced_val}/
-            )
+          expect {
+            parser.evaluate_string(scope, source, __FILE__)
+          }.to raise_error {|error|
+            expect(error.message).to match(/The string '#{coerced_val}' was automatically coerced to the numerical value #{coerced_val}/)
+            expect(error.backtrace.first).to match(/runtime3_support\.rb.+optionally_fail/)
+          }
         end
       end
 


### PR DESCRIPTION
We currently make exceptions so that we may at some point display them,
even though in many cases we do not actually display them.

For some environments we may create many exceptions (that are relatively
expensive) without ever displaying them.

This removes the creation of exceptions in optionally_fail (callers
should now create exceptions if they need to pass them through). I have
not updated any callers however because this doesn't seem to break any
tests (and the motivating example is from numerical coercion where a
customer is hitting this warning on nearly every manifest).

This needs a ticket if it is to be merged. I'm only putting it now for
discussion.