### PR TITLE
(PUP-10347) Reconnect when using a cached connection

### DIFF
--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -141,4 +141,15 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       end
     end
   end
+
+  context 'persistent connections' do
+    it "detects when the server has closed the connection and reconnects" do
+      server.start_server do |port|
+        uri = URI("https://127.0.0.1:#{port}")
+
+        expect(client.get(uri, ssl_context: root_context)).to be_success
+        expect(client.get(uri, ssl_context: root_context)).to be_success
+      end
+    end
+  end
 end

--- a/spec/integration/network/http_pool_spec.rb
+++ b/spec/integration/network/http_pool_spec.rb
@@ -98,8 +98,16 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
                            %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
         end
       end
-    end
 
+      it "detects when the server has closed the connection and reconnects" do
+        server.start_server do |port|
+          http = connection(hostname, port)
+
+          expect(http.request_get('/')).to be_a(Net::HTTPSuccess)
+          expect(http.request_get('/')).to be_a(Net::HTTPSuccess)
+        end
+      end
+    end
 
     context "when using single use HTTPS connections" do
       include_examples 'HTTPS client'


### PR DESCRIPTION
Previously, if puppet made an HTTP(S) connection using the new HTTP client, and the server responded that it wanted to keep the connection alive, but decided later to close it, such as when puppetserver restarts, then the HTTP client would receive an EOFError as soon as it tried to reuse the connection.

The issue was due to Puppet::HTTP::Client making a non-local return from the block passed to Net::HTTP#request, which caused the Net::HTTP#end_transport method to be skipped, which resulted in the last_communicated instance variable never being set. The next time a request was made, the Net::HTTP connection thought it was "newly connected", so it skipped the logic to check if it had exceeded the keepalive timeout or if the remote side closed the connection[1].

The legacy Connection class did not have this problem because it uses the non-block form of Net::HTTP#request, which always calls Net::HTTP#end_transport. The HTTP client cannot use the non-block form, because it always results in the response body being read into memory.

This commit changes the client to not call return within the block passed toNet::HTTP#request, and adds tests for the legacy Connection and newer Client.

[1] https://github.com/ruby/ruby/blob/v2_5_7/lib/net/http.rb#L1537-L1546