### PR TITLE
(PUP-4442) Improve Uniquefile mkdir error message

### DIFF
--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -174,6 +174,10 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
       lock = tmpname + '.lock'
       mkdir(lock)
       yield
+    rescue Errno::ENOENT => e
+      ex = Errno::ENOENT.new("A directory component in #{lock} does not exist or is a dangling symbolic link")
+      ex.set_backtrace(e.backtrace)
+      raise ex
     ensure
       rmdir(lock) if Puppet::FileSystem.exist?(lock)
     end

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Puppet::FileSystem::Uniquefile do
+  include PuppetSpec::Files
+
   it "makes the name of the file available" do
     Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|
       expect(file.path).to match(/foo/)
@@ -65,6 +67,15 @@ describe Puppet::FileSystem::Uniquefile do
     expect(Puppet::FileSystem::Uniquefile).not_to receive(:rmdir)
 
     Puppet::FileSystem::Uniquefile.open_tmp('foo') { |tmp| }
+  end
+
+  it "reports when a parent directory does not exist" do
+    dir = tmpdir('uniquefile')
+    lock = File.join(dir, 'path', 'to', 'lock')
+
+    expect {
+      Puppet::FileSystem::Uniquefile.open_tmp(lock) { |tmp| }
+    }.to raise_error(Errno::ENOENT, %r{No such file or directory - A directory component in .* does not exist or is a dangling symbolic link})
   end
 
   context "Ruby 1.9.3 Tempfile tests" do


### PR DESCRIPTION
Ruby emits a useless error message if the mkdir fails because the parent
directory doesn't exist. This often shows up when
puppet tries to create a lockfile, such as when managing a file resource
whose parent doesn't exist, because it's not managed.