### PR TITLE
(PUP-10147) Don't resolve the compiler service for the locales mount

### DIFF
--- a/lib/puppet/configurer/plugin_handler.rb
+++ b/lib/puppet/configurer/plugin_handler.rb
@@ -36,9 +36,7 @@ class Puppet::Configurer::PluginHandler
     locales = Gem::Version.new(server_agent_version) >= SUPPORTED_LOCALES_MOUNT_AGENT_VERSION
     unless locales
       session = Puppet.lookup(:http_session)
-      compiler = session.route_to(:puppet)
-      server_version = session.server_version(compiler.url)
-      locales = server_version && Gem::Version.new(server_version) >= SUPPORTED_LOCALES_MOUNT_AGENT_VERSION
+      locales = session.supports?(:puppet, 'locales')
     end
 
     if locales

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -1,10 +1,5 @@
-require 'semantic_puppet'
-
 class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
   API = '/puppet/v3'.freeze
-
-  # puppet major version where JSON is enabled by default
-  MAJOR_VERSION_JSON_DEFAULT = 5
 
   def initialize(client, session, server, port)
     url = build_url(API, server || Puppet[:report_server], port || Puppet[:report_port])
@@ -26,15 +21,13 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
 
     @session.process_response(response)
 
-    return response.body.to_s if response.success?
-
-    server_version = response[Puppet::HTTP::HEADER_PUPPET_VERSION]
-    if server_version && SemanticPuppet::Version.parse(server_version).major < MAJOR_VERSION_JSON_DEFAULT &&
-       Puppet[:preferred_serialization_format] != 'pson'
+    if response.success?
+      response.body.to_s
+    elsif !@session.supports?(:report, 'json') && Puppet[:preferred_serialization_format] != 'pson'
       #TRANSLATORS "pson", "preferred_serialization_format", and "puppetserver" should not be translated
-      raise Puppet::HTTP::ProtocolError.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: server_version })
+      raise Puppet::HTTP::ProtocolError.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: response[Puppet::HTTP::HEADER_PUPPET_VERSION]})
+    else
+      raise Puppet::HTTP::ResponseError.new(response)
     end
-
-    raise Puppet::HTTP::ResponseError.new(response)
   end
 end

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -1,9 +1,13 @@
 class Puppet::HTTP::Session
   # capabilities for a site
   CAP_LOCALES = 'locales'.freeze
+  CAP_JSON = 'json'.freeze
 
   # puppet version where locales mount was added
   SUPPORTED_LOCALES_MOUNT_AGENT_VERSION = Gem::Version.new("5.3.4")
+
+  # puppet version where JSON was enabled by default
+  SUPPORTED_JSON_DEFAULT = Gem::Version.new("5.0.0")
 
   def initialize(client, resolvers)
     @client = client
@@ -66,6 +70,8 @@ class Puppet::HTTP::Session
     case capability
     when CAP_LOCALES
       !server_version.nil? && Gem::Version.new(server_version) >= SUPPORTED_LOCALES_MOUNT_AGENT_VERSION
+    when CAP_JSON
+      server_version.nil? || Gem::Version.new(server_version) >= SUPPORTED_JSON_DEFAULT
     else
       false
     end

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -93,4 +93,22 @@ describe Puppet::Configurer::PluginHandler do
       expect(times_called).to eq(2)
     end
   end
+
+  context "nil server agent version" do
+    it "returns downloaded plugin, fact, but not locale filenames" do
+      times_called = 0
+      allow_any_instance_of(Puppet::Configurer::Downloader).to receive(:evaluate) do
+        times_called += 1
+
+        if times_called == 1
+          %w[/a]
+        else
+          %w[/b]
+        end
+      end
+
+      expect(pluginhandler.download_plugins(environment)).to match_array(%w[/a /b])
+      expect(times_called).to eq(2)
+    end
+  end
 end

--- a/spec/unit/configurer/plugin_handler_spec.rb
+++ b/spec/unit/configurer/plugin_handler_spec.rb
@@ -6,13 +6,17 @@ describe Puppet::Configurer::PluginHandler do
   let(:pluginhandler) { Puppet::Configurer::PluginHandler.new() }
   let(:environment)   { Puppet::Node::Environment.create(:myenv, []) }
 
+  before :each do
+    # PluginHandler#load_plugin has an extra-strong rescue clause
+    # this mock is to make sure that we don't silently ignore errors
+    expect(Puppet).not_to receive(:err)
+  end
+
   context "server agent version is 5.3.4" do
-    before :each do
-      # PluginHandler#load_plugin has an extra-strong rescue clause
-      # this mock is to make sure that we don't silently ignore errors
-      expect(Puppet).not_to receive(:err)
-      # Server_agent version needs to be at 5.3.4 in order to mount locales
-      Puppet.push_context({:server_agent_version => "5.3.4"})
+    around do |example|
+      Puppet.override(server_agent_version: "5.3.4") do
+        example.run
+      end
     end
 
     it "downloads plugins, facts, and locales" do
@@ -43,12 +47,10 @@ describe Puppet::Configurer::PluginHandler do
   end
 
   context "server agent version is 5.3.3" do
-    before :each do
-      # PluginHandler#load_plugin has an extra-strong rescue clause
-      # this mock is to make sure that we don't silently ignore errors
-      expect(Puppet).not_to receive(:err)
-      # Server_agent version needs to be at 5.3.4 in order to mount locales
-      Puppet.push_context({:server_agent_version => "5.3.3"})
+    around do |example|
+      Puppet.override(server_agent_version: "5.3.3") do
+        example.run
+      end
     end
 
     it "returns downloaded plugin, fact, but not locale filenames" do
@@ -69,13 +71,10 @@ describe Puppet::Configurer::PluginHandler do
   end
 
   context "blank server agent version" do
-    before :each do
-      # PluginHandler#load_plugin has an extra-strong rescue clause
-      # this mock is to make sure that we don't silently ignore errors
-      expect(Puppet).not_to receive(:err)
-      # Server_agent version needs to be at 5.3.4 in order to mount locales
-      # A blank version will default to 0.0
-      Puppet.push_context({:server_agent_version => ""})
+    around do |example|
+      Puppet.override(server_agent_version: "") do
+        example.run
+      end
     end
 
     it "returns downloaded plugin, fact, but not locale filenames" do

--- a/spec/unit/face/plugin_spec.rb
+++ b/spec/unit/face/plugin_spec.rb
@@ -10,9 +10,10 @@ describe Puppet::Face[:plugin, :current] do
   end
 
   context "download" do
-    before :each do
-      #Server_agent version needs to be at 5.3.4 in order to mount locales
-      Puppet.push_context({:server_agent_version => "5.3.4"})
+    around do |example|
+      Puppet.override(server_agent_version: "5.3.4") do
+        example.run
+      end
     end
 
     it "downloads plugins, external facts, and locales" do
@@ -61,9 +62,10 @@ describe Puppet::Face[:plugin, :current] do
   end
 
   context "download when server_agent_version is 5.3.3" do
-    before :each do
-      #Server_agent version needs to be at 5.3.4 in order to mount locales
-      Puppet.push_context({:server_agent_version => "5.3.3"})
+    around do |example|
+      Puppet.override(server_agent_version: "5.3.3") do
+        example.run
+      end
     end
 
     it "downloads plugins, and external facts, but not locales" do
@@ -87,10 +89,10 @@ describe Puppet::Face[:plugin, :current] do
   end
 
   context "download when server_agent_version is blank" do
-    before :each do
-      #Server_agent version needs to be at 5.3.4 in order to mount locales
-      #A blank version will default to 0.0
-      Puppet.push_context({:server_agent_version => ""})
+    around do |example|
+      Puppet.override(server_agent_version: "") do
+        example.run
+      end
     end
 
     it "downloads plugins, and external facts, but not locales" do

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -213,5 +213,40 @@ describe Puppet::HTTP::Session do
         expect(session).to_not be_supports(:puppet, 'locales')
       end
     end
+
+    context 'json' do
+      it 'does not support json if the cached service has not been resolved' do
+        session = described_class.new(client, [])
+
+        expect(session).to_not be_supports(:puppet, 'json')
+      end
+
+      it "supports json if the cached service's version is 5 or greater" do
+        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '5.5.12'}, uri)
+
+        session.route_to(:puppet)
+        session.process_response(response)
+
+        expect(session).to be_supports(:puppet, 'json')
+      end
+
+      it "does not support json if the cached service's version is less than 5.0" do
+        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '4.10.1'}, uri)
+
+        session.route_to(:puppet)
+        session.process_response(response)
+
+        expect(session).to_not be_supports(:puppet, 'json')
+      end
+
+      it "supports json if the cached service's version is missing" do
+        response = Puppet::HTTP::Response.new({}, uri)
+
+        session.route_to(:puppet)
+        session.process_response(response)
+
+        expect(session).to be_supports(:puppet, 'json')
+      end
+    end
   end
 end

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -165,4 +165,53 @@ describe Puppet::HTTP::Session do
       }.to raise_error(Puppet::HTTP::RouteError, 'No more routes to ca')
     end
   end
+
+  context 'when retrieving capabilities' do
+    let(:session) do
+      resolver = DummyResolver.new(good_service)
+      described_class.new(client, [resolver])
+    end
+
+    it 'raises for unknown service names' do
+      expect {
+        session = described_class.new(client, [])
+        session.supports?(:westbound, 'a capability')
+      }.to raise_error(ArgumentError, "Unknown service westbound")
+    end
+
+    context 'locales' do
+      it 'does not support locales if the cached service has not been resolved' do
+        session = described_class.new(client, [])
+
+        expect(session).to_not be_supports(:puppet, 'locales')
+      end
+
+      it "supports locales if the cached service's version is 5.3.4 or greater" do
+        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '5.3.4'}, uri)
+
+        session.route_to(:puppet)
+        session.process_response(response)
+
+        expect(session).to be_supports(:puppet, 'locales')
+      end
+
+      it "does not support locales if the cached service's version is 5.3.3" do
+        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '5.3.3'}, uri)
+
+        session.route_to(:puppet)
+        session.process_response(response)
+
+        expect(session).to_not be_supports(:puppet, 'locales')
+      end
+
+      it "does not support locales if the cached service's version is missing" do
+        response = Puppet::HTTP::Response.new({}, uri)
+
+        session.route_to(:puppet)
+        session.process_response(response)
+
+        expect(session).to_not be_supports(:puppet, 'locales')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, if the agent run failed to connect to the compiler service, then it
would exit without falling back to the cached catalog.

This occurred because we only store `server_agent_version` in the context for
successful REST requests. If the "plugins" and "pluginfacts" mounts fail to
connect, then `Session#route_to` triggered the resolution logic, and that would
raise after exhausting the various resolvers.

Now we check if the compiler service has been resolved without triggered the
resolution code. If we haven't connected to the compiler service successfully at
some point earlier in the run, then preserve the original 6.x behavior of
skipping the "locales" mount.

Ideally, pluginsync would abort if any part of it failed, but that is a larger
issue, see PUP-1763.