### PR TITLE
(maint) Speed up rspec tests

### DIFF
--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -146,6 +146,10 @@ module Puppet::Test
       Puppet::SSL::Host.reset
       Puppet::SSL::Host.ca_location = :none
 
+      Puppet::Node::Facts.indirection.terminus_class = :memory
+      facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
+      Puppet::Node::Facts.indirection.save(facts)
+
       Puppet.clear_deprecation_warnings
     end
 

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -143,6 +143,9 @@ module Puppet::Test
       Puppet::Application.clear!
       Puppet::Util::Profiler.clear
 
+      Puppet::SSL::Host.reset
+      Puppet::SSL::Host.ca_location = :none
+
       Puppet.clear_deprecation_warnings
     end
 

--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -8,6 +8,10 @@ describe Puppet::Node::Facts::Facter do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 
+  before :each do
+    Puppet::Node::Facts.indirection.terminus_class = :facter
+  end
+
   it "preserves case in fact values" do
     Facter.add(:downcase_test) do
       setcode do

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -14,14 +14,6 @@ describe Puppet::Application::Apply do
     Puppet[:reports] = "none"
   end
 
-  after :each do
-    Puppet::Node::Facts.indirection.reset_terminus_class
-    Puppet::Node::Facts.indirection.cache_class = nil
-
-    Puppet::Node.indirection.reset_terminus_class
-    Puppet::Node.indirection.cache_class = nil
-  end
-
   [:debug,:loadclasses,:test,:verbose,:use_nodes,:detailed_exitcodes,:catalog, :write_catalog_summary].each do |option|
     it "should declare handle_#{option} method" do
       expect(@apply).to respond_to("handle_#{option}".to_sym)
@@ -182,13 +174,11 @@ describe Puppet::Application::Apply do
         Puppet[:prerun_command] = ''
         Puppet[:postrun_command] = ''
 
-        Puppet::Node::Facts.indirection.terminus_class = :memory
-        Puppet::Node::Facts.indirection.cache_class = :memory
         Puppet::Node.indirection.terminus_class = :memory
         Puppet::Node.indirection.cache_class = :memory
 
-        @facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
-        Puppet::Node::Facts.indirection.save(@facts)
+        facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
+        Puppet::Node::Facts.indirection.save(facts)
 
         @node = Puppet::Node.new(Puppet[:node_name_value])
         Puppet::Node.indirection.save(@node)

--- a/spec/unit/configurer/fact_handler_spec.rb
+++ b/spec/unit/configurer/fact_handler_spec.rb
@@ -22,10 +22,6 @@ describe Puppet::Configurer::FactHandler do
 
   let(:facthandler) { FactHandlerTester.new('production') }
 
-  before :each do
-    Puppet::Node::Facts.indirection.terminus_class = :memory
-  end
-
   describe "when finding facts" do
     it "should use the node name value to retrieve the facts" do
       foo_facts = Puppet::Node::Facts.new('foo')

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -4,9 +4,6 @@ require 'webmock/rspec'
 
 describe Puppet::Configurer do
   before do
-    Puppet::Node::Facts.indirection.terminus_class = :memory
-    Puppet::Node::Facts.indirection.save(facts)
-
     Puppet[:server] = "puppetmaster"
     Puppet[:report] = true
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -9,19 +9,9 @@ describe Puppet::Resource::Catalog::Compiler do
   let(:node_name) { "foo" }
   let(:node) { Puppet::Node.new(node_name)}
 
-  before do
-    allow(Facter).to receive(:to_hash).and_return({})
-  end
-
   describe "when initializing" do
     before do
-      expect(Puppet).to receive(:version).and_return(1)
-      expect(Facter).to receive(:value).with('fqdn').and_return("my.server.com")
-      expect(Facter).to receive(:value).with('ipaddress').and_return("my.ip.address")
-    end
-
-    it "should gather data about itself" do
-      Puppet::Resource::Catalog::Compiler.new
+      allow(Puppet).to receive(:version).and_return(1)
     end
 
     it "should cache the server metadata and reuse it" do
@@ -38,8 +28,6 @@ describe Puppet::Resource::Catalog::Compiler do
 
   describe "when finding catalogs" do
     before do
-      allow(Facter).to receive(:value).and_return("whatever")
-
       allow(node).to receive(:merge)
       allow(Puppet::Node.indirection).to receive(:find).and_return(node)
       @request = Puppet::Indirector::Request.new(:catalog, :find, node_name, nil, :node => node_name)
@@ -246,10 +234,10 @@ describe Puppet::Resource::Catalog::Compiler do
 
   describe "when handling a request with facts" do
     before do
-      Puppet::Node::Facts.indirection.terminus_class = :memory
       allow(Facter).to receive(:value).and_return("something")
 
-      @facts = Puppet::Node::Facts.new('hostname', "fact" => "value", "architecture" => "i386")
+      facts = Puppet::Node::Facts.new('hostname', "fact" => "value", "architecture" => "i386")
+      Puppet::Node::Facts.indirection.save(facts)
     end
 
     def a_legacy_request_that_contains(facts, format = :pson)
@@ -267,6 +255,8 @@ describe Puppet::Resource::Catalog::Compiler do
     end
 
     context "when extracting facts from the request" do
+      let(:facts) { Puppet::Node::Facts.new("hostname") }
+
       it "should do nothing if no facts are provided" do
         request = Puppet::Indirector::Request.new(:catalog, :find, "hostname", nil)
         request.options[:facts] = nil
@@ -276,21 +266,21 @@ describe Puppet::Resource::Catalog::Compiler do
 
       it "should deserialize the facts without changing the timestamp" do
         time = Time.now
-        @facts.timestamp = time
-        request = a_request_that_contains(@facts)
+        facts.timestamp = time
+        request = a_request_that_contains(facts)
         facts = compiler.extract_facts_from_request(request)
         expect(facts.timestamp).to eq(time)
       end
 
       it "accepts PSON facts from older agents" do
-        request = a_legacy_request_that_contains(@facts)
+        request = a_legacy_request_that_contains(facts)
 
         facts = compiler.extract_facts_from_request(request)
-        expect(facts).to eq(@facts)
+        expect(facts).to eq(facts)
       end
 
       it "rejects YAML facts" do
-        request = a_legacy_request_that_contains(@facts, :yaml)
+        request = a_legacy_request_that_contains(facts, :yaml)
 
         expect {
           compiler.extract_facts_from_request(request)
@@ -298,7 +288,7 @@ describe Puppet::Resource::Catalog::Compiler do
       end
 
       it "rejects unknown fact formats" do
-        request = a_request_that_contains(@facts)
+        request = a_request_that_contains(facts)
         request.options[:facts_format] = 'unknown-format'
 
         expect {
@@ -308,15 +298,17 @@ describe Puppet::Resource::Catalog::Compiler do
     end
 
     context "when saving facts from the request" do
+      let(:facts) { Puppet::Node::Facts.new("hostname") }
+
       it "should save facts if they were issued by the request" do
-        request = a_request_that_contains(@facts)
+        request = a_request_that_contains(facts)
 
         options = {
           :environment => request.environment,
           :transaction_uuid => request.options[:transaction_uuid],
         }
 
-        expect(Puppet::Node::Facts.indirection).to receive(:save).with(@facts, nil, options)
+        expect(Puppet::Node::Facts.indirection).to receive(:save).with(facts, nil, options)
         compiler.find(request)
       end
 
@@ -328,7 +320,7 @@ describe Puppet::Resource::Catalog::Compiler do
           :transaction_uuid => request.options[:transaction_uuid],
         }
 
-        expect(Puppet::Node::Facts.indirection).not_to receive(:save).with(@facts, nil, options)
+        expect(Puppet::Node::Facts.indirection).not_to receive(:save).with(facts, nil, options)
         compiler.find(request)
       end
     end
@@ -336,7 +328,6 @@ describe Puppet::Resource::Catalog::Compiler do
 
   describe "when finding nodes" do
     it "should look node information up via the Node class with the provided key" do
-      allow(Facter).to receive(:value).and_return("whatever")
       request = Puppet::Indirector::Request.new(:catalog, :find, node_name, nil)
       allow(compiler).to receive(:compile)
 
@@ -416,7 +407,6 @@ describe Puppet::Resource::Catalog::Compiler do
 
   describe "when filtering resources" do
     before :each do
-      allow(Facter).to receive(:value)
       @catalog = double('catalog')
       allow(@catalog).to receive(:respond_to?).with(:filter).and_return(true)
     end

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -714,6 +714,9 @@ describe 'Puppet Pal' do
 
       context 'facts are supported such that' do
         it 'they are obtained if they are not given' do
+          facts = Puppet::Node::Facts.new(Puppet[:certname], 'puppetversion' => Puppet.version)
+          Puppet::Node::Facts.indirection.save(facts)
+
           testing_env_dir # creates the structure
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath ) do |ctx|
             ctx.with_script_compiler {|c| c.evaluate_string("$facts =~ Hash and $facts[puppetversion] == '#{Puppet.version}'") }


### PR DESCRIPTION
Previously we were running facter many times during specs due to facter being
the default facts terminus.

This commit changes the default terminus to :memory when running tests, and
saves an empty facts node so it's available to tests. We only run facter once
in the facts integration test, and there we opt-in by setting the terminus
to `:facter`.

This commit only addresses tests that use the indirector to access facter. It
doesn't change how code or tests call Facter.value(key) or Facter[:key]
directly. More work is needed to ensure those calls don't cause facter to run.

It's not necessary to clear termini or caches before/after tests as that's
already done in the spec_helper.

Also delete useless test.

On OSX with 16 workers, rake parallel:spec now runs 25% faster:

    Before:
    Finished in 1 minute 36.44 seconds
    25020 examples, 0 failures, 51 pending

    After:
    Finished in 1 minute 11.3 seconds
    25019 examples, 0 failures, 51 pending

On Windows with 2 workers, it runs about 15% faster:

    Before:
    Finished in 10 minutes 6 seconds
    24765 examples, 0 failures, 104 pending

    After:
    Finished in 8 minutes 35 seconds
    24764 examples, 0 failures, 104 pending

---

Backport commit to fix an issue with openssl 1.1

---
Backport commit to clear Puppet::SSL::Host state between tests.