### PR TITLE
(PUP-10717) Puppet should not append facts to facter results

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -39,7 +39,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
                Puppet::Node::Facts.new(request.key, Facter.to_hash)
              end
 
-    result.add_local_facts
+    result.add_local_facts unless request.options[:resolve_options]
     result.sanitize
     result
   end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -170,6 +170,12 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
+    it 'should NOT add local facts' do
+      expect(facts).not_to receive(:add_local_facts)
+
+      @facter.find(@request)
+    end
+
     describe 'when Facter version is lower than 4.0.40' do
       before :each do
         allow(Facter).to receive(:respond_to?).and_return(false)


### PR DESCRIPTION
When using `puppet facts show` puppet appends local facts to result. This is not desirable, `puppet facts show` supports custom user queries, for example `puppet facts show os` should only show `os` fact, but because of the append, it will show the local facts as well.

The PR excludes local facts when `puppet facts show` is called.