### PR TITLE
(maint) Merge up 5c8f9a to master fix

### DIFF
--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -440,7 +440,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
 
   describe "#insync_enabled?" do
     let(:provider) do
-      described_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
+      provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
     end
 
     before do


### PR DESCRIPTION
Aligns usage of `provider_class` instead of `described_class` in `systemd_spec.rb`.