### PR TITLE
(PUP-10322) Set puppet logger in facter-ng.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -81,7 +81,10 @@ module Puppet
             begin
               original_facter = Object.const_get(:Facter)
               Object.send(:remove_const, :Facter)
-              require 'facter-ng'
+
+              Kernel.require 'facter-ng'
+              # It is required to re-setup logger for facter-ng
+              Puppet::Util::Logging.setup_facter_logging!
             rescue LoadError
               Object.const_set(:Facter, original_facter)
               raise ArgumentError, 'facter-ng could not be loaded'


### PR DESCRIPTION
When we enable facterng feature flag `puppet config set facterng true` and run `puppet facts --debug` log messages use Facter 4 logger instead of Puppet logger

Facter 4 logger output format is
```
[<date_time> ] <log-level> <class-name> - <log-message>
```

Puppet debug logs fro facter
```
Debug: Facter: <log-message>{code}
```

When staring puppet, `setup_facter_logging!` method from `module Puppet::Util::Logging` is called before feature switches are evaluated. The `setup_facter_logging!` tells Facter to use the Puppet logger in order to log debug messages. If the `facterng` feature switch if enables, we load facter-ng (Facter 4), but we need to `setup_facter_logging!` again in order to send the Puppet logger to facter-ng. 