### PR TITLE
(PUP-10359) Resolve problems uncovered when running 'server' acceptance tests

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -271,14 +271,16 @@ class Puppet::HTTP::Client
 
     server_list_setting = Puppet.settings.setting(:server_list)
     if server_list_setting.value && !server_list_setting.value.empty?
-      services = [:puppet]
+      # use server list to resolve all services
+      services = Puppet::HTTP::Service::SERVICE_NAMES.dup
 
-      # If we have not explicitly set :ca_server either on the command line or
-      # in puppet.conf, we want to be able to try the servers defined by
-      # :server_list when resolving the :ca service. Otherwise, :server_list
-      # should only be used with the :puppet service.
-      if !Puppet.settings.set_by_config?(:ca_server)
-        services << :ca
+      # except if it's been explicitly set
+      if Puppet.settings.set_by_config?(:ca_server)
+        services.delete(:ca)
+      end
+
+      if Puppet.settings.set_by_config?(:report_server)
+        services.delete(:report)
       end
 
       resolvers << Puppet::HTTP::Resolver::ServerList.new(self, server_list_setting: server_list_setting, default_port: Puppet[:masterport], services: services)

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -70,11 +70,8 @@ class Puppet::HTTP::Service
   end
 
   def get_mime_types(model)
-    unless @mime_types
-      network_formats = model.supported_formats - EXCLUDED_FORMATS
-      @mime_types = network_formats.map { |f| model.get_format(f).mime }
-    end
-    @mime_types
+    network_formats = model.supported_formats - EXCLUDED_FORMATS
+    network_formats.map { |f| model.get_format(f).mime }
   end
 
   def formatter_for_response(response)

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -271,7 +271,7 @@ module Puppet
       end
     end
 
-    def get_from_content_uri_source(content_uri, &block)
+    def get_from_content_uri_source(url, &block)
       session = Puppet.lookup(:http_session)
       api = session.route_to(:fileserver, url: url)
 

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -22,10 +22,11 @@ describe Puppet::HTTP::Resolver do
   end
 
   context 'when resolving using server_list' do
+    let(:subject) { Puppet::HTTP::Resolver::ServerList.new(client, server_list_setting: Puppet.settings.setting(:server_list), default_port: 8142, services: Puppet::HTTP::Service::SERVICE_NAMES) }
+
     before :each do
       Puppet[:server_list] = 'ca.example.com:8141,apple.example.com'
     end
-    let(:subject) { Puppet::HTTP::Resolver::ServerList.new(client, server_list_setting: Puppet.settings.setting(:server_list), default_port: 8142, services: [:puppet, :ca]) }
 
     it 'returns a service based on the current server_list setting' do
       stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 200)

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -679,6 +679,15 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         resource.write(source)
       end
 
+      it 'should request static file content' do
+        metadata.content_uri = "puppet://#{Puppet[:server]}:8140/path/to/file"
+
+        stub_request(:get, %r{/puppet/v3/static_file_content/path/to/file})
+          .to_return(status: 200, body: '', headers: { 'Content-Type' => 'application/octet-stream' })
+
+        resource.write(source)
+      end
+
       describe 'when handling file_content responses' do
         before do
           File.open(filename, 'w') {|f| f.write "initial file content"}


### PR DESCRIPTION
Previously the agent did not accept rich data in the catalog because the
service cached the mime types from the previous node request.

Don't cache mime types in the service since they can be different for each model.

---
Retrieving static catalogs was broken because of a variable name mismatch.

---
Resolving fileserver and report services using server_list was broken because the server list resolver was only used for the ca and report services. Instead use the server_list resolver for all services, and exclude ones that have been explicitly configured in puppet.conf or the command line.