### PR TITLE
(PUP-10664) Log server_list exceptions as they occur

### DIFF
--- a/lib/puppet/http/resolver.rb
+++ b/lib/puppet/http/resolver.rb
@@ -28,12 +28,12 @@ class Puppet::HTTP::Resolver
   # @param [Symbol] name the service to resolve
   # @param [Puppet::SSL::SSLContext] ssl_context (nil) optional ssl context to
   #   use when creating a connection
-  # @param [Proc] error_handler (nil) optional callback for each error
-  #   encountered while resolving a route.
+  # @param [Proc] canceled_handler (nil) optional callback allowing a resolver
+  #   to cancel resolution.
   #
   # @raise [NotImplementedError] this base class is not implemented
   #
-  def resolve(session, name, ssl_context: nil, error_handler: nil)
+  def resolve(session, name, ssl_context: nil, canceled_handler: nil)
     raise NotImplementedError
   end
 
@@ -45,17 +45,14 @@ class Puppet::HTTP::Resolver
   # @param [Puppet::HTTP::Session] session
   # @param [Puppet::HTTP::Service] service
   # @param [Puppet::SSL::SSLContext] ssl_context
-  # @param [Proc] error_handler (nil) optional callback for each error
-  #   encountered while resolving a route.
   #
   # @return [Boolean] Returns true if a connection is successful, false otherwise
   #
-  def check_connection?(session, service, ssl_context: nil, error_handler: nil)
+  def check_connection?(session, service, ssl_context: nil)
     service.connect(ssl_context: ssl_context)
     return true
   rescue Puppet::HTTP::ConnectionError => e
-    error_handler.call(e) if error_handler
-    Puppet.debug("Connection to #{service.url} failed, trying next route: #{e.message}")
+    Puppet.log_exception(e, "Connection to #{service.url} failed, trying next route: #{e.message}")
     return false
   end
 end

--- a/lib/puppet/http/resolver/settings.rb
+++ b/lib/puppet/http/resolver/settings.rb
@@ -13,14 +13,14 @@ class Puppet::HTTP::Resolver::Settings < Puppet::HTTP::Resolver
   # @param [Puppet::HTTP::Session] session
   # @param [Symbol] name the name of the service to be resolved
   # @param [Puppet::SSL::SSLContext] ssl_context
-  # @param [Proc] error_handler (nil) optional callback for each error
-  #   encountered while resolving a route.
+  # @param [Proc] canceled_handler (nil) optional callback allowing a resolver
+  #   to cancel resolution.
   #
   # @return [Puppet::HTTP::Service] if the service successfully connects,
   #   return it. Otherwise, return nil.
   #
-  def resolve(session, name, ssl_context: nil, error_handler: nil)
+  def resolve(session, name, ssl_context: nil, canceled_handler: nil)
     service = Puppet::HTTP::Service.create_service(@client, session, name)
-    check_connection?(session, service, ssl_context: ssl_context, error_handler: error_handler) ? service : nil
+    check_connection?(session, service, ssl_context: ssl_context) ? service : nil
   end
 end

--- a/lib/puppet/http/resolver/srv.rb
+++ b/lib/puppet/http/resolver/srv.rb
@@ -25,21 +25,21 @@ class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
   # @param [Puppet::HTTP::Session] session
   # @param [Symbol] name the service being resolved
   # @param [Puppet::SSL::SSLContext] ssl_context
-  # @param [Proc] error_handler (nil) optional callback for each error
-  #   encountered while resolving a route.
+  # @param [Proc] canceled_handler (nil) optional callback allowing a resolver
+  #   to cancel resolution.
   #
   # @return [Puppet::HTTP::Service] if an available service is found, return
   #   it. Return nil otherwise.
   #
-  def resolve(session, name, ssl_context: nil, error_handler: nil)
+  def resolve(session, name, ssl_context: nil, canceled_handler: nil)
     # Here we pass our HTTP service name as the DNS SRV service name
     # This is fine for :ca, but note that :puppet and :file are handled
     # specially in `each_srv_record`.
     @delegate.each_srv_record(@srv_domain, name) do |server, port|
       service = Puppet::HTTP::Service.create_service(@client, session, name, server, port)
-      return service if check_connection?(session, service, ssl_context: ssl_context, error_handler: error_handler)
+      return service if check_connection?(session, service, ssl_context: ssl_context)
     end
 
-    return nil
+    nil
   end
 end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1033,12 +1033,11 @@ describe Puppet::Configurer do
 
       stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: [500, "Internal Server Error"])
 
-      allow(Puppet).to receive(:debug)
-      expect(Puppet).to receive(:debug).with("Puppet server myserver:123 is unavailable: 500 Internal Server Error")
-
       expect {
         configurer.run
       }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list:/)
+
+      expect(@logs).to include(an_object_having_attributes(level: :err, message: /Puppet server myserver:123 is unavailable: 500 Internal Server Error/))
     end
 
     it "should error when no servers in 'server_list' are reachable" do

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -26,9 +26,9 @@ describe Puppet::HTTP::Session do
       @count = 0
     end
 
-    def resolve(session, name, ssl_context: nil, error_handler: nil)
+    def resolve(session, name, ssl_context: nil, canceled_handler: nil)
       @count += 1
-      return @service if check_connection?(session, @service, ssl_context: ssl_context, error_handler: error_handler)
+      return @service if check_connection?(session, @service, ssl_context: ssl_context)
     end
   end
 
@@ -67,19 +67,8 @@ describe Puppet::HTTP::Session do
         session.route_to(:ca)
       }.to raise_error(Puppet::HTTP::RouteError, 'No more routes to ca')
 
-      expect(@logs).to include(an_object_having_attributes(level: :err, message: "whoops1"),
-                               an_object_having_attributes(level: :err, message: "whoops2"))
-    end
-
-    it 'logs routing failures as debug until routing succeeds' do
-      Puppet[:log_level] = 'debug'
-
-      resolvers = [DummyResolver.new(bad_service), DummyResolver.new(good_service)]
-      session = described_class.new(client, resolvers)
-      session.route_to(:ca)
-
-      expect(@logs).to include(an_object_having_attributes(level: :debug, message: "Connection to #{uri} failed, trying next route: whoops"))
-      expect(@logs).to_not include(an_object_having_attributes(level: :err))
+      expect(@logs).to include(an_object_having_attributes(level: :err, message: "Connection to #{uri} failed, trying next route: whoops1"),
+                               an_object_having_attributes(level: :err, message: "Connection to #{uri} failed, trying next route: whoops2"))
     end
 
     it 'accepts an ssl context to use when connecting' do
@@ -167,16 +156,15 @@ describe Puppet::HTTP::Session do
       expect(service.url).to eq(URI("https://bar.example.com:8140/puppet-ca/v1"))
     end
 
-    it "fails if server_list doesn't return anything valid" do
-      Puppet[:server_list] = 'foo.example.com,bar.example.com'
+    it "does not fallback from server_list to the settings resolver when server_list is exhausted" do
+      Puppet[:server_list] = 'foo.example.com'
 
-      allow_any_instance_of(Puppet::Network::Resolver).to receive(:each_srv_record)
+      expect_any_instance_of(Puppet::HTTP::Resolver::Settings).to receive(:resolve).never
       stub_request(:get, "https://foo.example.com:8140/status/v1/simple/master").to_return(status: 500)
-      stub_request(:get, "https://bar.example.com:8140/status/v1/simple/master").to_return(status: 500)
 
       expect {
         session.route_to(:ca)
-      }.to raise_error(Puppet::Error, "Could not select a functional puppet master from server_list: 'foo.example.com,bar.example.com'")
+      }.to raise_error(Puppet::HTTP::RouteError, "No more routes to ca")
     end
 
     it "raises when there are no more routes" do


### PR DESCRIPTION
Previously, the server list resolver collected exceptions that occurred during
resolution. Now we log the exceptions at error level as they occur, which
eliminates the need for the `error_handler`.

The server list resolver also used to raise an error if the list was exhausted,
but that prevented the collected exceptions above from being logged at error
level. Now the server list resolver uses the `canceled_handler` to cancel
resolution (instead of raising) and its resolve method returns nil like other
resolvers.

The integration test relied on enabling debug for server_list tests. When that
is removed, it causes puppet to print the error to stderr instead of stdout.