### PR TITLE
(PUP-10223) Allow node definitions in apply blocks

### DIFF
--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -93,7 +93,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     o = container(idx)
     idx -= 1
     case o
-    when NilClass, Model::HostClassDefinition, Model::Program
+    when NilClass, Model::ApplyExpression, Model::HostClassDefinition, Model::Program
       # ok, stop scanning parents
     when Model::BlockExpression
       c = container(idx)

--- a/lib/puppet/pops/validation/tasks_checker.rb
+++ b/lib/puppet/pops/validation/tasks_checker.rb
@@ -40,7 +40,11 @@ class TasksChecker < Checker4_0
   end
 
   def check_NodeDefinition(o)
-    illegalTasksExpression(o)
+    if in_ApplyExpression?
+      super(o)
+    else
+      illegalTasksExpression(o)
+    end
   end
 
   def check_RelationshipExpression(o)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -486,10 +486,15 @@ describe "validating 4x" do
         expect(acceptor).to have_issue(Puppet::Pops::Issues::EXPRESSION_NOT_SUPPORTED_WHEN_SCRIPTING)
       end
 
-      it 'produces an error for node expressions' do
+      it 'allows node expressions' do
         acceptor = validate(parse('apply("foo.example.com") { node default {} }'))
+        expect(acceptor.error_count).to eql(0)
+      end
+
+      it 'produces an error for node expressions nested in a block' do
+        acceptor = validate(parse('apply("foo.example.com") { if true { node default {} } }'))
         expect(acceptor.error_count).to eql(1)
-        expect(acceptor).to have_issue(Puppet::Pops::Issues::EXPRESSION_NOT_SUPPORTED_WHEN_SCRIPTING)
+        expect(acceptor).to have_issue(Puppet::Pops::Issues::NOT_TOP_LEVEL)
       end
 
       it 'produces an error for resource definitions' do


### PR DESCRIPTION
Previously, we explicitly forbade node definitions in plans entirely as
Bolt didn't know how to interpret them. This changes to allowing node
definitions in apply blocks so that they can be interpreted by Bolt.

When validating node definitions, we now check whether we're in an apply
block and fail if we aren't. Otherwise, we defer to the standard
validator. That validation will fail however, because definitions are
only allowed at the top level. For the intents and purposes of a plan,
an apply block is effectively a top-level construct, as it will be used
as the top-level input to a catalog compilation. Therefore, we now allow
node definitions to be defined directly within apply blocks (but not
nested any deeper than that).

The last piece of the puzzle is to change the plan instantiator to not
treat these node definitions nested within apply blocks as though they
are top-level definitions that would constitute a single file illegaly
making multiple definitions. We now simply remove node definitions from
consideration when checking whether the plan file has multiple
definitions.