### PR TITLE
(PUP-10628) Remove Type and TypeSet from RichData

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -28,7 +28,7 @@ class StaticLoader < Loader
   BUILTIN_ALIASES = {
     'Data' => 'Variant[ScalarData,Undef,Hash[String,Data],Array[Data]]',
     'RichDataKey' => 'Variant[String,Numeric]',
-    'RichData' => 'Variant[Scalar,SemVerRange,Binary,Sensitive,Type,TypeSet,URI,Object,Undef,Default,Hash[RichDataKey,RichData],Array[RichData]]',
+    'RichData' => 'Variant[Scalar,SemVerRange,Binary,Sensitive,URI,Object,Undef,Default,Hash[RichDataKey,RichData],Array[RichData]]',
 
     # Backward compatible aliases.
     'Puppet::LookupKey' => 'RichDataKey',


### PR DESCRIPTION
Inferring if a hash (containing hiera data or facts) is an instance of RichData
is slow because the RichData alias includes the TypeSet type, and that will
infer the type of all elements in the hash.

This commit removes Type and TypeSet from RichData, which speeds up lookup 300x
when digging into a hiera hash containing 2000 elements and 3 levels.

This doesn't solve the issue where type inference is performed on each level of
the hash, so if there are N levels and M values in the innermost hash, then type
inference is performed N x M times.