### PR TITLE
(maint) Adjust OS X versions on acceptance tests

### DIFF
--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
@@ -1,5 +1,5 @@
-test_name "should not modify the home directory of an user on OS X 10.14" do
-  confine :to, :platform => /osx-10.14/
+test_name "should not modify the home directory of an user on OS X >= 10.14" do
+  confine :to, :platform => /osx-10.1[4-9]/
 
   tag 'audit:medium',
       'audit:acceptance' # Could be done as integration tests, but would
@@ -23,14 +23,14 @@ test_name "should not modify the home directory of an user on OS X 10.14" do
     end
 
     step "verify the error message is correct" do
-      expected_error = /OS X version 10\.14 does not allow changing home using puppet/
+      expected_error = /OS X version 10\.1[4-9] does not allow changing home using puppet/
       user_manifest = resource_manifest('user', user, ensure: 'present', home: "/opt/#{user}")
 
       apply_manifest_on(agent, user_manifest) do |result|
         assert_match(
           expected_error,
           result.stderr,
-          "Puppet fails to report an error when changing home directory on OS X 10.4"
+          "Puppet fails to report an error when changing home directory on OS X >= 10.14"
         )
       end
     end

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
@@ -1,5 +1,5 @@
-test_name "should not modify the uid of an user on OS X 10.14" do
-  confine :to, :platform => /osx-10.14/
+test_name "should not modify the uid of an user on OS X >= 10.14" do
+  confine :to, :platform => /osx-10.1[4-9]/
 
   tag 'audit:medium',
       'audit:acceptance' # Could be done as integration tests, but would
@@ -23,14 +23,14 @@ test_name "should not modify the uid of an user on OS X 10.14" do
     end
 
     step "verify the error message is correct" do
-      expected_error = /OS X version 10\.14 does not allow changing uid using puppet/
+      expected_error = /OS X version 10\.1[4-9] does not allow changing uid using puppet/
       user_manifest = resource_manifest('user', user, ensure: 'present', uid: rand(999999))
 
       apply_manifest_on(agent, user_manifest) do |result|
         assert_match(
           expected_error,
           result.stderr,
-          "Puppet fails to report an error when changing uid on OS X 10.4"
+          "Puppet fails to report an error when changing uid on OS X >= 10.14"
         )
       end
     end

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -434,8 +434,8 @@ Puppet::Type.type(:user).provide :directoryservice do
   ['home', 'uid', 'gid', 'comment', 'shell'].each do |setter_method|
     define_method("#{setter_method}=") do |value|
       if @property_hash[setter_method.intern]
-        if self.class.get_os_version == '10.14' && %w(home uid).include?(setter_method)
-          raise Puppet::Error, "OS X version 10\.14 does not allow changing #{setter_method} using puppet"
+        if self.class.get_os_version.split('.').last.to_i >= 14 && %w(home uid).include?(setter_method)
+          raise Puppet::Error, "OS X version #{self.class.get_os_version} does not allow changing #{setter_method} using puppet"
         end
         begin
           dscl '.', '-change', "/Users/#{resource.name}", self.class.ns_to_ds_attribute_map[setter_method.intern], @property_hash[setter_method.intern], value


### PR DESCRIPTION
This commit makes the assumption that macOS versions >= 10.14 will not
allow changing the home directory or UID of an user once created (this
has been true for 10.14, 10.15, and will also be for future versions I
assume), so make the checks more lenient.