### PR TITLE
(PUP-10434) Observe http_keepalive_timeout setting

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -28,7 +28,7 @@ class Puppet::HTTP::Client
   # @param [Integer] retry_limit number of HTTP reties allowed in a given
   #   request
   #
-  def initialize(pool: Puppet::Network::HTTP::Pool.new(15), ssl_context: nil, system_ssl_context: nil, redirect_limit: 10, retry_limit: 100)
+  def initialize(pool: Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout]), ssl_context: nil, system_ssl_context: nil, redirect_limit: 10, retry_limit: 100)
     @pool = pool
     @default_headers = {
       'X-Puppet-Version' => Puppet.version,

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -28,7 +28,7 @@ class Puppet::HTTP::Client
   # @param [Integer] retry_limit number of HTTP reties allowed in a given
   #   request
   #
-  def initialize(pool: Puppet::Network::HTTP::Pool.new, ssl_context: nil, system_ssl_context: nil, redirect_limit: 10, retry_limit: 100)
+  def initialize(pool: Puppet::Network::HTTP::Pool.new(15), ssl_context: nil, system_ssl_context: nil, redirect_limit: 10, retry_limit: 100)
     @pool = pool
     @default_headers = {
       'X-Puppet-Version' => Puppet.version,

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -9,7 +9,7 @@
 # @api private
 #
 class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
-  attr_reader :factory
+  attr_reader :factory, :keepalive_timeout
 
   def initialize(keepalive_timeout)
     @pool = {}

--- a/lib/puppet/network/http/pool.rb
+++ b/lib/puppet/network/http/pool.rb
@@ -9,11 +9,9 @@
 # @api private
 #
 class Puppet::Network::HTTP::Pool < Puppet::Network::HTTP::BasePool
-  FIFTEEN_SECONDS = 15
-
   attr_reader :factory
 
-  def initialize(keepalive_timeout = FIFTEEN_SECONDS)
+  def initialize(keepalive_timeout)
     @pool = {}
     @factory = Puppet::Network::HTTP::Factory.new
     @keepalive_timeout = keepalive_timeout

--- a/spec/integration/network/http_pool_spec.rb
+++ b/spec/integration/network/http_pool_spec.rb
@@ -107,7 +107,7 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
 
     context "when using persistent HTTPS connections" do
       around :each do |example|
-        pool = Puppet::Network::HTTP::Pool.new
+        pool = Puppet::Network::HTTP::Pool.new(15)
         Puppet.override(:http_pool => pool) do
           example.run
         end

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -775,4 +775,34 @@ describe Puppet::HTTP::Client do
       client.get(uri)
     end
   end
+
+  context "persistent connections" do
+    before :each do
+      stub_request(:get, uri)
+    end
+
+    it 'defaults keepalive to http_keepalive_timeout' do
+      expect(client.pool.keepalive_timeout).to eq(Puppet[:http_keepalive_timeout])
+    end
+
+    it 'reuses a cached connection' do
+      allow(Puppet).to receive(:debug)
+      expect(Puppet).to receive(:debug).with(/^Creating new connection/)
+      expect(Puppet).to receive(:debug).with(/^Using cached connection/)
+
+      client.get(uri)
+      client.get(uri)
+    end
+
+    it 'can be disabled' do
+      Puppet[:http_keepalive_timeout] = 0
+
+      allow(Puppet).to receive(:debug)
+      expect(Puppet).to receive(:debug).with(/^Creating new connection/).twice
+      expect(Puppet).to receive(:debug).with(/^Using cached connection/).never
+
+      client.get(uri)
+      client.get(uri)
+    end
+  end
 end

--- a/spec/unit/network/http/pool_spec.rb
+++ b/spec/unit/network/http/pool_spec.rb
@@ -26,11 +26,11 @@ describe Puppet::Network::HTTP::Pool do
   end
 
   def create_pool
-    Puppet::Network::HTTP::Pool.new
+    Puppet::Network::HTTP::Pool.new(15)
   end
 
   def create_pool_with_connections(site, *connections)
-    pool = Puppet::Network::HTTP::Pool.new
+    pool = Puppet::Network::HTTP::Pool.new(15)
     connections.each do |conn|
       pool.release(site, verifier, conn)
     end
@@ -38,7 +38,7 @@ describe Puppet::Network::HTTP::Pool do
   end
 
   def create_pool_with_http_connections(site, *connections)
-    pool = Puppet::Network::HTTP::Pool.new
+    pool = Puppet::Network::HTTP::Pool.new(15)
     connections.each do |conn|
       pool.release(site, nil, conn)
     end


### PR DESCRIPTION
The http client didn't construct the connection pool the same way that the legacy networking code did. As a result, connections made with the client did not observe the http_keepalive_timeout, so it couldn't be disabled or tuned.