### PR TITLE
(PUP-6380) Fallback to partial GET if HEAD is not supported

### DIFF
--- a/lib/puppet/http/redirector.rb
+++ b/lib/puppet/http/redirector.rb
@@ -60,6 +60,14 @@ class Puppet::HTTP::Redirector
       new_request[header] = value
     end
 
+    # mimic private Net::HTTP#addr_port
+    new_request['Host'] = if (location.scheme == 'https' && location.port == 443) ||
+                             (location.scheme == 'http' && location.port == 80)
+                            location.host
+                          else
+                            "#{location.host}:#{location.port}"
+                          end
+
     new_request
   end
 

--- a/lib/puppet/http/redirector.rb
+++ b/lib/puppet/http/redirector.rb
@@ -52,13 +52,7 @@ class Puppet::HTTP::Redirector
     raise Puppet::HTTP::TooManyRedirects.new(request.uri) if redirects >= @redirect_limit
 
     location = parse_location(response)
-    if location.relative?
-      url = request.uri.dup
-      url.path = location.path
-    else
-      url = location.dup
-    end
-    url.query = request.uri.query
+    url = request.uri.merge(location)
 
     new_request = request.class.new(url)
     new_request.body = request.body

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -89,11 +89,30 @@ class Puppet::HTTP::Response
   end
 
   # @api private
+  #
+  # Get a header case-insensitively.
+  # @param [String] name The header name
+  # @return [String] The header value
+  #
   def [](name)
     @nethttp[name]
   end
 
   # @api private
+  #
+  # Yield each header name and value. Returns an enumerator if no block is given.
+  #
+  # @yieldparam [String] header name
+  # @yieldparam [String] header value
+  #
+  def each_header(&block)
+    @nethttp.each_header(&block)
+  end
+
+  # @api private
+  #
+  # Drain the response body.
+  #
   def drain
     body
     true

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -535,6 +535,36 @@ describe Puppet::HTTP::Client do
       expect(response).to be_success
     end
 
+    it "updates the Host header from the Location host and port" do
+      stub_request(:get, start_url).with(headers: { 'Host' => 'www.example.com:8140' })
+        .to_return(redirect_to(url: other_host))
+      stub_request(:get, other_host).with(headers: { 'Host' => 'other.example.com:8140' })
+        .to_return(status: 200)
+
+      response = client.get(start_url)
+      expect(response).to be_success
+    end
+
+    it "omits the default HTTPS port from the Host header" do
+      stub_request(:get, start_url).with(headers: { 'Host' => 'www.example.com:8140' })
+        .to_return(redirect_to(url: "https://other.example.com/qux"))
+      stub_request(:get, "https://other.example.com/qux").with(headers: { 'Host' => 'other.example.com' })
+        .to_return(status: 200)
+
+      response = client.get(start_url)
+      expect(response).to be_success
+    end
+
+    it "omits the default HTTP port from the Host header" do
+      stub_request(:get, start_url).with(headers: { 'Host' => 'www.example.com:8140' })
+        .to_return(redirect_to(url: "http://other.example.com/qux"))
+      stub_request(:get, "http://other.example.com/qux").with(headers: { 'Host' => 'other.example.com' })
+        .to_return(status: 200)
+
+      response = client.get(start_url)
+      expect(response).to be_success
+    end
+
     it "applies query parameters from the location header" do
       query = { 'redirected' => false }
 

--- a/spec/unit/http/response_spec.rb
+++ b/spec/unit/http/response_spec.rb
@@ -66,4 +66,10 @@ describe Puppet::HTTP::Response do
 
     expect(client.get(uri)['Content-Encoding']).to eq('gzip')
   end
+
+  it "enumerates headers" do
+    stub_request(:get, uri).to_return(status: 200, headers: { 'Content-Encoding' => 'gzip' })
+
+    expect(client.get(uri).each_header.to_a).to eq([['content-encoding', 'gzip']])
+  end
 end

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -155,6 +155,26 @@ describe Puppet::Indirector::FileMetadata::Http do
 
       model.indirection.find(key)
     end
+
+    context "AWS" do
+      it "falls back to a partial GET" do
+        stub_request(:head, key)
+          .to_return(status: 403, headers: DEFAULT_HEADERS.merge({ "x-amz-request-id" => "EA308572DC91B4EA"}))
+        stub_request(:get, key)
+          .to_return(status: 200, headers: {'Range' => 'bytes=0-0'})
+
+        model.indirection.find(key)
+      end
+
+      it "returns nil if the GET fails" do
+        stub_request(:head, key)
+          .to_return(status: 403, headers: DEFAULT_HEADERS.merge({ "x-amz-request-id" => "EA308572DC91B4EA"}))
+        stub_request(:get, key)
+          .to_return(status: 403)
+
+        expect(model.indirection.find(key)).to be_nil
+      end
+    end
   end
 
   context "when searching" do

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -156,6 +156,15 @@ describe Puppet::Indirector::FileMetadata::Http do
       model.indirection.find(key)
     end
 
+    it "falls back to partial GET if HEAD is not allowed" do
+      stub_request(:head, key)
+        .to_return(status: 405)
+      stub_request(:get, key)
+        .to_return(status: 200, headers: {'Range' => 'bytes=0-0'})
+
+      model.indirection.find(key)
+    end
+
     context "AWS" do
       it "falls back to a partial GET" do
         stub_request(:head, key)


### PR DESCRIPTION
Allows puppet to retrieve file content from github releases and Amazon S3 buckets using the http(s) source parameter. Amazon strictly verifies presigned URLs, which exposed some issues with puppet's HTTP redirection handling:
* Preserve query parameters from the `Location` header
* Resolve relative URLs in `Location` header relative to the base URL
* Rewrite `Host` header based on new host/port
* If HEAD request for file metadata fails due to access denied or method not allowed, then fallback to a partial GET request.