### PR TITLE
(PUP-1289) Manage service logon credentials on Windows

### DIFF
--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -116,11 +116,12 @@ module Puppet
       # @param service [String] name of the service
       # @return None
       def run_nonexistent_service_tests(service)
-        step "Verify that a nonexistent service is considered stopped and disabled" do
+        step "Verify that a nonexistent service is considered stopped, disabled and no logonaccount is reported" do
           on(agent, puppet_resource('service', service)) do |result|
             { enable: false, ensure: :stopped }.each do |property, value|
               assert_match(/#{property}.*#{value}.*$/, result.stdout, "Puppet does not report #{property}=#{value} for a non-existent service")
             end
+            assert_no_match(/logonaccount\s+=>/, result.stdout, "Puppet reports logonaccount for a non-existent service")
           end
         end
       

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -109,7 +109,10 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
         raise Puppet::Error.new(_("Unknown service state '%{current_state}' for service '%{resource_name}'") % { current_state: current_state, resource_name: @resource[:name] })
     end
     debug("Service #{@resource[:name]} is #{current_state}")
-    return state
+    state
+  rescue => detail
+    Puppet.warning("Status for service #{@resource[:name]} could not be retrieved: #{detail}")
+    :stopped
   end
 
   def default_timeout

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -125,18 +125,15 @@ describe "Puppet::Util::Windows::User", :if => Puppet::Util::Platform.windows? d
       end
 
       it 'should raise error given that logon returns false' do
-
         allow(Puppet::Util::Windows::User).to receive(:logon_user_by_logon_type).with(
-            user, passwd, fLOGON32_LOGON_NETWORK, fLOGON32_PROVIDER_DEFAULT, anything).and_return (0)
+            user, '.', passwd, fLOGON32_LOGON_NETWORK, fLOGON32_PROVIDER_DEFAULT, anything).and_return (0)
         allow(Puppet::Util::Windows::User).to receive(:logon_user_by_logon_type).with(
-            user, passwd, fLOGON32_LOGON_INTERACTIVE, fLOGON32_PROVIDER_DEFAULT, anything).and_return(0)
+            user, '.', passwd, fLOGON32_LOGON_INTERACTIVE, fLOGON32_PROVIDER_DEFAULT, anything).and_return(0)
 
         expect {Puppet::Util::Windows::User.logon_user(user, passwd) {}}
             .to raise_error(Puppet::Util::Windows::Error, /Failed to logon user/)
-
       end
     end
-
 
     describe "password_is?" do
       it "should return false given an incorrect username and password" do

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -88,6 +88,14 @@ describe 'Puppet::Type::Service::Provider::Windows',
       expect(provider.status).to eql(:stopped)
     end
 
+    it "should report service as stopped when status cannot be retrieved" do
+      allow(service_util).to receive(:exists?).with(resource[:name]).and_return(true)
+      allow(service_util).to receive(:service_state).with(name).and_raise(Puppet::Error.new('Service query failed: The specified path is invalid.'))
+
+      expect(Puppet).to receive(:warning).with("Status for service #{resource[:name]} could not be retrieved: Service query failed: The specified path is invalid.")
+      expect(provider.status).to eql(:stopped)
+    end
+
     [
       :SERVICE_PAUSED,
       :SERVICE_PAUSE_PENDING

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -58,7 +58,7 @@ describe 'Puppet::Type::Service::Provider::Windows',
       it "should enable if managing enable and enable is true" do
         resource[:enable] = :true
         expect(service_util).to receive(:start)
-        expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_AUTO_START)
+        expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_AUTO_START})
 
         provider.start
       end
@@ -66,7 +66,7 @@ describe 'Puppet::Type::Service::Provider::Windows',
       it "should manual start if managing enable and enable is false" do
         resource[:enable] = :false
         expect(service_util).to receive(:start)
-        expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_DEMAND_START)
+        expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_DEMAND_START})
 
         provider.start
       end
@@ -178,12 +178,12 @@ describe 'Puppet::Type::Service::Provider::Windows',
 
   describe "#enable" do
     it "should set service start type to Service_Auto_Start when enabled" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_AUTO_START)
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_AUTO_START})
       provider.enable
     end
 
-    it "raises an error if set_startup_mode fails" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_AUTO_START).and_raise(Puppet::Error.new('foobar'))
+    it "raises an error if set_startup_configuration fails" do
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_AUTO_START}).and_raise(Puppet::Error.new('foobar'))
 
       expect {
         provider.enable
@@ -193,12 +193,12 @@ describe 'Puppet::Type::Service::Provider::Windows',
 
   describe "#disable" do
     it "should set service start type to Service_Disabled when disabled" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_DISABLED)
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_DISABLED})
       provider.disable
     end
 
-    it "raises an error if set_startup_mode fails" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_DISABLED).and_raise(Puppet::Error.new('foobar'))
+    it "raises an error if set_startup_configuration fails" do
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_DISABLED}).and_raise(Puppet::Error.new('foobar'))
 
       expect {
         provider.disable
@@ -208,12 +208,12 @@ describe 'Puppet::Type::Service::Provider::Windows',
 
   describe "#manual_start" do
     it "should set service start type to Service_Demand_Start (manual) when manual" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_DEMAND_START)
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_DEMAND_START})
       provider.manual_start
     end
 
-    it "raises an error if set_startup_mode fails" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_DEMAND_START).and_raise(Puppet::Error.new('foobar'))
+    it "raises an error if set_startup_configuration fails" do
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_DEMAND_START}).and_raise(Puppet::Error.new('foobar'))
 
       expect {
         provider.manual_start
@@ -223,12 +223,12 @@ describe 'Puppet::Type::Service::Provider::Windows',
 
   describe "#delayed_start" do
     it "should set service start type to Service_Config_Delayed_Auto_Start (delayed) when delayed" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_AUTO_START, true)
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_AUTO_START, delayed: true})
       provider.delayed_start
     end
 
-    it "raises an error if set_startup_mode fails" do
-      expect(service_util).to receive(:set_startup_mode).with(name, :SERVICE_AUTO_START, true).and_raise(Puppet::Error.new('foobar'))
+    it "raises an error if set_startup_configuration fails" do
+      expect(service_util).to receive(:set_startup_configuration).with(name, options: {startup_type: :SERVICE_AUTO_START, delayed: true}).and_raise(Puppet::Error.new('foobar'))
 
       expect {
         provider.delayed_start

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -145,6 +145,166 @@ describe test_title, "when validating attribute values" do
     end
   end
 
+  describe "the service logon credentials" do 
+    before do
+      provider_class_with_logon_credentials = Puppet::Type.type(:service).provide(:simple) do
+        has_features :manages_logon_credentials
+        def logonpassword=(value) end
+      end
+      allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class_with_logon_credentials)
+    end
+
+    describe "the 'logonaccount' property" do
+      it "should not be munged nor checked when not on Windows" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+        service = Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'NonWindowsUser')
+
+        expect { service }.not_to raise_error
+        expect(service[:logonaccount]).to eq('NonWindowsUser')
+      end
+
+      context "when on Windows", :if => Puppet::Util::Platform.windows? do
+        before do
+          allow(Puppet::Util::Windows::ADSI).to receive(:computer_name).and_return("myPC")
+          allow(Puppet::Util::Windows::User).to receive(:default_system_account?).and_return(true)
+        end
+
+        ['LocalSystem', '.\LocalSystem', 'myPC\LocalSystem', 'lOcALsysTem'].each do |user_input|
+          it "should succesfully munge #{user_input} to 'LocalSystem'" do
+            service = Puppet::Type.type(:service).new(:name => "yay", :logonaccount => user_input)
+
+            expect { service }.not_to raise_error
+            expect(service[:logonaccount]).to eq('LocalSystem')
+          end
+        end
+
+        it "should succesfully munge local account" do
+          allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).and_return(Puppet::Util::Windows::SID::Principal.new("myUser", nil, nil, "myPC", :SidTypeUser))
+          service = Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'myUser')
+
+          expect { service }.not_to raise_error
+          expect(service[:logonaccount]).to eq('.\myUser')
+        end
+
+        it "should succesfully munge domain account" do
+          allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).and_return(Puppet::Util::Windows::SID::Principal.new("DomainUser", nil, nil, "myDomain", :SidTypeUser))
+          service = Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'DomainUser')
+
+          expect { service }.not_to raise_error
+          expect(service[:logonaccount]).to eq('myDomain\DomainUser')
+        end
+
+        it "should succesfully munge well known user" do
+          allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).and_return(Puppet::Util::Windows::SID::Principal.new("LOCAL SERVICE", nil, nil, "NT AUTHORITY", :SidTypeWellKnownGroup))
+          service = Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'LocalService')
+
+          expect { service }.not_to raise_error
+          expect(service[:logonaccount]).to eq('NT AUTHORITY\LOCAL SERVICE')
+        end
+
+        it "should succesfully munge a SID" do
+          allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).and_return(Puppet::Util::Windows::SID::Principal.new("NETWORK SERVICE", nil, nil, "NT AUTHORITY", :SidTypeUser))
+          service = Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'S-1-5-20')
+
+          expect { service }.not_to raise_error
+          expect(service[:logonaccount]).to eq('NT AUTHORITY\NETWORK SERVICE')
+        end
+
+        it "should fail when account is invalid" do
+          allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).and_return(nil)
+          expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'InvalidUser') }.to raise_error(Puppet::Error, /\"InvalidUser\" is not a valid account/)
+        end
+
+        it "should fail when sid type is not user or well known user" do
+          allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).and_return(Puppet::Util::Windows::SID::Principal.new("Administrators", nil, nil, "BUILTIN", :SidTypeAlias))
+          expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'Administrators') }.to raise_error(Puppet::Error, /\"Administrators\" is not a valid account/)
+        end
+      end
+    end
+
+    describe "the logonpassword parameter" do
+      it "should fail when logonaccount is not being managed as well" do
+        expect { Puppet::Type.type(:service).new(:name => "yay", :logonpassword => 'myPass') }.to raise_error(Puppet::Error, /The 'logonaccount' parameter is mandatory when setting 'logonpassword'./)
+      end
+
+      it "should default to empty string when only logonaccount is being managed" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+        service = Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'myUser')
+
+        expect { service }.not_to raise_error
+        expect(service[:logonpassword]).to eq("")
+      end
+
+      it "should default to nil when not even logonaccount is being managed" do
+        service = Puppet::Type.type(:service).new(:name => "yay")
+        expect(service[:logonpassword]).to eq(nil)
+      end
+
+      it "should fail when logonpassword includes the ':' character" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+        expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'myUser', :logonpassword => 'my:Pass') }.to raise_error(Puppet::Error, /Passwords cannot include ':'/)
+      end
+
+      it "should not further check the password against given account when not on Windows" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+        expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'myUser', :logonpassword => 'myPass') }.not_to raise_error
+      end
+
+      context "when on Windows", :if => Puppet::Util::Platform.windows? do
+        before do
+          allow(Puppet::Util::Windows::ADSI).to receive(:computer_name).and_return("myPC")
+          allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).and_return(name_to_principal_result)
+        end
+
+        it "should pass validation when given account is 'LocalSystem'" do
+          allow(Puppet::Util::Windows::User).to receive(:localsystem?).with('LocalSystem').and_return(true)
+          allow(Puppet::Util::Windows::User).to receive(:default_system_account?).with('LocalSystem').and_return(false)
+
+          expect(Puppet::Util::Windows::SID).not_to receive(:name_to_principal)
+          expect(Puppet::Util::Windows::User).not_to receive(:password_is?)
+          expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'LocalSystem') }.not_to raise_error
+        end
+
+        ['LOCAL SERVICE', 'NETWORK SERVICE', 'SYSTEM'].each do |predefined_local_account|
+          describe "when given account is #{predefined_local_account}" do
+            let(:name_to_principal_result) do
+              Puppet::Util::Windows::SID::Principal.new(predefined_local_account, nil, nil, "NT AUTHORITY", :SidTypeUser)
+            end
+
+            it "should pass validation" do
+              allow(Puppet::Util::Windows::User).to receive(:localsystem?).with(predefined_local_account).and_return(false)
+              expect(Puppet::Util::Windows::User).to receive(:default_system_account?).with("NT AUTHORITY\\#{predefined_local_account}").and_return(true)
+
+              expect(Puppet::Util::Windows::User).not_to receive(:password_is?)
+              expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => predefined_local_account) }.not_to raise_error
+            end
+          end
+        end
+
+        let(:name_to_principal_result) do
+          Puppet::Util::Windows::SID::Principal.new("myUser", nil, nil, "myPC", :SidTypeUser)
+        end
+
+        describe "when given logonaccount is not a predefined local account" do
+          before do
+            allow(Puppet::Util::Windows::User).to receive(:localsystem?).with('myUser').and_return(false)
+            allow(Puppet::Util::Windows::User).to receive(:default_system_account?).with('.\\myUser').and_return(false)
+          end
+
+          it "should pass validation if password is proven correct" do
+            allow(Puppet::Util::Windows::User).to receive(:password_is?).with('myUser', 'myPass', '.').and_return(true)
+            expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'myUser', :logonpassword => 'myPass') }.not_to raise_error
+          end
+
+          it "should not pass validation if password check fails" do
+            allow(Puppet::Util::Windows::User).to receive(:password_is?).with('myUser', 'myWrongPass', '.').and_return(false)
+            expect { Puppet::Type.type(:service).new(:name => "yay", :logonaccount => 'myUser', :logonpassword => 'myWrongPass') }.to raise_error(Puppet::Error, /The given password is invalid for user '.\\myUser'/)
+          end
+        end
+      end
+    end
+  end
+
   it "should support :true as a value to :hasstatus" do
     srv = Puppet::Type.type(:service).new(:name => "yay", :hasstatus => :true)
     expect(srv[:hasstatus]).to eq(:true)
@@ -309,6 +469,22 @@ describe test_title, "when changing the host" do
     expect(@service.property(:enable)).to receive(:retrieve).and_return("whatever")
     expect(@service.property(:enable)).to receive(:insync?).and_return(false)
     expect(@service.property(:enable)).to receive(:sync)
+
+    allow(@service.provider).to receive(:stop)
+
+    @service.property(:ensure).sync
+  end
+
+  it "should sync the service's logonaccount state when changing the state of :ensure if :logonaccount is being managed" do
+    allow(@service.provider.class).to receive(:supports_parameter?).and_return(true)
+    allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+
+    @service[:ensure] = :stopped
+    @service[:logonaccount] = 'LocalSystem'
+
+    expect(@service.property(:logonaccount)).to receive(:retrieve).and_return("MyUser")
+    expect(@service.property(:logonaccount)).to receive(:insync?).and_return(false)
+    expect(@service.property(:logonaccount)).to receive(:sync)
 
     allow(@service.provider).to receive(:stop)
 

--- a/spec/unit/util/windows/service_spec.rb
+++ b/spec/unit/util/windows/service_spec.rb
@@ -599,27 +599,27 @@ describe "Puppet::Util::Windows::Service", :if => Puppet.features.microsoft_wind
     end
   end
 
-  describe "#set_startup_mode" do
+  describe "#set_startup_configuration" do
     let(:status_checks) { sequence('status_checks') }
 
     context "when the service control manager cannot be opened" do
       let(:scm) { FFI::Pointer::NULL_HANDLE }
       it "raises a puppet error" do
-        expect{ subject.set_startup_mode(mock_service_name, :SERVICE_DEMAND_START) }.to raise_error(Puppet::Error)
+        expect{ subject.set_startup_configuration(mock_service_name, options: {startup_type: :SERVICE_DEMAND_START}) }.to raise_error(Puppet::Error)
       end
     end
 
     context "when the service cannot be opened" do
       let(:service) { FFI::Pointer::NULL_HANDLE }
       it "raises a puppet error" do
-        expect{ subject.set_startup_mode(mock_service_name, :SERVICE_DEMAND_START) }.to raise_error(Puppet::Error)
+        expect{ subject.set_startup_configuration(mock_service_name, options: {startup_type: :SERVICE_DEMAND_START}) }.to raise_error(Puppet::Error)
       end
     end
 
     context "when the service can be opened" do
       it "Raises an error on an unsuccessful change" do
         expect(subject).to receive(:ChangeServiceConfigW).and_return(FFI::WIN32_FALSE)
-        expect{ subject.set_startup_mode(mock_service_name, :SERVICE_DEMAND_START) }.to raise_error(Puppet::Error)
+        expect{ subject.set_startup_configuration(mock_service_name, options: {startup_type: :SERVICE_DEMAND_START}) }.to raise_error(Puppet::Error)
       end
     end
   end


### PR DESCRIPTION
This feature allows puppet users to gain more control over their Windows services by now being able to manage the logon credentials for any of them as desired.

This commit adds the `logonaccount` property and the optional `logonpassword` parameter (not needed when the user specified in the `logonaccount` field has no password). These can be managed alone or in combination with the `ensure` property.

In the first case, the credentials will be checked for validity and then set but will not be used by the service until it is restarted. This respects the Windows GUI behaviour from `services.msc` where after changing the logon credentials, it prompts the user with the alert message `The new logon name will not take effect until you stop and restart the service.`.

When also managing `ensure` with it specified as `running` or `true` and the `logonaccount` is different from the current service settings, puppet will automatically restart the service to make instant use of the newly given credentials.

The `logonaccount` field accepts local users (when respecting the pattern `User`, `.\User` or `PCNAME\User`) and also from domain (respecting the pattern `DOMAIN\User`, `User@domain.com` or just `User` if the name doesn't also match with a local one as our user validation starts looking for its existence and information about it locally first, and if it's not found there, only then the search will continue onto the domain). It is not case sensitive and for the problematic language specific users (such as `System`, `Local Service`, `Network Service` etc.) their respective SIDs can be used instead (`S-1-5-18`, `S-1-5-19`, `S-1-5-20` etc.).