### PR TITLE
(maint) Remove ignored paths from GitHub Actions

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -4,9 +4,8 @@ name: RSpec tests
 on:
   push:
     branches: [master]
-    paths-ignore: ['**.md', 'docs/*', 'examples/*', 'ext/*', 'benchmarks/*']
   pull_request:
-    paths-ignore: ['**.md', 'docs/*', 'examples/*', 'ext/*', 'benchmarks/*']
+    branches: [master]
 
 jobs:
   rspec_tests:


### PR DESCRIPTION
Due to having all GitHub Actions jobs marked as required in the repository's GitHub Branch settings, we always had pull requests with stuck jobs waiting to be run when there were no code changes (no changes at all in cases like merge ups or only in `**.md` or `docs/*` or `examples/*` or `ext/*` or `benchmarks/*` files). Workaround for this was to have someone with enough rights on the repository to forcefully merge the pull request.

Example of stuck pull request: https://github.com/puppetlabs/puppet/pull/8392

This seemed the most detailed discussion regarding this topic in the GitHub Community: https://github.community/t/status-check-with-path-filter/18049

This commit makes all the jobs run always even if the files added/modified in the pull request can't impact the code in any way.

**Conflicts are expected at merge-up into main.**
