### PR TITLE
(PUP-10357) Basic implementation of Version::Range

### DIFF
--- a/lib/puppet/util/package/version/range.rb
+++ b/lib/puppet/util/package/version/range.rb
@@ -1,0 +1,50 @@
+require 'puppet/util/package/version/range/lt'
+require 'puppet/util/package/version/range/lt_eq'
+require 'puppet/util/package/version/range/gt'
+require 'puppet/util/package/version/range/gt_eq'
+require 'puppet/util/package/version/range/min_max'
+
+module Puppet::Util::Package::Version
+  class Range
+    class ValidationFailure < ArgumentError; end
+    # Parses a version range string into a comparable {Range} instance.
+    #
+    # Currently parsed version range string may take any of the following
+    # forms:
+    #
+    # * Regular Version strings
+    #   * ex. `"1.0.0"`, `"1.2.3-pre"`
+    # * Inequalities
+    #   * ex. `">1.0.0"`, `"<3.2.0"`, `">=4.0.0"`
+    # * Range Intersections (min is always first)
+    #   * ex. `">1.0.0 <=2.3.0"`
+    #
+    RANGE_SPLIT = /\s+/
+    FULL_REGEX = /\A((?:[<>=])+)(.+)\Z/
+
+    # @param range_string [String] the version range string to parse
+    # @param version_class [Version] a version class implementing comparison operators and parse method
+    # @return [Range] a new {Range} instance
+    # @api public
+    def self.parse(range_string, version_class)
+      raise ValidationFailure, "Unable to parse '#{range_string}' as a string" unless range_string.is_a?(String)
+      simples = range_string.split(RANGE_SPLIT).map do |simple|
+        match, operator, version = *simple.match(FULL_REGEX)
+        raise ValidationFailure, "Unable to parse '#{simple}' as a version range identifier" unless match
+        case operator
+        when '>'
+          Gt.new(version_class::parse(version))
+        when '>='
+          GtEq.new(version_class::parse(version))
+        when '<'
+          Lt.new(version_class::parse(version))
+        when '<='
+          LtEq.new(version_class::parse(version))
+        else
+          raise ValidationFailure, "Operator '#{operator}' is not implemented"
+        end
+      end
+      simples.size == 1 ? simples[0] : MinMax.new(simples[0], simples[1])
+    end
+  end
+end

--- a/lib/puppet/util/package/version/range/gt.rb
+++ b/lib/puppet/util/package/version/range/gt.rb
@@ -1,0 +1,14 @@
+require 'puppet/util/package/version/range/simple'
+
+module Puppet::Util::Package::Version
+  class Range
+    class Gt < Simple
+      def to_s
+        ">#{@version}"
+      end
+      def include?(version)
+        version > @version
+      end
+    end
+  end
+end

--- a/lib/puppet/util/package/version/range/gt_eq.rb
+++ b/lib/puppet/util/package/version/range/gt_eq.rb
@@ -1,0 +1,14 @@
+require 'puppet/util/package/version/range/simple'
+
+module Puppet::Util::Package::Version
+  class Range
+    class GtEq < Simple
+      def to_s
+        ">=#{@version}"
+      end
+      def include?(version)
+        version >= @version
+      end
+    end
+  end
+end

--- a/lib/puppet/util/package/version/range/lt.rb
+++ b/lib/puppet/util/package/version/range/lt.rb
@@ -1,0 +1,14 @@
+require 'puppet/util/package/version/range/simple'
+
+module Puppet::Util::Package::Version
+  class Range
+    class Lt< Simple
+      def to_s
+        "<#{@version}"
+      end
+      def include?(version)
+        version < @version
+      end
+    end
+  end
+end

--- a/lib/puppet/util/package/version/range/lt_eq.rb
+++ b/lib/puppet/util/package/version/range/lt_eq.rb
@@ -1,0 +1,14 @@
+require 'puppet/util/package/version/range/simple'
+
+module Puppet::Util::Package::Version
+  class Range
+    class LtEq < Simple
+      def to_s
+        "<=#{@version}"
+      end
+      def include?(version)
+        version <= @version
+      end
+    end
+  end
+end

--- a/lib/puppet/util/package/version/range/min_max.rb
+++ b/lib/puppet/util/package/version/range/min_max.rb
@@ -1,0 +1,18 @@
+require 'puppet/util/package/version/range'
+
+module Puppet::Util::Package::Version
+  class Range
+    class MinMax
+      def initialize(min, max)
+        @min = min
+        @max = max
+      end
+      def to_s
+        "#{@min} #{@max}"
+      end
+      def include?(version)
+        @min.include?(version) && @max.include?(version)
+      end
+    end
+  end
+end

--- a/lib/puppet/util/package/version/range/simple.rb
+++ b/lib/puppet/util/package/version/range/simple.rb
@@ -1,0 +1,11 @@
+require 'puppet/util/package/version/range'
+
+module Puppet::Util::Package::Version
+  class Range
+    class Simple
+      def initialize(version)
+        @version = version
+      end
+    end
+  end
+end

--- a/spec/unit/util/package/version/range_spec.rb
+++ b/spec/unit/util/package/version/range_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper'
+require 'puppet/util/package/version/range'
+
+class IntegerVersion
+  class ValidationFailure < ArgumentError; end
+  include Comparable
+  REGEX_FULL    = '(\d+)'.freeze
+  REGEX_FULL_RX = /\A#{REGEX_FULL}\Z/.freeze
+
+  def self.parse(ver)
+    match, version = *ver.match(REGEX_FULL_RX)
+    raise ValidationFailure, "Unable to parse '#{ver}' as a version identifier" unless match
+
+    new(version).freeze
+  end
+
+  attr_reader :version
+
+  def initialize(version)
+    @version = version.to_i
+  end
+
+  def <=>(other)
+    @version <=> other.version
+  end
+end
+
+describe Puppet::Util::Package::Version::Range do
+  context 'when creating new version range' do
+    it 'should raise unless String is passed' do
+      expect { Puppet::Util::Package::Version::Range.parse(:abc, IntegerVersion) }.to raise_error(Puppet::Util::Package::Version::Range::ValidationFailure)
+    end
+    it 'should raise if operator is not implemented' do
+      expect { Puppet::Util::Package::Version::Range.parse('=a', IntegerVersion) }.to raise_error(Puppet::Util::Package::Version::Range::ValidationFailure)
+    end
+    it 'should raise if operator cannot be parsed' do
+      expect { Puppet::Util::Package::Version::Range.parse('~=a', IntegerVersion) }.to raise_error(Puppet::Util::Package::Version::Range::ValidationFailure)
+    end
+    it 'should raise if version cannot be parsed' do
+      expect { Puppet::Util::Package::Version::Range.parse('>=a', IntegerVersion) }.to raise_error(IntegerVersion::ValidationFailure)
+    end
+  end
+  context 'when creating new version range with greater or equal operator' do
+    it 'it includes greater version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>=3', IntegerVersion)
+      v = IntegerVersion.parse('4')
+      expect(vr.include?(v)).to eql(true)
+    end
+
+    it 'it includes specified version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>=3', IntegerVersion)
+      v = IntegerVersion.parse('3')
+      expect(vr.include?(v)).to eql(true)
+    end
+
+    it 'it does not include lower version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>=3', IntegerVersion)
+      v = IntegerVersion.parse('2')
+      expect(vr.include?(v)).to eql(false)
+    end
+  end
+
+  context 'when creating new version range with greater operator' do
+    it 'it includes greater version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3', IntegerVersion)
+      v = IntegerVersion.parse('10')
+      expect(vr.include?(v)).to eql(true)
+    end
+
+    it 'it does not include specified version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3', IntegerVersion)
+      v = IntegerVersion.parse('3')
+      expect(vr.include?(v)).to eql(false)
+    end
+
+    it 'it does not include lower version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3', IntegerVersion)
+      v = IntegerVersion.parse('1')
+      expect(vr.include?(v)).to eql(false)
+    end
+  end
+
+  context 'when creating new version range with lower or equal operator' do
+    it 'it does not include greater version' do
+      vr = Puppet::Util::Package::Version::Range.parse('<=3', IntegerVersion)
+      v = IntegerVersion.parse('5')
+      expect(vr.include?(v)).to eql(false)
+    end
+
+    it 'it includes specified version' do
+      vr = Puppet::Util::Package::Version::Range.parse('<=3', IntegerVersion)
+      v = IntegerVersion.parse('3')
+      expect(vr.include?(v)).to eql(true)
+    end
+
+    it 'it includes lower version' do
+      vr = Puppet::Util::Package::Version::Range.parse('<=3', IntegerVersion)
+      v = IntegerVersion.parse('1')
+      expect(vr.include?(v)).to eql(true)
+    end
+  end
+
+  context 'when creating new version range with lower operator' do
+    it 'it does not include greater version' do
+      vr = Puppet::Util::Package::Version::Range.parse('<3', IntegerVersion)
+      v = IntegerVersion.parse('8')
+      expect(vr.include?(v)).to eql(false)
+    end
+
+    it 'it does not include specified version' do
+      vr = Puppet::Util::Package::Version::Range.parse('<3', IntegerVersion)
+      v = IntegerVersion.parse('3')
+      expect(vr.include?(v)).to eql(false)
+    end
+
+    it 'it includes lower version' do
+      vr = Puppet::Util::Package::Version::Range.parse('<3', IntegerVersion)
+      v = IntegerVersion.parse('2')
+      expect(vr.include?(v)).to eql(true)
+    end
+  end
+
+  context 'when creating new version range with interval' do
+    it 'it does not include greater version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3 <=5', IntegerVersion)
+      v = IntegerVersion.parse('7')
+      expect(vr.include?(v)).to eql(false)
+    end
+
+    it 'it includes specified max interval value' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3 <=5', IntegerVersion)
+      v = IntegerVersion.parse('5')
+      expect(vr.include?(v)).to eql(true)
+    end
+
+    it 'it includes in interval version' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3 <=5', IntegerVersion)
+      v = IntegerVersion.parse('4')
+      expect(vr.include?(v)).to eql(true)
+    end
+
+    it 'it does not include min interval value ' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3 <=5', IntegerVersion)
+      v = IntegerVersion.parse('3')
+      expect(vr.include?(v)).to eql(false)
+    end
+
+    it 'it does not include lower value ' do
+      vr = Puppet::Util::Package::Version::Range.parse('>3 <=5', IntegerVersion)
+      v = IntegerVersion.parse('2')
+      expect(vr.include?(v)).to eql(false)
+    end
+  end
+end


### PR DESCRIPTION
 This class is meant to be generic and to be used with any package version

 In order to instantiate a Version::Range, you need to provide:
 - a version_range string
 - a version class implementing parse method and comparison operators