### PR TITLE
(maint) Confine to facter < 4

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
-  s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 5"])
+  s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 4"])
   s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
   s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
   s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1")


### PR DESCRIPTION
Facter 4 currently breaks puppet tests. Confine to less than 4 until we
can get that sorted.