### PR TITLE
(maint) Update corrective_change reader's docs in the report object

### DIFF
--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -122,7 +122,7 @@ class Puppet::Transaction::Report
 
   # @!attribute [r] corrective_change
   #   @return [Boolean] true if the report contains any events and resources that had
-  #      corrective changes.
+  #      corrective changes, including noop corrective changes.
   attr_reader :corrective_change
 
   # @return [Boolean] true if one or more resources attempted to generate


### PR DESCRIPTION
This updates the reader's docs to mention that it also includes noop
corrective changes.

Signed-off-by: Enis Inan <enis.inan@puppet.com>