### PR TITLE
(maint) Fix systemd acceptance test

### DIFF
--- a/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
+++ b/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
@@ -5,32 +5,28 @@ test_name 'systemd service shows correct output when queried with "puppet resour
 
   tag 'audit:high'
 
-  package_name = {'el'     => 'httpd',
-                  'centos' => 'httpd',
-                  'fedora' => 'httpd',
-                  'debian' => 'apache2',
-                  'sles'   => 'apache2',
-                  'ubuntu' => 'cron'}
+  skip_test 'requires puppet service script from AIO agent package' if @options[:type] != 'aio'
+
+  package_name = 'puppet'
 
   # This test ensures that 'puppet resource' output matches the system state
   confine :to, {}, agents.select { |agent| supports_systemd?(agent) }
 
   agents.each do |agent|
-    platform = agent.platform.variant
-    initial_state = on(agent, puppet_resource('service', package_name[platform])).stdout
+    initial_state = on(agent, puppet_resource('service', package_name)).stdout
 
     teardown do
       apply_manifest_on(agent, initial_state)
     end
 
     step "Setting ensure=stopped and enable=true" do
-      on(agent, puppet_resource('service', package_name[platform], 'ensure=stopped', 'enable=true'))
+      on(agent, puppet_resource('service', package_name, 'ensure=stopped', 'enable=true'))
     end
 
     step "Expect reported status to match system state" do
-      on(agent, puppet_resource('service', package_name[platform], 'ensure=stopped', 'enable=true')) do
-        assert_match(/ensure\s*=>\s*'stopped'/, stdout, "Expected '#{package_name[platform]}' service to appear as stopped")
-        assert_match(/enable\s*=>\s*'true'/, stdout, "Expected '#{package_name[platform]}' service to appear as enabled")
+      on(agent, puppet_resource('service', package_name, 'ensure=stopped', 'enable=true')) do
+        assert_match(/ensure\s*=>\s*'stopped'/, stdout, "Expected '#{package_name}' service to appear as stopped")
+        assert_match(/enable\s*=>\s*'true'/, stdout, "Expected '#{package_name}' service to appear as enabled")
       end
     end
   end


### PR DESCRIPTION
Not all services are available on the required platforms. We should be
able to use the puppet service itself as we only want to enable it, so
it shouldn't interfere with the tests.

Caused by https://github.com/puppetlabs/puppet/pull/8126.