### PR TITLE
(DO NOT MERGE) POC for async scopes in Bolt

### DIFF
--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -110,13 +110,21 @@ class Closure < CallableSignature
       end
       Types::TypeMismatchDescriber.validate_parameters(closure_name, params_struct, args_hash)
       result = catch(:next) do
-        @evaluator.evaluate_block_with_bindings(closure_scope, args_hash, @model.body)
+        if Puppet[:tasks]
+          @evaluator.evaluate_concurrent_block_with_bindings(closure_scope, args_hash, @model.body)
+        else
+          @evaluator.evaluate_block_with_bindings(closure_scope, args_hash, @model.body)
+        end
       end
       Types::TypeAsserter.assert_instance_of(nil, return_type, result) do
         "value returned from #{closure_name}"
       end
     else
-      @evaluator.evaluate_block_with_bindings(closure_scope, args_hash, @model.body)
+      if Puppet[:tasks]
+        @evaluator.evaluate_concurrent_block_with_bindings(closure_scope, args_hash, @model.body)
+      else
+        @evaluator.evaluate_block_with_bindings(closure_scope, args_hash, @model.body)
+      end
     end
   end
   private :call_by_name_internal
@@ -230,7 +238,11 @@ class Closure < CallableSignature
 
     if type.callable?(final_args)
       result = catch(:next) do
-        @evaluator.evaluate_block_with_bindings(scope, variable_bindings, @model.body)
+        if Puppet[:tasks]
+          @evaluator.evaluate_concurrent_block_with_bindings(scope, variable_bindings, @model.body)
+        else
+          @evaluator.evaluate_block_with_bindings(scope, variable_bindings, @model.body)
+        end
       end
       Types::TypeAsserter.assert_instance_of(nil, return_type, result) do
         "value returned from #{closure_name}"

--- a/lib/puppet/pops/evaluator/evaluator_impl.rb
+++ b/lib/puppet/pops/evaluator/evaluator_impl.rb
@@ -178,6 +178,14 @@ class EvaluatorImpl
     end
   end
 
+  def evaluate_concurrent_block_with_bindings(scope, variable_bindings, block_expr)
+    # This creates a new scope object from the parent to use for the block
+    scope.with_new_scope(variable_bindings) do |newscope|
+      create_local_scope_from(variable_bindings, newscope)
+      evaluate(block_expr, newscope)
+    end
+  end
+
   # Implementation of case option matching.
   #
   # This is the type of matching performed in a case option, using == for every type


### PR DESCRIPTION
Bolt is looking to add asynchronous blocks to plans, which means that
using the existing scopes won't work. The current Parser::Scope creates
a 'global' table of variables, and tracks how many variables existed
when a new block begins. When the block finishes it 'pops' the list back
down to the original number when the block was created. This works
great for linear execution, but when blocks execute concurrently it
means that the number of variables created during the block may not be
equal to the difference between the global variables at the beginning
and end of the block. That's because variables from other blocks will
also get added and removed from the global scope while the block is
executing, modifying the length of the global scope. This also leaks
variables since variables defined in 'inner' blocks will be available
globally to outer blocks, since everything uses the same variable list
`@ephemeral`.

This PR is a proof-of-concept for a new evaluation model which will
create a new Parser::Scope object for each block and add any existing
variables from the outer scope to the new scope. This ensures that each
block has a unique scope that doesn't know about any other scopes, so
tracking variables is unnecessary. This isn't a fully formed solution,
as cleaning up scopes once the blocks have finished is unhandled and
there may be other issues with this approach.