### PR TITLE
(maint) Bump to JRuby 9.2.8.0 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - rvm: 2.6
       env: "CHECK=parallel:spec\\[2\\]"
 
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.8.0
       jdk: openjdk8
       env:
         - "_JAVA_OPTIONS='-Xmx1024m -Xms512m'"

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -88,7 +88,8 @@ describe Puppet::Node::Facts, "when indirecting" do
       @facts.sanitize
       fact_value = @facts.values['test']
       expect(fact_value).to eq(an_alien.to_s)
-      expect(fact_value.encoding).to eq(Encoding::UTF_8)
+      # JRuby 9.2.8 reports US-ASCII which is a subset of UTF-8
+      expect(fact_value.encoding).to eq(Encoding::UTF_8).or eq(Encoding::US_ASCII)
     end
 
   end


### PR DESCRIPTION
JRuby 9.2.0.0 has a bug in StringIO#binmode, and was fixed in 9.2.1.0. Move to
the same version that we're currently shipping in puppetserver.