### PR TITLE
(PUP-10590) Remove win32-process gem dependency

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -41,7 +41,6 @@ gem_platform_dependencies:
       ffi: ['> 1.9.24', '< 2']
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
-      win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'
@@ -51,7 +50,6 @@ gem_platform_dependencies:
       ffi: ['> 1.9.24', '< 2']
       # win32-xxxx gems are pinned due to PUP-6445
       win32-dir: '= 0.4.9'
-      win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       win32-service: '= 0.8.8'


### PR DESCRIPTION
This commit updates `project_data.yaml` to align with the win32-process
gem removal.

Depends on #8204 