### PR TITLE
(maint) use --force for gem update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 bundler_args: --jobs 4 --retry 2 --without packaging documentation
 before_install:
-  - yes | gem update --system
+  - gem update --system --force
 script:
   - "bundle exec rake $CHECK"
 notifications:


### PR DESCRIPTION
Rubygems release version 3.1.2 that contains the fix for --force: rubygems/rubygems#3030
This PR removes the yes workaround in favor for --force