### PR TITLE
(PUP-10163) Add thread safety for singletons using Visitor

### DIFF
--- a/lib/puppet/pops/model/pn_transformer.rb
+++ b/lib/puppet/pops/model/pn_transformer.rb
@@ -1,22 +1,18 @@
+require 'puppet/concurrent/thread_local_singleton'
+
 module Puppet::Pops
 module Model
 
 
 class PNTransformer
-  def self.visitor
-    @visitor ||= Visitor.new(nil, 'transform', 0, 0)
-  end
-
-  def self.singleton
-    @singleton ||= new(visitor)
-  end
+  extend Puppet::Concurrent::ThreadLocalSingleton
 
   def self.transform(ast)
     singleton.transform(ast)
   end
 
-  def initialize(visitor)
-    @visitor = visitor
+  def initialize
+    @visitor = Visitor.new(nil, 'transform', 0, 0)
   end
 
   def transform(ast)

--- a/lib/puppet/pops/serialization/json_path.rb
+++ b/lib/puppet/pops/serialization/json_path.rb
@@ -1,3 +1,5 @@
+require 'puppet/concurrent/thread_local_singleton'
+
 module Puppet::Pops
 module Serialization
 module JsonPath
@@ -31,9 +33,7 @@ module JsonPath
   #
   # @api private
   class Resolver
-    def self.singleton
-      @singleton ||= self.new
-    end
+    extend Puppet::Concurrent::ThreadLocalSingleton
 
     def initialize
       @parser = Parser::Parser.new

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -1,3 +1,5 @@
+require 'puppet/concurrent/thread_local_singleton'
+
 module Puppet::Pops
 module Types
 
@@ -238,22 +240,17 @@ class StringConverter
     end
   end
 
+  extend Puppet::Concurrent::ThreadLocalSingleton
+
   # @api public
   def self.convert(value, string_formats = :default)
     singleton.convert(value, string_formats)
   end
 
-  # @return [TypeConverter] the singleton instance
-  #
-  # @api public
-  def self.singleton
-    @tconv_instance ||= new
-  end
-
   # @api private
   #
   def initialize
-    @@string_visitor   ||= Visitor.new(self, "string", 3, 3)
+    @string_visitor = Visitor.new(self, "string", 3, 3)
   end
 
   DEFAULT_INDENTATION = Indentation.new(0, true, false).freeze
@@ -523,7 +520,7 @@ class StringConverter
 #  end
 
   def _convert(val_type, value, format_map, indentation)
-    @@string_visitor.visit_this_3(self, val_type, value, format_map, indentation)
+    @string_visitor.visit_this_3(self, val_type, value, format_map, indentation)
   end
   private :_convert
 

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -1,3 +1,5 @@
+require 'puppet/concurrent/thread_local_singleton'
+
 module Puppet::Pops
 module Types
 # The TypeCalculator can answer questions about puppet types.
@@ -99,6 +101,7 @@ module Types
 # @api public
 #
 class TypeCalculator
+  extend Puppet::Concurrent::ThreadLocalSingleton
 
   # @api public
   def self.assignable?(t1, t2)
@@ -135,18 +138,11 @@ class TypeCalculator
     singleton.iterable(t)
   end
 
-  # @return [TypeCalculator] the singleton instance
-  #
-  # @api private
-  def self.singleton
-    @tc_instance ||= new
-  end
-
   # @api public
   #
   def initialize
-    @@infer_visitor ||= Visitor.new(nil, 'infer',0,0)
-    @@extract_visitor ||= Visitor.new(nil, 'extract',0,0)
+    @infer_visitor = Visitor.new(nil, 'infer',0,0)
+    @extract_visitor = Visitor.new(nil, 'extract',0,0)
   end
 
   # Answers 'can an instance of type t2 be assigned to a variable of type t'.
@@ -250,7 +246,7 @@ class TypeCalculator
     elsif o.is_a?(Evaluator::PuppetProc)
       infer_PuppetProc(o)
     else
-      @@infer_visitor.visit_this_0(self, o)
+      @infer_visitor.visit_this_0(self, o)
     end
   end
 


### PR DESCRIPTION
Several singletons use Puppet::Pops::Visitor which has some caching. To
be sure that this is safe, implement these using ThreadLocalSingleton.
Some of these used class variables referred to from inside the singleton
instances. This seems redundant and should be safe to make instance
variables.