### PR TITLE
(PUP-10643) Fix `mark => none` not being idempotent with dpkg provider

### DIFF
--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
       elsif ['config-files', 'half-installed', 'unpacked', 'half-configured'].include?(hash[:status])
         hash[:ensure] = :absent
       end
-      hash[:mark] = :hold if hash[:desired] == 'hold'
+      hash[:mark] = hash[:desired] == 'hold' ? :hold : :none
     else
       Puppet.debug("Failed to match dpkg-query line #{line.inspect}")
     end


### PR DESCRIPTION
On Debian-based platforms, puppet will always report changes if `mark` is set to `none` on a resource. This commit updates the provider to properly parse packages that are not held.

Found in https://github.com/puppetlabs/puppet/pull/8267#issuecomment-675418735