### PR TITLE
(PUP-10623) Use Beaker::Host#user_* methods

### DIFF
--- a/acceptance/tests/resource/exec/should_run_command_as_user.rb
+++ b/acceptance/tests/resource/exec/should_run_command_as_user.rb
@@ -36,9 +36,9 @@ MANIFEST
     username = random_username
 
     # Create our user. Ensure that we start with a clean slate.
-    user_absent(agent, username)
-    user_present(agent, username)
-    teardown { user_absent(agent, username) }
+    agent.user_absent(username)
+    agent.user_present(username)
+    teardown { agent.user_absent(username) }
 
     tmpdir = agent.tmpdir("forbidden")
     on(agent, "chmod 700 #{tmpdir}")

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
@@ -15,7 +15,7 @@ test_name "should not modify the home directory of an user on OS X >= 10.14" do
 
   agents.each do |agent|
     teardown do
-      user_absent(agent, user)
+      agent.user_absent(user)
     end
 
     step "ensure the user is present" do

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
@@ -15,7 +15,7 @@ test_name "should not modify the uid of an user on OS X >= 10.14" do
 
   agents.each do |agent|
     teardown do
-      user_absent(agent, user)
+      agent.user_absent(user)
     end
 
     step "ensure the user is present" do

--- a/acceptance/tests/resource/user/should_modify_home.rb
+++ b/acceptance/tests/resource/user/should_modify_home.rb
@@ -16,7 +16,7 @@ test_name "should modify the home directory of an user on OS X < 10.14" do
 
   agents.each do |agent|
     teardown do
-      user_absent(agent, user)
+      agent.user_absent(user)
     end
 
     step "ensure the user is present" do

--- a/acceptance/tests/resource/user/should_modify_uid.rb
+++ b/acceptance/tests/resource/user/should_modify_uid.rb
@@ -16,7 +16,7 @@ test_name "should modify the uid of an user OS X < 10.14" do
 
   agents.each do |agent|
     teardown do
-      user_absent(agent, user)
+      agent.user_absent(user)
     end
 
     step "ensure the user is present" do


### PR DESCRIPTION
Commit 4f30d93c3eec899ebaca4d7b8eb89aaae89c746f removed the wrappers for `Beaker::Host#user_present` and `user_absent`.

This commit changes the code to also use the Beaker methods.