### PR TITLE
(PUP-10227) Preserve expectation for http.finish

### DIFF
--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -198,7 +198,10 @@ module Puppet::Network::HTTP
               current_request[header] = value
             end
           when 429, 503
-            connection.finish
+            if connection.started?
+              Puppet.debug("Closing connection for #{current_site}")
+              connection.finish
+            end
             response = handle_retry_after(current_response)
           else
             response = current_response

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -135,7 +135,7 @@ describe Puppet::Network::HTTP::Connection do
   end
 
   context "when response indicates an overloaded server" do
-    let(:http) { double('http') }
+    let(:http) { double('http', :started? => true) }
     let(:site) { Puppet::Network::HTTP::Site.new('http', 'my_server', 8140) }
     let(:verify) { Puppet::SSL::Validator.no_validator }
     let(:httpunavailable) { Net::HTTPServiceUnavailable.new('1.1', 503, 'Service Unavailable') }

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -245,6 +245,8 @@ describe Puppet::Network::HTTP::Pool do
 
     it 'finishes expired connections' do
       conn = create_connection(site)
+      allow(conn).to receive(:started?).and_return(true)
+      expect(conn).to receive(:finish)
 
       pool = create_pool_with_expired_connections(site, conn)
       expect(pool.factory).to receive(:create_connection).and_return(double('conn', :start => nil))
@@ -306,6 +308,8 @@ describe Puppet::Network::HTTP::Pool do
 
     it 'closes all cached connections' do
       conn = create_connection(site)
+      allow(conn).to receive(:started?).and_return(true)
+      expect(conn).to receive(:finish)
 
       pool = create_pool_with_connections(site, conn)
       pool.close


### PR DESCRIPTION
Stub the "Net::HTTP#started?" method so finish happens as expected. Protect
against Net::HTTP#finish being called twice, and ensure the "Closing connection"
debug message is printed after the redirect, since Pool#close_connection will be
a noop.