### PR TITLE
(PUP-8897) Fix `managehome` property for `useradd`

### DIFF
--- a/spec/unit/provider/user/openbsd_spec.rb
+++ b/spec/unit/provider/user/openbsd_spec.rb
@@ -45,6 +45,7 @@ describe Puppet::Type.type(:user).provider(:openbsd) do
   describe "#addcmd" do
     it "should return an array with the full command and expiry as MM/DD/YY" do
       allow(Facter).to receive(:value).with(:osfamily).and_return('OpenBSD')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease)
       resource[:expiry] = "1997-06-01"
       expect(provider.addcmd).to eq(['/usr/sbin/useradd', '-e', 'June 01 1997', 'myuser'])
     end


### PR DESCRIPTION
I did some digging on how `shadow-utils` and `libuser` implemented the
`-M` flag, and on the assumptions that Puppet made regarding this
flag.

First, the `shadow` library implemented the `-M` flag (also known as
`--no-create-home`) back in 2008, in this commit[1]. For reference,
the first tag containing this commit was 4.1.3, which was released on
April 15th 2009.

Second, RedHat has been maintaining their own patched version of
`shadow` called `shadow-utils`. What they do is get the upstream
`shadow` source, *extensively* patch it, then vendor it as
`shadow-utils`, which is present on every RedHat-based OS starting
with at least EL 5. Among the patches that RedHat applies is one that
adds the same `-M` functionality as the upstream project did. However,
RedHat has been doing this long before that. The oldest SRPM I could
find was `shadow-utils-4.0.17-12.el5.src.rpm`, in which the related
patch dates from July 2006.

As for the `libuser` package, the `luseradd` command seems to have had
this option since the beginning of times (see commit[2], it's inside a
suggestive ifdef but we're just going to ignore that for our own
sanity).

Now, the last puzzle piece is the Puppet code itself:

```ruby
def check_manage_home
  cmd = []
  if @resource.managehome? && (!@resource.forcelocal?)
    cmd << "-m"
  elsif (!@resource.managehome?) && Facter.value(:osfamily) == 'RedHat'
    cmd << "-M"
  end
  cmd
end
```

What we can conclude now is that the `-M` flag should be added in all
cases where `managehome` is false, but the current code also adds an
OS check. Going as far back as git can take us on this, we find the
flag added in this commit[3] dated August 14th 2006. Back then it made
sense that the only OSes that had `-M` were RedHat-based, since the
upstream `shadow` project was almost 3 years away from releasing their
own version of `-M`.

The solution here would be to remove the OS check altogether, since
most Linux distros have integrated the `-M` change from
`shadow`. However, this provider is also being used by Solaris and OpenBSD, which
do not have this flag (obviously). Then there's SLES 11 which we
still officially support, and which uses `pwdutils` instead of
`shadow` for passwd and shadow user information management, and which
does *not* have the `-M` flag. SUSE switched to `shadow` beginning
with SLES 12.

To make this as future-proof as possible, we pass `-M` for everything
except OpenBSD, Solaris and SLES 11.

[1] https://github.com/shadow-maint/shadow/commit/b18d46e68ddf06869bc042297814369e02564c9
[2] https://pagure.io/libuser/blame/apps/luseradd.c?identifier=1dd9fb1dc8b421e8c1822ba514adabd5eda97f7f#_45
[3] https://github.com/puppetlabs/puppet/commit/12452ee9ca294563f2e2724ff36f179004f9846f#diff-f5b9cc80dd02278d845d220721ac0217R32-R33