### PR TITLE
(PUP-10677) use puppet ruby in puppet_gem provider

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -26,9 +26,10 @@ module Puppet
       def gem_command(host, type='aio')
         if type == 'aio'
           if host['platform'] =~ /windows/
-            "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+            install_dir = on(host, facter('env_windows_installdir')).stdout.strip
+            %(cmd /c "#{install_dir}\\puppet\\bin\\gem.bat")
           else
-            "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
+            "/opt/puppetlabs/puppet/bin/gem"
           end
         else
           on(host, 'which gem').stdout.chomp

--- a/acceptance/tests/provider/package/puppet_gem.rb
+++ b/acceptance/tests/provider/package/puppet_gem.rb
@@ -1,0 +1,32 @@
+test_name "puppet_gem provider uses Puppet's ruby" do
+  tag 'audit:high'
+  confine :to, platform: /windows|redhat|ubuntu/
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::ManifestUtils
+
+  package = 'colorize'
+
+  agents.each do |agent|
+    teardown do
+      on(agent, puppet("resource package #{package} ensure=absent provider=puppet_gem"))
+    end
+
+    step "Install a gem" do
+      package_manifest = resource_manifest('package', package, { ensure: 'present', provider: 'puppet_gem' } )
+      apply_manifest_on(agent, package_manifest, :catch_failures => true) do
+
+        puppet_gem_list = on(agent, "#{gem_command(agent)} list").stdout
+        assert_match(/#{package} \(/, puppet_gem_list)
+      end
+    end
+
+    step "Uninstall a gem" do
+      package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'puppet_gem' } )
+      apply_manifest_on(agent, package_manifest, :catch_failures => true) do
+        puppet_gem_list = on(agent, "#{gem_command(agent)} list").stdout
+        assert_no_match(/#{package} \(/, puppet_gem_list)
+      end
+    end
+  end
+end

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -200,10 +200,10 @@ class WindowsDaemon < Puppet::Util::Windows::Daemon
       ENV['OPENSSL_CONF'] = File.join(base_dir, 'puppet', 'ssl', 'openssl.cnf').tr('/', '\\')
       ENV['SSL_CERT_DIR'] = File.join(base_dir, 'puppet', 'ssl', 'certs').tr('/', '\\')
       ENV['SSL_CERT_FILE'] = File.join(base_dir, 'puppet', 'ssl', 'cert.pem').tr('/', '\\')
-      ENV['Path'] = [
+      ENV['Path'] += [
         File.join(base_dir, 'puppet', 'bin'),
         File.join(base_dir, 'bin'),
-      ].join(';').tr('/', '\\') + ';' + ENV['Path']
+      ].join(';').tr('/', '\\') + ';'
 
       # ENV that uses forward slashes
       ENV['RUBYLIB'] = "#{File.join(base_dir, 'puppet','lib')};#{ENV['RUBYLIB']}"

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -5,10 +5,7 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   has_feature :versionable, :install_options, :uninstall_options
 
   if Puppet::Util::Platform.windows?
-    # On windows, we put our ruby ahead of anything that already
-    # existed on the system PATH. This means that we do not need to
-    # sort out the absolute path.
-    commands :gemcmd => "gem"
+    commands :gemcmd => File.join(Puppet::Util.get_env('PUPPET_DIR').to_s, 'bin', 'gem.bat')
   else
     commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
   end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   if Puppet::Util::Platform.windows?
-    let(:provider_gem_cmd) { 'gem' }
+    let(:provider_gem_cmd) { 'C:\Program Files\Puppet Labs\Puppet\puppet\bin\gem.bat' }
   else
     let(:provider_gem_cmd) { '/opt/puppetlabs/puppet/bin/gem' }
   end


### PR DESCRIPTION
Before this commit, on Windows, puppet_gem provider
was relying on puppet-agent to set puppet bin first
in PATH. With the changes in https://github.com/puppetlabs/puppet-agent/pull/1973
puppet bin is now appended in PATH so we need to explicitly
set the full path to gemcommand.