### PR TITLE
(PUP-10303) unresolvable domain accounts handling

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -66,11 +66,9 @@ Puppet::Type.type(:group).provide :windows_adsi do
   end
 
   def members
-    @members ||= Puppet::Util::Windows::ADSI::Group.name_sid_hash(group.members)
-
-    # @members.keys returns an array of SIDs. We need to convert those SIDs into
-    # names so that `puppet resource` prints the right output.
-    members_to_s(@members.keys).split(',')
+    group.members.map do |member|
+      member.to_s
+    end
   end
 
   def members=(members)


### PR DESCRIPTION
 After a domain user that is member of a local group is removed,
 puppet cannot manage respective local group anymore

 With this commit the method Puppet::Util::Windows::SID.name_to_principal
 was updated to:
   - handle '(unresolvable)' SID
   - return '(unresolvable)' SID in case SID is sent as parameter
   and cannot be resolved

 Also, since `group.members` is an array of Puppet::Util::Windows::SID::Principal,
 it should be enough to just `to_s` all of them in `members` method