### PR TITLE
(PUP-10724) Issue a deprecation warning if func3x_check is disabled

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2218,12 +2218,18 @@ EOT
    :func3x_check => {
      :default => true,
      :type => :boolean,
-     :desc => <<-'EOT'
+     :desc => <<-'EOT',
        Causes validation of loaded legacy Ruby functions (3x API) to raise errors about illegal constructs that
        could cause harm or that simply does not work. This flag is on by default. This flag is made available
        so that the validation can be turned off in case the method of validation is faulty - if encountered, please
        file a bug report.
      EOT
+     :call_hook => :on_initialize_and_write,
+     :hook => proc do |value|
+       unless value
+         Puppet.deprecation_warning(_("The 'func3x_check' setting is deprecated and will be removed in a future release."))
+       end
+     end
      },
   :tasks => {
     :default => false,

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -215,4 +215,20 @@ describe "Defaults" do
       end
     end
   end
+
+  describe "deprecated settings" do
+    it 'does not issue a deprecation warning by default' do
+      expect(Puppet).to receive(:deprecation_warning).never
+
+      Puppet.initialize_settings
+    end
+
+    it 'issues a deprecation warning when func3x_check is disabled' do
+      Puppet[:func3x_check] = false
+
+      expect(Puppet).to receive(:deprecation_warning).with("The 'func3x_check' setting is deprecated and will be removed in a future release.")
+
+      Puppet.initialize_settings
+    end
+  end
 end


### PR DESCRIPTION
The setting will be removed in puppet 7, so deprecate setting it to false in 6.x