### PR TITLE
(maint) Close the HTTP connection prior to sleeping

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -154,6 +154,10 @@ class Puppet::HTTP::Client
               interval = @retry_after_handler.retry_after_interval(request, response, retries)
               retries += 1
               if interval
+                if http.started?
+                  Puppet.debug("Closing connection for #{Puppet::Network::HTTP::Site.from_uri(request.uri)}")
+                  http.finish
+                end
                 Puppet.warning(_("Sleeping for %{interval} seconds before retrying the request") % { interval: interval })
                 ::Kernel.sleep(interval)
                 next


### PR DESCRIPTION
This is a continuation of work for PUP-10227.

To prevent thundering herds, puppetserver may return Retry-After and ask
the agent to sleep. This commit ensures the connection is closed prior
to sleeping.