### PR TITLE
(PUP-10238) Change default value of strict_hostname_checking to true

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1297,13 +1297,23 @@ EOT
       overridden by more specific settings (see `ca_port`, `report_port`).",
     },
     :node_name => {
-      :default    => "cert",
+      :default    => 'cert',
+      :type       => :enum,
+      :values     => ['cert', 'facter'],
+      :deprecated => :completely,
+      :hook       => proc { |val|
+        if val != 'cert'
+          Puppet.deprecation_warning("The node_name setting is deprecated and will be removed in a future release.")
+        end
+      },
       :desc       => "How the puppet master determines the client's identity
       and sets the 'hostname', 'fqdn' and 'domain' facts for use in the manifest,
       in particular for determining which 'node' statement applies to the client.
       Possible values are 'cert' (use the subject's CN in the client's
       certificate) and 'facter' (use the hostname that the client
-      reported in its facts)",
+      reported in its facts).
+
+      This setting is deprecated, please use explicit fact matching for classification.",
     },
     :bucketdir => {
       :default => "$vardir/bucket",
@@ -1432,10 +1442,19 @@ EOT
       :desc       => "Where the fileserver configuration is stored.",
     },
     :strict_hostname_checking => {
-      :default    => false,
+      :default    => true,
+      :type       => :boolean,
       :desc       => "Whether to only search for the complete
-            hostname as it is in the certificate when searching for node information
-            in the catalogs.",
+        hostname as it is in the certificate when searching for node information
+        in the catalogs or to match dot delimited segments of the cert's certname
+        and the hostname, fqdn, and/or domain facts.
+
+        This setting is deprecated and will be removed in a future release.",
+      :hook => proc { |val|
+        if val != true
+          Puppet.deprecation_warning("Setting strict_hostname_checking to false is deprecated and will be removed in a future release. Please use regular expressions in your node declarations or explicit fact matching for classification (though be warned that fact based classification may be considered insecure).")
+        end
+      }
     }
   )
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -414,7 +414,9 @@ end
 
 describe Puppet::Node, "when generating the list of names to search through" do
   before do
-    @node = Puppet::Node.new("foo.domain.com", :parameters => {"hostname" => "yay", "domain" => "domain.com"})
+    Puppet[:strict_hostname_checking] = false
+    @node = Puppet::Node.new("foo.domain.com",
+                             :parameters => {"hostname" => "yay", "domain" => "domain.com"})
   end
 
   it "returns an array of names" do
@@ -445,7 +447,6 @@ describe Puppet::Node, "when generating the list of names to search through" do
 
   describe "and :node_name is set to 'cert'" do
     before do
-      Puppet[:strict_hostname_checking] = false
       Puppet[:node_name] = "cert"
     end
 
@@ -454,8 +455,11 @@ describe Puppet::Node, "when generating the list of names to search through" do
     end
 
     describe "and strict hostname checking is enabled" do
-      it "only uses the passed-in key" do
+      before do
         Puppet[:strict_hostname_checking] = true
+      end
+
+      it "only uses the passed-in key" do
         expect(@node.names).to eq(["foo.domain.com"])
       end
     end
@@ -463,7 +467,6 @@ describe Puppet::Node, "when generating the list of names to search through" do
 
   describe "and :node_name is set to 'facter'" do
     before do
-      Puppet[:strict_hostname_checking] = false
       Puppet[:node_name] = "facter"
     end
 


### PR DESCRIPTION
Previously our default value of strict_hostname_checking was false which
allowed matching dotted segments of a nodes certname (its CN in its
certificate) as well as the segments of its fqdn fact, or hostname +
domain fact.

This was for compatibility when fact based classification within a
site.pp was a more common pattern and node declarations were much less
powerful than they are now.

With the ability to use regular expressions in a node declaration the
auto segmenting is no longer needed and with the ability to use facts
directly, to use fact interpetation in hiera lookups, or create a custom
external node classifier the injecting of facts into the nodes "name" is
unneeded.

The desire is to remove the setting completely in Puppet 7, while
leaving it in 6 so those that depend on this behavior have time to
re-write their site.pps to the newer styles.

strict_hostname_checking setting is not marked deprecated completely
because it will cause deprecation notices on setting access, which
happens as part of normal compilation for now. However it does mark
"node_name" setting as deprecated completely because it is now only
referenced in code that by default will not run (and will only run if
users change strict_hostname_checking back to false).