### PR TITLE
(PUP-9505) Quote facts that contain special string

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -116,7 +116,24 @@ class Puppet::Node::Facts
     @timestamp = Time.now
   end
 
+  def to_yaml
+    facts_to_display = Psych.parse_stream(YAML.dump(self))
+    quote_special_strings(facts_to_display)
+  end
+
   private
+
+  def quote_special_strings(fact_hash)
+    fact_hash.grep(Psych::Nodes::Scalar).each do |node|
+      next unless node.value =~ /:/
+
+      node.plain  = false
+      node.quoted = true
+      node.style  = Psych::Nodes::Scalar::DOUBLE_QUOTED
+    end
+
+    fact_hash.yaml
+  end
 
   def sanitize_fact(fact)
     if fact.is_a? Hash then

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -3,7 +3,7 @@ require 'puppet/application/facts'
 
 describe Puppet::Application::Facts do
   let(:app) { Puppet::Application[:facts] }
-  let(:values) { {"filesystems" => "apfs,autofs,devfs"} }
+  let(:values) { {"filesystems" => "apfs,autofs,devfs", "macaddress" => "64:52:11:22:03:25"} }
 
   before :each do
     Puppet::Node::Facts.indirection.terminus_class = :memory
@@ -21,6 +21,7 @@ describe Puppet::Application::Facts do
       name: whatever
       values:
         filesystems: apfs,autofs,devfs
+        macaddress: "64:52:11:22:03:25"
     END
 
     expect {
@@ -41,6 +42,7 @@ describe Puppet::Application::Facts do
       name: #{Puppet[:certname]}
       values:
         filesystems: apfs,autofs,devfs
+        macaddress: "64:52:11:22:03:25"
     END
 
     expect {


### PR DESCRIPTION
**Description of the problem:** `puppet facts --render-as yaml` outputs mac addresses unquoted.
If your mac address doesn't contain any chars A-F this is a problem as other tools parsing the resulted yaml will interpret the value as a sexagesimal (base 60) integer.
**Description of the fix:** use Psych to double quote any string that contains the `:` character (this affects macaddress, any date/time and ipv6 style values).