### PR TITLE
(PUP-9346) Change default hostcsr setting

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -248,7 +248,7 @@ END
     paths = {
       'private key' => Puppet[:hostprivkey],
       'public key'  => Puppet[:hostpubkey],
-      'certificate request' => File.join(Puppet[:requestdir], "#{Puppet[:certname]}.pem"),
+      'certificate request' => Puppet[:hostcsr],
       'certificate' => Puppet[:hostcert],
       'private key password file' => Puppet[:passfile]
     }

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -932,13 +932,13 @@ EOT
         Generally unused."
     },
     :hostcsr => {
-      :default => "$ssldir/csr_$certname.pem",
+      :default => "$requestdir/$certname.pem",
       :type   => :file,
       :mode => "0644",
       :owner => "service",
       :group => "service",
-      :deprecated  => :completely,
-      :desc => "This setting is deprecated."
+      :desc => "Where individual hosts store their certificate request (CSR)
+         while waiting for the CA to issue their certificate."
     },
     :hostcert => {
       :default => "$certdir/$certname.pem",

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -92,7 +92,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
   end
 
   context 'when submitting a CSR' do
-    let(:csr_path) { File.join(Puppet[:requestdir], "#{name}.pem") }
+    let(:csr_path) { Puppet[:hostcsr] }
 
     before do
       ssl.command_line.args << 'submit_request'
@@ -318,7 +318,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     end
 
     it 'deletes the request' do
-      path = File.join(Puppet[:requestdir], "#{Puppet[:certname]}.pem")
+      path = Puppet[:hostcsr]
       File.write(path, @host[:csr].to_pem)
 
       expects_command_to_pass(%r{Removed certificate request #{path}})


### PR DESCRIPTION
The default value did not reflect where puppet saves its CSR while waiting for
the CA to issue a certificate. Update the default value to match reality.