### PR TITLE
(PUP-10615) Add facts and vars back to ScriptCompiler scope

### DIFF
--- a/spec/unit/puppet_pal_2pec.rb
+++ b/spec/unit/puppet_pal_2pec.rb
@@ -708,6 +708,46 @@ describe 'Puppet Pal' do
         end
       end
 
+      context 'facts are supported such that' do
+        it 'they are obtained if they are not given' do
+          facts = Puppet::Node::Facts.new(Puppet[:certname], 'puppetversion' => Puppet.version)
+          Puppet::Node::Facts.indirection.save(facts)
+
+          testing_env_dir # creates the structure
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath ) do |ctx|
+            ctx.with_script_compiler {|c| c.evaluate_string("$facts =~ Hash and $facts[puppetversion] == '#{Puppet.version}'") }
+          end
+          expect(result).to eq(true)
+        end
+
+        it 'can be given as a hash when creating the environment' do
+          testing_env_dir # creates the structure
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: { 'myfact' => 42 }) do |ctx|
+            ctx.with_script_compiler {|c| c.evaluate_string("$facts =~ Hash and $facts[myfact] == 42") }
+          end
+          expect(result).to eq(true)
+        end
+
+        it 'can be overridden with a hash when creating a script compiler' do
+          testing_env_dir # creates the structure
+          result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: { 'myfact' => 42 }) do |ctx|
+            ctx.with_script_compiler(facts: { 'myfact' => 43 }) {|c| c.evaluate_string("$facts =~ Hash and $facts[myfact] == 43") }
+          end
+          expect(result).to eq(true)
+        end
+
+        it 'can be disabled with the :set_local_facts option' do
+          Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: { 'myfact' => 42}) do |ctx|
+            ctx.with_script_compiler(facts: { 'myfact' => 42 }, set_local_facts: false) do |compiler|
+              expect { compiler.evaluate_string('$facts') }.to raise_error(
+                Puppet::PreformattedError,
+                /Unknown variable: 'facts'/
+              )
+            end
+          end
+        end
+      end
+
       context 'supports tasks such that' do
         it '"task_signature" returns the signatures of a generic task' do
           result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: modulepath, facts: node_facts) do |ctx|


### PR DESCRIPTION
This reverts the changes made in #8063, which
removed facts and vars from PAL's ScriptCompiler scope. This
resulted in a breaking change that affected downstream projects
that rely on PAL's public API.

It also adds a new `:disable_facts` flag to `#with_script_compiler`,
which will prevent facts from being set for the compiler scope. The
default value for the flag is `false` to preserve the old behavior of
the script compiler, while allowing other tools (namely Bolt) the
ability to control the facts variables being set.