### PR TITLE
(PUP-10670) Prefer `serverport` if explicitly set

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1364,7 +1364,9 @@ EOT
       :desc       => "The default port puppet subcommands use to communicate
       with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
       overridden by more specific settings (see `ca_port`, `report_port`).",
-      :hook => proc { |value| Puppet[:serverport] = value }
+      :hook => proc do |value|
+        Puppet[:serverport] = value unless Puppet.settings.set_by_config?(:serverport)
+      end
     },
     :node_name => {
       :default    => 'cert',

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -28,6 +28,19 @@ describe "Puppet defaults" do
       Puppet.settings[:masterport] = 3939
       expect(Puppet.settings[:serverport]).to eq(3939)
     end
+
+    it "should not overwrite :serverport if explicitly set" do
+      Puppet.settings[:serverport] = 9000
+      Puppet.settings[:masterport] = 9001
+      expect(Puppet.settings[:serverport]).to eq(9000)
+    end
+  end
+
+  describe "when setting the :serverport" do
+    it "should also set the :masterport to the same value" do
+      Puppet.settings[:serverport] = 9000
+      expect(Puppet.settings[:masterport].to_i).to eq(9000)
+    end
   end
 
   describe "when setting the :factpath" do


### PR DESCRIPTION
If both `serverport` and `masterport` are set, prefer `serverport` (i.e. do not override `serverport` with the `masterport` value).

If only one of `masterport` and `serverport` are set, querying both settings should provide the same value.