### PR TITLE
(PUP-10147) Keep track of per-site versions in the session

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -222,6 +222,7 @@ module Puppet
         end
       },
       :ssl_host => proc { Puppet::SSL::Host.localhost },
+      :http_session => proc { Puppet.runtime["http"].create_session },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins },
       :rich_data => false
     }
@@ -307,7 +308,6 @@ module Puppet
 
   require 'puppet/runtime'
   @runtime = Puppet::Runtime.instance
-  @runtime['http'] = proc { Puppet::HTTP::Client.new }
 end
 
 # This feels weird to me; I would really like for us to get to a state where there is never a "require" statement

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -13,6 +13,7 @@ module Puppet
 
   module HTTP
     ACCEPT_ENCODING = "gzip;q=1.0,deflate;q=0.6,identity;q=0.3".freeze
+    HEADER_PUPPET_VERSION = "X-Puppet-Version".freeze
 
     require 'puppet/http/errors'
     require 'puppet/http/response'

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -142,7 +142,7 @@ class Puppet::HTTP::Client
         apply_auth(request, user, password)
 
         http.request(request) do |nethttp|
-          response = Puppet::HTTP::Response.new(nethttp)
+          response = Puppet::HTTP::Response.new(nethttp, request.uri)
           begin
             Puppet.debug("HTTP #{request.method.upcase} #{request.uri} returned #{response.code} #{response.reason}")
 

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -56,7 +56,7 @@ class Puppet::HTTP::Client
       if block_given?
         yield response
       else
-        response.read_body
+        response.body
       end
     end
   end
@@ -71,7 +71,7 @@ class Puppet::HTTP::Client
     request = Net::HTTP::Head.new(url, @default_headers.merge(headers))
 
     execute_streaming(request, ssl_context: ssl_context, user: user, password: password) do |response|
-      response.read_body
+      response.body
     end
   end
 
@@ -88,7 +88,7 @@ class Puppet::HTTP::Client
     request['Content-Type'] = content_type
 
     execute_streaming(request, ssl_context: ssl_context, user: user, password: password) do |response|
-      response.read_body
+      response.body
     end
   end
 
@@ -108,7 +108,7 @@ class Puppet::HTTP::Client
       if block_given?
         yield response
       else
-        response.read_body
+        response.body
       end
     end
   end
@@ -123,7 +123,7 @@ class Puppet::HTTP::Client
     request = Net::HTTP::Delete.new(url, @default_headers.merge(headers))
 
     execute_streaming(request, ssl_context: ssl_context, user: user, password: password) do |response|
-      response.read_body
+      response.body
     end
   end
 

--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -13,7 +13,7 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
         port = server[1] || @default_port
         uri = URI("https://#{host}:#{port}/status/v1/simple/master")
         if get_success?(uri, session, ssl_context: ssl_context)
-          return Puppet::HTTP::Service.create_service(@client, name, host, port)
+          return Puppet::HTTP::Service.create_service(@client, session, name, host, port)
         end
       end
       raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: @server_list_setting.print(@server_list_setting.value) }

--- a/lib/puppet/http/resolver/settings.rb
+++ b/lib/puppet/http/resolver/settings.rb
@@ -1,6 +1,6 @@
 class Puppet::HTTP::Resolver::Settings < Puppet::HTTP::Resolver
   def resolve(session, name, ssl_context: nil)
-    service = Puppet::HTTP::Service.create_service(@client, name)
+    service = Puppet::HTTP::Service.create_service(@client, session, name)
     check_connection?(session, service, ssl_context: ssl_context) ? service : nil
   end
 end

--- a/lib/puppet/http/resolver/srv.rb
+++ b/lib/puppet/http/resolver/srv.rb
@@ -10,7 +10,7 @@ class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
     # This is fine for :ca, but note that :puppet and :file are handled
     # specially in `each_srv_record`.
     @delegate.each_srv_record(@srv_domain, name) do |server, port|
-      service = Puppet::HTTP::Service.create_service(@client, name, server, port)
+      service = Puppet::HTTP::Service.create_service(@client, session, name, server, port)
       return service if check_connection?(session, service, ssl_context: ssl_context)
     end
 

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -1,6 +1,9 @@
 class Puppet::HTTP::Response
-  def initialize(nethttp)
+  attr_reader :nethttp, :url
+
+  def initialize(nethttp, url)
     @nethttp = nethttp
+    @url = url
   end
 
   def code

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -16,6 +16,8 @@ class Puppet::HTTP::Response
   end
 
   def read_body(&block)
+    raise ArgumentError, "A block is required" unless block_given?
+
     @nethttp.read_body(&block)
   end
 

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -4,16 +4,16 @@ class Puppet::HTTP::Service
   SERVICE_NAMES = [:ca, :fileserver, :puppet, :report].freeze
   EXCLUDED_FORMATS = [:yaml, :b64_zlib_yaml, :dot].freeze
 
-  def self.create_service(client, name, server = nil, port = nil)
+  def self.create_service(client, session, name, server = nil, port = nil)
     case name
     when :ca
-      Puppet::HTTP::Service::Ca.new(client, server, port)
+      Puppet::HTTP::Service::Ca.new(client, session, server, port)
     when :fileserver
-      Puppet::HTTP::Service::FileServer.new(client, server, port)
+      Puppet::HTTP::Service::FileServer.new(client, session, server, port)
     when :puppet
-      ::Puppet::HTTP::Service::Compiler.new(client, server, port)
+      ::Puppet::HTTP::Service::Compiler.new(client, session, server, port)
     when :report
-      Puppet::HTTP::Service::Report.new(client, server, port)
+      Puppet::HTTP::Service::Report.new(client, session, server, port)
     else
       raise ArgumentError, "Unknown service #{name}"
     end
@@ -23,8 +23,9 @@ class Puppet::HTTP::Service
     SERVICE_NAMES.include?(name)
   end
 
-  def initialize(client, url)
+  def initialize(client, session, url)
     @client = client
+    @session = session
     @url = url
   end
 

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -2,9 +2,9 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   HEADERS = { 'Accept' => 'text/plain' }.freeze
   API = '/puppet-ca/v1'.freeze
 
-  def initialize(client, server, port)
+  def initialize(client, session, server, port)
     url = build_url(API, server || Puppet[:ca_server], port || Puppet[:ca_port])
-    super(client, url)
+    super(client, session, url)
   end
 
   def get_certificate(name, ssl_context: nil)

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -14,6 +14,8 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
+    @session.process_response(response)
+
     return response.body.to_s if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
@@ -29,6 +31,8 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
+    @session.process_response(response)
+
     return response.body.to_s if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
@@ -42,6 +46,8 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       body: csr.to_pem,
       ssl_context: ssl_context
     )
+
+    @session.process_response(response)
 
     return response.body.to_s if response.success?
 

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -19,6 +19,8 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       },
     )
 
+    @session.process_response(response)
+
     return deserialize(response, Puppet::Node) if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
@@ -61,6 +63,8 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       body: body,
     )
 
+    @session.process_response(response)
+
     return deserialize(response, Puppet::Resource::Catalog) if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
@@ -78,6 +82,8 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       content_type: formatter.mime,
       body: serialize(formatter, facts),
     )
+
+    @session.process_response(response)
 
     return true if response.success?
 

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -1,9 +1,9 @@
 class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   API = '/puppet/v3'.freeze
 
-  def initialize(client, server, port)
+  def initialize(client, session, server, port)
     url = build_url(API, server || Puppet[:server], port || Puppet[:masterport])
-    super(client, url)
+    super(client, session, url)
   end
 
   def get_node(name, environment:, configured_environment: nil, transaction_uuid: nil)

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -4,9 +4,9 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   API = '/puppet/v3'.freeze
   PATH_REGEX = /^\//
 
-  def initialize(client, server, port)
+  def initialize(client, session, server, port)
     url = build_url(API, server || Puppet[:server], port || Puppet[:masterport])
-    super(client, url)
+    super(client, session, url)
   end
 
   def get_file_metadata(path:, environment:, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -26,6 +26,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
+    @session.process_response(response)
+
     return deserialize(response, Puppet::FileServing::Metadata) if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
@@ -51,6 +53,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
+    @session.process_response(response)
+
     return deserialize_multiple(response, Puppet::FileServing::Metadata) if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)
@@ -72,6 +76,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
         res.read_body(&block)
       end
     end
+
+    @session.process_response(response)
 
     return nil if response.success?
 

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -1,3 +1,5 @@
+require 'semantic_puppet'
+
 class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
   API = '/puppet/v3'.freeze
 
@@ -22,11 +24,13 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
+    @session.process_response(response)
+
     return response.body.to_s if response.success?
 
-    server_version = response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION]
+    server_version = response[Puppet::HTTP::HEADER_PUPPET_VERSION]
     if server_version && SemanticPuppet::Version.parse(server_version).major < MAJOR_VERSION_JSON_DEFAULT &&
-        Puppet[:preferred_serialization_format] != 'pson'
+       Puppet[:preferred_serialization_format] != 'pson'
       #TRANSLATORS "pson", "preferred_serialization_format", and "puppetserver" should not be translated
       raise Puppet::HTTP::ProtocolError.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: server_version })
     end

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -4,9 +4,9 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
   # puppet major version where JSON is enabled by default
   MAJOR_VERSION_JSON_DEFAULT = 5
 
-  def initialize(client, server, port)
+  def initialize(client, session, server, port)
     url = build_url(API, server || Puppet[:report_server], port || Puppet[:report_port])
-    super(client, url)
+    super(client, session, url)
   end
 
   def put_report(name, report, environment:, ssl_context: nil)

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -11,7 +11,7 @@ class Puppet::HTTP::Session
 
     # short circuit if explicit URL host & port given
     if url && url.host != nil && !url.host.empty?
-      service = Puppet::HTTP::Service.create_service(@client, name, url.host, url.port)
+      service = Puppet::HTTP::Service.create_service(@client, self, name, url.host, url.port)
       service.connect(ssl_context: ssl_context)
       return service
     end

--- a/lib/puppet/runtime.rb
+++ b/lib/puppet/runtime.rb
@@ -5,7 +5,9 @@ class Puppet::Runtime
   include Singleton
 
   def initialize
-    @runtime_services = {}
+    @runtime_services = {
+      'http' => proc { Puppet::HTTP::Client.new }
+    }
   end
   private :initialize
 
@@ -22,5 +24,10 @@ class Puppet::Runtime
 
   def []=(name, impl)
     @runtime_services[name] = impl
+  end
+
+  # for testing
+  def clear
+    initialize
   end
 end

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -136,10 +136,12 @@ module Puppet::Test
         {
           trusted_information:
             Puppet::Context::TrustedInformation.new('local', 'testing', {}, { "trusted_testhelper" => true }),
-          ssl_context: Puppet::SSL::SSLContext.new(cacerts: []).freeze
+          ssl_context: Puppet::SSL::SSLContext.new(cacerts: []).freeze,
+          http_session: proc { Puppet.runtime["http"].create_session }
         },
         "Context for specs")
 
+      Puppet.runtime.clear
       Puppet::Parser::Functions.reset
       Puppet::Application.clear!
       Puppet::Util::Profiler.clear

--- a/spec/integration/faces/plugin_spec.rb
+++ b/spec/integration/faces/plugin_spec.rb
@@ -53,7 +53,9 @@ describe "Puppet plugin face" do
     app = init_cli_args_and_apply_app
     expect do
       expect {
-        app.run
+        Puppet.override(server_agent_version: '6.13.0') do
+          app.run
+        end
       }.to exit_with(0)
     end.to have_printed(/No plugins downloaded/)
   end

--- a/spec/unit/http/response_spec.rb
+++ b/spec/unit/http/response_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'puppet/http'
+
+describe Puppet::HTTP::Response do
+  let(:uri) { URI.parse('https://www.example.com') }
+  let(:client) { Puppet::HTTP::Client.new }
+
+  it "returns the HTTP code" do
+    stub_request(:get, uri)
+
+    response = client.get(uri)
+    expect(response.code).to eq(200)
+  end
+
+  it "returns the HTTP reason string" do
+    stub_request(:get, uri).to_return(status: [418, "I'm a teapot"])
+
+    response = client.get(uri)
+    expect(response.reason).to eq("I'm a teapot")
+  end
+
+  it "returns the response body" do
+    stub_request(:get, uri).to_return(status: 200, body: "I'm the body")
+
+    response = client.get(uri)
+    expect(response.body).to eq("I'm the body")
+  end
+
+  it "streams the response body" do
+    stub_request(:get, uri).to_return(status: 200, body: "I'm the streaming body")
+
+    content = StringIO.new
+    client.get(uri) do |response|
+      response.read_body do |data|
+        content << data
+      end
+    end
+    expect(content.string).to eq("I'm the streaming body")
+  end
+
+  it "raises if a block isn't given when streaming" do
+    stub_request(:get, uri).to_return(status: 200, body: "")
+
+    expect {
+      client.get(uri) do |response|
+        response.read_body
+      end
+    }.to raise_error(Puppet::HTTP::HTTPError, %r{Request to https://www.example.com failed after .* seconds: A block is required})
+  end
+
+  it "returns success for all 2xx codes" do
+    stub_request(:get, uri).to_return(status: 202)
+
+    expect(client.get(uri)).to be_success
+  end
+
+  it "returns a header value" do
+    stub_request(:get, uri).to_return(status: 200, headers: { 'Content-Encoding' => 'gzip' })
+
+    expect(client.get(uri)['Content-Encoding']).to eq('gzip')
+  end
+end

--- a/spec/unit/http/response_spec.rb
+++ b/spec/unit/http/response_spec.rb
@@ -5,6 +5,13 @@ describe Puppet::HTTP::Response do
   let(:uri) { URI.parse('https://www.example.com') }
   let(:client) { Puppet::HTTP::Client.new }
 
+  it "returns the request URL" do
+    stub_request(:get, uri)
+
+    response = client.get(uri)
+    expect(response.url).to eq(uri)
+  end
+
   it "returns the HTTP code" do
     stub_request(:get, uri)
 

--- a/spec/unit/http/service/ca_spec.rb
+++ b/spec/unit/http/service/ca_spec.rb
@@ -5,6 +5,7 @@ require 'puppet/http'
 describe Puppet::HTTP::Service::Ca do
   let(:ssl_context) { Puppet::SSL::SSLContext.new }
   let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:session) { Puppet::HTTP::Session.new(client, []) }
   let(:subject) { client.create_session.route_to(:ca) }
 
   before :each do

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -5,15 +5,16 @@ require 'puppet/http'
 describe Puppet::HTTP::Service do
   let(:ssl_context) { Puppet::SSL::SSLContext.new }
   let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:session) { Puppet::HTTP::Session.new(client, []) }
   let(:url) { URI.parse('https://www.example.com') }
-  let(:service) { described_class.new(client, url) }
+  let(:service) { described_class.new(client, session, url) }
 
   it "returns a URI containing the base URL and path" do
     expect(service.with_base_url('/puppet/v3')).to eq(URI.parse("https://www.example.com/puppet/v3"))
   end
 
   it "doesn't modify frozen the base URL" do
-    service = described_class.new(client, url.freeze)
+    service = described_class.new(client, session, url.freeze)
     service.with_base_url('/puppet/v3')
   end
 
@@ -36,7 +37,7 @@ describe Puppet::HTTP::Service do
 
   it 'raises for unknown service names' do
     expect {
-      described_class.create_service(client, :westbound)
+      described_class.create_service(client, session, :westbound)
     }.to raise_error(ArgumentError, "Unknown service westbound")
   end
 


### PR DESCRIPTION
Process each response collecting per-site server versions. If server version
is >= 5 then JSON is supported. If version is >= 5.3.4, then the locales mount
is supported.

Because file metadata and content requests don't use the httpclient yet, we
have to lookup the server version in both the context and session.

The plugin integration test is unrealistic because it sets the metadata
and content termini to memory, so we can't determine what version the puppet
server is. So push a version onto the context during the test.