### PR TITLE
(PUP-10482) Use http client for http file metadata

### DIFF
--- a/lib/puppet/indirector/file_metadata/http.rb
+++ b/lib/puppet/indirector/file_metadata/http.rb
@@ -8,12 +8,12 @@ class Puppet::Indirector::FileMetadata::Http < Puppet::Indirector::GenericHttp
 
   include Puppet::FileServing::TerminusHelper
 
-  @http_method = :head
-
   def find(request)
-    head = super
+    uri = URI(request.uri)
+    client = Puppet.runtime[:http]
+    head = client.head(uri, headers: {'Connection' => 'close'}, options: {include_system_store: true})
 
-    if head.is_a?(Net::HTTPSuccess)
+    if head.success?
       metadata = Puppet::FileServing::HttpMetadata.new(head)
       metadata.checksum_type = request.options[:checksum_type] if request.options[:checksum_type]
       metadata.collect

--- a/lib/puppet/indirector/file_metadata/http.rb
+++ b/lib/puppet/indirector/file_metadata/http.rb
@@ -11,7 +11,7 @@ class Puppet::Indirector::FileMetadata::Http < Puppet::Indirector::GenericHttp
   def find(request)
     uri = URI(request.uri)
     client = Puppet.runtime[:http]
-    head = client.head(uri, headers: {'Connection' => 'close'}, options: {include_system_store: true})
+    head = client.head(uri, options: {include_system_store: true})
 
     if head.success?
       metadata = Puppet::FileServing::HttpMetadata.new(head)

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -267,7 +267,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
               agent.run
             }.to exit_with(4)
              .and output(/Notice: Applied catalog/).to_stdout
-             .and output(%r{Error: Could not retrieve file metadata for https://127.0.0.1:#{https_port}/path/to/file: .* certificate verify failed}).to_stderr
+             .and output(%r{Error: Could not retrieve file metadata for https://127.0.0.1:#{https_port}/path/to/file: certificate verify failed}).to_stderr
           end
 
           expect(File).to_not be_exist(path)

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -132,7 +132,12 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
     it "detects when the server has closed the connection and reconnects" do
       Puppet[:http_debug] = true
 
-      https_server.start_server do |port|
+      # advertise that we support keep-alive, but we don't really
+      response_proc = -> (req, res) {
+        res['Connection'] = 'Keep-Alive'
+      }
+
+      https_server.start_server(response_proc: response_proc) do |port|
         uri = URI("https://127.0.0.1:#{port}")
         kwargs = {headers: {'Content-Type' => 'text/plain'}, options: {ssl_context: root_context}}
 

--- a/spec/lib/puppet_spec/https.rb
+++ b/spec/lib/puppet_spec/https.rb
@@ -24,6 +24,12 @@ class PuppetSpec::HTTPSServer
     res = WEBrick::HTTPResponse.new(@config)
     res.status = 200
     res.body = 'OK'
+    # The server explicitly closes the connection after handling it,
+    # so explicitly tell the client we're not going to keep it open.
+    # Without this, ruby will add `Connection: Keep-Alive`, which
+    # confuses the client when it tries to reuse the half-closed
+    # connection.
+    res['Connection'] = 'close'
     response_proc.call(req, res) if response_proc
 
     res.send_response(ssl)

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -127,6 +127,12 @@ describe Puppet::Indirector::FileMetadata::Http do
       model.indirection.find(key)
     end
 
+    it "doesn't use persistent connections" do
+      stub_request(:head, key).with(headers: {'Connection' => 'close'})
+
+      model.indirection.find(key)
+    end
+
     it "follows redirects" do
       new_url = "https://example.com/different/path"
       redirect = { status: 200, headers: { 'Location' => new_url }, body: ""}

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -127,8 +127,12 @@ describe Puppet::Indirector::FileMetadata::Http do
       model.indirection.find(key)
     end
 
-    it "doesn't use persistent connections" do
-      stub_request(:head, key).with(headers: {'Connection' => 'close'})
+    it "tries to persist the connection" do
+      # HTTP/1.1 defaults to persistent connections, so check for
+      # the header's absence
+      stub_request(:head, key).with do |request|
+        expect(request.headers).to_not include('Connection')
+      end
 
       model.indirection.find(key)
     end

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -1,0 +1,147 @@
+require 'spec_helper'
+
+require 'puppet/indirector/file_metadata'
+require 'puppet/indirector/file_metadata/http'
+
+describe Puppet::Indirector::FileMetadata::Http do
+  DEFAULT_HEADERS = {
+    "Cache-Control" => "private, max-age=0",
+    "Connection" => "close",
+    "Content-Encoding" => "gzip",
+    "Content-Type" => "text/html; charset=ISO-8859-1",
+    "Date" => "Fri, 01 May 2020 17:16:00 GMT",
+    "Expires" => "-1",
+    "Server" => "gws"
+  }.freeze
+
+  let(:certname) { 'ziggy' }
+  # The model is Puppet:FileServing::Metadata
+  let(:model) { described_class.model }
+  # The http terminus creates instances of HttpMetadata which subclass Metadata
+  let(:metadata) { Puppet::FileServing::HttpMetadata.new(key) }
+  let(:key) { "https://example.com/path/to/file" }
+  # Digest::MD5.base64digest("") => "1B2M2Y8AsgTpgAmY7PhCfg=="
+  let(:content_md5) { {"Content-MD5" => "1B2M2Y8AsgTpgAmY7PhCfg=="} }
+  let(:last_modified) { {"Last-Modified" => "Wed, 01 Jan 2020 08:00:00 GMT"} }
+
+  before :each do
+    described_class.indirection.terminus_class = :http
+  end
+
+  context "when finding" do
+    it "returns http file metadata" do
+      stub_request(:head, key)
+        .to_return(status: 200, headers: DEFAULT_HEADERS)
+
+      result = model.indirection.find(key)
+      expect(result.ftype).to eq('file')
+      expect(result.path).to eq('/dev/null')
+      expect(result.relative_path).to be_nil
+      expect(result.destination).to be_nil
+      expect(result.checksum).to match(%r{mtime})
+      expect(result.owner).to be_nil
+      expect(result.group).to be_nil
+      expect(result.mode).to be_nil
+    end
+
+    it "reports an md5 checksum if present in the response" do
+      stub_request(:head, key)
+        .to_return(status: 200, headers: DEFAULT_HEADERS.merge(content_md5))
+
+      result = model.indirection.find(key)
+      expect(result.checksum_type).to eq(:md5)
+      expect(result.checksum).to eq("{md5}d41d8cd98f00b204e9800998ecf8427e")
+    end
+
+    it "reports an mtime checksum if present in the response" do
+      stub_request(:head, key)
+        .to_return(status: 200, headers: DEFAULT_HEADERS.merge(last_modified))
+
+      result = model.indirection.find(key)
+      expect(result.checksum_type).to eq(:mtime)
+      expect(result.checksum).to eq("{mtime}2020-01-01 08:00:00 UTC")
+    end
+
+    it "prefers md5" do
+      stub_request(:head, key)
+        .to_return(status: 200, headers: DEFAULT_HEADERS.merge(content_md5).merge(last_modified))
+
+      result = model.indirection.find(key)
+      expect(result.checksum_type).to eq(:md5)
+      expect(result.checksum).to eq("{md5}d41d8cd98f00b204e9800998ecf8427e")
+    end
+
+    it "prefers mtime when explicitly requested" do
+      stub_request(:head, key)
+        .to_return(status: 200, headers: DEFAULT_HEADERS.merge(content_md5).merge(last_modified))
+
+      result = model.indirection.find(key, checksum_type: :mtime)
+      expect(result.checksum_type).to eq(:mtime)
+      expect(result.checksum).to eq("{mtime}2020-01-01 08:00:00 UTC")
+    end
+
+    it "URL encodes special characters" do
+      pending("HTTP terminus doesn't encode the URI before parsing")
+
+      stub_request(:head, %r{/path%20to%20file})
+
+      model.indirection.find('https://example.com/path to file')
+    end
+
+    it "sends query parameters" do
+      stub_request(:head, key).with(query: {'a' => 'b'})
+
+      model.indirection.find("#{key}?a=b")
+    end
+
+    it "returns nil if the content doesn't exist" do
+      stub_request(:head, key).to_return(status: 404)
+
+      expect(model.indirection.find(key)).to be_nil
+    end
+
+    it "returns nil if fail_on_404" do
+      stub_request(:head, key).to_return(status: 404)
+
+      expect(model.indirection.find(key, fail_on_404: true)).to be_nil
+    end
+
+    it "returns nil on HTTP 500" do
+      stub_request(:head, key).to_return(status: 500)
+
+      # this is kind of strange, but it does allow puppet to try
+      # multiple `source => ["URL1", "URL2"]` and use the first
+      # one based on sourceselect
+      expect(model.indirection.find(key)).to be_nil
+    end
+
+    it "accepts all content types" do
+      stub_request(:head, key).with(headers: {'Accept' => '*/*'})
+
+      model.indirection.find(key)
+    end
+
+    it "sets puppet user-agent" do
+      stub_request(:head, key).with(headers: {'User-Agent' => Puppet[:http_user_agent]})
+
+      model.indirection.find(key)
+    end
+
+    it "follows redirects" do
+      new_url = "https://example.com/different/path"
+      redirect = { status: 200, headers: { 'Location' => new_url }, body: ""}
+      stub_request(:head, key).to_return(redirect)
+      stub_request(:head, new_url)
+
+      model.indirection.find(key)
+    end
+  end
+
+  context "when searching" do
+    it "raises an error" do
+      expect {
+        model.indirection.search(key)
+      }.to raise_error(Puppet::Error, 'cannot lookup multiple files')
+    end
+  end
+end

--- a/spec/unit/indirector/file_metadata/rest_spec.rb
+++ b/spec/unit/indirector/file_metadata/rest_spec.rb
@@ -6,6 +6,7 @@ require 'puppet/indirector/file_metadata/rest'
 describe Puppet::Indirector::FileMetadata::Rest do
   let(:certname) { 'ziggy' }
   let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
+  let(:model) { described_class.model }
 
   before :each do
     described_class.indirection.terminus_class = :rest
@@ -18,13 +19,13 @@ describe Puppet::Indirector::FileMetadata::Rest do
   context "when finding" do
     let(:uri) { %r{/puppet/v3/file_metadata/:mount/path/to/file} }
     let(:key) { "puppet:///:mount/path/to/file" }
-    let(:metadata) { Puppet::FileServing::Metadata.new('/path/to/file') }
+    let(:metadata) { model.new('/path/to/file') }
 
     it "returns file metadata" do
       stub_request(:get, uri)
         .to_return(status: 200, **metadata_response(metadata))
 
-      result = described_class.indirection.find(key)
+      result = model.indirection.find(key)
       expect(result.path).to eq('/path/to/file')
     end
 
@@ -32,20 +33,20 @@ describe Puppet::Indirector::FileMetadata::Rest do
       stub_request(:get, %r{/puppet/v3/file_metadata/:mount/path%20to%20file})
         .to_return(status: 200, **metadata_response(metadata))
 
-      described_class.indirection.find('puppet:///:mount/path to file')
+      model.indirection.find('puppet:///:mount/path to file')
     end
 
     it "returns nil if the content doesn't exist" do
       stub_request(:get, uri).to_return(status: 404)
 
-      expect(described_class.indirection.find(key)).to be_nil
+      expect(model.indirection.find(key)).to be_nil
     end
 
     it "raises if fail_on_404 is true" do
       stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
 
       expect {
-        described_class.indirection.find(key, fail_on_404: true)
+        model.indirection.find(key, fail_on_404: true)
       }.to raise_error(Puppet::Error, %r{Find /puppet/v3/file_metadata/:mount/path/to/file resulted in 404 with the message: {}})
     end
 
@@ -53,7 +54,7 @@ describe Puppet::Indirector::FileMetadata::Rest do
       stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
 
       expect {
-        described_class.indirection.find(key)
+        model.indirection.find(key)
       }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
     end
 
@@ -61,20 +62,20 @@ describe Puppet::Indirector::FileMetadata::Rest do
       stub_request(:get, %r{https://example.com:8140/puppet/v3/file_metadata/:mount/path/to/file})
         .to_return(status: 200, **metadata_response(metadata))
 
-      described_class.indirection.find("puppet://example.com:8140/:mount/path/to/file")
+      model.indirection.find("puppet://example.com:8140/:mount/path/to/file")
     end
   end
 
   context "when searching" do
     let(:uri) { %r{/puppet/v3/file_metadatas/:mount/path/to/dir} }
     let(:key) { "puppet:///:mount/path/to/dir" }
-    let(:metadatas) { [Puppet::FileServing::Metadata.new('/path/to/dir')] }
+    let(:metadatas) { [model.new('/path/to/dir')] }
 
     it "returns an array of file metadata" do
       stub_request(:get, uri)
         .to_return(status: 200, **metadata_response(metadatas))
 
-      result = described_class.indirection.search(key)
+      result = model.indirection.search(key)
       expect(result.first.path).to eq('/path/to/dir')
     end
 
@@ -82,26 +83,26 @@ describe Puppet::Indirector::FileMetadata::Rest do
       stub_request(:get, %r{/puppet/v3/file_metadatas/:mount/path%20to%20dir})
         .to_return(status: 200, **metadata_response(metadatas))
 
-      described_class.indirection.search('puppet:///:mount/path to dir')
+      model.indirection.search('puppet:///:mount/path to dir')
     end
 
     it "returns an empty array if the metadata doesn't exist" do
       stub_request(:get, uri).to_return(status: 404)
 
-      expect(described_class.indirection.search(key)).to eq([])
+      expect(model.indirection.search(key)).to eq([])
     end
 
     it "returns an empty array if the metadata doesn't exist and fail_on_404 is true" do
       stub_request(:get, uri).to_return(status: 404, headers: { 'Content-Type' => 'application/json'}, body: "{}")
 
-      expect(described_class.indirection.search(key, fail_on_404: true)).to eq([])
+      expect(model.indirection.search(key, fail_on_404: true)).to eq([])
     end
 
     it "raises an error on HTTP 500" do
       stub_request(:get, uri).to_return(status: 500, headers: { 'Content-Type' => 'application/json'}, body: "{}")
 
       expect {
-        described_class.indirection.search(key)
+        model.indirection.search(key)
       }.to raise_error(Net::HTTPError, %r{Error 500 on SERVER: })
     end
 
@@ -109,7 +110,7 @@ describe Puppet::Indirector::FileMetadata::Rest do
       stub_request(:get, %r{https://example.com:8140/puppet/v3/file_metadatas/:mount/path/to/dir})
         .to_return(status: 200, **metadata_response(metadatas))
 
-      described_class.indirection.search("puppet://example.com:8140/:mount/path/to/dir")
+      model.indirection.search("puppet://example.com:8140/:mount/path/to/dir")
     end
   end
 


### PR DESCRIPTION
Use our HTTP client when making HEAD requests to retrieve file metadata from http(s) sources. Continue to trust the system cert store and puppet CA when making https connections.

We now use persistent connections when making HEAD requests. Previously we made one non-persistent connection per file resource with an http(s) source.

Also update the rest terminus tests so we call `find`, etc on the model `Puppet::FileServing::Metadata` and not on the terminus. The former takes the URL, while the latter takes a request.