### PR TITLE
(PUP-10298) Yum version range support

### DIFF
--- a/acceptance/tests/provider/package/yum_semantic_versioning.rb
+++ b/acceptance/tests/provider/package/yum_semantic_versioning.rb
@@ -1,0 +1,66 @@
+test_name "yum provider should use semantic versioning for ensuring desired version" do
+  confine :to, :platform => /el-7/
+  tag 'audit:high'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::PackageUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  package = 'yum-utils'
+
+  lower_package_version = '1.1.31-34.el7'
+  middle_package_version = '1.1.31-42.el7'
+  higher_package_version = '1.1.31-45.el7'
+
+  agents.each do |agent|
+    yum_command = 'yum'
+
+    step "Setup: Skip test if box already has the package installed" do
+      on(agent, "rpm -q #{package}", :acceptable_exit_codes => [1,0]) do |result|
+        skip_test "package #{package} already installed on this box" unless result.output =~ /package #{package} is not installed/
+      end
+    end
+
+    step "Setup: Skip test if package versions are not available" do
+      on(agent, "yum list #{package} --showduplicates", :acceptable_exit_codes => [1,0]) do |result|
+        versions_available = [lower_package_version, middle_package_version, higher_package_version].all? {
+          |needed_versions| result.output.include? needed_versions }
+        skip_test "package #{package} versions not available on the box" unless versions_available
+      end
+    end
+
+    step "Using semantic versioning to downgrade to a desired version <= X" do
+      on(agent, "#{yum_command} install #{package} -y")
+      package_manifest = resource_manifest('package', package, { ensure: "<=#{lower_package_version}", provider: 'yum' } )
+      apply_manifest_on(agent, package_manifest, :catch_failures => true) do
+        installed_version = on(agent, "rpm -q #{package}").stdout
+        assert_match(/#{lower_package_version}/, installed_version)
+      end
+      # idempotency test
+      package_manifest = resource_manifest('package', package, { ensure: "<=#{lower_package_version}", provider: 'yum' } )
+      apply_manifest_on(agent, package_manifest, :catch_changes => true)
+      on(agent, "#{yum_command} remove #{package} -y")
+    end
+
+    step "Using semantic versioning to ensure a version >X <=Y" do
+      on(agent, "#{yum_command} install #{package} -y")
+      package_manifest = resource_manifest('package', package, { ensure: ">#{lower_package_version} <=#{higher_package_version}", provider: 'yum' } )
+      apply_manifest_on(agent, package_manifest) do
+        installed_version = on(agent, "rpm -q #{package}").stdout
+        assert_match(/#{higher_package_version}/, installed_version)
+      end
+      on(agent, "#{yum_command} remove #{package} -y")
+    end
+
+    step "Using semantic versioning to install a version >X <Y" do
+      package_manifest = resource_manifest('package', package, { ensure: ">#{lower_package_version} <#{higher_package_version}", provider: 'yum' } )
+      # installing a version >X <Y will install the highet version in between
+      apply_manifest_on(agent, package_manifest) do
+        installed_version = on(agent, "rpm -q #{package}").stdout
+        assert_match(/#{middle_package_version}/, installed_version)
+      end
+      on(agent, "#{yum_command} remove #{package} -y")
+    end
+
+  end
+end

--- a/lib/puppet/provider/package/rpm.rb
+++ b/lib/puppet/provider/package/rpm.rb
@@ -1,13 +1,17 @@
 require 'puppet/provider/package'
+require 'puppet/util/rpm_compare'
 
 # RPM packaging.  Should work anywhere that has rpm installed.
 Puppet::Type.type(:package).provide :rpm, :source => :rpm, :parent => Puppet::Provider::Package do
+  # provides Rpm parsing and comparison
+  include Puppet::Util::RpmCompare
+
   desc "RPM packaging support; should work anywhere with a working `rpm`
     binary.
 
     This provider supports the `install_options` and `uninstall_options`
     attributes, which allow command-line flags to be passed to rpm.
-These options should be specified as an array where each element is either a string or a hash."
+    These options should be specified as an array where each element is either a string or a hash."
 
   has_feature :versionable
   has_feature :install_options
@@ -22,31 +26,6 @@ These options should be specified as an array where each element is either a str
   self::NEVRA_REGEX  = %r{^'?(\S+) (\S+) (\S+) (\S+) (\S+)$}
   self::NEVRA_FIELDS = [:name, :epoch, :version, :release, :arch]
   self::MULTIVERSION_SEPARATOR = "; "
-
-  ARCH_LIST = [
-    'noarch',
-    'i386',
-    'i686',
-    'ppc',
-    'ppc64',
-    'armv3l',
-    'armv4b',
-    'armv4l',
-    'armv4tl',
-    'armv5tel',
-    'armv5tejl',
-    'armv6l',
-    'armv7l',
-    'm68kmint',
-    's390',
-    's390x',
-    'ia64',
-    'x86_64',
-    'sh3',
-    'sh4',
-  ]
-
-  ARCH_REGEX = Regexp.new(ARCH_LIST.join('|\.'))
 
   commands :rpm => "rpm"
 
@@ -204,200 +183,14 @@ These options should be specified as an array where each element is either a str
     join_options(resource[:uninstall_options])
   end
 
-  # This is an attempt at implementing RPM's
-  # lib/rpmvercmp.c rpmvercmp(a, b) in Ruby.
-  #
-  # Some of the things in here look REALLY
-  # UGLY and/or arbitrary. Our goal is to
-  # match how RPM compares versions, quirks
-  # and all.
-  #
-  # I've kept a lot of C-like string processing
-  # in an effort to keep this as identical to RPM
-  # as possible.
-  #
-  # returns 1 if str1 is newer than str2,
-  #         0 if they are identical
-  #        -1 if str1 is older than str2
-  def rpmvercmp(str1, str2)
-    return 0 if str1 == str2
-
-    front_strip_re = /^[^A-Za-z0-9~]+/
-
-    while str1.length > 0 or str2.length > 0
-      # trim anything that's in front_strip_re and != '~' off the beginning of each string
-      str1 = str1.gsub(front_strip_re, '')
-      str2 = str2.gsub(front_strip_re, '')
-
-      # "handle the tilde separator, it sorts before everything else"
-      if str1 =~ /^~/ && str2 =~ /^~/
-        # if they both have ~, strip it
-        str1 = str1[1..-1]
-        str2 = str2[1..-1]
-        next
-      elsif str1 =~ /^~/
-        return -1
-      elsif str2 =~ /^~/
-        return 1
-      end
-
-      break if str1.length == 0 or str2.length == 0
-
-      # "grab first completely alpha or completely numeric segment"
-      isnum = false
-      # if the first char of str1 is a digit, grab the chunk of continuous digits from each string
-      if str1 =~ /^[0-9]+/
-        if str1 =~ /^[0-9]+/
-          segment1 = $~.to_s
-          str1 = $~.post_match
-        else
-          segment1 = ''
-        end
-        if str2 =~ /^[0-9]+/
-          segment2 = $~.to_s
-          str2 = $~.post_match
-        else
-          segment2 = ''
-        end
-        isnum = true
-      # else grab the chunk of continuous alphas from each string (which may be '')
-      else
-        if str1 =~ /^[A-Za-z]+/
-          segment1 = $~.to_s
-          str1 = $~.post_match
-        else
-          segment1 = ''
-        end
-        if str2 =~ /^[A-Za-z]+/
-          segment2 = $~.to_s
-          str2 = $~.post_match
-        else
-          segment2 = ''
-        end
-      end
-
-      # if the segments we just grabbed from the strings are different types (i.e. one numeric one alpha),
-      # where alpha also includes ''; "numeric segments are always newer than alpha segments"
-      if segment2.length == 0
-        return 1 if isnum
-        return -1
-      end
-
-      if isnum
-        # "throw away any leading zeros - it's a number, right?"
-        segment1 = segment1.gsub(/^0+/, '')
-        segment2 = segment2.gsub(/^0+/, '')
-        # "whichever number has more digits wins"
-        return 1 if segment1.length > segment2.length
-        return -1 if segment1.length < segment2.length
-      end
-
-      # "strcmp will return which one is greater - even if the two segments are alpha
-      # or if they are numeric. don't return if they are equal because there might
-      # be more segments to compare"
-      rc = segment1 <=> segment2
-      return rc if rc != 0
-    end #end while loop
-
-    # if we haven't returned anything yet, "whichever version still has characters left over wins"
-    if str1.length > str2.length
-      return 1
-    elsif str1.length < str2.length
-      return -1
-    else
-      return 0
-    end
-  end
-
   def insync?(is)
     return false if [:purged, :absent].include?(is)
     return false if is.include?(self.class::MULTIVERSION_SEPARATOR) && !@resource[:install_only]
 
     should = resource[:ensure]
     is.split(self.class::MULTIVERSION_SEPARATOR).any? do |version|
-      0 == self.rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(version))
+      0 == rpm_compareEVR(rpm_parse_evr(should), rpm_parse_evr(version))
     end
-  end
-
-  # parse a rpm "version" specification
-  # this re-implements rpm's
-  # rpmUtils.miscutils.stringToVersion() in ruby
-  def rpm_parse_evr(s)
-    ei = s.index(':')
-    if ei
-      e = s[0,ei]
-      s = s[ei+1,s.length]
-    else
-      e = nil
-    end
-    begin
-      e = String(Integer(e))
-    rescue
-      # If there are non-digits in the epoch field, default to nil
-      e = nil
-    end
-    ri = s.index('-')
-    if ri
-      v = s[0,ri]
-      r = s[ri+1,s.length]
-      arch = r.scan(ARCH_REGEX)[0]
-      if arch
-        a = arch.delete('.')
-        r.gsub!(ARCH_REGEX, '')
-      end
-    else
-      v = s
-      r = nil
-    end
-    return { :epoch => e, :version => v, :release => r, :arch => a }
-  end
-
-  # how rpm compares two package versions:
-  # rpmUtils.miscutils.compareEVR(), which massages data types and then calls
-  # rpm.labelCompare(), found in rpm.git/python/header-py.c, which
-  # sets epoch to 0 if null, then compares epoch, then ver, then rel
-  # using compare_values() and returns the first non-0 result, else 0.
-  # This function combines the logic of compareEVR() and labelCompare().
-  #
-  # "version_should" can be v, v-r, or e:v-r.
-  # "version_is" will always be at least v-r, can be e:v-r
-  def rpm_compareEVR(should_hash, is_hash)
-    # pass on to rpm labelCompare
-
-    if !should_hash[:epoch].nil?
-      rc = compare_values(should_hash[:epoch], is_hash[:epoch])
-      return rc unless rc == 0
-    end
-
-    rc = compare_values(should_hash[:version], is_hash[:version])
-    return rc unless rc == 0
-
-    # here is our special case, PUP-1244.
-    # if should_hash[:release] is nil (not specified by the user),
-    # and comparisons up to here are equal, return equal. We need to
-    # evaluate to whatever level of detail the user specified, so we
-    # don't end up upgrading or *downgrading* when not intended.
-    #
-    # This should NOT be triggered if we're trying to ensure latest.
-    return 0 if should_hash[:release].nil?
-
-    rc = compare_values(should_hash[:release], is_hash[:release])
-
-    return rc
-  end
-
-  # this method is a native implementation of the
-  # compare_values function in rpm's python bindings,
-  # found in python/header-py.c, as used by rpm.
-  def compare_values(s1, s2)
-    if s1.nil? && s2.nil?
-      return 0
-    elsif ( not s1.nil? ) && s2.nil?
-      return 1
-    elsif s1.nil? && (not s2.nil?)
-      return -1
-    end
-    return rpmvercmp(s1, s2)
   end
 
   private

--- a/lib/puppet/util/package/version/rpm.rb
+++ b/lib/puppet/util/package/version/rpm.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'puppet/util/rpm_compare'
+
+module Puppet::Util::Package::Version
+  class Rpm < Numeric
+    # provides Rpm parsing and comparison
+    extend Puppet::Util::RpmCompare
+    include Puppet::Util::RpmCompare
+    include Comparable
+
+    class ValidationFailure < ArgumentError; end
+
+    def self.parse(ver)
+      raise ValidationFailure unless ver.is_a?(String)
+      version = rpm_parse_evr(ver)
+      new(version[:epoch], version[:version], version[:release], version[:arch]).freeze
+    end
+
+    def to_s
+      version_found = ''
+      version_found += "#{@epoch}:"   if @epoch
+      version_found += @version
+      version_found += "-#{@release}" if @release
+      version_found
+    end
+    alias inspect to_s
+
+    def initialize(epoch, version, release, arch)
+      @epoch   = epoch
+      @version = version
+      @release = release
+      @arch    = arch
+    end
+
+    attr_reader :epoch, :version, :release, :arch
+
+    def eql?(other)
+      other.is_a?(self.class) &&
+        @epoch.eql?(other.epoch) &&
+        @version.eql?(other.version) &&
+        @release.eql?(other.release) &&
+        @arch.eql?(other.arch)
+    end
+    alias == eql?
+
+    def <=>(other)
+      raise ArgumentError, _("Cannot compare, as %{other} is not a Rpm Version") % { other: other } unless other.is_a?(self.class)
+
+      cmp = @epoch <=> other.epoch
+      if cmp == 0
+        cmp = rpm_compareEVR(rpm_parse_evr(self.to_s), rpm_parse_evr(other.to_s))
+      end
+      cmp
+    end
+
+  end
+end

--- a/lib/puppet/util/rpm_compare.rb
+++ b/lib/puppet/util/rpm_compare.rb
@@ -1,0 +1,187 @@
+module Puppet::Util::RpmCompare
+
+  ARCH_LIST = %w(
+    noarch i386 i686 ppc ppc64 armv3l armv4b armv4l armv4tl armv5tel
+    armv5tejl armv6l armv7l m68kmint s390 s390x ia64 x86_64 sh3 sh4
+  ).freeze
+
+  ARCH_REGEX = Regexp.new(ARCH_LIST.join('|\.'))
+
+  # This is an attempt at implementing RPM's
+  # lib/rpmvercmp.c rpmvercmp(a, b) in Ruby.
+  #
+  # Some of the things in here look REALLY
+  # UGLY and/or arbitrary. Our goal is to
+  # match how RPM compares versions, quirks
+  # and all.
+  #
+  # I've kept a lot of C-like string processing
+  # in an effort to keep this as identical to RPM
+  # as possible.
+  #
+  # returns 1 if str1 is newer than str2,
+  #         0 if they are identical
+  #        -1 if str1 is older than str2
+  def rpmvercmp(str1, str2)
+    return 0 if str1 == str2
+
+    front_strip_re = /^[^A-Za-z0-9~]+/
+
+    while str1.length > 0 or str2.length > 0
+      # trim anything that's in front_strip_re and != '~' off the beginning of each string
+      str1 = str1.gsub(front_strip_re, '')
+      str2 = str2.gsub(front_strip_re, '')
+
+      # "handle the tilde separator, it sorts before everything else"
+      if str1 =~ /^~/ && str2 =~ /^~/
+        # if they both have ~, strip it
+        str1 = str1[1..-1]
+        str2 = str2[1..-1]
+        next
+      elsif str1 =~ /^~/
+        return -1
+      elsif str2 =~ /^~/
+        return 1
+      end
+
+      break if str1.length == 0 or str2.length == 0
+
+      # "grab first completely alpha or completely numeric segment"
+      isnum = false
+      # if the first char of str1 is a digit, grab the chunk of continuous digits from each string
+      if str1 =~ /^[0-9]+/
+        if str1 =~ /^[0-9]+/
+          segment1 = $~.to_s
+          str1 = $~.post_match
+        else
+          segment1 = ''
+        end
+        if str2 =~ /^[0-9]+/
+          segment2 = $~.to_s
+          str2 = $~.post_match
+        else
+          segment2 = ''
+        end
+        isnum = true
+      # else grab the chunk of continuous alphas from each string (which may be '')
+      else
+        if str1 =~ /^[A-Za-z]+/
+          segment1 = $~.to_s
+          str1 = $~.post_match
+        else
+          segment1 = ''
+        end
+        if str2 =~ /^[A-Za-z]+/
+          segment2 = $~.to_s
+          str2 = $~.post_match
+        else
+          segment2 = ''
+        end
+      end
+
+      # if the segments we just grabbed from the strings are different types (i.e. one numeric one alpha),
+      # where alpha also includes ''; "numeric segments are always newer than alpha segments"
+      if segment2.length == 0
+        return 1 if isnum
+        return -1
+      end
+
+      if isnum
+        # "throw away any leading zeros - it's a number, right?"
+        segment1 = segment1.gsub(/^0+/, '')
+        segment2 = segment2.gsub(/^0+/, '')
+        # "whichever number has more digits wins"
+        return 1 if segment1.length > segment2.length
+        return -1 if segment1.length < segment2.length
+      end
+
+      # "strcmp will return which one is greater - even if the two segments are alpha
+      # or if they are numeric. don't return if they are equal because there might
+      # be more segments to compare"
+      rc = segment1 <=> segment2
+      return rc if rc != 0
+    end #end while loop
+
+    # if we haven't returned anything yet, "whichever version still has characters left over wins"
+    return 1 if str1.length > str2.length
+    return -1 if str1.length < str2.length
+    0
+  end
+
+  # parse a rpm "version" specification
+  # this re-implements rpm's
+  # rpmUtils.miscutils.stringToVersion() in ruby
+  def rpm_parse_evr(full_version)
+    epoch_index = full_version.index(':')
+    if epoch_index
+      epoch = full_version[0,epoch_index]
+      full_version = full_version[epoch_index+1,full_version.length]
+    else
+      epoch = nil
+    end
+    begin
+      epoch = String(Integer(epoch))
+    rescue
+      # If there are non-digits in the epoch field, default to nil
+      epoch = nil
+    end
+    release_index = full_version.index('-')
+    if release_index
+      version = full_version[0,release_index]
+      release = full_version[release_index+1,full_version.length]
+      arch = release.scan(ARCH_REGEX)[0]
+      if arch
+        architecture = arch.delete('.')
+        release.gsub!(ARCH_REGEX, '')
+      end
+    else
+      version = full_version
+      release = nil
+    end
+    return { :epoch => epoch, :version => version, :release => release, :arch => architecture }
+  end
+
+  # this method is a native implementation of the
+  # compare_values function in rpm's python bindings,
+  # found in python/header-py.c, as used by rpm.
+  def compare_values(s1, s2)
+    return 0 if s1.nil? && s2.nil?
+    return 1 if ( not s1.nil? ) && s2.nil?
+    return -1 if s1.nil? && (not s2.nil?)
+    return rpmvercmp(s1, s2)
+  end
+
+  # how rpm compares two package versions:
+  # rpmUtils.miscutils.compareEVR(), which massages data types and then calls
+  # rpm.labelCompare(), found in rpm.git/python/header-py.c, which
+  # sets epoch to 0 if null, then compares epoch, then ver, then rel
+  # using compare_values() and returns the first non-0 result, else 0.
+  # This function combines the logic of compareEVR() and labelCompare().
+  #
+  # "version_should" can be v, v-r, or e:v-r.
+  # "version_is" will always be at least v-r, can be e:v-r
+  def rpm_compareEVR(should_hash, is_hash)
+    # pass on to rpm labelCompare
+
+    if !should_hash[:epoch].nil?
+      rc = compare_values(should_hash[:epoch], is_hash[:epoch])
+      return rc unless rc == 0
+    end
+
+    rc = compare_values(should_hash[:version], is_hash[:version])
+    return rc unless rc == 0
+
+    # here is our special case, PUP-1244.
+    # if should_hash[:release] is nil (not specified by the user),
+    # and comparisons up to here are equal, return equal. We need to
+    # evaluate to whatever level of detail the user specified, so we
+    # don't end up upgrading or *downgrading* when not intended.
+    #
+    # This should NOT be triggered if we're trying to ensure latest.
+    return 0 if should_hash[:release].nil?
+
+    rc = compare_values(should_hash[:release], is_hash[:release])
+
+    return rc
+  end
+end

--- a/spec/unit/util/package/version/rpm_spec.rb
+++ b/spec/unit/util/package/version/rpm_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+require 'puppet/util/package/version/rpm'
+
+describe Puppet::Util::Package::Version::Rpm do
+
+  context "when parsing an invalid version" do
+    it "if is parsing symbols" do
+      expect { described_class.parse(:absent)}.to raise_error(ArgumentError)
+    end
+  end
+
+  context "when creating new version" do
+    it "is parsing basic version" do
+      v = described_class.parse('1:2.8.8-1.el6')
+      expect([v.epoch, v.version, v.release, v.arch ]).to eq(['1', '2.8.8', '1.el6' , nil])
+    end
+
+    it "is parsing no epoch basic version" do
+      v = described_class.parse('2.8.8-1.el6')
+      expect([v.epoch, v.version, v.release, v.arch ]).to eq([nil, '2.8.8', '1.el6', nil])
+    end
+
+    it "is parsing no epoch basic short version" do
+      v = described_class.parse('7.15-8.fc29')
+      expect([v.epoch, v.version, v.release, v.arch ]).to eq([nil, '7.15', '8.fc29', nil])
+    end
+
+    it "is parsing no epoch and no release basic version" do
+      v = described_class.parse('2.8.8')
+      expect([v.epoch, v.version, v.release, v.arch ]).to eq([nil, '2.8.8', nil, nil])
+    end
+
+    it "is parsing no epoch complex version" do
+      v = described_class.parse('1.4-0.24.20120830CVS.fc31')
+      expect([v.epoch, v.version, v.release, v.arch ]).to eq([nil, '1.4', '0.24.20120830CVS.fc31', nil])
+    end
+  end
+
+  context "when comparing two versions" do
+    it "epoch has precedence" do
+      lower = described_class.parse('0:1.5.3-3.el6')
+      higher = described_class.parse('1:1.7.0-15.fc29')
+      expect(lower).to be < higher
+    end
+
+    it "handles equals letters-only versions" do
+      first = described_class.parse('abd-def')
+      second = described_class.parse('abd-def')
+      expect(first).to eq(second)
+    end
+
+    it "shorter version is smaller letters-only versions" do
+      lower = described_class.parse('ab')
+      higher = described_class.parse('abd')
+      expect(lower).to be < higher
+    end
+
+    it "shorter version is smaller even with digits" do
+      lower = described_class.parse('1.7')
+      higher = described_class.parse('1.7.0')
+      expect(lower).to be < higher
+    end
+
+    it "shorter version is smaller when number is less" do
+      lower = described_class.parse('1.7.0')
+      higher = described_class.parse('1.7.1')
+      expect(lower).to be < higher
+    end
+
+    it "shorter release is smaller " do
+      lower = described_class.parse('1.7.0-11.fc26')
+      higher = described_class.parse('1.7.0-11.fc27')
+      expect(lower).to be < higher
+    end
+
+    it "release letters are smaller letters-only" do
+      lower = described_class.parse('1.7.0-abc')
+      higher = described_class.parse('1.7.0-abd')
+      expect(lower).to be < higher
+    end
+
+    it "shorter release is smaller" do
+      lower = described_class.parse('1.7.0-11.fc2')
+      higher = described_class.parse('1.7.0-11.fc17')
+      expect(lower).to be < higher
+    end
+
+    it "handles equal release" do
+      first = described_class.parse('1.7.0-11.fc27')
+      second = described_class.parse('1.7.0-11.fc27')
+      expect(first).to eq(second)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds version range support for yum provider

example manifest will install the highest available version that is
above or equal 1.7.0
package { 'tree':
  ensure => ('>=1.7.0'),
  provider => 'yum',
}