### PR TITLE
(PUP-10657) Fix resource collector override leak

### DIFF
--- a/lib/puppet/pops/evaluator/collectors/abstract_collector.rb
+++ b/lib/puppet/pops/evaluator/collectors/abstract_collector.rb
@@ -45,9 +45,7 @@ class Puppet::Pops::Evaluator::Collectors::AbstractCollector
     return false if objects.empty?
 
     if @overrides and !objects.empty?
-      overrides[:source].meta_def(:child_of?) do |klass|
-        true
-      end
+      overrides[:source].override = true
 
       objects.each do |res|
         unless @collected.include?(res.ref)

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -34,7 +34,7 @@ class Puppet::Resource::Type
   DOUBLE_COLON = '::'.freeze
   EMPTY_ARRAY = [].freeze
 
-  attr_accessor :file, :line, :doc, :code, :parent, :resource_type_collection
+  attr_accessor :file, :line, :doc, :code, :parent, :resource_type_collection, :override
   attr_reader :namespace, :arguments, :behaves_like, :module_name
 
   # The attributes 'produces' and 'consumes' are arrays of the blueprints
@@ -63,6 +63,7 @@ class Puppet::Resource::Type
   # Are we a child of the passed class?  Do a recursive search up our
   # parentage tree to figure it out.
   def child_of?(klass)
+    return true if override
     return false unless parent
 
     return(klass == parent_type ? true : parent_type.child_of?(klass))


### PR DESCRIPTION
Use of a resource collector with an override block will cause Puppet
Server to retain `Puppet::Parser::Catalog` objects in memory after
requests finish.

The leak is caused by Resource Collector overriding the `child_of`
methods on the resources it operates on to always return `true`. This
forces the collector overrides to be merged in later by short-circuiting
the logic in `Puppet::Parser::Resource` that only accepts overrides from a
parent scope.[1][2]

Using `meta_def` to override a method results in the creation of a Ruby
"eigenclass" to hold the new method definition. The body of the method,
which accepts `klass` and always returns `true`, is provided by a Ruby
block. This block is an instance of a `Proc`, which means that it closes
over all variables that happen to be in scope. One of those variables is
`@scope`, which is a reference to the compiler scope.

JRuby doesn't always free eigenclass instances when the objects they
were created to modify go out of scope.[3]

Create an `override` accessor on the `Puppet::Resource::Type` class that
we set on overrides, and update the `Puppet::Resource::Type#child_of?`
method to check for that first.

This way we completely avoid defining methods on an instance at runtime.

[1] https://github.com/puppetlabs/puppet/blob/6.18.0/lib/puppet/parser/resource.rb#L167-L169
[2] https://github.com/puppetlabs/puppet/blob/6.18.0/lib/puppet/parser/resource.rb#L361
[3] https://github.com/jruby/jruby/issues/4968