### PR TITLE
(PUP-10580) Don't double encode path and query

### DIFF
--- a/lib/puppet/network/http/connection_adapter.rb
+++ b/lib/puppet/network/http/connection_adapter.rb
@@ -156,7 +156,7 @@ class Puppet::Network::HTTP::ConnectionAdapter < Puppet::Network::HTTP::Connecti
       url.query = abs_form.query if abs_form.query
       url
     else
-      URI("#{@site.addr}/#{Puppet::Util.uri_encode(normalize_path(path))}")
+      URI("#{@site.addr}/#{normalize_path(path)}")
     end
   end
 

--- a/lib/puppet/network/http/connection_adapter.rb
+++ b/lib/puppet/network/http/connection_adapter.rb
@@ -149,10 +149,12 @@ class Puppet::Network::HTTP::ConnectionAdapter < Puppet::Network::HTTP::Connecti
       # though clients are only supposed to send them to proxies, so the proxy knows
       # what upstream server to CONNECT to. This method creates a URL using the
       # scheme/host/port that the connection was created with, and appends the path
-      # portion of the absolute-form. The resulting request will use "origin-form"
+      # and query portions of the absolute-form. The resulting request will use "origin-form"
       # as it should have done all along.
-      url = URI(path)
-      URI("#{@site.addr}/#{normalize_path(url.path)}")
+      abs_form = URI(path)
+      url = URI("#{@site.addr}/#{normalize_path(abs_form.path)}")
+      url.query = abs_form.query if abs_form.query
+      url
     else
       URI("#{@site.addr}/#{Puppet::Util.uri_encode(normalize_path(path))}")
     end

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -8,6 +8,8 @@ describe Puppet::Network::HTTP::Connection do
   let(:port) { 8140 }
   let(:path) { '/foo' }
   let(:url) { "https://#{host}:#{port}#{path}" }
+  let(:params) { { 'key' => 'a value' } }
+  let(:encoded_url_with_params) { "#{url}?%7B%22key%22:%22a%20value%22%7D" }
 
   shared_examples_for "an HTTP connection" do |klass, legacy_api|
     subject { klass.new(host, port, :verify => Puppet::SSL::Validator.no_validator) }
@@ -81,9 +83,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:get, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:get, encoded_url_with_params)
 
-        subject.request_get("#{path}?foo=bar=baz") { |_| }
+        subject.request_get("#{path}?#{params.to_json}") { |_| }
       end
 
       it "merges custom headers with default ones" do
@@ -119,9 +121,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:head, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:head, encoded_url_with_params)
 
-        subject.request_head("#{path}?foo=bar=baz") { |_| }
+        subject.request_head("#{path}?#{params.to_json}") { |_| }
       end
 
       it "merges custom headers with default ones" do
@@ -157,9 +159,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:post, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:post, encoded_url_with_params)
 
-        subject.request_post("#{path}?foo=bar=baz", "") { |_| }
+        subject.request_post("#{path}?#{params.to_json}", "") { |_| }
       end
 
       it "merges custom headers with default ones" do
@@ -193,9 +195,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:get, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:get, encoded_url_with_params)
 
-        subject.get("#{path}?foo=bar=baz")
+        subject.get("#{path}?#{params.to_json}")
       end
 
       it "merges custom headers with default ones" do
@@ -236,9 +238,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:head, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:head, encoded_url_with_params)
 
-        subject.head("#{path}?foo=bar=baz")
+        subject.head("#{path}?#{params.to_json}")
       end
 
       it "merges custom headers with default ones" do
@@ -272,9 +274,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:put, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:put, encoded_url_with_params)
 
-        subject.put("#{path}?foo=bar=baz", "")
+        subject.put("#{path}?#{params.to_json}", "")
       end
 
       it "includes custom headers" do
@@ -328,9 +330,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:post, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:post, encoded_url_with_params)
 
-        subject.post("#{path}?foo=bar=baz", "", {'Content-Type' => 'text/plain'})
+        subject.post("#{path}?#{params.to_json}", "", {'Content-Type' => 'text/plain'})
       end
 
       it "includes custom headers" do
@@ -390,9 +392,9 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "stringifies keys and encodes values in the query" do
-        stub_request(:delete, url).with(query: "foo=bar%3Dbaz")
+        stub_request(:delete, encoded_url_with_params)
 
-        subject.delete("#{path}?foo=bar=baz")
+        subject.delete("#{path}?#{params.to_json}")
       end
 
       it "returns the response" do

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -101,9 +101,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:get, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:get, url_with_query)
 
-        response = subject.request_get(url) { |_| }
+        response = subject.request_get(url_with_query) { |_| }
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
@@ -138,9 +139,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:head, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:head, url_with_query)
 
-        response = subject.request_head(url) { |_| }
+        response = subject.request_head(url_with_query) { |_| }
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
@@ -175,9 +177,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:post, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:post, url_with_query)
 
-        response = subject.request_post(url, "") { |_| }
+        response = subject.request_post(url_with_query, "") { |_| }
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
@@ -217,9 +220,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:get, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:get, url_with_query)
 
-        response = subject.get(url)
+        response = subject.get(url_with_query)
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
@@ -252,9 +256,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:head, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:head, url_with_query)
 
-        response = subject.head(url)
+        response = subject.head(url_with_query)
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
@@ -307,9 +312,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:put, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:put, url_with_query)
 
-        response = subject.put(url, '')
+        response = subject.put(url_with_query, '')
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
@@ -362,9 +368,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:post, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:post, url_with_query)
 
-        response = subject.post(url, '')
+        response = subject.post(url_with_query, '')
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end
@@ -403,9 +410,10 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "accepts a URL string as the path" do
-        stub_request(:delete, url)
+        url_with_query = "#{url}?foo=bar"
+        stub_request(:delete, url_with_query)
 
-        response = subject.delete(url)
+        response = subject.delete(url_with_query)
         expect(response).to be_an_instance_of(Net::HTTPOK)
       end
     end


### PR DESCRIPTION
Puppet's connection adapter class URL encoded the request path and query parameters, whereas the old connection class did not. This restores the behavior that existed in 6.15.0.

Also include the query component when calling the connection adapter with the entire URL as a string, instead of just the path and query.