### PR TITLE
(maint) Update test to stub /status/v1/simple/server

### DIFF
--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1079,8 +1079,8 @@ describe Puppet::Configurer do
       Puppet.settings[:server_list] = "myserver:123,someotherservername"
       Puppet[:usecacheonfailure] = true
 
-      stub_request(:get, 'https://myserver:123/status/v1/simple/master').to_return(status: 400)
-      stub_request(:get, 'https://someotherservername:8140/status/v1/simple/master').to_return(status: 400)
+      stub_request(:get, 'https://myserver:123/status/v1/simple/server').to_return(status: 400)
+      stub_request(:get, 'https://someotherservername:8140/status/v1/simple/server').to_return(status: 400)
 
       options = {}
 


### PR DESCRIPTION
Commit 139b5e93a2b added a test that stubbed the old API, but the configurer was
modified in 8112327d45 to call the simple server service instead. Update the
test to match the code.