### PR TITLE
(PUP-10719) Collect gem directories from Gem::StubSpecifications

### DIFF
--- a/lib/puppet/util/rubygems.rb
+++ b/lib/puppet/util/rubygems.rb
@@ -41,7 +41,11 @@ module Puppet::Util::RubyGems
     def directories
       # `require 'mygem'` will consider and potentially load
       # prerelease gems, so we need to match that behavior.
-      Gem::Specification.latest_specs(true).collect do |spec|
+      #
+      # Just load the stub which points to the gem path, and
+      # delay loading the full specification until if/when the
+      # gem is required.
+      Gem::Specification.stubs.collect do |spec|
         File.join(spec.full_gem_path, 'lib')
       end
     end

--- a/spec/unit/util/rubygems_spec.rb
+++ b/spec/unit/util/rubygems_spec.rb
@@ -33,8 +33,8 @@ describe Puppet::Util::RubyGems::Source do
   describe '::Gems18Source' do
     before(:each) { allow(described_class).to receive(:source).and_return(Puppet::Util::RubyGems::Gems18Source) }
 
-    it "#directories returns the lib subdirs of Gem::Specification.latest_specs" do
-      expect(Gem::Specification).to receive(:latest_specs).with(true).and_return([fake_gem])
+    it "#directories returns the lib subdirs of Gem::Specification.stubs" do
+      expect(Gem::Specification).to receive(:stubs).and_return([fake_gem])
 
       expect(described_class.new.directories).to eq([gem_lib])
     end


### PR DESCRIPTION
Puppet calls `Puppet::Util::RubyGems::Source#directories` to get a list of
candidate paths for the autoloader, so that we can load types, features, etc
from gems, see commit 2a12fdd5c. However, `Gem::Specification.latest_specs`
parses the full gemspec, returning `Gem::Specification` objects.

The `Gem::Specification.stubs` method only parses the "stub line" in the
gemspec, for example:

    # -*- encoding: utf-8 -*-
    # stub: bigdecimal 1.3.4 ruby lib

And returns `Gem::StubSpecification` objects. Calling the `stubs` method is
about 6.7 times faster than `latest_specs` when running from packages, i.e. not
bundler.

The `stubs` method also preserves the behavior of returning pre-release gems, as
the pre-release filtering happens when converting stubs to full specs.

Doing so also fixes a strange puppet/rubygems bug whereby `Kernel.require` can
fail to load a gem, but rubygems will load and cache stubs. If the gemspec is
later moved, but `Gem.clear_paths` is not called, then rubygems will fail to
convert the stub to a full spec. See PUP-10719 for details.

    $ cat micro.rb
    require 'benchmark/ips'

    Benchmark.ips do |x|
      x.report("full specs") do
        Gem.clear_paths
        Gem::Specification.latest_specs(true)
      end

      x.report("stub specs") do
        Gem.clear_paths
        Gem::Specification.stubs
      end

      x.compare!
    end

    $ /opt/puppetlabs/puppet/bin/ruby micro.rb
    Warming up --------------------------------------
              full specs     7.000  i/100ms
              stub specs    48.000  i/100ms
    Calculating -------------------------------------
              full specs     72.956  (± 1.4%) i/s -    371.000  in   5.085961s
              stub specs    491.231  (± 0.8%) i/s -      2.496k in   5.081461s

    Comparison:
              stub specs:      491.2 i/s
              full specs:       73.0 i/s - 6.73x  (± 0.00) slower