### PR TITLE
(PUP-10210) 'unlimited' puppet config fails in fact

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1820,7 +1820,7 @@ EOT
       #{AS_DURATION}",
     },
     :maxwaitforcert => {
-      :default  => "unlimited",
+      :default  => "2147483647",
       :type     => :ttl,
       :desc     => "The maximum amount of time the Puppet agent should wait for its
       certificate request to be signed. A value of `unlimited` will cause puppet agent

--- a/lib/puppet/settings/ttl_setting.rb
+++ b/lib/puppet/settings/ttl_setting.rb
@@ -16,6 +16,9 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
   # A regex describing valid formats with groups for capturing the value and units
   FORMAT = /^(\d+)(y|d|h|m|s)?$/
 
+  # Value representing 'unlimited' (MAX_INT)(2147483647)
+  UNLIMITED_VALUE = 2**31 - 1
+
   def type
     :ttl
   end
@@ -27,7 +30,7 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
 
   def print(value)
     val = munge(value)
-    val == Float::INFINITY ? 'unlimited' : val
+    val == UNLIMITED_VALUE ? 'unlimited' : val
   end
 
   # Convert the value to Numeric, parsing numeric string with units if necessary.
@@ -40,7 +43,7 @@ class Puppet::Settings::TTLSetting < Puppet::Settings::BaseSetting
       value
 
     when value == 'unlimited'
-      Float::INFINITY
+     UNLIMITED_VALUE
 
     when (value.is_a?(String) and value =~ FORMAT)
       $1.to_i * UNITMAP[$2 || 's']

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -859,9 +859,10 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::NeedCACerts)
       end
 
-      it 'waits indefinitely by default' do
+      it 'waits almost indefinitely by default' do
         machine = described_class.new
-        expect(machine.wait_deadline).to eq(Float::INFINITY)
+        # wait_deadline should be increased by INT_MAX seconds (+- 2 seconds)
+        expect(machine.wait_deadline).to be_within(2).of(Time.now.to_i + (2**31 - 1))
       end
 
       it 'exits with 1 if maxwaitforcert is exceeded' do


### PR DESCRIPTION
If a custom fact returs a puppet settings that is 'unlimited', the JSON
parser will fail because it cannot treat Infinity.
Now puppet settings of ttl type that are set to 'unlimited' will have the value of
2147483647.
Also changed default value for maxtimeforcert setting from 'unlimited' to 2147483647.