### PR TITLE
(PUP-10314) Skip ssl debug for non-ssl connections

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -19,7 +19,11 @@ class Puppet::HTTP::Client
     start = Time.now
     ctx = ssl_context ? ssl_context : default_ssl_context
     site = Puppet::Network::HTTP::Site.from_uri(uri)
-    verifier = Puppet::SSL::Verifier.new(site.host, ctx)
+    verifier = if site.use_ssl?
+                 Puppet::SSL::Verifier.new(site.host, ctx)
+               else
+                 nil
+               end
     connected = false
 
     @pool.with_connection(site, verifier) do |http|

--- a/lib/puppet/network/http/base_pool.rb
+++ b/lib/puppet/network/http/base_pool.rb
@@ -4,7 +4,7 @@
 class Puppet::Network::HTTP::BasePool
   def start(site, verifier, http)
     Puppet.debug("Starting connection for #{site}")
-    if verifier
+    if site.use_ssl?
       verifier.setup_connection(http)
       begin
         http.start

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -75,7 +75,10 @@ class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
   # @api private
   def borrow(site, verifier)
     @pool[site] = active_sessions(site)
-    index = @pool[site].index { |session| verifier.reusable?(session.verifier) }
+    index = @pool[site].index do |session|
+      (verifier.nil? && session.verifier.nil?) ||
+        (!verifier.nil? && verifier.reusable?(session.verifier))
+    end
     session = index ? @pool[site].delete_at(index) : nil
     if session
       @pool.delete(site) if @pool[site].empty?

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -206,7 +206,6 @@ describe Puppet::Network::HTTP::Pool do
       conn = create_connection(site)
       pool = create_pool
       expect(pool.factory).to receive(:create_connection).with(site).and_return(conn)
-      expect(pool).to receive(:setsockopts)
 
       expect(pool.borrow(site, verifier)).to eq(conn)
     end
@@ -226,7 +225,6 @@ describe Puppet::Network::HTTP::Pool do
 
       conn = create_connection(site)
       expect(pool.factory).to receive(:create_connection).with(site).and_return(conn)
-      expect(pool).to receive(:setsockopts)
 
       expect(pool.borrow(site, verifier)).to eq(conn)
     end
@@ -258,7 +256,6 @@ describe Puppet::Network::HTTP::Pool do
     it 'returns a new connection if the ssl contexts are different' do
       old_conn = create_connection(site)
       pool = create_pool_with_connections(site, old_conn)
-      allow(pool).to receive(:setsockopts)
 
       new_conn = create_connection(site)
       allow(pool.factory).to receive(:create_connection).with(site).and_return(new_conn)
@@ -273,7 +270,6 @@ describe Puppet::Network::HTTP::Pool do
     it 'returns a cached connection if the ssl contexts are the same' do
       old_conn = create_connection(site)
       pool = create_pool_with_connections(site, old_conn)
-      allow(pool).to receive(:setsockopts)
 
       expect(pool.factory).not_to receive(:create_connection)
 
@@ -323,7 +319,6 @@ describe Puppet::Network::HTTP::Pool do
       expect(conn).to receive(:finish)
 
       pool = create_pool_with_expired_connections(site, conn)
-      expect(pool).to receive(:setsockopts)
       expect(pool.factory).to receive(:create_connection).and_return(double('conn', :start => nil, :use_ssl? => true))
 
       pool.borrow(site, verifier)
@@ -337,7 +332,6 @@ describe Puppet::Network::HTTP::Pool do
       expect(conn).to receive(:finish).and_raise(IOError, 'read timeout')
 
       pool = create_pool_with_expired_connections(site, conn)
-      expect(pool).to receive(:setsockopts)
       expect(pool.factory).to receive(:create_connection).and_return(double('open_conn', :start => nil, :use_ssl? => true))
 
       pool.borrow(site, verifier)

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -37,6 +37,14 @@ describe Puppet::Network::HTTP::Pool do
     pool
   end
 
+  def create_pool_with_http_connections(site, *connections)
+    pool = Puppet::Network::HTTP::Pool.new
+    connections.each do |conn|
+      pool.release(site, nil, conn)
+    end
+    pool
+  end
+
   def create_pool_with_expired_connections(site, *connections)
     # setting keepalive timeout to -1 ensures any newly added
     # connections have already expired
@@ -49,6 +57,10 @@ describe Puppet::Network::HTTP::Pool do
 
   def create_connection(site)
     double(site.addr, :started? => false, :start => nil, :finish => nil, :use_ssl? => true, :verify_mode => OpenSSL::SSL::VERIFY_PEER)
+  end
+
+  def create_http_connection(site)
+    double(site.addr, :started? => false, :start => nil, :finish => nil, :use_ssl? => false)
   end
 
   context 'when yielding a connection' do
@@ -219,6 +231,30 @@ describe Puppet::Network::HTTP::Pool do
       expect(pool.borrow(site, verifier)).to eq(conn)
     end
 
+    it 'returns a new HTTP connection if the cached connection is HTTPS' do
+      https_site = Puppet::Network::HTTP::Site.new('https', 'www.example.com', 443)
+      old_conn = create_connection(https_site)
+      pool = create_pool_with_connections(https_site, old_conn)
+
+      http_site = Puppet::Network::HTTP::Site.new('http', 'www.example.com', 443)
+      new_conn = create_http_connection(http_site)
+      allow(pool.factory).to receive(:create_connection).with(http_site).and_return(new_conn)
+
+      expect(pool.borrow(http_site, nil)).to eq(new_conn)
+    end
+
+    it 'returns a new HTTPS connection if the cached connection is HTTP' do
+      http_site = Puppet::Network::HTTP::Site.new('http', 'www.example.com', 443)
+      old_conn = create_http_connection(http_site)
+      pool = create_pool_with_http_connections(http_site, old_conn)
+
+      https_site = Puppet::Network::HTTP::Site.new('https', 'www.example.com', 443)
+      new_conn = create_connection(https_site)
+      allow(pool.factory).to receive(:create_connection).with(https_site).and_return(new_conn)
+
+      expect(pool.borrow(https_site, verifier)).to eq(new_conn)
+    end
+
     it 'returns a new connection if the ssl contexts are different' do
       old_conn = create_connection(site)
       pool = create_pool_with_connections(site, old_conn)
@@ -279,8 +315,8 @@ describe Puppet::Network::HTTP::Pool do
       expect(conn).to receive(:finish)
 
       pool = create_pool_with_expired_connections(site, conn)
-      expect(pool.factory).to receive(:create_connection).and_return(double('conn', :start => nil))
       expect(pool).to receive(:setsockopts)
+      expect(pool.factory).to receive(:create_connection).and_return(double('conn', :start => nil, :use_ssl? => true))
 
       pool.borrow(site, verifier)
     end
@@ -293,8 +329,8 @@ describe Puppet::Network::HTTP::Pool do
       expect(conn).to receive(:finish).and_raise(IOError, 'read timeout')
 
       pool = create_pool_with_expired_connections(site, conn)
-      expect(pool.factory).to receive(:create_connection).and_return(double('open_conn', :start => nil))
       expect(pool).to receive(:setsockopts)
+      expect(pool.factory).to receive(:create_connection).and_return(double('open_conn', :start => nil, :use_ssl? => true))
 
       pool.borrow(site, verifier)
     end

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -282,13 +282,21 @@ describe Puppet::Network::HTTP::Pool do
       expect(pool.borrow(site, new_verifier)).to equal(old_conn)
     end
 
+    it 'returns a cached connection if both connections are http' do
+      http_site = Puppet::Network::HTTP::Site.new('http', 'www.example.com', 80)
+      old_conn = create_http_connection(http_site)
+      pool = create_pool_with_http_connections(http_site, old_conn)
+
+      # 'equal' tests that it's the same object
+      expect(pool.borrow(http_site, nil)).to equal(old_conn)
+    end
+
     it 'returns started connections' do
       conn = create_connection(site)
       expect(conn).to receive(:start)
 
       pool = create_pool
       expect(pool.factory).to receive(:create_connection).with(site).and_return(conn)
-      expect(pool).to receive(:setsockopts)
 
       expect(pool.borrow(site, verifier)).to eq(conn)
     end


### PR DESCRIPTION
Trying to start a non-ssl connection in debug mode would fail trying to call a non-existent method `TCPSocket#ssl_version`.