### PR TITLE
(PUP-10527) Test puppet service runs puppet

### DIFF
--- a/acceptance/tests/resource/service/puppet_service_runs_puppet.rb
+++ b/acceptance/tests/resource/service/puppet_service_runs_puppet.rb
@@ -1,0 +1,30 @@
+require 'puppet/acceptance/service_utils'
+extend Puppet::Acceptance::ServiceUtils
+
+test_name 'Starting the puppet service should successfully run puppet' do
+
+  tag 'audit:high',
+      'audit:acceptance'
+
+  agents.each do |agent|
+    step 'Ensure stop puppet service' do
+      on(agent, puppet_resource('service', 'puppet', 'ensure=stopped'))
+      assert_service_status_on_host(agent, 'puppet', {'ensure' => 'stopped'})
+    end
+
+    statedir = on(agent, puppet('config', 'print', 'statedir')).stdout.chomp
+    mtime_cmd = "File.stat(\"#{statedir}/last_run_report.yaml\").mtime.to_i"
+    last_run_time = on(agent, "env PATH=\"#{agent['privatebindir']}:${PATH}\" ruby -e 'puts #{mtime_cmd}'").stdout.chomp
+
+    step 'Ensure start puppet service' do
+      on(agent, puppet_resource('service', 'puppet', 'ensure=running'))
+      assert_service_status_on_host(agent, 'puppet', {'ensure' => 'running'})
+    end
+
+    retry_params = {:max_retries => 10,
+                    :retry_interval => 2}
+    step 'Ensure last_run_report.yaml is updated' do
+      retry_on(agent, "env PATH=\"#{agent['privatebindir']}:${PATH}\" ruby -e 'exit #{mtime_cmd} > #{last_run_time}'", retry_params)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an acceptance test to ensure that starting the puppet
service on agents runs puppet.  This validation was missing from the
`puppet_service_management.rb` test.  Due to the comprehensive nature of
the existing test, this test is added independently to reduce execution
time.  The existing test takes about 4m to execute while this specific
case takes about 30s.