### PR TITLE
(PUP-10234) Add ppAuthCertExt to custom_extensions

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -803,13 +803,17 @@ This is useful for embedding a pre-shared key for autosigning policy executables
 ("challenge password") OID.
 
 Extension requests will be permanently embedded in the final certificate.
-Extension OIDs must be in the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`) or
-"ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`) OID arcs. The ppRegCertExt arc is
+Extension OIDs must be in the "ppRegCertExt" (`1.3.6.1.4.1.34380.1.1`),
+"ppPrivCertExt" (`1.3.6.1.4.1.34380.1.2`), or
+"ppAuthCertExt" (`1.3.6.1.4.1.34380.1.3`) OID arcs. The ppRegCertExt arc is
 reserved for four of the most common pieces of data to embed: `pp_uuid` (`.1`),
 `pp_instance_id` (`.2`), `pp_image_name` (`.3`), and `pp_preshared_key` (`.4`)
 --- in the YAML file, these can be referred to by their short descriptive names
 instead of their full OID. The ppPrivCertExt arc is unregulated, and can be used
-for site-specific extensions.
+for site-specific extensions. The ppAuthCert arc is reserved for two pieces of
+data to embed: `pp_authorization` (`.1`) and `pp_auth_role` (`.13`). As with
+ppRegCertExt, in the YAML file, these can be referred to by their short
+descriptive name instead of their full OID.
 EOT
     },
     :certdir => {

--- a/lib/puppet/ssl/certificate.rb
+++ b/lib/puppet/ssl/certificate.rb
@@ -50,7 +50,8 @@ DOC
   def custom_extensions
     custom_exts = content.extensions.select do |ext|
       Puppet::SSL::Oids.subtree_of?('ppRegCertExt', ext.oid) or
-        Puppet::SSL::Oids.subtree_of?('ppPrivCertExt', ext.oid)
+        Puppet::SSL::Oids.subtree_of?('ppPrivCertExt', ext.oid) or
+        Puppet::SSL::Oids.subtree_of?('ppAuthCertExt', ext.oid)
     end
 
     custom_exts.map do |ext|

--- a/spec/unit/ssl/certificate_spec.rb
+++ b/spec/unit/ssl/certificate_spec.rb
@@ -138,6 +138,13 @@ describe Puppet::SSL::Certificate do
         expect(cert.custom_extensions).to include('oid' => '1.3.6.1.4.1.34380.1.2.1', 'value' => 'x509 :(')
       end
 
+      it "returns extensions under the ppAuthCertExt" do
+        exts = {'pp_auth_role' => 'taketwo'}
+        cert = build_cert(:extension_requests => exts)
+        sign_wrapped_cert(cert)
+        expect(cert.custom_extensions).to include('oid' => 'pp_auth_role', 'value' => 'taketwo')
+      end
+
       it "doesn't return standard extensions" do
         cert = build_cert(:dns_alt_names => 'foo')
         expect(cert.custom_extensions).to be_empty


### PR DESCRIPTION
    PUP-6258 introduced the new oid ppAuthCertExt, but this new OID was
    never added to the custom_extensions method. This commit adds the
    missing OID and ensures that it can be accessed.