### PR TITLE
(PUP-10604) Guard against JRuby FIPS

### DIFF
--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -1,4 +1,6 @@
-require 'rubygems/commands/list_command'
+unless Puppet::Util::Platform.jruby_fips?
+  require 'rubygems/commands/list_command'
+end
 require 'stringio'
 require 'uri'
 
@@ -15,6 +17,8 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
   has_feature :versionable, :install_options, :uninstall_options
 
   confine :feature => :hocon
+  # see SERVER-2578
+  confine :fips_enabled => false
 
   # Define the default provider package command name, as the parent 'gem' provider is targetable.
   # Required by Puppet::Provider::Package::Targetable::resource_or_provider_command


### PR DESCRIPTION
Puppetserver still loads all types and providers during catalog compilation,
and JRuby with FIPS enabled cannot require rubygems. So guard the require
statement like we do in puppet/ssl/openssl_loader.

The `/opt/puppetlabs/bin/puppetserver gem install` command will fail
when running with JRuby with FIPS, so confine the provider when
`fips_enabled` is false. That way trying to manage a puppetserver gem
will print:

    Error: /Stage[main]/Main/Package[uuid]: Provider puppetserver_gem is not functional on this host

instead of:

    Error: Execution of '/opt/puppetlabs/bin/puppetserver gem install --no-document <gem>' returned 1:
      ERROR:  Loading command: install (NameError)
      cannot load (ext) (org.jruby.ext.openssl.OpenSSL)