### PR TITLE
(PUP-10236) Tag untagged acceptance tests

### DIFF
--- a/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
+++ b/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
@@ -1,4 +1,10 @@
 test_name "C97899 - Agent run should fail if environment is unreadable" do
+
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor', # use mk_temp_environment_with_teardown
+      'server'
+
   skip_test 'requires a puppetserver master for managing the environment' if hosts_with_role(hosts, 'master').length == 0 or not @options[:is_puppetserver]
   jruby_version = on(master, 'puppetserver ruby --version').stdout
   skip_test 'This is only valid on JRuby 1.7' unless jruby_version =~ /^jruby 1\.7/

--- a/acceptance/tests/environment/negative/agent_run_should_fail_if_site_pp_unreadable.rb
+++ b/acceptance/tests/environment/negative/agent_run_should_fail_if_site_pp_unreadable.rb
@@ -1,4 +1,10 @@
 test_name "C98160 - Agent run should fail if an environment's site.pp is unreadable" do
+
+  tag 'audit:medium',
+      'audit:integration',
+      'audit:refactor', # use mk_temp_environment_with_teardown
+      'server'
+
   skip_test 'requires a master for managing the environment' if hosts_with_role(hosts, 'master').length == 0
 
   testdir = ''

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -1,8 +1,13 @@
 test_name 'puppet module list (with environment)'
+
+tag 'server',
+    'audit:medium',
+    'audit:acceptance',
+    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+                       # Wrap steps in blocks in accordance with Beaker style guide
+
 require 'puppet/acceptance/module_utils'
 extend Puppet::Acceptance::ModuleUtils
-
-tag 'server'
 
 tmpdir = master.tmpdir('module-list-with-environment')
 

--- a/acceptance/tests/utf8/utf8-recursive-copy.rb
+++ b/acceptance/tests/utf8/utf8-recursive-copy.rb
@@ -1,4 +1,8 @@
 test_name "PUP-8735: UTF-8 characters are preserved after recursively copying directories" do
+
+  tag 'audit:high', # utf-8 is high impact in general
+      'audit:integration' # not package dependent but may want to vary platform by LOCALE/encoding
+
   # Translation is not supported on these platforms:
   confine :except, :platform => /^eos-/
   confine :except, :platform => /^cisco/

--- a/acceptance/tests/windows/enable_password_changes_special_users.rb
+++ b/acceptance/tests/windows/enable_password_changes_special_users.rb
@@ -1,4 +1,8 @@
 test_name 'Puppet should change passwords for disabled, expired, or locked out Windows user accounts' do
+
+  tag 'audit:medium',
+      'audit:acceptance'
+
   require 'date'
   require 'puppet/acceptance/windows_utils'
 


### PR DESCRIPTION
This commit adds 'audit' tags to untagged acceptance tests to ensure
that they are properly scoped when using Beaker's tagging facility to
filter tests.

[skip-ci]