### PR TITLE
(PUP-10547) Manage user rights on Windows

### DIFF
--- a/acceptance/tests/resource/user/should_manage_roles_on_windows.rb
+++ b/acceptance/tests/resource/user/should_manage_roles_on_windows.rb
@@ -1,0 +1,100 @@
+test_name "Manage roles for a Windows user" do
+  confine :to, :platform => 'windows'
+
+  tag 'audit:high',
+      'audit:acceptance'
+
+  require 'puppet/acceptance/windows_utils'
+  extend Puppet::Acceptance::WindowsUtils
+
+  def user_manifest(name, params)
+    params_str = params.map do |param, value|
+      value_str = value.to_s
+      value_str = "\"#{value_str}\"" if value.is_a?(String)
+
+      "  #{param} => #{value_str}"
+    end.join(",\n")
+
+    <<-MANIFEST
+user { '#{name}':
+  #{params_str}
+}
+MANIFEST
+  end
+
+  newUser = "tempUser#{rand(999999).to_i}"
+
+  teardown do
+    on(agent, puppet("resource user #{newUser} ensure=absent")) do |result|
+      assert_match(/User\[#{newUser}\]\/ensure: removed/, result.stdout)
+    end
+  end
+
+  agents.each do |agent|
+    step "Create a new user named #{newUser}" do
+      apply_manifest_on(agent, user_manifest(newUser, ensure: :present), expect_changes: true) do |result|
+        assert_match(/User\[#{newUser}\]\/ensure: created/, result.stdout)
+      end
+    end
+
+    step "Verify that a new user has no roles" do
+      on(agent, puppet("resource user #{newUser}")) do |result|
+        assert_no_match(/roles\s+=>/, result.stdout)
+      end
+    end
+
+    step "Verify that puppet can grant #{newUser} a right" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['SeServiceLogonRight']), expect_changes: true) do |result|
+        assert_match(/User\[#{newUser}\]\/roles: roles changed  to 'SeServiceLogonRight'/, result.stdout)
+      end
+    end
+
+    step "Verify that puppet can grant #{newUser} a privilege also" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['SeBackupPrivilege']), expect_changes: true) do |result|
+        assert_match(/User\[#{newUser}\]\/roles: roles changed SeServiceLogonRight to 'SeBackupPrivilege,SeServiceLogonRight'/, result.stdout)
+      end
+    end
+
+    step "Verify that puppet can not grant #{newUser} an invalid role" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['InvalidRoleName']), :acceptable_exit_codes => [4], catch_changes: true) do |result|
+        assert_match(/Calling `LsaAddAccountRights` returned 'Win32 Error Code 0x00000521'. One or more of the given rights\/privilleges are incorrect./, result.stderr)
+      end
+    end
+
+    step "Verify that puppet can remove all of #{newUser}'s roles when managing :roles as an empty array and :role_membership as inclusive" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: [], role_membership: :inclusive), expect_changes: true) do |result|
+        assert_match(/User\[#{newUser}\]\/roles: roles changed SeBackupPrivilege,SeServiceLogonRight to ''/, result.stdout)
+      end
+    end
+
+    step "Verify that puppet can grant #{newUser} more than one right at the same time" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['SeDenyServiceLogonRight', 'SeDenyBatchLogonRight']), expect_changes: true) do |result|
+        assert_match(/User\[#{newUser}\]\/roles: roles changed  to 'SeDenyBatchLogonRight,SeDenyServiceLogonRight'/, result.stdout)
+      end
+    end
+
+    step "Verify that :role_membership managed as minimum just appends given role to existing ones" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['SeBackupPrivilege'], role_membership: :minimum), expect_changes: true) do |result|
+        assert_match(/User\[#{newUser}\]\/roles: roles changed SeDenyServiceLogonRight,SeDenyBatchLogonRight to 'SeBackupPrivilege,SeDenyBatchLogonRight,SeDenyServiceLogonRight'/, result.stdout)
+      end
+    end
+
+    step "Verify that :roles noops when #{newUser} already has given role while managing :role_membership as minimum" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['SeBackupPrivilege'], role_membership: :minimum), catch_changes: true) do |result|
+        assert_no_match(/User\[#{newUser}\]\/roles: roles changed/, result.stdout)
+      end
+    end
+
+    step "Verify that while not managing :role_membership, the behaviour remains the same, with noop from :roles when #{newUser} already has the given role" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['SeBackupPrivilege']), catch_changes: true) do |result|
+        assert_no_match(/User\[#{newUser}\]\/roles: roles changed/, result.stdout)
+      end
+    end
+
+    step "Verify that while managing :role_membership as inclusive, #{newUser} remains only with the given roles" do
+      apply_manifest_on(agent, user_manifest(newUser, roles: ['SeBackupPrivilege', 'SeServiceLogonRight'], role_membership: :inclusive), expect_changes: true) do |result|
+        assert_match(/User\[#{newUser}\]\/roles: roles changed SeBackupPrivilege,SeDenyServiceLogonRight,SeDenyBatchLogonRight to 'SeBackupPrivilege,SeServiceLogonRight'/, result.stdout)
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -288,7 +288,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   # UNSUPPORTED
   #- **roles**
   #    The roles the user has.  Multiple roles should be
-  #    specified as an array.  Requires features manages_solaris_rbac.
+  #    specified as an array.  Requires features manages_roles.
   # UNSUPPORTED
   #- **key_membership**
   #    Whether specified key value pairs should be treated as the only

--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
     set("shell", value)
   end
 
-  has_features :manages_homedir, :allows_duplicates, :manages_solaris_rbac, :manages_passwords, :manages_password_age, :manages_shell
+  has_features :manages_homedir, :allows_duplicates, :manages_solaris_rbac, :manages_roles, :manages_passwords, :manages_password_age, :manages_shell
 
   def check_valid_shell
     unless File.exist?(@resource.should(:shell))

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -97,6 +97,18 @@ module Puppet
           return :absent
         end
       end
+
+      def sync
+        event = super
+
+        property = @resource.property(:roles)
+        if property
+          val = property.retrieve
+          property.sync unless property.safe_insync?(val)
+        end
+
+        event
+      end
     end
 
     newproperty(:home) do
@@ -520,7 +532,7 @@ module Puppet
       end
 
       reqs
-    end
+    end unless Puppet::Util::Platform.windows?
 
     newparam(:role_membership) do
       desc "Whether specified roles should be considered the **complete list**

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -40,7 +40,10 @@ module Puppet
        implement PBKDF2 passwords with salt properties."
 
     feature :manages_solaris_rbac,
-      "The provider can manage roles and normal users"
+      "The provider can manage normal users"
+
+    feature :manages_roles,
+      "The provider can manage roles"
 
     feature :manages_expiry,
       "The provider can manage the expiry date for a user."
@@ -505,7 +508,7 @@ module Puppet
       provider.exists?
     end
 
-    newproperty(:roles, :parent => Puppet::Property::List, :required_features => :manages_solaris_rbac) do
+    newproperty(:roles, :parent => Puppet::Property::List, :required_features => :manages_roles) do
       desc "The roles the user has.  Multiple roles should be
         specified as an array."
 

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -196,6 +196,20 @@ module Puppet::Util::Windows::APITypes
   FFI.typedef :uchar, :byte
   FFI.typedef :uint16, :wchar
 
+  # Definitions for data types used in LSA structures and functions
+  # https://docs.microsoft.com/en-us/windows/win32/api/ntsecapi/
+  # https://docs.microsoft.com/sr-latn-rs/windows/win32/secmgmt/management-data-types
+  FFI.typedef :pointer, :pwstr
+  FFI.typedef :pointer, :pulong
+  FFI.typedef :pointer, :lsa_handle
+  FFI.typedef :pointer, :plsa_handle
+  FFI.typedef :pointer, :psid
+  FFI.typedef :pointer, :pvoid
+  FFI.typedef :pointer, :plsa_unicode_string
+  FFI.typedef :pointer, :plsa_object_attributes
+  FFI.typedef :uint32,  :ntstatus
+  FFI.typedef :dword,   :access_mask
+
   module ::FFI::WIN32
     extend ::FFI::Library
 

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -215,5 +215,12 @@ describe "Puppet::Util::Windows::User", :if => Puppet::Util::Platform.windows? d
         expect(Puppet::Util::Windows::User.localsystem?('OtherUser')).to eq(false)
       end
     end
+
+    describe "get_rights" do
+      it "should be empty when given user does not exist" do
+        allow(Puppet::Util::Windows::SID).to receive(:name_to_principal).with('NonExistingUser').and_return(nil)
+        expect(Puppet::Util::Windows::User.get_rights('NonExistingUser')).to eq("")
+      end
+    end
   end
 end

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe Puppet::Type.type(:user) do
   before :each do
     @provider_class = described_class.provide(:simple) do
-      has_features :manages_expiry, :manages_password_age, :manages_passwords, :manages_solaris_rbac, :manages_shell
+      has_features :manages_expiry, :manages_password_age, :manages_passwords, :manages_solaris_rbac, :manages_roles, :manages_shell
       mk_resource_methods
       def create; end
       def delete; end
@@ -33,6 +33,10 @@ describe Puppet::Type.type(:user) do
 
   it "should have a manages_solaris_rbac feature" do
     expect(described_class.provider_feature(:manages_solaris_rbac)).not_to be_nil
+  end
+
+  it "should have a manages_roles feature" do
+    expect(described_class.provider_feature(:manages_roles)).not_to be_nil
   end
 
   it "should have a manages_expiry feature" do


### PR DESCRIPTION
This feature allows puppet to manage the rights and privileges of Windows users through the existing `roles` property. The accepted values are, as described in Microsoft documentation, certain constant names (https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-rights-assignment) which can be passed in an array or as a string when it is just one.

This property comes in pair with the `role_membership` parameter which offers better control over the desired state through the two supported values: `minimum` (default) and `inclusive`. When this parameter is set to `minimum`, the given roles are appended to the existing ones. When it is set to `inclusive`, managed user remains only with the given roles.  The `roles` property set to an empty array in combination with the `role_membership` set to `inclusive` can be used to remove all roles
of a user.