### PR TITLE
(PUP-10324) Adapt HTTP API to puppetserver's external implementation

### DIFF
--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -30,5 +30,6 @@ module Puppet
     require 'puppet/http/client'
     require 'puppet/http/redirector'
     require 'puppet/http/retry_after_handler'
+    require 'puppet/http/external_client'
   end
 end

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -19,17 +19,16 @@ class Puppet::HTTP::Client
 
   def connect(uri, options: {}, &block)
     start = Time.now
-
-    ssl_context = options.fetch(:ssl_context, nil)
-    include_system_store = options.fetch(:include_system_store, false)
-    ctx = resolve_ssl_context(ssl_context, include_system_store)
-    site = Puppet::Network::HTTP::Site.from_uri(uri)
-    verifier = if site.use_ssl?
-                 Puppet::SSL::Verifier.new(site.host, ctx)
-               else
-                 nil
-               end
+    verifier = nil
     connected = false
+
+    site = Puppet::Network::HTTP::Site.from_uri(uri)
+    if site.use_ssl?
+      ssl_context = options.fetch(:ssl_context, nil)
+      include_system_store = options.fetch(:include_system_store, false)
+      ctx = resolve_ssl_context(ssl_context, include_system_store)
+      verifier = Puppet::SSL::Verifier.new(site.host, ctx)
+    end
 
     @pool.with_connection(site, verifier) do |http|
       connected = true

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -52,11 +52,7 @@ class Puppet::HTTP::Client
   end
 
   def get(url, headers: {}, params: {}, options: {}, &block)
-    query = encode_params(params)
-    unless query.empty?
-      url = url.dup
-      url.query = query
-    end
+    url = encode_query(url, params)
 
     request = Net::HTTP::Get.new(url, @default_headers.merge(headers))
 
@@ -70,11 +66,7 @@ class Puppet::HTTP::Client
   end
 
   def head(url, headers: {}, params: {}, options: {})
-    query = encode_params(params)
-    unless query.empty?
-      url = url.dup
-      url.query = query
-    end
+    url = encode_query(url, params)
 
     request = Net::HTTP::Head.new(url, @default_headers.merge(headers))
 
@@ -85,12 +77,7 @@ class Puppet::HTTP::Client
 
   def put(url, headers: {}, params: {}, options: {})
     body = options.fetch(:body) { |_| raise ArgumentError, "'put' requires a 'body' option" }
-
-    query = encode_params(params)
-    unless query.empty?
-      url = url.dup
-      url.query = query
-    end
+    url = encode_query(url, params)
 
     request = Net::HTTP::Put.new(url, @default_headers.merge(headers))
     request.body = body
@@ -105,12 +92,7 @@ class Puppet::HTTP::Client
 
   def post(url, headers: {}, params: {}, options: {}, &block)
     body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
-
-    query = encode_params(params)
-    unless query.empty?
-      url = url.dup
-      url.query = query
-    end
+    url = encode_query(url, params)
 
     request = Net::HTTP::Post.new(url, @default_headers.merge(headers))
     request.body = body
@@ -128,11 +110,7 @@ class Puppet::HTTP::Client
   end
 
   def delete(url, headers: {}, params: {}, options: {})
-    query = encode_params(params)
-    unless query.empty?
-      url = url.dup
-      url.query = query
-    end
+    url = encode_query(url, params)
 
     request = Net::HTTP::Delete.new(url, @default_headers.merge(headers))
 
@@ -143,6 +121,16 @@ class Puppet::HTTP::Client
 
   def close
     @pool.close
+  end
+
+  protected
+
+  def encode_query(url, params)
+    return url if params.empty?
+
+    url = url.dup
+    url.query = encode_params(params)
+    url
   end
 
   private

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -85,6 +85,8 @@ class Puppet::HTTP::Client
   end
 
   def put(url, headers: {}, params: {}, options: {})
+    body = options.fetch(:body) { |_| raise ArgumentError, "'put' requires a 'body' option" }
+
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -92,13 +94,10 @@ class Puppet::HTTP::Client
     end
 
     request = Net::HTTP::Put.new(url, @default_headers.merge(headers))
-
-    body = options.fetch(:body) { |_| raise ArgumentError, "'put' requires a 'body' option" }
-    content_type = options.fetch(:content_type) { |_| raise ArgumentError, "'put' requires a 'content_type' option" }
-
     request.body = body
     request['Content-Length'] = body.bytesize
-    request['Content-Type'] = content_type
+
+    raise ArgumentError, "'put' requires a 'content-type' header" unless request['Content-Type']
 
     execute_streaming(request, options: options) do |response|
       response.body
@@ -106,6 +105,8 @@ class Puppet::HTTP::Client
   end
 
   def post(url, headers: {}, params: {}, options: {}, &block)
+    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
+
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -113,13 +114,10 @@ class Puppet::HTTP::Client
     end
 
     request = Net::HTTP::Post.new(url, @default_headers.merge(headers))
-
-    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
-    content_type = options.fetch(:content_type) { |_| raise ArgumentError, "'post' requires a 'content_type' option" }
-
     request.body = body
     request['Content-Length'] = body.bytesize
-    request['Content-Type'] = content_type
+
+    raise ArgumentError, "'post' requires a 'content-type' header" unless request['Content-Type']
 
     execute_streaming(request, options: options) do |response|
       if block_given?

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -81,7 +81,7 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Put.new(url, @default_headers.merge(headers))
     request.body = body
-    request['Content-Length'] = body.bytesize
+    request.content_length = body.bytesize
 
     raise ArgumentError, "'put' requires a 'content-type' header" unless request['Content-Type']
 
@@ -96,7 +96,7 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Post.new(url, @default_headers.merge(headers))
     request.body = body
-    request['Content-Length'] = body.bytesize
+    request.content_length = body.bytesize
 
     raise ArgumentError, "'post' requires a 'content-type' header" unless request['Content-Type']
 

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -18,11 +18,7 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
   # (see Puppet::HTTP::Client#get)
   # @api private
   def get(url, headers: {}, params: {}, options: {}, &block)
-    query = encode_params(params)
-    unless query.empty?
-      url = url.dup
-      url.query = query
-    end
+    url = encode_query(url, params)
 
     options[:use_ssl] = url.scheme == 'https'
     if options[:user] && options[:password]
@@ -47,12 +43,7 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
   # @api private
   def post(url, headers: {}, params: {}, options: {}, &block)
     body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
-
-    query = encode_params(params)
-    unless query.empty?
-      url = url.dup
-      url.query = query
-    end
+    url = encode_query(url, params)
 
     options[:use_ssl] = url.scheme == 'https'
     if options[:user] && options[:password]

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -50,8 +50,6 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
       options[:basic_auth] = { user: options[:user], password: options[:password] }
     end
 
-    headers['Content-Length'] = body ? body.bytesize.to_s : "0"
-
     client = @http_client_class.new(url.host, url.port, options)
     response = Puppet::HTTP::Response.new(client.post(url.request_uri, body, headers, options), url)
 

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -1,0 +1,107 @@
+#
+# Adapts an external http_client_class to the HTTP client API. The former
+# is typically registered by puppetserver and only implements a subset of
+# the Puppet::Network::HTTP::Connection methods. As a result, only the
+# `get` and `post` methods are supported. Calling `delete`, etc will
+# raise a NotImplementedError.
+#
+# @api private
+class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
+  # Create an external http client
+  #
+  # @param [Class] http_client_class The class to create to handle the request
+  # @api private
+  def initialize(http_client_class)
+    @http_client_class = http_client_class
+  end
+
+  # (see Puppet::HTTP::Client#get)
+  # @api private
+  def get(url, headers: {}, params: {}, options: {}, &block)
+    query = encode_params(params)
+    unless query.empty?
+      url = url.dup
+      url.query = query
+    end
+
+    options[:use_ssl] = url.scheme == 'https'
+    if options[:user] && options[:password]
+      options[:basic_auth] = { user: options[:user], password: options[:password] }
+    end
+
+    client = @http_client_class.new(url.host, url.port, options)
+    response = Puppet::HTTP::Response.new(client.get(url.request_uri, headers, options), url)
+
+    if block_given?
+      yield response
+    else
+      response
+    end
+  rescue Puppet::HTTP::HTTPError
+    raise
+  rescue => e
+    raise Puppet::HTTP::HTTPError.new(e.message, e)
+  end
+
+  # (see Puppet::HTTP::Client#post)
+  # @api private
+  def post(url, headers: {}, params: {}, options: {}, &block)
+    query = encode_params(params)
+    unless query.empty?
+      url = url.dup
+      url.query = query
+    end
+
+    options[:use_ssl] = url.scheme == 'https'
+    if options[:user] && options[:password]
+      options[:basic_auth] = { user: options[:user], password: options[:password] }
+    end
+
+    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
+    headers['Content-Type'] = options[:content_type]
+    headers['Content-Length'] = body ? body.bytesize.to_s : "0"
+
+    client = @http_client_class.new(url.host, url.port, options)
+    response = Puppet::HTTP::Response.new(client.post(url.request_uri, body, headers, options), url)
+
+    if block_given?
+      yield response
+    else
+      response
+    end
+  rescue Puppet::HTTP::HTTPError
+    raise
+  rescue => e
+    raise Puppet::HTTP::HTTPError.new(e.message, e)
+  end
+
+  # Close the external http client.
+  #
+  # @api private
+  def close
+    # This is a noop as puppetserver doesn't provide a way to close its http client.
+  end
+
+  # The following are intentionally not documented
+
+  def create_session
+    raise NotImplementedError
+  end
+
+  def connect(uri, options: {}, &block)
+    raise NotImplementedError
+  end
+
+  def head(url, headers: {}, params: {}, options: {})
+    raise NotImplementedError
+  end
+
+  def put(url, headers: {}, params: {}, options: {})
+    raise NotImplementedError
+  end
+
+  def delete(url, headers: {}, params: {}, options: {})
+    raise NotImplementedError
+  end
+
+end

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -46,6 +46,8 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
   # (see Puppet::HTTP::Client#post)
   # @api private
   def post(url, headers: {}, params: {}, options: {}, &block)
+    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
+
     query = encode_params(params)
     unless query.empty?
       url = url.dup
@@ -57,8 +59,6 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
       options[:basic_auth] = { user: options[:user], password: options[:password] }
     end
 
-    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
-    headers['Content-Type'] = options[:content_type]
     headers['Content-Length'] = body ? body.bytesize.to_s : "0"
 
     client = @http_client_class.new(url.host, url.port, options)

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -35,11 +35,13 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   end
 
   def put_certificate_request(name, csr, ssl_context: nil)
+    headers = add_puppet_headers(HEADERS)
+    headers['Content-Type'] = 'text/plain'
+
     response = @client.put(
       with_base_url("/certificate_request/#{name}"),
-      headers: add_puppet_headers(HEADERS),
+      headers: headers,
       options: {
-        content_type: 'text/plain',
         body: csr.to_pem,
         ssl_context: ssl_context
       }

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -50,7 +50,10 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       "#{key}=#{Puppet::Util.uri_query_encode(value.to_s)}"
     end.join("&")
 
-    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Resource::Catalog).join(', '))
+    headers = add_puppet_headers(
+      'Accept' => get_mime_types(Puppet::Resource::Catalog).join(', '),
+      'Content-Type' => 'application/x-www-form-urlencoded'
+    )
 
     response = @client.post(
       with_base_url("/catalog/#{name}"),
@@ -58,7 +61,6 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       # for legacy reasons we always send environment as a query parameter too
       params: { environment: environment },
       options: {
-        content_type: 'application/x-www-form-urlencoded',
         body: body
       }
     )
@@ -85,15 +87,17 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   def put_facts(name, environment:, facts:)
     formatter = Puppet::Network::FormatHandler.format_for(Puppet[:preferred_serialization_format])
 
-    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Node::Facts).join(', '))
+    headers = add_puppet_headers(
+      'Accept' => get_mime_types(Puppet::Node::Facts).join(', '),
+      'Content-Type' => formatter.mime
+    )
 
     response = @client.put(
       with_base_url("/facts/#{name}"),
       headers: headers,
       params: { environment: environment },
       options: {
-        content_type: formatter.mime,
-         body: serialize(formatter, facts)
+        body: serialize(formatter, facts)
       }
     )
 

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -8,14 +8,16 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
 
   def put_report(name, report, environment:)
     formatter = Puppet::Network::FormatHandler.format_for(Puppet[:preferred_serialization_format])
-    headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Transaction::Report).join(', '))
+    headers = add_puppet_headers(
+      'Accept' => get_mime_types(Puppet::Transaction::Report).join(', '),
+      'Content-Type' => formatter.mime
+    )
 
     response = @client.put(
       with_base_url("/report/#{name}"),
       headers: headers,
       params: { environment: environment },
       options: {
-        content_type: formatter.mime,
         body: serialize(formatter, report)
       }
     )

--- a/lib/puppet/network/http_pool.rb
+++ b/lib/puppet/network/http_pool.rb
@@ -19,6 +19,7 @@ module Puppet::Network::HttpPool
   end
   def self.http_client_class=(klass)
     @http_client_class = klass
+    Puppet.runtime['http'] = Puppet::HTTP::ExternalClient.new(klass)
   end
 
   # Retrieve a connection for the given host and port.

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -261,25 +261,25 @@ describe Puppet::HTTP::Client do
         expect(request.headers).to_not include('X-Puppet-Profiling')
       end
 
-      client.put(uri, options: {content_type: 'text/plain', body: ""})
+      client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: { body: ""})
     end
 
     it "stringifies keys and encodes values in the query" do
       stub_request(:put, "https://www.example.com").with(query: "foo=bar%3Dbaz")
 
-      client.put(uri, params: {:foo => "bar=baz"}, options: {content_type: 'text/plain', body: ""})
+      client.put(uri, params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
     end
 
     it "includes custom headers" do
       stub_request(:put, "https://www.example.com").with(headers: { 'X-Foo' => 'Bar' })
 
-      client.put(uri, headers: {'X-Foo' => 'Bar'}, options: {content_type: 'text/plain', body: ""})
+      client.put(uri, headers: {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'}, options: {body: ""})
     end
 
     it "returns the response" do
       stub_request(:put, uri)
 
-      response = client.put(uri, options: {content_type: 'text/plain', body: ""})
+      response = client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
       expect(response).to be_an_instance_of(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
@@ -288,19 +288,19 @@ describe Puppet::HTTP::Client do
     it "sets content-length and content-type for the body" do
       stub_request(:put, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
 
-      client.put(uri, options: {content_type: 'text/plain', body: "hello"})
+      client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello"})
     end
 
      it 'raises an ArgumentError if `body` is missing from the options hash' do
        expect {
-         client.put(uri, options: {content_type: 'text/plain'})
+         client.put(uri, headers: {'Content-Type' => 'text/plain'})
        }.to raise_error(ArgumentError, /'put' requires a 'body' option/)
      end
 
-     it 'raises an ArgumentError if `content_type` is missing from the options hash' do
+     it 'raises an ArgumentError if `content_type` is missing from the headers hash' do
        expect {
          client.put(uri, options: {body: ''})
-       }.to raise_error(ArgumentError, /'put' requires a 'content_type' option/)
+       }.to raise_error(ArgumentError, /'put' requires a 'content-type' header/)
      end
 
     context 'when connecting' do
@@ -309,18 +309,18 @@ describe Puppet::HTTP::Client do
 
         other_context = Puppet::SSL::SSLContext.new
 
-        client.put(uri, options: {content_type: 'text/plain', body: "", ssl_context: other_context})
+        client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: other_context})
       end
 
       it 'uses the system store' do
         stub_request(:put, uri)
 
-        client.put(uri, options: {content_type: 'text/plain', body: "", include_system_store: true})
+        client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", include_system_store: true})
       end
 
       it 'raises an HTTPError if both are specified' do
         expect {
-          client.put(uri, options: {content_type: 'text/plain', body: "", ssl_context: puppet_context, include_system_store: true})
+          client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: puppet_context, include_system_store: true})
         }.to raise_error(Puppet::HTTP::HTTPError, /The ssl_context and include_system_store parameters are mutually exclusive/)
       end
     end
@@ -330,25 +330,25 @@ describe Puppet::HTTP::Client do
     it "includes default HTTP headers" do
       stub_request(:post, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./})
 
-      client.post(uri, options: {content_type: 'text/plain', body: ""})
+      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
     end
 
     it "stringifies keys and encodes values in the query" do
       stub_request(:post, "https://www.example.com").with(query: "foo=bar%3Dbaz")
 
-      client.post(uri, params: {:foo => "bar=baz"}, options: {content_type: 'text/plain', body: ""})
+      client.post(uri, params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
     end
 
     it "includes custom headers" do
       stub_request(:post, "https://www.example.com").with(headers: { 'X-Foo' => 'Bar' })
 
-      client.post(uri, headers: {'X-Foo' => 'Bar'}, options: {content_type: 'text/plain', body: ""})
+      client.post(uri, headers: {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'}, options: {body: ""})
     end
 
     it "returns the response" do
       stub_request(:post, uri)
 
-      response = client.post(uri, options: {content_type: 'text/plain', body: ""})
+      response = client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
       expect(response).to be_an_instance_of(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
@@ -357,14 +357,14 @@ describe Puppet::HTTP::Client do
     it "sets content-length and content-type for the body" do
       stub_request(:post, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
 
-      client.post(uri, options: {content_type: 'text/plain', body: "hello"})
+      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello"})
     end
 
     it "streams the response body when a block is given" do
       stub_request(:post, uri).to_return(body: "abc")
 
       io = StringIO.new
-      client.post(uri, options: {content_type: 'text/plain', body: ""}) do |response|
+      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""}) do |response|
         response.read_body do |data|
           io.write(data)
         end
@@ -373,17 +373,16 @@ describe Puppet::HTTP::Client do
       expect(io.string).to eq("abc")
     end
 
-
     it 'raises an ArgumentError if `body` is missing from the options hash' do
       expect {
-        client.post(uri, options: {content_type: 'text/plain'})
+        client.post(uri, headers: {'Content-Type' => 'text/plain'})
       }.to raise_error(ArgumentError, /'post' requires a 'body' option/)
     end
 
-    it 'raises an ArgumentError if `content_type` is missing from the options hash' do
+    it 'raises an ArgumentError if `content_type` is missing from the headers hash' do
       expect {
         client.post(uri, options: {body: ''})
-      }.to raise_error(ArgumentError, /'post' requires a 'content_type' option/)
+      }.to raise_error(ArgumentError, /'post' requires a 'content-type' header/)
     end
 
     context 'when connecting' do
@@ -392,18 +391,18 @@ describe Puppet::HTTP::Client do
 
         other_context = Puppet::SSL::SSLContext.new
 
-        client.post(uri, options: {content_type: 'text/plain', body: "", ssl_context: other_context})
+        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: other_context})
       end
 
       it 'uses the system store' do
         stub_request(:post, uri)
 
-        client.post(uri, options: {content_type: 'text/plain', body: "", include_system_store: true})
+        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", include_system_store: true})
       end
 
       it 'raises an HTTPError if both are specified' do
         expect {
-          client.post(uri, options: {content_type: 'text/plain', body: "", ssl_context: puppet_context, include_system_store: true})
+          client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: puppet_context, include_system_store: true})
         }.to raise_error(Puppet::HTTP::HTTPError, /The ssl_context and include_system_store parameters are mutually exclusive/)
       end
     end
@@ -476,7 +475,7 @@ describe Puppet::HTTP::Client do
     it "submits credentials for PUT requests" do
       stub_request(:put, uri).with(basic_auth: credentials)
 
-      client.put(uri, options: {content_type: 'text/plain', body: "hello", user: 'user', password: 'pass'})
+      client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello", user: 'user', password: 'pass'})
     end
 
     it "returns response containing access denied" do
@@ -527,7 +526,7 @@ describe Puppet::HTTP::Client do
       stub_request(:put, start_url).to_return(redirect_to(url: bar_url))
       stub_request(:put, bar_url).to_return(status: 200)
 
-      response = client.put(start_url, options: {body: "", content_type: 'text/plain'})
+      response = client.put(start_url, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
       expect(response).to be_success
     end
 
@@ -580,7 +579,7 @@ describe Puppet::HTTP::Client do
       stub_request(:put, start_url).with(body: data).to_return(redirect_to(url: bar_url))
       stub_request(:put, bar_url).with(body: data).to_return(status: 200)
 
-      response = client.put(start_url, options: {body: data, content_type: 'text/plain'})
+      response = client.put(start_url, headers: {'Content-Type' => 'text/plain'}, options: {body: data})
       expect(response).to be_success
     end
 

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -75,6 +75,14 @@ describe Puppet::HTTP::Client do
       client.connect(uri, options: {include_system_store: true})
     end
 
+    it 'does not create a verifier for HTTP connections' do
+      expect(pool).to receive(:with_connection) do |_, verifier|
+        expect(verifier).to be_nil
+      end
+
+      client.connect(URI.parse('http://www.example.com'))
+    end
+
     it 'raises an HTTPError if both are specified' do
       expect {
         client.connect(uri, options: {ssl_context: puppet_context, include_system_store: true})

--- a/spec/unit/http/external_client_spec.rb
+++ b/spec/unit/http/external_client_spec.rb
@@ -106,13 +106,13 @@ describe Puppet::HTTP::ExternalClient do
     it "stringifies keys and encodes values in the query" do
       stub_request(:post, "https://www.example.com").with(query: "foo=bar%3Dbaz")
 
-      client.post(uri, params: {:foo => "bar=baz"}, options: {content_type: 'text/plain', body: ""})
+      client.post(uri, params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
     end
 
     it "returns the response" do
       stub_request(:post, uri)
 
-      response = client.post(uri, options: {content_type: 'text/plain', body: ""})
+      response = client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
       expect(response).to be_an_instance_of(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
@@ -121,14 +121,14 @@ describe Puppet::HTTP::ExternalClient do
     it "sets content-length and content-type for the body" do
       stub_request(:post, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
 
-      client.post(uri, options: {content_type: 'text/plain', body: "hello"})
+      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello"})
     end
 
     it "streams the response body when a block is given" do
       stub_request(:post, uri).to_return(body: "abc")
 
       io = StringIO.new
-      client.post(uri, options: {content_type: 'text/plain', body: ""}) do |response|
+      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""}) do |response|
         response.read_body do |data|
           io.write(data)
         end
@@ -143,13 +143,13 @@ describe Puppet::HTTP::ExternalClient do
 
         other_context = Puppet::SSL::SSLContext.new
 
-        client.post(uri, options: {content_type: 'text/plain', body: "", ssl_context: other_context})
+        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: other_context})
       end
 
       it 'accepts include_system_store' do
         stub_request(:post, uri)
 
-        client.post(uri, options: {content_type: 'text/plain', body: "", include_system_store: true})
+        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", include_system_store: true})
       end
     end
   end

--- a/spec/unit/http/external_client_spec.rb
+++ b/spec/unit/http/external_client_spec.rb
@@ -1,0 +1,195 @@
+require 'spec_helper'
+require 'puppet/http'
+
+# Simple "external" client to make get & post requests. This is used
+# to test the old HTTP API, such as requiring use_ssl and basic_auth
+# to be passed as options.
+class Puppet::HTTP::TestExternal
+  def initialize(host, port, options = {})
+    @host = host
+    @port = port
+    @options = options
+    @factory = Puppet::Network::HTTP::Factory.new
+  end
+
+  def get(path, headers = {}, options = {})
+    request = Net::HTTP::Get.new(path, headers)
+    do_request(request, options)
+  end
+
+  def post(path, data, headers = nil, options = {})
+    request = Net::HTTP::Post.new(path, headers)
+    do_request(request, options)
+  end
+
+  def do_request(request, options)
+    if options[:basic_auth]
+      request.basic_auth(options[:basic_auth][:user], options[:basic_auth][:password])
+    end
+
+    site = Puppet::Network::HTTP::Site.new(@options[:use_ssl] ? 'https' : 'http', @host, @port)
+    http = @factory.create_connection(site)
+    http.start
+    begin
+      http.request(request)
+    ensure
+      http.finish
+    end
+  end
+end
+
+describe Puppet::HTTP::ExternalClient do
+  let(:uri) { URI.parse('https://www.example.com') }
+  let(:http_client_class) { Puppet::HTTP::TestExternal }
+  let(:client) { described_class.new(http_client_class) }
+  let(:credentials) { ['user', 'pass'] }
+
+  context "for GET requests" do
+    it "stringifies keys and encodes values in the query" do
+      stub_request(:get, uri).with(query: "foo=bar%3Dbaz")
+
+      client.get(uri, params: {:foo => "bar=baz"})
+    end
+
+    it "fails if a user passes in an invalid param type" do
+      environment = Puppet::Node::Environment.create(:testing, [])
+
+      expect{client.get(uri, params: {environment: environment})}.to raise_error(Puppet::HTTP::SerializationError, /HTTP REST queries cannot handle values of type/)
+    end
+
+    it "returns the response" do
+      stub_request(:get, uri)
+
+      response = client.get(uri)
+      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_success
+      expect(response.code).to eq(200)
+    end
+
+    it "returns the entire response body" do
+      stub_request(:get, uri).to_return(body: "abc")
+
+      expect(client.get(uri).body).to eq("abc")
+    end
+
+    it "streams the response body when a block is given" do
+      stub_request(:get, uri).to_return(body: "abc")
+
+      io = StringIO.new
+      client.get(uri) do |response|
+        response.read_body do |data|
+          io.write(data)
+        end
+      end
+
+      expect(io.string).to eq("abc")
+    end
+
+    context 'when connecting' do
+      it 'accepts an ssl context' do
+        stub_request(:get, uri).to_return(body: "abc")
+
+        other_context = Puppet::SSL::SSLContext.new
+
+        client.get(uri, options: {ssl_context: other_context})
+      end
+
+      it 'accepts include_system_store' do
+        stub_request(:get, uri).to_return(body: "abc")
+
+        client.get(uri, options: {include_system_store: true})
+      end
+    end
+  end
+
+  context "for POST requests" do
+    it "stringifies keys and encodes values in the query" do
+      stub_request(:post, "https://www.example.com").with(query: "foo=bar%3Dbaz")
+
+      client.post(uri, params: {:foo => "bar=baz"}, options: {content_type: 'text/plain', body: ""})
+    end
+
+    it "returns the response" do
+      stub_request(:post, uri)
+
+      response = client.post(uri, options: {content_type: 'text/plain', body: ""})
+      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_success
+      expect(response.code).to eq(200)
+    end
+
+    it "sets content-length and content-type for the body" do
+      stub_request(:post, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
+
+      client.post(uri, options: {content_type: 'text/plain', body: "hello"})
+    end
+
+    it "streams the response body when a block is given" do
+      stub_request(:post, uri).to_return(body: "abc")
+
+      io = StringIO.new
+      client.post(uri, options: {content_type: 'text/plain', body: ""}) do |response|
+        response.read_body do |data|
+          io.write(data)
+        end
+      end
+
+      expect(io.string).to eq("abc")
+    end
+
+    context 'when connecting' do
+      it 'accepts an ssl context' do
+        stub_request(:post, uri)
+
+        other_context = Puppet::SSL::SSLContext.new
+
+        client.post(uri, options: {content_type: 'text/plain', body: "", ssl_context: other_context})
+      end
+
+      it 'accepts include_system_store' do
+        stub_request(:post, uri)
+
+        client.post(uri, options: {content_type: 'text/plain', body: "", include_system_store: true})
+      end
+    end
+  end
+
+  context "Basic Auth" do
+    it "submits credentials for GET requests" do
+      stub_request(:get, uri).with(basic_auth: credentials)
+
+      client.get(uri, options: {user: 'user', password: 'pass'})
+    end
+
+    it "submits credentials for POST requests" do
+      stub_request(:post, uri).with(basic_auth: credentials)
+
+      client.post(uri, options: {content_type: 'text/plain', body: "hello", user: 'user', password: 'pass'})
+    end
+
+    it "returns response containing access denied" do
+      stub_request(:get, uri).with(basic_auth: credentials).to_return(status: [403, "Ye Shall Not Pass"])
+
+      response = client.get(uri, options: {user: 'user', password: 'pass'})
+      expect(response.code).to eq(403)
+      expect(response.reason).to eq("Ye Shall Not Pass")
+      expect(response).to_not be_success
+    end
+
+    it 'omits basic auth if user is nil' do
+      stub_request(:get, uri).with do |req|
+        expect(req.headers).to_not include('Authorization')
+      end
+
+      client.get(uri, options: {user: nil, password: 'pass'})
+    end
+
+    it 'omits basic auth if password is nil' do
+      stub_request(:get, uri).with do |req|
+        expect(req.headers).to_not include('Authorization')
+      end
+
+      client.get(uri, options: {user: 'user', password: nil})
+    end
+  end
+end

--- a/spec/unit/http/external_client_spec.rb
+++ b/spec/unit/http/external_client_spec.rb
@@ -118,8 +118,8 @@ describe Puppet::HTTP::ExternalClient do
       expect(response.code).to eq(200)
     end
 
-    it "sets content-length and content-type for the body" do
-      stub_request(:post, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
+    it "sets content-type for the body" do
+      stub_request(:post, uri).with(headers: {"Content-Type" => "text/plain"})
 
       client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello"})
     end


### PR DESCRIPTION
Adds Puppet::HTTP::ExternalClient. It implements a subset of the new HTTP API and delegates to the external `http_client_class`, if it's been overridden (via puppetserver).

Moves `content-type` from an option to the header.

DRY query parameter encoding.