### PR TITLE
(PUP-10363) Cache the server list url not the service

### DIFF
--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -76,12 +76,15 @@ describe Puppet::HTTP::Resolver do
       passed = stub_request(:get, "https://apple.example.com:8142/status/v1/simple/master").to_return(status: 200)
 
       service = subject.resolve(session, :puppet)
+      expect(service).to be_a(Puppet::HTTP::Service::Compiler)
       expect(service.url.to_s).to eq("https://apple.example.com:8142/puppet/v3")
 
       service = subject.resolve(session, :fileserver)
+      expect(service).to be_a(Puppet::HTTP::Service::FileServer)
       expect(service.url.to_s).to eq("https://apple.example.com:8142/puppet/v3")
 
       service = subject.resolve(session, :report)
+      expect(service).to be_a(Puppet::HTTP::Service::Report)
       expect(service.url.to_s).to eq("https://apple.example.com:8142/puppet/v3")
 
       expect(failed).to have_been_requested


### PR DESCRIPTION
The server_list resolver cached the service whose host and port it first
connected to, such as Puppet::HTTP::Service::Compiler. However, the next
request for a different service, would return the cached service, which wasn't
what the caller expected.

Instead cache the URL that we successfully connected to, and use that to
create the service of the correct type.