### PR TITLE
(PUP-10289) Route HttpPool requests to the HTTP client

### DIFF
--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -55,7 +55,8 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   # Should we use puppet's http client to make requests. Will return
   # false when running in puppetserver
   def use_http_client?
-    Puppet::Network::HttpPool.http_client_class == Puppet::Network::HTTP::Connection
+    Puppet::Network::HttpPool.http_client_class == Puppet::Network::HTTP::Connection ||
+      Puppet::Network::HttpPool.http_client_class == Puppet::Network::HTTP::ConnectionAdapter
   end
 
   # Provide appropriate headers.

--- a/lib/puppet/network/http/connection_adapter.rb
+++ b/lib/puppet/network/http/connection_adapter.rb
@@ -1,0 +1,165 @@
+class Puppet::Network::HTTP::ConnectionAdapter < Puppet::Network::HTTP::Connection
+  def initialize(host, port, options = {})
+    super(host, port, options)
+
+    @client = Puppet.runtime[:http]
+  end
+
+  def get(path, headers = {}, options = {})
+    headers ||= {}
+    options[:ssl_context] ||= resolve_ssl_context
+    options[:redirect_limit] ||= @redirect_limit
+
+    with_error_handling do
+      resp = @client.get(to_url(path), headers: headers, options: options)
+      resp.nethttp
+    end
+  end
+
+  def post(path, data, headers = nil, options = {})
+    headers ||= {}
+    headers['Content-Type'] ||= "application/x-www-form-urlencoded"
+    data ||= ''
+    options[:ssl_context] ||= resolve_ssl_context
+    options[:redirect_limit] ||= @redirect_limit
+
+    with_error_handling do
+      resp = @client.post(to_url(path), data, headers: headers, options: options)
+      resp.nethttp
+    end
+  end
+
+  def head(path, headers = {}, options = {})
+    headers ||= {}
+    options[:ssl_context] ||= resolve_ssl_context
+    options[:redirect_limit] ||= @redirect_limit
+
+    with_error_handling do
+      resp = @client.head(to_url(path), headers: headers, options: options)
+      resp.nethttp
+    end
+  end
+
+  def delete(path, headers = {'Depth' => 'Infinity'}, options = {})
+    headers ||= {}
+    options[:ssl_context] ||= resolve_ssl_context
+    options[:redirect_limit] ||= @redirect_limit
+
+    with_error_handling do
+      resp = @client.delete(to_url(path), headers: headers, options: options)
+      resp.nethttp
+    end
+  end
+
+  def put(path, data, headers = nil, options = {})
+    headers ||= {}
+    headers['Content-Type'] ||= "application/x-www-form-urlencoded"
+    data ||= ''
+    options[:ssl_context] ||= resolve_ssl_context
+    options[:redirect_limit] ||= @redirect_limit
+
+    with_error_handling do
+      resp = @client.put(to_url(path), data, headers: headers, options: options)
+      resp.nethttp
+    end
+  end
+
+  def request_get(*args, &block)
+    path, headers = *args
+    headers ||= {}
+    options = {
+      ssl_context: resolve_ssl_context,
+      redirect_limit: @redirect_limit
+    }
+
+    resp = @client.get(to_url(path), headers: headers, options: options) do |response|
+      yield response.nethttp if block_given?
+    end
+    resp.nethttp
+  end
+
+  def request_head(*args, &block)
+    path, headers = *args
+    headers ||= {}
+    options = {
+      ssl_context: resolve_ssl_context,
+      redirect_limit: @redirect_limit
+    }
+
+    response = @client.head(to_url(path), headers: headers, options: options)
+    yield response.nethttp if block_given?
+    response.nethttp
+  end
+
+  def request_post(*args, &block)
+    path, data, headers = *args
+    headers ||= {}
+    headers['Content-Type'] ||= "application/x-www-form-urlencoded"
+    options = {
+      ssl_context: resolve_ssl_context,
+      redirect_limit: @redirect_limit
+    }
+
+    resp = @client.post(to_url(path), data, headers: headers, options: options) do |response|
+      yield response.nethttp if block_given?
+    end
+    resp.nethttp
+  end
+
+  private
+
+  # The old Connection class ignores the ssl_context on the Puppet stack,
+  # and always loads certs/keys based on what is currently in the filesystem.
+  # If the files are missing, it would attempt to bootstrap the certs/keys
+  # while in the process of making a network request, due to the call to
+  # Puppet.lookup(:ssl_host) in Puppet::SSL::Validator::DefaultValidator#setup_connection.
+  # This class doesn't preserve the boostrap behavior because that is handled
+  # outside of this class, and can only be triggered by running `puppet ssl` or
+  # `puppet agent`.
+  def resolve_ssl_context
+    # don't need an ssl context for http connections
+    return nil unless @site.use_ssl?
+
+    # if our verifier has an ssl_context, use that
+    ctx = @verifier.ssl_context
+    return ctx if ctx
+
+    # load available certs
+    cert = Puppet::X509::CertProvider.new
+    ssl = Puppet::SSL::SSLProvider.new
+    begin
+      password = cert.load_private_key_password
+      ssl.load_context(certname: Puppet[:certname], password: password)
+    rescue Puppet::SSL::SSLError => e
+      Puppet.log_exception(e)
+
+      # if we don't have cacerts, then create a root context that doesn't
+      # trust anything. The old code used to fallback to VERIFY_NONE,
+      # which we don't want to emulate.
+      ssl.create_root_context(cacerts: [])
+    end
+  end
+
+  def to_url(path)
+    normalized_path = if path[0] == '/'
+                        path[1..-1]
+                      else
+                        path
+                      end
+    URI("#{@site.addr}/#{Puppet::Util.uri_encode(normalized_path)}")
+  end
+
+  def with_error_handling(&block)
+    yield
+  rescue Puppet::HTTP::TooManyRedirects => e
+    raise Puppet::Network::HTTP::RedirectionLimitExceededException.new(_("Too many HTTP redirections for %{host}:%{port}") % { host: @host, port: @port }, e)
+  rescue Puppet::HTTP::HTTPError => e
+    Puppet.log_exception(e, e.message)
+    case e.cause
+    when Net::OpenTimeout, Net::ReadTimeout, Net::HTTPError, EOFError
+      raise e.cause
+    else
+      raise e
+    end
+  end
+end

--- a/lib/puppet/network/http_pool.rb
+++ b/lib/puppet/network/http_pool.rb
@@ -1,4 +1,5 @@
 require 'puppet/network/http/connection'
+require 'puppet/network/http/connection_adapter'
 require 'puppet/util/platform'
 
 module Puppet::Network; end
@@ -12,7 +13,7 @@ module Puppet::Network; end
 #
 module Puppet::Network::HttpPool
 
-  @http_client_class = Puppet::Network::HTTP::Connection
+  @http_client_class = Puppet::Network::HTTP::ConnectionAdapter
 
   def self.http_client_class
     @http_client_class

--- a/lib/puppet/runtime.rb
+++ b/lib/puppet/runtime.rb
@@ -11,7 +11,8 @@ class Puppet::Runtime
     @runtime_services = {
       http: proc do
         klass = Puppet::Network::HttpPool.http_client_class
-        if klass == Puppet::Network::HTTP::Connection
+        if klass == Puppet::Network::HTTP::Connection ||
+           klass == Puppet::Network::HTTP::ConnectionAdapter
           Puppet::HTTP::Client.new
         else
           Puppet::HTTP::ExternalClient.new(klass)

--- a/lib/puppet/ssl/verifier_adapter.rb
+++ b/lib/puppet/ssl/verifier_adapter.rb
@@ -6,10 +6,18 @@
 #   loaded above.
 #
 class Puppet::SSL::VerifierAdapter
-  attr_reader :validator
+  attr_reader :validator, :ssl_context
 
   def initialize(validator)
     @validator = validator
+
+    if validator.is_a?(Puppet::SSL::Validator::NoValidator)
+      ssl = Puppet::SSL::SSLProvider.new
+      @ssl_context = ssl.create_insecure_context
+    else
+      # nil means use the default SSLContext
+      @ssl_context = nil
+    end
   end
 
   # Return true if `self` is reusable with `verifier` meaning they

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -54,7 +54,7 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a verifier" do
-        verifier = Puppet::SSL::Verifier.new('fqdn', double('ssl_context'))
+        verifier = Puppet::SSL::Verifier.new(host, double('ssl_context'))
         conn = Puppet::Network::HTTP::Connection.new(host, port, :use_ssl => true, :verifier => verifier)
 
         expect(conn.verifier).to eq(verifier)
@@ -260,6 +260,13 @@ describe Puppet::Network::HTTP::Connection do
 
       subject.put(path, nil)
     end
+
+    it 'defaults content-type to application/x-www-form-urlencoded' do
+      pending("Net::HTTP sends a default content-type header, but it's not visible to webmock")
+      stub_request(:put, url).with(headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
+
+      subject.put(path, '')
+    end
   end
 
   context "for POST requests" do
@@ -299,6 +306,13 @@ describe Puppet::Network::HTTP::Connection do
       stub_request(:post, url).with(body: '')
 
       subject.post(path, nil)
+    end
+
+    it 'defaults content-type to application/x-www-form-urlencoded' do
+      pending("Net::HTTP sends a default content-type header, but it's not visible to webmock")
+      stub_request(:post, url).with(headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
+
+      subject.post(path, "")
     end
   end
 
@@ -383,6 +397,14 @@ describe Puppet::Network::HTTP::Connection do
 
       conn = create_connection(:redirect_limit => 3)
       expects_limit_exceeded(conn)
+    end
+
+    it 'raises an exception when the location header is missing' do
+      stub_request(:get, "http://me.example.com:8140/").to_return(status: 302)
+
+      expect {
+        create_connection.get('/')
+      }.to raise_error(URI::InvalidURIError, /bad URI/)
     end
   end
 

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -9,557 +9,557 @@ describe Puppet::Network::HTTP::Connection do
   let(:url) { "https://#{host}:#{port}#{path}" }
 
   shared_examples_for "an HTTP connection" do |klass|
-  subject { klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator) }
+    subject { klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator) }
 
-  context "when providing HTTP connections" do
-    context "when initializing http instances" do
-      it "should return an http instance created with the passed host and port" do
-        conn = klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator)
+    context "when providing HTTP connections" do
+      context "when initializing http instances" do
+        it "should return an http instance created with the passed host and port" do
+          conn = klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator)
 
-        expect(conn.address).to eq(host)
-        expect(conn.port).to eq(port)
+          expect(conn.address).to eq(host)
+          expect(conn.port).to eq(port)
+        end
+
+        it "should enable ssl on the http instance by default" do
+          conn = klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator)
+
+          expect(conn).to be_use_ssl
+        end
+
+        it "can disable ssl using an option and ignore the verify" do
+          conn = klass.new(host, port, :use_ssl => false)
+
+          expect(conn).to_not be_use_ssl
+        end
+
+        it "can enable ssl using an option" do
+          conn = klass.new(host, port, :use_ssl => true, :verify => Puppet::SSL::Validator.no_validator)
+
+          expect(conn).to be_use_ssl
+        end
+
+        it "ignores the ':verify' option when ssl is disabled" do
+          conn = klass.new(host, port, :use_ssl => false, :verify => Puppet::SSL::Validator.no_validator)
+
+          expect(conn.verifier).to be_nil
+        end
+
+        it "wraps the validator in an adapter" do
+          conn = klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator)
+
+          expect(conn.verifier).to be_a_kind_of(Puppet::SSL::VerifierAdapter)
+        end
+
+        it "should raise Puppet::Error when invalid options are specified" do
+          expect { klass.new(host, port, :invalid_option => nil) }.to raise_error(Puppet::Error, 'Unrecognized option(s): :invalid_option')
+        end
+
+        it "accepts a verifier" do
+          verifier = Puppet::SSL::Verifier.new(host, double('ssl_context'))
+          conn = klass.new(host, port, :use_ssl => true, :verifier => verifier)
+
+          expect(conn.verifier).to eq(verifier)
+        end
+
+        it "raises if the wrong verifier class is specified" do
+          expect {
+            klass.new(host, port, :verifier => Puppet::SSL::Validator.default_validator)
+          }.to raise_error(ArgumentError,
+                           "Expected an instance of Puppet::SSL::Verifier but was passed a Puppet::SSL::Validator::DefaultValidator")
+        end
+      end
+    end
+
+    context "for streaming GET requests" do
+      it 'yields the response' do
+        stub_request(:get, url)
+
+        expect { |b|
+          subject.request_get('/foo', {}, &b)
+        }.to yield_with_args(Net::HTTPResponse)
       end
 
-      it "should enable ssl on the http instance by default" do
-        conn = klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator)
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:get, url).with(query: "foo=bar%3Dbaz")
 
-        expect(conn).to be_use_ssl
+        subject.request_get("#{path}?foo=bar=baz") { |_| }
       end
 
-      it "can disable ssl using an option and ignore the verify" do
-        conn = klass.new(host, port, :use_ssl => false)
+      it "merges custom headers with default ones" do
+        stub_request(:get, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
 
-        expect(conn).to_not be_use_ssl
+        subject.request_get(path, {'X-Foo' => 'Bar'}) { |_| }
       end
 
-      it "can enable ssl using an option" do
-        conn = klass.new(host, port, :use_ssl => true, :verify => Puppet::SSL::Validator.no_validator)
+      it "returns the response" do
+        stub_request(:get, url)
 
-        expect(conn).to be_use_ssl
+        response = subject.request_get(path) { |_| }
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+    end
+
+    context "for streaming head requests" do
+      it 'yields the response when request_head is called' do
+        stub_request(:head, url)
+
+        expect { |b|
+          subject.request_head('/foo', {}, &b)
+        }.to yield_with_args(Net::HTTPResponse)
       end
 
-      it "ignores the ':verify' option when ssl is disabled" do
-        conn = klass.new(host, port, :use_ssl => false, :verify => Puppet::SSL::Validator.no_validator)
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:head, url).with(query: "foo=bar%3Dbaz")
 
-        expect(conn.verifier).to be_nil
+        subject.request_head("#{path}?foo=bar=baz") { |_| }
       end
 
-      it "wraps the validator in an adapter" do
-        conn = klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator)
+      it "merges custom headers with default ones" do
+        stub_request(:head, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
 
-        expect(conn.verifier).to be_a_kind_of(Puppet::SSL::VerifierAdapter)
+        subject.request_head(path, {'X-Foo' => 'Bar'}) { |_| }
       end
 
-      it "should raise Puppet::Error when invalid options are specified" do
-        expect { klass.new(host, port, :invalid_option => nil) }.to raise_error(Puppet::Error, 'Unrecognized option(s): :invalid_option')
+      it "returns the response" do
+        stub_request(:head, url)
+
+        response = subject.request_head(path) { |_| }
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+    end
+
+    context "for streaming post requests" do
+      it 'yields the response when request_post is called' do
+        stub_request(:post, url)
+
+        expect { |b|
+          subject.request_post('/foo', "param: value", &b)
+        }.to yield_with_args(Net::HTTPResponse)
       end
 
-      it "accepts a verifier" do
-        verifier = Puppet::SSL::Verifier.new(host, double('ssl_context'))
-        conn = klass.new(host, port, :use_ssl => true, :verifier => verifier)
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:post, url).with(query: "foo=bar%3Dbaz")
 
-        expect(conn.verifier).to eq(verifier)
+        subject.request_post("#{path}?foo=bar=baz", "") { |_| }
       end
 
-      it "raises if the wrong verifier class is specified" do
+      it "merges custom headers with default ones" do
+        stub_request(:post, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
+
+        subject.request_post(path, "", {'X-Foo' => 'Bar'}) { |_| }
+      end
+
+      it "returns the response" do
+        stub_request(:post, url)
+
+        response = subject.request_post(path, "") { |_| }
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+    end
+
+    context "for GET requests" do
+      it "includes default HTTP headers" do
+        stub_request(:get, url).with(headers: {'User-Agent' => /./})
+
+        subject.get(path)
+      end
+
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:get, url).with(query: "foo=bar%3Dbaz")
+
+        subject.get("#{path}?foo=bar=baz")
+      end
+
+      it "merges custom headers with default ones" do
+        stub_request(:get, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
+
+        subject.get(path, {'X-Foo' => 'Bar'})
+      end
+
+      it "returns the response" do
+        stub_request(:get, url)
+
+        response = subject.get(path)
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+
+      it "returns the entire response body" do
+        stub_request(:get, url).to_return(body: "abc")
+
+        response = subject.get(path)
+        expect(response.body).to eq("abc")
+      end
+    end
+
+    context "for HEAD requests" do
+      it "includes default HTTP headers" do
+        stub_request(:head, url).with(headers: {'User-Agent' => /./})
+
+        subject.head(path)
+      end
+
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:head, url).with(query: "foo=bar%3Dbaz")
+
+        subject.head("#{path}?foo=bar=baz")
+      end
+
+      it "merges custom headers with default ones" do
+        stub_request(:head, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
+
+        subject.head(path, {'X-Foo' => 'Bar'})
+      end
+
+      it "returns the response" do
+        stub_request(:head, url)
+
+        response = subject.head(path)
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+    end
+
+    context "for PUT requests" do
+      it "includes default HTTP headers" do
+        stub_request(:put, url).with(headers: {'User-Agent' => /./})
+
+        subject.put(path, "", {'Content-Type' => 'text/plain'})
+      end
+
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:put, url).with(query: "foo=bar%3Dbaz")
+
+        subject.put("#{path}?foo=bar=baz", "")
+      end
+
+      it "includes custom headers" do
+        stub_request(:put, url).with(headers: { 'X-Foo' => 'Bar' })
+
+        subject.put(path, "", {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'})
+      end
+
+      it "returns the response" do
+        stub_request(:put, url)
+
+        response = subject.put(path, "", {'Content-Type' => 'text/plain'})
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+
+      it "sets content-type for the body" do
+        stub_request(:put, url).with(headers: {"Content-Type" => "text/plain"})
+
+        subject.put(path, "hello", {'Content-Type' => 'text/plain'})
+      end
+
+      it 'sends an empty body' do
+        stub_request(:put, url).with(body: '')
+
+        subject.put(path, nil)
+      end
+
+      it 'defaults content-type to application/x-www-form-urlencoded' do
+        pending("Net::HTTP sends a default content-type header, but it's not visible to webmock")
+        stub_request(:put, url).with(headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
+
+        subject.put(path, '')
+      end
+    end
+
+    context "for POST requests" do
+      it "includes default HTTP headers" do
+        stub_request(:post, url).with(headers: {'User-Agent' => /./})
+
+        subject.post(path, "", {'Content-Type' => 'text/plain'})
+      end
+
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:post, url).with(query: "foo=bar%3Dbaz")
+
+        subject.post("#{path}?foo=bar=baz", "", {'Content-Type' => 'text/plain'})
+      end
+
+      it "includes custom headers" do
+        stub_request(:post, url).with(headers: { 'X-Foo' => 'Bar' })
+
+        subject.post(path, "", {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'})
+      end
+
+      it "returns the response" do
+        stub_request(:post, url)
+
+        response = subject.post(path, "", {'Content-Type' => 'text/plain'})
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+
+      it "sets content-type for the body" do
+        stub_request(:post, url).with(headers: {"Content-Type" => "text/plain"})
+
+        subject.post(path, "hello", {'Content-Type' => 'text/plain'})
+      end
+
+      it 'sends an empty body' do
+        stub_request(:post, url).with(body: '')
+
+        subject.post(path, nil)
+      end
+
+      it 'defaults content-type to application/x-www-form-urlencoded' do
+        pending("Net::HTTP sends a default content-type header, but it's not visible to webmock")
+        stub_request(:post, url).with(headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
+
+        subject.post(path, "")
+      end
+    end
+
+    context "for DELETE requests" do
+      it "includes default HTTP headers" do
+        stub_request(:delete, url).with(headers: {'User-Agent' => /./})
+
+        subject.delete(path)
+      end
+
+      it "merges custom headers with default ones" do
+        stub_request(:delete, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
+
+        subject.delete(path, {'X-Foo' => 'Bar'})
+      end
+
+      it "stringifies keys and encodes values in the query" do
+        stub_request(:delete, url).with(query: "foo=bar%3Dbaz")
+
+        subject.delete("#{path}?foo=bar=baz")
+      end
+
+      it "returns the response" do
+        stub_request(:delete, url)
+
+        response = subject.delete(path)
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+        expect(response.code).to eq("200")
+      end
+
+      it "returns the entire response body" do
+        stub_request(:delete, url).to_return(body: "abc")
+
+        expect(subject.delete(path).body).to eq("abc")
+      end
+    end
+
+    context "when response is a redirect" do
+      subject { klass }
+
+      def create_connection(options = {})
+        options[:use_ssl] = false
+        options[:verify] = Puppet::SSL::Validator.no_validator
+        subject.new(host, port, options)
+      end
+
+      def redirect_to(url)
+        { status: 302, headers: { 'Location' => url } }
+      end
+
+      it "should follow the redirect to the final resource location" do
+        stub_request(:get, "http://me.example.com:8140/foo").to_return(redirect_to("http://me.example.com:8140/bar"))
+        stub_request(:get, "http://me.example.com:8140/bar").to_return(status: 200)
+
+        create_connection.get('/foo')
+      end
+
+      def expects_limit_exceeded(conn)
         expect {
-          klass.new(host, port, :verifier => Puppet::SSL::Validator.default_validator)
-        }.to raise_error(ArgumentError,
-                         "Expected an instance of Puppet::SSL::Verifier but was passed a Puppet::SSL::Validator::DefaultValidator")
+          conn.get('/')
+        }.to raise_error(Puppet::Network::HTTP::RedirectionLimitExceededException)
+      end
+
+      it "should not follow any redirects when the limit is 0" do
+        stub_request(:get, "http://me.example.com:8140/").to_return(redirect_to("http://me.example.com:8140/foo"))
+
+        conn = create_connection(:redirect_limit => 0)
+        expects_limit_exceeded(conn)
+      end
+
+      it "should follow the redirect once" do
+        stub_request(:get, "http://me.example.com:8140/").to_return(redirect_to("http://me.example.com:8140/foo"))
+        stub_request(:get, "http://me.example.com:8140/foo").to_return(redirect_to("http://me.example.com:8140/bar"))
+
+        conn = create_connection(:redirect_limit => 1)
+        expects_limit_exceeded(conn)
+      end
+
+      it "should raise an exception when the redirect limit is exceeded" do
+        stub_request(:get, "http://me.example.com:8140/").to_return(redirect_to("http://me.example.com:8140/foo"))
+        stub_request(:get, "http://me.example.com:8140/foo").to_return(redirect_to("http://me.example.com:8140/bar"))
+        stub_request(:get, "http://me.example.com:8140/bar").to_return(redirect_to("http://me.example.com:8140/baz"))
+        stub_request(:get, "http://me.example.com:8140/baz").to_return(redirect_to("http://me.example.com:8140/qux"))
+
+        conn = create_connection(:redirect_limit => 3)
+        expects_limit_exceeded(conn)
+      end
+
+      it 'raises an exception when the location header is missing' do
+        stub_request(:get, "http://me.example.com:8140/").to_return(status: 302)
+
+        expect {
+          create_connection.get('/')
+        }.to raise_error(URI::InvalidURIError, /bad URI/)
       end
     end
-  end
 
-  context "for streaming GET requests" do
-    it 'yields the response' do
-      stub_request(:get, url)
+    context "when response indicates an overloaded server" do
+      def retry_after(datetime)
+        stub_request(:get, url)
+          .to_return(status: [503, 'Service Unavailable'], headers: {'Retry-After' => datetime}).then
+          .to_return(status: 200)
+      end
 
-      expect { |b|
-        subject.request_get('/foo', {}, &b)
-      }.to yield_with_args(Net::HTTPResponse)
+      it "should return a 503 response if Retry-After is not set" do
+        stub_request(:get, url).to_return(status: [503, 'Service Unavailable'])
+
+        result = subject.get('/foo')
+        expect(result.code).to eq("503")
+      end
+
+      it "should return a 503 response if Retry-After is not convertible to an Integer or RFC 2822 Date" do
+        retry_after('foo')
+
+        result = subject.get('/foo')
+        expect(result.code).to eq("503")
+      end
+
+      it "should close the connection before sleeping" do
+        retry_after('42')
+
+        http1 = Net::HTTP.new(host, port)
+        http1.use_ssl = true
+        allow(http1).to receive(:started?).and_return(true)
+
+        http2 = Net::HTTP.new(host, port)
+        http2.use_ssl = true
+        allow(http1).to receive(:started?).and_return(true)
+
+        # The "with_connection" method is required to yield started connections
+        pool = Puppet.lookup(:http_pool)
+        allow(pool).to receive(:with_connection).and_yield(http1).and_yield(http2)
+
+        expect(http1).to receive(:finish).ordered
+        expect(::Kernel).to receive(:sleep).with(42).ordered
+
+        subject.get('/foo')
+      end
+
+      it "should sleep and retry if Retry-After is an Integer" do
+        retry_after('42')
+
+        expect(::Kernel).to receive(:sleep).with(42)
+
+        result = subject.get('/foo')
+        expect(result.code).to eq("200")
+      end
+
+      it "should sleep and retry if Retry-After is an RFC 2822 Date" do
+        retry_after('Wed, 13 Apr 2005 15:18:05 GMT')
+
+        now = DateTime.new(2005, 4, 13, 8, 17, 5, '-07:00')
+        allow(DateTime).to receive(:now).and_return(now)
+
+        expect(::Kernel).to receive(:sleep).with(60)
+
+        result = subject.get('/foo')
+        expect(result.code).to eq("200")
+      end
+
+      it "should sleep for no more than the Puppet runinterval" do
+        retry_after('60')
+
+        Puppet[:runinterval] = 30
+
+        expect(::Kernel).to receive(:sleep).with(30)
+
+        subject.get('/foo')
+      end
+
+      it "should sleep for 0 seconds if the RFC 2822 date has past" do
+        retry_after('Wed, 13 Apr 2005 15:18:05 GMT')
+
+        expect(::Kernel).to receive(:sleep).with(0)
+
+        subject.get('/foo')
+      end
     end
 
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:get, url).with(query: "foo=bar%3Dbaz")
+    context "basic auth" do
+      let(:auth) { { :user => 'user', :password => 'password' } }
+      let(:creds) { [ 'user', 'password'] }
 
-      subject.request_get("#{path}?foo=bar=baz") { |_| }
+      it "is allowed in get requests" do
+        stub_request(:get, url).with(basic_auth: creds)
+
+        subject.get('/foo', nil, :basic_auth => auth)
+      end
+
+      it "is allowed in post requests" do
+        stub_request(:post, url).with(basic_auth: creds)
+
+        subject.post('/foo', 'data', nil, :basic_auth => auth)
+      end
+
+      it "is allowed in head requests" do
+        stub_request(:head, url).with(basic_auth: creds)
+
+        subject.head('/foo', nil, :basic_auth => auth)
+      end
+
+      it "is allowed in delete requests" do
+        stub_request(:delete, url).with(basic_auth: creds)
+
+        subject.delete('/foo', nil, :basic_auth => auth)
+      end
+
+      it "is allowed in put requests" do
+        stub_request(:put, url).with(basic_auth: creds)
+
+        subject.put('/foo', 'data', nil, :basic_auth => auth)
+      end
     end
 
-    it "merges custom headers with default ones" do
-      stub_request(:get, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
-
-      subject.request_get(path, {'X-Foo' => 'Bar'}) { |_| }
-    end
-
-    it "returns the response" do
-      stub_request(:get, url)
-
-      response = subject.request_get(path) { |_| }
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-  end
-
-  context "for streaming head requests" do
-    it 'yields the response when request_head is called' do
-      stub_request(:head, url)
-
-      expect { |b|
-        subject.request_head('/foo', {}, &b)
-      }.to yield_with_args(Net::HTTPResponse)
-    end
-
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:head, url).with(query: "foo=bar%3Dbaz")
-
-      subject.request_head("#{path}?foo=bar=baz") { |_| }
-    end
-
-    it "merges custom headers with default ones" do
-      stub_request(:head, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
-
-      subject.request_head(path, {'X-Foo' => 'Bar'}) { |_| }
-    end
-
-    it "returns the response" do
-      stub_request(:head, url)
-
-      response = subject.request_head(path) { |_| }
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-  end
-
-  context "for streaming post requests" do
-    it 'yields the response when request_post is called' do
-      stub_request(:post, url)
-
-      expect { |b|
-        subject.request_post('/foo', "param: value", &b)
-      }.to yield_with_args(Net::HTTPResponse)
-    end
-
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:post, url).with(query: "foo=bar%3Dbaz")
-
-      subject.request_post("#{path}?foo=bar=baz", "") { |_| }
-    end
-
-    it "merges custom headers with default ones" do
-      stub_request(:post, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
-
-      subject.request_post(path, "", {'X-Foo' => 'Bar'}) { |_| }
-    end
-
-    it "returns the response" do
-      stub_request(:post, url)
-
-      response = subject.request_post(path, "") { |_| }
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-  end
-
-  context "for GET requests" do
-    it "includes default HTTP headers" do
-      stub_request(:get, url).with(headers: {'User-Agent' => /./})
-
-      subject.get(path)
-    end
-
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:get, url).with(query: "foo=bar%3Dbaz")
-
-      subject.get("#{path}?foo=bar=baz")
-    end
-
-    it "merges custom headers with default ones" do
-      stub_request(:get, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
-
-      subject.get(path, {'X-Foo' => 'Bar'})
-    end
-
-    it "returns the response" do
-      stub_request(:get, url)
-
-      response = subject.get(path)
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-
-    it "returns the entire response body" do
-      stub_request(:get, url).to_return(body: "abc")
-
-      response = subject.get(path)
-      expect(response.body).to eq("abc")
-    end
-  end
-
-  context "for HEAD requests" do
-    it "includes default HTTP headers" do
-      stub_request(:head, url).with(headers: {'User-Agent' => /./})
-
-      subject.head(path)
-    end
-
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:head, url).with(query: "foo=bar%3Dbaz")
-
-      subject.head("#{path}?foo=bar=baz")
-    end
-
-    it "merges custom headers with default ones" do
-      stub_request(:head, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
-
-      subject.head(path, {'X-Foo' => 'Bar'})
-    end
-
-    it "returns the response" do
-      stub_request(:head, url)
-
-      response = subject.head(path)
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-  end
-
-  context "for PUT requests" do
-    it "includes default HTTP headers" do
-      stub_request(:put, url).with(headers: {'User-Agent' => /./})
-
-      subject.put(path, "", {'Content-Type' => 'text/plain'})
-    end
-
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:put, url).with(query: "foo=bar%3Dbaz")
-
-      subject.put("#{path}?foo=bar=baz", "")
-    end
-
-    it "includes custom headers" do
-      stub_request(:put, url).with(headers: { 'X-Foo' => 'Bar' })
-
-      subject.put(path, "", {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'})
-    end
-
-    it "returns the response" do
-      stub_request(:put, url)
-
-      response = subject.put(path, "", {'Content-Type' => 'text/plain'})
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-
-    it "sets content-type for the body" do
-      stub_request(:put, url).with(headers: {"Content-Type" => "text/plain"})
-
-      subject.put(path, "hello", {'Content-Type' => 'text/plain'})
-    end
-
-    it 'sends an empty body' do
-      stub_request(:put, url).with(body: '')
-
-      subject.put(path, nil)
-    end
-
-    it 'defaults content-type to application/x-www-form-urlencoded' do
-      pending("Net::HTTP sends a default content-type header, but it's not visible to webmock")
-      stub_request(:put, url).with(headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
-
-      subject.put(path, '')
-    end
-  end
-
-  context "for POST requests" do
-    it "includes default HTTP headers" do
-      stub_request(:post, url).with(headers: {'User-Agent' => /./})
-
-      subject.post(path, "", {'Content-Type' => 'text/plain'})
-    end
-
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:post, url).with(query: "foo=bar%3Dbaz")
-
-      subject.post("#{path}?foo=bar=baz", "", {'Content-Type' => 'text/plain'})
-    end
-
-    it "includes custom headers" do
-      stub_request(:post, url).with(headers: { 'X-Foo' => 'Bar' })
-
-      subject.post(path, "", {'X-Foo' => 'Bar', 'Content-Type' => 'text/plain'})
-    end
-
-    it "returns the response" do
-      stub_request(:post, url)
-
-      response = subject.post(path, "", {'Content-Type' => 'text/plain'})
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-
-    it "sets content-type for the body" do
-      stub_request(:post, url).with(headers: {"Content-Type" => "text/plain"})
-
-      subject.post(path, "hello", {'Content-Type' => 'text/plain'})
-    end
-
-    it 'sends an empty body' do
-      stub_request(:post, url).with(body: '')
-
-      subject.post(path, nil)
-    end
-
-    it 'defaults content-type to application/x-www-form-urlencoded' do
-      pending("Net::HTTP sends a default content-type header, but it's not visible to webmock")
-      stub_request(:post, url).with(headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
-
-      subject.post(path, "")
-    end
-  end
-
-  context "for DELETE requests" do
-    it "includes default HTTP headers" do
-      stub_request(:delete, url).with(headers: {'User-Agent' => /./})
-
-      subject.delete(path)
-    end
-
-    it "merges custom headers with default ones" do
-      stub_request(:delete, url).with(headers: { 'X-Foo' => 'Bar', 'User-Agent' => /./ })
-
-      subject.delete(path, {'X-Foo' => 'Bar'})
-    end
-
-    it "stringifies keys and encodes values in the query" do
-      stub_request(:delete, url).with(query: "foo=bar%3Dbaz")
-
-      subject.delete("#{path}?foo=bar=baz")
-    end
-
-    it "returns the response" do
-      stub_request(:delete, url)
-
-      response = subject.delete(path)
-      expect(response).to be_an_instance_of(Net::HTTPOK)
-      expect(response.code).to eq("200")
-    end
-
-    it "returns the entire response body" do
-      stub_request(:delete, url).to_return(body: "abc")
-
-      expect(subject.delete(path).body).to eq("abc")
-    end
-  end
-
-  context "when response is a redirect" do
-    subject { klass }
-
-    def create_connection(options = {})
-      options[:use_ssl] = false
-      options[:verify] = Puppet::SSL::Validator.no_validator
-      subject.new(host, port, options)
-    end
-
-    def redirect_to(url)
-      { status: 302, headers: { 'Location' => url } }
-    end
-
-    it "should follow the redirect to the final resource location" do
-      stub_request(:get, "http://me.example.com:8140/foo").to_return(redirect_to("http://me.example.com:8140/bar"))
-      stub_request(:get, "http://me.example.com:8140/bar").to_return(status: 200)
-
-      create_connection.get('/foo')
-    end
-
-    def expects_limit_exceeded(conn)
-      expect {
-        conn.get('/')
-      }.to raise_error(Puppet::Network::HTTP::RedirectionLimitExceededException)
-    end
-
-    it "should not follow any redirects when the limit is 0" do
-      stub_request(:get, "http://me.example.com:8140/").to_return(redirect_to("http://me.example.com:8140/foo"))
-
-      conn = create_connection(:redirect_limit => 0)
-      expects_limit_exceeded(conn)
-    end
-
-    it "should follow the redirect once" do
-      stub_request(:get, "http://me.example.com:8140/").to_return(redirect_to("http://me.example.com:8140/foo"))
-      stub_request(:get, "http://me.example.com:8140/foo").to_return(redirect_to("http://me.example.com:8140/bar"))
-
-      conn = create_connection(:redirect_limit => 1)
-      expects_limit_exceeded(conn)
-    end
-
-    it "should raise an exception when the redirect limit is exceeded" do
-      stub_request(:get, "http://me.example.com:8140/").to_return(redirect_to("http://me.example.com:8140/foo"))
-      stub_request(:get, "http://me.example.com:8140/foo").to_return(redirect_to("http://me.example.com:8140/bar"))
-      stub_request(:get, "http://me.example.com:8140/bar").to_return(redirect_to("http://me.example.com:8140/baz"))
-      stub_request(:get, "http://me.example.com:8140/baz").to_return(redirect_to("http://me.example.com:8140/qux"))
-
-      conn = create_connection(:redirect_limit => 3)
-      expects_limit_exceeded(conn)
-    end
-
-    it 'raises an exception when the location header is missing' do
-      stub_request(:get, "http://me.example.com:8140/").to_return(status: 302)
-
-      expect {
-        create_connection.get('/')
-      }.to raise_error(URI::InvalidURIError, /bad URI/)
-    end
-  end
-
-  context "when response indicates an overloaded server" do
-    def retry_after(datetime)
-      stub_request(:get, url)
-        .to_return(status: [503, 'Service Unavailable'], headers: {'Retry-After' => datetime}).then
-        .to_return(status: 200)
-    end
-
-    it "should return a 503 response if Retry-After is not set" do
-      stub_request(:get, url).to_return(status: [503, 'Service Unavailable'])
-
-      result = subject.get('/foo')
-      expect(result.code).to eq("503")
-    end
-
-    it "should return a 503 response if Retry-After is not convertible to an Integer or RFC 2822 Date" do
-      retry_after('foo')
-
-      result = subject.get('/foo')
-      expect(result.code).to eq("503")
-    end
-
-    it "should close the connection before sleeping" do
-      retry_after('42')
-
-      http1 = Net::HTTP.new(host, port)
-      http1.use_ssl = true
-      allow(http1).to receive(:started?).and_return(true)
-
-      http2 = Net::HTTP.new(host, port)
-      http2.use_ssl = true
-      allow(http1).to receive(:started?).and_return(true)
-
-      # The "with_connection" method is required to yield started connections
-      pool = Puppet.lookup(:http_pool)
-      allow(pool).to receive(:with_connection).and_yield(http1).and_yield(http2)
-
-      expect(http1).to receive(:finish).ordered
-      expect(::Kernel).to receive(:sleep).with(42).ordered
+    it "sets HTTP User-Agent header" do
+      puppet_ua = "Puppet/#{Puppet.version} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})"
+      stub_request(:get, url).with(headers: { 'User-Agent' => puppet_ua })
 
       subject.get('/foo')
     end
 
-    it "should sleep and retry if Retry-After is an Integer" do
-      retry_after('42')
+    describe 'connection request errors' do
+      it "logs and raises generic http errors" do
+        generic_error = Net::HTTPError.new('generic error', double("response"))
+        stub_request(:get, url).to_raise(generic_error)
 
-      expect(::Kernel).to receive(:sleep).with(42)
+        expect(Puppet).to receive(:log_exception).with(anything, /^.*failed: generic error$/)
+        expect { subject.get('/foo') }.to raise_error(generic_error)
+      end
 
-      result = subject.get('/foo')
-      expect(result.code).to eq("200")
+      it "logs and raises timeout errors" do
+        timeout_error = Timeout::Error.new
+        stub_request(:get, url).to_raise(timeout_error)
+
+        expect(Puppet).to receive(:log_exception).with(anything, /^.*timed out after .* seconds$/)
+        expect { subject.get('/foo') }.to raise_error(timeout_error)
+      end
+
+      it "logs and raises eof errors" do
+        eof_error = EOFError
+        stub_request(:get, url).to_raise(eof_error)
+
+        expect(Puppet).to receive(:log_exception).with(anything, /^.*interrupted after .* seconds$/)
+        expect { subject.get('/foo') }.to raise_error(eof_error)
+      end
     end
-
-    it "should sleep and retry if Retry-After is an RFC 2822 Date" do
-      retry_after('Wed, 13 Apr 2005 15:18:05 GMT')
-
-      now = DateTime.new(2005, 4, 13, 8, 17, 5, '-07:00')
-      allow(DateTime).to receive(:now).and_return(now)
-
-      expect(::Kernel).to receive(:sleep).with(60)
-
-      result = subject.get('/foo')
-      expect(result.code).to eq("200")
-    end
-
-    it "should sleep for no more than the Puppet runinterval" do
-      retry_after('60')
-
-      Puppet[:runinterval] = 30
-
-      expect(::Kernel).to receive(:sleep).with(30)
-
-      subject.get('/foo')
-    end
-
-    it "should sleep for 0 seconds if the RFC 2822 date has past" do
-      retry_after('Wed, 13 Apr 2005 15:18:05 GMT')
-
-      expect(::Kernel).to receive(:sleep).with(0)
-
-      subject.get('/foo')
-    end
-  end
-
-  context "basic auth" do
-    let(:auth) { { :user => 'user', :password => 'password' } }
-    let(:creds) { [ 'user', 'password'] }
-
-    it "is allowed in get requests" do
-      stub_request(:get, url).with(basic_auth: creds)
-
-      subject.get('/foo', nil, :basic_auth => auth)
-    end
-
-    it "is allowed in post requests" do
-      stub_request(:post, url).with(basic_auth: creds)
-
-      subject.post('/foo', 'data', nil, :basic_auth => auth)
-    end
-
-    it "is allowed in head requests" do
-      stub_request(:head, url).with(basic_auth: creds)
-
-      subject.head('/foo', nil, :basic_auth => auth)
-    end
-
-    it "is allowed in delete requests" do
-      stub_request(:delete, url).with(basic_auth: creds)
-
-      subject.delete('/foo', nil, :basic_auth => auth)
-    end
-
-    it "is allowed in put requests" do
-      stub_request(:put, url).with(basic_auth: creds)
-
-      subject.put('/foo', 'data', nil, :basic_auth => auth)
-    end
-  end
-
-  it "sets HTTP User-Agent header" do
-    puppet_ua = "Puppet/#{Puppet.version} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})"
-    stub_request(:get, url).with(headers: { 'User-Agent' => puppet_ua })
-
-    subject.get('/foo')
-  end
-
-  describe 'connection request errors' do
-    it "logs and raises generic http errors" do
-      generic_error = Net::HTTPError.new('generic error', double("response"))
-      stub_request(:get, url).to_raise(generic_error)
-
-      expect(Puppet).to receive(:log_exception).with(anything, /^.*failed: generic error$/)
-      expect { subject.get('/foo') }.to raise_error(generic_error)
-    end
-
-    it "logs and raises timeout errors" do
-      timeout_error = Timeout::Error.new
-      stub_request(:get, url).to_raise(timeout_error)
-
-      expect(Puppet).to receive(:log_exception).with(anything, /^.*timed out after .* seconds$/)
-      expect { subject.get('/foo') }.to raise_error(timeout_error)
-    end
-
-    it "logs and raises eof errors" do
-      eof_error = EOFError
-      stub_request(:get, url).to_raise(eof_error)
-
-      expect(Puppet).to receive(:log_exception).with(anything, /^.*interrupted after .* seconds$/)
-      expect { subject.get('/foo') }.to raise_error(eof_error)
-    end
-  end
   end
 
   describe Puppet::Network::HTTP::Connection do

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -55,7 +55,7 @@ describe Puppet::Network::HttpPool do
   describe "when managing http instances" do
     it "should return an http instance created with the passed host and port" do
       http = Puppet::Network::HttpPool.http_instance("me", 54321)
-      expect(http).to be_an_instance_of Puppet::Network::HTTP::Connection
+      expect(http).to be_a_kind_of Puppet::Network::HTTP::Connection
       expect(http.address).to eq('me')
       expect(http.port).to    eq(54321)
     end

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -10,10 +10,7 @@ class Puppet::Network::HttpPool::FooClient
 end
 
 describe Puppet::Network::HttpPool do
-  before :each do
-    Puppet::SSL::Key.indirection.terminus_class = :memory
-    Puppet::SSL::CertificateRequest.indirection.terminus_class = :memory
-  end
+  include PuppetSpec::Files
 
   describe "when registering an http client class" do
     let(:http_impl) { Puppet::Network::HttpPool::FooClient }
@@ -109,53 +106,35 @@ describe Puppet::Network::HttpPool do
     end
 
     describe 'peer verification' do
-      def setup_standard_ssl_configuration
-        ca_cert_file = File.expand_path('/path/to/ssl/certs/ca_cert.pem')
 
-        Puppet[:ssl_client_ca_auth] = ca_cert_file
-        allow(Puppet::FileSystem).to receive(:exist?).with(ca_cert_file).and_return(true)
-      end
+      before(:each) do
+        Puppet[:ssldir] = tmpdir('ssl')
+        Puppet.settings.use(:main)
 
-      def setup_standard_hostcert
-        host_cert_file = File.expand_path('/path/to/ssl/certs/host_cert.pem')
-        allow(Puppet::FileSystem).to receive(:exist?).with(host_cert_file).and_return(true)
-
-        Puppet[:hostcert] = host_cert_file
-      end
-
-      def setup_standard_ssl_host
-        cert = double('cert', :content => 'real_cert')
-        key  = double('key',  :content => 'real_key')
-        host = double('host', :certificate => cert, :key => key, :ssl_store => double('store'))
-
-        allow(Puppet::SSL::Host).to receive(:localhost).and_return(host)
-      end
-
-      before do
-        setup_standard_ssl_configuration
-        setup_standard_hostcert
-        setup_standard_ssl_host
+        Puppet[:certname] = 'signed'
+        File.write(Puppet[:localcacert], cert_fixture('ca.pem'))
+        File.write(Puppet[:hostcrl], crl_fixture('crl.pem'))
+        File.write(Puppet[:hostcert], cert_fixture('signed.pem'))
+        File.write(Puppet[:hostprivkey], key_fixture('signed-key.pem'))
       end
 
       it 'enables peer verification by default' do
-        response = Net::HTTPOK.new('1.1', 200, 'body')
-        conn = Puppet::Network::HttpPool.http_instance("me", 54321, true)
-        expect(conn).to receive(:execute_request) do |http, _|
-          expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
+        stub_request(:get, "https://me:54321")
 
-          response
+        conn = Puppet::Network::HttpPool.http_instance("me", 54321, true)
+        expect_any_instance_of(Net::HTTP).to receive(:start) do |http|
+          expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
         end
 
         conn.get('/')
       end
 
       it 'can disable peer verification' do
-        response = Net::HTTPOK.new('1.1', 200, 'body')
-        conn = Puppet::Network::HttpPool.http_instance("me", 54321, true, false)
-        expect(conn).to receive(:execute_request) do |http, _|
-          expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+        stub_request(:get, "https://me:54321")
 
-          response
+        conn = Puppet::Network::HttpPool.http_instance("me", 54321, true, false)
+        expect_any_instance_of(Net::HTTP).to receive(:start) do |http|
+          expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
         end
 
         conn.get('/')


### PR DESCRIPTION
Calls to `Puppet::Network::HttpPool.http_instance` and friends are routed through the HTTP client while preserving the return value and exceptions. As result `Puppet::Network::HTTP::Connection` is never used in puppet and any extension (like puppetdb terminus) calling the method will not notice the change.