### PR TITLE
(PUP-10226) URL encode paths in http client

### DIFF
--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -30,7 +30,7 @@ class Puppet::HTTP::Service
 
   def with_base_url(path)
     u = @url.dup
-    u.path += path
+    u.path += Puppet::Util.uri_encode(path)
     u
   end
 

--- a/spec/unit/http/service/report_spec.rb
+++ b/spec/unit/http/service/report_spec.rb
@@ -72,6 +72,13 @@ describe Puppet::HTTP::Service::Report do
       subject.put_report('infinity', report, environment: environment)
     end
 
+    it 'percent encodes the uri before submitting the report' do
+      stub_request(:put, "https://www.example.com/puppet/v3/report/node%20name?environment=testing")
+        .to_return(status: 200, body: "", headers: {})
+
+      subject.put_report('node name', report, environment: environment)
+    end
+
     it 'raises response error if unsuccessful' do
       stub_request(:put, url).to_return(status: [400, 'Bad Request'], headers: {'X-Puppet-Version' => '6.1.8' })
 

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -17,6 +17,10 @@ describe Puppet::HTTP::Service do
     service.with_base_url('/puppet/v3')
   end
 
+  it "percent encodes paths before appending them to the path" do
+    expect(service.with_base_url('/path/with/a space')).to eq(URI.parse("https://www.example.com/path/with/a%20space"))
+  end
+
   it "connects to the base URL with a nil ssl context" do
     expect(client).to receive(:connect).with(url, ssl_context: nil)
 


### PR DESCRIPTION
In various services, we allow arbitrary strings to be added to an http
request url. We need to ensure the urls we pass into an http request are
valid, so this commits adds percent encoding.