### PR TITLE
(PUP-10470) Pass credentials in basic_auth

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -37,18 +37,19 @@ class Puppet::Forge
         uri = URI(str)
 
         headers = { "User-Agent" => user_agent }
-        user = nil
-        password = nil
+        basic_auth = nil
 
         if forge_authorization
           headers["Authorization"] = forge_authorization
         elsif @uri.user && @uri.password
-          user = @uri.user
-          password = @uri.password
+          basic_auth = {
+            user: @uri.user,
+            password: @uri.password
+          }
         end
 
         http = Puppet.runtime['http']
-        response = http.get(uri, headers: headers, options: {user: user, password: password, ssl_context: @ssl_context})
+        response = http.get(uri, headers: headers, options: {basic_auth: basic_auth, ssl_context: @ssl_context})
         io.write(response.body) if io.respond_to?(:write)
         response
       rescue Puppet::SSL::CertVerifyError => e

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -277,8 +277,7 @@ class Puppet::HTTP::Client
   private
 
   def execute_streaming(request, options: {}, &block)
-    user = options.fetch(:user, nil)
-    password = options.fetch(:password, nil)
+    basic_auth = options.fetch(:basic_auth, nil)
 
     redirects = 0
     retries = 0
@@ -287,7 +286,7 @@ class Puppet::HTTP::Client
 
     while !done do
       connect(request.uri, options: options) do |http|
-        apply_auth(request, user, password)
+        apply_auth(request, basic_auth)
 
         # don't call return within the `request` block
         http.request(request) do |nethttp|
@@ -395,9 +394,9 @@ class Puppet::HTTP::Client
     @default_system_ssl_context = ssl.create_system_context(cacerts: cacerts)
   end
 
-  def apply_auth(request, user, password)
-    if user && password
-      request.basic_auth(user, password)
+  def apply_auth(request, basic_auth)
+    if basic_auth
+      request.basic_auth(basic_auth[:user], basic_auth[:password])
     end
   end
 

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -21,9 +21,6 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
     url = encode_query(url, params)
 
     options[:use_ssl] = url.scheme == 'https'
-    if options[:user] && options[:password]
-      options[:basic_auth] = { user: options[:user], password: options[:password] }
-    end
 
     client = @http_client_class.new(url.host, url.port, options)
     response = Puppet::HTTP::Response.new(client.get(url.request_uri, headers, options), url)
@@ -46,9 +43,6 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
     url = encode_query(url, params)
 
     options[:use_ssl] = url.scheme == 'https'
-    if options[:user] && options[:password]
-      options[:basic_auth] = { user: options[:user], password: options[:password] }
-    end
 
     client = @http_client_class.new(url.host, url.port, options)
     response = Puppet::HTTP::Response.new(client.post(url.request_uri, body, headers, options), url)

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -26,8 +26,10 @@ Puppet::Reports.register_report(:http) do
     }
 
     if url.user && url.password
-      options[:user] = url.user
-      options[:password] = url.password
+      options[:basic_auth] = {
+        user: url.user,
+        password: url.password
+      }
     end
 
     client = Puppet.runtime['http']

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -474,38 +474,38 @@ describe Puppet::HTTP::Client do
     it "submits credentials for GET requests" do
       stub_request(:get, uri).with(basic_auth: credentials)
 
-      client.get(uri, options: {user: 'user', password: 'pass'})
+      client.get(uri, options: {basic_auth: {user: 'user', password: 'pass'}})
     end
 
     it "submits credentials for PUT requests" do
       stub_request(:put, uri).with(basic_auth: credentials)
 
-      client.put(uri, "hello", headers: {'Content-Type' => 'text/plain'}, options: {user: 'user', password: 'pass'})
+      client.put(uri, "hello", headers: {'Content-Type' => 'text/plain'}, options: {basic_auth: {user: 'user', password: 'pass'}})
     end
 
     it "returns response containing access denied" do
       stub_request(:get, uri).with(basic_auth: credentials).to_return(status: [403, "Ye Shall Not Pass"])
 
-      response = client.get(uri, options: {user: 'user', password: 'pass'})
+      response = client.get(uri, options: {basic_auth: {user: 'user', password: 'pass'}})
       expect(response.code).to eq(403)
       expect(response.reason).to eq("Ye Shall Not Pass")
       expect(response).to_not be_success
     end
 
-    it 'omits basic auth if user is nil' do
+    it 'includes basic auth if user is nil' do
       stub_request(:get, uri).with do |req|
-        expect(req.headers).to_not include('Authorization')
+        expect(req.headers).to include('Authorization')
       end
 
-      client.get(uri, options: {user: nil, password: 'pass'})
+      client.get(uri, options: {basic_auth: {user: nil, password: 'pass'}})
     end
 
-    it 'omits basic auth if password is nil' do
+    it 'includes basic auth if password is nil' do
       stub_request(:get, uri).with do |req|
-        expect(req.headers).to_not include('Authorization')
+        expect(req.headers).to include('Authorization')
       end
 
-      client.get(uri, options: {user: 'user', password: nil})
+      client.get(uri, options: {basic_auth: {user: 'user', password: nil}})
     end
   end
 
@@ -557,7 +557,7 @@ describe Puppet::HTTP::Client do
       stub_request(:get, start_url).with(basic_auth: credentials).to_return(redirect_to(url: bar_url))
       stub_request(:get, bar_url).with(basic_auth: credentials).to_return(status: 200)
 
-      client.get(start_url, options: {user: 'user', password: 'pass'})
+      client.get(start_url, options: {basic_auth: {user: 'user', password: 'pass'}})
     end
 
     it "redirects given a relative location" do

--- a/spec/unit/http/external_client_spec.rb
+++ b/spec/unit/http/external_client_spec.rb
@@ -164,38 +164,38 @@ describe Puppet::HTTP::ExternalClient do
     it "submits credentials for GET requests" do
       stub_request(:get, uri).with(basic_auth: credentials)
 
-      client.get(uri, options: {user: 'user', password: 'pass'})
+      client.get(uri, options: {basic_auth: {user: 'user', password: 'pass'}})
     end
 
     it "submits credentials for POST requests" do
       stub_request(:post, uri).with(basic_auth: credentials)
 
-      client.post(uri, "", options: {content_type: 'text/plain', user: 'user', password: 'pass'})
+      client.post(uri, "", options: {content_type: 'text/plain', basic_auth: {user: 'user', password: 'pass'}})
     end
 
     it "returns response containing access denied" do
       stub_request(:get, uri).with(basic_auth: credentials).to_return(status: [403, "Ye Shall Not Pass"])
 
-      response = client.get(uri, options: {user: 'user', password: 'pass'})
+      response = client.get(uri, options: { basic_auth: {user: 'user', password: 'pass'}})
       expect(response.code).to eq(403)
       expect(response.reason).to eq("Ye Shall Not Pass")
       expect(response).to_not be_success
     end
 
-    it 'omits basic auth if user is nil' do
+    it 'includes basic auth if user is nil' do
       stub_request(:get, uri).with do |req|
-        expect(req.headers).to_not include('Authorization')
+        expect(req.headers).to include('Authorization')
       end
 
-      client.get(uri, options: {user: nil, password: 'pass'})
+      client.get(uri, options: {basic_auth: {user: nil, password: 'pass'}})
     end
 
-    it 'omits basic auth if password is nil' do
+    it 'includes basic auth if password is nil' do
       stub_request(:get, uri).with do |req|
-        expect(req.headers).to_not include('Authorization')
+        expect(req.headers).to include('Authorization')
       end
 
-      client.get(uri, options: {user: 'user', password: nil})
+      client.get(uri, options: {basic_auth: {user: 'user', password: nil}})
     end
   end
 end


### PR DESCRIPTION
The old API accepts credenials as options[:basic_auth] which contains a
hash with username and password. The new API had flattened these so that
username was options[:user] and password was options[:password]. This
commit reverts back to the old way so that credentials are namespaced
and passed in as options[:basic_auth][:user] and
options[:basic_auth][:password]