### PR TITLE
(PUP-10288) Close http pool before sleeping

### DIFF
--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -259,7 +259,7 @@ Licensed under the Apache 2.0 License
         end
       end
       devices.collect do |devicename,device|
-        pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
+        pool = Puppet.runtime['http'].pool
         Puppet.override(:http_pool => pool) do
           # TODO when we drop support for ruby < 2.5 we can remove the extra block here
           begin

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -1,6 +1,5 @@
 # The client for interacting with the puppetmaster config server.
 require 'timeout'
-require 'puppet/network/http_pool'
 require 'puppet/util'
 require 'securerandom'
 #require 'puppet/parser/script_compiler'
@@ -196,7 +195,7 @@ class Puppet::Configurer
   # This just passes any options on to the catalog,
   # which accepts :tags and :ignoreschedules.
   def run(options = {})
-    pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
+    pool = Puppet.runtime['http'].pool
     # We create the report pre-populated with default settings for
     # environment and transaction_uuid very early, this is to ensure
     # they are sent regardless of any catalog compilation failures or

--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -41,7 +41,7 @@ Puppet::Face.define(:plugin, '0.0.1') do
     when_invoked do |options|
       remote_environment_for_plugins = Puppet::Node::Environment.remote(Puppet[:environment])
 
-      pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
+      pool = Puppet.runtime['http'].pool
       Puppet.override(:http_pool => pool) do
         begin
           handler = Puppet::Configurer::PluginHandler.new()

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -1,4 +1,6 @@
 class Puppet::HTTP::Client
+  attr_reader :pool
+
   def initialize(pool: Puppet::Network::HTTP::Pool.new, ssl_context: nil, redirect_limit: 10, retry_limit: 100)
     @pool = pool
     @default_headers = {

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -278,6 +278,10 @@ class Puppet::SSL::StateMachine
       else
         Puppet.info(_("Will try again in %{time} seconds.") % {time: time})
 
+        # close persistent connections and session state before sleeping
+        Puppet.runtime['http'].close
+        @machine.session = nil
+
         Kernel.sleep(time)
 
         # our ssl directory may have been cleaned while we were

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -877,6 +877,16 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
           }.to exit_with(1)
         }.to output(/Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(.*\). Exiting now because the maxwaitforcert timeout has been exceeded./).to_stdout
       end
+
+      it 'closes the pool before sleeping' do
+        machine = described_class.new(waitforcert: 15)
+
+        state = Puppet::SSL::StateMachine::Wait.new(machine)
+        expect(Puppet.runtime['http'].pool).to receive(:close).and_call_original
+        expect(Kernel).to receive(:sleep).with(15).ordered
+
+        state.next_state
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, requests based on `Puppet::Network::HttpPool.http_instance` and the
http client used two different pools, so it was possible for connections to not
be reused when they could be.

This commit pushes the http client's pool onto the context for cases where we
explicitly want to use persistent connections.

----

When running the ssl state machine, close the pool before sleeping so that we
don't keep connections open on the server. It also avoids trying to reuse a
connection that the remote side closed due to an idle timeout. This is similar
to the change made in 8639f0c5176b6bf65c0b9b18803f20708f7bfe28 for PUP-10227.

