### PR TITLE
(PUP-2820) Print meaningful disable_warnings error message

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -168,8 +168,8 @@ module Puppet
         valid   = %w[deprecations undefined_variables undefined_resources]
         invalid = values - (values & valid)
         if not invalid.empty?
-          raise ArgumentError, _("Cannot disable unrecognized warning types %{invalid}.") % { invalid: invalid.inspect } +
-              ' ' + _("Valid values are %{values}.") % { values: valid.inspect}
+          raise ArgumentError, _("Cannot disable unrecognized warning types '%{invalid}'.") % { invalid: invalid.join(',') } +
+              ' ' + _("Valid values are '%{values}'.") % { values: valid.join(', ') }
         end
       end
     },


### PR DESCRIPTION
Since disable_warnings is an array-based setting, join the values so the error
message describes what valid input looks like:

    Cannot disable unrecognized warning types 'foo'. Valid values are 'deprecations, undefined_variables, undefined_resources'.

Previously it displayed a stringified array, which isn't a valid value for
that setting:

    Cannot disable unrecognized warning types ["foo"]. Valid values are ["deprecations", "undefined_variables", "undefined_resources"].