### PR TITLE
(PUP-10716) Fix show action output formatting

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -127,8 +127,6 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       summary _("Show legacy facts when querying all facts.")
     end
 
-    render_as :json
-
     when_invoked do |*args|
       options = args.pop
 
@@ -141,6 +139,10 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       result = Puppet::Node::Facts.indirection.find(Puppet.settings[:certname], options)
 
       result.values
+    end
+
+    when_rendering :console do |result|
+      Puppet::Util::Json.dump(result, :pretty => true)
     end
   end
 end

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -50,4 +50,21 @@ describe Puppet::Application::Facts do
     }.to exit_with(0)
      .and output(expected).to_stdout
   end
+
+  context 'when show action is called' do
+    let(:expected) { "{\n  \"filesystems\": \"apfs,autofs,devfs\",\n  \"macaddress\": \"64:52:11:22:03:25\"\n}\n" }
+
+    before :each do
+      Puppet::Node::Facts.indirection.terminus_class = :facter
+      allow(Facter).to receive(:resolve).and_return(values)
+      app.command_line.args = %w{show}
+    end
+
+    it 'correctly displays facts with default formatting' do
+      expect {
+        app.run
+      }.to exit_with(0)
+               .and output(expected).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
**Description of the problem:** when `puppet facts show` action is called without indicating the render, the default render is `json` which is not pretty printed.
**Description of the fix:** The default render should be `console` (the default for `find` action) and in order to display the facts as a pretty json a new method (when_rendering :console) was implemented.