### PR TITLE
(PUP-8051) waitforlock and maxwaitforlock setting

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -43,6 +43,7 @@ class Puppet::Agent
     end
 
     result = nil
+    wait_for_lock_deadline = nil
     block_run = Puppet::Application.controlled_run do
       splay client_options.fetch :splay, Puppet[:splay]
       result = run_in_fork(should_fork) do
@@ -60,8 +61,20 @@ class Puppet::Agent
               end
             end
           rescue Puppet::LockError
-            Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
-            nil
+            wait_for_lock_deadline ||= Time.now.to_i + Puppet[:maxwaitforlock]
+
+            if Puppet[:waitforlock]  < 1
+              Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
+              nil
+            elsif Time.now.to_i > wait_for_lock_deadline
+              Puppet.notice _("Exiting now because the maxwaitforlock timeout has been exceeded.")
+              nil
+            else
+              Puppet.info _("Another puppet instance is already running; --waitforlock flag used, waiting for running instance to finish.")
+              Puppet.info _("Will try again in %{time} seconds.") % {time: Puppet[:waitforlock]}
+              sleep Puppet[:waitforlock]
+              retry
+            end
           rescue RunTimeoutError => detail
             Puppet.log_exception(detail, _("Execution of %{client_class} did not complete within %{runtimeout} seconds and was terminated.") %
               {client_class: client_class,

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1882,6 +1882,25 @@ EOT
       certificate request to be signed. A value of `unlimited` will cause puppet agent
       to ask for a signed certificate indefinitely.
       #{AS_DURATION}",
+    },
+    :waitforlock => {
+      :default  => "0",
+      :type     => :duration,
+      :desc     => "How frequently puppet agent should try running when there is an
+      already ongoing puppet agent instance.
+
+      This argument is by default disabled (value set to 0). In this case puppet agent will
+      immediatly exit if it cannot run at that moment. When a value other than 0 is set, this
+      can also be used in combination with the `maxwaitforlock` argument.
+      #{AS_DURATION}",
+    },
+    :maxwaitforlock => {
+      :default  => "1m",
+      :type     => :ttl,
+      :desc     => "The maximum amount of time the puppet agent should wait for an
+      already running puppet agent to finish before starting a new one. This is set by default to 1 minute.
+      A value of `unlimited` will cause puppet agent to wait indefinitely. 
+      #{AS_DURATION}",
     }
   )
 

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -326,4 +326,69 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
       end
     end
   end
+
+  context 'multiple agents running' do
+    it "exits if an agent is already running" do
+      path = Puppet[:agent_catalog_run_lockfile]
+
+      th = Thread.new {
+        %x{ruby -e "$0 = 'puppet'; File.write('#{path}', Process.pid); sleep(2)"}
+      }
+
+      until File.exists?(path) && File.size(path) > 0 do
+        sleep 0.1
+      end
+
+      expect {
+        agent.command_line.args << '--test'
+        agent.run
+      }.to exit_with(1).and output(/Run of Puppet configuration client already in progress; skipping/).to_stdout
+
+      th.kill # kill thread so we don't wait too much
+    end
+
+    it "waits for other agent run to finish before starting" do
+      server.start_server do |port|
+        path = Puppet[:agent_catalog_run_lockfile]
+        Puppet[:masterport] = port
+        Puppet[:waitforlock] = 1
+
+        th = Thread.new {
+          %x{ruby -e "$0 = 'puppet'; File.write('#{path}', Process.pid); sleep(2)"}
+        }
+
+        until File.exists?(path) && File.size(path) > 0 do
+          sleep 0.1
+        end
+
+        expect {
+          agent.command_line.args << '--test'
+          agent.run
+        }.to exit_with(0).and output(/Info: Will try again in #{Puppet[:waitforlock]} seconds./).to_stdout
+
+        th.kill # kill thread so we don't wait too much
+      end
+    end
+
+    it "exits if maxwaitforlock is exceeded" do
+      path = Puppet[:agent_catalog_run_lockfile]
+      Puppet[:waitforlock] = 1
+      Puppet[:maxwaitforlock] = 0.5
+
+      th = Thread.new {
+        %x{ruby -e "$0 = 'puppet'; File.write('#{path}', Process.pid); sleep(2)"}
+      }
+
+      until File.exists?(path) && File.size(path) > 0 do
+        sleep 0.1
+      end
+
+      expect {
+        agent.command_line.args << '--test'
+        agent.run
+      }.to exit_with(1).and output(/Exiting now because the maxwaitforlock timeout has been exceeded./).to_stdout
+
+      th.kill # kill thread so we don't wait too much
+    end
+  end
 end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -179,6 +179,52 @@ describe Puppet::Agent do
       expect(@agent.run).to eq(:result)
     end
 
+    describe "and a puppet agent is already running" do
+      before(:each) do
+        allow_any_instance_of(Object).to receive(:sleep)
+        lockfile = double('lockfile')
+        expect(@agent).to receive(:lockfile).and_return(lockfile).at_least(:once)
+        # so the lock method raises Puppet::LockError
+        allow(lockfile).to receive(:lock).and_return(false)
+      end
+
+      it "should notify that a run is already in progres" do
+        client = AgentTestClient.new
+        expect(AgentTestClient).to receive(:new).and_return(client)
+        expect(Puppet).to receive(:notice).with(/Run of .* already in progress; skipping .* exists/)
+        @agent.run
+      end
+
+      it "should inform that a run is already in progres and try to run every X seconds if waitforlock is used" do
+        # so the locked file exists
+        allow(File).to receive(:file?).and_return(true)
+        # so we don't have to wait again for the run to exit (default maxwaitforcert is 60)
+        # first 0 is to get the time, second 0 is to inform user, then 1000 so the time expires
+        allow(Time).to receive(:now).and_return(0, 0, 1000)
+        allow(Puppet).to receive(:info)
+        client = AgentTestClient.new
+        expect(AgentTestClient).to receive(:new).and_return(client)
+
+        Puppet[:waitforlock] = 1
+        Puppet[:maxwaitforlock] = 2
+        expect(Puppet).to receive(:info).with(/Another puppet instance is already running; --waitforlock flag used, waiting for running instance to finish./)
+        expect(Puppet).to receive(:info).with(/Will try again in #{Puppet[:waitforlock]} seconds./)
+        @agent.run
+      end
+
+      it "should notify that the run is exiting if waitforlock is used and maxwaitforlock is exceeded" do
+        # so we don't have to wait again for the run to exit (default maxwaitforcert is 60)
+        # first 0 is to get the time, then 1000 so that the time expires
+        allow(Time).to receive(:now).and_return(0, 1000)
+        client = AgentTestClient.new
+        expect(AgentTestClient).to receive(:new).and_return(client)
+
+        Puppet[:waitforlock] = 1
+        expect(Puppet).to receive(:notice).with(/Exiting now because the maxwaitforlock timeout has been exceeded./)
+        @agent.run
+      end
+    end
+    
     describe "when should_fork is true", :if => Puppet.features.posix? && RUBY_PLATFORM != 'java' do
       before do
         @agent = Puppet::Agent.new(AgentTestClient, true)


### PR DESCRIPTION
Before this commit, an agent run would immediately exit if there was an already ongoing instance. There was no possibility of making it wait and retry before doing so. The only workaround was to manually retry multiple times until the agent lockfile was released.

Two CLI arguments/puppet configuration settings were added in aid of this issue.

Description for `waitforlock`:

> How frequently puppet agent should try running when there is an
> already ongoing puppet agent instance.
> This argument is by default disabled (value set to 0). In this case puppet agent will
> immediatly exit if it cannot run at that moment. When a value other than 0 is set, this
> can also be used in combination with the `maxwaitforlock` argument.

Description for `maxwaitforlock`: 

> The maximum amount of time the puppet agent should wait for an
> already running puppet agent to finish before starting a new one. This is set by default to 1 minute.
> A value of `unlimited` will cause puppet agent to wait indefinitely.