### PR TITLE
(PUP-10671) Update setting section search path

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -44,7 +44,7 @@ class Puppet::Settings
   REQUIRED_APP_SETTINGS = [:logdir, :confdir, :vardir, :codedir]
 
   # The acceptable sections of the puppet.conf configuration file.
-  ALLOWED_SECTION_NAMES = ['main', 'master', 'agent', 'user'].freeze
+  ALLOWED_SECTION_NAMES = ['main', 'server', 'master', 'agent', 'user'].freeze
 
   NONE = 'none'.freeze
 
@@ -829,7 +829,16 @@ class Puppet::Settings
       SearchPathElement.new(:cli, :values),
     ]
     searchpath << SearchPathElement.new(environment.intern, :environment) if environment
-    searchpath << SearchPathElement.new(run_mode, :section) if run_mode
+
+    if run_mode
+      if [:master, :server].include?(run_mode)
+        searchpath << SearchPathElement.new(:server, :section)
+        searchpath << SearchPathElement.new(:master, :section)
+      else
+        searchpath << SearchPathElement.new(run_mode, :section)
+      end
+    end
+
     searchpath << SearchPathElement.new(:main, :section)
   end
 


### PR DESCRIPTION
Puppet adds a section to its searchpath based on the run mode. This is what enables puppetserver running in `:master` run mode to load settings from the `[master]` section. As a result of the switch to `:server` run
mode, then applications running in server run mode, like `puppet lookup`, will no longer read settings from `[master]`.

If our run mode is `:server` or `:master`, add sections for both, in that order, so that `:server` takes precedence over `:master`.

Add `server` as an allowed section name to be able to test this change, and update the remaining `master` run mode tests to use `server`.