### PR TITLE
(maint) Merge master to main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group(:test) do
   gem "json-schema", "~> 2.0", require: false
   gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2')
   gem "rspec", "~> 3.1", require: false
+  gem "rspec-expectations", ["~> 3.9", "!= 3.9.3"]
   gem "rspec-its", "~> 1.1", require: false
   gem 'vcr', '~> 5.0', require: false
   gem 'webmock', '~> 3.0', require: false

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -440,7 +440,12 @@ Puppet::Face.define(:epp, '0.0.1') do
 
   def render_inline(epp_source, compiler, options)
     template_args = get_values(compiler, options)
-    Puppet::Pops::Evaluator::EppEvaluator.inline_epp(compiler.topscope, epp_source, template_args)
+    result = Puppet::Pops::Evaluator::EppEvaluator.inline_epp(compiler.topscope, epp_source, template_args)
+    if result.instance_of?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      result.unwrap
+    else
+      result
+    end
   end
 
   def render_file(epp_template_name, compiler, options, show_filename, file_nbr)
@@ -457,7 +462,12 @@ Puppet::Face.define(:epp, '0.0.1') do
       if template_file.nil? && Puppet::FileSystem.exist?(epp_template_name)
         epp_template_name = File.expand_path(epp_template_name)
       end
-      output << Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, epp_template_name, compiler.environment, template_args)
+      result = Puppet::Pops::Evaluator::EppEvaluator.epp(compiler.topscope, epp_template_name, compiler.environment, template_args)
+      if result.instance_of?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        output << result.unwrap
+      else
+        output << result
+      end
     rescue Puppet::ParseError => detail
       Puppet.err("--- #{epp_template_name}") if show_filename
       raise detail

--- a/lib/puppet/functions/epp.rb
+++ b/lib/puppet/functions/epp.rb
@@ -40,6 +40,7 @@ Puppet::Functions.create_function(:epp, Puppet::Functions::InternalFunction) do
     scope_param
     param 'String', :path
     optional_param 'Hash[Pattern[/^\w+$/], Any]', :parameters
+    return_type 'Variant[String, Sensitive[String]]'
   end
 
   def epp(scope, path, parameters = nil)

--- a/lib/puppet/functions/inline_epp.rb
+++ b/lib/puppet/functions/inline_epp.rb
@@ -51,6 +51,7 @@ Puppet::Functions.create_function(:inline_epp, Puppet::Functions::InternalFuncti
     scope_param()
     param 'String', :template
     optional_param 'Hash[Pattern[/^\w+$/], Any]', :parameters
+    return_type 'Variant[String, Sensitive[String]]'
   end
 
   def inline_epp(scope, template, parameters = nil)

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -181,4 +181,12 @@ describe "Defaults" do
       end
     end
   end
+
+  describe "deprecated settings" do
+    it 'does not issue a deprecation warning by default' do
+      expect(Puppet).to receive(:deprecation_warning).never
+
+      Puppet.initialize_settings
+    end
+  end
 end


### PR DESCRIPTION
* upstream/master:
  (packaging) Updating the puppet.pot file
  (PUP-10724) Issue a deprecation warning if func3x_check is disabled
  (PUP-10722) Fix masterport not honored
  (packaging) Bump to version '6.19.1' [no-promote]
  (PUP-8969) Preserve sensitiveness of epp templates

Conflicts:
	lib/puppet/defaults.rb
	spec/unit/defaults_spec.rb

facterng and func3x_check settings were removed in main. Keep test from master
which asserts settings don't raise deprecation warnings by default.