### PR TITLE
(maint) Fix i18n acceptance tests

### DIFF
--- a/acceptance/tests/i18n/modules/puppet_agent.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent.rb
@@ -14,12 +14,14 @@ test_name 'C100565: puppet agent with module should translate messages' do
   extend Puppet::Acceptance::I18nDemoUtils
 
   language = 'ja_JP'
-  step "configure server locale to #{language}" do
-    configure_master_system_locale(language)
-  end
+  disable_i18n_default_master = master.puppet['disable_i18n']
 
   step 'enable i18n on master' do
     on(master, puppet("config set disable_i18n false"))
+  end
+
+  step "configure server locale to #{language}" do
+    configure_master_system_locale(language)
   end
 
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))
@@ -30,6 +32,7 @@ test_name 'C100565: puppet agent with module should translate messages' do
 
   teardown do
     step 'resetting the server locale' do
+      on(master, puppet("config set disable_i18n #{ disable_i18n_default_master }"))
       reset_master_system_locale
     end
     step 'uninstall the module' do
@@ -48,7 +51,9 @@ test_name 'C100565: puppet agent with module should translate messages' do
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }
 
     type_path = agent.tmpdir('provider')
+    disable_i18n_default_agent = agent.puppet['disable_i18n']
     teardown do
+      on(agent, puppet("config set disable_i18n #{ disable_i18n_default_agent }"))
       agent.rm_rf(type_path)
     end
 

--- a/acceptance/tests/i18n/modules/puppet_apply.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply.rb
@@ -1,7 +1,7 @@
 test_name 'C100567: puppet apply of module should translate messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
-  tag 'audit:high',
+  tag 'audit:medium',
       'audit:acceptance'
 
   require 'puppet/acceptance/temp_file_utils'
@@ -35,13 +35,15 @@ test_name 'C100567: puppet apply of module should translate messages' do
       install_i18n_demo_module(agent)
     end
 
-    step 'enable i18n' do
-      on(agent, puppet("config set disable_i18n false"))
-    end
-
+    disable_i18n_default_agent = agent.puppet['disable_i18n']
     teardown do
+      on(agent, puppet("config set disable_i18n #{ disable_i18n_default_agent }"))
       uninstall_i18n_demo_module(agent)
       on(agent, "rm -rf '#{type_path}'")
+    end
+
+    step 'enable i18n' do
+      on(agent, puppet("config set disable_i18n false"))
     end
 
     step "Run puppet apply of a module with language #{agent_language} and verify the translations" do

--- a/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
@@ -2,7 +2,7 @@ test_name 'C100574: puppet apply using a module should translate messages in a l
 
   confine :except, :platform => /^windows/ # Can't print Finish on an English or Japanese code page
 
-  tag 'audit:high',
+  tag 'audit:medium',
       'audit:acceptance'
 
   require 'puppet/acceptance/temp_file_utils'
@@ -29,18 +29,20 @@ test_name 'C100574: puppet apply using a module should translate messages in a l
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }
 
+    type_path = agent.tmpdir('provider')
+    disable_i18n_default_agent = agent.puppet['disable_i18n']
+    teardown do
+      on(agent, puppet("config set disable_i18n #{ disable_i18n_default_agent }"))
+      uninstall_i18n_demo_module(agent)
+      on(agent, "rm -rf '#{type_path}'")
+    end
+
     step 'install a i18ndemo module' do
       install_i18n_demo_module(agent)
     end
-    type_path = agent.tmpdir('provider')
 
     step 'enable i18n' do
       on(agent, puppet("config set disable_i18n false"))
-    end
-
-    teardown do
-      uninstall_i18n_demo_module(agent)
-      on(agent, "rm -rf '#{type_path}'")
     end
 
     step "Run puppet apply of a module with language #{agent_language} and verify default english returned" do

--- a/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
@@ -21,14 +21,20 @@ test_name 'C100568: puppet apply of module for an unsupported language should fa
       next
     end
 
-    step 'install a i18ndemo module' do
-      install_i18n_demo_module(agent)
-    end
     type_path = agent.tmpdir('provider')
-
+    disable_i18n_default_agent = agent.puppet['disable_i18n']
     teardown do
+      on(agent, puppet("config set disable_i18n #{ disable_i18n_default_agent }"))
       uninstall_i18n_demo_module(agent)
       on(agent, "rm -rf '#{type_path}'")
+    end
+
+    step 'enable i18n' do
+      on(agent, puppet("config set disable_i18n false"))
+    end
+
+    step 'install a i18ndemo module' do
+      install_i18n_demo_module(agent)
     end
 
     step "Run puppet apply of a module with language #{unsupported_language} and verify default english returned" do

--- a/acceptance/tests/i18n/modules/puppet_describe.rb
+++ b/acceptance/tests/i18n/modules/puppet_describe.rb
@@ -1,7 +1,7 @@
 test_name 'C100576: puppet describe with module type translates message' do
   confine :except, :platform => /^solaris/ # translation not supported
 
-  tag 'audit:high',
+  tag 'audit:medium',
       'audit:acceptance'
 
   require 'puppet/acceptance/i18n_utils'
@@ -27,16 +27,18 @@ test_name 'C100576: puppet describe with module type translates message' do
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }
 
+    disable_i18n_default_agent = agent.puppet['disable_i18n']
+    teardown do
+      on(agent, puppet("config set disable_i18n #{ disable_i18n_default_agent }"))
+      uninstall_i18n_demo_module(agent)
+    end
+
     step 'enable i18n' do
       on(agent, puppet("config set disable_i18n false"))
     end
 
     step 'install a i18ndemo module' do
       install_i18n_demo_module(agent)
-    end
-
-    teardown do
-      uninstall_i18n_demo_module(agent)
     end
 
     step "Run puppet describe from a module with language #{agent_language} and verify the translations" do

--- a/acceptance/tests/i18n/modules/puppet_face.rb
+++ b/acceptance/tests/i18n/modules/puppet_face.rb
@@ -1,7 +1,7 @@
 test_name 'C100573: puppet application/face with module translates messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
-  tag 'audit:high',
+  tag 'audit:medium',
       'audit:acceptance'
 
   require 'puppet/acceptance/i18n_utils'
@@ -27,12 +27,18 @@ test_name 'C100573: puppet application/face with module translates messages' do
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }
 
-    step 'install a i18ndemo module' do
-      install_i18n_demo_module(agent)
+    disable_i18n_default_agent = agent.puppet['disable_i18n']
+    teardown do
+      on(agent, puppet("config set disable_i18n #{ disable_i18n_default_agent }"))
+      uninstall_i18n_demo_module(agent)
     end
 
-    teardown do
-      uninstall_i18n_demo_module(agent)
+    step 'enable i18n' do
+      on(agent, puppet("config set disable_i18n false"))
+    end
+
+    step 'install a i18ndemo module' do
+      install_i18n_demo_module(agent)
     end
 
     step "Run puppet i18ndemo (face/application from a module with language #{agent_language} and verify the translations" do

--- a/acceptance/tests/i18n/modules/puppet_resource.rb
+++ b/acceptance/tests/i18n/modules/puppet_resource.rb
@@ -1,7 +1,7 @@
 test_name 'C100572: puppet resource with module translates messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
-  tag 'audit:high',
+  tag 'audit:medium',
       'audit:acceptance'
 
   require 'puppet/acceptance/i18n_utils'
@@ -27,12 +27,18 @@ test_name 'C100572: puppet resource with module translates messages' do
     skip_test("test machine is missing #{agent_language} locale. Skipping") if agent_language.nil?
     shell_env_language = { 'LANGUAGE' => agent_language, 'LANG' => agent_language }
 
-    step 'install a i18ndemo module' do
-      install_i18n_demo_module(agent)
+    disable_i18n_default_agent = agent.puppet['disable_i18n']
+    teardown do
+      on(agent, puppet("config set disable_i18n #{ disable_i18n_default_agent }"))
+      uninstall_i18n_demo_module(agent)
     end
 
-    teardown do
-      uninstall_i18n_demo_module(agent)
+    step 'enable i18n' do
+      on(agent, puppet("config set disable_i18n false"))
+    end
+
+    step 'install a i18ndemo module' do
+      install_i18n_demo_module(agent)
     end
 
     step "Run puppet resource for a module with language #{agent_language} and verify the translations" do


### PR DESCRIPTION
During the change of `disable_i18n`'s default value from `false` to `true` there have been reactivated multiple acceptance tests. One of those tests, `tests/i18n/modules/puppet_agent.rb`, was failing constantly on the first run and passing after. This was due to puppetserver's load of `puppet.conf` configuration file in memory at the service's startup.

This was fixed by ensuring the desired `disable_i18n` value before restarting the `puppetserver` service and doing proper test teardown by reverting it to the original/default value. All i18n acceptance tests have been adapted in the same way.