### PR TITLE
(PUP-10213) Do not create unused exceptions in evaluation

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -33,7 +33,7 @@ module Runtime3Support
   # @raise [Puppet::ParseError] an evaluation error initialized from the arguments (TODO: Change to EvaluationError?)
   #
   def optionally_fail(issue, semantic, options={}, except=nil)
-    if except.nil?
+    if except.nil? && diagnostic_producer.severity_producer[issue] == :error
       # Want a stacktrace, and it must be passed as an exception
       begin
        raise EvaluationError.new()


### PR DESCRIPTION
Previously, `optionally_fail` in `Runtime3Support` would always create an
exception if it was not given one. However, said exception would only be
used if the issue reported was given a severity of `:error`. On certain
platforms creating exceptions are slow and some users have many warnings
within their manifests which can lead to slow compile times.

This patch checks with the `diagnostic_producer`'s `severity_producer` to
see if the given issue warrants a backtrace before creating an exception
to provide one. If no backtrace is needed (we do not currently report
backtraces for warnings) then we skip the creation of an exception.

A note about the tests. I did not find any specific tests around
`optionally_fail` though I added assertions to the `EvaluatorImpl` tests
where we already test error, warning, and ignore behavior largely provided
by `Runtime3Support`. The warning and ignore assertions fail w/o this
patch and the error assertions pass, showing backwards compat.

Please let me know if there's a better place to put these tests.