### PR TITLE
(PUP-10248) Windows pidlock can raise access denied

### DIFF
--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -67,8 +67,12 @@ class Puppet::Util::Pidlock
     elsif Puppet.features.microsoft_windows?
       # On Windows, we're checking if the filesystem path name of the running
       # process is our vendored ruby:
-      exe_path = Puppet::Util::Windows::Process::get_process_image_name_by_pid(lock_pid)
-      @lockfile.unlock unless exe_path =~ /\\bin\\ruby.exe$/
+      begin
+        exe_path = Puppet::Util::Windows::Process::get_process_image_name_by_pid(lock_pid)
+        @lockfile.unlock unless exe_path =~ /\\bin\\ruby.exe$/
+      rescue Puppet::Util::Windows::Error => e
+        Puppet.debug("Failed to read pidfile #{file_path}: #{e.message}")
+      end
     end
   end
   private :clear_if_stale

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -124,26 +124,27 @@ module Puppet::Util::Windows::Process
   def get_process_image_name_by_pid(pid)
     image_name = ""
 
-     open_process(PROCESS_QUERY_INFORMATION, false, pid) do |phandle|
-
-       FFI::MemoryPointer.new(:dword, 1) do |exe_name_length_ptr|
-        # UTF is 2 bytes/char:
-        max_chars = MAX_PATH_LENGTH + 1
-        exe_name_length_ptr.write_dword(max_chars)
-        FFI::MemoryPointer.new(:wchar, max_chars) do |exe_name_ptr|
-          use_win32_path_format = 0
-          result = QueryFullProcessImageNameW(phandle, use_win32_path_format, exe_name_ptr, exe_name_length_ptr)
-          if result == FFI::WIN32_FALSE
-            raise Puppet::Util::Windows::Error.new(
-              "QueryFullProcessImageNameW(phandle, #{use_win32_path_format}, " +
-              "exe_name_ptr, #{max_chars}")
+    Puppet::Util::Windows::Security.with_privilege(Puppet::Util::Windows::Security::SE_DEBUG_NAME) do
+      open_process(PROCESS_QUERY_INFORMATION, false, pid) do |phandle|
+        FFI::MemoryPointer.new(:dword, 1) do |exe_name_length_ptr|
+          # UTF is 2 bytes/char:
+          max_chars = MAX_PATH_LENGTH + 1
+          exe_name_length_ptr.write_dword(max_chars)
+          FFI::MemoryPointer.new(:wchar, max_chars) do |exe_name_ptr|
+            use_win32_path_format = 0
+            result = QueryFullProcessImageNameW(phandle, use_win32_path_format, exe_name_ptr, exe_name_length_ptr)
+            if result == FFI::WIN32_FALSE
+              raise Puppet::Util::Windows::Error.new(
+                      "QueryFullProcessImageNameW(phandle, #{use_win32_path_format}, " +
+                      "exe_name_ptr, #{max_chars}")
+            end
+            image_name = exe_name_ptr.read_wide_string(exe_name_length_ptr.read_dword)
           end
-          image_name = exe_name_ptr.read_wide_string(exe_name_length_ptr.read_dword)
         end
       end
     end
 
-     image_name
+    image_name
   end
   module_function :get_process_image_name_by_pid
 

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -97,6 +97,7 @@ module Puppet::Util::Windows::Security
   FILE = Puppet::Util::Windows::File
 
   SE_BACKUP_NAME              = 'SeBackupPrivilege'
+  SE_DEBUG_NAME               = 'SeDebugPrivilege'
   SE_RESTORE_NAME             = 'SeRestorePrivilege'
 
   DELETE                      = 0x00010000


### PR DESCRIPTION
Prior to this commit, if puppet is running in the background as a service, and the user runs `puppet agent -t` in the foreground, the foreground process may not have permission to open the process token for the background process running as `LocalSystem`, causing puppet to raise with an ambiguous error message.

To fix this, we open the process token with the `SeDebugPrivilege`, which allows access to any process.