### PR TITLE
(PUP-10656) Provide a JSON fact terminus

### DIFF
--- a/lib/puppet/indirector/fact_search.rb
+++ b/lib/puppet/indirector/fact_search.rb
@@ -1,0 +1,60 @@
+# module containing common methods used by json and yaml facts indirection terminus
+module Puppet::Indirector::FactSearch
+  def node_matches?(facts, options)
+    options.each do |key, value|
+      type, name, operator = key.to_s.split(".")
+      operator ||= 'eq'
+
+      return false unless node_matches_option?(type, name, operator, value, facts)
+    end
+    return true
+  end
+
+  def node_matches_option?(type, name, operator, value, facts)
+    case type
+    when "meta"
+      case name
+      when "timestamp"
+        compare_timestamp(operator, facts.timestamp, Time.parse(value))
+      end
+    when "facts"
+      compare_facts(operator, facts.values[name], value)
+    end
+  end
+
+  def compare_facts(operator, value1, value2)
+    return false unless value1
+
+    case operator
+    when "eq"
+      value1.to_s == value2.to_s
+    when "le"
+      value1.to_f <= value2.to_f
+    when "ge"
+      value1.to_f >= value2.to_f
+    when "lt"
+      value1.to_f < value2.to_f
+    when "gt"
+      value1.to_f > value2.to_f
+    when "ne"
+      value1.to_s != value2.to_s
+    end
+  end
+
+  def compare_timestamp(operator, value1, value2)
+    case operator
+    when "eq"
+      value1 == value2
+    when "le"
+      value1 <= value2
+    when "ge"
+      value1 >= value2
+    when "lt"
+      value1 < value2
+    when "gt"
+      value1 > value2
+    when "ne"
+      value1 != value2
+    end
+  end
+end

--- a/lib/puppet/indirector/facts/json.rb
+++ b/lib/puppet/indirector/facts/json.rb
@@ -1,0 +1,27 @@
+require 'puppet/node/facts'
+require 'puppet/indirector/json'
+require 'puppet/indirector/fact_search'
+
+class Puppet::Node::Facts::Json < Puppet::Indirector::JSON
+  desc "Store client facts as flat files, serialized using JSON, or
+    return deserialized facts from disk."
+
+  include Puppet::Indirector::FactSearch
+  
+  def search(request)
+    node_names = []
+    Dir.glob(json_dir_path).each do |file|
+      facts = load_json_from_file(file, '')
+      if facts && node_matches?(facts, request.options)
+        node_names << facts.name
+      end
+    end
+    node_names
+  end
+
+  private
+
+  def json_dir_path
+    self.path("*")
+  end
+end

--- a/lib/puppet/indirector/facts/yaml.rb
+++ b/lib/puppet/indirector/facts/yaml.rb
@@ -1,9 +1,12 @@
 require 'puppet/node/facts'
 require 'puppet/indirector/yaml'
+require 'puppet/indirector/fact_search'
 
 class Puppet::Node::Facts::Yaml < Puppet::Indirector::Yaml
   desc "Store client facts as flat files, serialized using YAML, or
     return deserialized facts from disk."
+
+  include Puppet::Indirector::FactSearch
 
   def search(request)
     node_names = []
@@ -22,63 +25,5 @@ class Puppet::Node::Facts::Yaml < Puppet::Indirector::Yaml
   def yaml_dir_path
     base = Puppet.run_mode.server? ? Puppet[:yamldir] : Puppet[:clientyamldir]
     File.join(base, 'facts', '*.yaml')
-  end
-
-  def node_matches?(facts, options)
-    options.each do |key, value|
-      type, name, operator = key.to_s.split(".")
-      operator ||= 'eq'
-
-      return false unless node_matches_option?(type, name, operator, value, facts)
-    end
-    return true
-  end
-
-  def node_matches_option?(type, name, operator, value, facts)
-    case type
-    when "meta"
-      case name
-      when "timestamp"
-        compare_timestamp(operator, facts.timestamp, Time.parse(value))
-      end
-    when "facts"
-      compare_facts(operator, facts.values[name], value)
-    end
-  end
-
-  def compare_facts(operator, value1, value2)
-    return false unless value1
-
-    case operator
-    when "eq"
-      value1.to_s == value2.to_s
-    when "le"
-      value1.to_f <= value2.to_f
-    when "ge"
-      value1.to_f >= value2.to_f
-    when "lt"
-      value1.to_f < value2.to_f
-    when "gt"
-      value1.to_f > value2.to_f
-    when "ne"
-      value1.to_s != value2.to_s
-    end
-  end
-
-  def compare_timestamp(operator, value1, value2)
-    case operator
-    when "eq"
-      value1 == value2
-    when "le"
-      value1 <= value2
-    when "ge"
-      value1 >= value2
-    when "lt"
-      value1 < value2
-    when "gt"
-      value1 > value2
-    when "ne"
-      value1 != value2
-    end
   end
 end

--- a/lib/puppet/indirector/json.rb
+++ b/lib/puppet/indirector/json.rb
@@ -41,11 +41,15 @@ class Puppet::Indirector::JSON < Puppet::Indirector::Terminus
       raise ArgumentError, _("invalid key")
     end
 
-    base = Puppet.run_mode.server? ? Puppet[:server_datadir] : Puppet[:client_datadir]
+    base = data_dir
     File.join(base, self.class.indirection_name.to_s, name.to_s + ext)
   end
 
   private
+
+  def data_dir()
+    Puppet.run_mode.server? ? Puppet[:server_datadir] : Puppet[:client_datadir]
+  end
 
   def load_json_from_file(file, key)
     json = nil

--- a/spec/unit/indirector/facts/json_spec.rb
+++ b/spec/unit/indirector/facts/json_spec.rb
@@ -1,0 +1,255 @@
+require 'spec_helper'
+
+require 'puppet/node/facts'
+require 'puppet/indirector/facts/json'
+
+def dir_containing_json_facts(hash)
+  jsondir = tmpdir('json_facts')
+
+  Puppet[:client_datadir] = jsondir
+  dir = File.join(jsondir, 'facts')
+  Dir.mkdir(dir)
+  hash.each_pair do |file, facts|
+    File.open(File.join(dir, file), 'wb') do |f|
+      f.write(JSON.dump(facts))
+    end
+  end
+end
+
+describe Puppet::Node::Facts::Json do
+  include PuppetSpec::Files
+
+  it "should be a subclass of the Json terminus" do
+    expect(Puppet::Node::Facts::Json.superclass).to equal(Puppet::Indirector::JSON)
+  end
+
+  it "should have documentation" do
+    expect(Puppet::Node::Facts::Json.doc).not_to be_nil
+    expect(Puppet::Node::Facts::Json.doc).not_to be_empty
+  end
+
+  it "should be registered with the facts indirection" do
+    indirection = Puppet::Indirector::Indirection.instance(:facts)
+    expect(Puppet::Node::Facts::Json.indirection).to equal(indirection)
+  end
+
+  it "should have its name set to :json" do
+    expect(Puppet::Node::Facts::Json.name).to eq(:json)
+  end
+
+  it "should allow network requests" do
+    # Doesn't allow json as a network format, but allows `puppet facts upload`
+    # to update the JSON cache on a master.
+    expect(Puppet::Node::Facts::Json.new.allow_remote_requests?).to be(true)
+  end
+
+  describe "#search" do
+    def assert_search_matches(matching, nonmatching, query)
+      request = Puppet::Indirector::Request.new(:inventory, :search, nil, nil, query)
+
+      dir_containing_json_facts(matching.merge(nonmatching))
+
+      results = Puppet::Node::Facts::Json.new.search(request)
+      expect(results).to match_array(matching.values.map {|facts| facts.name})
+    end
+
+    it "should return node names that match the search query options" do
+      assert_search_matches({
+          'matching.json'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386", 'processor_count' => '4'),
+          'matching1.json' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "i386", 'processor_count' => '4', 'randomfact' => 'foo')
+        },
+        {
+          "nonmatching.json"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '4'),
+          "nonmatching1.json" => Puppet::Node::Facts.new("nonmatchingnode1", "architecture" => "powerpc", 'processor_count' => '5'),
+          "nonmatching2.json" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5'),
+          "nonmatching3.json" => Puppet::Node::Facts.new("nonmatchingnode3",                              'processor_count' => '4'),
+        },
+        {'facts.architecture' => 'i386', 'facts.processor_count' => '4'}
+      )
+    end
+
+    it "should return empty array when no nodes match the search query options" do
+      assert_search_matches({}, {
+          "nonmatching.json"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '10'),
+          "nonmatching1.json" => Puppet::Node::Facts.new("nonmatchingnode1", "architecture" => "powerpc", 'processor_count' => '5'),
+          "nonmatching2.json" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5'),
+          "nonmatching3.json" => Puppet::Node::Facts.new("nonmatchingnode3",                              'processor_count' => '4'),
+        },
+        {'facts.processor_count.lt' => '4', 'facts.processor_count.gt' => '4'}
+      )
+    end
+
+    it "should return node names that match the search query options with the greater than operator" do
+      assert_search_matches({
+          'matching.json'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
+          'matching1.json' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '10', 'randomfact' => 'foo')
+        },
+        {
+          "nonmatching.json"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '4'),
+          "nonmatching2.json" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '3'),
+          "nonmatching3.json" => Puppet::Node::Facts.new("nonmatchingnode3"                                                       ),
+        },
+        {'facts.processor_count.gt' => '4'}
+      )
+    end
+
+    it "should return node names that match the search query options with the less than operator" do
+      assert_search_matches({
+          'matching.json'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
+          'matching1.json' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '30', 'randomfact' => 'foo')
+        },
+        {
+          "nonmatching.json"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '50' ),
+          "nonmatching2.json" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '100'),
+          "nonmatching3.json" => Puppet::Node::Facts.new("nonmatchingnode3"                                                         ),
+        },
+        {'facts.processor_count.lt' => '50'}
+      )
+    end
+
+    it "should return node names that match the search query options with the less than or equal to operator" do
+      assert_search_matches({
+          'matching.json'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '5'),
+          'matching1.json' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '50', 'randomfact' => 'foo')
+        },
+        {
+          "nonmatching.json"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '100' ),
+          "nonmatching2.json" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '5000'),
+          "nonmatching3.json" => Puppet::Node::Facts.new("nonmatchingnode3"                                                          ),
+        },
+        {'facts.processor_count.le' => '50'}
+      )
+    end
+
+    it "should return node names that match the search query options with the greater than or equal to operator" do
+      assert_search_matches({
+          'matching.json'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => "i386",    'processor_count' => '100'),
+          'matching1.json' => Puppet::Node::Facts.new("matchingnode1", "architecture" => "powerpc", 'processor_count' => '50', 'randomfact' => 'foo')
+        },
+        {
+          "nonmatching.json"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "powerpc", 'processor_count' => '40'),
+          "nonmatching2.json" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386",    'processor_count' => '9' ),
+          "nonmatching3.json" => Puppet::Node::Facts.new("nonmatchingnode3"                                                        ),
+        },
+        {'facts.processor_count.ge' => '50'}
+      )
+    end
+
+    it "should return node names that match the search query options with the not equal operator" do
+      assert_search_matches({
+          'matching.json'  => Puppet::Node::Facts.new("matchingnode",  "architecture" => 'arm'                           ),
+          'matching1.json' => Puppet::Node::Facts.new("matchingnode1", "architecture" => 'powerpc', 'randomfact' => 'foo')
+        },
+        {
+          "nonmatching.json"  => Puppet::Node::Facts.new("nonmatchingnode",  "architecture" => "i386"                           ),
+          "nonmatching2.json" => Puppet::Node::Facts.new("nonmatchingnode2", "architecture" => "i386", 'processor_count' => '9' ),
+          "nonmatching3.json" => Puppet::Node::Facts.new("nonmatchingnode3"                                                     ),
+        },
+        {'facts.architecture.ne' => 'i386'}
+      )
+    end
+
+    def apply_timestamp(facts, timestamp)
+      facts.timestamp = timestamp
+      facts
+    end
+
+    it "should be able to query based on meta.timestamp.gt" do
+      assert_search_matches({
+          '2010-11-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+        },
+        {
+          '2010-10-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-10-15.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+        },
+        {'meta.timestamp.gt' => '2010-10-15'}
+      )
+    end
+
+    it "should be able to query based on meta.timestamp.le" do
+      assert_search_matches({
+          '2010-10-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+          '2010-10-15.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+        },
+        {
+          '2010-11-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+        },
+        {'meta.timestamp.le' => '2010-10-15'}
+      )
+    end
+
+    it "should be able to query based on meta.timestamp.lt" do
+      assert_search_matches({
+          '2010-10-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+        },
+        {
+          '2010-11-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-15.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+        },
+        {'meta.timestamp.lt' => '2010-10-15'}
+      )
+    end
+
+    it "should be able to query based on meta.timestamp.ge" do
+      assert_search_matches({
+          '2010-11-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-15.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+        },
+        {
+          '2010-10-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+        },
+        {'meta.timestamp.ge' => '2010-10-15'}
+      )
+    end
+
+    it "should be able to query based on meta.timestamp.eq" do
+      assert_search_matches({
+          '2010-10-15.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+        },
+        {
+          '2010-11-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+        },
+        {'meta.timestamp.eq' => '2010-10-15'}
+      )
+    end
+
+    it "should be able to query based on meta.timestamp" do
+      assert_search_matches({
+          '2010-10-15.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+        },
+        {
+          '2010-11-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+        },
+        {'meta.timestamp' => '2010-10-15'}
+      )
+    end
+
+    it "should be able to query based on meta.timestamp.ne" do
+      assert_search_matches({
+          '2010-11-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-01", {}), Time.parse("2010-11-01")),
+          '2010-11-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-11-10", {}), Time.parse("2010-11-10")),
+          '2010-10-01.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-01", {}), Time.parse("2010-10-01")),
+          '2010-10-10.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-10", {}), Time.parse("2010-10-10")),
+        },
+        {
+          '2010-10-15.json' => apply_timestamp(Puppet::Node::Facts.new("2010-10-15", {}), Time.parse("2010-10-15")),
+        },
+        {'meta.timestamp.ne' => '2010-10-15'}
+      )
+    end
+  end
+end


### PR DESCRIPTION
We have a YAML terminus for facts, however YAML can problematic for hexidecimal numbers (see PUP-9505).
Additionally, JSON is generally a better serialization format for machines to understand, is a smaller spec than YAML, has a relatively mature ecosystem in Java around parsing/serializing, and is backwards compatible with YAML for recent YAML parsers (YAML has become a superset of JSON).
For these reasons we should implement a JSON terminus for facts (there already exists one for catalogs) and users should be encouraged to use it instead of the YAML terminus.

Original PR: #8287 
node and report json terminus added in #8398 