### PR TITLE
(PUP-10390) Ruby file gets loaded twice

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -19,6 +19,9 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
 
   has_feature :versionable, :install_options, :uninstall_options, :targetable, :version_ranges
 
+  GEM_VERSION =       Puppet::Util::Package::Version::Gem
+  GEM_VERSION_RANGE = Puppet::Util::Package::Version::Range
+
   # Override the specificity method to return 1 if gem is not set as default provider
   def self.specificity
     match = default_match
@@ -132,16 +135,16 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
 
     unless should =~ Regexp.union(/,/, Gem::Requirement::PATTERN)
       begin
-        should_range = Puppet::Util::Package::Version::Range.parse(should, Puppet::Util::Package::Version::Gem)
-      rescue Puppet::Util::Package::Version::Range::ValidationFailure, Puppet::Util::Package::Version::Gem::ValidationFailure
+        should_range = GEM_VERSION_RANGE.parse(should, GEM_VERSION)
+      rescue GEM_VERSION_RANGE::ValidationFailure, GEM_VERSION::ValidationFailure
         Puppet.debug("Cannot parse #{should} as a ruby gem version range")
         return false
       end
 
       return is.any? do |version|
         begin
-          should_range.include?(Puppet::Util::Package::Version::Gem.parse(version))
-        rescue Puppet::Util::Package::Version::Gem::ValidationFailure
+          should_range.include?(GEM_VERSION.parse(version))
+        rescue GEM_VERSION::ValidationFailure
           Puppet.debug("Cannot parse #{version} as a ruby gem version")
           false
         end
@@ -172,10 +175,10 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
 
     unless should =~ Regexp.union(/,/, Gem::Requirement::PATTERN)
       begin
-        should_range = Puppet::Util::Package::Version::Range.parse(should, Puppet::Util::Package::Version::Gem)
+        should_range = GEM_VERSION_RANGE.parse(should, GEM_VERSION)
         should = should_range.to_gem_version
         useversion = true
-      rescue Puppet::Util::Package::Version::Range::ValidationFailure, Puppet::Util::Package::Version::Gem::ValidationFailure
+      rescue GEM_VERSION_RANGE::ValidationFailure, GEM_VERSION::ValidationFailure
         Puppet.debug("Cannot parse #{should} as a ruby gem version range. Falling through.")
       end
     end

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -1,5 +1,3 @@
-require 'puppet/provider/package/gem'
-
 Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   desc "Puppet Ruby Gem support. This provider is useful for managing
         gems needed by the ruby provided in the puppet-agent package."


### PR DESCRIPTION
In certain environments, the methods and variables in ’puppet/provider/package/gem.rb’ were being initialized twice. First and only consequences of this issue appeared when constant variables were added to this file and warnings regarding double initialisation/definition were shown to the user at every puppet run.

This happened only when puppet’s autoloader from ‘puppet/util/autoload.rb’ parsed and loaded ’puppet/provider/package/puppet_gem.rb’ first and after it did the same with ’puppet/provider/package/gem.rb’, even though ’puppet/provider/package/puppet_gem.rb’ required ‘puppet/provider/package/gem.rb’ already. The loading order is important for producing this issue. It can be affected by factors such as operating system, modules installed and decisional mechanisms used (like the 'specificity' method from ‘puppet/provider.rb’).

Due to complexity reasons, the final solution was to simply remove the unnecessary ‘puppet/provider/package/gem’ requirement instead of digging deeper in the workings of the autoloading mechanism and risking regressions while trying to improve it. Additionally, a small refactoring was done (code readability improvement) and because of similarities, this solution was checked against PUP-9794.