### PR TITLE
(PUP-10432) Fix yum provider check_updates.

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -25,6 +25,8 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
   defaultfor :osfamily => :redhat
 
+  VERSION_REGEX = /^(?:(\d+):)?(\S+)-(\S+)$/
+
   def self.prefetch(packages)
     raise Puppet::Error, _("The yum provider can only be used as root") if Process.euid != 0
     super
@@ -93,7 +95,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
 
     body.split(/^\s*\n/).each do |line|
       line.split.each_slice(3) do |tuple|
-        next unless tuple[0].include?('.') && tuple[1] =~ /^(?:(\d+):)?(\S+)-(\S+)$/
+        next unless tuple[0].include?('.') && tuple[1] =~ VERSION_REGEX
 
         hash = update_to_hash(*tuple[0..1])
         # Create entries for both the package name without a version and a
@@ -118,7 +120,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       raise _("Failed to parse package name and architecture from '%{pkgname}'") % { pkgname: pkgname }
     end
 
-    match = pkgversion.match(/^(?:(\d+):)?(\S+)-(\S+)$/)
+    match = pkgversion.match(VERSION_REGEX)
     epoch = match[1] || '0'
     version = match[2]
     release = match[3]

--- a/spec/fixtures/unit/provider/package/yum/yum-check-update-subscription-manager.txt
+++ b/spec/fixtures/unit/provider/package/yum/yum-check-update-subscription-manager.txt
@@ -1,0 +1,9 @@
+Loaded plugins: product-id, search-disabled-repos, subscription-manager
+
+This system is not registered with an entitlement server. You can use subscription-manager to register on.
+
+curl.i686                               7.32.0-10.fc20           updates
+curl.x86_64                             7.32.0-10.fc20           updates
+gawk.i686                               4.1.0-3.fc20             updates
+dhclient.i686                           12:4.1.1-38.P1.fc20      updates
+java-1.8.0-openjdk.x86_64               1:1.8.0.131-2.b11.el7_3  updates

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -55,7 +55,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
       end
     end
 
-    describe 'with install_options' do 
+    describe 'with install_options' do
       it 'can parse disable-repo with array of strings' do
           resource[:install_options] = ['--disable-repo=dev*', '--disable-repo=prod*']
           expect(provider).to receive(:execute) do | arr|
@@ -192,6 +192,15 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
       it "ignores all mentions of plugin output" do
         expect(output).not_to include("Random plugin")
+      end
+    end
+
+    context "with subscription manager enabled " do
+      let(:check_update) { File.read(my_fixture("yum-check-update-subscription-manager.txt")) }
+      let(:output) { described_class.parse_updates(check_update) }
+
+      it "parses correctly formatted entries" do
+        expect(output['curl.x86_64']).to eq([{:name => 'curl', :epoch => '0', :version => '7.32.0', :release => '10.fc20', :arch => 'x86_64'}])
       end
     end
   end


### PR DESCRIPTION
RedHat RHBA-2020:1028 changed the output of `yum check-update`
when subscription manager is enabled(adding extra blank lines) breaking
the `check_updates` method of `yum provider`.

This commit changes how we parse the output of `yum check-update`
in order not to depend on the first blank line occurred but rather
split by blank lines, and check on each chunk to see
if we can extract package information.