### PR TITLE
(PUP-10267) Support routing to the file server given a URL

### DIFF
--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -10,11 +10,11 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     super(client, url)
   end
 
-  def get_file_metadata(mount_point:, path:, environment:, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
-    headers = add_puppet_headers({ 'ACCEPT' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
+  def get_file_metadata(path:, environment:, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
+    headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
 
     response = @client.get(
-      with_base_url("/file_metadata/#{mount_point}/#{path}"),
+      with_base_url("/file_metadata/#{path}"),
       headers: headers,
       params: {
         links: links,
@@ -30,11 +30,11 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     raise Puppet::HTTP::ResponseError.new(response)
   end
 
-  def get_file_metadatas(mount_point:, path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
-    headers = add_puppet_headers({ 'ACCEPT' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
+  def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
+    headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
 
     response = @client.get(
-      with_base_url("/file_metadatas/#{mount_point}/#{path}"),
+      with_base_url("/file_metadatas/#{path}"),
       headers: headers,
       params: {
         recurse: recurse,
@@ -53,10 +53,10 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     raise Puppet::HTTP::ResponseError.new(response)
   end
 
-  def get_file_content(mount_point:, path:, environment:, ssl_context: nil, &block)
+  def get_file_content(path:, environment:, ssl_context: nil, &block)
     headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
     response = @client.get(
-      with_base_url("/file_content/#{mount_point}/#{path}"),
+      with_base_url("/file_content/#{path}"),
       headers: headers,
       params: {
         environment: environment

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -2,8 +2,7 @@ require 'puppet/file_serving/metadata'
 
 class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   API = '/puppet/v3'.freeze
-
-  EXCLUDED_FORMATS = [:yaml, :b64_zlib_yaml, :dot]
+  PATH_REGEX = /^\//
 
   def initialize(client, server, port)
     url = build_url(API, server || Puppet[:server], port || Puppet[:masterport])
@@ -11,10 +10,12 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   end
 
   def get_file_metadata(path:, environment:, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
+    validate_path(path)
+
     headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
 
     response = @client.get(
-      with_base_url("/file_metadata/#{path}"),
+      with_base_url("/file_metadata#{path}"),
       headers: headers,
       params: {
         links: links,
@@ -31,10 +32,12 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   end
 
   def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
+    validate_path(path)
+
     headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
 
     response = @client.get(
-      with_base_url("/file_metadatas/#{path}"),
+      with_base_url("/file_metadatas#{path}"),
       headers: headers,
       params: {
         recurse: recurse,
@@ -54,9 +57,11 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   end
 
   def get_file_content(path:, environment:, ssl_context: nil, &block)
+    validate_path(path)
+
     headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
     response = @client.get(
-      with_base_url("/file_content/#{path}"),
+      with_base_url("/file_content#{path}"),
       headers: headers,
       params: {
         environment: environment
@@ -71,5 +76,10 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     return nil if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
+  end
+  private
+
+  def validate_path(path)
+    raise ArgumentError, "Path must start with a slash" unless path =~ PATH_REGEX
   end
 end

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -64,9 +64,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       ssl_context: ssl_context
     ) do |res|
       if res.success?
-        res.read_body do |data|
-          yield data
-        end
+        res.read_body(&block)
       end
     end
 

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -11,7 +11,9 @@ class Puppet::HTTP::Session
 
     # short circuit if explicit URL host & port given
     if url && url.host != nil && !url.host.empty?
-      return Puppet::HTTP::Service.create_service(@client, name, url.host, url.port)
+      service = Puppet::HTTP::Service.create_service(@client, name, url.host, url.port)
+      service.connect(ssl_context: ssl_context)
+      return service
     end
 
     cached = @resolved_services[name]

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -6,8 +6,13 @@ class Puppet::HTTP::Session
     @resolution_exceptions = []
   end
 
-  def route_to(name, ssl_context: nil)
+  def route_to(name, url: nil, ssl_context: nil)
     raise ArgumentError, "Unknown service #{name}" unless Puppet::HTTP::Service.valid_name?(name)
+
+    # short circuit if explicit URL host & port given
+    if url && url.host != nil && !url.host.empty?
+      return Puppet::HTTP::Service.create_service(@client, name, url.host, url.port)
+    end
 
     cached = @resolved_services[name]
     return cached if cached

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_fetch_if_not_on_the_local_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_fetch_if_not_on_the_local_disk.yml
@@ -133,41 +133,6 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
     uri: http://my-server/file/
     body:

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_not_update_if_content_on_disk_is_up-to-date.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_not_update_if_content_on_disk_is_up-to-date.yml
@@ -137,43 +137,6 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Content-MD5:
-      - Es93YfogzPk5EimSmqb9XQ==
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
     uri: http://my-server/file/
     body:

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_update_if_content_differs_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_update_if_content_differs_on_disk.yml
@@ -137,43 +137,6 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Content-MD5:
-      - Es93YfogzPk5EimSmqb9XQ==
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
     uri: http://my-server/file/
     body:

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_mtime_is_older_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_mtime_is_older_on_disk.yml
@@ -133,41 +133,6 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
     uri: http://my-server/file/
     body:

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_no_header_specified.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_no_header_specified.yml
@@ -129,39 +129,6 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
     uri: http://my-server/file/
     body:

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_not_on_the_local_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_not_on_the_local_disk.yml
@@ -133,41 +133,6 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
     uri: http://my-server/file/
     body:

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_not_update_if_mtime_is_newer_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_not_update_if_mtime_is_newer_on_disk.yml
@@ -133,41 +133,6 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
     uri: http://my-server/file/
     body:

--- a/spec/unit/http/service/file_server_spec.rb
+++ b/spec/unit/http/service/file_server_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::HTTP::Service::FileServer do
         expect(request.headers).to_not include('X-Puppet-Profiling')
       end
 
-      subject.get_file_content(mount_point: ':mount', path: ':path', environment: environment) { |data| }
+      subject.get_file_content(path: ':mount/:path', environment: environment) { |data| }
     end
 
     it 'includes the X-Puppet-Profiling header when Puppet[:profile] is true' do
@@ -33,7 +33,7 @@ describe Puppet::HTTP::Service::FileServer do
 
       Puppet[:profile] = true
 
-      subject.get_file_content(mount_point: ':mount', path: ':path', environment: environment) { |data| }
+      subject.get_file_content(path: ':mount/:path', environment: environment) { |data| }
     end
   end
 
@@ -42,16 +42,17 @@ describe Puppet::HTTP::Service::FileServer do
       Puppet[:server] = 'file.example.com'
       Puppet[:masterport] = 8141
 
-      stub_request(:get, "https://file.example.com:8141/puppet/v3/file_content/mount/path?environment=testing")
+      stub_request(:get, "https://file.example.com:8141/puppet/v3/file_content/:mount/:path?environment=testing")
 
-      subject.get_file_content(mount_point: 'mount', path: 'path', environment: environment) { |data| }
+      subject.get_file_content(path: ':mount/:path', environment: environment) { |data| }
     end
   end
 
   context 'retrieving file metadata' do
     let(:path) { tmpfile('get_file_metadata') }
-    let(:url) { "https://www.example.com/puppet/v3/file_metadata/infinity/#{path}?checksum_type=md5&environment=testing&links=manage&source_permissions=ignore" }
+    let(:url) { "https://www.example.com/puppet/v3/file_metadata/:mount/#{path}?checksum_type=md5&environment=testing&links=manage&source_permissions=ignore" }
     let(:filemetadata) { Puppet::FileServing::Metadata.new(path) }
+    let(:request_path) { ":mount/#{path}"}
 
     it 'submits a request for file metadata to the server' do
       stub_request(:get, url).with(
@@ -60,7 +61,7 @@ describe Puppet::HTTP::Service::FileServer do
         status: 200, body: filemetadata.render, headers: { 'Content-Type' => 'application/json' }
       )
 
-      metadata = subject.get_file_metadata(mount_point: 'infinity', path: path, environment: environment)
+      metadata = subject.get_file_metadata(path: request_path, environment: environment)
       expect(metadata.path).to eq(path)
     end
 
@@ -68,7 +69,7 @@ describe Puppet::HTTP::Service::FileServer do
       stub_request(:get, url).to_return(status: 200, body: '', headers: {})
 
       expect {
-        subject.get_file_metadata(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadata(path: request_path, environment: environment)
       }.to raise_error(Puppet::HTTP::ProtocolError, "No content type in http response; cannot parse")
     end
 
@@ -76,7 +77,7 @@ describe Puppet::HTTP::Service::FileServer do
       stub_request(:get, url).to_return(status: 200, body: '', headers: { 'Content-Type' => 'text/yaml' })
 
       expect {
-        subject.get_file_metadata(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadata(path: request_path, environment: environment)
       }.to raise_error(Puppet::HTTP::ProtocolError, "Content-Type is unsupported")
     end
 
@@ -84,7 +85,7 @@ describe Puppet::HTTP::Service::FileServer do
       stub_request(:get, url).to_return(status: [400, 'Bad Request'])
 
       expect {
-        subject.get_file_metadata(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadata(path: request_path, environment: environment)
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
         expect(err.message).to eq('Bad Request')
@@ -98,16 +99,17 @@ describe Puppet::HTTP::Service::FileServer do
       )
 
       expect {
-        subject.get_file_metadata(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadata(path: request_path, environment: environment)
       }.to raise_error(Puppet::HTTP::SerializationError, /Failed to deserialize Puppet::FileServing::Metadata from json/)
     end
   end
 
   context 'retrieving multiple file metadatas' do
     let(:path) { tmpfile('get_file_metadatas') }
-    let(:url) { "https://www.example.com/puppet/v3/file_metadatas/infinity/#{path}?checksum_type=md5&links=manage&recurse=false&source_permissions=ignore&environment=testing" }
+    let(:url) { "https://www.example.com/puppet/v3/file_metadatas/:mount/#{path}?checksum_type=md5&links=manage&recurse=false&source_permissions=ignore&environment=testing" }
     let(:filemetadatas) { [Puppet::FileServing::Metadata.new(path)] }
     let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+    let(:request_path) { ":mount/#{path}"}
 
     it 'submits a request for file metadata to the server' do
       stub_request(:get, url).with(
@@ -116,19 +118,19 @@ describe Puppet::HTTP::Service::FileServer do
         status: 200, body: formatter.render_multiple(filemetadatas), headers: { 'Content-Type' => 'application/json' }
       )
 
-      metadatas = subject.get_file_metadatas(mount_point: 'infinity', path: path, environment: environment)
+      metadatas = subject.get_file_metadatas(path: request_path, environment: environment)
       expect(metadatas.first.path).to eq(path)
     end
 
     it 'automatically converts an array of parameters to the stringified query' do
-      url = "https://www.example.com/puppet/v3/file_metadatas/infinity/#{path}?checksum_type=md5&environment=testing&ignore=CVS&ignore=.git&ignore=.hg&links=manage&recurse=false&source_permissions=ignore"
+      url = "https://www.example.com/puppet/v3/file_metadatas/:mount/#{path}?checksum_type=md5&environment=testing&ignore=CVS&ignore=.git&ignore=.hg&links=manage&recurse=false&source_permissions=ignore"
       stub_request(:get, url).with(
         headers: {'Accept'=>'application/json, application/x-msgpack, text/pson',}
       ).to_return(
         status: 200, body: formatter.render_multiple(filemetadatas), headers: { 'Content-Type' => 'application/json' }
       )
 
-      metadatas = subject.get_file_metadatas(mount_point: 'infinity', path: path, environment: environment, ignore: ['CVS', '.git', '.hg'])
+      metadatas = subject.get_file_metadatas(path: request_path, environment: environment, ignore: ['CVS', '.git', '.hg'])
       expect(metadatas.first.path).to eq(path)
     end
 
@@ -136,7 +138,7 @@ describe Puppet::HTTP::Service::FileServer do
       stub_request(:get, url).to_return(status: 200, body: '', headers: {})
 
       expect {
-        subject.get_file_metadatas(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadatas(path: request_path, environment: environment)
       }.to raise_error(Puppet::HTTP::ProtocolError, "No content type in http response; cannot parse")
     end
 
@@ -144,7 +146,7 @@ describe Puppet::HTTP::Service::FileServer do
       stub_request(:get, url).to_return(status: 200, body: '', headers: { 'Content-Type' => 'text/yaml' })
 
       expect {
-        subject.get_file_metadatas(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadatas(path: request_path, environment: environment)
       }.to raise_error(Puppet::HTTP::ProtocolError, "Content-Type is unsupported")
     end
 
@@ -152,7 +154,7 @@ describe Puppet::HTTP::Service::FileServer do
       stub_request(:get, url).to_return(status: [400, 'Bad Request'])
 
       expect {
-        subject.get_file_metadatas(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadatas(path: request_path, environment: environment)
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
         expect(err.message).to eq('Bad Request')
@@ -166,13 +168,13 @@ describe Puppet::HTTP::Service::FileServer do
       )
 
       expect {
-        subject.get_file_metadatas(mount_point: 'infinity', path: path, environment: environment)
+        subject.get_file_metadatas(path: request_path, environment: environment)
       }.to raise_error(Puppet::HTTP::SerializationError, /Failed to deserialize multiple Puppet::FileServing::Metadata from json/)
     end
   end
 
   context 'getting file content' do
-    let(:uri) {"https://www.example.com:443/puppet/v3/file_content/infinity/eternal?environment=testing"}
+    let(:uri) {"https://www.example.com:443/puppet/v3/file_content/:mount/:path?environment=testing"}
 
     it 'yields file content' do
       stub_request(:get, uri).with do |request|
@@ -180,7 +182,7 @@ describe Puppet::HTTP::Service::FileServer do
       end.to_return(status: 200, body: "and beyond")
 
       expect { |b|
-        subject.get_file_content(mount_point: 'infinity', path: 'eternal', environment: environment, &b)
+        subject.get_file_content(path: ':mount/:path', environment: environment, &b)
       }.to yield_with_args("and beyond")
     end
 
@@ -188,7 +190,7 @@ describe Puppet::HTTP::Service::FileServer do
       stub_request(:get, uri).to_return(status: [400, 'Bad Request'])
 
       expect {
-        subject.get_file_content(mount_point: 'infinity', path: 'eternal', environment: environment) { |data| }
+        subject.get_file_content(path: ':mount/:path', environment: environment) { |data| }
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
         expect(err.message).to eq('Bad Request')

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -73,6 +73,23 @@ describe Puppet::HTTP::Session do
         session.route_to(:westbound)
       }.to raise_error(ArgumentError, "Unknown service westbound")
     end
+
+    it 'routes to the service when given a puppet URL with an explicit host' do
+      session = described_class.new(client, [])
+      url = URI('puppet://example.com:8140/:modules/:module/path/to/file')
+      service = session.route_to(:fileserver, url: url)
+
+      expect(service.url.to_s).to eq("https://example.com:8140/puppet/v3")
+    end
+
+    it 'resolves the route when given a generic puppet:/// URL' do
+      resolvers = [DummyResolver.new(good_service)]
+      session = described_class.new(client, resolvers)
+      url = URI('puppet:///:modules/:module/path/to/file')
+      service = session.route_to(:fileserver, url: url)
+
+      expect(service.url).to eq(good_service.url)
+    end
   end
 
   context 'when resolving using multiple resolvers' do

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -75,11 +75,25 @@ describe Puppet::HTTP::Session do
     end
 
     it 'routes to the service when given a puppet URL with an explicit host' do
+      allow_any_instance_of(Net::HTTP).to receive(:start)
+
       session = described_class.new(client, [])
-      url = URI('puppet://example.com:8140/:modules/:module/path/to/file')
+      url = URI("puppet://example.com:8140/:modules/:module/path/to/file")
       service = session.route_to(:fileserver, url: url)
 
       expect(service.url.to_s).to eq("https://example.com:8140/puppet/v3")
+    end
+
+    it 'raises a connection error if we cannot connect' do
+      allow_any_instance_of(Net::HTTP).to receive(:start).and_raise(Net::OpenTimeout)
+
+      session = described_class.new(client, [])
+      url = URI('puppet://example.com:8140/:modules/:module/path/to/file')
+
+      expect {
+        session.route_to(:fileserver, url: url)
+      }.to raise_error(Puppet::HTTP::ConnectionError,
+                       %r{Request to https://example.com:8140/puppet/v3 timed out connect operation after .* seconds})
     end
 
     it 'resolves the route when given a generic puppet:/// URL' do


### PR DESCRIPTION
The `Session.route_to` method takes an optional URL parameter. If given and a non-nil/empty host is specified, then always route to that host.

Changes the fileserver methods to require an absolute "joined" path such as "/plugins" and "/modules/<module>/path/to/file", and adds path validation.

Prunes stale HTTP request/responses from VCR recordings.