### PR TITLE
(PUP-10407) Don't chown log file destination

### DIFF
--- a/lib/puppet/util/log/destinations.rb
+++ b/lib/puppet/util/log/destinations.rb
@@ -90,17 +90,8 @@ Puppet::Util::Log.newdesttype :file do
       end
     end
 
-    file = File.open(path,  File::WRONLY|File::CREAT|File::APPEND)
+    file = File.open(path, File::WRONLY|File::CREAT|File::APPEND)
     file.puts('[') if need_array_start
-
-    # Give ownership to the user and group puppet will run as
-    if Puppet.features.root? && !Puppet::Util::Platform.windows? && !file_exists
-      begin
-        FileUtils.chown(Puppet[:user], Puppet[:group], path)
-      rescue ArgumentError, Errno::EPERM
-        Puppet.err _("Unable to set ownership to %{user}:%{group} for log file: %{path}") % { user: Puppet[:user], group: Puppet[:group], path: path }
-      end
-    end
 
     @file = file
 

--- a/spec/unit/util/log/destinations_spec.rb
+++ b/spec/unit/util/log/destinations_spec.rb
@@ -44,41 +44,13 @@ describe Puppet::Util::Log.desttypes[:file] do
       end
     end
 
-    describe "on POSIX systems", :if => Puppet.features.posix? do
+    describe "on POSIX systems", :unless => Puppet::Util::Platform.windows? do
       describe "with a normal file" do
         let (:parent) { Pathname.new('/tmp') }
         let (:abspath) { '/tmp/log' }
         let (:relpath) { 'log' }
 
         it_behaves_like "file destination"
-
-        it "logs an error if it can't chown the file owner & group" do
-          allow(File).to receive(:exist?).with(parent).and_return(true)
-          expect(File).to receive(:exist?).with(Pathname.new(abspath)).and_return(false)
-          expect(FileUtils).to receive(:chown).with(Puppet[:user], Puppet[:group], abspath).and_raise(Errno::EPERM)
-          expect(Puppet.features).to receive(:root?).and_return(true)
-          expect(Puppet).to receive(:err).with("Unable to set ownership to #{Puppet[:user]}:#{Puppet[:group]} for log file: #{abspath}")
-
-          @class.new(abspath)
-        end
-
-        it "doesn't attempt to chown when running as non-root" do
-          allow(File).to receive(:exist?).with(parent).and_return(true)
-          expect(File).to receive(:exist?).with(Pathname.new(abspath)).and_return(false)
-          expect(FileUtils).not_to receive(:chown).with(Puppet[:user], Puppet[:group], abspath)
-          expect(Puppet.features).to receive(:root?).and_return(false)
-
-          @class.new(abspath)
-        end
-
-        it "doesn't attempt to chown when file already exists" do
-          allow(File).to receive(:exist?).with(parent).and_return(true)
-          expect(File).to receive(:exist?).with(Pathname.new(abspath)).and_return(true)
-          expect(FileUtils).not_to receive(:chown).with(Puppet[:user], Puppet[:group], abspath)
-          expect(Puppet.features).to receive(:root?).and_return(true)
-
-          @class.new(abspath)
-        end
       end
 
       describe "with a JSON file" do


### PR DESCRIPTION
The puppet master process used to drop privileges to the Puppet[:user] and
Puppet[:group], and then reopen its log destinations, so it was necessary that
its log file destination be owned by those accounts.

In puppet 4, the puppet-agent package no longer creates the `puppet` user and
group, only the pouppetserver package does that. As a result, running puppet
agent as root on a host that wasn't the puppetserver would always log a `Unable
to set ownership` error message.

This commit removes the `chown` logic as it's not needed for puppet agents. Also
confine the test based on Puppet::Util::Platform and not features. The latter
requires the features subsystem and is overkill for what's needed here.