### PR TITLE
(PUP-10473) Verify puppetserver registers its authconfigloader

### DIFF
--- a/lib/puppet/network/authorization.rb
+++ b/lib/puppet/network/authorization.rb
@@ -1,7 +1,19 @@
 module Puppet::Network
   module Authorization
-    def self.authconfigloader_class=(_)
-      # legacy auth is not supported, ignore
+    class << self
+      # This method is deprecated and will be removed in a future release.
+      def authconfigloader_class=(klass)
+        @authconfigloader_class = klass
+      end
+
+      # Verify something external to puppet is authorizing REST requests, so
+      # we don't fail insecurely due to misconfiguration.
+      def check_external_authorization(method, path)
+        if @authconfigloader_class.nil?
+          message = "Forbidden request: #{path} (method #{method})"
+          raise Puppet::Network::HTTP::Error::HTTPNotAuthorizedError.new(message, Puppet::Network::HTTP::Issues::FAILED_AUTHORIZATION)
+        end
+      end
     end
   end
 end

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -17,7 +17,6 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   before do
     Puppet::IndirectorTesting.indirection.terminus_class = :memory
     Puppet::IndirectorTesting.indirection.terminus.clear
-    allow(handler).to receive(:warn_if_near_expiration)
   end
 
   describe "when converting a URI into a request" do

--- a/spec/unit/network/http/api_spec.rb
+++ b/spec/unit/network/http/api_spec.rb
@@ -70,6 +70,16 @@ describe Puppet::Network::HTTP::API do
     end
 
     describe "when processing master routes" do
+      # simulate puppetserver registering its authconfigloader class
+      around :each do |example|
+        Puppet::Network::Authorization.authconfigloader_class = Object
+        begin
+          example.run
+        ensure
+          Puppet::Network::Authorization.authconfigloader_class = nil
+        end
+      end
+
       it "responds to v3 indirector requests" do
         req = Puppet::Network::HTTP::Request.from_hash(:path => "#{master_prefix}/v3/node/foo",
                                                        :params => {:environment => "production"},

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -101,11 +101,6 @@ describe Puppet::Network::HTTP::Handler do
       { :status => 200 }
     end
 
-    before do
-      allow(handler).to receive(:check_authorization)
-      allow(handler).to receive(:warn_if_near_expiration)
-    end
-
     it "should setup a profiler when the puppet-profiling header exists" do
       request = a_request
       request[:headers][Puppet::Network::HTTP::HEADER_ENABLE_PROFILING.downcase] = "true"


### PR DESCRIPTION
Verify puppetserver registered its authconfigloader class, which indicates it
will authorize REST requests. If it fails to do so, either due to
misconfiguration or bug, then return HTTP Unauthorized (401) for all v3 REST
endpoints so we fail securely.

Note when legacy routes was enabled (in 6.x) indirected routes performed the
authorization check within its `indirection2uri` method. But here we do the
check before the route is called, since we just need to know the request method
and path to format the error message.