### PR TITLE
(PUP-10648) consider usecacheonfailure when using server_list

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -58,7 +58,7 @@ class Puppet::Configurer
   def initialize(transaction_uuid = nil, job_id = nil)
     @running = false
     @splayed = false
-    @pluginsync_failed = false
+    @running_failure = false
     @cached_catalog_status = 'not_used'
     @environment = Puppet[:environment]
     @transaction_uuid = transaction_uuid || SecureRandom.uuid
@@ -71,14 +71,14 @@ class Puppet::Configurer
   # Get the remote catalog, yo.  Returns nil if no catalog can be found.
   def retrieve_catalog(query_options)
     query_options ||= {}
-    if Puppet[:use_cached_catalog] || @pluginsync_failed
+    if Puppet[:use_cached_catalog] || @running_failure
       result = retrieve_catalog_from_cache(query_options)
     end
 
     if result
       if Puppet[:use_cached_catalog]
         @cached_catalog_status = 'explicitly_requested'
-      elsif @pluginsync_failed
+      elsif @running_failure
         @cached_catalog_status = 'on_failure'
       end
 
@@ -225,12 +225,26 @@ class Puppet::Configurer
         # mode. We shouldn't try to do any failover in that case.
         if options[:catalog].nil? && do_failover
           server, port = find_functional_server
-          if server.nil?
-            raise Puppet::Error, _("Could not select a functional puppet master from server_list: '%{server_list}'") % { server_list: Puppet.settings.value(:server_list, Puppet[:environment].to_sym, true) }
-          else
-            #TRANSLATORS 'server_list' is the name of a setting and should not be translated
-            Puppet.debug _("Selected puppet server from the `server_list` setting: %{server}:%{port}") % { server: server, port: port }
-            report.master_used = "#{server}:#{port}"
+          begin
+            if server.nil?
+              raise Puppet::Error, _("Could not select a functional puppet server from server_list: '%{server_list}'") % { server_list: Puppet.settings.value(:server_list, Puppet[:environment].to_sym, true) }
+            else
+              #TRANSLATORS 'server_list' is the name of a setting and should not be translated
+              Puppet.debug _("Selected puppet server from the `server_list` setting: %{server}:%{port}") % { server: server, port: port }
+              report.master_used = "#{server}:#{port}"
+            end
+          rescue Puppet::Error => detail
+            if Puppet[:usecacheonfailure]
+              options[:pluginsync] = false
+              @running_failure = true
+              if server.nil?
+                server = Puppet[:server_list].first[0]
+                port = Puppet[:server_list].first[1] || Puppet[:masterport]
+              end
+              Puppet.log_exception(detail)
+            else
+              raise detail
+            end
           end
           Puppet.override(server: server, serverport: port) do
             completed = run_internal(options)
@@ -541,7 +555,7 @@ class Puppet::Configurer
       @handler.download_plugins(remote_environment_for_plugins)
     rescue Puppet::Error => detail
       if !Puppet[:ignore_plugin_errors] && Puppet[:usecacheonfailure]
-        @pluginsync_failed = true
+        @running_failure = true
       else
         raise detail
       end

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1056,8 +1056,9 @@ describe Puppet::Configurer do
       expect(options[:report].master_used).to eq('myserver:123')
     end
 
-    it "should report when a server is unavailable" do
+    it "should report when usecacheonfailure is false and server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
+      Puppet[:usecacheonfailure] = false
 
       stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: [500, "Internal Server Error"])
 
@@ -1065,18 +1066,32 @@ describe Puppet::Configurer do
       expect(Puppet).to receive(:debug).with("Puppet server myserver:123 is unavailable: 500 Internal Server Error")
       expect {
         configurer.run
-      }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list:/)
+      }.to raise_error(Puppet::Error, /Could not select a functional puppet server from server_list:/)
     end
 
     it "should error when no servers in 'server_list' are reachable" do
       Puppet.settings[:server_list] = "myserver:123,someotherservername"
+      Puppet[:usecacheonfailure] = false
+
+      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 400)
+      stub_request(:get, 'https://someotherservername:8140/status/v1/simple/master').to_return(status: 400)
+
+      expect{
+        configurer.run
+      }.to raise_error(Puppet::Error, /Could not select a functional puppet server from server_list: 'myserver:123,someotherservername'/)
+    end
+
+    it "should not error when usecacheonfailure is true and no servers in 'server_list' are reachable" do
+      Puppet.settings[:server_list] = "myserver:123,someotherservername"
+      Puppet[:usecacheonfailure] = true
 
       stub_request(:get, 'https://myserver/status/v1/simple/master').to_return(status: 400)
       stub_request(:get, 'https://someotherservername/status/v1/simple/master').to_return(status: 400)
 
-      expect{
-        configurer.run
-      }.to raise_error(Puppet::Error, /Could not select a functional puppet master from server_list: 'myserver:123,someotherservername'/)
+      options = {}
+
+      expect(configurer.run(options)).to eq(0)
+      expect(options[:report].master_used).to be_nil
     end
 
     it "should not make multiple node requests when the server is found" do


### PR DESCRIPTION
 In case no server from `server_list` is available and `usecacheonfailure`
 is set to `true`, skip pluginsync and use cached catalog