### PR TITLE
(PUP-9481) Validate certname in sections other than main

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -841,7 +841,10 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
           **Note:** You must set the certname in the main section of the puppet.conf file. Setting it in a different section causes errors.
 
         Defaults to the node's fully qualified domain name.",
-      :hook => proc { |value| raise(ArgumentError, _("Certificate names must be lower case")) unless value == value.downcase }},
+      :call_hook => :on_initialize_and_write,
+      :hook => proc { |value|
+        raise(ArgumentError, _("Certificate names must be lower case")) unless value == value.downcase
+      }},
     :dns_alt_names => {
       :default => '',
       :desc    => <<EOT,

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -5,6 +5,22 @@ class Puppet::Settings::BaseSetting
   attr_accessor :name, :desc, :section, :default, :call_hook
   attr_reader :short, :deprecated
 
+  # Hooks are called during different parts of the settings lifecycle:
+  #
+  # * :on_write_only - This is the default hook type. The hook will be called
+  #   if its value is set in `main` or programmatically. If its value is set in
+  #   a section that doesn't match the application's run mode, it will be
+  #   ignored entirely. If the section does match the run mode, the value will
+  #   be used, but the hook will not be called!
+  #
+  # * :on_define_and_write - The hook behaves the same as above, except it is
+  #   also called immediately when the setting is defined in
+  #   {Puppet::Settings.define_settings}. In that case, the hook receives the
+  #   default value as specified.
+  #
+  # * :on_initialize_and_write - The hook will be called if the value is set in
+  #   `main`, the section that matches the run mode, or programmatically.
+  #
   def self.available_call_hook_values
     [:on_define_and_write, :on_initialize_and_write, :on_write_only]
   end

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'puppet/settings/errors'
 
 # The base setting type
@@ -21,27 +22,34 @@ class Puppet::Settings::BaseSetting
   # * :on_initialize_and_write - The hook will be called if the value is set in
   #   `main`, the section that matches the run mode, or programmatically.
   #
+  HOOK_TYPES = Set.new([:on_define_and_write, :on_initialize_and_write, :on_write_only]).freeze
+
   def self.available_call_hook_values
-    [:on_define_and_write, :on_initialize_and_write, :on_write_only]
+    HOOK_TYPES.to_a
   end
 
+  # Registers a hook to be called later based on the type of hook specified in `value`.
+  #
+  # @param value [Symbol] One of {HOOK_TYPES}
   def call_hook=(value)
     if value.nil?
       #TRANSLATORS ':%{name}', ':call_hook', and ':on_write_only' should not be translated
       Puppet.warning _("Setting :%{name} :call_hook is nil, defaulting to :on_write_only") % { name: name }
       value = :on_write_only
     end
-    unless self.class.available_call_hook_values.include?(value)
+    unless HOOK_TYPES.include?(value)
       #TRANSLATORS 'call_hook' is a Puppet option name and should not be translated
       raise ArgumentError, _("Invalid option %{value} for call_hook") % { value: value }
     end
     @call_hook = value
   end
 
+  # @see {HOOK_TYPES}
   def call_hook_on_define?
     call_hook == :on_define_and_write
   end
 
+  # @see {HOOK_TYPES}
   def call_hook_on_initialize?
     call_hook == :on_initialize_and_write
   end

--- a/spec/integration/environments/setting_hooks_spec.rb
+++ b/spec/integration/environments/setting_hooks_spec.rb
@@ -12,7 +12,7 @@ describe "setting hooks" do
     end
 
     it "accesses correct directory environment settings after initializing a setting with an on_write hook" do
-      expect(Puppet.settings.setting(:certname).call_hook).to eq(:on_write_only) 
+      expect(Puppet.settings.setting(:strict).call_hook).to eq(:on_write_only)
 
       File.open(File.join(confdir, "puppet.conf"), "w:UTF-8") do |f|
         f.puts("environmentpath=#{environmentpath}")

--- a/spec/lib/puppet_spec/settings.rb
+++ b/spec/lib/puppet_spec/settings.rb
@@ -12,7 +12,12 @@ module PuppetSpec::Settings
     :codedir      => { :type => :directory, :default => "test", :desc => "codedir" },
     :vardir       => { :type => :directory, :default => "test", :desc => "vardir" },
     :rundir       => { :type => :directory, :default => "test", :desc => "rundir" },
-  }
+  }.freeze
+
+  TEST_APP_DEFAULT_VALUES = TEST_APP_DEFAULT_DEFINITIONS.inject({}) do |memo, (key, value)|
+    memo[key] = value[:default]
+    memo
+  end.freeze
 
   def set_puppet_conf(confdir, settings)
     write_file(File.join(confdir, "puppet.conf"), settings)

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -409,94 +409,94 @@ describe Puppet::Settings do
           describe "and definition invalid" do
             it "should raise error if no hook defined" do
               expect do
-                @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => val})
+                @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :call_hook => val})
               end.to raise_error(ArgumentError, /no :hook/)
             end
 
             it "should include the setting name in the error message" do
               expect do
-                @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => val})
-              end.to raise_error(ArgumentError, /for :hooker/)
+                @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :call_hook => val})
+              end.to raise_error(ArgumentError, /for :setting/)
             end
           end
 
           describe "and definition valid" do
             before(:each) do
               hook_values = []
-              @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => val, :hook => lambda { |v| hook_values << v  }})
+              @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :call_hook => val, :hook => lambda { |v| hook_values << v  }})
             end
 
             it "should call the hook when value written" do
-              expect(@settings.setting(:hooker)).to receive(:handle).with("something").once
-              @settings[:hooker] = "something"
+              expect(@settings.setting(:setting)).to receive(:handle).with("something").once
+              @settings[:setting] = "something"
             end
           end
         end
       end
 
       it "should have a default value of :on_write_only" do
-        @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
-        expect(@settings.setting(:hooker).call_hook).to eq(:on_write_only)
+        @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
+        expect(@settings.setting(:setting).call_hook).to eq(:on_write_only)
       end
 
       describe "when nil" do
         it "should generate a warning" do
           expect(Puppet).to receive(:warning)
-          @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => nil, :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :call_hook => nil, :hook => lambda { |v| hook_values << v  }})
         end
 
         it "should use default" do
-          @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => nil, :hook => lambda { |v| hook_values << v  }})
-          expect(@settings.setting(:hooker).call_hook).to eq(:on_write_only)
+          @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :call_hook => nil, :hook => lambda { |v| hook_values << v  }})
+          expect(@settings.setting(:setting).call_hook).to eq(:on_write_only)
         end
       end
 
       describe "when invalid" do
         it "should raise an error" do
           expect do
-            @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => :foo, :hook => lambda { |v| hook_values << v  }})
+            @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :call_hook => :foo, :hook => lambda { |v| hook_values << v  }})
           end.to raise_error(ArgumentError, /invalid.*call_hook/i)
         end
       end
 
       describe "when :on_write_only" do
         it "returns its hook type" do
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |_| }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |_| }})
 
-          expect(@settings.setting(:hooker).call_hook).to eq(:on_write_only)
+          expect(@settings.setting(:setting).call_hook).to eq(:on_write_only)
         end
 
         it "should not call the hook at definition" do
           hook_values = []
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
 
           expect(hook_values).to eq(%w[])
         end
 
         it "calls the hook when initializing global defaults with the value from the `main` section" do
           hook_values = []
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
           END
           @settings.initialize_global_settings
 
-          expect(@settings[:hooker]).to eq('in_main')
+          expect(@settings[:setting]).to eq('in_main')
           expect(hook_values).to eq(%w[in_main])
         end
 
         it "doesn't call the hook when initializing app defaults" do
           hook_values = []
           @settings.define_settings(:main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS)
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
             [agent]
-            hooker=in_agent
+            setting=in_agent
           END
           @settings.initialize_global_settings
 
@@ -504,20 +504,20 @@ describe Puppet::Settings do
 
           @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULT_VALUES)
 
-          expect(@settings[:hooker]).to eq('in_main')
+          expect(@settings[:setting]).to eq('in_main')
           expect(hook_values).to eq(%w[])
         end
 
         it "doesn't call the hook with value from a section that matches the run_mode" do
           hook_values = []
           @settings.define_settings(:main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS)
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |v| hook_values << v  }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
             [agent]
-            hooker=in_agent
+            setting=in_agent
           END
           @settings.initialize_global_settings
 
@@ -525,49 +525,49 @@ describe Puppet::Settings do
 
           @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULT_VALUES.merge(:run_mode => :agent))
 
-          expect(@settings[:hooker]).to eq('in_agent')
+          expect(@settings[:setting]).to eq('in_agent')
           expect(hook_values).to eq(%w[])
         end
       end
 
       describe "when :on_define_and_write" do
         it "returns its hook type" do
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |_| }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |_| }})
 
-          expect(@settings.setting(:hooker).call_hook).to eq(:on_define_and_write)
+          expect(@settings.setting(:setting).call_hook).to eq(:on_define_and_write)
         end
 
         it "should call the hook at definition with the default value" do
           hook_values = []
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
 
           expect(hook_values).to eq(%w[yay])
         end
 
         it "calls the hook when initializing global defaults with the value from the `main` section" do
           hook_values = []
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
           END
           @settings.initialize_global_settings
 
-          expect(@settings[:hooker]).to eq('in_main')
+          expect(@settings[:setting]).to eq('in_main')
           expect(hook_values).to eq(%w[yay in_main])
         end
 
         it "doesn't call the hook when initializing app defaults" do
           hook_values = []
           @settings.define_settings(:main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS)
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
             [agent]
-            hooker=in_agent
+            setting=in_agent
           END
           @settings.initialize_global_settings
 
@@ -575,20 +575,20 @@ describe Puppet::Settings do
 
           @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULT_VALUES)
 
-          expect(@settings[:hooker]).to eq('in_main')
+          expect(@settings[:setting]).to eq('in_main')
           expect(hook_values).to eq([])
         end
 
         it "doesn't call the hook with value from a section that matches the run_mode" do
           hook_values = []
           @settings.define_settings(:main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS)
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| hook_values << v  }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
             [agent]
-            hooker=in_agent
+            setting=in_agent
           END
 
           @settings.initialize_global_settings
@@ -598,7 +598,7 @@ describe Puppet::Settings do
           @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULT_VALUES.merge(:run_mode => :agent))
 
           # The correct value is returned
-          expect(@settings[:hooker]).to eq('in_agent')
+          expect(@settings[:setting]).to eq('in_agent')
 
           # but the hook is never called, seems like a bug!
           expect(hook_values).to eq([])
@@ -607,41 +607,41 @@ describe Puppet::Settings do
 
       describe "when :on_initialize_and_write" do
         it "returns its hook type" do
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |_| }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |_| }})
 
-          expect(@settings.setting(:hooker).call_hook).to eq(:on_initialize_and_write)
+          expect(@settings.setting(:setting).call_hook).to eq(:on_initialize_and_write)
         end
 
         it "should not call the hook at definition" do
           hook_values = []
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v }})
           expect(hook_values).to eq([])
         end
 
         it "calls the hook when initializing global defaults with the value from the `main` section" do
           hook_values = []
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
           END
           @settings.initialize_global_settings
 
-          expect(@settings[:hooker]).to eq('in_main')
+          expect(@settings[:setting]).to eq('in_main')
           expect(hook_values).to eq(%w[in_main])
         end
 
         it "calls the hook when initializing app defaults" do
           hook_values = []
           @settings.define_settings(:main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS)
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
             [agent]
-            hooker=in_agent
+            setting=in_agent
           END
           @settings.initialize_global_settings
 
@@ -649,20 +649,20 @@ describe Puppet::Settings do
 
           @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULT_VALUES)
 
-          expect(@settings[:hooker]).to eq('in_main')
+          expect(@settings[:setting]).to eq('in_main')
           expect(hook_values).to eq(%w[in_main])
         end
 
         it "calls the hook with the overridden value from a section that matches the run_mode" do
           hook_values = []
           @settings.define_settings(:main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS)
-          @settings.define_settings(:main, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v  }})
+          @settings.define_settings(:main, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_initialize_and_write, :hook => lambda { |v| hook_values << v  }})
 
           File.write(config_file, <<~END)
             [main]
-            hooker=in_main
+            setting=in_main
             [agent]
-            hooker=in_agent
+            setting=in_agent
           END
           @settings.initialize_global_settings
 
@@ -670,7 +670,7 @@ describe Puppet::Settings do
 
           @settings.initialize_app_defaults(PuppetSpec::Settings::TEST_APP_DEFAULT_VALUES.merge(:run_mode => :agent))
 
-          expect(@settings[:hooker]).to eq('in_agent')
+          expect(@settings[:setting]).to eq('in_agent')
           expect(hook_values).to eq(%w[in_agent])
         end
       end
@@ -678,33 +678,33 @@ describe Puppet::Settings do
 
     it "should call passed blocks when values are set" do
       values = []
-      @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| values << v }})
+      @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |v| values << v }})
       expect(values).to eq([])
 
-      @settings[:hooker] = "something"
+      @settings[:setting] = "something"
       expect(values).to eq(%w{something})
     end
 
     it "should call passed blocks when values are set via the command line" do
       values = []
-      @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :hook => lambda { |v| values << v }})
+      @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :hook => lambda { |v| values << v }})
       expect(values).to eq([])
 
-      @settings.handlearg("--hooker", "yay")
+      @settings.handlearg("--setting", "yay")
 
       expect(values).to eq(%w{yay})
     end
 
     it "should provide an option to call passed blocks during definition" do
       values = []
-      @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| values << v }})
+      @settings.define_settings(:section, :setting => {:default => "yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| values << v }})
       expect(values).to eq(%w{yay})
     end
 
     it "should pass the fully interpolated value to the hook when called on definition" do
       values = []
       @settings.define_settings(:section, :one => { :default => "test", :desc => "a" })
-      @settings.define_settings(:section, :hooker => {:default => "$one/yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| values << v }})
+      @settings.define_settings(:section, :setting => {:default => "$one/yay", :desc => "boo", :call_hook => :on_define_and_write, :hook => lambda { |v| values << v }})
       expect(values).to eq(%w{test/yay})
     end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -87,7 +87,6 @@ describe Puppet::Settings do
     end
   end
 
-
   describe "when initializing application defaults do" do
     let(:default_values) do
       values = {}
@@ -148,6 +147,7 @@ describe Puppet::Settings do
           end.to_not raise_error
         end
       end
+
       describe "if no interpolation error" do
         it "should not raise an error" do
           hook_values = []
@@ -177,6 +177,7 @@ describe Puppet::Settings do
               @settings.send(:call_hooks_deferred_to_application_initialization, options)
             end.to raise_error(Puppet::Settings::InterpolationError)
           end
+
           it "should contain the setting name in error message" do
             hook_values = []
             @settings.define_settings(
@@ -193,6 +194,7 @@ describe Puppet::Settings do
             end.to raise_error(Puppet::Settings::InterpolationError, /badhook/)
           end
         end
+
         describe "if no interpolation error" do
           it "should not raise an error" do
             hook_values = []
@@ -405,12 +407,14 @@ describe Puppet::Settings do
                 @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => val})
               end.to raise_error(ArgumentError, /no :hook/)
             end
+
             it "should include the setting name in the error message" do
               expect do
                 @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => val})
               end.to raise_error(ArgumentError, /for :hooker/)
             end
           end
+
           describe "and definition valid" do
             before(:each) do
               hook_values = []
@@ -435,6 +439,7 @@ describe Puppet::Settings do
           expect(Puppet).to receive(:warning)
           @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => nil, :hook => lambda { |v| hook_values << v  }})
         end
+
         it "should use default" do
           @settings.define_settings(:section, :hooker => {:default => "yay", :desc => "boo", :call_hook => nil, :hook => lambda { |v| hook_values << v  }})
           expect(@settings.setting(:hooker).call_hook).to eq(:on_write_only)


### PR DESCRIPTION
If a setting is set or overridden in a section other than `main` and the section matches the application's run_mode, then puppet will use the value, but only call the setting's hook if it's of type `:on_initialize_and_write`. This explains why specifying a `certname` containing uppercase letters in the `main` section wasn't rejected as expected. This changes the `certname` setting's hook to `:on_initialize_and_write` and adds tests.