### PR TITLE
(PUP-10286) Delete the pool entry when the last connection is borrowed

### DIFF
--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -74,6 +74,8 @@ class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
     index = @pool[site].index { |session| verifier.reusable?(session.verifier) }
     session = index ? @pool[site].delete_at(index) : nil
     if session
+      @pool.delete(site) if @pool[site].empty?
+
       Puppet.debug("Using cached connection for #{site}")
       session.connection
     else

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -279,6 +279,14 @@ describe Puppet::Network::HTTP::Pool do
 
       pool.borrow(site, verifier)
     end
+
+    it 'deletes the session when the last connection is borrowed' do
+      conn = create_connection(site)
+      pool = create_pool_with_connections(site, conn)
+      pool.borrow(site, verifier)
+
+      expect(pool.pool[site]).to be_nil
+    end
   end
 
   context 'when releasing a connection' do


### PR DESCRIPTION
Previously when the last connection for a site was borrowed, the pool still
contained a map entry for the site to an empty array of connections. The
entry persists until the pool is closed or a new connection is attempted
for the same site.

Now delete the map entry when the last connection for a site is borrowed.