### PR TITLE
(PUP-10351) Puppet Agent fails to self-restart

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -43,6 +43,9 @@ class Puppet::Agent
     end
 
     result = nil
+    waitforlock = 2
+    maxwaitforlock = 30
+    wait_for_lock_deadline = nil
     block_run = Puppet::Application.controlled_run do
       splay client_options.fetch :splay, Puppet[:splay]
       result = run_in_fork(should_fork) do
@@ -60,8 +63,17 @@ class Puppet::Agent
               end
             end
           rescue Puppet::LockError
-            Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
-            nil
+            wait_for_lock_deadline ||= Time.now.to_i + maxwaitforlock
+
+            if Time.now.to_i > wait_for_lock_deadline
+              Puppet.notice _("Exiting now because the maximum wait for lock time has been exceeded.")
+              nil
+            else
+              Puppet.info _("Another puppet instance is already running")
+              Puppet.info _("Waiting for it to finish. Will try again in %{time} seconds.") % {time: waitforlock}
+              sleep waitforlock
+              retry
+            end
           rescue RunTimeoutError => detail
             Puppet.log_exception(detail, _("Execution of %{client_class} did not complete within %{runtimeout} seconds and was terminated.") %
               {client_class: client_class,

--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -95,7 +95,7 @@ class Puppet::Daemon
 
   def restart
     Puppet::Application.restart!
-    reexec unless agent and agent.running?
+    reexec
   end
 
   def reopen_logs

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -224,7 +224,6 @@ describe Puppet::Daemon, :unless => Puppet.features.microsoft_windows? do
     end
 
     it "should reexec itself if the agent is not running" do
-      expect(agent).to receive(:running?).and_return(false)
       daemon.agent = agent
       expect(daemon).to receive(:reexec)
 


### PR DESCRIPTION
Before this change, puppet agent could get in a repeatedly `restart_requested` state. 

This happens due to two agent runs taking place at about the same time where the second one needs to reload the puppet service(or simply receives a HUP signal) and can't restart because the first run is still in progress.