### PR TITLE
(PUP-10379) Load bolt project into environment module list

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -297,7 +297,13 @@ class Puppet::Node::Environment
   def modules
     if @modules.nil?
       module_references = []
-      seen_modules = {}
+      project = Puppet.lookup(:bolt_project) { nil }
+      seen_modules = if project
+                       module_references << project.to_h
+                       { project.name => true }
+                     else
+                       {}
+                     end
       modulepath.each do |path|
         Dir.entries(path).each do |name|
           next unless Puppet::Module.is_module_directory?(name, path)

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -76,6 +76,21 @@ describe Puppet::Node::Environment do
     expect(mods[0].path).to eq(File.join(base, "dir1", "mod"))
   end
 
+  it "should not yield a module with the same name as a defined Bolt project" do
+    project_path = File.join(tmpfile('project'), 'bolt_project')
+    FileUtils.mkdir_p(project_path)
+    project = Struct.new("Project", :name, :path).new('project', project_path)
+
+    Puppet.override(bolt_project: project) do
+      base = tmpfile("base")
+      FileUtils.mkdir_p([File.join(base, 'project'), File.join(base, 'other')])
+      environment = Puppet::Node::Environment.create(:env, [base])
+      mods = environment.modules
+      expect(mods.length).to eq(2)
+      expect(mods.map(&:path)).to eq([project_path, File.join(base, 'other')])
+    end
+  end
+
   shared_examples_for "the environment's initial import" do |settings|
     it "a manifest referring to a directory invokes parsing of all its files in sorted order" do
       settings.each do |name, value|

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -422,6 +422,22 @@ describe Puppet::Node::Environment do
 
             env.modules
           end
+
+          it "includes the Bolt project in modules if it's defined" do
+            path = tmpdir('project')
+            PuppetSpec::Modules.generate_files('bolt_project', path)
+            project = Struct.new("Project", :name, :path).new('bolt_project', path)
+
+            Puppet.override(bolt_project: project) do
+              %w{foo bar}.each do |mod_name|
+                PuppetSpec::Modules.generate_files(mod_name, first_modulepath)
+              end
+              %w{bee baz}.each do |mod_name|
+                PuppetSpec::Modules.generate_files(mod_name, second_modulepath)
+              end
+              expect(env.modules.collect{|mod| mod.name}.sort).to eq(%w{bolt_project foo bar bee baz}.sort)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
If the keyword `bolt_project` is defined, the Bolt project should be
loaded at the head of the `Puppet::Node::Environment#modules` list of
modules. Bolt sets a temporary environment when running which it uses to
load modules on it's modulepath. We want to maintain this behavior and
also load the Bolt project directory configure by the user as a
standalone module. This ensures that any modules with the same name as
the Bolt project aren't loaded, so that the Bolt project can safely
shadow existing modules only when specified in Bolt. Additionally this
ensures that only the Bolt project is loaded as a module, not any
sibling directories. The keyword should only ever be set in Bolt
contexts and should not impact Puppet environments.