### PR TITLE
(PUP-10715) Show action default for puppet facts

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -31,7 +31,6 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
 
     $ puppet facts find
   EOT
-  find.default = true
 
   deactivate_action(:destroy)
   deactivate_action(:search)
@@ -85,12 +84,13 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
   end
 
   action(:show) do
-    summary _("Facter plugin sync")
+    summary _("Retrieve current node's facts.")
     arguments _("[<facts>]")
     description <<-'EOT'
-    Reads facts from the local system using facter gem.
+    Reads facts from the local system using `facter` terminus.
+    A query can be provided to retrieve just a specific fact or a set of facts.
     EOT
-    returns "The output of facter with added puppet specific facts"
+    returns "The output of facter with added puppet specific facts."
     notes <<-'EOT'
 
     EOT
@@ -99,6 +99,7 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
 
     $ puppet facts show os
     EOT
+    default true
 
     option("--config-file " + _("<path>")) do
       default_to { nil }

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -67,4 +67,22 @@ describe Puppet::Application::Facts do
                .and output(expected).to_stdout
     end
   end
+
+  context 'when default action is called' do
+    let(:expected) { "---\nfilesystems: apfs,autofs,devfs\nmacaddress: 64:52:11:22:03:25\n" }
+
+    before :each do
+      Puppet::Node::Facts.indirection.terminus_class = :facter
+      allow(Facter).to receive(:resolve).and_return(values)
+      app.command_line.args = %w{--render-as yaml}
+    end
+
+    it 'calls show action' do
+      expect {
+        app.run
+      }.to exit_with(0)
+               .and output(expected).to_stdout
+      expect(app.action.name).to eq(:show)
+    end
+  end
 end


### PR DESCRIPTION
Make `show` action the default action for `puppet facts` application. Previously, the default one was the `find` action.