### PR TITLE
(PUP-10379) Replace environment loader with project loader in Bolt context

### DIFF
--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -26,7 +26,7 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
   def discover(type, error_collector = nil, name_authority = Puppet::Pops::Pcore::RUNTIME_NAME_AUTHORITY, &block)
     result = []
     @dependency_loaders.each { |loader| result.concat(loader.discover(type, error_collector, name_authority, &block)) }
-    result.concat(super)
+    result.concat(super).uniq!
     result
   end
 

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -123,6 +123,28 @@ describe 'loaders' do
     expect(loaders.private_environment_loader().to_s).to eql("(DependencyLoader 'environment private' [])")
   end
 
+  context 'with bolt_project set' do
+    let(:project) { Struct.new("Project", :name, :path).new('moduleb', File.join(module_without_metadata, 'moduleb')) }
+
+    before :all do
+      Puppet[:tasks] = true
+    end
+
+    after :all do
+      Puppet[:tasks] = false
+    end
+
+    it 'creates a bolt project loader if bolt_project keyword is set' do
+      Puppet.override(bolt_project: project) do
+        loaders = Puppet::Pops::Loaders.new(empty_test_env)
+        expect(loaders.public_environment_loader).to be_a(Puppet::Pops::Loader::ModuleLoaders::FileBased)
+        expect(loaders.public_environment_loader.to_s).to eql("(ModuleLoader::FileBased 'moduleb' 'moduleb')")
+        expect(loaders.private_environment_loader()).to be_a(Puppet::Pops::Loader::DependencyLoader)
+        expect(loaders.private_environment_loader().to_s).to eql("(DependencyLoader 'environment private' [])")
+      end
+    end
+  end
+
   context 'when loading from a module' do
     it 'loads a ruby function using a qualified or unqualified name' do
       loaders = Puppet::Pops::Loaders.new(environment_for(module_with_metadata))


### PR DESCRIPTION
When loading modules as part of running Bolt we want to load the Bolt
project directory as a single module if `bolt_project` is configured.
The environment loader already behaves this way by creating a module
loader with the module name 'environment', then loading modules from
it's modulepath using a dependency loader. Because Bolt doesn't make use
of environments or have a concept of an environment, we're able to swap
in the hardcoded 'environment' module for the project directory to load
as a standalone module.

This is sufficient for loading the Bolt project, but because all modules
have the environment as a dependency when listing artifacts for the
project directory module it duplicates the entries for each module
instance. For example if you modulpath includes 33 modules, each task or
plan in the Bolt project "module" will be returned 33 times. Without
modifying how dependencies are loaded, the simplest way around this is
to deduplicate the list.