### PR TITLE
(PUP-10038) Send profile header to the report service

### DIFF
--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -20,17 +20,12 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   end
 
   def get_certificate_revocation_list(if_modified_since: nil, ssl_context: nil)
-    request_headers = if if_modified_since
-                        h = add_puppet_headers(HEADERS).dup
-                        h['If-Modified-Since'] = if_modified_since.httpdate
-                        h
-                      else
-                        add_puppet_headers(HEADERS)
-                      end
+    headers = add_puppet_headers(HEADERS)
+    headers['If-Modified-Since'] = if_modified_since.httpdate if if_modified_since
 
     response = @client.get(
       with_base_url("/certificate_revocation_list/ca"),
-      headers: request_headers,
+      headers: headers,
       ssl_context: ssl_context
     )
 

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -19,7 +19,7 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
 
     response = @client.put(
       with_base_url("/report/#{name}"),
-      headers: { 'ACCEPT' => mime_types.join(', ') },
+      headers: add_puppet_headers('ACCEPT' => mime_types.join(', ')),
       params: { :environment => environment },
       content_type: formatter.mime,
       body: formatter.render(report),
@@ -31,8 +31,8 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
     server_version = response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION]
     if server_version && SemanticPuppet::Version.parse(server_version).major < MAJOR_VERSION_JSON_DEFAULT &&
         Puppet[:preferred_serialization_format] != 'pson'
-      #TRANSLATORS "pson", "preffered_serialization_format", and "puppetserver" should not be translated
-      raise Puppet::Error.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: server_version })
+      #TRANSLATORS "pson", "preferred_serialization_format", and "puppetserver" should not be translated
+      raise Puppet::HTTP::ProtocolError.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: server_version })
     end
 
     raise Puppet::HTTP::ResponseError.new(response)


### PR DESCRIPTION
Add the profile headers when submitting the report. Also raise a protocol
error when talking to an older server that doesn't support JSON.

Since `add_puppet_headers` always returns a duplicate, it's safe to mutate that
when sending the if-modified-since header.