### PR TITLE
(maint) Update console color setting for Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -347,8 +347,7 @@ module Puppet
       :default => "ansi",
       :type    => :string,
       :desc    => "Whether to use colors when logging to the console.  Valid values are
-        `ansi` (equivalent to `true`), `html`, and `false`, which produces no color.
-        Defaults to false on Windows, as its console does not support ansi colors.",
+        `ansi` (equivalent to `true`), `html`, and `false`, which produces no color."
     },
     :mkusers => {
         :default  => false,


### PR DESCRIPTION
Commit f40cc71e8 updated the description for the color setting, but that part
was lost along the way, likely when the file was reformatted in bf9ac399bd539
and conflicts resolved.