### PR TITLE
Add debug information when SSL peers are being verified

### DIFF
--- a/lib/puppet/ssl/validator/default_validator.rb
+++ b/lib/puppet/ssl/validator/default_validator.rb
@@ -196,7 +196,9 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
   def has_authz_peer_cert(peer_certs, authz_certs)
     peer_certs.any? do |peer_cert|
       authz_certs.any? do |authz_cert|
-        peer_cert.verify(authz_cert.public_key)
+        result = peer_cert.verify(authz_cert.public_key)
+        Puppet.debug("Validating #{peer_cert.subject} using #{authz_cert.subject} (result: #{result})")
+        result
       end
     end
   end


### PR DESCRIPTION
It's useful when debugging the SSL configuration of agents to have an easy way to debug what's the SSL peer being verified and the trusted CA certificates being used.

This patch adds a debug message indicating the subject of the peer being verified, the subject of each CA certificate being used to verify signatures with and the result of the vefification for each pair.