### PR TITLE
(PUP-10260) Use http client for rest requests

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -63,7 +63,7 @@ class Puppet::Configurer
   end
 
   # Get the remote catalog, yo.  Returns nil if no catalog can be found.
-  def retrieve_catalog(query_options)
+  def retrieve_catalog(facts, query_options)
     query_options ||= {}
     result = retrieve_catalog_from_cache(query_options) if Puppet[:use_cached_catalog]
     if result
@@ -71,7 +71,7 @@ class Puppet::Configurer
 
       Puppet.info _("Using cached catalog from environment '%{environment}'") % { environment: result.environment }
     else
-      result = retrieve_new_catalog(query_options)
+      result = retrieve_new_catalog(facts, query_options)
 
       if !result
         if !Puppet[:usecacheonfailure]
@@ -98,12 +98,11 @@ class Puppet::Configurer
   end
 
   # Convert a plain resource catalog into our full host catalog.
-  def convert_catalog(result, duration, options = {})
+  def convert_catalog(result, duration, facts, options = {})
     catalog = nil
 
     catalog_conversion_time = thinmark do
       # Will mutate the result and replace all Deferred values with resolved values
-      facts = options[:convert_with_facts]
       if facts
         Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(facts, result)
       end
@@ -132,6 +131,7 @@ class Puppet::Configurer
     end
 
     facts_hash = {}
+    facts = nil
     if Puppet::Resource::Catalog.indirection.terminus_class == :rest
       # This is a bit complicated.  We need the serialized and escaped facts,
       # and we need to know which format they're encoded in.  Thus, we
@@ -140,15 +140,14 @@ class Puppet::Configurer
       # facts_for_uploading may set Puppet[:node_name_value] as a side effect
       facter_time = thinmark do
         facts = find_facts
-        options[:convert_with_facts] =  facts
         facts_hash = encode_facts(facts) # encode for uploading # was: facts_for_uploading
       end
       options[:report].add_times(:fact_generation, facter_time) if options[:report]
     end
-    facts_hash
+    [facts_hash, facts]
   end
 
-  def prepare_and_retrieve_catalog(cached_catalog, options, query_options)
+  def prepare_and_retrieve_catalog(cached_catalog, facts, options, query_options)
     # set report host name now that we have the fact
     options[:report].host = Puppet[:node_name_value]
 
@@ -164,7 +163,7 @@ class Puppet::Configurer
     catalog = cached_catalog || options[:catalog]
     unless catalog
       # retrieve_catalog returns resource catalog
-      catalog = retrieve_catalog(query_options)
+      catalog = retrieve_catalog(facts, query_options)
       Puppet.err _("Could not retrieve catalog; skipping run") unless catalog
     end
     catalog
@@ -272,7 +271,7 @@ class Puppet::Configurer
 
     begin
       unless Puppet[:node_name_fact].empty?
-        query_options = get_facts(options)
+        query_options, facts = get_facts(options)
       end
 
       configured_environment = Puppet[:environment] if Puppet.settings.set_by_config?(:environment)
@@ -305,6 +304,7 @@ class Puppet::Configurer
               @environment = node.environment.to_s
               report.environment = @environment
               query_options = nil
+              facts = nil
             else
               Puppet.info _("Using configured environment '%{env}'") % { env: @environment }
             end
@@ -329,11 +329,11 @@ class Puppet::Configurer
         :loaders => Puppet::Pops::Loaders.new(local_node_environment, true)
       }, "Local node environment for configurer transaction")
 
-      query_options = get_facts(options) unless query_options
+      query_options, facts = get_facts(options) unless query_options
       query_options[:configured_environment] = configured_environment
       options[:convert_for_node] = node
 
-      catalog = prepare_and_retrieve_catalog(cached_catalog, options, query_options)
+      catalog = prepare_and_retrieve_catalog(cached_catalog, facts, options, query_options)
       unless catalog
         return nil
       end
@@ -356,11 +356,11 @@ class Puppet::Configurer
         @environment = catalog.environment
         report.environment = @environment
 
-        query_options = get_facts(options)
+        query_options, facts = get_facts(options)
         query_options[:configured_environment] = configured_environment
 
         # if we get here, ignore the cached catalog
-        catalog = prepare_and_retrieve_catalog(nil, options, query_options)
+        catalog = prepare_and_retrieve_catalog(nil, facts, options, query_options)
         return nil unless catalog
         tries += 1
       end
@@ -372,7 +372,7 @@ class Puppet::Configurer
       else
         # REMIND @duration is the time spent loading the last catalog, and doesn't
         # account for things like we failed to download and fell back to the cache
-        ral_catalog = convert_catalog(catalog, @duration, options)
+        ral_catalog = convert_catalog(catalog, @duration, facts, options)
 
         # If not noop, commit the cached resource catalog (not ral catalog). Ideally
         # we'd just copy the downloaded response body, instead of serializing the
@@ -515,7 +515,7 @@ class Puppet::Configurer
     return nil
   end
 
-  def retrieve_new_catalog(query_options)
+  def retrieve_new_catalog(facts, query_options)
     result = nil
     @duration = thinmark do
       result = Puppet::Resource::Catalog.indirection.find(

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -525,7 +525,8 @@ class Puppet::Configurer
           # don't update cache until after environment converges
           :ignore_cache_save => true,
           :environment       => Puppet::Node::Environment.remote(@environment),
-          :fail_on_404       => true
+          :fail_on_404       => true,
+          :facts_for_catalog => facts
         )
       )
     end

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -23,7 +23,7 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
     @session.process_response(response)
 
     if response.success?
-      response.body.to_s
+      response
     elsif !@session.supports?(:report, 'json') && Puppet[:preferred_serialization_format] != 'pson'
       #TRANSLATORS "pson", "preferred_serialization_format", and "puppetserver" should not be translated
       raise Puppet::HTTP::ProtocolError.new(_("To submit reports to a server running puppetserver %{server_version}, set preferred_serialization_format to pson") % { server_version: response[Puppet::HTTP::HEADER_PUPPET_VERSION]})

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -26,7 +26,7 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
 
     session = Puppet.lookup(:http_session)
     api = session.route_to(:puppet)
-    catalog = api.post_catalog(
+    api.post_catalog(
       request.key,
       facts: facts,
       environment: request.environment.to_s,
@@ -36,9 +36,6 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
       static_catalog: request.options[:static_catalog],
       checksum_type: checksum_type
     )
-    # current tests rely on crazy behavior introduced in 089ac3e37dd
-    catalog.name = request.key
-    catalog
   rescue Puppet::HTTP::ResponseError => e
     if e.response.code == 404
       return nil unless request.options[:fail_on_404]

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -3,4 +3,51 @@ require 'puppet/indirector/rest'
 
 class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
   desc "Find resource catalogs over HTTP via REST."
+
+  def find(request)
+    return super unless use_http_client?
+
+    # URL encoded facts and facts_format are passed as indirector
+    # request options, so we have to reverse that (unescape, then parse),
+    # and pass a facts object to the http client.
+    format = request.options[:facts_format]
+    if format
+      formatter = Puppet::Network::FormatHandler.format_for(format)
+      facts = formatter.intern(Puppet::Node::Facts, CGI.unescape(request.options[:facts]))
+    else
+      facts = Puppet::Node::Facts.new(request.key, environment: request.environment.to_s)
+    end
+
+    checksum_type = if request.options[:checksum_type]
+                      request.options[:checksum_type].split('.')
+                    else
+                      Puppet[:supported_checksum_types]
+                    end
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    catalog = api.post_catalog(
+      request.key,
+      facts: facts,
+      environment: request.environment.to_s,
+      configured_environment: request.options[:configured_environment],
+      transaction_uuid: request.options[:transaction_uuid],
+      job_uuid: request.options[:job_id],
+      static_catalog: request.options[:static_catalog],
+      checksum_type: checksum_type
+    )
+    # current tests rely on crazy behavior introduced in 089ac3e37dd
+    catalog.name = request.key
+    catalog
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -7,17 +7,6 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
   def find(request)
     return super unless use_http_client?
 
-    # URL encoded facts and facts_format are passed as indirector
-    # request options, so we have to reverse that (unescape, then parse),
-    # and pass a facts object to the http client.
-    format = request.options[:facts_format]
-    if format
-      formatter = Puppet::Network::FormatHandler.format_for(format)
-      facts = formatter.intern(Puppet::Node::Facts, CGI.unescape(request.options[:facts]))
-    else
-      facts = Puppet::Node::Facts.new(request.key, environment: request.environment.to_s)
-    end
-
     checksum_type = if request.options[:checksum_type]
                       request.options[:checksum_type].split('.')
                     else
@@ -28,7 +17,7 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
     api = session.route_to(:puppet)
     api.post_catalog(
       request.key,
-      facts: facts,
+      facts: request.options[:facts_for_catalog],
       environment: request.environment.to_s,
       configured_environment: request.options[:configured_environment],
       transaction_uuid: request.options[:transaction_uuid],

--- a/lib/puppet/indirector/facts/rest.rb
+++ b/lib/puppet/indirector/facts/rest.rb
@@ -4,9 +4,50 @@ require 'puppet/indirector/rest'
 class Puppet::Node::Facts::Rest < Puppet::Indirector::REST
   desc "Find and save facts about nodes over HTTP via REST."
 
+  def find(request)
+    return super unless use_http_client?
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.get_facts(
+      request.key,
+      environment: request.environment.to_s
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
+
   def save(request)
     raise ArgumentError, _("PUT does not accept options") unless request.options.empty?
 
+    return legacy_save(request) unless use_http_client?
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.put_facts(
+      request.key,
+      facts: request.instance,
+      environment: request.environment.to_s
+    )
+
+    # preserve existing behavior
+    nil
+  rescue Puppet::HTTP::ResponseError => e
+    # always raise even if fail_on_404 is false
+    raise convert_to_http_error(e.response.nethttp)
+  end
+
+  private
+
+  def legacy_save(request)
     response = do_request(request) do |req|
       http_put(req, IndirectedRoutes.request_to_uri(req), req.instance.render, headers.merge({ "Content-Type" => req.instance.mime }))
     end

--- a/lib/puppet/indirector/file_content/rest.rb
+++ b/lib/puppet/indirector/file_content/rest.rb
@@ -6,4 +6,33 @@ class Puppet::Indirector::FileContent::Rest < Puppet::Indirector::REST
   desc "Retrieve file contents via a REST HTTP interface."
 
   use_srv_service(:fileserver)
+
+  def find(request)
+    return super unless use_http_client?
+
+    content = StringIO.new
+
+    url = URI.parse(Puppet::Util.uri_encode(request.uri))
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:fileserver, url: url)
+
+    api.get_file_content(
+      path: URI.unescape(url.path),
+      environment: request.environment.to_s,
+    ) do |data|
+      content << data
+    end
+
+    Puppet::FileServing::Content.from_binary(content.string)
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/indirector/file_content/rest.rb
+++ b/lib/puppet/indirector/file_content/rest.rb
@@ -11,6 +11,7 @@ class Puppet::Indirector::FileContent::Rest < Puppet::Indirector::REST
     return super unless use_http_client?
 
     content = StringIO.new
+    content.binmode
 
     url = URI.parse(Puppet::Util.uri_encode(request.uri))
     session = Puppet.lookup(:http_session)

--- a/lib/puppet/indirector/file_metadata/rest.rb
+++ b/lib/puppet/indirector/file_metadata/rest.rb
@@ -6,4 +6,54 @@ class Puppet::Indirector::FileMetadata::Rest < Puppet::Indirector::REST
   desc "Retrieve file metadata via a REST HTTP interface."
 
   use_srv_service(:fileserver)
+
+  def find(request)
+    return super unless use_http_client?
+
+    url = URI.parse(Puppet::Util.uri_encode(request.uri))
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:fileserver, url: url)
+
+    api.get_file_metadata(
+      path: URI.unescape(url.path),
+      environment: request.environment.to_s,
+      links: request.options[:links],
+      checksum_type: request.options[:checksum_type],
+      source_permissions: request.options[:source_permissions]
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
+
+  def search(request)
+    return super unless use_http_client?
+
+    url = URI.parse(Puppet::Util.uri_encode(request.uri))
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:fileserver, url: url)
+
+    api.get_file_metadatas(
+      path: URI.unescape(url.path),
+      environment: request.environment.to_s,
+      recurse: request.options[:recurse],
+      recurselimit: request.options[:recurselimit],
+      ignore: request.options[:ignore],
+      links: request.options[:links],
+      checksum_type: request.options[:checksum_type],
+      source_permissions: request.options[:source_permissions],
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    # since it's search, return empty array instead of nil
+    return [] if e.response.code == 404
+
+    raise convert_to_http_error(e.response.nethttp)
+  end
 end

--- a/lib/puppet/indirector/node/rest.rb
+++ b/lib/puppet/indirector/node/rest.rb
@@ -4,4 +4,27 @@ require 'puppet/indirector/rest'
 class Puppet::Node::Rest < Puppet::Indirector::REST
   desc "Get a node via REST. Puppet agent uses this to allow the puppet master
     to override its environment."
+
+  def find(request)
+    return super unless use_http_client?
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.get_node(
+      request.key,
+      environment: request.environment.to_s,
+      configured_environment: request.options[:configured_environment],
+      transaction_uuid: request.options[:transaction_uuid]
+    )
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -52,6 +52,12 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     Puppet::Util::Connection.determine_port(port_setting, server_setting)
   end
 
+  # Should we use puppet's http client to make requests. Will return
+  # false when running in puppetserver
+  def use_http_client?
+    Puppet::Network::HttpPool.http_client_class == Puppet::Network::HTTP::Connection
+  end
+
   # Provide appropriate headers.
   def headers
     # yaml is not allowed on the network

--- a/lib/puppet/indirector/status/rest.rb
+++ b/lib/puppet/indirector/status/rest.rb
@@ -6,4 +6,21 @@ class Puppet::Indirector::Status::Rest < Puppet::Indirector::REST
   desc "Get puppet master's status via REST. Useful because it tests the health
     of both the web server and the indirector."
 
+  def find(request)
+    return super unless use_http_client?
+
+    session = Puppet.lookup(:http_session)
+    api = session.route_to(:puppet)
+    api.get_status(request.key)
+  rescue Puppet::HTTP::ResponseError => e
+    if e.response.code == 404
+      return nil unless request.options[:fail_on_404]
+
+      _, body = parse_response(e.response.nethttp)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      raise convert_to_http_error(e.response.nethttp)
+    end
+  end
 end

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -2,10 +2,7 @@ require 'puppet/file_serving/content'
 require 'puppet/file_serving/metadata'
 require 'puppet/file_serving/terminus_helper'
 
-require 'puppet/util/http_proxy'
-require 'puppet/network/http'
-require 'puppet/network/http/api/indirected_routes'
-require 'puppet/network/http/compression'
+require 'puppet/http'
 
 module Puppet
   # Copy files from a local or remote source.  This state *only* does any work
@@ -14,11 +11,6 @@ module Puppet
   # this state, during retrieval, modifies the appropriate other states
   # so that things get taken care of appropriately.
   Puppet::Type.type(:file).newparam(:source) do
-    include Puppet::Network::HTTP::Compression.module
-
-    BINARY_MIME_TYPES = [
-      Puppet::Network::FormatHandler.format_for('binary').mime
-    ].join(', ').freeze
 
     attr_accessor :source, :local
     desc <<-'EOT'
@@ -279,45 +271,54 @@ module Puppet
       end
     end
 
-    def get_from_puppet_source(source_uri, content_uri, &block)
-      options = { :environment => resource.catalog.environment_instance }
-      if content_uri
-        options[:code_id] = resource.catalog.code_id
-        request = Puppet::Indirector::Request.new(:static_file_content, :find, content_uri, nil, options)
+    def get_from_content_uri_source(content_uri, &block)
+      session = Puppet.lookup(:http_session)
+      api = session.route_to(:fileserver, url: url)
+
+      api.get_static_file_content(
+        path: URI.unescape(url.path),
+        environment: resource.catalog.environment_instance.to_s,
+        code_id: resource.catalog.code_id,
+        &block
+      )
+    end
+
+    def get_from_source_uri_source(url, &block)
+      session = Puppet.lookup(:http_session)
+      api = session.route_to(:fileserver, url: url)
+
+      api.get_file_content(
+        path: URI.unescape(url.path),
+        environment: resource.catalog.environment_instance.to_s,
+        &block
+      )
+    end
+
+    def get_from_http_source(url, &block)
+      client = Puppet.runtime['http']
+      client.get(url) do |response|
+        raise Puppet::HTTP::ResponseError.new(response) unless response.success?
+
+        response.read_body(&block)
+      end
+    end
+
+    def chunk_file_from_source(&block)
+      if uri.scheme =~ /^https?/
+        get_from_http_source(uri, &block)
+      elsif metadata.content_uri
+        content_url = URI.parse(Puppet::Util.uri_encode(metadata.content_uri))
+        get_from_content_uri_source(content_url, &block)
       else
-        request = Puppet::Indirector::Request.new(:file_content, :find, source_uri, nil, options)
+        get_from_source_uri_source(uri, &block)
       end
-
-      request.do_request(:fileserver) do |req|
-        ssl_context = Puppet.lookup(:ssl_context)
-        connection = Puppet::Network::HttpPool.connection(req.server, req.port, ssl_context: ssl_context)
-        connection.request_get(Puppet::Network::HTTP::API::IndirectedRoutes.request_to_uri(req), add_accept_encoding({"Accept" => BINARY_MIME_TYPES}), &block)
-      end
+    rescue Puppet::HTTP::ResponseError => e
+      handle_response_error(e.response)
     end
 
-    def get_from_http_source(source_uri, &block)
-      Puppet::Util::HttpProxy.request_with_redirects(URI(source_uri), :get, &block)
-    end
-
-    def get_from_source(&block)
-      source_uri = metadata.source
-      if source_uri =~ /^https?:/
-        get_from_http_source(source_uri, &block)
-      else
-        get_from_puppet_source(source_uri, metadata.content_uri, &block)
-      end
-    end
-
-    def chunk_file_from_source
-      get_from_source do |response|
-        case response.code
-        when /^2/;  uncompress(response) { |uncompressor| response.read_body { |chunk| yield uncompressor.uncompress(chunk) } }
-        else
-          # Raise the http error if we didn't get a 'success' of some kind.
-          message = "Error #{response.code} on SERVER: #{(response.body||'').empty? ? response.message : uncompress_body(response)}"
-          raise Net::HTTPError.new(message, response)
-        end
-      end
+    def handle_response_error(response)
+      message = "Error #{response.code} on SERVER: #{response.body.empty? ? response.reason : response.body}"
+      raise Net::HTTPError.new(message, response.nethttp)
     end
   end
 

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_fetch_if_not_on_the_local_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_fetch_if_not_on_the_local_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_not_update_if_content_on_disk_is_up-to-date.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_not_update_if_content_on_disk_is_up-to-date.yml
@@ -69,76 +69,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Content-MD5:
-      - Es93YfogzPk5EimSmqb9XQ==
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_update_if_content_differs_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_md5/should_update_if_content_differs_on_disk.yml
@@ -69,76 +69,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Content-MD5:
-      - Es93YfogzPk5EimSmqb9XQ==
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_mtime_is_older_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_mtime_is_older_on_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_no_header_specified.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_no_header_specified.yml
@@ -65,72 +65,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_not_on_the_local_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_fetch_if_not_on_the_local_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_not_update_if_mtime_is_newer_on_disk.yml
+++ b/spec/fixtures/vcr/cassettes/Puppet_Type_File/when_sourcing/from_http/using_mtime/should_not_update_if_mtime_is_newer_on_disk.yml
@@ -67,74 +67,8 @@ http_interactions:
     http_version: 
   recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
 - request:
-    method: head
-    uri: http://my-server/file/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ! 'OK '
-    headers:
-      Etag:
-      - 62e0b-184a-550f415e
-      Content-Type:
-      - text/html
-      Content-Length:
-      - '6218'
-      Last-Modified:
-      - Sun, 22 Mar 2015 22:25:34 GMT
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
-    method: head
-    uri: http://my-server/file
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: ! 'Moved Permanently '
-    headers:
-      Location:
-      - http://my-server/file/
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Sun, 22 Mar 2015 22:57:44 GMT
-      Content-Length:
-      - '44'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Mar 2015 22:57:44 GMT
-- request:
     method: get
-    uri: http://my-server/file/
+    uri: http://my-server/file
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -854,7 +854,7 @@ describe Puppet::Configurer do
     it "should not update the cached catalog in noop mode" do
       Puppet[:noop] = true
 
-      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:post, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
 
       Puppet::Resource::Catalog.indirection.cache_class = :json
       path = Puppet::Resource::Catalog.indirection.cache.path(catalog.name)
@@ -868,7 +868,7 @@ describe Puppet::Configurer do
       Puppet[:noop] = false
       Puppet[:log_level] = 'info'
 
-      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:post, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
 
       Puppet::Resource::Catalog.indirection.cache_class = :json
       cache_path = Puppet::Resource::Catalog.indirection.cache.path(Puppet[:node_name_value])
@@ -881,7 +881,7 @@ describe Puppet::Configurer do
     end
 
     it "successfully applies the catalog without a cache" do
-      stub_request(:get, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:post, %r{/puppet/v3/catalog}).to_return(:status => 200, :body => catalog.render(:json), :headers => {'Content-Type' => 'application/json'})
 
       Puppet::Resource::Catalog.indirection.cache_class = nil
 
@@ -1041,7 +1041,7 @@ describe Puppet::Configurer do
       Puppet::Resource::Catalog.indirection.terminus_class = :rest
 
       stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 200)
-      stub_request(:get, %r{https://myserver:123/puppet/v3/catalog}).to_return(status: 200)
+      stub_request(:post, %r{https://myserver:123/puppet/v3/catalog}).to_return(status: 200)
       node_request = stub_request(:get, %r{https://myserver:123/puppet/v3/node/}).to_return(status: 200)
 
       configurer.run

--- a/spec/unit/http/service/report_spec.rb
+++ b/spec/unit/http/service/report_spec.rb
@@ -80,6 +80,14 @@ describe Puppet::HTTP::Service::Report do
       subject.put_report('node name', report, environment: environment)
     end
 
+    it 'returns the response whose body contains the list of report processors' do
+      body = "[\"store\":\"http\"]"
+      stub_request(:put, url)
+        .to_return(status: 200, body: body, headers: {'Content-Type' => 'application/json'})
+
+      expect(subject.put_report('infinity', report, environment: environment).body).to eq(body)
+    end
+
     it 'raises response error if unsuccessful' do
       stub_request(:put, url).to_return(status: [400, 'Bad Request'], headers: {'X-Puppet-Version' => '6.1.8' })
 

--- a/spec/unit/indirector/catalog/rest_spec.rb
+++ b/spec/unit/indirector/catalog/rest_spec.rb
@@ -20,13 +20,13 @@ describe Puppet::Resource::Catalog::Rest do
   end
 
   it 'finds a catalog' do
-    stub_request(:get, uri).to_return(**catalog_response(catalog))
+    stub_request(:post, uri).to_return(**catalog_response(catalog))
 
     expect(described_class.indirection.find(certname)).to be_a(Puppet::Resource::Catalog)
   end
 
   it "serializes the environment" do
-    stub_request(:get, uri)
+    stub_request(:post, uri)
       .with(query: hash_including('environment' => 'outerspace'))
       .to_return(**catalog_response(catalog))
 
@@ -37,27 +37,27 @@ describe Puppet::Resource::Catalog::Rest do
     env = Puppet::Node::Environment.remote('outerspace')
     catalog = Puppet::Resource::Catalog.new(certname, env)
 
-    stub_request(:get, uri).to_return(**catalog_response(catalog))
+    stub_request(:post, uri).to_return(**catalog_response(catalog))
 
     expect(described_class.indirection.find(certname).environment_instance).to eq(env)
   end
 
   it 'returns nil if the node does not exist' do
-    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+    stub_request(:post, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
 
     expect(described_class.indirection.find(certname)).to be_nil
   end
 
   it 'raises if fail_on_404 is specified' do
-    stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
+    stub_request(:post, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: "{}")
 
     expect{
       described_class.indirection.find(certname, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/catalog/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/catalog/ziggy resulted in 404 with the message: {}})
   end
 
   it 'raises Net::HTTPError on 500' do
-    stub_request(:get, uri).to_return(status: 500)
+    stub_request(:post, uri).to_return(status: 500)
 
     expect{
       described_class.indirection.find(certname)

--- a/spec/unit/indirector/facts/rest_spec.rb
+++ b/spec/unit/indirector/facts/rest_spec.rb
@@ -46,7 +46,7 @@ describe Puppet::Node::Facts::Rest do
 
       expect{
         described_class.indirection.find(certname, fail_on_404: true)
-      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/facts/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/facts/ziggy resulted in 404 with the message: {}})
     end
 
     it 'raises Net::HTTPError on 500' do

--- a/spec/unit/indirector/file_content/rest_spec.rb
+++ b/spec/unit/indirector/file_content/rest_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Indirector::FileContent::Rest do
 
     expect {
       described_class.indirection.find(key, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_content/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_content/:mount/path/to/file resulted in 404 with the message: {}})
   end
 
   it "raises an error on HTTP 500" do

--- a/spec/unit/indirector/file_content/rest_spec.rb
+++ b/spec/unit/indirector/file_content/rest_spec.rb
@@ -15,11 +15,11 @@ describe Puppet::Indirector::FileContent::Rest do
     {body: "some content", headers: { 'Content-Type' => 'application/octet-stream' } }
   end
 
-  it "returns content as utf-8 string" do
+  it "returns content as a binary string" do
     stub_request(:get, uri).to_return(status: 200, **file_content_response)
 
     file_content = described_class.indirection.find(key)
-    expect(file_content.content.encoding).to eq(Encoding::UTF_8)
+    expect(file_content.content.encoding).to eq(Encoding::BINARY)
     expect(file_content.content).to eq('some content')
   end
 

--- a/spec/unit/indirector/file_metadata/rest_spec.rb
+++ b/spec/unit/indirector/file_metadata/rest_spec.rb
@@ -46,7 +46,7 @@ describe Puppet::Indirector::FileMetadata::Rest do
 
       expect {
         described_class.indirection.find(key, fail_on_404: true)
-      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_metadata/:mount/path/to/file\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+      }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_metadata/:mount/path/to/file resulted in 404 with the message: {}})
     end
 
     it "raises an error on HTTP 500" do

--- a/spec/unit/indirector/node/rest_spec.rb
+++ b/spec/unit/indirector/node/rest_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::Node::Rest do
 
     expect{
       described_class.indirection.find(certname, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/node/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/node/ziggy resulted in 404 with the message: {}})
   end
 
   it 'raises Net::HTTPError on 500' do

--- a/spec/unit/indirector/report/rest_spec.rb
+++ b/spec/unit/indirector/report/rest_spec.rb
@@ -64,6 +64,13 @@ describe Puppet::Transaction::Report::Rest do
     expect(described_class.indirection.save(report)).to be_nil
   end
 
+  it "parses charset from response content-type" do
+    stub_request(:put, uri)
+      .to_return(status: 200, body: JSON.dump(["store"]), headers: { 'Content-Type' => 'application/json;charset=utf-8' })
+
+    expect(described_class.indirection.save(report)).to eq(["store"])
+  end
+
   describe "when the server major version is less than 5" do
     it "raises if the save fails and we're not using pson" do
       Puppet[:preferred_serialization_format] = "json"
@@ -74,7 +81,7 @@ describe Puppet::Transaction::Report::Rest do
 
       expect {
         described_class.indirection.save(report)
-      }.to raise_error(Puppet::Error, /Server version 4.10.1 does not accept reports in 'json'/)
+      }.to raise_error(Puppet::Error, /To submit reports to a server running puppetserver 4.10.1, set preferred_serialization_format to pson/)
     end
 
     it "raises with HTTP 500 if the save fails and we're already using pson" do

--- a/spec/unit/indirector/status/rest_spec.rb
+++ b/spec/unit/indirector/status/rest_spec.rb
@@ -37,7 +37,7 @@ describe Puppet::Indirector::Status::Rest do
 
     expect{
       described_class.indirection.find(certname, fail_on_404: true)
-    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/status/ziggy\?environment=\*root\*&fail_on_404=true resulted in 404 with the message: {}})
+    }.to raise_error(Puppet::Error, %r{Find /puppet/v3/status/ziggy resulted in 404 with the message: {}})
   end
 
   it 'raises Net::HTTPError on 500' do


### PR DESCRIPTION
Modify the various rest termini to use the http client to make rest requests instead of relying on the base `Puppet::Indirector::REST` terminus. This mostly decouples the indirector from making http requests.

For now, we continue to use the base rest terminus when running in puppetserver.

Blocked on https://github.com/puppetlabs/puppet/pull/8007