### PR TITLE
(PUP-7446) Remove win32-service gem dependency

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -44,7 +44,6 @@ gem_platform_dependencies:
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
-      win32-service: '= 0.8.8'
       minitar: '~> 0.9'
   x64-mingw32:
     gem_runtime_dependencies:
@@ -54,7 +53,6 @@ gem_platform_dependencies:
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
-      win32-service: '= 0.8.8'
       minitar: '~> 0.9'
 bundle_platforms:
   universal-darwin: all


### PR DESCRIPTION
This commit updates project_data.yaml to align with the win32-service
gem removal.

Depends on #8194