### PR TITLE
(maint) Skip 'last_run_summary_report.rb' test on Japanese Windows

### DIFF
--- a/acceptance/tests/agent/last_run_summary_report.rb
+++ b/acceptance/tests/agent/last_run_summary_report.rb
@@ -5,6 +5,8 @@ test_name "The 'last_run_summary.yaml' report has the right location and permiss
   extend Puppet::Acceptance::TempFileUtils
   
   agents.each do |agent|
+    skip_test('This test does not work on Windows in japanese') if agent['platform'] =~ /windows/ && agent['locale'] == 'ja'
+
     custom_publicdir = agent.tmpdir('custom_public_dir')
 
     statedir = on(agent, puppet('config print statedir')).stdout.chomp


### PR DESCRIPTION
The `last_run_summary_report.rb` acceptance test needs to be skipped on Windows machines in Japanese due to malformed output.

Error found:
`Expected /None:\(R\)/ to match "...PC-NAME\\Ȃ:(R)\n..."`