### PR TITLE
(PUP-9602) Only register autoloaded types if not already loaded

### DIFF
--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -128,7 +128,7 @@ module Manager
 
       loc = block_given? ? block.source_location : nil
       uri = loc.nil? ? nil : URI("#{Puppet::Util.path_to_uri(loc[0])}?line=#{loc[1]}")
-      Puppet::Pops::Loaders.register_runtime3_type(name, uri)
+      Puppet::Pops::Loaders.register_runtime3_type(name, uri, true)
 
       klass
     end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -140,7 +140,7 @@ class Loaders
   # @param name [String,Symbol] the name of the entity being set
   # @param origin [URI] the origin or the source where the type is defined
   # @api private
-  def self.register_runtime3_type(name, origin)
+  def self.register_runtime3_type(name, origin, ignore_duplicate = false)
     loaders = Puppet.lookup(:loaders) { nil }
     return nil if loaders.nil?
 
@@ -150,6 +150,10 @@ class Loaders
     name = name.to_s
     caps_name = Types::TypeFormatter.singleton.capitalize_segments(name)
     typed_name = Loader::TypedName.new(:type, name)
+    if ignore_duplicate
+      te = rt3_loader.get_entry(typed_name)
+      return nil unless te.nil? || te.value.nil?
+    end
     rt3_loader.set_entry(typed_name, Types::PResourceType.new(caps_name), origin)
     nil
   end


### PR DESCRIPTION
During catalog compilation the `Runtime3TypeLoader` tries to load resource types
from pcore and register them in its `named_values` hash.

During catalog application the autoloader loads resource types and registers
them with the `Runtime3TypeLoader`. Attempting to register a type twice causes
an `Attempt to redefine entity` error.

When using `puppet apply` this error could occur since catalog compilation and
application happen in the same process and the same set of loaders are used for
both.

One solution would be to create separate loaders for `puppet apply`, but that
would significantly slow down `puppet apply` in the common case where there
aren't pcore generated types.

This commit updates the metatype manager to only register the autoloaded
resource type if it hasn't been loaded yet.