### PR TITLE
(maint) Use block form of Puppet.debug

### DIFF
--- a/lib/puppet/confine.rb
+++ b/lib/puppet/confine.rb
@@ -67,7 +67,7 @@ class Puppet::Confine
   def valid?
     values.each do |value|
       unless pass?(value)
-        Puppet.debug(label + ": " + message(value))
+        Puppet.debug { label + ": " + message(value) }
         return false
       end
     end

--- a/lib/puppet/confine/any.rb
+++ b/lib/puppet/confine/any.rb
@@ -19,7 +19,7 @@ class Puppet::Confine::Any < Puppet::Confine
     if @values.any? { |value| pass?(value) }
       true
     else
-      Puppet.debug("#{label}: #{message(@values)}")
+      Puppet.debug { "#{label}: #{message(@values)}" }
       false
     end
   end

--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -63,7 +63,7 @@ Puppet.features.add(:manages_symlinks) do
 
           true
         rescue LoadError
-          Puppet.debug("CreateSymbolicLink is not available")
+          Puppet.debug { "CreateSymbolicLink is not available" }
           false
         end
       end

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -54,12 +54,12 @@ class Puppet::FileSystem::FileImpl
     while !written
       ::File.open(path, options, mode) do |rf|
         if rf.flock(::File::LOCK_EX|::File::LOCK_NB)
-          Puppet.debug(_("Locked '%{path}'") % { path: path })
+          Puppet.debug{ _("Locked '%{path}'") % { path: path } }
           yield rf
           written = true
-          Puppet.debug(_("Unlocked '%{path}'") % { path: path })
+          Puppet.debug{ _("Unlocked '%{path}'") % { path: path } }
         else
-          Puppet.debug("Failed to lock '%s' retrying in %.2f milliseconds" % [path, wait * 1000])
+          Puppet.debug{ "Failed to lock '%s' retrying in %.2f milliseconds" % [path, wait * 1000] }
           sleep wait
           timeout -= wait
           wait *= 2

--- a/lib/puppet/gettext/config.rb
+++ b/lib/puppet/gettext/config.rb
@@ -65,7 +65,7 @@ module Puppet::GettextConfig
     return if @gettext_disabled || !gettext_loaded?
     domain_name = domain_name.to_sym
 
-    Puppet.debug "Reset text domain to #{domain_name.inspect}"
+    Puppet.debug { "Reset text domain to #{domain_name.inspect}" }
     FastGettext.add_text_domain(domain_name,
                                 type: :chain,
                                 chain: [],
@@ -115,10 +115,10 @@ module Puppet::GettextConfig
     domain_name = domain_name.to_sym
 
     if FastGettext.translation_repositories.include?(domain_name)
-      Puppet.debug "Use text domain #{domain_name.inspect}"
+      Puppet.debug { "Use text domain #{domain_name.inspect}" }
       FastGettext.text_domain = domain_name
     else
-      Puppet.debug "Requested unknown text domain #{domain_name.inspect}"
+      Puppet.debug { "Requested unknown text domain #{domain_name.inspect}" }
     end
   end
 
@@ -139,10 +139,10 @@ module Puppet::GettextConfig
 
     deleted = FastGettext.translation_repositories.delete(domain_name)
     if FastGettext.text_domain == domain_name
-      Puppet.debug "Deleted current text domain #{domain_name.inspect}: #{!deleted.nil?}"
+      Puppet.debug { "Deleted current text domain #{domain_name.inspect}: #{!deleted.nil?}" }
       FastGettext.text_domain = nil
     else
-      Puppet.debug "Deleted text domain #{domain_name.inspect}: #{!deleted.nil?}"
+      Puppet.debug { "Deleted text domain #{domain_name.inspect}: #{!deleted.nil?}" }
     end
   end
 

--- a/lib/puppet/gettext/module_translations.rb
+++ b/lib/puppet/gettext/module_translations.rb
@@ -13,9 +13,9 @@ module Puppet::ModuleTranslations
 
       module_name = mod.forge_name.tr('/', '-')
       if Puppet::GettextConfig.load_translations(module_name, mod.locale_directory, :po)
-        Puppet.debug "Loaded translations for #{module_name}."
+        Puppet.debug { "Loaded translations for #{module_name}." }
       elsif Puppet::GettextConfig.gettext_loaded?
-        Puppet.debug "Could not find translation files for #{module_name} at #{mod.locale_directory}. Skipping translation initialization."
+        Puppet.debug { "Could not find translation files for #{module_name} at #{mod.locale_directory}. Skipping translation initialization." }
       else
         Puppet.warn_once("gettext_unavailable", "gettext_unavailable", "No gettext library found, skipping translation initialization.")
       end
@@ -31,9 +31,9 @@ module Puppet::ModuleTranslations
     Dir.glob("#{vardir}/locales/#{locale}/*.po") do |f|
       module_name = File.basename(f, ".po")
       if Puppet::GettextConfig.load_translations(module_name, File.join(vardir, "locales"), :po)
-        Puppet.debug "Loaded translations for #{module_name}."
+        Puppet.debug { "Loaded translations for #{module_name}." }
       elsif Puppet::GettextConfig.gettext_loaded?
-        Puppet.debug "Could not load translations for #{module_name}."
+        Puppet.debug { "Could not load translations for #{module_name}." }
       else
         Puppet.warn_once("gettext_unavailable", "gettext_unavailable", "No gettext library found, skipping translation initialization.")
       end

--- a/lib/puppet/indirector/exec.rb
+++ b/lib/puppet/indirector/exec.rb
@@ -22,7 +22,7 @@ class Puppet::Indirector::Exec < Puppet::Indirector::Terminus
     end
 
     if output =~ /\A\s*\Z/ # all whitespace
-      Puppet.debug "Empty response for #{name} from #{self.name} terminus"
+      Puppet.debug { "Empty response for #{name} from #{self.name} terminus" }
       return nil
     else
       return output

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -55,7 +55,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       if Puppet::Util::Log.sendlevel?(:info)
         Puppet.info _("Loading facts")
         Dir.glob("#{dir}/*.rb").each do |file|
-          Puppet.debug "Loading facts from #{file}"
+          Puppet.debug { "Loading facts from #{file}" }
         end
       end
 
@@ -71,7 +71,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     request.environment.modules.each do |m|
       if m.has_external_facts?
         dir = m.plugin_fact_directory
-        Puppet.debug "Loading external facts from #{dir}"
+        Puppet.debug { "Loading external facts from #{dir}" }
         dirs << dir
       end
     end
@@ -79,7 +79,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     # Add system external fact directory if it exists
     if FileTest.directory?(Puppet[:pluginfactdest])
       dir = Puppet[:pluginfactdest]
-      Puppet.debug "Loading external facts from #{dir}"
+      Puppet.debug { "Loading external facts from #{dir}" }
       dirs << dir
     end
 

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -269,7 +269,7 @@ class Puppet::Indirector::Indirection
       return nil
     end
 
-    Puppet.debug "Using cached #{self.name} for #{request.key}"
+    Puppet.debug { "Using cached #{self.name} for #{request.key}" }
     cached
   rescue => detail
     Puppet.log_exception(detail, _("Cached %{indirection} for %{request} failed: %{detail}") % { indirection: self.name, request: request.key, detail: detail })

--- a/lib/puppet/indirector/report/processor.rb
+++ b/lib/puppet/indirector/report/processor.rb
@@ -26,9 +26,9 @@ class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
   # LAK:NOTE This isn't necessarily the best design, but it's backward
   # compatible and that's good enough for now.
   def process(report)
-    Puppet.debug "Received report to process from #{report.host}"
+    Puppet.debug { "Received report to process from #{report.host}" }
     processors do |mod|
-      Puppet.debug "Processing report from #{report.host} with processor #{mod}"
+      Puppet.debug { "Processing report from #{report.host} with processor #{mod}" }
       # We have to use a dup because we're including a module in the
       # report.
       newrep = report.dup

--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -107,8 +107,7 @@ class Puppet::Module
     define_method(type + '?') do
       type_subpath = subpath(location)
       unless Puppet::FileSystem.exist?(type_subpath)
-        Puppet.debug("No #{type} found in subpath '#{type_subpath}' " +
-                         "(file / directory does not exist)")
+        Puppet.debug { "No #{type} found in subpath '#{type_subpath}' (file / directory does not exist)" }
         return false
       end
 

--- a/lib/puppet/network/format_support.rb
+++ b/lib/puppet/network/format_support.rb
@@ -49,7 +49,7 @@ module Puppet::Network::FormatSupport
 
       result = put_preferred_format_first(result).map(&:name)
 
-      Puppet.debug "#{friendly_name} supports formats: #{result.join(' ')}"
+      Puppet.debug { "#{friendly_name} supports formats: #{result.join(' ')}" }
 
       result
     end
@@ -81,7 +81,7 @@ module Puppet::Network::FormatSupport
       }
 
       if preferred.empty?
-        Puppet.debug "Value of 'preferred_serialization_format' (#{preferred_format}) is invalid for #{friendly_name}, using default (#{list.first.name})"
+        Puppet.debug { "Value of 'preferred_serialization_format' (#{preferred_format}) is invalid for #{friendly_name}, using default (#{list.first.name})" }
       else
         list = preferred + list.reject { |format|
           format.mime.end_with?(preferred_format)

--- a/lib/puppet/network/http/route.rb
+++ b/lib/puppet/network/http/route.rb
@@ -67,11 +67,11 @@ class Puppet::Network::HTTP::Route
   end
 
   def matches?(request)
-    Puppet.debug("Evaluating match for #{self.inspect}")
+    Puppet.debug { "Evaluating match for #{self.inspect}" }
     if match(request.routing_path)
       return true
     else
-      Puppet.debug("Did not match path (#{request.routing_path.inspect})")
+      Puppet.debug { "Did not match path (#{request.routing_path.inspect})" }
     end
     return false
   end

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -335,9 +335,10 @@ class Puppet::Node::Environment
   # @param name [String] The directory name
   def warn_about_mistaken_path(path, name)
     if name == "lib"
-      Puppet.debug("Warning: Found directory named 'lib' in module path ('#{path}/lib'); unless " +
-          "you are expecting to load a module named 'lib', your module path may be set " +
-          "incorrectly.")
+      Puppet.debug {
+        "Warning: Found directory named 'lib' in module path ('#{path}/lib'); unless you \
+        are expecting to load a module named 'lib', your module path may be set incorrectly."
+      }
     end
   end
 

--- a/lib/puppet/parameter.rb
+++ b/lib/puppet/parameter.rb
@@ -429,7 +429,7 @@ class Puppet::Parameter
     begin
       ret = unsafe_munge(value)
     rescue Puppet::Error => detail
-      Puppet.debug "Reraising #{detail}"
+      Puppet.debug { "Reraising #{detail}" }
       raise
     rescue => detail
       raise Puppet::DevError, _("Munging failed for value %{value} in class %{class_name}: %{detail}") % { value: value.inspect, class_name: self.name, detail: detail }, detail.backtrace

--- a/lib/puppet/parser/type_loader.rb
+++ b/lib/puppet/parser/type_loader.rb
@@ -81,7 +81,7 @@ class Puppet::Parser::TypeLoader
   end
 
   def parse_file(file)
-    Puppet.debug("importing '#{file}' in environment #{environment}")
+    Puppet.debug { "importing '#{file}' in environment #{environment}" }
     parser = Puppet::Parser::ParserFactory.parser
     parser.file = file
     return parser.parse
@@ -118,7 +118,7 @@ class Puppet::Parser::TypeLoader
         # still be parsed. Mark this file as loaded so that
         # it would not be parsed next time (handle it as if
         # it was successfully parsed).
-        Puppet.debug("Unable to parse '#{file}': #{e.message}")
+        Puppet.debug { "Unable to parse '#{file}': #{e.message}" }
       end
     else
       loaded_asts << parse_file(file)

--- a/lib/puppet/pops/lookup/context.rb
+++ b/lib/puppet/pops/lookup/context.rb
@@ -47,7 +47,7 @@ class EnvironmentContext < Adaptable::Adapter
     file_data = @file_data_cache[path]
     stat = Puppet::FileSystem.stat(path)
     unless file_data && file_data.valid?(stat)
-      Puppet.debug("File at '#{path}' was changed, reloading") if file_data
+      Puppet.debug { "File at '#{path}' was changed, reloading" } if file_data
       content = Puppet::FileSystem.read(path, :encoding => 'utf-8')
       file_data = FileData.new(path, stat.ino, stat.mtime, stat.size, block_given? ? yield(content) : content)
       @file_data_cache[path] = file_data

--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -126,7 +126,7 @@ Puppet::Type.type(:file).provide :windows do
           # If the SYSTEM account does _not_ have FullControl in this scenario, we should
           # force the resource out of sync no matter what.
           #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-          Puppet.debug _("%{resource_name}: %{mode_part_type} set to SYSTEM. SYSTEM permissions cannot be set below FullControl ('7')") % { resource_name: resource[:name], mode_part_type: mode_part['type']}
+          Puppet.debug { _("%{resource_name}: %{mode_part_type} set to SYSTEM. SYSTEM permissions cannot be set below FullControl ('7')") % { resource_name: resource[:name], mode_part_type: mode_part['type']} }
           return nil
         end
       end

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1058,7 +1058,7 @@ Generated on #{Time.now}.
 
     return if sections.empty?
 
-    Puppet.debug("Applying settings catalog for sections #{sections.join(', ')}")
+    Puppet.debug { "Applying settings catalog for sections #{sections.join(', ')}" }
 
     begin
       catalog = to_catalog(*sections).to_ral

--- a/lib/puppet/ssl/validator/default_validator.rb
+++ b/lib/puppet/ssl/validator/default_validator.rb
@@ -104,7 +104,7 @@ class Puppet::SSL::Validator::DefaultValidator #< class Puppet::SSL::Validator
         crl = store_context.current_crl
         if crl
           if crl.last_update && crl.last_update < Time.now + FIVE_MINUTES_AS_SECONDS
-            Puppet.debug("Ignoring CRL not yet valid, current time #{Time.now.utc}, CRL last updated #{crl.last_update.utc}")
+            Puppet.debug { "Ignoring CRL not yet valid, current time #{Time.now.utc}, CRL last updated #{crl.last_update.utc}" }
             preverify_ok = true
           else
             @verify_errors << "#{error_string} for #{crl.issuer.to_utf8}"

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -202,7 +202,7 @@ class Puppet::Transaction
     # mark the end of transaction evaluate.
     report.transaction_completed = true
 
-    Puppet.debug "Finishing transaction #{object_id}"
+    Puppet.debug { "Finishing transaction #{object_id}" }
   end
 
   # Wraps application run state check to flag need to interrupt processing
@@ -373,7 +373,7 @@ class Puppet::Transaction
     type_name = provider_class.resource_type.name
     return if @prefetched_providers[type_name][provider_class.name] ||
       @prefetch_failed_providers[type_name][provider_class.name]
-    Puppet.debug "Prefetching #{provider_class.name} resources for #{type_name}"
+    Puppet.debug { "Prefetching #{provider_class.name} resources for #{type_name}" }
     begin
       provider_class.prefetch(resources)
     rescue LoadError, Puppet::MissingCommand => detail

--- a/lib/puppet/trusted_external.rb
+++ b/lib/puppet/trusted_external.rb
@@ -3,7 +3,7 @@ module Puppet::TrustedExternal
   def retrieve(certname)
     command = Puppet[:trusted_external_command]
     return nil unless command
-    Puppet.debug _("Retrieving trusted external data from %{command}") % {command: command}
+    Puppet.debug { _("Retrieving trusted external data from %{command}") % {command: command} }
     setting_type = Puppet.settings.setting(:trusted_external_command).type
     if setting_type == :file
       return fetch_data(command, certname)
@@ -17,7 +17,7 @@ module Puppet::TrustedExternal
       abs_path = Puppet::FileSystem.expand_path(file)
       executable_file = Puppet::FileSystem.file?(abs_path) && Puppet::FileSystem.executable?(abs_path)
       unless executable_file
-        Puppet.debug _("Skipping non-executable file %{file}")  % { file: abs_path }
+        Puppet.debug { _("Skipping non-executable file %{file}")  % { file: abs_path } }
         next
       end
       basename = file.basename(file.extname).to_s

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1212,8 +1212,9 @@ class Type
         title = instance.respond_to?(:title) ? instance.title : instance.name
         other = provider_instances[title]
         if other
-          Puppet.debug "%s %s found in both %s and %s; skipping the %s version" %
-            [self.name.to_s.capitalize, title, other.class.name, instance.class.name, instance.class.name]
+          Puppet.debug {
+            "%s %s found in both %s and %s; skipping the %s version" % [self.name.to_s.capitalize, title, other.class.name, instance.class.name, instance.class.name]
+          }
           next
         end
         provider_instances[title] = instance
@@ -1895,7 +1896,7 @@ end
     name = name.intern
 
     if unprovide(name)
-      Puppet.debug "Reloading #{name} #{self.name} provider"
+      Puppet.debug { "Reloading #{name} #{self.name} provider" }
     end
 
     pname = options[:parent]

--- a/lib/puppet/util/character_encoding.rb
+++ b/lib/puppet/util/character_encoding.rb
@@ -19,8 +19,9 @@ module Puppet::Util::CharacterEncoding
       begin
         if original_encoding == Encoding::UTF_8
           if !string_copy.valid_encoding?
-            Puppet.debug(_("%{value} is already labeled as UTF-8 but this encoding is invalid. It cannot be transcoded by Puppet.") %
-              { value: string.dump })
+            Puppet.debug {
+              _("%{value} is already labeled as UTF-8 but this encoding is invalid. It cannot be transcoded by Puppet.") % { value: string.dump }
+            }
           end
           # String is already valid UTF-8 - noop
           return string_copy
@@ -40,8 +41,9 @@ module Puppet::Util::CharacterEncoding
         # Catch both our own self-determined failure to transcode as well as any
         # error on ruby's part, ie Encoding::UndefinedConversionError on a
         # failure to encode!.
-        Puppet.debug(_("%{error}: %{value} cannot be transcoded by Puppet.") %
-          { error: detail.inspect, value: string.dump })
+        Puppet.debug {
+          _("%{error}: %{value} cannot be transcoded by Puppet.") % { error: detail.inspect, value: string.dump }
+        }
         return string_copy
       end
     end
@@ -67,7 +69,9 @@ module Puppet::Util::CharacterEncoding
       if string_copy.force_encoding(Encoding::UTF_8).valid_encoding?
         return string_copy
       else
-        Puppet.debug(_("%{value} is not valid UTF-8 and result of overriding encoding would be invalid.") % { value: string.dump })
+        Puppet.debug {
+          _("%{value} is not valid UTF-8 and result of overriding encoding would be invalid.") % { value: string.dump }
+        }
         # Set copy back to its original encoding before returning
         return string_copy.force_encoding(original_encoding)
       end

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -68,7 +68,7 @@ module Puppet::Util::Execution
     if respond_to? :debug
       debug "Executing '#{command_str}'"
     else
-      Puppet.debug "Executing '#{command_str}'"
+      Puppet.debug { "Executing '#{command_str}'" }
     end
 
     # force the run of the command with
@@ -186,7 +186,7 @@ module Puppet::Util::Execution
     if respond_to? :debug
       debug "Executing#{user_log_s}: '#{command_str}'"
     else
-      Puppet.debug "Executing#{user_log_s}: '#{command_str}'"
+      Puppet.debug { "Executing#{user_log_s}: '#{command_str}'" }
     end
 
     null_file = Puppet::Util::Platform.windows? ? 'NUL' : '/dev/null'

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -60,7 +60,7 @@ module Puppet::Util::Windows::APITypes
 
       str.encode(dst_encoding, str.encoding, encode_options)
     rescue EncodingError => e
-      Puppet.debug "Unable to convert value #{str.nil? ? 'nil' : str.dump} to encoding #{dst_encoding} due to #{e.inspect}"
+      Puppet.debug { "Unable to convert value #{str.nil? ? 'nil' : str.dump} to encoding #{dst_encoding} due to #{e.inspect}" }
       raise
     end
 

--- a/lib/puppet/util/windows/security.rb
+++ b/lib/puppet/util/windows/security.rb
@@ -340,10 +340,10 @@ module Puppet::Util::Windows::Security
           Puppet.warning _("Setting control rights for %{path} owner SYSTEM to less than Full Control rights. Setting SYSTEM rights to less than Full Control may have unintented consequences for operations on this file") % { path: path }
         elsif managing_owner && isownergroup
           #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-          Puppet.debug _("%{path} owner and group both set to user SYSTEM, but group is not managed directly: SYSTEM user rights will be set to FullControl by group") % { path: path }
+          Puppet.debug { _("%{path} owner and group both set to user SYSTEM, but group is not managed directly: SYSTEM user rights will be set to FullControl by group") % { path: path } }
         else
           #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-          Puppet.debug _("An attempt to set mode %{mode} on item %{path} would result in the owner, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
+          Puppet.debug { _("An attempt to set mode %{mode} on item %{path} would result in the owner, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path } }
           owner_allow = FILE::FILE_ALL_ACCESS
         end
       end
@@ -356,10 +356,10 @@ module Puppet::Util::Windows::Security
           Puppet.warning _("Setting control rights for %{path} group SYSTEM to less than Full Control rights. Setting SYSTEM rights to less than Full Control may have unintented consequences for operations on this file") % { path: path }
         elsif managing_group && isownergroup
           #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-          Puppet.debug _("%{path} owner and group both set to user SYSTEM, but owner is not managed directly: SYSTEM user rights will be set to FullControl by owner") % { path: path }
+          Puppet.debug { _("%{path} owner and group both set to user SYSTEM, but owner is not managed directly: SYSTEM user rights will be set to FullControl by owner") % { path: path } }
         else
           #TRANSLATORS 'SYSTEM' is a Windows name and should not be translated
-          Puppet.debug _("An attempt to set mode %{mode} on item %{path} would result in the group, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path }
+          Puppet.debug { _("An attempt to set mode %{mode} on item %{path} would result in the group, SYSTEM, to have less than Full Control rights. This attempt has been corrected to Full Control") % { mode: mode.to_s(8), path: path } }
           group_allow = FILE::FILE_ALL_ACCESS
         end
       end

--- a/spec/unit/confine_spec.rb
+++ b/spec/unit/confine_spec.rb
@@ -54,10 +54,11 @@ describe Puppet::Confine do
     end
 
     it "should log failing confines with the label and message" do
+      Puppet[:log_level] = 'debug'
       allow(@confine).to receive(:pass?).and_return(false)
       expect(@confine).to receive(:message).and_return("My message")
       expect(@confine).to receive(:label).and_return("Mylabel")
-      expect(Puppet).to receive(:debug).with("Mylabel: My message")
+      expect(Puppet).to receive(:debug) { |&b| expect(b.call).to eq("Mylabel: My message") }
       @confine.valid?
     end
   end

--- a/spec/unit/network/format_support_spec.rb
+++ b/spec/unit/network/format_support_spec.rb
@@ -67,8 +67,9 @@ describe Puppet::Network::FormatHandler do
       end
 
       it "should log a debug message" do
-        expect(Puppet).to receive(:debug).with("Value of 'preferred_serialization_format' (unsupported) is invalid for FormatTester, using default (two)")
-        expect(Puppet).to receive(:debug).with("FormatTester supports formats: two one")
+        Puppet[:log_level] = 'debug'
+        expect(Puppet).to receive(:debug) { |&b| expect(b.call).to eq("Value of 'preferred_serialization_format' (unsupported) is invalid for FormatTester, using default (two)") }
+        expect(Puppet).to receive(:debug) { |&b| expect(b.call).to eq("FormatTester supports formats: two one") }
         FormatTester.supported_formats
       end
     end

--- a/spec/unit/util/character_encoding_spec.rb
+++ b/spec/unit/util/character_encoding_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Util::CharacterEncoding do
         let(:invalid_utf8_string) { "\xfd\xf1".force_encoding(Encoding::UTF_8) }
 
         it "should issue a debug message" do
-          expect(Puppet).to receive(:debug).with(/encoding is invalid/)
+          expect(Puppet).to receive(:debug) { |&b| expect(b.call).to match(/encoding is invalid/) }
           Puppet::Util::CharacterEncoding.convert_to_utf_8(invalid_utf8_string)
         end
 
@@ -80,7 +80,7 @@ describe Puppet::Util::CharacterEncoding do
         end
 
         it "should issue a debug message that the string was not transcodable" do
-          expect(Puppet).to receive(:debug).with(/cannot be transcoded/)
+          expect(Puppet).to receive(:debug) { |&b| expect(b.call).to match(/cannot be transcoded/) }
           PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::Windows_31J) do
             Puppet::Util::CharacterEncoding.convert_to_utf_8(invalid_win_31j)
           end
@@ -124,7 +124,7 @@ describe Puppet::Util::CharacterEncoding do
           let(:euc_kr) { [253, 241].pack('C*').force_encoding(Encoding::ASCII) }
 
           it "should issue a debug message" do
-            expect(Puppet).to receive(:debug).with(/cannot be transcoded/)
+            expect(Puppet).to receive(:debug) { |&b| expect(b.call).to match(/cannot be transcoded/) }
             Puppet::Util::CharacterEncoding.convert_to_utf_8(euc_kr)
           end
 
@@ -168,7 +168,7 @@ describe Puppet::Util::CharacterEncoding do
       let(:foo) { 'foo' }
 
       it "should issue a debug message" do
-        expect(Puppet).to receive(:debug).with(/not valid UTF-8/)
+        expect(Puppet).to receive(:debug) { |&b| expect(b.call).to match(/not valid UTF-8/) }
         Puppet::Util::CharacterEncoding.override_encoding_to_utf_8(oslash)
       end
 


### PR DESCRIPTION
Prefer the block form of `Puppet.debug` when passing an interpolated message, so
that the interpolation can be avoided when running in non-debug. This is similar
to commit 2d0d7333b, but includes server-side puppet code that is called on
every request, such as features, confines, gettext, network formats and route
matching. It also updates file system and Windows code paths that are triggered
for every file resource.