### PR TITLE
(PUP-7582) Error on virtual and exported classes

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -505,7 +505,7 @@ module Runtime3Support
       # Store config issues, ignore or warning
       p[Issues::RT_NO_STORECONFIGS_EXPORT]    = Puppet[:storeconfigs] ? :ignore : :warning
       p[Issues::RT_NO_STORECONFIGS]           = Puppet[:storeconfigs] ? :ignore : :warning
-      p[Issues::CLASS_NOT_VIRTUALIZABLE]      = Puppet[:strict] == :off ? :warning : Puppet[:strict]
+      p[Issues::CLASS_NOT_VIRTUALIZABLE]      = :error
       p[Issues::NUMERIC_COERCION]             = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
       p[Issues::SERIALIZATION_DEFAULT_CONVERTED_TO_STRING] = Puppet[:strict] == :off ? :warning : Puppet[:strict]
       p[Issues::SERIALIZATION_UNKNOWN_CONVERTED_TO_STRING] = Puppet[:strict] == :off ? :warning : Puppet[:strict]

--- a/lib/puppet/pops/validation/validator_factory_4_0.rb
+++ b/lib/puppet/pops/validation/validator_factory_4_0.rb
@@ -35,7 +35,7 @@ class ValidatorFactory_4_0 < Factory
     p[Issues::DUPLICATE_KEY]                  = Puppet[:strict] == :off ? :ignore : Puppet[:strict]
     p[Issues::NAME_WITH_HYPHEN]               = :error
     p[Issues::EMPTY_RESOURCE_SPECIALIZATION]  = :ignore
-    p[Issues::CLASS_NOT_VIRTUALIZABLE]        = Puppet[:strict] == :off ? :warning : Puppet[:strict]
+    p[Issues::CLASS_NOT_VIRTUALIZABLE]        = :error
     p
   end
 end

--- a/spec/integration/parser/catalog_spec.rb
+++ b/spec/integration/parser/catalog_spec.rb
@@ -48,44 +48,6 @@ describe "A catalog" do
         expect(resources_in(agent_catalog)).
           to include_in_order(*resources_in_declaration_order)
       end
-
-      it "does not contain unrealized, virtual resources" do
-        virtual_resources = ["Unrealized[unreal]", "Class[Unreal]"]
-
-        master_catalog, agent_catalog = master_and_agent_catalogs_for(<<-EOM)
-          class unreal { }
-          define unrealized() { }
-
-          class real {
-            @unrealized { "unreal": }
-            @class { "unreal": }
-          }
-
-          include real
-        EOM
-
-        expect(resources_in(master_catalog)).to_not include(*virtual_resources)
-        expect(resources_in(agent_catalog)).to_not include(*virtual_resources)
-      end
-
-      it "does not contain unrealized, exported resources" do
-        exported_resources = ["Unrealized[unreal]", "Class[Unreal]"]
-
-        master_catalog, agent_catalog = master_and_agent_catalogs_for(<<-EOM)
-          class unreal { }
-          define unrealized() { }
-
-          class real {
-            @@unrealized { "unreal": }
-            @@class { "unreal": }
-          }
-
-          include real
-        EOM
-
-        expect(resources_in(master_catalog)).to_not include(*exported_resources)
-        expect(resources_in(agent_catalog)).to_not include(*exported_resources)
-      end
     end
   end
 

--- a/spec/unit/parser/functions/create_resources_spec.rb
+++ b/spec/unit/parser/functions/create_resources_spec.rb
@@ -257,31 +257,13 @@ describe 'function for dynamically creating resources' do
       expect(catalog.resource(:class, "bar")).not_to be_nil
     end
 
-    [:off, :warning].each do | strictness |
-      it "should warn if strict = #{strictness} and class is exported" do
-        Puppet[:strict] = strictness
-        collect_notices('class test{} create_resources("@@class", {test => {}})')
-        expect(warnings).to include(/Classes are not virtualizable/)
-      end
-    end
-
-    it 'should error if strict = error and class is exported' do
-      Puppet[:strict] = :error
+    it 'should error if class is exported' do
       expect{
         compile_to_catalog('class test{} create_resources("@@class", {test => {}})')
       }.to raise_error(/Classes are not virtualizable/)
     end
 
-    [:off, :warning].each do | strictness |
-      it "should warn if strict = #{strictness} and class is virtual" do
-        Puppet[:strict] = strictness
-        collect_notices('class test{} create_resources("@class", {test => {}})')
-        expect(warnings).to include(/Classes are not virtualizable/)
-      end
-    end
-
-    it 'should error if strict = error and class is virtual' do
-      Puppet[:strict] = :error
+    it 'should error if class is virtual' do
       expect{
         compile_to_catalog('class test{} create_resources("@class", {test => {}})')
       }.to raise_error(/Classes are not virtualizable/)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -179,17 +179,17 @@ describe "validating 4x" do
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
 
-    it 'produces a warning for virtual class resource' do
+    it 'produces an error for virtual class resource' do
       acceptor = validate(parse('@class { test: }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
-    it 'produces a warning for exported class resource' do
+    it 'produces an error for exported class resource' do
       acceptor = validate(parse('@@class { test: }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
@@ -310,17 +310,17 @@ describe "validating 4x" do
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_DEFAULT)
     end
 
-    it 'produces a warning for virtual class resource' do
+    it 'produces an error for virtual class resource' do
       acceptor = validate(parse('@class { test: }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
 
-    it 'produces a warning for exported class resource' do
+    it 'produces an error for exported class resource' do
       acceptor = validate(parse('@@class { test: }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
+      expect(acceptor.warning_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::CLASS_NOT_VIRTUALIZABLE)
     end
   end


### PR DESCRIPTION
Previously puppet would warn or error if it encountered a virtual
class (indicated by `@class`) or an exported class (indicated by `@@class`)
based on the `Puppet[:strict]` setting. By default, puppet would warn, yet
include resources from the virtual class in the catalog. So the resources in the
virtual class weren't virtual! Also note, it wasn't possible to turn off the
warning.

This commit makes puppet always error on virtual and exported classes. The
validator_factory_4_0.rb validates static resource expressions, while
runtime3_support validates `create_resources` calls, which can be used to create
resources at runtime.

The integration tests are removed since we already test for validation errors in
unit tests.