### PR TITLE
(PUP-10583) Change default digest_algorithm to SHA256

### DIFF
--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -56,18 +56,6 @@ agents.each do |agent|
 
   dir = on(agent, puppet_filebucket("--configprint clientbucketdir")).stdout.chomp
 
-  md5_manifest = %Q|
-    filebucket { 'local':
-      path => '#{dir}',
-    }
-
-    file { '#{target}':
-      ensure  => present,
-      content => '{md5}18571d3a04b2bb7ccfdbb2c44c72caa9',
-      backup  => local,
-    }
-  |
-
   sha256_manifest = %Q|
     filebucket { 'local':
       path => '#{dir}',
@@ -81,11 +69,7 @@ agents.each do |agent|
   |
 
   step "Applying Manifest on Agent"
-  if on(agent, facter("fips_enabled")).stdout =~ /true/
-    apply_manifest_on agent, sha256_manifest
-  else    
-    apply_manifest_on agent, md5_manifest
-  end
+  apply_manifest_on agent, sha256_manifest
 
   step "Validate filebucket checksum file contents"
   on agent, "cat #{target}" do

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -16,6 +16,10 @@ class Puppet::Application::Filebucket < Puppet::Application
     _("Store and retrieve files in a filebucket")
   end
 
+  def digest_algorithm
+    Puppet.default_digest_algorithm
+  end
+
   def help
     <<-HELP
 
@@ -38,14 +42,14 @@ Puppet filebucket can operate in three modes, with only one mode per call:
 
 backup:
   Send one or more files to the specified file bucket. Each sent file is
-  printed with its resulting md5 sum.
+  printed with its resulting #{digest_algorithm} sum.
 
 get:
-  Return the text associated with an md5 sum. The text is printed to
+  Return the text associated with an #{digest_algorithm} sum. The text is printed to
   stdout, and only one file can be retrieved at a time.
 
 restore:
-  Given a file path and an md5 sum, store the content associated with
+  Given a file path and an #{digest_algorithm} sum, store the content associated with
   the sum into the specified file path. You can specify an entirely new
   path to this argument; you are not restricted to restoring the content
   to its original location.
@@ -212,8 +216,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
   end
 
   def get
-    md5 = args.shift
-    out = @client.getfile(md5)
+    digest = args.shift
+    out = @client.getfile(digest)
     print out
   end
 
@@ -229,8 +233,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
         $stderr.puts _("%{file}: cannot read file") % { file: file }
         next
       end
-      md5 = @client.backup(file)
-      puts "#{file}: #{md5}"
+      digest = @client.backup(file)
+      puts "#{file}: #{digest}"
     end
   end
 
@@ -243,8 +247,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
   def restore
     file = args.shift
-    md5 = args.shift
-    @client.restore(file, md5)
+    digest = args.shift
+    @client.restore(file, digest)
   end
 
   def diff

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -17,19 +17,19 @@ module Puppet
   def self.valid_digest_algorithms
     Puppet::Util::Platform.fips_enabled? ?
       %w[sha256 sha384 sha512 sha224] :
-      %w[md5 sha256 sha384 sha512 sha224]
+      %w[sha256 sha384 sha512 sha224 md5]
   end
 
   def self.default_file_checksum_types
     Puppet::Util::Platform.fips_enabled? ?
       %w[sha256 sha384 sha512 sha224] :
-      %w[md5 sha256 sha384 sha512 sha224]
+      %w[sha256 sha384 sha512 sha224 md5]
   end
 
   def self.valid_file_checksum_types
     Puppet::Util::Platform.fips_enabled? ?
       %w[sha256 sha256lite sha384 sha512 sha224 sha1 sha1lite mtime ctime] :
-      %w[md5 md5lite sha256 sha256lite sha384 sha512 sha224 sha1 sha1lite mtime ctime]
+      %w[sha256 sha256lite sha384 sha512 sha224 sha1 sha1lite md5 md5lite mtime ctime]
   end
 
   def self.default_basemodulepath
@@ -793,9 +793,9 @@ API to expire the cache as needed
           only use lowercase letters, numbers, periods, underscores, and dashes. (That is,
           it should match `/\A[a-z0-9._-]+\Z/`.)
         * The special value `ca` is reserved, and can't be used as the certname
-          for a normal node.         
+          for a normal node.
 
-          **Note:** You must set the certname in the main section of the puppet.conf file. Setting it in a different section causes errors.
+          **Note:** You must set the certname in the main section of the puppet.conf file. Setting it in a different section causes errors.
 
         Defaults to the node's fully qualified domain name.",
       :hook => proc { |value| raise(ArgumentError, _("Certificate names must be lower case")) unless value == value.downcase }},
@@ -1836,7 +1836,7 @@ EOT
       :type     => :ttl,
       :desc     => "The maximum amount of time the puppet agent should wait for an
       already running puppet agent to finish before starting a new one. This is set by default to 1 minute.
-      A value of `unlimited` will cause puppet agent to wait indefinitely. 
+      A value of `unlimited` will cause puppet agent to wait indefinitely.
       #{AS_DURATION}",
     }
   )

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -11,7 +11,7 @@ module Puppet
   end
 
   def self.default_digest_algorithm
-    Puppet::Util::Platform.fips_enabled? ? 'sha256' : 'md5'
+    'sha256'
   end
 
   def self.valid_digest_algorithms

--- a/lib/puppet/file_serving/http_metadata.rb
+++ b/lib/puppet/file_serving/http_metadata.rb
@@ -51,7 +51,7 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
   def collect
     # Prefer the checksum_type from the indirector request options
     # but fall back to the alternative otherwise
-    [ @checksum_type, :md5, :sha256, :sha1, :mtime ].each do |type|
+    [ @checksum_type, :sha256, :sha1, :md5, :mtime ].each do |type|
       @checksum_type = type
       @checksum = @checksums[type]
       break if @checksum

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -77,9 +77,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   # @param [Boolean] static_catalog Indicates if the file metadata(s) are inlined
   #   in the catalog. This informs the agent if it needs to make a second request
   #   to retrieve metadata in addition to the initial catalog request.
-  # @param [Array<String>] checksum_type An array of accepted checksum type.
-  #   Currently defaults to `["md5", "sha256", "sha384", "sha512", "sha224"]`,
-  #   or `["sha256", "sha384", "sha512", "sha224"]` if fips is enabled.
+  # @param [Array<String>] checksum_type An array of accepted checksum types.
   #
   # @return [Array<Puppet::HTTP::Response, Puppet::Resource::Catalog>] An array
   #   containing the request response and the deserialized catalog returned by

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -42,8 +42,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   # @param [Symbol] links Can be one of either `:follow` or `:manage`, defines
   #   how links are handled.
   # @param [String] checksum_type The digest algorithm used to verify the file.
-  #   Currently if fips is enabled, this defaults to `sha256`. Otherwise, it
-  #   defaults to `md5`.
+  #   Defaults to `sha256`.
   # @param [Symbol] source_permissions Can be one of `:use`, `:use_when_creating`,
   #   or `:ignore`. This parameter tells the server if it should include the
   #   file permissions in the response. If set to `:ignore`, the server will

--- a/lib/puppet/type/file/checksum.rb
+++ b/lib/puppet/type/file/checksum.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:file).newparam(:checksum) do
 
   desc "The checksum type to use when determining whether to replace a file's contents.
 
-    The default checksum type is md5."
+    The default checksum type is #{Puppet.default_digest_algorithm}."
 
   newvalues(*Puppet::Util::Checksums.known_checksum_types)
 

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -245,7 +245,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
           agent.command_line.args << '--test'
           agent.run
         }.to exit_with(2)
-         .and output(/content changed '{md5}d41d8cd98f00b204e9800998ecf8427e' to '{md5}4cf49285ae567157ebfba72bd04ccf32'/).to_stdout
+         .and output(/content changed '{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' to '{sha256}3bef83ad320b471d8e3a03c9b9f150749eea610fe266560395d3195cfbd8e6b8'/).to_stdout
 
         # verify puppet restored binary content
         expect(File.binread(path)).to eq(binary_content)

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -532,7 +532,7 @@ class amod::bad_type {
       ).and matching(
          /dir1\/dir2\]\/ensure: created/
       ).and matching(
-         /dir1\/dir2\/file\]\/ensure: defined content as '{md5}51f37efb13c3a1e486106f90db6490a5'/
+         /dir1\/dir2\/file\]\/ensure: defined content as '{sha256}b37c1d77e09471b3139b2cdfee449fd8ba72ebf7634d52023aff0c0cd088cf1b'/
       )).to_stdout
 
       dest_file = File.join(base_dir, 'dir1', 'dir2', 'file')

--- a/spec/integration/application/filebucket_spec.rb
+++ b/spec/integration/application/filebucket_spec.rb
@@ -11,7 +11,7 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
   let(:filebucket) { Puppet::Application[:filebucket] }
   let(:backup_file) { tmpfile('backup_file') }
   let(:text) { 'some random text' }
-  let(:md5) { Digest::MD5.file(backup_file).to_s }
+  let(:sha256) { Digest::SHA256.file(backup_file).to_s }
 
   before :each do
     Puppet[:log_level] = 'debug'
@@ -22,13 +22,13 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
     filebucket.command_line.args = ['backup', backup_file, '--local']
     expect {
       filebucket.run
-    }.to output(/: #{md5}/).to_stdout
+    }.to output(/: #{sha256}/).to_stdout
 
     dest = tmpfile('file_bucket_restore')
-    filebucket.command_line.args = ['restore', dest, md5, '--local']
+    filebucket.command_line.args = ['restore', dest, sha256, '--local']
     expect {
       filebucket.run
-    }.to output(/FileBucket read #{md5}/).to_stdout
+    }.to output(/FileBucket read #{sha256}/).to_stdout
 
     expect(FileUtils.compare_file(backup_file, dest)).to eq(true)
   end
@@ -40,11 +40,11 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
         filebucket.command_line.args = ['backup', backup_file]
         filebucket.run
       }.to output(a_string_matching(
-        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/md5\/#{md5}\/#{File.realpath(backup_file)}\?environment\=production returned 404 Not Found}
+        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/sha256\/#{sha256}\/#{File.realpath(backup_file)}\?environment\=production returned 404 Not Found}
       ).and matching(
-        %r{Debug: HTTP PUT https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/md5\/#{md5}\/#{File.realpath(backup_file)}\?environment\=production returned 200 OK}
+        %r{Debug: HTTP PUT https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/sha256\/#{sha256}\/#{File.realpath(backup_file)}\?environment\=production returned 200 OK}
       ).and matching(
-        %r{#{backup_file}: #{md5}}
+        %r{#{backup_file}: #{sha256}}
       )).to_stdout
 
       expect(File.binread(File.join(server.upload_directory, 'filebucket'))).to eq(text)
@@ -61,9 +61,9 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
         filebucket.command_line.args = ['backup', backup_file]
         filebucket.run
       }.to output(a_string_matching(
-        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/md5/b10778ecd8b08dff525e367cf15b2622/}
+        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/sha256/f3aee54d781e413862eb068d89661f930385cc81bbafffc68477ff82eb9bea43/}
       ).and matching(
-        %r{Debug: HTTP PUT https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/md5/b10778ecd8b08dff525e367cf15b2622/}
+        %r{Debug: HTTP PUT https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/sha256/f3aee54d781e413862eb068d89661f930385cc81bbafffc68477ff82eb9bea43/}
       )).to_stdout
 
       expect(File.binread(File.join(server.upload_directory, 'filebucket'))).to eq(binary)
@@ -80,9 +80,9 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
         filebucket.command_line.args = ['backup', backup_file]
         filebucket.run
       }.to output(a_string_matching(
-        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/md5/48856faf4534a876adeadc72aec53cb2/}
+        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/sha256/51643361c79ecaef25a8de802de24f570ba25d9c2df1d22d94fade11b4f466cc/}
       ).and matching(
-        %r{Debug: HTTP PUT https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/md5/48856faf4534a876adeadc72aec53cb2/}
+        %r{Debug: HTTP PUT https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file/sha256/51643361c79ecaef25a8de802de24f570ba25d9c2df1d22d94fade11b4f466cc/}
       )).to_stdout
 
       expect(File.read(File.join(server.upload_directory, 'filebucket'), encoding: 'utf-8')).to eq(utf8)
@@ -100,9 +100,9 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
         filebucket.command_line.args = ['backup', backup_file]
         filebucket.run
       }.to output(a_string_matching(
-        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/md5\/#{md5}\/#{File.realpath(backup_file)}\?environment\=production returned 200 OK}
+        %r{Debug: HTTP HEAD https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/sha256\/#{sha256}\/#{File.realpath(backup_file)}\?environment\=production returned 200 OK}
       ).and matching(
-        %r{#{backup_file}: #{md5}}
+        %r{#{backup_file}: #{sha256}}
       )).to_stdout
     end
   end
@@ -119,7 +119,7 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
         filebucket.command_line.args = ['get', 'fac251367c9e083c6b1f0f3181']
         filebucket.run
       }.to output(a_string_matching(
-        %r{Debug: HTTP GET https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/md5\/fac251367c9e083c6b1f0f3181\?environment\=production returned 200 OK}
+        %r{Debug: HTTP GET https:\/\/127.0.0.1:#{port}\/puppet\/v3\/file_bucket_file\/sha256\/fac251367c9e083c6b1f0f3181\?environment\=production returned 200 OK}
       ).and matching(
         %r{something to store}
        )).to_stdout
@@ -191,8 +191,8 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
         File.binwrite(f, "bar\nbaz")
         f
       }
-      let(:checksuma) { Digest::MD5.file(filea).to_s }
-      let(:checksumb) { Digest::MD5.file(fileb).to_s }
+      let(:checksuma) { Digest::SHA256.file(filea).to_s }
+      let(:checksumb) { Digest::SHA256.file(fileb).to_s }
 
       it 'compares to files stored in a local bucket' do
         expect {

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 require 'puppet_spec/files'
@@ -657,9 +658,9 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
     CHECKSUM_TYPES_TO_TRY.each do |checksum_type, checksum|
       describe "when checksum_type is #{checksum_type}" do
-        # FileBucket uses the globally configured default for lookup by digest, which right now is MD5.
+        # FileBucket uses the globally configured default for lookup by digest, which right now is SHA256.
         it_should_behave_like "files are backed up", {:checksum => checksum_type} do
-          let(:filebucket_digest) { Proc.new {|x| Puppet::Util::Checksums.md5(x)} }
+          let(:filebucket_digest) { Proc.new {|x| Puppet::Util::Checksums.sha256(x)} }
         end
       end
     end
@@ -1727,7 +1728,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
                                                #{test_cmd} "644" == "$(#{stat_cmd} ^)"
                                                }))
       report = catalog.apply.report
-      expect(report.resource_statuses["File[#{path}]"].events.first.message).to match(/defined content as '{md5}/)
+      expect(report.resource_statuses["File[#{path}]"].events.first.message).to match(/defined content as '{sha256}/)
       expect(report.resource_statuses["File[#{path}]"]).not_to be_failed
       expect(Puppet::FileSystem.exist?(path)).to be_truthy
     end
@@ -1741,7 +1742,7 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
                                                #{test_cmd} "555" == "$(#{stat_cmd} ^)"
                                                }))
       report = catalog.apply.report
-      expect(report.resource_statuses["File[#{path}]"].events.first.message).to match(/defined content as '{md5}/)
+      expect(report.resource_statuses["File[#{path}]"].events.first.message).to match(/defined content as '{sha256}/)
       expect(report.resource_statuses["File[#{path}]"]).not_to be_failed
       expect(Puppet::FileSystem.exist?(path)).to be_truthy
     end

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -187,11 +187,11 @@ describe Puppet::Application::Filebucket do
         @filebucket.get
       end
 
-      it "should call the client getfile method with the given md5" do
-        md5="DEADBEEF"
-        allow(@filebucket).to receive(:args).and_return([md5])
+      it "should call the client getfile method with the given digest" do
+        digest = 'DEADBEEF'
+        allow(@filebucket).to receive(:args).and_return([digest])
 
-        expect(@client).to receive(:getfile).with(md5)
+        expect(@client).to receive(:getfile).with(digest)
 
         @filebucket.get
       end
@@ -225,12 +225,12 @@ describe Puppet::Application::Filebucket do
     end
 
     describe "the command restore" do
-      it "should call the client getfile method with the given md5" do
-        md5="DEADBEEF"
-        file="testfile"
-        allow(@filebucket).to receive(:args).and_return([file, md5])
+      it "should call the client getfile method with the given digest" do
+        digest = 'DEADBEEF'
+        file = 'testfile'
+        allow(@filebucket).to receive(:args).and_return([file, digest])
 
-        expect(@client).to receive(:restore).with(file,md5)
+        expect(@client).to receive(:restore).with(file, digest)
 
         @filebucket.restore
       end
@@ -238,55 +238,55 @@ describe Puppet::Application::Filebucket do
 
     describe "the command diff" do
       it "should call the client diff method with 2 given checksums" do
-        md5a="DEADBEEF"
-        md5b="BEEF"
+        digest_a = 'DEADBEEF'
+        digest_b = 'BEEF'
         allow(Puppet::FileSystem).to receive(:exist?).and_return(false)
-        allow(@filebucket).to receive(:args).and_return([md5a, md5b])
+        allow(@filebucket).to receive(:args).and_return([digest_a, digest_b])
 
-        expect(@client).to receive(:diff).with(md5a,md5b, nil, nil)
-
-        @filebucket.diff
-      end
-
-      it "should call the clien diff with a path if the second argument is a file" do
-        md5a="DEADBEEF"
-        md5b="BEEF"
-        allow(Puppet::FileSystem).to receive(:exist?).with(md5a).and_return(false)
-        allow(Puppet::FileSystem).to receive(:exist?).with(md5b).and_return(true)
-        allow(@filebucket).to receive(:args).and_return([md5a, md5b])
-
-        expect(@client).to receive(:diff).with(md5a, nil, nil, md5b)
+        expect(@client).to receive(:diff).with(digest_a, digest_b, nil, nil)
 
         @filebucket.diff
       end
 
-      it "should call the clien diff with a path if the first argument is a file" do
-        md5a="DEADBEEF"
-        md5b="BEEF"
-        allow(Puppet::FileSystem).to receive(:exist?).with(md5a).and_return(true)
-        allow(Puppet::FileSystem).to receive(:exist?).with(md5b).and_return(false)
-        allow(@filebucket).to receive(:args).and_return([md5a, md5b])
+      it "should call the client diff with a path if the second argument is a file" do
+        digest_a = 'DEADBEEF'
+        digest_b = 'BEEF'
+        allow(Puppet::FileSystem).to receive(:exist?).with(digest_a).and_return(false)
+        allow(Puppet::FileSystem).to receive(:exist?).with(digest_b).and_return(true)
+        allow(@filebucket).to receive(:args).and_return([digest_a, digest_b])
 
-        expect(@client).to receive(:diff).with(nil, md5b, md5a, nil)
+        expect(@client).to receive(:diff).with(digest_a, nil, nil, digest_b)
+
+        @filebucket.diff
+      end
+
+      it "should call the client diff with a path if the first argument is a file" do
+        digest_a = 'DEADBEEF'
+        digest_b = 'BEEF'
+        allow(Puppet::FileSystem).to receive(:exist?).with(digest_a).and_return(true)
+        allow(Puppet::FileSystem).to receive(:exist?).with(digest_b).and_return(false)
+        allow(@filebucket).to receive(:args).and_return([digest_a, digest_b])
+
+        expect(@client).to receive(:diff).with(nil, digest_b, digest_a, nil)
 
         @filebucket.diff
       end
 
       it "should call the clien diff with paths if the both arguments are files" do
-        md5a="DEADBEEF"
-        md5b="BEEF"
-        allow(Puppet::FileSystem).to receive(:exist?).with(md5a).and_return(true)
-        allow(Puppet::FileSystem).to receive(:exist?).with(md5b).and_return(true)
-        allow(@filebucket).to receive(:args).and_return([md5a, md5b])
+        digest_a = 'DEADBEEF'
+        digest_b = 'BEEF'
+        allow(Puppet::FileSystem).to receive(:exist?).with(digest_a).and_return(true)
+        allow(Puppet::FileSystem).to receive(:exist?).with(digest_b).and_return(true)
+        allow(@filebucket).to receive(:args).and_return([digest_a, digest_b])
 
-        expect(@client).to receive(:diff).with(nil, nil, md5a, md5b)
+        expect(@client).to receive(:diff).with(nil, nil, digest_a, digest_b)
 
         @filebucket.diff
       end
 
       it "should fail if only one checksum is given" do
-        md5a="DEADBEEF"
-        allow(@filebucket).to receive(:args).and_return([md5a])
+        digest_a = 'DEADBEEF'
+        allow(@filebucket).to receive(:args).and_return([digest_a])
 
         expect { @filebucket.diff }.to raise_error Puppet::Error
       end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -366,7 +366,7 @@ describe Puppet::Configurer do
 
     it "sets the checksum_type query param to the default supported_checksum_types in a catalog request" do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything,
-        hash_including(checksum_type: 'md5.sha256.sha384.sha512.sha224'))
+        hash_including(checksum_type: 'sha256.sha384.sha512.sha224.md5'))
       configurer.run
     end
 

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -77,9 +77,9 @@ describe "Defaults" do
   end
 
   describe '.supported_checksum_types' do
-    it 'defaults to md5, sha256, sha384, sha512, sha224 when FIPS is not enabled' do
+    it 'defaults to sha256, sha384, sha512, sha224, md5 when FIPS is not enabled' do
       allow(Puppet::Util::Platform).to receive(:fips_enabled?).and_return(false)
-      expect(Puppet.default_file_checksum_types).to eq(%w[md5 sha256 sha384 sha512 sha224])
+      expect(Puppet.default_file_checksum_types).to eq(%w[sha256 sha384 sha512 sha224 md5])
     end
 
     it 'defaults to sha256, sha384, sha512, sha224 when FIPS is enabled' do
@@ -89,8 +89,8 @@ describe "Defaults" do
   end
 
   describe 'Puppet[:supported_checksum_types]' do
-    it 'defaults to md5, sha256, sha512, sha384, sha224' do
-      expect(Puppet.settings[:supported_checksum_types]).to eq(%w[md5 sha256 sha384 sha512 sha224])
+    it 'defaults to sha256, sha512, sha384, sha224, md5' do
+      expect(Puppet.settings[:supported_checksum_types]).to eq(%w[sha256 sha384 sha512 sha224 md5])
     end
 
     it 'should raise an error on an unsupported checksum type' do

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -65,9 +65,9 @@ describe "Defaults" do
   end
 
   describe '.default_digest_algorithm' do
-    it 'defaults to md5 when FIPS is not enabled' do
+    it 'defaults to sha256 when FIPS is not enabled' do
       allow(Puppet::Util::Platform).to receive(:fips_enabled?).and_return(false)
-      expect(Puppet.default_digest_algorithm).to eq('md5')
+      expect(Puppet.default_digest_algorithm).to eq('sha256')
     end
 
     it 'defaults to sha256 when FIPS is enabled' do

--- a/spec/unit/http/service/file_server_spec.rb
+++ b/spec/unit/http/service/file_server_spec.rb
@@ -41,7 +41,7 @@ describe Puppet::HTTP::Service::FileServer do
 
   context 'retrieving file metadata' do
     let(:path) { tmpfile('get_file_metadata') }
-    let(:url) { "https://www.example.com/puppet/v3/file_metadata/:mount/#{path}?checksum_type=md5&environment=testing&links=manage&source_permissions=ignore" }
+    let(:url) { "https://www.example.com/puppet/v3/file_metadata/:mount/#{path}?checksum_type=sha256&environment=testing&links=manage&source_permissions=ignore" }
     let(:filemetadata) { Puppet::FileServing::Metadata.new(path) }
     let(:request_path) { "/:mount/#{path}"}
 
@@ -122,7 +122,7 @@ describe Puppet::HTTP::Service::FileServer do
 
   context 'retrieving multiple file metadatas' do
     let(:path) { tmpfile('get_file_metadatas') }
-    let(:url) { "https://www.example.com/puppet/v3/file_metadatas/:mount/#{path}?checksum_type=md5&links=manage&recurse=false&source_permissions=ignore&environment=testing" }
+    let(:url) { "https://www.example.com/puppet/v3/file_metadatas/:mount/#{path}?checksum_type=sha256&links=manage&recurse=false&source_permissions=ignore&environment=testing" }
     let(:filemetadatas) { [Puppet::FileServing::Metadata.new(path)] }
     let(:formatter) { Puppet::Network::FormatHandler.format(:json) }
     let(:request_path) { "/:mount/#{path}"}
@@ -158,7 +158,7 @@ describe Puppet::HTTP::Service::FileServer do
     end
 
     it 'automatically converts an array of parameters to the stringified query' do
-      url = "https://www.example.com/puppet/v3/file_metadatas/:mount/#{path}?checksum_type=md5&environment=testing&ignore=CVS&ignore=.git&ignore=.hg&links=manage&recurse=false&source_permissions=ignore"
+      url = "https://www.example.com/puppet/v3/file_metadatas/:mount/#{path}?checksum_type=sha256&environment=testing&ignore=CVS&ignore=.git&ignore=.hg&links=manage&recurse=false&source_permissions=ignore"
       stub_request(:get, url).with(
         headers: {'Accept'=>'application/json, application/x-msgpack, text/pson',}
       ).to_return(

--- a/spec/unit/indirector/file_bucket_file/file_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/file_spec.rb
@@ -18,7 +18,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
     describe "when servicing a save request" do
       it "should return a result whose content is empty" do
         bucket_file = Puppet::FileBucket::File.new('stuff')
-        result = Puppet::FileBucket::File.indirection.save(bucket_file, "md5/c13d88cb4cb02003daedb8a84e5d272a")
+        result = Puppet::FileBucket::File.indirection.save(bucket_file, "sha256/35bafb1ce99aef3ab068afbaabae8f21fd9b9f02d3a9442e364fa92c0b3eeef0")
         expect(result.contents).to be_empty
       end
 
@@ -34,12 +34,14 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
         end
         children.each { |child| Process.wait(child) }
 
-        paths = File.read("#{Puppet[:bucketdir]}/9/8/b/f/7/d/8/c/98bf7d8c15784f0a3d63204441e1e2aa/paths").lines.to_a
+        paths = File.read("#{Puppet[:bucketdir]}/d/1/b/2/a/5/9/f/d1b2a59fbea7e20077af9f91b27e95e865061b270be03ff539ab3b73587882e8/paths").lines.to_a
         expect(paths.length).to eq(1)
         expect(Puppet::FileBucket::File.indirection.head("#{bucket_file.checksum_type}/#{bucket_file.checksum_data}/testing")).to be_truthy
       end
 
       it "fails if the contents collide with existing contents" do
+        Puppet[:digest_algorithm] = 'md5'
+
         # This is the shortest known MD5 collision (little endian). See https://eprint.iacr.org/2010/643.pdf
         first_contents = [0x6165300e,0x87a79a55,0xf7c60bd0,0x34febd0b,
                           0x6503cf04,0x854f709e,0xfb0fc034,0x874c9c65,
@@ -66,7 +68,7 @@ describe Puppet::FileBucketFile::File, :uses_checksums => true do
       context "when the contents file exists but is corrupted and does not match the expected checksum" do
         let(:original_contents) { "a file that will get corrupted" }
         let(:bucket_file) { Puppet::FileBucket::File.new(original_contents) }
-        let(:contents_file) { "#{Puppet[:bucketdir]}/8/e/6/4/f/8/5/d/8e64f85dd54a412f65edabcafe44d491/contents" }
+        let(:contents_file) { "#{Puppet[:bucketdir]}/7/7/4/1/0/2/7/9/77410279bb789b799c2f38bf654b46a509dd27ddad6e47a6684805e9ba390bce/contents" }
 
         before(:each) do
           # Ensure we're starting with a clean slate - no pre-existing backup

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -612,14 +612,14 @@ describe Puppet::Transaction::ResourceHarness do
       allow_any_instance_of(Puppet::Transaction::Event).to receive(:corrective_change).and_return(true)
       status = @harness.evaluate(resource)
       sync_event = status.events[0]
-      expect(sync_event.message).to match(/content changed '{md5}[0-9a-f]+' to '{md5}[0-9a-f]+' \(corrective\)/)
+      expect(sync_event.message).to match(/content changed '{sha256}[0-9a-f]+' to '{sha256}[0-9a-f]+' \(corrective\)/)
     end
 
     it "contains no modifier when intentional change" do
       allow_any_instance_of(Puppet::Transaction::Event).to receive(:corrective_change).and_return(false)
       status = @harness.evaluate(resource)
       sync_event = status.events[0]
-      expect(sync_event.message).to match(/content changed '{md5}[0-9a-f]+' to '{md5}[0-9a-f]+'$/)
+      expect(sync_event.message).to match(/content changed '{sha256}[0-9a-f]+' to '{sha256}[0-9a-f]+'$/)
     end
   end
 end

--- a/spec/unit/type/file/checksum_spec.rb
+++ b/spec/unit/type/file/checksum_spec.rb
@@ -18,8 +18,8 @@ describe checksum do
     @checksum.sum("foobar")
   end
 
-  it "should use :md5 to sum when no value is set" do
-    expect(@checksum).to receive(:md5).with("foobar").and_return("yay")
+  it "should use :sha256 to sum when no value is set" do
+    expect(@checksum).to receive(:sha256).with("foobar").and_return("yay")
     @checksum.sum("foobar")
   end
 
@@ -47,8 +47,8 @@ describe checksum do
     expect(@checksum.sum("foobar")).to eq("{sha384}#{sum}")
   end
 
-  it "should use :md5 as its default type" do
-    expect(@checksum.default).to eq(:md5)
+  it "should use :sha256 as its default type" do
+    expect(@checksum.default).to eq(:sha256)
   end
 
   it "should use its current value when asked to sum a file's content" do
@@ -57,8 +57,8 @@ describe checksum do
     @checksum.sum_file(@path)
   end
 
-  it "should use :md5 to sum a file when no value is set" do
-    expect(@checksum).to receive(:md5_file).with(@path).and_return("yay")
+  it "should use :sha256 to sum a file when no value is set" do
+    expect(@checksum).to receive(:sha256_file).with(@path).and_return("yay")
     @checksum.sum_file(@path)
   end
 

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe Puppet::Type.type(:file) do
@@ -778,7 +779,7 @@ describe Puppet::Type.type(:file) do
     it "should set the checksum parameter based on the metadata" do
       allow(file).to receive(:perform_recursion).and_return([@first])
       allow(@resource).to receive(:[]=)
-      expect(@resource).to receive(:[]=).with(:checksum, "md5")
+      expect(@resource).to receive(:[]=).with(:checksum, "sha256")
       file.recurse_remote("first" => @resource)
     end
 
@@ -814,7 +815,7 @@ describe Puppet::Type.type(:file) do
       allow(file).to receive(:perform_recursion).and_return([@first])
 
       allow(file).to receive(:[]=)
-      expect(file). to receive(:[]=).with(:checksum, "md5")
+      expect(file). to receive(:[]=).with(:checksum, "sha256")
 
       file.recurse_remote("first" => @resource)
     end


### PR DESCRIPTION
Puppet's `digest_algorithm` setting defaults to `md5`, which is outdated. This commit switches it to to `sha256`.

Update spec tests accordingly.