### PR TITLE
(maint) Ensure CHILD_STATUS is set

### DIFF
--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -14,10 +14,8 @@ describe "base service provider" do
 
   subject { provider }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    cmd = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(cmd, {:failonfail => false})
+  before(:all) do
+    `exit 0`
   end
 
   context "basic operations" do

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Bsd',
-         :unless => Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:bsd) }
+
+  before(:all) do
+    `exit 0`
+  end
 
   before :each do
     allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class)

--- a/spec/unit/provider/service/daemontools_spec.rb
+++ b/spec/unit/provider/service/daemontools_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Daemontools',
-         unless: Puppet::Util::Platform.jruby? do
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:daemontools) }
 
   before(:each) do

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -1,13 +1,11 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Debian',
-         unless: Puppet::Util::Platform.jruby? do
+         unless: Puppet::Util::Platform.jruby? || Puppet::Util::Platform.windows? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:debian) }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  before(:all) do
+    `exit 0`
   end
 
   before(:each) do

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Freebsd',
-         unless: Puppet::Util::Platform.jruby? do
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:freebsd) }
 
   before :each do

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
-describe 'Puppet::Type::Service::Provider::Gentoo', unless: Puppet::Util::Platform.jruby? do
+describe 'Puppet::Type::Service::Provider::Gentoo',
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:gentoo) }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  before(:all) do
+    `exit 0`
   end
 
   before :each do

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
-describe 'Puppet::Type::Service::Provider::Init', unless: Puppet::Util::Platform.jruby? do
+describe 'Puppet::Type::Service::Provider::Init',
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:init) }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    cmd = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(cmd, {:failonfail => false})
+  before :all do
+    `exit 0`
   end
 
   before do

--- a/spec/unit/provider/service/launchd_spec.rb
+++ b/spec/unit/provider/service/launchd_spec.rb
@@ -1,20 +1,19 @@
 require 'spec_helper'
 
-describe 'Puppet::Type::Service::Provider::Launchd', unless: Puppet::Util::Platform.jruby? do
+describe 'Puppet::Type::Service::Provider::Launchd',
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:launchd) }
-
   let (:plistlib) { Puppet::Util::Plist }
   let (:joblabel) { "com.foo.food" }
   let (:provider) { subject.class }
   let (:resource) { Puppet::Type.type(:service).new(:name => joblabel, :provider => :launchd) }
   let (:launchd_overrides_6_9) { '/var/db/launchd.db/com.apple.launchd/overrides.plist' }
   let (:launchd_overrides_10_) { '/var/db/com.apple.xpc.launchd/disabled.plist' }
+
   subject { resource.provider }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  before :all do
+    `exit 0`
   end
 
   describe "the type interface" do

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
-describe 'Puppet::Type::Service::Provider::Openrc', unless: Puppet::Util::Platform.jruby? do
+describe 'Puppet::Type::Service::Provider::Openrc',
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:openrc) }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    cmd = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(cmd, {:failonfail => false})
+  before :all do
+    `exit 0`
   end
 
   before :each do

--- a/spec/unit/provider/service/openwrt_spec.rb
+++ b/spec/unit/provider/service/openwrt_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Openwrt',
-    :if => Puppet.features.posix? && !Puppet::Util::Platform.jruby? do
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:openwrt) }
 
   let(:resource) do

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Redhat',
-         if: Puppet.features.posix? && !Puppet::Util::Platform.jruby?do
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:redhat) }
 
   # `execute` and `texecute` start a new process, consequently setting $CHILD_STATUS to a Process::Status instance,

--- a/spec/unit/provider/service/runit_spec.rb
+++ b/spec/unit/provider/service/runit_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe 'Puppet::Type::Service::Provider::Runit', unless: Puppet::Util::Platform.jruby? do
+describe 'Puppet::Type::Service::Provider::Runit',
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:runit) }
 
   before(:each) do

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Smf',
-         if: Puppet.features.posix? && !Puppet::Util::Platform.jruby? do
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:smf) }
 
   before(:each) do

--- a/spec/unit/provider/service/src_spec.rb
+++ b/spec/unit/provider/service/src_spec.rb
@@ -1,13 +1,11 @@
 require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Src',
-         unless: Puppet::Util::Platform.jruby? do
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:provider_class) { Puppet::Type.type(:service).provider(:src) }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  before :all do
+    `exit 0`
   end
 
   before :each do

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
-describe 'Puppet::Type::Service::Provider::Systemd', unless: Puppet::Util::Platform.jruby? || Puppet::Util::Platform.windows? do
+describe 'Puppet::Type::Service::Provider::Systemd',
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
+
   let(:provider_class) { Puppet::Type.type(:service).provider(:systemd) }
 
   before :each do

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -1,14 +1,13 @@
 require 'spec_helper'
 
-describe 'Puppet::Type::Service::Provider::Upstart', unless: Puppet::Util::Platform.jruby? do
+describe 'Puppet::Type::Service::Provider::Upstart',
+         unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   let(:manual) { "\nmanual" }
   let(:start_on_default_runlevels) {  "\nstart on runlevel [2,3,4,5]" }
   let!(:provider_class) { Puppet::Type.type(:service).provider(:upstart) }
 
-  if Puppet::Util::Platform.windows?
-    # Get a pid for $CHILD_STATUS to latch on to
-    command = "cmd.exe /c \"exit 0\""
-    Puppet::Util::Execution.execute(command, {:failonfail => false})
+  before :each do
+    `exit 0`
   end
 
   def given_contents_of(file, content)


### PR DESCRIPTION
Running with latest facter 4 gem causes CHILD_STATUS to not necessarily be set.
Execute a command so it'll be set, similar to commit 50007768c6. Also
consistently skip *nix service tests on Windows and JRuby.