### PR TITLE
(PUP-10483) Modify $LOAD_PATH when settings are initialized

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -15,6 +15,7 @@ end
 # Autoload paths, either based on names or all at once.
 class Puppet::Util::Autoload
   include Puppet::Concurrent::Synchronized
+  extend Puppet::Concurrent::Synchronized
 
   @loaded = {}
 

--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -129,19 +129,6 @@ class Puppet::Util::Autoload
     end
 
     # @api private
-    def vendored_modules
-      dir = Puppet[:vendormoduledir]
-      if dir && File.directory?(dir)
-        Dir.entries(dir)
-          .reject { |f| f =~ /^\./ }
-          .collect { |f| File.join(dir, f, "lib") }
-          .find_all { |d| FileTest.directory?(d) }
-      else
-        []
-      end
-    end
-
-    # @api private
     def gem_directories
       gem_source.directories
     end
@@ -168,11 +155,6 @@ class Puppet::Util::Autoload
       # "app_defaults_initialized?" method on the main puppet Settings object.
       # --cprice 2012-03-16
       if Puppet.settings.app_defaults_initialized?
-        unless @initialized
-          $LOAD_PATH.unshift(Puppet[:libdir])
-          $LOAD_PATH.concat(vendored_modules)
-          @initialized = true
-        end
         gem_directories + module_directories(env) + $LOAD_PATH
       else
         gem_directories + $LOAD_PATH

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -99,4 +99,21 @@ describe Puppet do
       expect(Puppet.runtime[:http]).to eq(impl)
     end
   end
+
+  context "initializing $LOAD_PATH" do
+    it "should add libdir and module paths to the load path" do
+      libdir = tmpdir('libdir_test')
+      vendor_dir = tmpdir('vendor_modules')
+      module_libdir = File.join(vendor_dir, 'amodule_core', 'lib')
+      FileUtils.mkdir_p(module_libdir)
+
+      Puppet[:libdir] = libdir
+      Puppet[:vendormoduledir] = vendor_dir
+      Puppet.initialize_settings
+
+      expect($LOAD_PATH).to include(libdir)
+      expect($LOAD_PATH).to include(module_libdir)
+    end
+
+  end
 end

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -23,10 +23,10 @@ describe Puppet::Util::Autoload do
 
     def with_libdir(libdir)
       begin
-        Puppet::Util::Autoload.instance_variable_set(:@initialized, false)
         old_loadpath = $LOAD_PATH.dup
         old_libdir = Puppet[:libdir]
         Puppet[:libdir] = libdir
+        $LOAD_PATH.unshift(libdir)
         yield
       ensure
         Puppet[:libdir] = old_libdir
@@ -83,6 +83,7 @@ describe Puppet::Util::Autoload do
 
       libdir = File.expand_path('/libdir1')
       Puppet[:vendormoduledir] = vendor_dir
+      Puppet.initialize_settings
 
       with_libdir(libdir) do
         expect(@autoload.class).to receive(:gem_directories).and_return(%w{/one /two})


### PR DESCRIPTION
Move $LOAD_PATH modification earlier so that it happens when Puppet is
single threaded. This moves the vendor module inclusion to a settings hook,
and libdir to app default initialization.