### PR TITLE
(maint) Iterable performance improvements

### DIFF
--- a/lib/puppet/functions/reverse_each.rb
+++ b/lib/puppet/functions/reverse_each.rb
@@ -84,7 +84,7 @@ Puppet::Functions.create_function(:reverse_each) do
 
   def reverse_each(iterable)
     # produces an Iterable
-    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).reverse_each
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable, true).reverse_each
   end
 
   def reverse_each_block(iterable, &block)

--- a/lib/puppet/functions/step.rb
+++ b/lib/puppet/functions/step.rb
@@ -88,7 +88,7 @@ Puppet::Functions.create_function(:step) do
 
   def step(iterable, step)
     # produces an Iterable
-    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).step(step)
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable, true).step(step)
   end
 
   def step_block(iterable, step, &block)

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -208,6 +208,26 @@ module Puppet::Pops::Types
       @enumeration.send(name, *arguments, &block)
     end
 
+    def next
+      @enumeration.next
+    end
+
+    def map(*args, &block)
+      @enumeration.map(*args, &block)
+    end
+
+    def reduce(*args, &block)
+      @enumeration.reduce(*args, &block)
+    end
+
+    def all?(&block)
+      @enumeration.all?(&block)
+    end
+
+    def any?(&block)
+      @enumeration.any?(&block)
+    end
+
     def step(step, &block)
       raise ArgumentError if step <= 0
       r = self

--- a/lib/puppet/pops/types/iterable.rb
+++ b/lib/puppet/pops/types/iterable.rb
@@ -23,13 +23,16 @@ module Puppet::Pops::Types
     #
     # An `ArgumentError` is raised for all other objects.
     #
-    # @param o [Object] The object to produce an `Iterable` for
+    # @param my_caller [Object] The calling object to reference in errors
+    # @param obj [Object] The object to produce an `Iterable` for
+    # @param infer_elements [Boolean] Whether or not to recursively infer all elements of obj. Optional
+    #
     # @return [Iterable,nil] The produced `Iterable`
     # @raise [ArgumentError] In case an `Iterable` cannot be produced
     # @api public
-    def self.asserted_iterable(caller, obj)
-      iter = self.on(obj)
-      raise ArgumentError, "#{caller.class}(): wrong argument type (#{obj.class}; is not Iterable." if iter.nil?
+    def self.asserted_iterable(my_caller, obj, infer_elements = false)
+      iter = self.on(obj, nil, infer_elements)
+      raise ArgumentError, "#{my_caller.class}(): wrong argument type (#{obj.class}; is not Iterable." if iter.nil?
       iter
     end
 
@@ -48,11 +51,14 @@ module Puppet::Pops::Types
     # The value `nil` is returned for all other objects.
     #
     # @param o [Object] The object to produce an `Iterable` for
-    # @param element_type [PAnyType] the element type for the iterator. Optional (inferred if not provided)
+    # @param element_type [PAnyType] the element type for the iterator. Optional
+    # @param infer_elements [Boolean] if element_type is nil, whether or not to recursively
+    #   infer types for the entire collection. Optional
+    #
     # @return [Iterable,nil] The produced `Iterable` or `nil` if it couldn't be produced
     #
     # @api public
-    def self.on(o, element_type = nil)
+    def self.on(o, element_type = nil, infer_elements = true)
       case o
       when IteratorProducer
         o.iterator
@@ -64,7 +70,7 @@ module Puppet::Pops::Types
         if o.empty?
           Iterator.new(PUnitType::DEFAULT, o.each)
         else
-          if element_type.nil?
+          if element_type.nil? && infer_elements
             tc = TypeCalculator.singleton
             element_type = PVariantType.maybe_create(o.map {|e| tc.infer_set(e) })
           end
@@ -75,7 +81,7 @@ module Puppet::Pops::Types
         if o.empty?
           HashIterator.new(PHashType::DEFAULT_KEY_PAIR_TUPLE, o.each)
         else
-          if element_type.nil?
+          if element_type.nil? && infer_elements
             tc = TypeCalculator.singleton
             element_type = PTupleType.new([
               PVariantType.maybe_create(o.keys.map {|e| tc.infer_set(e) }),


### PR DESCRIPTION
commit message from 4a137aa8e1902f10fe999659dd079272d444b538:

In Puppet's functions involving iteration we call
`Iterable.asserted_iterable()` to ensure whatever we are given is
properly coerced into an iterator. However, we also do a recursive type
inference on any elements of an Array, or keys and values if passed a
Hash. This is unnecessary for nearly every workflow and can be
prohibitively costly when working with large collections.

The one usage that could use an Iterator with typed elements is if a
user called `step` or `reverse_each` and attempted to save that
value or pass it into a 4x Puppet function defined w/in a .pp file. In
those cases a user _could_ assert that they received an
Iterator[SomeElementType].

To account for this we add a new optional parameter to
`Iterable.asserted_iterable` and `Iterable.on` that allows us to control
whether collection elements are recursively typed. We now only request
elements of a collection to be recursively typed if the user has called
the specific arities of `reverse_each` or `step`.

----------------------------------------------------------------------

from commit c27195cc58bf8ebe9768554090049148bc159480:

Within Iterable we register a method_missing hook to delegate any
methods called on it that have not been defined to the wrapped
enumeration. However, we call several methods within our functions that
we can easily track and know will end up being handled by
method_missing.

Instead of leaving the delegation of methods we need for core Puppet
functions to the method_missing handler this patch directly delegates
for explicitness.
