### PR TITLE
(PUP-10316) Update "http" report processor to use the http client

### DIFF
--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -309,7 +309,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
       ssl_file = tmpfile('systemstore')
       File.write(ssl_file, unknown_ca_cert.to_pem)
 
-      response_proc = -> res {
+      response_proc = -> (req, res) {
         res.status = 200
         res.body = response_body
       }

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -7,29 +7,7 @@ require 'puppet_spec/https'
 describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
-
-  before :all do
-    WebMock.disable!
-  end
-
-  after :all do
-    WebMock.enable!
-  end
-
-  before :each do
-    # make sure we don't take too long
-    Puppet[:http_connect_timeout] = '5s'
-    Puppet[:server] = '127.0.0.1'
-    Puppet[:certname] = '127.0.0.1'
-
-    Puppet[:localcacert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'ca.pem')
-    Puppet[:hostcrl] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'crl.pem')
-    Puppet[:hostprivkey] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1-key.pem')
-    Puppet[:hostcert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1.pem')
-
-    facts = Puppet::Node::Facts.new(Puppet[:certname])
-    Puppet::Node::Facts.indirection.save(facts)
-  end
+  include_context "https client"
 
   let(:server) { PuppetSpec::Puppetserver.new }
   let(:agent) { Puppet::Application[:agent] }

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'puppet_spec/files'
 require 'puppet_spec/compiler'
+require 'puppet_spec/https'
 
 describe "apply" do
   include PuppetSpec::Files
@@ -575,6 +576,57 @@ class amod::bad_type {
 
       dest_file = File.join(base_dir, 'dir1', 'dir2', 'file')
       expect(File.read(dest_file)).to eq("content from the module")
+    end
+  end
+
+  context 'http report processor' do
+    before :all do
+      WebMock.disable!
+    end
+
+    after :all do
+      WebMock.enable!
+    end
+
+    before :each do
+      Puppet[:reports] = 'http'
+
+      # make sure we don't take too long
+      Puppet[:http_connect_timeout] = '5s'
+      Puppet[:server] = '127.0.0.1'
+      Puppet[:certname] = '127.0.0.1'
+
+      Puppet[:localcacert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'ca.pem')
+      Puppet[:hostcrl] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'crl.pem')
+      Puppet[:hostprivkey] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1-key.pem')
+      Puppet[:hostcert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1.pem')
+
+      facts = Puppet::Node::Facts.new(Puppet[:certname])
+      Puppet::Node::Facts.indirection.save(facts)
+    end
+
+    let(:apply) { Puppet::Application[:apply] }
+
+    it 'submits a report via reporturl' do
+      report = nil
+
+      response_proc = -> (req, res) {
+        report = Puppet::Transaction::Report.convert_from(:yaml, req.body)
+      }
+
+      https = PuppetSpec::HTTPSServer.new
+      https.start_server(response_proc: response_proc) do |https_port|
+        Puppet[:reporturl] = "https://127.0.0.1:#{https_port}/reports/upload"
+
+        expect {
+          apply.command_line.args = ['-e', 'notify { "hi": }']
+          apply.run
+        }.to exit_with(0)
+         .and output(/Applied catalog/).to_stdout
+
+        expect(report).to be_a(Puppet::Transaction::Report)
+        expect(report.resource_statuses['Notify[hi]']).to be_a(Puppet::Resource::Status)
+      end
     end
   end
 end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -580,29 +580,10 @@ class amod::bad_type {
   end
 
   context 'http report processor' do
-    before :all do
-      WebMock.disable!
-    end
-
-    after :all do
-      WebMock.enable!
-    end
+    include_context 'https client'
 
     before :each do
       Puppet[:reports] = 'http'
-
-      # make sure we don't take too long
-      Puppet[:http_connect_timeout] = '5s'
-      Puppet[:server] = '127.0.0.1'
-      Puppet[:certname] = '127.0.0.1'
-
-      Puppet[:localcacert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'ca.pem')
-      Puppet[:hostcrl] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'crl.pem')
-      Puppet[:hostprivkey] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1-key.pem')
-      Puppet[:hostcert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1.pem')
-
-      facts = Puppet::Node::Facts.new(Puppet[:certname])
-      Puppet::Node::Facts.indirection.save(facts)
     end
 
     let(:apply) { Puppet::Application[:apply] }

--- a/spec/integration/application/plugin_spec.rb
+++ b/spec/integration/application/plugin_spec.rb
@@ -3,25 +3,7 @@ require 'puppet/face'
 require 'puppet_spec/puppetserver'
 
 describe "puppet plugin" do
-  before :all do
-    WebMock.disable!
-  end
-
-  after :all do
-    WebMock.enable!
-  end
-
-  before :each do
-    # make sure we don't take too long
-    Puppet[:http_connect_timeout] = '5s'
-    Puppet[:server] = '127.0.0.1'
-    Puppet[:certname] = '127.0.0.1'
-
-    Puppet[:localcacert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'ca.pem')
-    Puppet[:hostcrl] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'crl.pem')
-    Puppet[:hostprivkey] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1-key.pem')
-    Puppet[:hostcert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1.pem')
-  end
+  include_context "https client"
 
   let(:server) { PuppetSpec::Puppetserver.new }
   let(:plugin) { Puppet::Application[:plugin] }

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -4,30 +4,16 @@ require 'puppet_spec/files'
 
 describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
+  include_context "https client"
 
-  before :all do
-    WebMock.disable!
-  end
-
-  after :all do
-    WebMock.enable!
-  end
-
-  before :each do
-    # make sure we don't take too long
-    Puppet[:http_connect_timeout] = '5s'
-  end
-
-  let(:hostname) { '127.0.0.1' }
   let(:wrong_hostname) { 'localhost' }
-  let(:server) { PuppetSpec::HTTPSServer.new }
   let(:client) { Puppet::HTTP::Client.new }
   let(:ssl_provider) { Puppet::SSL::SSLProvider.new }
-  let(:root_context) { ssl_provider.create_root_context(cacerts: [server.ca_cert], crls: [server.ca_crl]) }
+  let(:root_context) { ssl_provider.create_root_context(cacerts: [https_server.ca_cert], crls: [https_server.ca_crl]) }
 
   context "when verifying an HTTPS server" do
     it "connects over SSL" do
-      server.start_server do |port|
+      https_server.start_server do |port|
         res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: root_context})
         expect(res).to be_success
       end
@@ -46,7 +32,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
     end
 
     it "raises if the server's cert doesn't match the hostname we connected to" do
-      server.start_server do |port|
+      https_server.start_server do |port|
         expect {
           client.get(URI("https://#{wrong_hostname}:#{port}"), options: {ssl_context: root_context})
         }.to raise_error { |err|
@@ -63,7 +49,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       wrong_ca = cert_fixture('netlock-arany-utf8.pem')
       alt_context = ssl_provider.create_root_context(cacerts: [wrong_ca], revocation: false)
 
-      server.start_server do |port|
+      https_server.start_server do |port|
         expect {
           client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: alt_context})
         }.to raise_error(Puppet::SSL::CertVerifyError,
@@ -73,7 +59,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
 
     it "prints TLS protocol and ciphersuite in debug" do
       Puppet[:log_level] = 'debug'
-      server.start_server do |port|
+      https_server.start_server do |port|
         client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: root_context})
         # TLS version string can be TLSv1 or TLSv1.[1-3], but not TLSv1.0
         expect(@logs).to include(
@@ -93,11 +79,11 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
 
     it "mutually authenticates the connection" do
       client_context = ssl_provider.create_context(
-        cacerts: [server.ca_cert], crls: [server.ca_crl],
-        client_cert: server.server_cert, private_key: server.server_key
+        cacerts: [https_server.ca_cert], crls: [https_server.ca_crl],
+        client_cert: https_server.server_cert, private_key: https_server.server_key
       )
 
-      server.start_server(ctx_proc: ctx_proc) do |port|
+      https_server.start_server(ctx_proc: ctx_proc) do |port|
         res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: client_context})
         expect(res).to be_success
       end
@@ -106,9 +92,9 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
 
   context "with a system trust store" do
     it "connects when the client trusts the server's CA" do
-      system_context = ssl_provider.create_system_context(cacerts: [server.ca_cert])
+      system_context = ssl_provider.create_system_context(cacerts: [https_server.ca_cert])
 
-      server.start_server do |port|
+      https_server.start_server do |port|
         res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: system_context})
         expect(res).to be_success
       end
@@ -117,13 +103,13 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
     it "connects when the server's CA is in the system store" do
       # create a temp cacert bundle
       ssl_file = tmpfile('systemstore')
-      File.write(ssl_file, server.ca_cert)
+      File.write(ssl_file, https_server.ca_cert)
 
       # override path to system cacert bundle, this must be done before
       # the SSLContext is created and the call to X509::Store.set_default_paths
       Puppet::Util.withenv("SSL_CERT_FILE" => ssl_file) do
         system_context = ssl_provider.create_system_context(cacerts: [])
-        server.start_server do |port|
+        https_server.start_server do |port|
           res = client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: system_context})
           expect(res).to be_success
         end
@@ -133,7 +119,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
     it "raises if the server's CA is not in the context or system store" do
       system_context = ssl_provider.create_system_context(cacerts: [cert_fixture('netlock-arany-utf8.pem')])
 
-      server.start_server do |port|
+      https_server.start_server do |port|
         expect {
           client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: system_context})
         }.to raise_error(Puppet::SSL::CertVerifyError,
@@ -144,7 +130,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
 
   context 'persistent connections' do
     it "detects when the server has closed the connection and reconnects" do
-      server.start_server do |port|
+      https_server.start_server do |port|
         uri = URI("https://127.0.0.1:#{port}")
 
         expect(client.get(uri, options: {ssl_context: root_context})).to be_success

--- a/spec/integration/module_tool/forge_spec.rb
+++ b/spec/integration/module_tool/forge_spec.rb
@@ -41,7 +41,7 @@ describe Puppet::Forge, unless: Puppet::Util::Platform.jruby? do
     # override path to system cacert bundle, this must be done before
     # the SSLContext is created and the call to X509::Store.set_default_paths
     Puppet::Util.withenv("SSL_CERT_FILE" => ssl_file) do
-      response_proc = -> res {
+      response_proc = -> (req, res) {
         res.status = 200
         res.body = release_response
       }

--- a/spec/integration/module_tool/forge_spec.rb
+++ b/spec/integration/module_tool/forge_spec.rb
@@ -4,21 +4,8 @@ require 'puppet_spec/https'
 
 describe Puppet::Forge, unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
+  include_context "https client"
 
-  before :all do
-    WebMock.disable!
-  end
-
-  after :all do
-    WebMock.enable!
-  end
-
-  before :each do
-    # make sure we don't take too long
-    Puppet[:http_connect_timeout] = '5s'
-  end
-
-  let(:hostname) { '127.0.0.1' }
   let(:wrong_hostname) { 'localhost' }
   let(:server) { PuppetSpec::HTTPSServer.new }
   let(:ssl_provider) { Puppet::SSL::SSLProvider.new }

--- a/spec/lib/puppet_spec/https.rb
+++ b/spec/lib/puppet_spec/https.rb
@@ -18,10 +18,13 @@ class PuppetSpec::HTTPSServer
     req = WEBrick::HTTPRequest.new(@config)
     req.parse(ssl)
 
+    # always drain request body
+    req.body
+
     res = WEBrick::HTTPResponse.new(@config)
     res.status = 200
     res.body = 'OK'
-    response_proc.call(res) if response_proc
+    response_proc.call(req, res) if response_proc
 
     res.send_response(ssl)
   end
@@ -52,7 +55,7 @@ class PuppetSpec::HTTPSServer
 
               loop do
                 readable, = IO.select([ssls, stop_pipe_r])
-                break if readable.include? stop_pipe_r
+                break if readable.include?(stop_pipe_r)
 
                 ssl = ssls.accept
                 begin

--- a/spec/shared_contexts/https.rb
+++ b/spec/shared_contexts/https.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.shared_context('https client') do
+  before :all do
+    WebMock.disable!
+  end
+
+  after :all do
+    WebMock.enable!
+  end
+
+  before :each do
+    # make sure we don't take too long
+    Puppet[:http_connect_timeout] = '5s'
+    Puppet[:server] = '127.0.0.1'
+    Puppet[:certname] = '127.0.0.1'
+
+    Puppet[:localcacert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'ca.pem')
+    Puppet[:hostcrl] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', 'crl.pem')
+    Puppet[:hostprivkey] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1-key.pem')
+    Puppet[:hostcert] = File.join(PuppetSpec::FIXTURE_DIR, 'ssl', '127.0.0.1.pem')
+
+    # set in memory facts since certname is changed above
+    facts = Puppet::Node::Facts.new(Puppet[:certname])
+    Puppet::Node::Facts.indirection.save(facts)
+  end
+
+  let(:https_server) { PuppetSpec::HTTPSServer.new }
+end

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -1,101 +1,118 @@
 require 'spec_helper'
 require 'puppet/reports'
 
-processor = Puppet::Reports.report(:http)
+describe Puppet::Reports.report(:http) do
+  subject { Puppet::Transaction::Report.new.extend(described_class) }
 
-describe processor do
-  subject { Puppet::Transaction::Report.new.extend(processor) }
+  let(:url) { "https://puppet.example.com/report/upload" }
+
+  before :each do
+    Puppet[:reporturl] = url
+  end
 
   describe "when setting up the connection" do
-    let(:http) { double("http") }
-    let(:httpok) { Net::HTTPOK.new('1.1', 200, '') }
+    it "raises if the connection fails" do
+      stub_request(:post, url).to_raise(Errno::ECONNREFUSED.new('Connection refused - connect(2)'))
 
-    before :each do
-      expect(http).to receive(:post).and_return(httpok)
+      expect {
+        subject.process
+      }.to raise_error(Errno::ECONNREFUSED, /Connection refused/)
     end
 
     it "configures the connection for ssl when using https" do
-      Puppet[:reporturl] = 'https://testing:8080/the/path'
+      stub_request(:post, url)
 
       expect(Puppet::Network::HttpPool).to receive(:connection).with(
-        'testing', 8080, hash_including(ssl_context: instance_of(Puppet::SSL::SSLContext))
-      ).and_return(http)
+        anything, anything, hash_including(ssl_context: instance_of(Puppet::SSL::SSLContext))
+      ).and_call_original
 
       subject.process
     end
 
     it "does not configure the connection for ssl when using http" do
-      Puppet[:reporturl] = 'http://testing:8080/the/path'
+      Puppet[:reporturl] = 'http://puppet.example.com:8080/the/path'
+      stub_request(:post, Puppet[:reporturl])
 
       expect(Puppet::Network::HttpPool).to receive(:connection).with(
-        'testing', 8080, use_ssl: false, ssl_context: nil
-      ).and_return(http)
+        anything, anything, use_ssl: false, ssl_context: nil
+      ).and_call_original
 
       subject.process
     end
   end
 
   describe "when making a request" do
-    let(:connection) { double("connection") }
-    let(:httpok) { Net::HTTPOK.new('1.1', 200, '') }
-    let(:options) { {:metric_id => [:puppet, :report, :http]} }
+    it "uses the path specified by the 'reporturl' setting" do
+      req = stub_request(:post, url)
 
-    before :each do
-      expect(Puppet::Network::HttpPool).to receive(:connection).and_return(connection)
+      subject.process
+
+      expect(req).to have_been_requested
     end
 
-    it "should use the path specified by the 'reporturl' setting" do
-      report_path = URI.parse(Puppet[:reporturl]).path
-      expect(connection).to receive(:post).with(report_path, anything, anything, options).and_return(httpok)
+    it "uses the username and password specified by the 'reporturl' setting" do
+      Puppet[:reporturl] = "https://user:pass@puppet.example.com/report/upload"
+
+      req = stub_request(:post, %r{/report/upload}).with(basic_auth: ['user', 'pass'])
+
+      subject.process
+
+      expect(req).to have_been_requested
+    end
+
+    it "passes metric_id options" do
+      stub_request(:post, url)
+
+      expect_any_instance_of(Puppet::Network::HTTP::Connection).to receive(:post).with(anything, anything, anything, hash_including(metric_id: [:puppet, :report, :http])).and_call_original
 
       subject.process
     end
 
-    it "should use the username and password specified by the 'reporturl' setting" do
-      Puppet[:reporturl] = "https://user:pass@myhost.mydomain:1234/report/upload"
-
-      expect(connection).to receive(:post).with(anything, anything, anything,
-                                                {:metric_id => [:puppet, :report, :http],
-                                                 :basic_auth => {
-                                                   :user => 'user',
-                                                   :password => 'pass'
-                                                 }}).and_return(httpok)
+    it "passes the report as YAML" do
+      req = stub_request(:post, url).with(body: subject.to_yaml)
 
       subject.process
+
+      expect(req).to have_been_requested
     end
 
-    it "should give the body as the report as YAML" do
-      expect(connection).to receive(:post).with(anything, subject.to_yaml, anything, options).and_return(httpok)
+    it "sets content-type to 'application/x-yaml'" do
+      req = stub_request(:post, url).with(headers: {'Content-Type' => 'application/x-yaml'})
 
       subject.process
+
+      expect(req).to have_been_requested
     end
 
-    it "should set content-type to 'application/x-yaml'" do
-      expect(connection).to receive(:post).with(anything, anything, hash_including("Content-Type" => "application/x-yaml"), options).and_return(httpok)
+    it "doesn't log anything if the request succeeds" do
+      req = stub_request(:post, url).to_return(status: [200, "OK"])
 
       subject.process
+
+      expect(req).to have_been_requested
+      expect(@logs).to eq([])
     end
 
-    Net::HTTPResponse::CODE_TO_OBJ.each do |code, klass|
-      if code.to_i >= 200 and code.to_i < 300
-        it "should succeed on http code #{code}" do
-          response = klass.new('1.1', code, '')
-          expect(connection).to receive(:post).and_return(response)
+    it "follows redirects" do
+      location = {headers: {'Location' => url}}
 
-          expect(Puppet).not_to receive(:err)
-          subject.process
-        end
-      end
+      req = stub_request(:post, url)
+              .to_return(**location, status: [301, "Moved Permanently"]).then
+              .to_return(**location, status: [302, "Found"]).then
+              .to_return(**location, status: [307, "Temporary Redirect"]).then
+              .to_return(status: [200, "OK"])
 
-      if code.to_i >= 300 && ![301, 302, 307].include?(code.to_i)
-        it "should log error on http code #{code}" do
-          response = klass.new('1.1', code, '')
-          expect(connection).to receive(:post).and_return(response)
+      subject.process
 
-          expect(Puppet).to receive(:err)
-          subject.process
-        end
-      end
+      expect(req).to have_been_requested.times(4)
+    end
+
+    it "logs an error if the request fails" do
+      stub_request(:post, url).to_return(status: [500, "Internal Server Error"])
+
+      subject.process
+
+      expect(@logs).to include(having_attributes(level: :err, message: "Unable to submit report to #{url} [500] Internal Server Error"))
     end
   end
 end


### PR DESCRIPTION
Blocked on https://github.com/puppetlabs/puppet/pull/8051

Update the "http" report processor to send reports using the http client. The normal client is used when running `puppet apply`. When running in puppetserver, the external http client is used, which delegates to puppetserver.

Adds an integration test to verify `puppet apply` submits a report to an HTTPS URL whose server cert is issued by the puppet CA.

Adds an "https client" shared context to simplify test setup.