### PR TITLE
(PUP-7791) add debug message when using latest packages

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -251,6 +251,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       return "#{upd[:epoch]}:#{upd[:version]}-#{upd[:release]}"
     else
       # Yum didn't find updates, pretend the current version is the latest
+      self.debug "Yum didn't find updates, current version (#{properties[:ensure]}) is the latest"
       version = properties[:ensure]
       raise Puppet::DevError, _("Tried to get latest on a missing package") if version == :absent || version == :purged
       return version


### PR DESCRIPTION
Before this commit, there's no indication of the current package
version when package resource is configured with latest, even
when running puppet agent with the debug flag,

After this commit a debug message with current version will be shown
if no upgrade upgrade is available.

```
Debug: Package[rsync](provider=yum): Yum didn't find updates, current version(3.1.2-10.el7) is the latest.
```