### PR TITLE
(PUP-10490) Drop httpclient gem dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
-  s.add_runtime_dependency(%q<httpclient>, "~> 2.8")
   s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
   s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -23,7 +23,6 @@ gem_runtime_dependencies:
   fast_gettext: '~> 1.1'
   locale: '~> 2.1'
   multi_json: '~> 1.10'
-  httpclient: '~> 2.8'
   puppet-resource_api: '~>1.5'
   concurrent-ruby: '~> 1.0'
   deep_merge: '~> 1.0'


### PR DESCRIPTION
We ended up not using the httpclient gem, drop it for now.