### PR TITLE
(PUP-10599) skip local external facts on lookup

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -90,8 +90,14 @@ class Puppet::Application::Lookup < Puppet::Application
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?
 
-    Puppet.settings.use :main, :master, :ssl, :metrics
-
+    if options[:node]
+      Puppet::Util.skip_external_facts do
+        Puppet.settings.use :main, :master, :ssl, :metrics
+      end
+    else
+      Puppet.settings.use :main, :master, :ssl, :metrics
+    end
+    
     setup_terminuses
   end
 
@@ -364,6 +370,12 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
     Puppet[:code] = 'undef' unless options[:compile]
     compiler = Puppet::Parser::Compiler.new(node)
-    compiler.compile { |catalog| yield(compiler.topscope); catalog }
+    if options[:node]
+      Puppet::Util.skip_external_facts do 
+        compiler.compile { |catalog| yield(compiler.topscope); catalog }
+      end
+    else
+      compiler.compile { |catalog| yield(compiler.topscope); catalog }
+    end
   end
 end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -758,6 +758,19 @@ module Util
     Random.new(seed).rand(max)
   end
   module_function :deterministic_rand_int
+
+  # Executes a block of code, wrapped around Facter.load_external(false) and
+  # Facter.load_external(true) which will cause Facter to not evaluate external facts.
+  def skip_external_facts
+    return yield unless Facter.respond_to? :load_external
+    begin
+      Facter.load_external(false)
+      yield
+    ensure
+      Facter.load_external(true)
+    end
+  end
+  module_function :skip_external_facts
 end
 end
 

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -90,6 +90,19 @@ describe 'lookup' do
       expect(lookup('a')).to eql('value a')
     end
 
+    it 'loads external facts when running without --node' do
+      expect(Puppet::Util).not_to receive(:skip_external_facts)
+      expect(Facter).not_to receive(:load_external)
+      lookup('a')
+    end
+
+    it 'skip loading of external facts when run with --node' do
+      app.options[:node] = "random_node"
+      expect(Facter).to receive(:load_external).once.with(false)
+      expect(Facter).to receive(:load_external).once.with(true)
+      lookup('a')
+    end
+
     context 'uses node_terminus' do
       require 'puppet/indirector/node/exec'
       require 'puppet/indirector/node/plain'


### PR DESCRIPTION
Some puppet default settings required facter to retrieve the data which
caused facter to load all external facts that are not used. This can
slow down puppet if external facts are slow.

To disable loading of external facts, Facter.load_external(false) must be 
called before Facter starts resolving facts.
Puppet::Util.skip_external_facts should set Facter.load_external(false) 
before executing the block of code, and after that it sets Facter.load_external(true).