### PR TITLE
(PUP-10355) Don't emit a deprecation warning when using http_instance

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -236,7 +236,7 @@ module Puppet
           raise e
         end
       },
-      :ssl_host => proc { Puppet::SSL::Host.localhost },
+      :ssl_host => proc { Puppet::SSL::Host.localhost(true) },
       :http_session => proc { Puppet.runtime["http"].create_session },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins },
       :rich_data => false

--- a/lib/puppet/ssl/host.rb
+++ b/lib/puppet/ssl/host.rb
@@ -22,9 +22,9 @@ class Puppet::SSL::Host
 
   attr_writer :key, :certificate, :certificate_request, :crl_usage
 
-  def self.localhost
+  def self.localhost(suppress_warning = false)
     return @localhost if @localhost
-    @localhost = new
+    @localhost = new(nil, false, suppress_warning)
     @localhost.generate unless @localhost.certificate
     @localhost.key
     @localhost
@@ -225,14 +225,14 @@ ERROR_STRING
   end
   private :validate_csr_with_key
 
-  def initialize(name = nil, device = false)
+  def initialize(name = nil, device = false, suppress_warning = false)
     @name = (name || Puppet[:certname]).downcase
     @device = device
     Puppet::SSL::Base.validate_certname(@name)
     @key = @certificate = @certificate_request = nil
     @crl_usage = Puppet.settings[:certificate_revocation]
     @crl_path = Puppet.settings[:hostcrl]
-    Puppet.deprecation_warning(_("Puppet::SSL::Host is deprecated and will be removed in a future release of Puppet."));
+    Puppet.deprecation_warning(_("Puppet::SSL::Host is deprecated and will be removed in a future release of Puppet.")) unless suppress_warning
   end
 
   # Extract the public key from the private key.

--- a/spec/integration/network/http_pool_spec.rb
+++ b/spec/integration/network/http_pool_spec.rb
@@ -81,6 +81,16 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
         end
       end
 
+      it "doesn't generate a Puppet::SSL::Host deprecation warning" do
+        server.start_server do |port|
+          http = connection(hostname, port)
+          res = http.get('/')
+          expect(res.code).to eq('200')
+        end
+
+        expect(@logs).to eq([])
+      end
+
       it "detects when the server has closed the connection and reconnects" do
         server.start_server do |port|
           http = connection(hostname, port)

--- a/spec/integration/network/http_pool_spec.rb
+++ b/spec/integration/network/http_pool_spec.rb
@@ -24,14 +24,6 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
   let(:server) { PuppetSpec::HTTPSServer.new }
 
   context "when calling deprecated HttpPool methods" do
-    let(:ssl_host) {
-      # use server's cert/key as the client cert/key
-      host = Puppet::SSL::Host.new
-      host.key = Puppet::SSL::Key.from_instance(server.server_key, host.name)
-      host.certificate = Puppet::SSL::Certificate.from_instance(server.server_cert, host.name)
-      host
-    }
-
     before(:each) do
       ssldir = tmpdir('http_pool')
       Puppet[:ssldir] = ssldir
@@ -41,16 +33,6 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
       File.write(Puppet[:hostcrl], server.ca_crl.to_pem)
       File.write(Puppet[:hostcert], server.server_cert.to_pem)
       File.write(Puppet[:hostprivkey], server.server_key.to_pem)
-    end
-
-    # Can't use `around(:each)` because it will cause ssl_host to be
-    # created outside of any rspec example, and $confdir won't be set
-    before(:each) do
-      Puppet.push_context(ssl_host: ssl_host)
-    end
-
-    after (:each) do
-      Puppet.pop_context
     end
 
     def connection(host, port)

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -51,8 +51,10 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       allow_any_instance_of(Puppet::SSL::Host).to receive(:generate)
     end
 
-    it "should have a method for producing an instance to manage the local host's keys" do
-      expect(Puppet::SSL::Host).to respond_to(:localhost)
+    it "is deprecated" do
+      Puppet::SSL::Host.localhost
+
+      expect(@logs).to include(an_object_having_attributes(message: /Puppet::SSL::Host is deprecated/))
     end
 
     it "should allow to reset localhost" do


### PR DESCRIPTION
Allow the deprecation warning to be suppressed as the Host object is
still used when connections are made via `HttpPool.http_instance`. Calls
to `Puppet::SSL::Host.new` or `.localhost` will generate the deprecation
warning.