### PR TITLE
(PUP-10235) Support enabling DNF modules

### DIFF
--- a/acceptance/tests/provider/package/dnfmodule_enable_only.rb
+++ b/acceptance/tests/provider/package/dnfmodule_enable_only.rb
@@ -1,0 +1,42 @@
+test_name "dnfmodule can change flavors" do
+  confine :to, :platform => /el-8-x86_64/  # only el/centos 8 have the appstream repo
+  tag 'audit:high'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::PackageUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  without_profile = '389-ds'
+  with_profile = 'swig'
+
+  agents.each do |agent|
+    skip_test('appstream repo not present') unless on(agent, 'dnf repolist').stdout.include?('appstream')
+    teardown do
+      apply_manifest_on(agent, resource_manifest('package', without_profile, ensure: 'absent', provider: 'dnfmodule'))
+      apply_manifest_on(agent, resource_manifest('package', with_profile, ensure: 'absent', provider: 'dnfmodule'))
+    end
+  end
+
+  step "Enable module with no default profile: #{without_profile}" do
+    apply_manifest_on(agent, resource_manifest('package', without_profile, ensure: 'present', provider: 'dnfmodule'), expect_changes: true)
+    on(agent, "dnf module list --enabled | grep #{without_profile}")
+  end
+
+  step "Ensure idempotency for: #{without_profile}" do
+    apply_manifest_on(agent, resource_manifest('package', without_profile, ensure: 'present', provider: 'dnfmodule'), catch_changes: true)
+  end
+
+  step "Enable module with a profile: #{with_profile}" do
+    apply_manifest_on(agent, resource_manifest('package', with_profile, ensure: 'present', enable_only: true, provider: 'dnfmodule'), expect_changes: true)
+    on(agent, "dnf module list --enabled | grep #{with_profile}")
+  end
+
+  step "Ensure idempotency for: #{with_profile}" do
+    apply_manifest_on(agent, resource_manifest('package', with_profile, ensure: 'present', enable_only: true, provider: 'dnfmodule'), catch_changes: true)
+  end
+
+  step "Install a flavor for: #{with_profile}" do
+    apply_manifest_on(agent, resource_manifest('package', with_profile, ensure: 'present', flavor: 'common', provider: 'dnfmodule'), expect_changes: true)
+    on(agent, "dnf module list --installed | grep #{with_profile}")
+  end
+end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -485,6 +485,26 @@ module Puppet
       newvalues(:true, :false)
     end
 
+    newparam(:enable_only, :boolean => false, :parent => Puppet::Parameter::Boolean) do
+      desc <<-EOT
+        Tells `dnf module` to only enable a specific module, instead
+        of installing its default profile.
+
+        Modules with no default profile will be enabled automatically
+        without the use of this parameter.
+
+        Conflicts with the `flavor` property, which selects a profile
+        to install.
+      EOT
+      defaultto false
+
+      validate do |value|
+        if [true, :true, "true"].include?(value) && @resource[:flavor]
+          raise ArgumentError, _('Cannot have both `enable_only => true` and `flavor`')
+        end
+      end
+    end
+
     newparam(:install_only, :boolean => false, :parent => Puppet::Parameter::Boolean, :required_features => :install_only) do
       desc <<-EOT
         It should be set for packages that should only ever be installed,

--- a/spec/fixtures/unit/provider/package/dnfmodule/dnf-module-list-enabled.txt
+++ b/spec/fixtures/unit/provider/package/dnfmodule/dnf-module-list-enabled.txt
@@ -1,10 +1,12 @@
 localmirror-appstream
 Name         Stream       Profiles                                  Summary                                                            
+389-ds       1.4 [e]                                                389 Directory Server (base)                                           
 gimp         2.8 [d][e]   common [d], devel [i]                     gimp module                                                        
 mariadb      10.3 [d][e]  client [i], server [d], galera            MariaDB Module                                                     
 nodejs       10 [d][e]    common [d], development, minimal [i], s2i Javascript runtime                                                 
 perl         5.26 [d][e]  common [d], minimal [i]                   Practical Extraction and Report Language                           
 postgresql   10 [d][e]    client, server [d] [i]                    PostgreSQL server and client module                                
+ruby         2.5 [d][e]   common [d]                                An interpreter of object-oriented scripting language                  
 rust-toolset rhel8 [d][e] common [d] [i]                            Rust                                                               
 subversion   1.10 [d][e]  common [d], server [i]                    Apache Subversion                                                  
 


### PR DESCRIPTION
Add an optional `enable_only` parameter to the package type.

If set to `true` on a `dnfmodule` resource, it will cause the module
to be enabled instead of installed. The flag cannot be set together
with the `flavor` property, since they conflict.

DNF modules that have no default profile (and cannot be installed)
will be enabled by default, so there is no need to add `enable_only`.

To enable a module that has a default profile, `enabled_only` has to
be set.