### PR TITLE
(PUP-7814) Add ssl_trust_store setting to load trusted CA certs

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -992,6 +992,15 @@ EOT
         and reject the CA certificate if the values do not match. This only applies
         during the first download of the CA certificate."
     },
+    :ssl_trust_store => {
+      :default => nil,
+      :type => :file,
+      :desc => "A file containing CA certificates in PEM format that puppet should trust
+        when making HTTPS requests. This **only** applies to https requests to non-puppet
+        infrastructure, such as retrieving file metadata and content from https file sources,
+        puppet module tool and the 'http' report processor. This setting is ignored when
+        making requests to puppet:// URLs such as catalog and report requests.",
+    },
     :ssl_client_ca_auth => {
       :type  => :file,
       :mode  => "0644",


### PR DESCRIPTION
If `Puppet[:ssl_trust_store]` is not nil and refers to a non-empty file, then
puppet will add that as a trusted CA store when making HTTPS requests to
non-puppet infrastructure, in addition to the puppet CA(s) and CA certs in the
puppet-agent CA cert bundle.

The setting will be ignored if the path refers to an empty file. A warning will
be emitted if the path refers to a directory, etc.