### PR TITLE
(PUP-10322) Update facterng feature flag not to use Kernel.require

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -82,7 +82,7 @@ module Puppet
               original_facter = Object.const_get(:Facter)
               Object.send(:remove_const, :Facter)
 
-              Kernel.require 'facter-ng'
+              require 'facter-ng'
               # It is required to re-setup logger for facter-ng
               Puppet::Util::Logging.setup_facter_logging!
             rescue LoadError
@@ -1640,7 +1640,7 @@ EOT
       :default => [],
       :type => :http_extra_headers,
       :desc => "The list of extra headers that will be sent with http requests to the master.
-      The header definition consists of a name and a value separated by a colon." 
+      The header definition consists of a name and a value separated by a colon."
     },
     :ignoreschedules => {
       :default    => false,

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -188,7 +188,7 @@ describe "Defaults" do
     end
 
     it "raises an exception if facter-ng could not be loaded" do
-      allow(Kernel).to receive(:require).with('facter-ng').and_raise(LoadError)
+      allow_any_instance_of(Puppet::Settings::BooleanSetting).to receive(:require).with('facter-ng').and_raise(LoadError)
 
       expect{ Puppet.settings[:facterng] = true }.to raise_exception ArgumentError, 'facter-ng could not be loaded'
     end
@@ -200,7 +200,7 @@ describe "Defaults" do
         Object.send(:remove_const, :Facter)
         Object.const_set(:Facter, Module.new)
 
-        allow(Kernel).to receive(:require).with('facter-ng').and_return(true)
+        allow_any_instance_of(Puppet::Settings::BooleanSetting).to receive(:require).with('facter-ng').and_return(true)
         allow(Facter).to receive(:respond_to?).and_return(false)
       end
 


### PR DESCRIPTION
Removed expliciti call to Kernel.require due to the fact that the require method is monkey patched by Rubygems, and by default Kernel.require does not search for gems and raises LoadError