### PR TITLE
(PUP-10477) remove non-local return from agent.rb

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -61,15 +61,15 @@ class Puppet::Agent
             end
           rescue Puppet::LockError
             Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
-            return
+            nil
           rescue RunTimeoutError => detail
             Puppet.log_exception(detail, _("Execution of %{client_class} did not complete within %{runtimeout} seconds and was terminated.") %
               {client_class: client_class,
               runtimeout: Puppet[:runtimeout]})
-            return 1
+            nil
           rescue StandardError => detail
             Puppet.log_exception(detail, _("Could not run %{client_class}: %{detail}") % { client_class: client_class, detail: detail })
-            1
+            nil
           end
         end
       end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -291,7 +291,7 @@ describe Puppet::Agent do
         expect(client).not_to receive(:handling)
         expect(Puppet).to receive(:log_exception).with(be_an_instance_of(Puppet::Agent::RunTimeoutError), anything)
 
-        expect(@agent.run).to eq(1)
+        expect(@agent.run).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
When agent run is done in a forked process and an error is raised,
having an explicitly return in a block ends up in hitting a
LocalJumpError.

```
-- Logs begin at Thu 2020-04-30 10:08:03 UTC, end at Thu 2020-04-30 10:09:20 UTC. --
Apr 30 10:08:12 formative-child systemd[1]: Started Puppet agent.
Apr 30 10:08:12 formative-child systemd[1]: Starting Puppet agent...
Apr 30 10:08:17 formative-child puppet-agent[874]: Starting Puppet client version 6.15.0
Apr 30 10:08:17 formative-child puppet-agent[1265]: Could not run Puppet configuration client: undefined local variable or method `a' for #<Puppet::Agent:0x0000000002c8aad0>
Apr 30 10:08:17 formative-child puppet[874]: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:98:in `fork': unexpected return
```