### PR TITLE
(PUP-2608) Return default file metadatas for builtin mounts

### DIFF
--- a/lib/puppet/file_serving/mount/locales.rb
+++ b/lib/puppet/file_serving/mount/locales.rb
@@ -16,14 +16,13 @@ class Puppet::FileServing::Mount::Locales < Puppet::FileServing::Mount
   def search(relative_path, request)
     # We currently only support one kind of search on locales - return
     # them all.
-    Puppet.debug("Warning: calling Locales.search with empty module path.") if request.environment.modules.empty?
     paths = request.environment.modules.find_all { |mod| mod.locales? }.collect { |mod| mod.locale_directory }
     if paths.empty?
       # If the modulepath is valid then we still need to return a valid root
       # directory for the search, but make sure nothing inside it is
       # returned.
       request.options[:recurse] = false
-      request.environment.modulepath.empty? ? nil : request.environment.modulepath
+      request.environment.modulepath.empty? ? [Puppet[:codedir]] : request.environment.modulepath
     else
       paths
     end

--- a/lib/puppet/file_serving/mount/pluginfacts.rb
+++ b/lib/puppet/file_serving/mount/pluginfacts.rb
@@ -16,14 +16,13 @@ class Puppet::FileServing::Mount::PluginFacts < Puppet::FileServing::Mount
   def search(relative_path, request)
     # We currently only support one kind of search on plugins - return
     # them all.
-    Puppet.debug("Warning: calling Plugins.search with empty module path.") if request.environment.modules.empty?
     paths = request.environment.modules.find_all { |mod| mod.pluginfacts? }.collect { |mod| mod.plugin_fact_directory }
     if paths.empty?
       # If the modulepath is valid then we still need to return a valid root
       # directory for the search, but make sure nothing inside it is
       # returned.
       request.options[:recurse] = false
-      request.environment.modulepath.empty? ? nil : request.environment.modulepath
+      request.environment.modulepath.empty? ? [Puppet[:codedir]] : request.environment.modulepath
     else
       paths
     end

--- a/lib/puppet/file_serving/mount/plugins.rb
+++ b/lib/puppet/file_serving/mount/plugins.rb
@@ -16,14 +16,13 @@ class Puppet::FileServing::Mount::Plugins < Puppet::FileServing::Mount
   def search(relative_path, request)
     # We currently only support one kind of search on plugins - return
     # them all.
-    Puppet.debug("Warning: calling Plugins.search with empty module path.") if request.environment.modules.empty?
     paths = request.environment.modules.find_all { |mod| mod.plugins? }.collect { |mod| mod.plugin_directory }
     if paths.empty?
       # If the modulepath is valid then we still need to return a valid root
       # directory for the search, but make sure nothing inside it is
       # returned.
       request.options[:recurse] = false
-      request.environment.modulepath.empty? ? nil : request.environment.modulepath
+      request.environment.modulepath.empty? ? [Puppet[:codedir]] : request.environment.modulepath
     else
       paths
     end

--- a/spec/unit/file_serving/mount/locales_spec.rb
+++ b/spec/unit/file_serving/mount/locales_spec.rb
@@ -52,13 +52,13 @@ describe Puppet::FileServing::Mount::Locales do
       expect(@mount.search("foo/bar", @request)).to eq(["/"])
     end
 
-    it "should return nil if no modules can be found that have locales and modulepath is invalid" do
+    it "should return the default search module path if no modules can be found that have locales and modulepath is invalid" do
       mod = double('module')
       allow(mod).to receive(:locales?).and_return(false)
 
       allow(@environment).to receive(:modules).and_return([])
       allow(@environment).to receive(:modulepath).and_return([])
-      expect(@mount.search("foo/bar", @request)).to be_nil
+      expect(@mount.search("foo/bar", @request)).to eq([Puppet[:codedir]])
     end
 
     it "should return the locale paths for each module that has locales" do

--- a/spec/unit/file_serving/mount/pluginfacts_spec.rb
+++ b/spec/unit/file_serving/mount/pluginfacts_spec.rb
@@ -52,13 +52,13 @@ describe Puppet::FileServing::Mount::PluginFacts do
       expect(@mount.search("foo/bar", @request)).to eq(["/"])
     end
 
-    it "should return nil if no modules can be found that have plugins and modulepath is invalid" do
+    it "should return the default search module path if no modules can be found that have plugins and modulepath is invalid" do
       mod = double('module')
       allow(mod).to receive(:pluginfacts?).and_return(false)
 
       allow(@environment).to receive(:modules).and_return([])
       allow(@environment).to receive(:modulepath).and_return([])
-      expect(@mount.search("foo/bar", @request)).to be_nil
+      expect(@mount.search("foo/bar", @request)).to eq([Puppet[:codedir]])
     end
 
     it "should return the plugin paths for each module that has plugins" do

--- a/spec/unit/file_serving/mount/plugins_spec.rb
+++ b/spec/unit/file_serving/mount/plugins_spec.rb
@@ -52,13 +52,13 @@ describe Puppet::FileServing::Mount::Plugins do
       expect(@mount.search("foo/bar", @request)).to eq(["/"])
     end
 
-    it "should return nil if no modules can be found that have plugins and modulepath is invalid" do
+    it "should return the default search module path if no modules can be found that have plugins and modulepath is invalid" do
       mod = double('module')
       allow(mod).to receive(:plugins?).and_return(false)
 
       allow(@environment).to receive(:modules).and_return([])
       allow(@environment).to receive(:modulepath).and_return([])
-      expect(@mount.search("foo/bar", @request)).to be_nil
+      expect(@mount.search("foo/bar", @request)).to eq([Puppet[:codedir]])
     end
 
     it "should return the plugin paths for each module that has plugins" do


### PR DESCRIPTION
Previously the agent printed an ugly warning if it tried to pluginsync, but the
server did not have any top-level module directories. The puppetserver packages
create several default module directories like `/etc/puppetlabs/code/modules`
so this doesn't often occur, though it used to occur with a newly installed
webrick puppet master in 4.x, and can occur if the directories are deleted.

The motivation for this change is because the server's file metadata response
should differentiate between the set of file metadata is empty versus missing.
The agent should fail in the latter case, but not the former.

This commit changes the `search` method for plugins,pluginfacts,locales mount
points to return the default path Puppet[:codedir] so that the file server
returns FileMetadata for that directory, which the agent will apply to its
:plugindest, :pluginfactsdest, :localedest puppet settings, respectively.

Also remove warning, which is logged at debug, but doesn't use the block form
so the strings are allocated for every pluginsync request.