### PR TITLE
(maint) Merge 5.5.x to 6.4.x

### DIFF
--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -146,6 +146,10 @@ module Puppet::Test
 
       Puppet::SSL::Host.reset
 
+      Puppet::Node::Facts.indirection.terminus_class = :memory
+      facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
+      Puppet::Node::Facts.indirection.save(facts)
+
       Puppet.clear_deprecation_warnings
     end
 

--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -7,6 +7,10 @@ describe Puppet::Node::Facts::Facter do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
 
+  before :each do
+    Puppet::Node::Facts.indirection.terminus_class = :facter
+  end
+
   it "preserves case in fact values" do
     Facter.add(:downcase_test) do
       setcode do

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -14,14 +14,6 @@ describe Puppet::Application::Apply do
     Puppet[:reports] = "none"
   end
 
-  after :each do
-    Puppet::Node::Facts.indirection.reset_terminus_class
-    Puppet::Node::Facts.indirection.cache_class = nil
-
-    Puppet::Node.indirection.reset_terminus_class
-    Puppet::Node.indirection.cache_class = nil
-  end
-
   [:debug,:loadclasses,:test,:verbose,:use_nodes,:detailed_exitcodes,:catalog, :write_catalog_summary].each do |option|
     it "should declare handle_#{option} method" do
       expect(@apply).to respond_to("handle_#{option}".to_sym)
@@ -182,13 +174,11 @@ describe Puppet::Application::Apply do
         Puppet[:prerun_command] = ''
         Puppet[:postrun_command] = ''
 
-        Puppet::Node::Facts.indirection.terminus_class = :memory
-        Puppet::Node::Facts.indirection.cache_class = :memory
         Puppet::Node.indirection.terminus_class = :memory
         Puppet::Node.indirection.cache_class = :memory
 
-        @facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
-        Puppet::Node::Facts.indirection.save(@facts)
+        facts = Puppet::Node::Facts.new(Puppet[:node_name_value])
+        Puppet::Node::Facts.indirection.save(facts)
 
         @node = Puppet::Node.new(Puppet[:node_name_value])
         Puppet::Node.indirection.save(@node)

--- a/spec/unit/configurer/fact_handler_spec.rb
+++ b/spec/unit/configurer/fact_handler_spec.rb
@@ -22,10 +22,6 @@ describe Puppet::Configurer::FactHandler do
 
   let(:facthandler) { FactHandlerTester.new('production') }
 
-  before :each do
-    Puppet::Node::Facts.indirection.terminus_class = :memory
-  end
-
   describe "when finding facts" do
     it "should use the node name value to retrieve the facts" do
       foo_facts = Puppet::Node::Facts.new('foo')

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -4,9 +4,6 @@ require 'webmock/rspec'
 
 describe Puppet::Configurer do
   before do
-    Puppet::Node::Facts.indirection.terminus_class = :memory
-    Puppet::Node::Facts.indirection.save(facts)
-
     Puppet[:server] = "puppetmaster"
     Puppet[:report] = true
 

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -710,6 +710,9 @@ describe 'Puppet Pal' do
 
       context 'facts are supported such that' do
         it 'they are obtained if they are not given' do
+          facts = Puppet::Node::Facts.new(Puppet[:certname], 'puppetversion' => Puppet.version)
+          Puppet::Node::Facts.indirection.save(facts)
+
           testing_env_dir # creates the structure
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath ) do |ctx|
             ctx.with_script_compiler {|c| c.evaluate_string("$facts =~ Hash and $facts[puppetversion] == '#{Puppet.version}'") }

--- a/spec/unit/puppet_pal_catalog_spec.rb
+++ b/spec/unit/puppet_pal_catalog_spec.rb
@@ -710,6 +710,9 @@ describe 'Puppet Pal' do
 
       context 'facts are supported such that' do
         it 'they are obtained if they are not given' do
+          facts = Puppet::Node::Facts.new(Puppet[:certname], 'puppetversion' => Puppet.version)
+          Puppet::Node::Facts.indirection.save(facts)
+
           testing_env_dir # creates the structure
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath ) do |ctx|
             ctx.with_catalog_compiler {|c| c.evaluate_string("$facts =~ Hash and $facts[puppetversion] == '#{Puppet.version}'") }


### PR DESCRIPTION
* upstream/5.5.x:
  (maint) Use memory terminus for facts indirection
  (maint) Reset ca_location between tests
  (maint) Ignore X509 purpose during cert verification
  (maint) Lift x509 store's purpose

Conflicts:
	lib/puppet/ssl/certificate_authority.rb
	lib/puppet/test/test_helper.rb
	spec/unit/indirector/catalog/compiler_spec.rb
	spec/unit/ssl/certificate_authority_spec.rb

Certificate authority and Host#ca_location= were deleted in 6.0

Add puppetversion to in-memory facts to puppet_pal_catalog_spec.rb. That
test is new in 6.x.
