### PR TITLE
(PUP-10437) systemd provider listing static services fix

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect|bad)\s*$/i).each do |m|
+    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect|bad|static)\s*$/i).each do |m|
       Puppet.debug("#{m[0]} marked as bad by `systemctl`. It is recommended to be further checked.") if m[1] == "bad"
       i << new(:name => m[0])
     end

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -26,7 +26,8 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect)\s*$/i).each do |m|
+    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect|bad)\s*$/i).each do |m|
+      Puppet.debug("#{m[0]} marked as bad by `systemctl`. It is recommended to be further checked.") if m[1] == "bad"
       i << new(:name => m[0])
     end
     return i

--- a/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
+++ b/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
@@ -5,3 +5,4 @@ autovt@.service                             disabled
 avahi-daemon.service                        enabled
 blk-availability.service                    disabled
 brandbot.service                            static
+apparmor.service                            bad

--- a/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
+++ b/spec/fixtures/unit/provider/service/systemd/list_unit_files_services
@@ -6,3 +6,11 @@ avahi-daemon.service                        enabled
 blk-availability.service                    disabled
 brandbot.service                            static
 apparmor.service                            bad
+udev.service                                enabled-runtime
+ufw.service                                 linked
+umountfs.service                            linked-runtime
+umountnfs.service                           masked
+umountroot.service                          masked-runtime
+urandom.service                             indirect
+user@.service                               generated
+uuidd.service                               transient

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -154,6 +154,7 @@ describe Puppet::Type.type(:service).provider(:systemd) do
         apparmor.service
         umountnfs.service
         urandom.service
+        brandbot.service
       })
     end
 

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -151,9 +151,16 @@ describe Puppet::Type.type(:service).provider(:systemd) do
         autovt@.service
         avahi-daemon.service
         blk-availability.service
+        apparmor.service
       })
     end
-  end
+
+    it "should print a debug message when a service with the state `bad` is found" do
+      expect(described_class).to receive(:systemctl).with('list-unit-files', '--type', 'service', '--full', '--all', '--no-pager').and_return(File.read(my_fixture('list_unit_files_services')))
+      expect(Puppet).to receive(:debug).with("apparmor.service marked as bad by `systemctl`. It is recommended to be further checked.")
+      described_class.instances
+    end
+  end 
 
   describe "#start" do
     it "should use the supplied start command if specified" do

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -152,6 +152,8 @@ describe Puppet::Type.type(:service).provider(:systemd) do
         avahi-daemon.service
         blk-availability.service
         apparmor.service
+        umountnfs.service
+        urandom.service
       })
     end
 


### PR DESCRIPTION
Even though, services that are in the `static` state can not be enabled due to missing information in the `[Install]` unit file section (puppet actually shows them always as enabled but a debug log is printed every time there is an enabling/disabling attempt and no changes are done),
they can be started/stopped (and status can be checked), so puppet is able to show information about them. Before this commit, puppet already presented information about these services but only when asked about a particular service by name (`puppet resource service <static_service_name>`).  When listing information about all available services (`puppet resource service`), `static` services were omitted, causing inconsistency in puppet's behaviour.