### PR TITLE
(PUP-10619) Evict environments based on last used time

### DIFF
--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -1,6 +1,6 @@
 test_name "Environment control of static catalogs"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
     'server'

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -1,6 +1,6 @@
 test_name "Agent should use environment given by ENC for fetching remote files" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor', # This test should be rolled into use_enc_environment
       'server'

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -4,7 +4,7 @@ test_name 'C98115 compilation should get new values in variables on each compila
 
   confine :except, :platform => /^(aix|osx|solaris)/
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'server'
 

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -2,7 +2,7 @@ test_name "Lookup data using the agnostic lookup function" do
   # pre-docs:
   # https://puppet-on-the-edge.blogspot.com/2015/01/puppet-40-data-in-modules-and.html
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -682,9 +682,8 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
       A value of `0` will disable caching. This setting can also be set to
       `unlimited`, which will cache environments until the server is restarted
       or told to refresh the cache. All other values will result in Puppet
-      server evicting expired environments. The expiration time is computed
-      based on either when the environment was created or last accessed, see
-      `environment_timeout_mode`.
+      server evicting environments that haven't been used within the last
+      `environment_timeout` seconds.
 
       You should change this setting once your Puppet deployment is doing
       non-trivial work. We chose the default value of `0` because it lets new
@@ -697,32 +696,13 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
       * Setting this to a number that will keep your most actively used
         environments cached, but allow testing environments to fall out of the
         cache and reduce memory usage. A value of 3 minutes (3m) is a reasonable
-        value. This option requires setting `environment_timeout_mode` to
-        `from_last_used`.
+        value.
 
       Once you set `environment_timeout` to a non-zero value, you need to tell
       Puppet server to read new code from disk using the `environment-cache` API
       endpoint after you deploy new code. See the docs for the Puppet Server
       [administrative API](https://puppet.com/docs/puppetserver/latest/admin-api/v1/environment-cache.html).
-      ",
-      :hook => proc do |val|
-        if Puppet[:environment_timeout_mode] == :from_created
-          unless [0, 'unlimited', Float::INFINITY].include?(val)
-            Puppet.deprecation_warning("Evicting environments based on their creation time is deprecated, please set `environment_timeout_mode` to `from_last_used` instead.")
-          end
-        end
-      end
-    },
-    :environment_timeout_mode => {
-      :default => :from_created,
-      :type    => :symbolic_enum,
-      :values  => [:from_created, :from_last_used],
-      :desc => "How Puppet interprets the `environment_timeout` setting when
-      `environment_timeout` is neither `0` nor `unlimited`. If set to
-      `from_created`, then the environment will be evicted `environment_timeout`
-      seconds from when it was created. If set to `from_last_used` then the
-      environment will be evicted `environment_timeout` seconds from when it
-      was last used."
+      "
     },
     :environment_data_provider => {
       :desc       => "The name of a registered environment data provider used when obtaining environment

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -677,7 +677,6 @@ config_version=$vardir/random/scripts
 
       it "evicts an environment that hasn't been recently touched" do
         Puppet[:environment_timeout] = 1
-        Puppet[:environment_timeout_mode] = :from_last_used
 
         with_environment_loaded(service) do |cached|
           future = Time.now + 60
@@ -694,7 +693,6 @@ config_version=$vardir/random/scripts
 
       it "reuses an environment that was recently touched" do
         Puppet[:environment_timeout] = 60
-        Puppet[:environment_timeout_mode] = :from_last_used
 
         with_environment_loaded(service) do |cached|
           # reuse the already cached environment
@@ -707,7 +705,6 @@ config_version=$vardir/random/scripts
 
       it "evicts a recently touched environment" do
         Puppet[:environment_timeout] = 60
-        Puppet[:environment_timeout_mode] = :from_last_used
 
         # see note above about "twice"
         expect(service).to receive(:expired?).twice.and_return(true)


### PR DESCRIPTION
Remove `environment_timeout_mode` setting and change default behavior to `from_last_used`.

There is no change in behavior if `environment_timeout` is `0` or `unlimited`.

Otherwise, evict environments if not used within the last `environment_timeout` seconds. Also remove deprecation warning, since the setting now works as expected.