### PR TITLE
(PUP-10598) Update expectation when puppet agent fails

### DIFF
--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -58,9 +58,9 @@ test_name 'Test behavior of directory environments when environmentpath is set t
     }
 
     agents.each do |host|
-      unless host['locale'] == 'ja'
+      if host['locale'] != 'ja'
         expectations[:puppet_agent][:matches] = [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
-                                                 %r{Could not retrieve catalog; skipping run}]
+                                                 %r{Error: Failed to apply catalog: Failed to retrieve}]
       end
     end
 


### PR DESCRIPTION
Prior to PUP-10598, puppet would ignore the pluginsync errors due to the
non-existent environment on the server and would fail when trying to request a
catalog.

As of PUP-10598, puppet will fail on the first pluginsync error, so the error
message is different. The overall behavior is similar though. The cached catalog
is ignored since `puppet agent --test` implies `--no-usecacheonfailure`.