### PR TITLE
(maint) Don't retry the lock if the deadline is now

### DIFF
--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -64,10 +64,10 @@ class Puppet::Agent
             now = Time.now.to_i
             wait_for_lock_deadline ||= now + Puppet[:maxwaitforlock]
 
-            if Puppet[:waitforlock]  < 1
+            if Puppet[:waitforlock] < 1
               Puppet.notice _("Run of %{client_class} already in progress; skipping  (%{lockfile_path} exists)") % { client_class: client_class, lockfile_path: lockfile_path }
               nil
-            elsif now > wait_for_lock_deadline
+            elsif now >= wait_for_lock_deadline
               Puppet.notice _("Exiting now because the maxwaitforlock timeout has been exceeded.")
               nil
             else


### PR DESCRIPTION
Commit c5a8687ffee intended to switch the comparison to >= so that if the
deadline is the same as now (in integer seconds since the epoch) then we
shouldn't retry the lock. If the values were equal then the test would sometimes
fail on slow systems (windows appveyor) because the background thread exited and
released the lock before the retry occurred, so it didn't exit with the expected
message.