### PR TITLE
(PUP-10549) Print unacceptable format names not objects

### DIFF
--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -210,7 +210,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     return formatter if formatter
 
     raise Puppet::Network::HTTP::Error::HTTPNotAcceptableError.new(
-            _("No supported formats are acceptable (Accept: %{accepted_formats})") % { accepted_formats: formats },
+            _("No supported formats are acceptable (Accept: %{accepted_formats})") % { accepted_formats: formats.map(&:mime).join(', ') },
             Puppet::Network::HTTP::Issues::UNSUPPORTED_FORMAT)
   end
 

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -343,7 +343,8 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
 
       expect {
         handler.call(request, response)
-      }.to raise_error(Puppet::Network::HTTP::Error::HTTPNotAcceptableError, /No supported formats are acceptable/)
+      }.to raise_error(Puppet::Network::HTTP::Error::HTTPNotAcceptableError,
+                       %r{No supported formats are acceptable \(Accept: application/json, text/pson\)})
     end
 
     it "should return [] when searching returns an empty array" do


### PR DESCRIPTION
Print the list of format names that are unacceptable, not the
Puppet::Network::Format objects.