### PR TITLE
(PUP-10650) Remove PTypeType and PTypeSetType from RichData

### DIFF
--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -28,7 +28,7 @@ class StaticLoader < Loader
   BUILTIN_ALIASES = {
     'Data' => 'Variant[ScalarData,Undef,Hash[String,Data],Array[Data]]',
     'RichDataKey' => 'Variant[String,Numeric]',
-    'RichData' => 'Variant[Scalar,SemVerRange,Binary,Sensitive,Type,TypeSet,URI,Object,Undef,Default,Hash[RichDataKey,RichData],Array[RichData]]',
+    'RichData' => 'Variant[Scalar,SemVerRange,Binary,Sensitive,URI,Object,Undef,Default,Hash[RichDataKey,RichData],Array[RichData]]',
 
     # Backward compatible aliases.
     'Puppet::LookupKey' => 'RichDataKey',


### PR DESCRIPTION
The RichData alias included Type and TypeSet which correspond to PTypeType and
PTypeSetType. While pcore can serialize those objects, we don't in practice.

Also if lookup returns a large hiera hash that happens to include a top-level
`pcore_version` key, then pops will perform full type inference on the hash,
thinking it's a TypeSetType#instance?. To avoid that pitfall remove the Type and
TypeSet types from RichData.

The `Type` and `TypeSet` types were missing from the
'rich_data_compatibile_types` shared context. So the TypeCalculator specs were
never testing that they were instances of RichData. Had the types been included,
then this commit would have removed them.