### PR TITLE
(PUP-10405) Fix `undefined method` error when querying environments

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -247,11 +247,10 @@ module Puppet::Environments
     end
 
     def valid_environment_names
-      if Puppet::FileSystem.directory?(@environment_dir)
-        Puppet::FileSystem.children(@environment_dir).map do |child|
-          Puppet::FileSystem.basename_string(child).intern if validated_directory(child)
-        end.compact
-      end
+      return [] unless Puppet::FileSystem.directory?(@environment_dir)
+      Puppet::FileSystem.children(@environment_dir).map do |child|
+        Puppet::FileSystem.basename_string(child).intern if validated_directory(child)
+      end.compact
     end
   end
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -35,6 +35,7 @@ describe Puppet::Environments do
         FS::MemoryFile.a_directory("modules"),
         FS::MemoryFile.a_directory("manifests"),
       ]),
+      FS::MemoryFile.a_missing_file("missing")
     ])
   end
 
@@ -87,6 +88,13 @@ describe Puppet::Environments do
       loader_from(:filesystem => [envdir],
                   :directory => envdir) do |loader|
         expect(loader.list).to include_in_any_order(environment(:env1), environment(:env2))
+      end
+    end
+
+    it "proceeds with non-existant env dir" do
+      loader_from(:filesystem => [directory_tree],
+                  :directory => directory_tree.children.last) do |loader|
+        expect(loader.list).to eq([])
       end
     end
 


### PR DESCRIPTION
This commit ensures that we return an empty array, rather than `nil`, when
validating environment directories. Previously, if you didn't have an
`@environment_dir`, an `undefined method` error would be thrown when trying to
query environments:
```
$ curl https://localhost:8140/puppet/v3/environments -H "Content-type: application/json" -k
{"message":"Server Error: undefined method `collect' for nil:NilClass","issue_kind":"RUNTIME_ERROR"}%
```