### PR TITLE
(PUP-2641) Try harder to print type's description

### DIFF
--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -67,13 +67,15 @@ class TypeDoc
     @types.keys.sort_by(&:to_s).each do |name|
       type = @types[name]
       s = type.doc.gsub(/\s+/, " ")
-      n = s.index(". ")
-      if n.nil?
+      if s.empty?
         s = ".. no documentation .."
-      elsif n > 45
-        s = s[0, 45] + " ..."
       else
-        s = s[0, n]
+        n = s.index(".") || s.length
+        if n > 45
+          s = s[0, 45] + " ..."
+        else
+          s = s[0, n]
+        end
       end
       printf "%-15s - %s\n", name, s
     end

--- a/spec/unit/application/describe_spec.rb
+++ b/spec/unit/application/describe_spec.rb
@@ -61,6 +61,59 @@ describe Puppet::Application::Describe do
     }.to output(/Meta Parameters.*#{Regexp.escape('**notify**')}/m).to_stdout
   end
 
+  it "outputs no documentation if the summary is missing" do
+    Puppet::Type.newtype(:describe_test) {}
+
+    describe.command_line.args << '--list'
+    expect {
+      describe.run
+    }.to output(/#{Regexp.escape("describe_test   - .. no documentation ..")}/).to_stdout
+  end
+
+  it "outputs the first short sentence ending in a dot" do
+    Puppet::Type.newtype(:describe_test) do
+      @doc = "ends in a dot."
+    end
+
+    describe.command_line.args << '--list'
+    expect {
+      describe.run
+    }.to output(/#{Regexp.escape("describe_test   - ends in a dot\n")}/).to_stdout
+  end
+
+  it "outputs the first short sentence missing a dot" do
+    Puppet::Type.newtype(:describe_test) do
+      @doc = "missing a dot"
+    end
+
+    describe.command_line.args << '--list'
+    expect {
+      describe.run
+    }.to output(/describe_test   - missing a dot\n/).to_stdout
+  end
+
+  it "truncates long summaries ending in a dot" do
+    Puppet::Type.newtype(:describe_test) do
+      @doc = "This sentence is more than 45 characters and ends in a dot."
+    end
+
+    describe.command_line.args << '--list'
+    expect {
+      describe.run
+    }.to output(/#{Regexp.escape("describe_test   - This sentence is more than 45 characters and  ...")}/).to_stdout
+  end
+
+  it "truncates long summaries missing a dot" do
+    Puppet::Type.newtype(:describe_test) do
+      @doc = "This sentence is more than 45 characters and is missing a dot"
+    end
+
+    describe.command_line.args << '--list'
+    expect {
+      describe.run
+    }.to output(/#{Regexp.escape("describe_test   - This sentence is more than 45 characters and  ...")}/).to_stdout
+  end
+
   it "formats text with long non-space runs without garbling" do
     f = Formatter.new(76)
 

--- a/spec/unit/application/describe_spec.rb
+++ b/spec/unit/application/describe_spec.rb
@@ -3,95 +3,80 @@ require 'spec_helper'
 require 'puppet/application/describe'
 
 describe Puppet::Application::Describe do
-  before :each do
-    @describe = Puppet::Application[:describe]
+  let(:describe) { Puppet::Application[:describe] }
+
+  it "lists all types" do
+    describe.command_line.args << '--list'
+
+    expect {
+      describe.run
+    }.to output(/These are the types known to puppet:/).to_stdout
   end
 
-  it "should declare a main command" do
-    expect(@describe).to respond_to(:main)
+  it "describes a single type" do
+    describe.command_line.args << 'exec'
+
+    expect {
+      describe.run
+    }.to output(/exec.*====.*Executes external commands/m).to_stdout
   end
 
-  it "should declare a preinit block" do
-    expect(@describe).to respond_to(:preinit)
+  it "describes multiple types" do
+    describe.command_line.args.concat(['exec', 'file'])
+
+    expect {
+      describe.run
+    }.to output(/Executes external commands.*Manages files, including their content, ownership, and permissions./m).to_stdout
   end
 
-  [:providers,:list,:meta].each do |option|
-    it "should declare handle_#{option} method" do
-      expect(@describe).to respond_to("handle_#{option}".to_sym)
-    end
+  it "describes parameters for the type by default" do
+    describe.command_line.args << 'exec'
 
-    it "should store argument value when calling handle_#{option}" do
-      expect(@describe.options).to receive(:[]=).with("#{option}".to_sym, 'arg')
-      @describe.send("handle_#{option}".to_sym, 'arg')
-    end
+    expect {
+      describe.run
+    }.to output(/Parameters\n----------/m).to_stdout
   end
 
+  it "lists parameter names, but excludes description in short mode" do
+    describe.command_line.args.concat(['exec', '-s'])
 
-  describe "in preinit" do
-    it "should set options[:parameters] to true" do
-      @describe.preinit
-
-      expect(@describe.options[:parameters]).to be_truthy
-    end
+    expect {
+      describe.run
+    }.to output(/Parameters.*command, creates, cwd/m).to_stdout
   end
 
-  describe "when handling parameters" do
-    it "should set options[:parameters] to false" do
-      @describe.handle_short(nil)
+  it "outputs providers for the type" do
+    describe.command_line.args.concat(['exec', '--providers'])
 
-      expect(@describe.options[:parameters]).to be_falsey
-    end
+    expect {
+      describe.run
+    }.to output(/Providers.*#{Regexp.escape('**posix**')}.*#{Regexp.escape('**windows**')}/m).to_stdout
   end
 
-  describe "during setup" do
-    it "should collect arguments in options[:types]" do
-      allow(@describe.command_line).to receive(:args).and_return(['1','2'])
-      @describe.setup
+  it "lists metaparameters for a type" do
+    describe.command_line.args.concat(['exec', '--meta'])
 
-      expect(@describe.options[:types]).to eq(['1','2'])
-    end
+    expect {
+      describe.run
+    }.to output(/Meta Parameters.*#{Regexp.escape('**notify**')}/m).to_stdout
   end
 
-  describe "when running" do
+  it "formats text with long non-space runs without garbling" do
+    f = Formatter.new(76)
 
-    before :each do
-      @typedoc = double('type_doc')
-      allow(TypeDoc).to receive(:new).and_return(@typedoc)
-    end
-
-    it "should call list_types if options list is set" do
-      @describe.options[:list] = true
-
-      expect(@typedoc).to receive(:list_types)
-
-      @describe.run_command
-    end
-
-    it "should call format_type for each given types" do
-      @describe.options[:list] = false
-      @describe.options[:types] = ['type']
-
-      expect(@typedoc).to receive(:format_type).with('type', @describe.options)
-      @describe.run_command
-    end
-  end
-
-  it "should format text with long non-space runs without garbling" do
-    @f = Formatter.new(76)
-
-    @teststring = <<TESTSTRING
+    teststring = <<TESTSTRING
 . 12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 nick@magpie.puppetlabs.lan
 **this part should not repeat!**
 TESTSTRING
 
-    @expected_result = <<EXPECTED
+    expected_result = <<EXPECTED
 .
 1234567890123456789012345678901234567890123456789012345678901234567890123456
 7890123456789012345678901234567890 nick@magpie.puppetlabs.lan
 **this part should not repeat!**
 EXPECTED
 
-    result = @f.wrap(@teststring, {:indent => 0, :scrub => true})
-    expect(result).to eql(@expected_result)
+    result = f.wrap(teststring, {:indent => 0, :scrub => true})
+    expect(result).to eql(expected_result)
   end
 end


### PR DESCRIPTION
Previously if the description for a type was missing a dot, then `puppet
describe --list` would print `.. no documentation ..` for that type. Now print
as much as the description as will fit, stopping at the end of the string or
the first dot, whichever comes first.