### PR TITLE
(DOCS) (DOCUMENT-1084) fix Deferred value note

### DIFF
--- a/lib/puppet/functions/call.rb
+++ b/lib/puppet/functions/call.rb
@@ -51,7 +51,7 @@
 #
 # Would notice the value of `$facts['processors']['count']` at the time when the `call` is made.
 #
-# * Deferred values supported since Puppet 5.6.0
+# * Deferred values supported since Puppet 6.0
 #
 # @since 5.0.0
 #


### PR DESCRIPTION
Note that Deferred has been supported since Puppet 6.0