### PR TITLE
(PUP-10292) Evaluate trusted-external lazily

### DIFF
--- a/spec/unit/context/trusted_information_spec.rb
+++ b/spec/unit/context/trusted_information_spec.rb
@@ -90,6 +90,23 @@ describe Puppet::Context::TrustedInformation, :unless => RUBY_PLATFORM == 'java'
 
       expect(trusted.external).to eq(external_data)
     end
+
+    it 'does not run the trusted external command when creating a trusted context' do
+      Puppet[:trusted_external_command] = '/usr/bin/generate_data.sh'
+
+      expect(Puppet::Util::Execution).to receive(:execute).never
+      Puppet::Context::TrustedInformation.remote(true, 'cert name', cert)
+    end
+
+    it 'only runs the trusted external command the first time it is invoked' do
+      Puppet[:trusted_external_command] = '/usr/bin/generate_data.sh'
+
+      expect(Puppet::Util::Execution).to receive(:execute).with(['/usr/bin/generate_data.sh', 'cert name'], anything).and_return(JSON.dump(external_data)).once
+
+      trusted = Puppet::Context::TrustedInformation.remote(true, 'cert name', cert)
+      trusted.external
+      trusted.external
+    end
   end
 
   context "when local" do


### PR DESCRIPTION
Trusted external command may be expensive to run, so we only want to run it if we actually want/use the trusted external data. Previously, this command was invoked on pretty much every call, including file metadata requests, of which there can be hundreds during some Puppet runs.

After this commit, the trusted external command should typically only be invoked twice per Puppet run - once when the agent requests a Node, for environment, to start Pluginsync, and once when the agent requests a catalog.