### PR TITLE
(PUP-10617) Thread ssl_context through when resolving server list

### DIFF
--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -60,7 +60,7 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
 
       service = Puppet::HTTP::Service.create_service(@client, session, :puppetserver, host, port)
       begin
-        service.get_simple_status
+        service.get_simple_status(ssl_context: ssl_context)
         @resolved_url = service.url
         return Puppet::HTTP::Service.create_service(@client, session, name, @resolved_url.host, @resolved_url.port)
       rescue Puppet::HTTP::ResponseError => detail

--- a/lib/puppet/http/service/puppetserver.rb
+++ b/lib/puppet/http/service/puppetserver.rb
@@ -20,13 +20,16 @@ class Puppet::HTTP::Service::Puppetserver < Puppet::HTTP::Service
 
   # Request the puppetserver's simple status
   #
+  # @param [Puppet::SSL::SSLContext] ssl_context to use when establishing
+  # the connection.
   # @return Puppet::HTTP::Response The HTTP response
   # @api private
   #
-  def get_simple_status
+  def get_simple_status(ssl_context: nil)
     response = @client.get(
       with_base_url("/status/v1/simple/master"),
       headers: add_puppet_headers({}),
+      options: {ssl_context: ssl_context}
     )
 
     process_response(response)

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -52,6 +52,15 @@ describe Puppet::HTTP::Resolver do
       subject.resolve(session, :ca)
     end
 
+    it 'uses the provided ssl context during resolution' do
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 200)
+
+      other_ctx = Puppet::SSL::SSLContext.new
+      expect(client).to receive(:connect).with(URI("https://ca.example.com:8141/status/v1/simple/master"), options: {ssl_context: other_ctx}).and_call_original
+
+      subject.resolve(session, :ca, ssl_context: other_ctx)
+    end
+
     it 'logs unsuccessful HTTP 500 responses' do
       Puppet[:log_level] = "debug"
 

--- a/spec/unit/http/service/puppetserver_spec.rb
+++ b/spec/unit/http/service/puppetserver_spec.rb
@@ -66,5 +66,17 @@ describe Puppet::HTTP::Service::Puppetserver do
         expect(err.response.code).to eq(500)
       end
     end
+
+    it 'accepts an ssl context' do
+      stub_request(:get, url)
+        .to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
+
+      other_ctx = Puppet::SSL::SSLContext.new
+      expect(client).to receive(:connect).with(URI(url), options: {ssl_context: other_ctx}).and_call_original
+
+      session = client.create_session
+      service = Puppet::HTTP::Service.create_service(client, session, :puppetserver, 'puppetserver.example.com', 8140)
+      service.get_simple_status(ssl_context: other_ctx)
+    end
   end
 end


### PR DESCRIPTION
Commit 01f72c395cd1 modified the resolver so it no longer passed the SSLContext
through to the HTTP client. This was ok if the client had completed SSL
initialization previously. But if called during `puppet ssl bootstrap`, then
the client would attempt to load the default SSLContext and fail, since the CA
cert hadn't been retrieved yet.