### PR TITLE
(PUP-10260) Add rest terminus tests

### DIFF
--- a/spec/unit/indirector/catalog/rest_spec.rb
+++ b/spec/unit/indirector/catalog/rest_spec.rb
@@ -3,7 +3,64 @@ require 'spec_helper'
 require 'puppet/indirector/catalog/rest'
 
 describe Puppet::Resource::Catalog::Rest do
-  it "should be a sublcass of Puppet::Indirector::REST" do
-    expect(Puppet::Resource::Catalog::Rest.superclass).to equal(Puppet::Indirector::REST)
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/catalog/ziggy} }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+  let(:catalog) { Puppet::Resource::Catalog.new(certname) }
+
+  before :each do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def catalog_response(catalog)
+    { body: formatter.render(catalog), headers: {'Content-Type' => formatter.mime } }
+  end
+
+  it 'finds a catalog' do
+    stub_request(:get, uri).to_return(**catalog_response(catalog))
+
+    expect(described_class.indirection.find(certname)).to be_a(Puppet::Resource::Catalog)
+  end
+
+  it "serializes the environment" do
+    stub_request(:get, uri)
+      .with(query: hash_including('environment' => 'outerspace'))
+      .to_return(**catalog_response(catalog))
+
+    described_class.indirection.find(certname, environment: Puppet::Node::Environment.remote('outerspace'))
+  end
+
+  it 'constructs a catalog environment_instance' do
+    env = Puppet::Node::Environment.remote('outerspace')
+    catalog = Puppet::Resource::Catalog.new(certname, env)
+
+    stub_request(:get, uri).to_return(**catalog_response(catalog))
+
+    expect(described_class.indirection.find(certname).environment_instance).to eq(env)
+  end
+
+  it 'returns nil if the node does not exist' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect(described_class.indirection.find(certname)).to be_nil
+  end
+
+  it 'raises if fail_on_404 is specified' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect{
+      described_class.indirection.find(certname, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/catalog/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it 'raises Net::HTTPError on 500' do
+    stub_request(:get, uri).to_return(status: 500)
+
+    expect{
+      described_class.indirection.find(certname)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
   end
 end

--- a/spec/unit/indirector/facts/rest_spec.rb
+++ b/spec/unit/indirector/facts/rest_spec.rb
@@ -3,42 +3,97 @@ require 'spec_helper'
 require 'puppet/indirector/facts/rest'
 
 describe Puppet::Node::Facts::Rest do
-  it "should be a sublcass of Puppet::Indirector::REST" do
-    expect(Puppet::Node::Facts::Rest.superclass).to equal(Puppet::Indirector::REST)
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/facts/ziggy} }
+  let(:facts) { Puppet::Node::Facts.new(certname, test_fact: 'test value') }
+
+  before do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
   end
 
-  let(:model) { Puppet::Node::Facts }
-  before(:each) { model.indirection.terminus_class = :rest }
+  describe '#find' do
+    let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
 
-  def mock_response(code, body, content_type='text/plain', encoding=nil)
-    obj = double('http response', :code => code.to_s, :body => body)
-    allow(obj).to receive(:[]).with('content-type').and_return(content_type)
-    allow(obj).to receive(:[]).with('content-encoding').and_return(encoding)
-    allow(obj).to receive(:[]).with(Puppet::Network::HTTP::HEADER_PUPPET_VERSION).and_return(Puppet.version)
-    obj
+    def facts_response(facts)
+      { body: formatter.render(facts), headers: {'Content-Type' => formatter.mime } }
+    end
+
+    it 'finds facts' do
+      stub_request(:get, uri).to_return(**facts_response(facts))
+
+      expect(described_class.indirection.find(certname)).to be_a(Puppet::Node::Facts)
+    end
+
+    it "serializes the environment" do
+      stub_request(:get, uri)
+        .with(query: hash_including('environment' => 'outerspace'))
+        .to_return(**facts_response(facts))
+
+      described_class.indirection.find(certname, environment: Puppet::Node::Environment.remote('outerspace'))
+    end
+
+    it 'returns nil if the facts do not exist' do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+      expect(described_class.indirection.find(certname)).to be_nil
+    end
+
+    it 'raises if fail_on_404 is specified' do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+      expect{
+        described_class.indirection.find(certname, fail_on_404: true)
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/facts/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    end
+
+    it 'raises Net::HTTPError on 500' do
+      stub_request(:get, uri).to_return(status: 500)
+
+      expect{
+        described_class.indirection.find(certname)
+      }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+    end
   end
 
   describe '#save' do
-    subject { model.indirection.terminus(:rest) }
+    it 'returns nil on success' do
+      stub_request(:put, %r{/puppet/v3/facts})
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json'}, body: '')
 
-    let(:connection) { double('mock http connection', :verify_callback= => nil) }
-    let(:node_name) { 'puppet.node.test' }
-    let(:data) { model.new(node_name, {test_fact: 'test value'}) }
-    let(:request) { Puppet::Indirector::Request.new(:facts, :save, node_name, data) }
-
-    before :each do
-      allow(subject).to receive(:network).and_return(connection)
+      expect(described_class.indirection.save(facts)).to be_nil
     end
 
-    context 'when a 404 response is received' do
-      let(:response) { mock_response(404, '{}', 'test/json') }
+    it "serializes the environment" do
+      stub_request(:put, uri)
+        .with(query: hash_including('environment' => 'outerspace'))
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json'}, body: '')
 
-      before(:each) { expect(connection).to receive(:put).and_return(response) }
+      described_class.indirection.save(facts, nil, environment: Puppet::Node::Environment.remote('outerspace'))
+    end
 
-      it 'riases with HTTP 404' do
-        expect{ subject.save(request) }.to raise_error(Net::HTTPError,
-                                                       /Error 404 on SERVER/)
-      end
+    it 'raises if options are specified' do
+      expect {
+        described_class.indirection.save(facts, nil, foo: :bar)
+      }.to raise_error(ArgumentError, /PUT does not accept options/)
+    end
+
+    it 'raises with HTTP 404' do
+      stub_request(:put, %r{/puppet/v3/facts}).to_return(status: 404)
+
+      expect {
+        described_class.indirection.save(facts)
+      }.to raise_error(Net::HTTPError, /Error 404 on SERVER/)
+    end
+
+    it 'raises with HTTP 500' do
+      stub_request(:put, %r{/puppet/v3/facts}).to_return(status: 500)
+
+      expect {
+        described_class.indirection.save(facts)
+      }.to raise_error(Net::HTTPError, /Error 500 on SERVER/)
     end
   end
 end

--- a/spec/unit/indirector/file_content/rest_spec.rb
+++ b/spec/unit/indirector/file_content/rest_spec.rb
@@ -3,9 +3,60 @@ require 'spec_helper'
 require 'puppet/indirector/file_content/rest'
 
 describe Puppet::Indirector::FileContent::Rest do
-  it "should add the node's cert name to the arguments"
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/file_content/:mount/path/to/file} }
+  let(:key) { "puppet:///:mount/path/to/file" }
 
-  it "should set the content type to text/plain"
+  before :each do
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def file_content_response
+    {body: "some content", headers: { 'Content-Type' => 'application/octet-stream' } }
+  end
+
+  it "returns content as utf-8 string" do
+    stub_request(:get, uri).to_return(status: 200, **file_content_response)
+
+    file_content = described_class.indirection.find(key)
+    expect(file_content.content.encoding).to eq(Encoding::UTF_8)
+    expect(file_content.content).to eq('some content')
+  end
+
+  it "URL encodes special characters" do
+    stub_request(:get, %r{/puppet/v3/file_content/:mount/path%20to%20file}).to_return(status: 200, **file_content_response)
+
+    described_class.indirection.find('puppet:///:mount/path to file')
+  end
+
+  it "returns nil if the content doesn't exist" do
+    stub_request(:get, uri).to_return(status: 404)
+
+    expect(described_class.indirection.find(key)).to be_nil
+  end
+
+  it "raises if fail_on_404 is true" do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+    expect {
+      described_class.indirection.find(key, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_content/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it "raises an error on HTTP 500" do
+    stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+    expect {
+      described_class.indirection.find(key)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+  end
+
+  it "connects to a specific host" do
+    stub_request(:get, %r{https://example.com:8140/puppet/v3/file_content/:mount/path/to/file})
+      .to_return(status: 200, **file_content_response)
+
+    described_class.indirection.find("puppet://example.com:8140/:mount/path/to/file")
+  end
 
   it "should use the :fileserver SRV service" do
     expect(Puppet::Indirector::FileContent::Rest.srv_service).to eq(:fileserver)

--- a/spec/unit/indirector/file_metadata/rest_spec.rb
+++ b/spec/unit/indirector/file_metadata/rest_spec.rb
@@ -3,8 +3,115 @@ require 'spec_helper'
 require 'puppet/indirector/file_metadata'
 require 'puppet/indirector/file_metadata/rest'
 
-describe "Puppet::Indirector::Metadata::Rest" do
-  it "should add the node's cert name to the arguments"
+describe Puppet::Indirector::FileMetadata::Rest do
+  let(:certname) { 'ziggy' }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+
+  before :each do
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def metadata_response(metadata)
+    { body: formatter.render(metadata), headers: {'Content-Type' => formatter.mime } }
+  end
+
+  context "when finding" do
+    let(:uri) { %r{/puppet/v3/file_metadata/:mount/path/to/file} }
+    let(:key) { "puppet:///:mount/path/to/file" }
+    let(:metadata) { Puppet::FileServing::Metadata.new('/path/to/file') }
+
+    it "returns file metadata" do
+      stub_request(:get, uri)
+        .to_return(status: 200, **metadata_response(metadata))
+
+      result = described_class.indirection.find(key)
+      expect(result.path).to eq('/path/to/file')
+    end
+
+    it "URL encodes special characters" do
+      stub_request(:get, %r{/puppet/v3/file_metadata/:mount/path%20to%20file})
+        .to_return(status: 200, **metadata_response(metadata))
+
+      described_class.indirection.find('puppet:///:mount/path to file')
+    end
+
+    it "returns nil if the content doesn't exist" do
+      stub_request(:get, uri).to_return(status: 404)
+
+      expect(described_class.indirection.find(key)).to be_nil
+    end
+
+    it "raises if fail_on_404 is true" do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect {
+        described_class.indirection.find(key, fail_on_404: true)
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_metadata/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    end
+
+    it "raises an error on HTTP 500" do
+      stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect {
+        described_class.indirection.find(key)
+      }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+    end
+
+    it "connects to a specific host" do
+      stub_request(:get, %r{https://example.com:8140/puppet/v3/file_metadata/:mount/path/to/file})
+        .to_return(status: 200, **metadata_response(metadata))
+
+      described_class.indirection.find("puppet://example.com:8140/:mount/path/to/file")
+    end
+  end
+
+  context "when searching" do
+    let(:uri) { %r{/puppet/v3/file_metadatas/:mount/path/to/dir} }
+    let(:key) { "puppet:///:mount/path/to/dir" }
+    let(:metadatas) { [Puppet::FileServing::Metadata.new('/path/to/dir')] }
+
+    it "returns an array of file metadata" do
+      stub_request(:get, uri)
+        .to_return(status: 200, **metadata_response(metadatas))
+
+      result = described_class.indirection.search(key)
+      expect(result.first.path).to eq('/path/to/dir')
+    end
+
+    it "URL encodes special characters" do
+      stub_request(:get, %r{/puppet/v3/file_metadatas/:mount/path%20to%20dir})
+        .to_return(status: 200, **metadata_response(metadatas))
+
+      described_class.indirection.search('puppet:///:mount/path to dir')
+    end
+
+    it "returns an empty array if the metadata doesn't exist" do
+      stub_request(:get, uri).to_return(status: 404)
+
+      expect(described_class.indirection.search(key)).to eq([])
+    end
+
+    it "returns an empty array if the metadata doesn't exist and fail_on_404 is true" do
+      stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect(described_class.indirection.search(key, fail_on_404: true)).to eq([])
+    end
+
+    it "raises an error on HTTP 500" do
+      stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
+
+      expect {
+        described_class.indirection.search(key)
+      }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+    end
+
+    it "connects to a specific host" do
+      stub_request(:get, %r{https://example.com:8140/puppet/v3/file_metadatas/:mount/path/to/dir})
+        .to_return(status: 200, **metadata_response(metadatas))
+
+      described_class.indirection.search("puppet://example.com:8140/:mount/path/to/dir")
+    end
+  end
 
   it "should use the :fileserver SRV service" do
     expect(Puppet::Indirector::FileMetadata::Rest.srv_service).to eq(:fileserver)

--- a/spec/unit/indirector/node/rest_spec.rb
+++ b/spec/unit/indirector/node/rest_spec.rb
@@ -3,9 +3,64 @@ require 'spec_helper'
 require 'puppet/indirector/node/rest'
 
 describe Puppet::Node::Rest do
-  before do
-    @searcher = Puppet::Node::Rest.new
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/node/ziggy} }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+  let(:node) { Puppet::Node.new(certname) }
+
+  before :each do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
   end
 
+  def node_response(node)
+    { body: formatter.render(node), headers: {'Content-Type' => formatter.mime } }
+  end
 
+  it 'finds a node' do
+    stub_request(:get, uri).to_return(**node_response(node))
+
+    expect(described_class.indirection.find(certname)).to be_a(Puppet::Node)
+  end
+
+  it "serializes the environment" do
+    stub_request(:get, uri)
+      .with(query: hash_including('environment' => 'outerspace'))
+      .to_return(**node_response(node))
+
+    described_class.indirection.find(certname, environment: Puppet::Node::Environment.remote('outerspace'))
+  end
+
+  it 'preserves the node environment_name as a symbol' do
+    env = Puppet::Node::Environment.remote('outerspace')
+    node = Puppet::Node.new(certname, environment: env)
+
+    stub_request(:get, uri).to_return(**node_response(node))
+
+    expect(described_class.indirection.find(certname).environment_name).to eq(:outerspace)
+  end
+
+  it 'returns nil if the node does not exist' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect(described_class.indirection.find(certname)).to be_nil
+  end
+
+  it 'raises if fail_on_404 is specified' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect{
+      described_class.indirection.find(certname, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/node/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it 'raises Net::HTTPError on 500' do
+    stub_request(:get, uri).to_return(status: 500)
+
+    expect{
+      described_class.indirection.find(certname)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
+  end
 end

--- a/spec/unit/indirector/status/rest_spec.rb
+++ b/spec/unit/indirector/status/rest_spec.rb
@@ -3,7 +3,48 @@ require 'spec_helper'
 require 'puppet/indirector/status/rest'
 
 describe Puppet::Indirector::Status::Rest do
-  it "should be a subclass of Puppet::Indirector::REST" do
-    expect(Puppet::Indirector::Status::Rest.superclass).to equal(Puppet::Indirector::REST)
+  let(:certname) { 'ziggy' }
+  let(:uri) { %r{/puppet/v3/status/ziggy} }
+  let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+
+  before :each do
+    Puppet[:server] = 'compiler.example.com'
+    Puppet[:masterport] = 8140
+
+    described_class.indirection.terminus_class = :rest
+  end
+
+  def status_response(node)
+    { body: formatter.render(node), headers: {'Content-Type' => formatter.mime } }
+  end
+
+  it 'finds server status' do
+    node = Puppet::Status.new(certname)
+
+    stub_request(:get, uri).to_return(**status_response(node))
+
+    expect(described_class.indirection.find(certname)).to be_a(Puppet::Status)
+  end
+
+  it 'returns nil if the node does not exist' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect(described_class.indirection.find(certname)).to be_nil
+  end
+
+  it 'raises if fail_on_404 is specified' do
+    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+
+    expect{
+      described_class.indirection.find(certname, fail_on_404: true)
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/status/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+  end
+
+  it 'raises Net::HTTPError on 500' do
+    stub_request(:get, uri).to_return(status: 500)
+
+    expect{
+      described_class.indirection.find(certname)
+    }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
   end
 end


### PR DESCRIPTION
Adds tests for rest termini. Use webmock instead of manually stubbing Net::HTTP. 