### PR TITLE
(PUP-10673) Call simple server status endpoint

### DIFF
--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -25,7 +25,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
           agent.command_line.args << '--test'
           agent.run
         }.to exit_with(0)
-         .and output(%r{HTTP GET https://127.0.0.1:#{port}/status/v1/simple/master returned 200 OK}).to_stdout
+         .and output(%r{HTTP GET https://127.0.0.1:#{port}/status/v1/simple/server returned 200 OK}).to_stdout
       end
     end
 
@@ -39,7 +39,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
           agent.run
         }.to exit_with(0)
          .and output(%r{Notice: Applied catalog}).to_stdout
-         .and output(%r{Unable to connect to server from server_list setting: Request to https://puppet.example.com:#{port}/status/v1/simple/master failed}).to_stderr
+         .and output(%r{Unable to connect to server from server_list setting: Request to https://puppet.example.com:#{port}/status/v1/simple/server failed}).to_stderr
 
         report = Puppet::Transaction::Report.convert_from(:yaml, File.read(Puppet[:lastrunreport]))
         expect(report.master_used).to eq("127.0.0.1:#{port}")

--- a/spec/lib/puppet_spec/puppetserver.rb
+++ b/spec/lib/puppet_spec/puppetserver.rb
@@ -103,7 +103,7 @@ class PuppetSpec::Puppetserver
   end
 
   def register_mounts(mounts: {})
-    register_mount('/status/v1/simple/master', proc { |req, res|  }, nil)
+    register_mount('/status/v1/simple/server', proc { |req, res|  }, nil)
     register_mount('/puppet/v3/node', mounts[:node], NodeServlet)
     register_mount('/puppet/v3/catalog', mounts[:catalog], CatalogServlet)
     register_mount('/puppet/v3/file_metadatas', mounts[:file_metadatas], FileMetadatasServlet)

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -115,15 +115,15 @@ describe Puppet::Application::Filebucket do
       end
 
       it "should default to the first good server_list entry if server_list is set" do
-        stub_request(:get, "https://foo:8140/status/v1/simple/master").to_return(status: 200)
+        stub_request(:get, "https://foo:8140/status/v1/simple/server").to_return(status: 200)
         Puppet[:server_list] = "foo,bar,baz"
         expect(Puppet::FileBucket::Dipper).to receive(:new).with(hash_including(Server: "foo"))
         @filebucket.setup
       end
 
       it "should walk server_list until it finds a good entry" do
-        stub_request(:get, "https://foo:8140/status/v1/simple/master").to_return(status: 502)
-        stub_request(:get, "https://bar:8140/status/v1/simple/master").to_return(status: 200)
+        stub_request(:get, "https://foo:8140/status/v1/simple/server").to_return(status: 502)
+        stub_request(:get, "https://bar:8140/status/v1/simple/server").to_return(status: 200)
         Puppet[:server_list] = "foo,bar,baz"
         expect(Puppet::FileBucket::Dipper).to receive(:new).with(hash_including(Server: "bar"))
         @filebucket.setup
@@ -131,6 +131,8 @@ describe Puppet::Application::Filebucket do
 
       # FileBucket catches any exceptions raised, logs them, then just exits
       it "raises an error if there are no functional servers in server_list" do
+        stub_request(:get, "https://foo:8140/status/v1/simple/server").to_return(status: 404)
+        stub_request(:get, "https://bar:8140/status/v1/simple/server").to_return(status: 404)
         stub_request(:get, "https://foo:8140/status/v1/simple/master").to_return(status: 404)
         stub_request(:get, "https://bar:8140/status/v1/simple/master").to_return(status: 404)
         Puppet[:server] = 'horacio'
@@ -146,7 +148,7 @@ describe Puppet::Application::Filebucket do
       end
 
       it "should take both the server and port specified in server_list" do
-        stub_request(:get, "https://foo:632/status/v1/simple/master").to_return(status: 200)
+        stub_request(:get, "https://foo:632/status/v1/simple/server").to_return(status: 200)
         Puppet[:server_list] = "foo:632,bar:6215,baz:351"
         expect(Puppet::FileBucket::Dipper).to receive(:new).with({ :Server => "foo", :Port => 632 })
         @filebucket.setup

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1043,7 +1043,7 @@ describe Puppet::Configurer do
     it "should select a server when it receives 200 OK response" do
       Puppet.settings[:server_list] = ["myserver:123"]
 
-      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 200)
+      stub_request(:get, 'https://myserver:123/status/v1/simple/server').to_return(status: 200)
 
       options = {}
       configurer.run(options)
@@ -1054,7 +1054,7 @@ describe Puppet::Configurer do
     it "should report when a server is unavailable" do
       Puppet.settings[:server_list] = ["myserver:123"]
 
-      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: [500, "Internal Server Error"])
+      stub_request(:get, 'https://myserver:123/status/v1/simple/server').to_return(status: [500, "Internal Server Error"])
 
       expect {
         configurer.run
@@ -1066,8 +1066,8 @@ describe Puppet::Configurer do
     it "should error when no servers in 'server_list' are reachable" do
       Puppet.settings[:server_list] = "myserver:123,someotherservername"
 
-      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 400)
-      stub_request(:get, 'https://someotherservername:8140/status/v1/simple/master').to_return(status: 400)
+      stub_request(:get, 'https://myserver:123/status/v1/simple/server').to_return(status: 400)
+      stub_request(:get, 'https://someotherservername:8140/status/v1/simple/server').to_return(status: 400)
 
       expect{
         configurer.run
@@ -1080,7 +1080,7 @@ describe Puppet::Configurer do
       Puppet::Node.indirection.terminus_class = :rest
       Puppet::Resource::Catalog.indirection.terminus_class = :rest
 
-      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 200)
+      stub_request(:get, 'https://myserver:123/status/v1/simple/server').to_return(status: 200)
       stub_request(:post, %r{https://myserver:123/puppet/v3/catalog}).to_return(status: 200)
       node_request = stub_request(:get, %r{https://myserver:123/puppet/v3/node/}).to_return(status: 200)
 

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -28,7 +28,7 @@ describe Puppet::HTTP::Resolver do
     end
 
     it 'returns a service based on the current server_list setting' do
-      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 200)
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: 200)
 
       service = subject.resolve(session, :ca)
       expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
@@ -36,7 +36,7 @@ describe Puppet::HTTP::Resolver do
     end
 
     it 'returns a service based on the current server_list setting if the server returns any success codes' do
-      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 202)
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: 202)
 
       service = subject.resolve(session, :ca)
       expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
@@ -46,24 +46,24 @@ describe Puppet::HTTP::Resolver do
     it 'includes extra http headers' do
       Puppet[:http_extra_headers] = 'region:us-west'
 
-      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master")
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server")
         .with(headers: {'Region' => 'us-west'})
 
       subject.resolve(session, :ca)
     end
 
     it 'uses the provided ssl context during resolution' do
-      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 200)
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: 200)
 
       other_ctx = Puppet::SSL::SSLContext.new
-      expect(client).to receive(:connect).with(URI("https://ca.example.com:8141/status/v1/simple/master"), options: {ssl_context: other_ctx}).and_call_original
+      expect(client).to receive(:connect).with(URI("https://ca.example.com:8141/status/v1/simple/server"), options: {ssl_context: other_ctx}).and_call_original
 
       subject.resolve(session, :ca, ssl_context: other_ctx)
     end
 
     it 'logs unsuccessful HTTP 500 responses' do
-      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: [500, 'Internal Server Error'])
-      stub_request(:get, "https://apple.example.com:8142/status/v1/simple/master").to_return(status: 200)
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: [500, 'Internal Server Error'])
+      stub_request(:get, "https://apple.example.com:8142/status/v1/simple/server").to_return(status: 200)
 
       subject.resolve(session, :ca)
 
@@ -71,8 +71,8 @@ describe Puppet::HTTP::Resolver do
     end
 
     it 'cancels resolution if no servers in server_list are accessible' do
-      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 503)
-      stub_request(:get, "https://apple.example.com:8142/status/v1/simple/master").to_return(status: 503)
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: 503)
+      stub_request(:get, "https://apple.example.com:8142/status/v1/simple/server").to_return(status: 503)
 
       canceled = false
       canceled_handler = lambda { |cancel| canceled = cancel }
@@ -82,8 +82,8 @@ describe Puppet::HTTP::Resolver do
     end
 
     it 'cycles through server_list until a valid server is found' do
-      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 503)
-      stub_request(:get, "https://apple.example.com:8142/status/v1/simple/master").to_return(status: 200)
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: 503)
+      stub_request(:get, "https://apple.example.com:8142/status/v1/simple/server").to_return(status: 200)
 
       service = subject.resolve(session, :ca)
       expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
@@ -91,8 +91,8 @@ describe Puppet::HTTP::Resolver do
     end
 
     it 'resolves once per session' do
-      failed = stub_request(:get, "https://ca.example.com:8141/status/v1/simple/master").to_return(status: 503)
-      passed = stub_request(:get, "https://apple.example.com:8142/status/v1/simple/master").to_return(status: 200)
+      failed = stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: 503)
+      passed = stub_request(:get, "https://apple.example.com:8142/status/v1/simple/server").to_return(status: 200)
 
       service = subject.resolve(session, :puppet)
       expect(service).to be_a(Puppet::HTTP::Service::Compiler)

--- a/spec/unit/http/service/puppetserver_spec.rb
+++ b/spec/unit/http/service/puppetserver_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::HTTP::Service::Puppetserver do
 
   context 'when making requests' do
     it 'includes default HTTP headers' do
-      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/master").with do |request|
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/server").with do |request|
         expect(request.headers).to include({'X-Puppet-Version' => /./, 'User-Agent' => /./})
         expect(request.headers).to_not include('X-Puppet-Profiling')
       end.to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
@@ -23,7 +23,7 @@ describe Puppet::HTTP::Service::Puppetserver do
     it 'includes extra headers' do
       Puppet[:http_extra_headers] = 'region:us-west'
 
-      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/master")
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/server")
         .with(headers: {'Region' => 'us-west'})
         .to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
 
@@ -36,7 +36,7 @@ describe Puppet::HTTP::Service::Puppetserver do
       Puppet[:server] = 'compiler2.example.com'
       Puppet[:masterport] = 8141
 
-      stub_request(:get, "https://compiler2.example.com:8141/status/v1/simple/master")
+      stub_request(:get, "https://compiler2.example.com:8141/status/v1/simple/server")
         .to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
 
       subject.get_simple_status
@@ -44,7 +44,7 @@ describe Puppet::HTTP::Service::Puppetserver do
   end
 
   context 'when getting puppetserver status' do
-    let(:url) { "https://puppetserver.example.com:8140/status/v1/simple/master" }
+    let(:url) { "https://puppetserver.example.com:8140/status/v1/simple/server" }
 
     it 'returns the request response and status' do
       stub_request(:get, url)
@@ -77,6 +77,36 @@ describe Puppet::HTTP::Service::Puppetserver do
       session = client.create_session
       service = Puppet::HTTP::Service.create_service(client, session, :puppetserver, 'puppetserver.example.com', 8140)
       service.get_simple_status(ssl_context: other_ctx)
+    end
+  end
+
+  context 'when /status/v1/simple/server returns not found' do
+    it 'calls /status/v1/simple/master' do
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/server")
+        .to_return(status: [404, 'not found: server'])
+
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/master")
+        .to_return(body: "running", headers: {'Content-Type' => 'text/plain;charset=utf-8'})
+
+      resp, status = subject.get_simple_status
+      expect(resp).to be_a(Puppet::HTTP::Response)
+      expect(status).to eq('running')
+    end
+
+    it 'raises a response error if fallback is unsuccessful' do
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/server")
+        .to_return(status: [404, 'not found: server'])
+
+      stub_request(:get, "https://puppetserver.example.com:8140/status/v1/simple/master")
+        .to_return(status: [404, 'not found: master'])
+
+      expect {
+        subject.get_simple_status
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq('not found: master')
+        expect(err.response.code).to eq(404)
+      end
     end
   end
 end

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -148,8 +148,8 @@ describe Puppet::HTTP::Session do
       Puppet[:server_list] = 'foo.example.com,bar.example.com,baz.example.com'
 
       allow_any_instance_of(Puppet::HTTP::DNS).to receive(:each_srv_record)
-      stub_request(:get, "https://foo.example.com:8140/status/v1/simple/master").to_return(status: 500)
-      stub_request(:get, "https://bar.example.com:8140/status/v1/simple/master").to_return(status: 200)
+      stub_request(:get, "https://foo.example.com:8140/status/v1/simple/server").to_return(status: 500)
+      stub_request(:get, "https://bar.example.com:8140/status/v1/simple/server").to_return(status: 200)
 
       service = session.route_to(:ca)
 
@@ -160,7 +160,7 @@ describe Puppet::HTTP::Session do
       Puppet[:server_list] = 'foo.example.com'
 
       expect_any_instance_of(Puppet::HTTP::Resolver::Settings).to receive(:resolve).never
-      stub_request(:get, "https://foo.example.com:8140/status/v1/simple/master").to_return(status: 500)
+      stub_request(:get, "https://foo.example.com:8140/status/v1/simple/server").to_return(status: 500)
 
       expect {
         session.route_to(:ca)
@@ -179,7 +179,7 @@ describe Puppet::HTTP::Session do
     Puppet::HTTP::Service::SERVICE_NAMES.each do |name|
       it "resolves #{name} using server_list" do
         Puppet[:server_list] = 'apple.example.com'
-        req = stub_request(:get, "https://apple.example.com:8140/status/v1/simple/master").to_return(status: 200)
+        req = stub_request(:get, "https://apple.example.com:8140/status/v1/simple/server").to_return(status: 200)
 
         session.route_to(name)
 
@@ -201,7 +201,7 @@ describe Puppet::HTTP::Session do
 
     it 'resolves once for all services in a session' do
       Puppet[:server_list] = 'apple.example.com'
-      req = stub_request(:get, "https://apple.example.com:8140/status/v1/simple/master").to_return(status: 200)
+      req = stub_request(:get, "https://apple.example.com:8140/status/v1/simple/server").to_return(status: 200)
 
       Puppet::HTTP::Service::SERVICE_NAMES.each do |name|
         session.route_to(name)
@@ -212,7 +212,7 @@ describe Puppet::HTTP::Session do
 
     it 'resolves server_list for each new session' do
       Puppet[:server_list] = 'apple.example.com'
-      req = stub_request(:get, "https://apple.example.com:8140/status/v1/simple/master").to_return(status: 200)
+      req = stub_request(:get, "https://apple.example.com:8140/status/v1/simple/server").to_return(status: 200)
 
       client.create_session.route_to(:puppet)
       client.create_session.route_to(:puppet)


### PR DESCRIPTION
This commit updates the path of simple server status
to `/status/v1/simple/server`. If this returns 404
it calls `/status/v1/simple/server` to ensure
backwards compatibility.