### PR TITLE
(PUP-1763) Stop agent run if pluginsync fails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,8 @@ group(:development, :test) do
   gem 'addressable', '< 2.5.0'
   # webmock requires hashdiff which requires ruby 2 as of 0.3.9
   gem 'hashdiff', '0.3.8'
-  gem 'webmock', '~> 1.24'
-  gem 'vcr', '~> 2.9'
+  gem 'webmock', '~> 2.3'
+  gem 'vcr', '~> 5.0'
   gem "hiera-eyaml", *location_for(ENV['HIERA_EYAML_LOCATION'])
 
   gem 'memory_profiler', :platforms => [:mri_21, :mri_22, :mri_23, :mri_24, :mri_25]

--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -24,19 +24,25 @@ class Puppet::Configurer::Downloader
 
   def initialize(name, path, source, ignore = nil, environment = nil, source_permissions = :ignore)
     @name, @path, @source, @ignore, @environment, @source_permissions = name, path, source, ignore, environment, source_permissions
-  end
 
-  def catalog
-    catalog = Puppet::Resource::Catalog.new("PluginSync", @environment)
-    catalog.host_config = false
-    catalog.add_resource(file)
-    catalog
   end
 
   def file
-    args = default_arguments.merge(:path => path, :source => source)
-    args[:ignore] = ignore.split if ignore
-    Puppet::Type.type(:file).new(args)
+    unless @file
+      args = default_arguments.merge(:path => path, :source => source)
+      args[:ignore] = ignore.split if ignore
+      @file = Puppet::Type.type(:file).new(args)
+    end
+    @file
+  end
+
+  def catalog
+    unless @catalog
+      @catalog = Puppet::Resource::Catalog.new("PluginSync", @environment)
+      @catalog.host_config = false
+      @catalog.add_resource(file)
+    end
+    @catalog
   end
 
   private

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1894,7 +1894,6 @@ EOT
       is used for retrieval, so anything that is a valid file source can
       be used here.",
     },
-
     :pluginsync => {
       :default    => true,
       :type       => :boolean,
@@ -1908,6 +1907,13 @@ EOT
     :pluginsignore => {
         :default  => ".svn CVS .git .hg",
         :desc     => "What files to ignore when pulling down plugins.",
+    },
+    :ignore_plugin_errors => {
+      :default    => true,
+      :type       => :boolean,
+      :desc       => "Whether the puppet run should ignore errors during pluginsync. If the setting
+        is false and there are errors during pluginsync, then the agent will abort the run and
+        submit a report containing information about the failed run."
     }
   )
 

--- a/spec/integration/faces/plugin_spec.rb
+++ b/spec/integration/faces/plugin_spec.rb
@@ -1,59 +1,41 @@
 require 'spec_helper'
-require 'puppet/face'
-require 'puppet/file_serving/metadata'
-require 'puppet/file_serving/content'
-require 'puppet/indirector/memory'
+require 'webmock/rspec'
 
-module PuppetFaceIntegrationSpecs
 describe "Puppet plugin face" do
-  INDIRECTORS = [
-    Puppet::Indirector::FileMetadata,
-    Puppet::Indirector::FileContent,
-  ]
+  before :each do
+    metadata = "[{\"path\":\"/etc/puppetlabs/code\",\"relative_path\":\".\",\"links\":\"follow\",\"owner\":0,\"group\":0,\"mode\":420,\"checksum\":{\"type\":\"ctime\",\"value\":\"{ctime}2020-07-10 14:00:00 -0700\"},\"type\":\"directory\",\"destination\":null}]"
+    stub_request(:get, %r{/puppet/v3/file_metadatas/(plugins|locales)}).to_return(status: 200, body: metadata, headers: {'Content-Type' => 'application/json'})
 
-  INDIRECTED_CLASSES = [
-    Puppet::FileServing::Metadata,
-    Puppet::FileServing::Content,
-    Puppet::Node::Facts,
-  ]
-
-  INDIRECTORS.each do |indirector|
-    class indirector::Memory < Puppet::Indirector::Memory
-      def find(request)
-        model.new('/dev/null', { 'type' => 'directory' })
-      end
-    end
+    # response retains owner/group/mode due to source_permissions => use
+    facts_metadata = "[{\"path\":\"/etc/puppetlabs/code\",\"relative_path\":\".\",\"links\":\"follow\",\"owner\":500,\"group\":500,\"mode\":493,\"checksum\":{\"type\":\"ctime\",\"value\":\"{ctime}2020-07-10 14:00:00 -0700\"},\"type\":\"directory\",\"destination\":null}]"
+    stub_request(:get, %r{/puppet/v3/file_metadatas/pluginfacts}).to_return(status: 200, body: facts_metadata, headers: {'Content-Type' => 'application/json'})
   end
 
-  before do
-    FileUtils.mkdir(File.join(Puppet[:vardir], 'lib'))
-    FileUtils.mkdir(File.join(Puppet[:vardir], 'facts.d'))
-    FileUtils.mkdir(File.join(Puppet[:vardir], 'locales'))
-    @termini_classes = {}
-    INDIRECTED_CLASSES.each do |indirected|
-      @termini_classes[indirected] = indirected.indirection.terminus_class
-      indirected.indirection.terminus_class = :memory
-    end
+  it "processes a download request resulting in no changes" do
+    # /opt/puppetlabs/puppet/cache/facts.d will be created based on our umask.
+    # If the mode on disk is not 0755, then the mode from the metadata response
+    # (493 => 0755) will be applied, resulting in "plugins were downloaded"
+    # message. Enforce a umask so the results are consistent.
+    Puppet::FileSystem.mkpath(Puppet[:pluginfactdest])
+    Puppet::FileSystem.chmod(0755, Puppet[:pluginfactdest])
+
+    app = Puppet::Application[:plugin]
+    app.command_line.args << 'download'
+    expect {
+      app.run
+    }.to exit_with(0)
+      .and output(/No plugins downloaded/).to_stdout
   end
 
-  after do
-    INDIRECTED_CLASSES.each do |indirected|
-      indirected.indirection.terminus_class = @termini_classes[indirected]
-      indirected.indirection.termini.clear
-    end
-  end
+  it "updates the facts.d mode", unless: Puppet::Util::Platform.windows? do
+    Puppet::FileSystem.mkpath(Puppet[:pluginfactdest])
+    Puppet::FileSystem.chmod(0775, Puppet[:pluginfactdest])
 
-  def init_cli_args_and_apply_app(args = ["download"])
-    Puppet::Application.find(:plugin).new(double('command_line', :subcommand_name => :plugin, :args => args))
+    app = Puppet::Application[:plugin]
+    app.command_line.args << 'download'
+    expect {
+      app.run
+    }.to exit_with(0)
+     .and output(/Downloaded these plugins: .*facts\.d/).to_stdout
   end
-
-  it "processes a download request" do
-    app = init_cli_args_and_apply_app
-    expect do
-      expect {
-        app.run
-      }.to exit_with(0)
-    end.to have_printed(/No plugins downloaded/)
-  end
-end
 end

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -228,5 +228,15 @@ describe Puppet::Configurer::Downloader do
 
       expect { @dler.evaluate }.not_to raise_error
     end
+
+    it "raises an exception if catalog application fails" do
+      Puppet[:ignore_plugin_errors] = false
+
+      expect(@dler.file).to receive(:retrieve).and_raise(Puppet::Error, "testing")
+
+      expect {
+        @dler.evaluate
+      }.to raise_error(Puppet::Error, /testing/)
+    end
   end
 end


### PR DESCRIPTION
If an error occurs during pluginsync and `Puppet[:ignore_plugin_errors]` is
false, then stop the run, otherwise facts needed to compile the catalog and
types/providers needed to apply the catalog will be missing. The lack of facts
can cause compilation to fail, and the lack of type & providers can cause
application to fail, or worse data corruption due to mismatched versions of old
plugins and new catalogs or vice versa. To ensure backwards compatibility, the
setting defaults to true, so there is no change in current behavior, though the
default value will be changed to false in Puppet 7.

Part of the reason for the old behavior is that 4.x and earlier webrick-based
puppet master replied with HTTP 404 if it didn't have any modules installed with
at least one `lib` directory OR if the requested environment didn't exist. The
former is not an error, while the latter is. Had we changed the agent's behavior
earlier, then agents would fail until at least one module was installed on the
server.

Puppetserver 5.0 and above replies with HTTP 404 if none of the top-level
`modules` directories exist such as `/etc/puppetlabs/code/modules`, but it no
longer requires at least one module with a `lib` directory. The puppetserver
package creates several `modules` directories during installation, so HTTP 404
should only occur if the requested environment doesn't exist on the server.

This commit updates the downloader so it doesn't rescue errors that occur during
pluginsync for facts, lib and locales. This does mean that the agent will fail
fast during environment convergence, so it will never attempt to request a
catalog from a non-existent environment. This isn't an issue, because previously
the server rejected the agent's request in the indirected routes handler, before
the ENC had a chance to influence the agent's environment.

Blocked on PR #8221 