### PR TITLE
(PUP-10319) Invalidate rubygems cache after uninstalling puppet_gem package

### DIFF
--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -14,4 +14,10 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   else
     commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
   end
+
+  def uninstall
+    super
+    Puppet.debug("Invalidating rubygems cache after uninstalling gem '#{resource[:name]}'")
+    Puppet::Util::Autoload.gem_source.clear_paths
+  end
 end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -67,6 +67,14 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
       expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{uninstall --executables --all myresource --force --bindir=/usr/bin}).and_return('')
       provider.uninstall
     end
+
+    it 'should invalidate the rubygems cache' do
+      gem_source = double('gem_source')
+      allow(Puppet::Util::Autoload).to receive(:gem_source).and_return(gem_source)
+      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{uninstall --executables --all myresource}).and_return('')
+      expect(gem_source).to receive(:clear_paths)
+      provider.uninstall
+    end
   end
 
   context 'calculated specificity' do


### PR DESCRIPTION
Without this patch after a gem is uninstalled from puppet's ruby
environment using the `puppet_gem` `package` provider other actions in
an agent's run fail.  For instance, modifying a file fails whilst trying
to back it up.

eg.
```
Error: Could not back up /some/file: pid: 21277 nil spec! included in [#<Gem::StubSpecifi...
--- SNIP (massive array ommitted) ---
]
/opt/puppetlabs/puppet/lib/ruby/2.5.0/rubygems/specification.rb:743:in `_all'
/opt/puppetlabs/puppet/lib/ruby/2.5.0/rubygems/specification.rb:1153:in `latest_specs'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/rubygems.rb:44:in `directories'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/autoload.rb:142:in `gem_directories'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/autoload.rb:172:in `search_directories'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/autoload.rb:98:in `get_file'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/autoload.rb:62:in `load_file'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/autoload.rb:201:in `load'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/instance_loader.rb:51:in `loaded_instance'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/terminus.rb:112:in `terminus_class'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/indirection.rb:366:in `make_terminus'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/indirection.rb:140:in `terminus'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/file_bucket_file/selector.rb:16:in `get_terminus'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/file_bucket_file/selector.rb:20:in `head'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/indirection.rb:260:in `head'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/file_bucket/dipper.rb:48:in `backup'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/backups.rb:82:in `backup_file_with_filebucket'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/backups.rb:28:in `perform_backup_with_bucket'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/backups.rb:15:in `perform_backup'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type/file.rb:1024:in `backup_existing'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type/file.rb:761:in `remove_existing'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type/file.rb:888:in `write'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type/file/data_sync.rb:93:in `contents_sync'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type/file/content.rb:136:in `sync'
--- SNIP ---
```

This commit is inspired by
https://github.com/puppetlabs/puppet/pull/2415/commits/b61fa207bc2084acdf4935d15d4c0e90d63074b4
(https://github.com/puppetlabs/puppet/pull/2415)