### PR TITLE
(PUP-10247) Only try to match strings in file log destination

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -47,7 +47,7 @@ Puppet::Util::Log.newdesttype :file do
   require 'fileutils'
 
   def self.match?(obj)
-    Puppet::Util.absolute_path?(obj)
+    obj.is_a?(String) && Puppet::Util.absolute_path?(obj)
   end
 
   def close


### PR DESCRIPTION
The "file" log destination type matches any log destination that is an
absolute file path. It determines that by calling
Puppet::Util.absolute_path? on the log destination name. That method
creates a regex and checks whether the argument matches. If the argument
is not a string (for instance, when it is a Puppet::Transaction::Report
object) then the default Object#=~ implementation is typically invoked
and always returns nil. This is technically correct, as the non-string
object is not in fact an absolute path. Thus, the "file" destination
never actually matches non-strings.

In Ruby 2.7, the default Object#=~ method is deprecated and a warning is
issued whenever an object is used as a log destination. This commit
therefore changes the "file" log destination to first check whether its
argument is a String before calling Puppet::Util.absolute_path? on it.