### PR TITLE
(PUP-10286) Expect nil session when connection is closed

### DIFF
--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -174,7 +174,7 @@ describe Puppet::Network::HTTP::Pool do
         pool.with_connection(site, verifier) {|c| }
       end
 
-      it "doesn't add a closed  connection back to the pool" do
+      it "doesn't add a closed connection back to the pool" do
         http = Net::HTTP.new(site.addr)
         http.use_ssl = true
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
@@ -184,7 +184,7 @@ describe Puppet::Network::HTTP::Pool do
 
         pool.with_connection(site, verifier) {|c| c.finish}
 
-        expect(pool.pool[site]).to be_empty
+        expect(pool.pool[site]).to be_nil
       end
     end
   end


### PR DESCRIPTION
Due to a semantic conflict between 5727d31e08 and 762446ad19, if the last
cached connection for a site is borrowed, and later closed, then sessions for
that site will be nil instead of an empty array.