### PR TITLE
(PUP-10401) Pip package provider outputs warning on puppet run

### DIFF
--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -1,8 +1,6 @@
 # Puppet package provider for Python's `pip3` package management frontend.
 # <http://pip.pypa.io/>
 
-require 'puppet/provider/package/pip'
-
 Puppet::Type.type(:package).provide :pip3,
   :parent => :pip do
 


### PR DESCRIPTION
In certain environments, the methods and variables in ’puppet/provider/package/pip.rb’ were being initialized twice. First and only consequences of this issue appeared when constant variables were added to this file and warnings regarding double initialisation/definition were shown to the user at every puppet run.

This happened only when puppet’s autoloader from ‘puppet/util/autoload.rb’ parsed and loaded ’puppet/provider/package/pip3.rb’ first and after it did the same with ’puppet/provider/package/pip.rb’, even though ’puppet/provider/package/pip3.rb’ required ‘puppet/provider/package/pip.rb’ already. The loading order is important for producing this issue. It can be affected by factors such as operating system, modules installed and decisional mechanisms used (like the 'specificity' method from ‘puppet/provider.rb’).

Due to complexity reasons, the final solution was to simply remove the unnecessary ‘puppet/provider/package/pip’ requirement instead of digging deeper in the workings of the autoloading mechanism and risking regressions while trying to improve it. Additionally, because of similarities, this solution was checked against PUP-9794.