### PR TITLE
(PUP-10246) Use dsimport to set OS X user passwords on macOS 10.15 and higher

### DIFF
--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -2,9 +2,6 @@ test_name "should allow password, salt, and iteration attributes in OSX"
 
 confine :to, :platform => /osx/
 
-# TODO PUP-10246: fix user password management on macOS >= 10.15
-confine :except, :platform => /osx-10.1[5-9]/
-
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -386,7 +386,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     if (Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.7') > 0)
       assert_full_pbkdf2_password
 
-      sleep 2
+      sleep 3
       flush_dscl_cache
       users_plist = get_users_plist(@resource.name)
       shadow_hash_data = get_shadow_hash_data(users_plist)
@@ -403,7 +403,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     if (Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.7') > 0)
       assert_full_pbkdf2_password
 
-      sleep 2
+      sleep 3
       flush_dscl_cache
       users_plist = get_users_plist(@resource.name)
       shadow_hash_data = get_shadow_hash_data(users_plist)
@@ -571,7 +571,32 @@ Puppet::Type.type(:user).provide :directoryservice do
     else
       users_plist['ShadowHashData'] = [binary_plist]
     end
-    write_users_plist_to_disk(users_plist)
+    if Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.15') < 0
+      write_users_plist_to_disk(users_plist)
+    else
+      write_and_import_shadow_hash_data(users_plist['ShadowHashData'].first)
+    end
+  end
+
+  # This method writes the ShadowHashData plist in a temporary file,
+  # then imports it using dsimport. macOS versions 10.15 and newer do
+  # not support directly managing binary plists, so we have to use an
+  # intermediary.
+  # dsimport is an archaic utilitary with hard-to-find documentation
+  #
+  # See http://web.archive.org/web/20090106120111/http://support.apple.com/kb/TA21305?viewlocale=en_US
+  # for information regarding the dsimport syntax
+  def write_and_import_shadow_hash_data(data_plist)
+    Tempfile.create("dsimport_#{@resource.name}", :encoding => Encoding::ASCII) do |dsimport_file|
+      dsimport_file.write <<-DSIMPORT
+0x0A 0x5C 0x3A 0x2C dsRecTypeStandard:Users 2 dsAttrTypeStandard:RecordName base64:dsAttrTypeNative:ShadowHashData
+#{@resource.name}:#{Base64.strict_encode64(data_plist)}
+      DSIMPORT
+      dsimport_file.flush
+      # Delete the user's existing ShadowHashData, since dsimport appends, not replaces
+      dscl('.', 'delete', "/Users/#{@resource.name}", 'ShadowHashData')
+      dsimport(dsimport_file.path, '/Local/Default', 'M')
+    end
   end
 
   # This method accepts an argument of a hex password hash, and base64


### PR DESCRIPTION
Due to macOS 10.15 no longer allowing direct manipulation of binary
plists under `/var/db/dslocal/nodes/Default/users`, we cannot set or
change user passwords.

This commmit implements a workaround involving the `dsimport` utlilty,
which we can use to directly manipulate the user plists.

We also sleep for one more second before flushing the dscl cache,
since the cache takes longer to populate after using `dsimport`.