### PR TITLE
(maint) remove references to master where we don't need them

### DIFF
--- a/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
+++ b/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
@@ -47,9 +47,6 @@ test_name "The Exec resource should run commands in the specified cwd" do
   end
 
   agents.each do |agent|
-    # skip the agent on the master, as we don't need to run the tests on the master too
-    next if agent == master
-
     testdir = agent.tmpdir("mock_testdir")
     if agent.platform =~ /windows/
       path = 'C:\Windows\System32'


### PR DESCRIPTION
As this test doesn't require a master host to exist, we should remove
all references to master. We have the option to run tests without even
bothering to provision a master. When we do this, any reference to a
master in the tests will cause that test to fail. We want to be able to
run this test without provisioning a master host, so we need to remove
the reference to a master.