### PR TITLE
(PUP-10628) Check for an instance of PTypeSetType

### DIFF
--- a/lib/puppet/pops/types/p_meta_type.rb
+++ b/lib/puppet/pops/types/p_meta_type.rb
@@ -22,7 +22,7 @@ class PMetaType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    assignable?(TypeCalculator.infer(o), guard)
+    raise NotImplementedError, "Subclass of PMetaType should implement 'instance?'"
   end
 
   # Called from the TypeParser once it has found a type using the Loader. The TypeParser will

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -350,15 +350,7 @@ class PTypeSetType < PMetaType
   end
 
   def instance?(o, guard = nil)
-    # KEY_NAME_AUTHORITY, KEY_VERSION and Pcore::KEY_PCORE_URI seem to be optional, for example
-    # https://github.com/puppetlabs/puppet/blob/6.18.0/lib/puppet/pops/model/ast.rb#L4952-L4956,
-    if o.is_a?(Hash) &&
-       o.include?(KEY_NAME) &&
-       o.include?(Pcore::KEY_PCORE_VERSION) &&
-      super(o, guard)
-    else
-      false
-    end
+    o.is_a?(PTypeSetType)
   end
 
   DEFAULT = self.new({

--- a/spec/shared_contexts/types_setup.rb
+++ b/spec/shared_contexts/types_setup.rb
@@ -187,6 +187,8 @@ shared_context 'types_setup' do
     result << Puppet::Pops::Types::PURIType
     result << Puppet::Pops::Types::PTupleType.new([tf.rich_data])
     result << Puppet::Pops::Types::PObjectType
+    result << Puppet::Pops::Types::PTypeType
+    result << Puppet::Pops::Types::PTypeSetType
     result
   end
   def rich_data_compatible_types


### PR DESCRIPTION
Check that the object passed to `PTypeSetType#instance?` is an instance of
`PTypeSetType` or subclass, instead of a `Hash` with a pcore_uri key. This
redoes the change from commit 786e8b366.

The `PTypeType#instance?` method already checks for specific classes, so doesn't
cause full type inference of a Hash.

Add the `PTypeType` and `PTypeSetType` to the list of rich data compatible
classes, so they are tested in the type calculator specs. Those classes
correspond to the `Type` and `TypeSet` in the `RichData` alias.