### PR TITLE
(PUP-10419) disable for dnf module

### DIFF
--- a/acceptance/tests/provider/package/dnfmodule_ensure_versionable.rb
+++ b/acceptance/tests/provider/package/dnfmodule_ensure_versionable.rb
@@ -29,4 +29,13 @@ test_name "dnfmodule is versionable" do
       assert_match('postgres (PostgreSQL) 9.6', version.stdout, 'package version not correct')
     end
   end
+
+  step "Ensure we can disable a package" do
+    apply_manifest_on(agent, resource_manifest('package', package, ensure: :disabled, provider: 'dnfmodule'))
+    on(agent, "dnf module list | grep #{package}") do |output|
+      output.stdout.each_line do |line|
+        assert_match("\[x\]", line, 'package not disabled')
+      end
+    end
+  end
 end

--- a/spec/fixtures/unit/provider/package/dnfmodule/dnf-module-list.txt
+++ b/spec/fixtures/unit/provider/package/dnfmodule/dnf-module-list.txt
@@ -9,5 +9,11 @@ postgresql   10 [d][e]    client, server [d] [i]                    PostgreSQL s
 ruby         2.5 [d][e]   common [d]                                An interpreter of object-oriented scripting language                  
 rust-toolset rhel8 [d][e] common [d] [i]                            Rust                                                               
 subversion   1.10 [d][e]  common [d], server [i]                    Apache Subversion                                                  
+scala        2.10 [d]     common [d]                                A hybrid functional/object-oriented language for the JVM
+squid        4 [d]        common [d]                                Squid - Optimising Web Delivery
+subversion   1.10 [d]     common [d], server                        Apache Subversion
+swig         3.0 [d][x]   common [d], complete                      Connects C/C++/Objective C to some high-level programming languages
+varnish      6 [d]        common [d]                                Varnish HTTP cache
+virt         rhel [d][x]  common [d]                                Virtualization module
 
 Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled


### PR DESCRIPTION
This PR adds the ability disable a dnf module.
It was done by creating a new value for
ensure field, only available for dnf module.

Ex:

"package { 'package_name':
  ensure => 'disabled',
  provider => 'dnfmodule'
}"