### PR TITLE
(PUP-10667) consider `usecacheonfailure` when pluginsync fails

### DIFF
--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -63,6 +63,20 @@ describe Puppet::Configurer do
       expect(summary["time"]["last_run"]).to be_between(t1, t2)
     end
 
+    it "applies a cached catalog if pluginsync fails when usecacheonfailure is true" do
+      Puppet[:ignore_plugin_errors] = false
+
+      Puppet[:use_cached_catalog] = false
+      Puppet[:usecacheonfailure] = true
+
+      report = Puppet::Transaction::Report.new
+      expect_any_instance_of(Puppet::Configurer::Downloader).to receive(:evaluate).and_raise(Puppet::Error, 'Failed to retrieve: some file')
+      expect(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(@catalog)
+
+      @configurer.run(pluginsync: true, report: report)
+      expect(report.cached_catalog_status).to eq('on_pluginsync_failure')
+    end
+
     describe 'resubmitting facts' do
       context 'when resubmit_facts is set to false' do
         it 'should not send data' do

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -106,6 +106,24 @@ describe Puppet::Configurer do
       expect(@logs).to include(an_object_having_attributes(level: :err, message: %r{Failed to apply catalog: Failed to retrieve pluginfacts: Could not retrieve information from environment production source\(s\) puppet:///pluginfacts}))
     end
 
+    it "applies a cached catalog if pluginsync fails when usecacheonfailure is true" do
+      Puppet[:ignore_plugin_errors] = false
+
+      Puppet[:use_cached_catalog] = false
+      Puppet[:usecacheonfailure] = true
+
+      body = "{\"message\":\"Not Found: Could not find environment 'fasdfad'\",\"issue_kind\":\"RUNTIME_ERROR\"}"
+      stub_request(:get, %r{/puppet/v3/file_metadatas/pluginfacts}).to_return(
+        status: 404, body: body, headers: {'Content-Type' => 'application/json'}
+      )
+      stub_request(:get, %r{/puppet/v3/file_metadata/pluginfacts}).to_return(
+        status: 404, body: body, headers: {'Content-Type' => 'application/json'}
+      )
+
+      expect(configurer.run(pluginsync: true, :report => report)).to eq(0)
+      expect(report.cached_catalog_status).to eq('on_pluginsync_failure')
+    end
+
     it "applies a cached catalog when it can't connect to the master" do
       error = Errno::ECONNREFUSED.new('Connection refused - connect(2)')
 


### PR DESCRIPTION
In case pluginsync fails and `ignore_plugin_errors` is `false`, puppet should
apply cached catalog if `usecacheonfailure` is `true`