### PR TITLE
(PUP-10543) Fallback to partial GET if HEAD request to puppetserver fails

### DIFF
--- a/lib/puppet/indirector/file_metadata/http.rb
+++ b/lib/puppet/indirector/file_metadata/http.rb
@@ -17,13 +17,9 @@ class Puppet::Indirector::FileMetadata::Http < Puppet::Indirector::GenericHttp
     return create_httpmetadata(head, checksum_type) if head.success?
 
     case head.code
-    when 403
-      # AMZ presigned URL?
-      if head.each_header.find { |k,_| k =~ /^x-amz-/i }
-        get = partial_get(client, uri)
-        return create_httpmetadata(get, checksum_type) if get.success?
-      end
-    when 405
+    when 403, 405
+      # AMZ presigned URL and puppetserver may return 403
+      # instead of 405. Fallback to partial get
       get = partial_get(client, uri)
       return create_httpmetadata(get, checksum_type) if get.success?
     end

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -165,24 +165,22 @@ describe Puppet::Indirector::FileMetadata::Http do
       model.indirection.find(key)
     end
 
-    context "AWS" do
-      it "falls back to a partial GET" do
-        stub_request(:head, key)
-          .to_return(status: 403, headers: DEFAULT_HEADERS.merge({ "x-amz-request-id" => "EA308572DC91B4EA"}))
-        stub_request(:get, key)
-          .to_return(status: 200, headers: {'Range' => 'bytes=0-0'})
+    it "falls back to partial GET if HEAD is forbidden" do
+      stub_request(:head, key)
+        .to_return(status: 403)
+      stub_request(:get, key)
+        .to_return(status: 200, headers: {'Range' => 'bytes=0-0'})
 
-        model.indirection.find(key)
-      end
+      model.indirection.find(key)
+    end
 
-      it "returns nil if the GET fails" do
-        stub_request(:head, key)
-          .to_return(status: 403, headers: DEFAULT_HEADERS.merge({ "x-amz-request-id" => "EA308572DC91B4EA"}))
-        stub_request(:get, key)
-          .to_return(status: 403)
+    it "returns nil if the partial GET fails" do
+      stub_request(:head, key)
+        .to_return(status: 403)
+      stub_request(:get, key)
+        .to_return(status: 403)
 
-        expect(model.indirection.find(key)).to be_nil
-      end
+      expect(model.indirection.find(key)).to be_nil
     end
   end
 


### PR DESCRIPTION
HEAD requests to puppetserver will fail for default routes like
`/puppet-ca/v1/certificate/ca`, because puppetserver only allows GET requests in
its default tk-auth. Requests to custom mount points can also fail if the user
forgets to explicitly allow HEAD.

Since there are multiple ways HEAD can fail, fallback to a partial GET
request.