### PR TITLE
(PUP-10644) Add show action for puppet facts

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -83,4 +83,65 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       nil
     end
   end
+
+  action(:show) do
+    summary _("Facter plugin sync")
+    arguments _("[<facts>]")
+    description <<-'EOT'
+    Reads facts from the local system using facter gem.
+    EOT
+    returns "The output of facter with added puppet specific facts"
+    notes <<-'EOT'
+
+    EOT
+    examples <<-'EOT'
+    retrieve facts:
+
+    $ puppet facts show os
+    EOT
+
+    option("--config-file " + _("<path>")) do
+      default_to { nil }
+      summary _("The location of the config file for Facter.")
+    end
+
+    option("--custom-dir " + _("<path>")) do
+      default_to { nil }
+      summary _("The path to a directory that contains custom facts.")
+    end
+
+    option("--external-dir " + _("<path>")) do
+      default_to { nil }
+      summary _("The path to a directory that contains external facts.")
+    end
+
+    option("--no-block") do
+      summary _("Disable fact blocking mechanism.")
+    end
+
+    option("--no-cache") do
+      summary _("Disable fact caching mechanism.")
+    end
+
+    option("--show-legacy") do
+      summary _("Show legacy facts when querying all facts.")
+    end
+
+    render_as :json
+
+    when_invoked do |*args|
+      options = args.pop
+
+      Puppet.settings.preferred_run_mode = :agent
+      Puppet::Node::Facts.indirection.terminus_class = :facter
+
+
+      options[:user_query] = args
+      options[:resolve_options] = true
+      result = Puppet::Node::Facts.indirection.find(Puppet.settings[:certname], options)
+
+      result.values
+    end
+  end
 end
+

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -71,4 +71,8 @@ CONF
                                log.message =~ /Uploading facts for '.*' to 'puppet\.server\.test'/}
     end
   end
+
+  describe "#show" do
+    it { is_expected.to be_action :show }
+  end
 end


### PR DESCRIPTION
This PR adds a new action for puppet facts _(puppet facts show)_. This action is more configurable (supports all the arguments that facter does, and can be called to retrieve only a fact or a list of facts).
Depends on: [FACT-2774](https://github.com/puppetlabs/facter/pull/2054)