### PR TITLE
(maint) revert schema increment and new value added to cached_catalog_status

### DIFF
--- a/api/schemas/report.json
+++ b/api/schemas/report.json
@@ -111,12 +111,11 @@
         },
 
         "cached_catalog_status": {
-            "description": "Whether a cached catalog was used, and if so, why it was used. Enumerator with one of the values:\n\n* `not_used`, if a cached catalog was not used.\n* `explicitly_requested`, if a cached catalog was used because the use_cached_catalog option was set.\n* `on_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the agent failed to download a new catalog. \n* `on_pluginsync_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the pluginsync failed while having ignore_plugin_errors set to false.",
+            "description": "Whether a cached catalog was used, and if so, why it was used. Enumerator with one of the values:\n\n* `not_used`, if a cached catalog was not used.\n* `explicitly_requested`, if a cached catalog was used because the use_cached_catalog option was set.\n* `on_failure`, if a cached catalog was used because the usecacheonfailure setting was set and the agent failed to download a new catalog",
             "enum": [
               "not_used",
               "explicitly_requested",
-              "on_failure",
-              "on_pluginsync_failure"
+              "on_failure"
             ]
         },
 
@@ -128,7 +127,7 @@
         "report_format": {
             "description": "The report format version documented by this schema",
             "type":        "integer",
-            "enum":        ["11", 11]
+            "enum":        ["10", 10]
         },
 
         "puppet_version": {

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -79,7 +79,7 @@ class Puppet::Configurer
       if Puppet[:use_cached_catalog]
         @cached_catalog_status = 'explicitly_requested'
       elsif @pluginsync_failed
-        @cached_catalog_status = 'on_pluginsync_failure'
+        @cached_catalog_status = 'on_failure'
       end
 
       Puppet.info _("Using cached catalog from environment '%{environment}'") % { environment: result.environment }

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -224,7 +224,7 @@ class Puppet::Transaction::Report
     @external_times ||= {}
     @host = Puppet[:node_name_value]
     @time = Time.now
-    @report_format = 11
+    @report_format = 10
     @puppet_version = Puppet.version
     @configuration_version = configuration_version
     @transaction_uuid = transaction_uuid

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -74,7 +74,7 @@ describe Puppet::Configurer do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(@catalog)
 
       @configurer.run(pluginsync: true, report: report)
-      expect(report.cached_catalog_status).to eq('on_pluginsync_failure')
+      expect(report.cached_catalog_status).to eq('on_failure')
     end
 
     describe 'resubmitting facts' do

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -121,7 +121,7 @@ describe Puppet::Configurer do
       )
 
       expect(configurer.run(pluginsync: true, :report => report)).to eq(0)
-      expect(report.cached_catalog_status).to eq('on_pluginsync_failure')
+      expect(report.cached_catalog_status).to eq('on_failure')
     end
 
     it "applies a cached catalog when it can't connect to the master" do


### PR DESCRIPTION
While fixing `ignore_plugin_errors`/`usecacheonfailure` interaction
a new specific value was added for cached_catalog_status. This new
value does not bring enough benefit vs complexity, reverting to
using generic `on_failure` value