### PR TITLE
(PUP-10148) Include X-Puppet-Profiling Header

### DIFF
--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -33,6 +33,12 @@ class Puppet::HTTP::Service
 
   protected
 
+  def add_puppet_headers(headers)
+    modified_headers = headers.dup
+    modified_headers['X-Puppet-Profiling'] = 'true' if Puppet[:profile]
+    modified_headers
+  end
+
   def build_url(api, server, port)
     URI::HTTPS.build(host: server,
                      port: port,

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -10,7 +10,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   def get_certificate(name, ssl_context: nil)
     response = @client.get(
       with_base_url("/certificate/#{name}"),
-      headers: HEADERS,
+      headers: add_puppet_headers(HEADERS),
       ssl_context: ssl_context
     )
 

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -85,7 +85,10 @@ describe Puppet::HTTP::Client do
 
   context "for GET requests" do
     it "includes default HTTP headers" do
-      stub_request(:get, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./})
+      stub_request(:get, uri).with do |request|
+        expect(request.headers).to include({'X-Puppet-Version' => /./, 'User-Agent' => /./})
+        expect(request.headers).to_not include('X-Puppet-Profiling')
+      end
 
       client.get(uri)
     end
@@ -168,7 +171,10 @@ describe Puppet::HTTP::Client do
 
   context "for PUT requests" do
     it "includes default HTTP headers" do
-      stub_request(:put, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./})
+      stub_request(:put, uri).with do |request|
+        expect(request.headers).to include({'X-Puppet-Version' => /./, 'User-Agent' => /./})
+        expect(request.headers).to_not include('X-Puppet-Profiling')
+      end
 
       client.put(uri, content_type: 'text/plain', body: "")
     end

--- a/spec/unit/http/service/ca_spec.rb
+++ b/spec/unit/http/service/ca_spec.rb
@@ -12,6 +12,28 @@ describe Puppet::HTTP::Service::Ca do
     Puppet[:ca_port] = 443
   end
 
+  context 'when making requests' do
+    let(:uri) {"https://www.example.com:443/puppet-ca/v1/certificate/ca"}
+
+    it 'includes default HTTP headers' do
+      stub_request(:get, uri).with do |request|
+        expect(request.headers).to include({'X-Puppet-Version' => /./, 'User-Agent' => /./})
+        expect(request.headers).to_not include('X-Puppet-Profiling')
+      end
+
+      subject.get_certificate('ca')
+    end
+
+
+    it 'includes the X-Puppet-Profiling header when Puppet[:profile] is true' do
+      stub_request(:get, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./, 'X-Puppet-Profiling' => 'true'})
+
+      Puppet[:profile] = true
+
+      subject.get_certificate('ca')
+    end
+  end
+
   context 'when routing to the CA service' do
     let(:cert) { cert_fixture('ca.pem') }
     let(:pem) { cert.to_pem }


### PR DESCRIPTION
When `Puppet[:profile]` is true, we should always add
`'X-Puppet-Profiling' => 'true'` to all requests made by
`Puppet::HTTP::Client`. By default, this header should be omitted.

This header is used to tell the server that it may log
profiling data for that agent run. See
https://github.com/puppetlabs/puppet/blob/90f42e963a2f2147a6153977e7ef3cbacad5a0ef/docs/profiling.md