### PR TITLE
(PUP-10572) Create loaders in the agent application

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -365,8 +365,17 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
       daemon.set_signal_traps
 
       log_config if Puppet[:daemonize]
-      
-      Puppet.override(ssl_context: wait_for_certificates) do
+
+      # run ssl state machine, waiting if needed
+      ssl_context = wait_for_certificates
+
+      # Each application is responsible for pushing loaders onto the context.
+      # Use the current environment that has already been established, though
+      # it may change later during the configurer run.
+      env = Puppet.lookup(:current_environment)
+      Puppet.override(ssl_context: ssl_context,
+                      current_environment: env,
+                      loaders: Puppet::Pops::Loaders.new(env, true)) do
         if Puppet[:onetime]
           onetime(daemon)
         else


### PR DESCRIPTION
Puppet failed to load cached catalogs containing rich data, because the
Configurer hadn't yet created the loaders necessary to deserialize the catalog
using pcore. This affected rich data types like Binary and Deferred, but not
Sensitive, since it predates pcore and is serialized differently.

This commit moves the creation of the loaders to the `agent` application similar
to how the `apply` and `device` applications already handle it. See commits
b9878fd0258 and b30ecfcc429.

If the environment changes based on the node response, then update the current
environment like we did before. Note there is a separate ticket to update the
current environment if the environment changes due to catalog convergence, see
PUP-10308.

This commit also preserves creation of the loaders if it hasn't been done
before requesting a catalog. That part should be removed in puppet 7.

This PR targets master because rich data wasn't enabled on the agent until puppet 6