### PR TITLE
(PUP-10260) Add http service methods

### DIFF
--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -122,4 +122,10 @@ class Puppet::HTTP::Service
       raise Puppet::HTTP::SerializationError.new("Failed to deserialize multiple #{model} from #{formatter.name}: #{err.message}", err)
     end
   end
+
+  def process_response(response)
+    @session.process_response(response)
+
+    raise Puppet::HTTP::ResponseError.new(response) unless response.success?
+  end
 end

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -14,11 +14,9 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return response.body.to_s if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    response.body.to_s
   end
 
   def get_certificate_revocation_list(if_modified_since: nil, ssl_context: nil)
@@ -31,11 +29,9 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return response.body.to_s if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    response.body.to_s
   end
 
   def put_certificate_request(name, csr, ssl_context: nil)
@@ -47,10 +43,8 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return response.body.to_s if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    response.body.to_s
   end
 end

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -19,11 +19,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       },
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::Node) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    deserialize(response, Puppet::Node)
   end
 
   def get_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
@@ -63,11 +61,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       body: body,
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::Resource::Catalog) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    deserialize(response, Puppet::Resource::Catalog)
   end
 
   def get_facts(name, environment:)
@@ -79,11 +75,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       params: { environment: environment }
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::Node::Facts) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    deserialize(response, Puppet::Node::Facts)
   end
 
   def put_facts(name, environment:, facts:)
@@ -99,11 +93,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       body: serialize(formatter, facts),
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return true if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    true
   end
 
   def get_status(name)
@@ -118,10 +110,8 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       },
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::Status) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    deserialize(response, Puppet::Status)
   end
 end

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -89,4 +89,23 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
 
     raise Puppet::HTTP::ResponseError.new(response)
   end
+
+  def get_status(name)
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Status).join(', '))
+
+    response = @client.get(
+      with_base_url("/status/#{name}"),
+      headers: headers,
+      params: {
+        # environment is required, but meaningless, default to production
+        environment: 'production'
+      },
+    )
+
+    @session.process_response(response)
+
+    return deserialize(response, Puppet::Status) if response.success?
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
 end

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -70,6 +70,22 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     raise Puppet::HTTP::ResponseError.new(response)
   end
 
+  def get_facts(name, environment:)
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Node::Facts).join(', '))
+
+    response = @client.get(
+      with_base_url("/facts/#{name}"),
+      headers: headers,
+      params: { environment: environment }
+    )
+
+    @session.process_response(response)
+
+    return deserialize(response, Puppet::Node::Facts) if response.success?
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
+
   def put_facts(name, environment:, facts:)
     formatter = Puppet::Network::FormatHandler.format_for(Puppet[:preferred_serialization_format])
 

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -24,7 +24,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     deserialize(response, Puppet::Node)
   end
 
-  def get_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
+  def post_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
     if Puppet[:preferred_serialization_format] == "pson"
       formatter = Puppet::Network::FormatHandler.format_for(:pson)
       # must use 'pson' instead of 'text/pson'

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -12,7 +12,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_file_metadata(path:, environment:, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
     validate_path(path)
 
-    headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', '))
 
     response = @client.get(
       with_base_url("/file_metadata#{path}"),
@@ -34,7 +34,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
     validate_path(path)
 
-    headers = add_puppet_headers({ 'Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', ') })
+    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', '))
 
     response = @client.get(
       with_base_url("/file_metadatas#{path}"),
@@ -59,7 +59,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_file_content(path:, environment:, ssl_context: nil, &block)
     validate_path(path)
 
-    headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
+    headers = add_puppet_headers('Accept' => 'application/octet-stream')
     response = @client.get(
       with_base_url("/file_content#{path}"),
       headers: headers,
@@ -81,7 +81,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   def get_static_file_content(path:, environment:, code_id:, ssl_context: nil, &block)
     validate_path(path)
 
-    headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
+    headers = add_puppet_headers('Accept' => 'application/octet-stream')
     response = @client.get(
       with_base_url("/static_file_content#{path}"),
       headers: headers,

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -26,11 +26,9 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize(response, Puppet::FileServing::Metadata) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    deserialize(response, Puppet::FileServing::Metadata)
   end
 
   def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore, ssl_context: nil)
@@ -53,11 +51,9 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
-    @session.process_response(response)
+    process_response(response)
 
-    return deserialize_multiple(response, Puppet::FileServing::Metadata) if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    deserialize_multiple(response, Puppet::FileServing::Metadata)
   end
 
   def get_file_content(path:, environment:, ssl_context: nil, &block)
@@ -77,11 +73,9 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       end
     end
 
-    @session.process_response(response)
+    process_response(response)
 
-    return nil if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    nil
   end
 
   def get_static_file_content(path:, environment:, code_id:, ssl_context: nil, &block)
@@ -102,11 +96,9 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       end
     end
 
-    @session.process_response(response)
+    process_response(response)
 
-    return nil if response.success?
-
-    raise Puppet::HTTP::ResponseError.new(response)
+    nil
   end
 
   private

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -83,6 +83,32 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
 
     raise Puppet::HTTP::ResponseError.new(response)
   end
+
+  def get_static_file_content(path:, environment:, code_id:, ssl_context: nil, &block)
+    validate_path(path)
+
+    headers = add_puppet_headers({'Accept' => 'application/octet-stream' })
+    response = @client.get(
+      with_base_url("/static_file_content#{path}"),
+      headers: headers,
+      params: {
+        environment: environment,
+        code_id: code_id,
+      },
+      ssl_context: ssl_context
+    ) do |res|
+      if res.success?
+        res.read_body(&block)
+      end
+    end
+
+    @session.process_response(response)
+
+    return nil if response.success?
+
+    raise Puppet::HTTP::ResponseError.new(response)
+  end
+
   private
 
   def validate_path(path)

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -19,6 +19,7 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
       ssl_context: ssl_context
     )
 
+    # override parent's process_response handling
     @session.process_response(response)
 
     if response.success?

--- a/spec/unit/http/service/compiler_spec.rb
+++ b/spec/unit/http/service/compiler_spec.rb
@@ -12,6 +12,7 @@ describe Puppet::HTTP::Service::Compiler do
   let(:node) { Puppet::Node.new(certname) }
   let(:facts) { Puppet::Node::Facts.new(certname) }
   let(:catalog) { Puppet::Resource::Catalog.new(certname) }
+  let(:status) { Puppet::Status.new }
   let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
 
   before :each do
@@ -337,6 +338,59 @@ describe Puppet::HTTP::Service::Compiler do
       expect {
         subject.put_facts(certname, environment: 'production', facts: invalid_facts)
       }.to raise_error(Puppet::HTTP::SerializationError, /Failed to serialize Puppet::Node::Facts to json: "\\xE2" from ASCII-8BIT to UTF-8/)
+    end
+  end
+
+  context 'when getting status' do
+    let(:uri) { %r{/puppet/v3/status/ziggy} }
+    let(:status_response) { { body: formatter.render(status), headers: {'Content-Type' => formatter.mime } } }
+
+    it 'always sends production' do
+      stub_request(:get, uri)
+          .with(query: hash_including("environment" => "production"))
+          .to_return(**status_response)
+
+      subject.get_status(certname)
+    end
+
+    it 'returns a deserialized status' do
+      stub_request(:get, uri)
+        .to_return(**status_response)
+
+      s = subject.get_status(certname)
+      expect(s).to be_a(Puppet::Status)
+      expect(s.status).to eq("is_alive" => true)
+    end
+
+    it 'raises a response error if unsuccessful' do
+      stub_request(:get, uri)
+        .to_return(status: [500, "Server Error"])
+
+      expect {
+        subject.get_status(certname)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq('Server Error')
+        expect(err.response.code).to eq(500)
+      end
+    end
+
+    it 'raises a protocol error if the content-type header is missing' do
+      stub_request(:get, uri)
+        .to_return(body: "content-type is missing")
+
+      expect {
+        subject.get_status(certname)
+      }.to raise_error(Puppet::HTTP::ProtocolError, /No content type in http response; cannot parse/)
+    end
+
+    it 'raises a serialization error if the content is invalid' do
+      stub_request(:get, uri)
+        .to_return(body: "this isn't valid JSON", headers: {'Content-Type' => 'application/json'})
+
+      expect {
+        subject.get_status(certname)
+      }.to raise_error(Puppet::HTTP::SerializationError, /Failed to deserialize Puppet::Status from json/)
     end
   end
 end

--- a/spec/unit/http/service/compiler_spec.rb
+++ b/spec/unit/http/service/compiler_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::HTTP::Service::Compiler do
         expect(request.headers).to_not include('X-Puppet-Profiling')
       end.to_return(body: formatter.render(catalog), headers: {'Content-Type' => formatter.mime })
 
-      subject.get_catalog(certname, environment: environment, facts: facts)
+      subject.post_catalog(certname, environment: environment, facts: facts)
     end
   end
 
@@ -43,7 +43,7 @@ describe Puppet::HTTP::Service::Compiler do
       stub_request(:post, "https://compiler2.example.com:8141/puppet/v3/catalog/ziggy?environment=testing")
         .to_return(body: formatter.render(catalog), headers: {'Content-Type' => formatter.mime })
 
-      subject.get_catalog(certname, environment: environment, facts: facts)
+      subject.post_catalog(certname, environment: environment, facts: facts)
     end
   end
 
@@ -58,7 +58,7 @@ describe Puppet::HTTP::Service::Compiler do
       Puppet[:http_extra_headers] = 'Example-Header:real-thing,another:thing'
       Puppet[:profile] = true
 
-      subject.get_catalog(certname, environment: environment, facts: facts)
+      subject.post_catalog(certname, environment: environment, facts: facts)
     end
 
     it 'submits facts as application/json by default' do
@@ -66,7 +66,7 @@ describe Puppet::HTTP::Service::Compiler do
         .with(body: hash_including("facts_format" => /application\/json/))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: environment, facts: facts)
+      subject.post_catalog(certname, environment: environment, facts: facts)
     end
 
     it 'submits facts as pson if set as the preferred format' do
@@ -76,7 +76,7 @@ describe Puppet::HTTP::Service::Compiler do
         .with(body: hash_including("facts_format" => /pson/))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: environment, facts: facts)
+      subject.post_catalog(certname, environment: environment, facts: facts)
     end
 
     it 'includes environment as a query parameter AND in the POST body' do
@@ -85,7 +85,7 @@ describe Puppet::HTTP::Service::Compiler do
               body: hash_including("environment" => 'outerspace'))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: 'outerspace', facts: facts)
+      subject.post_catalog(certname, environment: 'outerspace', facts: facts)
     end
 
     it 'includes configured_environment' do
@@ -93,7 +93,7 @@ describe Puppet::HTTP::Service::Compiler do
         .with(body: hash_including("configured_environment" => 'agent_specified'))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: 'production', facts: facts, configured_environment: 'agent_specified')
+      subject.post_catalog(certname, environment: 'production', facts: facts, configured_environment: 'agent_specified')
     end
 
     it 'includes transaction_uuid' do
@@ -103,7 +103,7 @@ describe Puppet::HTTP::Service::Compiler do
         .with(body: hash_including("transaction_uuid" => uuid))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: 'production', facts: facts, transaction_uuid: uuid)
+      subject.post_catalog(certname, environment: 'production', facts: facts, transaction_uuid: uuid)
     end
 
     it 'includes job_uuid' do
@@ -113,7 +113,7 @@ describe Puppet::HTTP::Service::Compiler do
         .with(body: hash_including("job_uuid" => uuid))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: 'production', facts: facts, job_uuid: uuid)
+      subject.post_catalog(certname, environment: 'production', facts: facts, job_uuid: uuid)
     end
 
     it 'includes static_catalog' do
@@ -121,7 +121,7 @@ describe Puppet::HTTP::Service::Compiler do
         .with(body: hash_including("static_catalog" => "false"))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: 'production', facts: facts, static_catalog: false)
+      subject.post_catalog(certname, environment: 'production', facts: facts, static_catalog: false)
     end
 
     it 'includes dot-separated list of checksum_types' do
@@ -129,14 +129,14 @@ describe Puppet::HTTP::Service::Compiler do
         .with(body: hash_including("checksum_type" => "sha256.sha384"))
         .to_return(**catalog_response)
 
-      subject.get_catalog(certname, environment: 'production', facts: facts, checksum_type: %w[sha256 sha384])
+      subject.post_catalog(certname, environment: 'production', facts: facts, checksum_type: %w[sha256 sha384])
     end
 
     it 'returns a deserialized catalog' do
       stub_request(:post, uri)
         .to_return(**catalog_response)
 
-      cat = subject.get_catalog(certname, environment: 'production', facts: facts)
+      cat = subject.post_catalog(certname, environment: 'production', facts: facts)
       expect(cat).to be_a(Puppet::Resource::Catalog)
       expect(cat.name).to eq(certname)
     end
@@ -146,7 +146,7 @@ describe Puppet::HTTP::Service::Compiler do
         .to_return(status: [500, "Server Error"])
 
       expect {
-        subject.get_catalog(certname, environment: 'production', facts: facts)
+        subject.post_catalog(certname, environment: 'production', facts: facts)
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
         expect(err.message).to eq('Server Error')
@@ -159,7 +159,7 @@ describe Puppet::HTTP::Service::Compiler do
         .to_return(body: "content-type is missing")
 
       expect {
-        subject.get_catalog(certname, environment: 'production', facts: facts)
+        subject.post_catalog(certname, environment: 'production', facts: facts)
       }.to raise_error(Puppet::HTTP::ProtocolError, /No content type in http response; cannot parse/)
     end
 
@@ -168,7 +168,7 @@ describe Puppet::HTTP::Service::Compiler do
         .to_return(body: "this isn't valid JSON", headers: {'Content-Type' => 'application/json'})
 
       expect {
-        subject.get_catalog(certname, environment: 'production', facts: facts)
+        subject.post_catalog(certname, environment: 'production', facts: facts)
       }.to raise_error(Puppet::HTTP::SerializationError, /Failed to deserialize Puppet::Resource::Catalog from json/)
     end
 
@@ -196,7 +196,7 @@ describe Puppet::HTTP::Service::Compiler do
             .with(body: hash_including("facts" => /#{test_fact[:encoded]}/))
             .to_return(**catalog_response)
 
-          subject.get_catalog(certname, environment: environment, facts: facts)
+          subject.post_catalog(certname, environment: environment, facts: facts)
         end
       end
     end


### PR DESCRIPTION
Add service methods for getting facts, status, static file content.
Rename get_catalog to post_catalog
Simplify response handling.

Blocked on https://github.com/puppetlabs/puppet/pull/8006