### PR TITLE
(PUP-9726) Refactor symbolic_modes test

### DIFF
--- a/acceptance/lib/puppet/acceptance/temp_file_utils.rb
+++ b/acceptance/lib/puppet/acceptance/temp_file_utils.rb
@@ -146,11 +146,13 @@ module Puppet
       def stat(host, path)
         require File.join(File.dirname(__FILE__),'common_utils.rb')
         ruby = Puppet::Acceptance::CommandUtils.ruby_command(host)
-        owner = on(host, "#{ruby} -e 'require \"etc\"; puts (Etc.getpwuid(File.stat(\"#{path}\").uid).name)'").stdout.chomp
-        group = on(host, "#{ruby} -e 'require \"etc\"; puts (Etc.getgrgid(File.stat(\"#{path}\").gid).name)'").stdout.chomp
-        mode  = on(host, "#{ruby} -e 'puts (File.stat(\"#{path}\").mode & 07777)'").stdout.chomp.to_i
-
-        [owner, group, mode]
+        serialized_stat = on(host, "#{ruby} -e 'require \"etc\"; \
+                                                require \"yaml\"; \
+                                                owner = (Etc.getpwuid(File.stat(\"#{path}\").uid).name); \
+                                                group = (Etc.getgrgid(File.stat(\"#{path}\").gid).name); \
+                                                mode = (File.stat(\"#{path}\").mode & 07777); \
+                                                puts YAML::dump([owner,group,mode])'").stdout.chomp
+        YAML::load(serialized_stat)
       end
 
       def initialize_temp_dirs()

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -183,14 +183,14 @@ test_name 'file resource: symbolic modes' do
   agents.each do |agent|
     is_solaris = agent['platform'].include?('solaris')
 
-    on(agent, puppet('resource user symuser ensure=present'))
-    on(agent, puppet('resource group symgroup ensure=present'))
+    manifest = "user { 'symuser': ensure => 'present'} group { 'symgroup': ensure => 'present' }"
+    apply_manifest_on(agent, manifest)
     base_dir_create = agent.tmpdir('symbolic-modes-create_test')
     base_dir_modify = agent.tmpdir('symbolic-modes-modify_test')
 
     teardown do
-      on(agent, puppet('resource user symuser ensure=absent'))
-      on(agent, puppet('resource group symgroup ensure=absent'))
+      manifest = "user { 'symuser': ensure => 'absent'} group { 'symgroup': ensure => 'absent' }"
+      apply_manifest_on(agent, manifest)
       on(agent, "rm -rf '#{base_dir_create}' '#{base_dir_modify}'")
     end
 

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -102,10 +102,10 @@ test_name 'file resource: symbolic modes' do
       files       = @file_list.collect {|x| "'#{x.path}'" }
       directories = @directory_list.collect {|x| "'#{x.path}'" }
 
-      @testcase.on(@agent, "touch #{files.join(' ')}")
-      @testcase.on(@agent, "mkdir -p #{directories.join(' ')}")
-      @testcase.on(@agent, "chown symuser:symgroup #{files.join(' ')} #{directories.join(' ')}")
       cmd_list = []
+      cmd_list << "touch #{files.join(' ')}"
+      cmd_list << "mkdir -p #{directories.join(' ')}"
+      cmd_list << "chown symuser:symgroup #{files.join(' ')} #{directories.join(' ')}"
       (@file_list + @directory_list).each do |file|
         cmd_list << "chmod #{file.start_mode.to_s(8)} '#{file.path}'"
       end


### PR DESCRIPTION
This PR refactors the symbolic_modes acceptance test to reduce the number of discrete beaker system calls to perform its task.

Prior to this change, this test took 50.20 seconds to execute.  With this change, the test time is reduced to 24.30 seconds.