### PR TITLE
(PUP-8338) Stream file content when using puppet apply

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -277,14 +277,14 @@ module Puppet
       if Puppet[:default_file_terminus] == :file_server
         yield content
       elsif local?
-        chunk_file_from_disk { |chunk| yield chunk }
+        chunk_file_from_disk(full_path) { |chunk| yield chunk }
       else
         chunk_file_from_source { |chunk| yield chunk }
       end
     end
 
-    def chunk_file_from_disk
-      File.open(full_path, "rb") do |src|
+    def chunk_file_from_disk(local_path)
+      File.open(local_path, "rb") do |src|
         while chunk = src.read(8192) #rubocop:disable Lint/AssignmentInCondition
           yield chunk
         end

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -261,13 +261,13 @@ module Puppet
       end
     end
 
-    def each_chunk_from
+    def each_chunk_from(&block)
       if Puppet[:default_file_terminus] == :file_server && scheme == 'puppet' && (uri.host.nil? || uri.host.empty?)
-        chunk_file_from_disk(metadata.path) { |chunk| yield chunk }
+        chunk_file_from_disk(metadata.path, &block)
       elsif local?
-        chunk_file_from_disk(full_path) { |chunk| yield chunk }
+        chunk_file_from_disk(full_path, &block)
       else
-        chunk_file_from_source { |chunk| yield chunk }
+        chunk_file_from_source(&block)
       end
     end
 


### PR DESCRIPTION
By default, requests to "puppet" URLs are routed to the `rest` file_metadata and
file_content termini. However, if the host and port are unspecified, such as
"puppet:///modules/mod/file", then we route metadata and content requests based
on the `Puppet[:default_file_terminus]` setting[1]. When running `puppet apply`,
the setting is set to `file_server`, so that metadata and content are handled
by in the in-process file server.

The in-process file server resolves the path portion of the URL
"/modules/mod/file" and returns a `Metadata` object taking into consideration
the environment, whether to follow or manage links, checksum, etc.

Prior to this commit, when configured to use the in-process file server, puppet
retrieved file content using the indirector for all sources (absolute path or
puppet/http/https URLs).

With this commit, if the source is "puppet:///", then we copy the file from the
already resolved metadata path on-disk. As a result of this change, we no longer
load or cache entire files into memory when running `puppet apply`. Note we
don't need to take the environment or links into account when copying file
content, because that was already handled when resolving the file metadata.

For other types of sources, we stream the local or remote file in the same way
that `puppet agent` does.

Also note we no longer use the indirector to retrieve file content, so the
indirection and its termini can be deprecated in the near future.

The host nil vs empty check is because of changes to the ruby API in 2.5.

[1] https://github.com/puppetlabs/puppet/blob/6.13.0/lib/puppet/file_serving/terminus_selector.rb#L18-L23