### PR TITLE
(maint) Fix service assertions in acceptance

### DIFF
--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -83,8 +83,8 @@ module Puppet
       # @param block [Proc] optional: block to verify service state
       # @return None
       def assert_service_status_on_host(host, service, status, &block)
-        ensure_status = "ensure => '#{status[:ensure]}'" if status[:ensure]
-        enable_status = "enable => '#{status[:enable]}'" if status[:enable]
+        ensure_status = "ensure.+=> '#{status[:ensure]}'" if status[:ensure]
+        enable_status = "enable.+=> '#{status[:enable]}'" if status[:enable]
 
         on host, puppet_resource('service', service) do
           assert_match(/'#{service}'.+#{ensure_status}.+#{enable_status}/m, stdout, "Service status does not match expectation #{status}")

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -84,7 +84,7 @@ SCRIPT
   step "Start the service on #{agent} when service is stopped, and check outoput" do
     on agent, puppet_resource('service', svc, 'ensure=stopped')
     on agent, puppet_resource('service', svc, 'ensure=running') do |result|
-      assert_match(/service { '#{svc}':\n  ensure => 'running',\n}$/, stdout, 'Service status change failed')
+      assert_match(/service { '#{svc}':\n  ensure.+=> 'running',\n}$/, stdout, 'Service status change failed')
     end
   end
 
@@ -92,7 +92,7 @@ SCRIPT
   step "Start the service on #{agent} when service is running, and check outoput" do
     on agent, puppet_resource('service', svc, 'ensure=running')
     on agent, puppet_resource('service', svc, 'ensure=stopped') do |result|
-      assert_match(/service { '#{svc}':\n  ensure => 'stopped',\n}$/, stdout, 'Service status change failed')
+      assert_match(/service { '#{svc}':\n  ensure.+=> 'stopped',\n}$/, stdout, 'Service status change failed')
     end
   end
 

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -45,7 +45,7 @@ test_name "SMF: basic tests" do
 
     step "SMF: ensure you can query the service with the ral" do
       on(agent, puppet("resource service tstapp")) do
-        assert_match( /ensure => 'running'/, result.stdout, "err: #{agent}")
+        assert_match( /ensure.+=> 'running'/, result.stdout, "err: #{agent}")
       end
     end
 

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -78,8 +78,8 @@ agents.each do |agent|
   step "Masking the #{package_name[platform]} service"
   apply_manifest_on(agent, manifest_service_masked, :catch_failures => true)
   on(agent, puppet_resource('service', package_name[platform])) do
-    assert_match(/ensure => 'stopped'/, stdout, "Expected #{package_name[platform]} service to be stopped")
-    assert_match(/enable => 'false'/, stdout, "Expected #{package_name[platform]} service to be masked")
+    assert_match(/ensure.+=> 'stopped'/, stdout, "Expected #{package_name[platform]} service to be stopped")
+    assert_match(/enable.+=> 'false'/, stdout, "Expected #{package_name[platform]} service to be masked")
     on(agent, "readlink #{masked_symlink_systemd}") do
       assert_equal('/dev/null', stdout.chomp, "Expected service symlink to point to /dev/null")
     end
@@ -88,8 +88,8 @@ agents.each do |agent|
   step "Enabling the #{package_name[platform]} service"
   apply_manifest_on(agent, manifest_service_enabled, :catch_failures => true)
   on(agent, puppet_resource('service', package_name[platform])) do
-    assert_match(/ensure => 'running'/, stdout, "Expected #{package_name[platform]} service to be running")
-    assert_match(/enable => 'true'/, stdout, "Expected #{package_name[platform]} service to be enabled")
+    assert_match(/ensure.+=> 'running'/, stdout, "Expected #{package_name[platform]} service to be running")
+    assert_match(/enable.+=> 'true'/, stdout, "Expected #{package_name[platform]} service to be enabled")
     on(agent, "readlink #{symlink_systemd}") do
       assert_equal(init_script_systemd, stdout.chomp, "Expected service symlink to point to systemd init script")
     end


### PR DESCRIPTION
This came up when runnning all acceptance tests for Ruby 2.7. We have additional spaces in the `puppet resource` output due to a param with a longer name, so update the assertions to match that.