### PR TITLE
(PUP-10618) Use load_as_module? to load Bolt project

### DIFF
--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -298,7 +298,7 @@ class Puppet::Node::Environment
     if @modules.nil?
       module_references = []
       project = Puppet.lookup(:bolt_project) { nil }
-      seen_modules = if project
+      seen_modules = if project && project.load_as_module?
                        module_references << project.to_h
                        { project.name => true }
                      else

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -79,7 +79,7 @@ describe Puppet::Node::Environment do
   it "should not yield a module with the same name as a defined Bolt project" do
     project_path = File.join(tmpfile('project'), 'bolt_project')
     FileUtils.mkdir_p(project_path)
-    project = Struct.new("Project", :name, :path).new('project', project_path)
+    project = Struct.new("Project", :name, :path, :load_as_module?).new('project', project_path, true)
 
     Puppet.override(bolt_project: project) do
       base = tmpfile("base")

--- a/spec/unit/node/environment_spec.rb
+++ b/spec/unit/node/environment_spec.rb
@@ -426,7 +426,7 @@ describe Puppet::Node::Environment do
           it "includes the Bolt project in modules if it's defined" do
             path = tmpdir('project')
             PuppetSpec::Modules.generate_files('bolt_project', path)
-            project = Struct.new("Project", :name, :path).new('bolt_project', path)
+            project = Struct.new("Project", :name, :path, :load_as_module?).new('bolt_project', path, true)
 
             Puppet.override(bolt_project: project) do
               %w{foo bar}.each do |mod_name|
@@ -437,6 +437,23 @@ describe Puppet::Node::Environment do
               end
               expect(env.modules.collect{|mod| mod.name}.sort).to eq(%w{bolt_project foo bar bee baz}.sort)
             end
+          end
+
+          it "does not include the Bolt project in modules if load_as_module? is false" do
+            path = tmpdir('project')
+            PuppetSpec::Modules.generate_files('bolt_project', path)
+            project = Struct.new("Project", :name, :path, :load_as_module?).new('bolt_project', path, false)
+
+            Puppet.override(bolt_project: project) do
+              %w{foo bar}.each do |mod_name|
+                PuppetSpec::Modules.generate_files(mod_name, first_modulepath)
+              end
+              %w{bee baz}.each do |mod_name|
+                PuppetSpec::Modules.generate_files(mod_name, second_modulepath)
+              end
+              expect(env.modules.collect{|mod| mod.name}.sort).to eq(%w{foo bar bee baz}.sort)
+            end
+
           end
         end
       end


### PR DESCRIPTION
Previously, Bolt would only set the `bolt_project` Puppet setting if the
project was loadable, in this case if it had a name. However Bolt always
has a project, it just may not get loaded as a module. This presented
issues when we needed to know where the Bolt project was located in
Bolt's custom Puppet functions, but the Bolt project wasn't named. The
interim solution for this was to set a new Puppet setting
`bolt_project_data` to read from the custom Puppet functions. This
introduces a more robust solution, which is to only load the project if
a method `load_as_module?` returns true. This lets us always set the
`bolt_project` Puppet setting for access throughout the Bolt lifecycle,
while only loading the project as a module when valid.

See https://github.com/puppetlabs/bolt/issues/2051 for more details.