### PR TITLE
(PUP-10414) Replace deprecated calls to `--configprint`

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -160,7 +160,7 @@ class WindowsDaemon < Win32::Daemon
 
   def parse_runinterval(puppet_path)
     begin
-      runinterval = %x{ #{puppet_path} config --section agent print runinterval }.to_i
+      runinterval = %x{ #{puppet_path} config --section agent --log_level notice print runinterval }.to_i
       if runinterval == 0
         runinterval = 1800
         log_err("Failed to determine runinterval, defaulting to #{runinterval} seconds")
@@ -175,8 +175,8 @@ class WindowsDaemon < Win32::Daemon
 
   def parse_log_level(puppet_path,cmdline_debug)
     begin
-      loglevel = %x{ #{puppet_path} config --section agent print log_level }.chomp
-      unless loglevel
+      loglevel = %x{ #{puppet_path} config --section agent --log_level notice print log_level }.chomp
+      unless loglevel && respond_to?("log_#{loglevel}")
         loglevel = :notice
         log_err("Failed to determine loglevel, defaulting to #{loglevel}")
       end

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -160,7 +160,7 @@ class WindowsDaemon < Win32::Daemon
 
   def parse_runinterval(puppet_path)
     begin
-      runinterval = %x{ #{puppet_path} agent --configprint runinterval }.to_i
+      runinterval = %x{ #{puppet_path} config --section agent print runinterval }.to_i
       if runinterval == 0
         runinterval = 1800
         log_err("Failed to determine runinterval, defaulting to #{runinterval} seconds")
@@ -175,7 +175,7 @@ class WindowsDaemon < Win32::Daemon
 
   def parse_log_level(puppet_path,cmdline_debug)
     begin
-      loglevel = %x{ #{puppet_path} agent --configprint log_level}.chomp
+      loglevel = %x{ #{puppet_path} config --section agent print log_level }.chomp
       unless loglevel
         loglevel = :notice
         log_err("Failed to determine loglevel, defaulting to #{loglevel}")


### PR DESCRIPTION
Replace deprecated usage of `puppet --configprint` with `puppet config print`.