### PR TITLE
(maint) Don't wait when deadline is 0

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -61,12 +61,13 @@ class Puppet::Agent
               end
             end
           rescue Puppet::LockError
-            wait_for_lock_deadline ||= Time.now.to_i + Puppet[:maxwaitforlock]
+            now = Time.now.to_i
+            wait_for_lock_deadline ||= now + Puppet[:maxwaitforlock]
 
             if Puppet[:waitforlock]  < 1
               Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
               nil
-            elsif Time.now.to_i > wait_for_lock_deadline
+            elsif now > wait_for_lock_deadline
               Puppet.notice _("Exiting now because the maxwaitforlock timeout has been exceeded.")
               nil
             else

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -303,7 +303,7 @@ class Puppet::SSL::StateMachine
         NeedCACerts.new(@machine)
       elsif @machine.waitforlock < 1
         LockFailure.new(@machine, _("Another puppet instance is already running and the waitforlock setting is set to 0; exiting"))
-      elsif Time.now.to_i > @machine.waitlock_deadline
+      elsif Time.now.to_i >= @machine.waitlock_deadline
         LockFailure.new(@machine, _("Another puppet instance is already running and the maxwaitforlock timeout has been exceeded; exiting"))
       else
         Puppet.info _("Another puppet instance is already running; waiting for it to finish")

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -373,7 +373,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
     it "exits if maxwaitforlock is exceeded" do
       path = Puppet[:agent_catalog_run_lockfile]
       Puppet[:waitforlock] = 1
-      Puppet[:maxwaitforlock] = 0.5
+      Puppet[:maxwaitforlock] = 0
 
       th = Thread.new {
         %x{ruby -e "$0 = 'puppet'; File.write('#{path}', Process.pid); sleep(2)"}


### PR DESCRIPTION
Previously the "exits if maxwaitforlock is exceeded" test sometimes failed
because it started a background thread to lock the lockfile and slept for 2
seconds before exiting. Meanwhile the main thread ran the `agent` application
which can take some time to execute. The 0.5 maxwaitforlock setting also forced
the main thread to always retry the lock once, and that incurred a 1 second
penalty based on `waitforlock`. So if the background thread exited (which
releases the lock) before the main thread retried, then the main thread would
acquire the lock and never output the expected "Exiting now..." message.

This commits sets the maxwaitforlock setting to 0 and changes the inequality to
'>=' to ensure we don't retry the lock when the setting is 0. We also memoize
Time.now, so that we don't cross a second boundary between the time we calculate
the deadline and when we check to see if we reached the deadline.