### PR TITLE
(PUP-10711) Add `:port` and `:integer` setting types and update defaults

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1302,6 +1302,7 @@ EOT
     },
     :serverport => {
       :default    => 8140,
+      :type       => :port,
       :desc       => "The default port puppet subcommands use to communicate
       with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
       overridden by more specific settings (see `ca_port`, `report_port`).",
@@ -1310,7 +1311,8 @@ EOT
       end
     },
     :masterport => {
-      :default    => 8140,
+      :default    => "$serverport",
+      :type       => :port,
       :desc       => "The default port puppet subcommands use to communicate
       with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
       overridden by more specific settings (see `ca_port`, `report_port`).",
@@ -1633,6 +1635,7 @@ EOT
     },
     :ca_port => {
       :default    => "$serverport",
+      :type       => :port,
       :desc       => "The port to use for the certificate authority.",
     },
     :preferred_serialization_format => {
@@ -1722,6 +1725,7 @@ EOT
     },
     :report_port => {
       :default  => "$serverport",
+      :type     => :port,
       :desc     => "The port to communicate with the report_server.",
     },
     :report => {

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -21,6 +21,8 @@ class Puppet::Settings
   require 'puppet/settings/file_or_directory_setting'
   require 'puppet/settings/path_setting'
   require 'puppet/settings/boolean_setting'
+  require 'puppet/settings/integer_setting'
+  require 'puppet/settings/port_setting'
   require 'puppet/settings/terminus_setting'
   require 'puppet/settings/duration_setting'
   require 'puppet/settings/ttl_setting'
@@ -733,6 +735,8 @@ class Puppet::Settings
       :file_or_directory => FileOrDirectorySetting,
       :path       => PathSetting,
       :boolean    => BooleanSetting,
+      :integer    => IntegerSetting,
+      :port       => PortSetting,
       :terminus   => TerminusSetting,
       :duration   => DurationSetting,
       :ttl        => TTLSetting,

--- a/lib/puppet/settings/integer_setting.rb
+++ b/lib/puppet/settings/integer_setting.rb
@@ -1,0 +1,17 @@
+class Puppet::Settings::IntegerSetting < Puppet::Settings::BaseSetting
+  def munge(value)
+    return value if Integer === value
+
+    begin
+      value = Integer(value)
+    rescue ArgumentError, TypeError
+      raise Puppet::Settings::ValidationError, _("Cannot convert '%{value}' to an integer for parameter: %{name}") % { value: value.inspect, name: @name }
+    end
+
+    value
+  end
+
+  def type
+    :integer
+  end
+end

--- a/lib/puppet/settings/port_setting.rb
+++ b/lib/puppet/settings/port_setting.rb
@@ -1,0 +1,15 @@
+class Puppet::Settings::PortSetting < Puppet::Settings::IntegerSetting
+  def munge(value)
+    value = super
+
+    if value < 0 || value > 65535
+      raise Puppet::Settings::ValidationError, _("Value '%{value}' is not a valid port number for parameter: %{name}") % { value: value.inspect, name: @name }
+    end
+
+    value
+  end
+
+  def type
+    :port
+  end
+end

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -175,18 +175,18 @@ describe "Puppet defaults" do
 
     it "should use the default serverport value when report port is unspecified" do
       Puppet.settings[:serverport] = "1234"
-      expect(Puppet.settings[:report_port]).to eq("1234")
+      expect(Puppet.settings[:report_port]).to eq(1234)
     end
 
     it "should use the default masterport value when report port is unspecified" do
       Puppet.settings[:masterport] = "1234"
-      expect(Puppet.settings[:report_port]).to eq("1234")
+      expect(Puppet.settings[:report_port]).to eq(1234)
     end
 
     it "should use report_port when set" do
       Puppet.settings[:serverport] = "1234"
       Puppet.settings[:report_port] = "5678"
-      expect(Puppet.settings[:report_port]).to eq("5678")
+      expect(Puppet.settings[:report_port]).to eq(5678)
     end
   end
 

--- a/spec/unit/settings/integer_setting_spec.rb
+++ b/spec/unit/settings/integer_setting_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+require 'puppet/settings'
+require 'puppet/settings/integer_setting'
+
+describe Puppet::Settings::IntegerSetting do
+  let(:setting) { described_class.new(:settings => double('settings'), :desc => "test") }
+
+  it "is of type :integer" do
+    expect(setting.type).to eq(:integer)
+  end
+
+  describe "when munging the setting" do
+    it "returns the same value if given a positive integer" do
+      expect(setting.munge(5)).to eq(5)
+    end
+
+    it "returns the same value if given a negative integer" do
+      expect(setting.munge(-25)).to eq(-25)
+    end
+
+    it "returns an integer if given a valid integer as string" do
+      expect(setting.munge('12')).to eq(12)
+    end
+
+    it "returns an integer if given a valid negative integer as string" do
+      expect(setting.munge('-12')).to eq(-12)
+    end
+
+    it "returns an integer if given a valid positive integer as string" do
+      expect(setting.munge('+12')).to eq(12)
+    end
+
+    it "raises if given an invalid value" do
+      expect { setting.munge('a5') }.to raise_error(Puppet::Settings::ValidationError)
+    end
+
+    it "raises if given nil" do
+      expect { setting.munge(nil) }.to raise_error(Puppet::Settings::ValidationError)
+    end
+  end
+end

--- a/spec/unit/settings/port_setting_spec.rb
+++ b/spec/unit/settings/port_setting_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+require 'puppet/settings'
+require 'puppet/settings/port_setting'
+
+describe Puppet::Settings::PortSetting do
+  let(:setting) { described_class.new(:settings => double('settings'), :desc => "test") }
+
+  it "is of type :port" do
+    expect(setting.type).to eq(:port)
+  end
+
+  describe "when munging the setting" do
+    it "returns the same value if given a valid port as integer" do
+      expect(setting.munge(5)).to eq(5)
+    end
+
+    it "returns an integer if given valid port as string" do
+      expect(setting.munge('12')).to eq(12)
+    end
+
+    it "raises if given a negative port number" do
+      expect { setting.munge('-5') }.to raise_error(Puppet::Settings::ValidationError)
+    end
+
+    it "raises if the port number is too high" do
+      expect { setting.munge(65536) }.to raise_error(Puppet::Settings::ValidationError)
+    end
+
+  end
+end


### PR DESCRIPTION
This is just a POC. As some setting types were quite specific I decided to implement a `PortSetting` type instead of `IntegerSetting`. On second thought, it would also make sense to have both, and have `PortSetting` inherit from `IntegerSetting`, as there might be cases in the future where we just want to ensure a setting is a valid integer.

Note that we also have the `:ca_port` and `:report_port` settings initialized the same way, which I have not yet changed, but I think they should be the same for consistency.

Thoughts? This change can also be considered breaking in a way, as the setting is now an integer (internally at least, the user can still set it to a string in puppet.conf if they want).