### PR TITLE
(PUP-10164) Parse Content-MD5 leniently

### DIFF
--- a/lib/puppet/file_serving/http_metadata.rb
+++ b/lib/puppet/file_serving/http_metadata.rb
@@ -18,7 +18,7 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
     checksum = http_response['content-md5']
     if checksum
       # convert base64 digest to hex
-      checksum = checksum.unpack("m0").first.unpack("H*").first
+      checksum = checksum.unpack("m").first.unpack("H*").first
       @checksums[:md5] = "{md5}#{checksum}"
     end
 

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -80,6 +80,16 @@ describe Puppet::Indirector::FileMetadata::Http do
       expect(result.checksum).to eq("{mtime}2020-01-01 08:00:00 UTC")
     end
 
+    it "leniently parses base64" do
+      # Content-MD5 header is missing '==' padding
+      stub_request(:head, key)
+        .to_return(status: 200, headers: DEFAULT_HEADERS.merge("Content-MD5" => "1B2M2Y8AsgTpgAmY7PhCfg"))
+
+      result = model.indirection.find(key)
+      expect(result.checksum_type).to eq(:md5)
+      expect(result.checksum).to eq("{md5}d41d8cd98f00b204e9800998ecf8427e")
+    end
+
     it "URL encodes special characters" do
       pending("HTTP terminus doesn't encode the URI before parsing")
 


### PR DESCRIPTION
Previously, we parsed the Content-MD5 header strictly (RFC 4648), but some
webservers don't include padding, so parse the header leniently (RFC 2045).

Blocked on https://github.com/puppetlabs/puppet/pull/8131