### PR TITLE
(maint) Use callback to report on resolver exceptions

### DIFF
--- a/lib/puppet/http/resolver/settings.rb
+++ b/lib/puppet/http/resolver/settings.rb
@@ -13,12 +13,14 @@ class Puppet::HTTP::Resolver::Settings < Puppet::HTTP::Resolver
   # @param [Puppet::HTTP::Session] session
   # @param [Symbol] name the name of the service to be resolved
   # @param [Puppet::SSL::SSLContext] ssl_context
+  # @param [Proc] error_handler (nil) optional callback for each error
+  #   encountered while resolving a route.
   #
   # @return [Puppet::HTTP::Service] if the service successfully connects,
   #   return it. Otherwise, return nil.
   #
-  def resolve(session, name, ssl_context: nil)
+  def resolve(session, name, ssl_context: nil, error_handler: nil)
     service = Puppet::HTTP::Service.create_service(@client, session, name)
-    check_connection?(session, service, ssl_context: ssl_context) ? service : nil
+    check_connection?(session, service, ssl_context: ssl_context, error_handler: error_handler) ? service : nil
   end
 end

--- a/lib/puppet/http/resolver/srv.rb
+++ b/lib/puppet/http/resolver/srv.rb
@@ -25,17 +25,19 @@ class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
   # @param [Puppet::HTTP::Session] session
   # @param [Symbol] name the service being resolved
   # @param [Puppet::SSL::SSLContext] ssl_context
+  # @param [Proc] error_handler (nil) optional callback for each error
+  #   encountered while resolving a route.
   #
   # @return [Puppet::HTTP::Service] if an available service is found, return
   #   it. Return nil otherwise.
   #
-  def resolve(session, name, ssl_context: nil)
+  def resolve(session, name, ssl_context: nil, error_handler: nil)
     # Here we pass our HTTP service name as the DNS SRV service name
     # This is fine for :ca, but note that :puppet and :file are handled
     # specially in `each_srv_record`.
     @delegate.each_srv_record(@srv_domain, name) do |server, port|
       service = Puppet::HTTP::Service.create_service(@client, session, name, server, port)
-      return service if check_connection?(session, service, ssl_context: ssl_context)
+      return service if check_connection?(session, service, ssl_context: ssl_context, error_handler: error_handler)
     end
 
     return nil

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -23,9 +23,9 @@ describe Puppet::HTTP::Session do
       @count = 0
     end
 
-    def resolve(session, name, ssl_context: nil)
+    def resolve(session, name, ssl_context: nil, error_handler: nil)
       @count += 1
-      return @service if check_connection?(session, @service, ssl_context: ssl_context)
+      return @service if check_connection?(session, @service, ssl_context: ssl_context, error_handler: error_handler)
     end
   end
 


### PR DESCRIPTION
Previously, resolver exceptions were collected in the session, and were only
cleared the next time `route_to` was called. To ensure the exceptions have the
same lifetime as the call to `route_to` and no more, pass an error_handler
callback to the `route_to` method. The callback will be called once per
exception that occurs during the resolution process.