### PR TITLE
(PUP-7526) Adds pip2 provider

### DIFF
--- a/lib/puppet/provider/package/pip2.rb
+++ b/lib/puppet/provider/package/pip2.rb
@@ -1,0 +1,17 @@
+# Puppet package provider for Python's `pip2` package management frontend.
+# <http://pip.pypa.io/>
+
+Puppet::Type.type(:package).provide :pip2,
+  :parent => :pip do
+
+  desc "Python packages via `pip2`.
+
+  This provider supports the `install_options` attribute, which allows command-line flags to be passed to pip2.
+  These options should be specified as an array where each element is either a string or a hash."
+
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options, :targetable
+
+  def self.cmd
+    ["pip2"]
+  end
+end

--- a/spec/unit/provider/package/pip2_spec.rb
+++ b/spec/unit/provider/package/pip2_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:package).provider(:pip2) do
+
+  it { is_expected.to be_installable }
+  it { is_expected.to be_uninstallable }
+  it { is_expected.to be_upgradeable }
+  it { is_expected.to be_versionable }
+  it { is_expected.to be_install_options }
+  it { is_expected.to be_targetable }
+
+  it "should inherit most things from pip provider" do
+    expect(described_class < Puppet::Type.type(:package).provider(:pip))
+  end
+
+  it "should use pip2 command" do
+    expect(described_class.cmd).to eq(["pip2"])
+  end
+
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
+
+end


### PR DESCRIPTION
As Python2 is being deprecated, users need a way to migrate to Python3. The default `provider => 'pip'` should be using Python3. This MR does not make that change. This MR is an intermediate step to allow users to explicitly use Python2 pip.