### PR TITLE
(PUP-10483) Synchronize $LOAD_PATH

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,10 +1,13 @@
 require 'puppet/version'
+require 'puppet/concurrent/synchronized'
 
 if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.3.0")
   raise LoadError, "Puppet #{Puppet.version} requires Ruby 2.3.0 or greater, found Ruby #{RUBY_VERSION.dup}."
 end
 
 Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.3.0'
+
+$LOAD_PATH.extend(Puppet::Concurrent::Synchronized)
 
 # see the bottom of the file for further inclusions
 # Also see the new Vendor support - towards the end


### PR DESCRIPTION
Since we may not have control over everywhere that manipulates
$LOAD_PATH in a threaded context, just try to synchronize it whenever
running on JRuby.