### PR TITLE
(PUP-10366) defense to `exit` calls

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -61,7 +61,7 @@ class Puppet::Agent
             end
           rescue Puppet::LockError
             Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
-            return
+            return 1
           rescue RunTimeoutError => detail
             Puppet.log_exception(detail, _("Execution of %{client_class} did not complete within %{runtimeout} seconds and was terminated.") %
               {client_class: client_class,
@@ -95,7 +95,7 @@ class Puppet::Agent
         atForkHandler.child
         $0 = _("puppet agent: applying configuration")
         begin
-          exit(yield)
+          exit(yield || 1)
         rescue NoMemoryError
           exit(254)
         end
@@ -117,7 +117,7 @@ class Puppet::Agent
       @client = client_class.new(transaction_uuid, job_id)
     rescue StandardError => detail
       Puppet.log_exception(detail, _("Could not create instance of %{client_class}: %{detail}") % { client_class: client_class, detail: detail })
-      return
+      return 1
     end
     yield @client
   ensure

--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -96,10 +96,8 @@ class Puppet::Agent
         $0 = _("puppet agent: applying configuration")
         begin
           exit(yield)
-        rescue SystemExit
-          exit(-1)
         rescue NoMemoryError
-          exit(-2)
+          exit(254)
         end
       end
     ensure
@@ -107,13 +105,7 @@ class Puppet::Agent
     end
 
     exit_code = Process.waitpid2(child_pid)
-    case exit_code[1].exitstatus
-    when -1
-      raise SystemExit
-    when -2
-      raise NoMemoryError
-    end
-    exit_code[1].exitstatus
+    exit(exit_code[1].exitstatus)
   end
 
   private

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -185,31 +185,26 @@ describe Puppet::Agent do
 
         # So we don't actually try to hit the filesystem.
         allow(@agent).to receive(:lock).and_yield
-
-        allow(Kernel).to receive(:fork)
-        allow(Process).to receive(:waitpid2).and_return([123, double('process::status', :exitstatus => 0)])
-        allow(@agent).to receive(:exit)
       end
 
       it "should run the agent in a forked process" do
         client = AgentTestClient.new
         expect(AgentTestClient).to receive(:new).and_return(client)
 
-        expect(client).to receive(:run)
+        expect(client).to receive(:run).and_return(0)
 
         expect(Kernel).to receive(:fork).and_yield
-        @agent.run
+        expect { @agent.run }.to exit_with(0)
       end
 
       it "should exit child process if child exit" do
         client = AgentTestClient.new
         expect(AgentTestClient).to receive(:new).and_return(client)
 
-        expect(client).to receive(:run).and_raise(SystemExit)
+        expect(client).to receive(:run).and_raise(SystemExit.new(-1))
 
         expect(Kernel).to receive(:fork).and_yield
-        expect(@agent).to receive(:exit).with(-1)
-        @agent.run
+        expect { @agent.run }.to exit_with(-1)
       end
 
       it 'should exit with 1 if an exception is raised' do
@@ -219,31 +214,26 @@ describe Puppet::Agent do
         expect(client).to receive(:run).and_raise(StandardError)
 
         expect(Kernel).to receive(:fork).and_yield
-        expect(@agent).to receive(:exit).with(1)
-        @agent.run
+        expect { @agent.run }.to exit_with(1)
       end
 
-      it "should re-raise exit happening in the child" do
-        allow(Process).to receive(:waitpid2).and_return([123, double('process::status', :exitstatus => -1)])
-        expect { @agent.run }.to raise_error(SystemExit)
-      end
+      it 'should exit with 254 if NoMemoryError exception is raised' do
+        client = AgentTestClient.new
+        expect(AgentTestClient).to receive(:new).and_return(client)
 
-      it "should re-raise NoMoreMemory happening in the child" do
-        allow(Process).to receive(:waitpid2).and_return([123, double('process::status', :exitstatus => -2)])
-        expect { @agent.run }.to raise_error(NoMemoryError)
-      end
+        expect(client).to receive(:run).and_raise(NoMemoryError)
 
-      it "should return the child exit code" do
-        allow(Process).to receive(:waitpid2).and_return([123, double('process::status', :exitstatus => 777)])
-        expect(@agent.run).to eq(777)
+        expect(Kernel).to receive(:fork).and_yield
+        expect { @agent.run }.to exit_with(254)
       end
 
       it "should return the block exit code as the child exit code" do
         expect(Kernel).to receive(:fork).and_yield
-        expect(@agent).to receive(:exit).with(777)
-        @agent.run_in_fork {
-          777
-        }
+        expect {
+          @agent.run_in_fork {
+            777
+          }
+        }.to exit_with(777)
       end
     end
 

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -235,6 +235,24 @@ describe Puppet::Agent do
           }
         }.to exit_with(777)
       end
+
+      it "should return `1` exit code if the block returns `nil`" do
+        expect(Kernel).to receive(:fork).and_yield
+        expect {
+          @agent.run_in_fork {
+            nil
+          }
+        }.to exit_with(1)
+      end
+
+      it "should return `1` exit code if the block returns `false`" do
+        expect(Kernel).to receive(:fork).and_yield
+        expect {
+          @agent.run_in_fork {
+            false
+          }
+        }.to exit_with(1)
+      end
     end
 
     describe "on Windows", :if => Puppet.features.microsoft_windows? do


### PR DESCRIPTION
Before this commit, `run_in_fork` is calling `exit` with value
returned by block without any check. If a block returns `nil`,
puppet run will fail and raise `TypeError` exception.

With this correction, in case a block returns `nil` puppet will
call `exit(1)` an run will fail.