### PR TITLE
(PUP-10296) Add version range support to pip package provider

### DIFF
--- a/acceptance/tests/provider/package/pip.rb
+++ b/acceptance/tests/provider/package/pip.rb
@@ -1,15 +1,19 @@
 test_name "pip provider should install, use install_options with latest, and uninstall" do
   confine :to, :template => /centos/
-  tag 'audit:low'
+  tag 'audit:high'
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils
   extend Puppet::Acceptance::ManifestUtils
 
   package = 'colorize'
+  pip_command = 'pip'
+
+  teardown do
+    on(agent, "#{pip_command} uninstall #{package} --disable-pip-version-check --yes", :accept_all_exit_codes => true)
+  end
 
   agents.each do |agent|
-    pip_command = 'pip'
     step "Setup: Install EPEL Repository, Python and Pip" do
       package_present(agent, 'epel-release')
       if agent.platform =~ /el-8/
@@ -22,12 +26,38 @@ test_name "pip provider should install, use install_options with latest, and uni
       end
     end
 
-    step "Install a pip package" do
+    step "Ensure presence of a pip package" do
       package_manifest = resource_manifest('package', package, { ensure: 'present', provider: 'pip' } )
       apply_manifest_on(agent, package_manifest, :catch_failures => true) do
         list = on(agent, "#{pip_command} list --disable-pip-version-check").stdout
         assert_match(/#{package} \(/, list)
       end
+      on(agent, "#{pip_command} uninstall #{package} --disable-pip-version-check --yes")
+    end
+
+    step "Install a pip package using version range" do
+      package_manifest1 = resource_manifest('package', package, { ensure: '<=1.1.0', provider: 'pip' } )
+      package_manifest2 = resource_manifest('package', package, { ensure: '<1.0.4',  provider: 'pip' } )
+
+      # Make a fresh package install (with version lower than or equal to 1.1.0)
+      apply_manifest_on(agent, package_manifest1, :expect_changes => true) do
+        list = on(agent, "#{pip_command} list --disable-pip-version-check").stdout
+        match = list.match(/#{package} \((.+)\)/)
+        installed_version = match[1] if match
+        assert_match(installed_version, '1.1.0')
+      end
+
+      # Reapply same manifest and expect no changes
+      apply_manifest_on(agent, package_manifest1, :catch_changes => true)
+
+      # Reinstall over existing package (with version lower than 1.0.4) and expect changes (to be 1.0.3)
+      apply_manifest_on(agent, package_manifest2, :expect_changes => true) do
+        list = on(agent, "#{pip_command} list --disable-pip-version-check").stdout
+        match = list.match(/#{package} \((.+)\)/)
+        installed_version = match[1] if match
+        assert_match(installed_version, '1.0.3')
+      end
+
       on(agent, "#{pip_command} uninstall #{package} --disable-pip-version-check --yes")
     end
 

--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -1,6 +1,8 @@
 # Puppet package provider for Python's `pip` package management frontend.
 # <http://pip.pypa.io/>
 
+require 'puppet/util/package/version/pip'
+require 'puppet/util/package/version/range'
 require 'puppet/provider/package_targetable'
 require 'puppet/util/http_proxy'
 
@@ -11,7 +13,10 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
   This provider supports the `install_options` attribute, which allows command-line flags to be passed to pip.
   These options should be specified as an array where each element is either a string or a hash."
 
-  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :version_ranges, :install_options, :targetable
+
+  PIP_VERSION       = Puppet::Util::Package::Version::Pip
+  PIP_VERSION_RANGE = Puppet::Util::Package::Version::Range
 
   # Override the specificity method to return 1 if pip is not set as default provider
   def self.specificity
@@ -25,7 +30,6 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   # Define the default provider package command name when the provider is targetable.
   # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command
-
   def self.provider_command
     # Ensure pip can upgrade pip, which usually puts pip into a new path /usr/local/bin/pip (compared to /usr/bin/pip)
     self.cmd.map { |c| which(c) }.find { |c| c != nil }
@@ -58,7 +62,6 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   # Return an array of structured information about every installed package
   # that's managed by `pip` or an empty array if `pip` is not available.
-
   def self.instances(target_command = nil)
     if target_command
       command = target_command
@@ -105,7 +108,6 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   # Return structured information about a particular package or `nil`
   # if the package is not installed or `pip` itself is not available.
-
   def query
     command = resource_or_provider_command
     self.class.validate_command(command)
@@ -116,9 +118,7 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     return nil
   end
 
-  # Use pip CLI to look up versions from PyPI repositories,
-  # honoring local pip config such as custom repositories.
-
+  # Return latest version available for current package
   def latest
     command = resource_or_provider_command
     self.class.validate_command(command)
@@ -132,30 +132,11 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
   end
 
   # Less resource-intensive approach for pip version 1.5.4 and newer.
-
   def latest_with_new_pip
-    command = resource_or_provider_command
-    self.class.validate_command(command)
-
-    command_and_options = [command, 'install', "#{@resource[:name]}==versionplease"]
-    command_and_options << install_options if @resource[:install_options]
-    execpipe command_and_options do |process|
-      process.collect do |line|
-        # PIP OUTPUT: Could not find a version that satisfies the requirement example==versionplease (from versions: 1.2.3, 4.5.6)
-        if line =~ /from versions: /
-          textAfterLastMatch = $'.chomp(")\n")
-          versionList = textAfterLastMatch.split(', ').sort do |x,y|
-            Puppet::Util::Package.versioncmp(x, y)
-          end
-          return versionList.last
-        end
-      end
-      return nil
-    end
+    available_versions_with_new_pip.last
   end
 
   # More resource-intensive approach for pip version 1.5.3 and older.
-
   def latest_with_old_pip
     command = resource_or_provider_command
     self.class.validate_command(command)
@@ -175,29 +156,117 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     end
   end
 
+  # Use pip CLI to look up versions from PyPI repositories,
+  # honoring local pip config such as custom repositories.
+  def available_versions
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
+    command_version = self.class.pip_version(command)
+    if Puppet::Util::Package.versioncmp(command_version, '1.5.4') == -1
+      available_versions_with_old_pip
+    else
+      available_versions_with_new_pip
+    end
+  end
+
+  def available_versions_with_new_pip
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
+    command_and_options = [command, 'install', "#{@resource[:name]}==versionplease"]
+    command_and_options << install_options if @resource[:install_options]
+    execpipe command_and_options do |process|
+      process.collect do |line|
+        # PIP OUTPUT: Could not find a version that satisfies the requirement example==versionplease (from versions: 1.2.3, 4.5.6)
+        if line =~ /from versions: (.+)\)/
+          versionList = $1.split(', ').sort do |x,y|
+            Puppet::Util::Package.versioncmp(x, y)
+          end
+          return versionList
+        end
+      end
+    end
+    []
+  end
+
+  def available_versions_with_old_pip
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
+    Dir.mktmpdir("puppet_pip") do |dir|
+      command_and_options = [command, 'install', "#{@resource[:name]}", '-d', "#{dir}", '-v']
+      command_and_options << install_options if @resource[:install_options]
+      execpipe command_and_options do |process|
+        process.collect do |line|
+          # PIP OUTPUT: Using version 0.10.1 (newest of versions: 1.2.3, 4.5.6)
+          if line =~ /Using version .+? \(newest of versions: (.+?)\)/
+            versionList = $1.split(', ').sort do |x,y|
+              Puppet::Util::Package.versioncmp(x, y)
+            end
+            return versionList
+          end
+        end
+      end
+      return []
+    end
+  end
+
+  # Finds the most suitable version available in a given range
+  def best_version(should_range)
+    included_available_versions = []
+    available_versions.each do |version|
+      version = PIP_VERSION.parse(version)
+      included_available_versions.push(version) if should_range.include?(version)
+    end
+
+    included_available_versions.sort!
+    return included_available_versions.last unless included_available_versions.empty?
+
+    Puppet.debug("No available version for package #{@resource[:name]} is included in range #{should_range}")
+    should_range
+  end
+
   # Install a package.  The ensure parameter may specify installed,
   # latest, a version number, or, in conjunction with the source
   # parameter, an SCM revision.  In that case, the source parameter
   # gives the fully-qualified URL to the repository.
-
   def install
     command = resource_or_provider_command
     self.class.validate_command(command)
 
+    should = @resource[:ensure]
     command_options = %w{install -q}
     command_options +=  install_options if @resource[:install_options]
     if @resource[:source]
-      if String === @resource[:ensure]
-        command_options << "#{@resource[:source]}@#{@resource[:ensure]}#egg=#{@resource[:name]}"
+      if String === should
+        command_options << "#{@resource[:source]}@#{should}#egg=#{@resource[:name]}"
       else
         command_options << "#{@resource[:source]}#egg=#{@resource[:name]}"
       end
     else
-      case @resource[:ensure]
-      when String
-        command_options << "#{@resource[:name]}==#{@resource[:ensure]}"
+      case should
       when :latest
         command_options << "--upgrade" << @resource[:name]
+      when String
+        begin
+          should_range = PIP_VERSION_RANGE.parse(should, PIP_VERSION)
+          should = best_version(should_range)
+
+          unless should == should_range
+            command_options << "#{@resource[:name]}==#{should}"
+          else
+            # when no suitable version for the given range was found, let pip handle
+            if should.is_a?(PIP_VERSION_RANGE::MinMax)
+              command_options << "#{@resource[:name]} #{should.split.join(',')}"
+            else
+              command_options << "#{@resource[:name]} #{should}"
+            end
+          end
+        rescue PIP_VERSION_RANGE::ValidationFailure, PIP_VERSION::ValidationFailure
+          Puppet.debug("Cannot parse #{should} as a pip version range, falling through.")
+          command_options << "#{@resource[:name]}==#{should}"
+        end
       else
         command_options << @resource[:name]
       end
@@ -208,7 +277,6 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   # Uninstall a package. Uninstall won't work reliably on Debian/Ubuntu unless this issue gets fixed.
   # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562544
-
   def uninstall
     command = resource_or_provider_command
     self.class.validate_command(command)
@@ -224,6 +292,26 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
 
   def install_options
     join_options(@resource[:install_options])
+  end
+
+  def insync?(is)
+    return false unless is && is != :absent
+    begin
+      should = @resource[:ensure]
+      should_range = PIP_VERSION_RANGE.parse(should, PIP_VERSION)
+    rescue PIP_VERSION_RANGE::ValidationFailure, PIP_VERSION::ValidationFailure
+      Puppet.debug("Cannot parse #{should} as a pip version range")
+      return false
+    end
+
+    begin
+      is_version = PIP_VERSION.parse(is)
+    rescue PIP_VERSION::ValidationFailure
+      Puppet.debug("Cannot parse #{is} as a pip version")
+      return false
+    end
+
+    should_range.include?(is_version)
   end
 
   def self.quote(path)

--- a/lib/puppet/util/package/version/pip.rb
+++ b/lib/puppet/util/package/version/pip.rb
@@ -1,0 +1,169 @@
+module Puppet::Util::Package::Version
+  class Pip
+    include Comparable
+
+    VERSION_PATTERN = "
+      v?
+      (?:
+        (?:(?<epoch>[0-9]+)!)?                              # epoch
+        (?<release>[0-9]+(?:\\.[0-9]+)*)                    # release segment
+        (?<pre>                                             # pre-release
+          [-_\\.]?
+          (?<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
+          [-_\\.]?
+          (?<pre_n>[0-9]+)?
+        )?
+        (?<post>                                            # post release
+          (?:-(?<post_n1>[0-9]+))
+          |
+          (?:
+            [-_\\.]?
+            (?<post_l>post|rev|r)
+            [-_\\.]?
+            (?<post_n2>[0-9]+)?
+          )
+        )?
+        (?<dev>                                             # dev release
+          [-_\\.]?
+          (?<dev_l>dev)
+          [-_\\.]?
+          (?<dev_n>[0-9]+)?
+        )?
+      )
+      (?:\\+(?<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?      # local version
+    ".freeze
+
+    def self.parse(version)
+      raise ValidationFailure, version.to_s unless version.is_a? String
+
+      matched = version.match(Regexp.new(("^\\s*") + VERSION_PATTERN + ("\\s*$"), Regexp::EXTENDED | Regexp::MULTILINE | Regexp::IGNORECASE))
+      raise ValidationFailure, version unless matched
+
+      new(matched)
+    end
+
+    def self.compare(version_a, version_b)
+      version_a = parse(version_a) unless version_a.is_a?(self)
+      version_b = parse(version_b) unless version_a.is_a?(self)
+
+      version_a <=> version_b
+    end
+
+    def to_s
+      parts = []
+
+      parts.push("#{@epoch_data}!")           if @epoch_data && @epoch_data != 0
+      parts.push(@release_data.join("."))     if @release_data
+      parts.push(@pre_data.join)              if @pre_data
+      parts.push(".post#{@post_data[1]}")     if @post_data
+      parts.push(".dev#{@dev_data[1]}")       if @dev_data
+      parts.push("+#{@local_data.join(".")}") if @local_data
+
+      parts.join
+    end
+    alias inspect to_s
+
+    def eql?(other)
+      other.is_a?(self.class) && key.eql?(other.key)
+    end
+    alias == eql?
+
+    def <=>(other)
+      raise ValidationFailure, other.to_s unless other.is_a?(self.class)
+      compare(key, other.key)
+    end
+
+    attr_reader :key
+
+    private
+
+    def initialize(matched)
+      @epoch_data   = matched[:epoch].to_i
+      @release_data = matched[:release].split('.').map(&:to_i)                                       if matched[:release]
+      @pre_data     = parse_letter_version(matched[:pre_l], matched[:pre_n])                         if matched[:pre_l]  || matched[:pre_n]
+      @post_data    = parse_letter_version(matched[:post_l], matched[:post_n1] || matched[:post_n2]) if matched[:post_l] || matched[:post_n1] || matched[:post_n2]
+      @dev_data     = parse_letter_version(matched[:dev_l], matched[:dev_n])                         if matched[:dev_l]  || matched[:dev_n]
+      @local_data   = parse_local_version(matched[:local])                                           if matched[:local]
+
+      @key = compose_key(@epoch_data, @release_data, @pre_data, @post_data, @dev_data, @local_data)
+    end
+
+    def parse_letter_version(letter, number)
+      if letter
+        number = 0 if !number
+        letter.downcase!
+
+        if letter == "alpha"
+          letter = "a"
+        elsif letter == "beta"
+          letter = "b"
+        elsif ["c", "pre", "preview"].include?(letter)
+          letter = "rc"
+        elsif ["rev", "r"].include?(letter)
+          letter = "post"
+        end
+
+        return [letter, number.to_i]
+      end
+
+      ["post", number.to_i] if !letter && number
+    end
+
+    def parse_local_version(local_version)
+      local_version.split(/[\\._-]/).map{|part| part =~ /[0-9]+/ && part !~ /[a-zA-Z]+/ ? part.to_i : part.downcase} if local_version
+    end
+
+    def compose_key(epoch, release, pre, post, dev, local)
+      release_key = release.reverse
+      release_key.each_with_index do |element, index|
+        break unless element == 0
+        release_key.delete_at(index) unless release_key.at(index + 1) != 0
+      end
+      release_key.reverse!
+
+      if !pre && !post && dev
+        pre_key = -Float::INFINITY
+      else
+        pre_key = pre || Float::INFINITY
+      end
+
+      post_key = post || -Float::INFINITY
+
+      dev_key = dev || Float::INFINITY
+
+      if !local
+        local_key = -Float::INFINITY
+      else
+        local_key = local.map{|i| (i.is_a? Integer) ? [i, ""] : [-Float::INFINITY, i]}
+      end
+
+      [epoch, release_key, pre_key, post_key, dev_key, local_key]
+    end
+
+    def compare(this, other)
+      if (this.is_a? Array) && (other.is_a? Array)
+        this  << -Float::INFINITY if this.length < other.length
+        other << -Float::INFINITY if this.length > other.length
+
+        this.each_with_index do |element, index|
+          return compare(element, other.at(index)) if element != other.at(index)
+        end
+      elsif (this.is_a? Array) && !(other.is_a? Array)
+        raise Puppet::Error, 'Cannot compare #{this} (Array) with #{other} (#{other.class}). Only ±Float::INFINITY accepted.' unless other.abs == Float::INFINITY
+        return this.first.to_f <=> other
+      elsif !(this.is_a? Array) && (other.is_a? Array)
+        raise Puppet::Error, 'Cannot compare #{this} (#{this.class}) with #{other} (Array). Only ±Float::INFINITY accepted.' unless this.abs == Float::INFINITY
+        return this <=> other.first.to_f
+      else
+        return this <=> other
+      end
+      0
+    end
+
+    class ValidationFailure < ArgumentError
+      def initialize(version)
+        super("#{version} is not a valid python package version. Please refer to https://www.python.org/dev/peps/pep-0440/.")
+      end
+    end
+  end
+end

--- a/spec/unit/util/package/version/pip_spec.rb
+++ b/spec/unit/util/package/version/pip_spec.rb
@@ -1,0 +1,458 @@
+require 'spec_helper'
+require 'puppet/util/package/version/pip'
+
+describe Puppet::Util::Package::Version::Pip do
+  describe "initialization" do
+    shared_examples_for 'a valid version' do |input_version, output = input_version|
+      [input_version, input_version.swapcase].each do |input|
+        it "transforms #{input} back to string(#{output}) succesfully" do
+          version = described_class.parse(input)
+          expect(version.to_s).to eq(output)
+        end
+      end
+
+      describe "comparison" do
+        version = described_class.parse(input_version)
+
+        # rubocop:disable UselessComparison
+        it "#{input_version} shouldn't be lesser than itself" do
+          expect(version <  version).to eq(false)
+        end
+
+        it "#{input_version} shouldn't be greater than itself" do
+          expect(version >  version).to eq(false)
+        end
+
+        it "#{input_version} shouldn't be equal with itself" do
+          expect(version != version).to eq(false)
+        end
+
+        it "#{input_version} should be equal to itself" do
+          expect(version == version).to eq(true)
+        end
+      end
+    end
+
+    shared_examples_for 'an invalid version' do |invalid_input|
+      [invalid_input, invalid_input.swapcase].each do |input|
+        it "should not be able to transform #{invalid_input} to string" do
+          expect{ described_class.parse(input) }.to raise_error(described_class::ValidationFailure)
+        end
+      end
+
+      describe "comparison" do
+        valid_version = described_class.parse("1.0")
+
+        it "should raise error when checking if #{invalid_input} is lesser than a valid version" do
+          expect{ valid_version <  invalid_input }.to raise_error(described_class::ValidationFailure)
+        end
+
+        it "should raise error when checking if #{invalid_input} is greater than a valid version" do
+          expect{ valid_version >  invalid_input }.to raise_error(described_class::ValidationFailure)
+        end
+
+        it "should raise error when checking if #{invalid_input} is greater or equal than a valid version" do
+          expect{ valid_version >= invalid_input }.to raise_error(described_class::ValidationFailure)
+        end
+
+        it "should raise error when checking if #{invalid_input} is lesser or equal than a valid version" do
+          expect{ valid_version <= invalid_input }.to raise_error(described_class::ValidationFailure)
+        end
+      end
+    end
+
+    describe "when only release segment is present in provided version" do
+      context "should work with any number of integer elements" do
+        context "when it has 1 element" do
+          it_should_behave_like 'a valid version', "1"
+        end
+        context "when it has 2 elements" do
+          it_should_behave_like 'a valid version', "1.1"
+        end
+
+        context "when it has 3 elements" do
+          it_should_behave_like 'a valid version', "1.1.1"
+        end
+
+        context "when it has 4 elements" do
+          it_should_behave_like 'a valid version', "1.1.1.1"
+        end
+
+        context "when it has 10 elements" do
+          it_should_behave_like 'a valid version', "1.1.1.1.1.1.1.1.1.1"
+        end
+      end
+
+      describe "should work with elements which are zero" do
+        context "when it ends with 1 zero" do
+          it_should_behave_like 'a valid version', "1.0"
+        end
+
+        context "when it ends with 2 zeros" do
+          it_should_behave_like 'a valid version', "1.0.0"
+        end
+
+        context "when it ends with 3 zeros" do
+          it_should_behave_like 'a valid version', "1.0.0.0"
+        end
+
+        context "when it starts with 1 zero" do
+          it_should_behave_like 'a valid version', "0.1"
+        end
+
+        context "when it starts with 2 zeros" do
+          it_should_behave_like 'a valid version', "0.0.1"
+        end
+
+        context "when it starts with 3 zeros" do
+          it_should_behave_like 'a valid version', "0.0.0.1"
+        end
+
+        context "when it is just a zero" do
+          it_should_behave_like 'a valid version', "0"
+        end
+
+        context "when it is full of just zeros" do
+          it_should_behave_like 'a valid version', "0.0.0"
+        end
+      end
+
+      describe "should work with elements containing multiple digits" do
+        context "when it has two digit elements" do
+          it_should_behave_like 'a valid version', "1.10.1"
+        end
+
+        context "when it has three digit elements" do
+          it_should_behave_like 'a valid version', "1.101.1.11"
+        end
+
+        context "when it has four digit elements" do
+          it_should_behave_like 'a valid version', "2019.0.11"
+        end
+
+        context "when it has a numerical element starting with zero" do
+          # the zero will dissapear
+          it_should_behave_like 'a valid version', "1.09.10", "1.9.10"
+        end
+
+        context "when it starts with multiple zeros" do
+          # the zeros will dissapear
+          it_should_behave_like 'a valid version', "0010.0000.0011", "10.0.11"
+        end
+      end
+
+      context "should fail because of misplaced letters" do
+        context "when it starts with letters" do
+          it_should_behave_like 'an invalid version', "d.2"
+          it_should_behave_like 'an invalid version', "ee.2"
+        end
+
+        context "when it has only letters" do
+          it_should_behave_like 'an invalid version', "d.c"
+          it_should_behave_like 'an invalid version', "dd.c"
+        end
+      end
+    end
+
+    describe "when the epoch segment is present in provided version" do
+      context "should work when epoch is an integer" do
+        context "when epoch has 1 digit" do
+          it_should_behave_like 'a valid version', "1!1.0.0"
+        end
+
+        context "when epoch has 2 digits" do
+          it_should_behave_like 'a valid version', "10!1.0.0"
+        end
+
+        context "when epoch is zero" do
+          # versions without epoch specified are considered to have epoch 0
+          # it is accepted as input but it should be ignored at output
+          it_should_behave_like 'a valid version', "0!1.0.0", "1.0.0"
+        end
+      end
+
+      context "should fail when epoch contains letters" do
+        context "when epoch starts with a letter" do
+          it_should_behave_like 'an invalid version', "a9!1.0.0"
+        end
+
+        context "when epoch ends with a letter" do
+          it_should_behave_like 'an invalid version', "9a!1.0.0"
+        end
+      end
+    end
+
+    describe "when the pre-release segment is present in provided version" do
+      context "when pre-release contains the letter a" do
+        it_should_behave_like 'a valid version', "1.0a", "1.0a0"
+        it_should_behave_like 'a valid version', "1.0a0"
+      end
+
+      context "when pre-release contains the letter b" do
+        it_should_behave_like 'a valid version', "1.0b", "1.0b0"
+        it_should_behave_like 'a valid version', "1.0b0"
+      end
+
+      context "when pre-release contains the letter c" do
+        it_should_behave_like 'a valid version', "1.0c",  "1.0rc0"
+        it_should_behave_like 'a valid version', "1.0c0", "1.0rc0"
+      end
+
+      context "when pre-release contains the string alpha" do
+        it_should_behave_like 'a valid version', "1.0alpha",  "1.0a0"
+        it_should_behave_like 'a valid version', "1.0alpha0", "1.0a0"
+      end
+
+      context "when pre-release contains the string beta" do
+        it_should_behave_like 'a valid version', "1.0beta",  "1.0b0"
+        it_should_behave_like 'a valid version', "1.0beta0", "1.0b0"
+      end
+
+      context "when pre-release contains the string rc" do
+        it_should_behave_like 'a valid version', "1.0rc",  "1.0rc0"
+        it_should_behave_like 'a valid version', "1.0rc0", "1.0rc0"
+      end
+
+      context "when pre-release contains the string pre" do
+        it_should_behave_like 'a valid version', "1.0pre",  "1.0rc0"
+        it_should_behave_like 'a valid version', "1.0pre0", "1.0rc0"
+      end
+
+      context "when pre-release contains the string preview" do
+        it_should_behave_like 'a valid version', "1.0preview",  "1.0rc0"
+        it_should_behave_like 'a valid version', "1.0preview0", "1.0rc0"
+      end
+
+      context "when pre-release contains multiple zeros at the beginning" do
+        it_should_behave_like 'a valid version', "1.0.beta.00",  "1.0b0"
+        it_should_behave_like 'a valid version', "1.0.beta.002", "1.0b2"
+      end
+
+      context "when pre-release elements are separated by dots" do
+        it_should_behave_like 'a valid version', "1.0.alpha",   "1.0a0"
+        it_should_behave_like 'a valid version', "1.0.alpha.0", "1.0a0"
+        it_should_behave_like 'a valid version', "1.0.alpha.2", "1.0a2"
+      end
+
+      context "when pre-release elements are separated by dashes" do
+        it_should_behave_like 'a valid version', "1.0-alpha",   "1.0a0"
+        it_should_behave_like 'a valid version', "1.0-alpha-0", "1.0a0"
+        it_should_behave_like 'a valid version', "1.0-alpha-2", "1.0a2"
+      end
+
+      context "when pre-release elements are separated by underscores" do
+        it_should_behave_like 'a valid version', "1.0_alpha",   "1.0a0"
+        it_should_behave_like 'a valid version', "1.0_alpha_0", "1.0a0"
+        it_should_behave_like 'a valid version', "1.0_alpha_2", "1.0a2"
+      end
+
+      context "when pre-release elements are separated by mixed symbols" do
+        it_should_behave_like 'a valid version', "1.0-alpha_5", "1.0a5"
+        it_should_behave_like 'a valid version', "1.0-alpha.5", "1.0a5"
+        it_should_behave_like 'a valid version', "1.0_alpha-5", "1.0a5"
+        it_should_behave_like 'a valid version', "1.0_alpha.5", "1.0a5"
+        it_should_behave_like 'a valid version', "1.0.alpha-5", "1.0a5"
+        it_should_behave_like 'a valid version', "1.0.alpha_5", "1.0a5"
+      end
+    end
+
+    describe "when the post-release segment is present in provided version" do
+      context "when post-release is just an integer" do
+        it_should_behave_like 'a valid version', "1.0-9",  "1.0.post9"
+        it_should_behave_like 'a valid version', "1.0-10", "1.0.post10"
+      end
+
+      context "when post-release is just an integer and starts with zero" do
+        it_should_behave_like 'a valid version', "1.0-09",  "1.0.post9"
+        it_should_behave_like 'a valid version', "1.0-009", "1.0.post9"
+      end
+
+      context "when post-release contains the string post" do
+        it_should_behave_like 'a valid version', "1.0post",  "1.0.post0"
+        it_should_behave_like 'a valid version', "1.0post0", "1.0.post0"
+        it_should_behave_like 'a valid version', "1.0post1", "1.0.post1"
+        it_should_behave_like 'an invalid version', "1.0-0.post1"
+      end
+
+      context "when post-release contains the string rev" do
+        it_should_behave_like 'a valid version', "1.0rev",  "1.0.post0"
+        it_should_behave_like 'a valid version', "1.0rev0", "1.0.post0"
+        it_should_behave_like 'a valid version', "1.0rev1", "1.0.post1"
+        it_should_behave_like 'an invalid version', "1.0-0.rev1"
+      end
+
+      context "when post-release contains the letter r" do
+        it_should_behave_like 'a valid version', "1.0r",  "1.0.post0"
+        it_should_behave_like 'a valid version', "1.0r0", "1.0.post0"
+        it_should_behave_like 'a valid version', "1.0r1", "1.0.post1"
+        it_should_behave_like 'an invalid version', "1.0-0.r1"
+      end
+
+      context "when post-release elements are separated by dashes" do
+        it_should_behave_like 'a valid version', "1.0-post-22", "1.0.post22"
+        it_should_behave_like 'a valid version', "1.0-rev-22",  "1.0.post22"
+        it_should_behave_like 'a valid version', "1.0-r-22",    "1.0.post22"
+      end
+
+      context "when post-release elements are separated by underscores" do
+        it_should_behave_like 'a valid version', "1.0_post_22", "1.0.post22"
+        it_should_behave_like 'a valid version', "1.0_rev_22",  "1.0.post22"
+        it_should_behave_like 'a valid version', "1.0_r_22",    "1.0.post22"
+      end
+
+      context "when post-release elements are separated by dots" do
+        it_should_behave_like 'a valid version', "1.0.post.22", "1.0.post22"
+        it_should_behave_like 'a valid version', "1.0.rev.22",  "1.0.post22"
+        it_should_behave_like 'a valid version', "1.0.r.22",    "1.0.post22"
+      end
+
+      context "when post-release elements are separated by mixed symbols" do
+        it_should_behave_like 'a valid version', "1.0-r_5", "1.0.post5"
+        it_should_behave_like 'a valid version', "1.0-r.5", "1.0.post5"
+        it_should_behave_like 'a valid version', "1.0_r-5", "1.0.post5"
+        it_should_behave_like 'a valid version', "1.0_r.5", "1.0.post5"
+        it_should_behave_like 'a valid version', "1.0.r-5", "1.0.post5"
+        it_should_behave_like 'a valid version', "1.0.r_5", "1.0.post5"
+      end
+    end
+
+    describe "when the dev release segment is present in provided version" do
+      context "when dev release is only the keyword dev" do
+        it_should_behave_like 'a valid version', "1.0dev",  "1.0.dev0"
+        it_should_behave_like 'a valid version', "1.0-dev", "1.0.dev0"
+        it_should_behave_like 'a valid version', "1.0_dev", "1.0.dev0"
+        it_should_behave_like 'a valid version', "1.0.dev", "1.0.dev0"
+      end
+
+      context "when dev release contains the keyword dev and a number" do
+        it_should_behave_like 'a valid version', "1.0dev2",    "1.0.dev2"
+        it_should_behave_like 'a valid version', "1.0-dev33",  "1.0.dev33"
+        it_should_behave_like 'a valid version', "1.0.dev11",  "1.0.dev11"
+        it_should_behave_like 'a valid version', "1.0_dev101", "1.0.dev101"
+      end
+
+      context "when dev release's number element starts with 0" do
+        it_should_behave_like 'a valid version', "1.0dev02",     "1.0.dev2"
+        it_should_behave_like 'a valid version', "1.0-dev033",   "1.0.dev33"
+        it_should_behave_like 'a valid version', "1.0_dev0101",  "1.0.dev101"
+        it_should_behave_like 'a valid version', "1.0.dev00011", "1.0.dev11"
+      end
+
+      context "when dev release elements are separated by dashes" do
+        it_should_behave_like 'a valid version', "1.0-dev",    "1.0.dev0"
+        it_should_behave_like 'a valid version', "1.0-dev-2",  "1.0.dev2"
+        it_should_behave_like 'a valid version', "1.0-dev-22", "1.0.dev22"
+      end
+
+      context "when dev release elements are separated by underscores" do
+        it_should_behave_like 'a valid version', "1.0_dev",    "1.0.dev0"
+        it_should_behave_like 'a valid version', "1.0_dev_2",  "1.0.dev2"
+        it_should_behave_like 'a valid version', "1.0_dev_22", "1.0.dev22"
+      end
+
+      context "when dev release elements are separated by dots" do
+        it_should_behave_like 'a valid version', "1.0.dev",    "1.0.dev0"
+        it_should_behave_like 'a valid version', "1.0.dev.2",  "1.0.dev2"
+        it_should_behave_like 'a valid version', "1.0.dev.22", "1.0.dev22"
+      end
+
+      context "when dev release elements are separated by mixed symbols" do
+        it_should_behave_like 'a valid version', "1.0-dev_5", "1.0.dev5"
+        it_should_behave_like 'a valid version', "1.0-dev.5", "1.0.dev5"
+        it_should_behave_like 'a valid version', "1.0_dev-5", "1.0.dev5"
+        it_should_behave_like 'a valid version', "1.0_dev.5", "1.0.dev5"
+        it_should_behave_like 'a valid version', "1.0.dev-5", "1.0.dev5"
+        it_should_behave_like 'a valid version', "1.0.dev_5", "1.0.dev5"
+      end
+    end
+
+    describe "when the local version segment is present in provided version" do
+      it_should_behave_like 'an invalid version', "1.0+"
+
+      context "when local version is just letters" do
+        it_should_behave_like 'a valid version', "1.0+local"
+        it_should_behave_like 'a valid version', "1.0+Local", "1.0+local"
+      end
+
+      context "when local version contains numbers" do
+        it_should_behave_like 'a valid version', "1.0+10"
+        it_should_behave_like 'a valid version', "1.0+01",    "1.0+1"
+        it_should_behave_like 'a valid version', "1.0+01L",   "1.0+01l"
+        it_should_behave_like 'a valid version', "1.0+L101L", "1.0+l101l"
+      end
+
+      context "when local version contains multiple elements" do
+        it_should_behave_like 'a valid version', "1.0+10.local"
+        it_should_behave_like 'a valid version', "1.0+abc.def.ghi"
+        it_should_behave_like 'a valid version', "1.0+01.abc",            "1.0+1.abc"
+        it_should_behave_like 'a valid version', "1.0+01L.0001",          "1.0+01l.1"
+        it_should_behave_like 'a valid version', "1.0+L101L.local",       "1.0+l101l.local"
+        it_should_behave_like 'a valid version', "1.0+dash-undrsc_dot.5", "1.0+dash.undrsc.dot.5"
+      end
+    end
+  end
+
+  describe "comparison of versions" do
+    # This array must remain sorted (smallest to highest version).
+    versions = [
+      "0.1",
+      "0.10",
+      "0.10.1",
+      "0.10.1.0.1",
+      "1.0.dev456",
+      "1.0a1",
+      "1.0a2.dev456",
+      "1.0a12.dev456",
+      "1.0a12",
+      "1.0b1.dev456",
+      "1.0b2",
+      "1.0b2.post345.dev456",
+      "1.0b2.post345",
+      "1.0b2-346",
+      "1.0c1.dev456",
+      "1.0c1",
+      "1.0rc2",
+      "1.0c3",
+      "1.0",
+      "1.0.post456.dev34",
+      "1.0.post456",
+      "1.1.dev1",
+      "1.2+123abc",
+      "1.2+123abc456",
+      "1.2+abc",
+      "1.2+abc123",
+      "1.2+abc123def",
+      "1.2+1234.abc",
+      "1.2+123456",
+      "1.2.r32+123456",
+      "1.2.rev33+123456",
+      "1!1.0b2.post345.dev456",
+      "1!1.0",
+      "1!1.0.post456.dev34",
+      "1!1.0.post456",
+      "1!1.2.rev33+123456",
+      "2!2.3.4.alpha5.rev6.dev7+abc89"
+    ]
+
+    versions.combination(2).to_a.each do |version_pair|
+      lower_version = described_class.parse(version_pair.first)
+      greater_version = described_class.parse(version_pair.last)
+      
+      it "#{lower_version} should be equal to #{lower_version}" do
+        expect(lower_version == lower_version).to eq(true)
+      end
+
+      it "#{lower_version} should not be equal to #{greater_version}" do
+        expect(lower_version != greater_version).to eq(true)
+      end
+
+      it "#{lower_version} should be lower than #{greater_version}" do
+        expect(lower_version < greater_version).to eq(true)
+      end
+
+      it "#{greater_version} should be greater than #{lower_version}" do
+        expect(greater_version > lower_version).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support of `>`, `>=`, `<`,` <=`, `>=A <=B` ranges for package version specified in the :ensure manifest field. This will install a version that satisfies the provided range. The package version must respect pip's package versioning format (https://www.python.org/dev/peps/pep-0440/).