### PR TITLE
(maint) do not explicitly call `exit` in `run_in_fork`

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -105,7 +105,7 @@ class Puppet::Agent
     end
 
     exit_code = Process.waitpid2(child_pid)
-    exit(exit_code[1].exitstatus)
+    exit_code[1].exitstatus
   end
 
   private


### PR DESCRIPTION
due to bad understanding of code removed in 5ea240ac30, we expected
that `exit(-1)` will set `exitstatus` to `-1` and `raise SystemExit`,
while what happened  was that `exitstatus` was interpreted as `unsigned char`
and had value of `255`, hence `run_in_fork` will always just return `exitstatus`