### PR TITLE
(PUP-8937) Check AIX package state after install

### DIFF
--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -29,6 +29,15 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
 
   attr_accessor   :latest_info
 
+  STATE_CODE = {
+    'A' => :applied,
+    'B' => :broken,
+    'C' => :committed,
+    'E' => :efix_locked,
+    'O' => :obsolete,
+    '?' => :inconsistent,
+  }.freeze
+
   def self.srclistcmd(source)
     [ command(:installp), "-L", "-d", source ]
   end
@@ -96,6 +105,11 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
     if output =~ /^#{Regexp.escape(@resource[:name])}\s+.*\s+Already superseded by.*$/
       self.fail _("aix package provider is unable to downgrade packages")
     end
+
+    pkg_info = query
+    if pkg_info && [:broken, :inconsistent].include?(pkg_info[:status])
+      self.fail _("Package '%{name}' is in a %{status} state and requires manual intervention") % { name: @resource[:name], status: pkg_info[:status] }
+    end
   end
 
   def self.pkglist(hash = {})
@@ -106,8 +120,9 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
     end
 
     begin
-      list = execute(cmd).scan(/^[^#][^:]*:([^:]*):([^:]*)/).collect { |n,e|
-        { :name => n, :ensure => e, :provider => self.name }
+      list = execute(cmd).scan(/^[^#][^:]*:([^:]*):([^:]*):[^:]*:[^:]*:([^:])/).collect { |n,e,s|
+        e = :absent if [:broken, :inconsistent].include?(STATE_CODE[s])
+        { :name => n, :ensure => e, :status => STATE_CODE[s], :provider => self.name }
       }
     rescue Puppet::ExecutionFailure => detail
       if hash[:pkgname]


### PR DESCRIPTION
Previously, when installing packages on AIX systems, Puppet would only check the package name and version to ensure presence.

If a package is in a broken or inconsistent state, Puppet would not report any error, causing false positives concerning installed packages.

Extend the package query regular expression to also take into account the package state, which can be one of the following:

```
A – Applied.
B – Broken.
C – Committed.
E – EFIX Locked.
O – Obsolete. (partially migrated to newer version)
? – Inconsistent State...Run lppchk -v.
```

If the package we are installing gets into a broken (B) or inconsistent (?) state, we abort the installation. We also treat packages marked with these codes as absent when querying installed packages.

~Open point: should we log broken and inconsistent packages when querying?~ I added a warning log for every broken/inconsistent package found on the system.