### PR TITLE
(PUP-10628) Short circuit TypeSetType inference

### DIFF
--- a/benchmarks/hiera_env_lookup/benchmarker.rb
+++ b/benchmarks/hiera_env_lookup/benchmarker.rb
@@ -32,34 +32,34 @@ class Benchmarker
   end
 
   def generate
+    # $codedir/
+    #   environments/benchmarking/
+    #     hiera.yaml
+    #     data/
+    #       test/data.yaml
+    #       common.yaml
+    #
     env_dir = File.join(@target, 'environments', 'benchmarking')
     hiera_yaml = File.join(env_dir, 'hiera.yaml')
-    env_conf = File.join(env_dir, 'environment.conf')
     datadir = File.join(env_dir, 'data')
     datadir_test = File.join(datadir, 'test')
     test_data_yaml = File.join(datadir_test, 'data.yaml')
     common_yaml = File.join(datadir, 'common.yaml')
 
-    mkdir_p(env_dir)
-    mkdir_p(datadir)
     mkdir_p(datadir_test)
 
     File.open(hiera_yaml, 'w') do |f|
       f.puts(<<-YAML)
-version: 4
-datadir: data
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
 hierarchy:
   - name: Common
-    backend: yaml
-    path: common
+    path: common.yaml
   - name: Configured
-    backend: yaml
-    path: "%{confdir}/data"
-      YAML
-    end
-
-    File.open(env_conf, 'w') do |f|
-      f.puts("environment_data_provider=hiera")
+    path: test/data.yaml
+YAML
     end
 
     File.open(common_yaml, 'w') do |f|

--- a/benchmarks/hiera_env_lookup/benchmarker.rb
+++ b/benchmarks/hiera_env_lookup/benchmarker.rb
@@ -26,6 +26,11 @@ class Benchmarker
           invocation = Puppet::Pops::Lookup::Invocation.new(scope)
           Puppet::Pops::Lookup.lookup("x#{index}", nil, nil, true, nil, invocation)
         end
+
+        100.times do
+          invocation = Puppet::Pops::Lookup::Invocation.new(scope)
+          Puppet::Pops::Lookup.lookup("h1.h2.h3.k0", nil, nil, true, nil, invocation)
+        end
       end
       catalog
     end
@@ -73,6 +78,15 @@ YAML
 
     File.open(test_data_yaml, 'w') do |f|
       100.times { |index| f.puts("x#{index}: \"%{hiera('cbm#{index}')}\"")}
+
+      f.puts(<<-YAML)
+h1:
+  h2:
+    h3:
+YAML
+      100.times { |index| f.puts(<<-YAML) }
+      k#{index}: v#{index}
+YAML
     end
 
     templates = File.join('benchmarks', 'hiera_env_lookup')

--- a/benchmarks/hiera_global_lookup/benchmarker.rb
+++ b/benchmarks/hiera_global_lookup/benchmarker.rb
@@ -26,6 +26,11 @@ class Benchmarker
           invocation = Puppet::Pops::Lookup::Invocation.new(scope)
           Puppet::Pops::Lookup.lookup("x#{index}", nil, nil, true, nil, invocation)
         end
+
+        100.times do
+          invocation = Puppet::Pops::Lookup::Invocation.new(scope)
+          Puppet::Pops::Lookup.lookup("h1.h2.h3.k0", nil, nil, true, nil, invocation)
+        end
       end
       catalog
     end
@@ -75,6 +80,15 @@ YAML
 
     File.open(test_data_yaml, 'w') do |f|
       100.times { |index| f.puts("x#{index}: \"%{hiera('cbm#{index}')}\"")}
+
+      f.puts(<<-YAML)
+h1:
+  h2:
+    h3:
+YAML
+      100.times { |index| f.puts(<<-YAML) }
+      k#{index}: v#{index}
+YAML
     end
 
     templates = File.join('benchmarks', 'hiera_global_lookup')

--- a/benchmarks/hiera_global_lookup/benchmarker.rb
+++ b/benchmarks/hiera_global_lookup/benchmarker.rb
@@ -32,6 +32,13 @@ class Benchmarker
   end
 
   def generate
+    # $codedir/
+    #   environments/benchmarking/
+    #   hiera.yaml
+    #   data/
+    #     test/data.yaml
+    #     common.yaml
+    #
     env_dir = File.join(@target, 'environments', 'benchmarking')
     hiera_yaml = File.join(@target, 'hiera.yaml')
     datadir = File.join(@target, 'data')
@@ -40,20 +47,21 @@ class Benchmarker
     common_yaml = File.join(datadir, 'common.yaml')
 
     mkdir_p(env_dir)
-    mkdir_p(datadir)
     mkdir_p(datadir_test)
 
     File.open(hiera_yaml, 'w') do |f|
       f.puts(<<-YAML)
 ---
-:backends: yaml
-:yaml:
-   :datadir: #{datadir}
-:hierarchy:
-   - "%{confdir}/data"
-   - common
-:logger: noop
-      YAML
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: Configured
+    path: test/data.yaml
+  - name: Common
+    path: common.yaml
+YAML
     end
 
     File.open(common_yaml, 'w') do |f|

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -349,6 +349,18 @@ class PTypeSetType < PMetaType
     self.class == o.class && @name_authority == o.name_authority && @name == o.name && @version == o.version
   end
 
+  def instance?(o, guard = nil)
+    # KEY_NAME_AUTHORITY, KEY_VERSION and Pcore::KEY_PCORE_URI seem to be optional, for example
+    # https://github.com/puppetlabs/puppet/blob/6.18.0/lib/puppet/pops/model/ast.rb#L4952-L4956,
+    if o.is_a?(Hash) &&
+       o.include?(KEY_NAME) &&
+       o.include?(Pcore::KEY_PCORE_VERSION) &&
+      super(o, guard)
+    else
+      false
+    end
+  end
+
   DEFAULT = self.new({
     KEY_NAME => 'DefaultTypeSet',
     KEY_NAME_AUTHORITY => Pcore::RUNTIME_NAME_AUTHORITY,


### PR DESCRIPTION
Update `hiera_env_lookup` and `hiera_global_lookup` benchmarks to hiera 5, add a nested hash to the hiera data with 100 elements. Dig into the innermost hash 100 times.

Short-circuit TypeSetType reference to avoid performing type inference on the entire hash.

This doesn't solve the issue where type inference is performed on each level of the hash, so if there are N levels, then type inference is performed N times.

The global lookup benchmark for each commit:

```
$ git rebase -i 8032ed3031 --exec 'git rev-parse HEAD && bundle exec rake benchmark:hiera_global_lookup ITERATIONS=5'
Executing: git rev-parse HEAD && bundle exec rake benchmark:hiera_global_lookup ITERATIONS=5
898804a373b77486517fa421332fc359feedb682
mkdir -p /var/folders/8m/d6146zxd6bv_3h8y4ykvvxh40000gn/T/hiera_global_lookup20200825-39054-41r96y
                 user     system      total        real
Run 1        1.600197   0.024084   1.634950 (  1.642572)
Run 2        1.607884   0.005274   1.613158 (  1.614356)
Run 3        1.549855   0.003362   1.553217 (  1.554476)
Run 4        1.594044   0.004711   1.598755 (  1.600612)
Run 5        1.537545   0.003548   1.541093 (  1.542445)
> total:     7.889525   0.040979   7.941173 (  7.954461)
> avg:       1.577905   0.008196   1.588235 (  1.590892)
Executing: git rev-parse HEAD && bundle exec rake benchmark:hiera_global_lookup ITERATIONS=5
322928be4aae44698032ff232f99522980e7fbea
mkdir -p /var/folders/8m/d6146zxd6bv_3h8y4ykvvxh40000gn/T/hiera_global_lookup20200825-39106-1tuayou
                 user     system      total        real
Run 1       79.939910   0.589946  80.540360 ( 80.643803)
Run 2       78.371908   0.479818  78.851726 ( 78.926486)
Run 3       77.636818   0.372531  78.009349 ( 78.069454)
Run 4       78.642264   0.366147  79.008411 ( 79.077411)
Run 5       80.531298   0.433729  80.965027 ( 81.070837)
> total:   395.122198   2.242171 397.374873 (397.787991)
> avg:      79.024440   0.448434  79.474975 ( 79.557598)
Executing: git rev-parse HEAD && bundle exec rake benchmark:hiera_global_lookup ITERATIONS=5
786e8b36667fcfcb445d2c8d10bd1ad2765a6608
mkdir -p /var/folders/8m/d6146zxd6bv_3h8y4ykvvxh40000gn/T/hiera_global_lookup20200825-39270-6n8ntu
                 user     system      total        real
Run 1        4.349452   0.028784   4.388743 (  4.402555)
Run 2        4.569901   0.011152   4.581053 (  4.591476)
Run 3        4.444223   0.007421   4.451644 (  4.456354)
Run 4        4.488973   0.014232   4.503205 (  4.510145)
Run 5        4.192619   0.003740   4.196359 (  4.200008)
> total:    22.045168   0.065329  22.121004 ( 22.160538)
> avg:       4.409034   0.013066   4.424201 (  4.432108)
Successfully rebased and updated refs/heads/type_set_type_infer_10628.
```

The first commit benchmarks lookup without using a nested hash.

The second commit adds the nested hash lookup and takes 79.474975/79.474975 = 50 times longer.

The third commit short circuits TypeSetType inference and takes 79.474975/4.424201 = 18 times less time. As compared to the first commit, the hash lookup takes 4.424201/1.588235 = 2.79 times longer, which may be due to the lookup validating each level of the hash (so 3 times in the benchmark).