### PR TITLE
(PUP-10408) Remove deprecated '-noidme' flag from pkgdmg package provider

### DIFF
--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -102,7 +102,7 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
       if source =~ /\.dmg$/i
         # If you fix this to use open-uri again, you must update the docs above. -NF
         File.open(cached_source) do |dmg|
-          xml_str = hdiutil "mount", "-plist", "-nobrowse", "-readonly", "-noidme", "-mountrandom", "/tmp", dmg.path
+          xml_str = hdiutil "mount", "-plist", "-nobrowse", "-readonly", "-mountrandom", "/tmp", dmg.path
           hdiutil_info = Puppet::Util::Plist.parse_plist(xml_str)
           raise Puppet::Error.new(_("No disk entities returned by mount at %{path}") % { path: dmg.path }) unless hdiutil_info.has_key?("system-entities")
           mounts = hdiutil_info["system-entities"].collect { |entity|

--- a/spec/unit/provider/package/pkgdmg_spec.rb
+++ b/spec/unit/provider/package/pkgdmg_spec.rb
@@ -45,7 +45,7 @@ describe Puppet::Type.type(:package).provider(:pkgdmg) do
     it "should call hdiutil to mount and eject the disk image" do
       allow(Dir).to receive(:entries).and_return([])
       expect(provider.class).to receive(:hdiutil).with("eject", fake_mountpoint).and_return(0)
-      expect(provider.class).to receive(:hdiutil).with("mount", "-plist", "-nobrowse", "-readonly", "-noidme", "-mountrandom", "/tmp", '/tmp/foo').and_return('a plist')
+      expect(provider.class).to receive(:hdiutil).with("mount", "-plist", "-nobrowse", "-readonly", "-mountrandom", "/tmp", '/tmp/foo').and_return('a plist')
       expect(Puppet::Util::Plist).to receive(:parse_plist).with('a plist').and_return(fake_hdiutil_plist)
       provider.install
     end


### PR DESCRIPTION
This pull request supersedes #8072. 

The pkgdmg package provider uses the '-noidme' flag with hdiutil, which was deprecated in macOS 10.15. See man hdiutil for more information. In macOS 10.15 the '-noidme' flag causes hdiutil to output a deprecation warning, which then causes pkgdmg to fail to parse the plist xml that hdiutil generates, which then causes the package installation to fail in puppet.

This change removes the '-noidme' flag from pkgdmg in order to prevent the deprecation warning from hdiutil, and restore functionality to pkgdmg in macOS 10.15 and above. Additonally, after reviewing the man page for hdiutil in macOS 10.14, it seems the '-noidme' flag is unnecessary for older versions of macOS as hdiutil appears to not perform idme actions by default. This change also removes the '-noidme' flag from the pkgdmg test in order to bring it up-to-date with the change in pkgdmg.