### PR TITLE
(PUP-10152) Prevent Pacman package provider doing partial upgrades

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -132,9 +132,6 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
   # We rescue the main check from Pacman with a check on the AUR using yaourt, if installed
   def latest
-    # Synchronize the database
-    pacman "-Sy"
-
     resource_name = @resource[:name]
 
     # If target is a group, construct the group version
@@ -243,7 +240,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     else
       fail _("Source %{source} is not supported by pacman") % { source: source }
     end
-    pacman "--noconfirm", "--noprogressbar", "-Sy"
+    pacman "--noconfirm", "--noprogressbar", "-S"
     pacman "--noconfirm", "--noprogressbar", "-U", source
   end
 
@@ -255,7 +252,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
     cmd = %w{--noconfirm --needed --noprogressbar}
     cmd += install_options if @resource[:install_options]
-    cmd << "-Sy" << resource_name
+    cmd << "-S" << resource_name
 
     if self.class.yaourt?
       yaourt(*cmd)

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -26,14 +26,14 @@ describe Puppet::Type.type(:package).provider(:pacman) do
     end
 
     it "should call pacman to install the right package quietly when yaourt is not installed" do
-      args = ['--noconfirm', '--needed', '--noprogressbar', '-Sy', resource[:name]]
+      args = ['--noconfirm', '--needed', '--noprogressbar', '-S', resource[:name]]
       expect(provider).to receive(:pacman).at_least(:once).with(*args).and_return('')
       provider.install
     end
 
     it "should call yaourt to install the right package quietly when yaourt is installed" do
       allow(described_class).to receive(:yaourt?).and_return(true)
-      args = ['--noconfirm', '--needed', '--noprogressbar', '-Sy', resource[:name]]
+      args = ['--noconfirm', '--needed', '--noprogressbar', '-S', resource[:name]]
       expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
       provider.install
     end
@@ -68,14 +68,14 @@ describe Puppet::Type.type(:package).provider(:pacman) do
       end
 
       it "should call pacman to install the right package quietly when yaourt is not installed" do
-        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-Sy', resource[:name]]
+        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-S', resource[:name]]
         expect(provider).to receive(:pacman).at_least(:once).with(*args).and_return('')
         provider.install
       end
 
       it "should call yaourt to install the right package quietly when yaourt is installed" do
         expect(described_class).to receive(:yaourt?).and_return(true)
-        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-Sy', resource[:name]]
+        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-S', resource[:name]]
         expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
         provider.install
       end
@@ -94,7 +94,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
             resource[:source] = source
 
             expect(executor).to receive(:execute).
-              with(include("-Sy") & include("--noprogressbar"), no_extra_options).
+              with(include("-S") & include("--noprogressbar"), no_extra_options).
               ordered.
               and_return("")
 
@@ -117,7 +117,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
         it "should install from the path segment of the URL" do
           expect(executor).to receive(:execute).
-            with(include("-Sy") & include("--noprogressbar") & include("--noconfirm"),
+            with(include("-S") & include("--noprogressbar") & include("--noconfirm"),
                  no_extra_options).
             ordered.
             and_return("")
@@ -348,21 +348,7 @@ EOF
   end
 
   describe "when determining the latest version" do
-    it "should refresh package list" do
-      expect(executor).to receive(:execute).
-        ordered.
-        with(['/usr/bin/pacman', '-Sy'], no_extra_options)
-
-      expect(executor).to receive(:execute).
-        ordered.
-        and_return("")
-
-      provider.latest
-    end
-
     it "should get query pacman for the latest version" do
-      expect(executor).to receive(:execute).ordered
-
       expect(executor).to receive(:execute).
         ordered.
         with(['/usr/bin/pacman', '-Sp', '--print-format', '%v', resource[:name]], no_extra_options).
@@ -379,7 +365,6 @@ EOF
 
     it "should return a virtual group version when resource is a package group" do
       allow(described_class).to receive(:group?).and_return(true)
-      expect(executor).to receive(:execute).with(['/usr/bin/pacman', '-Sy'], no_extra_options).ordered
       expect(executor).to receive(:execute).with(['/usr/bin/pacman', '-Sp', '--print-format', '%n %v', resource[:name]], no_extra_options).ordered.
         and_return(<<EOF)
 package2 1.0.1


### PR DESCRIPTION
Using the `-y` switch in Pacman refreshes the catalog, but doesn't
upgrade existing packages. This causes a "partial upgrade".
From the Arch Linux wiki: [Partial upgrades are
unsupported](https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported)

This change removes the `-y` switch. It will be up to the user to
refresh the catalog and upgrade the system _explicitly_. The other
approach would be to have both the `-y` _and_ `-u` switches, but that
would mean that installing a package through Puppet would implicitly
upgrade the whole of the system - I don't think that would be desirable.