### PR TITLE
(PUP-10309) Reduce UTF-8 acceptance risk

### DIFF
--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -9,7 +9,7 @@
 # Where applicable, we should be able to do this in different locales
 test_name 'PUP-6777 Manage users with UTF-8 comments' do
 
-  tag 'audit:high',
+  tag 'audit:medium',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/utf8/utf8-in-function-args.rb
+++ b/acceptance/tests/utf8/utf8-in-function-args.rb
@@ -1,6 +1,6 @@
 test_name 'utf-8 characters in function parameters' do
 
-  tag 'audit:high',        # utf-8 is high impact in general
+  tag 'audit:medium',
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
       'audit:refactor'     # if keeping, use mk_temp_environment_with_teardown
 


### PR DESCRIPTION
This commit reduces the audit risk level of UTF-8 acceptance tests from
"audit:high" to "audit:medium".