### PR TITLE
(PUP-8014) Add environment_timeout_mode

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -447,10 +447,7 @@ module Puppet::Environments
     # Creates a suitable cache entry given the time to live for one environment
     #
     def entry(env)
-      mru_entry = Puppet.settings.set_by_config?(:environment_ttl)
-      ttl = if mru_entry
-              Puppet[:environment_ttl]
-            elsif (conf = get_conf(env.name))
+      ttl = if (conf = get_conf(env.name))
               conf.environment_timeout
             else
               Puppet[:environment_timeout]
@@ -462,7 +459,7 @@ module Puppet::Environments
       when Float::INFINITY
         Entry.new(env)              # Entry that never expires (avoids syscall to get time)
       else
-        if mru_entry
+        if Puppet[:environment_timeout_mode] == :from_last_used
           MRUEntry.new(env, ttl)    # Entry that expires in ttl from when it was last touched
         else
           TTLEntry.new(env, ttl)    # Entry that expires in ttl from when it was created

--- a/lib/puppet/network/http/api/master/v3/environments.rb
+++ b/lib/puppet/network/http/api/master/v3/environments.rb
@@ -24,12 +24,7 @@ class Puppet::Network::HTTP::API::Master::V3::Environments
   private
 
   def timeout(env)
-    ttl = if Puppet.settings.set_by_config?(:environment_ttl)
-            Puppet[:environment_ttl]
-          else
-            @env_loader.get_conf(env.name).environment_timeout
-          end
-
+    ttl = @env_loader.get_conf(env.name).environment_timeout
     if ttl == Float::INFINITY
       "unlimited"
     else

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -676,7 +676,8 @@ config_version=$vardir/random/scripts
       end
 
       it "evicts an environment that hasn't been recently touched" do
-        Puppet[:environment_ttl] = 1
+        Puppet[:environment_timeout] = 1
+        Puppet[:environment_timeout_mode] = :from_last_used
 
         with_environment_loaded(service) do |cached|
           future = Time.now + 60
@@ -692,7 +693,8 @@ config_version=$vardir/random/scripts
       end
 
       it "reuses an environment that was recently touched" do
-        Puppet[:environment_ttl] = 60
+        Puppet[:environment_timeout] = 60
+        Puppet[:environment_timeout_mode] = :from_last_used
 
         with_environment_loaded(service) do |cached|
           # reuse the already cached environment
@@ -704,7 +706,8 @@ config_version=$vardir/random/scripts
       end
 
       it "evicts a recently touched environment" do
-        Puppet[:environment_ttl] = 60
+        Puppet[:environment_timeout] = 60
+        Puppet[:environment_timeout_mode] = :from_last_used
 
         # see note above about "twice"
         expect(service).to receive(:expired?).twice.and_return(true)

--- a/spec/unit/network/http/api/master/v3/environments_spec.rb
+++ b/spec/unit/network/http/api/master/v3/environments_spec.rb
@@ -33,16 +33,6 @@ describe Puppet::Network::HTTP::API::Master::V3::Environments do
     })
   end
 
-  it "prefers environment_ttl" do
-    Puppet[:environment_ttl] = 60
-
-    handler.call(request, response)
-
-    expect(response.code).to eq(200)
-    expect(response.type).to eq("application/json")
-    expect(JSON.parse(response.body)["environments"]["production"]["settings"]["environment_timeout"]).to eq(60)
-  end
-
   it "the response conforms to the environments schema for unlimited timeout" do
     Puppet[:environment_timeout] = 'unlimited'
 


### PR DESCRIPTION
The `environment_ttl` setting was added to replace `environment_timeout`, but
having two settings complicates the upgrade process for the common case where
the timeout is set to 'unlimited'. If we naively upgrade, then puppet server
will switch from always cache to never cache, due to the default value of
`environment_ttl=0`.

This commit preserves the existing behavior of `environment_timeout` when the
value is `0` or `unlimited`.

Otherwise, the `environment_timeout` value is the time to live relative to when
the environment was created or last used. The `environment_timeout_mode` setting
defaults to `from_created`, but can be set to `from_last_used`.