### PR TITLE
(PUP-10436) Remove strict_hostname_checking & node_name setting/usage

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1359,25 +1359,6 @@ EOT
       with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
       overridden by more specific settings (see `ca_port`, `report_port`).",
     },
-    :node_name => {
-      :default    => 'cert',
-      :type       => :enum,
-      :values     => ['cert', 'facter'],
-      :deprecated => :completely,
-      :hook       => proc { |val|
-        if val != 'cert'
-          Puppet.deprecation_warning("The node_name setting is deprecated and will be removed in a future release.")
-        end
-      },
-      :desc       => "How the puppet master determines the client's identity
-      and sets the 'hostname', 'fqdn' and 'domain' facts for use in the manifest,
-      in particular for determining which 'node' statement applies to the client.
-      Possible values are 'cert' (use the subject's CN in the client's
-      certificate) and 'facter' (use the hostname that the client
-      reported in its facts).
-
-      This setting is deprecated, please use explicit fact matching for classification.",
-    },
     :bucketdir => {
       :default => "$vardir/bucket",
       :type => :directory,

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1478,23 +1478,7 @@ EOT
       :default    => "$confdir/fileserver.conf",
       :type       => :file,
       :desc       => "Where the fileserver configuration is stored.",
-    },
-    :strict_hostname_checking => {
-      :default    => true,
-      :type       => :boolean,
-      :desc       => "Whether to only search for the complete
-        hostname as it is in the certificate when searching for node information
-        in the catalogs or to match dot delimited segments of the cert's certname
-        and the hostname, fqdn, and/or domain facts.
-
-        This setting is deprecated and will be removed in a future release.",
-      :hook => proc { |val|
-        if val != true
-          Puppet.deprecation_warning("Setting strict_hostname_checking to false is deprecated and will be removed in a future release. Please use regular expressions in your node declarations or explicit fact matching for classification (though be warned that fact based classification may be considered insecure).")
-        end
-      }
-    }
-  )
+    })
 
   settings.define_settings(:device,
     :devicedir =>  {

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -183,27 +183,7 @@ class Puppet::Node
   # Calculate the list of names we might use for looking
   # up our node.  This is only used for AST nodes.
   def names
-    return [name] if Puppet.settings[:strict_hostname_checking]
-
-    names = []
-
-    names += split_name(name) if name.include?(".")
-
-    # First, get the fqdn
-    fqdn = parameters["fqdn"]
-    unless fqdn
-      if parameters["hostname"] and parameters["domain"]
-        fqdn = parameters["hostname"] + "." + parameters["domain"]
-      else
-        Puppet.warning _("Host is missing hostname and/or domain: %{name}") % { name: name }
-      end
-    end
-
-    # Now that we (might) have the fqdn, add each piece to the name
-    # list to search, in order of longest to shortest.
-    names += split_name(fqdn) if fqdn
-
-    names.uniq
+    @names ||= [name]
   end
 
   def split_name(name)

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -203,15 +203,6 @@ class Puppet::Node
     # list to search, in order of longest to shortest.
     names += split_name(fqdn) if fqdn
 
-    # And make sure the node name is first, since that's the most
-    # likely usage.
-    #   The name is usually the Certificate CN, but it can be
-    # set to the 'facter' hostname instead.
-    if Puppet[:node_name] == 'cert'
-      names.unshift name
-    else
-      names.unshift parameters["hostname"]
-    end
     names.uniq
   end
 

--- a/spec/integration/parser/node_spec.rb
+++ b/spec/integration/parser/node_spec.rb
@@ -117,15 +117,6 @@ describe 'node statements' do
       expect(catalog).to have_resource('Notify[matched]')
     end
 
-    it 'selects a node that is a prefix of the agent name' do
-      Puppet[:strict_hostname_checking] = false
-      catalog = compile_to_catalog(<<-MANIFEST, Puppet::Node.new("node.name.com"))
-      node 'node.name' { notify { matched: } }
-      MANIFEST
-
-      expect(catalog).to have_resource('Notify[matched]')
-    end
-
     it 'does not treat regex symbols as a regex inside a string literal' do
       catalog = compile_to_catalog(<<-MANIFEST, Puppet::Node.new("nodexname"))
       node 'node.name' { notify { 'not matched': } }

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -447,34 +447,4 @@ describe Puppet::Node, "when generating the list of names to search through" do
     expect(@node.names).to include("foo.deep.sub.domain")
     expect(@node.names).to include("foo.deep.sub")
   end
-
-  describe "and :node_name is set to 'cert'" do
-    before do
-      Puppet[:node_name] = "cert"
-    end
-
-    it "uses the passed-in key as the first value" do
-      expect(@node.names[0]).to eq("foo.domain.com")
-    end
-
-    describe "and strict hostname checking is enabled" do
-      before do
-        Puppet[:strict_hostname_checking] = true
-      end
-
-      it "only uses the passed-in key" do
-        expect(@node.names).to eq(["foo.domain.com"])
-      end
-    end
-  end
-
-  describe "and :node_name is set to 'facter'" do
-    before do
-      Puppet[:node_name] = "facter"
-    end
-
-    it "uses the node's 'hostname' fact as the first value" do
-      expect(@node.names[0]).to eq("yay")
-    end
-  end
 end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -417,34 +417,12 @@ end
 
 describe Puppet::Node, "when generating the list of names to search through" do
   before do
-    Puppet[:strict_hostname_checking] = false
     @node = Puppet::Node.new("foo.domain.com",
                              :parameters => {"hostname" => "yay", "domain" => "domain.com"})
   end
 
-  it "returns an array of names" do
+  it "returns an array of one name" do
     expect(@node.names).to be_instance_of(Array)
-  end
-
-  describe "and the node name is fully qualified" do
-    it "contains an entry for each part of the node name" do
-      expect(@node.names).to include("foo.domain.com")
-      expect(@node.names).to include("foo.domain")
-      expect(@node.names).to include("foo")
-    end
-  end
-
-  it "includes the node's fqdn" do
-    expect(@node.names).to include("yay.domain.com")
-  end
-
-  it "combines and include the node's hostname and domain if no fqdn is available" do
-    expect(@node.names).to include("yay.domain.com")
-  end
-
-  it "contains an entry for each name available by stripping a segment of the fqdn" do
-    @node.parameters["fqdn"] = "foo.deep.sub.domain.com"
-    expect(@node.names).to include("foo.deep.sub.domain")
-    expect(@node.names).to include("foo.deep.sub")
+    expect(@node.names).to eq ["foo.domain.com"]
   end
 end


### PR DESCRIPTION
Deprecated in 6.x because of security concerns, defaults changed to the implementation this pr uses. Modern site.pps can do all of the things that these enabled in more explicit way for those that want to opt-in to this kind of behavior.