### PR TITLE
(PUP-3721) Include provider parameter in puppet resource output

### DIFF
--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -5,7 +5,7 @@ class Puppet::Application::Resource < Puppet::Application
   attr_accessor :host, :extra_params
 
   def preinit
-    @extra_params = []
+    @extra_params = [:provider]
   end
 
   option("--debug","-d")

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -12,9 +12,9 @@ describe Puppet::Application::Resource do
   end
 
   describe "in preinit" do
-    it "should init extra_params to empty array" do
+    it "should include provider parameter by default" do
       @resource_app.preinit
-      expect(@resource_app.extra_params).to eq([])
+      expect(@resource_app.extra_params).to eq([:provider])
     end
   end
 


### PR DESCRIPTION
The `puppet resource <type>` command lists all instances from all suitable
providers. However, the output is ambiguous when a resource with the same name
but different providers is present, such as gem and rpm/apt packages.

Include the provider parameter in the output of `puppet resource` to avoid
ambiguity.