### PR TITLE
(PUP-10240) Move development gem dependencies to .gemspec

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -40,6 +40,16 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
   s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
 
+  s.add_development_dependency("json-schema", "~> 2.0")
+  s.add_development_dependency("rake", "~> 12.2")
+  s.add_development_dependency("rspec", "~> 3.1")
+  s.add_development_dependency("rspec-its", "~> 1.1")
+  s.add_development_dependency("vcr", "~> 5.0")
+  s.add_development_dependency("webmock", "~> 3.0")
+  s.add_development_dependency("yard")
+  s.add_development_dependency("rubocop", "~> 0.49")
+  s.add_development_dependency("rubocop-i18n", "~> 1.2.0")
+
   # loads platform specific gems like ffi, win32 platform gems
   # as additional runtime dependencies
   gem_deps_path = File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml')

--- a/.gemspec
+++ b/.gemspec
@@ -30,15 +30,15 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
-  s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 4"])
-  s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
-  s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
-  s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1")
-  s.add_runtime_dependency(%q<locale>, "~> 2.1")
-  s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
-  s.add_runtime_dependency(%q<httpclient>, "~> 2.8")
-  s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
-  s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
+  s.add_runtime_dependency("facter", [">= 2.4.0", "< 4"])
+  s.add_runtime_dependency("hiera", [">= 3.2.1", "< 4"])
+  s.add_runtime_dependency("semantic_puppet", "~> 1.0")
+  s.add_runtime_dependency("fast_gettext", "~> 1.1")
+  s.add_runtime_dependency("locale", "~> 2.1")
+  s.add_runtime_dependency("multi_json", "~> 1.13")
+  s.add_runtime_dependency("httpclient", "~> 2.8")
+  s.add_runtime_dependency("concurrent-ruby", "~> 1.0")
+  s.add_runtime_dependency("deep_merge", "~> 1.0")
 
   s.add_development_dependency("json-schema", "~> 2.0")
   s.add_development_dependency("rake", "~> 12.2")

--- a/Gemfile
+++ b/Gemfile
@@ -35,19 +35,6 @@ group(:features) do
   gem 'puppetserver-ca', '~> 1.1', require: false
 end
 
-group(:test) do
-  gem "json-schema", "~> 2.0", require: false
-  gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2')
-  gem "rspec", "~> 3.1", require: false
-  gem "rspec-its", "~> 1.1", require: false
-  gem 'vcr', '~> 5.0', require: false
-  gem 'webmock', '~> 3.0', require: false
-  gem 'yard', require: false
-
-  gem 'rubocop', '~> 0.49', require: false, platforms: [:ruby]
-  gem 'rubocop-i18n', '~> 1.2.0', require: false, platforms: [:ruby]
-end
-
 group(:profiling, optional: true) do
   gem 'memory_profiler', require: false, platforms: [:mri]
   gem 'pry', require: false, platforms: [:ruby]

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group(:test) do
   gem 'rubocop-i18n', '~> 1.2.0', require: false, platforms: [:ruby]
 end
 
-group(:development, optional: true) do
+group(:profiling, optional: true) do
   gem 'memory_profiler', require: false, platforms: [:mri]
   gem 'pry', require: false, platforms: [:ruby]
   gem "racc", "1.4.9", require: false, platforms: [:ruby]

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -43,7 +43,7 @@ To run a scenario you do:
 ## Profiling Benchmarks
 
 You can also run `heap_dump`, `memory_profile` or `profile` tasks for each
-scenario. You'll first need to run `bundle install --with development` to
+scenario. You'll first need to run `bundle install --with profiling` to
 install the prerequisite gems.
 
 The `heap_dump` task generates a heap dump with object allocation

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -27,6 +27,16 @@ gem_runtime_dependencies:
   puppet-resource_api: '~>1.5'
   concurrent-ruby: '~> 1.0'
   deep_merge: '~> 1.0'
+gem_development_dependencies:
+  json-schema: '~> 2.0'
+  rake: '~> 12.2'
+  rspec: '~> 3.1'
+  rspec-its: '~> 1.1'
+  vcr: '~> 5.0'
+  webmock: '~> 3.0'
+  yard:
+  rubocop: '~> 0.49'
+  rubocop-i18n: '~> 1.2.0'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -105,7 +105,7 @@ namespace :benchmark do
         begin
           require 'memory_profiler'
         rescue LoadError
-          abort("Run `bundle install --with development` to install the 'memory_profiler' gem.")
+          abort("Run `bundle install --with profiling` to install the 'memory_profiler' gem.")
         end
 
         report = MemoryProfiler.report do

--- a/tasks/parser.rake
+++ b/tasks/parser.rake
@@ -17,6 +17,6 @@ task :require_racc do
   begin
     require 'racc'
   rescue LoadError
-    abort("Run `bundle install --with development` to install the `racc` gem.")
+    abort("Run `bundle install --with profiling` to install the `racc` gem.")
   end
 end


### PR DESCRIPTION
Move development gem dependencies from the Gemfile to .gemspec and project_data.yaml. As a result, the dependencies are included in the published puppet gem.

It is no longer possible to specify `RAKE_LOCATION` as an environment variable,
but that is no longer needed in 6.x, as we relaxed the constraint in 2c6bdea.