### PR TITLE
(PUP-10256) Add `versioned_environment_dirs` feature flag

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -263,6 +263,13 @@ module Puppet
         major releases of Puppet. Should be used with caution, as in development
         features are experimental and can have unexpected effects."
     },
+    :versioned_environment_dirs => {
+      :default => false,
+      :type => :boolean,
+      :desc => "Whether or not to look for versioned environment directories,
+      symlinked from `$environmentpath/<environment>`. This is an experimental
+      feature and should be used with caution."
+    },
     :static_catalogs => {
       :default    => true,
       :type       => :boolean,


### PR DESCRIPTION
This commit adds a feature flag (setting) for using versioned environment
directories, symlinked to the configured environment directory. This enables
the work for lockless deployments.