### PR TITLE
(PUP-10353) Replace keyword arguments to generic options hash

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -48,7 +48,7 @@ class Puppet::Forge
         end
 
         http = Puppet.runtime['http']
-        response = http.get(uri, headers: headers, user: user, password: password, ssl_context: @ssl_context)
+        response = http.get(uri, headers: headers, options: {user: user, password: password, ssl_context: @ssl_context})
         io.write(response.body) if io.respond_to?(:write)
         response
       rescue Puppet::SSL::CertVerifyError => e

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -18,8 +18,11 @@ class Puppet::HTTP::Client
     Puppet::HTTP::Session.new(self, @resolvers)
   end
 
-  def connect(uri, ssl_context: nil, include_system_store: false, &block)
+  def connect(uri, options: {}, &block)
     start = Time.now
+
+    ssl_context = options.fetch(:ssl_context, nil)
+    include_system_store = options.fetch(:include_system_store, false)
     ctx = resolve_ssl_context(ssl_context, include_system_store)
     site = Puppet::Network::HTTP::Site.from_uri(uri)
     verifier = if site.use_ssl?
@@ -50,7 +53,7 @@ class Puppet::HTTP::Client
                 {uri: uri, elapsed: elapsed(start), message: e.message}, e, connected)
   end
 
-  def get(url, headers: {}, params: {}, user: nil, password: nil, ssl_context: nil, include_system_store: false, &block)
+  def get(url, headers: {}, params: {}, options: {}, &block)
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -59,7 +62,7 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Get.new(url, @default_headers.merge(headers))
 
-    execute_streaming(request, user: user, password: password, ssl_context: ssl_context, include_system_store: include_system_store) do |response|
+    execute_streaming(request, options: options) do |response|
       if block_given?
         yield response
       else
@@ -68,7 +71,7 @@ class Puppet::HTTP::Client
     end
   end
 
-  def head(url, headers: {}, params: {}, user: nil, password: nil, ssl_context: nil, include_system_store: false)
+  def head(url, headers: {}, params: {}, options: {})
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -77,12 +80,12 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Head.new(url, @default_headers.merge(headers))
 
-    execute_streaming(request, user: user, password: password, ssl_context: ssl_context, include_system_store: include_system_store) do |response|
+    execute_streaming(request, options: options) do |response|
       response.body
     end
   end
 
-  def put(url, headers: {}, params: {}, content_type:, body:, user: nil, password: nil, ssl_context: nil, include_system_store: false)
+  def put(url, headers: {}, params: {}, options: {})
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -90,16 +93,20 @@ class Puppet::HTTP::Client
     end
 
     request = Net::HTTP::Put.new(url, @default_headers.merge(headers))
+
+    body = options.fetch(:body) { |_| raise ArgumentError, "'put' requires a 'body' option" }
+    content_type = options.fetch(:content_type) { |_| raise ArgumentError, "'put' requires a 'content_type' option" }
+
     request.body = body
     request['Content-Length'] = body.bytesize
     request['Content-Type'] = content_type
 
-    execute_streaming(request, user: user, password: password, ssl_context: ssl_context, include_system_store: include_system_store) do |response|
+    execute_streaming(request, options: options) do |response|
       response.body
     end
   end
 
-  def post(url, headers: {}, params: {}, content_type:, body:, user: nil, password: nil, ssl_context: nil, include_system_store: false, &block)
+  def post(url, headers: {}, params: {}, options: {}, &block)
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -107,11 +114,15 @@ class Puppet::HTTP::Client
     end
 
     request = Net::HTTP::Post.new(url, @default_headers.merge(headers))
+
+    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
+    content_type = options.fetch(:content_type) { |_| raise ArgumentError, "'post' requires a 'content_type' option" }
+
     request.body = body
     request['Content-Length'] = body.bytesize
     request['Content-Type'] = content_type
 
-    execute_streaming(request, user: user, password: password, ssl_context: ssl_context, include_system_store: include_system_store) do |response|
+    execute_streaming(request, options: options) do |response|
       if block_given?
         yield response
       else
@@ -120,7 +131,7 @@ class Puppet::HTTP::Client
     end
   end
 
-  def delete(url, headers: {}, params: {}, user: nil, password: nil, ssl_context: nil, include_system_store: false)
+  def delete(url, headers: {}, params: {}, options: {})
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -129,7 +140,7 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Delete.new(url, @default_headers.merge(headers))
 
-    execute_streaming(request, user: user, password: password, ssl_context: ssl_context, include_system_store: include_system_store) do |response|
+    execute_streaming(request, options: options) do |response|
       response.body
     end
   end
@@ -140,14 +151,17 @@ class Puppet::HTTP::Client
 
   private
 
-  def execute_streaming(request, user: nil, password: nil, ssl_context:, include_system_store:, &block)
+  def execute_streaming(request, options: {}, &block)
+    user = options.fetch(:user, nil)
+    password = options.fetch(:password, nil)
+
     redirects = 0
     retries = 0
     response = nil
     done = false
 
     while !done do
-      connect(request.uri, ssl_context: ssl_context, include_system_store: include_system_store) do |http|
+      connect(request.uri, options: options) do |http|
         apply_auth(request, user, password)
 
         # don't call return within the `request` block

--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -23,7 +23,7 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
   end
 
   def get_success?(uri, session, ssl_context: nil)
-    response = @client.get(uri, ssl_context: ssl_context)
+    response = @client.get(uri, options: {ssl_context: ssl_context})
     return true if response.success?
 
     Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -36,7 +36,7 @@ class Puppet::HTTP::Service
   end
 
   def connect(ssl_context: nil)
-    @client.connect(@url, ssl_context: ssl_context)
+    @client.connect(@url, options: {ssl_context: ssl_context})
   end
 
   protected

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -11,7 +11,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     response = @client.get(
       with_base_url("/certificate/#{name}"),
       headers: add_puppet_headers(HEADERS),
-      ssl_context: ssl_context
+      options: {ssl_context: ssl_context}
     )
 
     process_response(response)
@@ -26,7 +26,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     response = @client.get(
       with_base_url("/certificate_revocation_list/ca"),
       headers: headers,
-      ssl_context: ssl_context
+      options: {ssl_context: ssl_context}
     )
 
     process_response(response)
@@ -38,9 +38,11 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     response = @client.put(
       with_base_url("/certificate_request/#{name}"),
       headers: add_puppet_headers(HEADERS),
-      content_type: 'text/plain',
-      body: csr.to_pem,
-      ssl_context: ssl_context
+      options: {
+        content_type: 'text/plain',
+        body: csr.to_pem,
+        ssl_context: ssl_context
+      }
     )
 
     process_response(response)

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -57,8 +57,10 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       headers: headers,
       # for legacy reasons we always send environment as a query parameter too
       params: { environment: environment },
-      content_type: 'application/x-www-form-urlencoded',
-      body: body,
+      options: {
+        content_type: 'application/x-www-form-urlencoded',
+        body: body
+      }
     )
 
     process_response(response)
@@ -89,8 +91,10 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       with_base_url("/facts/#{name}"),
       headers: headers,
       params: { environment: environment },
-      content_type: formatter.mime,
-      body: serialize(formatter, facts),
+      options: {
+        content_type: formatter.mime,
+         body: serialize(formatter, facts)
+      }
     )
 
     process_response(response)

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -14,8 +14,10 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
       with_base_url("/report/#{name}"),
       headers: headers,
       params: { environment: environment },
-      content_type: formatter.mime,
-      body: serialize(formatter, report)
+      options: {
+        content_type: formatter.mime,
+        body: serialize(formatter, report)
+      }
     )
 
     # override parent's process_response handling

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -28,7 +28,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
   context "when verifying an HTTPS server" do
     it "connects over SSL" do
       server.start_server do |port|
-        res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: root_context)
+        res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: root_context})
         expect(res).to be_success
       end
     end
@@ -41,14 +41,14 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       port = tcps.connect_address.ip_port
 
       expect {
-        client.get(URI("https://127.0.0.1:#{port}"), ssl_context: root_context)
+        client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: root_context})
       }.to raise_error(Puppet::HTTP::ConnectionError, %r{^Request to https://127.0.0.1:#{port} timed out connect operation after .* seconds})
     end
 
     it "raises if the server's cert doesn't match the hostname we connected to" do
       server.start_server do |port|
         expect {
-          client.get(URI("https://#{wrong_hostname}:#{port}"), ssl_context: root_context)
+          client.get(URI("https://#{wrong_hostname}:#{port}"), options: {ssl_context: root_context})
         }.to raise_error { |err|
           expect(err).to be_instance_of(Puppet::SSL::CertMismatchError)
           expect(err.message).to match(/Server hostname '#{wrong_hostname}' did not match server certificate; expected one of (.+)/)
@@ -65,7 +65,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
 
       server.start_server do |port|
         expect {
-          client.get(URI("https://127.0.0.1:#{port}"), ssl_context: alt_context)
+          client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: alt_context})
         }.to raise_error(Puppet::SSL::CertVerifyError,
                          %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
       end
@@ -74,7 +74,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
     it "prints TLS protocol and ciphersuite in debug" do
       Puppet[:log_level] = 'debug'
       server.start_server do |port|
-        client.get(URI("https://127.0.0.1:#{port}"), ssl_context: root_context)
+        client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: root_context})
         # TLS version string can be TLSv1 or TLSv1.[1-3], but not TLSv1.0
         expect(@logs).to include(
           an_object_having_attributes(level: :debug, message: /Using TLSv1(\.[1-3])? with cipher .*/),
@@ -98,7 +98,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       )
 
       server.start_server(ctx_proc: ctx_proc) do |port|
-        res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: client_context)
+        res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: client_context})
         expect(res).to be_success
       end
     end
@@ -109,7 +109,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       system_context = ssl_provider.create_system_context(cacerts: [server.ca_cert])
 
       server.start_server do |port|
-        res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: system_context)
+        res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: system_context})
         expect(res).to be_success
       end
     end
@@ -124,7 +124,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       Puppet::Util.withenv("SSL_CERT_FILE" => ssl_file) do
         system_context = ssl_provider.create_system_context(cacerts: [])
         server.start_server do |port|
-          res = client.get(URI("https://127.0.0.1:#{port}"), ssl_context: system_context)
+          res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: system_context})
           expect(res).to be_success
         end
       end
@@ -135,7 +135,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
 
       server.start_server do |port|
         expect {
-          client.get(URI("https://127.0.0.1:#{port}"), ssl_context: system_context)
+          client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: system_context})
         }.to raise_error(Puppet::SSL::CertVerifyError,
                          %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
       end
@@ -147,8 +147,8 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       server.start_server do |port|
         uri = URI("https://127.0.0.1:#{port}")
 
-        expect(client.get(uri, ssl_context: root_context)).to be_success
-        expect(client.get(uri, ssl_context: root_context)).to be_success
+        expect(client.get(uri, options: {ssl_context: root_context})).to be_success
+        expect(client.get(uri, options: {ssl_context: root_context})).to be_success
       end
     end
   end

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::HTTP::Service do
        @client.get(
         url,
         headers: add_puppet_headers({'Default-Header' => 'default-value'}),
-        ssl_context: ssl_context
+        options: {ssl_context: ssl_context}
       )
     end
 
@@ -82,14 +82,14 @@ describe Puppet::HTTP::Service do
   end
 
   it "connects to the base URL with a nil ssl context" do
-    expect(client).to receive(:connect).with(url, ssl_context: nil)
+    expect(client).to receive(:connect).with(url, options: {ssl_context: nil})
 
     service.connect
   end
 
   it "accepts an optional ssl_context" do
     other_ctx = Puppet::SSL::SSLContext.new
-    expect(client).to receive(:connect).with(url, ssl_context: other_ctx)
+    expect(client).to receive(:connect).with(url, options: {ssl_context: other_ctx})
 
     service.connect(ssl_context: other_ctx)
   end


### PR DESCRIPTION
This commit removes keyword arguments in favor of a generic options
hash. Though keyword arguments are cleaner, we decided to go with the
options hash to give us more flexibility moving forward. As we add new
options, like report compression, we need to be able to do so without
changing the API. If the new option is there, we use it, otherwise, we
behave like we previously did. This makes everything a bit easier and
eliminates the need to have puppetserver enforce hard dependencies on
puppet versions because of API changes.