### PR TITLE
(PUP-10542) Generate AST for apply blocks with 0 statements

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -876,11 +876,11 @@ class EvaluatorImpl
   def eval_ApplyExpression(o, scope)
     # All expressions are wrapped in an ApplyBlockExpression so we can identify the contents of
     # that block. However we don't want to serialize the block expression, so unwrap here.
-    body = if o.body.statements.count > 1
-      Model::BlockExpression.from_asserted_hash(o.body._pcore_init_hash)
-    else
-      o.body.statements[0]
-    end
+    body = if o.body.statements.count == 1
+             o.body.statements[0]
+           else
+             Model::BlockExpression.from_asserted_hash(o.body._pcore_init_hash)
+           end
 
     Puppet.lookup(:apply_executor).apply(unfold([], o.arguments, scope), body, scope)
   end

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -1578,7 +1578,10 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       let(:applicator) { double('apply_executor') }
 
       it 'invokes an apply_executor' do
-        expect(applicator).to receive(:apply).with(['arg1', 'arg2'], nil, scope).and_return(:result)
+        expect(applicator).to receive(:apply).with(
+          ['arg1', 'arg2'],
+          instance_of(Puppet::Pops::Model::BlockExpression),
+          scope).and_return(:result)
         src = "apply('arg1', 'arg2') { }"
         Puppet.override(apply_executor: applicator) do
           expect(parser.evaluate_string(scope, src)).to eq(:result)
@@ -1591,6 +1594,17 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
           instance_of(Puppet::Pops::Model::ResourceExpression),
           scope).and_return(:result)
         src = "apply(['arg1']) { notify { 'hello': } }"
+        Puppet.override(apply_executor: applicator) do
+          expect(parser.evaluate_string(scope, src)).to eq(:result)
+        end
+      end
+
+      it 'returns a BlockExpression with an empty apply block' do
+        expect(applicator).to receive(:apply).with(
+          [['arg1']],
+          instance_of(Puppet::Pops::Model::BlockExpression),
+          scope).and_return(:result)
+        src = "apply(['arg1']) { }"
         Puppet.override(apply_executor: applicator) do
           expect(parser.evaluate_string(scope, src)).to eq(:result)
         end


### PR DESCRIPTION
Previously we would generate a BlockExpression for apply blocks with
multiple statements, and assumed if an apply block had less than 2
statements that it had 1 statement and we would return that statement.
This meant that for apply blocks with 0 statements the AST would
be `nil`, which caused issues when we assumed it was a proper AST. This
now generates a BlockExpression for every case except when the block has
1 statement, in which case it returns the statement.