### PR TITLE
(PUP-10444) Deprecate http file content terminus

### DIFF
--- a/lib/puppet/indirector/file_content/http.rb
+++ b/lib/puppet/indirector/file_content/http.rb
@@ -10,6 +10,11 @@ class Puppet::Indirector::FileContent::Http < Puppet::Indirector::GenericHttp
 
   @http_method = :get
 
+  def initialize
+    Puppet.deprecation_warning(_("Puppet::Indirector::FileContent::Http is deprecated. Use Puppet::HTTP::Client instead."))
+    super
+  end
+
   def find(request)
     response = super
     model.from_binary(uncompress_body(response))


### PR DESCRIPTION
Puppet no longer uses the 'http' terminus to retrieve file content, so deprecate
it in preparation for puppet 7. Puppet **does** use the 'http' terminus for file
metadata, so that one is unchanged.

There are no tests for the terminus, so the warning is only printed if you
explicitly call a method on the indirection:

    irb(main):008:0> Puppet::FileServing::Content.indirection.terminus_class = 'http'
    => "http"
    irb(main):009:0> Puppet::FileServing::Content.indirection.find('https://foo.com')
    Warning: Puppet::Indirector::FileContent::Http is deprecated. Use Puppet::HTTP::Client instead.
    (location: /Users/josh/work/puppet/lib/puppet/indirector/file_content/http.rb:15:in `initialize')