### PR TITLE
(PE-29443) Avoid hash order dependency in deserialization

### DIFF
--- a/lib/puppet/pops/serialization/from_data_converter.rb
+++ b/lib/puppet/pops/serialization/from_data_converter.rb
@@ -154,10 +154,10 @@ module Serialization
         if pcore_type && (pcore_type.is_a?(String) || pcore_type.is_a?(Hash))
           @pcore_type_procs[pcore_type].call(value, pcore_type)
         else
-          build({}) { value.each_pair { |key, elem| with(key) { convert(elem) }}}
+          build(value) { value.each_pair { |key, elem| with(key) { convert(elem) }}}
         end
       elsif value.is_a?(Array)
-        build([]) { value.each_with_index { |elem, idx| with(idx) { convert(elem)}}}
+        build(value) { value.each_with_index { |elem, idx| with(idx) { convert(elem)}}}
       else
         build(value)
       end


### PR DESCRIPTION
Without this change the "order" of deserializtion matters. Local References that are out of order are unable to be resolved.