### PR TITLE
(PUP-10480) Deprecate 'puppet module search'

### DIFF
--- a/lib/puppet/face/module/search.rb
+++ b/lib/puppet/face/module/search.rb
@@ -5,6 +5,8 @@ Puppet::Face.define(:module, '1.0.0') do
   action(:search) do
     summary _("Search the Puppet Forge for a module.")
     description <<-EOT
+      This action has been deprecated. Please use the Puppet Forge to search for modules.
+
       Searches a repository for modules whose names, descriptions, or keywords
       match the provided search term.
     EOT
@@ -22,6 +24,7 @@ Puppet::Face.define(:module, '1.0.0') do
     arguments _("<search_term>")
 
     when_invoked do |term, options|
+      Puppet.deprecation_warning(_("This action has been deprecated. Please use the Puppet Forge to search for modules."))
       Puppet::ModuleTool.set_option_defaults options
       Puppet::ModuleTool::Applications::Searcher.new(term, Puppet::Forge.new(options[:module_repository] || Puppet[:module_repository]), options).run
     end
@@ -94,5 +97,7 @@ Puppet::Face.define(:module, '1.0.0') do
         highlight[format % [ name.sub('/', '-'), desc, "@#{author}", [keywords].flatten.join(' ') ]]
       end.join
     end
+
+    deprecate
   end
 end

--- a/spec/unit/face/module/search_spec.rb
+++ b/spec/unit/face/module/search_spec.rb
@@ -211,4 +211,21 @@ describe "puppet module search" do
       end
     end
   end
+
+  it "should include a deprecation warning" do
+    stub_request(:get, "https://forgeapi.puppet.com/v3/modules?query=puppetlabs-apache").to_return(status: 200, body: [answers: [], result: :success])
+
+    subject.search("puppetlabs-apache")
+
+    expect(@logs).to include(an_object_having_attributes(level: :warning, message: /This action has been deprecated. Please use the Puppet Forge to search for modules./))
+  end
+
+  it "omits the warning when deprecations are disabled" do
+    stub_request(:get, "https://forgeapi.puppet.com/v3/modules?query=puppetlabs-apache").to_return(status: 200, body: [answers: [], result: :success])
+
+    Puppet[:disable_warnings] = 'deprecations'
+    subject.search("puppetlabs-apache")
+
+    expect(@logs).not_to include(an_object_having_attributes(level: :warning))
+  end
 end


### PR DESCRIPTION
Rather than using `puppet module` to search for modules, users should
go to the Puppet Forge to search modules.