### PR TITLE
Add Ruby 2.7 to test travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
         - "_JAVA_OPTIONS='-Xmx1024m -Xms512m'"
         - "CHECK=parallel:spec\\[2\\]"
 
+    - rvm: 2.7
+      env: "CHECK=parallel:spec\\[2\\]"
+
     - rvm: 2.5
       env: "CHECK=rubocop"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ matrix:
 
 # Ruby versions under test
 platform:
+  - Ruby27-x64
   - Ruby26-x64
   - Ruby25-x64
   - Ruby24-x64


### PR DESCRIPTION
Ruby 2.7 got released some time ago so I think it makes sense to also
test against it.