### PR TITLE
(maint) Update language ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,13 +11,8 @@
 /lib/puppet/provider/service @puppetlabs/night-s-watch
 /lib/puppet/provider/user @puppetlabs/night-s-watch
 
-# language
-/lib/puppet/datatypes @puppetlabs/language
-/lib/puppet/functions @puppetlabs/language
-/lib/puppet/pal @puppetlabs/language
-/lib/puppet/parser @puppetlabs/language
-/lib/puppet/pops @puppetlabs/language
-/lib/puppet/syntax_checkers @puppetlabs/language
+# PAL
+/lib/puppet/pal @puppetlabs/bolt
 
 # puppet device
 /lib/puppet/application/device.rb @puppetlabs/networking


### PR DESCRIPTION
There are no longer any members of the puppetlabs/language team. All of
their work has fallen to the puppetlabs/puppetserver-maintainers team
who is already a co-owner of the entire repository.

However, Bolt is the primary consumer of PAL and will own it.