### PR TITLE
(maint) Remove some constant redefinition warnings

### DIFF
--- a/spec/unit/indirector/resource/ral_spec.rb
+++ b/spec/unit/indirector/resource/ral_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'puppet/type/user'
 require 'puppet/indirector/resource/ral'
 
 describe "Puppet::Resource::Ral" do
@@ -18,7 +17,7 @@ describe "Puppet::Resource::Ral" do
       wrong_instance = double("wrong user", :name => "bob")
       my_instance    = double("my user",    :name => "root", :to_resource => my_resource)
 
-      expect(Puppet::Type::User).to receive(:instances).and_return([ wrong_instance, my_instance, wrong_instance ])
+      expect(Puppet::Type.type(:user)).to receive(:instances).and_return([ wrong_instance, my_instance, wrong_instance ])
       expect(Puppet::Resource::Ral.new.find(@request)).to eq(my_resource)
     end
 
@@ -32,8 +31,8 @@ describe "Puppet::Resource::Ral" do
       root = double("Root User")
       root_resource = double("Root Resource")
 
-      expect(Puppet::Type::User).to receive(:instances).and_return([ wrong_instance, wrong_instance ])
-      expect(Puppet::Type::User).to receive(:new).with(hash_including(name: "root")).and_return(root)
+      expect(Puppet::Type.type(:user)).to receive(:instances).and_return([ wrong_instance, wrong_instance ])
+      expect(Puppet::Type.type(:user)).to receive(:new).with(hash_including(name: "root")).and_return(root)
       expect(root).to receive(:to_resource).and_return(root_resource)
 
       result = Puppet::Resource::Ral.new.find(@request)
@@ -51,7 +50,7 @@ describe "Puppet::Resource::Ral" do
       my_resource = double("my user resource", :title => "my user resource")
       my_instance = double("my user", :name => "root", :to_resource => my_resource)
 
-      expect(Puppet::Type::User).to receive(:instances).and_return([ my_instance ])
+      expect(Puppet::Type.type(:user)).to receive(:instances).and_return([ my_instance ])
       expect(Puppet::Resource::Ral.new.search(@request)).to eq([my_resource])
     end
 
@@ -69,7 +68,7 @@ describe "Puppet::Resource::Ral" do
 
       @request = double('request', :key => "user/root", :options => {})
 
-      expect(Puppet::Type::User).to receive(:instances).and_return([ my_instance, wrong_instance ])
+      expect(Puppet::Type.type(:user)).to receive(:instances).and_return([ my_instance, wrong_instance ])
       expect(Puppet::Resource::Ral.new.search(@request)).to eq([my_resource])
     end
 
@@ -87,7 +86,7 @@ describe "Puppet::Resource::Ral" do
 
       @request = double('request', :key => "user/", :options => {:name => "bob"})
 
-      expect(Puppet::Type::User).to receive(:instances).and_return([ my_instance, wrong_instance ])
+      expect(Puppet::Type.type(:user)).to receive(:instances).and_return([ my_instance, wrong_instance ])
       expect(Puppet::Resource::Ral.new.search(@request)).to eq([my_resource])
     end
 
@@ -105,7 +104,7 @@ describe "Puppet::Resource::Ral" do
 
       @request = double('request', :key => "user/", :options => {})
 
-      expect(Puppet::Type::User).to receive(:instances).and_return([ b_instance, a_instance ])
+      expect(Puppet::Type.type(:user)).to receive(:instances).and_return([ b_instance, a_instance ])
       expect(Puppet::Resource::Ral.new.search(@request)).to eq([a_resource, b_resource])
     end
   end

--- a/spec/unit/settings/autosign_setting_spec.rb
+++ b/spec/unit/settings/autosign_setting_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 require 'puppet/settings'
 require 'puppet/settings/autosign_setting'
-require 'puppet/type/file'
 
 describe Puppet::Settings::AutosignSetting do
   let(:settings) do
@@ -75,6 +74,7 @@ describe Puppet::Settings::AutosignSetting do
     it "converts the file path to a file resource", :if => !Puppet::Util::Platform.windows? do
       path = File.expand_path('/path/to/autosign.conf')
       allow(settings).to receive(:value).with('autosign', nil, false).and_return(path)
+      allow(Puppet::FileSystem).to receive(:exist?).and_call_original
       allow(Puppet::FileSystem).to receive(:exist?).with(path).and_return(true)
       expect(Puppet.features).to receive(:root?).and_return(true)
 

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -3,8 +3,6 @@ require 'matchers/include_in_order'
 require 'puppet_spec/compiler'
 
 require 'puppet/transaction'
-require 'puppet/type/exec'
-require 'puppet/type/notify'
 require 'fileutils'
 
 describe Puppet::Transaction do

--- a/spec/unit/type/file/ensure_spec.rb
+++ b/spec/unit/type/file/ensure_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
-require 'puppet/type/file/ensure'
 
-describe Puppet::Type::File::Ensure do
+describe Puppet::Type.type(:file).attrclass(:ensure) do
   include PuppetSpec::Files
 
   let(:path) { tmpfile('file_ensure') }

--- a/spec/unit/util/at_fork_spec.rb
+++ b/spec/unit/util/at_fork_spec.rb
@@ -5,6 +5,7 @@ describe 'Puppet::Util::AtFork' do
 
   before :each do
     Puppet::Util.class_exec do
+      remove_const(:AtFork) if defined?(Puppet::Util::AtFork)
       const_set(:AtFork, Module.new)
     end
   end


### PR DESCRIPTION
Previously, puppet tests could generate warnings like

    warning: already initialized constant CREATORS

due to puppet types being loaded twice. This happened if a spec required the
type directly and it was later loaded by the autoloader. This is possible
because the autoloader does not consult $LOADED_FEATURES before checking to see
if a file should be loaded.

Updates tests to lookup a type on-demand using `Puppet::Type.type(:name)`.

There are still some warnings due to faces.
