### PR TITLE
(PUP-10673) Call simple server status endpoint

### DIFF
--- a/lib/puppet/http/service/puppetserver.rb
+++ b/lib/puppet/http/service/puppetserver.rb
@@ -26,13 +26,24 @@ class Puppet::HTTP::Service::Puppetserver < Puppet::HTTP::Service
   # @api private
   #
   def get_simple_status(ssl_context: nil)
-    response = @client.get(
-      with_base_url("/status/v1/simple/master"),
-      headers: add_puppet_headers({}),
-      options: {ssl_context: ssl_context}
-    )
+    request_path = "/status/v1/simple/master"
 
-    process_response(response)
+    begin
+      response = @client.get(
+        with_base_url(request_path),
+        headers: add_puppet_headers({}),
+        options: {ssl_context: ssl_context}
+      )
+
+      process_response(response)
+    rescue Puppet::HTTP::ResponseError => e
+      if e.response.code == 404 && e.response.url.path == "/status/v1/simple/master"
+        request_path = "/status/v1/simple/server"
+        retry
+      else
+        raise e
+      end
+    end
 
     [response, response.body.to_s]
   end

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -131,8 +131,8 @@ describe Puppet::Application::Filebucket do
 
       # FileBucket catches any exceptions raised, logs them, then just exits
       it "raises an error if there are no functional servers in server_list" do
-        stub_request(:get, "https://foo:8140/status/v1/simple/master").to_return(status: 404)
-        stub_request(:get, "https://bar:8140/status/v1/simple/master").to_return(status: 404)
+        stub_request(:get, "https://foo:8140/status/v1/simple/master").to_return(status: 400)
+        stub_request(:get, "https://bar:8140/status/v1/simple/master").to_return(status: 400)
         Puppet[:server] = 'horacio'
         Puppet[:server_list] = "foo,bar"
 


### PR DESCRIPTION
This commit adds a fallback for the simple status call
to `/status/v1/simple/server` if `/status/v1/simple/master`
returns 404.