### PR TITLE
(PUP-10379) Load Bolt project as a Puppet module

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -4,6 +4,7 @@ require 'puppet/indirector'
 class Puppet::Node
   require 'puppet/node/facts'
   require 'puppet/node/environment'
+  require 'puppet/node/bolt_project'
 
   # Set up indirection, so that nodes can be looked for in
   # the node sources.

--- a/lib/puppet/node/bolt_project.rb
+++ b/lib/puppet/node/bolt_project.rb
@@ -1,0 +1,75 @@
+# A project is a special type of environment used for developing Bolt content. 
+class Puppet::Node::BoltProject < Puppet::Node::Environment
+  # Create a new project with the given name
+  #
+  # @param name [Symbol] the name of the project
+  # @param path [String] the absolute path to the project
+  # @param modulepath [Array<String>] the list of paths from which to load modules
+  # @param manifest [String] the path to the manifest for the environment or
+  #   the constant Puppet::Node::Environment::NO_MANIFEST if there is none.
+  # @param config_version [String] path to a script whose output will be added
+  #   to report logs (optional)
+  # @return [Puppet::Node::Environment]
+  #
+  # @api public
+  def self.create(name, path, modulepath, manifest = NO_MANIFEST, config_version = nil)
+    new(name, path, modulepath, manifest, config_version)
+  end
+
+  # Instantiate a new project
+  #
+  # @param name [Symbol] The environment name
+  # @param path [String] the absolute path to the project
+  def initialize(name, path, modulepath, manifest, config_version)
+    @path = path
+    @lock = Puppet::Concurrent::Lock.new
+    @name = name.intern
+    @modulepath = self.class.expand_dirs(self.class.extralibs() + modulepath)
+    @manifest = manifest == NO_MANIFEST ? manifest : Puppet::FileSystem.expand_path(manifest)
+    @config_version = config_version
+  end
+
+  # Return all modules for the project in the order they appear in the
+  # modulepath.
+  # @note If multiple modules with the same name are present they will
+  #   both be added, but methods like {#module} and {#module_by_forge_name}
+  #   will return the first matching entry in this list.
+  # @note This value is cached so that the filesystem doesn't have to be
+  #   re-enumerated every time this method is invoked, since that
+  #   enumeration could be a costly operation and this method is called
+  #   frequently. The cache expiry is determined by `Puppet[:filetimeout]`.
+  # @api public
+  # @return [Array<Puppet::Module>] All modules for this environment
+  def modules 
+    if @modules.nil?
+      module_references = []
+      seen_modules = {}
+
+      # This cannot have a duplicate name with boltlib modules, so it's safe to
+      # put it at the front of the modulepath
+      project_name = File.basename(@path)
+      module_references << {:name => project_name, :path => @path }
+      seen_modules[project_name] = true
+
+      modulepath.each do |path|
+        Dir.entries(path).each do |name|
+          next unless Puppet::Module.is_module_directory?(name, path)
+          warn_about_mistaken_path(path, name)
+          if not seen_modules[name]
+            module_references << {:name => name, :path => File.join(path, name)}
+            seen_modules[name] = true
+          end
+        end
+      end
+      @modules = module_references.collect do |reference|
+        begin
+          Puppet::Module.new(reference[:name], reference[:path], self)
+        rescue Puppet::Module::Error => e
+          Puppet.log_exception(e)
+          nil
+        end
+      end.compact
+    end
+    @modules
+  end
+end

--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -232,6 +232,36 @@ module Pal
       )
   end
 
+  def self.in_bolt_project(proj_name,
+      project_path: nil,
+      modulepath:    [],
+      settings_hash: {},
+      facts:         nil,
+      variables:     {},
+      &block
+    )
+    # Parameter validation
+    assert_non_empty_string(proj_name, _("temporary project name"))
+    assert_optionally_empty_array(modulepath, 'modulepath')
+    unless block_given?
+      raise ArgumentError, _("A block must be given to 'in_bolt_project'")
+    end
+
+    project = if project_path
+                # Load the modulepath including the current Bolt project
+                Puppet::Node::BoltProject.create(proj_name, project_path, modulepath)
+              else
+                # Load just the modulepath
+                Puppet::Node::Environment.create(proj_name, modulepath)
+              end
+
+    in_environment_context(
+      # Only load the project 'environment'
+      Puppet::Environments::Static.new(project),
+      project, facts, variables, &block
+    )
+  end
+
   # Defines the context in which to perform puppet operations (evaluation, etc)
   # The code to evaluate in this context is given in a block.
   #

--- a/spec/integration/node/bolt_project_spec.rb
+++ b/spec/integration/node/bolt_project_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+
+describe Puppet::Node::BoltProject do
+  include PuppetSpec::Files
+
+  def a_module_in(name, dir)
+    FileUtils.mkdir_p(File.join(dir, name))[0]
+  end
+
+  it "should be able to return each module from its environment with the environment, name, and path set correctly" do
+    base = tmpfile("env_modules")
+    Dir.mkdir(base)
+
+    dirs = []
+    mods = {}
+    %w{1 2}.each do |num|
+      dir = File.join(base, "dir#{num}")
+      dirs << dir
+
+      mods["mod#{num}"] = a_module_in("mod#{num}", dir)
+    end
+    mods[File.basename(Dir.pwd)] = Dir.pwd
+
+    project = Puppet::Node::BoltProject.create(:foo, Dir.pwd, dirs)
+
+    project.modules.each do |mod|
+      expect(mod.environment).to eq(project)
+      expect(mod.path).to eq(mods[mod.name])
+    end
+  end
+
+  it "should not yield the same module from project dir and modulepath" do
+    base = tmpfile("env_modules")
+    Dir.mkdir(base)
+
+    dir = File.join(base, "no_dup")
+    a_module_in(File.basename(Dir.pwd), "no_dup")
+    project = Puppet::Node::BoltProject.create(:foo, Dir.pwd, [dir])
+
+    mods = project.modules
+    expect(mods.length).to eq(1)
+    expect(mods[0].path).to eq(Dir.pwd)
+  end
+
+  it "should include the current directory as a module" do
+    project = Puppet::Node::BoltProject.create(:foo, Dir.pwd, [])
+
+    mods = project.modules
+    expect(mods.length).to eq(1)
+    expect(mods[0].path).to eq(Dir.pwd)
+  end
+end

--- a/spec/unit/node/bolt_project_spec.rb
+++ b/spec/unit/node/bolt_project_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'puppet/node/bolt_project'
+require 'puppet/util/execution'
+require 'puppet_spec/modules'
+require 'puppet/parser/parser_factory'
+
+describe Puppet::Node::BoltProject do
+  let(:proj) { Puppet::Node::BoltProject.create("testing", Dir.pwd, []) }
+
+  include PuppetSpec::Files
+
+  context 'the bolt project' do
+    describe "when modeling a specific project" do
+      let(:first_modulepath) { tmpdir('firstmodules') }
+      let(:second_modulepath) { tmpdir('secondmodules') }
+      let(:proj) { Puppet::Node::BoltProject.create(:modules_test, Dir.pwd, [first_modulepath, second_modulepath]) }
+      let(:pup_module) { Puppet::Module.new('puppet', Dir.pwd, proj) }
+
+      describe "module data" do
+        describe ".module" do
+          it "returns the cwd module if requested" do
+            expect(proj.module('puppet')).to eq(pup_module)
+          end
+        end
+
+        describe "#modules_by_path" do
+          it "does not include cwd" do
+            expect(proj.modules_by_path).to eq({
+              first_modulepath => [],
+              second_modulepath => []
+            })
+          end
+        end
+
+        describe ".modules" do
+          it "returns just the cwd if there are no modules" do
+            expect(proj.modules).to eq([pup_module])
+          end
+
+          it "returns a module named for every directory in each module path, including the cwd" do
+            %w{foo bar}.each do |mod_name|
+              PuppetSpec::Modules.generate_files(mod_name, first_modulepath)
+            end
+            %w{bee baz}.each do |mod_name|
+              PuppetSpec::Modules.generate_files(mod_name, second_modulepath)
+            end
+            expect(proj.modules.collect{|mod| mod.name}.sort).to eq(%w{foo bar bee baz puppet}.sort)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new class, Puppet::Node::BoltProject, which loads the
directory Bolt was run from as a Puppet module prepended to the list of
modules loaded from the modulepath. The class inherits from
Puppet::Node::Environment and only overrides the `modules` method to
insert the cwd "module" into the list of modules. This is only
intended for use with Bolt, and is instantiated through the Pal method
`in_bolt_project`, which will either create a BoltProject class if Bolt
is configured to load the project dir as a module, otherwise it will
create a Puppet::Node::Environment.