### PR TITLE
(PUP-10659) Fix Data Type casting causing memory leaks in Puppet Server

### DIFF
--- a/lib/puppet/functions/new.rb
+++ b/lib/puppet/functions/new.rb
@@ -991,12 +991,17 @@ Puppet::Functions.create_function(:new, Puppet::Functions::InternalFunction) do
 
   def new_instance(scope, t, *args)
     return args[0] if args.size == 1 && !t.is_a?(Puppet::Pops::Types::PInitType) && t.instance?(args[0])
-    result = assert_type(t, new_function_for_type(t, scope).call(scope, *args))
+    result = assert_type(t, new_function_for_type(t).call(scope, *args))
     return block_given? ? yield(result) : result
   end
 
-  def new_function_for_type(t, scope)
-    @new_function_cache ||= Hash.new() {|hsh, key| hsh[key] = key.new_function.new(scope, loader) }
+  def new_function_for_type(t)
+    @new_function_cache ||= {}
+
+    unless @new_function_cache.key?(t)
+      @new_function_cache[t] = t.new_function.new(nil, loader)
+    end
+
     @new_function_cache[t]
   end
 


### PR DESCRIPTION
Casting between Puppet Data Types, such as `Integer("9")`, will cause
Puppet Server to retain `Puppet::Parser::Catalog` objects in memory
after requests finish.

This is caused by two issues in the `new_function_for_type` method:

- The cache is a Hash instance with a lambda function that creates
  constructor functions as they are requested. This lambda closes over
  the Compiler scope value passed the first time `new()` is called, which
  keeps that scope in memory.
- The Compiler `scope` value passed the first time new() is called is
  further passed into the constructor function when it is created. The
  function then stores it as a local variable.[1]

Refactor the `new_function_for_type` method to pass `nil` instead of
`scope` when creating the constructor function. The functions will fall
back to using the current Compiler's global scope if the value
previously populated by `scope` is referenced.[2]

Similar work to initialize functions with `nil` as the closure scope was
done in https://github.com/puppetlabs/puppet/commit/915d934ad06.

[1] https://github.com/puppetlabs/puppet/blob/6.18.0/lib/puppet/pops/functions/function.rb#L23
[2] https://github.com/puppetlabs/puppet/blob/6.18.0/lib/puppet/pops/functions/function.rb#L78-L79