### PR TITLE
(PUP-10598) Change default value of ignore_plugin_errors to false

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1887,7 +1887,7 @@ EOT
         :desc     => "What files to ignore when pulling down plugins.",
     },
     :ignore_plugin_errors => {
-      :default    => true,
+      :default    => false,
       :type       => :boolean,
       :desc       => "Whether the puppet run should ignore errors during pluginsync. If the setting
         is false and there are errors during pluginsync, then the agent will abort the run and

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -189,6 +189,8 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should return all changed file paths" do
+      Puppet[:ignore_plugin_errors] = true
+
       trans = double('transaction')
 
       catalog = double('catalog')
@@ -204,6 +206,8 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should yield the resources if a block is given" do
+      Puppet[:ignore_plugin_errors] = true
+
       trans = double('transaction')
 
       catalog = double('catalog')
@@ -221,6 +225,8 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should catch and log exceptions" do
+      Puppet[:ignore_plugin_errors] = true
+
       expect(Puppet).to receive(:log_exception)
       # The downloader creates a new catalog for each apply, and really the only object
       # that it is possible to stub for the purpose of generating a puppet error
@@ -230,8 +236,6 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "raises an exception if catalog application fails" do
-      Puppet[:ignore_plugin_errors] = false
-
       expect(@dler.file).to receive(:retrieve).and_raise(Puppet::Error, "testing")
 
       expect {

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -639,6 +639,8 @@ describe Puppet::Configurer do
       end
 
       it "should pluginsync and compile a new catalog if none is found in the cache" do
+        Puppet[:ignore_plugin_errors] = true
+
         expects_fallback_to_new_catalog(catalog)
         stub_request(:get, %r{/puppet/v3/file_metadatas?/plugins}).to_return(:status => 404)
         stub_request(:get, %r{/puppet/v3/file_metadatas?/pluginfacts}).to_return(:status => 404)
@@ -650,6 +652,8 @@ describe Puppet::Configurer do
       end
 
       it "should not attempt to retrieve a cached catalog again if the first attempt failed" do
+        Puppet[:ignore_plugin_errors] = true
+
         expect(Puppet::Node.indirection).to receive(:find).and_return(nil)
         expects_neither_new_or_cached_catalog
         expects_pluginsync


### PR DESCRIPTION
If `ignore_plugin_errors` is true(default value before this commit),
puppet agents can fail to pluginsync and will be missing facts/types/providers
that may be needed to request and apply the catalog.

For example, missing custom/external facts can change which classes are
included in the catalog or cause compilation failures if the manifests
references the missing fact