### PR TITLE
Revert "Merge pull request #8305 from ciprianbadescu/PUP-10598/ignore_plugin_errors

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1893,7 +1893,7 @@ EOT
         :desc     => "What files to ignore when pulling down plugins.",
     },
     :ignore_plugin_errors => {
-      :default    => false,
+      :default    => true,
       :type       => :boolean,
       :desc       => "Whether the puppet run should ignore errors during pluginsync. If the setting
         is false and there are errors during pluginsync, then the agent will abort the run and

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -189,8 +189,6 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should return all changed file paths" do
-      Puppet[:ignore_plugin_errors] = true
-
       trans = double('transaction')
 
       catalog = double('catalog')
@@ -206,8 +204,6 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should yield the resources if a block is given" do
-      Puppet[:ignore_plugin_errors] = true
-
       trans = double('transaction')
 
       catalog = double('catalog')
@@ -225,8 +221,6 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "should catch and log exceptions" do
-      Puppet[:ignore_plugin_errors] = true
-
       expect(Puppet).to receive(:log_exception)
       # The downloader creates a new catalog for each apply, and really the only object
       # that it is possible to stub for the purpose of generating a puppet error
@@ -236,6 +230,8 @@ describe Puppet::Configurer::Downloader do
     end
 
     it "raises an exception if catalog application fails" do
+      Puppet[:ignore_plugin_errors] = false
+
       expect(@dler.file).to receive(:retrieve).and_raise(Puppet::Error, "testing")
 
       expect {

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -639,8 +639,6 @@ describe Puppet::Configurer do
       end
 
       it "should pluginsync and compile a new catalog if none is found in the cache" do
-        Puppet[:ignore_plugin_errors] = true
-
         expects_fallback_to_new_catalog(catalog)
         stub_request(:get, %r{/puppet/v3/file_metadatas?/plugins}).to_return(:status => 404)
         stub_request(:get, %r{/puppet/v3/file_metadatas?/pluginfacts}).to_return(:status => 404)
@@ -652,8 +650,6 @@ describe Puppet::Configurer do
       end
 
       it "should not attempt to retrieve a cached catalog again if the first attempt failed" do
-        Puppet[:ignore_plugin_errors] = true
-
         expect(Puppet::Node.indirection).to receive(:find).and_return(nil)
         expects_neither_new_or_cached_catalog
         expects_pluginsync


### PR DESCRIPTION
This reverts commit 2ec586ee80466f04273a8d4972387a5cdeaead7d, reversing
changes made to 8427686c0fd6c0f994e202a378263a0d5f565e96.

The following tests are failing in puppetserver CI, because the agent no longer falls back to its cached catalog if pluginsync fails:

```
$ export GEM_SOURCE=https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/
$ bx rake ci:test:aio TESTS=tests/environment/environment_scenario-bad.rb SHA=05976d1e8992c60316ced4290b9f919a0b933938 SERVER_VERSION=7.0.0.SNAPSHOT.2020.09.08T1653 TEST_TARGET=redhat7-64a OPTIONS='--preserve-hosts=always'
...
$ bx beaker exec tests/report/cached_catalog_status_in_report.rb
...
```

I went ahead and reverted this as we'll need to fix PUP-1763 in 5.5.x and then switch the default value in 7, and didn't want to block puppetserver CI while that happens.