### PR TITLE
(PUP-10677) gem provider uses system ruby

### DIFF
--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -5,10 +5,7 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   has_feature :versionable, :install_options, :uninstall_options
 
   if Puppet::Util::Platform.windows?
-    # On windows, we put our ruby ahead of anything that already
-    # existed on the system PATH. This means that we do not need to
-    # sort out the absolute path.
-    commands :gemcmd => "gem"
+    commands :gemcmd => File.join(Puppet::Util.get_env('PUPPET_DIR').to_s, 'bin', 'gem.bat')
   else
     commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
   end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -15,19 +15,20 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   end
 
   if Puppet::Util::Platform.windows?
-    let(:provider_gem_cmd) { 'gem' }
+    let(:provider_gem_cmd) { 'C:\Program Files\Puppet Labs\Puppet\puppet\bin\gem.bat' }
   else
     let(:provider_gem_cmd) { '/opt/puppetlabs/puppet/bin/gem' }
   end
 
   custom_environment = {"HOME"=>ENV["HOME"]}
-  custom_environment['PKG_CONFIG_PATH'] = '/opt/puppetlabs/puppet/lib/pkgconfig' unless Puppet::Util::Platform.windows?
+  custom_environment['PKG_CONFIG_PATH'] = '/opt/puppetlabs/puppet/lib/pkgconfig'
 
   let(:execute_options) { {:failonfail => true, :combine => true, :custom_environment => custom_environment} }
 
   before :each do
     resource.provider = provider
     allow(described_class).to receive(:command).with(:gemcmd).and_return(provider_gem_cmd)
+    allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
   end
 
   context "when installing" do


### PR DESCRIPTION
Because `INSTALL_DIR/puppet/bin` is prepended to PATH,
gem provider always uses Puppet's Ruby.
This commit changes the gem provider to execute commands
in a specific environment that has a PATH which does not
contain `puppet/bin`.

It also updates the puppet_gem provider to use
the full path for the Puppet's gem executable