### PR TITLE
(PUP-10481) Deprecate Puppet::Network::HTTP::{Connection,NoCachePool,…

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -242,10 +242,7 @@ module Puppet
 
     {
       :environments => Puppet::Environments::Cached.new(Puppet::Environments::Combined.new(*loaders)),
-      :http_pool => proc {
-        require 'puppet/network/http'
-        Puppet::Network::HTTP::NoCachePool.new
-      },
+      :http_pool => proc { Puppet.runtime[:http].pool },
       :ssl_context => proc {
         begin
           cert = Puppet::X509::CertProvider.new

--- a/lib/puppet/network/http/compression.rb
+++ b/lib/puppet/network/http/compression.rb
@@ -20,9 +20,11 @@ module Puppet::Network::HTTP::Compression
     def uncompress_body(response)
       case response['content-encoding']
       when 'gzip'
+        Puppet.deprecation_warning(_('Puppet::Network::HTTP::Compression::Active#uncompress_body is deprecated.'))
         # ZLib::GzipReader has an associated encoding, by default Encoding.default_external
         return Zlib::GzipReader.new(StringIO.new(response.body), :encoding => Encoding::BINARY).read
       when 'deflate'
+        Puppet.deprecation_warning(_('Puppet::Network::HTTP::Compression::Active#uncompress_body is deprecated.'))
         return Zlib::Inflate.new.inflate(response.body)
       when nil, 'identity'
         return response.body
@@ -32,6 +34,7 @@ module Puppet::Network::HTTP::Compression
     end
 
     def uncompress(response)
+      Puppet.deprecation_warning(_('Puppet::Network::HTTP::Compression::Active#uncompress is deprecated.'))
       raise Net::HTTPError.new("No block passed", response) unless block_given?
 
       case response['content-encoding']
@@ -71,6 +74,7 @@ module Puppet::Network::HTTP::Compression
       end
 
       def uncompress(chunk)
+        Puppet.deprecation_warning(_('Puppet::Network::HTTP::Compression::ZlibAdapter#uncompress is deprecated.'))
         out = @uncompressor.inflate(chunk)
         @first = false
         return out
@@ -97,6 +101,7 @@ module Puppet::Network::HTTP::Compression
 
   module None
     def uncompress_body(response)
+      Puppet.deprecation_warning(_('Puppet::Network::HTTP::Compression::None#uncompress_body is deprecated.'))
       response.body
     end
 
@@ -105,12 +110,14 @@ module Puppet::Network::HTTP::Compression
     end
 
     def uncompress(response)
+      Puppet.deprecation_warning(_('Puppet::Network::HTTP::Compression::None#uncompress is deprecated.'))
       yield IdentityAdapter.new
     end
   end
 
   class IdentityAdapter
     def uncompress(chunk)
+      Puppet.deprecation_warning(_('Puppet::Network::HTTP::Compression::IdentityAdapter#uncompress is deprecated.'))
       chunk
     end
 

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -343,6 +343,8 @@ module Puppet::Network::HTTP
     end
 
     def with_connection(site, &block)
+      Puppet.deprecation_warning(_('Puppet::Network::HTTP::Connection is deprecated. Please use Puppet::Network::HTTP::ConnectionAdapter instead.'))
+
       response = nil
       @pool.with_connection(site, @verifier) do |conn|
         response = yield conn

--- a/lib/puppet/network/http/nocache_pool.rb
+++ b/lib/puppet/network/http/nocache_pool.rb
@@ -3,6 +3,7 @@
 # @api private
 class Puppet::Network::HTTP::NoCachePool < Puppet::Network::HTTP::BasePool
   def initialize(factory = Puppet::Network::HTTP::Factory.new)
+    Puppet.deprecation_warning(_('Puppet::Network::HTTP::NoCachePool is deprecated.'))
     @factory = factory
   end
 

--- a/spec/unit/network/http/nocache_pool_spec.rb
+++ b/spec/unit/network/http/nocache_pool_spec.rb
@@ -39,4 +39,26 @@ describe Puppet::Network::HTTP::NoCachePool do
   it 'has a close method' do
     Puppet::Network::HTTP::NoCachePool.new.close
   end
+
+  it 'logs a deprecation warning' do
+    http  = double('http', start: nil, finish: nil, started?: true)
+
+    factory = Puppet::Network::HTTP::Factory.new
+    allow(factory).to receive(:create_connection).and_return(http)
+    Puppet::Network::HTTP::NoCachePool.new(factory)
+
+    expect(@logs).to include(an_object_having_attributes(level: :warning, message: /Puppet::Network::HTTP::NoCachePool is deprecated/))
+  end
+
+  it 'omits the warning when deprecations are disabled' do
+    Puppet[:disable_warnings] = 'deprecations'
+
+    http  = double('http', start: nil, finish: nil, started?: true)
+
+    factory = Puppet::Network::HTTP::Factory.new
+    allow(factory).to receive(:create_connection).and_return(http)
+    Puppet::Network::HTTP::NoCachePool.new(factory)
+
+    expect(@logs).to eq([])
+  end
 end

--- a/spec/unit/network/http_spec.rb
+++ b/spec/unit/network/http_spec.rb
@@ -4,6 +4,6 @@ require 'puppet/network/http'
 describe Puppet::Network::HTTP do
   it 'defines an http_pool context' do
     pool = Puppet.lookup(:http_pool)
-    expect(pool).to be_a(Puppet::Network::HTTP::NoCachePool)
+    expect(pool).to be_a(Puppet::Network::HTTP::Pool)
   end
 end


### PR DESCRIPTION
…Compression}

Now that we've routed HttpPool requests through the ConnectionAdapter,
these classes should no longer be in use.