### PR TITLE
(PUP-8900) Upload facts using http client

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -75,13 +75,16 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
         facts.name = Puppet[:node_name_value]
       end
 
-      Puppet::Node::Facts.indirection.terminus_class = :rest
-      server = Puppet::Node::Facts::Rest.server
-      Puppet.notice(_("Uploading facts for '%{node}' to: '%{server}'") % {
-                    node: Puppet[:node_name_value],
-                    server: server})
+      client = Puppet.runtime['http']
+      session = client.create_session
+      puppet = session.route_to(:puppet)
 
-      Puppet::Node::Facts.indirection.save(facts, nil, :environment => Puppet.lookup(:current_environment))
+      Puppet.notice(_("Uploading facts for '%{node}' to '%{server}'") % {
+                    node: Puppet[:node_name_value],
+                    server: puppet.url.hostname})
+
+      puppet.put_facts(Puppet[:node_name_value], facts: facts, environment: Puppet.lookup(:current_environment).name.to_s)
+      nil
     end
   end
 end

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -68,7 +68,7 @@ CONF
       subject.upload
 
       expect(@logs).to be_any {|log| log.level == :notice &&
-                               log.message =~ /Uploading facts for '.*' to: 'puppet\.server\.test'/}
+                               log.message =~ /Uploading facts for '.*' to 'puppet\.server\.test'/}
     end
   end
 end

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -12,9 +12,12 @@ describe Puppet::Face[:facts, '0.0.1'] do
     let(:model) { Puppet::Node::Facts }
     let(:test_data) { model.new('puppet.node.test', {test_fact: 'test value'}) }
     let(:facter_terminus) { model.indirection.terminus(:facter) }
-    let(:rest_terminus) { model.indirection.terminus(:rest) }
 
     before(:each) do
+      Puppet[:facts_terminus] = :memory
+      Puppet::Node::Facts.indirection.save(test_data)
+      allow(Puppet::Node::Facts.indirection).to receive(:terminus_class=).with(:facter)
+
       Puppet.settings.parse_config(<<-CONF)
 [main]
 server=puppet.server.invalid
@@ -26,41 +29,42 @@ CONF
 
       # Faces start in :user run mode
       Puppet.settings.preferred_run_mode = :user
-
-      allow(facter_terminus).to receive(:find).with(instance_of(Puppet::Indirector::Request)).and_return(test_data)
-      allow(rest_terminus).to receive(:save).with(instance_of(Puppet::Indirector::Request)).and_return(nil)
     end
 
-    it { is_expected.to be_action :upload }
-
-    it "finds facts from terminus_class :facter" do
-      expect(facter_terminus).to receive(:find).with(instance_of(Puppet::Indirector::Request)).and_return(test_data)
-
-      subject.upload
-    end
-
-    it "saves facts to terminus_class :rest" do
-      expect(rest_terminus).to receive(:save).with(instance_of(Puppet::Indirector::Request)).and_return(nil)
+    it "uploads facts as application/json" do
+      stub_request(:put, 'https://puppet.server.test:8140/puppet/v3/facts/puppet.node.test?environment=*root*')
+        .with(
+          headers: { 'Content-Type' => 'application/json' },
+          body: hash_including(
+            {
+              "name" => "puppet.node.test",
+              "values" => {
+                "test_fact" => "test value"
+              }
+            }
+          )
+        )
 
       subject.upload
     end
 
     it "passes the current environment" do
-      env = Puppet::Node::Environment.remote('qa')
-      expect(model.indirection).to receive(:save).with(anything, nil, :environment => env)
+      stub_request(:put, 'https://puppet.server.test:8140/puppet/v3/facts/puppet.node.test?environment=qa')
 
-      Puppet.override(:current_environment => env) do
+      Puppet.override(:current_environment => Puppet::Node::Environment.remote('qa')) do
         subject.upload
       end
     end
 
-    it "uses settings from the agent section of puppet.conf" do
-      expect(facter_terminus).to receive(:find).with(have_attributes(key: 'puppet.node.test')).and_return(test_data)
+    it "uses settings from the agent section of puppet.conf to resolve the node name" do
+      stub_request(:put, /puppet.node.test/)
 
       subject.upload
     end
 
     it "logs the name of the server that received the upload" do
+      stub_request(:put, 'https://puppet.server.test:8140/puppet/v3/facts/puppet.node.test?environment=*root*')
+
       subject.upload
 
       expect(@logs).to be_any {|log| log.level == :notice &&


### PR DESCRIPTION
Previously, `puppet facts upload` only tried the first entry in `server_list`,
but never fell back to other entries in the list.

Now it uses the http client which attempts to connect to each entry in the
`server_list`, so that `puppet facts upload` behaves the same as `puppet
agent` for SRV, server_list or server resolution..

There's one minor change to the log message to remove the extra ':'