### PR TITLE
(maint) document the 'other' set_server_facts

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -387,6 +387,8 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
   # Initialize our server fact hash; we add these to each client, and they
   # won't change while we're running, so it's safe to cache the values.
+  #
+  # See also set_server_facts in Puppet::Server::Compiler in puppetserver.
   def set_server_facts
     @server_facts = {}
 


### PR DESCRIPTION
Document the other set_server_facts in puppetserver,
to reduce the chance of them being out of sync.