### PR TITLE
(PUP-10609) Fix zypper ensure version

### DIFF
--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -187,6 +187,9 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
     if should.is_a?(String)
       begin
         should_version = Puppet::Util::Package::Version::Range.parse(should, Puppet::Util::Package::Version::Rpm)
+        if should_version.is_a?(RPM_VERSION_RANGE::Eq)
+          return super
+        end
       rescue Puppet::Util::Package::Version::Range::ValidationFailure, Puppet::Util::Package::Version::Rpm::ValidationFailure
         Puppet.debug("Cannot parse #{should} as a RPM version range")
         return super

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -309,5 +309,19 @@ describe Puppet::Type.type(:package).provider(:zypper) do
 
       it { is_expected.to be false }
     end
+
+    context 'when using eq range' do
+      context 'when ensure without release' do
+        before { allow(@resource).to receive(:[]).with(:ensure).and_return('1.19') }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when ensure with release' do
+        before { allow(@resource).to receive(:[]).with(:ensure).and_return('1.19-2') }
+
+        it { is_expected.to be true }
+      end
+    end
   end
 end


### PR DESCRIPTION
When a version without release is set, zypper
should rely on the rpm comparision, same as yum.