### PR TITLE
Enable Windows compatibility with service provider base

### DIFF
--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:service).provide :base, :parent => :service do
 
   "
 
-  commands :kill => "kill"
+  optional_commands :kill => "kill"
 
   # get the proper 'ps' invocation for the platform
   # ported from the facter 2.x implementation, since facter 3.x


### PR DESCRIPTION
There is currently an incompatibility with the service provider `base` and Windows.  The provider checks for the command `kill` which Windows does not have.  Changing `commands` to `optional_commands` allows you to create a custom service on Windows.  You will have to specify `stop` on your custom service.

Example configuration with Windows:

```puppet
service {'vault_service':
      ensure    => 'running',
      provider  => 'base',
      start     => ['powershell.exe', '-c', "Start-Process vault.exe -ArgumentList \'agent -config=${vault_agent_win::vault_dir}/${vault_agent_win::config_file}\' -NoNewWindow"],
      stop      => ['powershell.exe', '-c', "Get-Process -Id (Get-Content -Path ${vault_agent_win::vault_dir}/.pidfile) -ErrorAction SilentlyContinue | Stop-Process"],
      status    => ['powershell.exe', '-c', "try{Get-Process -Id (Get-Content -Path ${vault_agent_win::vault_dir}/.pidfile) -ErrorAction Stop; exit 0} catch {exit 1}"],
  }
```