### PR TITLE
(PUP-10221) Add implementation_class method to PObjectTypeExtension

### DIFF
--- a/lib/puppet/pops/types/p_object_type_extension.rb
+++ b/lib/puppet/pops/types/p_object_type_extension.rb
@@ -153,6 +153,16 @@ class PObjectTypeExtension < PAnyType
     @base_type.simple_name
   end
 
+  # @api private
+  def implementation_class(create = true)
+    @base_type.implementation_class(create)
+  end
+
+  # @api private
+  def parameter_info(impl_class)
+    @base_type.parameter_info(impl_class)
+  end
+
   protected
 
   # Checks that the given `param_values` hash contains all keys present in the `parameters` of

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -296,9 +296,14 @@ module Serialization
           expect(val2).to be_a(Types::PObjectTypeExtension)
           expect(val2).to eql(val)
         end
+
+        it 'with POjbectTypeExtension type being converted' do
+          val = { 'ObjectExtension' => type.create(34) }
+          expect(to_converter.convert(val))
+            .to eq({"ObjectExtension"=>{"__ptype"=>"MyType", "x"=>34}})
+        end
       end
     end
-
 
     it 'Array of rich data' do
       # Sensitive omitted because it doesn't respond to ==


### PR DESCRIPTION
This adds the `implementation_class` method to `PObjectTypeExtension` type,
which simply calls the base types `implementation_class` method. This
method is called as part of serializing `Puppet::Datatypes::Error`
objects, which currently errors if the method isn't defined.