### PR TITLE
(maint) Cache located Position info

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -14,7 +14,6 @@ class Puppet::Parser::Resource < Puppet::Resource
 
   attr_accessor :source, :scope, :collector_id
   attr_accessor :virtual, :override, :translated, :catalog, :evaluated
-  attr_accessor :file, :line
 
   attr_reader :exported, :parameters
 

--- a/lib/puppet/parser/resource/param.rb
+++ b/lib/puppet/parser/resource/param.rb
@@ -4,12 +4,28 @@ class Puppet::Parser::Resource::Param
   include Puppet::Util::Errors
   include Puppet::Util::MethodHelper
 
-  attr_accessor :name, :value, :source, :add, :file, :line
+  attr_accessor :name, :value, :source, :add, :ast_node
 
   def initialize(hash)
     set_options(hash)
     requiredopts(:name)
     @name = @name.intern
+  end
+
+  def line
+    @line ||= @ast_node && @ast_node.line
+  end
+
+  def line=(lineno)
+    @line = lineno
+  end
+
+  def file
+    @file ||= @ast_node && @ast_node.file
+  end
+
+  def file=(filepath)
+    @file = filepath
   end
 
   def line_to_i

--- a/lib/puppet/pops/model/ast.rb
+++ b/lib/puppet/pops/model/ast.rb
@@ -104,11 +104,11 @@ class Positioned < PopsObject
   end
 
   def line
-    @locator.line_for_offset(@offset)
+    @located_line ||= @locator.line_for_offset(@offset)
   end
 
   def pos
-    @locator.pos_on_line(@offset)
+    @located_pos ||= @locator.pos_on_line(@offset)
   end
 
   def initialize(locator, offset, length)


### PR DESCRIPTION
We do not calculate line and column number information during tokenizing
since many tokens do not require that information. Instead we save the
byte offset from the start of the file in each token and the AST node.
Then when we need the location information the "locator" looks up what
line and column would correspond to that byte offset within that file.

This works well if we never save any information between catalog
compiles and have relatively few AST nodes that require there location
information.

However, our usage of location info has expanded over time as well as
users' usage of AST nodes that look up their location info (eg
NamedFunctionExpressions). Now a PE Puppet Server node looks up 11k
locations per compile. None of these are particularly expensive but
amount to a lot of work that we just don't have to do.

There are two important concerns about this:
1. I don't think this is thread safe and consequently not portable to
6.x. I believe we might want to evaluate if it is worth changing the AST
Factory methods to compute their location data when constructed and
dispensing with the locator for most AST Nodes.

2. There appears to be an issue with resource AttributeOperations not
correctly inheriting this behavior. Consequently, this only properly
saves the location data for 7k of the 11k locations used to compile a PE
Puppet Server catalog.