### PR TITLE
(PUP-10433) Add --no-gpg-checks as global option

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -89,6 +89,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
     options = []
     options << quiet
     options << '--no-gpg-check' unless inst_opts.delete('--no-gpg-check').nil?
+    options << '--no-gpg-checks' unless inst_opts.delete('--no-gpg-checks').nil?
     options << :install
 
     #zypper 0.6.13 (OpenSuSE 10.2) does not support auto agree with licenses

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -176,6 +176,19 @@ describe Puppet::Type.type(:package).provider(:zypper) do
       @provider.install
     end
 
+    it "should install the package with --no-gpg-checks" do
+      allow(@resource).to receive(:[]).with(:name).and_return("php5")
+      allow(@resource).to receive(:[]).with(:install_options).and_return(['--no-gpg-checks', {'-p' => '/vagrant/files/localrepo/'}])
+      allow(@resource).to receive(:should).with(:ensure).and_return("5.4.10-4.5.6")
+      allow(@resource).to receive(:allow_virtual?).and_return(false)
+      allow(@provider).to receive(:zypper_version).and_return("1.2.8")
+
+      expect(@provider).to receive(:zypper).with('--quiet', '--no-gpg-checks', :install,
+        '--auto-agree-with-licenses', '--no-confirm', '-p=/vagrant/files/localrepo/', 'php5-5.4.10-4.5.6')
+      expect(@provider).to receive(:query).and_return("php5 0 5.4.10 4.5.6 x86_64")
+      @provider.install
+    end
+
     it "should install package with hash install options" do
       allow(@resource).to receive(:[]).with(:name).and_return('vim')
       allow(@resource).to receive(:[]).with(:install_options).and_return([{ '--a' => 'foo', '--b' => '"quoted bar"' }])


### PR DESCRIPTION
This PR updates the global option "--no-gpg-check" to "--no-gpg-checks". "--no-gpg-checks" is the correct flag from the zypper documentation:  https://en.opensuse.org/SDB:Zypper_manual_(plain)

"--no-gpg-check" works because zypper supports unique name abbreviations for flags:
https://github.com/openSUSE/zypper/blob/master/src/utils/flags/zyppflags.cc#L378 but this causes confusion when using this flag in a Puppet manifest.

Zypper also accepts multiple options of the same type, so:
```
/usr/bin/zypper --no-gpg-check --no-gpg-checks install --auto-agree-with-licenses --no-confirm apache 
```
does the same thing as:
```
/usr/bin/zypper --no-gpg-checks install --auto-agree-with-licenses --no-confirm apache 
```