### PR TITLE
(PUP-7163) systemd provider 'indirect' service fix

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -34,6 +34,22 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     return []
   end
 
+  # Static services cannot be enabled or disabled manually. Indirect services 
+  # should not be enabled or disabled due to limitations in systemd (see 
+  # https://github.com/systemd/systemd/issues/6681).
+  def enabled_insync?(current)
+    case cached_enabled?
+    when 'static'
+      Puppet.debug("Unable to enable or disable static service #{@resource[:name]}")
+      return true
+    when 'indirect'
+      Puppet.debug("Service #{@resource[:name]} is in 'indirect' state and cannot be enabled/disabled")
+      return true
+    else
+      current == @resource[:enable]
+    end
+  end
+
   # This helper ensures that the enable state cache is always reset
   # after a systemctl enable operation. A particular service state is not guaranteed
   # after such an operation, so the cache must be emptied to prevent inconsistencies

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -78,14 +78,8 @@ module Puppet
         provider.delayed_start
       end
 
-      # This only makes sense on systemd systems. Static services cannot be enabled
-      # or disabled manually.
       def insync?(current)
-        if provider.respond_to?(:cached_enabled?) && provider.cached_enabled? == 'static'
-          Puppet.debug("Unable to enable or disable static service #{@resource[:name]}")
-          return true
-        end
-
+        return provider.enabled_insync?(current) if provider.respond_to?(:enabled_insync?)
         super(current)
       end
 

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -372,6 +372,67 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     end
   end
 
+  describe "#insync_enabled?" do
+    let(:provider) do
+      described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
+    end
+
+    before do
+      allow(provider).to receive(:cached_enabled?).and_return(service_state)
+    end
+
+    context 'when service state is static' do
+      let(:service_state) { 'static' }
+
+      it 'is always enabled_insync even if current value is the same as expected' do
+        expect(provider).to be_enabled_insync(:false)
+      end
+
+      it 'is always enabled_insync even if current value is not the same as expected' do
+        expect(provider).to be_enabled_insync(:true)
+      end
+
+      it 'logs a debug messsage' do
+        expect(Puppet).to receive(:debug).with("Unable to enable or disable static service sshd.service")
+        provider.enabled_insync?(:true)
+      end
+    end
+
+    context 'when service state is indirect' do
+      let(:service_state) { 'indirect' }
+
+      it 'is always enabled_insync even if current value is the same as expected' do
+        expect(provider).to be_enabled_insync(:false)
+      end
+
+      it 'is always enabled_insync even if current value is not the same as expected' do
+        expect(provider).to be_enabled_insync(:true)
+      end
+
+      it 'logs a debug messsage' do
+        expect(Puppet).to receive(:debug).with("Service sshd.service is in 'indirect' state and cannot be enabled/disabled")
+        provider.enabled_insync?(:true)
+      end
+    end
+
+    context 'when service state is enabled' do
+      let(:service_state) { 'enabled' }
+
+      it 'is enabled_insync if current value is the same as expected' do
+        expect(provider).to be_enabled_insync(:false)
+      end
+
+      it 'is not enabled_insync if current value is not the same as expected' do
+        expect(provider).not_to be_enabled_insync(:true)
+      end
+
+      it 'logs no debug messsage' do
+        expect(Puppet).not_to receive(:debug)
+        provider.enabled_insync?(:true)
+      end
+    end
+  end
+
   describe "#get_start_link_count" do
     it "should strip the '.service' from the search if present in the resource name" do
       provider = described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))


### PR DESCRIPTION
Services that are in the `indirect` state should not be enabled or disabled by puppet. The `systemctl` call with the `is-enabled` argument will continue to report the service to be in a `indirect` state even after attempting enable/disable it, causing puppet to retry at every run if the manifest requests so. Before this commit it reported false changes each time also.

A debug log will be shown each time there is an attempt to enable/disable an `indirect` service and no changes will be done.