### PR TITLE
(PUP-10303) unresolvable domain accounts handling

### DIFF
--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
     # since the default array_matching comparison is not commutative
 
     # dupes automatically weeded out when hashes built
-    current_members = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current)
+    current_members = Puppet::Util::Windows::ADSI::Group.name_sid_hash(current, true)
     specified_members = Puppet::Util::Windows::ADSI::Group.name_sid_hash(should)
 
     current_sids = current_members.keys.to_a
@@ -52,7 +52,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
         account = sid.account
       end
       resource.debug("#{sid.domain}\\#{account} (#{sid.sid})")
-      "#{sid.domain}\\#{account}"
+      sid.domain ? "#{sid.domain}\\#{account}" : account
     end
     return users.join(',')
   end
@@ -66,7 +66,7 @@ Puppet::Type.type(:group).provide :windows_adsi do
   end
 
   def members
-    @members ||= Puppet::Util::Windows::ADSI::Group.name_sid_hash(group.members)
+    @members ||= Puppet::Util::Windows::ADSI::Group.name_sid_hash(group.members, true)
 
     # @members.keys returns an array of SIDs. We need to convert those SIDs into
     # names so that `puppet resource` prints the right output.

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -180,11 +180,11 @@ module Puppet::Util::Windows::ADSI
         sids
       end
 
-      def name_sid_hash(names)
+      def name_sid_hash(names, allow_unresolved = false)
         return {} if names.nil? || names.empty?
 
         sids = names.map do |name|
-          sid = Puppet::Util::Windows::SID.name_to_principal(name)
+          sid = Puppet::Util::Windows::SID.name_to_principal(name, allow_unresolved)
           raise Puppet::Error.new( _("Could not resolve name: %{name}") % { name: name } ) if !sid
           [sid.sid, sid]
         end

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -64,7 +64,7 @@ module Puppet::Util::Windows
     # 'BUILTIN\Administrators', or 'S-1-5-32-544', and will return the
     # SID object. Returns nil if the account doesn't exist.
     # This method returns a SID::Principal with the account, domain, SID, etc
-    def name_to_principal(name)
+    def name_to_principal(name, allow_unresolved = false)
       # Apparently, we accept a symbol..
       name = name.to_s.strip if name
 
@@ -79,7 +79,7 @@ module Puppet::Util::Windows
 
       raw_sid_bytes ? Principal.lookup_account_sid(raw_sid_bytes) : Principal.lookup_account_name(name)
     rescue
-      nil
+      (allow_unresolved && raw_sid_bytes) ? unresolved_principal(name, raw_sid_bytes) : nil
     end
     module_function :name_to_principal
     class << self; alias name_to_sid_object name_to_principal; end
@@ -236,7 +236,7 @@ module Puppet::Util::Windows
     # @api private
     def self.unresolved_principal(name, sid_bytes)
       Principal.new(
-        name + " (unresolvable)", # account
+        name, # account
         sid_bytes, # sid_bytes
         name, # sid string
         nil, #domain

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -160,7 +160,7 @@ describe Puppet::Util::Windows::ADSI::Group,
 
       # unresolvable SID
       expect(admins.members[1].sid).to eq('S-1-5-21-3661721861-956923663-2119435483-1112')
-      expect(admins.members[1].account).to eq('S-1-5-21-3661721861-956923663-2119435483-1112 (unresolvable)')
+      expect(admins.members[1].account).to eq('S-1-5-21-3661721861-956923663-2119435483-1112')
       expect(admins.members[1].account_type).to eq(:SidTypeUnknown)
     end
 

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -78,9 +78,9 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     let(:group3) { double(:account => 'group3', :domain => '.', :sid => 'group3sid') }
 
     before :each do
-      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('group1').and_return(group1)
-      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('group2').and_return(group2)
-      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('group3').and_return(group3)
+      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('group1', any_args).and_return(group1)
+      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('group2', any_args).and_return(group2)
+      allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('group3', any_args).and_return(group3)
     end
 
     it "should return true for same lists of members" do

--- a/spec/unit/util/windows/adsi_spec.rb
+++ b/spec/unit/util/windows/adsi_spec.rb
@@ -466,8 +466,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           expect(Puppet::Util::Windows::SID).to receive(:octet_string_to_principal).with([0]).and_return(sids[0])
           expect(Puppet::Util::Windows::SID).to receive(:octet_string_to_principal).with([1]).and_return(sids[1])
 
-          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('user2').and_return(sids[1])
-          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('DOMAIN2\user3').and_return(sids[2])
+          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('user2', false).and_return(sids[1])
+          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('DOMAIN2\user3', false).and_return(sids[2])
 
           expect(Puppet::Util::Windows::ADSI).to receive(:sid_uri).with(sids[0]).and_return("WinNT://DOMAIN/user1,user")
           expect(Puppet::Util::Windows::ADSI).to receive(:sid_uri).with(sids[2]).and_return("WinNT://DOMAIN2/user3,user")
@@ -493,8 +493,8 @@ describe Puppet::Util::Windows::ADSI, :if => Puppet.features.microsoft_windows? 
           expect(Puppet::Util::Windows::SID).to receive(:octet_string_to_principal).with([0]).and_return(sids[0])
           expect(Puppet::Util::Windows::SID).to receive(:octet_string_to_principal).with([1]).and_return(sids[1])
 
-          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('user2').and_return(sids[1])
-          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('DOMAIN2\user3').and_return(sids[2])
+          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('user2', any_args).and_return(sids[1])
+          expect(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('DOMAIN2\user3', any_args).and_return(sids[2])
 
           expect(Puppet::Util::Windows::ADSI).to receive(:sid_uri).with(sids[2]).and_return("WinNT://DOMAIN2/user3,user")
 

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -201,9 +201,9 @@ describe "Puppet::Util::Windows::SID", :if => Puppet.features.microsoft_windows?
       principal = subject.ads_to_principal(unresolvable_user)
 
       expect(principal).to be_an_instance_of(Puppet::Util::Windows::SID::Principal)
-      expect(principal.account).to eq('S-1-1-1 (unresolvable)')
+      expect(principal.account).to eq('S-1-1-1')
       expect(principal.domain).to eq(nil)
-      expect(principal.domain_account).to eq('S-1-1-1 (unresolvable)')
+      expect(principal.domain_account).to eq('S-1-1-1')
       expect(principal.sid).to eq('S-1-1-1')
       expect(principal.sid_bytes).to eq(valid_octet_invalid_user)
       expect(principal.account_type).to eq(:SidTypeUnknown)


### PR DESCRIPTION
 After a domain user that is member of a local group is removed,
 puppet cannot manage respective local group anymore

 In this commit methods `name_sid_hash` and `name_to_principal` where
 extended to allow option to handle unresolved SIDs. Current members
 handling was changed to allow unresolved SIDs.

 `unresolved_principal` method was also updated to not add
 ' (unresolvable)' to a Principal as this will whill change
 'S-1-2-3' to 'S-1-2-3 (unresolvable)' and will make
 it dificult to transform back.