### PR TITLE
(PUP-5707) Support X-Checksum-* headers

### DIFF
--- a/lib/puppet/file_serving/http_metadata.rb
+++ b/lib/puppet/file_serving/http_metadata.rb
@@ -51,7 +51,7 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
   def collect
     # Prefer the checksum_type from the indirector request options
     # but fall back to the alternative otherwise
-    [ @checksum_type, :md5, :sha256, :sha384, :sha512, :sha224, :sha1, :mtime ].each do |type|
+    [ @checksum_type, :md5, :sha256, :sha1, :mtime ].each do |type|
       @checksum_type = type
       @checksum = @checksums[type]
       break if @checksum

--- a/lib/puppet/file_serving/http_metadata.rb
+++ b/lib/puppet/file_serving/http_metadata.rb
@@ -22,6 +22,21 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
       @checksums[:md5] = "{md5}#{checksum}"
     end
 
+    checksum = http_response['X-Checksum-Md5']
+    if checksum
+      @checksums[checksum_type] = "{md5}#{checksum}"
+    end
+
+    checksum = http_response['X-Checksum-Sha1']
+    if checksum
+      @checksums[checksum_type] = "{sha1}#{checksum}"
+    end
+
+    checksum = http_response['X-Checksum-Sha256']
+    if checksum
+      @checksums[checksum_type] = "{sha256}#{checksum}"
+    end
+
     last_modified = http_response['last-modified']
     if last_modified
       mtime = DateTime.httpdate(last_modified).to_time
@@ -39,7 +54,7 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
   def collect
     # Prefer the checksum_type from the indirector request options
     # but fall back to the alternative otherwise
-    [ @checksum_type, :md5, :sha256, :sha384, :sha512, :sha224, :mtime ].each do |type|
+    [ @checksum_type, :md5, :sha256, :sha384, :sha512, :sha224, :sha1, :mtime ].each do |type|
       @checksum_type = type
       @checksum = @checksums[type]
       break if @checksum

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -428,7 +428,7 @@ Puppet::Type.newtype(:file) do
       @parameters[:content].value = @parameters[:checksum].sum(@parameters[:content].actual_content)
     end
 
-    if self[:checksum] && self[:checksum_value] && !send("#{self[:checksum]}?", self[:checksum_value])
+    if self[:checksum] && self[:checksum_value] && !valid_checksum?(self[:checksum], self[:checksum_value])
       self.fail _("Checksum value '%{value}' is not a valid checksum type %{checksum}") % { value: self[:checksum_value], checksum: self[:checksum] }
     end
 

--- a/lib/puppet/type/file/checksum.rb
+++ b/lib/puppet/type/file/checksum.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:file).newparam(:checksum) do
 
     The default checksum type is md5."
 
-  newvalues "md5", "md5lite", "sha224", "sha256", "sha256lite", "sha384", "sha512", "mtime", "ctime", "none"
+  newvalues(*Puppet::Util::Checksums.known_checksum_types)
 
   defaultto do
     Puppet[:digest_algorithm].to_sym
@@ -23,18 +23,18 @@ Puppet::Type.type(:file).newparam(:checksum) do
 
   def sum(content)
     content = content.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? content.binary_buffer : content
-    type = digest_algorithm()
+    type = digest_algorithm
     "{#{type}}" + send(type, content)
   end
 
   def sum_file(path)
-    type = digest_algorithm()
+    type = digest_algorithm
     method = type.to_s + "_file"
     "{#{type}}" + send(method, path).to_s
   end
 
   def sum_stream(&block)
-    type = digest_algorithm()
+    type = digest_algorithm
     method = type.to_s + "_stream"
     checksum = send(method, &block)
     "{#{type}}#{checksum}"

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -236,7 +236,7 @@ module Puppet::Util::Checksums
 
   # Return the :mtime timestamp of a file.
   def mtime_file(filename)
-    Puppet::FileSystem.stat(filename).send(:mtime)
+    Puppet::FileSystem.stat(filename).mtime
   end
 
   # by definition this doesn't exist
@@ -306,7 +306,7 @@ module Puppet::Util::Checksums
 
   # Return the :ctime of a file.
   def ctime_file(filename)
-    Puppet::FileSystem.stat(filename).send(:ctime)
+    Puppet::FileSystem.stat(filename).ctime
   end
 
   def ctime_stream(&block)

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -23,6 +23,10 @@ module Puppet::Util::Checksums
     KNOWN_CHECKSUMS
   end
 
+  def valid_checksum?(type, value)
+    !!send("#{type}?", value)
+  end
+
   class FakeChecksum
     def <<(*args)
       self

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -7,11 +7,20 @@ require 'time'
 module Puppet::Util::Checksums
   module_function
 
+  KNOWN_CHECKSUMS = [
+    :sha256, :sha256lite,
+    :md5, :md5lite,
+    :sha1, :sha1lite,
+    :sha512,
+    :sha384,
+    :sha224,
+    :mtime, :ctime, :none
+  ].freeze
+
   # It's not a good idea to use some of these in some contexts: for example, I
   # wouldn't try bucketing a file using the :none checksum type.
   def known_checksum_types
-    [:sha256, :sha256lite, :md5, :md5lite, :sha1, :sha1lite, :sha512, :sha384, :sha224, 
-      :mtime, :ctime, :none]
+    KNOWN_CHECKSUMS
   end
 
   class FakeChecksum

--- a/lib/puppet/util/checksums.rb
+++ b/lib/puppet/util/checksums.rb
@@ -25,6 +25,8 @@ module Puppet::Util::Checksums
 
   def valid_checksum?(type, value)
     !!send("#{type}?", value)
+  rescue NoMethodError
+    false
   end
 
   class FakeChecksum

--- a/spec/unit/util/checksums_spec.rb
+++ b/spec/unit/util/checksums_spec.rb
@@ -77,10 +77,8 @@ describe Puppet::Util::Checksums do
     expect(@summer).to_not be_valid_checksum('sha1', 'wronglength')
   end
 
-  it "raises if the checksum type is unknown" do
-    expect {
-      @summer.valid_checksum?('rot13', 'doesntmatter')
-    }.to raise_error(NoMethodError, /undefined method/)
+  it "returns false if the checksum type is unknown" do
+    expect(@summer).to_not be_valid_checksum('rot13', 'doesntmatter')
   end
 
   {:md5 => Digest::MD5, :sha1 => Digest::SHA1, :sha256 => Digest::SHA256, :sha512 => Digest::SHA512, :sha384 => Digest::SHA384}.each do |sum, klass|

--- a/spec/unit/util/checksums_spec.rb
+++ b/spec/unit/util/checksums_spec.rb
@@ -65,6 +65,24 @@ describe Puppet::Util::Checksums do
     expect(@summer.sumtype("asdfasdfa")).to be_nil
   end
 
+  it "has a list of known checksum types" do
+    expect(@summer.known_checksum_types).to match_array(content_sums + file_only)
+  end
+
+  it "returns true if the checksum is valid" do
+    expect(@summer).to be_valid_checksum('sha1', 'fcc1715b22278a9dae322b0a34935f10d1608b9f')
+  end
+
+  it "returns false if the checksum is known but invalid" do
+    expect(@summer).to_not be_valid_checksum('sha1', 'wronglength')
+  end
+
+  it "raises if the checksum type is unknown" do
+    expect {
+      @summer.valid_checksum?('rot13', 'doesntmatter')
+    }.to raise_error(NoMethodError, /undefined method/)
+  end
+
   {:md5 => Digest::MD5, :sha1 => Digest::SHA1, :sha256 => Digest::SHA256, :sha512 => Digest::SHA512, :sha384 => Digest::SHA384}.each do |sum, klass|
     describe("when using #{sum}") do
       it "should use #{klass} to calculate string checksums" do


### PR DESCRIPTION
Artifactory generates X-Checksum-{Md5,Sha1,Sha256} headers, so parse them from
the HTTP response, if present, when determining the remote checksum.

There is a draft RFC for Want-Digest and Digest headers, but it's not
finalized yet: https://tools.ietf.org/html/draft-ietf-httpbis-digest-headers

This commit also sets the header fields on the response instead of stubbing
methods.

This is based on PR #5707 originally authored by Dylan Cochran <heliocentric@gmail.com>
and committed by Peter Souter <peter.souter+GIT@puppet.com>

Blocked on PR #8197