### PR TITLE
(PUP-10307) Don't require the environment to exist locally

### DIFF
--- a/lib/puppet/application/plugin.rb
+++ b/lib/puppet/application/plugin.rb
@@ -1,3 +1,4 @@
 require 'puppet/application/face_base'
 class Puppet::Application::Plugin < Puppet::Application::FaceBase
+  environment_mode :not_required
 end


### PR DESCRIPTION
When running `puppet plugin download` on a host that isn't the master, the
environment directory likely doesn't exist, so configure the environment mode
to not require it in the same way we do for `puppet agent`.