### PR TITLE
(WIP) Add Puppet::Transaction::Report#userdata 

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -180,6 +180,7 @@ class Puppet::Configurer
   def apply_catalog(catalog, options)
     report = options[:report]
     report.configuration_version = catalog.version
+    binding.pry
 
     benchmark(:notice, _("Applied catalog in %{seconds} seconds")) do
       apply_catalog_time = thinmark do

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -9,6 +9,7 @@ if not defined? ::Bundler
   end
 end
 
+require 'pry' # FIXME JJM - Remove this
 require 'puppet'
 require 'puppet/util'
 require "puppet/util/rubygems"

--- a/lib/puppet/vendor/load_report_userdata.rb
+++ b/lib/puppet/vendor/load_report_userdata.rb
@@ -1,0 +1,2 @@
+$: << File.join([File.dirname(__FILE__), "report_userdata/lib"])
+require 'report_userdata'

--- a/lib/puppet/vendor/report_userdata/lib/report_userdata.rb
+++ b/lib/puppet/vendor/report_userdata/lib/report_userdata.rb
@@ -1,0 +1,20 @@
+require 'puppet/transaction'
+require 'puppet/transaction/report'
+
+module ReportExtensions
+  # User specified data stored as a Hash.  The value must be serializable to
+  # JSON.  The intent of this userdata is to allow end users to embed their own
+  # data into the report for use with their own custom report processors.
+  #
+  # @return [Hash] userdata
+  attr_accessor :userdata
+
+  def initialize(*args)
+    super(*args)
+    @userdata = {}
+  end
+end
+
+class Puppet::Transaction::Report
+  prepend ReportExtensions
+end


### PR DESCRIPTION
Without this patch the transaction report created by the agent does not
have an attribute to store user defined data.  This is a problem because
we need to store the following pieces of data in the report object to
make the data accessible via BQ and Data Studio:

 1. All classes
 2. Top level compiler variables from the catalog
 3. A way to identify if a change to code is included in the enforcement
    run.  Similar to config version, but may include additional data.

This patch addresses the problem by establishing an userdata attribute
which is a Hash map.  The schema of the value is not specified and left
to the user to define.  The value must be serializable to JSON encoding
so that the data may be loaded into BQ.

Next steps:

 * [ ] Verify the attribute is present on the puppetserver.
 * [ ] Verify a report processor has access to the data.
 * [ ] Verify to_data_hash() includes userdata
 * [ ] Add classes to the userdata.
 * [ ] Add facts to the userdata.
 * [ ] Add top level variables from the catalog to the userdata.