### PR TITLE
(PUP-10375) Latest package version for pip provider fixed

### DIFF
--- a/lib/puppet/util/package/version/pip.rb
+++ b/lib/puppet/util/package/version/pip.rb
@@ -44,7 +44,7 @@ module Puppet::Util::Package::Version
 
     def self.compare(version_a, version_b)
       version_a = parse(version_a) unless version_a.is_a?(self)
-      version_b = parse(version_b) unless version_a.is_a?(self)
+      version_b = parse(version_b) unless version_b.is_a?(self)
 
       version_a <=> version_b
     end
@@ -132,7 +132,7 @@ module Puppet::Util::Package::Version
       dev_key = dev || Float::INFINITY
 
       if !local
-        local_key = -Float::INFINITY
+        local_key = [[-Float::INFINITY, ""]]
       else
         local_key = local.map{|i| (i.is_a? Integer) ? [i, ""] : [-Float::INFINITY, i]}
       end
@@ -150,14 +150,12 @@ module Puppet::Util::Package::Version
         end
       elsif (this.is_a? Array) && !(other.is_a? Array)
         raise Puppet::Error, 'Cannot compare #{this} (Array) with #{other} (#{other.class}). Only ±Float::INFINITY accepted.' unless other.abs == Float::INFINITY
-        return this.first.to_f <=> other
+        return other == -Float::INFINITY ? 1 : -1
       elsif !(this.is_a? Array) && (other.is_a? Array)
         raise Puppet::Error, 'Cannot compare #{this} (#{this.class}) with #{other} (Array). Only ±Float::INFINITY accepted.' unless this.abs == Float::INFINITY
-        return this <=> other.first.to_f
-      else
-        return this <=> other
+        return this == -Float::INFINITY ? -1 : 1
       end
-      0
+      this <=> other
     end
 
     class ValidationFailure < ArgumentError

--- a/spec/unit/util/package/version/pip_spec.rb
+++ b/spec/unit/util/package/version/pip_spec.rb
@@ -417,10 +417,13 @@ describe Puppet::Util::Package::Version::Pip do
       "1.0.post456.dev34",
       "1.0.post456",
       "1.1.dev1",
+      "1.2",
       "1.2+123abc",
       "1.2+123abc456",
       "1.2+abc",
       "1.2+abc123",
+      "1.2+abc123-def2",
+      "1.2+abc123-def2-0",
       "1.2+abc123def",
       "1.2+1234.abc",
       "1.2+123456",
@@ -433,6 +436,13 @@ describe Puppet::Util::Package::Version::Pip do
       "1!1.2.rev33+123456",
       "2!2.3.4.alpha5.rev6.dev7+abc89"
     ]
+
+    it "should find versions list to be already sorted" do
+      sorted_versions = versions.sort do |x,y|
+        described_class.compare(x, y)
+      end
+      expect(versions).to eq(sorted_versions)
+    end
 
     versions.combination(2).to_a.each do |version_pair|
       lower_version = described_class.parse(version_pair.first)
@@ -448,10 +458,6 @@ describe Puppet::Util::Package::Version::Pip do
 
       it "#{lower_version} should be lower than #{greater_version}" do
         expect(lower_version < greater_version).to eq(true)
-      end
-
-      it "#{greater_version} should be greater than #{lower_version}" do
-        expect(greater_version > lower_version).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Sorting and comparison mechanism fixed when deciding the latest version available for a python package. Mechanism will fall through old implementation when unexpected version patterns appear as input.