### PR TITLE
(Maint) fix rubocop and update report schema

### DIFF
--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -111,11 +111,12 @@
         },
 
         "cached_catalog_status": {
-            "description": "Whether a cached catalog was used, and if so, why it was used. Enumerator with one of the values:\n\n* `not_used`, if a cached catalog was not used.\n* `explicitly_requested`, if a cached catalog was used because the use_cached_catalog option was set.\n* `on_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the agent failed to download a new catalog",
+            "description": "Whether a cached catalog was used, and if so, why it was used. Enumerator with one of the values:\n\n* `not_used`, if a cached catalog was not used.\n* `explicitly_requested`, if a cached catalog was used because the use_cached_catalog option was set.\n* `on_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the agent failed to download a new catalog. \n* `on_pluginsync_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the pluginsync failed while having ignore_plugin_errors set to false.",
             "enum": [
               "not_used",
               "explicitly_requested",
-              "on_failure"
+              "on_failure",
+              "on_pluginsync_failure"
             ]
         },
 
@@ -127,7 +128,7 @@
         "report_format": {
             "description": "The report format version documented by this schema",
             "type":        "integer",
-            "enum":        ["10", 10]
+            "enum":        ["11", 11]
         },
 
         "puppet_version": {

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -71,12 +71,16 @@ class Puppet::Configurer
   # Get the remote catalog, yo.  Returns nil if no catalog can be found.
   def retrieve_catalog(query_options)
     query_options ||= {}
-    if (Puppet[:use_cached_catalog] && result = retrieve_catalog_from_cache(query_options))
-      @cached_catalog_status = 'explicitly_requested'
+    if Puppet[:use_cached_catalog] || @pluginsync_failed
+      result = retrieve_catalog_from_cache(query_options)
+    end
 
-      Puppet.info _("Using cached catalog from environment '%{environment}'") % { environment: result.environment }
-    elsif (@pluginsync_failed && result = retrieve_catalog_from_cache(query_options))
-      @cached_catalog_status = 'on_pluginsync_failure'
+    if result
+      if Puppet[:use_cached_catalog]
+        @cached_catalog_status = 'explicitly_requested'
+      elsif @pluginsync_failed
+        @cached_catalog_status = 'on_pluginsync_failure'
+      end
 
       Puppet.info _("Using cached catalog from environment '%{environment}'") % { environment: result.environment }
     else

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -224,7 +224,7 @@ class Puppet::Transaction::Report
     @external_times ||= {}
     @host = Puppet[:node_name_value]
     @time = Time.now
-    @report_format = 10
+    @report_format = 11
     @puppet_version = Puppet.version
     @configuration_version = configuration_version
     @transaction_uuid = transaction_uuid


### PR DESCRIPTION
Schema was incremented because new value was added for the `cached_catalog_status` report field:
`on_pluginsync_failure` to be used when a cached catalog was used because the usecacheonfailure setting was set and the pluginsync failed while having ignore_plugin_errors set to false