### PR TITLE
(PUP-10509) Drop support for Ruby < 2.5

### DIFF
--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -1,4 +1,4 @@
-test_name 'C97760: Bignum in reduce() should not cause exception' do
+test_name 'C97760: Integer in reduce() should not cause exception' do
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
 
@@ -8,7 +8,7 @@ test_name 'C97760: Bignum in reduce() should not cause exception' do
   app_type = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
 
-  step 'On master, create site.pp with bignum' do
+  step 'On master, create site.pp with integer' do
     create_sitepp(master, tmp_environment, <<-SITEPP)
 $data = [
 {

--- a/lib/puppet/http/factory.rb
+++ b/lib/puppet/http/factory.rb
@@ -31,10 +31,8 @@ class Puppet::HTTP::Factory
     http.open_timeout = Puppet[:http_connect_timeout]
     http.keep_alive_timeout = KEEP_ALIVE_TIMEOUT if http.respond_to?(:keep_alive_timeout=)
 
-    if http.respond_to?(:max_retries)
-      # 0 means make one request and never retry
-      http.max_retries = 0
-    end
+    # 0 means make one request and never retry
+    http.max_retries = 0
 
     if Puppet[:sourceaddress]
       Puppet.debug("Using source IP #{Puppet[:sourceaddress]}")

--- a/lib/puppet/pops/model/model_label_provider.rb
+++ b/lib/puppet/pops/model/model_label_provider.rb
@@ -85,8 +85,6 @@ class ModelLabelProvider
   def label_SelectorExpression o          ; "Selector Expression"               end
   def label_SelectorEntry o               ; "Selector Option"                   end
   def label_Integer o                     ; "Integer"                           end
-  def label_Fixnum o                      ; "Integer"                           end
-  def label_Bignum o                      ; "Integer"                           end
   def label_Float o                       ; "Float"                             end
   def label_String o                      ; "String"                            end
   def label_Regexp o                      ; "Regexp"                            end

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -102,30 +102,3 @@ unless Puppet::Util::Platform.jruby_fips?
     end
   end
 end
-
-# The Enumerable#uniq method was added in Ruby 2.4.0 (https://bugs.ruby-lang.org/issues/11090)
-# This is a backport to earlier Ruby versions.
-#
-unless Enumerable.instance_methods.include?(:uniq)
-  module Enumerable
-    def uniq
-      result = []
-      uniq_map = {}
-      if block_given?
-        each do |value|
-          key = yield value
-          next if uniq_map.has_key?(key)
-          uniq_map[key] = true
-          result << value
-        end
-      else
-        each do |value|
-          next if uniq_map.has_key?(value)
-          uniq_map[value] = true
-          result << value
-        end
-      end
-      result
-    end
-  end
-end

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -103,25 +103,6 @@ unless Puppet::Util::Platform.jruby_fips?
   end
 end
 
-unless Puppet::Util::Platform.jruby_fips?
-  unless OpenSSL::PKey::EC.instance_methods.include?(:private?)
-    class OpenSSL::PKey::EC
-      # Added in ruby 2.4.0 in https://github.com/ruby/ruby/commit/7c971e61f04
-      alias :private? :private_key?
-    end
-  end
-
-  unless OpenSSL::PKey::EC.singleton_methods.include?(:generate)
-    class OpenSSL::PKey::EC
-      # Added in ruby 2.4.0 in https://github.com/ruby/ruby/commit/85500b66342
-      def self.generate(string)
-        ec = OpenSSL::PKey::EC.new(string)
-        ec.generate_key
-      end
-    end
-  end
-end
-
 # The Enumerable#uniq method was added in Ruby 2.4.0 (https://bugs.ruby-lang.org/issues/11090)
 # This is a backport to earlier Ruby versions.
 #

--- a/lib/puppet/util/retry_action.rb
+++ b/lib/puppet/util/retry_action.rb
@@ -7,7 +7,7 @@ module Puppet::Util::RetryAction
   # Execute the supplied block retrying with exponential backoff.
   #
   # @param [Hash] options the retry options
-  # @option options [FixNum] :retries Maximum number of times to retry.
+  # @option options [Integer] :retries Maximum number of times to retry.
   # @option options [Array<Exception>] :retry_exceptions ([StandardError]) Optional array of exceptions that are allowed to be retried.
   # @yield The block to be executed.
   def self.retry_action(options = {})

--- a/lib/puppet/util/windows/eventlog.rb
+++ b/lib/puppet/util/windows/eventlog.rb
@@ -46,8 +46,8 @@ class Puppet::Util::Windows::EventLog
   end
 
   # Report an event to this instance's event log handle. Accepts a string to
-  #   report (:data => <string>) and event type (:event_type => FixNum) and id
-  # (:event_id => FixNum) as returned by #to_native. The additional arguments to
+  #   report (:data => <string>) and event type (:event_type => Integer) and id
+  # (:event_id => Integer) as returned by #to_native. The additional arguments to
   # ReportEventW seen in this method aren't exposed - though ReportEventW
   # technically can accept multiple strings as well as raw binary data to log,
   # we accept a single string from Puppet::Util::Log

--- a/spec/unit/file_bucket/file_spec.rb
+++ b/spec/unit/file_bucket/file_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::FileBucket::File, :uses_checksums => true do
   end
 
   it "should require contents to be a string" do
-    expect { Puppet::FileBucket::File.new(5) }.to raise_error(ArgumentError, /contents must be a String or Pathname, got a (?:Fixnum|Integer)$/)
+    expect { Puppet::FileBucket::File.new(5) }.to raise_error(ArgumentError, /contents must be a String or Pathname, got a Integer$/)
   end
 
   it "should complain about options other than :bucket_path" do

--- a/spec/unit/functions/camelcase_spec.rb
+++ b/spec/unit/functions/camelcase_spec.rb
@@ -15,7 +15,7 @@ describe 'the camelcase function' do
     expect(compile_to_catalog("notify { String(42.camelcase == 42): }")).to have_resource('Notify[true]')
   end
 
-  it 'performs capitalize of international UTF-8 characters', :if => RUBY_VERSION >= "2.4" do
+  it 'performs camelcase of international UTF-8 characters' do
     expect(compile_to_catalog("notify { 'åäö_äö'.camelcase: }")).to have_resource('Notify[ÅäöÄö]')
   end
 

--- a/spec/unit/functions/capitalize_spec.rb
+++ b/spec/unit/functions/capitalize_spec.rb
@@ -15,7 +15,7 @@ describe 'the capitalize function' do
     expect(compile_to_catalog("notify { String(42.capitalize == 42): }")).to have_resource('Notify[true]')
   end
 
-  it 'performs capitalize of international UTF-8 characters', :if => RUBY_VERSION >= "2.4" do
+  it 'performs capitalize of international UTF-8 characters' do
     expect(compile_to_catalog("notify { 'åäö'.capitalize: }")).to have_resource('Notify[Åäö]')
   end
 

--- a/spec/unit/functions/downcase_spec.rb
+++ b/spec/unit/functions/downcase_spec.rb
@@ -15,7 +15,7 @@ describe 'the downcase function' do
     expect(compile_to_catalog("notify { String(42.downcase == 42): }")).to have_resource('Notify[true]')
   end
 
-  it 'performs capitalize of international UTF-8 characters', :if => RUBY_VERSION >= "2.4" do
+  it 'performs downcase of international UTF-8 characters' do
     expect(compile_to_catalog("notify { 'ÅÄÖ'.downcase: }")).to have_resource('Notify[åäö]')
   end
 

--- a/spec/unit/functions/upcase_spec.rb
+++ b/spec/unit/functions/upcase_spec.rb
@@ -15,7 +15,7 @@ describe 'the upcase function' do
     expect(compile_to_catalog("notify { String(42.upcase == 42): }")).to have_resource('Notify[true]')
   end
 
-  it 'performs capitalize of international UTF-8 characters', :if => RUBY_VERSION >= "2.4" do
+  it 'performs upcase of international UTF-8 characters' do
     expect(compile_to_catalog("notify { 'åäö'.upcase: }")).to have_resource('Notify[ÅÄÖ]')
   end
 

--- a/spec/unit/http/factory_spec.rb
+++ b/spec/unit/http/factory_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::HTTP::Factory do
     expect(conn.keep_alive_timeout).to eq(2147483647)
   end
 
-  it "disables ruby's max retry on 2.5 and up", if: RUBY_VERSION.to_f >= 2.5 do
+  it "disables ruby's max retry" do
     conn = create_connection(site)
 
     expect(conn.max_retries).to eq(0)

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -818,14 +818,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       end
     end
 
-    # Integer for >= 2.4.0, otherwise Fixnum
-    int_class_name = 0.class.name
-
     # Errors when wrong number/type of keys are used
     {
-      "Array[0]"                    => "Array-Type[] arguments must be types. Got #{int_class_name}",
-      "Hash[0]"                     => "Hash-Type[] arguments must be types. Got #{int_class_name}",
-      "Hash[Integer, 0]"            => "Hash-Type[] arguments must be types. Got #{int_class_name}",
+      "Array[0]"                    => "Array-Type[] arguments must be types. Got Integer",
+      "Hash[0]"                     => "Hash-Type[] arguments must be types. Got Integer",
+      "Hash[Integer, 0]"            => "Hash-Type[] arguments must be types. Got Integer",
       "Array[Integer,1,2,3]"        => 'Array-Type[] accepts 1 to 3 arguments. Got 4',
       "Array[Integer,String]"       => "A Type's size constraint arguments must be a single Integer type, or 1-2 integers (or default). Got a String-Type",
       "Hash[Integer,String, 1,2,3]" => 'Hash-Type[] accepts 2 to 4 arguments. Got 5',
@@ -833,7 +830,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "'abc'[1.0]"                  => "A substring operation does not accept a Float as a character index. Expected an Integer",
       "'abc'[1, x]"                 => "A substring operation does not accept a String as a character index. Expected an Integer",
       "'abc'[1,2,3]"                => "String supports [] with one or two arguments. Got 3",
-      "NotUndef[0]"                 => "NotUndef-Type[] argument must be a Type or a String. Got #{int_class_name}",
+      "NotUndef[0]"                 => "NotUndef-Type[] argument must be a Type or a String. Got Integer",
       "NotUndef[a,b]"               => 'NotUndef-Type[] accepts 0 to 1 arguments. Got 2',
       "Resource[0]"                 => 'First argument to Resource[] must be a resource type or a String. Got Integer',
       "Resource[a, 0]"              => 'Error creating type specialization of a Resource-Type, Cannot use Integer where a resource title String is expected',

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -629,7 +629,7 @@ module Serialization
     it 'the value of a type description is something other than a String or a Hash' do
       expect do
         from_converter.convert({ '__ptype' => { '__ptype' => 'Pcore::TimestampType', '__pvalue' => 12345 }})
-      end.to raise_error(/Cannot create a Pcore::TimestampType from a (Fixnum|Integer)/)
+      end.to raise_error(/Cannot create a Pcore::TimestampType from a Integer/)
     end
   end
 end

--- a/spec/unit/pops/types/type_calculator_spec.rb
+++ b/spec/unit/pops/types/type_calculator_spec.rb
@@ -141,11 +141,11 @@ describe 'The type calculator' do
 
   context 'when inferring ruby' do
 
-    it 'fixnum translates to PIntegerType' do
+    it 'integer translates to PIntegerType' do
       expect(calculator.infer(1).class).to eq(PIntegerType)
     end
 
-    it 'large fixnum (or bignum depending on architecture) translates to PIntegerType' do
+    it 'large integer translates to PIntegerType' do
       expect(calculator.infer(2**33).class).to eq(PIntegerType)
     end
 
@@ -329,7 +329,7 @@ describe 'The type calculator' do
         expect(object_t('name' => 'DerivedObjectArray')).to be_instance(derived_object)
       end
 
-      it 'with fixnum values translates to PArrayType[PIntegerType]' do
+      it 'with integer values translates to PArrayType[PIntegerType]' do
         expect(calculator.infer([1,2]).element_type.class).to eq(PIntegerType)
       end
 
@@ -407,7 +407,7 @@ describe 'The type calculator' do
         expect(et.class).to eq(PEnumType)
       end
 
-      it 'with array of string values and array of fixnums translates to PArrayType[PArrayType[PScalarDataType]]' do
+      it 'with array of string values and array of integers translates to PArrayType[PArrayType[PScalarDataType]]' do
         et = calculator.infer([['first', 'array'], [1,2]])
         expect(et.class).to eq(PArrayType)
         et = et.element_type
@@ -425,7 +425,7 @@ describe 'The type calculator' do
         expect(et.class).to eq(PEnumType)
       end
 
-      it 'with hash of string values and hash of fixnums translates to PArrayType[PHashType[PScalarDataType]]' do
+      it 'with hash of string values and hash of integers translates to PArrayType[PHashType[PScalarDataType]]' do
         et = calculator.infer([{:first => 'first', :second => 'second' }, {:first => 1, :second => 2 }])
         expect(et.class).to eq(PArrayType)
         et = et.element_type
@@ -489,7 +489,7 @@ describe 'The type calculator' do
         expect(calculator.infer({'first' => 1, 'second' => 2}).key_type.class).to eq(PEnumType)
       end
 
-      it 'with fixnum values translates to PHashType[key, PIntegerType]' do
+      it 'with integer values translates to PHashType[key, PIntegerType]' do
         expect(calculator.infer({:first => 1, :second => 2}).value_type.class).to eq(PIntegerType)
       end
 

--- a/spec/unit/pops/types/type_factory_spec.rb
+++ b/spec/unit/pops/types/type_factory_spec.rb
@@ -151,7 +151,7 @@ describe 'The type factory' do
       expect(hc.class_name).to eq('x')
     end
 
-    it 'array_of(fixnum) returns PArrayType[PIntegerType]' do
+    it 'array_of(integer) returns PArrayType[PIntegerType]' do
       at = TypeFactory.array_of(1)
       expect(at.class()).to eq(PArrayType)
       expect(at.element_type.class).to eq(PIntegerType)

--- a/spec/unit/pops/visitor_spec.rb
+++ b/spec/unit/pops/visitor_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Pops::Visitor do
 
     it "should select method for superclass" do
       duck_processor = DuckProcessor.new
-      expect(duck_processor.hi(42)).to match(/Howdy (?:Fixnum|Integer)/)
+      expect(duck_processor.hi(42)).to match(/Howdy Integer/)
     end
 
     it "should select method for superclass" do

--- a/spec/unit/settings/http_extra_headers_spec.rb
+++ b/spec/unit/settings/http_extra_headers_spec.rb
@@ -46,18 +46,16 @@ describe Puppet::Settings::HttpExtraHeadersSetting do
     end
 
     describe 'raises an error when' do
-
-      # Ruby 2.3 reports the class of these objects as Fixnum, whereas later ruby versions report them as Integer
       it 'is given an unexpected object type' do
         expect {
           subject.munge(65)
-          }.to raise_error(ArgumentError, /^Expected an Array, String, or Hash, got a (Integer|Fixnum)/)
+          }.to raise_error(ArgumentError, /^Expected an Array, String, or Hash, got a Integer/)
       end
 
       it 'is given an array of unexpected object types' do
         expect {
           subject.munge([65, 82])
-          }.to raise_error(ArgumentError, /^Expected an Array or String, got a (Integer|Fixnum)/)
+          }.to raise_error(ArgumentError, /^Expected an Array or String, got a Integer/)
       end
     end
   end

--- a/spec/unit/type/file/ensure_spec.rb
+++ b/spec/unit/type/file/ensure_spec.rb
@@ -85,7 +85,7 @@ describe Puppet::Type.type(:file).attrclass(:ensure) do
         }.to raise_error(Puppet::Error, /Cannot create #{newpath}; parent directory #{File.dirname(newpath)} does not exist/)
       end
 
-      it "should accept octal mode as fixnum" do
+      it "should accept octal mode as integer" do
         resource[:mode] = '0700'
         expect(resource).to receive(:property_fix)
         expect(Dir).to receive(:mkdir).with(path, 0700)

--- a/spec/unit/type/file/mode_spec.rb
+++ b/spec/unit/type/file/mode_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Type.type(:file).attrclass(:mode) do
     it "should reject non-string values" do
       expect {
         mode.value = 0755
-      }.to raise_error(Puppet::Error, /The file mode specification must be a string, not '(?:Fixnum|Integer)'/)
+      }.to raise_error(Puppet::Error, /The file mode specification must be a string, not 'Integer'/)
     end
 
     it "should accept values specified as octal numbers in strings" do

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -135,9 +135,3 @@ describe SecureRandom do
     expect(SecureRandom.uuid).to match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i)
   end
 end
-
-describe 'Enumerable' do
-  it 'expects uniq to work on an Enumerable' do
-    expect(['c', 'c', 'C'].reverse_each.uniq).to eql(['C', 'c'])
-  end
-end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
 describe Puppet::Util::RunMode do
-  # Discriminator for tests that attempts to unset HOME since that, for reasons currently unknown,
-  # doesn't work in Ruby >= 2.4.0
-  def self.gte_ruby_2_4
-    @gte_ruby_2_4 ||= SemanticPuppet::Version.parse(RUBY_VERSION) >= SemanticPuppet::Version.parse('2.4.0')
-  end
-
   before do
     @run_mode = Puppet::Util::RunMode.new('fake')
   end
@@ -34,14 +28,6 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path('~/.puppetlabs/etc/puppet')) }
         end
       end
-
-      it "fails when asking for the conf_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
-        as_non_root do
-          without_home do
-            expect { @run_mode.conf_dir }.to raise_error ArgumentError, /couldn't find HOME/
-          end
-        end
-      end
     end
 
     describe "#code_dir" do
@@ -62,14 +48,6 @@ describe Puppet::Util::RunMode do
           as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path('~/.puppetlabs/etc/code')) }
         end
       end
-
-      it "fails when asking for the code_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
-        as_non_root do
-          without_home do
-            expect { @run_mode.code_dir }.to raise_error ArgumentError, /couldn't find HOME/
-          end
-        end
-      end
     end
 
     describe "#var_dir" do
@@ -80,14 +58,6 @@ describe Puppet::Util::RunMode do
       it "has vardir ~/.puppetlabs/opt/puppet/cache when run as non-root" do
         as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/cache')) }
       end
-
-      it "fails when asking for the var_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
-        as_non_root do
-          without_home do
-            expect { @run_mode.var_dir }.to raise_error ArgumentError, /couldn't find HOME/
-          end
-        end
-      end
     end
 
     describe "#public_dir" do
@@ -97,14 +67,6 @@ describe Puppet::Util::RunMode do
 
       it "has publicdir ~/.puppetlabs/opt/puppet/public when run as non-root" do
         as_non_root { expect(@run_mode.public_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/public')) }
-      end
-
-      it "fails when asking for the public_dir as non-root and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
-        as_non_root do
-          without_home do
-            expect { @run_mode.public_dir }.to raise_error ArgumentError, /couldn't find HOME/
-          end
-        end
       end
     end
 
@@ -119,14 +81,6 @@ describe Puppet::Util::RunMode do
         it "has default logdir ~/.puppetlabs/var/log" do
           as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
-
-        it "fails when asking for the log_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
-          as_non_root do
-            without_home do
-              expect { @run_mode.log_dir }.to raise_error ArgumentError, /couldn't find HOME/
-            end
-          end
-        end
       end
     end
 
@@ -140,14 +94,6 @@ describe Puppet::Util::RunMode do
       describe "when run as non-root" do
         it "has default rundir ~/.puppetlabs/var/run" do
           as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
-        end
-
-        it "fails when asking for the run_dir and there is no $HOME", :unless => gte_ruby_2_4 || Puppet::Util::Platform.windows? do
-          as_non_root do
-            without_home do
-              expect { @run_mode.run_dir }.to raise_error ArgumentError, /couldn't find HOME/
-            end
-          end
         end
       end
     end
@@ -176,18 +122,6 @@ describe Puppet::Util::RunMode do
       it "has confdir in ~/.puppetlabs/etc/puppet when run as non-root" do
         as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path("~/.puppetlabs/etc/puppet")) }
       end
-
-      it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%", :unless => gte_ruby_2_4 do
-        as_non_root do
-          without_env('HOME') do
-            without_env('HOMEDRIVE') do
-              without_env('USERPROFILE') do
-                expect { @run_mode.conf_dir }.to raise_error ArgumentError, /couldn't find HOME/
-              end
-            end
-          end
-        end
-      end
     end
 
     describe "#code_dir" do
@@ -197,18 +131,6 @@ describe Puppet::Util::RunMode do
 
       it "has codedir in ~/.puppetlabs/etc/code when run as non-root" do
         as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path("~/.puppetlabs/etc/code")) }
-      end
-
-      it "fails when asking for the code_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%", :unless => gte_ruby_2_4 do
-        as_non_root do
-          without_env('HOME') do
-            without_env('HOMEDRIVE') do
-              without_env('USERPROFILE') do
-                expect { @run_mode.code_dir }.to raise_error ArgumentError, /couldn't find HOME/
-              end
-            end
-          end
-        end
       end
     end
 
@@ -220,18 +142,6 @@ describe Puppet::Util::RunMode do
       it "has vardir in ~/.puppetlabs/opt/puppet/cache when run as non-root" do
         as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/cache")) }
       end
-
-      it "fails when asking for the conf_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%", :unless => gte_ruby_2_4 do
-        as_non_root do
-          without_env('HOME') do
-            without_env('HOMEDRIVE') do
-              without_env('USERPROFILE') do
-                expect { @run_mode.var_dir }.to raise_error ArgumentError, /couldn't find HOME/
-              end
-            end
-          end
-        end
-      end
     end
 
     describe "#public_dir" do
@@ -241,18 +151,6 @@ describe Puppet::Util::RunMode do
 
       it "has publicdir in ~/.puppetlabs/opt/puppet/public when run as non-root" do
         as_non_root { expect(@run_mode.public_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/public")) }
-      end
-
-      it "fails when asking for the public_dir as non-root and there is no %HOME%, %HOMEDRIVE%, and %USERPROFILE%", :unless => gte_ruby_2_4 do
-        as_non_root do
-          without_env('HOME') do
-            without_env('HOMEDRIVE') do
-              without_env('USERPROFILE') do
-                expect { @run_mode.public_dir }.to raise_error ArgumentError, /couldn't find HOME/
-              end
-            end
-          end
-        end
       end
     end
 
@@ -267,18 +165,6 @@ describe Puppet::Util::RunMode do
         it "has default logdir ~/.puppetlabs/var/log" do
           as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
-
-        it "fails when asking for the log_dir and there is no $HOME", :unless => gte_ruby_2_4 do
-          as_non_root do
-            without_env('HOME') do
-              without_env('HOMEDRIVE') do
-                without_env('USERPROFILE') do
-                  expect { @run_mode.log_dir }.to raise_error ArgumentError, /couldn't find HOME/
-                end
-              end
-            end
-          end
-        end
       end
     end
 
@@ -292,18 +178,6 @@ describe Puppet::Util::RunMode do
       describe "when run as non-root" do
         it "has default rundir ~/.puppetlabs/var/run" do
           as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
-        end
-
-        it "fails when asking for the run_dir and there is no $HOME", :unless => gte_ruby_2_4 do
-          as_non_root do
-            without_env('HOME') do
-              without_env('HOMEDRIVE') do
-                without_env('USERPROFILE') do
-                  expect { @run_mode.run_dir }.to raise_error ArgumentError, /couldn't find HOME/
-                end
-              end
-            end
-          end
         end
       end
     end
@@ -349,9 +223,5 @@ describe Puppet::Util::RunMode do
     yield
   ensure
     Puppet::Util.set_env(name, saved)
-  end
-
-  def without_home(&block)
-    without_env('HOME', &block)
   end
 end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -3,12 +3,6 @@ require 'spec_helper'
 describe Puppet::Util do
   include PuppetSpec::Files
 
-  # Discriminator for tests that attempts to unset HOME since that, for reasons currently unknown,
-  # doesn't work in Ruby >= 2.4.0
-  def self.gte_ruby_2_4
-    @gte_ruby_2_4 ||= SemanticPuppet::Version.parse(RUBY_VERSION) >= SemanticPuppet::Version.parse('2.4.0')
-  end
-
   if Puppet::Util::Platform.windows?
     def set_mode(mode, file)
       Puppet::Util::Windows::Security.set_mode(mode, file)
@@ -667,18 +661,6 @@ describe Puppet::Util do
 
     it "should return nil if no executable found" do
       expect(Puppet::Util.which('doesnotexist')).to be_nil
-    end
-
-    it "should warn if the user's HOME is not set but their PATH contains a ~", :unless => gte_ruby_2_4 do
-      env_path = %w[~/bin /usr/bin /bin].join(File::PATH_SEPARATOR)
-
-      env = {:HOME => nil, :PATH => env_path}
-      env.merge!({:HOMEDRIVE => nil, :USERPROFILE => nil}) if Puppet::Util::Platform.windows?
-
-      expect(Puppet::Util::Warnings).to receive(:warnonce).once
-      Puppet::Util.withenv(env) do
-        Puppet::Util.which('foo')
-      end
     end
 
     it "should reject directories" do


### PR DESCRIPTION
Drop distinction between Bignum and Fixnum (they were unified as Integer in 2.4), remove some monkey patches and conditional spec logic.