### PR TITLE
(PUP-10671) Add `server` run mode and alias

### DIFF
--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -103,7 +103,7 @@ file { '#{moduledir}/yaml_terminus/lib/puppet/indirector/resource/#{storeconfigs
     class Puppet::Resource::#{terminus_class_name} < Puppet::Indirector::Yaml
       desc "Read resource instances from cached catalogs"
       def search(request)
-        catalog_dir = File.join(Puppet.run_mode.master? ? Puppet[:yamldir] : Puppet[:clientyamldir], "catalog", "*")
+        catalog_dir = File.join(Puppet.run_mode.server? ? Puppet[:yamldir] : Puppet[:clientyamldir], "catalog", "*")
         results = Dir.glob(catalog_dir).collect { |file|
           catalog = Puppet::Resource::Catalog.convert_from(:pson, File.read(file))
           if catalog.name == request.options[:host]

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -1,7 +1,7 @@
 require 'puppet/application'
 
 class Puppet::Application::Doc < Puppet::Application
-  run_mode :master
+  run_mode :server
 
   attr_accessor :unknown_args, :manifest
 

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -8,7 +8,7 @@ class Puppet::Application::Lookup < Puppet::Application
   RUN_HELP = _("Run 'puppet lookup --help' for more details").freeze
   DEEP_MERGE_OPTIONS = '--knock-out-prefix, --sort-merged-arrays, and --merge-hash-arrays'.freeze
 
-  run_mode :master
+  run_mode :server
 
   # Options for lookup
   option('--merge TYPE') do |arg|

--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -97,7 +97,7 @@ Puppet::Indirector::Face.define(:catalog, '0.0.1') do
       A serialized catalog.
     EOT
     when_invoked do |*args|
-      Puppet.settings.preferred_run_mode = :master
+      Puppet.settings.preferred_run_mode = :server
       Puppet::Face[:catalog, :current].find(*args)
     end
   end

--- a/lib/puppet/face/node.rb
+++ b/lib/puppet/face/node.rb
@@ -32,11 +32,11 @@ Puppet::Indirector::Face.define(:node, '0.0.1') do
 
     $ puppet node find somenode.puppetlabs.lan --terminus plain --render-as yaml
 
-    Retrieve a node using the puppet master's configured ENC:
+    Retrieve a node using the Puppet Server's configured ENC:
 
-    $ puppet node find somenode.puppetlabs.lan --terminus exec --run_mode master --render-as yaml
+    $ puppet node find somenode.puppetlabs.lan --terminus exec --run_mode server --render-as yaml
 
-    Retrieve the same node from the puppet master:
+    Retrieve the same node from the Puppet Server:
 
     $ puppet node find somenode.puppetlabs.lan --terminus rest --render-as yaml
   EOT

--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -26,9 +26,9 @@ Puppet::Face.define(:node, '0.0.1') do
       # definition, and should not be modifiable beyond that.  This is one of
       # the only places left in the code that tries to manipulate it. Other
       # parts of code that handle certificates behave differently if the
-      # run_mode is master. Those other behaviors are needed for cleaning the
+      # run_mode is server. Those other behaviors are needed for cleaning the
       # certificates correctly.
-      Puppet.settings.preferred_run_mode = "master"
+      Puppet.settings.preferred_run_mode = "server"
 
       Puppet::Node::Facts.indirection.terminus_class = :yaml
       Puppet::Node::Facts.indirection.cache_class = :yaml

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -75,7 +75,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
   # Is our compiler part of a network, or are we just local?
   def networked?
-    Puppet.run_mode.master?
+    Puppet.run_mode.server?
   end
 
   private

--- a/lib/puppet/indirector/facts/yaml.rb
+++ b/lib/puppet/indirector/facts/yaml.rb
@@ -20,7 +20,7 @@ class Puppet::Node::Facts::Yaml < Puppet::Indirector::Yaml
 
   # Return the path to a given node's file.
   def yaml_dir_path
-    base = Puppet.run_mode.master? ? Puppet[:yamldir] : Puppet[:clientyamldir]
+    base = Puppet.run_mode.server? ? Puppet[:yamldir] : Puppet[:clientyamldir]
     File.join(base, 'facts', '*.yaml')
   end
 

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -41,7 +41,7 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
       raise ArgumentError, _("invalid key")
     end
 
-    base = Puppet.run_mode.master? ? Puppet[:server_datadir] : Puppet[:client_datadir]
+    base = Puppet.run_mode.server? ? Puppet[:server_datadir] : Puppet[:client_datadir]
     File.join(base, self.class.indirection_name.to_s, name.to_s + ext)
   end
 

--- a/lib/puppet/indirector/msgpack.rb
+++ b/lib/puppet/indirector/msgpack.rb
@@ -48,7 +48,7 @@ class Puppet::Indirector::Msgpack < Puppet::Indirector::Terminus
       raise ArgumentError, _("invalid key")
     end
 
-    base = Puppet.run_mode.master? ? Puppet[:server_datadir] : Puppet[:client_datadir]
+    base = Puppet.run_mode.server? ? Puppet[:server_datadir] : Puppet[:client_datadir]
     File.join(base, self.class.indirection_name.to_s, name.to_s + ext)
   end
 

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -40,7 +40,7 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
       raise ArgumentError, _("invalid key")
     end
 
-    base = Puppet.run_mode.master? ? Puppet[:yamldir] : Puppet[:clientyamldir]
+    base = Puppet.run_mode.server? ? Puppet[:yamldir] : Puppet[:clientyamldir]
     File.join(base, self.class.indirection_name.to_s, name.to_s + ext)
   end
 

--- a/lib/puppet/pops/evaluator/runtime3_converter.rb
+++ b/lib/puppet/pops/evaluator/runtime3_converter.rb
@@ -79,9 +79,9 @@ class Runtime3Converter
 
   def convert_String(o, scope, undef_value)
     # Although wasteful, a dup is needed because user code may mutate these strings when applying
-    # Resources. This does not happen when in master mode since it only uses Resources that are
+    # Resources. This does not happen when in server mode since it only uses Resources that are
     # in puppet core and those are all safe.
-    o.frozen? && !Puppet.run_mode.master? ? o.dup : o
+    o.frozen? && !Puppet.run_mode.server? ? o.dup : o
   end
 
   def convert_Object(o, scope, undef_value)

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -330,7 +330,7 @@ class Puppet::Settings
     end
 
     option_parser.on('--run_mode',
-                     "The effective 'run mode' of the application: master, agent, or user.",
+                     "The effective 'run mode' of the application: server, agent, or user.",
                      :REQUIRED) do |arg|
       Puppet.settings.preferred_run_mode = arg
     end
@@ -564,7 +564,7 @@ class Puppet::Settings
   # @api private
   def preferred_run_mode=(mode)
     mode = mode.to_s.downcase.intern
-    raise ValidationError, "Invalid run mode '#{mode}'" unless [:master, :agent, :user].include?(mode)
+    raise ValidationError, "Invalid run mode '#{mode}'" unless [:server, :master, :agent, :user].include?(mode)
     @preferred_run_mode_name = mode
     # Changing the run mode has far-reaching consequences. Flush any cached
     # settings so they will be re-generated.
@@ -659,7 +659,7 @@ class Puppet::Settings
     if explicit_config_file?
       return self[:config]
     else
-      return File.join(Puppet::Util::RunMode[:master].conf_dir, config_file_name)
+      return File.join(Puppet::Util::RunMode[:server].conf_dir, config_file_name)
     end
   end
   private :main_config_file

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -18,8 +18,12 @@ module Puppet
         end
       end
 
+      def server?
+        name == :master || name == :server
+      end
+
       def master?
-        name == :master
+        name == :master || name == :server
       end
 
       def agent?

--- a/spec/unit/application/doc_spec.rb
+++ b/spec/unit/application/doc_spec.rb
@@ -234,8 +234,8 @@ describe Puppet::Application::Doc do
         end
       end
 
-      it "should operate in master run_mode" do
-        expect(@doc.class.run_mode.name).to eq(:master)
+      it "should operate in server run_mode" do
+        expect(@doc.class.run_mode.name).to eq(:server)
 
         @doc.setup_rdoc
       end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -118,6 +118,11 @@ describe Puppet::Application do
       @appclass.run_mode :agent
       expect(@appclass.run_mode.name).to eq(:agent)
     end
+
+    it "considers :server to be master" do
+      @appclass.run_mode :server
+      expect(@appclass.run_mode).to be_master
+    end
   end
 
   describe ".environment_mode" do
@@ -147,7 +152,7 @@ describe Puppet::Application do
   describe "when dealing with run_mode" do
 
     class TestApp < Puppet::Application
-      run_mode :master
+      run_mode :server
       def run_command
         # no-op
       end
@@ -159,16 +164,16 @@ describe Puppet::Application do
       app = TestApp.new
       app.initialize_app_defaults
 
-      expect(Puppet.run_mode).to be_master
+      expect(Puppet.run_mode).to be_server
     end
 
     it "should sadly and frighteningly allow run_mode to change at runtime via #run" do
       app = TestApp.new
       app.run
 
-      expect(app.class.run_mode.name).to eq(:master)
+      expect(app.class.run_mode.name).to eq(:server)
 
-      expect(Puppet.run_mode).to be_master
+      expect(Puppet.run_mode).to be_server
     end
   end
 

--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -74,9 +74,9 @@ describe Puppet::Face[:node, '0.0.1'] do
           subject.clean('hostname')
         end
 
-        it "should run in master mode" do
+        it "should run in server mode" do
           subject.clean('hostname')
-          expect(Puppet.run_mode).to be_master
+          expect(Puppet.run_mode).to be_server
         end
 
         it "should set node cache as yaml" do

--- a/spec/unit/indirector/catalog/json_spec.rb
+++ b/spec/unit/indirector/catalog/json_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::Resource::Catalog::Json do
     end
 
     before :each do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:server_datadir] = tmpdir('jsondir')
       FileUtils.mkdir_p(File.join(Puppet[:server_datadir], 'indirector_testing'))
       Puppet.push_context(:loaders => Puppet::Pops::Loaders.new(env))

--- a/spec/unit/indirector/json_spec.rb
+++ b/spec/unit/indirector/json_spec.rb
@@ -11,24 +11,24 @@ describe Puppet::Indirector::JSON do
 
   context "#path" do
     before :each do
-      Puppet[:server_datadir] = '/sample/datadir/master'
+      Puppet[:server_datadir] = '/sample/datadir/server'
       Puppet[:client_datadir] = '/sample/datadir/client'
     end
 
-    it "uses the :server_datadir setting if this is the master" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+    it "uses the :server_datadir setting if this is the server" do
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       expected = File.join(Puppet[:server_datadir], 'indirector_testing', 'testing.json')
       expect(subject.path('testing')).to eq(expected)
     end
 
-    it "uses the :client_datadir setting if this is not the master" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(false)
+    it "uses the :client_datadir setting if this is not the server" do
+      allow(Puppet.run_mode).to receive(:server?).and_return(false)
       expected = File.join(Puppet[:client_datadir], 'indirector_testing', 'testing.json')
       expect(subject.path('testing')).to eq(expected)
     end
 
     it "overrides the default extension with a supplied value" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       expected = File.join(Puppet[:server_datadir], 'indirector_testing', 'testing.not-json')
       expect(subject.path('testing', '.not-json')).to eq(expected)
     end
@@ -50,7 +50,7 @@ describe Puppet::Indirector::JSON do
 
   context "handling requests" do
     before :each do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:server_datadir] = tmpdir('jsondir')
       FileUtils.mkdir_p(File.join(Puppet[:server_datadir], 'indirector_testing'))
     end
@@ -158,7 +158,7 @@ describe Puppet::Indirector::JSON do
 
   context "#search" do
     before :each do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:server_datadir] = tmpdir('jsondir')
       FileUtils.mkdir_p(File.join(Puppet[:server_datadir], 'indirector_testing'))
     end

--- a/spec/unit/indirector/msgpack_spec.rb
+++ b/spec/unit/indirector/msgpack_spec.rb
@@ -11,24 +11,24 @@ describe Puppet::Indirector::Msgpack, :if => Puppet.features.msgpack? do
 
   context "#path" do
     before :each do
-      Puppet[:server_datadir] = '/sample/datadir/master'
+      Puppet[:server_datadir] = '/sample/datadir/server'
       Puppet[:client_datadir] = '/sample/datadir/client'
     end
 
-    it "uses the :server_datadir setting if this is the master" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+    it "uses the :server_datadir setting if this is the server" do
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       expected = File.join(Puppet[:server_datadir], 'indirector_testing', 'testing.msgpack')
       expect(subject.path('testing')).to eq(expected)
     end
 
-    it "uses the :client_datadir setting if this is not the master" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(false)
+    it "uses the :client_datadir setting if this is not the server" do
+      allow(Puppet.run_mode).to receive(:server?).and_return(false)
       expected = File.join(Puppet[:client_datadir], 'indirector_testing', 'testing.msgpack')
       expect(subject.path('testing')).to eq(expected)
     end
 
     it "overrides the default extension with a supplied value" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       expected = File.join(Puppet[:server_datadir], 'indirector_testing', 'testing.not-msgpack')
       expect(subject.path('testing', '.not-msgpack')).to eq(expected)
     end
@@ -50,7 +50,7 @@ describe Puppet::Indirector::Msgpack, :if => Puppet.features.msgpack? do
 
   context "handling requests" do
     before :each do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:server_datadir] = tmpdir('msgpackdir')
       FileUtils.mkdir_p(File.join(Puppet[:server_datadir], 'indirector_testing'))
     end
@@ -158,7 +158,7 @@ describe Puppet::Indirector::Msgpack, :if => Puppet.features.msgpack? do
 
   context "#search" do
     before :each do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:server_datadir] = tmpdir('msgpackdir')
       FileUtils.mkdir_p(File.join(Puppet[:server_datadir], 'indirector_testing'))
     end

--- a/spec/unit/indirector/yaml_spec.rb
+++ b/spec/unit/indirector/yaml_spec.rb
@@ -38,30 +38,30 @@ describe Puppet::Indirector::Yaml do
 
   before :each do
     Puppet[:clientyamldir] = dir
-    allow(Puppet.run_mode).to receive(:master?).and_return(false)
+    allow(Puppet.run_mode).to receive(:server?).and_return(false)
   end
 
   describe "when choosing file location" do
-    it "should use the server_datadir if the run_mode is master" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+    it "should use the server_datadir if the run_mode is server" do
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:yamldir] = serverdir
       expect(terminus.path(:me)).to match(/^#{serverdir}/)
     end
 
-    it "should use the client yamldir if the run_mode is not master" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(false)
+    it "should use the client yamldir if the run_mode is not server" do
+      allow(Puppet.run_mode).to receive(:server?).and_return(false)
       Puppet[:clientyamldir] = clientdir
       expect(terminus.path(:me)).to match(/^#{clientdir}/)
     end
 
     it "should use the extension if one is specified" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:yamldir] = serverdir
       expect(terminus.path(:me,'.farfignewton')).to match(%r{\.farfignewton$})
     end
 
     it "should assume an extension of .yaml if none is specified" do
-      allow(Puppet.run_mode).to receive(:master?).and_return(true)
+      allow(Puppet.run_mode).to receive(:server?).and_return(true)
       Puppet[:yamldir] = serverdir
       expect(terminus.path(:me)).to match(%r{\.yaml$})
     end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Settings do
   include Matchers::Resource
 
   let(:main_config_file_default_location) do
-    File.join(Puppet::Util::RunMode[:master].conf_dir, "puppet.conf")
+    File.join(Puppet::Util::RunMode[:server].conf_dir, "puppet.conf")
   end
 
   let(:user_config_file_default_location) do
@@ -112,9 +112,9 @@ describe Puppet::Settings do
     #  case behaviors / uses.  However, until that time... we need to make sure that our private run_mode=
     #  setter method gets properly called during app initialization.
     it "sets the preferred run mode when initializing the app defaults" do
-      @settings.initialize_app_defaults(default_values.merge(:run_mode => :master))
+      @settings.initialize_app_defaults(default_values.merge(:run_mode => :server))
 
-      expect(@settings.preferred_run_mode).to eq(:master)
+      expect(@settings.preferred_run_mode).to eq(:server)
     end
 
     it "creates ancestor directories for all required app settings" do
@@ -382,7 +382,7 @@ describe Puppet::Settings do
 
     it "should clear the cache when the preferred_run_mode is changed" do
       expect(@settings).to receive(:flush_cache)
-      @settings.preferred_run_mode = :master
+      @settings.preferred_run_mode = :server
     end
 
     it "should not clear other values when setting getopt-specific values" do
@@ -1900,18 +1900,18 @@ describe Puppet::Settings do
     end
 
     it "should set preferred run mode from --run_mode <foo> string without error" do
-      args = ["--run_mode", "master"]
-      expect(settings).not_to receive(:handlearg).with("--run_mode", "master")
+      args = ["--run_mode", "server"]
+      expect(settings).not_to receive(:handlearg).with("--run_mode", "server")
       expect { settings.send(:parse_global_options, args) } .to_not raise_error
-      expect(Puppet.settings.preferred_run_mode).to eq(:master)
+      expect(Puppet.settings.preferred_run_mode).to eq(:server)
       expect(args.empty?).to eq(true)
     end
 
     it "should set preferred run mode from --run_mode=<foo> string without error" do
-      args = ["--run_mode=master"]
-      expect(settings).not_to receive(:handlearg).with("--run_mode", "master")
+      args = ["--run_mode=server"]
+      expect(settings).not_to receive(:handlearg).with("--run_mode", "server")
       expect { settings.send(:parse_global_options, args) }.to_not raise_error
-      expect(Puppet.settings.preferred_run_mode).to eq(:master)
+      expect(Puppet.settings.preferred_run_mode).to eq(:server)
       expect(args.empty?).to eq(true)
     end
   end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -25,12 +25,12 @@ describe Puppet::Util::RunMode do
         as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path('~/.puppetlabs/etc/puppet')) }
       end
 
-      context "master run mode" do
+      context "server run mode" do
         before do
-          @run_mode = Puppet::Util::UnixRunMode.new('master')
+          @run_mode = Puppet::Util::UnixRunMode.new('server')
         end
 
-        it "has confdir ~/.puppetlabs/etc/puppet when run as non-root and master run mode" do
+        it "has confdir ~/.puppetlabs/etc/puppet when run as non-root and server run mode" do
           as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path('~/.puppetlabs/etc/puppet')) }
         end
       end
@@ -53,12 +53,12 @@ describe Puppet::Util::RunMode do
         as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path('~/.puppetlabs/etc/code')) }
       end
 
-      context "master run mode" do
+      context "server run mode" do
         before do
-          @run_mode = Puppet::Util::UnixRunMode.new('master')
+          @run_mode = Puppet::Util::UnixRunMode.new('server')
         end
 
-        it "has codedir ~/.puppetlabs/etc/code when run as non-root and master run mode" do
+        it "has codedir ~/.puppetlabs/etc/code when run as non-root and server run mode" do
           as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path('~/.puppetlabs/etc/code')) }
         end
       end


### PR DESCRIPTION
Add "server" run mode that behaves like "master"

It should be possible to set the run mode (eg in an external application) using the "server" or "master" run mode.

Update applications in puppet to use the "server" run mode as needed, such as "puppet lookup".