### PR TITLE
(PUP-10295) Add range intersection support to gem package provider

### DIFF
--- a/lib/puppet/util/package/version/gem.rb
+++ b/lib/puppet/util/package/version/gem.rb
@@ -1,0 +1,15 @@
+module Puppet::Util::Package::Version
+  class Gem < ::Gem::Version
+    def self.parse(version)
+      raise ValidationFailure, version unless version.is_a? String
+      raise ValidationFailure, version unless version =~ ANCHORED_VERSION_PATTERN
+      new(version)
+    end
+
+    class ValidationFailure < ArgumentError
+      def initialize(version)
+        super("#{version} is not a valid ruby gem version.")
+      end
+    end
+  end
+end

--- a/lib/puppet/util/package/version/range/min_max.rb
+++ b/lib/puppet/util/package/version/range/min_max.rb
@@ -10,6 +10,9 @@ module Puppet::Util::Package::Version
       def to_s
         "#{@min} #{@max}"
       end
+      def to_gem_version
+        "#{@min}, #{@max}"
+      end
       def include?(version)
         @min.include?(version) && @max.include?(version)
       end


### PR DESCRIPTION
Add support for range intersection (min,max such as: `>=A <=B`) specified in the :ensure manifest field. This will install a version that satisfies the provided range.