### PR TITLE
(maint) [WIP] Use canonical forge_name

### DIFF
--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -239,7 +239,7 @@ Puppet::Face.define(:module, '1.0.0') do
   #
   def list_build_node(mod, parent, params)
     str = ''
-    str << (mod.forge_name ? mod.forge_name.tr('/', '-') : mod.name)
+    str << (mod.forge_name ? mod.forge_name : mod.name)
     str << ' (' + colorize(:cyan, mod.version ? "v#{mod.version}" : '???') + ')'
 
     unless File.dirname(mod.path) == params[:path]

--- a/lib/puppet/gettext/module_translations.rb
+++ b/lib/puppet/gettext/module_translations.rb
@@ -11,7 +11,7 @@ module Puppet::ModuleTranslations
     modules.each do |mod|
       next unless mod.forge_name && mod.has_translations?(Puppet::GettextConfig.current_locale)
 
-      module_name = mod.forge_name.tr('/', '-')
+      module_name = mod.forge_name
       if Puppet::GettextConfig.load_translations(module_name, mod.locale_directory, :po)
         Puppet.debug "Loaded translations for #{module_name}."
       elsif Puppet::GettextConfig.gettext_loaded?

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -237,7 +237,7 @@ class Puppet::Module
     @metadata = data = read_metadata
     return if data.empty?
 
-    @forge_name = data['name'].tr('-', '/') if data['name']
+    @forge_name = data['name'].tr('/', '-') if data['name']
 
     [:source, :author, :version, :license, :dependencies].each do |attr|
       value = data[attr.to_s]
@@ -249,7 +249,7 @@ class Puppet::Module
         end
         value.each do |dep|
           name = dep['name']
-          dep['name'] = name.tr('-', '/') unless name.nil?
+          dep['name'] = name.tr('/', '-') unless name.nil?
           dep['version_requirement'] ||= '>= 0.0.0'
         end
       end
@@ -346,7 +346,7 @@ class Puppet::Module
   def dependencies_as_modules
     dependent_modules = []
     dependencies and dependencies.each do |dep|
-      _, dep_name = dep["name"].split('/')
+      _, dep_name = dep["name"].split('-')
       found_module = environment.module(dep_name)
       dependent_modules << found_module if found_module
     end

--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -140,7 +140,7 @@ module Puppet::ModuleTool
             releases.each do |rel|
               installed_module = installed_modules_source.by_name[rel.name.split('-').last]
               if installed_module
-                next if installed_module.has_metadata? && installed_module.forge_name.tr('/', '-') == rel.name
+                next if installed_module.has_metadata? && installed_module.forge_name == rel.name
 
                 if rel.name != name
                   dependency = {
@@ -306,7 +306,7 @@ module Puppet::ModuleTool
           @environment.modules_by_path[options[:target_dir]].each do |mod|
             if mod.has_metadata?
               metadata = {
-                :name    => mod.forge_name.tr('/', '-'),
+                :name    => mod.forge_name,
                 :version => mod.version
               }
               next if release[:module] == metadata[:name]

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -49,7 +49,7 @@ module Puppet::ModuleTool
 
       def find_installed_module
         @environment.modules_by_path.values.flatten.each do |mod|
-          mod_name = (mod.forge_name || mod.name).tr('/', '-')
+          mod_name = (mod.forge_name || mod.name)
           if mod_name == @name
             @unfiltered << {
               :name    => mod_name,
@@ -100,7 +100,7 @@ module Puppet::ModuleTool
           if mod.has_metadata? && !changes.empty?
             raise LocalChangesError,
               :action            => :uninstall,
-              :module_name       => (mod.forge_name || mod.name).tr('/', '-'),
+              :module_name       => (mod.forge_name || mod.name),
               :requested_version => @options[:version],
               :installed_version => mod.version
           end
@@ -108,7 +108,7 @@ module Puppet::ModuleTool
 
         if !@options[:force] && !mod.required_by.empty?
           raise ModuleIsRequiredError,
-            :module_name       => (mod.forge_name || mod.name).tr('/', '-'),
+            :module_name       => (mod.forge_name || mod.name),
             :required_by       => mod.required_by,
             :requested_version => @options[:version],
             :installed_version => mod.version

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -40,7 +40,7 @@ module Puppet::ModuleTool
         begin
           all_modules = @environment.modules_by_path.values.flatten
           matching_modules = all_modules.select do |x|
-            x.forge_name && x.forge_name.tr('/', '-') == name
+            x.forge_name && x.forge_name == name
           end
 
           if matching_modules.empty?
@@ -146,7 +146,7 @@ module Puppet::ModuleTool
           releases.each do |rel|
             mod = installed_modules_source.by_name[rel.name.split('-').last]
             if mod
-              next if mod.has_metadata? && mod.forge_name.tr('/', '-') == rel.name
+              next if mod.has_metadata? && mod.forge_name == rel.name
 
               if rel.name != name
                 dependency = {

--- a/lib/puppet/module_tool/installed_modules.rb
+++ b/lib/puppet/module_tool/installed_modules.rb
@@ -57,7 +57,7 @@ module Puppet::ModuleTool
       def initialize(source, mod)
         @mod = mod
         @metadata = mod.metadata
-        name = mod.forge_name.tr('/', '-')
+        name = mod.forge_name
         begin
           version = SemanticPuppet::Version.parse(mod.version)
         rescue SemanticPuppet::Version::ValidationFailure

--- a/lib/puppet/module_tool/local_tarball.rb
+++ b/lib/puppet/module_tool/local_tarball.rb
@@ -46,7 +46,7 @@ module Puppet::ModuleTool
       def initialize(source, mod)
         @mod = mod
         @metadata = mod.metadata
-        name = mod.forge_name.tr('/', '-')
+        name = mod.forge_name
         version = SemanticPuppet::Version.parse(mod.version)
         release = "#{name}@#{version}"
 

--- a/lib/puppet/module_tool/shared_behaviors.rb
+++ b/lib/puppet/module_tool/shared_behaviors.rb
@@ -8,7 +8,7 @@ module Puppet::ModuleTool::Shared
     @installed  = Hash.new { |h,k| h[k] = [] }
 
     @environment.modules_by_path.values.flatten.each do |mod|
-      mod_name = (mod.forge_name || mod.name).tr('/', '-')
+      mod_name = (mod.forge_name || mod.name)
       @installed[mod_name] << mod
       d = @local["#{mod_name}@#{mod.version}"]
       (mod.dependencies || []).each do |hash|

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -265,14 +265,14 @@ class Puppet::Node::Environment
     modules.find {|mod| mod.name == name}
   end
 
-  # Locate a module instance by the full forge name (EG authorname/module)
+  # Locate a module instance by the full forge name (EG authorname-module)
   #
   # @api public
   #
   # @param forge_name [String] The module name
   # @return [Puppet::Module, nil] The module if found, else nil
   def module_by_forge_name(forge_name)
-    _, modname = forge_name.split('/')
+    _, modname = forge_name.split('-')
     found_mod = self.module(modname)
     found_mod and found_mod.forge_name == forge_name ?
       found_mod :
@@ -394,7 +394,7 @@ class Puppet::Node::Environment
       deps[mod.forge_name] ||= []
 
       mod.dependencies and mod.dependencies.each do |mod_dep|
-        dep_name = mod_dep['name'].tr('-', '/')
+        dep_name = mod_dep['name'].tr('/', '-')
         (deps[dep_name] ||= []) << {
           'name'                => mod.forge_name,
           'version'             => mod.version,

--- a/spec/lib/puppet_spec/modules.rb
+++ b/spec/lib/puppet_spec/modules.rb
@@ -14,7 +14,7 @@ module PuppetSpec::Modules
         metadata[:license] ||= 'to kill'
         metadata[:dependencies] ||= []
 
-        metadata[:name] = "#{metadata[:author]}/#{name}"
+        metadata[:name] = "#{metadata[:author]}-#{name}"
 
         File.open(File.join(module_dir, 'metadata.json'), 'w') do |f|
           f.write(metadata.to_json)

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -140,7 +140,7 @@ describe Puppet::Module do
       Puppet.settings[:modulepath] = @modpath
     end
 
-    it "should resolve module dependencies using forge names" do
+    it "should resolve module dependencies using forge names with slashes" do
       parent = PuppetSpec::Modules.create(
         'parent',
         @modpath,
@@ -166,6 +166,34 @@ describe Puppet::Module do
 
       expect(parent.unmet_dependencies).to eq([])
     end
+
+    it "should resolve module dependencies using hyphenated forge names" do
+      parent = PuppetSpec::Modules.create(
+        'parent',
+        @modpath,
+        :metadata => {
+          :author => 'foo',
+          :dependencies => [{
+            "name" => "foo-child"
+          }]
+        },
+        :environment => env
+      )
+      child = PuppetSpec::Modules.create(
+        'child',
+        @modpath,
+        :metadata => {
+          :author => 'foo',
+          :dependencies => []
+        },
+        :environment => env
+      )
+
+      expect(env).to receive(:module_by_forge_name).with('foo-child').and_return(child)
+
+      expect(parent.unmet_dependencies).to eq([])
+    end
+
 
     it "should list modules that are missing" do
       mod = PuppetSpec::Modules.create(

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -162,7 +162,7 @@ describe Puppet::Module do
         :environment => env
       )
 
-      expect(env).to receive(:module_by_forge_name).with('foo/child').and_return(child)
+      expect(env).to receive(:module_by_forge_name).with('foo-child').and_return(child)
 
       expect(parent.unmet_dependencies).to eq([])
     end
@@ -180,13 +180,13 @@ describe Puppet::Module do
         :environment => env
       )
 
-      expect(env).to receive(:module_by_forge_name).with('baz/foobar').and_return(nil)
+      expect(env).to receive(:module_by_forge_name).with('baz-foobar').and_return(nil)
 
       expect(mod.unmet_dependencies).to eq([{
         :reason => :missing,
-        :name   => "baz/foobar",
+        :name   => "baz-foobar",
         :version_constraint => ">= 2.2.0",
-        :parent => { :name => 'puppetlabs/needy', :version => 'v9.9.9' },
+        :parent => { :name => 'puppetlabs-needy', :version => 'v9.9.9' },
         :mod_details => { :installed_version => nil }
       }])
     end
@@ -204,13 +204,13 @@ describe Puppet::Module do
         :environment => env
       )
 
-      expect(env).to receive(:module_by_forge_name).with('baz/foobar=bar').and_return(nil)
+      expect(env).to receive(:module_by_forge_name).with('baz-foobar=bar').and_return(nil)
 
       expect(mod.unmet_dependencies).to eq([{
         :reason => :missing,
-        :name   => "baz/foobar=bar",
+        :name   => "baz-foobar=bar",
         :version_constraint => ">= 2.2.0",
-        :parent => { :name => 'puppetlabs/needy', :version => 'v9.9.9' },
+        :parent => { :name => 'puppetlabs-needy', :version => 'v9.9.9' },
         :mod_details => { :installed_version => nil }
       }])
     end
@@ -255,17 +255,17 @@ describe Puppet::Module do
 
       expect(mod.unmet_dependencies).to eq([{
         :reason => :version_mismatch,
-        :name   => "baz/foobar",
+        :name   => "baz-foobar",
         :version_constraint => ">= 2.2.0",
-        :parent => { :version => "v9.9.9", :name => "puppetlabs/test_gte_req" },
+        :parent => { :version => "v9.9.9", :name => "puppetlabs-test_gte_req" },
         :mod_details => { :installed_version => "2.0.0" }
       }])
 
       expect(mod2.unmet_dependencies).to eq([{
         :reason => :version_mismatch,
-        :name   => "baz/foobar",
+        :name   => "baz-foobar",
         :version_constraint => "v1.0.0",
-        :parent => { :version => "v9.9.9", :name => "puppetlabs/test_specific_req" },
+        :parent => { :version => "v9.9.9", :name => "puppetlabs-test_specific_req" },
         :mod_details => { :installed_version => "2.0.0" }
       }])
 
@@ -322,9 +322,9 @@ describe Puppet::Module do
 
       expect(mod.unmet_dependencies).to eq([{
         :reason => :non_semantic_version,
-        :parent => { :version => "v9.9.9", :name => "puppetlabs/foobar" },
+        :parent => { :version => "v9.9.9", :name => "puppetlabs-foobar" },
         :mod_details => { :installed_version => "5.1" },
-        :name => "baz/foobar",
+        :name => "baz-foobar",
         :version_constraint => ">= 0.0.0"
       }])
     end
@@ -388,8 +388,8 @@ describe Puppet::Module do
       expect(mod.unmet_dependencies).to eq([{
         :reason => :missing,
         :mod_details => { :installed_version => nil },
-        :parent => { :version => "v9.9.9", :name => "puppetlabs/#{name}" },
-        :name => "baz/notsatisfied",
+        :parent => { :version => "v9.9.9", :name => "puppetlabs-#{name}" },
+        :name => "baz-notsatisfied",
         :version_constraint => ">= 2.2.0"
       }])
     end
@@ -952,12 +952,12 @@ describe Puppet::Module do
     )
     expect(dependable.required_by).to match_array([
       {
-        "name"    => "beggar/needy",
+        "name"    => "beggar-needy",
         "version" => "9.9.9",
         "version_requirement" => ">= 2.2.0"
       },
       {
-        "name"    => "spoiled/wantit",
+        "name"    => "spoiled-wantit",
         "version" => "9.9.9",
         "version_requirement" => "< 5.0.0"
       }

--- a/spec/unit/module_tool/applications/uninstaller_spec.rb
+++ b/spec/unit/module_tool/applications/uninstaller_spec.rb
@@ -51,7 +51,7 @@ describe Puppet::ModuleTool::Applications::Uninstaller do
     before { preinstall('pmtacceptance-apache', '0.0.4') }
 
     it "should uninstall the module" do
-      expect(subject[:affected_modules].first.forge_name).to eq("pmtacceptance/stdlib")
+      expect(subject[:affected_modules].first.forge_name).to eq("pmtacceptance-stdlib")
     end
 
     it "should only uninstall the requested module" do
@@ -159,7 +159,7 @@ describe Puppet::ModuleTool::Applications::Uninstaller do
 
         it "should ignore local changes" do
           expect(subject[:affected_modules].length).to eq(1)
-          expect(subject[:affected_modules].first.forge_name).to eq("pmtacceptance/stdlib")
+          expect(subject[:affected_modules].first.forge_name).to eq("pmtacceptance-stdlib")
         end
 
         it 'uninstalls in FIPS mode' do
@@ -173,7 +173,7 @@ describe Puppet::ModuleTool::Applications::Uninstaller do
 
         it "should ignore broken dependencies" do
           expect(subject[:affected_modules].length).to eq(1)
-          expect(subject[:affected_modules].first.forge_name).to eq("pmtacceptance/stdlib")
+          expect(subject[:affected_modules].first.forge_name).to eq("pmtacceptance-stdlib")
         end
       end
     end

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -311,32 +311,32 @@ describe Puppet::Node::Environment do
             )
 
             expect(env.module_requirements).to eq({
-              'puppetlabs/alpha' => [],
-              'puppetlabs/foo' => [
+              'puppetlabs-alpha' => [],
+              'puppetlabs-foo' => [
                 {
-                  "name"    => "puppetlabs/bar",
+                  "name"    => "puppetlabs-bar",
                   "version" => "9.9.9",
                   "version_requirement" => "<= 2.0.0"
                 }
               ],
-              'puppetlabs/bar' => [
+              'puppetlabs-bar' => [
                 {
-                  "name"    => "puppetlabs/alpha",
+                  "name"    => "puppetlabs-alpha",
                   "version" => "9.9.9",
                   "version_requirement" => "~3.0.0"
                 },
                 {
-                  "name"    => "puppetlabs/baz",
+                  "name"    => "puppetlabs-baz",
                   "version" => "9.9.9",
                   "version_requirement" => "3.0.0"
                 },
                 {
-                  "name"    => "puppetlabs/foo",
+                  "name"    => "puppetlabs-foo",
                   "version" => "9.9.9",
                   "version_requirement" => ">= 1.0.0"
                 }
               ],
-              'puppetlabs/baz' => []
+              'puppetlabs-baz' => []
             })
           end
         end
@@ -348,7 +348,7 @@ describe Puppet::Node::Environment do
               first_modulepath,
               module_options
             )
-            expect(env.module_by_forge_name('puppetlabs/baz')).to eq(mod)
+            expect(env.module_by_forge_name('puppetlabs-baz')).to eq(mod)
           end
 
           it "does not find modules with same name by the wrong author" do
@@ -358,11 +358,11 @@ describe Puppet::Node::Environment do
               :metadata => {:author => 'sneakylabs'},
               :environment => env
             )
-            expect(env.module_by_forge_name('puppetlabs/baz')).to eq(nil)
+            expect(env.module_by_forge_name('puppetlabs-baz')).to eq(nil)
           end
 
           it "returns nil when the module can't be found" do
-            expect(env.module_by_forge_name('ima/nothere')).to be_nil
+            expect(env.module_by_forge_name('ima-nothere')).to be_nil
           end
         end
 


### PR DESCRIPTION
This just corrects the separator on the `forge_name` attribute of
modules now that we've standardized on the `-` rather than the `/`. All
the tests having to do with modules pass. I don't know if I'm
misunderstanding the full scope of what this method is intended for
though, so please don't merge without review by someone who knows that
part of the code and the history of the forge name inconsistencies.