### PR TITLE
(PUP-10142) Refactor settings default initialization

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -22,6 +22,7 @@ require 'puppet/external/pson/common'
 require 'puppet/external/pson/version'
 require 'puppet/external/pson/pure'
 require 'puppet/gettext/config'
+require 'puppet/defaults'
 
 
 #------------------------------------------------------------
@@ -87,6 +88,7 @@ module Puppet
 
   # Store a new default value.
   def self.define_settings(section, hash)
+    Puppet.deprecation_warning('The method Puppet.define_settings is deprecated and will be removed in a future release')
     @@settings.define_settings(section, hash)
   end
 
@@ -121,8 +123,9 @@ module Puppet
     Puppet::Util::RunMode[@@settings.preferred_run_mode]
   end
 
-  # Load all of the settings.
-  require 'puppet/defaults'
+  # Modify the settings with defaults defined in `initialize_default_settings` method in puppet/defaults.rb. This can
+  # be used in the initialization of new Puppet::Settings objects in the puppetserver project.
+  Puppet.initialize_default_settings!(settings)
 
   # Now that settings are loaded we have the code loaded to be able to issue
   # deprecation warnings. Warn if we're on a deprecated ruby version.

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -65,7 +65,11 @@ module Puppet
 
   AS_DURATION = %q{This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y).}
 
-  define_settings(:main,
+  # @api public
+  # @param args [Puppet::Settings] the settings object to define default settings for
+  # @return void
+  def self.initialize_default_settings!(settings)
+  settings.define_settings(:main,
     :facterng => {
         :default => false,
         :type    => :boolean,
@@ -84,7 +88,7 @@ module Puppet
     }
   )
 
-  define_settings(:main,
+  settings.define_settings(:main,
     :confdir  => {
         :default  => nil,
         :type     => :directory,
@@ -121,7 +125,7 @@ module Puppet
     }
   )
 
-  define_settings(:main,
+  settings.define_settings(:main,
     :logdir => {
         :default  => nil,
         :type     => :directory,
@@ -225,7 +229,7 @@ module Puppet
     }
   )
 
-  define_settings(:main,
+  settings.define_settings(:main,
     :priority => {
       :default => nil,
       :type    => :priority,
@@ -541,12 +545,12 @@ module Puppet
     :hiera_config => {
       :default => lambda do
         config = nil
-        codedir = Puppet.settings[:codedir]
+        codedir = settings[:codedir]
         if codedir.is_a?(String)
           config = File.expand_path(File.join(codedir, 'hiera.yaml'))
           config = nil unless Puppet::FileSystem.exist?(config)
         end
-        config = File.expand_path(File.join(Puppet.settings[:confdir], 'hiera.yaml')) if config.nil?
+        config = File.expand_path(File.join(settings[:confdir], 'hiera.yaml')) if config.nil?
         config
       end,
       :desc    => "The hiera configuration file. Puppet only reads this file on startup, so you must restart the puppet master every time you edit it.",
@@ -610,7 +614,7 @@ module Puppet
     :http_proxy_password =>{
       :default    => "none",
       :hook       => proc do |value|
-        if Puppet.settings[:http_proxy_password] =~ /[@!# \/]/
+        if settings[:http_proxy_password] =~ /[@!# \/]/
           raise "Passwords set in the http_proxy_password setting must be valid as part of a URL, and any reserved characters must be URL-encoded. We received: #{value}"
         end
       end,
@@ -754,7 +758,7 @@ API to expire the cache as needed
     }
   )
 
-  Puppet.define_settings(:module_tool,
+  settings.define_settings(:module_tool,
     :module_repository  => {
       :default  => 'https://forgeapi.puppet.com',
       :desc     => "The module repository",
@@ -773,7 +777,7 @@ API to expire the cache as needed
     }
   )
 
-    Puppet.define_settings(
+    settings.define_settings(
     :main,
 
     # We have to downcase the fqdn, because the current ssl stuff (as opposed to in master) doesn't have good facilities for
@@ -1084,7 +1088,7 @@ EOT
     }
   )
 
-    define_settings(
+    settings.define_settings(
     :ca,
     :ca_name => {
       :default => "Puppet CA: $certname",
@@ -1202,7 +1206,7 @@ EOT
 
   # Define the config default.
 
-    define_settings(:application,
+    settings.define_settings(:application,
       :config_file_name => {
           :type     => :string,
           :default  => Puppet::Settings.default_config_file_name,
@@ -1227,7 +1231,7 @@ EOT
       },
   )
 
-  define_settings(:environment,
+  settings.define_settings(:environment,
     :manifest => {
       :default    => nil,
       :type       => :file_or_directory,
@@ -1270,7 +1274,7 @@ EOT
     }
   )
 
-  define_settings(:master,
+  settings.define_settings(:master,
     :user => {
       :default    => "puppet",
       :desc       => "The user Puppet Server will run as. Used to ensure
@@ -1463,7 +1467,7 @@ EOT
     }
   )
 
-  define_settings(:device,
+  settings.define_settings(:device,
     :devicedir =>  {
         :default  => "$vardir/devices",
         :type     => :directory,
@@ -1478,7 +1482,7 @@ EOT
     }
   )
 
-  define_settings(:agent,
+  settings.define_settings(:agent,
     :node_name_value => {
       :default => "$certname",
       :desc => "The explicit value used for the node name for all requests the agent
@@ -1831,7 +1835,7 @@ EOT
 
   # Plugin information.
 
-  define_settings(
+  settings.define_settings(
     :main,
     :plugindest => {
       :type       => :directory,
@@ -1874,7 +1878,7 @@ EOT
 
   # Central fact information.
 
-    define_settings(
+    settings.define_settings(
     :main,
     :factpath => {
       :type     => :path,
@@ -1891,7 +1895,7 @@ EOT
     }
   )
 
-  define_settings(
+  settings.define_settings(
     :transaction,
     :tags => {
       :default    => "",
@@ -1919,7 +1923,7 @@ EOT
     }
   )
 
-    define_settings(
+    settings.define_settings(
     :main,
     :external_nodes => {
         :default  => "none",
@@ -1944,7 +1948,7 @@ EOT
     }
     )
 
-        define_settings(
+        settings.define_settings(
         :ldap,
     :ldapssl => {
       :default  => false,
@@ -2013,7 +2017,7 @@ EOT
     }
   )
 
-  define_settings(:master,
+  settings.define_settings(:master,
     :storeconfigs => {
       :default  => false,
       :type     => :boolean,
@@ -2031,7 +2035,7 @@ EOT
         require 'puppet/node/facts'
         if value
           Puppet::Resource::Catalog.indirection.set_global_setting(:cache_class, :store_configs)
-          Puppet.settings.override_default(:catalog_cache_terminus, :store_configs)
+          settings.override_default(:catalog_cache_terminus, :store_configs)
           Puppet::Node::Facts.indirection.set_global_setting(:cache_class, :store_configs)
           Puppet::Resource.indirection.set_global_setting(:terminus_class, :store_configs)
         end
@@ -2046,7 +2050,7 @@ EOT
     }
   )
 
-  define_settings(:parser,
+  settings.define_settings(:parser,
    :max_errors => {
      :default => 10,
      :desc => <<-'EOT'
@@ -2098,7 +2102,7 @@ EOT
     EOT
     }
   )
-  define_settings(:puppetdoc,
+  settings.define_settings(:puppetdoc,
     :document_all => {
         :default  => false,
         :type     => :boolean,
@@ -2107,7 +2111,7 @@ EOT
     }
   )
 
-  define_settings(
+  settings.define_settings(
     :main,
     :rich_data => {
       :default  => true,
@@ -2124,5 +2128,5 @@ EOT
       EOT
     }
   )
-
+  end
 end


### PR DESCRIPTION
Previous to this commit, the puppet settings defaults were loaded
when the defaults.rb file was required. That design makes it
difficult to generate new settings objects; additionally, code
that executes by simply requiring the file seems less than ideal.

This change stops the code from executing by simply requiring the
defaults.rb file, and refactors it to become a class method that
modifies a settings object that is passed in. As a result of this
refactor, the `Puppet.define_settings` method is no longer required
as a bridge to the @@settings object and is removed.