### PR TITLE
(PUP-10511) fix resource array with sensitive parameters

### DIFF
--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -337,10 +337,11 @@ class Puppet::Parser::Resource < Puppet::Resource
   end
 
   def replace_sensitive_data
-    parameters.each_pair do |name, param|
+    parameters.keys.each do |name|
+      param = parameters[name]
       if param.value.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
         @sensitive_parameters << name
-        param.value = param.value.unwrap
+        parameters[name] = Puppet::Parser::Resource::Param.from_param(param, param.value.unwrap)
       end
     end
   end

--- a/lib/puppet/parser/resource/param.rb
+++ b/lib/puppet/parser/resource/param.rb
@@ -19,4 +19,10 @@ class Puppet::Parser::Resource::Param
   def to_s
     "#{self.name} => #{self.value}"
   end
+
+  def self.from_param(param, value)
+    new_param = param.dup
+    new_param.value = value
+    return new_param
+  end
 end


### PR DESCRIPTION
In case of resource arrays, the parameters are shared between resources

```
test_mod::service { ["ServiceA","ServiceB"]:
  password => Sensitive("password")
}
```

This leads to trouble for Sensitive parameters as puppet will unwrap the
value for first resource and will validate it against Sensitive type for
the second resource.

With this change, the parameter and it's value are duplicated when
resource is created.