### PR TITLE
(PUP-10506) Fix `purge_ssh_keys` requiring homedir

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -719,17 +719,11 @@ module Puppet
         value = test_sym if [:true, :false].include? test_sym
 
         return [] if value == :false
-        home = resource[:home]
-        if value == :true and not home
-          raise ArgumentError, _("purge_ssh_keys can only be true for users with a defined home directory")
-        end
+        home = resource[:home] || Dir.home(resource[:name])
 
         return [ "#{home}/.ssh/authorized_keys" ] if value == :true
         # value is an array - munge each value
         [ value ].flatten.map do |entry|
-          if entry =~ /^~|^%h/ and not home
-            raise ArgumentError, _("purge_ssh_keys value '%{value}' meta character ~ or %{home_placeholder} only allowed for users with a defined home directory") % { value: value, home_placeholder: '%h' }
-          end
           entry.gsub!(/^~\//, "#{home}/")
           entry.gsub!(/^%h\//, "#{home}/")
           entry

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 require 'spec_helper'
 
 describe Puppet::Type.type(:user) do
@@ -484,28 +484,30 @@ describe Puppet::Type.type(:user) do
     end
 
     context "with no home directory specified" do
-      it "should not accept true" do
-        expect {
-          described_class.new(:name => "a", :purge_ssh_keys => true)
-        }.to raise_error(Puppet::Error, /purge_ssh_keys can only be true for users with a defined home directory/)
+      before(:each) do
+        allow(Dir).to receive(:home).with('a').and_return('/home/a')
       end
 
-      it "should not accept the ~ wildcard" do
-        expect {
-          described_class.new(:name => "a", :purge_ssh_keys => "~/keys")
-        }.to raise_error(Puppet::Error, /meta character ~ or %h only allowed for users with a defined home directory/)
+      it "should accept true" do
+        described_class.new(:name => "a", :purge_ssh_keys => true)
       end
 
-      it "should not accept the %h wildcard" do
-        expect {
-          described_class.new(:name => "a", :purge_ssh_keys => "%h/keys")
-        }.to raise_error(Puppet::Error, /meta character ~ or %h only allowed for users with a defined home directory/)
+      it "should accept the ~ wildcard" do
+        described_class.new(:name => "a", :purge_ssh_keys => "~/keys")
+      end
+
+      it "should accept the %h wildcard" do
+        described_class.new(:name => "a", :purge_ssh_keys => "%h/keys")
       end
     end
 
     context "with a valid parameter" do
       let(:paths) do
         [ "/dev/null", "/tmp/keyfile" ].map { |path| File.expand_path(path) }
+      end
+
+      before(:each) do
+        allow(Dir).to receive(:home).with('test').and_return('/home/test')
       end
 
       subject do
@@ -532,6 +534,10 @@ describe Puppet::Type.type(:user) do
         res = described_class.new(:name => "test_user_name", :purge_ssh_keys => purge_param)
         res.catalog = Puppet::Resource::Catalog.new
         res
+      end
+
+      before(:each) do
+        allow(Dir).to receive(:home).with('test_user_name').and_return('/home/test_user_name')
       end
 
       context "when purging is disabled" do


### PR DESCRIPTION
Previously, if `purge_ssh_keys` was set on a user resource similar to:

```puppet
user { 'testuser':
  purge_ssh_keys => true
}
```

Application would fail since the `purge_ssh_keys` parameter requires the home directory to also be managed by Puppet.

This commit adds a fallback to `Dir.home(username)` for resources that do not specify the `home` parameter.