### PR TITLE
(PUP-10603) Consistently encode metadata and content for http URLs

### DIFF
--- a/lib/puppet/indirector/file_metadata/http.rb
+++ b/lib/puppet/indirector/file_metadata/http.rb
@@ -10,6 +10,7 @@ class Puppet::Indirector::FileMetadata::Http < Puppet::Indirector::GenericHttp
 
   def find(request)
     checksum_type = request.options[:checksum_type]
+    # See URL encoding comment in Puppet::Type::File::ParamSource#chunk_file_from_source
     uri = URI(request.uri)
     client = Puppet.runtime[:http]
     head = client.head(uri, options: {include_system_store: true})

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -322,7 +322,12 @@ module Puppet
 
     def chunk_file_from_source(&block)
       if uri.scheme =~ /^https?/
-        get_from_http_source(uri, &block)
+        # Historically puppet has not encoded the http(s) source URL before parsing
+        # it, for example, if the path contains spaces, then it must be URL encoded
+        # as %20 in the manifest. Puppet behaves the same when retrieving file
+        # metadata via http(s), see Puppet::Indirector::FileMetadata::Http#find.
+        url = URI.parse(metadata.source)
+        get_from_http_source(url, &block)
       elsif metadata.content_uri
         content_url = URI.parse(Puppet::Util.uri_encode(metadata.content_uri))
         get_from_content_uri_source(content_url, &block)


### PR DESCRIPTION
Prior to 6.16, puppet assumed http file sources in manifests were already URL
encoded. So to reference a URL path with a space, you had to specify:

    source => 'http://example.com/b%20c'

Similarly, if the query contained a character that wasn't a URL code point[1],
such as 'b[c', then it had to be URL encoded in the manifest:

    source => 'http://example.com?q=b%5Bc'

Commit 11eee4e886d changed the http content request so it called the `uri`
reader method instead of calling `URI(metadata.source)`. The former encodes the
source using `Puppet::Util.uri_encode` before parsing it, which could result in
double encoded source URLs. It also meant the http content used different levels
of encoding than the previous http metadata request.

The `uri_encode` method also incorrectly assumes `=` characters are query
delimiters, which may not be the case for a base64 encoded signature with
trailing padding characters like

    sig=JaZhcqxT4akJcOwUdUGrQB2m1geUoh89iL8WMag8a8c=

This commit restores the previous behavior of using `URI(metadata.source)`
instead of the `uri` reader. Doing so bypasses the `=` issue in query strings,
which is filed as PUP-10613 and will be fixed later, and ensures the metadata
and content requests use the same levels of encoding.

[1] https://url.spec.whatwg.org/#url-code-points