### PR TITLE
(PUP-7737) Allow http report processor to trust the system CA store

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1795,6 +1795,16 @@ EOT
       :type     => :boolean,
       :desc     => "Whether to send reports after every transaction.",
     },
+    :report_include_system_store => {
+      :default  => false,
+      :type     => :boolean,
+      :desc     => "Whether the 'http' report processor should include the system
+        certificate store when submitting reports to HTTPS URLs. If false, then
+        the 'http' processor will only trust HTTPS report servers whose certificates
+        are issued by the puppet CA or one of its intermediate CAs. If true, the
+        processor will additionally trust CA certificates in the system's
+        certificate store."
+    },
     :resubmit_facts => {
       :default  => false,
       :type     => :boolean,

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -23,6 +23,7 @@ Puppet::Reports.register_report(:http) do
     options = {
       :metric_id => [:puppet, :report, :http],
       :body => self.to_yaml,
+      :include_system_store => Puppet[:report_include_system_store],
     }
 
     if url.user && url.password


### PR DESCRIPTION
Blocked on https://github.com/puppetlabs/puppet/pull/8054

Adds a `Puppet[:report_include_system_store]` setting that defaults to false. If
set to true, the "http" report processor will trust the system certificate store
when submitting reports to an HTTPS report server. If false, then the processor
only trusts the puppet CA.

When installed from puppet-agent packages the system store is installed in
`/opt/puppetlabs/puppet/ssl/cert*` or on Windows
`C:\Program Files\Puppet Labs\Puppet\puppet\ssl\cert*`.

Note this change only affects the `http` report processor when running `puppet
apply`. A separate change is needed in puppetserver when the "http" processor
runs in puppetserver.