### PR TITLE
(PUP-9602) Ignore pcore resource loader for puppet apply

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -307,7 +307,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
   private
 
   def create_loaders(env)
-    Puppet::Pops::Loaders.new(env)
+    # Ignore both 'cached_puppet_lib' and pcore resource type loaders
+    Puppet::Pops::Loaders.new(env, false, false)
   end
 
   def read_catalog(text)

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -7,10 +7,10 @@ module Loader
 #
 # @api private
 class Runtime3TypeLoader < BaseLoader
-  def initialize(parent_loader, loaders, environment, env_path)
+  def initialize(parent_loader, loaders, environment, resource_3x_loader)
     super(parent_loader, environment.name)
     @environment = environment
-    @resource_3x_loader = env_path.nil? ? nil : ModuleLoaders.pcore_resource_type_loader_from(parent_loader, loaders, env_path)
+    @resource_3x_loader = resource_3x_loader
   end
 
   def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -7,6 +7,8 @@ module Loader
 #
 # @api private
 class Runtime3TypeLoader < BaseLoader
+  attr_reader :resource_3x_loader
+
   def initialize(parent_loader, loaders, environment, resource_3x_loader)
     super(parent_loader, environment.name)
     @environment = environment

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -387,7 +387,13 @@ class Loaders
     else
       # Create the 3.x resource type loader
       static_loader.runtime_3_init
-      @runtime3_type_loader = add_loader_by_name(Loader::Runtime3TypeLoader.new(parent_loader, self, environment, env_conf.nil? ? nil : env_path))
+      # Create pcore resource type loader, if applicable
+      pcore_resource_type_loader = if env_path
+                                     Loader::ModuleLoaders.pcore_resource_type_loader_from(parent_loader, self, env_path)
+                                   else
+                                     nil
+                                   end
+      @runtime3_type_loader = add_loader_by_name(Loader::Runtime3TypeLoader.new(parent_loader, self, environment, pcore_resource_type_loader))
 
       if env_path.nil?
         # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -18,18 +18,18 @@ class Loaders
   attr_reader :private_environment_loader
   attr_reader :environment
 
-  def self.new(environment, for_agent = false)
+  def self.new(environment, for_agent = false, load_from_pcore = true)
     environment.lock.synchronize do
       obj = environment.loaders
       if obj.nil?
         obj = self.allocate
-        obj.send(:initialize, environment, for_agent)
+        obj.send(:initialize, environment, for_agent, load_from_pcore)
       end
       obj
     end
   end
 
-  def initialize(environment, for_agent)
+  def initialize(environment, for_agent, load_from_pcore = true)
     # Protect against environment havoc
     raise ArgumentError.new(_("Attempt to redefine already initialized loaders for environment")) unless environment.loaders.nil?
     environment.loaders = self
@@ -51,12 +51,13 @@ class Loaders
     #    TODO: loaders need to work when also running in an agent doing catalog application. There is no
     #    concept of environment the same way as when running as a master (except when doing apply).
     #    The creation mechanisms should probably differ between the two.
-    @private_environment_loader = if for_agent
-      @puppet_cache_loader = create_puppet_cache_loader()
-      create_environment_loader(environment, @puppet_cache_loader)
-    else
-      create_environment_loader(environment, @puppet_system_loader)
-    end
+    @private_environment_loader =
+      if for_agent
+        @puppet_cache_loader = create_puppet_cache_loader
+        create_environment_loader(environment, @puppet_cache_loader, load_from_pcore)
+      else
+        create_environment_loader(environment, @puppet_system_loader, load_from_pcore)
+      end
 
     Pcore.init_env(@private_environment_loader)
 
@@ -362,7 +363,7 @@ class Loaders
     Loader::ModuleLoaders.cached_loader_from(puppet_system_loader, self)
   end
 
-  def create_environment_loader(environment, parent_loader)
+  def create_environment_loader(environment, parent_loader, load_from_pcore = true)
     # This defines where to start parsing/evaluating - the "initial import" (to use 3x terminology)
     # Is either a reference to a single .pp file, or a directory of manifests. If the environment becomes
     # a module and can hold functions, types etc. then these are available across all other modules without
@@ -388,7 +389,7 @@ class Loaders
       # Create the 3.x resource type loader
       static_loader.runtime_3_init
       # Create pcore resource type loader, if applicable
-      pcore_resource_type_loader = if env_path
+      pcore_resource_type_loader = if load_from_pcore && env_path
                                      Loader::ModuleLoaders.pcore_resource_type_loader_from(parent_loader, self, env_path)
                                    else
                                      nil

--- a/spec/fixtures/integration/application/apply/environments/spec/.resource_types/applytest.pp
+++ b/spec/fixtures/integration/application/apply/environments/spec/.resource_types/applytest.pp
@@ -1,0 +1,25 @@
+# This file was automatically generated on 2020-07-09 16:08:52 -0700.
+# Use the 'puppet generate types' command to regenerate this file.
+
+Puppet::Resource::ResourceType3.new(
+  'applytest',
+  [
+    Puppet::Resource::Param(Any, 'message')
+  ],
+  [
+    # An arbitrary tag for your own reference; the name of the message.
+    Puppet::Resource::Param(Any, 'name', true),
+
+    # The specific backend to use for this `applytest`
+    # resource. You will seldom need to specify this --- Puppet will usually
+    # discover the appropriate provider for your platform.Available providers are:
+    # 
+    # ruby
+    # :
+    Puppet::Resource::Param(Any, 'provider')
+  ],
+  {
+    /(?m-ix:(.*))/ => ['name']
+  },
+  true,
+  false)

--- a/spec/fixtures/integration/application/apply/environments/spec/modules/amod/lib/puppet/provider/applytest/applytest.rb
+++ b/spec/fixtures/integration/application/apply/environments/spec/modules/amod/lib/puppet/provider/applytest/applytest.rb
@@ -1,0 +1,2 @@
+Puppet::Type.type(:applytest).provide(:applytest) do
+end

--- a/spec/fixtures/integration/application/apply/environments/spec/modules/amod/lib/puppet/type/applytest.rb
+++ b/spec/fixtures/integration/application/apply/environments/spec/modules/amod/lib/puppet/type/applytest.rb
@@ -1,0 +1,25 @@
+# If you make changes to this file, regenerate the pcore resource type using
+# bundle exec puppet generate types --environmentpath spec/fixtures/integration/application/apply/environments -E spec
+Puppet::Type.newtype(:applytest) do
+  newproperty(:message) do
+    def sync
+      Puppet.send(@resource[:loglevel], self.should)
+    end
+
+    def retrieve
+      :absent
+    end
+
+    def insync?(is)
+      false
+    end
+
+    defaultto { @resource[:name] }
+  end
+
+  newparam(:name) do
+    desc "An arbitrary tag for your own reference; the name of the message."
+    Puppet.notice('the Puppet::Type says hello')
+    isnamevar
+  end
+end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -30,65 +30,44 @@ describe "apply", unless: Puppet::Util::Platform.jruby? do
       expect(File.read(file_to_create)).to eq("my stuff")
     end
 
+    context 'and pcore types are available' do
+      let(:envdir) { my_fixture('environments') }
+      let(:env_name) { 'spec' }
+
+      before(:each) do
+        Puppet[:environmentpath] = envdir
+        Puppet[:environment] = env_name
+      end
+
+      it 'does not load the pcore type' do
+        pending("PUP-9602")
+
+        apply = Puppet::Application[:apply]
+        apply.command_line.args = [ '-e', "Applytest { message => 'the default'} applytest { 'applytest was here': }" ]
+
+        expect {
+          apply.run
+        }.to exit_with(0)
+         .and output(a_string_matching(
+           /the Puppet::Type says hello/
+         ).and matching(
+           /applytest was here/
+         )).to_stdout
+      end
+    end
+
     context 'from environment with a pcore defined resource type' do
       include PuppetSpec::Compiler
 
-      let!(:envdir) { tmpdir('environments') }
+      let(:envdir) { my_fixture('environments') }
       let(:env_name) { 'spec' }
-      let(:dir_structure) {
-        {
-          '.resource_types' => {
-            'applytest.pp' => <<-CODE
-            Puppet::Resource::ResourceType3.new(
-              'applytest',
-              [Puppet::Resource::Param.new(String, 'message')],
-              [Puppet::Resource::Param.new(String, 'name', true)])
-          CODE
-          },
-          'modules' => {
-            'amod' => {
-              'lib' => {
-                'puppet' => {
-                  'type' => { 'applytest.rb' => <<-CODE
-Puppet::Type.newtype(:applytest) do
-newproperty(:message) do
-  def sync
-    Puppet.send(@resource[:loglevel], self.should)
-  end
-
-  def retrieve
-    :absent
-  end
-
-  def insync?(is)
-    false
-  end
-
-  defaultto { @resource[:name] }
-end
-
-newparam(:name) do
-  desc "An arbitrary tag for your own reference; the name of the message."
-  Puppet.notice('the Puppet::Type says hello')
-  isnamevar
-end
-end
-                  CODE
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
       let(:environments) { Puppet::Environments::Directories.new(envdir, []) }
       let(:env) { Puppet::Node::Environment.create(:'spec', [File.join(envdir, 'spec', 'modules')]) }
       let(:node) { Puppet::Node.new('test', :environment => env) }
+
       around(:each) do |example|
         Puppet::Type.rmtype(:applytest)
         Puppet[:environment] = env_name
-        dir_contained_in(envdir, env_name => dir_structure)
         Puppet.override(:environments => environments, :current_environment => env) do
           example.run
         end

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -40,8 +40,6 @@ describe "apply", unless: Puppet::Util::Platform.jruby? do
       end
 
       it 'does not load the pcore type' do
-        pending("PUP-9602")
-
         apply = Puppet::Application[:apply]
         apply.command_line.args = [ '-e', "Applytest { message => 'the default'} applytest { 'applytest was here': }" ]
 

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -94,6 +94,18 @@ describe 'loaders' do
     end
   end
 
+  def expect_loader_hierarchy(loaders, expected_loaders)
+    actual_loaders = []
+
+    loader = loaders.private_environment_loader
+    while loader
+      actual_loaders << [loader.loader_name, loader]
+      loader = loader.parent
+    end
+
+    expect(actual_loaders).to contain_exactly(*expected_loaders)
+  end
+
   it 'creates a puppet_system loader' do
     loaders = Puppet::Pops::Loaders.new(empty_test_env)
     expect(loaders.puppet_system_loader()).to be_a(Puppet::Pops::Loader::ModuleLoaders::FileBased)
@@ -121,6 +133,47 @@ describe 'loaders' do
     expect(loaders.public_environment_loader().to_s).to eql("(SimpleEnvironmentLoader 'environment')")
     expect(loaders.private_environment_loader()).to be_a(Puppet::Pops::Loader::DependencyLoader)
     expect(loaders.private_environment_loader().to_s).to eql("(DependencyLoader 'environment private' [])")
+  end
+
+  it 'creates a hierarchy of loaders' do
+    expect_loader_hierarchy(
+      Puppet::Pops::Loaders.new(empty_test_env),
+      [
+        [nil,                   Puppet::Pops::Loader::StaticLoader],
+        ['puppet_system',       Puppet::Pops::Loader::ModuleLoaders::LibRootedFileBased],
+        [empty_test_env.name,   Puppet::Pops::Loader::Runtime3TypeLoader],
+        ['environment',         Puppet::Pops::Loader::SimpleEnvironmentLoader],
+        ['environment private', Puppet::Pops::Loader::DependencyLoader],
+      ]
+    )
+  end
+
+  it 'excludes the Runtime3TypeLoader when tasks are enabled' do
+    Puppet[:tasks] = true
+
+    expect_loader_hierarchy(
+      Puppet::Pops::Loaders.new(empty_test_env),
+      [
+        [nil,                   Puppet::Pops::Loader::StaticLoader],
+        ['puppet_system',       Puppet::Pops::Loader::ModuleLoaders::LibRootedFileBased],
+        ['environment',         Puppet::Pops::Loader::ModuleLoaders::EmptyLoader],
+        ['environment private', Puppet::Pops::Loader::DependencyLoader],
+      ]
+    )
+  end
+
+  it 'includes the agent cache loader when for_agent is true' do
+    expect_loader_hierarchy(
+      Puppet::Pops::Loaders.new(empty_test_env, true),
+      [
+        [nil,                   Puppet::Pops::Loader::StaticLoader],
+        ['puppet_system',       Puppet::Pops::Loader::ModuleLoaders::LibRootedFileBased],
+        ['cached_puppet_lib',   Puppet::Pops::Loader::ModuleLoaders::LibRootedFileBased],
+        [empty_test_env.name,   Puppet::Pops::Loader::Runtime3TypeLoader],
+        ['environment',         Puppet::Pops::Loader::SimpleEnvironmentLoader],
+        ['environment private', Puppet::Pops::Loader::DependencyLoader],
+      ],
+    )
   end
 
   context 'when loading from a module' do

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -99,6 +99,12 @@ describe 'loaders' do
       expect(pcore_loader).to be_a(Puppet::Pops::Loader::ModuleLoaders::FileBased)
     end
 
+    it 'does not create a pcore resource type loader if requested not to' do
+      env.loaders = nil # clear cached loaders
+      loaders = Puppet::Pops::Loaders.new(env, false, false)
+      expect(loaders.runtime3_type_loader.resource_3x_loader).to be_nil
+    end
+
     it 'does not create a pcore resource type loader for an empty environment' do
       loaders = Puppet::Pops::Loaders.new(empty_test_env)
       expect(loaders.runtime3_type_loader.resource_3x_loader).to be_nil

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -92,6 +92,17 @@ describe 'loaders' do
     it 'errors with message about empty file for files that contain no logic' do
       expect{loader.load(:resource_type_pp, 'empty')}.to raise_error(ArgumentError, /it is empty/)
     end
+
+    it 'creates a pcore resource type loader' do
+      pcore_loader = env.loaders.runtime3_type_loader.resource_3x_loader
+      expect(pcore_loader.loader_name).to eq('pcore_resource_types')
+      expect(pcore_loader).to be_a(Puppet::Pops::Loader::ModuleLoaders::FileBased)
+    end
+
+    it 'does not create a pcore resource type loader for an empty environment' do
+      loaders = Puppet::Pops::Loaders.new(empty_test_env)
+      expect(loaders.runtime3_type_loader.resource_3x_loader).to be_nil
+    end
   end
 
   def expect_loader_hierarchy(loaders, expected_loaders)


### PR DESCRIPTION
Previously, `puppet apply` failed if the manifest referenced a resource default,
and there existed pcore resource types for that resource in
`<env>/.resource_types/<type>.pp`. The resulting error was:

    Could not autoload puppet/type/applytest: Attempt to redefine entity

During compilation the Runtime3TypeLoader delegated to the pcore loader to load
the resource type from the <type>.pp file, and cached the resulting
PResourceType object in the Runtime3TypeLoader's cache.

Later during catalog compilation, the `Catalog#to_ral` method called the
metatype manager to autoload the resource type and register it with the
Runtime3TypeLoader. However, due to the already registered PResourceType object,
the above error was raised.

To fix this issue we could include the pcore loader during compilation, but
exclude it from catalog application. However, creating two hierarchies is slow.
Instead this commit modifies the apply application to disable the pcore loader,
so that the '<type>.pp' files are ignored. The autoloader will load types during
catalog compilation and those types will be reused during catalog application,
which is the same way puppet used to behave before the pcore loader was
introduced.
