### PR TITLE
(PUP-10171) Support changing package flavors 

### DIFF
--- a/acceptance/tests/provider/package/dnfmodule_manages_flavors.rb
+++ b/acceptance/tests/provider/package/dnfmodule_manages_flavors.rb
@@ -1,0 +1,31 @@
+test_name "dnfmodule can change flavors" do
+  confine :to, :platform => /el-8-x86_64/  # only el/centos 8 have the appstream repo
+  tag 'audit:low'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::PackageUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  package = "postgresql"
+
+  agents.each do |agent|
+    skip_test('appstream repo not present') unless on(agent, 'dnf repolist').stdout.include?('appstream')
+    teardown do
+      apply_manifest_on(agent, resource_manifest('package', package, ensure: 'absent', provider: 'dnfmodule'))
+    end
+  end
+
+  step "Install the client #{package} flavor" do
+    apply_manifest_on(agent, resource_manifest('package', package, ensure: 'present', flavor: 'client', provider: 'dnfmodule'))
+    on(agent, "dnf module list --installed | grep #{package} | sed -E 's/\\[d\\] //g'") do |output|
+      assert_match('client [i]', output.stdout, 'installed flavor not correct')
+    end
+  end
+
+  step "Install the server #{package} flavor" do
+    apply_manifest_on(agent, resource_manifest('package', package, ensure: 'present', flavor: 'server', provider: 'dnfmodule'))
+    on(agent, "dnf module list --installed | grep #{package} | sed -E 's/\\[d\\] //g'") do |output|
+      assert_match('server [i]', output.stdout, 'installed flavor not correct')
+    end
+  end
+end

--- a/lib/puppet/provider/package/dnfmodule.rb
+++ b/lib/puppet/provider/package/dnfmodule.rb
@@ -12,7 +12,7 @@ require 'puppet/provider/package'
 
 Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
 
-  has_feature :installable, :uninstallable, :versionable
+  has_feature :installable, :uninstallable, :versionable, :supports_flavors
   #has_feature :upgradeable
   # it's not (yet) feasible to make this upgradeable since module streams don't
   # always have matching version types (i.e. idm has streams DL1 and client,
@@ -83,5 +83,12 @@ Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
     execute([command(:dnf), 'module', 'remove', '-d', '0', '-e', self.class.error_level, '-y', @resource[:name]])
     reset  # reset module to the default stream
   end
-end
 
+  def flavor
+    @property_hash[:flavor]
+  end
+
+  def flavor=(value)
+    install if flavor != @resource.should(:flavor)
+  end
+end

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -20,6 +20,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
   has_feature :install_options
   has_feature :uninstall_options
   has_feature :upgradeable
+  has_feature :supports_flavors
 
   def self.instances
     packages = []
@@ -238,5 +239,16 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
 
   def purge
     pkgdelete "-c", "-q", @resource[:name]
+  end
+
+  def flavor
+    @property_hash[:flavor]
+  end
+
+  def flavor=(value)
+    if flavor != @resource.should(:flavor)
+      uninstall
+      install
+    end
   end
 end

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
     begin
       execpipe(listcmd) do |process|
         # our regex for matching pkg_info output
-        regex = /^(.*)-(\d[^-]*)[-]?(\w*)(.*)$/
+        regex = /^(.*)-(\d[^-]*)[-]?([\w-]*)(.*)$/
         fields = [:name, :ensure, :flavor ]
         hash = {}
 

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -62,6 +62,7 @@ module Puppet
       passed to the installer command."
     feature :uninstall_options, "The provider accepts options to be
       passed to the uninstaller command."
+    feature :supports_flavors, "The provider accepts flavors, which are specific variants of packages."
     feature :package_settings, "The provider accepts package_settings to be
       ensured for the given package. The meaning and format of these settings is
       provider-specific.",
@@ -401,6 +402,11 @@ module Puppet
       end
     end
 
+    newproperty(:flavor, :required_features => :supports_flavors) do
+      desc "OpenBSD and DNF modules support 'flavors', which are
+        further specifications for which type of package you want."
+    end
+
     newparam(:source) do
       desc "Where to find the package file. This is only used by providers that don't
         automatically download packages from a central repository. (For example:
@@ -478,11 +484,6 @@ module Puppet
         Normally apt will bail if you try this."
 
       newvalues(:true, :false)
-    end
-
-    newparam(:flavor) do
-      desc "OpenBSD and DNF modules support 'flavors', which are
-        further specifications for which type of package you want."
     end
 
     newparam(:install_only, :boolean => false, :parent => Puppet::Parameter::Boolean, :required_features => :install_only) do

--- a/spec/unit/provider/package/dnfmodule_spec.rb
+++ b/spec/unit/provider/package/dnfmodule_spec.rb
@@ -161,6 +161,28 @@ describe Puppet::Type.type(:package).provider(:dnfmodule) do
         provider.install
       end
     end
+
+    context "with an installed flavor" do
+      before do
+        provider.instance_variable_get('@property_hash')[:flavor] = 'minimal'
+      end
+
+      it "should remove existing packages and reset the module stream before installing another flavor" do
+        resource[:flavor] = 'common'
+        expect(provider).to receive(:execute).thrice.with(array_including(/remove|reset|install/))
+        provider.flavor = resource[:flavor]
+      end
+
+      it "should not do anything if the flavor doesn't change" do
+        resource[:flavor] = 'minimal'
+        expect(provider).not_to receive(:execute)
+        provider.flavor = resource[:flavor]
+      end
+
+      it "should return the existing flavor" do
+        expect(provider.flavor).to eq('minimal')
+      end
+    end
   end
 
   context "parsing the output of module list --installed" do

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -395,4 +395,21 @@ describe Puppet::Type.type(:package).provider(:openbsd) do
       end
     end
   end
+
+  context "#flavor" do
+    before do
+      provider.instance_variable_get('@property_hash')[:flavor] = 'no_x11-python'
+    end
+
+    it 'should return the existing flavor' do
+      expect(provider.flavor).to eq('no_x11-python')
+    end
+
+    it 'should remove and install the new flavor if different' do
+      provider.resource[:flavor] = 'no_x11-ruby'
+      expect(provider).to receive(:uninstall).ordered
+      expect(provider).to receive(:install).ordered
+      provider.flavor = provider.resource[:flavor]
+    end
+  end
 end

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -30,6 +30,10 @@ describe Puppet::Type.type(:package) do
     expect(Puppet::Type.type(:package).provider_feature(:versionable)).not_to be_nil
   end
 
+  it "should have a :supports_flavors feature" do
+    expect(Puppet::Type.type(:package).provider_feature(:supports_flavors)).not_to be_nil
+  end
+
   it "should have a :package_settings feature that requires :package_settings_insync?, :package_settings and :package_settings=" do
     expect(Puppet::Type.type(:package).provider_feature(:package_settings).methods).to eq([:package_settings_insync?, :package_settings, :package_settings=])
   end
@@ -52,6 +56,10 @@ describe Puppet::Type.type(:package) do
 
     it "should have a package_settings property" do
       expect(Puppet::Type.type(:package).attrtype(:package_settings)).to eq(:property)
+    end
+
+    it "should have a flavor property" do
+      expect(Puppet::Type.type(:package).attrtype(:flavor)).to eq(:property)
     end
   end
 


### PR DESCRIPTION
On platforms where we have the `flavor` parameter, we cannot change it once a package is installed. The only way to do it is to use `ensure => absent` on the package, then install the different flavor.

This behavior is achievable on both `dnfmodule` and `openbsd` package providers. To do this we change `flavor` to be a property instead of a parameter, so it gets tracked as part of the resource state.

To ensure we don't call flavor methods on unsupported providers, we confine the property to the newly added `supports_flavors` feature.

I manually tested this on an OpenBSD box, but I'll write some specs too.