### PR TITLE
(maint) Refactor response body reading

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -126,13 +126,7 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Get.new(url, @default_headers.merge(headers))
 
-    execute_streaming(request, options: options) do |response|
-      if block_given?
-        yield response
-      else
-        response.body
-      end
-    end
+    execute_streaming(request, options: options, &block)
   end
 
   #
@@ -158,9 +152,7 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Head.new(url, @default_headers.merge(headers))
 
-    execute_streaming(request, options: options) do |response|
-      response.body
-    end
+    execute_streaming(request, options: options)
   end
 
   #
@@ -193,9 +185,7 @@ class Puppet::HTTP::Client
 
     raise ArgumentError, "'put' requires a 'content-type' header" unless request['Content-Type']
 
-    execute_streaming(request, options: options) do |response|
-      response.body
-    end
+    execute_streaming(request, options: options)
   end
 
   #
@@ -228,13 +218,7 @@ class Puppet::HTTP::Client
 
     raise ArgumentError, "'post' requires a 'content-type' header" unless request['Content-Type']
 
-    execute_streaming(request, options: options) do |response|
-      if block_given?
-        yield response
-      else
-        response.body
-      end
-    end
+    execute_streaming(request, options: options, &block)
   end
 
   #
@@ -260,9 +244,7 @@ class Puppet::HTTP::Client
 
     request = Net::HTTP::Delete.new(url, @default_headers.merge(headers))
 
-    execute_streaming(request, options: options) do |response|
-      response.body
-    end
+    execute_streaming(request, options: options)
   end
 
   #
@@ -329,7 +311,11 @@ class Puppet::HTTP::Client
               end
             end
 
-            yield response
+            if block_given?
+              yield response
+            else
+              response.body
+            end
           ensure
             response.drain
           end


### PR DESCRIPTION
The `execute_request` method always ensures the response body is drained so it's
not necessary to call `response.body` in cases where we're not streaming the
response. It also avoids confusion as to whether `execute_request` returns the
response body or the request.