### PR TITLE
(maint) Exclude rspec-expectations 3.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group(:test) do
   gem "json-schema", "~> 2.0", require: false
   gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2')
   gem "rspec", "~> 3.1", require: false
+  gem "rspec-expectations", ["~> 3.9", "!= 3.9.3"]
   gem "rspec-its", "~> 1.1", require: false
   gem 'vcr', '~> 5.0', require: false
   gem 'webmock', '~> 3.0', require: false


### PR DESCRIPTION
There is a regression with keyword args[1], exclude that version.

https://github.com/rspec/rspec-expectations/issues/1221