### PR TITLE
(PUP-10364) Add pp_owner ppRegCertExt OID

### DIFF
--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -61,6 +61,7 @@ module Puppet::SSL::Oids
     ["1.3.6.1.4.1.34380.1.1.23", 'pp_cloudplatform', 'Puppet Node Cloud Platform Name'],
     ["1.3.6.1.4.1.34380.1.1.24", 'pp_apptier', 'Puppet Node Application Tier'],
     ["1.3.6.1.4.1.34380.1.1.25", 'pp_hostname', 'Puppet Node Hostname'],
+    ["1.3.6.1.4.1.34380.1.1.26", 'pp_owner', 'Puppet Node Owner'],
 
     ["1.3.6.1.4.1.34380.1.2", 'ppPrivCertExt', 'Puppet Private Certificate Extension'],
 

--- a/spec/unit/ssl/oids_spec.rb
+++ b/spec/unit/ssl/oids_spec.rb
@@ -33,6 +33,7 @@ describe Puppet::SSL::Oids do
       'pp_cloudplatform'    => '1.3.6.1.4.1.34380.1.1.23',
       'pp_apptier'          => '1.3.6.1.4.1.34380.1.1.24',
       'pp_hostname'         => '1.3.6.1.4.1.34380.1.1.25',
+      'pp_owner'            => '1.3.6.1.4.1.34380.1.1.26',
       'ppPrivCertExt'       => '1.3.6.1.4.1.34380.1.2',
       'ppAuthCertExt'       => '1.3.6.1.4.1.34380.1.3',
       'pp_authorization'    => '1.3.6.1.4.1.34380.1.3.1',


### PR DESCRIPTION
In Puppet-as-a-Service use cases it is common for individual nodes to be owned by various different tenant, or customer, teams. None of the registered ppRegCertExt OIDs we currently provide cleanly allow generic specification of an owner in this context.

Provide a new OID, pp_owner, which generically fits this use case.