### PR TITLE
(PUP-10255) Follow symlinks in environment path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage/
 *.iml
 .rakeTasks
 .idea/
+spec_order.txt

--- a/lib/puppet/file_system/memory_file.rb
+++ b/lib/puppet/file_system/memory_file.rb
@@ -23,6 +23,10 @@ class Puppet::FileSystem::MemoryFile
         :children => children)
   end
 
+  def self.a_symlink(target_path, source_path)
+    new(target_path, :exist? => true, :symlink? => true, :source_path => source_path)
+  end
+
   def initialize(path, properties)
     @path = path
     @properties = properties
@@ -34,6 +38,8 @@ class Puppet::FileSystem::MemoryFile
   def directory?; @properties[:directory?]; end
   def exist?; @properties[:exist?]; end
   def executable?; @properties[:executable?]; end
+  def symlink?; @properties[:symlink?]; end
+  def source_path; @properties[:source_path]; end
 
   def each_line(&block)
     handle.each_line(&block)

--- a/lib/puppet/file_system/memory_impl.rb
+++ b/lib/puppet/file_system/memory_impl.rb
@@ -23,6 +23,19 @@ class Puppet::FileSystem::MemoryImpl
     path.executable?
   end
 
+  def symlink?(path)
+    path.symlink?
+  end
+
+  def readlink(path)
+    path = path.path
+    link = find(path)
+    return Puppet::FileSystem::MemoryFile.a_missing_file(path) unless link
+    source = link.source_path
+    return Puppet::FileSystem::MemoryFile.a_missing_file(link) unless source
+    find(source) || Puppet::FileSystem::MemoryFile.a_missing_file(source)
+  end
+
   def children(path)
     path.children
   end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -1,3 +1,4 @@
+require 'puppet/environments'
 require 'puppet/node'
 require 'puppet/resource/catalog'
 require 'puppet/indirector/code'
@@ -173,6 +174,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   # Initially restricted to files sourced from codedir via puppet:/// uri.
   def inline_metadata(catalog, checksum_type)
     environment_path = Pathname.new File.join(Puppet[:environmentpath], catalog.environment, "")
+    environment_path = Puppet::Environments::Directories.real_path(environment_path)
     list_of_resources = catalog.resources.find_all { |res| res.type == "File" }
 
     # TODO: get property/parameter defaults if entries are nil in the resource

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1239,6 +1239,8 @@ Generated on #{Time.now}.
     configured_environment = self[:environment]
     if configured_environment == "production" && envdir && Puppet::FileSystem.exist?(envdir)
       configured_environment_path = File.join(envdir, configured_environment)
+      # If configured_environment_path is a symlink, assume the source path is being managed
+      # elsewhere, so don't do any of this configuration
       if !Puppet::FileSystem.symlink?(configured_environment_path)
         parameters = { :ensure => 'directory' }
         unless Puppet::FileSystem.exist?(configured_environment_path)


### PR DESCRIPTION
This commit adds a `real_path` method that will follow symlinks in the given
directory, which is then used when getting the environment.conf and generating
metadata for a given environment. This enables us to have multiple code
dirs for a given environment, with the set `environmentpath` pointing to the
most recent version, which enables lockless deployments.