### PR TITLE
(maint) Restrict where aix nim test runs

### DIFF
--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -1,8 +1,12 @@
 test_name "NIM package provider should work correctly"
 
-confine :to, :platform => "aix"
-
-# NOTE: This test is duplicated in the pe_acceptance_tests repo
+# nim test is slow, confine to only aix 7.2 and recent puppet versions
+confine :to, :platform => "aix" do |aix|
+  version = on(aix, 'puppet --version').stdout
+  version &&
+    Gem::Version.new(version) > Gem::Version.new('6.4.0') &&
+    on(aix, 'facter operatingsystemrelease').stdout == '7.2'
+end
 
 teardown do
     test_apply('cdrecord', 'absent', '')


### PR DESCRIPTION
The AIX NIM master is overloaded when this test runs across multiple
branches and AIX versions. Since the code hasn't changed in any
meaningful way since 2015, restrict the test to only AIX 7.2 and
releases greater than 6.4.

Remove outdated comment about pe_acceptance_tests

Cherry-pick 885581a88bacefa8f01c67833cf54f6a0e476e2f to 4.10.x