### PR TITLE
(PUP-10479) systemd wrongly reports enabled state

### DIFF
--- a/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
+++ b/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
@@ -1,0 +1,38 @@
+require 'puppet/acceptance/service_utils'
+extend Puppet::Acceptance::ServiceUtils
+
+test_name 'systemd service shows correct output when queried with "puppet resource"' do
+
+  tag 'audit:high'
+
+  package_name = {'el'     => 'httpd',
+                  'centos' => 'httpd',
+                  'fedora' => 'httpd',
+                  'debian' => 'apache2',
+                  'sles'   => 'apache2',
+                  'ubuntu' => 'cron'}
+
+  # This test ensures that 'puppet resource' output matches the system state
+  confine :to, {}, agents.select { |agent| supports_systemd?(agent) }
+
+  agents.each do |agent|
+    platform = agent.platform.variant
+    initial_state = on(agent, puppet_resource('service', package_name[platform])).stdout
+
+    teardown do
+      apply_manifest_on(agent, initial_state)
+    end
+
+    step "Setting ensure=stopped and enable=true" do
+      on(agent, puppet_resource('service', package_name[platform], 'ensure=stopped', 'enable=true'))
+    end
+
+    step "Expect reported status to match system state" do
+      on(agent, puppet_resource('service', package_name[platform], 'ensure=stopped', 'enable=true')) do
+        assert_match(/ensure\s*=>\s*'stopped'/, stdout, "Expected '#{package_name[platform]}' service to appear as stopped")
+        assert_match(/enable\s*=>\s*'true'/, stdout, "Expected '#{package_name[platform]}' service to appear as enabled")
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
When a systemd service is managed with `puppet resource`,
inconsistencies could be encountered depending on the properties
managed.

`Puppet::Type.to_resource` checks the status of each parameter,
ultimately calling the `enabled?` method in the systemd provider. If
`statuscmd` was previously called, it would have overwritten the
contents of `$CHILD_STATUS`, which is used by the `enabled?` method as
the exit code of `systemctl is-enabled`.

This could happen when passing both `ensure=stopped` and
`enabled=true` to a service, causing `systemctl is-active` to exit
with 3. When `enabled?` is called again, `$CHILD_STATUS` refers to the
context of the `is-active` call, which is not relevant anymore.

To fix this, we update the method calling `is-enabled` to also return
the exit code.