### PR TITLE
(PUP-10315) Use http client to process the server list

### DIFF
--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -27,7 +27,7 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
     return true if response.success?
 
     Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %
-                 { host: host, port: port, code: response.code, reason: response.message })
+                 { host: uri.host, port: uri.port, code: response.code, reason: response.reason })
     return false
   rescue => detail
     session.add_exception(detail)


### PR DESCRIPTION
Blocked on https://github.com/puppetlabs/puppet/pull/8010

If server_list is specified, then use the http client to route to the `puppet`
service and store the resulting server and port in the context so that
Puppet::Util::Connection.determine_{server,port} still return the last
resolved server/port.

If we failed to connect to an entry in the server list, then we tried to
access a variable that didn't exist while logging the debug message, which
masked why the server wasn't available.