### PR TITLE
(PUP-9251) Deprecate application orchestration

### DIFF
--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -1,8 +1,11 @@
 require 'puppet/util/json'
 require 'puppet/parser/environment_compiler'
 
+# @deprecated application orchestration will be removed in puppet 7
 class Puppet::Network::HTTP::API::Master::V3::Environment
   def call(request, response)
+    Puppet.deprecation_warning("Application orchestration is deprecated. See https://puppet.com/docs/puppet/5.5/deprecated_language.html")
+
     env_name = request.routing_path.split('/').last
     env = Puppet.lookup(:environments).get(env_name)
     code_id = request.params[:code_id]

--- a/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
@@ -1,6 +1,8 @@
 class Puppet::Parser::Compiler
   # Validator that asserts that all capability resources that are referenced by 'consume' or 'require' has
   # been exported by some other resource in the environment
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   class CatalogValidator::EnvironmentRelationshipValidator < CatalogValidator
 
     def validate

--- a/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
@@ -1,5 +1,7 @@
 class Puppet::Parser::Compiler
   # Validator that asserts that only application components can appear inside a site.
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   class CatalogValidator::SiteValidator < CatalogValidator
     def self.validation_stage?(stage)
       PRE_FINISH.equal?(stage)

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -1,5 +1,6 @@
 require 'puppet/parser/compiler'
 
+# @deprecated application orchestration will be removed in puppet 7
 class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   def self.compile(env, code_id=nil)
     begin
@@ -54,6 +55,8 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   end
 
   def compile
+    Puppet.deprecation_warning("Application orchestration is deprecated. See https://puppet.com/docs/puppet/5.5/deprecated_language.html")
+
     add_function_overrides
     begin
       Puppet.override(@context_overrides, _("For compiling environment catalog %{env}") % { env: environment.name }) do

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -913,5 +913,10 @@ module Issues
   LOADER_FAILURE = issue :LOADER_FAILURE, :type do
     _('Failed to load: %{type_name}') % { type: type }
   end
+
+  DEPRECATED_APP_ORCHESTRATION = issue :DEPRECATED_APP_ORCHESTRATION, :klass do
+    _("Use of the application-orchestration %{expr} is deprecated. See http://links.puppet.com/tbd-app-orchestration-deprecation" % { expr: label(klass) })
+  end
+
 end
 end

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -915,7 +915,7 @@ module Issues
   end
 
   DEPRECATED_APP_ORCHESTRATION = issue :DEPRECATED_APP_ORCHESTRATION, :klass do
-    _("Use of the application-orchestration %{expr} is deprecated. See http://links.puppet.com/tbd-app-orchestration-deprecation" % { expr: label(klass) })
+    _("Use of the application-orchestration %{expr} is deprecated. See https://puppet.com/docs/puppet/5.5/deprecated_language.html" % { expr: label(klass) })
   end
 
 end

--- a/lib/puppet/pops/resource/resource_type_impl.rb
+++ b/lib/puppet/pops/resource/resource_type_impl.rb
@@ -248,6 +248,8 @@ class ResourceTypeImpl
   #######################
 
   # Applications are not supported
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   def application?
     false
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -194,6 +194,11 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     end
   end
 
+  def check_Application(o)
+    check_NamedDefinition(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
+  end
+
   def check_AssignmentExpression(o)
     case o.operator
     when '='
@@ -291,6 +296,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   end
 
   def check_CapabilityMapping(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
     ok =
     case o.component
     when Model::QualifiedReference
@@ -848,6 +854,10 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   def check_SelectorEntry(o)
     rvalue(o.matching_expr)
+  end
+
+  def check_SiteDefinition(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
   end
 
   def check_UnaryExpression(o)

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -31,6 +31,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::RT_NO_STORECONFIGS]            = Puppet[:storeconfigs] ? :ignore : :warning
 
     p[Issues::FUTURE_RESERVED_WORD]          = :deprecation
+    p[Issues::DEPRECATED_APP_ORCHESTRATION]  = :deprecation
 
     p[Issues::DUPLICATE_KEY]                 = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]              = :error

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -11,6 +11,7 @@ class Puppet::Resource::Type
   include Puppet::Util::Warnings
   include Puppet::Util::Errors
 
+  # @deprecated application orchestration will be removed in puppet 7 (capability_mapping, application, site)
   RESOURCE_KINDS = [:hostclass, :node, :definition, :capability_mapping, :application, :site]
 
   # Map the names used in our documentation to the names used internally
@@ -69,6 +70,8 @@ class Puppet::Resource::Type
 
   # Evaluate the resources produced by the given resource. These resources are
   # evaluated in a separate but identical scope from the rest of the resource.
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   def evaluate_produces(resource, scope)
     # Only defined types and classes can produce capabilities
     return unless definition? || hostclass?
@@ -159,19 +162,23 @@ class Puppet::Resource::Type
     @module_name = options[:module_name]
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def produces
     @produces || EMPTY_ARRAY
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def consumes
     @consumes || EMPTY_ARRAY
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def add_produces(blueprint)
     @produces ||= []
     @produces << blueprint
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def add_consumes(blueprint)
     @consumes ||= []
     @consumes << blueprint
@@ -233,6 +240,7 @@ class Puppet::Resource::Type
     when :node
       :node
     when :site
+      # @deprecated application orchestration will be removed in puppet 7
       :site
     end
 

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -110,8 +110,10 @@ class Type
 
   # Allow declaring that a type is actually a capability
   class << self
+    # @deprecated application orchestration will be removed in puppet 7
     attr_accessor :is_capability
 
+    # @deprecated application orchestration will be removed in puppet 7
     def is_capability?
       c = is_capability
       c.nil? ? false : c
@@ -123,6 +125,8 @@ class Type
   # represent application instances, this implementation always returns
   # +false+. Having this method though makes code checking whether a
   # resource is an application instance simpler
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   def self.application?
       false
   end

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1671,6 +1671,7 @@ class Type
     }
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   newmetaparam(:export, :parent => RelationshipMetaparam, :attributes => {:direction => :out, :events => :NONE}) do
           desc <<EOS
 Export a capability resource.
@@ -1696,6 +1697,7 @@ web { server:
 EOS
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   newmetaparam(:consume, :parent => RelationshipMetaparam, :attributes => {:direction => :in, :events => :NONE}) do
           desc <<EOS
 Consume a capability resource.

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -367,6 +367,13 @@ EOS
       }.to raise_error(/'Cap\[cap\]' is exported by both 'Prod\[one\]' and 'Prod\[two\]'/)
     end
 
+    it "issues deprecation warnings" do
+      expect {compile_collect_log(MANIFEST_WO_NODE)}.not_to raise_error
+      expect(warnings).to include(/Capability Mapping is deprecated/) # there are two of these
+      expect(warnings).to include(/Application is deprecated/)
+      expect(warnings).to include(/Site Definition is deprecated/)
+    end
+
     context "for producing node" do
       let(:compiled_node) { Puppet::Node.new('first', :environment => env) }
       let(:compiled_catalog) { compile_to_catalog(MANIFEST, compiled_node)}


### PR DESCRIPTION
Deprecate language keywords `site`, `application`, `produces`, `consumes`
Deprecate environment catalog and validators
Deprecate `export` and `consume` metaparameters
Deprecate `environment` REST API