### PR TITLE
(PUP-8969) Preserve sensitiveness of epp templates

### DIFF
--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -440,7 +440,12 @@ Puppet::Face.define(:epp, '0.0.1') do
 
   def render_inline(epp_source, compiler, options)
     template_args = get_values(compiler, options)
-    Puppet::Pops::Evaluator::EppEvaluator.inline_epp(compiler.topscope, epp_source, template_args)
+    result = Puppet::Pops::Evaluator::EppEvaluator.inline_epp(compiler.topscope, epp_source, template_args)
+    if result.instance_of?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      result.unwrap
+    else
+      result
+    end
   end
 
   def render_file(epp_template_name, compiler, options, show_filename, file_nbr)
@@ -457,7 +462,12 @@ Puppet::Face.define(:epp, '0.0.1') do
       if template_file.nil? && Puppet::FileSystem.exist?(epp_template_name)
         epp_template_name = File.expand_path(epp_template_name)
       end
-      output << Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, epp_template_name, compiler.environment, template_args)
+      result = Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, epp_template_name, compiler.environment, template_args)
+      if result.instance_of?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        output << result.unwrap
+      else
+        output << result
+      end
     rescue Puppet::ParseError => detail
       Puppet.err("--- #{epp_template_name}") if show_filename
       raise detail

--- a/lib/puppet/functions/epp.rb
+++ b/lib/puppet/functions/epp.rb
@@ -40,6 +40,7 @@ Puppet::Functions.create_function(:epp, Puppet::Functions::InternalFunction) do
     scope_param
     param 'String', :path
     optional_param 'Hash[Pattern[/^\w+$/], Any]', :parameters
+    return_type 'Variant[String, Sensitive[String]]'
   end
 
   def epp(scope, path, parameters = nil)

--- a/lib/puppet/functions/inline_epp.rb
+++ b/lib/puppet/functions/inline_epp.rb
@@ -51,6 +51,7 @@ Puppet::Functions.create_function(:inline_epp, Puppet::Functions::InternalFuncti
     scope_param()
     param 'String', :template
     optional_param 'Hash[Pattern[/^\w+$/], Any]', :parameters
+    return_type 'Variant[String, Sensitive[String]]'
   end
 
   def inline_epp(scope, template, parameters = nil)


### PR DESCRIPTION
If an EPP template contains a Sensitive data type, then join the unwrapped
value, but wrap the entire result as Sensitive. This way the underlying
sensitive value is preserved, and the caller can access it by unwrapping the
entire result. Previously, the result was always a string and contained the
generic 'Sensitive [redacted]' message, so the underlying sensitive value was
lost.

Update the `epp` and `inline_epp` function signatures, since they can both
return either String or Sensitive[String].

Update the `epp` application to unwrap sensitive values produced by the above
functions.