### PR TITLE
(PUP-10510) Set correct title when collecting resources

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1205,15 +1205,16 @@ class Type
       provider.instances.collect do |instance|
         # We always want to use the "first" provider instance we find, unless the resource
         # is already managed and has a different provider set
-        other = provider_instances[instance.name]
+        title = instance.respond_to?(:title) ? instance.title : instance.name
+        other = provider_instances[title]
         if other
           Puppet.debug "%s %s found in both %s and %s; skipping the %s version" %
-            [self.name.to_s.capitalize, instance.name, other.class.name, instance.class.name, instance.class.name]
+            [self.name.to_s.capitalize, title, other.class.name, instance.class.name, instance.class.name]
           next
         end
-        provider_instances[instance.name] = instance
+        provider_instances[title] = instance
 
-        result = new(:name => instance.name, :provider => instance)
+        result = new(:name => instance.name, :provider => instance, :title => title)
         properties.each { |name| result.newattr(name) }
         result
       end


### PR DESCRIPTION
This came up when investigating why sshkeys_core 2.0.0 does not purge
keys. To add support for multiple SSH key types per name, composite
namevars had to be implemented. However, the functionality only worked
one-way (when ensuring resources as opposed to querying existing
resources).

Ensuring a resource of type:

```puppet
sshkey { 'testuser@ssh-dss':
    ensure => 'present',
    ...
}
```

would correctly evaluate to the following Puppet resource:

```puppet
Sshkey[testuser@ssh-rsa]{:name=>"testuser", :type=>"ssh-rsa", :key=>"..."}
```
Purging sshkeys would create different resources:

```puppet
Sshkey[testuser]{:name=>"testuser", :key=>"..."}
```

Meaning that multiple key types with the same name would not get
parsed correctly.

This happens due to `Puppet::Type.instances` not taking multiple
namevars into account when creating resources. To circumvent this we
call the `title` method on the provider if available to get the
composite name of the resource. Similar functionality seems to also
have been implemented in `Puppet::Type.hash2resource` which tries to
set the resource title to `hash[:title]` if present, so having this
additional key is enough for things to work.

After this change, querying instances with `puppet resource` will list
all SSH keys (even if there are multiple key types with the same name).

Info on how to reproduce this is available in the ticket description.