### PR TITLE
(PUP-10722) Fix masterport not honored

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -385,6 +385,19 @@ class Puppet::Settings
     call_hooks_deferred_to_application_initialization
     issue_deprecations
 
+    run_mode = Puppet::Util::RunMode[self.preferred_run_mode]
+    if run_mode.agent? || run_mode.server?
+      if self.set_in_section?(:masterport, run_mode.name) && !self.set_in_section?(:serverport, run_mode.name)
+        self[:serverport] = self[:masterport]
+      elsif self.set_by_config?(:masterport) && !self.set_by_config?(:serverport)
+        self[:serverport] = self[:masterport]
+      elsif self.set_in_section?(:serverport, run_mode.name) && !self.set_in_section?(:masterport, run_mode.name)
+        self[:masterport] = self[:serverport]
+      elsif self.set_by_config?(:serverport) && !self.set_by_config?(:masterport)
+        self[:masterport] = self[:serverport]
+      end
+    end
+
     REQUIRED_APP_SETTINGS.each do |key|
       create_ancestors(Puppet[key])
     end
@@ -913,6 +926,16 @@ class Puppet::Settings
       if vals
         vals.lookup(param)
       end
+    end
+  end
+
+  # Allow later inspection to determine if the setting was set by user
+  # config, rather than a default setting.
+  def set_in_section?(param, section)
+    param = param.to_sym
+    vals = searchpath_values(SearchPathElement.new(section, :section))
+    if vals
+      vals.lookup(param)
     end
   end
 


### PR DESCRIPTION
PUP-10670 introduced the `serverport` alias for `masterport` and changed Puppet to use it internally instead of `masterport`.
This introduced the following change in behaviour:
- when setting `masterport` in any section different than `main`(eg. agent), this is ignored and the default `serverport` value is used.
- users that have `masterport` set in their configuration, in a different section than `main`(eg. agent), are also affected as Puppet
  will not pick up the value set for `masterport` and it will use the default `serverport` value.

This is due to the setting hooks not being called when they are set in sections other than `main`.

In addition to the setting hooks, check and set masterport and serverport when `initialize_app_defaults` is called, if required.