### PR TITLE
(PUP-10471) Use symbols for implementation names

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -150,7 +150,7 @@ module Puppet
   # @param args [Array<String>] the command line arguments to use for initialization
   # @param require_config [Boolean] controls loading of Puppet configuration files
   # @param global_settings [Boolean] controls push to global context after settings object initialization
-  # @param runtime_implementations [Hash<String, Object>] runtime implementations to register
+  # @param runtime_implementations [Hash<Symbol, Object>] runtime implementations to register
   # @return [void]
   def self.initialize_settings(args = [], require_config = true, push_settings_globally = true, runtime_implementations = {})
     do_initialize_settings_for_run_mode(:user, args, require_config, push_settings_globally, runtime_implementations)
@@ -241,7 +241,7 @@ module Puppet
         end
       },
       :ssl_host => proc { Puppet::SSL::Host.localhost(true) },
-      :http_session => proc { Puppet.runtime["http"].create_session },
+      :http_session => proc { Puppet.runtime[:http].create_session },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins },
       :rich_data => false
     }

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -259,7 +259,7 @@ Licensed under the Apache 2.0 License
         end
       end
       devices.collect do |devicename,device|
-        pool = Puppet.runtime['http'].pool
+        pool = Puppet.runtime[:http].pool
         Puppet.override(:http_pool => pool) do
           # TODO when we drop support for ruby < 2.5 we can remove the extra block here
           begin

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -90,7 +90,7 @@ HELP
     @cert_provider = Puppet::X509::CertProvider.new
     @ssl_provider = Puppet::SSL::SSLProvider.new
     @machine = Puppet::SSL::StateMachine.new
-    @session = Puppet.runtime['http'].create_session
+    @session = Puppet.runtime[:http].create_session
   end
 
   def setup_logs

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -194,7 +194,7 @@ class Puppet::Configurer
   # This just passes any options on to the catalog,
   # which accepts :tags and :ignoreschedules.
   def run(options = {})
-    pool = Puppet.runtime['http'].pool
+    pool = Puppet.runtime[:http].pool
     # We create the report pre-populated with default settings for
     # environment and transaction_uuid very early, this is to ensure
     # they are sent regardless of any catalog compilation failures or
@@ -459,7 +459,7 @@ class Puppet::Configurer
     ::Facter.clear
     facts = find_facts
 
-    client = Puppet.runtime['http']
+    client = Puppet.runtime[:http]
     session = client.create_session
     puppet = session.route_to(:puppet)
 

--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -75,7 +75,7 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
         facts.name = Puppet[:node_name_value]
       end
 
-      client = Puppet.runtime['http']
+      client = Puppet.runtime[:http]
       session = client.create_session
       puppet = session.route_to(:puppet)
 

--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -41,7 +41,7 @@ Puppet::Face.define(:plugin, '0.0.1') do
     when_invoked do |options|
       remote_environment_for_plugins = Puppet::Node::Environment.remote(Puppet[:environment])
 
-      pool = Puppet.runtime['http'].pool
+      pool = Puppet.runtime[:http].pool
       Puppet.override(:http_pool => pool) do
         begin
           handler = Puppet::Configurer::PluginHandler.new

--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -48,7 +48,7 @@ class Puppet::Forge
           }
         end
 
-        http = Puppet.runtime['http']
+        http = Puppet.runtime[:http]
         response = http.get(uri, headers: headers, options: {basic_auth: basic_auth, ssl_context: @ssl_context})
         io.write(response.body) if io.respond_to?(:write)
         response

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -32,7 +32,7 @@ Puppet::Reports.register_report(:http) do
       }
     end
 
-    client = Puppet.runtime['http']
+    client = Puppet.runtime[:http]
     client.post(url, self.to_yaml, headers: headers, options: options) do |response|
       unless response.success?
         Puppet.err _("Unable to submit report to %{url} [%{code}] %{message}") % { url: Puppet[:reporturl].to_s, code: response.code, message: response.reason }

--- a/lib/puppet/runtime.rb
+++ b/lib/puppet/runtime.rb
@@ -1,12 +1,15 @@
 require 'puppet/http'
 require 'singleton'
 
+# Provides access to runtime implementations.
+#
+# @api private
 class Puppet::Runtime
   include Singleton
 
   def initialize
     @runtime_services = {
-      'http' => proc do
+      http: proc do
         klass = Puppet::Network::HttpPool.http_client_class
         if klass == Puppet::Network::HTTP::Connection
           Puppet::HTTP::Client.new
@@ -18,6 +21,11 @@ class Puppet::Runtime
   end
   private :initialize
 
+  # Get a runtime implementation.
+  #
+  # @param name [Symbol] the name of the implementation
+  # @return [Object] the runtime implementation
+  # @api private
   def [](name)
     service = @runtime_services[name]
     raise ArgumentError, "Unknown service #{name}" unless service
@@ -29,11 +37,18 @@ class Puppet::Runtime
     end
   end
 
+  # Register a runtime implementation.
+  #
+  # @param name [Symbol] the name of the implementation
+  # @param impl [Object] the runtime implementation
+  # @api private
   def []=(name, impl)
     @runtime_services[name] = impl
   end
 
-  # for testing
+  # Clears all implementations. This is used for testing.
+  #
+  # @api private
   def clear
     initialize
   end

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -279,8 +279,8 @@ class Puppet::SSL::StateMachine
         Puppet.info(_("Will try again in %{time} seconds.") % {time: time})
 
         # close persistent connections and session state before sleeping
-        Puppet.runtime['http'].close
-        @machine.session = Puppet.runtime['http'].create_session
+        Puppet.runtime[:http].close
+        @machine.session = Puppet.runtime[:http].create_session
 
         @machine.unlock
         Kernel.sleep(time)
@@ -373,7 +373,7 @@ class Puppet::SSL::StateMachine
     @lockfile = lockfile
     @digest = digest
     @ca_fingerprint = ca_fingerprint
-    @session = Puppet.runtime['http'].create_session
+    @session = Puppet.runtime[:http].create_session
   end
 
   # Run the state machine for CA certs and CRLs.

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -137,7 +137,7 @@ module Puppet::Test
           trusted_information:
             Puppet::Context::TrustedInformation.new('local', 'testing', {}, { "trusted_testhelper" => true }),
           ssl_context: Puppet::SSL::SSLContext.new(cacerts: []).freeze,
-          http_session: proc { Puppet.runtime["http"].create_session }
+          http_session: proc { Puppet.runtime[:http].create_session }
         },
         "Context for specs")
 

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -297,7 +297,7 @@ module Puppet
     end
 
     def get_from_http_source(url, &block)
-      client = Puppet.runtime['http']
+      client = Puppet.runtime[:http]
       client.get(url, options: {include_system_store: true}) do |response|
         raise Puppet::HTTP::ResponseError.new(response) unless response.success?
 

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -36,22 +36,22 @@ describe Puppet::Network::HttpPool do
     end
 
     it "uses the default http client" do
-      expect(Puppet.runtime['http']).to be_an_instance_of(Puppet::HTTP::Client)
+      expect(Puppet.runtime[:http]).to be_an_instance_of(Puppet::HTTP::Client)
     end
 
     it "switches to the external client implementation" do
       Puppet::Network::HttpPool.http_client_class = http_impl
 
-      expect(Puppet.runtime['http']).to be_an_instance_of(Puppet::HTTP::ExternalClient)
+      expect(Puppet.runtime[:http]).to be_an_instance_of(Puppet::HTTP::ExternalClient)
     end
 
     it "always uses an explicitly registered http implementation" do
       Puppet::Network::HttpPool.http_client_class = http_impl
 
       new_impl = double('new_http_impl')
-      Puppet.initialize_settings([], true, true, "http" => new_impl)
+      Puppet.initialize_settings([], true, true, http: new_impl)
 
-      expect(Puppet.runtime['http']).to eq(new_impl)
+      expect(Puppet.runtime[:http]).to eq(new_impl)
     end
   end
 

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -88,14 +88,15 @@ describe Puppet do
     it 'does not register an implementation by default' do
       Puppet.initialize_settings
 
-      expect(Puppet.runtime['http']).to be_an_instance_of(Puppet::HTTP::Client)
+      expect(Puppet.runtime[:http]).to be_an_instance_of(Puppet::HTTP::Client)
     end
 
     it 'allows an implementation to be registered' do
       impl = double('http')
-      Puppet.initialize_settings([], true, true, { 'http' => impl })
+      Puppet.initialize_settings([], true, true, http: impl)
 
-      expect(Puppet.runtime['http']).to eq(impl)
+
+      expect(Puppet.runtime[:http]).to eq(impl)
     end
   end
 end

--- a/spec/unit/reports/http_spec.rb
+++ b/spec/unit/reports/http_spec.rb
@@ -64,7 +64,7 @@ describe Puppet::Reports.report(:http) do
     it "passes metric_id options" do
       stub_request(:post, url)
 
-      expect(Puppet.runtime['http']).to receive(:post).with(anything, anything, hash_including(options: hash_including(metric_id: [:puppet, :report, :http]))).and_call_original
+      expect(Puppet.runtime[:http]).to receive(:post).with(anything, anything, hash_including(options: hash_including(metric_id: [:puppet, :report, :http]))).and_call_original
 
       subject.process
     end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -882,7 +882,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         machine = described_class.new(waitforcert: 15)
 
         state = Puppet::SSL::StateMachine::Wait.new(machine)
-        expect(Puppet.runtime['http'].pool).to receive(:close).and_call_original
+        expect(Puppet.runtime[:http].pool).to receive(:close).and_call_original
         expect(Kernel).to receive(:sleep).with(15).ordered
 
         state.next_state


### PR DESCRIPTION
Use symbols for names of runtime implementations, so that callers don't need to
allocate a string (puppet doesn't enforce frozen string literals yet).

Supersedes PR #8115