### PR TITLE
(PUP-10617) Resolve server_list using puppetserver service

### DIFF
--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -22,6 +22,7 @@ module Puppet
     require 'puppet/http/service/ca'
     require 'puppet/http/service/compiler'
     require 'puppet/http/service/file_server'
+    require 'puppet/http/service/puppetserver'
     require 'puppet/http/service/report'
     require 'puppet/http/session'
     require 'puppet/http/resolver'

--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -22,7 +22,6 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
     @server_list_setting = server_list_setting
     @default_port = default_port
     @services = services
-    @resolved_url = nil
   end
 
   #
@@ -58,41 +57,24 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
     @server_list_setting.value.each do |server|
       host = server[0]
       port = server[1] || @default_port
-      uri = URI("https://#{host}:#{port}/status/v1/simple/master")
-      if get_success?(uri, session, ssl_context: ssl_context, error_handler: error_handler)
-        @resolved_url = uri
-        return Puppet::HTTP::Service.create_service(@client, session, name, host, port)
+
+      service = Puppet::HTTP::Service.create_service(@client, session, :puppetserver, host, port)
+      begin
+        service.get_simple_status
+        @resolved_url = service.url
+        return Puppet::HTTP::Service.create_service(@client, session, name, @resolved_url.host, @resolved_url.port)
+      rescue Puppet::HTTP::ResponseError => detail
+        Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %
+                     { host: service.url.host, port: service.url.port, code: detail.response.code, reason: detail.response.reason })
+
+        error_handler.call(detail) if error_handler
+      rescue Puppet::HTTP::HTTPError => detail
+        Puppet.debug _("Unable to connect to server from server_list setting: %{detail}") % {detail: detail}
+
+        error_handler.call(detail) if error_handler
       end
     end
 
     raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: @server_list_setting.print(@server_list_setting.value) }
-  end
-
-  #
-  # @api private
-  #
-  # Check if a server and port is available
-  #
-  # @param [URI] uri A URI created from the server and port to test
-  # @param [Puppet::HTTP::Session] session
-  # @param [Puppet::SSL::SSLContext] ssl_context
-  # @param [Proc] error_handler (nil) optional callback for each error
-  #   encountered while resolving a route.
-  #
-  # @return [Boolean] true if a successful response is returned by the server,
-  #   false otherwise
-  #
-  def get_success?(uri, session, ssl_context: nil, error_handler: nil)
-    response = @client.get(uri, options: {ssl_context: ssl_context})
-    return true if response.success?
-
-    Puppet.debug(_("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %
-                 { host: uri.host, port: uri.port, code: response.code, reason: response.reason })
-    return false
-  rescue => detail
-    error_handler.call(detail) if error_handler
-    #TRANSLATORS 'server_list' is the name of a setting and should not be translated
-    Puppet.debug _("Unable to connect to server from server_list setting: %{detail}") % {detail: detail}
-    return false
   end
 end

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -10,7 +10,7 @@ class Puppet::HTTP::Service
 
   # @api private
   # @return [Array<Symbol>] available services
-  SERVICE_NAMES = [:ca, :fileserver, :puppet, :report].freeze
+  SERVICE_NAMES = [:ca, :fileserver, :puppet, :puppetserver, :report].freeze
 
   # @api private
   # @return [Array<Symbol>] format types that are unsupported
@@ -43,6 +43,8 @@ class Puppet::HTTP::Service
       Puppet::HTTP::Service::FileServer.new(client, session, server, port)
     when :puppet
       ::Puppet::HTTP::Service::Compiler.new(client, session, server, port)
+    when :puppetserver
+      ::Puppet::HTTP::Service::Puppetserver.new(client, session, server, port)
     when :report
       Puppet::HTTP::Service::Report.new(client, session, server, port)
     else

--- a/lib/puppet/http/service/puppetserver.rb
+++ b/lib/puppet/http/service/puppetserver.rb
@@ -1,0 +1,36 @@
+# The puppetserver service.
+#
+# @api private
+#
+class Puppet::HTTP::Service::Puppetserver < Puppet::HTTP::Service
+  # @param [Puppet::HTTP::Client] client
+  # @param [Puppet::HTTP::Session] session
+  # @param [String] server If an explicit server is given,
+  #   create a service using that server. If server is nil, the default value
+  #   is used to create the service.
+  # @param [Integer] port If an explicit port is given, create
+  #   a service using that port. If port is nil, the default value is used to
+  #   create the service.
+  # @api private
+  #
+  def initialize(client, session, server, port)
+    url = build_url('', server || Puppet[:server], port || Puppet[:masterport])
+    super(client, session, url)
+  end
+
+  # Request the puppetserver's simple status
+  #
+  # @return Puppet::HTTP::Response The HTTP response
+  # @api private
+  #
+  def get_simple_status
+    response = @client.get(
+      with_base_url("/status/v1/simple/master"),
+      headers: add_puppet_headers({}),
+    )
+
+    process_response(response)
+
+    [response, response.body.to_s]
+  end
+end

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -43,6 +43,15 @@ describe Puppet::HTTP::Resolver do
       expect(service.url.to_s).to eq("https://ca.example.com:8141/puppet-ca/v1")
     end
 
+    it 'includes extra http headers' do
+      Puppet[:http_extra_headers] = 'region:us-west'
+
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master")
+        .with(headers: {'Region' => 'us-west'})
+
+      subject.resolve(session, :ca)
+    end
+
     it 'logs unsuccessful HTTP 500 responses' do
       Puppet[:log_level] = "debug"
 

--- a/spec/unit/http/service/puppetserver_spec.rb
+++ b/spec/unit/http/service/puppetserver_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'puppet/http'
+
+describe Puppet::HTTP::Service::Puppetserver do
+  let(:ssl_context) { Puppet::SSL::SSLContext.new }
+  let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
+  let(:subject) { client.create_session.route_to(:puppetserver) }
+
+  before :each do
+    Puppet[:server] = 'puppetserver.example.com'
+  end
+
+  context 'when making requests' do
+    it 'includes default HTTP headers' do
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/master").with do |request|
+        expect(request.headers).to include({'X-Puppet-Version' => /./, 'User-Agent' => /./})
+        expect(request.headers).to_not include('X-Puppet-Profiling')
+      end.to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
+
+      subject.get_simple_status
+    end
+
+    it 'includes extra headers' do
+      Puppet[:http_extra_headers] = 'region:us-west'
+
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/master")
+        .with(headers: {'Region' => 'us-west'})
+        .to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
+
+      subject.get_simple_status
+    end
+  end
+
+  context 'when routing to the puppetserver service' do
+    it 'defaults the server and port based on settings' do
+      Puppet[:server] = 'compiler2.example.com'
+      Puppet[:masterport] = 8141
+
+      stub_request(:get, "https://compiler2.example.com:8141/status/v1/simple/master")
+        .to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
+
+      subject.get_simple_status
+    end
+  end
+
+  context 'when getting puppetserver status' do
+    let(:url) { "https://puppetserver.example.com:8140/status/v1/simple/master" }
+
+    it 'returns the request response and status' do
+      stub_request(:get, url)
+        .to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
+
+      resp, status = subject.get_simple_status
+      expect(resp).to be_a(Puppet::HTTP::Response)
+      expect(status).to eq('running')
+    end
+
+    it 'raises a response error if unsuccessful' do
+      stub_request(:get, url).to_return(status: [500, 'Internal Server Error'])
+
+      expect {
+        subject.get_simple_status
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq("Internal Server Error")
+        expect(err.response.code).to eq(500)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously puppet related HTTP headers like `X-Puppet-Version` and those specified in `Puppet[:http_extra_headers]` were not sent in the simple status request, because the ServerList resolver made a "raw" HTTPS request. This commit adds a `puppetserver` service endpoint for REST APIs implemented in puppetserver/clojure and modifies the ServerList resolver to use that.