### PR TITLE
(maint) Merge up 5.5.x to master

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1554,7 +1554,7 @@ EOT
     :statefile => {
       :default => "$statedir/state.yaml",
       :type => :file,
-      :mode => "0660",
+      :mode => "0640",
       :desc => "Where puppet agent and puppet master store state associated
         with the running configuration.  In the case of puppet master,
         this file reflects the state discovered through interacting
@@ -1576,7 +1576,7 @@ EOT
     :transactionstorefile => {
       :default => "$statedir/transactionstore.yaml",
       :type => :file,
-      :mode => "0660",
+      :mode => "0640",
       :desc => "Transactional storage file for persisting data between
         transactions for the purposes of infering information (such as
         corrective_change) on new data received."

--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -1,8 +1,11 @@
 require 'puppet/util/json'
 require 'puppet/parser/environment_compiler'
 
+# @deprecated application orchestration will be removed in puppet 7
 class Puppet::Network::HTTP::API::Master::V3::Environment
   def call(request, response)
+    Puppet.deprecation_warning("Application orchestration is deprecated. See https://puppet.com/docs/puppet/5.5/deprecated_language.html")
+
     env_name = request.routing_path.split('/').last
     env = Puppet.lookup(:environments).get(env_name)
     code_id = request.params[:code_id]

--- a/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/env_relationship_validator.rb
@@ -1,6 +1,8 @@
 class Puppet::Parser::Compiler
   # Validator that asserts that all capability resources that are referenced by 'consume' or 'require' has
   # been exported by some other resource in the environment
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   class CatalogValidator::EnvironmentRelationshipValidator < CatalogValidator
 
     def validate

--- a/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
+++ b/lib/puppet/parser/compiler/catalog_validator/site_validator.rb
@@ -1,5 +1,7 @@
 class Puppet::Parser::Compiler
   # Validator that asserts that only application components can appear inside a site.
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   class CatalogValidator::SiteValidator < CatalogValidator
     def self.validation_stage?(stage)
       PRE_FINISH.equal?(stage)

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -1,5 +1,6 @@
 require 'puppet/parser/compiler'
 
+# @deprecated application orchestration will be removed in puppet 7
 class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   def self.compile(env, code_id=nil)
     begin
@@ -54,6 +55,8 @@ class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
   end
 
   def compile
+    Puppet.deprecation_warning("Application orchestration is deprecated. See https://puppet.com/docs/puppet/5.5/deprecated_language.html")
+
     add_function_overrides
     begin
       Puppet.override(@context_overrides, _("For compiling environment catalog %{env}") % { env: environment.name }) do

--- a/lib/puppet/parser/resource.rb
+++ b/lib/puppet/parser/resource.rb
@@ -338,10 +338,11 @@ class Puppet::Parser::Resource < Puppet::Resource
   end
 
   def replace_sensitive_data
-    parameters.each_pair do |name, param|
+    parameters.keys.each do |name|
+      param = parameters[name]
       if param.value.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
         @sensitive_parameters << name
-        param.value = param.value.unwrap
+        parameters[name] = Puppet::Parser::Resource::Param.from_param(param, param.value.unwrap)
       end
     end
   end

--- a/lib/puppet/parser/resource/param.rb
+++ b/lib/puppet/parser/resource/param.rb
@@ -26,4 +26,10 @@ class Puppet::Parser::Resource::Param
   def to_s
     "#{self.name} => #{self.value}"
   end
+
+  def self.from_param(param, value)
+    new_param = param.dup
+    new_param.value = value
+    return new_param
+  end
 end

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -920,5 +920,10 @@ module Issues
   LOADER_FAILURE = issue :LOADER_FAILURE, :type do
     _('Failed to load: %{type_name}') % { type: type }
   end
+
+  DEPRECATED_APP_ORCHESTRATION = issue :DEPRECATED_APP_ORCHESTRATION, :klass do
+    _("Use of the application-orchestration %{expr} is deprecated. See https://puppet.com/docs/puppet/5.5/deprecated_language.html" % { expr: label(klass) })
+  end
+
 end
 end

--- a/lib/puppet/pops/resource/resource_type_impl.rb
+++ b/lib/puppet/pops/resource/resource_type_impl.rb
@@ -248,6 +248,8 @@ class ResourceTypeImpl
   #######################
 
   # Applications are not supported
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   def application?
     false
   end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -199,6 +199,11 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     end
   end
 
+  def check_Application(o)
+    check_NamedDefinition(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
+  end
+
   def check_AssignmentExpression(o)
     case o.operator
     when '='
@@ -296,6 +301,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
   end
 
   def check_CapabilityMapping(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
     ok =
     case o.component
     when Model::QualifiedReference
@@ -863,6 +869,10 @@ class Checker4_0 < Evaluator::LiteralEvaluator
 
   def check_SelectorEntry(o)
     rvalue(o.matching_expr)
+  end
+
+  def check_SiteDefinition(o)
+    acceptor.accept(Issues::DEPRECATED_APP_ORCHESTRATION, o, {:klass => o})
   end
 
   def check_UnaryExpression(o)

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -31,6 +31,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::RT_NO_STORECONFIGS]             = Puppet[:storeconfigs] ? :ignore : :warning
 
     p[Issues::FUTURE_RESERVED_WORD]           = :deprecation
+    p[Issues::DEPRECATED_APP_ORCHESTRATION]   = :deprecation
 
     p[Issues::DUPLICATE_KEY]                  = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]               = :error

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -11,6 +11,7 @@ class Puppet::Resource::Type
   include Puppet::Util::Warnings
   include Puppet::Util::Errors
 
+  # @deprecated application orchestration will be removed in puppet 7 (capability_mapping, application, site)
   RESOURCE_KINDS = [:hostclass, :node, :definition, :capability_mapping, :application, :site]
 
   # Map the names used in our documentation to the names used internally
@@ -69,6 +70,8 @@ class Puppet::Resource::Type
 
   # Evaluate the resources produced by the given resource. These resources are
   # evaluated in a separate but identical scope from the rest of the resource.
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   def evaluate_produces(resource, scope)
     # Only defined types and classes can produce capabilities
     return unless definition? || hostclass?
@@ -161,19 +164,23 @@ class Puppet::Resource::Type
     @module_name = options[:module_name]
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def produces
     @produces || EMPTY_ARRAY
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def consumes
     @consumes || EMPTY_ARRAY
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def add_produces(blueprint)
     @produces ||= []
     @produces << blueprint
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   def add_consumes(blueprint)
     @consumes ||= []
     @consumes << blueprint
@@ -235,6 +242,7 @@ class Puppet::Resource::Type
     when :node
       :node
     when :site
+      # @deprecated application orchestration will be removed in puppet 7
       :site
     end
 

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -116,8 +116,10 @@ class Type
 
   # Allow declaring that a type is actually a capability
   class << self
+    # @deprecated application orchestration will be removed in puppet 7
     attr_accessor :is_capability
 
+    # @deprecated application orchestration will be removed in puppet 7
     def is_capability?
       c = is_capability
       c.nil? ? false : c
@@ -129,6 +131,8 @@ class Type
   # represent application instances, this implementation always returns
   # +false+. Having this method though makes code checking whether a
   # resource is an application instance simpler
+  #
+  # @deprecated application orchestration will be removed in puppet 7
   def self.application?
       false
   end
@@ -1714,6 +1718,7 @@ class Type
     }
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   newmetaparam(:export, :parent => RelationshipMetaparam, :attributes => {:direction => :out, :events => :NONE}) do
           desc <<EOS
 Export a capability resource.
@@ -1739,6 +1744,7 @@ web { server:
 EOS
   end
 
+  # @deprecated application orchestration will be removed in puppet 7
   newmetaparam(:consume, :parent => RelationshipMetaparam, :attributes => {:direction => :in, :events => :NONE}) do
           desc <<EOS
 Consume a capability resource.

--- a/lib/puppet/util/windows/registry.rb
+++ b/lib/puppet/util/windows/registry.rb
@@ -234,7 +234,7 @@ module Puppet::Util::Windows
         begin
           case type
             when Win32::Registry::REG_SZ, Win32::Registry::REG_EXPAND_SZ
-              result = [ type, sanitize(data_ptr.read_wide_string(string_length)) ]
+              result = [ type, data_ptr.read_wide_string(string_length, Encoding::UTF_8, true) ]
             when Win32::Registry::REG_MULTI_SZ
               result = [ type, data_ptr.read_wide_string(string_length).split(/\0/) ]
             when Win32::Registry::REG_BINARY
@@ -312,12 +312,6 @@ module Puppet::Util::Windows
       end
 
       result
-    end
-
-    def sanitize(value)
-      # Replace null bytes with a space
-      value.tr!("\x00", ' ')
-      value
     end
 
     ffi_convention :stdcall

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -834,6 +834,17 @@ describe Puppet::Parser::Compiler do
           MANIFEST
         end.to raise_error(/Foo\[bar\]:\s+parameter 'a' expects a value for key 'd'\s+parameter 'a' unrecognized key 'c'/m)
       end
+
+      it 'handles Sensitive type in resource array' do
+        catalog = compile_to_catalog(<<-MANIFEST)
+          define foo(Sensitive[String] $password) {
+            notify{ "${title}": message => "${password}" }
+          }
+          foo { ['testA', 'testB']: password =>Sensitive('some password') }
+        MANIFEST
+        expect(catalog).to have_resource("Notify[testA]").with_parameter(:message, 'Sensitive [value redacted]')
+        expect(catalog).to have_resource("Notify[testB]").with_parameter(:message, 'Sensitive [value redacted]')
+      end
     end
 
     context 'when using typed parameters in class' do

--- a/spec/integration/util/windows/registry_spec.rb
+++ b/spec/integration/util/windows/registry_spec.rb
@@ -259,23 +259,23 @@ describe Puppet::Util::Windows::Registry do
         {
           name: 'REG_SZ',
           type: Win32::Registry::REG_SZ,
-          value: "reg sz\u0000 string",
-          expected_value: "reg sz  string"
+          value: "reg sz\u0000\u0000 string",
+          expected_value: "reg sz"
         },
         {
           name: 'REG_SZ_2',
           type: Win32::Registry::REG_SZ,
-          value: "reg sz\x00 string",
-          expected_value: "reg sz  string"
+          value: "reg sz 2\x00\x00 string",
+          expected_value: "reg sz 2"
         },
         {
           name: 'REG_EXPAND_SZ',
           type: Win32::Registry::REG_EXPAND_SZ,
-          value: "\0reg expand string",
-          expected_value: " reg expand string"
+          value: "\0\0\0reg expand string",
+          expected_value: ""
         }
       ].each do |pair|
-        it 'replaces null bytes with spaces' do
+        it 'reads up to the first wide null' do
           hklm.create("#{puppet_key}\\#{subkey_name}", Win32::Registry::KEY_ALL_ACCESS) do |reg|
             reg.write(value_name, pair[:type], pair[:value])
           end

--- a/spec/unit/parser/environment_compiler_spec.rb
+++ b/spec/unit/parser/environment_compiler_spec.rb
@@ -366,6 +366,13 @@ EOS
       }.to raise_error(/'Cap\[cap\]' is exported by both 'Prod\[one\]' and 'Prod\[two\]'/)
     end
 
+    it "issues deprecation warnings" do
+      expect {compile_collect_log(MANIFEST_WO_NODE)}.not_to raise_error
+      expect(warnings).to include(/Capability Mapping is deprecated/) # there are two of these
+      expect(warnings).to include(/Application is deprecated/)
+      expect(warnings).to include(/Site Definition is deprecated/)
+    end
+
     context "for producing node" do
       let(:compiled_node) { Puppet::Node.new('first', :environment => env) }
       let(:compiled_catalog) { compile_to_catalog(MANIFEST, compiled_node)}

--- a/spec/unit/util/windows/api_types_spec.rb
+++ b/spec/unit/util/windows/api_types_spec.rb
@@ -56,7 +56,7 @@ describe "FFI::MemoryPointer", :if => Puppet::Util::Platform.windows? do
         # uchar here is synonymous with byte
         ptr.put_array_of_uchar(0, bad_string_bytes)
 
-        read_string = ptr.read_wide_string(bad_string.length, Encoding::UTF_8, :invalid => :replace)
+        read_string = ptr.read_wide_string(bad_string.length, Encoding::UTF_8, false, :invalid => :replace)
       end
 
       expect(read_string).to eq("hello invalid world\uFFFD")


### PR DESCRIPTION
* upstream/5.5.x:
  (packaging) Updating the puppet.pot file
  (PUP-10511) fix resource array with sensitive parameters
  (PUP-9251) Deprecate export & consume metaparameters
  (PUP-9251) Deprecate `environment` REST API
  (PUP-9251) Deprecate apporch environment catalog
  (PUP-10536) strip after wide terminator
  (PUP-8922) update permision for state files
  (PUP-9251) Update app orchestration link
  (PUP-9251) Deprecate application orchestration constructs

* Conflicts:
  lib/puppet/pops/validation/validator_factory_4_0.rb (mismatch in
  whitespace)