### PR TITLE
(PUP-9566) Include user-specified headers in http requests

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1633,6 +1633,12 @@ EOT
       :default    => lambda { Puppet::Settings.domain_fact },
       :desc       => "The domain which will be queried to find the SRV records of servers to use.",
     },
+    :http_extra_headers => {
+      :default => [],
+      :type => :http_extra_headers,
+      :desc => "The list of extra headers that will be sent with http requests to the master.
+      The header definition consists of a name and a value separated by a colon." 
+    },
     :ignoreschedules => {
       :default    => false,
       :type       => :boolean,

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -43,7 +43,22 @@ class Puppet::HTTP::Service
 
   def add_puppet_headers(headers)
     modified_headers = headers.dup
+
+    # Add 'X-Puppet-Profiling' to enable performance profiling if turned on
     modified_headers['X-Puppet-Profiling'] = 'true' if Puppet[:profile]
+
+    # Add additional user-defined headers if they are defined
+    Puppet[:http_extra_headers].each do |name, value|
+      if modified_headers.keys.find { |key| key.casecmp(name) == 0 }
+        Puppet.warning(_('Ignoring extra header "%{name}" as it was previously set.') % { name: name })
+      else
+        if value.nil? || value.empty?
+          Puppet.warning(_('Ignoring extra header "%{name}" as it has no value.') % { name: name })
+        else
+          modified_headers[name] = value
+        end
+      end
+    end
     modified_headers
   end
 

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -30,6 +30,7 @@ class Puppet::Settings
   require 'puppet/settings/value_translator'
   require 'puppet/settings/environment_conf'
   require 'puppet/settings/server_list_setting'
+  require 'puppet/settings/http_extra_headers_setting'
   require 'puppet/settings/certificate_revocation_setting'
 
   # local reference for convenience
@@ -727,6 +728,7 @@ class Puppet::Settings
       :priority   => PrioritySetting,
       :autosign   => AutosignSetting,
       :server_list => ServerListSetting,
+      :http_extra_headers => HttpExtraHeadersSetting,
       :certificate_revocation => CertificateRevocationSetting
   }
 

--- a/lib/puppet/settings/http_extra_headers_setting.rb
+++ b/lib/puppet/settings/http_extra_headers_setting.rb
@@ -1,0 +1,25 @@
+class Puppet::Settings::HttpExtraHeadersSetting < Puppet::Settings::BaseSetting
+
+  def type
+    :http_extra_headers
+  end
+
+  def munge(headers)
+    return headers if headers.is_a?(Hash)
+
+    headers = headers.split(/\s*,\s*/) if headers.is_a?(String)
+
+    raise ArgumentError, _("Expected an Array, String, or Hash, got a %{klass}") % { klass: headers.class } unless headers.is_a?(Array)
+
+    headers.map! { |header|
+      case header
+      when String
+        header.split(':')
+      when Array
+        header
+      else
+        raise ArgumentError, _("Expected an Array or String, got a %{klass}") % { klass: header.class }
+      end
+    }
+  end
+end

--- a/spec/unit/http/service/ca_spec.rb
+++ b/spec/unit/http/service/ca_spec.rb
@@ -24,15 +24,6 @@ describe Puppet::HTTP::Service::Ca do
 
       subject.get_certificate('ca')
     end
-
-
-    it 'includes the X-Puppet-Profiling header when Puppet[:profile] is true' do
-      stub_request(:get, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./, 'X-Puppet-Profiling' => 'true'})
-
-      Puppet[:profile] = true
-
-      subject.get_certificate('ca')
-    end
   end
 
   context 'when routing to the CA service' do
@@ -65,6 +56,15 @@ describe Puppet::HTTP::Service::Ca do
     let(:pem) { cert.to_pem }
     let(:url) { "https://www.example.com/puppet-ca/v1/certificate/ca" }
 
+    it 'includes headers set via the :http_extra_headers and :profile settings' do
+      stub_request(:get, url).with(headers: {'Example-Header' => 'real-thing', 'another' => 'thing', 'X-Puppet-Profiling' => 'true'})
+
+      Puppet[:http_extra_headers] = 'Example-Header:real-thing,another:thing'
+      Puppet[:profile] = true
+
+      subject.get_certificate('ca')
+    end
+
     it 'gets a certificate from the "certificate" endpoint' do
       stub_request(:get, url).to_return(body: pem)
 
@@ -94,6 +94,15 @@ describe Puppet::HTTP::Service::Ca do
     let(:crl) { crl_fixture('crl.pem') }
     let(:pem) { crl.to_pem }
     let(:url) { "https://www.example.com/puppet-ca/v1/certificate_revocation_list/ca" }
+
+    it 'includes headers set via the :http_extra_headers and :profile settings' do
+      stub_request(:get, url).with(headers: {'Example-Header' => 'real-thing', 'another' => 'thing', 'X-Puppet-Profiling' => 'true'})
+
+      Puppet[:http_extra_headers] = 'Example-Header:real-thing,another:thing'
+      Puppet[:profile] = true
+
+      subject.get_certificate_revocation_list
+    end
 
     it 'gets a CRL from "certificate_revocation_list" endpoint' do
       stub_request(:get, url).to_return(body: pem)
@@ -136,6 +145,15 @@ describe Puppet::HTTP::Service::Ca do
     let(:request) { request_fixture('request.pem') }
     let(:pem) { request.to_pem }
     let(:url) { "https://www.example.com/puppet-ca/v1/certificate_request/infinity" }
+
+    it 'includes headers set via the :http_extra_headers and :profile settings' do
+      stub_request(:put, url).with(headers: {'Example-Header' => 'real-thing', 'another' => 'thing', 'X-Puppet-Profiling' => 'true'})
+
+      Puppet[:http_extra_headers] = 'Example-Header:real-thing,another:thing'
+      Puppet[:profile] = true
+
+      subject.put_certificate_request('infinity', request)
+    end
 
     it 'submits a CSR to the "certificate_request" endpoint' do
       stub_request(:put, url).with(body: pem, headers: { 'Content-Type' => 'text/plain' })

--- a/spec/unit/http/service/report_spec.rb
+++ b/spec/unit/http/service/report_spec.rb
@@ -25,14 +25,6 @@ describe Puppet::HTTP::Service::Report do
 
       subject.put_report('report', report, environment: environment)
     end
-
-    it 'includes the X-Puppet-Profiling header when Puppet[:profile] is true' do
-      stub_request(:put, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./, 'X-Puppet-Profiling' => 'true'})
-
-      Puppet[:profile] = true
-
-      subject.put_report('report', report, environment: environment)
-    end
   end
 
   context 'when routing to the report service' do
@@ -59,6 +51,15 @@ describe Puppet::HTTP::Service::Report do
 
   context 'when submitting a report' do
     let(:url) { "https://www.example.com/puppet/v3/report/infinity?environment=testing" }
+
+    it 'includes puppet headers set via the :http_extra_headers and :profile settings' do
+      stub_request(:put, url).with(headers: {'Example-Header' => 'real-thing', 'another' => 'thing', 'X-Puppet-Profiling' => 'true'})
+
+      Puppet[:http_extra_headers] = 'Example-Header:real-thing,another:thing'
+      Puppet[:profile] = true
+
+      subject.put_report('infinity', report, environment: environment)
+    end
 
     it 'submits a report to the "report" endpoint' do
       stub_request(:put, url)

--- a/spec/unit/settings/http_extra_headers_spec.rb
+++ b/spec/unit/settings/http_extra_headers_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+require 'puppet/settings'
+require 'puppet/settings/http_extra_headers_setting'
+
+describe Puppet::Settings::HttpExtraHeadersSetting do
+  subject { described_class.new(:settings => double('settings'), :desc => "test") }
+
+  it "is of type :http_extra_headers" do
+    expect(subject.type).to eq :http_extra_headers
+  end
+
+  describe "munging the value" do
+    let(:final_value) { [['header1', 'foo'], ['header2', 'bar']] }
+
+    describe "when given a string" do
+      it "splits multiple values into an array" do
+        expect(subject.munge("header1:foo,header2:bar")).to match_array(final_value)
+      end
+
+      it "strips whitespace between elements" do
+        expect(subject.munge("header1:foo , header2:bar")).to match_array(final_value)
+      end
+
+      it "creates an array when one item is given" do
+        expect(subject.munge("header1:foo")).to match_array([['header1', 'foo']])
+      end
+    end
+
+    describe "when given an array of strings" do
+      it "returns an array of arrays" do
+        expect(subject.munge(['header1:foo', 'header2:bar'])).to match_array(final_value)
+      end
+    end
+
+    describe "when given an array of arrays" do
+      it "returns an array of arrays" do
+        expect(subject.munge([['header1', 'foo'], ['header2', 'bar']])).to match_array(final_value)
+      end
+    end
+
+    describe "when given a hash" do
+      it "returns the hash" do
+        expect(subject.munge({'header1' => 'foo', 'header2' => 'bar'})).to match_array(final_value)
+      end
+    end
+
+    describe 'raises an error when' do
+
+      # Ruby 2.3 reports the class of these objects as Fixnum, whereas later ruby versions report them as Integer
+      it 'is given an unexpected object type' do
+        expect {
+          subject.munge(65)
+          }.to raise_error(ArgumentError, /^Expected an Array, String, or Hash, got a (Integer|Fixnum)/)
+      end
+
+      it 'is given an array of unexpected object types' do
+        expect {
+          subject.munge([65, 82])
+          }.to raise_error(ArgumentError, /^Expected an Array or String, got a (Integer|Fixnum)/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When we submit a request to the server, we now have the ability to add
in additional arbitrary headers. This should be isolated only to
requests made to a puppetserver, and these headers should not be
included in a request to an arbitrary external host.

These headers can be set with the `:http_extra_headers` setting in
Puppet. As illustrated in the various tests, this setting can be defined
in the following four forms:

  - string:
    `'header1:value,header2:value'`
  - array:
    `['header1:value', 'header2:value']`
  - array of arrays:
    `[['header1', 'value'], ['header2', 'value']]`
  - hash:
    `{'header1' => 'value', 'header2' => 'value'}`.

This commit also updates tests for the different services. It bundles
the test for the puppet profile header with the test for these custom
headers. These are both set in the same method, so a single test for
both makes sense. I also added the test for each different type of http
connection for the different services, to ensure consistent behavior
across all of them.