### PR TITLE
(maint) Backport ignore X509 purpose during cert verification

### DIFF
--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -441,11 +441,11 @@ class Puppet::SSL::CertificateAuthority
   # Certificate Revocation List and flags
   #
   # @return [OpenSSL::X509::Store]
-  def create_x509_store
-    store = OpenSSL::X509::Store.new()
+  def create_x509_store(purpose)
+    store = OpenSSL::X509::Store.new
     store.add_file(Puppet[:cacert])
     store.add_crl(crl.content) if self.crl
-    store.purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT
+    store.purpose = purpose
     if Puppet.lookup(:certificate_revocation)
       store.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL | OpenSSL::X509::V_FLAG_CRL_CHECK
     end
@@ -486,17 +486,18 @@ class Puppet::SSL::CertificateAuthority
   # certificate with that name.
   #
   # @param name [String] certificate name to verify
+  # @param purpose [Integer] bitwise combination of X509::PURPOSE_*
   #
   # @raise [ArgumentError] if the certificate name cannot be found
   #   (i.e. doesn't exist or is unsigned)
   # @raise [CertificateVerficationError] if the certificate has been revoked
   #
   # @return [Boolean] true if signed, there are no cases where false is returned
-  def verify(name)
+  def verify(name, purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT)
     unless cert = Puppet::SSL::Certificate.indirection.find(name)
       raise ArgumentError, _("Could not find a certificate for %{name}") % { name: name }
     end
-    store = create_x509_store
+    store = create_x509_store(purpose)
 
     raise CertificateVerificationError.new(store.error), store.error_string unless store.verify(cert.content)
   end

--- a/lib/puppet/ssl/certificate_authority.rb
+++ b/lib/puppet/ssl/certificate_authority.rb
@@ -441,7 +441,7 @@ class Puppet::SSL::CertificateAuthority
   # Certificate Revocation List and flags
   #
   # @return [OpenSSL::X509::Store]
-  def create_x509_store(purpose)
+  def create_x509_store(purpose = OpenSSL::X509::PURPOSE_ANY)
     store = OpenSSL::X509::Store.new
     store.add_file(Puppet[:cacert])
     store.add_crl(crl.content) if self.crl
@@ -493,7 +493,7 @@ class Puppet::SSL::CertificateAuthority
   # @raise [CertificateVerficationError] if the certificate has been revoked
   #
   # @return [Boolean] true if signed, there are no cases where false is returned
-  def verify(name, purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT)
+  def verify(name, purpose = OpenSSL::X509::PURPOSE_ANY)
     unless cert = Puppet::SSL::Certificate.indirection.find(name)
       raise ArgumentError, _("Could not find a certificate for %{name}") % { name: name }
     end

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -877,8 +877,7 @@ describe Puppet::SSL::CertificateAuthority do
       end
 
       it "should set the store purpose to OpenSSL::X509::PURPOSE_SSL_CLIENT" do
-        Puppet[:cacert] = cacert
-        expect(@store).to receive(:add_file).with(cacert)
+        @store.expects(:purpose=).with OpenSSL::X509::PURPOSE_SSL_CLIENT
 
         @ca.verify("me")
       end

--- a/spec/unit/ssl/certificate_authority_spec.rb
+++ b/spec/unit/ssl/certificate_authority_spec.rb
@@ -876,8 +876,8 @@ describe Puppet::SSL::CertificateAuthority do
         @ca.verify("me")
       end
 
-      it "should set the store purpose to OpenSSL::X509::PURPOSE_SSL_CLIENT" do
-        @store.expects(:purpose=).with OpenSSL::X509::PURPOSE_SSL_CLIENT
+      it "should set the store purpose to OpenSSL::X509::PURPOSE_ANY" do
+        expect(@store).to receive(:purpose=).with OpenSSL::X509::PURPOSE_ANY
 
         @ca.verify("me")
       end


### PR DESCRIPTION
Backport PUP-9064 as specs fail when running with openssl 1.1 due to
certificate verification now checking the purpose field.

The puppet cert, ca, etc subcommands have various methods for
determining if a certificate is valid. This is used to see which certs
have been signed, are still waiting to be signed, or have been revoked.
Historically, puppet set the purpose to PURPOSE_SSL_CLIENT on the
X509::Store used to verify certificates, but ruby+openssl 1.0 ignored
it. When using openssl 1.1, purpose is checked, which causes
CertificateAuthority#verify to raise an error when verifying the puppet
CA cert, since it doesn't have the 'SSL Client' purpose. This
corresponds to the 'id-kp-clientAuth' extended key usage extension[1].

However, puppet doesn't really need to care about the purpose when
determining if the cert has been signed, is expired, or revoked. This
commit changes the verify method to default to PURPOSE_ANY, and
preserves the behavior prior to openssl 1.1.

Note this does not affect TLS communication between the agent and
server. When acting as an SSL client, openssl always verifies that the
server's cert has the id-kp-serverAuth extended key usage extension. If
it doesn't, openssl sends a fatal TLS alert message of type 42 'Bad
Certificate' and closes the connection.

[1] https://tools.ietf.org/html/rfc5280#section-4.2.1.12