### PR TITLE
(docs) add note to clarify enable param

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -51,7 +51,11 @@ module Puppet
       desc "Whether a service should be enabled to start at boot.
         This property behaves differently depending on the platform;
         wherever possible, it relies on local tools to enable or disable
-        a given service. Default values depend on the platform."
+        a given service. Default values depend on the platform.
+        
+        If you don't specify a value for the `enable` attribute, Puppet leaves
+        that aspect of the service alone and your operating system determines 
+        the behavior."
 
       newvalue(:true, :event => :service_enabled) do
         provider.enable


### PR DESCRIPTION
Adds a note to the service type to clarify enable parameter behavior. (see DOC-4016)