### PR TITLE
(PUP-10585) Allow transaction store to YAML load Time

### DIFF
--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -62,7 +62,7 @@ class Puppet::Transaction::Persistence
     result = nil
     Puppet::Util.benchmark(:debug, _("Loaded transaction store file in %{seconds} seconds")) do
       begin
-        result = Puppet::Util::Yaml.safe_load_file(filename, [Symbol])
+        result = Puppet::Util::Yaml.safe_load_file(filename, [Symbol, Time])
       rescue Puppet::Util::Yaml::YamlLoadError => detail
         Puppet.log_exception(detail, _("Transaction store file %{filename} is corrupt (%{detail}); replacing") % { filename: filename, detail: detail })
 

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -123,6 +123,21 @@ describe Puppet::Transaction::Persistence do
         persistence = Puppet::Transaction::Persistence.new
         persistence.load
       end
+
+      it 'should load Time and Symbols' do
+        write_state_file(<<~END)
+          File[/tmp/audit]:
+            parameters:
+              mtime:
+                system_value:
+                  - 2020-07-15 05:38:12.427678398 +00:00
+              ensure:
+                system_value:
+        END
+
+        persistence = Puppet::Transaction::Persistence.new
+        expect(persistence.load.dig("File[/tmp/audit]", "parameters", "mtime", "system_value")).to contain_exactly(be_a(Time))
+      end
     end
   end
 


### PR DESCRIPTION
Commit 0b6563eea09 allowed Puppet::Util::Storage to load Symbol and Time from
yaml, but only added Symbol to Puppet::Transaction::Persistence. As a result,
puppet would fail to load the transactionstore if it had stored a Time in the
prior run, issue a error and prevent puppet from reporting on corrective change.

Add Time to the allowed list of classes and add a test like the "should load
Time and Symbols" test in storage_spec.