### PR TITLE
(maint) Process the entire server list

### DIFF
--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -27,7 +27,7 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
     return true if response.success?
 
     Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %
-                 { host: host, port: port, code: response.code, reason: response.message })
+                 { host: uri.host, port: uri.port, code: response.code, reason: response.reason })
     return false
   rescue => detail
     session.add_exception(detail)


### PR DESCRIPTION
If we failed to connect to any entry in the server list, then we never tried
entries that followed, because the debug message for the failed entry tried to
access a variable that didn't exist.