### PR TITLE
(PUP-10260) Use http client for REST requests

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -526,7 +526,8 @@ class Puppet::Configurer
           # don't update cache until after environment converges
           :ignore_cache_save => true,
           :environment       => Puppet::Node::Environment.remote(@environment),
-          :fail_on_404       => true
+          :fail_on_404       => true,
+          :facts_for_catalog => facts
         )
       )
     end

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -107,4 +107,10 @@ class Puppet::HTTP::Service
       raise Puppet::HTTP::SerializationError.new("Failed to deserialize multiple #{model} from #{formatter.name}: #{err.message}", err)
     end
   end
+
+  def process_response(response)
+    @session.process_response(response)
+
+    raise Puppet::HTTP::ResponseError.new(response) unless response.success?
+  end
 end

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -14,11 +14,9 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return response.body.to_s if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return response.body.to_s
   end
 
   def get_certificate_revocation_list(if_modified_since: nil, ssl_context: nil)
@@ -31,11 +29,9 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return response.body.to_s if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return response.body.to_s
   end
 
   def put_certificate_request(name, csr, ssl_context: nil)
@@ -47,10 +43,8 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return response.body.to_s if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return response.body.to_s
   end
 end

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -19,11 +19,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       },
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::Node) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return deserialize(response, Puppet::Node)
   end
 
   def get_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
@@ -63,11 +61,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       body: body,
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::Resource::Catalog) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return deserialize(response, Puppet::Resource::Catalog)
   end
 
   def put_facts(name, environment:, facts:)
@@ -83,11 +79,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       body: serialize(formatter, facts),
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return true if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    true
   end
 
   def get_status(name)
@@ -102,10 +96,8 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       },
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::Status) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return deserialize(response, Puppet::Status)
   end
 end

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -102,6 +102,8 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       },
     )
 
+    @session.process_response(response)
+
     return deserialize(response, Puppet::Status) if response.success?
 
     raise Puppet::HTTP::ResponseError.new(response)

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -66,6 +66,20 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     return deserialize(response, Puppet::Resource::Catalog)
   end
 
+  def get_facts(name, environment:)
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Node::Facts).join(', '))
+
+    response = @client.get(
+      with_base_url("/facts/#{name}"),
+      headers: headers,
+      params: { environment: environment }
+    )
+
+    process_response(response)
+
+    return deserialize(response, Puppet::Node::Facts)
+  end
+
   def put_facts(name, environment:, facts:)
     formatter = Puppet::Network::FormatHandler.format_for(Puppet[:preferred_serialization_format])
 

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -89,4 +89,21 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
 
     raise Puppet::HTTP::ResponseError.new(response)
   end
+
+  def get_status(name)
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Status).join(', '))
+
+    response = @client.get(
+      with_base_url("/status/#{name}"),
+      headers: headers,
+      params: {
+        # environment is required, but meaningless, default to production
+        environment: 'production'
+      },
+    )
+
+    return deserialize(response, Puppet::Status) if response.success?
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
 end

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -12,7 +12,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_file_metadata(path:, environment:, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
     validate_path(path)
 
-    headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', '))
 
     response = @client.get(
       with_base_url("/file_metadata#{path}"),
@@ -34,7 +34,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
     validate_path(path)
 
-    headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', '))
 
     response = @client.get(
       with_base_url("/file_metadatas#{path}"),
@@ -59,7 +59,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_file_content(path:, environment:, ssl_context: nil, &block)
     validate_path(path)
 
-    headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
+    headers = add_puppet_headers('Accept' => 'application/octet-stream')
     response = @client.get(
       with_base_url("/file_content#{path}"),
       headers: headers,
@@ -81,7 +81,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_static_file_content(path:, environment:, code_id:, ssl_context: nil, &block)
     validate_path(path)
 
-    headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
+    headers = add_puppet_headers('Accept' => 'application/octet-stream')
     response = @client.get(
       with_base_url("/static_file_content#{path}"),
       headers: headers,

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -26,11 +26,9 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::FileServing::Metadata) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return deserialize(response, Puppet::FileServing::Metadata)
   end
 
   def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
@@ -53,11 +51,9 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize_multiple(response, Puppet::FileServing::Metadata) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return deserialize_multiple(response, Puppet::FileServing::Metadata)
   end
 
   def get_file_content(path:, environment:, ssl_context: nil, &block)
@@ -77,12 +73,11 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       end
     end
 
-    @session.process_response(response)
+    process_response(response)
 
-    return nil if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    return nil
   end
+
   private
 
   def validate_path(path)

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -78,6 +78,29 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     return nil
   end
 
+  def get_static_file_content(path:, environment:, code_id:, ssl_context: nil, &block)
+    validate_path(path)
+
+    headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
+    response = @client.get(
+      with_base_url("/static_file_content#{path}"),
+      headers: headers,
+      params: {
+        environment: environment,
+        code_id: code_id,
+      },
+      ssl_context: ssl_context
+    ) do |res|
+      if res.success?
+        res.read_body(&block)
+      end
+    end
+
+    process_response(response)
+
+    return nil
+  end
+
   private
 
   def validate_path(path)

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -22,7 +22,7 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
     @session.process_response(response)
 
     if response.success?
-      response.body.to_s
+      response
     elsif !@session.supports?(:report, 'json') && Puppet[:preferred_serialization_format] != 'pson'
       #TRANSLATORS "pson", "preferred_serialization_format", and "puppetserver" should not be translated
       raise Puppet::HTTP::ProtocolError.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: response[Puppet::HTTP::HEADER_PUPPET_VERSION]})

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -19,7 +19,7 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
     if response.success?
       response
@@ -29,5 +29,11 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
     else
       raise Puppet::HTTP::ResponseError.new(response)
     end
+  end
+
+  protected
+
+  def process_response(response)
+    @session.process_response(response)
   end
 end

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -7,17 +7,6 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
   def find(request)
     return super unless use_http_client?
 
-    # URL encoded facts and facts_format are passed as indirector
-    # request options, so we have to reverse that (unescape, then parse),
-    # and pass a facts object to the http client.
-    format = request.options[:facts_format]
-    if format
-      formatter = Puppet::Network::FormatHandler.format_for(format)
-      facts = formatter.intern(Puppet::Node::Facts, CGI.unescape(request.options[:facts]))
-    else
-      facts = Puppet::Node::Facts.new(request.key, environment: request.environment.to_s)
-    end
-
     checksum_type = if request.options[:checksum_type]
                       request.options[:checksum_type].split('.')
                     else
@@ -28,7 +17,7 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
     api = session.route_to(:puppet)
     api.get_catalog(
       request.key,
-      facts: facts,
+      facts: request.options[:facts_for_catalog],
       environment: request.environment.to_s,
       configured_environment: request.options[:configured_environment],
       transaction_uuid: request.options[:transaction_uuid],

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -3,4 +3,51 @@ require 'puppet/indirector/rest'
 
 class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
   desc "Find resource catalogs over HTTP via REST."
+
+  def find(request)
+    return super unless use_http_client?
+
+    # URL encoded facts and facts_format are passed as indirector
+    # request options, so we have to reverse that (unescape, then parse),
+    # and pass a facts object to the http client.
+    format = request.options[:facts_format]
+    if format
+      formatter = Puppet::Network::FormatHandler.format_for(format)
+      facts = formatter.intern(Puppet::Node::Facts, CGI.unescape(request.options[:facts]))
+    else
+      facts = Puppet::Node::Facts.new(request.key, environment: request.environment.to_s)
+    end
+
+    checksum_type = if request.options[:checksum_type]
+                      request.options[:checksum_type].split('.')
+                    else
+                      Puppet[:supported_checksum_types]
+                    end
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    catalog = api.get_catalog(
+      request.key,
+      facts: facts,
+      environment: request.environment.to_s,
+      configured_environment: request.options[:configured_environment],
+      transaction_uuid: request.options[:transaction_uuid],
+      job_uuid: request.options[:job_id],
+      static_catalog: request.options[:static_catalog],
+      checksum_type: checksum_type
+    )
+    # current tests rely on crazy behavior introduced in 089ac3e37dd
+    catalog.name = request.key
+    catalog
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -26,7 +26,7 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
 
     session = Puppet.lookup(:http_session)
     api = session.route_to(:puppet)
-    catalog = api.get_catalog(
+    api.get_catalog(
       request.key,
       facts: facts,
       environment: request.environment.to_s,
@@ -36,9 +36,6 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
       static_catalog: request.options[:static_catalog],
       checksum_type: checksum_type
     )
-    # current tests rely on crazy behavior introduced in 089ac3e37dd
-    catalog.name = request.key
-    catalog
   rescue Puppet::HTTP::ResponseError => e
     if e.response.code == 404
       return nil unless request.options[:fail_on_404]

--- a/lib/puppet/indirector/facts/rest.rb
+++ b/lib/puppet/indirector/facts/rest.rb
@@ -7,6 +7,26 @@ class Puppet::Node::Facts::Rest < Puppet::Indirector::REST
   def save(request)
     raise ArgumentError, _("PUT does not accept options") unless request.options.empty?
 
+    return legacy_save(request) unless use_http_client?
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.put_facts(
+      request.key,
+      facts: request.instance,
+      environment: request.environment.to_s
+    )
+
+    # preserve existing behavior
+    nil
+  rescue Puppet::HTTP::ResponseError => e
+    # always raise even if fail_on_404 is false
+    raise convert_to_http_error(e.response.nethttp)
+  end
+
+  private
+
+  def legacy_save(request)
     response = do_request(request) do |req|
       http_put(req, IndirectedRoutes.request_to_uri(req), req.instance.render, headers.merge({ "Content-Type" => req.instance.mime }))
     end

--- a/lib/puppet/indirector/facts/rest.rb
+++ b/lib/puppet/indirector/facts/rest.rb
@@ -4,6 +4,25 @@ require 'puppet/indirector/rest'
 class Puppet::Node::Facts::Rest < Puppet::Indirector::REST
   desc "Find and save facts about nodes over HTTP via REST."
 
+  def find(request)
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.get_facts(
+      request.key,
+      environment: request.environment.to_s
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
+
   def save(request)
     raise ArgumentError, _("PUT does not accept options") unless request.options.empty?
 

--- a/lib/puppet/indirector/file_content/rest.rb
+++ b/lib/puppet/indirector/file_content/rest.rb
@@ -6,4 +6,33 @@ class Puppet::Indirector::FileContent::Rest < Puppet::Indirector::REST
   desc "Retrieve file contents via a REST HTTP interface."
 
   use_srv_service(:fileserver)
+
+  def find(request)
+    return super unless use_http_client?
+
+    content = StringIO.new
+
+    url = URI.parse(Puppet::Util.uri_encode(request.uri))
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:fileserver, url: url)
+
+    api.get_file_content(
+      path: URI.unescape(url.path),
+      environment: request.environment.to_s,
+    ) do |data|
+      content << data
+    end
+
+    Puppet::FileServing::Content.from_binary(content.string)
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/indirector/file_content/rest.rb
+++ b/lib/puppet/indirector/file_content/rest.rb
@@ -11,6 +11,7 @@ class Puppet::Indirector::FileContent::Rest < Puppet::Indirector::REST
     return super unless use_http_client?
 
     content = StringIO.new
+    content.binmode
 
     url = URI.parse(Puppet::Util.uri_encode(request.uri))
     session = Puppet.lookup(:http_session)

--- a/lib/puppet/indirector/file_metadata/rest.rb
+++ b/lib/puppet/indirector/file_metadata/rest.rb
@@ -6,4 +6,53 @@ class Puppet::Indirector::FileMetadata::Rest < Puppet::Indirector::REST
   desc "Retrieve file metadata via a REST HTTP interface."
 
   use_srv_service(:fileserver)
+
+  def find(request)
+    return super unless use_http_client?
+
+    url = URI.parse(Puppet::Util.uri_encode(request.uri))
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:fileserver, url: url)
+
+    api.get_file_metadata(
+      path: URI.unescape(url.path),
+      environment: request.environment.to_s,
+      links: request.options[:links],
+      checksum_type: request.options[:checksum_type],
+      source_permissions: request.options[:source_permissions]
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
+
+  def search(request)
+    return super unless use_http_client?
+
+    url = URI.parse(Puppet::Util.uri_encode(request.uri))
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:fileserver, url: url)
+
+    api.get_file_metadatas(
+      path: URI.unescape(url.path),
+      environment: request.environment.to_s,
+      recurse: request.options[:recurse],
+      recurselimit: request.options[:recurselimit],
+      ignore: request.options[:ignore],
+      links: request.options[:links],
+      checksum_type: request.options[:checksum_type],
+      source_permissions: request.options[:source_permissions],
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    return [] if e.response.code == 404
+
+    raise convert_to_http_error(e.response.nethttp)
+  end
 end

--- a/lib/puppet/indirector/node/rest.rb
+++ b/lib/puppet/indirector/node/rest.rb
@@ -4,4 +4,27 @@ require 'puppet/indirector/rest'
 class Puppet::Node::Rest < Puppet::Indirector::REST
   desc "Get a node via REST. Puppet agent uses this to allow the puppet master
     to override its environment."
+
+  def find(request)
+    return super unless use_http_client?
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.get_node(
+      request.key,
+      environment: request.environment.to_s,
+      configured_environment: request.options[:configured_environment],
+      transaction_uuid: request.options[:transaction_uuid]
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -52,6 +52,12 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     Puppet::Util::Connection.determine_port(port_setting, server_setting)
   end
 
+  # Should we use puppet's http client to make requests. Will return
+  # false when running in puppetserver
+  def use_http_client?
+    Puppet::Network::HttpPool.http_client_class == Puppet::Network::HTTP::Connection
+  end
+
   # Provide appropriate headers.
   def headers
     # yaml is not allowed on the network

--- a/lib/puppet/indirector/status/rest.rb
+++ b/lib/puppet/indirector/status/rest.rb
@@ -6,4 +6,19 @@ class Puppet::Indirector::Status::Rest < Puppet::Indirector::REST
   desc "Get puppet master's status via REST. Useful because it tests the health
     of both the web server and the indirector."
 
+  def find(request)
+    return super unless use_http_client?
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.get_status(request.key)
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -2,10 +2,7 @@ require 'puppet/file_serving/content'
 require 'puppet/file_serving/metadata'
 require 'puppet/file_serving/terminus_helper'
 
-require 'puppet/util/http_proxy'
-require 'puppet/network/http'
-require 'puppet/network/http/api/indirected_routes'
-require 'puppet/network/http/compression'
+require 'puppet/http'
 
 module Puppet
   # Copy files from a local or remote source.  This state *only* does any work
@@ -14,11 +11,6 @@ module Puppet
   # this state, during retrieval, modifies the appropriate other states
   # so that things get taken care of appropriately.
   Puppet::Type.type(:file).newparam(:source) do
-    include Puppet::Network::HTTP::Compression.module
-
-    BINARY_MIME_TYPES = [
-      Puppet::Network::FormatHandler.format_for('binary').mime
-    ].join(', ').freeze
 
     attr_accessor :source, :local
     desc <<-'EOT'
@@ -291,45 +283,54 @@ module Puppet
       end
     end
 
-    def get_from_puppet_source(source_uri, content_uri, &block)
-      options = { :environment => resource.catalog.environment_instance }
-      if content_uri
-        options[:code_id] = resource.catalog.code_id
-        request = Puppet::Indirector::Request.new(:static_file_content, :find, content_uri, nil, options)
+    def get_from_content_uri_source(content_uri, &block)
+      session = Puppet.lookup(:http_session)
+      api = session.route_to(:fileserver, url: url)
+
+      api.get_static_file_content(
+        path: URI.unescape(url.path),
+        environment: resource.catalog.environment_instance.to_s,
+        code_id: resource.catalog.code_id,
+        &block
+      )
+    end
+
+    def get_from_source_uri_source(url, &block)
+      session = Puppet.lookup(:http_session)
+      api = session.route_to(:fileserver, url: url)
+
+      api.get_file_content(
+        path: URI.unescape(url.path),
+        environment: resource.catalog.environment_instance.to_s,
+        &block
+      )
+    end
+
+    def get_from_http_source(url, &block)
+      client = Puppet.runtime['http']
+      client.get(url) do |response|
+        raise Puppet::HTTP::ResponseError.new(response) unless response.success?
+
+        response.read_body(&block)
+      end
+    end
+
+    def chunk_file_from_source(&block)
+      if uri.scheme =~ /^https?/
+        get_from_http_source(uri, &block)
+      elsif metadata.content_uri
+        content_url = URI.parse(Puppet::Util.uri_encode(metadata.content_uri))
+        get_from_content_uri_source(content_url, &block)
       else
-        request = Puppet::Indirector::Request.new(:file_content, :find, source_uri, nil, options)
+        get_from_source_uri_source(uri, &block)
       end
-
-      request.do_request(:fileserver) do |req|
-        ssl_context = Puppet.lookup(:ssl_context)
-        connection = Puppet::Network::HttpPool.connection(req.server, req.port, ssl_context: ssl_context)
-        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => BINARY_MIME_TYPES}), &block)
-      end
+    rescue Puppet::HTTP::ResponseError => e
+      handle_response_error(e.response)
     end
 
-    def get_from_http_source(source_uri, &block)
-      Puppet::Util::HttpProxy.request_with_redirects(URI(source_uri), :get, &block)
-    end
-
-    def get_from_source(&block)
-      source_uri = metadata.source
-      if source_uri =~ /^https?:/
-        get_from_http_source(source_uri, &block)
-      else
-        get_from_puppet_source(source_uri, metadata.content_uri, &block)
-      end
-    end
-
-    def chunk_file_from_source
-      get_from_source do |response|
-        case response.code
-        when /^2/;  uncompress(response) { |uncompressor| response.read_body { |chunk| yield uncompressor.uncompress(chunk) } }
-        else
-          # Raise the http error if we didn't get a 'success' of some kind.
-          message = "Error #{response.code} on SERVER: #{(response.body||'').empty? ? response.message : uncompress_body(response)}"
-          raise Net::HTTPError.new(message, response)
-        end
-      end
+    def handle_response_error(response)
+      message = "Error #{response.code} on SERVER: #{response.body.empty? ? response.reason : response.body}"
+      raise Net::HTTPError.new(message, response.nethttp)
     end
   end
 

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_fetch_if_not_on_the_local_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_fetch_if_not_on_the_local_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_not_update_if_content_on_disk_is_up-to-date.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_not_update_if_content_on_disk_is_up-to-date.yml
@@ -69,76 +69,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Content-MD5:
-      - Es93YfogzPk5EimSmqb9XQ==
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_update_if_content_differs_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_update_if_content_differs_on_disk.yml
@@ -69,76 +69,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Content-MD5:
-      - Es93YfogzPk5EimSmqb9XQ==
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_mtime_is_older_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_mtime_is_older_on_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_no_header_specified.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_no_header_specified.yml
@@ -65,72 +65,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_not_on_the_local_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_not_on_the_local_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_not_update_if_mtime_is_newer_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_not_update_if_mtime_is_newer_on_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -854,7 +854,7 @@ describe Puppet::Configurer do
     it "should not update the cached catalog in noop mode" do
       Puppet[:noop] = true
 
-      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:post, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
 
       Puppet::Resource::Catalog.indirection.cache_class = :json
       path = Puppet::Resource::Catalog.indirection.cache.path(catalog.name)
@@ -868,7 +868,7 @@ describe Puppet::Configurer do
       Puppet[:noop] = false
       Puppet[:log_level] = 'info'
 
-      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:post, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
 
       Puppet::Resource::Catalog.indirection.cache_class = :json
       cache_path = Puppet::Resource::Catalog.indirection.cache.path(Puppet[:node_name_value])
@@ -881,7 +881,7 @@ describe Puppet::Configurer do
     end
 
     it "successfully applies the catalog without a cache" do
-      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:post, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
 
       Puppet::Resource::Catalog.indirection.cache_class = nil
 
@@ -1041,7 +1041,7 @@ describe Puppet::Configurer do
       Puppet::Resource::Catalog.indirection.terminus_class = :rest
 
       stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 200)
-      stub_request(:get, %r{https://myserver:123/puppet/v3/catalog}).to_return(status: 200)
+      stub_request(:post, %r{https://myserver:123/puppet/v3/catalog}).to_return(status: 200)
       node_request = stub_request(:get, %r{https://myserver:123/puppet/v3/node/}).to_return(status: 200)
 
       configurer.run

--- a/spec/unit/http/service/compiler_spec.rb
+++ b/spec/unit/http/service/compiler_spec.rb
@@ -272,6 +272,59 @@ describe Puppet::HTTP::Service::Compiler do
     end
   end
 
+  context 'when getting facts' do
+    let(:uri) { %r{/puppet/v3/facts/ziggy} }
+    let(:facts_response) { { body: formatter.render(facts), headers: {'Content-Type' => formatter.mime } } }
+
+    it 'includes environment' do
+      stub_request(:get, uri)
+          .with(query: hash_including("environment" => "outerspace"))
+          .to_return(**facts_response)
+
+      subject.get_facts(certname, environment: 'outerspace')
+    end
+
+    it 'returns a deserialized facts object' do
+      stub_request(:get, uri)
+        .to_return(**facts_response)
+
+      n = subject.get_facts(certname, environment: 'production')
+      expect(n).to be_a(Puppet::Node::Facts)
+      expect(n.name).to eq(certname)
+    end
+
+    it 'raises a response error if unsuccessful' do
+      stub_request(:get, uri)
+        .to_return(status: [500, "Server Error"])
+
+      expect {
+        subject.get_facts(certname, environment: 'production')
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq('Server Error')
+        expect(err.response.code).to eq(500)
+      end
+    end
+
+    it 'raises a protocol error if the content-type header is missing' do
+      stub_request(:get, uri)
+        .to_return(body: "content-type is missing")
+
+      expect {
+        subject.get_facts(certname, environment: 'production')
+      }.to raise_error(Puppet::HTTP::ProtocolError, /No content type in http response; cannot parse/)
+    end
+
+    it 'raises a serialization error if the content is invalid' do
+      stub_request(:get, uri)
+        .to_return(body: "this isn't valid JSON", headers: {'Content-Type' => 'application/json'})
+
+      expect {
+        subject.get_facts(certname, environment: 'production')
+      }.to raise_error(Puppet::HTTP::SerializationError, /Failed to deserialize Puppet::Node::Facts from json/)
+    end
+  end
+
   context 'when putting facts' do
     let(:uri) { %r{/puppet/v3/facts/ziggy} }
 

--- a/spec/unit/http/service/file_server_spec.rb
+++ b/spec/unit/http/service/file_server_spec.rb
@@ -216,4 +216,37 @@ describe Puppet::HTTP::Service::FileServer do
       }.to raise_error(ArgumentError, 'Path must start with a slash')
     end
   end
+
+  context 'getting static file content' do
+    let(:code_id) { "0fc72115-adc6-4b1a-aa50-8f31b3ece440" }
+    let(:uri) { "https://www.example.com:443/puppet/v3/static_file_content/:mount/:path?environment=testing&code_id=#{code_id}"}
+
+    it 'yields file content' do
+      stub_request(:get, uri).with do |request|
+        expect(request.headers).to include({'Accept' => 'application/octet-stream'})
+      end.to_return(status: 200, body: "and beyond")
+
+      expect { |b|
+        subject.get_static_file_content(path: '/:mount/:path', environment: environment, code_id: code_id, &b)
+      }.to yield_with_args("and beyond")
+    end
+
+    it 'raises response error if unsuccessful' do
+      stub_request(:get, uri).to_return(status: [400, 'Bad Request'])
+
+      expect {
+        subject.get_static_file_content(path: '/:mount/:path', environment: environment, code_id: code_id) { |data| }
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq('Bad Request')
+        expect(err.response.code).to eq(400)
+      end
+    end
+
+    it 'raises response error if path is relative' do
+      expect {
+        subject.get_static_file_content(path: 'relative_path', environment: environment, code_id: code_id) { |data| }
+      }.to raise_error(ArgumentError, 'Path must start with a slash')
+    end
+  end
 end

--- a/spec/unit/http/service/report_spec.rb
+++ b/spec/unit/http/service/report_spec.rb
@@ -79,6 +79,14 @@ describe Puppet::HTTP::Service::Report do
       subject.put_report('node name', report, environment: environment)
     end
 
+    it 'returns the response whose body contains the list of report processors' do
+      body = "[\"store\":\"http\"]"
+      stub_request(:put, url)
+        .to_return(status: 200, body: body, headers: {'Content-Type' => 'application/json'})
+
+      expect(subject.put_report('infinity', report, environment: environment).body).to eq(body)
+    end
+
     it 'raises response error if unsuccessful' do
       stub_request(:put, url).to_return(status: [400, 'Bad Request'], headers: {'X-Puppet-Version' => '6.1.8' })
 

--- a/spec/unit/indirector/catalog/rest_spec.rb
+++ b/spec/unit/indirector/catalog/rest_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Resource::Catalog::Rest do
   it 'finds a catalog' do
     catalog = Puppet::Resource::Catalog.new(certname)
 
-    stub_request(:get, uri).to_return(**catalog_response(catalog))
+    stub_request(:post, uri).to_return(**catalog_response(catalog))
 
     expect(described_class.indirection.find(certname)).to be_a(Puppet::Resource::Catalog)
   end
@@ -30,27 +30,27 @@ describe Puppet::Resource::Catalog::Rest do
     env = Puppet::Node::Environment.remote('outerspace')
     catalog = Puppet::Resource::Catalog.new(certname, env)
 
-    stub_request(:get, uri).to_return(**catalog_response(catalog))
+    stub_request(:post, uri).to_return(**catalog_response(catalog))
 
     expect(described_class.indirection.find(certname).environment_instance).to eq(env)
   end
 
   it 'returns nil if the node does not exist' do
-    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+    stub_request(:post, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
 
     expect(described_class.indirection.find(certname)).to be_nil
   end
 
   it 'raises if fail_on_404 is specified' do
-    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+    stub_request(:post, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
 
     expect{
       described_class.indirection.find(certname, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/catalog/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/catalog/ziggy resulted in 404 with the message: {}})
   end
 
   it 'raises Net::HTTPError on 500' do
-    stub_request(:get, uri).to_return(status: 500)
+    stub_request(:post, uri).to_return(status: 500)
 
     expect{
       described_class.indirection.find(certname)

--- a/spec/unit/indirector/catalog/rest_spec.rb
+++ b/spec/unit/indirector/catalog/rest_spec.rb
@@ -3,7 +3,57 @@ require 'spec_helper'
 require 'puppet/indirector/catalog/rest'
 
 describe Puppet::Resource::Catalog::Rest do
-  it "should be a sublcass of Puppet::Indirector::REST" do
-    expect(Puppet::Resource::Catalog::Rest.superclass).to equal(Puppet::Indirector::REST)
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/catalog/ziggy} }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+
+  before :each do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def catalog_response(catalog)
+    { body: formatter.render(catalog), headers: {'Content-Type' => formatter.mime } }
+  end
+
+  it 'finds a catalog' do
+    catalog = Puppet::Resource::Catalog.new(certname)
+
+    stub_request(:get, uri).to_return(**catalog_response(catalog))
+
+    expect(described_class.indirection.find(certname)).to be_a(Puppet::Resource::Catalog)
+  end
+
+  it 'constructs a catalog environment_instance' do
+    env = Puppet::Node::Environment.remote('outerspace')
+    catalog = Puppet::Resource::Catalog.new(certname, env)
+
+    stub_request(:get, uri).to_return(**catalog_response(catalog))
+
+    expect(described_class.indirection.find(certname).environment_instance).to eq(env)
+  end
+
+  it 'returns nil if the node does not exist' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect(described_class.indirection.find(certname)).to be_nil
+  end
+
+  it 'raises if fail_on_404 is specified' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect{
+      described_class.indirection.find(certname, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/catalog/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it 'raises Net::HTTPError on 500' do
+    stub_request(:get, uri).to_return(status: 500)
+
+    expect{
+      described_class.indirection.find(certname)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
   end
 end

--- a/spec/unit/indirector/facts/rest_spec.rb
+++ b/spec/unit/indirector/facts/rest_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Node::Facts::Rest do
 
       expect{
         described_class.indirection.find(certname, fail_on_404: true)
-      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/facts/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/facts/ziggy resulted in 404 with the message: {}})
     end
 
     it 'raises Net::HTTPError on 500' do

--- a/spec/unit/indirector/facts/rest_spec.rb
+++ b/spec/unit/indirector/facts/rest_spec.rb
@@ -3,42 +3,83 @@ require 'spec_helper'
 require 'puppet/indirector/facts/rest'
 
 describe Puppet::Node::Facts::Rest do
-  it "should be a sublcass of Puppet::Indirector::REST" do
-    expect(Puppet::Node::Facts::Rest.superclass).to equal(Puppet::Indirector::REST)
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/facts/ziggy} }
+  let(:facts) { Puppet::Node::Facts.new(certname, test_fact: 'test value') }
+
+  before do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
   end
 
-  let(:model) { Puppet::Node::Facts }
-  before(:each) { model.indirection.terminus_class = :rest }
+  describe '#find' do
+    let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
 
-  def mock_response(code, body, content_type='text/plain', encoding=nil)
-    obj = double('http response', :code => code.to_s, :body => body)
-    allow(obj).to receive(:[]).with('content-type').and_return(content_type)
-    allow(obj).to receive(:[]).with('content-encoding').and_return(encoding)
-    allow(obj).to receive(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).and_return(Puppet.version)
-    obj
+    def facts_response(facts)
+      { body: formatter.render(facts), headers: {'Content-Type' => formatter.mime } }
+    end
+
+    it 'finds facts' do
+      facts = Puppet::Node::Facts.new(certname)
+
+      stub_request(:get, uri).to_return(**facts_response(facts))
+
+      expect(described_class.indirection.find(certname)).to be_a(Puppet::Node::Facts)
+    end
+
+    it 'returns nil if the facts do not exist' do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+      expect(described_class.indirection.find(certname)).to be_nil
+    end
+
+    it 'raises if fail_on_404 is specified' do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+      expect{
+        described_class.indirection.find(certname, fail_on_404: true)
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/facts/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    end
+
+    it 'raises Net::HTTPError on 500' do
+      stub_request(:get, uri).to_return(status: 500)
+
+      expect{
+        described_class.indirection.find(certname)
+      }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+    end
   end
 
   describe '#save' do
-    subject { model.indirection.terminus(:rest) }
+    it 'returns nil on success' do
+      stub_request(:put, %r{/puppet/v3/facts})
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json'}, body: '')
 
-    let(:connection) { double('mock http connection', :verify_callback= => nil) }
-    let(:node_name) { 'puppet.node.test' }
-    let(:data) { model.new(node_name, {test_fact: 'test value'}) }
-    let(:request) { Puppet::Indirector::Request.new(:facts, :save, node_name, data) }
-
-    before :each do
-      allow(subject).to receive(:network).and_return(connection)
+      expect(described_class.indirection.save(facts)).to be_nil
     end
 
-    context 'when a 404 response is received' do
-      let(:response) { mock_response(404, '{}', 'test/json') }
+    it 'raises if options are specified' do
+      expect {
+        described_class.indirection.save(facts, nil, foo: :bar)
+      }.to raise_error(ArgumentError, /PUT does not accept options/)
+    end
 
-      before(:each) { expect(connection).to receive(:put).and_return(response) }
+    it 'raises with HTTP 404' do
+      stub_request(:put, %r{/puppet/v3/facts}).to_return(status: 404)
 
-      it 'riases with HTTP 404' do
-        expect{ subject.save(request) }.to raise_error(Net::HTTPError,
-                                                       /Error 404 on SERVER/)
-      end
+      expect {
+        described_class.indirection.save(facts)
+      }.to raise_error(Net::HTTPError, /Error 404 on SERVER/)
+    end
+
+    it 'raises with HTTP 500' do
+      stub_request(:put, %r{/puppet/v3/facts}).to_return(status: 500)
+
+      expect {
+        described_class.indirection.save(facts)
+      }.to raise_error(Net::HTTPError, /Error 500 on SERVER/)
     end
   end
 end

--- a/spec/unit/indirector/file_content/rest_spec.rb
+++ b/spec/unit/indirector/file_content/rest_spec.rb
@@ -3,9 +3,60 @@ require 'spec_helper'
 require 'puppet/indirector/file_content/rest'
 
 describe Puppet::Indirector::FileContent::Rest do
-  it "should add the node's cert name to the arguments"
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/file_content/:mount/path/to/file} }
+  let(:key) { "puppet:///:mount/path/to/file" }
 
-  it "should set the content type to text/plain"
+  before :each do
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def file_content_response
+    {body: "some content", headers: { 'Content-Type' => 'application/octet-stream' } }
+  end
+
+  it "returns content as utf-8 string" do
+    stub_request(:get, uri).to_return(status: 200, **file_content_response)
+
+    file_content = described_class.indirection.find(key)
+    expect(file_content.content.encoding).to eq(Encoding::UTF_8)
+    expect(file_content.content).to eq('some content')
+  end
+
+  it "URL encodes special characters" do
+    stub_request(:get, %r{/puppet/v3/file_content/:mount/path%20to%20file}).to_return(status: 200, **file_content_response)
+
+    described_class.indirection.find('puppet:///:mount/path to file')
+  end
+
+  it "returns nil if the content doesn't exist" do
+    stub_request(:get, uri).to_return(status: 404)
+
+    expect(described_class.indirection.find(key)).to be_nil
+  end
+
+  it "raises if fail_on_404 is true" do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+    expect {
+      described_class.indirection.find(key, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_content/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it "raises an error on HTTP 500" do
+    stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+    expect {
+      described_class.indirection.find(key)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+  end
+
+  it "connects to a specific host" do
+    stub_request(:get, %r{https://example.com:8140/puppet/v3/file_content/:mount/path/to/file})
+      .to_return(status: 200, **file_content_response)
+
+    described_class.indirection.find("puppet://example.com:8140/:mount/path/to/file")
+  end
 
   it "should use the :fileserver SRV service" do
     expect(Puppet::Indirector::FileContent::Rest.srv_service).to eq(:fileserver)

--- a/spec/unit/indirector/file_content/rest_spec.rb
+++ b/spec/unit/indirector/file_content/rest_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Indirector::FileContent::Rest do
 
     expect {
       described_class.indirection.find(key, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_content/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_content/:mount/path/to/file resulted in 404 with the message: {}})
   end
 
   it "raises an error on HTTP 500" do

--- a/spec/unit/indirector/file_content/rest_spec.rb
+++ b/spec/unit/indirector/file_content/rest_spec.rb
@@ -15,11 +15,11 @@ describe Puppet::Indirector::FileContent::Rest do
     {body: "some content", headers: { 'Content-Type' => 'application/octet-stream' } }
   end
 
-  it "returns content as utf-8 string" do
+  it "returns content as a binary string" do
     stub_request(:get, uri).to_return(status: 200, **file_content_response)
 
     file_content = described_class.indirection.find(key)
-    expect(file_content.content.encoding).to eq(Encoding::UTF_8)
+    expect(file_content.content.encoding).to eq(Encoding::BINARY)
     expect(file_content.content).to eq('some content')
   end
 

--- a/spec/unit/indirector/file_metadata/rest_spec.rb
+++ b/spec/unit/indirector/file_metadata/rest_spec.rb
@@ -46,7 +46,7 @@ describe Puppet::Indirector::FileMetadata::Rest do
 
       expect {
         described_class.indirection.find(key, fail_on_404: true)
-      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_metadata/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_metadata/:mount/path/to/file resulted in 404 with the message: {}})
     end
 
     it "raises an error on HTTP 500" do

--- a/spec/unit/indirector/file_metadata/rest_spec.rb
+++ b/spec/unit/indirector/file_metadata/rest_spec.rb
@@ -3,8 +3,115 @@ require 'spec_helper'
 require 'puppet/indirector/file_metadata'
 require 'puppet/indirector/file_metadata/rest'
 
-describe "Puppet::Indirector::Metadata::Rest" do
-  it "should add the node's cert name to the arguments"
+describe Puppet::Indirector::FileMetadata::Rest do
+  let(:certname) { 'ziggy' }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+
+  before :each do
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def metadata_response(metadata)
+    { body: formatter.render(metadata), headers: {'Content-Type' => formatter.mime } }
+  end
+
+  context "when finding" do
+    let(:uri) { %r{/puppet/v3/file_metadata/:mount/path/to/file} }
+    let(:key) { "puppet:///:mount/path/to/file" }
+    let(:metadata) { Puppet::FileServing::Metadata.new('/path/to/file') }
+
+    it "returns file metadata" do
+      stub_request(:get, uri)
+        .to_return(status: 200, **metadata_response(metadata))
+
+      result = described_class.indirection.find(key)
+      expect(result.path).to eq('/path/to/file')
+    end
+
+    it "URL encodes special characters" do
+      stub_request(:get, %r{/puppet/v3/file_metadata/:mount/path%20to%20file})
+        .to_return(status: 200, **metadata_response(metadata))
+
+      described_class.indirection.find('puppet:///:mount/path to file')
+    end
+
+    it "returns nil if the content doesn't exist" do
+      stub_request(:get, uri).to_return(status: 404)
+
+      expect(described_class.indirection.find(key)).to be_nil
+    end
+
+    it "raises if fail_on_404 is true" do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect {
+        described_class.indirection.find(key, fail_on_404: true)
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_metadata/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    end
+
+    it "raises an error on HTTP 500" do
+      stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect {
+        described_class.indirection.find(key)
+      }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+    end
+
+    it "connects to a specific host" do
+      stub_request(:get, %r{https://example.com:8140/puppet/v3/file_metadata/:mount/path/to/file})
+        .to_return(status: 200, **metadata_response(metadata))
+
+      described_class.indirection.find("puppet://example.com:8140/:mount/path/to/file")
+    end
+  end
+
+  context "when searching" do
+    let(:uri) { %r{/puppet/v3/file_metadatas/:mount/path/to/dir} }
+    let(:key) { "puppet:///:mount/path/to/dir" }
+    let(:metadatas) { [Puppet::FileServing::Metadata.new('/path/to/dir')] }
+
+    it "returns an array of file metadata" do
+      stub_request(:get, uri)
+        .to_return(status: 200, **metadata_response(metadatas))
+
+      result = described_class.indirection.search(key)
+      expect(result.first.path).to eq('/path/to/dir')
+    end
+
+    it "URL encodes special characters" do
+      stub_request(:get, %r{/puppet/v3/file_metadatas/:mount/path%20to%20dir})
+        .to_return(status: 200, **metadata_response(metadatas))
+
+      described_class.indirection.search('puppet:///:mount/path to dir')
+    end
+
+    it "returns an empty array if the metadata doesn't exist" do
+      stub_request(:get, uri).to_return(status: 404)
+
+      expect(described_class.indirection.search(key)).to eq([])
+    end
+
+    it "returns an empty array if the metadata doesn't exist and fail_on_404 is true" do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect(described_class.indirection.search(key, fail_on_404: true)).to eq([])
+    end
+
+    it "raises an error on HTTP 500" do
+      stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect {
+        described_class.indirection.search(key)
+      }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+    end
+
+    it "connects to a specific host" do
+      stub_request(:get, %r{https://example.com:8140/puppet/v3/file_metadatas/:mount/path/to/dir})
+        .to_return(status: 200, **metadata_response(metadatas))
+
+      described_class.indirection.search("puppet://example.com:8140/:mount/path/to/dir")
+    end
+  end
 
   it "should use the :fileserver SRV service" do
     expect(Puppet::Indirector::FileMetadata::Rest.srv_service).to eq(:fileserver)

--- a/spec/unit/indirector/node/rest_spec.rb
+++ b/spec/unit/indirector/node/rest_spec.rb
@@ -3,9 +3,57 @@ require 'spec_helper'
 require 'puppet/indirector/node/rest'
 
 describe Puppet::Node::Rest do
-  before do
-    @searcher = Puppet::Node::Rest.new
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/node/ziggy} }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+
+  before :each do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
   end
 
+  def node_response(node)
+    { body: formatter.render(node), headers: {'Content-Type' => formatter.mime } }
+  end
 
+  it 'finds a node' do
+    node = Puppet::Node.new(certname)
+
+    stub_request(:get, uri).to_return(**node_response(node))
+
+    expect(described_class.indirection.find(certname)).to be_a(Puppet::Node)
+  end
+
+  it 'preserves the node environment_name as a symbol' do
+    env = Puppet::Node::Environment.remote('outerspace')
+    node = Puppet::Node.new(certname, environment: env)
+
+    stub_request(:get, uri).to_return(**node_response(node))
+
+    expect(described_class.indirection.find(certname).environment_name).to eq(:outerspace)
+  end
+
+  it 'returns nil if the node does not exist' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect(described_class.indirection.find(certname)).to be_nil
+  end
+
+  it 'raises if fail_on_404 is specified' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect{
+      described_class.indirection.find(certname, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/node/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it 'raises Net::HTTPError on 500' do
+    stub_request(:get, uri).to_return(status: 500)
+
+    expect{
+      described_class.indirection.find(certname)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+  end
 end

--- a/spec/unit/indirector/node/rest_spec.rb
+++ b/spec/unit/indirector/node/rest_spec.rb
@@ -46,7 +46,7 @@ describe Puppet::Node::Rest do
 
     expect{
       described_class.indirection.find(certname, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/node/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/node/ziggy resulted in 404 with the message: {}})
   end
 
   it 'raises Net::HTTPError on 500' do

--- a/spec/unit/indirector/report/rest_spec.rb
+++ b/spec/unit/indirector/report/rest_spec.rb
@@ -37,6 +37,13 @@ describe Puppet::Transaction::Report::Rest do
       expect(described_class.indirection.save(instance)).to eq(["store", "http"])
     end
 
+    it "parses charset from response content-type" do
+      stub_request(:put, %r{/puppet/v3/report})
+        .to_return(status: 200, body: JSON.dump(["store"]), headers: { 'Content-Type' => 'application/json;charset=utf-8' })
+
+      expect(described_class.indirection.save(instance)).to eq(["store"])
+    end
+
     describe "when handling the response" do
       describe "when the server major version is less than 5" do
         it "raises if the save fails and we're not using pson" do
@@ -49,7 +56,7 @@ describe Puppet::Transaction::Report::Rest do
 
           expect {
             described_class.indirection.save(instance)
-          }.to raise_error(Puppet::Error, /Server version 4.10.1 does not accept reports in 'json'/)
+          }.to raise_error(Puppet::Error, /To submit reports to a server running puppetserver 4.10.1, set preferred_serialization_format to pson/)
         end
 
         it "raises with HTTP 500 if the save fails and we're already using pson" do

--- a/spec/unit/indirector/report/rest_spec.rb
+++ b/spec/unit/indirector/report/rest_spec.rb
@@ -22,43 +22,19 @@ describe Puppet::Transaction::Report::Rest do
     expect(Puppet::Transaction::Report::Rest.srv_service).to eq(:report)
   end
 
-  let(:model) { Puppet::Transaction::Report }
-  let(:terminus_class) { Puppet::Transaction::Report::Rest }
-  let(:terminus) { model.indirection.terminus(:rest) }
-  let(:indirection) { model.indirection }
-
   before(:each) do
-    Puppet::Transaction::Report.indirection.terminus_class = :rest
-  end
-
-  def mock_response(code, body, content_type='text/plain', encoding=nil)
-    obj = double('http 200 ok', :code => code.to_s, :body => body)
-    allow(obj).to receive(:[]).with('content-type').and_return(content_type)
-    allow(obj).to receive(:[]).with('content-encoding').and_return(encoding)
-    allow(obj).to receive(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).and_return(Puppet.version)
-    obj
-  end
-
-  def save_request(key, instance, options={})
-    Puppet::Indirector::Request.new(:report, :find, key, instance, options)
+    described_class.indirection.terminus_class = :rest
   end
 
   describe "#save" do
-    let(:response) { mock_response(200, 'body') }
-    let(:connection) { double('mock http connection', :put => response, :verify_callback= => nil) }
-    let(:instance) { model.new('the thing', 'some contents') }
-    let(:request) { save_request(instance.name, instance) }
+    let(:instance) { Puppet::Transaction::Report.new('the thing', 'some contents') }
     let(:body) { ["store", "http"].to_pson }
 
-    before :each do
-      allow(terminus).to receive(:network).and_return(connection)
-    end
-
     it "deserializes the response as an array of report processor names" do
-      response = mock_response('200', body, 'text/pson')
-      expect(connection).to receive(:put).and_return(response)
+      stub_request(:put, %r{/puppet/v3/report})
+        .to_return(status: 200, body: body, headers: { 'Content-Type' => 'text/pson' })
 
-      expect(terminus.save(request)).to eq(["store", "http"])
+      expect(described_class.indirection.save(instance)).to eq(["store", "http"])
     end
 
     describe "when handling the response" do
@@ -66,24 +42,26 @@ describe Puppet::Transaction::Report::Rest do
         it "raises if the save fails and we're not using pson" do
           Puppet[:preferred_serialization_format] = "json"
 
-          response = mock_response('500', '{}', 'text/pson')
-          allow(response).to receive(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).and_return("4.10.1")
-          expect(connection).to receive(:put).and_return(response)
+          stub_request(:put, %r{/puppet/v3/report})
+            .to_return(status: 500,
+                       body: "{}",
+                       headers: { 'Content-Type' => 'text/pson', Puppet::Network::HTTP::HEADER_PUPPET_VERSION => '4.10.1' })
 
           expect {
-            terminus.save(request)
+            described_class.indirection.save(instance)
           }.to raise_error(Puppet::Error, /Server version 4.10.1 does not accept reports in 'json'/)
         end
 
         it "raises with HTTP 500 if the save fails and we're already using pson" do
           Puppet[:preferred_serialization_format] = "pson"
 
-          response = mock_response('500', '{}', 'text/pson')
-          allow(response).to receive(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).and_return("4.10.1")
-          expect(connection).to receive(:put).and_return(response)
+          stub_request(:put, %r{/puppet/v3/report})
+            .to_return(status: 500,
+                       body: "{}",
+                       headers: { 'Content-Type' => 'text/pson', Puppet::Network::HTTP::HEADER_PUPPET_VERSION => '4.10.1' })
 
           expect {
-            terminus.save(request)
+            described_class.indirection.save(instance)
           }.to raise_error(Net::HTTPError, /Error 500 on SERVER/)
         end
       end

--- a/spec/unit/indirector/status/rest_spec.rb
+++ b/spec/unit/indirector/status/rest_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Indirector::Status::Rest do
 
     expect{
       described_class.indirection.find(certname, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/status/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/status/ziggy resulted in 404 with the message: {}})
   end
 
   it 'raises Net::HTTPError on 500' do

--- a/spec/unit/indirector/status/rest_spec.rb
+++ b/spec/unit/indirector/status/rest_spec.rb
@@ -3,7 +3,42 @@ require 'spec_helper'
 require 'puppet/indirector/status/rest'
 
 describe Puppet::Indirector::Status::Rest do
-  it "should be a subclass of Puppet::Indirector::REST" do
-    expect(Puppet::Indirector::Status::Rest.superclass).to equal(Puppet::Indirector::REST)
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/status/ziggy} }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+
+  before :each do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def status_response(node)
+    { body: formatter.render(node), headers: {'Content-Type' => formatter.mime } }
+  end
+
+  it 'finds server status' do
+    node = Puppet::Status.new(certname)
+
+    stub_request(:get, uri).to_return(**status_response(node))
+
+    expect(described_class.indirection.find(certname)).to be_a(Puppet::Status)
+  end
+
+  it 'raises if fail_on_404 is specified' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect{
+      described_class.indirection.find(certname, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/status/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it 'raises Net::HTTPError on 500' do
+    stub_request(:get, uri).to_return(status: 500)
+
+    expect{
+      described_class.indirection.find(certname)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
   end
 end

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -583,53 +583,64 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
 
     describe 'from remote source' do
       let(:source_content) { "source file content\n"*10 }
-      let(:source) { resource.newattr(:source) }
-      let(:response) { double('response', :[] => nil, :body => nil, :message => nil) }
-      let(:conn) { double('connection') }
+      let(:source) {
+        attr = resource.newattr(:source)
+        attr.metadata = metadata
+        attr
+      }
+      let(:metadata) {
+        Puppet::FileServing::Metadata.new(
+          '/modules/:module/foo',
+          {
+            'type' => 'file',
+            'source' => 'puppet:///modules/:module/foo'
+          }
+        )
+      }
 
       before do
         resource[:backup] = false
-
-        expectation = receive(:read_body)
-        source_content.lines.each { |line| expectation = expectation.and_yield(line) }
-        allow(response).to expectation
-        allow(conn).to receive(:request_get).and_yield(response)
       end
 
       it 'should use an explicit fileserver if source starts with puppet://' do
-        allow(response).to receive(:code).and_return('200')
-        allow(source).to receive(:metadata).and_return(double('metadata', :source => 'puppet://somehostname/test/foo', :ftype => 'file', :content_uri => nil))
-        expect(Puppet::Network::HttpPool).to receive(:connection).with('somehostname', 8140, anything).and_return(conn)
+        metadata.source = "puppet://somehostname:8140/modules/:module/foo"
+
+        stub_request(:get, %r{https://somehostname:8140/puppet/v3/file_content/modules/:module/foo})
+          .to_return(status: 200, body: metadata.to_json, headers: { 'Content-Type' => 'application/json' })
 
         resource.write(source)
       end
 
       it 'should use the default fileserver if source starts with puppet:///' do
-        allow(response).to receive(:code).and_return('200')
-        allow(source).to receive(:metadata).and_return(double('metadata', :source => 'puppet:///test/foo', :ftype => 'file', :content_uri => nil))
-        expect(Puppet::Network::HttpPool).to receive(:connection).with(Puppet[:server], 8140, anything).and_return(conn)
+        stub_request(:get, %r{https://#{Puppet[:server]}:8140/puppet/v3/file_content/modules/:module/foo})
+          .to_return(status: 200, body: metadata.to_json, headers: { 'Content-Type' => 'application/json' })
 
         resource.write(source)
       end
 
       it 'should percent encode reserved characters' do
-        allow(response).to receive(:code).and_return('200')
-        allow(Puppet::Network::HttpPool).to receive(:connection).and_return(conn)
-        allow(source).to receive(:metadata).and_return(double('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file', :content_uri => nil))
+        metadata.source = 'puppet:///modules/:module/foo bar'
 
-        expect(conn).to receive(:request_get).with("#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/v3/file_content/test/foo%20bar?environment=myenv&", anything).and_yield(response)
+        stub_request(:get, %r{/puppet/v3/file_content/modules/:module/foo%20bar})
+          .to_return(status: 200, body: metadata.to_json, headers: { 'Content-Type' => 'application/json' })
 
         resource.write(source)
       end
 
       it 'should request binary content' do
-        allow(response).to receive(:code).and_return('200')
-        allow(Puppet::Network::HttpPool).to receive(:connection).and_return(conn)
-        allow(source).to receive(:metadata).and_return(double('metadata', :source => 'puppet:///test/foo bar', :ftype => 'file', :content_uri => nil))
+        stub_request(:get, %r{/puppet/v3/file_content/modules/:module/foo}) do |request|
+          expect(request.headers).to include({'Accept' => 'application/octet-stream'})
+        end.to_return(status: 200, body: '', headers: { 'Content-Type' => 'application/octet-stream' })
 
-        expect(conn).to receive(:request_get) do |_, options|
-          expect(options).to include('Accept' => 'application/octet-stream')
-        end.and_yield(response)
+        resource.write(source)
+      end
+
+      it "should request file content from the catalog's environment" do
+        Puppet[:environment] = 'doesntexist'
+
+        stub_request(:get, %r{/puppet/v3/file_content})
+          .with(query: hash_including("environment" => "myenv"))
+          .to_return(status: 200, body: '', headers: { 'Content-Type' => 'application/octet-stream' })
 
         resource.write(source)
       end
@@ -639,26 +650,23 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
           File.open(filename, 'w') {|f| f.write "initial file content"}
         end
 
-        before(:each) do
-          allow(Puppet::Network::HttpPool).to receive(:connection).and_return(conn)
-          allow(source).to receive(:metadata).and_return(double('metadata', :source => 'puppet:///test/foo', :ftype => 'file', :content_uri => nil))
-        end
-
         it 'should not write anything if source is not found' do
-          allow(response).to receive(:code).and_return('404')
+          stub_request(:get, %r{/puppet/v3/file_content/modules/:module/foo}).to_return(status: 404)
 
-          expect { resource.write(source) }.to raise_error(Net::HTTPError, /404/)
+          expect { resource.write(source) }.to raise_error(Net::HTTPError, /Error 404 on SERVER:/)
           expect(File.read(filename)).to eq('initial file content')
         end
 
         it 'should raise an HTTP error in case of server error' do
-          allow(response).to receive(:code).and_return('500')
+          stub_request(:get, %r{/puppet/v3/file_content/modules/:module/foo}).to_return(status: 500)
 
-          expect { resource.write(source) }.to raise_error(Net::HTTPError, /500/)
+          expect { resource.write(source) }.to raise_error(Net::HTTPError, /Error 500 on SERVER/)
         end
 
         context 'and the request was successful' do
-          before(:each) { allow(response).to receive(:code).and_return('200') }
+          before do
+            stub_request(:get, %r{/puppet/v3/file_content/modules/:module/foo}).to_return(status: 200, body: source_content)
+          end
 
           it 'should write the contents to the file' do
             resource.write(source)


### PR DESCRIPTION
Blocked on https://github.com/puppetlabs/puppet/pull/7969

First some background. Puppet's indirector system requires each terminus (like `Puppet::Indirector::Catalog::Rest`) to inherit from a parent terminus (`Puppet::Indirector::Rest`) for each model (like `Puppet::Resource::Catalog`). The indirection's `find`, `search`, etc methods are polymorphic based on the specific terminus in use.

Before this PR, all of the `Puppet::Indirector::*::Rest` termini call their parent `Puppet::Indirector::Rest` terminus. So we were going through the trouble of subclassing, but not leveraging that for polymorphic behavior with respect to the model. For example, "search" for "file_metadata" routes to "/puppet/v3/file_metadatas", but "status" routes to "/puppet/v3/statuses". You would expect the logic for that to be in the REST terminus for each model. Instead it's buried in the call to `IndirectedRoutes.request_to_uri_and_body`.

This PR overrides find, search, etc in the REST terminus for each model. Each terminus routes to the appropriate REST service, and uses the http client to make the network request. For example, `Puppet::Indirection::Report::Rest` routes to the `:report` service, while `Puppet::Indirection::Metadata::Rest` routes to the `:fileserver` service.

As a result, the indirector is (mostly) decoupled from http request handling. I say mostly because some methods are not overridden, e.g. `Catalog.indirection.head`, and will end up calling the parent rest terminus. In the future, we can deprecate and raise errors to prevent that. Also, if we're running in puppetserver, then we currently fallback to the old behavior. In the future, puppetserver will register it's own http client and that condition can be removed.

This PR preserves how the rest termini are called, what they return, and the exceptions they raise. For example, `Puppet::Resource::Catalog.indirection.find` will still call the `find` method for the current catalog terminus and/or cache terminus.

The following termini are changed:

* node
* report
* catalog
* facts
* status
* file_metadata
* file_content

The following are unchanged, since using the indirector to load/save them is deprecated, and the termini are not used in puppet anymore:

* certificate
* certificate_request

This PR also adds unit tests in `spec/unit/indirector/*/rest_spec.rb` as there were none in many cases.
