### PR TITLE
(PUP-10038) Add Report HTTP Service

### DIFF
--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -18,6 +18,7 @@ module Puppet
     require 'puppet/http/response'
     require 'puppet/http/service'
     require 'puppet/http/service/ca'
+    require 'puppet/http/service/report'
     require 'puppet/http/session'
     require 'puppet/http/resolver'
     require 'puppet/http/resolver/server_list'

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -1,12 +1,14 @@
 class Puppet::HTTP::Service
   attr_reader :url
 
-  SERVICE_NAMES = [:ca].freeze
+  SERVICE_NAMES = [:ca, :report].freeze
 
   def self.create_service(client, name, server = nil, port = nil)
     case name
     when :ca
       Puppet::HTTP::Service::Ca.new(client, server, port)
+    when :report
+      Puppet::HTTP::Service::Report.new(client, server, port)
     else
       raise ArgumentError, "Unknown service #{name}"
     end

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -1,0 +1,40 @@
+class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
+  API = '/puppet/v3'.freeze
+  EXCLUDED_FORMATS = [:yaml, :b64_zlib_yaml, :dot]
+
+  # puppet major version where JSON is enabled by default
+  MAJOR_VERSION_JSON_DEFAULT = 5
+
+  def initialize(client, server, port)
+    url = build_url(API, server || Puppet[:report_server], port || Puppet[:report_port])
+    super(client, url)
+  end
+
+  def put_report(name, report, environment:, ssl_context: nil)
+    formatter = Puppet::Network::FormatHandler.format_for(Puppet[:preferred_serialization_format])
+
+    model = Puppet::Transaction::Report
+    network_formats = model.supported_formats - EXCLUDED_FORMATS
+    mime_types = network_formats.map { |f| model.get_format(f).mime }
+
+    response = @client.put(
+      with_base_url("/report/#{name}"),
+      headers: { 'ACCEPT' => mime_types.join(', ') },
+      params: { :environment => environment },
+      content_type: formatter.mime,
+      body: formatter.render(report),
+      ssl_context: ssl_context
+    )
+
+    return response.body.to_s if response.success?
+
+    server_version = response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION]
+    if server_version && SemanticPuppet::Version.parse(server_version).major < MAJOR_VERSION_JSON_DEFAULT &&
+        Puppet[:preferred_serialization_format] != 'pson'
+      #TRANSLATORS "pson", "preffered_serialization_format", and "puppetserver" should not be translated
+      raise Puppet::Error.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: server_version })
+    end
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
+end

--- a/spec/unit/http/service/report_spec.rb
+++ b/spec/unit/http/service/report_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'puppet/http'
+
+describe Puppet::HTTP::Service::Report do
+  let(:ssl_context) { Puppet::SSL::SSLContext.new }
+  let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:subject) { client.create_session.route_to(:report) }
+  let(:environment) { Puppet::Node::Environment.create(:testing, []) }
+  let(:report) { Puppet::Transaction::Report.new }
+
+  before :each do
+    Puppet[:report_server] = 'www.example.com'
+    Puppet[:report_port] = 443
+  end
+
+  context 'when routing to the report service' do
+    it 'defaults the server and port based on settings' do
+      Puppet[:report_server] = 'report.example.com'
+      Puppet[:report_port] = 8141
+
+      stub_request(:put, "https://report.example.com:8141/puppet/v3/report/report?environment=testing")
+
+      subject.put_report('report', report, environment: environment)
+    end
+
+    it 'fallbacks to server and masterport' do
+      Puppet[:report_server] = nil
+      Puppet[:report_port] = nil
+      Puppet[:server] = 'report2.example.com'
+      Puppet[:masterport] = 8142
+
+      stub_request(:put, "https://report2.example.com:8142/puppet/v3/report/report?environment=testing")
+
+      subject.put_report('report', report, environment: environment)
+    end
+  end
+
+  context 'when submitting a report' do
+    let(:url) { "https://www.example.com/puppet/v3/report/infinity?environment=testing" }
+
+    it 'submits a report to the "report" endpoint' do
+      stub_request(:put, url)
+        .with(
+          headers: {
+            'Accept'=>'application/json, application/x-msgpack, text/pson',
+            'Content-Type'=>'application/json',
+           }).
+         to_return(status: 200, body: "", headers: {})
+
+      subject.put_report('infinity', report, environment: environment)
+    end
+
+    it 'raises response error if unsuccessful' do
+      stub_request(:put, url).to_return(status: [400, 'Bad Request'], headers: {'X-Puppet-Version' => '6.1.8' })
+
+      expect {
+        subject.put_report('infinity', report, environment: environment)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq('Bad Request')
+        expect(err.response.code).to eq(400)
+      end
+    end
+
+    it 'raises an error if unsuccessful, the server version is < 5, and the current serialization format is not pson' do
+      Puppet[:preferred_serialization_format] = 'json'
+
+      stub_request(:put, url).to_return(status: [400, 'Bad Request'], headers: {'X-Puppet-Version' => '4.2.3' })
+
+      expect {
+        subject.put_report('infinity', report, environment: environment)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::Error)
+        expect(err.message).to eq('To submit reports to a server running puppetserver 4.2.3, set preferred_serialization_format to pson')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds in the Report HTTP service, which has the ability to
submit puppet run reports to the report server.