### PR TITLE
(maint) unify log messages with other providers

### DIFF
--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -124,7 +124,7 @@ Version table:
     end
 
     it "should select latest available version if range is specified" do
-      resource[:ensure] = '>72.0'
+      resource[:ensure] = '>60.0'
       expect(provider).to receive(:aptget) do |*command|
         expect(command[-1]).to eq("#{name}=72.0.1+build1-0ubuntu0.19.04.1")
       end


### PR DESCRIPTION
 downgrade warning to debug messages, as they are not warnings for
 our users

 also, fixed one code review remark that got somehow overlooked