### PR TITLE
(PUP-10320) update group membership user check

### DIFF
--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -74,6 +74,14 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     cmd
   end
 
+  def validate_members(members)
+    members.each do |member|
+      member.split(',').each do |user|
+        Etc.getpwnam(user.strip)
+      end
+    end
+  end
+
   def modifycmd(param, value)
     if @resource.forcelocal? || @resource[:members]
       cmd = [command(:localmodify)]
@@ -83,6 +91,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     end
 
     if param == :members
+      validate_members(value)
       value = members_to_s(value)
       purge_members if @resource[:auth_membership] && !members.empty?
     end
@@ -116,10 +125,6 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
 
   def purge_members
     localmodify('-m', members_to_s(members), @resource.name)
-  end
-
-  def member_valid?(user)
-    !!Etc.getpwnam(user)
   end
 
   private


### PR DESCRIPTION
 Group parameter `members` was validated by checking if each member user
 exists before the manifest is applied. This will make a manifest containing user creation and group members update with the new user to fail.

 By this change there is no parameter validation and the check of user existance
 is done right before group modify command execution.

 This is somehow consistent with other providers supporting `members` parameter
 (aix/windows) for which the group change command fails if user is not existing.