### PR TITLE
(PUP-10382) Ignore packages of which the latest version is not in the index

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -22,7 +22,11 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
 
   def self.get_latest_version(origin, version_list)
     if latest_version = version_list.lines.find { |l| l =~ /^#{origin} / }
-      latest_version = latest_version.split(' ').last.split(')').first
+      _name, compare, status = latest_version.chomp.split(' ', 3)
+      if ['!', '?'].include?(compare)
+        return nil
+      end
+      latest_version = status.split(' ').last.split(')').first
       return latest_version
     end
     nil

--- a/spec/fixtures/unit/provider/package/pkgng/pkg.version
+++ b/spec/fixtures/unit/provider/package/pkgng/pkg.version
@@ -1,3 +1,5 @@
 shells/bash-completion             <   needs updating (index has 2.1_3)
 ftp/curl                           <   needs updating (index has 7.33.0_2)
 shells/zsh                         <   needs updating (index has 5.0.4)
+sysutils/orphan                    ?   orphaned: sysutils/orphan
+sysutils/broken                    !   Comparison failed

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -169,6 +169,18 @@ describe Puppet::Type.type(:package).provider(:pkgng) do
       bash_comp_latest_version = described_class.get_latest_version('shells/bash-completion', version_list)
       expect(bash_comp_latest_version).to eq('2.1_3')
     end
+
+    it "should return nil when the package is orphaned" do
+      version_list = File.read(my_fixture('pkg.version'))
+      orphan_latest_version = described_class.get_latest_version('sysutils/orphan', version_list)
+      expect(orphan_latest_version).to be_nil
+    end
+
+    it "should return nil when the package is broken" do
+      version_list = File.read(my_fixture('pkg.version'))
+      broken_latest_version = described_class.get_latest_version('sysutils/broken', version_list)
+      expect(broken_latest_version).to be_nil
+    end
   end
 
   describe "confine" do


### PR DESCRIPTION
This is a fix for https://tickets.puppetlabs.com/browse/PUP-10382