### PR TITLE
(PUP-10289) Allow caller to pass a URL string when they meant a path

### DIFF
--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -99,6 +99,13 @@ describe Puppet::Network::HTTP::Connection do
         expect(response).to be_an_instance_of(Net::HTTPOK)
         expect(response.code).to eq("200")
       end
+
+      it "accepts a URL string as the path" do
+        stub_request(:get, url)
+
+        response = subject.request_get(url) { |_| }
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+      end
     end
 
     context "for streaming head requests" do
@@ -129,6 +136,13 @@ describe Puppet::Network::HTTP::Connection do
         expect(response).to be_an_instance_of(Net::HTTPOK)
         expect(response.code).to eq("200")
       end
+
+      it "accepts a URL string as the path" do
+        stub_request(:head, url)
+
+        response = subject.request_head(url) { |_| }
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+      end
     end
 
     context "for streaming post requests" do
@@ -158,6 +172,13 @@ describe Puppet::Network::HTTP::Connection do
         response = subject.request_post(path, "") { |_| }
         expect(response).to be_an_instance_of(Net::HTTPOK)
         expect(response.code).to eq("200")
+      end
+
+      it "accepts a URL string as the path" do
+        stub_request(:post, url)
+
+        response = subject.request_post(url, "") { |_| }
+        expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
 
@@ -194,6 +215,13 @@ describe Puppet::Network::HTTP::Connection do
         response = subject.get(path)
         expect(response.body).to eq("abc")
       end
+
+      it "accepts a URL string as the path" do
+        stub_request(:get, url)
+
+        response = subject.get(url)
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+      end
     end
 
     context "for HEAD requests" do
@@ -221,6 +249,13 @@ describe Puppet::Network::HTTP::Connection do
         response = subject.head(path)
         expect(response).to be_an_instance_of(Net::HTTPOK)
         expect(response.code).to eq("200")
+      end
+
+      it "accepts a URL string as the path" do
+        stub_request(:head, url)
+
+        response = subject.head(url)
+        expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
 
@@ -270,6 +305,13 @@ describe Puppet::Network::HTTP::Connection do
 
         subject.put(path, '')
       end
+
+      it "accepts a URL string as the path" do
+        stub_request(:put, url)
+
+        response = subject.put(url, '')
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+      end
     end
 
     context "for POST requests" do
@@ -318,6 +360,13 @@ describe Puppet::Network::HTTP::Connection do
 
         subject.post(path, "")
       end
+
+      it "accepts a URL string as the path" do
+        stub_request(:post, url)
+
+        response = subject.post(url, '')
+        expect(response).to be_an_instance_of(Net::HTTPOK)
+      end
     end
 
     context "for DELETE requests" do
@@ -351,6 +400,13 @@ describe Puppet::Network::HTTP::Connection do
         stub_request(:delete, url).to_return(body: "abc")
 
         expect(subject.delete(path).body).to eq("abc")
+      end
+
+      it "accepts a URL string as the path" do
+        stub_request(:delete, url)
+
+        response = subject.delete(url)
+        expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
 


### PR DESCRIPTION
The Connection class accepts a URL as the request path, and sends it in
"absolute-form" in the request line[1]:

    GET https://puppet:8140/ HTTP/1.1\r\n

Client's are only supposed to send absolute-form when CONNECT-ing to a proxy so
that the proxy knows which upstream server to forward the request to. However,
HTTP 1.1 servers are required to accept absolute-form, so things happen to work.

This commit allows the ConnectionAdapter to accept a URL like the Connection
class does, and passes a new URL to the client consisting of the current scheme,
server, port and path from the URL argument. The resulting request will be
made using "origin-form" as it should have been all along:

    GET / HTTP/1.1\r\n

There shouldn't be any compatibility issues as servers prefer "origin-form".
This commit also preserves the existing behavior of requiring the caller to URL
encode the string that is passed in, so "/foo%20bar" will work, but "/foo bar"
won't.

[1] https://httpwg.org/specs/rfc7230.html#absolute-form