### PR TITLE
(maint) JRuby SSLSocket#cipher returns a string unlike MRI

### DIFF
--- a/lib/puppet/network/http/base_pool.rb
+++ b/lib/puppet/network/http/base_pool.rb
@@ -26,6 +26,11 @@ class Puppet::Network::HTTP::BasePool
     socket = buffered_io.io
     return unless socket
 
-    Puppet.debug("Using #{socket.ssl_version} with cipher #{socket.cipher.first}")
+    cipher = if Puppet::Util::Platform.jruby?
+               socket.cipher
+             else
+               socket.cipher.first
+             end
+    Puppet.debug("Using #{socket.ssl_version} with cipher #{cipher}")
   end
 end


### PR DESCRIPTION
MRI's SSLSocket#cipher returns an array, while JRuby returns a string[1]. We
don't typically run our client http code under JRuby, but ensure we don't crash
when trying to print debug info.

[1] https://github.com/jruby/jruby/issues/2436