### PR TITLE
(PUP-10397) Remove facts and vars from ScriptCompiler scope

### DIFF
--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -422,37 +422,9 @@ module Pal
     # TRANSLATORS, the string "For puppet PAL" is not user facing
     Puppet.override({:current_environment => apply_environment}, "For puppet PAL") do
       begin
-        # support the following features when evaluating puppet code
-        # * $facts with facts from host running the script
-        # * $settings with 'settings::*' namespace populated, and '$settings::all_local' hash
-        # * $trusted as setup when using puppet apply
-        # * an environment
-        #
-
-        # fixup trusted information
         node.sanitize()
-
         compiler = create_internal_compiler(internal_compiler_class, node)
-        # compiler = Puppet::Parser::ScriptCompiler.new(node.environment, node.name)
-        topscope = compiler.topscope
-
-        # When scripting the trusted data are always local, but set them anyway
-        # When compiling for a catalog, the catalog compiler does this
-        unless internal_compiler_class == :catalog
-          topscope.set_trusted(node.trusted_data)
-
-          # Server facts are always about the local node's version etc.
-          topscope.set_server_facts(node.server_facts)
-
-          # Set $facts for the node running the script
-          facts_hash = node.facts.nil? ? {} : node.facts.values
-          topscope.set_facts(facts_hash)
-
-          # create the $settings:: variables
-          topscope.merge_settings(node.environment.name, false)
-        end
-
-        add_variables(topscope, pal_variables)
+        add_variables(compiler.topscope, pal_variables)
 
         case internal_compiler_class
         when :script

--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -708,35 +708,6 @@ describe 'Puppet Pal' do
         end
       end
 
-      context 'facts are supported such that' do
-        it 'they are obtained if they are not given' do
-          facts = Puppet::Node::Facts.new(Puppet[:certname], 'puppetversion' => Puppet.version)
-          Puppet::Node::Facts.indirection.save(facts)
-
-          testing_env_dir # creates the structure
-          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath ) do |ctx|
-            ctx.with_script_compiler {|c| c.evaluate_string("$facts =~ Hash and $facts[puppetversion] == '#{Puppet.version}'") }
-          end
-          expect(result).to eq(true)
-        end
-
-        it 'can be given as a hash when creating the environment' do
-          testing_env_dir # creates the structure
-          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: { 'myfact' => 42 }) do |ctx|
-            ctx.with_script_compiler {|c| c.evaluate_string("$facts =~ Hash and $facts[myfact] == 42") }
-          end
-          expect(result).to eq(true)
-        end
-
-        it 'can be overridden with a hash when creating a script compiler' do
-          testing_env_dir # creates the structure
-          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: { 'myfact' => 42 }) do |ctx|
-            ctx.with_script_compiler(facts: { 'myfact' => 43 }) {|c| c.evaluate_string("$facts =~ Hash and $facts[myfact] == 43") }
-          end
-          expect(result).to eq(true)
-        end
-      end
-
       context 'supports tasks such that' do
         it '"task_signature" returns the signatures of a generic task' do
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|


### PR DESCRIPTION
This updates the scope for a `ScriptCompiler` to not contain any
`$facts`, `$trusted`, or `$server_facts`.

This work is to enable the use of the `lookup` function in Bolt plans
outside of apply blocks. Since the concept of `facts`, etc. do not make
sense in the scope of running a plan, these fields should not be
available. Removing these fields from the scope disables the use of
interpolations outside of apply blocks.

Relates to puppetlabs/bolt#1403