### PR TITLE
(PUP-10395) Fix insync for gem version ranges

### DIFF
--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -152,7 +152,8 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
     end
     
     begin
-      dependency = Gem::Dependency.new('', should)
+      # Range intersections are not supported by Gem::Requirement, so just split by comma.
+      dependency = Gem::Dependency.new('', should.split(','))
     rescue ArgumentError
       # Bad requirements will cause an error during gem command invocation, so just return not in sync
       return false

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -257,6 +257,26 @@ context Puppet::Type.type(:package).provider(:gem) do
           resource[:ensure] = '3.6.2'
           expect(provider).to_not be_insync(is)
         end
+
+        it 'returns true for >2, <4' do
+          resource[:ensure] = '>2, <4'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for >=4, <5' do
+          resource[:ensure] = '>=4, <5'
+          expect(provider).to_not be_insync(is)
+        end
+
+        it 'returns true for >2 <4' do
+          resource[:ensure] = '>2 <4'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for >=4 <5' do
+          resource[:ensure] = '>=4 <5'
+          expect(provider).to_not be_insync(is)
+        end
       end
 
       context 'for string version' do
@@ -284,6 +304,26 @@ context Puppet::Type.type(:package).provider(:gem) do
 
         it 'returns false for 3.6.1' do
           resource[:ensure] = '3.6.1'
+          expect(provider).to_not be_insync(is)
+        end
+
+        it 'returns true for >=1.3, <2' do
+          resource[:ensure] = '>=1.3, <2'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for >1, <=1.3' do
+          resource[:ensure] = '>1, <=1.3'
+          expect(provider).to_not be_insync(is)
+        end
+
+        it 'returns true for >=1.3 <2' do
+          resource[:ensure] = '>=1.3 <2'
+          expect(provider).to be_insync(is)
+        end
+
+        it 'returns false for >1 <=1.3' do
+          resource[:ensure] = '>1 <=1.3'
           expect(provider).to_not be_insync(is)
         end
       end


### PR DESCRIPTION
When figuring out whether an installed gem version satisfies the manifest requirements, Puppet would run the requested version through `Gem::Dependency.new`.

Initializing `Gem::Dependency` with composed requirements (i.e. ">=1.2, <2") would trigger a parse error when parsing in `Gem::Requirement`. Since `Gem::Dependency` supports arrays of requirements, we fix this by splitting our requested version on comma.

On strings that do not have commas and are not valid Puppet version ranges (like "~> 1.0"), the split will be a noop (with the exception of it turning into array, which has no side effects on `Gem::Dependency.new`).