### PR TITLE
(PUP-9309) Remove SubLocatedExpression

### DIFF
--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -1021,11 +1021,6 @@ class EvaluatorImpl
     end
   end
 
-  # SubLocatable is simply an expression that holds location information
-  def eval_SubLocatedExpression o, scope
-    evaluate(o.expr, scope)
-  end
-
   # Evaluates Puppet DSL Heredoc
   def eval_HeredocExpression o, scope
     expr = o.text_expr

--- a/lib/puppet/pops/model/ast.pp
+++ b/lib/puppet/pops/model/ast.pp
@@ -343,24 +343,6 @@ type Puppet::AST = TypeSet[{
         }
       }
     }],
-    SubLocatedExpression => Object[{
-      parent => Expression,
-      attributes => {
-        'expr' => Expression,
-        'line_offsets' => {
-          type => Array[Integer],
-          value => []
-        },
-        'leading_line_count' => {
-          type => Optional[Integer],
-          value => undef
-        },
-        'leading_line_offset' => {
-          type => Optional[Integer],
-          value => undef
-        }
-      }
-    }],
     HeredocExpression => Object[{
       parent => Expression,
       attributes => {

--- a/lib/puppet/pops/model/ast.rb
+++ b/lib/puppet/pops/model/ast.rb
@@ -2535,102 +2535,6 @@ class SiteDefinition < Definition
   alias == eql?
 end
 
-class SubLocatedExpression < Expression
-  def self._pcore_type
-    @_pcore_type ||= Types::PObjectType.new('Puppet::AST::SubLocatedExpression', {
-      'parent' => Expression._pcore_type,
-      'attributes' => {
-        'expr' => Expression._pcore_type,
-        'line_offsets' => {
-          'type' => Types::PArrayType.new(Types::PIntegerType::DEFAULT),
-          'value' => []
-        },
-        'leading_line_count' => {
-          'type' => Types::POptionalType.new(Types::PIntegerType::DEFAULT),
-          'value' => nil
-        },
-        'leading_line_offset' => {
-          'type' => Types::POptionalType.new(Types::PIntegerType::DEFAULT),
-          'value' => nil
-        }
-      }
-    })
-  end
-
-  def self.from_hash(init_hash)
-    from_asserted_hash(Types::TypeAsserter.assert_instance_of('Puppet::AST::SubLocatedExpression initializer', _pcore_type.init_hash_type, init_hash))
-  end
-
-  def self.from_asserted_hash(init_hash)
-    new(
-      init_hash['locator'],
-      init_hash['offset'],
-      init_hash['length'],
-      init_hash['expr'],
-      init_hash.fetch('line_offsets') { _pcore_type['line_offsets'].value },
-      init_hash['leading_line_count'],
-      init_hash['leading_line_offset'])
-  end
-
-  def self.create(locator, offset, length, expr, line_offsets = _pcore_type['line_offsets'].value, leading_line_count = nil, leading_line_offset = nil)
-    ta = Types::TypeAsserter
-    attrs = _pcore_type.attributes(true)
-    ta.assert_instance_of('Puppet::AST::Positioned[locator]', attrs['locator'].type, locator)
-    ta.assert_instance_of('Puppet::AST::Positioned[offset]', attrs['offset'].type, offset)
-    ta.assert_instance_of('Puppet::AST::Positioned[length]', attrs['length'].type, length)
-    ta.assert_instance_of('Puppet::AST::SubLocatedExpression[expr]', attrs['expr'].type, expr)
-    ta.assert_instance_of('Puppet::AST::SubLocatedExpression[line_offsets]', attrs['line_offsets'].type, line_offsets)
-    ta.assert_instance_of('Puppet::AST::SubLocatedExpression[leading_line_count]', attrs['leading_line_count'].type, leading_line_count)
-    ta.assert_instance_of('Puppet::AST::SubLocatedExpression[leading_line_offset]', attrs['leading_line_offset'].type, leading_line_offset)
-    new(locator, offset, length, expr, line_offsets, leading_line_count, leading_line_offset)
-  end
-
-  attr_reader :expr
-  attr_reader :line_offsets
-  attr_reader :leading_line_count
-  attr_reader :leading_line_offset
-
-  def initialize(locator, offset, length, expr, line_offsets = _pcore_type['line_offsets'].value, leading_line_count = nil, leading_line_offset = nil)
-    super(locator, offset, length)
-    @hash = @hash ^ expr.hash ^ line_offsets.hash ^ leading_line_count.hash ^ leading_line_offset.hash
-    @expr = expr
-    @line_offsets = line_offsets
-    @leading_line_count = leading_line_count
-    @leading_line_offset = leading_line_offset
-  end
-
-  def _pcore_init_hash
-    result = super
-    result['expr'] = @expr
-    result['line_offsets'] = @line_offsets unless _pcore_type['line_offsets'].default_value?(@line_offsets)
-    result['leading_line_count'] = @leading_line_count unless @leading_line_count == nil
-    result['leading_line_offset'] = @leading_line_offset unless @leading_line_offset == nil
-    result
-  end
-
-  def _pcore_contents
-    yield(@expr) unless @expr.nil?
-  end
-
-  def _pcore_all_contents(path, &block)
-    path << self
-    unless @expr.nil?
-      block.call(@expr, path)
-      @expr._pcore_all_contents(path, &block)
-    end
-    path.pop
-  end
-
-  def eql?(o)
-    super &&
-    @expr.eql?(o.expr) &&
-    @line_offsets.eql?(o.line_offsets) &&
-    @leading_line_count.eql?(o.leading_line_count) &&
-    @leading_line_offset.eql?(o.leading_line_offset)
-  end
-  alias == eql?
-end
-
 class HeredocExpression < Expression
   def self._pcore_type
     @_pcore_type ||= Types::PObjectType.new('Puppet::AST::HeredocExpression', {
@@ -4902,7 +4806,6 @@ def self.register_pcore_types
   Model::TypeDefinition,
   Model::NodeDefinition,
   Model::SiteDefinition,
-  Model::SubLocatedExpression,
   Model::HeredocExpression,
   Model::HostClassDefinition,
   Model::PlanDefinition,

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -444,22 +444,6 @@ class Factory
     @init_hash['selectors'] = selectors
   end
 
-  # Builds a SubLocatedExpression - this wraps the expression in a sublocation configured
-  # from the given token
-  # A SubLocated holds its own locator that is used for subexpressions holding positions relative
-  # to what it describes.
-  #
-  def build_SubLocatedExpression(o, token, expression)
-    @init_hash[KEY_EXPR] = expression
-    @init_hash[KEY_OFFSET] = token.offset
-    @init_hash[KEY_LENGTH] =  token.length
-    locator = token.locator
-    @init_hash[KEY_LOCATOR] = locator
-    @init_hash['leading_line_count'] = locator.leading_line_count
-    @init_hash['leading_line_offset'] = locator.leading_line_offset
-    @init_hash['line_offsets'] = locator.line_index # index of lines in sublocated
-  end
-
   def build_SelectorEntry(o, matching, value)
     @init_hash['matching_expr'] = matching
     @init_hash['value_expr'] = value

--- a/lib/puppet/pops/model/model_tree_dumper.rb
+++ b/lib/puppet/pops/model/model_tree_dumper.rb
@@ -441,10 +441,6 @@ class Puppet::Pops::Model::ModelTreeDumper < Puppet::Pops::Model::TreeDumper
     [do_dump(o.matching_expr), "=>", do_dump(o.value_expr)]
   end
 
-  def dump_SubLocatedExpression o
-    ["sublocated", do_dump(o.expr)]
-  end
-
   def dump_TypeAlias(o)
     ['type-alias', o.name, do_dump(o.type_expr)]
   end

--- a/lib/puppet/pops/model/pn_transformer.rb
+++ b/lib/puppet/pops/model/pn_transformer.rb
@@ -297,10 +297,6 @@ class PNTransformer
     transform(e.body).as_call('site')
   end
 
-  def transform_SubLocatedExpression(e)
-    transform(e.expr)
-  end
-
   def transform_TextExpression(e)
     PN::Call.new('str', transform(e.expr))
   end

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -94,10 +94,6 @@ class TypeParser
     interpret_any(o.text_expr, context)
   end
 
-  def interpret_SubLocatedExpression(o, context)
-    interpret_any(o.expr, context)
-  end
-
   # @api private
   def interpret_QualifiedName(o, context)
     o.value


### PR DESCRIPTION
Commit caced6b59 changed how location information within a heredoc string was
calculated. As a result, the SubLocatedExpression AST class is no longer used.
This commit removes the class.