### PR TITLE
(PUP-3970) Remove wide string terminator workaround

### DIFF
--- a/lib/puppet/util/windows/eventlog.rb
+++ b/lib/puppet/util/windows/eventlog.rb
@@ -126,13 +126,8 @@ class Puppet::Util::Windows::EventLog
   def wide_string(str)
     # if given a nil string, assume caller wants to pass a nil pointer to win32
     return nil if str.nil?
-    # ruby (< 2.1) does not respect multibyte terminators, so it is possible
-    # for a string to contain a single trailing null byte, followed by garbage
-    # causing buffer overruns.
-    #
-    # See http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=41920&view=revision
-    newstr = str + "\0".encode(str.encoding)
-    newstr.encode!('UTF-16LE')
+
+    str.encode('UTF-16LE')
   end
 
   # Private duplicate of Puppet::Util::Windows::ApiTypes::from_string_to_wide_string

--- a/lib/puppet/util/windows/string.rb
+++ b/lib/puppet/util/windows/string.rb
@@ -4,13 +4,8 @@ module Puppet::Util::Windows::String
   def wide_string(str)
     # if given a nil string, assume caller wants to pass a nil pointer to win32
     return nil if str.nil?
-    # ruby (< 2.1) does not respect multibyte terminators, so it is possible
-    # for a string to contain a single trailing null byte, followed by garbage
-    # causing buffer overruns.
-    #
-    # See http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=41920&view=revision
-    newstr = str + "\0".encode(str.encoding)
-    newstr.encode!('UTF-16LE')
+
+    str.encode('UTF-16LE')
   end
   module_function :wide_string
 end

--- a/spec/unit/util/windows/string_spec.rb
+++ b/spec/unit/util/windows/string_spec.rb
@@ -4,15 +4,13 @@ require 'spec_helper'
 require 'puppet/util/windows'
 
 describe "Puppet::Util::Windows::String", :if => Puppet::Util::Platform.windows? do
-  UTF16_NULL = [0, 0]
-
   def wide_string(str)
     Puppet::Util::Windows::String.wide_string(str)
   end
 
   def converts_to_wide_string(string_value)
     expected = string_value.encode(Encoding::UTF_16LE)
-    expected_bytes = expected.bytes.to_a + UTF16_NULL
+    expected_bytes = expected.bytes.to_a
 
     expect(wide_string(string_value).bytes.to_a).to eq(expected_bytes)
   end


### PR DESCRIPTION
Ruby < 2.1 did not correctly handle multibyte terminators when allocating and
resizing wide strings, causing data to be read past the end of the buffer. It
was fixed in ruby 2.1.0[1], which we no longer support.

Ruby < 2.4 did not correct handle multibyte terminators when transcoding
strings, such as when calling `String#force_encoding('UTF-16')` and converting
the binary string with a single null terminator to a wide string with a wide
terminator. That was fixed in 2.4.0[2] and backported to 2.3 in [3], which is
the minimum version we support.

[1] https://github.com/ruby/ruby/commit/1549894a0699abdfab1fbba0e468afd3f2f990b3
[2] https://github.com/ruby/ruby/commit/f2ee22371b15411e818b23199161d1658ba08622
[3] https://github.com/ruby/ruby/commit/6f122a4f10512bb60795faa0021e498800a7f1b8

This is blocked on https://github.com/puppetlabs/puppet/pull/7943 and https://github.com/puppetlabs/puppet/pull/8202 and having those changes merged to master.