### PR TITLE
(maint) Merge 5.5.x to 6.4.x

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -148,9 +148,10 @@ class Puppet::Configurer
     facts_hash
   end
 
-  def prepare_and_retrieve_catalog(options, query_options)
+  def prepare_and_retrieve_catalog(cached_catalog, options, query_options)
     # set report host name now that we have the fact
     options[:report].host = Puppet[:node_name_value]
+
     query_options[:transaction_uuid] = @transaction_uuid
     query_options[:job_id] = @job_id
     query_options[:static_catalog] = @static_catalog
@@ -160,26 +161,19 @@ class Puppet::Configurer
     query_options[:checksum_type] = @checksum_type.join('.')
 
     # apply passes in ral catalog
-    catalog = options.delete(:catalog)
-    return catalog if catalog
-
-    # retrieve_catalog returns json catalog
-    catalog = retrieve_catalog(query_options)
-    return convert_catalog(catalog, @duration, options) if catalog
-
-    Puppet.err _("Could not retrieve catalog; skipping run")
-    nil
+    catalog = cached_catalog || options[:catalog]
+    unless catalog
+      # retrieve_catalog returns resource catalog
+      catalog = retrieve_catalog(query_options)
+      Puppet.err _("Could not retrieve catalog; skipping run") unless catalog
+    end
+    catalog
   end
 
   def prepare_and_retrieve_catalog_from_cache(options = {})
     result = retrieve_catalog_from_cache({:transaction_uuid => @transaction_uuid, :static_catalog => @static_catalog})
-    if result
-      Puppet.info _("Using cached catalog from environment '%{catalog_env}'") % { catalog_env: result.environment }
-      # get facts now so that the convert_catalog method can resolve deferred values
-      get_facts(options)
-      return convert_catalog(result, @duration, options)
-    end
-    nil
+    Puppet.info _("Using cached catalog from environment '%{catalog_env}'") % { catalog_env: result.environment } if result
+    result
   end
 
   # Apply supplied catalog and return associated application report
@@ -257,13 +251,12 @@ class Puppet::Configurer
       Puppet::GettextConfig.reset_text_domain('agent')
       Puppet::ModuleTranslations.load_from_vardir(Puppet[:vardir])
 
-      if catalog = prepare_and_retrieve_catalog_from_cache(options)
-        options[:catalog] = catalog
+      if cached_catalog = prepare_and_retrieve_catalog_from_cache(options)
         @cached_catalog_status = 'explicitly_requested'
 
-        if @environment != catalog.environment && !Puppet[:strict_environment_mode]
-          Puppet.notice _("Local environment: '%{local_env}' doesn't match the environment of the cached catalog '%{catalog_env}', switching agent to '%{catalog_env}'.") % { local_env: @environment, catalog_env: catalog.environment }
-          @environment = catalog.environment
+        if @environment != cached_catalog.environment && !Puppet[:strict_environment_mode]
+          Puppet.notice _("Local environment: '%{local_env}' doesn't match the environment of the cached catalog '%{catalog_env}', switching agent to '%{catalog_env}'.") % { local_env: @environment, catalog_env: cached_catalog.environment }
+          @environment = cached_catalog.environment
         end
 
         report.environment = @environment
@@ -284,7 +277,7 @@ class Puppet::Configurer
       configured_environment = Puppet[:environment] if Puppet.settings.set_by_config?(:environment)
 
       # We only need to find out the environment to run in if we don't already have a catalog
-      unless (options[:catalog] || Puppet[:strict_environment_mode])
+      unless (cached_catalog || options[:catalog] || Puppet[:strict_environment_mode])
         begin
           node = nil
           node_retr_time = thinmark do
@@ -339,7 +332,7 @@ class Puppet::Configurer
       query_options[:configured_environment] = configured_environment
       options[:convert_for_node] = node
 
-      unless catalog = prepare_and_retrieve_catalog(options, query_options)
+      unless catalog = prepare_and_retrieve_catalog(cached_catalog, options, query_options)
         return nil
       end
 
@@ -364,16 +357,37 @@ class Puppet::Configurer
         query_options = get_facts(options)
         query_options[:configured_environment] = configured_environment
 
-        return nil unless catalog = prepare_and_retrieve_catalog(options, query_options)
+        # if we get here, ignore the cached catalog
+        return nil unless catalog = prepare_and_retrieve_catalog(nil, options, query_options)
         tries += 1
+      end
+
+      # now that environment has converged, convert resource catalog into ral catalog
+      # unless we were given a RAL catalog
+      if !cached_catalog && options[:catalog]
+        ral_catalog = options[:catalog]
+      else
+        # REMIND @duration is the time spent loading the last catalog, and doesn't
+        # account for things like we failed to download and fell back to the cache
+        ral_catalog = convert_catalog(catalog, @duration, options)
+
+        # If not noop, commit the cached resource catalog (not ral catalog). Ideally
+        # we'd just copy the downloaded response body, instead of serializing the
+        # in-memory catalog, but that's hard due to the indirector.
+        indirection = Puppet::Resource::Catalog.indirection
+        if !Puppet[:noop] && indirection.cache?
+          request = indirection.request(:save, nil, catalog, environment: Puppet::Node::Environment.remote(catalog.environment))
+          Puppet.info("Caching catalog for #{request.key}")
+          indirection.cache.save(request)
+        end
       end
 
       execute_prerun_command or return nil
 
-      options[:report].code_id = catalog.code_id
-      options[:report].catalog_uuid = catalog.catalog_uuid
+      options[:report].code_id = ral_catalog.code_id
+      options[:report].catalog_uuid = ral_catalog.catalog_uuid
       options[:report].cached_catalog_status = @cached_catalog_status
-      apply_catalog(catalog, options)
+      apply_catalog(ral_catalog, options)
       true
     rescue => detail
       Puppet.log_exception(detail, _("Failed to apply catalog: %{detail}") % { detail: detail })
@@ -509,8 +523,8 @@ class Puppet::Configurer
         Puppet[:node_name_value],
         query_options.merge(
           :ignore_cache      => true,
-          # We never want to update the cached Catalog if we're running in noop mode.
-          :ignore_cache_save => Puppet[:noop],
+          # don't update cache until after environment converges
+          :ignore_cache_save => true,
           :environment       => Puppet::Node::Environment.remote(@environment),
           :fail_on_404       => true
         )

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -89,6 +89,8 @@ class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
   #
   # @api private
   def setsockopts(netio)
+    return unless netio
+
     socket = netio.io
     socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
   end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1,108 +1,90 @@
 require 'spec_helper'
 require 'puppet/configurer'
+require 'webmock/rspec'
 
 describe Puppet::Configurer do
   before do
-    allow(Puppet.settings).to receive(:use).and_return(true)
-    @agent = Puppet::Configurer.new
-    allow(@agent).to receive(:init_storage)
-    allow(Puppet::Util::Storage).to receive(:store)
+    Puppet::Node::Facts.indirection.terminus_class = :memory
+    Puppet::Node::Facts.indirection.save(facts)
+
     Puppet[:server] = "puppetmaster"
     Puppet[:report] = true
+
+    catalog.add_resource(resource)
   end
 
-  it "should include the Fact Handler module" do
-    expect(Puppet::Configurer.ancestors).to be_include(Puppet::Configurer::FactHandler)
-  end
+  let(:configurer) { Puppet::Configurer.new }
+  let(:report) { Puppet::Transaction::Report.new }
+  let(:catalog) { Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym)) }
+  let(:resource) { Puppet::Resource.new(:notice, 'a') }
+  let(:facts) { Puppet::Node::Facts.new(Puppet[:node_name_value]) }
 
   describe "when executing a pre-run hook" do
     it "should do nothing if the hook is set to an empty string" do
       Puppet.settings[:prerun_command] = ""
-      expect(Puppet::Util).not_to receive(:exec)
+      expect(Puppet::Util::Execution).not_to receive(:execute)
 
-      @agent.execute_prerun_command
+      configurer.execute_prerun_command
     end
 
     it "should execute any pre-run command provided via the 'prerun_command' setting" do
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      @agent.execute_prerun_command
+      configurer.execute_prerun_command
     end
 
     it "should fail if the command fails" do
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@agent.execute_prerun_command).to be_falsey
+      expect(configurer.execute_prerun_command).to be_falsey
     end
   end
 
   describe "when executing a post-run hook" do
     it "should do nothing if the hook is set to an empty string" do
       Puppet.settings[:postrun_command] = ""
-      expect(Puppet::Util).not_to receive(:exec)
+      expect(Puppet::Util::Execution).not_to receive(:execute)
 
-      @agent.execute_postrun_command
+      configurer.execute_postrun_command
     end
 
     it "should execute any post-run command provided via the 'postrun_command' setting" do
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      @agent.execute_postrun_command
+      configurer.execute_postrun_command
     end
 
     it "should fail if the command fails" do
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@agent.execute_postrun_command).to be_falsey
+      expect(configurer.execute_postrun_command).to be_falsey
     end
   end
 
   describe "when executing a catalog run" do
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
-      allow(@agent).to receive(:download_plugins)
-      Puppet::Node::Facts.indirection.terminus_class = :memory
-      @facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
-      Puppet::Node::Facts.indirection.save(@facts)
-
-      @catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
-      allow(@catalog).to receive(:to_ral).and_return(@catalog)
       Puppet::Resource::Catalog.indirection.terminus_class = :rest
-      allow(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(@catalog)
-      allow(@agent).to receive(:send_report)
-      allow(@agent).to receive(:save_last_run_summary)
-
-      allow(Puppet::Util::Log).to receive(:close_all)
-    end
-
-    after :all do
-      Puppet::Node::Facts.indirection.reset_terminus_class
-      Puppet::Resource::Catalog.indirection.reset_terminus_class
-    end
-
-    it "should initialize storage" do
-      expect(Puppet::Util::Storage).to receive(:load)
-      @agent.run
+      allow(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(catalog)
     end
 
     it "downloads plugins when told" do
-      expect(@agent).to receive(:download_plugins)
-      @agent.run(:pluginsync => true)
+      expect(configurer).to receive(:download_plugins)
+      configurer.run(:pluginsync => true)
     end
 
     it "does not download plugins when told" do
-      expect(@agent).not_to receive(:download_plugins)
-      @agent.run(:pluginsync => false)
+      expect(configurer).not_to receive(:download_plugins)
+      configurer.run(:pluginsync => false)
     end
 
     it "should carry on when it can't fetch its node definition" do
       error = Net::HTTPError.new(400, 'dummy server communication error')
       expect(Puppet::Node.indirection).to receive(:find).and_raise(error)
-      expect(@agent.run).to eq(0)
+      expect(configurer.run).to eq(0)
     end
 
     it "applies a cached catalog when it can't connect to the master" do
@@ -110,200 +92,157 @@ describe Puppet::Configurer do
 
       expect(Puppet::Node.indirection).to receive(:find).and_raise(error)
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(:ignore_cache => true)).and_raise(error)
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(:ignore_terminus => true)).and_return(@catalog)
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(:ignore_terminus => true)).and_return(catalog)
 
-      expect(@agent.run).to eq(0)
+      expect(configurer.run).to eq(0)
     end
 
     it "should initialize a transaction report if one is not provided" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
-      @agent.run
+      configurer.run
     end
 
     it "should respect node_name_fact when setting the host on a report" do
       Puppet[:node_name_fact] = 'my_name_fact'
-      @facts.values = {'my_name_fact' => 'node_name_from_fact'}
+      facts.values = {'my_name_fact' => 'node_name_from_fact'}
+      Puppet::Node::Facts.indirection.save(facts)
 
-      report = Puppet::Transaction::Report.new
-
-      @agent.run(:report => report)
+      configurer.run(:report => report)
       expect(report.host).to eq('node_name_from_fact')
     end
 
-    it "should pass the new report to the catalog" do
-      report = Puppet::Transaction::Report.new
-      allow(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@catalog).to receive(:apply).with(hash_including(report: report))
+    it "creates a new report when applying the catalog" do
+      options = {}
+      configurer.run(options)
 
-      @agent.run
+      expect(options[:report].metrics['time']['catalog_application']).to be_an_instance_of(Float)
     end
 
-    it "should use the provided report if it was passed one" do
-      report = Puppet::Transaction::Report.new
-      expect(@catalog).to receive(:apply).with(hash_including(report: report))
+    it "uses the provided report when applying the catalog" do
+      configurer.run(:report => report)
 
-      @agent.run(:report => report)
-    end
-
-    it "should set the report as a log destination" do
-      report = Puppet::Transaction::Report.new
-
-      expect(report).to receive(:<<).with(instance_of(Puppet::Util::Log)).at_least(:once)
-
-      @agent.run(:report => report)
-    end
-
-    it "should retrieve the catalog" do
-      expect(@agent).to receive(:retrieve_catalog)
-
-      @agent.run
+      expect(report.metrics['time']['catalog_application']).to be_an_instance_of(Float)
     end
 
     it "should log a failure and do nothing if no catalog can be retrieved" do
-      expect(@agent).to receive(:retrieve_catalog).and_return(nil)
+      expect(configurer).to receive(:retrieve_catalog).and_return(nil)
 
       expect(Puppet).to receive(:err).with("Could not retrieve catalog; skipping run")
 
-      @agent.run
+      configurer.run
     end
 
-    it "should apply the catalog with all options to :run" do
-      expect(@agent).to receive(:retrieve_catalog).and_return(@catalog)
+    it "passes arbitrary options when applying the catalog" do
+      expect(catalog).to receive(:apply).with(hash_including(one: true))
 
-      expect(@catalog).to receive(:apply).with(hash_including(one: true))
-      @agent.run :one => true
-    end
-
-    it "should accept a catalog and use it instead of retrieving a different one" do
-      expect(@agent).not_to receive(:retrieve_catalog)
-
-      expect(@catalog).to receive(:apply)
-      @agent.run :one => true, :catalog => @catalog
+      configurer.run(catalog: catalog, one: true)
     end
 
     it "should benchmark how long it takes to apply the catalog" do
-      expect(@agent).to receive(:benchmark).with(:notice, instance_of(String))
+      configurer.run(report: report)
 
-      expect(@agent).to receive(:retrieve_catalog).and_return(@catalog)
-
-      expect(@catalog).not_to receive(:apply) # because we're not yielding
-      @agent.run
-    end
-
-    it "should execute post-run hooks after the run" do
-      expect(@agent).to receive(:execute_postrun_command)
-
-      @agent.run
+      expect(report.logs).to include(an_object_having_attributes(level: :notice, message: /Applied catalog in .* seconds/))
     end
 
     it "should create report with passed transaction_uuid and job_id" do
-      @agent = Puppet::Configurer.new("test_tuuid", "test_jid")
-      allow(@agent).to receive(:init_storage)
+      configurer = Puppet::Configurer.new("test_tuuid", "test_jid")
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).with(anything, anything, 'test_tuuid', 'test_jid').and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
-      @agent.run
+      configurer.run
     end
 
     it "should send the report" do
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
       expect(report.environment).to eq("test")
       expect(report.transaction_uuid).to eq("aaaa")
 
-      @agent.run
+      configurer.run
     end
 
     it "should send the transaction report even if the catalog could not be retrieved" do
-      expect(@agent).to receive(:retrieve_catalog).and_return(nil)
+      expect(configurer).to receive(:retrieve_catalog).and_return(nil)
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
       expect(report.environment).to eq("test")
       expect(report.transaction_uuid).to eq("aaaa")
 
-      @agent.run
+      configurer.run
     end
 
     it "should send the transaction report even if there is a failure" do
-      expect(@agent).to receive(:retrieve_catalog).and_raise("whatever")
+      expect(configurer).to receive(:retrieve_catalog).and_raise("whatever")
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
       expect(report.environment).to eq("test")
       expect(report.transaction_uuid).to eq("aaaa")
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should remove the report as a log destination when the run is finished" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
-      @agent.run
+      configurer.run
 
       expect(Puppet::Util::Log.destinations).not_to include(report)
     end
 
     it "should return the report exit_status as the result of the run" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
       expect(report).to receive(:exit_status).and_return(1234)
 
-      expect(@agent.run).to eq(1234)
+      expect(configurer.run).to eq(1234)
     end
 
     it "should return nil if catalog application fails" do
-      expect(@catalog).to receive(:apply).and_raise(Puppet::Error, 'One or more resource dependency cycles detected in graph')
-      report = Puppet::Transaction::Report.new
-      expect(@agent.run(catalog: @catalog, report: report)).to be_nil
+      expect_any_instance_of(Puppet::Resource::Catalog).to receive(:apply).and_raise(Puppet::Error, 'One or more resource dependency cycles detected in graph')
+      expect(configurer.run(catalog: catalog, report: report)).to be_nil
     end
 
     it "should send the transaction report even if the pre-run command fails" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should include the pre-run command failure in the report" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
       expect(report.logs.find { |x| x.message =~ /Could not run command from prerun_command/ }).to be
     end
 
     it "should send the transaction report even if the post-run command fails" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
-      expect(@agent).to receive(:send_report).with(report)
+      expect(configurer).to receive(:send_report).with(report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should include the post-run command failure in the report" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       Puppet.settings[:postrun_command] = "/my/command"
@@ -311,7 +250,7 @@ describe Puppet::Configurer do
 
       expect(report).to receive(:<<) { |log, _| expect(log.message).to match(/Could not run command from postrun_command/) }.at_least(:once)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should execute post-run command even if the pre-run command fails" do
@@ -320,47 +259,42 @@ describe Puppet::Configurer do
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/precommand"]).and_raise(Puppet::ExecutionFailure, "Failed")
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/postcommand"])
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should finalize the report" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       expect(report).to receive(:finalize_report)
-      @agent.run
+      configurer.run
     end
 
     it "should not apply the catalog if the pre-run command fails" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@catalog).not_to receive(:apply)
-      expect(@agent).to receive(:send_report)
+      expect_any_instance_of(Puppet::Resource::Catalog).not_to receive(:apply)
+      expect(configurer).to receive(:send_report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should apply the catalog, send the report, and return nil if the post-run command fails" do
-      report = Puppet::Transaction::Report.new
       expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
 
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(@catalog).to receive(:apply)
-      expect(@agent).to receive(:send_report)
+      expect_any_instance_of(Puppet::Resource::Catalog).to receive(:apply)
+      expect(configurer).to receive(:send_report)
 
-      expect(@agent.run).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it 'includes total time metrics in the report after successfully applying the catalog' do
-      report = Puppet::Transaction::Report.new
-      allow(@catalog).to receive(:apply).with(hash_including(report: report))
-      @agent.run(report: report)
+      configurer.run(report: report)
 
       expect(report.metrics['time']).to be
       expect(report.metrics['time']['total']).to be_a_kind_of(Numeric)
@@ -370,17 +304,15 @@ describe Puppet::Configurer do
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      report = Puppet::Transaction::Report.new
-      @agent.run(report: report)
+      configurer.run(report: report)
 
       expect(report.metrics['time']).to be
       expect(report.metrics['time']['total']).to be_a_kind_of(Numeric)
     end
 
     it 'includes total time metrics in the report even if catalog retrieval fails' do
-      report = Puppet::Transaction::Report.new
-      allow(@agent).to receive(:prepare_and_retrieve_catalog_from_cache).and_raise
-      @agent.run(:report => report)
+      allow(configurer).to receive(:prepare_and_retrieve_catalog_from_cache).and_raise
+      configurer.run(:report => report)
 
       expect(report.metrics['time']).to be
       expect(report.metrics['time']['total']).to be_a_kind_of(Numeric)
@@ -388,102 +320,93 @@ describe Puppet::Configurer do
 
     it "should refetch the catalog if the server specifies a new environment in the catalog" do
       catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
-      expect(@agent).to receive(:retrieve_catalog).and_return(catalog).twice
+      expect(configurer).to receive(:retrieve_catalog).and_return(catalog).twice
 
-      @agent.run
+      configurer.run
     end
 
-    it "should change the environment setting if the server specifies a new environment in the catalog" do
-      allow(@catalog).to receive(:environment).and_return("second_env")
+    it "changes the configurer's environment if the server specifies a new environment in the catalog" do
+      allow_any_instance_of(Puppet::Resource::Catalog).to receive(:environment).and_return("second_env")
 
-      @agent.run
+      configurer.run
 
-      expect(@agent.environment).to eq("second_env")
+      expect(configurer.environment).to eq("second_env")
     end
 
-    it "should fix the report if the server specifies a new environment in the catalog" do
-      report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(@agent).to receive(:send_report).with(report)
+    it "changes the report's environment if the server specifies a new environment in the catalog" do
+      allow_any_instance_of(Puppet::Resource::Catalog).to receive(:environment).and_return("second_env")
 
-      allow(@catalog).to receive(:environment).and_return("second_env")
-      allow(@agent).to receive(:retrieve_catalog).and_return(@catalog)
-
-      @agent.run
+      configurer.run(report: report)
 
       expect(report.environment).to eq("second_env")
     end
 
     it "sends the transaction uuid in a catalog request" do
-      @agent.instance_variable_set(:@transaction_uuid, 'aaa')
+      configurer = Puppet::Configurer.new('aaa')
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(transaction_uuid: 'aaa'))
-      @agent.run
+      configurer.run
     end
 
     it "sends the transaction uuid in a catalog request" do
-      @agent.instance_variable_set(:@job_id, 'aaa')
+      configurer = Puppet::Configurer.new('b', 'aaa')
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(job_id: 'aaa'))
-      @agent.run
+      configurer.run
     end
 
     it "sets the static_catalog query param to true in a catalog request" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(static_catalog: true))
-      @agent.run
+      configurer.run
     end
 
     it "sets the checksum_type query param to the default supported_checksum_types in a catalog request" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything,
         hash_including(checksum_type: 'md5.sha256.sha384.sha512.sha224'))
-      @agent.run
+      configurer.run
     end
 
     it "sets the checksum_type query param to the supported_checksum_types setting in a catalog request" do
-      # Regenerate the agent to pick up the new setting
       Puppet[:supported_checksum_types] = ['sha256']
-      @agent = Puppet::Configurer.new
-      allow(@agent).to receive(:init_storage)
-      allow(@agent).to receive(:download_plugins)
-      allow(@agent).to receive(:send_report)
-      allow(@agent).to receive(:save_last_run_summary)
+      # Regenerate the agent to pick up the new setting
+      configurer = Puppet::Configurer.new
 
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(checksum_type: 'sha256'))
-      @agent.run
+      configurer.run
     end
 
     describe "when not using a REST terminus for catalogs" do
       it "should not pass any facts when retrieving the catalog" do
+        # This is weird, we collect facts when constructing the node,
+        # but we don't send them in the indirector request. Then the compiler
+        # looks up the node, and collects its facts, which we could have sent
+        # in the first place. This seems like a bug.
         Puppet::Resource::Catalog.indirection.terminus_class = :compiler
-        expect(@agent).not_to receive(:facts_for_uploading)
-        expect(Puppet::Resource::Catalog.indirection).to receive(:find) do |name, options|
-          options[:facts].nil?
-        end.and_return(@catalog)
 
-        @agent.run
+        expect(Puppet::Resource::Catalog.indirection).to receive(:find) do |name, options|
+          expect(options[:facts]).to be_nil
+        end.and_return(catalog)
+
+        configurer.run
       end
     end
 
     describe "when using a REST terminus for catalogs" do
-      it "should pass the prepared facts and the facts format as arguments when retrieving the catalog" do
+      it "should pass the url encoded facts and facts format as arguments when retrieving the catalog" do
         Puppet::Resource::Catalog.indirection.terminus_class = :rest
-        # the "facts_for_uploading" are prepeared by first finding facts, and then encoding them
-        # this mocks the "find" with a special value 12345, which is then expected back in the
-        # call to "encode" - the encode in turn returns mocked data that is asserted as being
-        # presented to the catalog terminus as options.
-        #
-        expect(@agent).to receive(:find_facts).and_return(12345)
-        expect(@agent).to receive(:encode_facts).with(12345).and_return(:facts => "myfacts", :facts_format => :foo)
-        expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(facts: "myfacts", facts_format: :foo)).and_return(@catalog)
 
-        @agent.run
+        facts.values = { 'foo' => 'bar' }
+        Puppet::Node::Facts.indirection.save(facts)
+
+        expect(
+          Puppet::Resource::Catalog.indirection
+        ).to receive(:find) do |_, options|
+          expect(options[:facts_format]).to eq("application/json")
+
+          unescaped = JSON.parse(CGI.unescape(options[:facts]))
+          expect(unescaped).to include("values" => {"foo" => "bar"})
+        end.and_return(catalog)
+
+        configurer.run
       end
-    end
-  end
-
-  describe "when initialized with a transaction_uuid" do
-    it "stores it" do
-      expect(SecureRandom).not_to receive(:uuid)
-      configurer = Puppet::Configurer.new('foo')
-      expect(configurer.instance_variable_get(:@transaction_uuid) == 'foo')
     end
   end
 
@@ -491,56 +414,52 @@ describe Puppet::Configurer do
     include PuppetSpec::Files
 
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
-      @configurer = Puppet::Configurer.new
       Puppet[:lastrunfile] = tmpfile('last_run_file')
-
-      @report = Puppet::Transaction::Report.new
       Puppet[:reports] = "none"
     end
 
     it "should print a report summary if configured to do so" do
       Puppet.settings[:summarize] = true
 
-      expect(@report).to receive(:summary).and_return("stuff")
+      expect(report).to receive(:summary).and_return("stuff")
 
-      expect(@configurer).to receive(:puts).with("stuff")
-      @configurer.send_report(@report)
+      expect(configurer).to receive(:puts).with("stuff")
+      configurer.send_report(report)
     end
 
     it "should not print a report summary if not configured to do so" do
       Puppet.settings[:summarize] = false
 
-      expect(@configurer).not_to receive(:puts)
-      @configurer.send_report(@report)
+      expect(configurer).not_to receive(:puts)
+      configurer.send_report(report)
     end
 
     it "should save the report if reporting is enabled" do
       Puppet.settings[:report] = true
 
-      expect(Puppet::Transaction::Report.indirection).to receive(:save).with(@report, nil, instance_of(Hash))
-      @configurer.send_report(@report)
+      expect(Puppet::Transaction::Report.indirection).to receive(:save).with(report, nil, instance_of(Hash))
+      configurer.send_report(report)
     end
 
     it "should not save the report if reporting is disabled" do
       Puppet.settings[:report] = false
 
-      expect(Puppet::Transaction::Report.indirection).not_to receive(:save).with(@report, nil, instance_of(Hash))
-      @configurer.send_report(@report)
+      expect(Puppet::Transaction::Report.indirection).not_to receive(:save).with(report, nil, instance_of(Hash))
+      configurer.send_report(report)
     end
 
     it "should save the last run summary if reporting is enabled" do
       Puppet.settings[:report] = true
 
-      expect(@configurer).to receive(:save_last_run_summary).with(@report)
-      @configurer.send_report(@report)
+      expect(configurer).to receive(:save_last_run_summary).with(report)
+      configurer.send_report(report)
     end
 
     it "should save the last run summary if reporting is disabled" do
       Puppet.settings[:report] = false
 
-      expect(@configurer).to receive(:save_last_run_summary).with(@report)
-      @configurer.send_report(@report)
+      expect(configurer).to receive(:save_last_run_summary).with(report)
+      configurer.send_report(report)
     end
 
     it "should log but not fail if saving the report fails" do
@@ -548,8 +467,9 @@ describe Puppet::Configurer do
 
       expect(Puppet::Transaction::Report.indirection).to receive(:save).and_raise("whatever")
 
-      expect(Puppet).to receive(:send_log).with(:err, 'Could not send report: whatever')
-      @configurer.send_report(@report)
+      configurer.send_report(report)
+
+      expect(@logs).to include(an_object_having_attributes(level: :err, message: 'Could not send report: whatever'))
     end
   end
 
@@ -557,22 +477,17 @@ describe Puppet::Configurer do
     include PuppetSpec::Files
 
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
-      @configurer = Puppet::Configurer.new
-
-      @report = double('report', :raw_summary => {})
-
       Puppet[:lastrunfile] = tmpfile('last_run_file')
     end
 
     it "should write the last run file" do
-      @configurer.save_last_run_summary(@report)
+      configurer.save_last_run_summary(report)
       expect(Puppet::FileSystem.exist?(Puppet[:lastrunfile])).to be_truthy
     end
 
     it "should write the raw summary as yaml" do
-      expect(@report).to receive(:raw_summary).and_return("summary")
-      @configurer.save_last_run_summary(@report)
+      expect(report).to receive(:raw_summary).and_return("summary")
+      configurer.save_last_run_summary(report)
       expect(File.read(Puppet[:lastrunfile])).to eq(YAML.dump("summary"))
     end
 
@@ -587,13 +502,14 @@ describe Puppet::Configurer do
 
       expect(Puppet::Util).to receive(:replace_file).and_yield(fh)
 
-      expect(Puppet).to receive(:send_log).with(:err, 'Could not save last run local report: failed to do print')
-      @configurer.save_last_run_summary(@report)
+      configurer.save_last_run_summary(report)
+
+      expect(@logs).to include(an_object_having_attributes(level: :err, message: 'Could not save last run local report: failed to do print'))
     end
 
     it "should create the last run file with the correct mode" do
       expect(Puppet.settings.setting(:lastrunfile)).to receive(:mode).and_return('664')
-      @configurer.save_last_run_summary(@report)
+      configurer.save_last_run_summary(report)
 
       if Puppet::Util::Platform.windows?
         require 'puppet/util/windows/security'
@@ -606,26 +522,28 @@ describe Puppet::Configurer do
 
     it "should report invalid last run file permissions" do
       expect(Puppet.settings.setting(:lastrunfile)).to receive(:mode).and_return('892')
-      expect(Puppet).to receive(:send_log).with(:err, /Could not save last run local report.*892 is invalid/)
-      @configurer.save_last_run_summary(@report)
+
+      configurer.save_last_run_summary(report)
+
+      expect(@logs).to include(an_object_having_attributes(level: :err, message: /Could not save last run local report.*892 is invalid/))
     end
   end
 
   describe "when requesting a node" do
     it "uses the transaction uuid in the request" do
       expect(Puppet::Node.indirection).to receive(:find).with(anything, hash_including(transaction_uuid: anything)).twice
-      @agent.run
+      configurer.run
     end
 
     it "sends an explicitly configured environment request" do
       expect(Puppet.settings).to receive(:set_by_config?).with(:environment).and_return(true)
       expect(Puppet::Node.indirection).to receive(:find).with(anything, hash_including(configured_environment: Puppet[:environment])).twice
-      @agent.run
+      configurer.run
     end
 
     it "does not send a configured_environment when using the default" do
       expect(Puppet::Node.indirection).to receive(:find).with(anything, hash_including(configured_environment: nil)).twice
-      @agent.run
+      configurer.run
     end
   end
 
@@ -656,14 +574,6 @@ describe Puppet::Configurer do
 
   describe "when retrieving a catalog" do
     before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
-      allow(@agent).to receive(:facts_for_uploading).and_return({})
-      allow(@agent).to receive(:download_plugins)
-
-      # retrieve a catalog in the current environment, so we don't try to converge unexpectedly
-      @catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
-
-      # this is the default when using a Configurer instance
       allow(Puppet::Resource::Catalog.indirection).to receive(:terminus_class).and_return(:rest)
     end
 
@@ -673,100 +583,139 @@ describe Puppet::Configurer do
       end
 
       it "should first look in the cache for a catalog" do
-        expects_cached_catalog_only(@catalog)
+        expects_cached_catalog_only(catalog)
 
-        expect(@agent.retrieve_catalog({})).to eq(@catalog)
+        configurer.run
       end
 
       it "should not make a node request or pluginsync when a cached catalog is successfully retrieved" do
         expect(Puppet::Node.indirection).not_to receive(:find)
-        expects_cached_catalog_only(@catalog)
-        expect(@agent).not_to receive(:download_plugins)
+        expects_cached_catalog_only(catalog)
+        expect(configurer).not_to receive(:download_plugins)
 
-        @agent.run
+        configurer.run
       end
 
       it "should make a node request and pluginsync when a cached catalog cannot be retrieved" do
         expect(Puppet::Node.indirection).to receive(:find).and_return(nil)
-        expects_fallback_to_new_catalog(@catalog)
-        expect(@agent).to receive(:download_plugins)
+        expects_fallback_to_new_catalog(catalog)
+        expect(configurer).to receive(:download_plugins)
 
-        @agent.run
+        configurer.run
       end
 
       it "should set its cached_catalog_status to 'explicitly_requested'" do
-        expects_cached_catalog_only(@catalog)
+        expects_cached_catalog_only(catalog)
 
-        @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('explicitly_requested')
+        options = {}
+        configurer.run(options)
+
+        expect(options[:report].cached_catalog_status).to eq('explicitly_requested')
       end
 
       it "should set its cached_catalog_status to 'explicitly requested' if the cached catalog is from a different environment" do
         cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
         expects_cached_catalog_only(cached_catalog)
 
-        @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('explicitly_requested')
+        options = {}
+        configurer.run(options)
+
+        expect(options[:report].cached_catalog_status).to eq('explicitly_requested')
       end
 
-      it "should compile a new catalog if none is found in the cache" do
-        expects_fallback_to_new_catalog(@catalog)
+      it "should pluginsync and compile a new catalog if none is found in the cache" do
+        expects_fallback_to_new_catalog(catalog)
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/plugins}).to_return(:status => 404)
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/pluginfacts}).to_return(:status => 404)
 
-        expect(@agent.retrieve_catalog({})).to eq(@catalog)
-      end
+        options = {}
+        configurer.run(options)
 
-      it "should set its cached_catalog_status to 'not_used' if no catalog is found in the cache" do
-        expects_fallback_to_new_catalog(@catalog)
-
-        @agent.retrieve_catalog({})
-        expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
+        expect(options[:report].cached_catalog_status).to eq('not_used')
       end
 
       it "should not attempt to retrieve a cached catalog again if the first attempt failed" do
         expect(Puppet::Node.indirection).to receive(:find).and_return(nil)
         expects_neither_new_or_cached_catalog
 
-        @agent.run
+        # after failing to use a cached catalog, we'll need to pluginsync before getting
+        # a new catalog, which also fails.
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/plugins}).to_return(:status => 404)
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/pluginfacts}).to_return(:status => 404)
+
+        configurer.run
       end
 
       it "should return the cached catalog when the environment doesn't match" do
         cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
         expects_cached_catalog_only(cached_catalog)
 
+        allow(Puppet).to receive(:info)
         expect(Puppet).to receive(:info).with("Using cached catalog from environment 'second_env'")
-        expect(@agent.retrieve_catalog({})).to eq(cached_catalog)
+
+        configurer.run
+      end
+
+      it "applies the catalog passed as options when the catalog cache terminus is not set" do
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/plugins}).to_return(:status => 404)
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/pluginfacts}).to_return(:status => 404)
+
+        catalog.add_resource(Puppet::Resource.new('notify', 'from apply'))
+        configurer.run(catalog: catalog.to_ral)
+
+        # make sure cache class is not set to avoid surprises later
+        expect(Puppet::Resource::Catalog.indirection).to_not be_cache
+        expect(@logs).to include(an_object_having_attributes(level: :notice, message: /defined 'message' as 'from apply'/))
+      end
+
+      it "applies the cached catalog when the catalog cache terminus is set, ignoring the catalog passed as options" do
+        Puppet::Resource::Catalog.indirection.cache_class = :json
+
+        cached_catalog = Puppet::Resource::Catalog.new(Puppet[:node_name_value], Puppet[:environment])
+        cached_catalog.add_resource(Puppet::Resource.new('notify', 'from cache'))
+
+        # update cached catalog
+        Puppet.settings.use(:main, :agent)
+        path = Puppet::Resource::Catalog.indirection.cache.path(cached_catalog.name)
+        FileUtils.mkdir(File.dirname(path))
+        File.write(path, cached_catalog.render(:json))
+
+        configurer.run(catalog: catalog.to_ral)
+
+        expect(@logs).to include(an_object_having_attributes(level: :notice, message: /defined 'message' as 'from cache'/))
       end
     end
 
     describe "and strict environment mode is set" do
       before do
-        allow(@catalog).to receive(:to_ral).and_return(@catalog)
-        allow(@catalog).to receive(:write_class_file)
-        allow(@catalog).to receive(:write_resource_file)
-        allow(@agent).to receive(:send_report)
-        allow(@agent).to receive(:save_last_run_summary)
         Puppet.settings[:strict_environment_mode] = true
       end
 
       it "should not make a node request" do
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/plugins}).to_return(:status => 404)
+        stub_request(:get, %r{/puppet/v3/file_metadatas?/pluginfacts}).to_return(:status => 404)
+        expects_new_catalog_only(catalog)
+        
         expect(Puppet::Node.indirection).not_to receive(:find)
 
-        @agent.run
+        configurer.run
       end
 
       it "should return nil when the catalog's environment doesn't match the agent specified environment" do
-        @agent.instance_variable_set(:@environment, 'second_env')
-        expects_new_catalog_only(@catalog)
+        Puppet[:environment] = 'second_env'
+        configurer = Puppet::Configurer.new
+
+        catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote("production"))
+        expects_new_catalog_only(catalog)
 
         expect(Puppet).to receive(:err).with("Not using catalog because its environment 'production' does not match agent specified environment 'second_env' and strict_environment_mode is set")
-        expect(@agent.run).to be_nil
+        expect(configurer.run).to be_nil
       end
 
-      it "should not return nil when the catalog's environment matches the agent specified environment" do
-        @agent.instance_variable_set(:@environment, 'production')
-        expects_new_catalog_only(@catalog)
+      it "should return 0 when the catalog's environment matches the agent specified environment" do
+        expects_new_catalog_only(catalog)
 
-        expect(@agent.run).to eq(0)
+        expect(configurer.run).to eq(0)
       end
 
       describe "and a cached catalog is explicitly requested" do
@@ -775,83 +724,81 @@ describe Puppet::Configurer do
         end
 
         it "should return nil when the cached catalog's environment doesn't match the agent specified environment" do
-          @agent.instance_variable_set(:@environment, 'second_env')
-          expects_cached_catalog_only(@catalog)
+          Puppet[:environment] = 'second_env'
+          configurer = Puppet::Configurer.new
+
+          catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote("production"))
+          expects_cached_catalog_only(catalog)
 
           expect(Puppet).to receive(:err).with("Not using catalog because its environment 'production' does not match agent specified environment 'second_env' and strict_environment_mode is set")
-          expect(@agent.run).to be_nil
+          expect(configurer.run).to be_nil
         end
 
         it "should proceed with the cached catalog if its environment matchs the local environment" do
-          Puppet.settings[:use_cached_catalog] = true
-          @agent.instance_variable_set(:@environment, 'production')
-          expects_cached_catalog_only(@catalog)
+          expects_cached_catalog_only(catalog)
 
-          expect(@agent.run).to eq(0)
+          expect(configurer.run).to eq(0)
         end
       end
     end
 
-    it "should use the Catalog class to get its catalog" do
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(@catalog)
-
-      @agent.retrieve_catalog({})
-    end
-
     it "should set its cached_catalog_status to 'not_used' when downloading a new catalog" do
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(@catalog)
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
+      options = {}
+      configurer.run(options)
+
+      expect(options[:report].cached_catalog_status).to eq('not_used')
     end
 
     it "should use its node_name_value to retrieve the catalog" do
-      allow(Facter).to receive(:value).and_return("eh")
+      myhost_facts = Puppet::Node::Facts.new("myhost.domain.com")
+      Puppet::Node::Facts.indirection.save(myhost_facts)
+
       Puppet.settings[:node_name_value] = "myhost.domain.com"
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with("myhost.domain.com", anything).and_return(@catalog)
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with("myhost.domain.com", anything).and_return(catalog)
 
-      @agent.retrieve_catalog({})
+      configurer.run
     end
 
-    it "should default to returning a catalog retrieved directly from the server, skipping the cache" do
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(@catalog)
+    it "should log when no catalog can be retrieved from the server" do
+      expects_fallback_to_cached_catalog(catalog)
 
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
-    end
-
-    it "should log and return the cached catalog when no catalog can be retrieved from the server" do
-      expects_fallback_to_cached_catalog(@catalog)
-
+      allow(Puppet).to receive(:info)
       expect(Puppet).to receive(:info).with("Using cached catalog from environment 'production'")
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
+      configurer.run
     end
 
     it "should set its cached_catalog_status to 'on_failure' when no catalog can be retrieved from the server" do
-      expects_fallback_to_cached_catalog(@catalog)
+      expects_fallback_to_cached_catalog(catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
+      options = {}
+      configurer.run(options)
+
+      expect(options[:report].cached_catalog_status).to eq('on_failure')
     end
 
     it "should not look in the cache for a catalog if one is returned from the server" do
-      expects_new_catalog_only(@catalog)
+      expects_new_catalog_only(catalog)
 
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
+      configurer.run
     end
 
     it "should return the cached catalog when retrieving the remote catalog throws an exception" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_raise("eh")
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_terminus: true)).and_return(@catalog)
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_terminus: true)).and_return(catalog)
 
-      expect(@agent.retrieve_catalog({})).to eq(@catalog)
+      configurer.run
     end
 
     it "should set its cached_catalog_status to 'on_failure' when retrieving the remote catalog throws an exception" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_raise("eh")
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_terminus: true)).and_return(@catalog)
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_terminus: true)).and_return(catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
+      options = {}
+      configurer.run(options)
+
+      expect(options[:report].cached_catalog_status).to eq('on_failure')
     end
 
     it "should log and return nil if no catalog can be retrieved from the server and :usecacheonfailure is disabled" do
@@ -860,120 +807,173 @@ describe Puppet::Configurer do
 
       expect(Puppet).to receive(:warning).with('Not using cache on failed catalog')
 
-      expect(@agent.retrieve_catalog({})).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should set its cached_catalog_status to 'not_used' if no catalog can be retrieved from the server and :usecacheonfailure is disabled or fails to retrieve a catalog" do
       Puppet[:usecacheonfailure] = false
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(nil)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
+      options = {}
+      configurer.run(options)
+
+      expect(options[:report].cached_catalog_status).to eq('not_used')
     end
 
     it "should return nil if no cached catalog is available and no catalog can be retrieved from the server" do
       expects_neither_new_or_cached_catalog
 
-      expect(@agent.retrieve_catalog({})).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should return nil if its cached catalog environment doesn't match server-specified environment" do
       cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
-      @agent.instance_variable_set(:@node_environment, 'production')
 
       expects_fallback_to_cached_catalog(cached_catalog)
 
+      allow(Puppet).to receive(:err)
       expect(Puppet).to receive(:err).with("Not using cached catalog because its environment 'second_env' does not match 'production'")
-      expect(@agent.retrieve_catalog({})).to be_nil
+      expect(configurer.run).to be_nil
     end
 
     it "should set its cached_catalog_status to 'not_used' if the cached catalog environment doesn't match server-specified environment" do
       cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote('second_env'))
-      @agent.instance_variable_set(:@node_environment, 'production')
 
       expects_fallback_to_cached_catalog(cached_catalog)
 
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('not_used')
-    end
-
-    it "should return its cached catalog if the environment matches the server-specified environment" do
-      cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment]))
-      @agent.instance_variable_set(:@node_environment, cached_catalog.environment)
-
-      expects_fallback_to_cached_catalog(cached_catalog)
-
-      expect(@agent.retrieve_catalog({})).to eq(cached_catalog)
+      options = {}
+      configurer.run(options)
+      expect(options[:report].cached_catalog_status).to eq('not_used')
     end
 
     it "should set its cached_catalog_status to 'on_failure' if the cached catalog environment matches server-specified environment" do
-      cached_catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment]))
-      @agent.instance_variable_set(:@node_environment, cached_catalog.environment)
+      expects_fallback_to_cached_catalog(catalog)
 
-      expects_fallback_to_cached_catalog(cached_catalog)
-
-      @agent.retrieve_catalog({})
-      expect(@agent.instance_variable_get(:@cached_catalog_status)).to eq('on_failure')
+      options = {}
+      configurer.run(options)
+      expect(options[:report].cached_catalog_status).to eq('on_failure')
     end
 
     it "should not update the cached catalog in noop mode" do
       Puppet[:noop] = true
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true, ignore_cache_save: true)).and_return(@catalog)
 
-      @agent.retrieve_catalog({})
+      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+
+      Puppet::Resource::Catalog.indirection.cache_class = :json
+      path = Puppet::Resource::Catalog.indirection.cache.path(catalog.name)
+
+      expect(File).to_not be_exist(path)
+      configurer.run
+      expect(File).to_not be_exist(path)
     end
 
     it "should update the cached catalog when not in noop mode" do
       Puppet[:noop] = false
-      expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true, ignore_cache_save: false)).and_return(@catalog)
+      Puppet[:log_level] = 'info'
 
-      @agent.retrieve_catalog({})
+      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+
+      Puppet::Resource::Catalog.indirection.cache_class = :json
+      cache_path = Puppet::Resource::Catalog.indirection.cache.path(Puppet[:node_name_value])
+
+      expect(File).to_not be_exist(cache_path)
+      configurer.run
+      expect(File).to be_exist(cache_path)
+
+      expect(@logs).to include(an_object_having_attributes(level: :info, message: "Caching catalog for #{Puppet[:node_name_value]}"))
+    end
+
+    it "successfully applies the catalog without a cache" do
+      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+
+      Puppet::Resource::Catalog.indirection.cache_class = nil
+
+      expect(configurer.run).to eq(0)
+    end
+
+    it "should not update the cached catalog when running puppet apply" do
+      Puppet::Resource::Catalog.indirection.cache_class = :json
+      path = Puppet::Resource::Catalog.indirection.cache.path(catalog.name)
+
+      expect(File).to_not be_exist(path)
+      configurer.run(catalog: catalog)
+      expect(File).to_not be_exist(path)
+    end
+  end
+
+  describe "when converging the environment" do
+    let(:apple) { Puppet::Resource::Catalog.new(Puppet[:node_name_value], Puppet::Node::Environment.remote('apple')) }
+    let(:banana) { Puppet::Resource::Catalog.new(Puppet[:node_name_value], Puppet::Node::Environment.remote('banana')) }
+
+    before :each do
+      apple.add_resource(resource)
+      banana.add_resource(resource)
+    end
+
+    it "converges after multiple attempts" do
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(apple, banana, banana)
+
+      allow(Puppet).to receive(:notice)
+      expect(Puppet).to receive(:notice).with("Local environment: 'production' doesn't match server specified environment 'apple', restarting agent run with environment 'apple'")
+      expect(Puppet).to receive(:notice).with("Local environment: 'apple' doesn't match server specified environment 'banana', restarting agent run with environment 'banana'")
+
+      configurer.run
+    end
+
+    it "raises if it can't converge after 4 tries after the initial catalog request" do
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(apple, banana, apple, banana, apple)
+
+      configurer.run
+
+      expect(@logs).to include(an_object_having_attributes(level: :err, message: "Failed to apply catalog: Catalog environment didn't stabilize after 4 fetches, aborting run"))
     end
   end
 
   describe "when converting the catalog" do
-    before do
-      allow(Puppet.settings).to receive(:use).and_return(true)
+    it "converts Puppet::Resource into Puppet::Type::Notify" do
+      expect(configurer).to receive(:apply_catalog) do |ral, _|
+        expect(ral.resources).to contain(an_instance_of(Puppet::Type::Notify))
+      end
 
-      allow(catalog).to receive(:to_ral).and_return(ral_catalog)
+      configurer.run(catalog: catalog)
     end
 
-    let (:catalog) { Puppet::Resource::Catalog.new('tester', Puppet::Node::Environment.remote(Puppet[:environment].to_sym)) }
-    let (:ral_catalog) { Puppet::Resource::Catalog.new('tester', Puppet::Node::Environment.remote(Puppet[:environment].to_sym)) }
+    it "adds default schedules" do
+      expect(configurer).to receive(:apply_catalog) do |ral, _|
+        expect(ral.resources.map(&:to_ref)).to contain(%w{Schedule[puppet] Schedule[hourly] Schedule[daily] Schedule[weekly] Schedule[monthly] Schedule[never]})
+      end
 
-    it "should convert the catalog to a RAL-formed catalog" do
-      expect(@agent.convert_catalog(catalog, 10)).to equal(ral_catalog)
+      configurer.run
     end
 
-    it "should finalize the catalog" do
-      expect(ral_catalog).to receive(:finalize)
+    it "records the retrieval duration to the catalog" do
+      expect(configurer).to receive(:apply_catalog) do |ral, _|
+        expect(ral.retrieval_duration).to be_an_instance_of(Float)
+      end
 
-      @agent.convert_catalog(catalog, 10)
+      configurer.run
     end
 
-    it "should record the passed retrieval time with the RAL catalog" do
-      expect(ral_catalog).to receive(:retrieval_duration=).with(10)
+    it "writes the class file containing applied settings classes" do
+      expect(File).to_not be_exist(Puppet[:classfile])
 
-      @agent.convert_catalog(catalog, 10)
+      configurer.run
+
+      expect(File.read(Puppet[:classfile]).chomp).to eq('settings')
     end
 
-    it "should write the RAL catalog's class file" do
-      expect(ral_catalog).to receive(:write_class_file)
+    it "writes an empty resource file since no resources are 'managed'" do
+      expect(File).to_not be_exist(Puppet[:resourcefile])
 
-      @agent.convert_catalog(catalog, 10)
+      configurer.run
+
+      expect(File.read(Puppet[:resourcefile]).chomp).to eq("")
     end
 
-    it "should write the RAL catalog's resource file" do
-      expect(ral_catalog).to receive(:write_resource_file)
+    it "adds the conversion time to the report" do
+      configurer.run(report: report)
 
-      @agent.convert_catalog(catalog, 10)
-    end
-
-    it "should set catalog conversion time on the report" do
-      report = Puppet::Transaction::Report.new
-
-      expect(report).to receive(:add_times).with(:convert_catalog, kind_of(Numeric))
-      @agent.convert_catalog(catalog, 10, {:report => report})
+      expect(report.metrics['time']['convert_catalog']).to be_an_instance_of(Float)
     end
   end
 
@@ -994,66 +994,62 @@ describe Puppet::Configurer do
   describe "when attempting failover" do
     it "should not failover if server_list is not set" do
       Puppet.settings[:server_list] = []
-      expect(@agent).not_to receive(:find_functional_server)
-      @agent.run
+      configurer.run
     end
 
     it "should not failover during an apply run" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      expect(@agent).not_to receive(:find_functional_server)
       catalog = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
-      @agent.run :catalog => catalog
+      configurer.run(catalog: catalog)
     end
 
     it "should select a server when it receives 200 OK response" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      response = Net::HTTPOK.new(nil, 200, 'OK')
-      allow(Puppet::Network::HttpPool).to receive(:connection).with('myserver', 123, anything).and_return(double('request', get: response))
-      allow(@agent).to receive(:run_internal)
+
+      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 200)
 
       options = {}
-      @agent.run(options)
+      configurer.run(options)
       expect(options[:report].master_used).to eq('myserver:123')
-    end
-
-    it "queries the simple status for the 'master' service" do
-      Puppet.settings[:server_list] = ["myserver:123"]
-      response = Net::HTTPOK.new(nil, 200, 'OK')
-      http = double('request')
-      expect(http).to receive(:get).with('/status/v1/simple/master').and_return(response)
-      allow(Puppet::Network::HttpPool).to receive(:connection).with('myserver', 123, anything).and_return(http)
-      allow(@agent).to receive(:run_internal)
-
-      @agent.run
     end
 
     it "should report when a server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      response = Net::HTTPInternalServerError.new(nil, 500, 'Internal Server Error')
-      allow(Puppet::Network::HttpPool).to receive(:connection).with('myserver', 123, anything).and_return(double('request', get: response))
 
+      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: [500, "Internal Server Error"])
+
+      allow(Puppet).to receive(:debug)
       expect(Puppet).to receive(:debug).with("Puppet server myserver:123 is unavailable: 500 Internal Server Error")
-      expect{ @agent.run }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list/)
+
+      expect {
+        configurer.run
+      }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list:/)
     end
 
     it "should error when no servers in 'server_list' are reachable" do
-      Puppet.settings[:server_list] = ["myserver:123"]
-      error = Net::HTTPError.new(400, 'dummy server communication error')
-      allow(Puppet::Network::HttpPool).to receive(:connection).with('myserver', 123, anything).and_return(double('request', get: error))
+      Puppet.settings[:server_list] = "myserver:123,someotherservername"
 
-      options = {}
-      expect{ @agent.run(options) }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list/)
-      expect(options[:report].master_used).to be_nil
+      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 400)
+      stub_request(:get, 'https://someotherservername:8140/status/v1/simple/master').to_return(status: 400)
+
+      expect{
+        configurer.run
+      }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list: 'myserver:123,someotherservername'/)
     end
 
     it "should not make multiple node requests when the server is found" do
       Puppet.settings[:server_list] = ["myserver:123"]
-      response = Net::HTTPOK.new(nil, 200, 'OK')
 
-      expect(Puppet::Network::HttpPool).to receive(:connection).with('myserver', 123, anything).and_return(double('request', get: response))
-      allow(@agent).to receive(:run_internal)
+      Puppet::Node.indirection.terminus_class = :rest
+      Puppet::Resource::Catalog.indirection.terminus_class = :rest
 
-      @agent.run
+      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 200)
+      stub_request(:get, %r{https://myserver:123/puppet/v3/catalog}).to_return(status: 200)
+      node_request = stub_request(:get, %r{https://myserver:123/puppet/v3/node/}).to_return(status: 200)
+
+      configurer.run
+
+      expect(node_request).to have_been_requested.once
     end
   end
 end


### PR DESCRIPTION
* upstream/5.5.x:
  (PUP-10160) Cached catalog takes precedence over options catalog
  (PUP-10160) Emit info message after caching catalog
  (PUP-10160) Convert catalog and update cache after convergence
  (PUP-10160) Don't conflate cached and ral catalogs
  (maint) Add environment convergence tests
  (maint) Add tests for cached catalog behaviors
  (maint) Use webmock to test server list
  (maint) Account for stubbed Net::HTTP
  (maint) Remove private method stubs
  (maint) Remove instance_variable_get/set
  (maint) Use let(:facts) instead of @facts
  (maint) Don't stub Catalog#to_ral
  (maint) Use let(:report) instead of @report
  (maint) Fix bad expectation
  (maint) Use let(:configurer) instead of @agent
  (maint) Don't stub storage
  (maint) Don't stub settings catalogs
  (maint) Don't execute facter during failover

Conflicts:
	lib/puppet/configurer.rb
	spec/unit/configurer_spec.rb

* Previously if `use_cached_catalog` was true, then puppet had to load facts
  after loading the cached catalog and before converting it to a RAL catalog[1].
  With these changes, we always load facts after loading the cached catalog, or
  downloading a new catalog, and before converting to a RAL catalog. So the
  extra `get_facts` call is removed.
* Deleted stub for Puppet::SSL::Host.localhost, as that's no longer used.
* Puppet 6 `log_exception` doesn't call `Puppet.err` directly[2], so adjust
  expectations to verify `@logs` contain the expected messages.
* Puppet 5 accepts HTTP 200 or 403 from the simple status endpoint, because not
  all versions of puppetserver 5 granted access to that endpoint by default. In
  Puppet 6, we require HTTP 200 to consider the server to be available.
* Prior to puppet 6, pluginsync could be configured separately from
  use_cached_catalog. In puppet 6, we always pluginsync when not using the
  cache, so tests that try the cache and fallback to requesting a new catalog,
  need to stub pluginsync http requests.

[1] https://github.com/puppetlabs/puppet/commit/091dba40812d18658485d47231a576ad331ccee8
[2] https://github.com/puppetlabs/puppet/commit/d12ee4ddc1f25eb1ae954682b028a3e9f91a1382