### PR TITLE
(PUP-10604) Include puppetserver_gem in core puppet

### DIFF
--- a/acceptance/tests/provider/package/puppetserver_gem.rb
+++ b/acceptance/tests/provider/package/puppetserver_gem.rb
@@ -1,0 +1,37 @@
+test_name "puppetserver_gem provider should install and uninstall" do
+  tag 'audit:high',
+      'server'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::PackageUtils
+  extend Puppet::Acceptance::ManifestUtils
+
+  skip_test 'puppetserver_gem is only suitable on server nodes' unless master
+
+  package = 'world_airports'
+
+  teardown do
+    # Ensure the gem is uninstalled if anything goes wrong
+    # TODO maybe execute this only if something fails, as it takes time
+    on(master, "puppetserver gem uninstall #{package}")
+  end
+
+  step "Installing a gem executes without error" do
+    package_manifest = resource_manifest('package', package, { ensure: 'present', provider: 'puppetserver_gem' } )
+    apply_manifest_on(master, package_manifest, catch_failures: true) do
+      list = on(master, "puppetserver gem list").stdout
+      assert_match(/#{package} \(/, list)
+    end
+
+    # Run again for idempotency
+    apply_manifest_on(master, package_manifest, catch_changes: true)
+  end
+
+  step "Uninstalling a gem executes without error" do
+    package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'puppetserver_gem' } )
+    apply_manifest_on(master, package_manifest, catch_failures: true) do
+      list = on(master, "puppetserver gem list").stdout
+      assert_no_match(/#{package} \(/, list)
+    end
+  end
+end

--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -1,0 +1,176 @@
+require 'rubygems/commands/list_command'
+require 'stringio'
+require 'uri'
+
+# Ruby gems support.
+Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
+  desc "Puppet Server Ruby Gem support. If a URL is passed via `source`, then
+    that URL is appended to the list of remote gem repositories which by default
+    contains rubygems.org; To ensure that only the specified source is used also
+    pass `--clear-sources` in via `install_options`; if a source is present but
+    is not a valid URL, it will be interpreted as the path to a local gem file.
+    If source is not present at all, the gem will be installed from the default
+    gem repositories."
+
+  has_feature :versionable, :install_options, :uninstall_options
+
+  confine :feature => :hocon
+
+  # Define the default provider package command name, as the parent 'gem' provider is targetable.
+  # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command
+
+  def self.provider_command
+    command(:puppetservercmd)
+  end
+
+  # The gem command uses HOME to locate a gemrc file.
+  # CommandDefiner in provider.rb will set failonfail, combine, and environment.
+
+  has_command(:puppetservercmd, '/opt/puppetlabs/bin/puppetserver') do
+    environment(HOME: ENV['HOME'])
+  end
+
+  def self.gemlist(options)
+    command_options = ['gem', 'list']
+
+    if options[:local]
+      command_options << '--local'
+    else
+      command_options << '--remote'
+    end
+
+    if options[:source]
+      command_options << '--source' << options[:source]
+    end
+
+    if options[:justme]
+      gem_regex = '\A' + options[:justme] + '\z'
+      command_options << gem_regex
+    end
+
+    if options[:local]
+      list = execute_rubygems_list_command(gem_regex)
+    else
+      begin
+        list = puppetservercmd(command_options)
+      rescue Puppet::ExecutionFailure => detail
+        raise Puppet::Error, _("Could not list gems: %{detail}") % { detail: detail }, detail.backtrace
+      end
+    end
+
+    # When `/tmp` is mounted `noexec`, `puppetserver gem list` will output:
+    # *** LOCAL GEMS ***
+    # causing gemsplit to output:
+    # Warning: Could not match *** LOCAL GEMS ***
+    gem_list = list
+                 .lines
+                 .select { |x| x =~ /^(\S+)\s+\((.+)\)/ }
+                 .map { |set| gemsplit(set) }
+
+    if options[:justme]
+      return gem_list.shift
+    else
+      return gem_list
+    end
+  end
+
+  def install(useversion = true)
+    command_options = ['gem', 'install']
+    command_options += install_options if resource[:install_options]
+
+    command_options << '-v' << resource[:ensure] if (!resource[:ensure].is_a? Symbol) && useversion
+
+    command_options << '--no-document'
+
+    if resource[:source]
+      begin
+        uri = URI.parse(resource[:source])
+      rescue => detail
+        self.fail Puppet::Error, _("Invalid source '%{uri}': %{detail}") % { uri: uri, detail: detail }, detail
+      end
+
+      case uri.scheme
+      when nil
+        # no URI scheme => interpret the source as a local file
+        command_options << resource[:source]
+      when /file/i
+        command_options << uri.path
+      when 'puppet'
+        # we don't support puppet:// URLs (yet)
+        raise Puppet::Error.new(_('puppet:// URLs are not supported as gem sources'))
+      else
+        # interpret it as a gem repository
+        command_options << '--source' << "#{resource[:source]}" << resource[:name]
+      end
+    else
+      command_options << resource[:name]
+    end
+
+    output = puppetservercmd(command_options)
+    # Apparently, some gem versions don't exit non-0 on failure.
+    self.fail _("Could not install: %{output}") % { output: output.chomp } if output.include?('ERROR')
+  end
+
+  def uninstall
+    command_options = ['gem', 'uninstall']
+    command_options << '--executables' << '--all' << resource[:name]
+    command_options += uninstall_options if resource[:uninstall_options]
+
+    output = puppetservercmd(command_options)
+    # Apparently, some gem versions don't exit non-0 on failure.
+    self.fail _("Could not uninstall: %{output}") % { output: output.chomp } if output.include?('ERROR')
+  end
+
+  private
+
+  # The puppetserver gem cli command is very slow, since it starts a JVM.
+  #
+  # Instead, for the list subcommand (which is executed with every puppet run),
+  # use the rubygems library from puppet ruby: setting GEM_HOME and GEM_PATH
+  # to the default values, or the values in the puppetserver configuration file.
+  #
+  # The rubygems library cannot access java platform gems,
+  # for example: json (1.8.3 java)
+  # but java platform gems should not be managed by this (or any) provider.
+
+  def self.execute_rubygems_list_command(gem_regex)
+    puppetserver_default_gem_home            = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
+    puppetserver_default_vendored_jruby_gems = '/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems'
+    puppet_default_vendor_gems               = '/opt/puppetlabs/puppet/lib/ruby/vendor_gems'
+    puppetserver_default_gem_path = [puppetserver_default_gem_home, puppetserver_default_vendored_jruby_gems, puppet_default_vendor_gems].join(':')
+
+    pe_puppetserver_conf_file = '/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf'
+    os_puppetserver_conf_file = '/etc/puppetlabs/puppetserver/puppetserver.conf'
+    puppetserver_conf_file = Facter.value(:pe_server_version) ? pe_puppetserver_conf_file : os_puppetserver_conf_file
+    puppetserver_conf = Hocon.load(puppetserver_conf_file)
+
+    gem_env = {}
+    if puppetserver_conf.empty? || puppetserver_conf.key?('jruby-puppet') == false
+      gem_env['GEM_HOME'] = puppetserver_default_gem_home
+      gem_env['GEM_PATH'] = puppetserver_default_gem_path
+    else
+      gem_env['GEM_HOME'] = puppetserver_conf['jruby-puppet'].key?('gem-home') ? puppetserver_conf['jruby-puppet']['gem-home'] : puppetserver_default_gem_home
+      gem_env['GEM_PATH'] = puppetserver_conf['jruby-puppet'].key?('gem-path') ? puppetserver_conf['jruby-puppet']['gem-path'].join(':') : puppetserver_default_gem_path
+    end
+    gem_env['GEM_SPEC_CACHE'] = "/tmp/#{$$}"
+    Gem.paths = gem_env
+
+    sio_inn = StringIO.new
+    sio_out = StringIO.new
+    sio_err = StringIO.new
+    stream_ui = Gem::StreamUI.new(sio_inn, sio_out, sio_err, false)
+    gem_list_cmd = Gem::Commands::ListCommand.new
+    gem_list_cmd.options[:domain] = :local
+    gem_list_cmd.options[:args] = [gem_regex] if gem_regex
+    gem_list_cmd.ui = stream_ui
+    gem_list_cmd.execute
+
+    # There is no method exclude default gems from the local gem list,
+    # for example: psych (default: 2.2.2)
+    # but default gems should not be managed by this (or any) provider.
+    gem_list = sio_out.string.lines.reject { |gem| gem =~ / \(default\: / }
+    gem_list.join("\n")
+  ensure
+    Gem.clear_paths
+  end
+end

--- a/spec/fixtures/unit/provider/package/puppetserver_gem/gem-list-local-packages
+++ b/spec/fixtures/unit/provider/package/puppetserver_gem/gem-list-local-packages
@@ -1,0 +1,30 @@
+concurrent-ruby (1.1.5)
+
+deep_merge (1.0.1)
+
+fast_gettext (1.1.2)
+
+gettext (3.2.2)
+
+hiera-eyaml (3.2.0)
+
+highline (1.6.21)
+
+hocon (1.3.1, 1.2.5)
+
+locale (2.1.3, 2.1.2)
+
+multi_json (1.14.1)
+
+optimist (3.0.1)
+
+puppet-resource_api (1.8.13)
+
+puppetserver-ca (1.8.0)
+
+semantic_puppet (1.0.2)
+
+text (1.3.1)
+
+world_airports (1.1.3)
+

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -46,6 +46,8 @@ describe Puppet::Type.type(:package).provider(:openbsd) do
     allow(described_class).to receive(:command).with(:pkginfo).and_return('/bin/pkg_info')
     allow(described_class).to receive(:command).with(:pkgadd).and_return('/bin/pkg_add')
     allow(described_class).to receive(:command).with(:pkgdelete).and_return('/bin/pkg_delete')
+
+    allow(Puppet::FileSystem).to receive(:exist?)
   end
 
   context "#instances" do

--- a/spec/unit/provider/package/puppetserver_gem_spec.rb
+++ b/spec/unit/provider/package/puppetserver_gem_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:package).provider(:puppetserver_gem) do
+  let(:resource) do
+    Puppet::Type.type(:package).new(
+      name: 'myresource',
+      ensure: :installed
+    )
+  end
+
+  let(:provider) do
+    provider = described_class.new
+    provider.resource = resource
+    provider
+  end
+
+  let(:provider_gem_cmd) { '/opt/puppetlabs/bin/puppetserver' }
+
+  custom_environment = { HOME: ENV['HOME'] }
+
+  let(:execute_options) { { failonfail: true, combine: true, custom_environment: custom_environment } }
+
+  before :each do
+    resource.provider = provider
+    allow(Puppet::Util).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+  end
+
+  describe "#install" do
+    it "uses the path to the gem command" do
+      allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
+      expect(Puppet::Util::Execution).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
+      provider.install
+    end
+
+    it "appends version if given" do
+      resource[:ensure] = ['1.2.1']
+      expect(described_class).to receive(:puppetservercmd).with(%w{gem install -v 1.2.1 --no-document myresource}).and_return('')
+      provider.install
+    end
+
+    context "with install_options" do
+      it "does not append the parameter by default" do
+        expect(described_class).to receive(:puppetservercmd).with(%w{gem install --no-document myresource}).and_return('')
+        provider.install
+      end
+
+      it "allows setting the parameter" do
+        resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
+        expect(described_class).to receive(:puppetservercmd).with(%w{gem install --force --bindir=/usr/bin --no-document myresource}).and_return('')
+        provider.install
+      end
+    end
+
+    context "with source" do
+      it "correctly sets http source" do
+        resource[:source] = 'http://rubygems.com'
+        expect(described_class).to receive(:puppetservercmd).with(%w{gem install --no-document --source http://rubygems.com myresource}).and_return('')
+        provider.install
+      end
+
+      it "correctly sets local file source" do
+        resource[:source] = 'paint-2.2.0.gem'
+        expect(described_class).to receive(:puppetservercmd).with(%w{gem install --no-document paint-2.2.0.gem}).and_return('')
+        provider.install
+      end
+
+      it "correctly sets local file source with URI scheme" do
+        resource[:source] = 'file:///root/paint-2.2.0.gem'
+        expect(described_class).to receive(:puppetservercmd).with(%w{gem install --no-document /root/paint-2.2.0.gem}).and_return('')
+        provider.install
+      end
+
+      it "raises if given a puppet URI scheme" do
+        resource[:source] = 'puppet:///paint-2.2.0.gem'
+        expect { provider.install }.to raise_error(Puppet::Error, 'puppet:// URLs are not supported as gem sources')
+      end
+
+      it "raises if given an invalid URI" do
+        resource[:source] = 'h;ttp://rubygems.com'
+        expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI\(is not URI\?\)/)
+      end
+    end
+  end
+
+  describe "#uninstall" do
+    it "uses the path to the gem command" do
+      allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
+      expect(Puppet::Util::Execution).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
+      provider.uninstall
+    end
+
+    context "with uninstall_options" do
+      it "does not append the parameter by default" do
+        expect(described_class).to receive(:puppetservercmd).with(%w{gem uninstall --executables --all myresource}).and_return('')
+        provider.uninstall
+      end
+
+      it "allows setting the parameter" do
+        resource[:uninstall_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
+        expect(described_class).to receive(:puppetservercmd).with(%w{gem uninstall --executables --all myresource --force --bindir=/usr/bin}).and_return('')
+        provider.uninstall
+      end
+    end
+  end
+
+  describe ".gemlist" do
+    context "listing installed packages" do
+      it "uses the puppet rubygems library to list local gems" do
+        expected = { name: 'world_airports', provider: :puppetserver_gem, ensure: ['1.1.3'] }
+        expect(described_class).to receive(:execute_rubygems_list_command).with(nil).and_return(File.read(my_fixture('gem-list-local-packages')))
+        expect(described_class.gemlist({ local: true })).to include(expected)
+      end
+    end
+
+    it "appends the gem source if given" do
+      expect(described_class).to receive(:puppetservercmd).with(%w{gem list --remote --source https://rubygems.com}).and_return('')
+      described_class.gemlist({ source: 'https://rubygems.com' })
+    end
+  end
+
+  context 'calculated specificity' do
+    context 'when is not defaultfor' do
+      subject { described_class.specificity }
+      it { is_expected.to eql 1 }
+    end
+
+    context 'when is defaultfor' do
+      let(:os) {  Facter.value(:operatingsystem) }
+      subject do
+        described_class.defaultfor(operatingsystem: os)
+        described_class.specificity
+      end
+      it { is_expected.to be > 100 }
+    end
+  end
+
+end


### PR DESCRIPTION
The puppetserver_gem package provider is currently available through the
puppetlabs-puppetserver_gem module.[1]

Pull the provider into core puppet, as decided in the ticket.

In addition to this, fix some Lint/AssignmentInCondition rubocop offsenses and
make the `self.execute_rubygems_list_command` private.

Add spec and acceptance tests.

[1] https://forge.puppet.com/puppetlabs/puppetserver_gem