### PR TITLE
(PUP-10263) facter-ng available on all platforms

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -71,12 +71,15 @@ module Puppet
         :type    => :boolean,
         :desc    => 'Whether to enable a pre-Facter 4.0 release of Facter (distributed as
           the "facter-ng" gem). This is not necessary if Facter 3.x or later is installed.
-          This setting is still experimental and has been only included on Windows builds',
+          This setting is still experimental.',
         :hook    => proc do |value|
-                      if value && Puppet::Util::Platform.windows?
+                      if value
                         begin
+                          ORIGINAL_FACTER = Object.const_get(:Facter)
+                          Object.send(:remove_const, :Facter)
                           require 'facter-ng'
                         rescue LoadError
+                          Object.const_set(:Facter, ORIGINAL_FACTER)
                           raise ArgumentError, 'facter-ng could not be loaded'
                         end
                       end

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -182,7 +182,7 @@ describe "Defaults" do
     end
   end
 
-  describe "facterng", :if => Puppet::Util::Platform.windows? do
+  describe "facterng" do
     it "defaults to false" do
       expect(Puppet[:facterng]).to be_falsey
     end


### PR DESCRIPTION
This commit makes facter-ng activation available on all platforms.
It also removes `Facter` module before loading `facter-ng`
to ensure that Facter 2.x and its Utils are not used.