### PR TITLE
(PUP-10363) Process server list once per session

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -11,11 +11,10 @@ class Puppet::HTTP::Client
     @default_system_ssl_context = system_ssl_context
     @redirector = Puppet::HTTP::Redirector.new(redirect_limit)
     @retry_after_handler = Puppet::HTTP::RetryAfterHandler.new(retry_limit, Puppet[:runinterval])
-    @resolvers = build_resolvers
   end
 
   def create_session
-    Puppet::HTTP::Session.new(self, @resolvers)
+    Puppet::HTTP::Session.new(self, build_resolvers)
   end
 
   def connect(uri, ssl_context: nil, include_system_store: false, &block)


### PR DESCRIPTION
Previously, puppet walked the server_list once per service: puppet, fileserver,
and report, assuming the corresponding settings were not overridden,
e.g. report_server.

Now walk the server_list once per session. So if we resolve server_list for the
`puppet` service, then use the same for other services.

Since the server_list resolver is now stateful, create new resolver instances
for each session.