### PR TITLE
(PUP-10469) Fix portage package provider confine

### DIFF
--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -20,9 +20,9 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     end
   end
 
-  confine :operatingsystem => :gentoo
+  confine :osfamily => :gentoo
 
-  defaultfor :operatingsystem => :gentoo
+  defaultfor :osfamily => :gentoo
 
   def self.instances
     result_format = self.eix_result_format

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -72,6 +72,11 @@ describe Puppet::Type.type(:package).provider(:portage) do
     expect(described_class).to be_reinstallable
   end
 
+  it "should be the default provider on :osfamily => Gentoo" do
+    expect(Facter).to receive(:value).with(:osfamily).and_return("Gentoo")
+    expect(described_class.default?).to be_truthy
+  end
+
   it 'should support string install options' do
     expect(@provider).to receive(:emerge).with('--foo', '--bar', @resource[:name])
 


### PR DESCRIPTION
The original confine against operatingsystem makes the portage provider unusable on other Gentoo-based distributions, if they have a proper operatingsystem name.

Switching it to confine against osfamily instead will let it be used for all Gentoo-based distributions, regardless of their name.