### PR TITLE
(maint) Merge up 5.5.x to master

### DIFF
--- a/lib/puppet/functions/reverse_each.rb
+++ b/lib/puppet/functions/reverse_each.rb
@@ -84,7 +84,7 @@ Puppet::Functions.create_function(:reverse_each) do
 
   def reverse_each(iterable)
     # produces an Iterable
-    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).reverse_each
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable, true).reverse_each
   end
 
   def reverse_each_block(iterable, &block)

--- a/lib/puppet/functions/step.rb
+++ b/lib/puppet/functions/step.rb
@@ -88,7 +88,7 @@ Puppet::Functions.create_function(:step) do
 
   def step(iterable, step)
     # produces an Iterable
-    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable).step(step)
+    Puppet::Pops::Types::Iterable.asserted_iterable(self, iterable, true).step(step)
   end
 
   def step_block(iterable, step, &block)

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -266,7 +266,7 @@ class Puppet::Node::Environment
   # @param name [String] The module name
   # @return [Puppet::Module, nil] The module if found, else nil
   def module(name)
-    modules.find {|mod| mod.name == name}
+    modules_by_name[name]
   end
 
   # Locate a module instance by the full forge name (EG authorname/module)
@@ -326,6 +326,12 @@ class Puppet::Node::Environment
     end
     @modules
   end
+
+  # @api private
+  def modules_by_name
+    @modules_by_name ||= Hash[modules.map { |mod| [mod.name, mod] }]
+  end
+  private :modules_by_name
 
   # Generate a warning if the given directory in a module path entry is named `lib`.
   #

--- a/lib/puppet/pops/adaptable.rb
+++ b/lib/puppet/pops/adaptable.rb
@@ -69,11 +69,7 @@ module Adaptable
     #
     def self.get(o)
       attr_name = self_attr_name
-      if o.instance_variable_defined?(attr_name)
-        o.instance_variable_get(attr_name)
-      else
-        nil
-      end
+      o.instance_variable_get(attr_name)
     end
 
     # Returns an existing adapter for the given object, or creates a new adapter if the
@@ -94,14 +90,13 @@ module Adaptable
     #
     def self.adapt(o, &block)
       attr_name = self_attr_name
-      value = o.instance_variable_get(attr_name) if o.instance_variable_defined?(attr_name)
+      value = o.instance_variable_get(attr_name)
       adapter = value || associate_adapter(create_adapter(o), o)
       if block_given?
-        case block.arity
-          when 1
-            block.call(adapter)
-          else
-            block.call(adapter, o)
+        if block.arity == 1
+          block.call(adapter)
+        else
+          block.call(adapter, o)
         end
       end
       adapter
@@ -127,8 +122,7 @@ module Adaptable
     def self.adapt_new(o, &block)
       adapter = associate_adapter(create_adapter(o), o)
       if block_given?
-        case block.arity
-        when 1
+        if block.arity == 1
           block.call(adapter)
         else
           block.call(adapter, o)

--- a/lib/puppet/pops/adapters.rb
+++ b/lib/puppet/pops/adapters.rb
@@ -99,6 +99,13 @@ module Adapters
 
     class PathsAndNameCacheAdapter < Puppet::Pops::Adaptable::Adapter
       attr_accessor :cache, :paths
+
+      def self.create_adapter(env)
+        adapter = super(env)
+        adapter.paths = env.modulepath.map { |p| Pathname.new(p) }
+        adapter.cache = {}
+        adapter
+      end
     end
 
     # Attempts to find the module that `instance` originates from by looking at it's {SourcePosAdapter} and
@@ -117,10 +124,7 @@ module Adapters
     def self.loader_name_by_source(environment, instance, file)
       file = instance.file if file.nil?
       return nil if file.nil? || EMPTY_STRING == file
-      pn_adapter = PathsAndNameCacheAdapter.adapt(environment) do |a|
-        a.paths ||= environment.modulepath.map { |p| Pathname.new(p) }
-        a.cache ||= {}
-      end
+      pn_adapter = PathsAndNameCacheAdapter.adapt(environment)
       dir = File.dirname(file)
       pn_adapter.cache.fetch(dir) do |key|
         mod = find_module_for_dir(environment, pn_adapter.paths, dir)


### PR DESCRIPTION
CONFLICT (content): Merge conflict in lib/puppet/util/autoload.rb
CONFLICT (content): Merge conflict in lib/puppet/pops/adaptable.rb
CONFLICT (content): Merge conflict in lib/puppet/parser/functions.rb

The `ModuleDirectoriesAdapter.adapt` part of autoload.rb was moved to a different `module_directories` method, so made the change there.

Adapt the code in functions.rb to account for the `@environment_module_lock` variable not present in 5.5.x.

Conflicts in adaptable.rb were due to how `adapter` is initialized in the `self.adapt` method. 5.5.x code had the initialization on a single line, vs. master which has it on 2 lines (probably due to a rubocop fix in 6c257fc7827989c2af2901f974666f0f23611153).

Not sure if I got everything right though, so I'd appreciate someone else taking a look.