### PR TITLE
(PUP-10544) Request protocol should take precedence over path

### DIFF
--- a/lib/puppet/file_serving/terminus_selector.rb
+++ b/lib/puppet/file_serving/terminus_selector.rb
@@ -7,11 +7,6 @@ module Puppet::FileServing::TerminusSelector
   def select(request)
     # We rely on the request's parsing of the URI.
 
-    # Short-circuit to :file if it's a fully-qualified path or specifies a 'file' protocol.
-    if Puppet::Util.absolute_path?(request.key)
-      return :file
-    end
-
     case request.protocol
     when "file"
       :file
@@ -21,10 +16,14 @@ module Puppet::FileServing::TerminusSelector
       else
         Puppet[:default_file_terminus]
       end
-   when "http","https"
-     :http
+    when "http","https"
+      :http
     when nil
-      :file_server
+      if Puppet::Util.absolute_path?(request.key)
+        :file
+      else
+        :file_server
+      end
     else
       raise ArgumentError, _("URI protocol '%{protocol}' is not currently supported for file serving") % { protocol: request.protocol }
     end

--- a/spec/unit/file_serving/terminus_selector_spec.rb
+++ b/spec/unit/file_serving/terminus_selector_spec.rb
@@ -3,62 +3,75 @@ require 'spec_helper'
 require 'puppet/file_serving/terminus_selector'
 
 describe Puppet::FileServing::TerminusSelector do
-  before do
-    @object = Object.new
-    @object.extend(Puppet::FileServing::TerminusSelector)
-
-    @request = double('request', :key => "mymod/myfile", :options => {:node => "whatever"}, :server => nil, :protocol => nil)
+  class TestSelector
+    include Puppet::FileServing::TerminusSelector
   end
+
+  def create_request(key)
+    Puppet::Indirector::Request.new(:indirection_name, :find, key, nil, {node: 'whatever'})
+  end
+
+  subject { TestSelector.new }
 
   describe "when being used to select termini" do
     it "should return :file if the request key is fully qualified" do
-      expect(@request).to receive(:key).and_return(File.expand_path('/foo'))
-      expect(@object.select(@request)).to eq(:file)
+      request = create_request(File.expand_path('/foo'))
+
+      expect(subject.select(request)).to eq(:file)
+    end
+
+    it "should return :file_server if the request key is relative" do
+      request = create_request('modules/my_module/path/to_file')
+
+      expect(subject.select(request)).to eq(:file_server)
     end
 
     it "should return :file if the URI protocol is set to 'file'" do
-      expect(@request).to receive(:protocol).and_return("file")
-      expect(@object.select(@request)).to eq(:file)
+      request = create_request(Puppet::Util.path_to_uri(File.expand_path("/foo")).to_s)
+
+      expect(subject.select(request)).to eq(:file)
     end
 
     it "should return :http if the URI protocol is set to 'http'" do
-      expect(@request).to receive(:protocol).and_return("http")
-      expect(@object.select(@request)).to eq :http
+      request = create_request("http://www.example.com")
+
+      expect(subject.select(request)).to eq(:http)
     end
 
     it "should return :http if the URI protocol is set to 'https'" do
-      expect(@request).to receive(:protocol).and_return("https")
-      expect(@object.select(@request)).to eq :http
+      request = create_request("https://www.example.com")
+
+      expect(subject.select(request)).to eq(:http)
     end
 
     it "should fail when a protocol other than :puppet, :http(s) or :file is used" do
-      allow(@request).to receive(:protocol).and_return("ftp")
-      expect { @object.select(@request) }.to raise_error(ArgumentError)
+      request = create_request("ftp://ftp.example.com")
+
+      expect {
+        subject.select(request)
+      }.to raise_error(ArgumentError, /URI protocol 'ftp' is not currently supported for file serving/)
     end
 
     describe "and the protocol is 'puppet'" do
-      before do
-        allow(@request).to receive(:protocol).and_return("puppet")
-      end
-
       it "should choose :rest when a server is specified" do
-        allow(@request).to receive(:protocol).and_return("puppet")
-        expect(@request).to receive(:server).and_return("foo")
-        expect(@object.select(@request)).to eq(:rest)
+        request = create_request("puppet://puppetserver.example.com")
+
+        expect(subject.select(request)).to eq(:rest)
       end
 
       # This is so a given file location works when bootstrapping with no server.
       it "should choose :rest when default_file_terminus is rest" do
-        allow(@request).to receive(:protocol).and_return("puppet")
         Puppet[:server] = 'localhost'
-        expect(@object.select(@request)).to eq(:rest)
+        request = create_request("puppet:///plugins")
+
+        expect(subject.select(request)).to eq(:rest)
       end
 
       it "should choose :file_server when default_file_terminus is file_server and no server is specified on the request" do
-        expect(@request).to receive(:protocol).and_return("puppet")
-        expect(@request).to receive(:server).and_return(nil)
         Puppet[:default_file_terminus] = 'file_server'
-        expect(@object.select(@request)).to eq(:file_server)
+        request = create_request("puppet:///plugins")
+
+        expect(subject.select(request)).to eq(:file_server)
       end
     end
   end

--- a/spec/unit/file_serving/terminus_selector_spec.rb
+++ b/spec/unit/file_serving/terminus_selector_spec.rb
@@ -44,6 +44,12 @@ describe Puppet::FileServing::TerminusSelector do
       expect(subject.select(request)).to eq(:http)
     end
 
+    it "should return :http if the path starts with a double slash" do
+      request = create_request("https://www.example.com//index.html")
+
+      expect(subject.select(request)).to eq(:http)
+    end
+
     it "should fail when a protocol other than :puppet, :http(s) or :file is used" do
       request = create_request("ftp://ftp.example.com")
 


### PR DESCRIPTION
Previously, if an indirector request's key was a URL, but the URL path started
with a double slash, then puppet thought it was a local absolute path. This
occurred because the indirector request strips the leading slash off the URL
path when setting its key, but the second slash remained, and that appeared to
be an absolute posix path.

This commit eliminates the premature optimization. Select the terminus based on
the request protocol. If no protocol is given and the request key is an absolute
path, then use the local :file terminus. Otherwise select the :file_server
terminus, which knows how to convert a mount path to a path on disk, such as
"modules/my_module/my_file".