### PR TITLE
(PUP-10713) Ensure environment cache is consistent when entries are cleared

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -424,7 +424,6 @@ module Puppet::Environments
       @cache.each_pair do |name, entry|
         evict_if_expired(name, entry, t)
       end
-      @next_expiration = @expirations.first || END_OF_TIME
     end
 
     # This implementation evicts the cache, and always gets the current
@@ -473,6 +472,7 @@ module Puppet::Environments
         @cache_expiration_service.evicted(name.to_sym)
         clear(name)
         @expirations.delete(entry.expires)
+        @next_expiration = @expirations.first || END_OF_TIME
         Puppet.settings.clear_environment_settings(name)
       end
     end

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -420,7 +420,7 @@ module Puppet::Environments
     def clear_all_expired()
       t = Time.now
       return if t < @next_expiration && ! @cache.any? {|name, _| @cache_expiration_service.expired?(name.to_sym) }
-      to_expire = @cache.select { |name, entry| entry.expires < t || @cache_expiration_service.expired?(name.to_sym) }
+      to_expire = @cache.select { |name, entry| entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym) }
       to_expire.each do |name, entry|
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
@@ -470,7 +470,8 @@ module Puppet::Environments
     # Evicts the entry if it has expired
     # Also clears caches in Settings that may prevent the entry from being updated
     def evict_if_expired(name)
-      if (result = @cache[name]) && (result.expired? || @cache_expiration_service.expired?(name.to_sym))
+      t = Time.now
+      if (entry = @cache[name]) && (entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym))
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
         clear(name)
@@ -489,7 +490,7 @@ module Puppet::Environments
       def touch
       end
 
-      def expired?
+      def expired?(now)
         false
       end
 
@@ -504,7 +505,7 @@ module Puppet::Environments
 
     # Always evicting entry
     class NotCachedEntry < Entry
-      def expired?
+      def expired?(now)
         true
       end
 
@@ -525,8 +526,8 @@ module Puppet::Environments
         @ttl_seconds = ttl_seconds
       end
 
-      def expired?
-        Time.now > @ttl
+      def expired?(now)
+        now > @ttl
       end
 
       def label

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -412,8 +412,13 @@ module Puppet::Environments
 
     # Clears all cached environments.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
-    def clear_all()
+    def clear_all
       super
+
+      @cache.keys.each do |name|
+        @cache_expiration_service.evicted(name)
+        Puppet.settings.clear_environment_settings(name)
+      end
       @cache = {}
       @expirations.clear
       @next_expiration = END_OF_TIME

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -469,12 +469,12 @@ module Puppet::Environments
 
     # Evicts the entry if it has expired
     # Also clears caches in Settings that may prevent the entry from being updated
-    def evict_if_expired(name)
-      t = Time.now
+    def evict_if_expired(name, t = Time.now)
       if (entry = @cache[name]) && (entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym))
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
         clear(name)
+        @expirations.delete(entry.expires)
         Puppet.settings.clear_environment_settings(name)
       end
     end

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -379,7 +379,6 @@ module Puppet::Environments
       elsif (result = @loader.get(name))
         # environment loaded, cache it
         cache_entry = entry(result)
-        @cache_expiration_service.created(result)
         add_entry(name, cache_entry)
         result
       end
@@ -389,6 +388,7 @@ module Puppet::Environments
     def add_entry(name, cache_entry)
       Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
       @cache[name] = cache_entry
+      @cache_expiration_service.created(cache_entry.value)
       expires = cache_entry.expires
       @expirations.add(expires)
       if @next_expiration > expires

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -397,12 +397,6 @@ module Puppet::Environments
     end
     private :add_entry
 
-    # Clears the cache of the environment with the given name.
-    # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
-    def clear(name)
-      @cache.delete(name)
-      Puppet::GettextConfig.delete_text_domain(name)
-    end
 
     # Clears all cached environments.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
@@ -470,7 +464,8 @@ module Puppet::Environments
       if entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym)
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
-        clear(name)
+        @cache.delete(name)
+        Puppet::GettextConfig.delete_text_domain(name)
         @expirations.delete(entry.expires)
         @next_expiration = @expirations.first || END_OF_TIME
         Puppet.settings.clear_environment_settings(name)

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -662,10 +662,7 @@ config_version=$vardir/random/scripts
       it "evicts an expired environment" do
         service = ReplayExpirationService.new
 
-        # The `Cached#clear_all_expired` method tries to optimize the case where
-        # no entries are expired. But if `Time.now < @next_expiration` and there is
-        # an expired entry, then the `service#expired?` method is called twice.
-        expect(service).to receive(:expired?).twice.and_return(true)
+        expect(service).to receive(:expired?).and_return(true)
 
         with_environment_loaded(service) do |cached|
           cached.get!(:an_environment)
@@ -709,8 +706,7 @@ config_version=$vardir/random/scripts
         Puppet[:environment_timeout] = 60
         Puppet[:environment_timeout_mode] = :from_last_used
 
-        # see note above about "twice"
-        expect(service).to receive(:expired?).twice.and_return(true)
+        expect(service).to receive(:expired?).and_return(true)
 
         with_environment_loaded(service) do |cached|
           # even though the environment was recently touched, it's been expired


### PR DESCRIPTION
Removes the `Puppet::Environments::Cached#clear` method, instead the puppetserver REST API should be used to evict a specific environment.

`Puppet::Environments::Cached#clear_if_expired` didn't recalculate `@next_expiration`

`Puppet::Environments::Cached#clear_all` didn't notify puppetserver of the evicted environments and didn't clear environment settings.

Removes unnecessary memoization of the next expiration time, the sorted set of environment expiration times and `Puppet::Environments::Cached::*Entry#expires` methods.

**NEEDS TESTS**