### PR TITLE
(PUP-10378) 'puppet resource service' omitting services on Ubuntu

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -30,7 +30,8 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect)\s*$/i).each do |m|
+    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect|bad)\s*$/i).each do |m|
+      Puppet.debug("#{m[0]} marked as bad by `systemctl`. It is recommended to be further checked.") if m[1] == "bad"
       i << new(:name => m[0])
     end
     return i

--- a/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
+++ b/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
@@ -5,3 +5,4 @@ autovt@.service                             disabled
 avahi-daemon.service                        enabled
 blk-availability.service                    disabled
 brandbot.service                            static
+apparmor.service                            bad

--- a/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
+++ b/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
@@ -6,3 +6,11 @@ avahi-daemon.service                        enabled
 blk-availability.service                    disabled
 brandbot.service                            static
 apparmor.service                            bad
+udev.service                                enabled-runtime
+ufw.service                                 linked
+umountfs.service                            linked-runtime
+umountnfs.service                           masked
+umountroot.service                          masked-runtime
+urandom.service                             indirect
+user@.service                               generated
+uuidd.service                               transient

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -187,9 +187,16 @@ describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platf
         autovt@.service
         avahi-daemon.service
         blk-availability.service
+        apparmor.service
       })
     end
-  end
+
+    it "should print a debug message when a service with the state `bad` is found" do
+      expect(provider_class).to receive(:systemctl).with('list-unit-files', '--type', 'service', '--full', '--all', '--no-pager').and_return(File.read(my_fixture('list_unit_files_services')))
+      expect(Puppet).to receive(:debug).with("apparmor.service marked as bad by `systemctl`. It is recommended to be further checked.")
+      provider_class.instances
+    end
+  end 
 
   describe "#start" do
     it "should use the supplied start command if specified" do

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -188,6 +188,8 @@ describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platf
         avahi-daemon.service
         blk-availability.service
         apparmor.service
+        umountnfs.service
+        urandom.service
       })
     end
 


### PR DESCRIPTION
Fixes inconsistency in puppet behaviour: services marked as `bad` by `systemctl` were omitted when listing all available services (via `puppet resource service`) but when querying individually the same services (via `puppet resource service <service_name>`) they actually appeared to be
enabled and running.

This weird behaviour has been discovered on Ubuntu 18.04 with pe_postgresql service where systemctl seemed to simply not like at all symlink chaining of unit conf files. Full details available in the comments section of the [ticket](https://tickets.puppetlabs.com/browse/PUP-10378).
