### PR TITLE
(PUP-6184) Remove win32/dir usage

### DIFF
--- a/acceptance/lib/puppet/acceptance/windows_utils.rb
+++ b/acceptance/lib/puppet/acceptance/windows_utils.rb
@@ -9,7 +9,7 @@ module Puppet
       def profile_base(agent)
         ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
         getbasedir = <<'END'
-require 'win32/dir'
+require 'puppet/util/windows/monkey_patches/dir'
 puts Dir::PROFILE.match(/(.*)\\\\[^\\\\]*/)[1]
 END
         on(agent, "#{ruby} -e \"#{getbasedir}\"").stdout.chomp

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -39,14 +39,10 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       ffi: ['> 1.9.24', '< 2']
-      # Use of win32-security is deprecated
-      win32-security: '= 0.2.5'
       minitar: '~> 0.9'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: ['> 1.9.24', '< 2']
-      # Use of win32-security is deprecated
-      win32-security: '= 0.2.5'
       minitar: '~> 0.9'
 bundle_platforms:
   universal-darwin: all

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -39,16 +39,12 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       ffi: ['> 1.9.24', '< 2']
-      # win32-xxxx gems are pinned due to PUP-6445
-      win32-dir: '= 0.4.9'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       minitar: '~> 0.9'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: ['> 1.9.24', '< 2']
-      # win32-xxxx gems are pinned due to PUP-6445
-      win32-dir: '= 0.4.9'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
       minitar: '~> 0.9'

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -2,7 +2,6 @@
 
 require 'fileutils'
 require 'puppet/util/windows/daemon'
-require 'win32/dir'
 
 # This file defines utilities for logging to eventlog. While it lives inside
 # Puppet, it is completely independent and loads no other parts of Puppet, so we
@@ -11,6 +10,9 @@ require 'puppet/util/windows/eventlog'
 
 # monkey patches ruby Process to add .create method
 require 'puppet/util/windows/monkey_patches/process'
+
+# monkey patch Dir to add constants
+require 'puppet/util/windows/monkey_patches/dir'
 
 class WindowsDaemon < Puppet::Util::Windows::Daemon
   CREATE_NEW_CONSOLE          = 0x00000010

--- a/install.rb
+++ b/install.rb
@@ -242,16 +242,10 @@ def prepare_installation
     $operatingsystem = Facter.value :operatingsystem
   end
 
-  if $operatingsystem == "windows"
-    # TODO check if this can be required here
-    # may need to change to require_relative
-    require 'puppet/util/windows/monkey_patches/dir'
-  end
-
   if not InstallOptions.configdir.nil?
     configdir = InstallOptions.configdir
   elsif $operatingsystem == "windows"
-    configdir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "etc")
+    configdir = File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "etc")
   else
     configdir = "/etc/puppetlabs/puppet"
   end
@@ -259,7 +253,7 @@ def prepare_installation
   if not InstallOptions.codedir.nil?
     codedir = InstallOptions.codedir
   elsif $operatingsystem == "windows"
-    codedir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "code")
+    codedir = File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "code")
   else
     codedir = "/etc/puppetlabs/code"
   end
@@ -267,7 +261,7 @@ def prepare_installation
   if not InstallOptions.vardir.nil?
     vardir = InstallOptions.vardir
   elsif $operatingsystem == "windows"
-    vardir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "cache")
+    vardir = File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "cache")
   else
     vardir = "/opt/puppetlabs/puppet/cache"
   end
@@ -275,7 +269,7 @@ def prepare_installation
   if not InstallOptions.rundir.nil?
     rundir = InstallOptions.rundir
   elsif $operatingsystem == "windows"
-    rundir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "var", "run")
+    rundir = File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "var", "run")
   else
     rundir = "/var/run/puppetlabs"
   end
@@ -283,7 +277,7 @@ def prepare_installation
   if not InstallOptions.logdir.nil?
     logdir = InstallOptions.logdir
   elsif $operatingsystem == "windows"
-    logdir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "puppet", "var", "log")
+    logdir = File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "var", "log")
   else
     logdir = "/var/log/puppetlabs/puppet"
   end
@@ -298,7 +292,7 @@ def prepare_installation
     localedir = InstallOptions.localedir
   else
     if $operatingsystem == "windows"
-      localedir = File.join(Dir::PROGRAM_FILES, "Puppet Labs", "Puppet", "puppet", "share", "locale")
+      localedir = File.join(ENV['PROGRAMFILES'], "Puppet Labs", "Puppet", "puppet", "share", "locale")
     else
       localedir = "/opt/puppetlabs/puppet/share/locale"
     end

--- a/install.rb
+++ b/install.rb
@@ -243,13 +243,9 @@ def prepare_installation
   end
 
   if $operatingsystem == "windows"
-    begin
-      # populates constants used to specify default Windows directories
-      require 'win32/dir'
-    rescue LoadError => e
-      puts "Cannot run on Microsoft Windows without the win32-process, win32-dir & win32-service gems: #{e}"
-      exit(-1)
-    end
+    # TODO check if this can be required here
+    # may need to change to require_relative
+    require 'puppet/util/windows/monkey_patches/dir'
   end
 
   if not InstallOptions.configdir.nil?

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -15,8 +15,6 @@ module Puppet::Util::Windows
   class EventLog; end
 
   if Puppet::Util::Platform.windows?
-    require 'Win32API' # case matters in this require!
-
     # Note: Setting codepage here globally ensures all strings returned via
     # WIN32OLE (Ruby's late-bound COM support) are encoded in Encoding::UTF_8
     #

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -24,8 +24,6 @@ module Puppet::Util::Windows
     # to 2048 (at least on US English Windows) and is not listed in the MS
     # locales table, here: https://msdn.microsoft.com/en-us/library/ms912047(v=winembedded.10).aspx
     require 'win32ole' ; WIN32OLE.codepage = WIN32OLE::CP_UTF8
-    # gems
-    require 'win32/dir'
 
     # these reference platform specific gems
     require 'puppet/util/windows/api_types'
@@ -46,6 +44,7 @@ module Puppet::Util::Windows
     require 'puppet/util/windows/registry'
     require 'puppet/util/windows/eventlog'
     require 'puppet/util/windows/service'
+    require 'puppet/util/windows/monkey_patches/dir'
     require 'puppet/util/windows/monkey_patches/process'
   end
 end

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -58,7 +58,7 @@ module Puppet::Util::Windows::APITypes
         str = str[0, i] if i
       end
 
-      str.encode(dst_encoding, str.encoding, encode_options)
+      str.encode(dst_encoding, str.encoding, **encode_options)
     rescue EncodingError => e
       Puppet.debug { "Unable to convert value #{str.nil? ? 'nil' : str.dump} to encoding #{dst_encoding} due to #{e.inspect}" }
       raise

--- a/lib/puppet/util/windows/monkey_patches/dir.rb
+++ b/lib/puppet/util/windows/monkey_patches/dir.rb
@@ -279,7 +279,7 @@ class Dir
           raise SystemCallError.new("DeviceIoControl", error)
         end
       ensure
-        CloseHandle(handle)
+        FFI::WIN32.CloseHandle(handle)
       end
     end
 
@@ -357,7 +357,7 @@ class Dir
           raise SystemCallError.new("DeviceIoControl", error)
         end
       ensure
-        CloseHandle(handle)
+        FFI::WIN32.CloseHandle(handle)
       end
     end
 
@@ -377,13 +377,14 @@ class Dir
   # a directory, or contains any files other than '.' or '..'.
   #
   def self.empty?(path)
-    PathIsDirectoryEmptyW(Puppet::Util::Windows::String.wide_string(path))
+    path = string_check(path)
+    PathIsDirectoryEmptyW(Puppet::Util::Windows::String.wide_string(path)) != 0
   end
 
   # Returns whether or not +path+ is a junction.
   #
   def self.junction?(path)
-    string_check(path)
+    path = string_check(path)
     bool = true
 
     attrib = GetFileAttributesW(Puppet::Util::Windows::String.wide_string(path))

--- a/lib/puppet/util/windows/monkey_patches/dir.rb
+++ b/lib/puppet/util/windows/monkey_patches/dir.rb
@@ -96,7 +96,7 @@ class Dir
 
   # Set Dir::MYDOCUMENTS to the same as Dir::PERSONAL if undefined
   unless defined? MYDOCUMENTS
-    MYDOCUMENTS = PERSONAL
+    MYDOCUMENTS = PERSONAL if defined? PERSONAL
   end
 
   class << self

--- a/lib/puppet/util/windows/monkey_patches/dir.rb
+++ b/lib/puppet/util/windows/monkey_patches/dir.rb
@@ -1,0 +1,417 @@
+require 'puppet/util/windows'
+
+class Dir
+  include Puppet::Util::Windows::File
+  extend Puppet::Util::Windows::File
+
+  # CSIDL constants
+  csidl = Hash[
+    "DESKTOP",                  0x0000,
+    "INTERNET",                 0x0001,
+    "PROGRAMS",                 0x0002,
+    "CONTROLS",                 0x0003,
+    "PRINTERS",                 0x0004,
+    "PERSONAL",                 0x0005,
+    "FAVORITES",                0x0006,
+    "STARTUP",                  0x0007,
+    "RECENT",                   0x0008,
+    "SENDTO",                   0x0009,
+    "BITBUCKET",                0x000a,
+    "STARTMENU",                0x000b,
+    "MYDOCUMENTS",              0x000c,
+    "MYMUSIC",                  0x000d,
+    "MYVIDEO",                  0x000e,
+    "DESKTOPDIRECTORY",         0x0010,
+    "DRIVES",                   0x0011,
+    "NETWORK",                  0x0012,
+    "NETHOOD",                  0x0013,
+    "FONTS",                    0x0014,
+    "TEMPLATES",                0x0015,
+    "COMMON_STARTMENU",         0x0016,
+    "COMMON_PROGRAMS",          0X0017,
+    "COMMON_STARTUP",           0x0018,
+    "COMMON_FAVORITES",         0x001f,
+    "COMMON_DESKTOPDIRECTORY",  0x0019,
+    "APPDATA",                  0x001a,
+    "PRINTHOOD",                0x001b,
+    "LOCAL_APPDATA",            0x001c,
+    "ALTSTARTUP",               0x001d,
+    "COMMON_ALTSTARTUP",        0x001e,
+    "INTERNET_CACHE",           0x0020,
+    "COOKIES",                  0x0021,
+    "HISTORY",                  0x0022,
+    "COMMON_APPDATA",           0x0023,
+    "WINDOWS",                  0x0024,
+    "SYSTEM",                   0x0025,
+    "PROGRAM_FILES",            0x0026,
+    "MYPICTURES",               0x0027,
+    "PROFILE",                  0x0028,
+    "SYSTEMX86",                0x0029,
+    "PROGRAM_FILESX86",         0x002a,
+    "PROGRAM_FILES_COMMON",     0x002b,
+    "PROGRAM_FILES_COMMONX86",  0x002c,
+    "COMMON_TEMPLATES",         0x002d,
+    "COMMON_DOCUMENTS",         0x002e,
+    "CONNECTIONS",              0x0031,
+    "COMMON_MUSIC",             0x0035,
+    "COMMON_PICTURES",          0x0036,
+    "COMMON_VIDEO",             0x0037,
+    "RESOURCES",                0x0038,
+    "RESOURCES_LOCALIZED",      0x0039,
+    "COMMON_OEM_LINKS",         0x003a,
+    "CDBURN_AREA",              0x003b,
+    "COMMON_ADMINTOOLS",        0x002f,
+    "ADMINTOOLS",               0x0030
+  ]
+
+  # Dynamically set each of the CSIDL constants
+  csidl.each do |key, value|
+    buf  = 0.chr * 1024
+    path = nil
+    buf.encode!(Encoding::UTF_16LE)
+
+    if SHGetFolderPathW(0, value, 0, 0, buf) == 0 # Current path
+      path = buf.strip
+    elsif SHGetFolderPathW(0, value, 0, 1, buf) == 0 # Default path
+      path = buf.strip
+    else
+      ptr   = FFI::MemoryPointer.new(:long)
+      info  = SHFILEINFO.new
+      flags = SHGFI_DISPLAYNAME | SHGFI_PIDL
+
+      if SHGetFolderLocation(0, value, 0, 0, ptr) == 0
+        if SHGetFileInfo(ptr.read_long, 0, info, info.size, flags) != 0
+          path = info[:szDisplayName].to_s
+          path.force_encoding(Encoding.default_external)
+        end
+      end
+    end
+
+    begin
+      Dir.const_set(key, path.encode(Encoding.default_external)) if path
+    rescue Encoding::UndefinedConversionError
+      Dir.const_set(key, path.encode(Encoding::UTF_8)) if path
+    end
+  end
+
+  # Set Dir::MYDOCUMENTS to the same as Dir::PERSONAL if undefined
+  unless defined? MYDOCUMENTS
+    MYDOCUMENTS = PERSONAL
+  end
+
+  class << self
+    alias old_glob glob
+
+    # Same as the standard MRI Dir.glob method except that it handles
+    # backslashes in path names.
+    #
+    def glob(glob_pattern, flags = 0, &block)
+      if glob_pattern.is_a?(Array)
+        temp = glob_pattern.map! { |pattern| string_check(pattern).tr("\\", "/") }
+      else
+        temp = string_check(glob_pattern).tr("\\", "/")
+      end
+
+      if flags.is_a?(Hash)
+        old_glob(temp, **flags, &block)
+      else
+        old_glob(temp, flags, &block)
+      end
+    end
+
+    alias old_ref []
+
+    # Same as the standard MRI Dir[] method except that it handles
+    # backslashes in path names.
+    #
+    def [](*glob_patterns)
+      temp = glob_patterns.map! { |pattern| "#{pattern}".tr("\\", "/") }
+      old_ref(*temp)
+    end
+
+    # JRuby normalizes the path by default.
+    unless RUBY_PLATFORM == "java"
+      alias oldgetwd getwd
+      alias oldpwd pwd
+
+      # Returns the present working directory. Unlike MRI, this method always
+      # normalizes the path.
+      #
+      # Examples:
+      #
+      #    Dir.chdir("C:/Progra~1")
+      #    Dir.getwd # => C:\Program Files
+      #
+      #    Dir.chdir("C:/PROGRAM FILES")
+      #    Dir.getwd # => C:\Program Files
+      #
+      def getwd
+        path1 = FFI::Buffer.new(:wint_t, 1024, true)
+        path2 = FFI::Buffer.new(:wint_t, 1024, true)
+        path3 = FFI::Buffer.new(:wint_t, 1024, true)
+
+        length = GetCurrentDirectoryW(path1.size, path1)
+
+        if length == 0 || length > path1.size
+          raise SystemCallError.new("GetCurrentDirectoryW", FFI.errno)
+        end
+
+        length = GetShortPathNameW(path1, path2, path2.size)
+
+        if length == 0 || length > path2.size
+          raise SystemCallError.new("GetShortPathNameW", FFI.errno)
+        end
+
+        length = GetLongPathNameW(path2, path3, path3.size)
+
+        if length == 0 || length > path3.size
+          raise SystemCallError.new("GetLongPathNameW", FFI.errno)
+        end
+
+        path = wstrip(path3.read_bytes(length * 2))
+
+        begin
+          path.encode(Encoding.default_external)
+        rescue Encoding::UndefinedConversionError
+          path.encode(Encoding::UTF_8)
+        end
+      end
+
+      alias :pwd :getwd
+
+      private
+
+      # Read a wide character string up until the first double null, and delete
+      # any remaining null characters.
+      def wstrip(str)
+        str.force_encoding(Encoding::UTF_16LE).encode(Encoding::UTF_8, invalid: :replace, undef: :replace).
+          split("\x00")[0].encode(Encoding.default_external)
+      end
+    end
+  end
+
+  # Creates the symlink +to+, linked to the existing directory +from+. If the
+  # +to+ directory already exists, it must be empty or an error is raised.
+  #
+  # Example:
+  #
+  #    Dir.mkdir('C:/from')
+  #    Dir.create_junction('C:/to', 'C:/from')
+  #
+  def self.create_junction(to, from)
+    to   = Puppet::Util::Windows::String.wide_string(string_check(to))
+    from = Puppet::Util::Windows::String.wide_string(string_check(from))
+
+    from_path = (0.chr * 1024).encode(Encoding::UTF_16LE)
+
+    length = GetFullPathNameW(from, from_path.size, from_path, nil)
+
+    if length == 0 || length > from_path.size
+      raise SystemCallError.new("GetFullPathNameW", FFI.errno)
+    else
+      from_path.strip!
+    end
+
+    to_path = (0.chr * 1024).encode(Encoding::UTF_16LE)
+
+    length = GetFullPathNameW(to, to_path.size, to_path, nil)
+
+    if length == 0 || length > to_path.size
+      raise SystemCallError.new("GetFullPathNameW", FFI.errno)
+    else
+      to_path.strip!
+    end
+
+    # You can create a junction to a directory that already exists, so
+    # long as it's empty.
+    unless CreateDirectoryW(to_path, nil)
+      if FFI.errno != ERROR_ALREADY_EXISTS
+        raise SystemCallError.new("CreateDirectoryW", FFI.errno)
+      end
+    end
+
+    begin
+      # Generic read & write + open existing + reparse point & backup semantics
+      handle = CreateFileW(
+        to_path,
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        nil,
+        OPEN_EXISTING,
+        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+        0
+      )
+
+      if handle == INVALID_HANDLE_VALUE
+        raise SystemCallError.new("CreateFileW", FFI.errno)
+      end
+
+      target = "\\??\\".encode(Encoding::UTF_16LE) + from_path
+
+      rdb = REPARSE_JDATA_BUFFER.new
+      rdb[:ReparseTag] = 2684354563 # IO_REPARSE_TAG_MOUNT_POINT
+      rdb[:ReparseDataLength] = target.bytesize + 12
+      rdb[:Reserved] = 0
+      rdb[:SubstituteNameOffset] = 0
+      rdb[:SubstituteNameLength] = target.bytesize
+      rdb[:PrintNameOffset] = target.bytesize + 2
+      rdb[:PrintNameLength] = 0
+      rdb[:PathBuffer] = target
+
+      bytes = FFI::MemoryPointer.new(:ulong)
+
+      begin
+        bool = DeviceIoControl(
+          handle,
+          CTL_CODE(FILE_DEVICE_FILE_SYSTEM, 41, METHOD_BUFFERED, 0),
+          rdb,
+          rdb[:ReparseDataLength] + rdb.header_size,
+          nil,
+          0,
+          bytes,
+          nil
+        )
+
+        error = FFI.errno
+
+        unless bool
+          RemoveDirectoryW(to_path)
+          raise SystemCallError.new("DeviceIoControl", error)
+        end
+      ensure
+        CloseHandle(handle)
+      end
+    end
+
+    self
+  end
+
+  # Returns the path that a given junction points to. Raises an
+  # Errno::ENOENT error if the given path does not exist. Returns false
+  # if it is not a junction.
+  #
+  # Example:
+  #
+  #    Dir.mkdir('C:/from')
+  #    Dir.create_junction('C:/to', 'C:/from')
+  #    Dir.read_junction("c:/to") # => "c:/from"
+  #
+  def self.read_junction(junction)
+    return false unless Dir.junction?(junction)
+
+    junction = Puppet::Util::Windows::String.wide_string(string_check(junction))
+
+    junction_path = (0.chr * 1024).encode(Encoding::UTF_16LE)
+
+    length = GetFullPathNameW(junction, junction_path.size, junction_path, nil)
+
+    if length == 0 || length > junction_path.size
+      raise SystemCallError.new("GetFullPathNameW", FFI.errno)
+    else
+      junction_path.strip!
+    end
+
+    begin
+      # Generic read & write + open existing + reparse point & backup semantics
+      handle = CreateFileW(
+        junction_path,
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        nil,
+        OPEN_EXISTING,
+        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+        0
+      )
+
+      if handle == INVALID_HANDLE_VALUE
+        raise SystemCallError.new("CreateFileW", FFI.errno)
+      end
+
+      rdb = REPARSE_JDATA_BUFFER.new
+      rdb[:ReparseTag] = 0
+      rdb[:ReparseDataLength] = 0
+      rdb[:Reserved] = 0
+      rdb[:SubstituteNameOffset] = 0
+      rdb[:SubstituteNameLength] = 0
+      rdb[:PrintNameOffset] = 0
+      rdb[:PrintNameLength] = 0
+      rdb[:PathBuffer] = ""
+
+      bytes = FFI::MemoryPointer.new(:ulong)
+
+      begin
+        bool = DeviceIoControl(
+          handle,
+          CTL_CODE(FILE_DEVICE_FILE_SYSTEM, 42, METHOD_BUFFERED, 0),
+          nil,
+          0,
+          rdb,
+          1024,
+          bytes,
+          nil
+        )
+
+        error = FFI.errno
+
+        unless bool
+          raise SystemCallError.new("DeviceIoControl", error)
+        end
+      ensure
+        CloseHandle(handle)
+      end
+    end
+
+    # MSDN says print and substitute names can be in any order
+    jname = (rdb[:PathBuffer].to_ptr + rdb[:SubstituteNameOffset]).read_string(rdb[:SubstituteNameLength])
+    jname = jname.bytes.to_a.pack("C*")
+    jname = jname.force_encoding(Encoding::UTF_16LE)
+    raise "Invalid junction name: #{jname.encode(Encoding::UTF_8)}" unless jname[0..3] == "\\??\\".encode(Encoding::UTF_16LE)
+    begin
+      File.expand_path(jname[4..-1].encode(Encoding.default_external))
+    rescue Encoding::UndefinedConversionError
+      File.expand_path(jname[4..-1].encode(Encoding::UTF_8))
+    end
+  end
+
+  # Returns whether or not +path+ is empty.  Returns false if +path+ is not
+  # a directory, or contains any files other than '.' or '..'.
+  #
+  def self.empty?(path)
+    PathIsDirectoryEmptyW(Puppet::Util::Windows::String.wide_string(path))
+  end
+
+  # Returns whether or not +path+ is a junction.
+  #
+  def self.junction?(path)
+    string_check(path)
+    bool = true
+
+    attrib = GetFileAttributesW(Puppet::Util::Windows::String.wide_string(path))
+
+    # Only directories with a reparse point attribute can be junctions
+    if attrib == INVALID_FILE_ATTRIBUTES ||
+        attrib & FILE_ATTRIBUTE_DIRECTORY == 0 ||
+        attrib & FILE_ATTRIBUTE_REPARSE_POINT == 0
+      bool = false
+    end
+
+    bool
+  end
+
+  class << self
+    alias reparse_dir? junction?
+
+    # Simulate MRI's contortions for a stringiness check.
+    def string_check(arg)
+      return arg if arg.is_a?(String)
+      return arg.send(:to_str) if arg.respond_to?(:to_str, true) # MRI honors it, even if private
+      return arg.to_path if arg.respond_to?(:to_path)
+      raise TypeError
+    end
+
+    # Macro from Windows header file, used by the create_junction method.
+    def CTL_CODE(device, function, method, access)
+      ((device) << 16) | ((access) << 14) | ((function) << 2) | (method)
+    end
+  end
+end

--- a/spec/integration/util/windows/monkey_patches/dir_spec.rb
+++ b/spec/integration/util/windows/monkey_patches/dir_spec.rb
@@ -1,0 +1,231 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Dir', if: Puppet::Util::Platform.windows? do
+
+  before(:all) do
+    @temp = Dir.tmpdir
+    @from = File.join(@temp, 'test_from_directory')
+    @ascii_to = File.join(@temp, 'test_to_directory')
+    @unicode_to = File.join(@temp, 'Ελλάσ')
+    @test_file = File.join(@from, 'test.txt')
+
+    Dir.mkdir(@from)
+  end
+
+  after(:all) do
+    FileUtils.rm_rf(@ascii_to)
+    FileUtils.rm_rf(@unicode_to)
+    FileUtils.rm_rf(@from)
+  end
+
+  let(:pattern1) { "C:\\Program Files\\Common Files\\System\\*.dll" }
+  let(:pattern2) { "C:\\Windows\\*.exe" }
+  let(:pathname1) { Pathname.new(pattern1) }
+  let(:pathname2) { Pathname.new(pattern2) }
+
+  let(:from) { @from }
+  let(:ascii_to) { @ascii_to }
+  let(:unicode_to) { @unicode_to }
+  let(:test_file) { @test_file }
+
+  describe '.glob' do
+    it 'handles backslashes' do
+      expect { Dir.glob(pattern1) }.not_to raise_error
+      expect(Dir.glob(pattern1)).not_to be_empty
+    end
+
+    it 'handles multiple strings' do
+      expect { Dir.glob([pattern1, pattern2]) }.not_to raise_error
+      expect(Dir.glob([pattern1, pattern2])).not_to be_empty
+    end
+
+    it 'still observes flags' do
+      expect { Dir.glob('*', File::FNM_DOTMATCH) }.not_to raise_error
+      expect(Dir.glob('*', File::FNM_DOTMATCH)).to include('.')
+    end
+
+    it 'still honors block' do
+      array = []
+      expect do
+        Dir.glob('*', File::FNM_DOTMATCH) { |m| array << m }
+      end.not_to raise_error
+      expect(array).to include('.')
+    end
+
+    it 'handles Pathname objects' do
+      expect { Dir.glob([pathname1, pathname2]) }.not_to raise_error
+      expect(Dir.glob([pathname1, pathname2])).not_to be_empty
+    end
+
+    it 'requires a stringy argument' do
+      expect { Dir.glob(nil) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '.[]' do
+    it 'handles backslashes' do
+      expect { Dir[pattern1] }.not_to raise_error
+      expect(Dir[pattern1]).not_to be_empty
+    end
+
+    it 'handles multiple arguments' do
+      expect { Dir[pattern1, pattern2] }.not_to raise_error
+      expect(Dir[pattern1, pattern2]).not_to be_empty
+    end
+
+    it 'handles Pathname arguments' do
+      expect { Dir[pathname1, pathname2] }.not_to raise_error
+      expect(Dir[pathname1, pathname2]).not_to be_empty
+    end
+  end
+
+  describe '.create_junction' do
+    after(:all) { FileUtils.rm_f(@test_file) }
+
+    it 'is callable' do
+      expect(Dir).to respond_to(:create_junction)
+    end
+
+    it 'works as expected with ASCII characters' do
+      expect { Dir.create_junction(ascii_to, from) }.not_to raise_error
+      expect(File).to exist(ascii_to)
+      File.open(test_file, 'w') { |fh| fh.puts 'Hello World' }
+      expect(Dir.entries(from)).to eq(Dir.entries(ascii_to))
+    end
+
+    it 'works as expected with unicode characters' do
+      expect { Dir.create_junction(unicode_to, from) }.not_to raise_error
+      expect(File).to exist(unicode_to)
+      File.open(test_file, 'w') { |fh| fh.puts 'Hello World' }
+      expect(Dir.entries(from)).to eq(Dir.entries(unicode_to))
+    end
+
+    it 'works as expected with Pathname objects' do
+      expect { Dir.create_junction(Pathname.new(ascii_to), Pathname.new(from)) }.not_to raise_error
+      expect(File).to exist(ascii_to)
+      File.open(test_file, 'w') { |fh| fh.puts 'Hello World' }
+      expect(Dir.entries(from)).to eq(Dir.entries(ascii_to))
+    end
+
+    it 'requires stringy arguments' do
+      expect { Dir.create_junction(nil, from) }.to raise_error(TypeError)
+      expect { Dir.create_junction(ascii_to, nil) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '.read_junction' do
+    it 'works as expected with ASCII characters' do
+      expect { Dir.create_junction(ascii_to, from) }.not_to raise_error
+      expect(File).to exist(ascii_to)
+      expect(Dir.read_junction(ascii_to)).to eq(from)
+    end
+
+    it 'works as expected with unicode characters' do
+      expect { Dir.create_junction(unicode_to, from) }.not_to raise_error
+      expect(File).to exist(unicode_to)
+      expect(Dir.read_junction(unicode_to)).to eq(from)
+    end
+
+    it 'is joinable with unicode characters' do
+      expect { Dir.create_junction(unicode_to, from) }.not_to raise_error
+      expect(File).to exist(unicode_to)
+      expect { File.join(Dir.read_junction(unicode_to), 'foo') }.not_to raise_error
+    end
+
+    it 'works as expected with Pathname objects' do
+      expect { Dir.create_junction(Pathname.new(ascii_to), Pathname.new(from)) }.not_to raise_error
+      expect(File).to exist(ascii_to)
+      expect(Dir.read_junction(ascii_to)).to eq(from)
+    end
+
+    it 'requires a stringy argument' do
+      expect { Dir.read_junction(nil) }.to raise_error(TypeError)
+      expect { Dir.read_junction([]) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '.junction?' do
+    it 'returns a boolean value' do
+      expect(Dir).to respond_to(:junction?)
+      expect { Dir.create_junction(ascii_to, from) }.not_to raise_error
+      expect(Dir.junction?(from)).to be false
+      expect(Dir.junction?(ascii_to)).to be true
+      expect(Dir.junction?(Pathname.new(ascii_to))).to be true
+    end
+  end
+
+  describe '.reparse_dir?' do
+    it 'aliases junction' do
+      expect(Dir).to respond_to(:reparse_dir?)
+      expect(Dir.method(:reparse_dir?)).to eq(Dir.method(:junction?))
+    end
+  end
+
+  describe '.empty?' do
+    it 'returns expected result' do
+      expect(Dir).to respond_to(:empty?)
+      expect(Dir.empty?("C:\\")).to be false
+      expect(Dir.empty?(from)).to be true
+      expect(Dir.empty?(Pathname.new(from))).to be true
+    end
+  end
+
+  describe '.pwd' do
+    it 'has basic functionality' do
+      expect(Dir).to respond_to(:pwd)
+      expect { Dir.pwd }.not_to raise_error
+      expect(Dir.pwd).to be_a_kind_of(String)
+    end
+
+    it 'aliases getwd' do
+      expect(Dir.method(:pwd)).to eq(Dir.method(:getwd))
+    end
+
+    it 'returns full path even if short path was just used' do
+      Dir.chdir("C:\\Progra~1")
+      expect(Dir.pwd).to eq("C:\\Program Files")
+    end
+
+    it 'returns full path even if long path was just used' do
+      Dir.chdir("C:\\Program Files")
+      expect(Dir.pwd).to eq("C:\\Program Files")
+    end
+
+    it 'uses standard case conventions' do
+      Dir.chdir("C:\\PROGRAM FILES")
+      expect(Dir.pwd).to eq("C:\\Program Files")
+    end
+
+    it 'converts forward slashes to backslashes' do
+      Dir.chdir("C:/Program Files")
+      expect(Dir.pwd).to eq("C:\\Program Files")
+    end
+  end
+
+  describe 'constants' do
+    ["DESKTOP", "INTERNET", "PROGRAMS", "CONTROLS",
+     "PRINTERS", "PERSONAL", "FAVORITES", "STARTUP", "RECENT", "SENDTO",
+     "BITBUCKET", "STARTMENU", "MYDOCUMENTS", "MYMUSIC", "MYVIDEO",
+     "DESKTOPDIRECTORY", "DRIVES", "NETWORK", "NETHOOD", "FONTS",
+     "TEMPLATES", "COMMON_STARTMENU", "COMMON_PROGRAMS",
+     "COMMON_STARTUP", "COMMON_FAVORITES", "COMMON_DESKTOPDIRECTORY",
+     "APPDATA", "PRINTHOOD", "LOCAL_APPDATA", "ALTSTARTUP",
+     "COMMON_ALTSTARTUP", "INTERNET_CACHE", "COOKIES", "HISTORY",
+     "COMMON_APPDATA", "WINDOWS", "SYSTEM", "PROGRAM_FILES",
+     "MYPICTURES", "PROFILE", "SYSTEMX86", "PROGRAM_FILESX86",
+     "PROGRAM_FILES_COMMON", "PROGRAM_FILES_COMMONX86",
+     "COMMON_TEMPLATES", "COMMON_DOCUMENTS", "CONNECTIONS",
+     "COMMON_MUSIC", "COMMON_PICTURES", "COMMON_VIDEO", "RESOURCES",
+     "RESOURCES_LOCALIZED", "COMMON_OEM_LINKS", "CDBURN_AREA",
+     "COMMON_ADMINTOOLS", "ADMINTOOLS"].each do |constant|
+      it "#{constant} is set" do
+        expect { Dir.const_get(constant) }.not_to raise_error
+        expect(Dir.const_get(constant)).to be_a_kind_of(String)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Defined missing functions, constants and structs in `puppet/util/windows/file`, and a private `wstrip` function in our Dir monkey-patch. The original gem monkey-patches the String class to define the method, but since we only use it in one place, we add it to Dir.

Also fixed some Ruby 2.7 warnings, and removed a stale require to Win32API which we don't use anymore.

Replaced win32-dir usage in install.rb with environment variables, and also removed the win32-security gem from project_data.yaml.

After this PR is merged we should no longer have dependencies on external win32 gems.