### PR TITLE
 (maint) Merge 5.5.x to master

### DIFF
--- a/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
+++ b/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
@@ -1,0 +1,34 @@
+require 'puppet/acceptance/service_utils'
+extend Puppet::Acceptance::ServiceUtils
+
+test_name 'systemd service shows correct output when queried with "puppet resource"' do
+
+  tag 'audit:high'
+
+  skip_test 'requires puppet service script from AIO agent package' if @options[:type] != 'aio'
+
+  package_name = 'puppet'
+
+  # This test ensures that 'puppet resource' output matches the system state
+  confine :to, {}, agents.select { |agent| supports_systemd?(agent) }
+
+  agents.each do |agent|
+    initial_state = on(agent, puppet_resource('service', package_name)).stdout
+
+    teardown do
+      apply_manifest_on(agent, initial_state)
+    end
+
+    step "Setting ensure=stopped and enable=true" do
+      on(agent, puppet_resource('service', package_name, 'ensure=stopped', 'enable=true'))
+    end
+
+    step "Expect reported status to match system state" do
+      on(agent, puppet_resource('service', package_name, 'ensure=stopped', 'enable=true')) do
+        assert_match(/ensure\s*=>\s*'stopped'/, stdout, "Expected '#{package_name}' service to appear as stopped")
+        assert_match(/enable\s*=>\s*'true'/, stdout, "Expected '#{package_name}' service to appear as enabled")
+      end
+    end
+  end
+end
+

--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -176,6 +176,10 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
       lock = tmpname + '.lock'
       mkdir(lock)
       yield
+    rescue Errno::ENOENT => e
+      ex = Errno::ENOENT.new("A directory component in #{lock} does not exist or is a dangling symbolic link")
+      ex.set_backtrace(e.backtrace)
+      raise ex
     ensure
       rmdir(lock) if Puppet::FileSystem.exist?(lock)
     end

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -121,6 +121,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
     options = []
     options << quiet
     options << '--no-gpg-check' unless inst_opts.delete('--no-gpg-check').nil?
+    options << '--no-gpg-checks' unless inst_opts.delete('--no-gpg-checks').nil?
     options << :install
 
     #zypper 0.6.13 (OpenSuSE 10.2) does not support auto agree with licenses

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   # should not be enabled or disabled due to limitations in systemd (see 
   # https://github.com/systemd/systemd/issues/6681).
   def enabled_insync?(current)
-    case cached_enabled?
+    case cached_enabled?[:output]
     when 'static'
       Puppet.debug("Unable to enable or disable static service #{@resource[:name]}")
       return true
@@ -86,12 +86,13 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def cached_enabled?
     return @cached_enabled if @cached_enabled
     cmd = [command(:systemctl), 'is-enabled', '--', @resource[:name]]
-    @cached_enabled = execute(cmd, :failonfail => false).strip
+    result = execute(cmd, :failonfail => false)
+    @cached_enabled = { output: result.chomp, exitcode: result.exitstatus }
   end
 
   def enabled?
-    output = cached_enabled?
-    code = $CHILD_STATUS.exitstatus
+    output = cached_enabled?[:output]
+    code = cached_enabled?[:exitcode]
 
     # The masked state is equivalent to the disabled state in terms of
     # comparison so we only care to check if it is masked if we want to keep

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Puppet::FileSystem::Uniquefile do
+  include PuppetSpec::Files
+
   it "makes the name of the file available" do
     Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|
       expect(file.path).to match(/foo/)
@@ -71,6 +73,15 @@ describe Puppet::FileSystem::Uniquefile do
     expect(Puppet::FileSystem::Uniquefile).not_to receive(:rmdir)
 
     Puppet::FileSystem::Uniquefile.open_tmp('foo') { |tmp| }
+  end
+
+  it "reports when a parent directory does not exist" do
+    dir = tmpdir('uniquefile')
+    lock = File.join(dir, 'path', 'to', 'lock')
+
+    expect {
+      Puppet::FileSystem::Uniquefile.open_tmp(lock) { |tmp| }
+    }.to raise_error(Errno::ENOENT, %r{No such file or directory - A directory component in .* does not exist or is a dangling symbolic link})
   end
 
   context "Ruby 1.9.3 Tempfile tests" do

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -176,6 +176,19 @@ describe Puppet::Type.type(:package).provider(:zypper) do
       @provider.install
     end
 
+    it "should install the package with --no-gpg-checks" do
+      allow(@resource).to receive(:[]).with(:name).and_return("php5")
+      allow(@resource).to receive(:[]).with(:install_options).and_return(['--no-gpg-checks', {'-p' => '/vagrant/files/localrepo/'}])
+      allow(@resource).to receive(:should).with(:ensure).and_return("5.4.10-4.5.6")
+      allow(@resource).to receive(:allow_virtual?).and_return(false)
+      allow(@provider).to receive(:zypper_version).and_return("1.2.8")
+
+      expect(@provider).to receive(:zypper).with('--quiet', '--no-gpg-checks', :install,
+        '--auto-agree-with-licenses', '--no-confirm', '-p=/vagrant/files/localrepo/', 'php5-5.4.10-4.5.6')
+      expect(@provider).to receive(:query).and_return("php5 0 5.4.10 4.5.6 x86_64")
+      @provider.install
+    end
+
     it "should install package with hash install options" do
       allow(@resource).to receive(:[]).with(:name).and_return('vim')
       allow(@resource).to receive(:[]).with(:install_options).and_return([{ '--a' => 'foo', '--b' => '"quoted bar"' }])

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -279,43 +279,43 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#enabled?" do
     it "should return :true if the service is enabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("enabled\n")
-      allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("enabled\n", 0))
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :true if the service is static" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','--', 'sshd.service'], :failonfail => false).and_return("static\n")
-      allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','--', 'sshd.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("static\n", 0))
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :false if the service is disabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("disabled\n")
-      allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("disabled\n", 1))
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :false if the service is indirect" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("indirect\n")
-      allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("indirect\n", 0))
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :false if the service is masked and the resource is attempting to be disabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("masked\n")
-      allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("masked\n", 1))
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :mask if the service is masked and the resource is attempting to be masked" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => 'mask'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).and_return("masked\n")
-      allow($CHILD_STATUS).to receive(:exitstatus).and_return(1)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("masked\n", 1))
       expect(provider.enabled?).to eq(:mask)
     end
   end
@@ -444,7 +444,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     end
 
     before do
-      allow(provider).to receive(:cached_enabled?).and_return(service_state)
+      allow(provider).to receive(:cached_enabled?).and_return({ output: service_state, exitcode: 0 })
     end
 
     context 'when service state is static' do


### PR DESCRIPTION
* pl/5.5.x:
  (PUP-4442) Improve Uniquefile mkdir error message
  (maint) Fix systemd test
  (PUP-10433) Add --no-gpg-checks as global option
  (PUP-10479) systemd wrongly reports enabled state

 Conflicts:
	spec/unit/provider/service/systemd_spec.rb

 Conflict were solved by keeping provider initialization from master
 `provider = provider_class.new(...)` and updating `provider.execute` mock
 from 5.5.x

