### PR TITLE
(PUP-10365) Fix https file source regression

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -298,7 +298,7 @@ module Puppet
 
     def get_from_http_source(url, &block)
       client = Puppet.runtime['http']
-      client.get(url) do |response|
+      client.get(url, options: {include_system_store: true}) do |response|
         raise Puppet::HTTP::ResponseError.new(response) unless response.success?
 
         response.read_body(&block)

--- a/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
@@ -1,0 +1,67 @@
+RSA Private-Key: (1024 bit, 2 primes)
+modulus:
+    00:c9:00:0c:66:d2:2d:df:a0:cc:4c:a5:7a:5b:67:
+    10:f1:d2:06:ac:01:0e:da:55:19:a3:dd:b7:85:9c:
+    f1:53:e6:a9:b4:c7:33:43:55:12:0e:e5:ec:cc:75:
+    28:e4:d2:36:2a:02:85:9e:a6:58:4e:f3:ba:91:83:
+    54:d2:b7:46:d4:00:b4:fc:86:9b:db:10:07:a7:8e:
+    47:e5:f0:27:1f:62:eb:94:68:37:c8:c4:d4:fc:ea:
+    0e:b0:94:5d:c3:5a:99:08:6c:f3:27:33:71:5a:47:
+    62:3e:df:18:10:d4:c0:08:2d:f1:47:6b:c1:19:46:
+    3e:32:2f:b4:57:91:50:4c:8f
+publicExponent: 65537 (0x10001)
+privateExponent:
+    1b:d6:c2:e0:f6:d9:5d:b0:d2:bb:06:ec:54:7e:88:
+    ed:45:4e:a1:42:20:41:83:29:e2:f5:51:76:d3:0e:
+    e5:b4:fb:ea:4a:f0:c1:b1:a5:a7:a4:96:d0:96:a5:
+    8c:53:c5:26:ba:64:b1:5d:8e:bb:98:ac:4d:7d:28:
+    21:6b:3b:06:e1:0b:a8:3f:d4:1a:24:26:47:2f:cf:
+    cd:be:37:73:dd:b6:e1:7b:11:18:3b:80:ec:19:9c:
+    d0:d7:22:47:6b:01:e3:af:5c:89:8f:16:dc:b0:b4:
+    b1:ed:e2:c2:09:84:be:ae:e8:c8:31:df:83:7d:f3:
+    10:75:4f:3a:6c:72:59:f9
+prime1:
+    00:ee:90:d8:4e:14:a3:a1:c7:28:4d:73:de:44:b9:
+    36:fd:96:5c:68:4e:65:96:6e:c6:55:06:8e:c1:8d:
+    dc:f7:f6:92:39:bb:bd:29:cd:4a:d3:e5:97:bc:65:
+    f9:48:40:fd:06:f8:ce:33:0b:03:cc:00:ed:62:00:
+    29:e4:4b:f7:7d
+prime2:
+    00:d7:b0:6a:67:9e:17:13:16:68:93:4b:65:f3:c3:
+    cf:f0:61:ad:d5:7a:57:da:db:6f:ca:90:4f:f7:1b:
+    2f:d1:76:de:4a:73:18:25:6f:f2:78:70:97:9b:7f:
+    a3:83:64:8e:1b:f5:4f:d4:3b:4e:27:1b:e4:97:90:
+    07:8d:ea:49:fb
+exponent1:
+    11:f9:a3:f2:ae:27:6e:27:1d:68:48:94:b4:c4:e7:
+    d9:cf:9c:82:d7:75:5c:12:58:ab:4b:65:32:3c:48:
+    2b:fe:ce:21:bf:7d:8f:4a:c2:9a:98:b0:08:27:fe:
+    d2:6c:e3:23:c5:57:74:0d:1e:6a:1e:9f:c4:44:92:
+    e3:7a:bd:d9
+exponent2:
+    28:eb:ed:a4:2f:18:4d:a4:c8:be:79:65:a4:74:18:
+    35:91:32:bb:f7:f4:47:2f:ae:ec:0d:a9:3e:46:c8:
+    31:c3:8d:b5:2e:54:fc:75:5a:d9:82:f3:20:ab:7c:
+    c8:67:01:97:48:59:96:f8:91:81:56:07:6e:c2:02:
+    cc:e8:10:95
+coefficient:
+    00:86:a8:b9:c6:24:d8:bc:eb:11:24:d5:e6:e7:17:
+    b4:a8:fc:3d:53:33:e5:a8:d0:f2:45:9d:aa:4e:0d:
+    14:46:cb:99:88:78:c9:ed:d2:9f:9f:dd:a3:81:71:
+    b6:ce:ff:df:06:3e:4c:bb:77:fa:bd:17:27:23:14:
+    4c:32:36:db:87
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDJAAxm0i3foMxMpXpbZxDx0gasAQ7aVRmj3beFnPFT5qm0xzND
+VRIO5ezMdSjk0jYqAoWeplhO87qRg1TSt0bUALT8hpvbEAenjkfl8CcfYuuUaDfI
+xNT86g6wlF3DWpkIbPMnM3FaR2I+3xgQ1MAILfFHa8EZRj4yL7RXkVBMjwIDAQAB
+AoGAG9bC4PbZXbDSuwbsVH6I7UVOoUIgQYMp4vVRdtMO5bT76krwwbGlp6SW0Jal
+jFPFJrpksV2Ou5isTX0oIWs7BuELqD/UGiQmRy/Pzb43c9224XsRGDuA7Bmc0Nci
+R2sB469ciY8W3LC0se3iwgmEvq7oyDHfg33zEHVPOmxyWfkCQQDukNhOFKOhxyhN
+c95EuTb9llxoTmWWbsZVBo7Bjdz39pI5u70pzUrT5Ze8ZflIQP0G+M4zCwPMAO1i
+ACnkS/d9AkEA17BqZ54XExZok0tl88PP8GGt1XpX2ttvypBP9xsv0XbeSnMYJW/y
+eHCXm3+jg2SOG/VP1DtOJxvkl5AHjepJ+wJAEfmj8q4nbicdaEiUtMTn2c+cgtd1
+XBJYq0tlMjxIK/7OIb99j0rCmpiwCCf+0mzjI8VXdA0eah6fxESS43q92QJAKOvt
+pC8YTaTIvnllpHQYNZEyu/f0Ry+u7A2pPkbIMcONtS5U/HVa2YLzIKt8yGcBl0hZ
+lviRgVYHbsICzOgQlQJBAIaoucYk2LzrESTV5ucXtKj8PVMz5ajQ8kWdqk4NFEbL
+mYh4ye3Sn5/do4Fxts7/3wY+TLt3+r0XJyMUTDI224c=
+-----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1.pem
@@ -1,0 +1,48 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Unknown CA
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Mar 10 06:54:16 2030 GMT
+        Subject: CN=127.0.0.1
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (1024 bit)
+                Modulus:
+                    00:c9:00:0c:66:d2:2d:df:a0:cc:4c:a5:7a:5b:67:
+                    10:f1:d2:06:ac:01:0e:da:55:19:a3:dd:b7:85:9c:
+                    f1:53:e6:a9:b4:c7:33:43:55:12:0e:e5:ec:cc:75:
+                    28:e4:d2:36:2a:02:85:9e:a6:58:4e:f3:ba:91:83:
+                    54:d2:b7:46:d4:00:b4:fc:86:9b:db:10:07:a7:8e:
+                    47:e5:f0:27:1f:62:eb:94:68:37:c8:c4:d4:fc:ea:
+                    0e:b0:94:5d:c3:5a:99:08:6c:f3:27:33:71:5a:47:
+                    62:3e:df:18:10:d4:c0:08:2d:f1:47:6b:c1:19:46:
+                    3e:32:2f:b4:57:91:50:4c:8f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:127.0.0.1, DNS:127.0.0.2
+    Signature Algorithm: sha256WithRSAEncryption
+         4a:a3:2e:2a:8f:6f:0e:5e:70:19:26:59:05:1d:59:3f:c5:39:
+         49:c4:cd:73:99:f2:08:8c:bc:fa:28:e4:33:38:f1:50:a3:0c:
+         8e:3b:a3:93:9e:37:5c:69:c0:d9:2d:f2:2e:31:d7:5a:61:d6:
+         91:22:6d:3c:1b:4f:c3:b6:57:13:5e:c9:5a:c8:6c:2e:bc:d6:
+         42:5b:f0:64:ec:7e:03:3c:f1:43:d9:f9:b7:f1:37:db:a5:0f:
+         b9:87:f5:4d:01:93:b4:a6:40:05:dc:ca:fd:31:5b:14:66:f0:
+         84:70:48:0c:b8:49:11:3d:f6:9e:aa:e7:b4:21:5b:e6:cc:67:
+         ca:d9
+-----BEGIN CERTIFICATE-----
+MIIBwjCCASugAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMwMDMxMDA2NTQxNlowFDESMBAGA1UE
+AwwJMTI3LjAuMC4xMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJAAxm0i3f
+oMxMpXpbZxDx0gasAQ7aVRmj3beFnPFT5qm0xzNDVRIO5ezMdSjk0jYqAoWeplhO
+87qRg1TSt0bUALT8hpvbEAenjkfl8CcfYuuUaDfIxNT86g6wlF3DWpkIbPMnM3Fa
+R2I+3xgQ1MAILfFHa8EZRj4yL7RXkVBMjwIDAQABoyMwITAfBgNVHREEGDAWggkx
+MjcuMC4wLjGCCTEyNy4wLjAuMjANBgkqhkiG9w0BAQsFAAOBgQBKoy4qj28OXnAZ
+JlkFHVk/xTlJxM1zmfIIjLz6KOQzOPFQowyOO6OTnjdcacDZLfIuMddaYdaRIm08
+G0/DtlcTXslayGwuvNZCW/Bk7H4DPPFD2fm38TfbpQ+5h/VNAZO0pkAF3Mr9MVsU
+ZvCEcEgMuEkRPfaeque0IVvmzGfK2Q==
+-----END CERTIFICATE-----

--- a/spec/fixtures/ssl/unknown-ca-key.pem
+++ b/spec/fixtures/ssl/unknown-ca-key.pem
@@ -1,0 +1,67 @@
+RSA Private-Key: (1024 bit, 2 primes)
+modulus:
+    00:c1:5e:5d:26:ae:73:17:5a:70:37:ac:42:25:ca:
+    05:10:86:17:23:6c:28:84:48:2a:4a:d4:b0:3a:2a:
+    d8:33:ae:58:67:6f:9b:4f:a6:b4:87:b1:ec:37:00:
+    69:8d:d5:cf:71:8a:96:e1:4a:f8:c8:81:36:f9:43:
+    ad:d8:d6:76:83:27:99:a4:48:17:c2:ef:9c:22:40:
+    4b:c6:58:21:88:e5:1d:37:79:4e:ba:31:e6:52:ec:
+    8c:23:ed:d6:ce:3b:58:ad:82:c7:ae:28:47:d4:e7:
+    cc:31:ac:78:c9:02:87:d0:b1:91:09:f6:1e:9a:c3:
+    4f:f6:5a:fe:a2:21:0e:c0:95
+publicExponent: 65537 (0x10001)
+privateExponent:
+    60:5b:b7:ab:98:ee:fd:4a:31:f5:6c:3f:a2:39:23:
+    80:f2:71:01:53:da:74:e0:c9:42:74:ee:44:6e:29:
+    42:c7:b4:82:06:d9:ac:3d:74:64:d2:42:d5:bd:bc:
+    db:d3:1a:06:88:7b:5b:55:52:d8:07:9b:ef:66:cc:
+    70:eb:9e:2e:2b:7e:c1:34:84:9a:83:34:b2:70:c6:
+    59:72:60:a0:f4:f5:d9:f2:76:ae:bf:7d:23:35:ee:
+    ad:b1:2d:c1:fe:05:7d:5b:7f:2c:da:87:ec:6e:b0:
+    a3:08:c9:bd:e5:30:a4:c2:6e:6e:50:c0:5e:31:f6:
+    33:ef:86:57:64:45:b7:c1
+prime1:
+    00:e1:d6:07:8c:c6:4d:90:fa:d6:40:9a:1f:e5:34:
+    50:16:72:9f:5b:83:c1:60:d5:73:39:c2:c6:ec:3a:
+    ed:24:fe:aa:5d:16:14:ba:85:a4:7d:5a:94:e8:63:
+    f9:dd:25:a8:2c:6b:ca:7c:43:c7:a9:92:ae:35:5c:
+    85:47:9e:51:e9
+prime2:
+    00:db:32:2e:59:ea:22:83:ce:d3:d5:7b:cb:b9:81:
+    b9:c2:4e:5b:08:ab:8f:66:21:34:55:61:50:57:02:
+    5e:d2:d9:09:8d:39:81:85:cd:4c:08:f3:b1:1a:b5:
+    b4:0c:3b:77:5e:c1:e0:95:f1:98:c6:f5:58:88:42:
+    50:b0:c3:41:cd
+exponent1:
+    00:b2:c8:27:4d:f0:a6:f3:41:40:60:00:23:83:e5:
+    f8:08:ed:50:ee:b7:cd:5d:05:5d:a4:ba:67:94:17:
+    ca:28:e1:5a:a9:3a:93:ca:5d:86:2c:9e:8b:07:b6:
+    2d:d6:3e:bb:75:ff:17:5b:6c:a5:21:bf:37:1e:93:
+    52:07:b2:74:11
+exponent2:
+    63:f3:51:e7:76:38:1e:da:65:05:e7:d9:51:d1:b1:
+    9e:c4:94:06:34:14:c3:81:48:97:d6:34:08:38:f0:
+    7c:3c:b3:7a:4e:4a:9d:74:ab:c3:39:3b:fc:ed:f6:
+    17:cd:d5:f4:c3:7b:61:64:35:42:24:06:26:bb:f6:
+    87:63:c1:d1
+coefficient:
+    00:8a:5b:12:c8:57:3c:1e:95:32:eb:5e:e3:92:50:
+    2c:7b:6a:02:a4:18:48:30:cc:23:9f:79:91:dd:56:
+    e8:ae:f7:93:47:ed:a6:26:35:6b:aa:7c:2c:f2:36:
+    01:33:f3:0f:df:50:c9:c8:0a:e7:6e:ec:ba:54:a0:
+    8d:0f:09:40:fd
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQDBXl0mrnMXWnA3rEIlygUQhhcjbCiESCpK1LA6Ktgzrlhnb5tP
+prSHsew3AGmN1c9xipbhSvjIgTb5Q63Y1naDJ5mkSBfC75wiQEvGWCGI5R03eU66
+MeZS7Iwj7dbOO1itgseuKEfU58wxrHjJAofQsZEJ9h6aw0/2Wv6iIQ7AlQIDAQAB
+AoGAYFu3q5ju/Uox9Ww/ojkjgPJxAVPadODJQnTuRG4pQse0ggbZrD10ZNJC1b28
+29MaBoh7W1VS2Aeb72bMcOueLit+wTSEmoM0snDGWXJgoPT12fJ2rr99IzXurbEt
+wf4FfVt/LNqH7G6wowjJveUwpMJublDAXjH2M++GV2RFt8ECQQDh1geMxk2Q+tZA
+mh/lNFAWcp9bg8Fg1XM5wsbsOu0k/qpdFhS6haR9WpToY/ndJagsa8p8Q8epkq41
+XIVHnlHpAkEA2zIuWeoig87T1XvLuYG5wk5bCKuPZiE0VWFQVwJe0tkJjTmBhc1M
+CPOxGrW0DDt3XsHglfGYxvVYiEJQsMNBzQJBALLIJ03wpvNBQGAAI4Pl+AjtUO63
+zV0FXaS6Z5QXyijhWqk6k8pdhiyeiwe2LdY+u3X/F1tspSG/Nx6TUgeydBECQGPz
+Ued2OB7aZQXn2VHRsZ7ElAY0FMOBSJfWNAg48Hw8s3pOSp10q8M5O/zt9hfN1fTD
+e2FkNUIkBia79odjwdECQQCKWxLIVzwelTLrXuOSUCx7agKkGEgwzCOfeZHdVuiu
+95NH7aYmNWuqfCzyNgEz8w/fUMnICudu7LpUoI0PCUD9
+-----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-ca.pem
+++ b/spec/fixtures/ssl/unknown-ca.pem
@@ -1,0 +1,59 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 0 (0x0)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Unknown CA
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Mar 10 06:54:16 2030 GMT
+        Subject: CN=Unknown CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (1024 bit)
+                Modulus:
+                    00:c1:5e:5d:26:ae:73:17:5a:70:37:ac:42:25:ca:
+                    05:10:86:17:23:6c:28:84:48:2a:4a:d4:b0:3a:2a:
+                    d8:33:ae:58:67:6f:9b:4f:a6:b4:87:b1:ec:37:00:
+                    69:8d:d5:cf:71:8a:96:e1:4a:f8:c8:81:36:f9:43:
+                    ad:d8:d6:76:83:27:99:a4:48:17:c2:ef:9c:22:40:
+                    4b:c6:58:21:88:e5:1d:37:79:4e:ba:31:e6:52:ec:
+                    8c:23:ed:d6:ce:3b:58:ad:82:c7:ae:28:47:d4:e7:
+                    cc:31:ac:78:c9:02:87:d0:b1:91:09:f6:1e:9a:c3:
+                    4f:f6:5a:fe:a2:21:0e:c0:95
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                E9:58:70:FE:F1:C1:AA:5A:70:7A:C1:02:11:1D:9A:F4:60:4F:70:76
+            Netscape Comment: 
+                Puppet Server Internal Certificate
+            X509v3 Authority Key Identifier: 
+                keyid:E9:58:70:FE:F1:C1:AA:5A:70:7A:C1:02:11:1D:9A:F4:60:4F:70:76
+
+    Signature Algorithm: sha256WithRSAEncryption
+         00:45:89:e8:68:a7:50:8c:92:84:3c:c4:e6:10:00:29:27:99:
+         c6:82:aa:aa:b5:0b:ef:97:58:bc:bb:e6:e7:93:7c:a7:ea:e5:
+         9a:61:1d:e3:4f:3f:f9:ac:c4:96:14:a5:1f:77:a6:01:dc:08:
+         15:9c:3f:66:29:92:80:49:e9:db:d9:22:fb:c3:86:bf:40:ab:
+         46:bf:c5:47:bb:c8:89:df:d4:ca:36:f5:08:c4:08:c6:0b:d6:
+         9e:8a:86:41:1e:7e:6f:a9:75:ef:8a:94:a9:fd:1a:9b:0f:55:
+         3a:55:e5:04:82:71:c3:47:78:62:8e:07:ed:dc:4e:ac:f9:33:
+         7b:27
+-----BEGIN CERTIFICATE-----
+MIICODCCAaGgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMwMDMxMDA2NTQxNlowFTETMBEGA1UE
+AwwKVW5rbm93biBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAwV5dJq5z
+F1pwN6xCJcoFEIYXI2wohEgqStSwOirYM65YZ2+bT6a0h7HsNwBpjdXPcYqW4Ur4
+yIE2+UOt2NZ2gyeZpEgXwu+cIkBLxlghiOUdN3lOujHmUuyMI+3WzjtYrYLHrihH
+1OfMMax4yQKH0LGRCfYemsNP9lr+oiEOwJUCAwEAAaOBlzCBlDAPBgNVHRMBAf8E
+BTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQU6Vhw/vHBqlpwesECER2a
+9GBPcHYwMQYJYIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2Vy
+dGlmaWNhdGUwHwYDVR0jBBgwFoAU6Vhw/vHBqlpwesECER2a9GBPcHYwDQYJKoZI
+hvcNAQELBQADgYEAAEWJ6GinUIyShDzE5hAAKSeZxoKqqrUL75dYvLvm55N8p+rl
+mmEd408/+azElhSlH3emAdwIFZw/ZimSgEnp29ki+8OGv0CrRr/FR7vIid/Uyjb1
+CMQIxgvWnoqGQR5+b6l174qUqf0amw9VOlXlBIJxw0d4Yo4H7dxOrPkzeyc=
+-----END CERTIFICATE-----

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -21,9 +21,9 @@ module Puppet
       id
     end
 
-    def initialize
+    def initialize(name = 'Test CA')
       @digest = OpenSSL::Digest::SHA256.new
-      info = create_cacert('Test CA')
+      info = create_cacert(name)
       @key = info[:private_key]
       @ca_cert = info[:cert]
       @ca_crl = create_crl(@ca_cert, @key)

--- a/spec/lib/puppet_spec/https.rb
+++ b/spec/lib/puppet_spec/https.rb
@@ -6,11 +6,11 @@ class PuppetSpec::HTTPSServer
 
   attr_reader :ca_cert, :ca_crl, :server_cert, :server_key
 
-  def initialize
-    @ca_cert = cert_fixture('ca.pem')
-    @ca_crl = crl_fixture('crl.pem')
-    @server_key = key_fixture('127.0.0.1-key.pem')
-    @server_cert = cert_fixture('127.0.0.1.pem')
+  def initialize(ca_cert: nil, ca_crl: nil, server_key: nil, server_cert: nil)
+    @ca_cert = ca_cert || cert_fixture('ca.pem')
+    @ca_crl = ca_crl || crl_fixture('crl.pem')
+    @server_key = server_key || key_fixture('127.0.0.1-key.pem')
+    @server_cert = server_cert || cert_fixture('127.0.0.1.pem')
     @config = WEBrick::Config::HTTP.dup
   end
 

--- a/tasks/generate_cert_fixtures.rake
+++ b/tasks/generate_cert_fixtures.rake
@@ -49,6 +49,10 @@ task(:gen_cert_fixtures) do
   #
   # bad-basic-constraints.pem        /CN=Test CA (bad isCA constraint)
   #
+  # unknown-ca.pemm                  /CN=Unknown CA
+  #                                   |
+  # unknown-127.0.0.1.pem             +- /CN=127.0.0.1
+  #
   # Keys
   # ====
   #
@@ -61,10 +65,20 @@ task(:gen_cert_fixtures) do
   # `request.pem` contains a valid CSR for /CN=pending, while `tampered_csr.pem`
   # is the same as `request.pem`, but it's public key has been replaced.
   #
-  ca = Puppet::TestCa.new
   dir = File.join(RAKE_ROOT, 'spec/fixtures/ssl')
 
+  # Create self-signed CA & key
+  unknown_ca = Puppet::TestCa.new('Unknown CA')
+  save(dir, 'unknown-ca.pem', unknown_ca.ca_cert)
+  save(dir, 'unknown-ca-key.pem', unknown_ca.key)
+
+  # Create an SSL cert for 127.0.0.1
+  signed = unknown_ca.create_cert('127.0.0.1', unknown_ca.ca_cert, unknown_ca.key, subject_alt_names: 'DNS:127.0.0.1,DNS:127.0.0.2')
+  save(dir, 'unknown-127.0.0.1.pem', signed[:cert])
+  save(dir, 'unknown-127.0.0.1-key.pem', signed[:private_key])
+
   # Create Test CA & CRL
+  ca = Puppet::TestCa.new
   save(dir, 'ca.pem', ca.ca_cert)
   save(dir, 'crl.pem', ca.ca_crl)
 


### PR DESCRIPTION
Commit 11eee4e886d3a67b1973610727df17306607f164 changed puppet to use the http
client to retrieve file content from https sources. In the process, we were
using the default SSLContext, whose X509 store only trusts the puppet PKI, so
connections to 3rd party HTTPS servers failed.

Pass `include_system_store` so that we use the system SSLContext.

Add an integration test to verify an agent can download file content from an
HTTPS server whose CA cert is not the puppet CA and is in the system CA bundle.
Also verify the download fails if the CA cert is not in the system CA bundle.