### PR TITLE
(PUP-10113) Speed up method calls and calls to []

### DIFF
--- a/benchmarks/type_inference/site.pp.erb
+++ b/benchmarks/type_inference/site.pp.erb
@@ -7,4 +7,5 @@ $val = [ $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $v1, $v2, $
 <% (size * 5).times do |i| %>
 each($val) | Struct[{key=>Variant[Integer[1,3],Enum[a,b,c]], value=>Struct[{mode=>Enum[read,write,update],path=>Array[String]}]}] $v | {  }
 # each($val) | $v | {  }
+$val.each | Struct[{key=>Variant[Integer[1,3],Enum[a,b,c]], value=>Struct[{mode=>Enum[read,write,update],path=>Array[String]}]}] $v | {  }
 <% end %>

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -27,7 +27,7 @@ class AccessOperator
   protected
 
   def access_Object(o, scope, keys)
-    type = Puppet::Pops::Types::TypeCalculator.infer(o)
+    type = Puppet::Pops::Types::TypeCalculator.infer_callable_methods_t(o)
     if type.is_a?(Puppet::Pops::Types::TypeWithMembers)
       access_func = type['[]']
       return access_func.invoke(o, scope, keys) unless access_func.nil?

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -20,7 +20,7 @@ class AccessOperator
     @semantic = access_expression
   end
 
-  def access (o, scope, *keys)
+  def access(o, scope, *keys)
     @@access_visitor.visit_this_2(self, o, scope, keys)
   end
 

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -947,7 +947,7 @@ class EvaluatorImpl
     name = name.value # the string function name
 
     obj = receiver[0]
-    receiver_type = Types::TypeCalculator.infer(obj)
+    receiver_type = Types::TypeCalculator.infer_callable_methods_t(obj)
     if receiver_type.is_a?(Types::TypeWithMembers)
       member = receiver_type[name]
       unless member.nil?

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -127,8 +127,8 @@ class TypeCalculator
   # @api private
   def self.infer_callable_methods_t(o)
     # If being a value that cannot have Pcore based methods callable from Puppet Language
-    if (o.is_a?(String) || 
-      o.is_a?(Numeric) || 
+    if (o.is_a?(String) ||
+      o.is_a?(Numeric) ||
       o.is_a?(TrueClass) ||
       o.is_a?(FalseClass) ||
       o.is_a?(Regexp) ||

--- a/lib/puppet/pops/types/type_calculator.rb
+++ b/lib/puppet/pops/types/type_calculator.rb
@@ -120,6 +120,30 @@ class TypeCalculator
     singleton.infer(o)
   end
 
+  # Infers a type if given object may have callable members, else returns nil.
+  # Caller must check for nil or if returned type supports members.
+  # This is a much cheaper call than doing a call to the general infer(o) method.
+  #
+  # @api private
+  def self.infer_callable_methods_t(o)
+    # If being a value that cannot have Pcore based methods callable from Puppet Language
+    if (o.is_a?(String) || 
+      o.is_a?(Numeric) || 
+      o.is_a?(TrueClass) ||
+      o.is_a?(FalseClass) ||
+      o.is_a?(Regexp) ||
+      o.instance_of?(Array) ||
+      o.instance_of?(Hash) ||
+      Types::PUndefType::DEFAULT.instance?(o)
+      )
+      return nil
+    end
+    # For other objects (e.g. PObjectType instances, and runtime types) full inference needed, since that will
+    # cover looking into the runtime type registry.
+    #
+    infer(o)
+  end
+
   # @api public
   def self.generalize(o)
     singleton.generalize(o)


### PR DESCRIPTION
Before this, the logic that evaluates method calls and the logic
that evaluates the [] operator would do a type inference and then check
if the type supports methods.
This was bad because it requires a full type inference that may be quite
expensive (for a large hash for example).

This is now fixed by adding a specific inference method in the
TypeCalculator that quickly returns nil for all types known to not have
methods, and infers the type for the rest.

Updates type inference benchmark. Chained function calls run nearly twice
as fast given the hash in the benchmark.

Supersedes #7797