### PR TITLE
(maint) Delete sync requires

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -1,5 +1,4 @@
 # The client for interacting with the puppetmaster config server.
-require 'sync'
 require 'timeout'
 require 'puppet/network/http_pool'
 require 'puppet/util'

--- a/lib/puppet/util/storage.rb
+++ b/lib/puppet/util/storage.rb
@@ -1,5 +1,4 @@
 require 'yaml'
-require 'sync'
 require 'singleton'
 require 'puppet/util/yaml'
 


### PR DESCRIPTION
Puppet used to rely on sync, but that was removed awhile ago. Remove the
orphaned require statements in preparation for ruby 2.7, as sync is now an
external gem.