### PR TITLE
(maint) Fix typo breaking reference chain

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -99,7 +99,7 @@ class Puppet::Transaction::ResourceHarness
   # We persist the last known values for the properties of a resource after resource
   # application.
   # @param [Puppet::Type] resource resource whose values we are to persist.
-  # @param [ResourceApplicationContent] context the application context to operate on.
+  # @param [ResourceApplicationContext] context the application context to operate on.
   def persist_system_values(resource, context)
     param_to_event = {}
     context.status.events.each do |ev|


### PR DESCRIPTION
As defined on L296, this is a ResourceApplicationContext, not a ResourceApplicationContent. The typo makes it a lot harder than necessary to understand what's going on here.