### PR TITLE
(PUP-10367) Source files using full_path

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -257,7 +257,7 @@ module Puppet
 
     def each_chunk_from(&block)
       if Puppet[:default_file_terminus] == :file_server && scheme == 'puppet' && (uri.host.nil? || uri.host.empty?)
-        chunk_file_from_disk(metadata.path, &block)
+        chunk_file_from_disk(metadata.full_path, &block)
       elsif local?
         chunk_file_from_disk(full_path, &block)
       else


### PR DESCRIPTION
This commit fixes a regression in 6.14.0 that prevented puppet apply from
sourcing a recursive directory.

`Metadata#path` is the absolute path from which metadata is collected. For files
and non-recursive directories, it is the same as `Metadata#full_path`.

However, for recursive directories, `path` and `full_path` are different for all
children of the directory. The `path` is always that of the base directory where
recursion started, while `full_path` is the absolute path of the subdirectory or
file within the base.