### PR TITLE
(PUP-7663) -1 instead if '' when expiry = :absent

### DIFF
--- a/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
+++ b/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
@@ -1,0 +1,34 @@
+test_name "verifies that puppet resource creates a user and assigns the correct expiry date when absent" do
+  confine :except, :platform => 'windows'
+  confine :except, :platform => /^eos-/ # See ARISTA-37
+  confine :except, :platform => /^cisco_/ # See PUP-5828
+
+  tag 'audit:medium',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                         # in ways that might require special permissions
+                         # or be harmful to the system running the test
+
+  user = "pl#{rand(999999).to_i}"
+
+  teardown do
+    step "cleanup"
+    agents.each do |host|
+      on(host, puppet_resource('user', user, 'ensure=absent'))
+    end
+  end
+  
+  agents.each do |host|
+    step "user should not exist"
+    on(host, puppet_resource('user', user, 'ensure=absent'), :acceptable_exit_codes => [0])
+  
+    step "create user with expiry=absent"
+    on(host, puppet_resource('user', user, 'ensure=present', 'expiry=absent'), :acceptable_exit_codes => [0])
+  
+    step "verify the user exists and expiry is not set (meaning never expire)"
+    on(host, puppet_resource('user', user)) do |result|
+      assert_match(/ensure.*=> 'present'/, result.stdout)
+      assert_no_match(/expiry.*=>/, result.stdout)
+    end
+  end
+end

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -21,7 +21,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   options :expiry, :method => :sp_expire,
     :munge => proc { |value|
       if value == :absent
-        ''
+        if Facter.value(:operatingsystem) && Facter.value(:operatingsystemmajrelease) == "11"
+          -1
+        else
+          ''
+        end
       else
         case Facter.value(:operatingsystem)
         when 'Solaris'

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -315,6 +315,14 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       expect(provider).to receive(:execute).with(['/usr/sbin/usermod', '-e', '', 'myuser'], hash_including(custom_environment: {}))
       provider.expiry = :absent
     end
+
+    it "should use -e with -1 when the expiry property is removed on SLES11" do
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('SLES')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('11')
+      resource[:expiry] = :absent
+      expect(provider).to receive(:execute).with(['/usr/sbin/usermod', '-e', -1, 'myuser'], hash_including(custom_environment: {}))
+      provider.expiry = :absent
+    end
   end
 
   describe "#comment" do


### PR DESCRIPTION
When a user is created, useradd will execute 'useradd -e -M test'.
Useradd -e on SLES requires a number of days parameter that is optional on other
platforms. Without the parameter, useradd -e on SLES will create an
expired user with expiration date on 1970-01-01.

The newly added -1 means the account will never expire