### PR TITLE
(PUP-10500) Allow codedir to be a symlink

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -103,7 +103,7 @@ module Puppet
     },
     :codedir  => {
         :default  => nil,
-        :type     => :directory,
+        :type     => :symlink_or_directory,
         :desc     => "The main Puppet code directory.  The default for this setting
           is calculated based on the user.  If the process is running as root or
           the user that Puppet is supposed to run as, it defaults to a system

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -19,6 +19,7 @@ class Puppet::Settings
   require 'puppet/settings/file_setting'
   require 'puppet/settings/directory_setting'
   require 'puppet/settings/file_or_directory_setting'
+  require 'puppet/settings/symlink_or_directory_setting'
   require 'puppet/settings/path_setting'
   require 'puppet/settings/boolean_setting'
   require 'puppet/settings/terminus_setting'
@@ -717,6 +718,7 @@ class Puppet::Settings
       :file       => FileSetting,
       :directory  => DirectorySetting,
       :file_or_directory => FileOrDirectorySetting,
+      :symlink_or_directory => SymlinkOrDirectorySetting,
       :path       => PathSetting,
       :boolean    => BooleanSetting,
       :terminus   => TerminusSetting,

--- a/lib/puppet/settings/symlink_or_directory_setting.rb
+++ b/lib/puppet/settings/symlink_or_directory_setting.rb
@@ -1,0 +1,14 @@
+class Puppet::Settings::SymlinkOrDirectorySetting < Puppet::Settings::DirectorySetting
+
+  def initialize(args)
+    super
+  end
+
+  def type
+    if Puppet::FileSystem.symlink?(self.value)
+      :symlink
+    else
+      :directory
+    end
+  end
+end

--- a/spec/lib/puppet_spec/settings.rb
+++ b/spec/lib/puppet_spec/settings.rb
@@ -9,7 +9,7 @@ module PuppetSpec::Settings
     :name         => { :default => "test", :desc => "name" },
     :logdir       => { :type => :directory, :default => "test", :desc => "logdir" },
     :confdir      => { :type => :directory, :default => "test", :desc => "confdir" },
-    :codedir      => { :type => :directory, :default => "test", :desc => "codedir" },
+    :codedir      => { :type => :symlink_or_directory, :default => "test", :desc => "codedir" },
     :vardir       => { :type => :directory, :default => "test", :desc => "vardir" },
     :rundir       => { :type => :directory, :default => "test", :desc => "rundir" },
   }

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -954,7 +954,7 @@ describe Puppet::Settings do
       @settings.define_settings(:main,
         :logdir       => { :type => :directory, :default => nil, :desc => "logdir" },
         :confdir      => { :type => :directory, :default => nil, :desc => "confdir" },
-        :codedir      => { :type => :directory, :default => nil, :desc => "codedir" },
+        :codedir      => { :type => :symlink_or_directory, :default => nil, :desc => "codedir" },
         :vardir       => { :type => :directory, :default => nil, :desc => "vardir" })
 
       text = <<-EOD
@@ -979,7 +979,7 @@ describe Puppet::Settings do
       @settings.define_settings(:main,
         :logdir       => { :type => :directory, :default => nil, :desc => "logdir" },
         :confdir      => { :type => :directory, :default => nil, :desc => "confdir" },
-        :codedir      => { :type => :directory, :default => nil, :desc => "codedir" },
+        :codedir      => { :type => :symlink_or_directory, :default => nil, :desc => "codedir" },
         :vardir       => { :type => :directory, :default => nil, :desc => "vardir" })
 
       text = <<-EOD


### PR DESCRIPTION
When using PE with code-manager and `versioned-deploys`, the codedir is a
symlink to a versioned code directory. This commit adds a `symlink_or_directory`
setting to allow the codedir to be either, depending on which mode you're
running in. Without this, puppetserver fails to restart while using
`versioned-deploys` because the settings catalog tries to create a directory
where there is already a symlink.