### PR TITLE
(PUP-10627) Makes last_run_summary.yaml readable for regular users

### DIFF
--- a/acceptance/tests/agent/last_run_summary_report.rb
+++ b/acceptance/tests/agent/last_run_summary_report.rb
@@ -1,0 +1,104 @@
+test_name "The 'last_run_summary.yaml' report has the right location and permissions" do
+  tag 'audit:high'
+
+  require 'puppet/acceptance/temp_file_utils'
+  extend Puppet::Acceptance::TempFileUtils
+  
+  agents.each do |agent|
+    custom_publicdir = agent.tmpdir('custom_public_dir')
+
+    statedir = on(agent, puppet('config print statedir')).stdout.chomp
+    fail_test("The 'statedir' config is not set!") if statedir.empty?
+
+    publicdir = on(agent, puppet('config print publicdir')).stdout.chomp
+    fail_test("The 'publicdir' config is not set!") if publicdir.empty?
+
+    teardown do
+      agent.rm_rf(custom_publicdir)
+      agent.rm_rf("#{publicdir}/*") unless publicdir.empty?
+      on(agent, puppet("config set publicdir #{publicdir}"))
+    end
+
+    step "Check if '#{publicdir}' was created during puppet installation" do
+      on(agent, "ls #{publicdir}", :acceptable_exit_codes => [0])
+    end
+
+    step "Check if '#{publicdir}' has '0755' permissions" do
+      if agent['platform'] =~ /windows/
+        on(agent, "icacls #{publicdir}") do |result|
+          # Linux 'Owner' permissions class equivalent
+          assert_match(/BUILTIN\\Administrators:.*\(F\)/, result.stdout)
+
+          # Known issue on Windows: 'C:\ProgramData\PuppetLabs\puppet' permissions are inherited
+          # by its subfolders and it does not have any permissions for 'Everyone' (see 'PuppetAppDir'
+          # in 'puppet-agent/resources/windows/wix/appdatafiles.wxs')
+          # Below line should be added when solution is found:
+          # assert_match(/Everyone:.*\(RX\)/, result.stdout)
+        end
+      else
+        on(agent, "ls -al #{publicdir}") do |result|
+          assert_match(/rwxr-xr-x.+\.$/, result.stdout)
+        end
+      end
+    end
+
+    step "Create the 'last_run_summary.yaml' report file by applying catalog" do
+      on(agent, puppet('agent -t')) do |result|
+        assert_match('Applied catalog', result.stdout)
+      end
+    end
+
+    step "Check if the 'last_run_summary.yaml' report file created has '0644' permissions" do
+      if agent['platform'] =~ /windows/
+        on(agent, "icacls #{File.join(publicdir, 'last_run_summary.yaml')}") do |result|
+          # Linux 'Owner' premissions class equivalent
+          assert_match('Administrator:(R,W', result.stdout)
+          # Linux 'Group' permissions class equivalent
+          assert_match('None:(R)', result.stdout)
+          # Linux 'Public' permissions class equivalent
+          assert_match('Everyone:(R)', result.stdout)
+        end
+      else
+        on(agent, "ls -al #{publicdir}") do |result|
+          assert_match(/rw-r--r--.+last_run_summary\.yaml$/, result.stdout)
+        end
+      end
+    end
+
+    step "Check that '#{statedir}' exists and has no 'last_run_summary.yaml' file" do
+      on(agent, "ls #{statedir}",:acceptable_exit_codes => [0]) do |result|
+        assert_no_match(/last_run_summary.yaml/, result.stdout)
+      end
+    end
+    
+    step "Check that 'publicdir' can be reconfigured" do
+      on(agent, puppet("config set publicdir #{custom_publicdir}"))
+      on(agent, puppet('config print publicdir')) do |result|
+        assert_match(custom_publicdir, result.stdout)
+      end
+    end
+
+    step "Create a new 'last_run_summary.yaml' report file by applying catalog" do
+      on(agent, puppet('agent -t')) do |result|
+        assert_match('Applied catalog', result.stdout)
+      end
+    end
+
+    step "Check if the 'last_run_summary.yaml' report file was created in the new location and still has '0644' permissions" do
+      if agent['platform'] =~ /windows/
+        on(agent, "icacls #{File.join(custom_publicdir, 'last_run_summary.yaml')}") do |result|
+          # Linux 'Owner' premissions class equivalent
+          assert_match('Administrator:(R,W', result.stdout)
+          # Linux 'Group' permissions class equivalent
+          assert_match('None:(R)', result.stdout)
+          # Linux 'Public' permissions class equivalent
+          assert_match('Everyone:(R)', result.stdout)
+        end
+      else
+        on(agent, "ls -al #{custom_publicdir}") do |result|
+          assert_match(/rw-r--r--.+last_run_summary\.yaml$/, result.stdout)
+        end
+      end
+    end
+  end
+end

--- a/install.rb
+++ b/install.rb
@@ -178,6 +178,9 @@ def prepare_installation
     opts.on('--vardir[=OPTIONAL]', 'Installation directory for var files', 'Default /opt/puppetlabs/puppet/cache') do |vardir|
       InstallOptions.vardir = vardir
     end
+    opts.on('--publicdir[=OPTIONAL]', 'Installation directory for public files such as the `last_run_summary.yaml` report', 'Default /opt/puppetlabs/puppet/public') do |publicdir|
+      InstallOptions.publicdir = publicdir
+    end
     opts.on('--rundir[=OPTIONAL]', 'Installation directory for state files', 'Default /var/run/puppetlabs') do |rundir|
       InstallOptions.rundir = rundir
     end
@@ -266,6 +269,14 @@ def prepare_installation
     vardir = "/opt/puppetlabs/puppet/cache"
   end
 
+  if not InstallOptions.publicdir.nil?
+    publicdir = InstallOptions.publicdir
+  elsif $operatingsystem == "windows"
+    publicdir = File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "public")
+  else
+    publicdir = "/opt/puppetlabs/puppet/public"
+  end
+
   if not InstallOptions.rundir.nil?
     rundir = InstallOptions.rundir
   elsif $operatingsystem == "windows"
@@ -332,6 +343,7 @@ def prepare_installation
   configdir = join(destdir, configdir)
   codedir = join(destdir, codedir)
   vardir = join(destdir, vardir)
+  publicdir = join(destdir, publicdir)
   rundir = join(destdir, rundir)
   logdir = join(destdir, logdir)
   bindir = join(destdir, bindir)
@@ -345,6 +357,7 @@ def prepare_installation
   FileUtils.makedirs(mandir)
   FileUtils.makedirs(sitelibdir)
   FileUtils.makedirs(vardir)
+  FileUtils.makedirs(publicdir)
   FileUtils.makedirs(rundir)
   FileUtils.makedirs(logdir)
   FileUtils.makedirs(localedir)
@@ -356,6 +369,7 @@ def prepare_installation
   InstallOptions.lib_dir = libdir
   InstallOptions.man_dir = mandir
   InstallOptions.var_dir = vardir
+  InstallOptions.public_dir = publicdir
   InstallOptions.run_dir = rundir
   InstallOptions.log_dir = logdir
   InstallOptions.locale_dir = localedir

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1751,8 +1751,14 @@ EOT
         for the node stored in puppetdb are current. However, this will double the fact
         submission load on puppetdb, so it is disabled by default.",
     },
+    :publicdir => {
+      :default  => nil,
+      :type     => :directory,
+      :mode     => "0755",
+      :desc     => "Where Puppet stores public files."
+    },
     :lastrunfile =>  {
-      :default  => "$statedir/last_run_summary.yaml",
+      :default  => "$publicdir/last_run_summary.yaml",
       :type     => :file,
       :mode     => "0644",
       :desc     => "Where puppet agent stores the last run report summary in yaml format."

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -24,6 +24,8 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
     val = object.default
     if name.to_s == 'vardir'
       val = 'Unix/Linux: /opt/puppetlabs/puppet/cache -- Windows: C:\ProgramData\PuppetLabs\puppet\cache -- Non-root user: ~/.puppetlabs/opt/puppet/cache'
+    elsif name.to_s == 'publicdir'
+      val = 'Unix/Linux: /opt/puppetlabs/puppet/public -- Windows: C:\ProgramData\PuppetLabs\puppet\public -- Non-root user: ~/.puppetlabs/opt/puppet/public'
     elsif name.to_s == 'confdir'
       val = 'Unix/Linux: /etc/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\etc -- Non-root user: ~/.puppetlabs/etc/puppet'
     elsif name.to_s == 'codedir'

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -52,13 +52,14 @@ class Puppet::Settings
   # returns reasonable application default settings values for a given run_mode.
   def self.app_defaults_for_run_mode(run_mode)
     {
-        :name     => run_mode.to_s,
-        :run_mode => run_mode.name,
-        :confdir  => run_mode.conf_dir,
-        :codedir  => run_mode.code_dir,
-        :vardir   => run_mode.var_dir,
-        :rundir   => run_mode.run_dir,
-        :logdir   => run_mode.log_dir,
+        :name      => run_mode.to_s,
+        :run_mode  => run_mode.name,
+        :confdir   => run_mode.conf_dir,
+        :codedir   => run_mode.code_dir,
+        :vardir    => run_mode.var_dir,
+        :publicdir => run_mode.public_dir,
+        :rundir    => run_mode.run_dir,
+        :logdir    => run_mode.log_dir,
     }
   end
 

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -220,6 +220,7 @@ module Puppet::Test
       {
           :logdir     => "/dev/null",
           :confdir    => "/dev/null",
+          :publicdir  => "/dev/null",
           :codedir    => "/dev/null",
           :vardir     => "/dev/null",
           :rundir     => "/dev/null",

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -70,6 +70,10 @@ module Puppet
         which_dir("/opt/puppetlabs/puppet/cache", "~/.puppetlabs/opt/puppet/cache")
       end
 
+      def public_dir
+        which_dir("/opt/puppetlabs/puppet/public", "~/.puppetlabs/opt/puppet/public")
+      end
+
       def run_dir
         which_dir("/var/run/puppetlabs", "~/.puppetlabs/var/run")
       end
@@ -90,6 +94,10 @@ module Puppet
 
       def var_dir
         which_dir(File.join(windows_common_base("puppet/cache")), "~/.puppetlabs/opt/puppet/cache")
+      end
+
+      def public_dir
+        which_dir(File.join(windows_common_base("puppet/public")), "~/.puppetlabs/opt/puppet/public")
       end
 
       def run_dir

--- a/spec/lib/puppet_spec/settings.rb
+++ b/spec/lib/puppet_spec/settings.rb
@@ -11,6 +11,7 @@ module PuppetSpec::Settings
     :confdir      => { :type => :directory, :default => "test", :desc => "confdir" },
     :codedir      => { :type => :directory, :default => "test", :desc => "codedir" },
     :vardir       => { :type => :directory, :default => "test", :desc => "vardir" },
+    :publicdir    => { :type => :directory, :default => "test", :desc => "publicdir" },
     :rundir       => { :type => :directory, :default => "test", :desc => "rundir" },
   }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,6 +148,7 @@ RSpec.configure do |config|
 
     base = PuppetSpec::Files.tmpdir('tmp_settings')
     Puppet[:vardir] = File.join(base, 'var')
+    Puppet[:publicdir] = File.join(base, 'public')
     Puppet[:confdir] = File.join(base, 'etc')
     Puppet[:codedir] = File.join(base, 'code')
     Puppet[:logdir] = "$vardir/log"
@@ -155,6 +156,7 @@ RSpec.configure do |config|
     Puppet[:hiera_config] = File.join(base, 'hiera')
 
     FileUtils.mkdir_p Puppet[:statedir]
+    FileUtils.mkdir_p Puppet[:publicdir]
 
     Puppet::Test::TestHelper.before_each_test()
   end


### PR DESCRIPTION
Before this commit, the `last_run_summary.yaml` report file (automatically generated after an agent run) was located in `/opt/puppetlabs/puppet/cache/state` on Linux and `C:\ProgramData\PuppetLabs\puppet\cache\state` on Microsoft Windows which isn't accessible by any user since it can sometimes contain other files with sensitive data in them. The `last_run_summary.yaml` does not contain such information.

This commit adds the `public` folder (full path being `/opt/puppetlabs/puppet/public` on Linux and `C:\ProgramData\PuppetLabs\puppet\public` on Microsoft Windows) with `0755`(rwxr-xr-x) permissions and changes the `last_run_summary.yaml` file default path inside it for public access. Similar files can easily be moved here in the future. The folder's existence is ensured after installation or upgrade of a puppet-agent.

The `puppet config set publicdir <custom_path>` cli command or adding the `publicdir = <custom_path>` line in the `puppet.conf` file can be used for changing the path.

Merging this will unlock [PA-3253](https://github.com/puppetlabs/puppet-agent/pull/1947) (acceptance tests for this PR will be run there also).