### PR TITLE
(maint) Update yardoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Documentation for Puppet and related projects can be found online at the
 
 ### HTTP API
 
-[HTTP API Index](https://puppet.com/docs/puppet/5.5/http_api/http_api_index.html)
+[HTTP API Index](https://puppet.com/docs/puppet/latest/http_api/http_api_index.html)
 
 ## Installation
 

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -27,16 +27,16 @@ require 'puppet/external/pson/pure'
 require 'puppet/gettext/config'
 require 'puppet/defaults'
 
-
-#------------------------------------------------------------
-# the top-level module
+# Defines the `Puppet` module. There are different entry points into Puppet
+# depending on your use case.
 #
-# all this really does is dictate how the whole system behaves, through
-# preferences for things like debugging
+# To use puppet as a library, see {Puppet::Pal}.
 #
-# it's also a place to find top-level commands like 'debug'
-
-# The main Puppet class. Everything is contained here.
+# To create a new application, see {Puppet::Application}.
+#
+# To create a new function, see {Puppet::Functions}.
+#
+# To access puppet's REST APIs, see https://puppet.com/docs/puppet/latest/http_api/http_api_index.html.
 #
 # @api public
 module Puppet

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -5,7 +5,13 @@ module Puppet
     end
   end
 
-  # @api private
+  # Contains an HTTP client for making network requests to puppet and other
+  # HTTP servers.
+  #
+  # @see Puppet::HTTP::Client
+  # @see Puppet::HTTP::HTTPError
+  # @see Puppet::HTTP::Response
+  # @api public
   module HTTP
     ACCEPT_ENCODING = "gzip;q=1.0,deflate;q=0.6,identity;q=0.3".freeze
     HEADER_PUPPET_VERSION = "X-Puppet-Version".freeze

--- a/lib/puppet/http/errors.rb
+++ b/lib/puppet/http/errors.rb
@@ -1,14 +1,26 @@
 module Puppet::HTTP
+  # A base class for puppet http errors
+  # @api public
   class HTTPError < Puppet::Error; end
 
+  # A connection error such as if the server refuses the connection.
+  # @api public
   class ConnectionError < HTTPError; end
 
+  # A failure to route to the server such as if the `server_list` is exhausted.
+  # @api public
   class RouteError < HTTPError; end
 
+  # An HTTP protocol error, such as the server's response missing a required header.
+  # @api public
   class ProtocolError < HTTPError; end
 
+  # An error serializing or deserializing an object via REST.
+  # @api public
   class SerializationError < HTTPError; end
 
+  # An error due to an unsuccessful HTTP response, such as HTTP 500.
+  # @api public
   class ResponseError < HTTPError
     attr_reader :response
 
@@ -18,12 +30,16 @@ module Puppet::HTTP
     end
   end
 
+  # An error if asked to follow too many redirects (such as HTTP 301).
+  # @api public
   class TooManyRedirects < HTTPError
     def initialize(addr)
       super(_("Too many HTTP redirections for %{addr}") % { addr: addr})
     end
   end
 
+  # An error if asked to retry (such as HTTP 503) too many times.
+  # @api public
   class TooManyRetryAfters < HTTPError
     def initialize(addr)
       super(_("Too many HTTP retries for %{addr}") % { addr: addr})

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -1,4 +1,3 @@
-#
 # Adapts an external http_client_class to the HTTP client API. The former
 # is typically registered by puppetserver and only implements a subset of
 # the Puppet::Network::HTTP::Connection methods. As a result, only the
@@ -7,10 +6,10 @@
 #
 # @api private
 class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
-  # Create an external http client
+
+  # Create an external http client.
   #
   # @param [Class] http_client_class The class to create to handle the request
-  # @api private
   def initialize(http_client_class)
     @http_client_class = http_client_class
   end
@@ -58,8 +57,7 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
     raise Puppet::HTTP::HTTPError.new(e.message, e)
   end
 
-  # Close the external http client.
-  #
+  # (see Puppet::HTTP::Client#close)
   # @api private
   def close
     # This is a noop as puppetserver doesn't provide a way to close its http client.

--- a/lib/puppet/http/factory.rb
+++ b/lib/puppet/http/factory.rb
@@ -8,7 +8,6 @@ require 'puppet/http'
 # specified {Puppet::HTTP::Site Site} and puppet settings.
 #
 # @api private
-#
 class Puppet::HTTP::Factory
   @@openssl_initialized = false
 

--- a/lib/puppet/http/factory.rb
+++ b/lib/puppet/http/factory.rb
@@ -2,10 +2,10 @@ require 'puppet/ssl/openssl_loader'
 require 'net/http'
 require 'puppet/http'
 
-# Factory for <tt>Net::HTTP</tt> objects.
+# Factory for `Net::HTTP` objects.
 #
-# Encapsulates the logic for creating a <tt>Net::HTTP</tt> object based on the
-# specified {Puppet::HTTP::Site Site} and puppet settings.
+# Encapsulates the logic for creating a `Net::HTTP` object based on the
+# specified {Site} and puppet settings.
 #
 # @api private
 class Puppet::HTTP::Factory

--- a/lib/puppet/http/pool.rb
+++ b/lib/puppet/http/pool.rb
@@ -1,5 +1,5 @@
-# A pool for persistent <tt>Net::HTTP</tt> connections. Connections are
-# stored in the pool indexed by their {Puppet::HTTP::Site Site}.
+# A pool for persistent `Net::HTTP` connections. Connections are
+# stored in the pool indexed by their {Site}.
 # Connections are borrowed from the pool, yielded to the caller, and
 # released back into the pool. If a connection is expired, it will be
 # closed either when a connection to that site is requested, or when

--- a/lib/puppet/http/pool.rb
+++ b/lib/puppet/http/pool.rb
@@ -7,7 +7,6 @@
 # same site, and will be reused in MRU order.
 #
 # @api private
-#
 class Puppet::HTTP::Pool
   attr_reader :factory, :keepalive_timeout
 

--- a/lib/puppet/http/pool_entry.rb
+++ b/lib/puppet/http/pool_entry.rb
@@ -2,7 +2,6 @@
 # an expiration time for the connection.
 #
 # @api private
-#
 class Puppet::HTTP::PoolEntry
   attr_reader :connection, :verifier
 

--- a/lib/puppet/http/redirector.rb
+++ b/lib/puppet/http/redirector.rb
@@ -1,23 +1,16 @@
-#
-# @api private
-#
 # Handle HTTP redirects
 #
+# @api private
 class Puppet::HTTP::Redirector
-  #
-  # @api private
-  #
   # Create a new redirect handler
   #
   # @param [Integer] redirect_limit maximum number of redirects allowed
   #
+  # @api private
   def initialize(redirect_limit)
     @redirect_limit = redirect_limit
   end
 
-  #
-  # @api private
-  #
   # Determine of the HTTP response code indicates a redirect
   #
   # @param [Net::HTTP] request request that received the response
@@ -25,6 +18,7 @@ class Puppet::HTTP::Redirector
   #
   # @return [Boolean] true if the response code is 301, 302, or 307.
   #
+  # @api private
   def redirect?(request, response)
     # Net::HTTPRedirection is not used because historically puppet
     # has only handled these, and we're not a browser
@@ -36,9 +30,6 @@ class Puppet::HTTP::Redirector
     end
   end
 
-  #
-  # @api private
-  #
   # Implement the HTTP request redirection
   #
   # @param [Net::HTTP] request request that has been redirected
@@ -48,6 +39,7 @@ class Puppet::HTTP::Redirector
   # @return [Net::HTTP] A new request based on the original request, but with
   #   the redirected location
   #
+  # @api private
   def redirect_to(request, response, redirects)
     raise Puppet::HTTP::TooManyRedirects.new(request.uri) if redirects >= @redirect_limit
 

--- a/lib/puppet/http/resolver.rb
+++ b/lib/puppet/http/resolver.rb
@@ -1,26 +1,17 @@
-#
-# @api private
-#
 # Resolver base class. Each resolver represents a different strategy for
 # resolving a service name into a list of candidate servers and ports.
 #
 # @abstract Subclass and override {#resolve} to create a new resolver.
-#
+# @api public
 class Puppet::HTTP::Resolver
   #
-  # @api private
-  #
-  # Create a new resolver
+  # Create a new resolver.
   #
   # @param [Puppet::HTTP::Client] client
-  #
   def initialize(client)
     @client = client
   end
 
-  #
-  # @api private
-  #
   # Return a working server/port for the resolver. This is the base
   # implementation and is meant to be a placeholder.
   #
@@ -33,14 +24,12 @@ class Puppet::HTTP::Resolver
   #
   # @raise [NotImplementedError] this base class is not implemented
   #
+  # @api public
   def resolve(session, name, ssl_context: nil, canceled_handler: nil)
     raise NotImplementedError
   end
 
-  #
-  # @api private
-  #
-  # Check a given connection to establish if it can be relied on for future use
+  # Check a given connection to establish if it can be relied on for future use.
   #
   # @param [Puppet::HTTP::Session] session
   # @param [Puppet::HTTP::Service] service
@@ -48,6 +37,7 @@ class Puppet::HTTP::Resolver
   #
   # @return [Boolean] Returns true if a connection is successful, false otherwise
   #
+  # @api public
   def check_connection?(session, service, ssl_context: nil)
     service.connect(ssl_context: ssl_context)
     return true

--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -1,12 +1,10 @@
-#
-# @api private
-#
 # Use the server_list setting to resolve a service. This resolver is only used
 # if server_list is set either on the command line or in the configuration file.
 #
+# @api public
 class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
-  #
-  # @api private
+
+  # Create a server list resolver.
   #
   # @param [Puppet::HTTP::Client] client
   # @param [Array<String>] server_list_setting array of servers set via the
@@ -24,15 +22,12 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
     @services = services
   end
 
-  #
-  # @api private
-  #
   # Walk the server_list to find a server and port that will connect successfully.
   #
-  # @param [Puppet::HTTP::Session] session <description>
+  # @param [Puppet::HTTP::Session] session
   # @param [Symbol] name the name of the service being resolved
   # @param [Puppet::SSL::SSLContext] ssl_context
-  # @param [Proc] canceled_handler (nil) optional callback allowing a resolver
+  # @param [Proc] canceled_handler optional callback allowing a resolver
   #   to cancel resolution.
   #
   # @return [nil] return nil if the service to be resolved does not support
@@ -43,6 +38,7 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
   # @raise [Puppet::Error] raise if none of the servers defined in server_list
   #   are available
   #
+  # @api public
   def resolve(session, name, ssl_context: nil, canceled_handler: nil)
     # If we're configured to use an explicit service host, e.g. report_server
     # then don't use server_list to resolve the `:report` service.

--- a/lib/puppet/http/resolver/settings.rb
+++ b/lib/puppet/http/resolver/settings.rb
@@ -1,24 +1,21 @@
-#
-# @api private
-#
 # Resolve a service using settings. This is the default resolver if none of the
 # other resolvers find a functional connection.
 #
+# @api public
 class Puppet::HTTP::Resolver::Settings < Puppet::HTTP::Resolver
-  #
-  # @api private
-  #
+
   # Resolve a service using the default server and port settings for this service.
   #
   # @param [Puppet::HTTP::Session] session
   # @param [Symbol] name the name of the service to be resolved
   # @param [Puppet::SSL::SSLContext] ssl_context
-  # @param [Proc] canceled_handler (nil) optional callback allowing a resolver
+  # @param [Proc] canceled_handler optional callback allowing a resolver
   #   to cancel resolution.
   #
   # @return [Puppet::HTTP::Service] if the service successfully connects,
   #   return it. Otherwise, return nil.
   #
+  # @api public
   def resolve(session, name, ssl_context: nil, canceled_handler: nil)
     service = Puppet::HTTP::Service.create_service(@client, session, name)
     check_connection?(session, service, ssl_context: ssl_context) ? service : nil

--- a/lib/puppet/http/resolver/srv.rb
+++ b/lib/puppet/http/resolver/srv.rb
@@ -1,11 +1,9 @@
+# Resolve a service using DNS SRV records.
 #
-# @api private
-#
-# Resolve a service using SRV
-#
+# @api public
 class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
-  #
-  # @api private
+
+  # Create an DNS SRV resolver.
   #
   # @param [Puppet::HTTP::Client] client
   # @param [String] domain srv domain
@@ -17,20 +15,18 @@ class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
     @delegate = Puppet::HTTP::DNS.new(dns)
   end
 
-  #
-  # @api private
-  #
   # Walk the available srv records and return the first that successfully connects
   #
   # @param [Puppet::HTTP::Session] session
   # @param [Symbol] name the service being resolved
   # @param [Puppet::SSL::SSLContext] ssl_context
-  # @param [Proc] canceled_handler (nil) optional callback allowing a resolver
+  # @param [Proc] canceled_handler optional callback allowing a resolver
   #   to cancel resolution.
   #
   # @return [Puppet::HTTP::Service] if an available service is found, return
   #   it. Return nil otherwise.
   #
+  # @api public
   def resolve(session, name, ssl_context: nil, canceled_handler: nil)
     # Here we pass our HTTP service name as the DNS SRV service name
     # This is fine for :ca, but note that :puppet and :file are handled

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -1,118 +1,103 @@
+# Represents the response returned from the server from an HTTP request.
 #
-# @api private
-#
-# Represents the response returned from the server from an HTTP request
-#
+# @api public
 class Puppet::HTTP::Response
   # @api private
   # @return [Net::HTTP] the Net::HTTP response
   attr_reader :nethttp
 
-  # @api private
   # @return [URI] the response uri
   attr_reader :url
 
-  #
-  # @api private
-  #
-  # Object to represent the response returned from an HTTP request
+  # Object to represent the response returned from an HTTP request.
   #
   # @param [Net::HTTP] nethttp the request response
   # @param [URI] url
-  #
   def initialize(nethttp, url)
     @nethttp = nethttp
     @url = url
   end
 
-  #
-  # @api private
-  #
-  # Extract the response code
+  # Extract the response code.
   #
   # @return [Integer] Response code for the request
   #
+  # @api public
   def code
     @nethttp.code.to_i
   end
 
-  #
-  # @api private
-  #
-  # Extract the response message
+  # Extract the response message.
   #
   # @return [String] Response message for the request
   #
+  # @api public
   def reason
     @nethttp.message
   end
 
-  #
-  # @api private
-  #
   # Returns the entire response body. Can be used instead of
-  #   Puppet::HTTP::Response.read_body, but both methods cannot be used for the
+  #   `Puppet::HTTP::Response.read_body`, but both methods cannot be used for the
   #   same response.
   #
   # @return [String] Response body for the request
   #
+  # @api public
   def body
     @nethttp.body
   end
 
-  #
-  # @api private
-  #
   # Streams the response body to the caller in chunks. Can be used instead of
-  #   Puppet::HTTP::Response.body, but both methods cannot be used for the same
+  #   `Puppet::HTTP::Response.body`, but both methods cannot be used for the same
   #   response.
   #
   # @yield [String] Streams the response body in chunks
   #
   # @raise [ArgumentError] raise if a block is not given
   #
+  # @api public
   def read_body(&block)
     raise ArgumentError, "A block is required" unless block_given?
 
     @nethttp.read_body(&block)
   end
 
-  #
-  # @api private
-  #
-  # Check if the request received a response of success
+  # Check if the request received a response of success (HTTP 2xx).
   #
   # @return [Boolean] Returns true if the response indicates success
   #
+  # @api public
   def success?
     @nethttp.is_a?(Net::HTTPSuccess)
   end
 
-  # @api private
-  #
   # Get a header case-insensitively.
+  #
   # @param [String] name The header name
   # @return [String] The header value
   #
+  # @api public
   def [](name)
     @nethttp[name]
   end
 
-  # @api private
-  #
   # Yield each header name and value. Returns an enumerator if no block is given.
   #
   # @yieldparam [String] header name
   # @yieldparam [String] header value
   #
+  # @api public
   def each_header(&block)
     @nethttp.each_header(&block)
   end
 
-  # @api private
+  # Ensure the response body is fully read so that the server is not blocked
+  # waiting for us to read data from the socket. Also if the caller streamed
+  # the response, but didn't read the data, we need a way to drain the socket
+  # before adding the connection back to the connection pool, otherwise the
+  # unread response data would "leak" into the next HTTP request/response.
   #
-  # Drain the response body.
-  #
+  # @api public
   def drain
     body
     true

--- a/lib/puppet/http/retry_after_handler.rb
+++ b/lib/puppet/http/retry_after_handler.rb
@@ -1,28 +1,20 @@
 require 'date'
 require 'time'
 
-#
-# @api private
-#
 # Parse information relating to responses containing a Retry-After headers
 #
+# @api private
 class Puppet::HTTP::RetryAfterHandler
-  #
-  # @api private
-  #
+
   # Create a handler to allow the system to sleep between HTTP requests
   #
   # @param [Integer] retry_limit number of retries allowed
   # @param [Integer] max_sleep maximum sleep time allowed
-  #
   def initialize(retry_limit, max_sleep)
     @retry_limit = retry_limit
     @max_sleep = max_sleep
   end
 
-  #
-  # @api private
-  #
   # Does the response from the server tell us to wait until we attempt the next
   # retry?
   #
@@ -32,6 +24,7 @@ class Puppet::HTTP::RetryAfterHandler
   # @return [Boolean] Return true if the response code is 429 or 503, return
   #   false otherwise
   #
+  # @api private
   def retry_after?(request, response)
     case response.code
     when 429, 503
@@ -41,9 +34,6 @@ class Puppet::HTTP::RetryAfterHandler
     end
   end
 
-  #
-  # @api private
-  #
   # The amount of time to wait before attempting a retry
   #
   # @param [Net::HTTP] request
@@ -55,6 +45,7 @@ class Puppet::HTTP::RetryAfterHandler
   # @raise [Puppet::HTTP::TooManyRetryAfters] raise if we have hit our retry
   #   limit
   #
+  # @api private
   def retry_after_interval(request, response, retries)
     raise Puppet::HTTP::TooManyRetryAfters.new(request.uri) if retries >= @retry_limit
 

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -1,24 +1,17 @@
+# Represents an abstract Puppet web service.
 #
-# @api private
-#
-# Represents a puppet web service
-#
+# @abstract Subclass and implement methods for the service's REST APIs.
+# @api public
 class Puppet::HTTP::Service
-  # @api private
   # @return [URI] the url associated with this service
   attr_reader :url
 
-  # @api private
   # @return [Array<Symbol>] available services
   SERVICE_NAMES = [:ca, :fileserver, :puppet, :puppetserver, :report].freeze
 
-  # @api private
   # @return [Array<Symbol>] format types that are unsupported
   EXCLUDED_FORMATS = [:yaml, :b64_zlib_yaml, :dot].freeze
 
-  #
-  # @api private
-  #
   # Create a new web service, which contains the URL used to connect to the
   # service. The four services implemented are `:ca`, `:fileserver`, `:puppet`,
   # and `:report`.
@@ -35,6 +28,7 @@ class Puppet::HTTP::Service
   #
   # @return [Puppet::HTTP::Service] an instance of the service type requested
   #
+  # @api private
   def self.create_service(client, session, name, server = nil, port = nil)
     case name
     when :ca
@@ -52,57 +46,49 @@ class Puppet::HTTP::Service
     end
   end
 
-  #
-  # @api private
-  #
   # Check if the service named is included in the list of available services.
   #
   # @param [Symbol] name
   #
   # @return [Boolean]
   #
+  # @api private
   def self.valid_name?(name)
     SERVICE_NAMES.include?(name)
   end
 
-  #
-  # @api private
-  #
-  # Create a new service
+  # Create a new service. Services should be created by calling `Puppet::HTTP::Session#route_to`.
   #
   # @param [Puppet::HTTP::Client] client
   # @param [Puppet::HTTP::Session] session
   # @param [URI] url The url to connect to
   #
+  # @api private
   def initialize(client, session, url)
     @client = client
     @session = session
     @url = url
   end
 
-  #
-  # @api private
-  #
   # Return the url with the given path encoded and appended
   #
   # @param [String] path the string to append to the base url
   #
   # @return [URI] the URI object containing the encoded path
   #
+  # @api public
   def with_base_url(path)
     u = @url.dup
     u.path += Puppet::Util.uri_encode(path)
     u
   end
 
+  # Open a connection using the given ssl context.
   #
-  # @api private
+  # @param [Puppet::SSL::SSLContext] ssl_context An optional ssl context to connect with
+  # @return [void]
   #
-  # Open a connection using the given ssl context
-  #
-  # @param [Puppet::SSL::SSLContext] ssl_context (nil) optional ssl context to
-  #   connect with
-  #
+  # @api public
   def connect(ssl_context: nil)
     @client.connect(@url, options: {ssl_context: ssl_context})
   end

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -1,26 +1,21 @@
+# The CA service is used to handle certificate related REST requests.
 #
-# @api private
-#
-# The Ca service is used to handle certificate requests
-#
+# @api public
 class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
-  # @api private
   # @return [Hash] default headers for the ca service
   HEADERS = { 'Accept' => 'text/plain' }.freeze
 
-  # @api private
   # @return [String] default API for the ca service
   API = '/puppet-ca/v1'.freeze
 
-  #
-  # @api private
+  # Use `Puppet::HTTP::Session.route_to(:ca)` to create or get an instance of this class.
   #
   # @param [Puppet::HTTP::Client] client
   # @param [Puppet::HTTP::Session] session
-  # @param [String] server (Puppet[:ca_server]) If an explicit server is given,
+  # @param [String] server (`Puppet[:ca_server]`) If an explicit server is given,
   #   create a service using that server. If server is nil, the default value
   #   is used to create the service.
-  # @param [Integer] port (Puppet[:ca_port]) If an explicit port is given, create
+  # @param [Integer] port (`Puppet[:ca_port]`) If an explicit port is given, create
   #   a service using that port. If port is nil, the default value is used to
   #   create the service.
   #
@@ -29,10 +24,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     super(client, session, url)
   end
 
-  #
-  # @api private
-  #
-  # Submit a GET request to retrieve the named certificate from the server
+  # Submit a GET request to retrieve the named certificate from the server.
   #
   # @param [String] name name of the certificate to request
   # @param [Puppet::SSL::SSLContext] ssl_context
@@ -40,6 +32,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   # @return [Array<Puppet::HTTP::Response, String>] An array containing the
   #   request response and the stringified body of the request response
   #
+  # @api public
   def get_certificate(name, ssl_context: nil)
     response = @client.get(
       with_base_url("/certificate/#{name}"),
@@ -52,11 +45,8 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     [response, response.body.to_s]
   end
 
-  #
-  # @api private
-  #
   # Submit a GET request to retrieve the certificate revocation list from the
-  #   server
+  #   server.
   #
   # @param [Time] if_modified_since If not nil, only download the CRL if it has
   #   been modified since the specified time.
@@ -65,6 +55,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   # @return [Array<Puppet::HTTP::Response, String>] An array containing the
   #   request response and the stringified body of the request response
   #
+  # @api public
   def get_certificate_revocation_list(if_modified_since: nil, ssl_context: nil)
     headers = add_puppet_headers(HEADERS)
     headers['If-Modified-Since'] = if_modified_since.httpdate if if_modified_since
@@ -80,10 +71,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
     [response, response.body.to_s]
   end
 
-  #
-  # @api private
-  #
-  # Submit a PUT request to send a certificate request to the server
+  # Submit a PUT request to send a certificate request to the server.
   #
   # @param [String] name The name of the certificate request being sent
   # @param [OpenSSL::X509::Request] csr Certificate request to send to the
@@ -92,6 +80,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   #
   # @return [Puppet::HTTP::Response] The request response
   #
+  # @api public
   def put_certificate_request(name, csr, ssl_context: nil)
     headers = add_puppet_headers(HEADERS)
     headers['Content-Type'] = 'text/plain'

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -1,23 +1,19 @@
-#
-# @api private
-#
 # The Compiler service is used to submit and retrieve data from the
 # puppetserver.
 #
+# @api public
 class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
-  # @api private
   # @return [String] Default API for the Compiler service
   API = '/puppet/v3'.freeze
 
-  #
-  # @api private
+  # Use `Puppet::HTTP::Session.route_to(:puppet)` to create or get an instance of this class.
   #
   # @param [Puppet::HTTP::Client] client
   # @param [Puppet::HTTP::Session] session
-  # @param [String] server (Puppet[:ca_server]) If an explicit server is given,
+  # @param [String] server (`Puppet[:server]`) If an explicit server is given,
   #   create a service using that server. If server is nil, the default value
   #   is used to create the service.
-  # @param [Integer] port (Puppet[:ca_port]) If an explicit port is given, create
+  # @param [Integer] port (`Puppet[:masterport]`) If an explicit port is given, create
   #   a service using that port. If port is nil, the default value is used to
   #   create the service.
   #
@@ -26,10 +22,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     super(client, session, url)
   end
 
-  #
-  # @api private
-  #
-  # Submit a GET request to retrieve a node from the server
+  # Submit a GET request to retrieve a node from the server.
   #
   # @param [String] name The name of the node being requested
   # @param [String] environment The name of the environment we are operating in
@@ -41,6 +34,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   # @return [Array<Puppet::HTTP::Response, Puppet::Node>] An array containing
   #   the request response and the deserialized requested node
   #
+  # @api public
   def get_node(name, environment:, configured_environment: nil, transaction_uuid: nil)
     headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Node).join(', '))
 
@@ -59,10 +53,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     [response, deserialize(response, Puppet::Node)]
   end
 
-  #
-  # @api private
-  #
-  # Submit a POST request to submit a catalog to the server
+  # Submit a POST request to submit a catalog to the server.
   #
   # @param [String] name The name of the catalog to be submitted
   # @param [Puppet::Node::Facts] facts Facts for this catalog
@@ -83,6 +74,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #   containing the request response and the deserialized catalog returned by
   #   the server
   #
+  # @api public
   def post_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
     if Puppet[:preferred_serialization_format] == "pson"
       formatter = Puppet::Network::FormatHandler.format_for(:pson)
@@ -127,10 +119,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     [response, deserialize(response, Puppet::Resource::Catalog)]
   end
 
-  #
-  # @api private
-  #
-  # Submit a GET request to retrieve the facts for the named node
+  # Submit a GET request to retrieve the facts for the named node.
   #
   # @param [String] name Name of the node to retrieve facts for
   # @param [String] environment Name of the environment we are operating in
@@ -139,6 +128,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #   containing the request response and the deserialized facts for the
   #   specified node
   #
+  # @api public
   def get_facts(name, environment:)
     headers = add_puppet_headers('Accept' => get_mime_types(Puppet::Node::Facts).join(', '))
 
@@ -153,10 +143,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     [response, deserialize(response, Puppet::Node::Facts)]
   end
 
-  #
-  # @api private
-  #
-  # Submits a PUT request to submit facts for the node to the server
+  # Submits a PUT request to submit facts for the node to the server.
   #
   # @param [String] name Name of the node we are submitting facts for
   # @param [String] environment Name of the environment we are operating in
@@ -164,6 +151,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #
   # @return [Puppet::HTTP::Response] The request response
   #
+  # @api public
   def put_facts(name, environment:, facts:)
     formatter = Puppet::Network::FormatHandler.format_for(Puppet[:preferred_serialization_format])
 
@@ -184,12 +172,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     response
   end
 
+  # Submit a GET request to retrieve a file stored with filebucket.
   #
-  # @api private
-  #
-  # Submit a GET request to retrieve a file stored with filebucket
-  #
-  # @param [String] path The request path, formatted by Puppet::FileBucket::Dipper
+  # @param [String] path The request path, formatted by `Puppet::FileBucket::Dipper`
   # @param [String] environment Name of the environment we are operating in.
   #   This should not impact filebucket at all, but is included to be consistent
   #   with legacy code.
@@ -204,6 +189,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #   containing the request response and the deserialized file returned from
   #   the server.
   #
+  # @api public
   def get_filebucket_file(path, environment:, bucket_path: nil, diff_with: nil, list_all: nil, fromdate: nil, todate: nil)
     headers = add_puppet_headers('Accept' => 'application/octet-stream')
 
@@ -225,12 +211,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     [response, deserialize(response, Puppet::FileBucket::File)]
   end
 
+  # Submit a PUT request to store a file with filebucket.
   #
-  # @api private
-  #
-  # Submit a PUT request to store a file with filebucket
-  #
-  # @param [String] path The request path, formatted by Puppet::FileBucket::Dipper
+  # @param [String] path The request path, formatted by `Puppet::FileBucket::Dipper`
   # @param [String] body The contents of the file to be backed
   # @param [String] environment Name of the environment we are operating in.
   #   This should not impact filebucket at all, but is included to be consistent
@@ -238,6 +221,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #
   # @return [Puppet::HTTP::Response] The response request
   #
+  # @api public
   def put_filebucket_file(path, body:, environment:)
     headers = add_puppet_headers({
       'Accept' => 'application/octet-stream',
@@ -258,12 +242,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
     response
   end
 
+  # Submit a HEAD request to check the status of a file stored with filebucket.
   #
-  # @api private
-  #
-  # Submit a HEAD request to check the status of a file stored with filebucket
-  #
-  # @param [String] path The request path, formatted by Puppet::FileBucket::Dipper
+  # @param [String] path The request path, formatted by `Puppet::FileBucket::Dipper`
   # @param [String] environment Name of the environment we are operating in.
   #   This should not impact filebucket at all, but is included to be consistent
   #   with legacy code.
@@ -271,6 +252,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #
   # @return [Puppet::HTTP::Response] The request response
   #
+  # @api public
   def head_filebucket_file(path, environment:, bucket_path: nil)
     headers = add_puppet_headers('Accept' => 'application/octet-stream')
 

--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -1,28 +1,24 @@
 require 'puppet/file_serving/metadata'
 
+# The FileServer service is used to retrieve file metadata and content.
 #
-# @api private
-#
-# The FileServer service is used to retrieve file metadata and content
+# @api public
 #
 class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
-  # @api private
   # @return [String] Default API for the FileServer service
   API = '/puppet/v3'.freeze
 
-  # @api private
   # @return [RegEx] RegEx used to determine if a path contains a leading slash
   PATH_REGEX = /^\//
 
-  #
-  # @api private
+  # Use `Puppet::HTTP::Session.route_to(:fileserver)` to create or get an instance of this class.
   #
   # @param [Puppet::HTTP::Client] client
   # @param [Puppet::HTTP::Session] session
-  # @param [String] server (Puppet[:ca_server]) If an explicit server is given,
+  # @param [String] server (`Puppet[:server]`) If an explicit server is given,
   #   create a service using that server. If server is nil, the default value
   #   is used to create the service.
-  # @param [Integer] port (Puppet[:ca_port]) If an explicit port is given, create
+  # @param [Integer] port (`Puppet[:masterport]`) If an explicit port is given, create
   #   a service using that port. If port is nil, the default value is used to
   #   create the service.
   #
@@ -31,11 +27,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     super(client, session, url)
   end
 
-  #
-  # @api private
-  #
-  # Submit a GET request to the server to retrieve the metadata for a specified
-  # file
+  # Submit a GET request to the server to retrieve the metadata for a specified file.
   #
   # @param [String] path path to the file to retrieve data from
   # @param [String] environment the name of the environment we are operating in
@@ -51,6 +43,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   # @return [Array<Puppet::HTTP::Response, Puppet::FileServing::Metadata>] An
   #   array with the request response and the deserialized metadata for the
   #   file returned from the server
+  #
+  # @api public
   #
   def get_file_metadata(path:, environment:, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore)
     validate_path(path)
@@ -73,9 +67,6 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     [response, deserialize(response, Puppet::FileServing::Metadata)]
   end
 
-  #
-  # @api private
-  #
   # Submit a GET request to the server to retrieve the metadata for multiple files
   #
   # @param [String] path path to the file(s) to retrieve data from
@@ -105,6 +96,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   #   An array with the request response and an array of the deserialized
   #   metadata for each file returned from the server
   #
+  # @api public
+  #
   def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore)
     validate_path(path)
 
@@ -129,10 +122,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     [response, deserialize_multiple(response, Puppet::FileServing::Metadata)]
   end
 
-  #
-  # @api private
-  #
-  # Submit a GET request to the server to retrieve content of a file
+  # Submit a GET request to the server to retrieve content of a file.
   #
   # @param [String] path path to the file to retrieve data from
   # @param [String] environment the name of the environment we are operating in
@@ -140,6 +130,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   # @yield [Sting] Yields the body of the response returned from the server
   #
   # @return [Puppet::HTTP::Response] The request response
+  #
+  # @api public
   #
   def get_file_content(path:, environment:, &block)
     validate_path(path)
@@ -162,10 +154,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
     response
   end
 
-  #
-  # @api private
-  #
-  # Submit a GET request to
+  # Submit a GET request to retrieve file content using the `static_file_content` API
+  # uniquely identified by (`code_id`, `environment`, `path`).
   #
   # @param [String] path path to the file to retrieve data from
   # @param [String] environment the name of the environment we are operating in
@@ -174,6 +164,8 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   # @yield [String] Yields the body of the response returned
   #
   # @return [Puppet::HTTP::Response] The request response
+  #
+  # @api public
   #
   def get_static_file_content(path:, environment:, code_id:, &block)
     validate_path(path)

--- a/lib/puppet/http/service/puppetserver.rb
+++ b/lib/puppet/http/service/puppetserver.rb
@@ -1,29 +1,32 @@
 # The puppetserver service.
 #
-# @api private
+# @api public
 #
 class Puppet::HTTP::Service::Puppetserver < Puppet::HTTP::Service
+
+  # Use `Puppet::HTTP::Session.route_to(:puppetserver)` to create or get an instance of this class.
+  #
   # @param [Puppet::HTTP::Client] client
   # @param [Puppet::HTTP::Session] session
-  # @param [String] server If an explicit server is given,
+  # @param [String] server (`Puppet[:server]`) If an explicit server is given,
   #   create a service using that server. If server is nil, the default value
   #   is used to create the service.
-  # @param [Integer] port If an explicit port is given, create
+  # @param [Integer] port (`Puppet[:masterport]`) If an explicit port is given, create
   #   a service using that port. If port is nil, the default value is used to
   #   create the service.
-  # @api private
   #
   def initialize(client, session, server, port)
     url = build_url('', server || Puppet[:server], port || Puppet[:masterport])
     super(client, session, url)
   end
 
-  # Request the puppetserver's simple status
+  # Request the puppetserver's simple status.
   #
   # @param [Puppet::SSL::SSLContext] ssl_context to use when establishing
   # the connection.
   # @return Puppet::HTTP::Response The HTTP response
-  # @api private
+  #
+  # @api public
   #
   def get_simple_status(ssl_context: nil)
     response = @client.get(

--- a/lib/puppet/http/service/report.rb
+++ b/lib/puppet/http/service/report.rb
@@ -1,16 +1,13 @@
+# The Report service is used to submit run reports to the report server.
 #
-# @api private
-#
-# The Report service is used to submit run reports to the report server
+# @api public
 #
 class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
 
-  # @api private
   # @return [String] Default API for the report service
   API = '/puppet/v3'.freeze
 
-  #
-  # @api private
+  # Use `Puppet::HTTP::Session.route_to(:report)` to create or get an instance of this class.
   #
   # @param [Puppet::HTTP::Client] client
   # @param [Puppet::HTTP::Session] session
@@ -21,21 +18,22 @@ class Puppet::HTTP::Service::Report < Puppet::HTTP::Service
   #   a service using that port. If port is nil, the default value is used to
   #   create the service.
   #
+  # @api private
+  #
   def initialize(client, session, server, port)
     url = build_url(API, server || Puppet[:report_server], port || Puppet[:report_port])
     super(client, session, url)
   end
 
-  #
-  # @api private
-  #
-  # Submit a report to the report server
+  # Submit a report to the report server.
   #
   # @param [String] name the name of the report being submitted
   # @param [Puppet::Transaction::Report] report run report to be submitted
   # @param [String] environment name of the agent environment
   #
   # @return [Puppet::HTTP::Response] response returned by the server
+  #
+  # @api public
   #
   def put_report(name, report, environment:)
     formatter = Puppet::Network::FormatHandler.format_for(Puppet[:preferred_serialization_format])

--- a/lib/puppet/http/session.rb
+++ b/lib/puppet/http/session.rb
@@ -1,8 +1,6 @@
-#
-# @api private
-#
 # The session is the mechanism by which services may be connected to and accessed.
 #
+# @api public
 class Puppet::HTTP::Session
   # capabilities for a site
   CAP_LOCALES = 'locales'.freeze
@@ -14,16 +12,15 @@ class Puppet::HTTP::Session
   # puppet version where JSON was enabled by default
   SUPPORTED_JSON_DEFAULT = Gem::Version.new("5.0.0")
 
-  #
-  # @api private
-  #
   # Create a new HTTP session. The session is the mechanism by which services
-  # may be connected to and accessed.
+  # may be connected to and accessed. Sessions should be created using
+  # `Puppet::HTTP::Client#create_session`.
   #
   # @param [Puppet::HTTP::Client] client the container for this session
   # @param [Array<Puppet::HTTP::Resolver>] resolvers array of resolver strategies
   #   to implement.
   #
+  # @api private
   def initialize(client, resolvers)
     @client = client
     @resolvers = resolvers
@@ -31,9 +28,6 @@ class Puppet::HTTP::Session
     @server_versions = {}
   end
 
-  #
-  # @api private
-  #
   # If an explicit server and port are specified on the command line or
   # configuration file, this method always returns a Service with that host and
   # port. Otherwise, we walk the list of resolvers in priority order:
@@ -45,12 +39,13 @@ class Puppet::HTTP::Session
   # is cached and returned if `route_to` is called again.
   #
   # @param [Symbol] name the service to resolve
-  # @param [URI] url (nil) optional explicit url to use, if it is already known
-  # @param [Puppet::SSL::SSLContext] ssl_context ssl_context ssl context to be
+  # @param [URI] url optional explicit url to use, if it is already known
+  # @param [Puppet::SSL::SSLContext] ssl_context ssl context to be
   #   used for connections
   #
   # @return [Puppet::HTTP::Service] the resolved service
   #
+  # @api public
   def route_to(name, url: nil, ssl_context: nil)
     raise ArgumentError, "Unknown service #{name}" unless Puppet::HTTP::Service.valid_name?(name)
 
@@ -82,14 +77,12 @@ class Puppet::HTTP::Session
     raise Puppet::HTTP::RouteError, "No more routes to #{name}"
   end
 
-  #
-  # @api private
-  #
   # Collect per-site server versions. This will allow us to modify future
   # requests based on the version of puppetserver we are talking to.
   #
   # @param [Puppet::HTTP::Response] response the request response containing headers
   #
+  # @api private
   def process_response(response)
     version = response[Puppet::HTTP::HEADER_PUPPET_VERSION]
     if version
@@ -98,9 +91,6 @@ class Puppet::HTTP::Session
     end
   end
 
-  #
-  # @api private
-  #
   # Determine if a session supports a capability. Depending on the server version
   # we are talking to, we know certain features are available or not. These
   # specifications are defined here so we can modify our requests appropriately.
@@ -110,6 +100,7 @@ class Puppet::HTTP::Session
   #
   # @return [Boolean]
   #
+  # @api public
   def supports?(name, capability)
     raise ArgumentError, "Unknown service #{name}" unless Puppet::HTTP::Service.valid_name?(name)
 

--- a/lib/puppet/http/site.rb
+++ b/lib/puppet/http/site.rb
@@ -4,7 +4,6 @@
 # for the second.
 #
 # @api private
-#
 class Puppet::HTTP::Site
   attr_reader :scheme, :host, :port
 

--- a/lib/puppet/pal/json_catalog_encoder.rb
+++ b/lib/puppet/pal/json_catalog_encoder.rb
@@ -4,6 +4,8 @@
 #
 # @api public
 #
+module Puppet
+module Pal
 class JsonCatalogEncoder
   # Is the resulting Json pretty printed or not.
   attr_reader :pretty
@@ -64,4 +66,6 @@ class JsonCatalogEncoder
     @filtered ||= (exclude_virtual ? catalog.filter { |r| r.virtual? } : catalog)
   end
   private :possibly_filtered_catalog
+end
+end
 end

--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -5,6 +5,7 @@ require 'puppet'
 require 'puppet/parser/script_compiler'
 require 'puppet/parser/catalog_compiler'
 
+module Puppet
 # This is the main entry point for "Puppet As a Library" PAL.
 # This file should be required instead of "puppet"
 # Initially, this will require ALL of puppet - over time this will change as the monolithical "puppet" is broken up
@@ -24,7 +25,7 @@ require 'puppet/parser/catalog_compiler'
 #   end
 #   # The result is what 'mymodule::myfunction' returns
 #
-module Puppet
+# @api public
 module Pal
 
   # Defines a context in which multiple operations in an env with a script compiler can be performed in a given block.
@@ -258,6 +259,7 @@ module Pal
   # @return [Object] returns what the given block returns
   # @yieldparam [Puppet::Pal] context, a context that responds to Puppet::Pal methods
   #
+  # @api public
   def self.in_environment(env_name,
       modulepath:    nil,
       pre_modulepath: [],

--- a/lib/puppet/ssl.rb
+++ b/lib/puppet/ssl.rb
@@ -2,9 +2,15 @@
 require 'puppet'
 require 'puppet/ssl/openssl_loader'
 
+# Responsible for bootstrapping an agent's certificate and private key, generating
+# SSLContexts for use in making HTTPS connections, and handling CSR attributes and
+# certificate extensions.
+#
+# @see Puppet::SSL::SSLProvider
 # @api private
-module Puppet::SSL # :nodoc:
+module Puppet::SSL
   CA_NAME = "ca".freeze
+
   require 'puppet/ssl/oids'
   require 'puppet/ssl/error'
   require 'puppet/ssl/ssl_context'

--- a/lib/puppet/ssl/certificate_signer.rb
+++ b/lib/puppet/ssl/certificate_signer.rb
@@ -27,6 +27,12 @@ class Puppet::SSL::CertificateSigner
     @digest
   end
 
+  # Sign a certificate signing request (CSR) with a private key.
+  #
+  # @param [OpenSSL::X509::Request] content The CSR to sign
+  # @param [OpenSSL::X509::PKey] key The private key to sign with
+  #
+  # @api private
   def sign(content, key)
     content.sign(key, @digest.new)
   end

--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -2,10 +2,11 @@ require 'puppet/ssl'
 
 # This module defines OIDs for use within Puppet.
 #
-# == ASN.1 Definition
+# # ASN.1 Definition
 #
 # The following is the formal definition of OIDs specified in this file.
 #
+# ```
 # puppetCertExtensions OBJECT IDENTIFIER ::= {iso(1) identified-organization(3)
 #    dod(6) internet(1) private(4) enterprise(1) 34380 1}
 #
@@ -22,6 +23,7 @@ require 'puppet/ssl'
 # pp_instance_id OBJECT IDENTIFIER ::= { registeredExtensions 2 }
 # pp_image_name OBJECT IDENTIFIER ::= { registeredExtensions 3 }
 # pp_preshared_key OBJECT IDENTIFIER ::= { registeredExtensions 4 }
+# ```
 #
 # @api private
 module Puppet::SSL::Oids

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -3,6 +3,23 @@ require 'puppet/ssl'
 # SSL Provider creates `SSLContext` objects that can be used to create
 # secure connections.
 #
+# @example To load an SSLContext from an existing private key and related certs/crls:
+#   ssl_context = provider.load_context
+#
+# @example To load an SSLContext from an existing password-protected private key and related certs/crls:
+#   ssl_context = provider.load_context(password: 'opensesame')
+#
+# @example To create an SSLContext from in-memory certs and keys:
+#   cacerts = [<OpenSSL::X509::Certificate>]
+#   crls = [<OpenSSL::X509::CRL>]
+#   key = <OpenSSL::X509::PKey>
+#   cert = <OpenSSL::X509::Certificate>
+#   ssl_context = provider.create_context(cacerts: cacerts, crls: crls, private_key: key, client_cert: cert)
+#
+# @example To create an SSLContext to connect to non-puppet HTTPS servers:
+#   cacerts = [<OpenSSL::X509::Certificate>]
+#   ssl_context = provider.create_root_context(cacerts: cacerts)
+#
 # @api private
 class Puppet::SSL::SSLProvider
   # Create an insecure `SSLContext`. Connections made from the returned context

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -10,7 +10,7 @@ require 'puppet/util/pidlock'
 # certs. This way we're sure about which SSLContext is being used during any
 # phase of the bootstrapping process.
 #
-# @private
+# @api private
 class Puppet::SSL::StateMachine
   class SSLState
     attr_reader :ssl_context
@@ -405,6 +405,7 @@ class Puppet::SSL::StateMachine
   #
   # @return [Puppet::SSL::SSLContext] initialized SSLContext
   # @raise [Puppet::Error] If we fail to generate an SSLContext
+  # @api private
   def ensure_ca_certificates
     final_state = run_machine(NeedLock.new(self), NeedKey)
     final_state.ssl_context
@@ -414,6 +415,7 @@ class Puppet::SSL::StateMachine
   #
   # @return [Puppet::SSL::SSLContext] initialized SSLContext
   # @raise [Puppet::Error] If we fail to generate an SSLContext
+  # @api private
   def ensure_client_certificate
     final_state = run_machine(NeedLock.new(self), Done)
     ssl_context = final_state.ssl_context

--- a/lib/puppet/ssl/verifier.rb
+++ b/lib/puppet/ssl/verifier.rb
@@ -14,6 +14,7 @@ class Puppet::SSL::Verifier
   # @param hostname [String] FQDN of the server we're attempting to connect to
   # @param ssl_context [Puppet::SSL::SSLContext] ssl_context containing CA certs,
   #   CRLs, etc needed to verify the server's certificate chain
+  # @api private
   def initialize(hostname, ssl_context)
     @hostname = hostname
     @ssl_context = ssl_context
@@ -25,6 +26,7 @@ class Puppet::SSL::Verifier
   #
   # @param verifier [Puppet::SSL::Verifier] the verifier to compare against
   # @return [Boolean] return true if a cached connection can be used, false otherwise
+  # @api private
   def reusable?(verifier)
     verifier.instance_of?(self.class) &&
       verifier.ssl_context.object_id == @ssl_context.object_id

--- a/lib/puppet/x509.rb
+++ b/lib/puppet/x509.rb
@@ -1,7 +1,11 @@
 require 'puppet'
 require 'puppet/ssl/openssl_loader'
 
-module Puppet::X509 # :nodoc:
+# Responsible for loading and saving certificates and private keys.
+#
+# @see Puppet::X509::CertProvider
+# @api private
+module Puppet::X509
   require 'puppet/x509/pem_store'
   require 'puppet/x509/cert_provider'
 end


### PR DESCRIPTION
This updates yardoc for public facing modules/classes.

There is one functional change, which is to move the `JsonCatalogEncoder` under `Puppet::Pal` as previously it was "leaking" into topscope. It just happened to work before because it was called from a class under the same constant.

To see the updated yardocs, run `$ bundle exec yard server -r` and then browse to `http://localhost:8808`