### PR TITLE
(maint) use --force for gem update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - if [[ $TRAVIS_RUBY_VERSION =~ ^(1.9|2.0|2.1|2.2) ]]; then
       gem update --system 2.7.8 && gem install bundler -v '< 2' --no-document;
     else
-      yes | gem update --system;
+      gem update --system --force;
     fi
 script:
   - "bundle exec rake $CHECK"


### PR DESCRIPTION
Rubygems release version 3.1.2 that contains the fix for --force: https://github.com/rubygems/rubygems/issues/3030
This PR removes the `yes` workaround in favor for --force