### PR TITLE
(maint) Server as daemon cleanup

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -489,9 +489,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
   end
 
   def daemonize_process_when(should_daemonize)
-    daemon = Puppet::Daemon.new(Puppet::Util::Pidlock.new(Puppet[:pidfile]))
+    daemon = Puppet::Daemon.new(@agent, Puppet::Util::Pidlock.new(Puppet[:pidfile]))
     daemon.argv = @argv
-    daemon.agent = @agent
 
     daemon.daemonize if should_daemonize
 

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -12,15 +12,15 @@ describe Puppet::Application::Agent do
   before :each do
     @puppetd = Puppet::Application[:agent]
 
-    @daemon = Puppet::Daemon.new(nil)
+    @agent = double('agent')
+    allow(Puppet::Agent).to receive(:new).and_return(@agent)
+
+    @daemon = Puppet::Daemon.new(@agent, nil)
     allow(@daemon).to receive(:daemonize)
     allow(@daemon).to receive(:start)
     allow(@daemon).to receive(:stop)
     allow(Puppet::Daemon).to receive(:new).and_return(@daemon)
     Puppet[:daemonize] = false
-
-    @agent = double('agent')
-    allow(Puppet::Agent).to receive(:new).and_return(@agent)
 
     @puppetd.preinit
     allow(Puppet::Util::Log).to receive(:newdestination)


### PR DESCRIPTION
Starting server as a daemon has been deprecated in 5.5.x and is now removed.
This commit cleans up the unused code left behind these changes.

Before merging:

- [x] #8113 needs to get merged up into master (depends on some of the changes)
- [x] cherrypicked commit needs to be removed from PR (a06bf3e)