### PR TITLE
(PUP-10376) specify the full path for the schtask

### DIFF
--- a/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
+++ b/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
@@ -31,7 +31,11 @@ test_name 'PUP-9719 Windows First Agent run as SYSTEM sets cache file permission
                     else
                       '%m/%d/%Y'
                     end
-      on agent, "schtasks /create /tn PuppetSystemRun /RL HIGHEST /RU SYSTEM /F /SC ONCE /SD #{(Date.today + 1).strftime(date_format)} /ST 23:59 /TR 'cmd /c puppet agent -t'"
+      on agent, %Q(
+        schtasks /create /tn PuppetSystemRun /RL HIGHEST /RU SYSTEM /F /SC ONCE /SD \
+        #{(Date.today + 1).strftime(date_format)} /ST 23:59 /TR \
+        'cmd /c \"%ProgramFiles%\\Puppet Labs\\Puppet\\bin\\puppet.bat\" agent -t'
+      )
       on agent, 'schtasks /run /tn PuppetSystemRun'
     end
 


### PR DESCRIPTION
Because this test was renabled in CI, tests are failing on 2008r2
because the task scheduler cannot find puppet in its PATH.

This commit  changes the test to explicitly specify the
full path for the scheduled task.