### PR TITLE
(PUP-6909) Useradd fails when a user expiry is nil

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       end
     },
     :unmunge => proc { |value|
-      if value == -1
+      if value == -1 || !(value.is_a? Numeric)
         :absent
       else
         # Expiry is days after 1970-01-01


### PR DESCRIPTION
When puppet tries to retrieve a current user expiry date, and that date
is set to nil. puppet will fail.

Now, puppet will wheck if the current expiry value is Numeric before
proceeding further.