### PR TITLE
(PUP-10146) Stream file content response body

### DIFF
--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -43,6 +43,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
         links: links,
         checksum_type: checksum_type,
         source_permissions: source_permissions,
+        environment: environment,
       },
       ssl_context: ssl_context
     )
@@ -52,11 +53,14 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     raise Puppet::HTTP::ResponseError.new(response)
   end
 
-  def get_file_content(mount_point:, path:, ssl_context: nil, &block)
+  def get_file_content(mount_point:, path:, environment:, ssl_context: nil, &block)
     headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
     response = @client.get(
       with_base_url("/file_content/#{mount_point}/#{path}"),
       headers: headers,
+      params: {
+        environment: environment
+      },
       ssl_context: ssl_context
     )
 

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -62,14 +62,15 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
         environment: environment
       },
       ssl_context: ssl_context
-    )
-
-    #response.body.force_encoding(Encoding::BINARY)
-    if block_given?
-      yield response.body if response.success?
-    else
-      return response.body if response.success?
+    ) do |res|
+      if res.success?
+        res.read_body do |data|
+          yield data
+        end
+      end
     end
+
+    return nil if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
   end

--- a/spec/unit/http/service/file_server_spec.rb
+++ b/spec/unit/http/service/file_server_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::HTTP::Service::FileServer do
   end
 
   context 'when making requests' do
-    let(:uri) {"https://www.example.com:443/puppet/v3/file_content/:mount/:path"}
+    let(:uri) {"https://www.example.com:443/puppet/v3/file_content/:mount/:path?environment=testing"}
 
     it 'includes default HTTP headers' do
       stub_request(:get, uri).with do |request|
@@ -25,7 +25,7 @@ describe Puppet::HTTP::Service::FileServer do
         expect(request.headers).to_not include('X-Puppet-Profiling')
       end
 
-      subject.get_file_content(mount_point: ':mount', path: ':path')
+      subject.get_file_content(mount_point: ':mount', path: ':path', environment: environment)
     end
 
     it 'includes the X-Puppet-Profiling header when Puppet[:profile] is true' do
@@ -33,7 +33,7 @@ describe Puppet::HTTP::Service::FileServer do
 
       Puppet[:profile] = true
 
-      subject.get_file_content(mount_point: ':mount', path: ':path')
+      subject.get_file_content(mount_point: ':mount', path: ':path', environment: environment)
     end
   end
 
@@ -42,13 +42,13 @@ describe Puppet::HTTP::Service::FileServer do
       Puppet[:server] = 'file.example.com'
       Puppet[:masterport] = 8141
 
-      stub_request(:get, "https://file.example.com:8141/puppet/v3/file_content/mount/path")
+      stub_request(:get, "https://file.example.com:8141/puppet/v3/file_content/mount/path?environment=testing")
 
-      subject.get_file_content(mount_point: 'mount', path: 'path')
+      subject.get_file_content(mount_point: 'mount', path: 'path', environment: environment)
     end
   end
 
-  context 'retriving file metadata' do
+  context 'retrieving file metadata' do
     let(:path) { tmpfile('get_file_metadata') }
     let(:url) { "https://www.example.com/puppet/v3/file_metadata/infinity/#{path}?checksum_type=md5&environment=testing&links=manage&source_permissions=ignore" }
     let(:filemetadata) { Puppet::FileServing::Metadata.new(path) }
@@ -103,9 +103,9 @@ describe Puppet::HTTP::Service::FileServer do
     end
   end
 
-  context 'retriving multiple file metadatas' do
+  context 'retrieving multiple file metadatas' do
     let(:path) { tmpfile('get_file_metadatas') }
-    let(:url) { "https://www.example.com/puppet/v3/file_metadatas/infinity/#{path}?checksum_type=md5&links=manage&recurse=false&source_permissions=ignore" }
+    let(:url) { "https://www.example.com/puppet/v3/file_metadatas/infinity/#{path}?checksum_type=md5&links=manage&recurse=false&source_permissions=ignore&environment=testing" }
     let(:filemetadatas) { [Puppet::FileServing::Metadata.new(path)] }
     let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
 
@@ -121,7 +121,7 @@ describe Puppet::HTTP::Service::FileServer do
     end
 
     it 'automatically converts an array of parameters to the stringified query' do
-      url = "https://www.example.com/puppet/v3/file_metadatas/infinity/#{path}?checksum_type=md5&ignore=CVS&ignore=.git&ignore=.hg&links=manage&recurse=false&source_permissions=ignore"
+      url = "https://www.example.com/puppet/v3/file_metadatas/infinity/#{path}?checksum_type=md5&environment=testing&ignore=CVS&ignore=.git&ignore=.hg&links=manage&recurse=false&source_permissions=ignore"
       stub_request(:get, url).with(
         headers: {'Accept'=>'application/json, application/x-msgpack, text/pson',}
       ).to_return(
@@ -172,21 +172,21 @@ describe Puppet::HTTP::Service::FileServer do
   end
 
   context 'getting file content' do
-    let(:uri) {"https://www.example.com:443/puppet/v3/file_content/infinity/eternal"}
+    let(:uri) {"https://www.example.com:443/puppet/v3/file_content/infinity/eternal?environment=testing"}
 
     it 'submits a request for the file content' do
       stub_request(:get, uri).with do |request|
         expect(request.headers).to include({'Accept' => 'application/octet-stream'})
       end.to_return(status: 200, body: '')
 
-      subject.get_file_content(mount_point: 'infinity', path: 'eternal')
+      subject.get_file_content(mount_point: 'infinity', path: 'eternal', environment: environment)
     end
 
     it 'raises response error if unsuccessful' do
       stub_request(:get, uri).to_return(status: [400, 'Bad Request'])
 
       expect {
-        subject.get_file_content(mount_point: 'infinity', path: 'eternal')
+        subject.get_file_content(mount_point: 'infinity', path: 'eternal', environment: environment)
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
         expect(err.message).to eq('Bad Request')


### PR DESCRIPTION
Previously if the caller specified a block, we yielded the entire response body
and then raised an exception due to the missing return.

Now, if the response is successful, stream the response body to the caller in
chunks, and return nil. Otherwise raise a Puppet::HTTP::ResponseError.

Also added some missing environment query parameters to file_metadatas (plural)
and file_content.