### PR TITLE
(PUP-8051) waitforlock puppet agent flag

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -43,6 +43,7 @@ class Puppet::Agent
     end
 
     result = nil
+    wait_for_lock_deadline = nil
     block_run = Puppet::Application.controlled_run do
       splay client_options.fetch :splay, Puppet[:splay]
       result = run_in_fork(should_fork) do
@@ -60,8 +61,20 @@ class Puppet::Agent
               end
             end
           rescue Puppet::LockError
-            Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
-            return
+            wait_for_lock_deadline ||= Time.now.to_i + Puppet[:maxwaitforlock]
+
+            if Puppet[:waitforlock]  < 1
+              Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
+              return 1
+            elsif Time.now.to_i > wait_for_lock_deadline
+              Puppet.notice _("Exiting now because the maxwaitforlock timeout has been exceeded.")
+              return 1
+            else
+              Puppet.info _("Another puppet instance is already running; --waitforlock flag used, waiting for running instance to finish.")
+              Puppet.info _("Will try again in %{time} seconds.") % {time: Puppet[:waitforlock]}
+              sleep Puppet[:waitforlock]
+              retry
+            end
           rescue RunTimeoutError => detail
             Puppet.log_exception(detail, _("Execution of %{client_class} did not complete within %{runtimeout} seconds and was terminated.") %
               {client_class: client_class,

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1862,6 +1862,24 @@ EOT
       certificate request to be signed. A value of `unlimited` will cause puppet agent
       to ask for a signed certificate indefinitely.
       #{AS_DURATION}",
+    },
+    :waitforlock => {
+      :default  => "0",
+      :type     => :duration,
+      :desc     => "How frequently puppet agent should try to start when there is an
+      already running instance of puppet agent. You can turn off waiting for running puppet
+      instances by specifying a time of 0, or a maximum amount of time to wait in the
+      `maxwaitforlock` setting, in which case puppet agent will exit if it cannot start.
+      Turned off by default.
+      #{AS_DURATION}",
+    },
+    :maxwaitforlock => {
+      :default  => "1m",
+      :type     => :ttl,
+      :desc     => "The maximum amount of time the Puppet agent should wait for
+      already running puppet agent to finish before starting. A value of `unlimited`
+      will cause puppet agent cause puppet agent to wait indefinitely.
+      #{AS_DURATION}",
     }
   )
 

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -348,4 +348,56 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
       end
     end
   end
+
+  context 'multiple agents running' do
+    before(:each) do
+      File.delete(Puppet[:agent_catalog_run_lockfile]) if File.file?(Puppet[:agent_catalog_run_lockfile])
+    end
+
+    it "exits if an agent is already running" do
+      server.start_server do |port|
+        path = Puppet[:agent_catalog_run_lockfile]
+        Puppet[:masterport] = port
+
+        t1 = Thread.new {
+          %x{ruby -e "File.write('#{path}', Process.pid); sleep(3); 'puppet keyword needed here'"}
+        }
+
+       sleep 0.5 # so that the file gets created
+
+        expect {
+          expect {
+            agent.command_line.args << '--test'
+            agent.run
+          }.to exit_with(1)
+        }.to output(/Run of Puppet configuration client already in progress; skipping/).to_stdout
+        
+        t1.kill # kill thread so we don't wait too much
+      end
+    end
+
+    it "waits for other agent run to finish before starting" do
+      server.start_server do |port|
+        path = Puppet[:agent_catalog_run_lockfile]
+        Puppet[:masterport] = port
+        Puppet[:waitforlock] = 1
+
+       t = Thread.new {
+          %x{ruby -e "File.write('#{path}', Process.pid); sleep(4); 'puppet keyword needed here'"}
+       }
+
+       sleep 0.5 # so that the file gets created
+
+        expect {
+        expect {
+          agent.command_line.args << '--test'
+          agent.run
+        }.to exit_with(0)
+      }.to output(/Info: Will try again in #{Puppet[:waitforlock]} seconds./).to_stdout
+
+        t.kill # kill thread so we don't wait too much
+      File.delete(Puppet[:agent_catalog_run_lockfile]) if File.file?(Puppet[:agent_catalog_run_lockfile])
+      end
+    end
+  end
 end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -179,6 +179,52 @@ describe Puppet::Agent do
       expect(@agent.run).to eq(:result)
     end
 
+    describe "and a puppet agent is already running" do
+      before(:each) do
+        allow_any_instance_of(Object).to receive(:sleep)
+        lockfile = double('lockfile')
+        expect(@agent).to receive(:lockfile).and_return(lockfile).at_least(:once)
+        # so the lock method raises Puppet::LockError
+        allow(lockfile).to receive(:lock).and_return(false)
+      end
+
+      it "should notify that a run is already in progres" do
+        client = AgentTestClient.new
+        expect(AgentTestClient).to receive(:new).and_return(client)
+        expect(Puppet).to receive(:notice).with(/Run of .* already in progress; skipping .* exists/)
+        @agent.run
+      end
+
+      it "should inform that a run is already in progres and try to run every X seconds if waitforlock is used" do
+        # so the locked file exists
+        allow(File).to receive(:file?).and_return(true)
+        # so we don't have to wait again for the run to exit (default maxwaitforcert is 60)
+        # first 0 is to get the time, second 0 is to inform user, then 1000 so the time expires
+        allow(Time).to receive(:now).and_return(0, 0, 1000)
+        allow(Puppet).to receive(:info)
+        client = AgentTestClient.new
+        expect(AgentTestClient).to receive(:new).and_return(client)
+
+        Puppet[:waitforlock] = 1
+        Puppet[:maxwaitforlock] = 2
+        expect(Puppet).to receive(:info).with(/Another puppet instance is already running; --waitforlock flag used, waiting for running instance to finish./)
+        expect(Puppet).to receive(:info).with(/Will try again in #{Puppet[:waitforlock]} seconds./)
+        @agent.run
+      end
+
+      it "should notify that the run is exiting if waitforlock is used and maxwaitforlock is exceeded" do
+        # so we don't have to wait again for the run to exit (default maxwaitforcert is 60)
+        # first 0 is to get the time, then 1000 so that the time expires
+        allow(Time).to receive(:now).and_return(0, 1000)
+        client = AgentTestClient.new
+        expect(AgentTestClient).to receive(:new).and_return(client)
+
+        Puppet[:waitforlock] = 1
+        expect(Puppet).to receive(:notice).with(/Exiting now because the maxwaitforlock timeout has been exceeded./)
+        @agent.run
+      end
+    end
+
     describe "when should_fork is true", :if => Puppet.features.posix? && RUBY_PLATFORM != 'java' do
       before do
         @agent = Puppet::Agent.new(AgentTestClient, true)


### PR DESCRIPTION
running puppet agent -t --waitforlock waits for any puppet runs that are
in progress to finish before starting the agent run