### PR TITLE
(maint) Update tests to actually not require a master host when running

### DIFF
--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -1,6 +1,4 @@
 test_name "C100300: Catalog containing binary data is applied correctly" do
-  skip_test 'requires a master for serving module content' if master.nil?
-
   require 'puppet/acceptance/common_utils'
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
@@ -8,7 +6,8 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  tag 'risk:medium'
+  tag 'risk:medium',
+      'server'
 
   test_num        = 'c100300'
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -3,10 +3,11 @@ test_name 'C98346: Binary data type' do
   extend Puppet::Acceptance::PuppetTypeTestTools
 
   tag 'audit:high',
-      'audit:integration' # Tests that binary data is retains integrity
-      # between server and agent transport/application.
-      # The weak link here is final ruby translation and
-      # should not be OS sensitive.
+      'audit:integration', # Tests that binary data is retains integrity
+                           # between server and agent transport/application.
+                           # The weak link here is final ruby translation and
+                           # should not be OS sensitive.
+      'server'
 
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -4,9 +4,10 @@ test_name 'C99627: can use Object types in the catalog and apply/agent' do
 
 tag 'audit:high',
     'audit:integration',
-    'audit:refactor'     # The use of apply on a reference system should
+    'audit:refactor',    # The use of apply on a reference system should
                          # be adequate to test puppet. Running this in
                          # context of server/agent should not be necessary.
+    'server'
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -7,6 +7,7 @@ tag 'audit:medium',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.
                        # Use mk_tmp_environment_with_teardown to create environment.
+    'server'
 
   testdir = master.tmpdir('lookup')
 

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -6,6 +6,7 @@ tag 'audit:medium',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local environment.
+    'server'
 
   # The following two lines are required for the puppetserver service to
   # start correctly. These should be removed when PUP-7102 is resolved.

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -2,6 +2,8 @@ test_name 'puppet module list (with environment)'
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
 
+tag 'server'
+
 tmpdir = master.tmpdir('module-list-with-environment')
 
 step 'Setup'

--- a/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
+++ b/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
@@ -1,5 +1,4 @@
 test_name "C100533: Agent sends json report for cached catalog" do
-  skip_test 'requires a master' if master.nil?
 
   tag 'risk:medium',
       'audit:medium',

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -7,14 +7,11 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  test_file_name     = File.basename(__FILE__, '.*')
-  tmp_environment    = mk_tmp_environment_with_teardown(master, test_file_name)
-  tmp_file           = {}
-
   tag 'audit:medium',
       'audit:integration',
       'audit:refactor',    # Uses a server currently, but is testing agent report
-      'broken:images'
+      'broken:images',
+      'server'
 
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -1,9 +1,8 @@
 test_name 'Ensure a file resource can have a UTF-8 source attribute, content, and path when served via a module' do
   tag 'audit:high',
       'broken:images',
-      'audit:acceptance'
-
-  skip_test 'requires a master for serving module content' if master.nil?
+      'audit:acceptance',
+      'server'
 
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
+++ b/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
@@ -1,5 +1,4 @@
 test_name "C100532: Server returns expected format when --preferred_serialization_format is set" do
-  skip_test 'requires a master' if master.nil?
 
   tag 'risk:medium',
       'audit:medium',

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -3,14 +3,14 @@ extend Puppet::Acceptance::CAUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
-disable_pe_enterprise_mcollective_agent_classes
-
 test_name "autosign command and csr attributes behavior (#7243,#7244)" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
   tag 'audit:high',        # cert/ca core behavior
       'audit:integration',
       'server'             # Ruby implementation is deprecated
+
+  disable_pe_enterprise_mcollective_agent_classes
 
   def assert_key_generated(name)
     assert_match(/Creating a new SSL key for #{name}/, stdout, "Expected agent to create a new SSL key for autosigning")

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -5,16 +5,16 @@ extend Puppet::Acceptance::TempFileUtils
 require 'puppet/acceptance/classifier_utils'
 extend Puppet::Acceptance::ClassifierUtils
 
-disable_pe_enterprise_mcollective_agent_classes
-
-initialize_temp_dirs
-
 test_name "certificate extensions available as trusted data" do
   confine :except, :platform => /^cisco_/ # See PUP-5827
 
   tag 'audit:high',        # ca/cert core functionality
       'audit:integration',
       'server'             # Ruby implimentation is deprecated
+
+  disable_pe_enterprise_mcollective_agent_classes
+
+  initialize_temp_dirs
 
   agent_certnames = []
 

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -4,13 +4,13 @@ require 'puppet/acceptance/temp_file_utils'
 
 extend Puppet::Acceptance::TempFileUtils
 
-initialize_temp_dirs()
-all_tests_passed = false
-
 tag 'audit:medium',      # tests basic custom module/pluginsync handling?
     'audit:refactor',    # Use block style `test_namme`
     'audit:integration',
     'server'
+
+initialize_temp_dirs()
+all_tests_passed = false
 
 ###############################################################################
 # BEGIN TEST LOGIC

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -2,7 +2,8 @@ test_name 'utf-8 characters in cached catalog' do
 
   tag 'audit:high', # utf-8 is high impact in general
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
-      'audit:refactor' # use mk_temp_environment_with_teardown
+      'audit:refactor', # use mk_temp_environment_with_teardown
+      'server'
 
   utf8chars     = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
   file_content  = "This is the file content. file #{utf8chars}"


### PR DESCRIPTION
Prior to this commit, some of the tests had code that required a master
host before we could specify the tags. The tags are important to define
first because they let us know when the test requires a provisioned
master. There are scenarios where we do not bother to provision a
puppetserver (aka master host). We need to be able to skip all tests
that require a server. These tests are generally tagged with 'server'.
However, if there is code evaluated before the tags are defined that
reference the master host, that test will fail. This commit fixes that.

This commit also adds 'server' tags if they're missing from a test.