### PR TITLE
(PUP-10496) Fix parsing version range for regular version

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -77,7 +77,10 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     if should.is_a?(String)
       begin
         should_range = VersionRange.parse(should, DebianVersion)
-        should = best_version(should_range)
+
+        unless should_range.is_a?(VersionRange::Eq)
+          should = best_version(should_range)
+        end
       rescue VersionRange::ValidationFailure, DebianVersion::ValidationFailure
         Puppet.debug("Cannot parse #{should} as a debian version range, falling through")
       end

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -43,6 +43,10 @@ defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
     if should.is_a?(String)
       begin
         should_version = RPM_VERSION_RANGE.parse(should, RPM_VERSION)
+
+        if should_version.is_a?(RPM_VERSION_RANGE::Eq)
+          return super
+        end
       rescue RPM_VERSION_RANGE::ValidationFailure, RPM_VERSION::ValidationFailure
         Puppet.debug("Cannot parse #{should} as a RPM version range")
         return super
@@ -192,6 +196,9 @@ defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
     if should.is_a?(String)
       begin
         should_range = RPM_VERSION_RANGE.parse(should, RPM_VERSION)
+        if should_range.is_a?(RPM_VERSION_RANGE::Eq)
+          return should
+        end
       rescue RPM_VERSION_RANGE::ValidationFailure, RPM_VERSION::ValidationFailure
         Puppet.debug("Cannot parse #{should} as a RPM version range")
         return should

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
   desc "Support for SuSE `zypper` package manager. Found in SLES10sp2+ and SLES11.
 
     This provider supports the `install_options` attribute, which allows command-line flags to be passed to zypper.
-    These options should be specified as an array where each element is either a 
+    These options should be specified as an array where each element is either a
     string or a hash."
 
   has_feature :versionable, :install_options, :virtual_packages
@@ -56,6 +56,10 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
         should_range = Puppet::Util::Package::Version::Range.parse(should, Puppet::Util::Package::Version::Rpm)
       rescue Puppet::Util::Package::Version::Range::ValidationFailure, Puppet::Util::Package::Version::Rpm::ValidationFailure
         Puppet.debug("Cannot parse #{should} as a RPM version range")
+        return should
+      end
+
+      if should_range.is_a?(Puppet::Util::Package::Version::Range::Eq)
         return should
       end
 

--- a/lib/puppet/util/package/version/range.rb
+++ b/lib/puppet/util/package/version/range.rb
@@ -2,6 +2,7 @@ require 'puppet/util/package/version/range/lt'
 require 'puppet/util/package/version/range/lt_eq'
 require 'puppet/util/package/version/range/gt'
 require 'puppet/util/package/version/range/gt_eq'
+require 'puppet/util/package/version/range/eq'
 require 'puppet/util/package/version/range/min_max'
 
 module Puppet::Util::Package::Version
@@ -20,7 +21,7 @@ module Puppet::Util::Package::Version
     #   * ex. `">1.0.0 <=2.3.0"`
     #
     RANGE_SPLIT = /\s+/
-    FULL_REGEX = /\A((?:[<>=])+)(.+)\Z/
+    FULL_REGEX = /\A((?:[<>=])*)(.+)\Z/
 
     # @param range_string [String] the version range string to parse
     # @param version_class [Version] a version class implementing comparison operators and parse method
@@ -40,6 +41,8 @@ module Puppet::Util::Package::Version
           Lt.new(version_class::parse(version))
         when '<='
           LtEq.new(version_class::parse(version))
+        when ''
+          Eq.new(version_class::parse(version))
         else
           raise ValidationFailure, "Operator '#{operator}' is not implemented"
         end

--- a/lib/puppet/util/package/version/range/eq.rb
+++ b/lib/puppet/util/package/version/range/eq.rb
@@ -1,0 +1,14 @@
+require 'puppet/util/package/version/range/simple'
+
+module Puppet::Util::Package::Version
+  class Range
+    class Eq < Simple
+      def to_s
+        "#{@version}"
+      end
+      def include?(version)
+        version == @version
+      end
+    end
+  end
+end

--- a/spec/unit/util/package/version/range_spec.rb
+++ b/spec/unit/util/package/version/range_spec.rb
@@ -34,12 +34,33 @@ describe Puppet::Util::Package::Version::Range do
       expect { Puppet::Util::Package::Version::Range.parse('=a', IntegerVersion) }.to raise_error(Puppet::Util::Package::Version::Range::ValidationFailure)
     end
     it 'should raise if operator cannot be parsed' do
-      expect { Puppet::Util::Package::Version::Range.parse('~=a', IntegerVersion) }.to raise_error(Puppet::Util::Package::Version::Range::ValidationFailure)
+      expect { Puppet::Util::Package::Version::Range.parse('~=a', IntegerVersion) }.to raise_error(IntegerVersion::ValidationFailure)
     end
     it 'should raise if version cannot be parsed' do
       expect { Puppet::Util::Package::Version::Range.parse('>=a', IntegerVersion) }.to raise_error(IntegerVersion::ValidationFailure)
     end
   end
+
+  context 'when creating new version range with regular version' do
+    it 'it does not include greater version' do
+      vr = Puppet::Util::Package::Version::Range.parse('3', IntegerVersion)
+      v = IntegerVersion.parse('4')
+      expect(vr.include?(v)).to eql(false)
+    end
+
+    it 'it includes specified version' do
+      vr = Puppet::Util::Package::Version::Range.parse('3', IntegerVersion)
+      v = IntegerVersion.parse('3')
+      expect(vr.include?(v)).to eql(true)
+    end
+
+    it 'it does not include lower version' do
+      vr = Puppet::Util::Package::Version::Range.parse('3', IntegerVersion)
+      v = IntegerVersion.parse('2')
+      expect(vr.include?(v)).to eql(false)
+    end
+  end
+
   context 'when creating new version range with greater or equal operator' do
     it 'it includes greater version' do
       vr = Puppet::Util::Package::Version::Range.parse('>=3', IntegerVersion)


### PR DESCRIPTION
Fix parsing version range for simple version string like '1.2.3'.

**Puppet Version:** 6.11.0
**Puppet Server Version**: 6.11.0
**OS Name/Version:** Debian 9

**Steps:**
`puppet resource package prometheus-client ensure='0.7.1' provider='pip3' --debug`

**Actual Behavior:**
Debug log contains strange string:

> Debug: Cannot parse 0.7.1 as a pip version range, falling through.



