### PR TITLE
(PUP-10228) Release ssl lockfile while sleeping

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -280,14 +280,11 @@ class Puppet::SSL::StateMachine
 
         # close persistent connections and session state before sleeping
         Puppet.runtime['http'].close
-        @machine.session = nil
-
-        Kernel.sleep(time)
-
-        # our ssl directory may have been cleaned while we were
-        # sleeping, start over from the top
         @machine.session = Puppet.runtime['http'].create_session
-        NeedCACerts.new(@machine)
+
+        @machine.unlock
+        Kernel.sleep(time)
+        NeedLock.new(@machine)
       end
     end
   end
@@ -414,6 +411,10 @@ class Puppet::SSL::StateMachine
 
   def lock
     @lockfile.lock
+  end
+
+  def unlock
+    @lockfile.unlock
   end
 
   private

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -197,7 +197,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
   end
 
   context 'when locking' do
-    let(:lockfile) { double('ssllockfile') }
+    let(:lockfile) { Puppet::Util::Pidlock.new(Puppet[:ssl_lockfile]) }
     let(:machine) { described_class.new(cert_provider: cert_provider, ssl_provider: ssl_provider, lockfile: lockfile) }
 
     # lockfile is deleted before `ensure_ca_certificates` returns, so
@@ -210,7 +210,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'locks the file prior to running the state machine and unlocks when done' do
-      expect(lockfile).to receive(:lock).and_return(true).ordered
+      expect(lockfile).to receive(:lock).and_call_original.ordered
       expect(cert_provider).to receive(:load_cacerts).and_return(cacerts).ordered
       expect(cert_provider).to receive(:load_crls).and_return(crls).ordered
       expect(lockfile).to receive(:unlock).ordered


### PR DESCRIPTION
When bootstrapping the agent's ssl subsystem, release the ssl lockfile prior
to sleeping (when the cert hasn't been issued yet), and reacquire the lockfile
after. If we fail to reacquire, raise an error as another puppet instance
acquired it.