### PR TITLE
(maint) Pass put/post body as an argument

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -178,7 +178,7 @@ class Puppet::HTTP::Client
   # @return [String] the body of the request response
   #
   def put(url, body, headers: {}, params: {}, options: {})
-    raise ArgumentError, "'put' requires a 'body' argument" unless body
+    raise ArgumentError, "'put' requires a string 'body' argument" unless body.is_a?(String)
     url = encode_query(url, params)
 
     request = Net::HTTP::Put.new(url, @default_headers.merge(headers))
@@ -211,7 +211,7 @@ class Puppet::HTTP::Client
   # @return [String] the body of the request response
   #
   def post(url, body, headers: {}, params: {}, options: {}, &block)
-    raise ArgumentError, "'post' requires a 'body' argument" unless body
+    raise ArgumentError, "'post' requires a string 'body' argument" unless body.is_a?(String)
     url = encode_query(url, params)
 
     request = Net::HTTP::Post.new(url, @default_headers.merge(headers))

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -165,10 +165,10 @@ class Puppet::HTTP::Client
   # Submits a PUT HTTP request to the given url
   #
   # @param [URI] url the location to submit the http request
+  # @param [String] body the body of the PUT request
   # @param [Hash] headers merged with the default headers defined by the client
   # @param [Hash] params encoded and set as the url query
   # @param [Hash] options passed through to the request execution
-  # @option options [String] :body the body of the PUT request
   # @option options [String] :content_type the type of the body content
   # @option options [Puppet::SSL::SSLContext] :ssl_context (nil) ssl context to
   #   be used for connections
@@ -177,8 +177,8 @@ class Puppet::HTTP::Client
   #
   # @return [String] the body of the request response
   #
-  def put(url, headers: {}, params: {}, options: {})
-    body = options.fetch(:body) { |_| raise ArgumentError, "'put' requires a 'body' option" }
+  def put(url, body, headers: {}, params: {}, options: {})
+    raise ArgumentError, "'put' requires a 'body' argument" unless body
     url = encode_query(url, params)
 
     request = Net::HTTP::Put.new(url, @default_headers.merge(headers))
@@ -198,10 +198,10 @@ class Puppet::HTTP::Client
   # Submits a POST HTTP request to the given url
   #
   # @param [URI] url the location to submit the http request
+  # @param [String] body the body of the POST request
   # @param [Hash] headers merged with the default headers defined by the client
   # @param [Hash] params encoded and set as the url query
   # @param [Hash] options passed through to the request execution
-  # @option options [String] :body the body of the PUT request
   # @option options [String] :content_type the type of the body content
   # @option options [Puppet::SSL::SSLContext] :ssl_context (nil) ssl context to
   #   be used for connections
@@ -210,8 +210,8 @@ class Puppet::HTTP::Client
   #
   # @return [String] the body of the request response
   #
-  def post(url, headers: {}, params: {}, options: {}, &block)
-    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
+  def post(url, body, headers: {}, params: {}, options: {}, &block)
+    raise ArgumentError, "'post' requires a 'body' argument" unless body
     url = encode_query(url, params)
 
     request = Net::HTTP::Post.new(url, @default_headers.merge(headers))

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -42,7 +42,7 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
   # (see Puppet::HTTP::Client#post)
   # @api private
   def post(url, body, headers: {}, params: {}, options: {}, &block)
-    raise ArgumentError.new("'post' requires a 'body' argument") unless body
+    raise ArgumentError.new("'post' requires a string 'body' argument") unless body.is_a?(String)
     url = encode_query(url, params)
 
     options[:use_ssl] = url.scheme == 'https'

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -41,8 +41,8 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
 
   # (see Puppet::HTTP::Client#post)
   # @api private
-  def post(url, headers: {}, params: {}, options: {}, &block)
-    body = options.fetch(:body) { |_| raise ArgumentError, "'post' requires a 'body' option" }
+  def post(url, body, headers: {}, params: {}, options: {}, &block)
+    raise ArgumentError.new("'post' requires a 'body' argument") unless body
     url = encode_query(url, params)
 
     options[:use_ssl] = url.scheme == 'https'
@@ -58,7 +58,7 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
     else
       response
     end
-  rescue Puppet::HTTP::HTTPError
+  rescue Puppet::HTTP::HTTPError, ArgumentError
     raise
   rescue => e
     raise Puppet::HTTP::HTTPError.new(e.message, e)

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -98,9 +98,9 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
 
     response = @client.put(
       with_base_url("/certificate_request/#{name}"),
+      csr.to_pem,
       headers: headers,
       options: {
-        body: csr.to_pem,
         ssl_context: ssl_context
       }
     )

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -118,12 +118,10 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
 
     response = @client.post(
       with_base_url("/catalog/#{name}"),
+      body,
       headers: headers,
       # for legacy reasons we always send environment as a query parameter too
       params: { environment: environment },
-      options: {
-        body: body
-      }
     )
 
     process_response(response)
@@ -178,11 +176,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
 
     response = @client.put(
       with_base_url("/facts/#{name}"),
+      serialize(formatter, facts),
       headers: headers,
       params: { environment: environment },
-      options: {
-        body: serialize(formatter, facts)
-      }
     )
 
     process_response(response)
@@ -279,12 +275,10 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
 
     response = @client.put(
       with_base_url("/file_bucket_file/#{path}"),
+      body,
       headers: headers,
       params: {
         environment: environment
-      },
-      options: {
-        body: body
       }
     )
 

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -46,11 +46,9 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
 
     response = @client.put(
       with_base_url("/report/#{name}"),
+      serialize(formatter, report),
       headers: headers,
       params: { environment: environment },
-      options: {
-        body: serialize(formatter, report)
-      }
     )
 
     # override parent's process_response handling

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -22,7 +22,6 @@ Puppet::Reports.register_report(:http) do
     # `reporturl` to store a report.
     options = {
       :metric_id => [:puppet, :report, :http],
-      :body => self.to_yaml,
       :include_system_store => Puppet[:report_include_system_store],
     }
 
@@ -32,7 +31,7 @@ Puppet::Reports.register_report(:http) do
     end
 
     client = Puppet.runtime['http']
-    client.post(url, headers: headers, options: options) do |response|
+    client.post(url, self.to_yaml, headers: headers, options: options) do |response|
       unless response.success?
         Puppet.err _("Unable to submit report to %{url} [%{code}] %{message}") % { url: Puppet[:reporturl].to_s, code: response.code, message: response.reason }
       end

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -134,14 +134,14 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
 
       https_server.start_server do |port|
         uri = URI("https://127.0.0.1:#{port}")
-        kwargs = {headers: {'Content-Type' => 'text/plain'}, options: {ssl_context: root_context, body: ''}}
+        kwargs = {headers: {'Content-Type' => 'text/plain'}, options: {ssl_context: root_context}}
 
         expect {
-          expect(client.post(uri, **kwargs)).to be_success
+          expect(client.post(uri, '', **kwargs)).to be_success
           # the server closes its connection after each request, so posting
           # again will force ruby to detect that the remote side closed the
           # connection, and reconnect
-          expect(client.post(uri, **kwargs)).to be_success
+          expect(client.post(uri, '', **kwargs)).to be_success
         }.to output(/Conn close because of EOF/).to_stderr
       end
     end

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -269,25 +269,25 @@ describe Puppet::HTTP::Client do
         expect(request.headers).to_not include('X-Puppet-Profiling')
       end
 
-      client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: { body: ""})
+      client.put(uri, "", headers: {'Content-Type' => 'text/plain'})
     end
 
     it "stringifies keys and encodes values in the query" do
       stub_request(:put, "https://www.example.com").with(query: "foo=bar%3Dbaz")
 
-      client.put(uri, params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      client.put(uri, "", params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'})
     end
 
     it "includes custom headers" do
       stub_request(:put, "https://www.example.com").with(headers: { 'X-Foo' => 'Bar' })
 
-      client.put(uri, headers: {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'}, options: {body: ""})
+      client.put(uri, "", headers: {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'})
     end
 
     it "returns the response" do
       stub_request(:put, uri)
 
-      response = client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      response = client.put(uri, "", headers: {'Content-Type' => 'text/plain'})
       expect(response).to be_an_instance_of(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
@@ -296,18 +296,18 @@ describe Puppet::HTTP::Client do
     it "sets content-length and content-type for the body" do
       stub_request(:put, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
 
-      client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello"})
+      client.put(uri, "hello", headers: {'Content-Type' => 'text/plain'})
     end
 
-     it 'raises an ArgumentError if `body` is missing from the options hash' do
+     it 'raises an ArgumentError if `body` is missing' do
        expect {
-         client.put(uri, headers: {'Content-Type' => 'text/plain'})
-       }.to raise_error(ArgumentError, /'put' requires a 'body' option/)
+         client.put(uri, nil, headers: {'Content-Type' => 'text/plain'})
+       }.to raise_error(ArgumentError, /'put' requires a 'body' argument/)
      end
 
      it 'raises an ArgumentError if `content_type` is missing from the headers hash' do
        expect {
-         client.put(uri, options: {body: ''})
+         client.put(uri, '')
        }.to raise_error(ArgumentError, /'put' requires a 'content-type' header/)
      end
 
@@ -317,18 +317,18 @@ describe Puppet::HTTP::Client do
 
         other_context = Puppet::SSL::SSLContext.new
 
-        client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: other_context})
+        client.put(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {ssl_context: other_context})
       end
 
       it 'uses the system store' do
         stub_request(:put, uri)
 
-        client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", include_system_store: true})
+        client.put(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {include_system_store: true})
       end
 
       it 'raises an HTTPError if both are specified' do
         expect {
-          client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: puppet_context, include_system_store: true})
+          client.put(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {ssl_context: puppet_context, include_system_store: true})
         }.to raise_error(Puppet::HTTP::HTTPError, /The ssl_context and include_system_store parameters are mutually exclusive/)
       end
     end
@@ -338,25 +338,25 @@ describe Puppet::HTTP::Client do
     it "includes default HTTP headers" do
       stub_request(:post, uri).with(headers: {'X-Puppet-Version' => /./, 'User-Agent' => /./})
 
-      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      client.post(uri, "", headers: {'Content-Type' => 'text/plain'})
     end
 
     it "stringifies keys and encodes values in the query" do
       stub_request(:post, "https://www.example.com").with(query: "foo=bar%3Dbaz")
 
-      client.post(uri, params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      client.post(uri, "", params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'})
     end
 
     it "includes custom headers" do
       stub_request(:post, "https://www.example.com").with(headers: { 'X-Foo' => 'Bar' })
 
-      client.post(uri, headers: {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'}, options: {body: ""})
+      client.post(uri, "", headers: {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'})
     end
 
     it "returns the response" do
       stub_request(:post, uri)
 
-      response = client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      response = client.post(uri, "", headers: {'Content-Type' => 'text/plain'})
       expect(response).to be_an_instance_of(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
@@ -365,14 +365,14 @@ describe Puppet::HTTP::Client do
     it "sets content-length and content-type for the body" do
       stub_request(:post, uri).with(headers: {"Content-Length" => "5", "Content-Type" => "text/plain"})
 
-      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello"})
+      client.post(uri, "hello", headers: {'Content-Type' => 'text/plain'})
     end
 
     it "streams the response body when a block is given" do
       stub_request(:post, uri).to_return(body: "abc")
 
       io = StringIO.new
-      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""}) do |response|
+      client.post(uri, "", headers: {'Content-Type' => 'text/plain'}) do |response|
         response.read_body do |data|
           io.write(data)
         end
@@ -381,15 +381,15 @@ describe Puppet::HTTP::Client do
       expect(io.string).to eq("abc")
     end
 
-    it 'raises an ArgumentError if `body` is missing from the options hash' do
+    it 'raises an ArgumentError if `body` is missing' do
       expect {
-        client.post(uri, headers: {'Content-Type' => 'text/plain'})
-      }.to raise_error(ArgumentError, /'post' requires a 'body' option/)
+        client.post(uri, nil, headers: {'Content-Type' => 'text/plain'})
+      }.to raise_error(ArgumentError, /'post' requires a 'body' argument/)
     end
 
     it 'raises an ArgumentError if `content_type` is missing from the headers hash' do
       expect {
-        client.post(uri, options: {body: ''})
+        client.post(uri, "")
       }.to raise_error(ArgumentError, /'post' requires a 'content-type' header/)
     end
 
@@ -399,18 +399,18 @@ describe Puppet::HTTP::Client do
 
         other_context = Puppet::SSL::SSLContext.new
 
-        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: other_context})
+        client.post(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: other_context})
       end
 
       it 'uses the system store' do
         stub_request(:post, uri)
 
-        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", include_system_store: true})
+        client.post(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {include_system_store: true})
       end
 
       it 'raises an HTTPError if both are specified' do
         expect {
-          client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: puppet_context, include_system_store: true})
+          client.post(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {ssl_context: puppet_context, include_system_store: true})
         }.to raise_error(Puppet::HTTP::HTTPError, /The ssl_context and include_system_store parameters are mutually exclusive/)
       end
     end
@@ -483,7 +483,7 @@ describe Puppet::HTTP::Client do
     it "submits credentials for PUT requests" do
       stub_request(:put, uri).with(basic_auth: credentials)
 
-      client.put(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello", user: 'user', password: 'pass'})
+      client.put(uri, "hello", headers: {'Content-Type' => 'text/plain'}, options: {user: 'user', password: 'pass'})
     end
 
     it "returns response containing access denied" do
@@ -534,7 +534,7 @@ describe Puppet::HTTP::Client do
       stub_request(:put, start_url).to_return(redirect_to(url: bar_url))
       stub_request(:put, bar_url).to_return(status: 200)
 
-      response = client.put(start_url, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      response = client.put(start_url, "", headers: {'Content-Type' => 'text/plain'})
       expect(response).to be_success
     end
 
@@ -587,7 +587,7 @@ describe Puppet::HTTP::Client do
       stub_request(:put, start_url).with(body: data).to_return(redirect_to(url: bar_url))
       stub_request(:put, bar_url).with(body: data).to_return(status: 200)
 
-      response = client.put(start_url, headers: {'Content-Type' => 'text/plain'}, options: {body: data})
+      response = client.put(start_url, data, headers: {'Content-Type' => 'text/plain'})
       expect(response).to be_success
     end
 

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -302,7 +302,7 @@ describe Puppet::HTTP::Client do
      it 'raises an ArgumentError if `body` is missing' do
        expect {
          client.put(uri, nil, headers: {'Content-Type' => 'text/plain'})
-       }.to raise_error(ArgumentError, /'put' requires a 'body' argument/)
+       }.to raise_error(ArgumentError, /'put' requires a string 'body' argument/)
      end
 
      it 'raises an ArgumentError if `content_type` is missing from the headers hash' do
@@ -384,7 +384,7 @@ describe Puppet::HTTP::Client do
     it 'raises an ArgumentError if `body` is missing' do
       expect {
         client.post(uri, nil, headers: {'Content-Type' => 'text/plain'})
-      }.to raise_error(ArgumentError, /'post' requires a 'body' argument/)
+      }.to raise_error(ArgumentError, /'post' requires a string 'body' argument/)
     end
 
     it 'raises an ArgumentError if `content_type` is missing from the headers hash' do

--- a/spec/unit/http/external_client_spec.rb
+++ b/spec/unit/http/external_client_spec.rb
@@ -140,7 +140,7 @@ describe Puppet::HTTP::ExternalClient do
     it 'raises an ArgumentError if `body` is missing' do
       expect {
         client.post(uri, nil, headers: {'Content-Type' => 'text/plain'})
-      }.to raise_error(ArgumentError, /'post' requires a 'body' argument/)
+      }.to raise_error(ArgumentError, /'post' requires a string 'body' argument/)
     end
 
     context 'when connecting' do

--- a/spec/unit/http/external_client_spec.rb
+++ b/spec/unit/http/external_client_spec.rb
@@ -106,13 +106,13 @@ describe Puppet::HTTP::ExternalClient do
     it "stringifies keys and encodes values in the query" do
       stub_request(:post, "https://www.example.com").with(query: "foo=bar%3Dbaz")
 
-      client.post(uri, params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      client.post(uri, "", params: {:foo => "bar=baz"}, headers: {'Content-Type' => 'text/plain'})
     end
 
     it "returns the response" do
       stub_request(:post, uri)
 
-      response = client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""})
+      response = client.post(uri, "", headers: {'Content-Type' => 'text/plain'})
       expect(response).to be_an_instance_of(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
@@ -121,14 +121,14 @@ describe Puppet::HTTP::ExternalClient do
     it "sets content-type for the body" do
       stub_request(:post, uri).with(headers: {"Content-Type" => "text/plain"})
 
-      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "hello"})
+      client.post(uri, "hello", headers: {'Content-Type' => 'text/plain'})
     end
 
     it "streams the response body when a block is given" do
       stub_request(:post, uri).to_return(body: "abc")
 
       io = StringIO.new
-      client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: ""}) do |response|
+      client.post(uri, "", headers: {'Content-Type' => 'text/plain'}) do |response|
         response.read_body do |data|
           io.write(data)
         end
@@ -137,19 +137,25 @@ describe Puppet::HTTP::ExternalClient do
       expect(io.string).to eq("abc")
     end
 
+    it 'raises an ArgumentError if `body` is missing' do
+      expect {
+        client.post(uri, nil, headers: {'Content-Type' => 'text/plain'})
+      }.to raise_error(ArgumentError, /'post' requires a 'body' argument/)
+    end
+
     context 'when connecting' do
       it 'accepts an ssl context' do
         stub_request(:post, uri)
 
         other_context = Puppet::SSL::SSLContext.new
 
-        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", ssl_context: other_context})
+        client.post(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {ssl_context: other_context})
       end
 
       it 'accepts include_system_store' do
         stub_request(:post, uri)
 
-        client.post(uri, headers: {'Content-Type' => 'text/plain'}, options: {body: "", include_system_store: true})
+        client.post(uri, "", headers: {'Content-Type' => 'text/plain'}, options: {include_system_store: true})
       end
     end
   end
@@ -164,7 +170,7 @@ describe Puppet::HTTP::ExternalClient do
     it "submits credentials for POST requests" do
       stub_request(:post, uri).with(basic_auth: credentials)
 
-      client.post(uri, options: {content_type: 'text/plain', body: "hello", user: 'user', password: 'pass'})
+      client.post(uri, "", options: {content_type: 'text/plain', user: 'user', password: 'pass'})
     end
 
     it "returns response containing access denied" do

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -64,7 +64,7 @@ describe Puppet::Reports.report(:http) do
     it "passes metric_id options" do
       stub_request(:post, url)
 
-      expect(Puppet.runtime['http']).to receive(:post).with(anything, hash_including(options: hash_including(metric_id: [:puppet, :report, :http]))).and_call_original
+      expect(Puppet.runtime['http']).to receive(:post).with(anything, anything, hash_including(options: hash_including(metric_id: [:puppet, :report, :http]))).and_call_original
 
       subject.process
     end


### PR DESCRIPTION
Pass the body of a PUT or POST request as an argument instead of contained in
the options hash.