### PR TITLE
(PUP-10640) make tests more reliable

### DIFF
--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -33,8 +33,8 @@ describe Puppet::Util::Windows::ADSI::User,
 
   describe '.[]' do
     it 'should return string attributes as UTF-8' do
-      administrator = Puppet::Util::Windows::ADSI::User.new('Administrator')
-      expect(administrator['Description'].encoding).to eq(Encoding::UTF_8)
+      user = Puppet::Util::Windows::ADSI::User.new('Guest')
+      expect(user['Description'].encoding).to eq(Encoding::UTF_8)
     end
   end
 

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -872,8 +872,7 @@ describe "Puppet::FileSystem" do
 
             # regardless of slash direction, return value is drive letter
             expanded = Puppet::FileSystem.expand_path(slash)
-            expect(expanded).to eq(ENV['SystemDrive'] + File::SEPARATOR)
-            expect(expanded).to eq(File.expand_path(slash))
+            expect(expanded).to match(/^[a-z]:/i)
           end
         end
 

--- a/spec/unit/provider/exec_spec.rb
+++ b/spec/unit/provider/exec_spec.rb
@@ -49,9 +49,10 @@ describe Puppet::Provider::Exec do
         # we can't reference that in our manifest. Windows PATHs can contain
         # double quotes and trailing backslashes, which confuse HEREDOC
         # interpolation below. So sanitize it:
-        ENV['PATH'].split(File::PATH_SEPARATOR).map do |dir|
-          dir.gsub(/"/, '\"').gsub(/\\$/, '')
-        end.join(File::PATH_SEPARATOR)
+        ENV['PATH'].split(File::PATH_SEPARATOR)
+                   .map { |dir| dir.gsub(/"/, '\"').gsub(/\\$/, '') }
+                   .map { |dir| Pathname.new(dir).cleanpath.to_s }
+                   .join(File::PATH_SEPARATOR)
       else
         ENV['PATH']
       end


### PR DESCRIPTION
the following tests have been updated
- spec/integration/util/windows/adsi_spec.rb:34
  Was making the assumption that `Administrator` user
  is present. Changed to `Guest` since `Administrator`
  is not available in all setups.

- spec/unit/file_system_spec.rb:870
  `Puppet::FileSystem.expand_path` expands relative
  to the drive that Puppet is executed from. The
  expect here was making the assumption that Puppet
  tests are run form `SystemDrive` which is not always
  the case. Updated the test to match that the expanded path
  starts with a drive letter.

- spec/unit/provider/exec_spec.rb
  ENV['PATH'] is not correctly handled by Ruby. Use
  Pathname.cleanpath no normalize the path that is
  used in the `exec` resource