### PR TITLE
(PUP-6916) Allow userinfo to be passed in the URL

### DIFF
--- a/lib/puppet/forge/repository.rb
+++ b/lib/puppet/forge/repository.rb
@@ -37,19 +37,15 @@ class Puppet::Forge
         uri = URI(str)
 
         headers = { "User-Agent" => user_agent }
-        basic_auth = nil
 
         if forge_authorization
+          uri.user = nil
+          uri.password = nil
           headers["Authorization"] = forge_authorization
-        elsif @uri.user && @uri.password
-          basic_auth = {
-            user: @uri.user,
-            password: @uri.password
-          }
         end
 
         http = Puppet.runtime[:http]
-        response = http.get(uri, headers: headers, options: {basic_auth: basic_auth, ssl_context: @ssl_context})
+        response = http.get(uri, headers: headers, options: {ssl_context: @ssl_context})
         io.write(response.body) if io.respond_to?(:write)
         response
       rescue Puppet::SSL::CertVerifyError => e

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -290,6 +290,11 @@ class Puppet::HTTP::Client
     redirector = Puppet::HTTP::Redirector.new(options.fetch(:redirect_limit, @default_redirect_limit))
 
     basic_auth = options.fetch(:basic_auth, nil)
+    unless basic_auth
+      if request.uri.user && request.uri.password
+        basic_auth = { user: request.uri.user, password: request.uri.password }
+      end
+    end
 
     redirects = 0
     retries = 0

--- a/lib/puppet/indirector/file_metadata/http.rb
+++ b/lib/puppet/indirector/file_metadata/http.rb
@@ -17,13 +17,9 @@ class Puppet::Indirector::FileMetadata::Http < Puppet::Indirector::GenericHttp
     return create_httpmetadata(head, checksum_type) if head.success?
 
     case head.code
-    when 403
-      # AMZ presigned URL?
-      if head.each_header.find { |k,_| k =~ /^x-amz-/i }
-        get = partial_get(client, uri)
-        return create_httpmetadata(get, checksum_type) if get.success?
-      end
-    when 405
+    when 403, 405
+      # AMZ presigned URL and puppetserver may return 403
+      # instead of 405. Fallback to partial get
       get = partial_get(client, uri)
       return create_httpmetadata(get, checksum_type) if get.success?
     end

--- a/lib/puppet/reports/http.rb
+++ b/lib/puppet/reports/http.rb
@@ -25,6 +25,8 @@ Puppet::Reports.register_report(:http) do
       :include_system_store => Puppet[:report_include_system_store],
     }
 
+    # Puppet's http client implementation accepts userinfo in the URL
+    # but puppetserver's does not. So pass credentials explicitly.
     if url.user && url.password
       options[:basic_auth] = {
         user: url.user,

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -507,6 +507,20 @@ describe Puppet::HTTP::Client do
 
       client.get(uri, options: {basic_auth: {user: 'user', password: nil}})
     end
+
+    it 'observes userinfo in the URL' do
+      stub_request(:get, uri).with(basic_auth: credentials)
+
+      client.get(URI("https://user:pass@www.example.com"))
+    end
+
+    it 'prefers explicit basic_auth credentials' do
+      uri = URI("https://ignored_user:ignored_pass@www.example.com")
+
+      stub_request(:get, "https://www.example.com").with(basic_auth: credentials)
+
+      client.get(uri, options: {basic_auth: {user: 'user', password: 'pass'}})
+    end
   end
 
   context "when redirecting" do

--- a/spec/unit/indirector/file_metadata/http_spec.rb
+++ b/spec/unit/indirector/file_metadata/http_spec.rb
@@ -165,24 +165,22 @@ describe Puppet::Indirector::FileMetadata::Http do
       model.indirection.find(key)
     end
 
-    context "AWS" do
-      it "falls back to a partial GET" do
-        stub_request(:head, key)
-          .to_return(status: 403, headers: DEFAULT_HEADERS.merge({ "x-amz-request-id" => "EA308572DC91B4EA"}))
-        stub_request(:get, key)
-          .to_return(status: 200, headers: {'Range' => 'bytes=0-0'})
+    it "falls back to partial GET if HEAD is forbidden" do
+      stub_request(:head, key)
+        .to_return(status: 403)
+      stub_request(:get, key)
+        .to_return(status: 200, headers: {'Range' => 'bytes=0-0'})
 
-        model.indirection.find(key)
-      end
+      model.indirection.find(key)
+    end
 
-      it "returns nil if the GET fails" do
-        stub_request(:head, key)
-          .to_return(status: 403, headers: DEFAULT_HEADERS.merge({ "x-amz-request-id" => "EA308572DC91B4EA"}))
-        stub_request(:get, key)
-          .to_return(status: 403)
+    it "returns nil if the partial GET fails" do
+      stub_request(:head, key)
+        .to_return(status: 403)
+      stub_request(:get, key)
+        .to_return(status: 403)
 
-        expect(model.indirection.find(key)).to be_nil
-      end
+      expect(model.indirection.find(key)).to be_nil
     end
   end
 


### PR DESCRIPTION
Puppet's http client supports passing basic authentication explicitly as
an option, as is done with the `http` report processor. This commit
makes it possible to pass a URL containing userinfo and have puppet use
those credentials. If both are passed, then the explicit `basic_auth`
parameter takes precedence.

Blocked on https://github.com/puppetlabs/puppet/pull/8199