### PR TITLE
(PUP-10476) PAL additions to support more use cases from bolt

### DIFF
--- a/lib/puppet/pal/catalog_compiler.rb
+++ b/lib/puppet/pal/catalog_compiler.rb
@@ -97,6 +97,11 @@ module Pal
       internal_compiler.evaluate_additions
     end
 
+    # Attempts to evaluate AST for node defnintions https://puppet.com/docs/puppet/latest/lang_node_definitions.html
+    # if there are any.
+    def evaluate_ast_node
+      internal_compiler.evaluate_ast_node
+    end
   end
 
 end

--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -424,7 +424,6 @@ module Pal
       begin
         node.sanitize()
         compiler = create_internal_compiler(internal_compiler_class, node)
-        add_variables(compiler.topscope, pal_variables)
 
         case internal_compiler_class
         when :script
@@ -440,6 +439,10 @@ module Pal
         # TRANSLATORS: Do not translate, symbolic name
         Puppet.override(overrides, "PAL::with_#{internal_compiler_class}_compiler") do
           compiler.compile do | compiler_yield |
+            # In case the varaibles passed to the compiler are PCore types defined in modules, they
+            # need to be deserialized and added from within the this scope, so that loaders are
+            # available during deserizlization.
+            add_variables(compiler.topscope, Puppet::Pops::Serialization::FromDataConverter.convert(pal_variables))
             # wrap the internal compiler to prevent it from leaking in the PAL API
             if block_given?
               yield(pal_compiler)


### PR DESCRIPTION
This commit makes two changes to PAL to support more features within puppet during a catalog compile:

1. When variables are passed to `.with_catalog_compiler` they are now deserialized if they are serialized pcore types
2. A new function was added to the compiler class within `.with_catalog_compiler` so that a process calling PAL functions can evaluate ast with node definitions. 