### PR TITLE
(PUP-10371) Add metric for total agent runtime

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -39,6 +39,7 @@ class Puppet::Application::Agent < Puppet::Application
       :graph => true,
       :fingerprint => false,
       :sourceaddress => nil,
+      :start_time => Time.now,
     }.each do |opt,val|
       options[opt] = val
     end
@@ -405,7 +406,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
   def onetime(daemon)
     begin
-      exitstatus = daemon.agent.run(:job_id => options[:job_id])
+      exitstatus = daemon.agent.run({:job_id => options[:job_id], :start_time => options[:start_time]})
     rescue => detail
       Puppet.log_exception(detail)
     end

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -217,13 +217,13 @@ class Puppet::Transaction::Report
   end
 
   # @api private
-  def initialize(configuration_version=nil, environment=nil, transaction_uuid=nil, job_id=nil)
+  def initialize(configuration_version=nil, environment=nil, transaction_uuid=nil, job_id=nil, start_time=Time.now)
     @metrics = {}
     @logs = []
     @resource_statuses = {}
     @external_times ||= {}
     @host = Puppet[:node_name_value]
-    @time = Time.now
+    @time = start_time
     @report_format = 10
     @puppet_version = Puppet.version
     @configuration_version = configuration_version

--- a/lib/puppet/util/at_fork.rb
+++ b/lib/puppet/util/at_fork.rb
@@ -13,7 +13,7 @@ require 'puppet'
 #   service.
 module Puppet::Util::AtFork
   @handler_class = loop do
-    if Facter.value(:operatingsystem) == 'Solaris'
+    if Puppet::Util::Platform.solaris?
       begin
         require 'puppet/util/at_fork/solaris'
         # using break to return a value from the loop block

--- a/lib/puppet/util/platform.rb
+++ b/lib/puppet/util/platform.rb
@@ -14,6 +14,11 @@ module Puppet
       end
       module_function :windows?
 
+      def solaris?
+        RUBY_PLATFORM.include?('solaris')
+      end
+      module_function :solaris?
+
       def default_paths
         return [] if windows?
 

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -122,6 +122,10 @@ describe Puppet::Application::Agent do
       end
     end
 
+    it "should log the agent start time" do
+      expect(@puppetd.options[:start_time]).to be_a(Time)
+    end
+
     it "should set waitforcert to 0 with --onetime and if --waitforcert wasn't given" do
       allow(@agent).to receive(:run).and_return(2)
       Puppet[:onetime] = true
@@ -505,7 +509,7 @@ describe Puppet::Application::Agent do
 
       it "should run the agent with the supplied job_id" do
         @puppetd.options[:job_id] = 'special id'
-        expect(@agent).to receive(:run).with(:job_id => 'special id').and_return(:report)
+        expect(@agent).to receive(:run).with(hash_including(:job_id => 'special id')).and_return(:report)
 
         expect { execute_agent }.to exit_with 0
       end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -148,7 +148,7 @@ describe Puppet::Configurer do
       configurer = Puppet::Configurer.new("test_tuuid", "test_jid")
 
       report = Puppet::Transaction::Report.new(nil, "test", "aaaa")
-      expect(Puppet::Transaction::Report).to receive(:new).with(anything, anything, 'test_tuuid', 'test_jid').and_return(report)
+      expect(Puppet::Transaction::Report).to receive(:new).with(anything, anything, 'test_tuuid', 'test_jid', anything).and_return(report)
       expect(configurer).to receive(:send_report).with(report)
 
       configurer.run

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -39,6 +39,10 @@ describe Puppet::Transaction::Report do
     expect(Puppet::Transaction::Report.new('cv', 'env', 'tid', 'some job id').job_id).to eq('some job id')
   end
 
+  it "should take a 'start_time' as an argument" do
+    expect(Puppet::Transaction::Report.new('cv', 'env', 'tid', 'some job id', 'my start time').time).to eq('my start time')
+  end
+
   it "should be able to set configuration_version" do
     report = Puppet::Transaction::Report.new
     report.configuration_version = "some version"

--- a/spec/unit/util/at_fork_spec.rb
+++ b/spec/unit/util/at_fork_spec.rb
@@ -19,7 +19,7 @@ describe 'Puppet::Util::AtFork' do
   describe '.get_handler' do
     context 'when on Solaris' do
       before :each do
-        expect(Facter).to receive(:value).with(:operatingsystem).and_return('Solaris')
+        expect(Puppet::Util::Platform).to receive(:solaris?).and_return(true)
       end
 
       after :each do
@@ -114,7 +114,7 @@ describe 'Puppet::Util::AtFork' do
 
     context 'when NOT on Solaris' do
       before :each do
-        expect(Facter).to receive(:value).with(:operatingsystem).and_return(nil)
+        expect(Puppet::Util::Platform).to receive(:solaris?).and_return(false)
       end
 
       def stub_noop_handler(namespace_only = false)


### PR DESCRIPTION
Prior to this commit, Puppet started metrics calculation somewhat late during runtime (at [`Configurer#run`](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/configurer.rb#L202)). This commit adds a new `startup_time` metric that includes the duration between startup and report initialization.

This is especially visible if the user has lots of external/custom facts, as Facter will evaluate all of them the first time `Facter.value` is called in Puppet, so facts are being loaded twice due to them being used in Puppet.

This is just a proof of concept as I'm not sure this is the way we should take. I also commented the Facter use in `atForkHandler` since it gets executed very early in the Puppet run and with that in place we don't get to `Application#run` until after the first run of facts is resolved.

I'm attaching a couple of flamegraphs[1] with more context:

For both runs I used a simple master/agent set up (although this should work with `puppet apply` as well), with the following external fact:

```sh-session
> cat /opt/puppetlabs/facter/facts.d/a.sh
sleep 3
echo "a=1"
```

1. atfork-fact.svg
- this goes from `command_line.rb` straight into `Application#find` where it drops to `atForkHandler`, at that point the first `Facter.value` is executed
- by the time we get to `Application#run`, facts have been evaluated and us initializing time there is not that accurate

2. no-atfork-fact.svg
- this drops directly to `Application#run` where I was able to get a `start_time` variable all the way to `configurer.rb` where the report is created.

In both graphs, the `<c function>`s at the bottom of the stacktrace are actually (C)Facter runs.

[1] https://gist.github.com/GabrielNagy/a242e9a5bf9441f92c25c3795d413a3b