### PR TITLE
(PUP-9405) Mark resources as failed if prefetch fails

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -383,9 +383,6 @@ class Puppet::Transaction
     rescue StandardError => detail
       message = _("Could not prefetch %{type_name} provider '%{name}': %{detail}") % { type_name: type_name, name: provider_class.name, detail: detail }
       Puppet.log_exception(detail, message)
-
-      raise unless Puppet.settings[:future_features]
-
       @prefetch_failed_providers[type_name][provider_class.name] = true
     end
     @prefetched_providers[type_name][provider_class.name] = true

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -376,11 +376,8 @@ class Puppet::Transaction
     Puppet.debug { "Prefetching #{provider_class.name} resources for #{type_name}" }
     begin
       provider_class.prefetch(resources)
-    rescue LoadError, Puppet::MissingCommand => detail
+    rescue LoadError, StandardError => detail
       #TRANSLATORS `prefetch` is a function name and should not be translated
-      message = _("Could not prefetch %{type_name} provider '%{name}': %{detail}") % { type_name: type_name, name: provider_class.name, detail: detail }
-      Puppet.log_exception(detail, message)
-    rescue StandardError => detail
       message = _("Could not prefetch %{type_name} provider '%{name}': %{detail}") % { type_name: type_name, name: provider_class.name, detail: detail }
       Puppet.log_exception(detail, message)
       @prefetch_failed_providers[type_name][provider_class.name] = true

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -603,9 +603,10 @@ describe Puppet::Transaction do
       expect { transaction.prefetch_if_necessary(resource) }.to raise_error(SystemExit, "SystemMessage")
     end
 
-    it "should rescue LoadError" do
+    it "should mark resources as failed when prefetching raises LoadError" do
       expect(resource.provider.class).to receive(:prefetch).and_raise(LoadError, "LoadMessage")
-      expect { transaction.prefetch_if_necessary(resource) }.not_to raise_error
+      transaction.prefetch_if_necessary(resource)
+      expect(transaction.prefetched_providers[:package][:pkgng]).to be_truthy
     end
 
     describe "and prefetching raises Puppet::Error" do


### PR DESCRIPTION
Previously, if prefetch raised `LoadError` or `Puppet::MissingCommand`, then it never marked the resources associated with the providers' type as failed. Similarly, if prefetch raised `StandardError`, then it never marked the resources as failed when `Puppet[:future_features]` was false (default). As a result, the overall transaction status would be "failure", but there wouldn't be any resource status events in the report for what the failure was.

Now we consistently mark resources as failed if `LoadError` or `StandardError` are raised. As a result of this change, if a provider's prefetch raises `LoadError` or `Puppet::MissingCommand`, then the provider will not be called later to create resources, since those exceptions indicate a provider dependency is missing, so there's no point in having the provider enforce desired state.