### PR TITLE
(PUP-10219) Windows confuses domain/local accounts

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -204,7 +204,8 @@ module Puppet::Util::Windows::ADSI
           if sid.account_type == "SidType#{@object_class.capitalize}".to_sym
             # Check if we're getting back a local user when domain-joined
             return true unless [:MEMBER_WORKSTATION, :MEMBER_SERVER].include?(Puppet::Util::Windows::ADSI.domain_role)
-            return sid.domain == Puppet::Util::Windows::ADSI.computer_name
+            # The resource domain and the computer name are not always case-matching
+            return sid.domain.casecmp(Puppet::Util::Windows::ADSI.computer_name) == 0
           end
 
           # 'well known group' is special as it can be a group like Everyone OR a user like SYSTEM

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -81,6 +81,13 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
       expect(klass.exists?(resource_name)).to eq(true)
     end
 
+    it "should be case insensitive when comparing the domain with the computer name" do
+      local_domain = 'TESTCOMPUTERNAME'
+      principal = double('Principal', :account => resource_name, :domain => local_domain, :account_type => account_type)
+      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with(resource_name).and_return(principal)
+      expect(klass.exists?(resource_name)).to eq(true)
+    end
+
     it "should return false if no local resource exists" do
       principal = double('Principal', :account => resource_name, :domain => 'AD_DOMAIN', :account_type => account_type)
       allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with(resource_name).and_return(principal)


### PR DESCRIPTION
Allow case mismatches when comparing the resource domain with the computer name. The computer name *should* always be uppercase, while the domain might be lowercase in some cases. It looks like Windows prefers uppercase but does not enforce it.