### PR TITLE
(maint) Run the scheduled agent job

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -176,7 +176,6 @@ class Puppet::Daemon
     end
 
     reparse_run.disable if Puppet[:filetimeout] == 0
-    agent_run.disable
 
     @scheduler.run_loop([reparse_run, agent_run, signal_loop])
   end


### PR DESCRIPTION
Commit 7d8b0d37664e1bdf274bfa04ccf7ef5e5ab425eb caused the scheduled agent run to be disabled, as a result the daemonized service would never run. Since the daemon always has an `agent`, just delete the line.