### PR TITLE
(PUP-8014) Cache actively used environments

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -727,12 +727,36 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
         unless [0, 'unlimited', Float::INFINITY].include?(val)
           Puppet.deprecation_warning(<<-WARNING)
 Fine grained control of environment timeouts is deprecated,
-please use `0` or `unlimited` to control default caching behavior
-and the environment-cache endpoint in Puppet Server's administrative
-API to expire the cache as needed
+please use `environment_ttl` instead.
           WARNING
         end
       end
+    },
+    :environment_ttl => {
+      :default    => "0",
+      :type       => :ttl,
+      :desc       => "How long after the last access Puppet server will wait to
+      evict an environment from the environment cache.
+
+      A value of `0` will disable caching. This setting can also be set to
+      `unlimited`, which will cache environments until the server is restarted
+      or told to refresh the cache. All other values will result in Puppet server
+      evicting environments that have not been accessed within that ttl.
+
+      You should change this setting once your Puppet deployment is doing
+      non-trivial work. We chose the default value of `0` because it lets new
+      users update their code without any extra steps, but it lowers the
+      performance of your Puppet server.
+
+      We recommend setting this to a number that will keep your most actively
+      used environments cached, but allow testing environments to fall out of
+      the cache and reduce memory usage. A value of 3 minutes (3m) is a
+      reasonable value.
+
+      Once you set `environment_ttl` to a non-zero value, you need to tell
+      Puppet server to read new code from disk using the `environment-cache` API
+      endpoint after you deploy new code. See the docs for the Puppet Server
+      [administrative API](https://puppet.com/docs/puppetserver/latest/admin-api/v1/environment-cache.html)."
     },
     :environment_data_provider => {
       :desc       => "The name of a registered environment data provider used when obtaining environment

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -372,7 +372,9 @@ module Puppet::Environments
       clear_all_expired
       result = @cache[name]
       if result
+        Puppet.debug {"Found in cache '#{name}' #{result.label}"}
         # found in cache
+        result.touch
         return result.value
       elsif (result = @loader.get(name))
         # environment loaded, cache it
@@ -475,6 +477,9 @@ module Puppet::Environments
         @value = value
       end
 
+      def touch
+      end
+
       def expired?
         false
       end
@@ -503,10 +508,10 @@ module Puppet::Environments
       end
     end
 
-    # Time to Live eviction policy entry
+    # Policy that expires in ttl_seconds from when it was created
     class TTLEntry < Entry
       def initialize(value, ttl_seconds)
-        super value
+        super(value)
         @ttl = Time.now + ttl_seconds
         @ttl_seconds = ttl_seconds
       end

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -305,13 +305,23 @@ module Puppet::Environments
     include Puppet::Concurrent::Synchronized
 
     class DefaultCacheExpirationService
+      # Called when the environment is created.
+      #
+      # @param [Puppet::Node::Environment] env
       def created(env)
       end
 
+      # Is the environment with this name expired?
+      #
+      # @param [Symbol] env_name The symbolic environment name
+      # @return [Boolean]
       def expired?(env_name)
         false
       end
 
+      # The environment with this name was evicted.
+      #
+      # @param [Symbol] env_name The symbolic environment name
       def evicted(env_name)
       end
     end
@@ -411,7 +421,7 @@ module Puppet::Environments
       to_expire = @cache.select { |name, entry| entry.expires < t || @cache_expiration_service.expired?(name.to_sym) }
       to_expire.each do |name, entry|
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
-        @cache_expiration_service.evicted(name)
+        @cache_expiration_service.evicted(name.to_sym)
         clear(name)
         @expirations.delete(entry.expires)
         Puppet.settings.clear_environment_settings(name)
@@ -449,9 +459,9 @@ module Puppet::Environments
     # Evicts the entry if it has expired
     # Also clears caches in Settings that may prevent the entry from being updated
     def evict_if_expired(name)
-      if (result = @cache[name]) && (result.expired? || @cache_expiration_service.expired?(name))
+      if (result = @cache[name]) && (result.expired? || @cache_expiration_service.expired?(name.to_sym))
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
-        @cache_expiration_service.evicted(name)
+        @cache_expiration_service.evicted(name.to_sym)
         clear(name)
         Puppet.settings.clear_environment_settings(name)
       end

--- a/lib/puppet/network/http/api/master/v3/environments.rb
+++ b/lib/puppet/network/http/api/master/v3/environments.rb
@@ -24,12 +24,16 @@ class Puppet::Network::HTTP::API::Master::V3::Environments
   private
 
   def timeout(env)
-    ttl = @env_loader.get_conf(env.name).environment_timeout
+    ttl = if Puppet.settings.set_by_config?(:environment_ttl)
+            Puppet[:environment_ttl]
+          else
+            @env_loader.get_conf(env.name).environment_timeout
+          end
+
     if ttl == Float::INFINITY
       "unlimited"
     else
       ttl
     end
   end
-
 end

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -436,25 +436,6 @@ config_version=$vardir/random/scripts
           end
         end
       end
-
-      context "custom cache expiration service" do
-        it "consults the custom service to expire the cache" do
-          loader_from(:filesystem => [directory_tree],
-                      :directory => directory_tree.children.first) do |loader|
-            service = ReplayExpirationService.new([true])
-            using_expiration_service(service) do
-
-              cached = Puppet::Environments::Cached.new(loader)
-              cached.get(:an_environment)
-              cached.get(:an_environment)
-
-              expect(service.created_envs).to include(:an_environment)
-              expect(service.expired_envs).to include(:an_environment)
-              expect(service.evicted_envs).to include(:an_environment)
-            end
-          end
-        end
-      end
     end
   end
 
@@ -645,6 +626,56 @@ config_version=$vardir/random/scripts
       end
     end
 
+    context "expiration policies" do
+      let(:service) { ReplayExpirationService.new }
+
+      # The environment named `:an_environment` will already be loaded when the
+      # block is yielded to
+      def with_environment_loaded(service, &block)
+        loader_from(:filesystem => [directory_tree], :directory => directory_tree.children.first) do |loader|
+          using_expiration_service(service) do
+            cached = Puppet::Environments::Cached.new(loader)
+            cached.get!(:an_environment)
+
+            yield cached if block_given?
+          end
+        end
+      end
+
+      it "notifies when the environment is first created" do
+        with_environment_loaded(service)
+
+        expect(service.created_envs).to eq([:an_environment])
+      end
+
+      it "does not evict an unexpired environment" do
+        Puppet[:environment_timeout] = 'unlimited'
+
+        with_environment_loaded(service) do |cached|
+          cached.get!(:an_environment)
+        end
+
+        expect(service.created_envs).to eq([:an_environment])
+        expect(service.evicted_envs).to eq([])
+      end
+
+      it "evicts an expired environment" do
+        service = ReplayExpirationService.new
+
+        # The `Cached#clear_all_expired` method tries to optimize the case where
+        # no entries are expired. But if `Time.now < @next_expiration` and there is
+        # an expired entry, then the `service#expired?` method is called twice.
+        expect(service).to receive(:expired?).twice.and_return(true)
+
+        with_environment_loaded(service) do |cached|
+          cached.get!(:an_environment)
+        end
+
+        expect(service.created_envs).to eq([:an_environment, :an_environment])
+        expect(service.evicted_envs).to eq([:an_environment])
+      end
+    end
+
     it "gets an environment.conf" do
       loader_from(:filesystem => [directory_tree], :directory => directory_tree.children.first) do |loader|
         expect(Puppet::Environments::Cached.new(loader).get_conf(:an_environment)).to match_environment_conf(:an_environment).
@@ -746,31 +777,21 @@ config_version=$vardir/random/scripts
     end
   end
 
-  class ReplayExpirationService
-    attr_reader :created_envs, :expired_envs, :evicted_envs
+  class ReplayExpirationService < Puppet::Environments::Cached::DefaultCacheExpirationService
+    attr_reader :created_envs, :evicted_envs
 
-    def initialize(expiration_sequence)
+    def initialize
       @created_envs = []
-      @expired_envs = []
       @evicted_envs = []
-      @expiration_sequence = expiration_sequence
     end
 
     def created(env)
       @created_envs << env.name
     end
 
-    def expired?(env_name)
-      # make expired? idempotent
-      return true if @expired_envs.include? (env_name)
-      @expired_envs << env_name
-      @expiration_sequence.pop
-    end
-
     def evicted(env_name)
       @evicted_envs << env_name
     end
   end
-
 end
 end

--- a/spec/unit/network/http/api/master/v3/environments_spec.rb
+++ b/spec/unit/network/http/api/master/v3/environments_spec.rb
@@ -33,6 +33,16 @@ describe Puppet::Network::HTTP::API::Master::V3::Environments do
     })
   end
 
+  it "prefers environment_ttl" do
+    Puppet[:environment_ttl] = 60
+
+    handler.call(request, response)
+
+    expect(response.code).to eq(200)
+    expect(response.type).to eq("application/json")
+    expect(JSON.parse(response.body)["environments"]["production"]["settings"]["environment_timeout"]).to eq(60)
+  end
+
   it "the response conforms to the environments schema for unlimited timeout" do
     Puppet[:environment_timeout] = 'unlimited'
 


### PR DESCRIPTION
This adds a new puppet setting `Puppet[:environment_ttl]` which is similar to the deprecated `Puppet[:environment_timeout]` except the former computes the expiration time as N seconds since the environment was last accessed, while the latter computes it relative to when the environment was created. This way heavily used environments will be cached, but onetime "dev" environments will not.

The `Puppet[:environment_ttl]` setting is global and cannot be set in `environment.conf`. Puppet will use the `Puppet[:environment_ttl]` setting if it is explicitly configured, otherwise it will fallback to using `Puppet[:timeout]`.

If `Puppet[:environment_ttl]` is set, then environments can still be evicted using the [environment-cache REST API](https://puppet.com/docs/puppetserver/5.3/admin-api/v1/environment-cache.html#delete-puppet-admin-apiv1environment-cache), even environments that were recently used.

The `/puppet/v3/environments` REST API returns the *active* environment timeout for each environment. This is either `environment_ttl` or `environment_timeout`. Another option would be to add `environment_ttl` to the response, but `environment_timeout` will be removed in puppet 7. So I opted for minimizing API breakage.