### PR TITLE
(PUP-10241) Force UTF-8 encoding on XML plist data

### DIFF
--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -1,5 +1,8 @@
 test_name "#8740: should not enumerate root directory"
+
 confine :except, :platform => 'windows'
+confine :except, :platform => /osx-10.1[5-9]/
+
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
     'audit:acceptance'

--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -2,6 +2,9 @@ test_name "should allow password, salt, and iteration attributes in OSX"
 
 confine :to, :platform => /osx/
 
+# TODO PUP-10246: fix user password management on macOS >= 10.15
+confine :except, :platform => /osx-10.1[5-9]/
+
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would

--- a/acceptance/tests/resource/user/should_modify_home.rb
+++ b/acceptance/tests/resource/user/should_modify_home.rb
@@ -1,6 +1,6 @@
 test_name "should modify the home directory of an user on OS X < 10.14" do
   confine :to, :platform => /osx/
-  confine :except, :platform => /osx-10.14/
+  confine :except, :platform => /osx-10.1[4-9]/
 
   tag 'audit:medium',
       'audit:acceptance' # Could be done as integration tests, but would

--- a/acceptance/tests/resource/user/should_modify_uid.rb
+++ b/acceptance/tests/resource/user/should_modify_uid.rb
@@ -1,6 +1,6 @@
 test_name "should modify the uid of an user OS X < 10.14" do
   confine :to, :platform => /osx/
-  confine :except, :platform => /osx-10.14/
+  confine :except, :platform => /osx-10.1[4-9]/
 
   tag 'audit:medium',
       'audit:acceptance' # Could be done as integration tests, but would

--- a/lib/puppet/util/plist.rb
+++ b/lib/puppet/util/plist.rb
@@ -56,6 +56,12 @@ module Puppet::Util::Plist
     # Read plist text using the CFPropertyList gem.
     def parse_plist(plist_data, file_path = '')
       bad_xml_doctype = /^.*<!DOCTYPE plist PUBLIC -\/\/Apple Computer.*$/
+      # Depending on where parse_plist is called from, plist_data can be either XML or binary.
+      # If we get XML, make sure ruby knows it's UTF-8 so we avoid invalid byte sequence errors.
+      if plist_data.include?('encoding="UTF-8"') && plist_data.encoding != Encoding::UTF_8
+        plist_data.force_encoding(Encoding::UTF_8)
+      end
+
       begin
         if plist_data =~ bad_xml_doctype
           plist_data.gsub!( bad_xml_doctype, plist_xml_doctype )

--- a/spec/unit/util/plist_spec.rb
+++ b/spec/unit/util/plist_spec.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 require 'spec_helper'
 require 'puppet/util/plist'
 require 'puppet_spec/files'
@@ -52,6 +54,19 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
     </dict>
     </plist>'
   end
+  let(:ascii_xml_plist) do
+    '<?xml version="1.0" encoding="UTF-8"?>
+     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+     <plist version="1.0">
+     <dict>
+       <key>RecordName</key>
+         <array>
+           <string>Timișoara</string>
+           <string>Tōkyō</string>
+         </array>
+     </dict>
+     </plist>'.force_encoding(Encoding::US_ASCII)
+  end
   let(:non_plist_data) do
     "Take my love, take my land
      Take me where I cannot stand
@@ -62,6 +77,7 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
     "\xCF\xFA\xED\xFE\a\u0000\u0000\u0001\u0003\u0000\u0000\x80\u0002\u0000\u0000\u0000\u0012\u0000\u0000\u0000\b"
   end
   let(:valid_xml_plist_hash) { {"LastUsedPrinters"=>[{"Network"=>"10.85.132.1", "PrinterID"=>"baskerville_corp_puppetlabs_net"}, {"Network"=>"10.14.96.1", "PrinterID"=>"Statler"}]} }
+  let(:ascii_xml_plist_hash) { {"RecordName"=>["Timișoara", "Tōkyō"]} }
   let(:plist_path) { file_containing('sample.plist', valid_xml_plist) }
   let(:binary_plist_magic_number) { 'bplist00' }
   let(:bad_xml_doctype) { '<!DOCTYPE plist PUBLIC -//Apple Computer' }
@@ -130,6 +146,10 @@ describe Puppet::Util::Plist, :if => Puppet.features.cfpropertylist? do
   describe "#parse_plist" do
     it "returns a valid hash when a valid XML plist is provided" do
       expect(subject.parse_plist(valid_xml_plist)).to eq(valid_xml_plist_hash)
+    end
+
+    it "returns a valid hash when an ASCII XML plist is provided" do
+      expect(subject.parse_plist(ascii_xml_plist)).to eq(ascii_xml_plist_hash)
     end
 
     it "raises a debug message and replaces a bad XML plist doctype should one be encountered" do


### PR DESCRIPTION
Apple Property List (plist) XML data is always UTF-8. When executing commands such as `/usr/bin/dscl -plist . readall /Groups`, Puppet would consider the command output to be US-ASCII, which could ultimately break if the output contained non-ASCII characters. Until now this didn't seem to be an issue, but with the addition of macOS 10.15 (Catalina) this isn't the case anymore.

The `Puppet::Util::Plist.parse_plist` method can be called with either XML or binary data, and based on this we can force the encoding of the XML data to UTF-8.

With a non-existing user:
```sh-session
> puppet resource user testuser ensure=present --debug
...
Debug: Prefetching directoryservice resources for user
Debug: Executing: '/usr/bin/dscl -plist . readall /Users'
Debug: Executing: '/usr/bin/dscl -plist . readall /Groups'
Debug: Failed with ArgumentError on : #<ArgumentError: invalid byte sequence in US-ASCII>
Error: Could not prefetch user provider 'directoryservice': undefined method `each' for nil:NilClass
Debug: Storing state
Debug: Pruned old state cache entries in 0.00 seconds
Debug: Stored state in 0.01 seconds
Error: Could not run: undefined method `each' for nil:NilClass
```