### PR TITLE
(PUP-8682) Allow disabling of settings catalog

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -255,6 +255,11 @@ module Puppet
         which occurs only on a Puppet Server master when the `code-id-command` and
         `code-content-command` settings are configured in its `puppetserver.conf` file.",
     },
+    :settings_catalog => {
+      :default    => true,
+      :type       => :boolean,
+      :desc       => "Whether to compile and apply the settings catalog",
+    },
     :strict_environment_mode => {
       :default    => false,
       :type       => :boolean,

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1654,6 +1654,23 @@ describe Puppet::Settings do
     end
   end
 
+  describe 'when settings_catalog is disabled' do
+    let(:settings) { Puppet::Settings.new }
+    before do
+      allow(Puppet).to receive(:[]).with(:settings_catalog).and_return(false)
+    end
+
+    it 'does not compile and apply settings catalog' do
+      expect(settings).not_to receive(:to_catalog)
+      settings.use(:main)
+    end
+
+    it 'logs a message that settings catalog is skipped' do
+      expect(Puppet).to receive(:debug).with('Skipping settings catalog for sections main')
+      settings.use(:main)
+    end
+  end
+
   describe "when dealing with printing configs" do
     before do
       @settings = Puppet::Settings.new


### PR DESCRIPTION
This commit adds a new setting `settings_catalog`
which defaults to `true`. This settings can is used
to configuer if Puppet will compile and apply the
settings catalog when `Puppet.settings.use(*sections)`
is used.