### PR TITLE
(maint) Merge 5.5.x to 6.4.x

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -213,6 +213,7 @@ module Puppet::Network::HTTP
               current_request[header] = value
             end
           when 429, 503
+            connection.finish
             response = handle_retry_after(current_response)
           else
             response = current_response

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -213,7 +213,7 @@ module Puppet::Network::HTTP
               current_request[header] = value
             end
           when 429, 503
-            connection.finish
+            connection.finish if connection.started?
             response = handle_retry_after(current_response)
           else
             response = current_response

--- a/lib/puppet/network/http/nocache_pool.rb
+++ b/lib/puppet/network/http/nocache_pool.rb
@@ -15,6 +15,10 @@ class Puppet::Network::HTTP::NoCachePool < Puppet::Network::HTTP::BasePool
     begin
       yield http
     ensure
+      unless http.started?
+        Puppet.debug("Cannot close connection for #{site}, connection is not started")
+        return 
+      end
       Puppet.debug("Closing connection for #{site}")
       http.finish
     end

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -33,7 +33,7 @@ class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
       reuse = false
       raise detail
     ensure
-      if reuse
+      if reuse && http.started?
         release(site, verifier, http)
       else
         close_connection(site, http)
@@ -56,13 +56,17 @@ class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
   end
 
   # Safely close a persistent connection.
+  # Don't try to close a connection that's already closed.
   #
   # @api private
   def close_connection(site, http)
+    return false unless http.started?
     Puppet.debug("Closing connection for #{site}")
     http.finish
+    true
   rescue => detail
     Puppet.log_exception(detail, _("Failed to close connection for %{site}: %{detail}") % { site: site, detail: detail })
+    nil
   end
 
   # Borrow and take ownership of a persistent connection. If a new

--- a/spec/unit/network/http/nocache_pool_spec.rb
+++ b/spec/unit/network/http/nocache_pool_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Network::HTTP::NoCachePool do
   let(:verifier) { double('verifier', :setup_connection => nil) }
 
   it 'yields a started connection' do
-    http  = double('http', start: nil, finish: nil)
+    http  = double('http', start: nil, finish: nil, started?: true)
 
     factory = Puppet::Network::HTTP::Factory.new
     allow(factory).to receive(:create_connection).and_return(http)
@@ -20,8 +20,8 @@ describe Puppet::Network::HTTP::NoCachePool do
   end
 
   it 'yields a new connection each time' do
-    http1  = double('http1', start: nil, finish: nil)
-    http2  = double('http2', start: nil, finish: nil)
+    http1  = double('http1', start: nil, finish: nil, started?: true)
+    http2  = double('http2', start: nil, finish: nil, started?: true)
 
     factory = Puppet::Network::HTTP::Factory.new
     allow(factory).to receive(:create_connection).and_return(http1, http2)

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -175,14 +175,13 @@ describe Puppet::Network::HTTP::Pool do
       end
 
       it "doesn't add a closed  connection back to the pool" do
-        http = Net::HTTP.new(site.addr)
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        http.start
+        conn = create_connection(site)
+        expect(conn).to receive(:use_ssl?).and_return(true)
+        expect(conn).to receive(:verify_mode).and_return(OpenSSL::SSL::VERIFY_PEER)
 
-        pool = create_pool_with_connections(site, http)
+        pool = create_pool_with_connections(site, conn)
 
-        pool.with_connection(site, verify) {|c| c.finish}
+        pool.with_connection(site, verifier) {|c| c.finish}
 
         expect(pool.pool[site]).to be_empty
       end
@@ -276,6 +275,9 @@ describe Puppet::Network::HTTP::Pool do
     it 'finishes expired connections' do
       conn = create_connection(site)
 
+      expect(conn).to receive(:started?).and_return(true)
+      expect(conn).to receive(:finish)
+
       pool = create_pool_with_expired_connections(site, conn)
       expect(pool.factory).to receive(:create_connection).and_return(double('conn', :start => nil))
       expect(pool).to receive(:setsockopts)
@@ -337,20 +339,19 @@ describe Puppet::Network::HTTP::Pool do
     it 'closes all cached connections' do
       conn = create_connection(site)
 
+      expect(conn).to receive(:started?).and_return(true)
+      expect(conn).to receive(:finish)
+
       pool = create_pool_with_connections(site, conn)
       pool.close
     end
 
     it 'allows a connection to be closed multiple times safely' do
-      http = Net::HTTP.new(site.addr)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      http.start
-
-      pool = create_pool
-
-      expect(pool.close_connection(site, http)).to eq(true)
-      expect(pool.close_connection(site, http)).to eq(false)
-    end
+      conn = create_connection(site)
+      expect(conn).to receive(:started?).and_return(true)
+      pool = create_pool_with_connections(site, conn)
+      expect(pool.close_connection(site, conn)).to eq(true)
+      expect(pool.close_connection(site, conn)).to eq(false)
+   end
   end
 end


### PR DESCRIPTION
This PR solves the conflicts for the merge-up between 5.5.x and 6.4.x
* puppetlabs/5.5.x:
  (PUP-10287) mailalias: comma inside commands fix
  (PUP-10227) Close the HTTP connection

Conflicts:
*	lib/puppet/network/http/pool.rb
*	lib/puppet/provider/mailalias/aliases.rb
*	spec/fixtures/integration/provider/mailalias/aliases/test1
*	spec/unit/network/http/connection_spec.rb

This PR also adds a defense for http.finish and fixes comments from this PR: https://github.com/puppetlabs/puppet/pull/7968