### PR TITLE
(PUP-10600) Undefined constant on Windows via AWS Session Manager

### DIFF
--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -26,6 +26,7 @@ module Puppet::Util::Windows
     require 'win32ole' ; WIN32OLE.codepage = WIN32OLE::CP_UTF8
     # gems
     require 'win32/process'
+    require 'puppet/util/windows/monkey_patches/dir'
     require 'win32/dir'
     require 'win32/service'
 

--- a/lib/puppet/util/windows/monkey_patches/dir.rb
+++ b/lib/puppet/util/windows/monkey_patches/dir.rb
@@ -1,0 +1,40 @@
+require 'win32/dir/constants'
+require 'win32/dir/functions'
+require 'win32/dir/structs'
+
+class DirMonkeyPatched
+  include ::Dir::Structs
+  include ::Dir::Constants
+  extend  ::Dir::Functions
+
+  path  = nil
+  key   = :PERSONAL
+  value = 0x0005
+  buf   = 0.chr * 1024
+  buf.encode!(Encoding::UTF_16LE)
+
+  if SHGetFolderPathW(0, value, 0, 0, buf) == 0 # Current path
+    path = buf.strip
+  elsif SHGetFolderPathW(0, value, 0, 1, buf) == 0 # Default path
+    path = buf.strip
+  else
+    FFI::MemoryPointer.new(:long) do |ptr|
+      if SHGetFolderLocation(0, value, 0, 0, ptr) == 0
+        SHFILEINFO.new do |info|
+          flags = SHGFI_DISPLAYNAME | SHGFI_PIDL
+          if SHGetFileInfo(ptr.read_long, 0, info, info.size, flags) != 0
+            path = info[:szDisplayName].to_s
+          end
+        end
+      end
+    end
+  end
+
+  if path.nil?
+    begin
+      Dir.const_set(key, ''.encode(Encoding.default_external))
+    rescue Encoding::UndefinedConversionError
+      Dir.const_set(key, ''.encode(Encoding::UTF_8))
+    end
+  end
+end

--- a/spec/integration/util/windows/monkey_patches/dir_spec.rb
+++ b/spec/integration/util/windows/monkey_patches/dir_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Dir, :if => Puppet::Util::Platform.windows? do
+  it "should always have the PERSONAL constant defined" do
+    expect(described_class).to be_const_defined(:PERSONAL)
+  end
+
+  it "should not raise any errors when accessing the PERSONAL constant" do
+    expect { described_class::PERSONAL }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Before this commit, attempts of installing or running puppet on Windows via AWS Session Manager failed constantly with a `<class:Dir>': uninitialized constant Dir::PERSONAL (Name Error)` error. This behaviour was identified on EC2 Windows Server 2019 instances.

The issue is found in the `win32-dir` gem which at some point tries to assign the `Dir::PERSONAL` constant to `Dir::MYDOCUMENTS` without checking if it is initialized/defined first, resulting in the `Name Error` error above. The unlikely scenario where this happens is as follows:

The AWS Session Manager communicates with a `SSM Agent` installed on the desired instance. A user called `ssm-user` is created, either manually or automatically by the `SSM Agent` installer (only versions older than 2.3.612.0), to facilitate the connection between the two entities. The root cause comes from this user which does not have a unique user profile and instead is using `C:\Windows\system32\config\systemprofile` so the gem cannot find a `Documents\My Documents` folder since such folders don't actually exist for it.

Since Puppet doesn't actually uses/needs this path, current fix is defining this constant as an empty string by default.