### PR TITLE
(maint) Clear registered termini instances after each test

### DIFF
--- a/lib/puppet/indirector/hiera.rb
+++ b/lib/puppet/indirector/hiera.rb
@@ -1,6 +1,10 @@
 require 'puppet/indirector/terminus'
 require 'hiera/scope'
 
+# This class can't be collapsed into Puppet::Indirector::DataBindings::Hiera
+# because some community plugins rely on this class directly, see PUP-1843.
+# This class is deprecated and will be deleted in a future release.
+# Use `Puppet::DataBinding.indirection.terminus(:hiera)` instead.
 class Puppet::Indirector::Hiera < Puppet::Indirector::Terminus
   def initialize(*args)
     if ! Puppet.features.hiera?

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -120,8 +120,11 @@ module Puppet::Test
       indirections = Puppet::Indirector::Indirection.send(:class_variable_get, :@@indirections)
       indirections.each do |indirector|
         $saved_indirection_state[indirector.name] = {
-            :@terminus_class => indirector.instance_variable_get(:@terminus_class),
-            :@cache_class    => indirector.instance_variable_get(:@cache_class)
+          :@terminus_class => indirector.instance_variable_get(:@terminus_class),
+          :@cache_class    => indirector.instance_variable_get(:@cache_class),
+          # dup the termini hash so termini created and registered during
+          # the test aren't stored in our saved_indirection_state
+          :@termini        => indirector.instance_variable_get(:@termini).dup
         }
       end
 

--- a/spec/integration/data_binding_spec.rb
+++ b/spec/integration/data_binding_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 require 'puppet_spec/compiler'
+require 'puppet/indirector/data_binding/hiera'
 
 describe "Data binding" do
   include PuppetSpec::Files

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -97,7 +97,8 @@ describe Puppet::Configurer do
     end
 
     it "should initialize a transaction report if one is not provided" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
+      # host and settings catalogs each create a report...
+      expect(Puppet::Transaction::Report).to receive(:new).and_return(report).twice
 
       configurer.run
     end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -197,11 +197,11 @@ describe Puppet::Configurer do
       expect(Puppet::Util::Log.destinations).not_to include(report)
     end
 
-    it "should return the report exit_status as the result of the run" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-      expect(report).to receive(:exit_status).and_return(1234)
+    it "should return an exit status of 2 due to the notify resource 'changing'" do
+      cat = Puppet::Resource::Catalog.new("tester", Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
+      cat.add_resource(Puppet::Type.type(:notify).new(:name => 'something changed'))
 
-      expect(configurer.run).to eq(1234)
+      expect(configurer.run(catalog: cat, report: report)).to eq(2)
     end
 
     it "should return nil if catalog application fails" do

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -192,9 +192,7 @@ describe Puppet::Configurer do
     end
 
     it "should remove the report as a log destination when the run is finished" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-
-      configurer.run
+      configurer.run(report: report)
 
       expect(Puppet::Util::Log.destinations).not_to include(report)
     end
@@ -207,7 +205,8 @@ describe Puppet::Configurer do
     end
 
     it "should return nil if catalog application fails" do
-      expect_any_instance_of(Puppet::Resource::Catalog).to receive(:apply).and_raise(Puppet::Error, 'One or more resource dependency cycles detected in graph')
+      expect(catalog).to receive(:apply).and_raise(Puppet::Error, 'One or more resource dependency cycles detected in graph')
+
       expect(configurer.run(catalog: catalog, report: report)).to be_nil
     end
 
@@ -222,34 +221,28 @@ describe Puppet::Configurer do
     end
 
     it "should include the pre-run command failure in the report" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
-      expect(configurer.run).to be_nil
+      expect(configurer.run(report: report)).to be_nil
       expect(report.logs.find { |x| x.message =~ /Could not run command from prerun_command/ }).to be
     end
 
     it "should send the transaction report even if the post-run command fails" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
       expect(configurer).to receive(:send_report).with(report)
 
-      expect(configurer.run).to be_nil
+      expect(configurer.run(report: report)).to be_nil
     end
 
     it "should include the post-run command failure in the report" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
       expect(report).to receive(:<<) { |log, _| expect(log.message).to match(/Could not run command from postrun_command/) }.at_least(:once)
 
-      expect(configurer.run).to be_nil
+      expect(configurer.run(report: report)).to be_nil
     end
 
     it "should execute post-run command even if the pre-run command fails" do
@@ -262,34 +255,28 @@ describe Puppet::Configurer do
     end
 
     it "should finalize the report" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-
       expect(report).to receive(:finalize_report)
-      configurer.run
+      configurer.run(report: report)
     end
 
     it "should not apply the catalog if the pre-run command fails" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-
       Puppet.settings[:prerun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
       expect_any_instance_of(Puppet::Resource::Catalog).not_to receive(:apply)
       expect(configurer).to receive(:send_report)
 
-      expect(configurer.run).to be_nil
+      expect(configurer.run(report: report)).to be_nil
     end
 
     it "should apply the catalog, send the report, and return nil if the post-run command fails" do
-      expect(Puppet::Transaction::Report).to receive(:new).and_return(report)
-
       Puppet.settings[:postrun_command] = "/my/command"
       expect(Puppet::Util::Execution).to receive(:execute).with(["/my/command"]).and_raise(Puppet::ExecutionFailure, "Failed")
 
       expect_any_instance_of(Puppet::Resource::Catalog).to receive(:apply)
       expect(configurer).to receive(:send_report)
 
-      expect(configurer.run).to be_nil
+      expect(configurer.run(report: report)).to be_nil
     end
 
     it 'includes total time metrics in the report after successfully applying the catalog' do

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -158,6 +158,7 @@ describe Puppet::SSL::Host do
 
       it "should not include defaults if we can't resolve our fqdn" do
         allow(Puppet::SSL::CertificateAuthority).to receive(:ca?).and_return(true)
+        allow(Facter).to receive(:value).and_call_original
         allow(Facter).to receive(:value).with(:fqdn).and_return(nil)
 
         expect(@cr).to receive(:generate).with(@key, {})
@@ -167,6 +168,7 @@ describe Puppet::SSL::Host do
 
       it "should provide defaults if we're bootstrapping the local master" do
         allow(Puppet::SSL::CertificateAuthority).to receive(:ca?).and_return(true)
+        allow(Facter).to receive(:value).and_call_original
         allow(Facter).to receive(:value).with(:fqdn).and_return('web.foo.com')
         allow(Facter).to receive(:value).with(:domain).and_return('foo.com')
 


### PR DESCRIPTION
Preserve the `@termini` hash before running each test so that it is restored at
the end. We have to duplicate the hash so that the saved copy isn't modified
during the test. The hash maps registered termini names (eg :processor) to
objects for each indirection (eg :report).

Prior to this, tests could reuse a terminus created and registered during an
earlier test. If the terminus' initialize method had side effects, like creating
a settings catalog, then those side effects could be skipped, causing the test
to fail, but not when run in isolation.