### PR TITLE
(maint) curl should follow redirect when downloading

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://puppetlabs.com"
   s.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
   s.require_paths = ["lib"]
-  s.rubyforge_project = "puppet"
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
   s.add_runtime_dependency(%q<facter>, [">= 2.0.1", "< 4"])

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -26,8 +26,8 @@ end
 step "download packages to use for test"
 
 on hosts, "mkdir -p #{dir}"
-on hosts, "curl neptune.puppetlabs.lan/misc/sudo.#{version1}.aix51.lam.bff > #{dir}/sudo.#{version1}.aix51.lam.bff"
-on hosts, "curl neptune.puppetlabs.lan/misc/sudo.#{version2}.aix51.lam.bff > #{dir}/sudo.#{version2}.aix51.lam.bff"
+on hosts, "curl -L neptune.puppetlabs.lan/misc/sudo.#{version1}.aix51.lam.bff > #{dir}/sudo.#{version1}.aix51.lam.bff"
+on hosts, "curl -L neptune.puppetlabs.lan/misc/sudo.#{version2}.aix51.lam.bff > #{dir}/sudo.#{version2}.aix51.lam.bff"
 
 step "setup manifests for testing"
 


### PR DESCRIPTION
Because a resource used in acceptance testing was moved to different
location and http redirect was set in place, we need to update
`curl` call to include `-L` argument to follow http redirects.

Also removed deprecated `rubyforge_project` to make spec tests pass